### PR TITLE
Align the ReviewGPT release audit with 0.5.117

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -974,13 +974,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.114')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.117')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.114'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.117'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1216,7 +1216,11 @@ describe('monorepo release flow coverage audit', () => {
       [
         '  if (!shouldSend) {',
         '    if (shouldAttachFiles) {',
-        "      cleanupConfirmedDraftAttachments('the upload');",
+        '      // A staged draft has not been sent, and the composer tile appears while',
+        '      // the browser is still reading the file off disk. Removing it here',
+        '      // cancels the upload and leaves a draft with no attachment, so',
+        '      // draft-only runs retain the generated artifacts.',
+        "      console.log('Retained generated local attachment artifact(s) for the unsent draft.');",
         '    }',
         "    ownedTargetId = '';",
       ].join('\n'),


### PR DESCRIPTION
## Why this PR exists

PR #958 upgraded `@cobuild/review-gpt` and its supply-chain exception from 0.5.114 to 0.5.117. The package also now retains generated attachment files for an unsent staged draft because deleting them while the browser is still reading them cancels the upload. The monorepo release audit still expected the previous version and immediate upload cleanup, so every pull request's synthetic merge against current `main` fails the CLI release-coverage job before its own changes can be evaluated.

## Developer goal and impact

Restore a truthful release audit for the already-merged ReviewGPT package behavior. This is test-only: it changes no production code, package version, dependency, lockfile, runtime behavior, or user experience.

## Invariants

- The audit still pins the exact ReviewGPT dependency and matching `minimumReleaseAgeExclude` entry.
- Sent attachments still use the package-owned cleanup path.
- Unsent staged attachments remain available until ChatGPT finishes reading them, matching the installed package's fail-safe behavior.
- No release scripts, provider behavior, or application code changes.

## Verification

- Before the fix, the focused audit reproduced the CI failure: expected `^0.5.114`, received `^0.5.117`.
- After the fix, the focused audit passes: **40 passed, 1 intentionally skipped**.
- `MURPH_VERIFY_EXECUTOR=crabbox pnpm verify:acceptance`: **passed** in Testbox `tbx_01kygcms9k6rjfje9yzbv7a6g5`.
- Canonical diff verification was invoked in Testbox `tbx_01kygc3py4h96sr1nmxq1vrgfk`; its package-wide CLI harness developed unrelated exact 60-second command timeouts across intervention, document, assistant, vault, device, and other untouched suites. The exact focused audit remained green. The equivalent GitHub `Release package coverage (cli)` job passed on the pushed head.
- GitHub CI: **27/27 checks passed**, including release build/typecheck, full CLI package coverage, app verification, and hosted E2E.
- `git diff --check` passed.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 7 | 3 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **7** | **3** |
