### PR TITLE
Realign the review-preset audit with the narrowed hard stop

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1311,7 +1311,12 @@ describe('monorepo release flow coverage audit', () => {
     expect(prDeepReviewPrompt).toContain(
       '`review-gpt-pr-context/since-previous-reviewed-head.diff`',
     )
-    expect(prDeepReviewPrompt).toContain('If any required artifact is missing, unreadable, stale,')
+    expect(prDeepReviewPrompt).toContain(
+      'Stop as `INVALID` only when the code evidence itself will not support a review:',
+    )
+    expect(prDeepReviewPrompt).toContain(
+      'Do not stop for a discrepancy confined to the descriptive content of',
+    )
     expect(prDeepReviewPrompt).not.toContain('repo.snapshot.zip')
     expect(prDeepReviewPrompt).not.toContain('repo.repomix.zip')
     expect(prDeepReviewPrompt.toLowerCase()).not.toContain('repomix')


### PR DESCRIPTION
## Why this PR exists

`main` is red. Commit `fb37483f15` narrowed the `pr-review` preset's `INVALID` rule so a stale PR body no longer discards a whole review round, which rewrote the paragraph that `packages/cli/test/release-script-coverage-audit.test.ts` asserts verbatim. The audit was not updated, so `Release package coverage (cli)` and the `Release checks` gate fail on every branch cut from or merged with `main`.

## User goal / user-visible behavior

No end-user behavior changes. The user here is anyone trying to land a PR: CI stops failing for a reason unrelated to their diff.

## User experience

Not applicable — no user-facing surface, copy, or flow is touched.

## Invariants the PR must preserve

- **The preset still hard-stops on unusable code evidence.** The audit must keep proving that a missing, unreadable, or non-corresponding `pr.diff`, `changed-files.txt`, `review-round.json`, round diff, or source snapshot returns `INVALID`.
- **A stale PR body must not discard a round.** That is exactly what `fb37483f15` fixed, and it previously had no assertion at all.
- **The audit keeps reading the repository preset**, not a packaged copy, so preset drift stays detectable.

## Non-obvious affected surfaces

None. One test file changes; no production code, preset text, config, or schema is touched.

## Preliminary specialist lenses

- **prompt** — not applicable. No prompt text, instruction stack, or tool description changes; this only realigns an assertion about a prompt that already changed on `main`.
- **frontend** — not applicable. No `apps/web` diff.
- **coverage** — applicable. Canonical command: `pnpm --filter @murphai/cli test`. Focused outcome on this head: `packages/cli/test/release-script-coverage-audit.test.ts` passes (40 passed, 1 skipped), and the whole `cli-release-smoke` project passes (3 files, 45 passed, 1 skipped). The same file fails on `main`.

## Change-shape breakdown

Classification rule: `packages/cli/test/**` is tests. Nothing else is touched.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests/fixtures | 6 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **6** | **1** |

## Design proof for user-facing frontend UI

Not applicable — no user-facing frontend UI diff.

## Final ReviewGPT gate

Skipped as a trivial, low-risk test-only change per `agent-docs/operations/pr-reviewgpt-loop.md` § Final Gate: When It Runs. Happy to run it if a reviewer wants it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787614858&installation_model_id=19880&pr_number=965&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F965&signature=f9f276b6869fc740353ba3ae292905e00136ce60172b756d16a62352c831f098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->