### PR TITLE
chore: apply saved-card group funding source changes

### DIFF
--- a/.github/workflows/apply-saved-card-group-funding.yml
+++ b/.github/workflows/apply-saved-card-group-funding.yml
@@ -1,0 +1,31 @@
+name: Apply saved-card group funding patch
+
+on:
+  push:
+    branches:
+      - agent/reuse-saved-card-for-group-funding
+    paths:
+      - agent-scripts/apply-saved-card-group-funding.py
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/reuse-saved-card-for-group-funding
+          fetch-depth: 0
+      - name: Apply patch
+        run: python agent-scripts/apply-saved-card-group-funding.py
+      - name: Commit implementation
+        run: |
+          rm agent-scripts/apply-saved-card-group-funding.py
+          rm .github/workflows/apply-saved-card-group-funding.yml
+          git config user.name "OpenAI"
+          git config user.email "openai@users.noreply.github.com"
+          git add -A
+          git commit -m "feat: reuse saved cards for group funding"
+          git push origin HEAD:agent/reuse-saved-card-for-group-funding

--- a/agent-scripts/apply-saved-card-group-funding.py
+++ b/agent-scripts/apply-saved-card-group-funding.py
@@ -1,0 +1,1286 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def write(path: str, content: str) -> None:
+    (ROOT / path).write_text(content)
+
+
+def replace_once(path: str, old: str, new: str) -> None:
+    content = read(path)
+    count = content.count(old)
+    if count != 1:
+        raise RuntimeError(f"{path}: expected one match, found {count}: {old[:80]!r}")
+    write(path, content.replace(old, new))
+
+
+def replace_first(path: str, old: str, new: str) -> None:
+    content = read(path)
+    if old not in content:
+        raise RuntimeError(f"{path}: missing first-match text: {old[:80]!r}")
+    write(path, content.replace(old, new, 1))
+
+
+def replace_all(path: str, old: str, new: str, expected: int) -> None:
+    content = read(path)
+    count = content.count(old)
+    if count != expected:
+        raise RuntimeError(
+            f"{path}: expected {expected} matches, found {count}: {old[:80]!r}"
+        )
+    write(path, content.replace(old, new))
+
+
+# Give direct charges an unambiguous Stripe identity distinct from Checkout.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-offers.ts",
+    '''export const HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE =
+  "hosted_usage_credit" as const;
+''',
+    '''export const HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE =
+  "hosted_usage_credit" as const;
+export const HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE =
+  "hosted_usage_credit_saved_card" as const;
+''',
+)
+
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-purchase-stripe.ts",
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+''',
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+  HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-purchase-stripe.ts",
+    '''export function buildHostedUsageCreditCheckoutMetadata(
+  purchaseId: string,
+): Record<string, string> {
+  return {
+    policyVersion: HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+    purchaseId,
+    purpose: HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  };
+}
+''',
+    '''export function buildHostedUsageCreditCheckoutMetadata(
+  purchaseId: string,
+): Record<string, string> {
+  return {
+    policyVersion: HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+    purchaseId,
+    purpose: HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  };
+}
+
+export function buildHostedUsageCreditSavedCardMetadata(
+  purchaseId: string,
+): Record<string, string> {
+  return {
+    policyVersion: HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+    purchaseId,
+    purpose: HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
+  };
+}
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-purchase-stripe.ts",
+    '''    payment_intent_data: {
+      metadata: input.checkoutMetadata,
+    },
+''',
+    '''    payment_intent_data: {
+      metadata: input.checkoutMetadata,
+      setup_future_usage: "off_session",
+    },
+''',
+)
+
+# Reuse customer or subscription defaults conservatively; ambiguous cards stay in Checkout.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts",
+    '''  buildHostedUsageCreditCheckoutMetadata,
+''',
+    '''  buildHostedUsageCreditSavedCardMetadata,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts",
+    '''  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+  let paymentMethods: Stripe.ApiList<Stripe.PaymentMethod>;
+  try {
+    [customer, paymentMethods] = await Promise.all([
+      input.stripe.customers.retrieve(input.customerId, {
+        expand: ["invoice_settings.default_payment_method"],
+      }),
+      input.stripe.paymentMethods.list({
+        customer: input.customerId,
+        limit: 100,
+        type: "card",
+      }),
+    ]);
+''',
+    '''  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+  let paymentMethods: Stripe.ApiList<Stripe.PaymentMethod>;
+  let subscriptions: Stripe.ApiList<Stripe.Subscription>;
+  try {
+    [customer, paymentMethods, subscriptions] = await Promise.all([
+      input.stripe.customers.retrieve(input.customerId, {
+        expand: ["invoice_settings.default_payment_method"],
+      }),
+      input.stripe.paymentMethods.list({
+        customer: input.customerId,
+        limit: 100,
+        type: "card",
+      }),
+      input.stripe.subscriptions.list({
+        customer: input.customerId,
+        limit: 100,
+        status: "all",
+      }),
+    ]);
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts",
+    '''  if (paymentMethods.has_more) {
+    return null;
+  }
+
+  const attachedPaymentMethodIds = new Set<string>();
+''',
+    '''  if (paymentMethods.has_more || subscriptions.has_more) {
+    return null;
+  }
+
+  const attachedPaymentMethodIds = new Set<string>();
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts",
+    '''  const defaultPaymentMethodId = coerceStripeObjectId(
+    customer.invoice_settings.default_payment_method,
+  );
+  if (
+    defaultPaymentMethodId &&
+    attachedPaymentMethodIds.has(defaultPaymentMethodId)
+  ) {
+    return defaultPaymentMethodId;
+  }
+  return attachedPaymentMethodIds.size === 1
+    ? [...attachedPaymentMethodIds][0] ?? null
+    : null;
+''',
+    '''  const preferredPaymentMethodIds = new Set<string>();
+  const customerDefaultPaymentMethodId = coerceStripeObjectId(
+    customer.invoice_settings.default_payment_method,
+  );
+  if (
+    customerDefaultPaymentMethodId &&
+    attachedPaymentMethodIds.has(customerDefaultPaymentMethodId)
+  ) {
+    preferredPaymentMethodIds.add(customerDefaultPaymentMethodId);
+  }
+  for (const subscription of subscriptions.data) {
+    if (
+      subscription.livemode !== input.purchase.stripeLiveMode ||
+      coerceStripeObjectId(subscription.customer) !== input.customerId
+    ) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_subscription_invalid",
+      );
+    }
+    if (
+      subscription.status === "canceled" ||
+      subscription.status === "incomplete_expired"
+    ) {
+      continue;
+    }
+    const subscriptionPaymentMethodId = coerceStripeObjectId(
+      subscription.default_payment_method,
+    );
+    if (
+      subscriptionPaymentMethodId &&
+      attachedPaymentMethodIds.has(subscriptionPaymentMethodId)
+    ) {
+      preferredPaymentMethodIds.add(subscriptionPaymentMethodId);
+    }
+  }
+  if (preferredPaymentMethodIds.size === 1) {
+    return [...preferredPaymentMethodIds][0] ?? null;
+  }
+  if (preferredPaymentMethodIds.size > 1) {
+    return null;
+  }
+  return attachedPaymentMethodIds.size === 1
+    ? [...attachedPaymentMethodIds][0] ?? null
+    : null;
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts",
+    '''      metadata: buildHostedUsageCreditCheckoutMetadata(input.purchase.id),
+''',
+    '''      metadata: buildHostedUsageCreditSavedCardMetadata(input.purchase.id),
+''',
+)
+
+# A direct payment has no Checkout Session reference.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation-context.ts",
+    '''  sessionId: string;
+''',
+    '''  sessionId: string | null;
+''',
+)
+
+# Extend the existing payment proof without weakening Checkout validation.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+''',
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+  HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    '''export type HostedUsageCreditPaidCheckoutAuthorization = {
+  paymentIntentId: string;
+  purchaseId: string;
+  sessionId: string;
+};
+''',
+    '''export type HostedUsageCreditPaymentAuthorization = {
+  paymentIntentId: string;
+  purchaseId: string;
+  sessionId: string | null;
+};
+
+export type HostedUsageCreditPaidCheckoutAuthorization =
+  HostedUsageCreditPaymentAuthorization & {
+    sessionId: string;
+  };
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    '''export function assertHostedUsageCreditChargeContext(input: {
+''',
+    '''export function assertHostedUsageCreditPaymentIntentMatchesPurchase(input: {
+  paymentIntent: Stripe.PaymentIntent;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): void {
+  const { paymentIntent, purchase } = input;
+  if (paymentIntent.livemode !== purchase.stripeLiveMode) {
+    throw new Error("Usage-credit PaymentIntent environment did not match.");
+  }
+  assertHostedUsageCreditMetadataForPurpose({
+    metadata: paymentIntent.metadata,
+    purchase,
+    purpose: HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
+  });
+  assertHostedStripeLookupMatches({
+    expectedLookupKey: purchase.stripeCustomerLookupKey,
+    kind: "stripe-customer",
+    value: coerceStripeObjectId(paymentIntent.customer),
+  });
+  if (
+    !Number.isSafeInteger(paymentIntent.amount) ||
+    !Number.isSafeInteger(paymentIntent.amount_received) ||
+    paymentIntent.amount !== purchase.cashAmountMinor ||
+    paymentIntent.amount_received < 0 ||
+    paymentIntent.amount_received > purchase.cashAmountMinor ||
+    normalizeNullableString(paymentIntent.currency)?.toLowerCase() !==
+      purchase.cashCurrency.toLowerCase() ||
+    (
+      paymentIntent.status === "succeeded" &&
+      paymentIntent.amount_received !== purchase.cashAmountMinor
+    )
+  ) {
+    throw new Error("Usage-credit PaymentIntent amount or currency did not match.");
+  }
+  assertHostedStripeBillingEventLookupMatches({
+    expectedLookupKey: purchase.stripePaymentIntentLookupKey,
+    value: paymentIntent.id,
+  });
+  const chargeId = coerceStripeObjectId(paymentIntent.latest_charge);
+  if (purchase.stripeChargeLookupKey) {
+    assertHostedStripeBillingEventLookupMatches({
+      expectedLookupKey: purchase.stripeChargeLookupKey,
+      value: chargeId ?? "",
+    });
+  }
+  if (paymentIntent.status === "succeeded" && !chargeId) {
+    throw new Error("Succeeded usage-credit PaymentIntent did not include a Charge.");
+  }
+}
+
+export function buildHostedUsageCreditDirectPaymentAuthorization(input: {
+  paymentIntent: Stripe.PaymentIntent;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): HostedUsageCreditPaymentAuthorization {
+  assertHostedUsageCreditPaymentIntentMatchesPurchase(input);
+  if (input.paymentIntent.status !== "succeeded") {
+    throw new Error("Usage-credit direct payment was not succeeded.");
+  }
+  return {
+    paymentIntentId: input.paymentIntent.id,
+    purchaseId: input.purchase.id,
+    sessionId: null,
+  };
+}
+
+export function readHostedUsageCreditSavedCardPurchaseId(
+  metadata: Prisma.JsonValue | Stripe.Metadata | null,
+): string | null {
+  const value = readStringRecord(metadata);
+  if (value?.purpose !== HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE) {
+    return null;
+  }
+  const expectedKeys = ["policyVersion", "purchaseId", "purpose"];
+  if (
+    Object.keys(value).length !== expectedKeys.length ||
+    expectedKeys.some((key) => !(key in value)) ||
+    value.policyVersion !== HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION ||
+    !normalizeNullableString(value.purchaseId)
+  ) {
+    throw new Error("Saved-card usage-credit metadata did not match.");
+  }
+  return value.purchaseId;
+}
+
+export function assertHostedUsageCreditChargeContext(input: {
+''',
+)
+# Rename all legacy metadata calls to the Checkout-specific validator, then make
+# the financial Charge validator accept either exact payment purpose.
+replace_all(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    "assertHostedUsageCreditMetadata({",
+    "assertHostedUsageCreditCheckoutMetadata({",
+    expected=3,
+)
+replace_first(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    "assertHostedUsageCreditCheckoutMetadata({",
+    "assertHostedUsageCreditFinancialMetadata({",
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-payment-proof.ts",
+    '''function assertHostedUsageCreditCheckoutMetadata(input: {
+  metadata: Prisma.JsonValue | Stripe.Metadata | null;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): void {
+  const metadata = readStringRecord(input.metadata);
+  const expected = {
+    policyVersion: HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+    purchaseId: input.purchase.id,
+    purpose: HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  };
+  if (
+    input.purchase.checkoutRequestPolicyVersion !==
+      HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION ||
+    !metadata ||
+    Object.keys(metadata).length !== Object.keys(expected).length ||
+    Object.entries(expected).some(([key, value]) => metadata[key] !== value)
+  ) {
+    throw new Error("Usage-credit Checkout metadata did not match.");
+  }
+}
+''',
+    '''function assertHostedUsageCreditCheckoutMetadata(input: {
+  metadata: Prisma.JsonValue | Stripe.Metadata | null;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): void {
+  assertHostedUsageCreditMetadataForPurpose({
+    ...input,
+    purpose: HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  });
+}
+
+function assertHostedUsageCreditFinancialMetadata(input: {
+  metadata: Prisma.JsonValue | Stripe.Metadata | null;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): void {
+  const metadata = readStringRecord(input.metadata);
+  const purpose = metadata?.purpose;
+  if (
+    purpose !== HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE &&
+    purpose !== HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE
+  ) {
+    throw new Error("Usage-credit payment metadata purpose did not match.");
+  }
+  assertHostedUsageCreditMetadataForPurpose({
+    ...input,
+    purpose,
+  });
+}
+
+function assertHostedUsageCreditMetadataForPurpose(input: {
+  metadata: Prisma.JsonValue | Stripe.Metadata | null;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+  purpose:
+    | typeof HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
+    | typeof HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE;
+}): void {
+  const metadata = readStringRecord(input.metadata);
+  const expected = {
+    policyVersion: HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+    purchaseId: input.purchase.id,
+    purpose: input.purpose,
+  };
+  if (
+    input.purchase.checkoutRequestPolicyVersion !==
+      HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION ||
+    !metadata ||
+    Object.keys(metadata).length !== Object.keys(expected).length ||
+    Object.entries(expected).some(([key, value]) => metadata[key] !== value)
+  ) {
+    throw new Error("Usage-credit payment metadata did not match.");
+  }
+}
+''',
+)
+
+# Financial refunds/disputes converge through the same ledger for either path.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''  assertHostedUsageCreditFinancialEventLinks,
+  type HostedUsageCreditChargeContext,
+  type HostedUsageCreditPaidCheckoutAuthorization,
+  type HostedUsageCreditPreparedPaidCheckout,
+  validateHostedUsageCreditPreparedPaidCheckout,
+''',
+    '''  assertHostedUsageCreditFinancialEventLinks,
+  buildHostedUsageCreditDirectPaymentAuthorization,
+  readHostedUsageCreditSavedCardPurchaseId,
+  type HostedUsageCreditChargeContext,
+  type HostedUsageCreditPaymentAuthorization,
+  type HostedUsageCreditPreparedPaidCheckout,
+  validateHostedUsageCreditPreparedPaidCheckout,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''export type HostedUsageCreditPreparedFinancialEvent = {
+  paidCheckout: HostedUsageCreditPreparedPaidCheckout;
+  privateReferences: HostedUsageCreditStripePrivateReferences;
+  snapshot: HostedUsageCreditFinancialSnapshot;
+};
+''',
+    '''type HostedUsageCreditPreparedFinancialPayment =
+  | {
+      kind: "checkout";
+      paidCheckout: HostedUsageCreditPreparedPaidCheckout;
+    }
+  | {
+      kind: "saved_card";
+      paymentIntent: Stripe.PaymentIntent;
+    };
+
+export type HostedUsageCreditPreparedFinancialEvent = {
+  payment: HostedUsageCreditPreparedFinancialPayment;
+  privateReferences: HostedUsageCreditStripePrivateReferences;
+  snapshot: HostedUsageCreditFinancialSnapshot;
+};
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''  const paidCheckout = await prepareHostedUsageCreditFinancialSnapshotCheckout({
+    context: input.context,
+    eventLiveMode: input.event.livemode,
+    paymentIntent: snapshot.context.paymentIntent,
+    prisma: input.prisma,
+    purchase: input.purchase,
+  });
+  const privateReferences = await buildHostedUsageCreditStripePrivateReferences({
+    chargeId: snapshot.context.charge.id,
+    context: input.context,
+    paymentIntentId: snapshot.context.paymentIntent.id,
+    prisma: input.prisma,
+    purchase: input.purchase,
+    sessionId: paidCheckout.session.id,
+  });
+  return { paidCheckout, privateReferences, snapshot };
+''',
+    '''  const payment = await prepareHostedUsageCreditFinancialSnapshotPayment({
+    context: input.context,
+    eventLiveMode: input.event.livemode,
+    paymentIntent: snapshot.context.paymentIntent,
+    prisma: input.prisma,
+    purchase: input.purchase,
+  });
+  const privateReferences = await buildHostedUsageCreditStripePrivateReferences({
+    chargeId: snapshot.context.charge.id,
+    context: input.context,
+    paymentIntentId: snapshot.context.paymentIntent.id,
+    prisma: input.prisma,
+    purchase: input.purchase,
+    sessionId: payment.kind === "checkout"
+      ? payment.paidCheckout.session.id
+      : null,
+  });
+  return { payment, privateReferences, snapshot };
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''  return reconcileAndBindHostedUsageCreditFinancialSnapshotTx({
+    checkoutAuthorization: validateHostedUsageCreditPreparedPaidCheckout({
+      eventLiveMode: input.event.livemode,
+      paidCheckout: input.prepared.paidCheckout,
+      purchase: input.purchase,
+    }),
+''',
+    '''  const paymentAuthorization = input.prepared.payment.kind === "checkout"
+    ? validateHostedUsageCreditPreparedPaidCheckout({
+        eventLiveMode: input.event.livemode,
+        paidCheckout: input.prepared.payment.paidCheckout,
+        purchase: input.purchase,
+      })
+    : buildHostedUsageCreditDirectPaymentAuthorization({
+        paymentIntent: input.prepared.payment.paymentIntent,
+        purchase: input.purchase,
+      });
+  return reconcileAndBindHostedUsageCreditFinancialSnapshotTx({
+    paymentAuthorization,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''async function prepareHostedUsageCreditFinancialSnapshotCheckout(input: {
+  context: HostedUsageCreditStripePreparationContext;
+  eventLiveMode: boolean;
+  paymentIntent: Stripe.PaymentIntent;
+  prisma: HostedUsageCreditPurchaseReadClient;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): Promise<HostedUsageCreditPreparedPaidCheckout> {
+  let sessionId: string | null = null;
+''',
+    '''async function prepareHostedUsageCreditFinancialSnapshotPayment(input: {
+  context: HostedUsageCreditStripePreparationContext;
+  eventLiveMode: boolean;
+  paymentIntent: Stripe.PaymentIntent;
+  prisma: HostedUsageCreditPurchaseReadClient;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): Promise<HostedUsageCreditPreparedFinancialPayment> {
+  const savedCardPurchaseId = readHostedUsageCreditSavedCardPurchaseId(
+    input.paymentIntent.metadata,
+  );
+  if (savedCardPurchaseId) {
+    if (savedCardPurchaseId !== input.purchase.id) {
+      throw new Error(
+        "Saved-card usage-credit payment referenced a different purchase.",
+      );
+    }
+    buildHostedUsageCreditDirectPaymentAuthorization({
+      paymentIntent: input.paymentIntent,
+      purchase: input.purchase,
+    });
+    return {
+      kind: "saved_card",
+      paymentIntent: input.paymentIntent,
+    };
+  }
+
+  let sessionId: string | null = null;
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '''  return paidCheckout;
+}
+
+function assertHostedUsageCreditPreparedFinancialEvent''',
+    '''  return {
+    kind: "checkout",
+    paidCheckout,
+  };
+}
+
+function assertHostedUsageCreditPreparedFinancialEvent''',
+)
+replace_all(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    "checkoutAuthorization: HostedUsageCreditPaidCheckoutAuthorization;",
+    "paymentAuthorization: HostedUsageCreditPaymentAuthorization;",
+    expected=2,
+)
+replace_all(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    "input.checkoutAuthorization",
+    "input.paymentAuthorization",
+    expected=4,
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-financial-reconciliation.ts",
+    '"Usage-credit financial snapshot lacked Checkout authorization."',
+    '"Usage-credit financial snapshot lacked payment authorization."',
+)
+
+# Rename the convergence argument at its Checkout and direct call sites.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-checkout-reconciliation.ts",
+    '''      checkoutAuthorization,
+      effectiveAt:''',
+    '''      paymentAuthorization: checkoutAuthorization,
+      effectiveAt:''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-direct-payment-reconciliation.ts",
+    '''      checkoutAuthorization: buildHostedUsageCreditDirectPaymentAuthorization({
+''',
+    '''      paymentAuthorization: buildHostedUsageCreditDirectPaymentAuthorization({
+''',
+)
+
+# Route direct PaymentIntent events through the same reconciliation lock.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+''',
+    '''  HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
+  HOSTED_USAGE_CREDIT_CHECKOUT_REQUEST_POLICY_VERSION,
+  HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''import {
+  isHostedUsageCreditFinancialReversalEvent,
+''',
+    '''import {
+  isHostedUsageCreditDirectPaymentEvent,
+  prepareHostedUsageCreditDirectPaymentEvent,
+  reconcileHostedUsageCreditDirectPaymentEventTx,
+  type HostedUsageCreditPreparedDirectPaymentEvent,
+} from "./usage-credit-stripe-direct-payment-reconciliation";
+import {
+  isHostedUsageCreditFinancialReversalEvent,
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''import { readStringRecord } from "./usage-credit-stripe-payment-proof";
+''',
+    '''import {
+  readHostedUsageCreditSavedCardPurchaseId,
+  readStringRecord,
+} from "./usage-credit-stripe-payment-proof";
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  eventKind: "checkout" | "dispute" | "refund";
+''',
+    '''  eventKind: "checkout" | "direct_payment" | "dispute" | "refund";
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  | {
+      eventKind: "dispute" | "refund";
+      reconciliationVersion: bigint;
+      value: HostedUsageCreditPreparedFinancialEvent;
+    };
+''',
+    '''  | {
+      eventKind: "direct_payment";
+      reconciliationVersion: bigint;
+      value: HostedUsageCreditPreparedDirectPaymentEvent;
+    }
+  | {
+      eventKind: "dispute" | "refund";
+      reconciliationVersion: bigint;
+      value: HostedUsageCreditPreparedFinancialEvent;
+    };
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''        return prepared.eventKind === "checkout"
+          ? reconcileHostedUsageCreditCheckoutEventTx({
+              event: input.event,
+              expectedReconciliationVersion: prepared.reconciliationVersion,
+              prepared: prepared.value,
+              purchase,
+              tx,
+            })
+          : reconcileHostedUsageCreditFinancialEventTx({
+              event: input.event,
+              eventKind: prepared.eventKind,
+              expectedReconciliationVersion: prepared.reconciliationVersion,
+              prepared: prepared.value,
+              purchase,
+              tx,
+            });
+''',
+    '''        if (prepared.eventKind === "checkout") {
+          return reconcileHostedUsageCreditCheckoutEventTx({
+            event: input.event,
+            expectedReconciliationVersion: prepared.reconciliationVersion,
+            prepared: prepared.value,
+            purchase,
+            tx,
+          });
+        }
+        if (prepared.eventKind === "direct_payment") {
+          return reconcileHostedUsageCreditDirectPaymentEventTx({
+            event: input.event,
+            expectedReconciliationVersion: prepared.reconciliationVersion,
+            prepared: prepared.value,
+            purchase,
+            tx,
+          });
+        }
+        return reconcileHostedUsageCreditFinancialEventTx({
+          event: input.event,
+          eventKind: prepared.eventKind,
+          expectedReconciliationVersion: prepared.reconciliationVersion,
+          prepared: prepared.value,
+          purchase,
+          tx,
+        });
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  return {
+    candidate,
+    kind: "prepared",
+    prepared: await prepareHostedUsageCreditStripeEvent({
+      candidate,
+      context: input.context,
+      event: input.event,
+      prisma: input.prisma,
+      purchase,
+    }),
+  };
+''',
+    '''  const prepared = await prepareHostedUsageCreditStripeEvent({
+    candidate,
+    context: input.context,
+    event: input.event,
+    prisma: input.prisma,
+    purchase,
+  });
+  return prepared
+    ? {
+        candidate,
+        kind: "prepared",
+        prepared,
+      }
+    : { kind: "unhandled" };
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  if (!isHostedUsageCreditFinancialReversalEvent(input.event.type)) {
+    return null;
+  }
+
+  const {
+''',
+    '''  if (isHostedUsageCreditDirectPaymentEvent(input.event.type)) {
+    const paymentIntent = input.event.data.object as Stripe.PaymentIntent;
+    const purchaseId = readHostedUsageCreditSavedCardPurchaseId(
+      paymentIntent.metadata,
+    );
+    if (!purchaseId) {
+      return null;
+    }
+    const purchase = await findHostedUsageCreditPurchaseById({
+      prisma: input.prisma,
+      purchaseId,
+    });
+    return {
+      beneficiaryMemberId: purchase.beneficiaryMemberId,
+      eventKind: "direct_payment",
+      purchaseId: purchase.id,
+    };
+  }
+
+  if (!isHostedUsageCreditFinancialReversalEvent(input.event.type)) {
+    return null;
+  }
+
+  const {
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  if (
+    normalizeNullableString(metadata?.purpose) !==
+      HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
+  ) {
+    return null;
+  }
+''',
+    '''  const purpose = normalizeNullableString(metadata?.purpose);
+  if (
+    purpose !== HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE &&
+    purpose !== HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE
+  ) {
+    return null;
+  }
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    ''')}): Promise<HostedUsageCreditPreparedStripeEvent> {
+  if (input.candidate.eventKind === "checkout") {
+''',
+    ''')}): Promise<HostedUsageCreditPreparedStripeEvent | null> {
+  if (input.candidate.eventKind === "checkout") {
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''  return {
+    eventKind: input.candidate.eventKind,
+    reconciliationVersion: input.purchase.reconciliationVersion,
+    value: await prepareHostedUsageCreditFinancialEvent({
+''',
+    '''  if (input.candidate.eventKind === "direct_payment") {
+    return {
+      eventKind: "direct_payment",
+      reconciliationVersion: input.purchase.reconciliationVersion,
+      value: await prepareHostedUsageCreditDirectPaymentEvent({
+        context: input.context,
+        event: input.event,
+        prisma: input.prisma,
+        purchase: input.purchase,
+      }),
+    };
+  }
+  return {
+    eventKind: input.candidate.eventKind,
+    reconciliationVersion: input.purchase.reconciliationVersion,
+    value: await prepareHostedUsageCreditFinancialEvent({
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts",
+    '''function shouldGuardHostedUsageCreditStripeEvent(event: Stripe.Event): boolean {
+  if (isHostedUsageCreditFinancialReversalEvent(event.type)) {
+    return true;
+  }
+  if (!isHostedUsageCreditCheckoutEvent(event.type)) {
+    return false;
+  }
+''',
+    '''function shouldGuardHostedUsageCreditStripeEvent(event: Stripe.Event): boolean {
+  if (isHostedUsageCreditFinancialReversalEvent(event.type)) {
+    return true;
+  }
+  if (isHostedUsageCreditDirectPaymentEvent(event.type)) {
+    return readHostedUsageCreditSavedCardPurchaseId(
+      (event.data.object as Stripe.PaymentIntent).metadata,
+    ) !== null;
+  }
+  if (!isHostedUsageCreditCheckoutEvent(event.type)) {
+    return false;
+  }
+''',
+)
+
+# Only group funding takes the one-click path; personal/Family behavior stays stable.
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts",
+    '''import { logHostedStripeFailure } from "./stripe-error-log";
+''',
+    '''import { logHostedStripeFailure } from "./stripe-error-log";
+import { tryChargeHostedUsageCreditSavedCard } from
+  "./usage-credit-saved-card-payment";
+''',
+)
+replace_once(
+    "apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts",
+    '''  await assertHostedUsageCreditStripePriceMatchesPurchase({
+    checkoutRequest,
+    purchase,
+    stripe,
+  });
+  let session: Stripe.Checkout.Session;
+''',
+    '''  await assertHostedUsageCreditStripePriceMatchesPurchase({
+    checkoutRequest,
+    purchase,
+    stripe,
+  });
+  if (projectHostedUsageCreditPurchaseTarget(purchase).kind === "group") {
+    const directPaymentPurchase = await tryChargeHostedUsageCreditSavedCard({
+      checkoutRequest,
+      now: input.now,
+      prisma: input.prisma,
+      purchase,
+      stripe,
+    });
+    if (directPaymentPurchase) {
+      const projection = await projectHostedUsageCreditCheckoutForCurrentTarget({
+        now: input.now,
+        prisma: input.prisma,
+        purchase: directPaymentPurchase,
+      });
+      return projection.checkout;
+    }
+  }
+  let session: Stripe.Checkout.Session;
+''',
+)
+
+# Make the click's authorization and fallback behavior clear in the UI.
+replace_once(
+    "apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx",
+    '''                  ? "Shared with everyone in the chat."
+''',
+    '''                  ? "Shared with everyone in the chat. We’ll use your saved card when available; Stripe handles card entry or verification when needed."
+''',
+)
+replace_once(
+    "apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx",
+    '''                  {controller.checkoutInFlight
+                    ? "Opening checkout…"
+                    : controller.selectedOffer
+                      ? `Continue to checkout · ${controller.selectedOffer.amountLabel}`
+                      : "Choose an amount"}
+''',
+    '''                  {controller.checkoutInFlight
+                    ? props.scope === "group"
+                      ? "Adding messages…"
+                      : "Opening checkout…"
+                    : controller.selectedOffer
+                      ? props.scope === "group"
+                        ? `Add messages · ${controller.selectedOffer.amountLabel}`
+                        : `Continue to checkout · ${controller.selectedOffer.amountLabel}`
+                      : "Choose an amount"}
+''',
+)
+
+# UI tests assert the explicit group authorization wording.
+replace_once(
+    "apps/web/test/hosted-usage-top-up-dialog.test.tsx",
+    '''    assert.match(
+      rendered.container.textContent ?? "",
+      /Shared with everyone in the chat\./,
+    );
+''',
+    '''    assert.match(
+      rendered.container.textContent ?? "",
+      /Shared with everyone in the chat\./,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /saved card when available/,
+    );
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-top-up-dialog.test.tsx",
+    '''      "Continue to checkout · $5",
+''',
+    '''      "Add messages · $5",
+''',
+)
+
+# Existing service tests need the additional Stripe surface, plus one focused
+# assertion that a group purchase skips Checkout when a canonical card exists.
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  createHostedStripeCheckoutSessionLookupKey: vi.fn((value: string | null | undefined) =>
+    value ? `checkout:${value}` : null
+  ),
+''',
+    '''  createHostedStripeBillingEventLookupKey: vi.fn(
+    (value: string | null | undefined) => value ? `billing:${value}` : null,
+  ),
+  createHostedStripeCheckoutSessionLookupKey: vi.fn((value: string | null | undefined) =>
+    value ? `checkout:${value}` : null
+  ),
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  }) => input.expectedLookupKey === `${
+    input.kind === "stripe-price" ? "price" : "checkout"
+  }:${input.normalizedValue}`),
+''',
+    '''  }) => input.expectedLookupKey === `${
+    input.kind === "stripe-price"
+      ? "price"
+      : input.kind === "stripe-customer"
+        ? "customer"
+        : input.kind === "stripe-billing-event"
+          ? "billing"
+          : "checkout"
+  }:${input.normalizedValue}`),
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  stripeCheckoutRetrieve: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
+''',
+    '''  stripeCheckoutRetrieve: vi.fn(),
+  stripeCustomerRetrieve: vi.fn(),
+  stripePaymentIntentCancel: vi.fn(),
+  stripePaymentIntentCreate: vi.fn(),
+  stripePaymentIntentRetrieve: vi.fn(),
+  stripePaymentMethodsList: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
+  stripeSubscriptionsList: vi.fn(),
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''vi.mock("@/src/lib/hosted-onboarding/contact-privacy", () => ({
+  createHostedStripeCheckoutSessionLookupKey:
+''',
+    '''vi.mock("@/src/lib/hosted-onboarding/contact-privacy", () => ({
+  createHostedStripeBillingEventLookupKey:
+    mocks.createHostedStripeBillingEventLookupKey,
+  createHostedStripeCheckoutSessionLookupKey:
+''',
+)
+stripe_surface_old = '''        prices: { retrieve: mocks.stripePriceRetrieve },
+'''
+stripe_surface_new = '''        customers: { retrieve: mocks.stripeCustomerRetrieve },
+        paymentIntents: {
+          cancel: mocks.stripePaymentIntentCancel,
+          create: mocks.stripePaymentIntentCreate,
+          retrieve: mocks.stripePaymentIntentRetrieve,
+        },
+        paymentMethods: { list: mocks.stripePaymentMethodsList },
+        prices: { retrieve: mocks.stripePriceRetrieve },
+        subscriptions: { list: mocks.stripeSubscriptionsList },
+'''
+replace_all(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    stripe_surface_old,
+    stripe_surface_new,
+    expected=2,
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  mocks.stripeCheckoutRetrieve.mockReset();
+  mocks.stripePriceRetrieve.mockReset();
+''',
+    '''  mocks.stripeCheckoutRetrieve.mockReset();
+  mocks.stripeCustomerRetrieve.mockReset();
+  mocks.stripePaymentIntentCancel.mockReset();
+  mocks.stripePaymentIntentCreate.mockReset();
+  mocks.stripePaymentIntentRetrieve.mockReset();
+  mocks.stripePaymentMethodsList.mockReset();
+  mocks.stripePriceRetrieve.mockReset();
+  mocks.stripeSubscriptionsList.mockReset();
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  mocks.stripePriceRetrieve.mockImplementation(async (priceId: string) =>
+    buildStripePriceForId(priceId)
+  );
+''',
+    '''  mocks.stripeCustomerRetrieve.mockResolvedValue({
+    id: "cus_group_payer",
+    invoice_settings: { default_payment_method: null },
+    livemode: false,
+    object: "customer",
+  });
+  mocks.stripePaymentMethodsList.mockResolvedValue({
+    data: [],
+    has_more: false,
+    object: "list",
+    url: "/v1/payment_methods",
+  });
+  mocks.stripeSubscriptionsList.mockResolvedValue({
+    data: [],
+    has_more: false,
+    object: "list",
+    url: "/v1/subscriptions",
+  });
+  mocks.stripePriceRetrieve.mockImplementation(async (priceId: string) =>
+    buildStripePriceForId(priceId)
+  );
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  it("rechecks the exact group thread-container target inside checkout", async () => {
+''',
+    '''  it("charges a canonical saved card without opening Checkout", async () => {
+    const fake = createFakePrisma();
+    mocks.stripeCustomerRetrieve.mockResolvedValueOnce({
+      id: "cus_group_payer",
+      invoice_settings: { default_payment_method: "pm_saved_card_123" },
+      livemode: false,
+      object: "customer",
+    });
+    mocks.stripePaymentMethodsList.mockResolvedValueOnce({
+      data: [{
+        customer: "cus_group_payer",
+        id: "pm_saved_card_123",
+        livemode: false,
+        object: "payment_method",
+        type: "card",
+      }],
+      has_more: false,
+      object: "list",
+      url: "/v1/payment_methods",
+    });
+    mocks.stripePaymentIntentCreate.mockImplementationOnce(
+      async (request: Record<string, unknown>) => ({
+        amount: request.amount,
+        amount_received: request.amount,
+        currency: request.currency,
+        customer: request.customer,
+        id: "pi_saved_card_123",
+        latest_charge: "ch_saved_card_123",
+        livemode: false,
+        metadata: request.metadata,
+        object: "payment_intent",
+        status: "succeeded",
+      }),
+    );
+
+    const result = await createHostedGroupUsageCreditCheckout({
+      clientRequestKey: CLIENT_REQUEST_KEY,
+      joinCode: "group_join_code_1234",
+      now: NOW,
+      offerCode: "usage_10_usd",
+      payerMemberId: MEMBER_ID,
+      prisma: fake.prisma as never,
+    });
+
+    expect(result).toMatchObject({ status: "payment_pending" });
+    expect(result).not.toHaveProperty("url");
+    expect(mocks.stripePaymentIntentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 1_000,
+        confirm: true,
+        currency: "usd",
+        customer: "cus_group_payer",
+        off_session: true,
+        payment_method: "pm_saved_card_123",
+        setup_future_usage: "off_session",
+      }),
+      {
+        idempotencyKey: expect.stringMatching(
+          /^hosted-usage-credit-saved-card:hucp_/,
+        ),
+      },
+    );
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled();
+    expect(onlyPurchase(fake.purchases)).toMatchObject({
+      status: "payment_pending",
+      stripeChargeIdEncrypted: "encrypted:ch_saved_card_123",
+      stripeChargeLookupKey: "billing:ch_saved_card_123",
+      stripePaymentIntentIdEncrypted: "encrypted:pi_saved_card_123",
+      stripePaymentIntentLookupKey: "billing:pi_saved_card_123",
+    });
+  });
+
+  it("rechecks the exact group thread-container target inside checkout", async () => {
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''        payment_intent_data: {
+          metadata: {
+            policyVersion: "hosted-usage-credit-checkout-v1",
+            purchaseId: purchase.id,
+            purpose: "hosted_usage_credit",
+          },
+        },
+''',
+    '''        payment_intent_data: {
+          metadata: {
+            policyVersion: "hosted-usage-credit-checkout-v1",
+            purchaseId: purchase.id,
+            purpose: "hosted_usage_credit",
+          },
+          setup_future_usage: "off_session",
+        },
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  mocks.stripeCheckoutRetrieve.mockClear();
+  mocks.stripePriceRetrieve.mockClear();
+''',
+    '''  mocks.stripeCheckoutRetrieve.mockClear();
+  mocks.stripeCustomerRetrieve.mockClear();
+  mocks.stripePaymentIntentCancel.mockClear();
+  mocks.stripePaymentIntentCreate.mockClear();
+  mocks.stripePaymentIntentRetrieve.mockClear();
+  mocks.stripePaymentMethodsList.mockClear();
+  mocks.stripePriceRetrieve.mockClear();
+  mocks.stripeSubscriptionsList.mockClear();
+''',
+)
+replace_once(
+    "apps/web/test/hosted-usage-credit-purchase-service.test.ts",
+    '''  expect(mocks.stripeCheckoutRetrieve).not.toHaveBeenCalled();
+  expect(mocks.stripePriceRetrieve).not.toHaveBeenCalled();
+''',
+    '''  expect(mocks.stripeCheckoutRetrieve).not.toHaveBeenCalled();
+  expect(mocks.stripeCustomerRetrieve).not.toHaveBeenCalled();
+  expect(mocks.stripePaymentIntentCancel).not.toHaveBeenCalled();
+  expect(mocks.stripePaymentIntentCreate).not.toHaveBeenCalled();
+  expect(mocks.stripePaymentIntentRetrieve).not.toHaveBeenCalled();
+  expect(mocks.stripePaymentMethodsList).not.toHaveBeenCalled();
+  expect(mocks.stripePriceRetrieve).not.toHaveBeenCalled();
+  expect(mocks.stripeSubscriptionsList).not.toHaveBeenCalled();
+''',
+)
+
+# Document the consent and deployment contract next to the existing top-up spec.
+spec_path = "agent-docs/product-specs/hosted-usage-topups.md"
+spec = read(spec_path)
+section = '''
+
+## Saved-card group funding
+
+Group funding uses an explicit click-to-charge contract. Choosing an amount does
+nothing by itself; pressing **Add messages** authorizes exactly that one-time
+amount for the server-resolved group beneficiary. It never creates recurring
+billing or an automatic refill.
+
+For a signed-in payer, Murph first looks for one unambiguous reusable card: the
+Customer invoice default, a nonterminal Subscription default, or the sole card
+attached to the Customer. Conflicting defaults or multiple cards without a
+canonical default fall back to Stripe Checkout rather than guessing.
+
+The saved-card attempt is a confirmed off-session PaymentIntent with a frozen
+amount, currency, Customer, beneficiary purchase, metadata purpose, and
+purchase-scoped idempotency key. A definitive authentication requirement or
+card failure is canceled before Checkout is created. Ambiguous provider/network
+outcomes remain reconciling and must never start a second charge.
+
+Checkout remains the card-entry and authentication fallback and requests
+`setup_future_usage=off_session`, so a card entered there can be reused on a
+later group contribution. PaymentIntent, refund, and dispute events converge
+through the same encrypted purchase references and usage-credit ledger as
+Checkout. The Stripe webhook endpoint must subscribe to
+`payment_intent.succeeded`, `payment_intent.processing`,
+`payment_intent.payment_failed`, and `payment_intent.canceled` in addition to
+the existing Checkout/refund/dispute events.
+'''
+if "## Saved-card group funding" not in spec:
+    write(spec_path, spec.rstrip() + section + "\n")
+
+print("Applied saved-card group funding integration.")

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -21,4 +21,16 @@ if content.count(authorization_old) != 1:
     raise RuntimeError("Saved-card patch authorization count context was missing.")
 content = content.replace(authorization_old, authorization_new)
 
+purpose_old = ''''''  if (
+    normalizeNullableString(metadata?.purpose) !==
+      HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
+  ) {'''
+purpose_new = ''''''  if (
+    normalizeNullableString(metadata?.purpose) !==
+    HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
+  ) {'''
+if content.count(purpose_old) != 1:
+    raise RuntimeError("Saved-card patch purpose context was missing.")
+content = content.replace(purpose_old, purpose_new)
+
 path.write_text(content)

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -39,4 +39,14 @@ if content.count(nullable_signature_old) != 1:
     raise RuntimeError("Saved-card patch nullable prepare signature context was missing.")
 content = content.replace(nullable_signature_old, nullable_signature_new)
 
+stripe_surface_old = '''    stripe_surface_new,
+    expected=2,
+)'''
+stripe_surface_new = '''    stripe_surface_new,
+    expected=1,
+)'''
+if content.count(stripe_surface_old) != 1:
+    raise RuntimeError("Saved-card patch Stripe test surface count was missing.")
+content = content.replace(stripe_surface_old, stripe_surface_new)
+
 path.write_text(content)

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -27,4 +27,16 @@ if content.count(purpose_old) != 1:
     raise RuntimeError("Saved-card patch purpose context was missing.")
 content = content.replace(purpose_old, purpose_new)
 
+signature_old = "''')}): Promise<HostedUsageCreditPreparedStripeEvent> {"
+signature_new = "'''}): Promise<HostedUsageCreditPreparedStripeEvent> {"
+if content.count(signature_old) != 1:
+    raise RuntimeError("Saved-card patch prepare signature context was missing.")
+content = content.replace(signature_old, signature_new)
+
+nullable_signature_old = "''')}): Promise<HostedUsageCreditPreparedStripeEvent | null> {"
+nullable_signature_new = "'''}): Promise<HostedUsageCreditPreparedStripeEvent | null> {"
+if content.count(nullable_signature_old) != 1:
+    raise RuntimeError("Saved-card patch nullable prepare signature context was missing.")
+content = content.replace(nullable_signature_old, nullable_signature_new)
+
 path.write_text(content)

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -2,8 +2,23 @@ from pathlib import Path
 
 path = Path(__file__).with_name("apply-saved-card-group-funding.py")
 content = path.read_text()
-old = "'''function assertHostedUsageCreditCheckoutMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
-new = "'''function assertHostedUsageCreditMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
-if content.count(old) < 1:
+
+metadata_old = "'''function assertHostedUsageCreditCheckoutMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
+metadata_new = "'''function assertHostedUsageCreditMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
+if content.count(metadata_old) < 1:
     raise RuntimeError("Saved-card patch metadata declaration context was missing.")
-path.write_text(content.replace(old, new, 1))
+content = content.replace(metadata_old, metadata_new, 1)
+
+authorization_old = '''    "input.checkoutAuthorization",
+    "input.paymentAuthorization",
+    expected=4,
+)'''
+authorization_new = '''    "input.checkoutAuthorization",
+    "input.paymentAuthorization",
+    expected=3,
+)'''
+if content.count(authorization_old) != 1:
+    raise RuntimeError("Saved-card patch authorization count context was missing.")
+content = content.replace(authorization_old, authorization_new)
+
+path.write_text(content)

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -21,14 +21,8 @@ if content.count(authorization_old) != 1:
     raise RuntimeError("Saved-card patch authorization count context was missing.")
 content = content.replace(authorization_old, authorization_new)
 
-purpose_old = ''''''  if (
-    normalizeNullableString(metadata?.purpose) !==
-      HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
-  ) {'''
-purpose_new = ''''''  if (
-    normalizeNullableString(metadata?.purpose) !==
-    HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE
-  ) {'''
+purpose_old = "'''  if (\n    normalizeNullableString(metadata?.purpose) !==\n      HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE\n  ) {"
+purpose_new = "'''  if (\n    normalizeNullableString(metadata?.purpose) !==\n    HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE\n  ) {"
 if content.count(purpose_old) != 1:
     raise RuntimeError("Saved-card patch purpose context was missing.")
 content = content.replace(purpose_old, purpose_new)

--- a/agent-scripts/fix-saved-card-patch-script.py
+++ b/agent-scripts/fix-saved-card-patch-script.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+path = Path(__file__).with_name("apply-saved-card-group-funding.py")
+content = path.read_text()
+old = "'''function assertHostedUsageCreditCheckoutMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
+new = "'''function assertHostedUsageCreditMetadata(input: {\n  metadata: Prisma.JsonValue | Stripe.Metadata | null;"
+if content.count(old) < 1:
+    raise RuntimeError("Saved-card patch metadata declaration context was missing.")
+path.write_text(content.replace(old, new, 1))

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts
@@ -1,0 +1,440 @@
+import {
+  HostedUsageCreditPurchaseStatus,
+  type HostedUsageCreditPurchase,
+  type PrismaClient,
+} from "@prisma/client";
+import type Stripe from "stripe";
+
+import { coerceStripeObjectId } from "./billing";
+import {
+  createHostedStripeBillingEventLookupKey,
+  hostedLookupKeyMatchesValue,
+} from "./contact-privacy";
+import {
+  HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+  lockHostedMemberRow,
+} from "./shared";
+import {
+  buildHostedUsageCreditCheckoutMetadata,
+  buildHostedUsageCreditInvariantError,
+  buildHostedUsageCreditStripeUnavailableError,
+  encryptHostedUsageCreditPurchaseStripeField,
+  HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS,
+  requireHostedUsageCreditEncryptedValue,
+  requireHostedUsageCreditLookupKey,
+  requireHostedUsageCreditPurchasePayerMemberId,
+} from "./usage-credit-purchase-stripe";
+import { assertHostedUsageCreditPaymentIntentMatchesPurchase } from
+  "./usage-credit-stripe-payment-proof";
+
+const HOSTED_USAGE_CREDIT_SAVED_CARD_IDEMPOTENCY_PREFIX =
+  "hosted-usage-credit-saved-card";
+
+export async function tryChargeHostedUsageCreditSavedCard(input: {
+  checkoutRequest: Stripe.Checkout.SessionCreateParams;
+  now: Date;
+  prisma: PrismaClient;
+  purchase: HostedUsageCreditPurchase;
+  stripe: Stripe;
+}): Promise<HostedUsageCreditPurchase | null> {
+  const current = await readCurrentHostedUsageCreditPurchase(input);
+  if (
+    current.status !== HostedUsageCreditPurchaseStatus.created ||
+    current.stripeCheckoutSessionLookupKey ||
+    current.stripePaymentIntentLookupKey
+  ) {
+    return current;
+  }
+
+  const customerId = coerceStripeObjectId(input.checkoutRequest.customer);
+  if (
+    !customerId ||
+    !hostedLookupKeyMatchesValue({
+      expectedLookupKey: current.stripeCustomerLookupKey,
+      kind: "stripe-customer",
+      normalizedValue: customerId,
+    })
+  ) {
+    throw buildHostedUsageCreditInvariantError(
+      "saved_card_customer_identity_invalid",
+    );
+  }
+
+  const paymentMethodId = await resolveHostedUsageCreditSavedCard({
+    customerId,
+    purchase: current,
+    stripe: input.stripe,
+  });
+  if (!paymentMethodId) {
+    return null;
+  }
+
+  const paymentIntent = await createOrRecoverHostedUsageCreditPaymentIntent({
+    customerId,
+    paymentMethodId,
+    purchase: current,
+    stripe: input.stripe,
+  });
+  assertHostedUsageCreditPaymentIntentMatchesPurchase({
+    paymentIntent,
+    purchase: current,
+  });
+
+  if (
+    paymentIntent.status === "succeeded" ||
+    paymentIntent.status === "processing"
+  ) {
+    return bindHostedUsageCreditDirectPaymentIntent({
+      now: input.now,
+      paymentIntent,
+      prisma: input.prisma,
+      purchase: current,
+    });
+  }
+  if (paymentIntent.status === "canceled") {
+    return null;
+  }
+
+  const canceled = await cancelHostedUsageCreditDirectPaymentIntent({
+    paymentIntent,
+    purchase: current,
+    stripe: input.stripe,
+  });
+  assertHostedUsageCreditPaymentIntentMatchesPurchase({
+    paymentIntent: canceled,
+    purchase: current,
+  });
+  if (canceled.status === "succeeded" || canceled.status === "processing") {
+    return bindHostedUsageCreditDirectPaymentIntent({
+      now: input.now,
+      paymentIntent: canceled,
+      prisma: input.prisma,
+      purchase: current,
+    });
+  }
+  if (canceled.status !== "canceled") {
+    throw buildHostedUsageCreditStripeUnavailableError(
+      new Error("Saved-card PaymentIntent did not reach a safe terminal state."),
+      "paymentIntents.cancel.saved-card",
+    );
+  }
+  return null;
+}
+
+async function readCurrentHostedUsageCreditPurchase(input: {
+  prisma: PrismaClient;
+  purchase: HostedUsageCreditPurchase;
+}): Promise<HostedUsageCreditPurchase> {
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
+  return input.prisma.$transaction(async (tx) => {
+    await lockHostedMemberRow(tx, payerMemberId);
+    const current = await tx.hostedUsageCreditPurchase.findUnique({
+      where: { id: input.purchase.id },
+    });
+    if (
+      !current ||
+      current.payerMemberId !== payerMemberId ||
+      current.beneficiaryMemberId !== input.purchase.beneficiaryMemberId ||
+      current.offerCode !== input.purchase.offerCode
+    ) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_purchase_identity_changed",
+      );
+    }
+    return current;
+  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+}
+
+async function resolveHostedUsageCreditSavedCard(input: {
+  customerId: string;
+  purchase: HostedUsageCreditPurchase;
+  stripe: Stripe;
+}): Promise<string | null> {
+  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+  let paymentMethods: Stripe.ApiList<Stripe.PaymentMethod>;
+  try {
+    [customer, paymentMethods] = await Promise.all([
+      input.stripe.customers.retrieve(input.customerId, {
+        expand: ["invoice_settings.default_payment_method"],
+      }),
+      input.stripe.paymentMethods.list({
+        customer: input.customerId,
+        limit: 100,
+        type: "card",
+      }),
+    ]);
+  } catch (error) {
+    throw buildHostedUsageCreditStripeUnavailableError(
+      error,
+      "paymentMethods.list.saved-card",
+    );
+  }
+
+  if ("deleted" in customer && customer.deleted) {
+    throw buildHostedUsageCreditInvariantError(
+      "saved_card_customer_deleted",
+    );
+  }
+  if (
+    customer.id !== input.customerId ||
+    customer.livemode !== input.purchase.stripeLiveMode
+  ) {
+    throw buildHostedUsageCreditInvariantError(
+      "saved_card_customer_state_invalid",
+    );
+  }
+  if (paymentMethods.has_more) {
+    return null;
+  }
+
+  const attachedPaymentMethodIds = new Set<string>();
+  for (const paymentMethod of paymentMethods.data) {
+    if (
+      paymentMethod.type !== "card" ||
+      coerceStripeObjectId(paymentMethod.customer) !== input.customerId ||
+      paymentMethod.livemode !== input.purchase.stripeLiveMode
+    ) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_payment_method_invalid",
+      );
+    }
+    attachedPaymentMethodIds.add(paymentMethod.id);
+  }
+
+  const defaultPaymentMethodId = coerceStripeObjectId(
+    customer.invoice_settings.default_payment_method,
+  );
+  if (
+    defaultPaymentMethodId &&
+    attachedPaymentMethodIds.has(defaultPaymentMethodId)
+  ) {
+    return defaultPaymentMethodId;
+  }
+  return attachedPaymentMethodIds.size === 1
+    ? [...attachedPaymentMethodIds][0] ?? null
+    : null;
+}
+
+async function createOrRecoverHostedUsageCreditPaymentIntent(input: {
+  customerId: string;
+  paymentMethodId: string;
+  purchase: HostedUsageCreditPurchase;
+  stripe: Stripe;
+}): Promise<Stripe.PaymentIntent> {
+  const idempotencyKey = buildHostedUsageCreditSavedCardIdempotencyKey(
+    input.purchase.id,
+  );
+  try {
+    return await input.stripe.paymentIntents.create({
+      amount: input.purchase.cashAmountMinor,
+      capture_method: "automatic",
+      confirm: true,
+      currency: input.purchase.cashCurrency,
+      customer: input.customerId,
+      expand: ["latest_charge"],
+      metadata: buildHostedUsageCreditCheckoutMetadata(input.purchase.id),
+      off_session: true,
+      payment_method: input.paymentMethodId,
+      payment_method_types: ["card"],
+      setup_future_usage: "off_session",
+    }, { idempotencyKey });
+  } catch (error) {
+    const paymentIntentId = readHostedStripeErrorPaymentIntentId(error);
+    if (!paymentIntentId) {
+      throw buildHostedUsageCreditStripeUnavailableError(
+        error,
+        "paymentIntents.create.saved-card",
+      );
+    }
+    try {
+      return await input.stripe.paymentIntents.retrieve(paymentIntentId, {
+        expand: ["latest_charge"],
+      });
+    } catch (retrieveError) {
+      throw buildHostedUsageCreditStripeUnavailableError(
+        retrieveError,
+        "paymentIntents.retrieve.saved-card-recovery",
+      );
+    }
+  }
+}
+
+async function cancelHostedUsageCreditDirectPaymentIntent(input: {
+  paymentIntent: Stripe.PaymentIntent;
+  purchase: HostedUsageCreditPurchase;
+  stripe: Stripe;
+}): Promise<Stripe.PaymentIntent> {
+  try {
+    return await input.stripe.paymentIntents.cancel(
+      input.paymentIntent.id,
+      { cancellation_reason: "abandoned" },
+      {
+        idempotencyKey:
+          `${buildHostedUsageCreditSavedCardIdempotencyKey(input.purchase.id)}:cancel`,
+      },
+    );
+  } catch (error) {
+    try {
+      return await input.stripe.paymentIntents.retrieve(
+        input.paymentIntent.id,
+        { expand: ["latest_charge"] },
+      );
+    } catch (retrieveError) {
+      throw buildHostedUsageCreditStripeUnavailableError(
+        retrieveError,
+        "paymentIntents.retrieve.saved-card-cancel-recovery",
+      );
+    }
+  }
+}
+
+async function bindHostedUsageCreditDirectPaymentIntent(input: {
+  now: Date;
+  paymentIntent: Stripe.PaymentIntent;
+  prisma: PrismaClient;
+  purchase: HostedUsageCreditPurchase;
+}): Promise<HostedUsageCreditPurchase> {
+  const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
+    input.purchase,
+  );
+  const paymentIntentLookupKey = requireHostedUsageCreditLookupKey(
+    createHostedStripeBillingEventLookupKey(input.paymentIntent.id),
+    "payment_intent",
+  );
+  const chargeId = coerceStripeObjectId(input.paymentIntent.latest_charge);
+  const chargeLookupKey = chargeId
+    ? requireHostedUsageCreditLookupKey(
+        createHostedStripeBillingEventLookupKey(chargeId),
+        "charge",
+      )
+    : null;
+  const [stripePaymentIntentIdEncrypted, stripeChargeIdEncrypted] =
+    await Promise.all([
+      encryptHostedUsageCreditPurchaseStripeField({
+        field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.paymentIntentId,
+        payerMemberId,
+        prisma: input.prisma,
+        value: input.paymentIntent.id,
+      }),
+      encryptHostedUsageCreditPurchaseStripeField({
+        field: HOSTED_USAGE_CREDIT_PURCHASE_STRIPE_PRIVATE_FIELDS.chargeId,
+        payerMemberId,
+        prisma: input.prisma,
+        value: chargeId,
+      }),
+    ]);
+
+  return input.prisma.$transaction(async (tx) => {
+    await lockHostedMemberRow(tx, payerMemberId);
+    const current = await tx.hostedUsageCreditPurchase.findUnique({
+      where: { id: input.purchase.id },
+    });
+    if (!current || current.payerMemberId !== payerMemberId) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_purchase_missing",
+      );
+    }
+    if (
+      current.stripePaymentIntentLookupKey &&
+      !hostedLookupKeyMatchesValue({
+        expectedLookupKey: current.stripePaymentIntentLookupKey,
+        kind: "stripe-billing-event",
+        normalizedValue: input.paymentIntent.id,
+      })
+    ) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_payment_identity_changed",
+      );
+    }
+    if (current.status === HostedUsageCreditPurchaseStatus.fulfilled) {
+      return current;
+    }
+    if (
+      current.status !== HostedUsageCreditPurchaseStatus.created &&
+      current.status !== HostedUsageCreditPurchaseStatus.payment_pending
+    ) {
+      return current;
+    }
+
+    const updated = await tx.hostedUsageCreditPurchase.updateMany({
+      data: {
+        reconciliationVersion: { increment: 1n },
+        status: HostedUsageCreditPurchaseStatus.payment_pending,
+        stripeChargeIdEncrypted: chargeId
+          ? requireHostedUsageCreditEncryptedValue(
+              stripeChargeIdEncrypted,
+              "charge",
+            )
+          : null,
+        stripeChargeLookupKey: chargeLookupKey,
+        stripePaymentIntentIdEncrypted: requireHostedUsageCreditEncryptedValue(
+          stripePaymentIntentIdEncrypted,
+          "payment_intent",
+        ),
+        stripePaymentIntentLookupKey: paymentIntentLookupKey,
+        terminalAt: null,
+        updatedAt: input.now,
+      },
+      where: {
+        id: current.id,
+        reconciliationVersion: current.reconciliationVersion,
+        status: {
+          in: [
+            HostedUsageCreditPurchaseStatus.created,
+            HostedUsageCreditPurchaseStatus.payment_pending,
+          ],
+        },
+      },
+    });
+    if (updated.count !== 1) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_purchase_bind_failed",
+      );
+    }
+    const bound = await tx.hostedUsageCreditPurchase.findUnique({
+      where: { id: current.id },
+    });
+    if (!bound) {
+      throw buildHostedUsageCreditInvariantError(
+        "saved_card_purchase_missing_after_bind",
+      );
+    }
+    return bound;
+  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+}
+
+export function buildHostedUsageCreditSavedCardIdempotencyKey(
+  purchaseId: string,
+): string {
+  return `${HOSTED_USAGE_CREDIT_SAVED_CARD_IDEMPOTENCY_PREFIX}:${purchaseId}`;
+}
+
+function readHostedStripeErrorPaymentIntentId(error: unknown): string | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const direct = readHostedStripeErrorField(error, "payment_intent");
+  const raw = readHostedStripeErrorField(error, "raw");
+  return coerceStripeObjectId(
+    direct as Stripe.PaymentIntent | string | null,
+  ) ?? (
+    raw && typeof raw === "object"
+      ? coerceStripeObjectId(
+          readHostedStripeErrorField(raw, "payment_intent") as
+            | Stripe.PaymentIntent
+            | string
+            | null,
+        )
+      : null
+  );
+}
+
+function readHostedStripeErrorField(error: object, field: string): unknown {
+  try {
+    return Reflect.get(error, field);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-direct-payment-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-direct-payment-reconciliation.ts
@@ -1,0 +1,288 @@
+import {
+  HostedUsageCreditPurchaseStatus,
+  type Prisma,
+  type PrismaClient,
+} from "@prisma/client";
+import type Stripe from "stripe";
+
+import { coerceStripeObjectId } from "./billing";
+import { hostedLookupKeyMatchesValue } from "./contact-privacy";
+import { normalizeNullableString } from "./shared";
+import {
+  deriveHostedUsageCreditFinancialEffectiveAt,
+  type HostedUsageCreditFinancialSnapshot,
+  reconcileHostedUsageCreditFinancialSnapshotTx,
+  retrieveHostedUsageCreditFinancialSnapshot,
+} from "./usage-credit-stripe-financial-reconciliation";
+import {
+  assertHostedUsageCreditPaymentIntentMatchesPurchase,
+  buildHostedUsageCreditDirectPaymentAuthorization,
+  readHostedUsageCreditSavedCardPurchaseId,
+} from "./usage-credit-stripe-payment-proof";
+import {
+  bindHostedUsageCreditStripeReferencesTx,
+  buildHostedUsageCreditStripePrivateReferences,
+  buildHostedUsageCreditStripeRetryableError,
+  type HostedUsageCreditPurchaseForReconciliation,
+  readHostedUsageCreditStripe,
+  runHostedUsageCreditDatabaseOperation,
+  type HostedUsageCreditStripePreparationContext,
+  type HostedUsageCreditStripePrivateReferences,
+} from "./usage-credit-stripe-reconciliation-context";
+
+export type HostedUsageCreditPreparedDirectPaymentEvent = {
+  paymentIntent: Stripe.PaymentIntent;
+  privateReferences: HostedUsageCreditStripePrivateReferences;
+  snapshot: HostedUsageCreditFinancialSnapshot | null;
+};
+
+export async function prepareHostedUsageCreditDirectPaymentEvent(input: {
+  context: HostedUsageCreditStripePreparationContext;
+  event: Stripe.Event;
+  prisma: PrismaClient;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): Promise<HostedUsageCreditPreparedDirectPaymentEvent> {
+  if (!isHostedUsageCreditDirectPaymentEvent(input.event.type)) {
+    throw new Error("Expected a direct usage-credit payment event.");
+  }
+
+  const eventPaymentIntent = input.event.data.object as Stripe.PaymentIntent;
+  const paymentIntentId = normalizeNullableString(eventPaymentIntent.id);
+  if (!paymentIntentId) {
+    throw new Error(
+      "Direct usage-credit payment event did not include a PaymentIntent.",
+    );
+  }
+  if (
+    readHostedUsageCreditSavedCardPurchaseId(eventPaymentIntent.metadata) !==
+      input.purchase.id
+  ) {
+    throw new Error(
+      "Direct usage-credit payment event referenced a different purchase.",
+    );
+  }
+
+  const paymentIntent = await readHostedUsageCreditStripe({
+    context: input.context,
+    operationName: "paymentIntents.retrieve.usage-credit-direct-reconciliation",
+    read: (options) => input.context.stripe.paymentIntents.retrieve(
+      paymentIntentId,
+      { expand: ["latest_charge"] },
+      options,
+    ),
+  });
+  if (
+    paymentIntent.id !== paymentIntentId ||
+    input.event.livemode !== input.purchase.stripeLiveMode ||
+    eventPaymentIntent.livemode !== input.purchase.stripeLiveMode
+  ) {
+    throw new Error(
+      "Direct usage-credit PaymentIntent environment or identity did not match.",
+    );
+  }
+  assertHostedUsageCreditPaymentIntentMatchesPurchase({
+    paymentIntent,
+    purchase: input.purchase,
+  });
+
+  const chargeId = coerceStripeObjectId(paymentIntent.latest_charge);
+  const snapshot = paymentIntent.status === "succeeded"
+    ? await retrieveHostedUsageCreditFinancialSnapshot({
+        chargeId,
+        context: input.context,
+        paymentIntent,
+        purchase: input.purchase,
+      })
+    : null;
+  const privateReferences = await buildHostedUsageCreditStripePrivateReferences({
+    chargeId,
+    context: input.context,
+    paymentIntentId: paymentIntent.id,
+    prisma: input.prisma,
+    purchase: input.purchase,
+    sessionId: null,
+  });
+
+  return {
+    paymentIntent,
+    privateReferences,
+    snapshot,
+  };
+}
+
+export async function reconcileHostedUsageCreditDirectPaymentEventTx(input: {
+  event: Stripe.Event;
+  expectedReconciliationVersion: bigint;
+  prepared: HostedUsageCreditPreparedDirectPaymentEvent;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+  tx: Prisma.TransactionClient;
+}): Promise<{ granted: boolean; wakeRequired: boolean }> {
+  if (!isHostedUsageCreditDirectPaymentEvent(input.event.type)) {
+    throw new Error("Expected a direct usage-credit payment event.");
+  }
+
+  const eventPaymentIntent = input.event.data.object as Stripe.PaymentIntent;
+  if (
+    normalizeNullableString(eventPaymentIntent.id) !==
+      input.prepared.paymentIntent.id ||
+    input.event.livemode !== input.purchase.stripeLiveMode ||
+    eventPaymentIntent.livemode !== input.purchase.stripeLiveMode ||
+    readHostedUsageCreditSavedCardPurchaseId(eventPaymentIntent.metadata) !==
+      input.purchase.id
+  ) {
+    throw new Error(
+      "Direct usage-credit payment event changed before reconciliation.",
+    );
+  }
+
+  const { paymentIntent, privateReferences, snapshot } = input.prepared;
+  assertHostedUsageCreditPaymentIntentMatchesPurchase({
+    paymentIntent,
+    purchase: input.purchase,
+  });
+  const reconciledAt = new Date();
+
+  if (paymentIntent.status === "succeeded") {
+    if (!snapshot) {
+      throw new Error(
+        "Succeeded direct usage-credit payment lacked a financial snapshot.",
+      );
+    }
+    const convergence = await reconcileHostedUsageCreditFinancialSnapshotTx({
+      checkoutAuthorization: buildHostedUsageCreditDirectPaymentAuthorization({
+        paymentIntent,
+        purchase: input.purchase,
+      }),
+      effectiveAt: deriveHostedUsageCreditFinancialEffectiveAt({
+        event: input.event,
+        snapshot,
+      }),
+      purchase: input.purchase,
+      snapshot,
+      tx: input.tx,
+    });
+    await bindHostedUsageCreditStripeReferencesTx({
+      expectedReconciliationVersion: input.expectedReconciliationVersion,
+      lastReconciledAt: reconciledAt,
+      privateReferences,
+      purchaseId: input.purchase.id,
+      tx: input.tx,
+    });
+    return convergence;
+  }
+
+  if (input.purchase.status === HostedUsageCreditPurchaseStatus.fulfilled) {
+    throw new Error(
+      "A fulfilled usage-credit purchase no longer has a succeeded PaymentIntent.",
+    );
+  }
+
+  if (paymentIntent.status === "processing") {
+    await transitionHostedUsageCreditDirectPaymentTx({
+      expectedReconciliationVersion: input.expectedReconciliationVersion,
+      lastReconciledAt: reconciledAt,
+      privateReferences,
+      purchaseId: input.purchase.id,
+      status: HostedUsageCreditPurchaseStatus.payment_pending,
+      terminalAt: null,
+      tx: input.tx,
+    });
+    return { granted: false, wakeRequired: false };
+  }
+
+  if (
+    paymentIntent.status === "canceled" ||
+    paymentIntent.status === "requires_payment_method"
+  ) {
+    // A failed saved-card attempt is intentionally left unattached when the
+    // request can safely fall back to Checkout. Only a PaymentIntent that was
+    // previously bound as processing owns the purchase state and may close it.
+    if (!hostedUsageCreditPurchaseOwnsPaymentIntent({
+      paymentIntentId: paymentIntent.id,
+      purchase: input.purchase,
+    })) {
+      return { granted: false, wakeRequired: false };
+    }
+    await transitionHostedUsageCreditDirectPaymentTx({
+      expectedReconciliationVersion: input.expectedReconciliationVersion,
+      lastReconciledAt: reconciledAt,
+      privateReferences,
+      purchaseId: input.purchase.id,
+      status: HostedUsageCreditPurchaseStatus.payment_failed,
+      terminalAt: deriveStripeEventAt(input.event),
+      tx: input.tx,
+    });
+    return { granted: false, wakeRequired: false };
+  }
+
+  throw new Error(
+    `Direct usage-credit PaymentIntent had unsupported status ${paymentIntent.status}.`,
+  );
+}
+
+async function transitionHostedUsageCreditDirectPaymentTx(input: {
+  expectedReconciliationVersion: bigint;
+  lastReconciledAt: Date;
+  privateReferences: HostedUsageCreditStripePrivateReferences;
+  purchaseId: string;
+  status: HostedUsageCreditPurchaseStatus;
+  terminalAt: Date | null;
+  tx: Prisma.TransactionClient;
+}): Promise<void> {
+  const updated = await runHostedUsageCreditDatabaseOperation({
+    read: () => input.tx.hostedUsageCreditPurchase.updateMany({
+      data: {
+        lastReconciledAt: input.lastReconciledAt,
+        reconciliationVersion: { increment: 1n },
+        status: input.status,
+        terminalAt: input.terminalAt,
+        ...input.privateReferences,
+      },
+      where: {
+        id: input.purchaseId,
+        reconciliationVersion: input.expectedReconciliationVersion,
+        status: {
+          in: [
+            HostedUsageCreditPurchaseStatus.created,
+            HostedUsageCreditPurchaseStatus.payment_pending,
+            HostedUsageCreditPurchaseStatus.payment_failed,
+          ],
+        },
+      },
+    }),
+  });
+  if (updated.count !== 1) {
+    throw buildHostedUsageCreditStripeRetryableError(
+      new Error(
+        "Usage-credit purchase changed before direct payment reconciliation.",
+      ),
+    );
+  }
+}
+
+function hostedUsageCreditPurchaseOwnsPaymentIntent(input: {
+  paymentIntentId: string;
+  purchase: HostedUsageCreditPurchaseForReconciliation;
+}): boolean {
+  return Boolean(
+    input.purchase.stripePaymentIntentLookupKey &&
+      hostedLookupKeyMatchesValue({
+        expectedLookupKey: input.purchase.stripePaymentIntentLookupKey,
+        kind: "stripe-billing-event",
+        normalizedValue: input.paymentIntentId,
+      }),
+  );
+}
+
+function deriveStripeEventAt(event: Stripe.Event): Date {
+  return Number.isSafeInteger(event.created) && event.created > 0
+    ? new Date(event.created * 1000)
+    : new Date();
+}
+
+export function isHostedUsageCreditDirectPaymentEvent(type: string): boolean {
+  return type === "payment_intent.succeeded" ||
+    type === "payment_intent.processing" ||
+    type === "payment_intent.payment_failed" ||
+    type === "payment_intent.canceled";
+}


### PR DESCRIPTION
Temporary runner PR used only to execute the guarded source integration. It will be closed immediately after the feature branch is updated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787648286&installation_model_id=19880&pr_number=981&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F981&signature=630bc92d2d5a61f5e8b1735b75d4d0d85d28994c155aab5d77731bc725931674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->