### PR TITLE
Fix named voice memo overrides

### DIFF
--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-voice-memo.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-voice-memo.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+import {
+  assistantVoiceOptionIdSchema,
+  assistantVoiceOptionIdValues,
+  assistantVoiceOptions,
+} from '@murphai/contracts'
 import type {
   AssistantResponseMedia,
 } from '@murphai/operator-config/assistant-cli-contracts'
@@ -16,11 +21,15 @@ import {
   type DynamicToolResult,
 } from './dynamic-tool-wrapper.js'
 
+const voiceRosterDescription = assistantVoiceOptions
+  .map((option) => `${option.label}=${option.id}`)
+  .join(', ')
+
 export const MURPH_GENERATE_VOICE_MEMO_TOOL = {
   namespace: 'murph',
   name: 'generate_voice_memo',
   description:
-    'Generate one short voice memo using ElevenLabs and attach it to the final assistant response. Use it only when the user requests voice, a known preference supports voice, or when a loaded Murph skill or product flow explicitly asks for a voice memo and marks voice welcome and privacy-safe. Otherwise prefer text. Defaults to Murph’s configured voice. Use voiceId only when the user explicitly asks for a different voice. If the user asks for voice memos only, attach the voice memo and leave the final response text empty. This does not send directly.',
+    'Generate one short voice memo using ElevenLabs and attach it to the final assistant response. Use it only when the user requests voice, a known preference supports voice, or when a loaded Murph skill or product flow explicitly asks for a voice memo and marks voice welcome and privacy-safe. Otherwise prefer text. Defaults to Murph’s voice configured for the running turn. Use voice only for a one-off override from the Murph voice roster when the user explicitly asks for a named voice; voice is a roster id, never an ElevenLabs voice id. Do not persist a one-off voice request. A murph.personalization voice update starts on a later turn, so when the user asks to save a voice and hear it immediately, save it and pass that same roster voice here. If the user asks for voice memos only, attach the voice memo and leave the final response text empty. This does not send directly.',
   inputSchema: {
     type: 'object',
     additionalProperties: false,
@@ -31,13 +40,14 @@ export const MURPH_GENERATE_VOICE_MEMO_TOOL = {
         maxLength: ELEVENLABS_TTS_MAX_TEXT_LENGTH,
         description: 'The exact text to speak in the voice memo.',
       },
-      voiceId: {
+      voice: {
         anyOf: [
-          { type: 'string', minLength: 1, maxLength: 200 },
+          { type: 'string', enum: [...assistantVoiceOptionIdValues] },
           { type: 'null' },
         ],
         default: null,
-        description: 'Optional ElevenLabs voice id. Defaults to Murph voice.',
+        description:
+          `Optional one-off Murph voice roster id. Omit it to use the voice configured for the running turn. Available voices: ${voiceRosterDescription}.`,
       },
     },
     required: ['text'],
@@ -47,7 +57,7 @@ export const MURPH_GENERATE_VOICE_MEMO_TOOL = {
 const generateVoiceMemoArgumentsSchema = z
   .object({
     text: z.string().trim().min(1).max(ELEVENLABS_TTS_MAX_TEXT_LENGTH),
-    voiceId: z.string().trim().min(1).max(200).nullable().default(null),
+    voice: assistantVoiceOptionIdSchema.nullable().default(null),
   })
   .strict()
 
@@ -56,11 +66,23 @@ export function parseGenerateVoiceMemoArguments(
 ):
   | { ok: true; args: GenerateVoiceMemoToolArgs }
   | { ok: false; validationDigest: SafeToolCallValidationDigest } {
-  return parseDynamicToolArguments({
+  const parsed = parseDynamicToolArguments({
     schema: generateVoiceMemoArgumentsSchema,
     toolName: 'murph.generate_voice_memo',
     value,
   })
+  if (!parsed.ok) {
+    return parsed
+  }
+
+  return {
+    ok: true,
+    args: {
+      text: parsed.args.text,
+      voiceId: null,
+      voiceOptionId: parsed.args.voice,
+    },
+  }
 }
 
 export async function executeGenerateVoiceMemoDynamicTool(input: {

--- a/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
+++ b/packages/assistant-engine/src/assistant-codex/generate-voice-memo-tool.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto'
 
 import {
+  resolveAssistantVoiceOption,
+  type AssistantVoiceOptionId,
+} from '@murphai/contracts'
+import {
   assistantVoiceMemoMusicModelId,
   assistantVoiceMemoMusicOutputFormat,
   assistantVoiceMemoSpeechOutputFormat,
@@ -27,6 +31,7 @@ import { normalizeNullableString } from '../assistant/shared.js'
 export interface GenerateVoiceMemoToolArgs {
   text: string
   voiceId: string | null
+  voiceOptionId?: AssistantVoiceOptionId | null
 }
 
 export interface GenerateSongToolArgs {
@@ -45,6 +50,7 @@ export type VoiceMemoDeliveryChannel = 'linq' | 'telegram'
 
 export interface VoiceMemoElevenLabsRuntimeConfig {
   apiKeyAvailable: boolean
+  defaultVoiceId?: string | null
   modelId: string | null
   voiceId: string | null
 }
@@ -93,9 +99,10 @@ export async function executeGenerateVoiceMemoTool(input: {
     return preflight
   }
 
-  const voiceId =
-    normalizeNullableString(input.args.voiceId) ??
-    runtime.elevenLabs.voiceId
+  const voiceId = resolveVoiceMemoVoiceId({
+    args: input.args,
+    runtime,
+  })
   if (!voiceId) {
     return {
       rpcSuccess: false,
@@ -123,6 +130,25 @@ export async function executeGenerateVoiceMemoTool(input: {
     runtime,
     signal: input.abortSignal ?? null,
   })
+}
+
+function resolveVoiceMemoVoiceId(input: {
+  args: GenerateVoiceMemoToolArgs
+  runtime: VoiceMemoToolRuntime
+}): string | null {
+  const voiceOptionId = input.args.voiceOptionId ?? null
+  if (voiceOptionId !== null) {
+    const voiceOption = resolveAssistantVoiceOption(voiceOptionId)
+    if (!voiceOption) {
+      return null
+    }
+
+    return normalizeNullableString(voiceOption.elevenLabsVoiceId) ??
+      normalizeNullableString(input.runtime.elevenLabs.defaultVoiceId)
+  }
+
+  return normalizeNullableString(input.args.voiceId) ??
+    input.runtime.elevenLabs.voiceId
 }
 
 export async function executeGenerateSongTool(input: {
@@ -288,14 +314,16 @@ export function createVoiceMemoToolRuntimeFromEnv(input: {
   }
 
   const apiKey = resolveElevenLabsApiKey(input.env)
+  const defaultVoiceId = resolveElevenLabsVoiceId(input.env)
   const elevenLabs: VoiceMemoElevenLabsRuntimeConfig = {
     apiKeyAvailable: apiKey !== null,
+    defaultVoiceId,
     modelId: normalizeHostedAiUsageAllowanceElevenLabsTtsModelId(
       resolveElevenLabsModelId(input.env),
     ),
     voiceId:
       normalizeNullableString(input.preferredVoiceId) ??
-      resolveElevenLabsVoiceId(input.env),
+      defaultVoiceId,
   }
 
   if (deliveryChannel === 'telegram') {

--- a/packages/assistant-engine/test/assistant-codex-voice-roster-override.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-voice-roster-override.test.ts
@@ -67,7 +67,7 @@ describe('voice memo roster overrides', () => {
       },
     })
 
-    expect(parsed).toEqual({
+    expect(parsed).toMatchObject({
       args: {
         text: 'A stern country reminder.',
         voiceId: null,

--- a/packages/assistant-engine/test/assistant-codex-voice-roster-override.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-voice-roster-override.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  executeGenerateVoiceMemoTool,
+  type VoiceMemoToolRuntime,
+} from '../src/assistant-codex/generate-voice-memo-tool.ts'
+import {
+  MURPH_GENERATE_VOICE_MEMO_TOOL,
+} from '../src/assistant-codex/dynamic-tools/generate-voice-memo.ts'
+import {
+  readMurphDynamicToolRequest,
+} from '../src/assistant-codex/dynamic-tools.ts'
+
+const countryElevenLabsVoiceId = 'Bj9UqZbhQsanLzgalpEG'
+
+function createTelegramRuntime(): VoiceMemoToolRuntime {
+  return {
+    elevenLabs: {
+      apiKeyAvailable: true,
+      defaultVoiceId: 'voice_classic_default',
+      modelId: 'eleven_multilingual_v2',
+      voiceId: 'voice_current_turn',
+    },
+    kind: 'telegram',
+  }
+}
+
+describe('voice memo roster overrides', () => {
+  it('exposes product voice ids instead of raw ElevenLabs ids', () => {
+    expect(MURPH_GENERATE_VOICE_MEMO_TOOL.inputSchema.properties).toHaveProperty(
+      'voice',
+    )
+    expect(MURPH_GENERATE_VOICE_MEMO_TOOL.inputSchema.properties).not.toHaveProperty(
+      'voiceId',
+    )
+    expect(MURPH_GENERATE_VOICE_MEMO_TOOL.description).toContain(
+      'voice is a roster id, never an ElevenLabs voice id',
+    )
+    expect(MURPH_GENERATE_VOICE_MEMO_TOOL.description).toContain(
+      'pass that same roster voice here',
+    )
+  })
+
+  it('parses a named Murph voice and rejects the legacy raw voiceId field', () => {
+    const parsed = readMurphDynamicToolRequest({
+      id: 1,
+      method: 'item/tool/call',
+      params: {
+        arguments: {
+          text: 'A stern country reminder.',
+          voice: 'country',
+        },
+        namespace: 'murph',
+        tool: 'generate_voice_memo',
+      },
+    })
+    const legacy = readMurphDynamicToolRequest({
+      id: 2,
+      method: 'item/tool/call',
+      params: {
+        arguments: {
+          text: 'A stern country reminder.',
+          voiceId: 'country',
+        },
+        namespace: 'murph',
+        tool: 'generate_voice_memo',
+      },
+    })
+
+    expect(parsed).toEqual({
+      args: {
+        text: 'A stern country reminder.',
+        voiceId: null,
+        voiceOptionId: 'country',
+      },
+      kind: 'generate-voice-memo',
+    })
+    expect(legacy).toMatchObject({
+      kind: 'invalid-generate-voice-memo-arguments',
+    })
+  })
+
+  it('resolves a one-off country override to its provider voice id', async () => {
+    const result = await executeGenerateVoiceMemoTool({
+      args: {
+        text: 'A stern country reminder.',
+        voiceId: null,
+        voiceOptionId: 'country',
+      },
+      runtime: createTelegramRuntime(),
+    })
+
+    expect(result).toMatchObject({
+      responseMedia: [
+        {
+          transport: {
+            generation: {
+              voiceId: countryElevenLabsVoiceId,
+            },
+          },
+        },
+      ],
+      rpcSuccess: true,
+    })
+  })
+
+  it('uses the environment default for the classic roster voice', async () => {
+    const result = await executeGenerateVoiceMemoTool({
+      args: {
+        text: 'Use the New York voice.',
+        voiceId: null,
+        voiceOptionId: 'classic',
+      },
+      runtime: createTelegramRuntime(),
+    })
+
+    expect(result).toMatchObject({
+      responseMedia: [
+        {
+          transport: {
+            generation: {
+              voiceId: 'voice_classic_default',
+            },
+          },
+        },
+      ],
+      rpcSuccess: true,
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Replaced the model-facing free-form ElevenLabs `voiceId` with a typed one-off `voice` selected from Murph's canonical voice roster.
- Resolve roster IDs such as `country` to the real ElevenLabs provider ID inside the runtime instead of trusting the model to know provider IDs.
- Preserve the configured current-turn voice when no override is supplied, and preserve the environment-backed New York/`classic` fallback for an explicit one-off override.
- Clarified the tool contract: one-off voice requests should not mutate room/member settings, while a same-turn save-and-demo should save through `murph.personalization` and pass the same roster voice to the memo tool because persistent voice changes begin on a later turn.
- Added regression coverage for `country`, `classic`, and rejection of the legacy raw `voiceId` field.

## Root cause

The tool schema told the model to use `voiceId` when the user requested another voice, but Murph's product-facing IDs are roster values such as `country`, not ElevenLabs voice IDs. The model therefore sent `country` directly to ElevenLabs and received `404 voice_not_found`. Separately, a saved personalization change is intentionally next-turn state, so omitting an explicit override during the same turn still used the old voice.

## Verification

- Added focused Vitest coverage for parsing and server-side voice resolution.
- Full CI is expected to validate workspace typechecking and the broader assistant test suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787792634&installation_model_id=19880&pr_number=1054&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1054&signature=de1574e3ad959f6effb9230bb3e9bdbc368e7e6929cf2d0ff1f22d4b50c3f7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->