### PR TITLE
Publish the July 25 changelog catch-up

### DIFF
--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -67,17 +67,17 @@ const RAW_CHANGELOG_EDITIONS = [
     publishedOn: "2026-07-25",
     title: "A Murph that knows when to speak",
     summary:
-      "Group Murph reads the floor, gets more creative, and handles Telegram one-tap joins. Murph can also check X through Grok, adapt outdoor reminders to the weather, and close billing and phone-call loops that used to strand people.",
+      "Group Murph reads the floor, gets more creative, and knows who is speaking on Telegram. Murph can also ask Grok about X, adapt outdoor reminders to the weather, and close billing and phone-call loops that used to strand people.",
     items: [
       {
-        id: "ask-grok-live-x-search",
+        id: "ask-grok-x-research",
         kind: "feature",
         priority: 5,
         title: "Ask Grok what people are saying on X",
         summary:
-          "Murph can now ask Grok about an account, a topic, or a post you share and bring the live X search answer back into your conversation.",
+          "Murph can now ask Grok to search X about an account, a topic, or a post you share, then bring Grok's returned answer back into your conversation.",
         details:
-          "Murph labels the answer as Grok's report, treats posts as unverified third-party content, and never invents links or authors that the search did not return. The exact provider cost for the call counts toward your Murph usage with no markup.",
+          "Murph labels the answer as Grok's unverified report and is instructed not to add links or authors beyond what Grok returned. The exact provider cost for the call counts toward your Murph usage with no markup.",
         relevanceTags: ["assistant", "search", "x", "research"],
         sourcePullRequests: [911],
         tryIt: {
@@ -114,16 +114,16 @@ const RAW_CHANGELOG_EDITIONS = [
         sourcePullRequests: [938],
       },
       {
-        id: "telegram-group-identity-and-one-tap-joins",
+        id: "telegram-group-sender-attribution",
         kind: "feature",
         priority: 4,
-        title: "Telegram groups know who said yes",
+        title: "Telegram group Murph knows who just spoke",
         summary:
-          "Murph can now attribute a Telegram group message to the linked member who sent it, and a member can accept a group offer from its one-tap Telegram button.",
+          "When a linked member writes in a Telegram group, Murph now attributes that turn to the right person and can use their username when no room name exists.",
         details:
-          "The button stays bound to the offer and the person who received it. Telegram acknowledges every tap so the loading spinner stops, gives a short next step when the person needs to link Telegram, join the group, or accept terms, and explains when a sharing limit blocks the action.",
+          "Challenge opt-ins no longer arrive anonymous, so Murph can tell who accepted and keep the group's conversation and shared state attached to the right member.",
         relevanceTags: ["telegram", "groups", "challenges", "messaging"],
-        sourcePullRequests: [924, 927],
+        sourcePullRequests: [927],
       },
       {
         id: "weather-aware-outdoor-reminders",

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -63,11 +63,236 @@ export interface ChangelogPage {
 
 const RAW_CHANGELOG_EDITIONS = [
   {
+    id: "2026-07-25",
+    publishedOn: "2026-07-25",
+    title: "A Murph that knows when to speak",
+    summary:
+      "Group Murph reads the floor, gets more creative, and handles Telegram one-tap joins. Murph can also check X through Grok, adapt outdoor reminders to the weather, and close billing and phone-call loops that used to strand people.",
+    items: [
+      {
+        id: "ask-grok-live-x-search",
+        kind: "feature",
+        priority: 5,
+        title: "Ask Grok what people are saying on X",
+        summary:
+          "Murph can now ask Grok about an account, a topic, or a post you share and bring the live X search answer back into your conversation.",
+        details:
+          "Murph labels the answer as Grok's report, treats posts as unverified third-party content, and never invents links or authors that the search did not return. The exact provider cost for the call counts toward your Murph usage with no markup.",
+        relevanceTags: ["assistant", "search", "x", "research"],
+        sourcePullRequests: [911],
+        tryIt: {
+          label: "Ask about X",
+          prompt: "What are people on X saying about zone 2 training this week?",
+        },
+      },
+      {
+        id: "unhinged-style-dial",
+        kind: "feature",
+        priority: 5,
+        title: "Ask Murph to loosen up",
+        summary:
+          "A new conversation-only Unhinged dial from 0 to 10 controls how restrained Murph keeps its wording, without changing safety, truth, privacy, consent, tool access, or reminder frequency.",
+        details:
+          "It works in private conversations and group chats with verified members, stays out of onboarding and web Settings, and moves in a small step when you ask for a little more or less. In a group, Murph raises it only when the room's own tone supports it.",
+        relevanceTags: ["assistant", "personalization", "groups", "messaging"],
+        sourcePullRequests: [916],
+        tryIt: {
+          label: "Turn it up",
+          prompt: "Turn up my Unhinged setting a little.",
+        },
+      },
+      {
+        id: "group-chat-creative-formats",
+        kind: "feature",
+        priority: 4,
+        title: "Group Murph has more ways to land the bit",
+        summary:
+          "When the room earns it, Murph can turn a shared photo into a new chat icon or over-deliver an apology as a song instead of waiting for someone to commission the joke.",
+        details:
+          "The room's own joke is the material. Murph keeps bodies and anyone visibly not in on it out of the bit, changes the icon if someone objects, and stays quiet when the complaint is that Murph spoke at all.",
+        relevanceTags: ["groups", "assistant", "images", "music"],
+        sourcePullRequests: [938],
+      },
+      {
+        id: "telegram-group-identity-and-one-tap-joins",
+        kind: "feature",
+        priority: 4,
+        title: "Telegram groups know who said yes",
+        summary:
+          "Murph can now attribute a Telegram group message to the linked member who sent it, and a member can accept a group offer from its one-tap Telegram button.",
+        details:
+          "The button stays bound to the offer and the person who received it. Telegram acknowledges every tap so the loading spinner stops, gives a short next step when the person needs to link Telegram, join the group, or accept terms, and explains when a sharing limit blocks the action.",
+        relevanceTags: ["telegram", "groups", "challenges", "messaging"],
+        sourcePullRequests: [924, 927],
+      },
+      {
+        id: "weather-aware-outdoor-reminders",
+        kind: "feature",
+        priority: 4,
+        title: "Outdoor reminders check the weather first",
+        summary:
+          "A reminder that tells you to go outside can now check current conditions and adapt the wording instead of sending you into the rain.",
+        details:
+          "Murph uses only a city or region you already shared, or offers once to save one. Declining does not block the reminder, and a failed weather read never prevents it from going out.",
+        relevanceTags: ["reminders", "weather", "privacy", "automation"],
+        sourcePullRequests: [934],
+      },
+      {
+        id: "group-murph-reads-the-floor",
+        kind: "improvement",
+        priority: 5,
+        title: "Group Murph knows when the floor belongs to someone else",
+        summary:
+          "Murph now distinguishes a live volley from catch-up, a joke from a plausible emergency, and a human-to-human beat from an opening that actually wants Murph.",
+        details:
+          "It may wait a few seconds while people are mid-burst, gives human punchlines more stage, and asks one short question when the health context is genuinely unclear. Timing never overrides the room's silence, reaction, or not-for-you rules.",
+        relevanceTags: ["groups", "assistant", "messaging", "safety"],
+        sourcePullRequests: [906, 928],
+      },
+      {
+        id: "phone-call-results-return-to-chat",
+        kind: "improvement",
+        priority: 5,
+        title: "Phone-call results come back to you",
+        summary:
+          "When a call Murph started finishes, Murph now sends the meaningful result back through the chat where it can reach you, in its own voice.",
+        details:
+          "The result is encrypted at rest, Murph treats the call transcript as untrusted, and a replay cannot send the same outcome twice.",
+        relevanceTags: ["phone-calls", "assistant", "messaging", "reliability"],
+        sourcePullRequests: [857],
+      },
+      {
+        id: "billing-recovery-finishes",
+        kind: "improvement",
+        priority: 5,
+        title: "Subscription recovery now has a way through",
+        summary:
+          "If your subscription lapses, Murph answers on your home line and points you to Subscription controls instead of dropping the text or sending you to a blocked signup wall.",
+        details:
+          "Resuming a paused subscription now carries the saved card onto the invoice, avoids an update the provider rejects while paused, and offers the billing page when the provider is still finishing.",
+        relevanceTags: ["billing", "messaging", "subscriptions", "reliability"],
+        sourcePullRequests: [925],
+      },
+      {
+        id: "one-click-launch-consent",
+        kind: "improvement",
+        priority: 4,
+        title: "Launch consent is one clear choice",
+        summary:
+          "After sign-in, accepting Murph's terms and health-data notices now takes one affirmative action instead of a row of checkboxes, with an equally clear Decline path.",
+        details:
+          "The prompt states that Murph does not sell your health data or train general-purpose AI models on Murph-managed health data. After repeated save failures, it offers a support route instead of trapping you in retries.",
+        relevanceTags: ["onboarding", "consent", "privacy", "auth"],
+        sourcePullRequests: [881],
+      },
+      {
+        id: "group-usage-pause-in-murphs-voice",
+        kind: "improvement",
+        priority: 4,
+        title: "A paused group hears from Murph, not a billing system",
+        summary:
+          "When a group runs out of included usage, Murph now explains the pause in its own voice and, when funding is available, gives the whole room a clear way to bring it back.",
+        relevanceTags: ["groups", "billing", "messaging", "copy"],
+        sourcePullRequests: [933],
+      },
+      {
+        id: "contact-card-in-app-browser-handoff",
+        kind: "improvement",
+        priority: 4,
+        title: "Contact cards escape in-app browsers",
+        summary:
+          "On iPhone, Add Murph to Contacts now hands off from an in-app browser to Safari instead of letting the embedded window swallow the contact-card download.",
+        details:
+          "The short-lived handoff stays bound to your account and chosen avatar. Setup completes only after Safari actually opens; if the launch is blocked, the picker stays open with a retry.",
+        relevanceTags: ["onboarding", "contacts", "iphone", "reliability"],
+        sourcePullRequests: [917],
+      },
+      {
+        id: "experiment-check-ins-survive-stray-files",
+        kind: "improvement",
+        priority: 4,
+        title: "Experiment check-ins survive stray files",
+        summary:
+          "A leftover folder in experiment storage can no longer disable every managed automation or archive active experiment check-ins. Unrelated reminders keep running while Murph retries a temporary experiment scan failure.",
+        relevanceTags: ["experiments", "reminders", "automation", "reliability"],
+        sourcePullRequests: [943],
+      },
+      {
+        id: "group-chat-renames-without-a-hosted-record",
+        kind: "improvement",
+        priority: 3,
+        title: "Even a lightweight group chat can be renamed",
+        summary:
+          "Murph can now rename the chat it is already in even when the group has not started a challenge or created a shared workspace. Updating Murph's own label follows when possible.",
+        relevanceTags: ["groups", "messaging", "tools", "reliability"],
+        sourcePullRequests: [939],
+      },
+      {
+        id: "voice-memo-failures-have-a-reason",
+        kind: "improvement",
+        priority: 3,
+        title: "Voice-memo failures are no longer a mystery",
+        summary:
+          "Murph now receives a safe description of why voice generation failed, while the maximum script length and generation timeout share one limit so overlong memos do not fail by design.",
+        details:
+          "Provider status and request identifiers reach secret-safe logs, giving Murph and support enough information to distinguish a timeout from a quota or request error.",
+        relevanceTags: ["voice", "assistant", "reliability", "support"],
+        sourcePullRequests: [935, 937],
+      },
+      {
+        id: "safe-database-start-retries",
+        kind: "improvement",
+        priority: 3,
+        title: "Brief database connection failures get a safe retry",
+        summary:
+          "If a database timeout proves that no query or transaction started, Murph's web service now retries it briefly instead of failing the request.",
+        details:
+          "A failure that may have reached the database is never replayed, so the retry cannot duplicate a completed action.",
+        relevanceTags: ["web", "database", "reliability", "retries"],
+        sourcePullRequests: [940],
+      },
+      {
+        id: "group-roster-durable-murph-activation",
+        kind: "improvement",
+        priority: 3,
+        title: "Group Murph knows who already set up Murph",
+        summary:
+          "The iMessage roster now separates people who completed Murph setup from people who never activated, without treating current plan status as identity. A paused or lapsed member is no longer mistaken for a stranger.",
+        relevanceTags: ["groups", "imessage", "onboarding", "privacy"],
+        sourcePullRequests: [929],
+      },
+      {
+        id: "silent-device-source-stalls-are-visible",
+        kind: "improvement",
+        priority: 3,
+        title: "Silent device stalls now leave a signal",
+        summary:
+          "If a push-based device source still looks connected but stops delivering data, Murph now records the silence as a source-stalled signal instead of treating every empty sync as a normal empty day.",
+        details:
+          "The check is observation only: it does not disconnect the source, block ingestion, or launch a recovery on its own.",
+        relevanceTags: ["devices", "sync", "reliability", "monitoring"],
+        sourcePullRequests: [930],
+      },
+      {
+        id: "homepage-group-challenge-story",
+        kind: "improvement",
+        priority: 3,
+        title: "The homepage gets to the group challenge faster",
+        summary:
+          "The hero now tells one story from the start: friends enter the chat, the challenge begins, and Murph carries it through standings, a roast voice memo, and the Sunday recap.",
+        details:
+          "The separate solo-demo act and its decorative controls are gone, and the security promises now read in one clean column.",
+        relevanceTags: ["homepage", "groups", "design", "polish"],
+        sourcePullRequests: [],
+      },
+    ],
+  },
+  {
     id: "2026-07-24",
     publishedOn: "2026-07-24",
     title: "Group chats that read the room",
     summary:
-      "Group replies stay as short as the question allows, Murph resends its contact card when someone missed it, and every group now has a working way to add usage before the conversation stops.",
+      "Group replies stay as short as the question allows, Home points Telegram members to the first message Murph needs, and you can ask Murph what changed in the product.",
     items: [
       {
         id: "group-replies-stay-short",
@@ -141,9 +366,37 @@ const RAW_CHANGELOG_EDITIONS = [
         priority: 3,
         title: "Linking Telegram finishes the signup step",
         summary:
-          "A linked Telegram account now completes messaging setup at join instead of asking again how Murph should reach you.",
+          "A linked Telegram account now completes messaging setup at join instead of asking again how Murph should reach you. Until you send the first message Telegram requires, Home puts Message Murph first and links straight to the chat.",
         relevanceTags: ["telegram", "onboarding", "auth"],
         sourcePullRequests: [],
+      },
+      {
+        id: "ask-murph-whats-new",
+        kind: "feature",
+        priority: 4,
+        title: "Ask Murph what changed",
+        summary:
+          "In an ordinary conversation, Murph can now read the public changelog and feature catalog to answer what is new or whether a capability has shipped, instead of answering from memory.",
+        details:
+          "Those two public feeds are the source of truth. If either feed is unavailable, Murph says so rather than guessing.",
+        relevanceTags: ["assistant", "changelog", "search", "messaging"],
+        sourcePullRequests: [],
+        tryIt: {
+          label: "Ask what's new",
+          prompt: "What changed in Murph this week?",
+        },
+      },
+      {
+        id: "account-deletion-exit-feedback",
+        kind: "improvement",
+        priority: 3,
+        title: "Account deletion asks one optional why",
+        summary:
+          "Before the final delete confirmation, you can pick a reason for leaving and add a note, or skip the question in one tap. The answer never gates deletion.",
+        details:
+          "If you answer, Murph keeps the optional feedback only after account deletion finishes and stores it without your member id.",
+        relevanceTags: ["settings", "privacy", "feedback", "account"],
+        sourcePullRequests: [926],
       },
     ],
   },

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -52,6 +52,7 @@ describe("ChangelogPage", () => {
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
     );
 
+    expect(markup).toContain("A Murph that knows when to speak");
     expect(markup).toContain("Group chats that read the room");
     expect(markup).toContain(
       "Updated documents, honest reactions, usage you can see",
@@ -62,7 +63,7 @@ describe("ChangelogPage", () => {
       "Standings that explain themselves, payments that finish",
     );
     expect(markup).toContain("Medical records, without the integration jargon");
-    expect(markup).toContain("Replies that know what they are answering");
+    expect(markup).not.toContain("Replies that know what they are answering");
     expect(markup).toContain("Improvements");
     expect(markup).not.toContain("Under the hood");
     expect(markup).not.toContain("Your records and measurements, in one place");
@@ -70,7 +71,7 @@ describe("ChangelogPage", () => {
     expect(markup).not.toContain("Better answers, better instincts");
     expect(markup).not.toContain("Murph referees your group challenge");
     expect(markup).toContain('aria-label="Changelog pages"');
-    expect(markup).toContain('href="/changelog?edition=2026-07-17"');
+    expect(markup).toContain('href="/changelog?edition=2026-07-18"');
     expect(markup).toContain(
       'href="/changelog?edition=2026-07-19#medical-records-plain-language"',
     );
@@ -105,7 +106,7 @@ describe("ChangelogPage", () => {
     );
     expect(markup).not.toContain("The latest seven days");
     expect(markup).toContain('href="/changelog"');
-    expect(markup).toContain('href="/changelog?edition=2026-07-02"');
+    expect(markup).toContain('href="/changelog?edition=2026-07-03"');
     expect(markup).toContain("Newer");
     expect(markup).toContain("Older");
   });
@@ -145,7 +146,7 @@ describe("ChangelogPage", () => {
 
     expect(metadata).toEqual(
       expect.objectContaining({
-        alternates: { canonical: "/changelog?edition=2026-07-10" },
+        alternates: { canonical: "/changelog?edition=2026-07-11" },
         openGraph: expect.objectContaining({
           images: [expect.objectContaining({ url: pageThreeCardUrl })],
         }),

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -79,6 +79,40 @@ describe("ChangelogPage", () => {
     expect(markup).not.toContain(">Newer<");
   });
 
+  it("renders the new try-it controls with their exact prompts", async () => {
+    const markup = renderToStaticMarkup(
+      await ChangelogPage({ searchParams: Promise.resolve({}) }),
+    );
+
+    expect(markup).toContain("Ask about X");
+    expect(markup).toContain("Turn it up");
+    expect(markup).toMatch(/Ask what(?:&#x27;|')s new/u);
+    expect(
+      mocks.resolveHostedMurphContactOptions.mock.calls.map(([input]) => input),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          message: {
+            body: "What are people on X saying about zone 2 training this week?",
+            subject: "Try it: Ask Grok what people are saying on X",
+          },
+        },
+        {
+          message: {
+            body: "Turn up my Unhinged setting a little.",
+            subject: "Try it: Ask Murph to loosen up",
+          },
+        },
+        {
+          message: {
+            body: "What changed in Murph this week?",
+            subject: "Try it: Ask Murph what changed",
+          },
+        },
+      ]),
+    );
+  });
+
   it("renders explanatory visuals for the major new features", async () => {
     const markup = renderToStaticMarkup(
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
@@ -140,10 +174,21 @@ describe("ChangelogPage", () => {
           .map((item) => item.id),
       ),
     );
-    const metadata = await generateMetadata({
-      searchParams: Promise.resolve({ edition: "2026-07-08" }),
-    });
+    const [pageOneMetadata, metadata] = await Promise.all([
+      generateMetadata({ searchParams: Promise.resolve({}) }),
+      generateMetadata({
+        searchParams: Promise.resolve({ edition: "2026-07-08" }),
+      }),
+    ]);
 
+    expect(pageOneMetadata).toEqual(
+      expect.objectContaining({
+        alternates: { canonical: "/changelog" },
+        openGraph: expect.objectContaining({
+          images: [expect.objectContaining({ url: pageOneCardUrl })],
+        }),
+      }),
+    );
     expect(metadata).toEqual(
       expect.objectContaining({
         alternates: { canonical: "/changelog?edition=2026-07-11" },

--- a/apps/web/test/changelog-routes.test.ts
+++ b/apps/web/test/changelog-routes.test.ts
@@ -24,7 +24,7 @@ describe("changelog routes", () => {
   it("publishes every item from the two newest editions with canonical links", async () => {
     const response = await getChangelogFeed(
       new Request(
-        "https://join.example.test/api/changelog?from=2026-07-19&to=2026-07-21",
+        "https://join.example.test/api/changelog?from=2026-07-24&to=2026-07-26",
       ),
     );
     const body = await response.json();
@@ -35,18 +35,18 @@ describe("changelog routes", () => {
     }>;
 
     expect(response.status).toBe(200);
-    expect(items).toHaveLength(13);
+    expect(items).toHaveLength(27);
     expect(items.map((item) => item.publishedOn)).toEqual([
-      ...Array.from({ length: 12 }, () => "2026-07-20"),
-      "2026-07-19",
+      ...Array.from({ length: 18 }, () => "2026-07-25"),
+      ...Array.from({ length: 9 }, () => "2026-07-24"),
     ]);
     expect(items.map((item) => item.id)).toEqual(
       expect.arrayContaining([
-        "challenge-standings-explain-missing-data",
-        "contaminant-tests-on-product-pages",
-        "pulse-finishes-after-payment-setup",
-        "strava-connections-paused",
-        "medical-records-plain-language",
+        "ask-grok-live-x-search",
+        "unhinged-style-dial",
+        "telegram-group-identity-and-one-tap-joins",
+        "ask-murph-whats-new",
+        "account-deletion-exit-feedback",
       ]),
     );
     for (const item of items) {

--- a/apps/web/test/changelog-routes.test.ts
+++ b/apps/web/test/changelog-routes.test.ts
@@ -42,9 +42,9 @@ describe("changelog routes", () => {
     ]);
     expect(items.map((item) => item.id)).toEqual(
       expect.arrayContaining([
-        "ask-grok-live-x-search",
+        "ask-grok-x-research",
         "unhinged-style-dial",
-        "telegram-group-identity-and-one-tap-joins",
+        "telegram-group-sender-attribution",
         "ask-murph-whats-new",
         "account-deletion-exit-feedback",
       ]),

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -32,10 +32,10 @@ describe("changelog registry", () => {
       {
         id: "2026-07-25",
         itemIds: [
-          "ask-grok-live-x-search",
+          "ask-grok-x-research",
           "unhinged-style-dial",
           "group-chat-creative-formats",
-          "telegram-group-identity-and-one-tap-joins",
+          "telegram-group-sender-attribution",
           "weather-aware-outdoor-reminders",
           "group-murph-reads-the-floor",
           "phone-call-results-return-to-chat",

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -22,13 +22,36 @@ describe("changelog registry", () => {
     expect(ids.length).toBeGreaterThan(0);
   });
 
-  it("publishes the complete July 20 through July 24 shipment set", () => {
+  it("publishes the complete July 20 through July 25 shipment set", () => {
     expect(
-      listChangelogEditions().slice(0, 5).map((edition) => ({
+      listChangelogEditions().slice(0, 6).map((edition) => ({
         id: edition.id,
         itemIds: edition.items.map((item) => item.id),
       })),
     ).toEqual([
+      {
+        id: "2026-07-25",
+        itemIds: [
+          "ask-grok-live-x-search",
+          "unhinged-style-dial",
+          "group-chat-creative-formats",
+          "telegram-group-identity-and-one-tap-joins",
+          "weather-aware-outdoor-reminders",
+          "group-murph-reads-the-floor",
+          "phone-call-results-return-to-chat",
+          "billing-recovery-finishes",
+          "one-click-launch-consent",
+          "group-usage-pause-in-murphs-voice",
+          "contact-card-in-app-browser-handoff",
+          "experiment-check-ins-survive-stray-files",
+          "group-chat-renames-without-a-hosted-record",
+          "voice-memo-failures-have-a-reason",
+          "safe-database-start-retries",
+          "group-roster-durable-murph-activation",
+          "silent-device-source-stalls-are-visible",
+          "homepage-group-challenge-story",
+        ],
+      },
       {
         id: "2026-07-24",
         itemIds: [
@@ -39,6 +62,8 @@ describe("changelog registry", () => {
           "group-join-permissions-preselected",
           "usage-top-up-returns-to-chat",
           "telegram-signup-completes-setup",
+          "ask-murph-whats-new",
+          "account-deletion-exit-feedback",
         ],
       },
       {
@@ -203,8 +228,8 @@ describe("changelog registry", () => {
   it("keeps the default archive window to seven calendar days", () => {
     const firstPage = resolveChangelogPage(1);
     expect(firstPage?.editions).toHaveLength(7);
-    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-07-24");
-    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-18");
+    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-07-25");
+    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-19");
   });
 
   it("resolves only known canonical edition cursors", () => {

--- a/apps/web/test/hosted-product-feedback-service.test.ts
+++ b/apps/web/test/hosted-product-feedback-service.test.ts
@@ -148,6 +148,20 @@ describe("normalizeHostedProductFeedback", () => {
     expect(normalizeHostedProductFeedback(makeFeedback())).toEqual(makeFeedback());
   });
 
+  it("accepts a newly published changelog id while rejecting unknown ids", () => {
+    const feedback = makeFeedback({
+      relatedChangelogItemIds: ["ask-grok-x-research"],
+      summary: "Interested in asking Grok about X.",
+    });
+
+    expect(normalizeHostedProductFeedback(feedback)).toEqual(feedback);
+    expect(() =>
+      normalizeHostedProductFeedback(makeFeedback({
+        relatedChangelogItemIds: ["not-a-real-item"],
+      })),
+    ).toThrow(HostedOnboardingError);
+  });
+
   it("normalizes bounded summary text", () => {
     expect(normalizeHostedProductFeedback(makeFeedback({
       summary: "  Wants   better message formatting.  ",


### PR DESCRIPTION
## Why this exists

The public changelog stopped at the July 24 edition while additional member-facing work continued to merge. That left the page, public JSON feed, and Murph's own product-update lookup behind the shipped product.

## User-visible goal and UX

A visitor opening `/changelog` should immediately see a July 25 edition that accurately summarizes every meaningful shipment merged after the prior changelog cutoff. The existing renderer remains the whole experience: the new edition appears first, the latest window still spans seven calendar days, and older editions move through the existing archive navigation.

The same registry continues to feed the public JSON endpoint and preview-card metadata. There is no asynchronous continuation or new recovery path; rendering and feed responses are immediate. Existing malformed or unknown archive cursors continue to fail through the established not-found path.

## Invariants

- Keep editions reverse-chronological with unique, stable edition and item IDs.
- Keep the default archive window at seven calendar days and preserve canonical cursor pagination.
- Keep the page and public JSON response on one changelog registry.
- Preserve stable item anchors, source PR attribution, feature/improvement grouping, and Try it prompts.
- Do not change the page layout, design components, or runtime ownership boundaries.
- Keep privacy, billing, and safety claims no broader than the merged implementation evidence.
- Intentionally allow newly published item IDs through the existing product-feedback validation boundary while continuing to reject unknown IDs.

## Non-obvious affected surfaces

- `/api/changelog` reads the same updated registry.
- Changelog preview-card item selection and canonical page metadata shift with the new leading edition.
- Murph's product-update lookup reads this public changelog, so factual phrasing matters beyond the web page.
- Published changelog IDs are also the canonical allowlist for member-linked durable product feedback. The added IDs can now be stored in `relatedChangelogItemIdsJson`; unknown IDs remain rejected.
- Account deletion continues to remove hosted product-feedback rows. Settings export remains vault-backed and does not serialize these server-side rows; neither privacy flow changes in this PR.

## Product-experience contract

- **Purpose:** give members a truthful, scannable account of meaningful shipments since the July 24 cutoff.
- **Smallest complete flow:** add the missing dated edition and July 24 tail items to the existing registry; reuse the current page, archive, feed, card renderer, and feedback-ID validation owner.
- **Immediate feedback:** the first changelog page renders the July 25 edition and six following calendar days.
- **Timing and continuation:** synchronous page/feed rendering; no queue, provider handoff, or delayed delivery.
- **Terminal delivery and recovery:** existing archive links, canonical URLs, stable anchors, and not-found behavior remain the terminal states.
- **Audit:** required local product-experience review completed with `NO FINDINGS` after factual source corrections. Final round-one review then identified three claim/surface gaps, all resolved below without changing the user journey.

## Preliminary specialist lenses

- **Prompt:** not applicable — no instruction stack, prompt assembly, tool description, or prompt regression behavior changed.
- **Frontend:** applicable — the registry adds a complete rendered edition, additional July 24 entries, and new Try it controls.
- **Coverage:** applicable — the specialist found that the newest public feed window, Try it payloads, and page-one preview metadata lacked positive coverage. The accepted test-only patch now covers all three; focused and canonical verification pass.
- **Outcome:** `SPECIALIST_OUTCOME: FINDINGS`; one accepted coverage finding resolved in commit `2b867bce6b06`. No production or UI correction was requested, and the preliminary pass is not rerun for its substantive test-only patch.

## Final review

Round one identified three accepted gaps:

- Removed the unreachable Telegram one-tap-join claim and now describe only shipped sender attribution.
- Narrowed Ask Grok wording to what the implementation proves: Murph asks Grok to search X, labels the returned report unverified, and is instructed not to add unsupported links or authors.
- Disclosed the changelog registry's existing product-feedback allowlist role and added direct coverage proving a newly published ID is accepted while an unknown ID is rejected.

Correction-verification round two reviewed exact head `ea921b4f8c7ab15c09a74a14aad60fff8e7166f1` and returned `ROUND_OUTCOME: PASS` with no qualifying findings.

The final review also identified two evidence/body discrepancies, now recorded accurately:

- The ignored PNG proofs were not present in the final review ZIP, so that gate did not independently inspect them. The preliminary frontend pass and parent inspection used the exact local files listed below.
- Account deletion covers hosted feedback rows; the vault-backed Settings export does not currently serialize them. This PR changes neither flow.

## Design proof

The existing changelog components and layout are reused unchanged. Fresh rendered evidence from exact current head `ea921b4f8c7ab15c09a74a14aad60fff8e7166f1`:

- `audit-packages/pr-960-rendered/changelog-desktop.png` — `/changelog`, 1440×1000.
- `audit-packages/pr-960-rendered/changelog-mobile.png` — `/changelog`, 390×844.
- `audit-packages/pr-960-rendered/changelog-preview-card.png` — selected five-item preview card, 1200×630.

The separate Claude UI double-check was attempted with Fable 5 and reported explicit usage-credit exhaustion. Per the completion workflow, no further Claude route was attempted and this is recorded as a non-blocking evidence gap.

## Change shape

ReviewGPT first-reviewed head: 2b867bce6b06b31e636ac2c7e259064dd8f6052e

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source / authored changelog content | 255 | 2 |
| Tests | 105 | 20 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

Current final-review head: `ea921b4f8c7ab15c09a74a14aad60fff8e7166f1`.

The final cross-cutting ReviewGPT gate applies because this static content makes privacy, billing, and health-safety claims, which are excluded from the low-risk static-content exemption.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/changelog.test.ts apps/web/test/changelog-page.test.tsx apps/web/test/changelog-routes.test.ts apps/web/test/hosted-product-feedback-service.test.ts` — 4 files, 33 tests passed after final round-one remediation.
- `pnpm test:diff apps/web/src/lib/changelog.ts apps/web/test/changelog.test.ts apps/web/test/changelog-page.test.tsx apps/web/test/changelog-routes.test.ts apps/web/test/hosted-product-feedback-service.test.ts` — passed policy and architecture guards, TypeScript, 510 test files / 6,508 executed tests, lint with 14 existing warnings and zero errors, dev smoke, and Next production build.
- Exact-head browser proof — desktop, mobile, and preview-card captures visually inspected; no direct identifiers or private content present.
- `git diff --check` — passed.
