### PR TITLE
Align the release audit with the ReviewGPT prompt contract

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1311,7 +1311,9 @@ describe('monorepo release flow coverage audit', () => {
     expect(prDeepReviewPrompt).toContain(
       '`review-gpt-pr-context/since-previous-reviewed-head.diff`',
     )
-    expect(prDeepReviewPrompt).toContain('If any required artifact is missing, unreadable, stale,')
+    expect(prDeepReviewPrompt).toContain(
+      'Stop as `INVALID` only when the code evidence itself will not support a review:',
+    )
     expect(prDeepReviewPrompt).not.toContain('repo.snapshot.zip')
     expect(prDeepReviewPrompt).not.toContain('repo.repomix.zip')
     expect(prDeepReviewPrompt.toLowerCase()).not.toContain('repomix')


### PR DESCRIPTION
## Why this PR exists

Current `main` changed the ReviewGPT invalidation contract so descriptive PR-body drift is recorded as a note instead of discarding a substantive review. The release-smoke audit still asserted the removed sentence, causing the CLI coverage shard—and therefore every PR's release gate—to fail deterministically.

## User goal / user-visible behavior

Restore a truthful green release gate without changing runtime behavior. ReviewGPT keeps the current prompt semantics; the smoke test now verifies the new code-evidence-only invalidation boundary.

## User experience

No user-facing UI or runtime behavior changes. This affects only repository verification.

## Invariants the PR must preserve

- ReviewGPT may stop as invalid only when the packaged code evidence cannot support review.
- Descriptive PR-body drift remains a note rather than a reason to discard substantive findings.
- The release audit continues to pin the prompt contract instead of weakening or removing coverage.

## Non-obvious affected surfaces

The CLI package coverage shard owns this repository-wide release-smoke test, so one stale assertion fails the aggregate release check even for PRs that do not touch the CLI or ReviewGPT.

## Preliminary specialist lenses

- Prompt: applicable because the changed executable assertion guards prompt-regression behavior; the production prompt itself is unchanged, and the assertion was checked against the live preset.
- Frontend: not applicable.
- Coverage: the existing contract test is updated to assert the current invalidation sentence. Focused Vitest passed: 40 passed, 1 skipped. Exact-head preliminary specialist review passed with no findings.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 3 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **3** | **1** |

## Design proof for user-facing frontend UI

Not applicable. No user-facing frontend UI diff.

## Deployment skew / compatibility

No deployment concern. This is test-only and can merge independently.

## Validation

- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts packages/cli/test/release-script-coverage-audit.test.ts --reporter=dot` — 40 passed, 1 skipped.

ReviewGPT first-reviewed head: 91e0dd35373d8ae9743f3b2796ab3c2d4e95b0c6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787613473&installation_model_id=19880&pr_number=963&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F963&signature=597812449758660640dbfbea6ee8fb1f1c5a01d2f62efa20b67061bc02ad902e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

