### PR TITLE
Temporary: verify PR #936 retention rollout safety fix

### DIFF
--- a/.github/pr936-retention-safety-fix/part-00.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-00.pyfrag
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path.cwd()
+
+
+def replace_once(relative: str, old: str, new: str) -> None:
+    path = ROOT / relative
+    text = path.read_text()
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"{relative}: expected one replacement target, found {count}")
+    path.write_text(text.replace(old, new, 1))
+
+
+def write(relative: str, content: str) -> None:
+    path = ROOT / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+write(
+    "apps/web/prisma/migrations/20260725190000_hosted_mailbox_content_retention/migration.sql",
+    '''-- This predeploy migration is intentionally expand-only. It adds the
+-- mailbox retirement markers without waking persisted snapshots, so a Vercel
+-- deployment can never race ahead of the stamping-capable Cloudflare runner.
+-- Phase-one snapshot rearming is a separate explicit post-smoke operation in
+-- the Cloudflare production deploy workflow.
+ALTER TABLE "hosted_mailbox_item"
+ADD COLUMN "content_retired_at" TIMESTAMP(3),
+ADD COLUMN "retention_disposition" TEXT;
+''',
+)
+
+write(
+    "apps/web/scripts/rearm-inbound-message-content-retention.ts",
+    '''import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client, type QueryResultRow } from "pg";
+
+import {
+  assertHostedWebMigrationOwner,
+  withHostedWebMigrationOwner,
+} from "./hosted-web-migration-owner";
+import {
+  resolveHostedWebMigrationDatabaseUrl,
+  type HostedWebMigrationEnvironment,
+} from "./run-prisma-migrate-deploy";
+
+const CONFIG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REARM_LOCK_NAME = "hosted_inbound_message_content_retention_phase_one";
+const REARM_LOCK_TIMEOUT = "5s";
+const REARM_STATEMENT_TIMEOUT = "30s";
+
+export const INBOUND_MESSAGE_CONTENT_RETENTION_REARM_OPT_IN =
+  "MURPH_RUN_INBOUND_MESSAGE_CONTENT_RETENTION_REARM";
+export const INBOUND_MESSAGE_CONTENT_RETENTION_REARM_MAX_SNAPSHOTS =
+  "MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS";
+
+export interface HostedInboundMessageContentRetentionRearmDatabase {
+  query<Row extends QueryResultRow = QueryResultRow>(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: Row[] }>;
+}
+
+export interface HostedInboundMessageContentRetentionRearmClient
+  extends HostedInboundMessageContentRetentionRearmDatabase {
+  connect(): Promise<unknown>;
+  end(): Promise<void>;
+}
+
+export interface HostedInboundMessageContentRetentionRearmResult {
+  rearmedAt: string;
+  rearmedCount: number;
+  snapshotCount: number;
+}
+
+export interface HostedInboundMessageContentRetentionRearmOptions {
+  clientFactory?: (
+    connectionString: string,
+  ) => HostedInboundMessageContentRetentionRearmClient;
+}
+
+export function shouldRunHostedInboundMessageContentRetentionRearm(
+  environment: HostedWebMigrationEnvironment,
+): boolean {
+  return environment[INBOUND_MESSAGE_CONTENT_RETENTION_REARM_OPT_IN] === "1";
+}
+
+export function readHostedInboundMessageContentRetentionRearmMaxSnapshots(
+  environment: HostedWebMigrationEnvironment,
+): number {
+  const raw = environment[
+    INBOUND_MESSAGE_CONTENT_RETENTION_REARM_MAX_SNAPSHOTS
+  ]?.trim();
+  if (!raw || !/^[1-9]\\d*$/u.test(raw)) {
+    throw new Error(
+      `${INBOUND_MESSAGE_CONTENT_RETENTION_REARM_MAX_SNAPSHOTS} must be a positive integer capacity ceiling.`,
+    );
+  }
+
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(
+      `${INBOUND_MESSAGE_CONTENT_RETENTION_REARM_MAX_SNAPSHOTS} exceeds the safe integer range.`,
+    );
+  }

--- a/.github/pr936-retention-safety-fix/part-01.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-01.pyfrag
@@ -1,0 +1,110 @@
+  }
+  return value;
+}
+
+export async function applyHostedInboundMessageContentRetentionRearm(
+  database: HostedInboundMessageContentRetentionRearmDatabase,
+  maxSnapshots: number,
+): Promise<HostedInboundMessageContentRetentionRearmResult> {
+  if (!Number.isSafeInteger(maxSnapshots) || maxSnapshots < 1) {
+    throw new TypeError("Inbound message-content retention maxSnapshots must be a positive integer.");
+  }
+
+  const result = await database.query<{
+    rearmedAt: string;
+    rearmedCount: string;
+    snapshotCount: string;
+  }>(
+    `
+      WITH persisted AS MATERIALIZED (
+        SELECT "user_id"
+        FROM "hosted_workspace"
+        WHERE "snapshot_ref" IS NOT NULL
+      ),
+      capacity AS (
+        SELECT COUNT(*)::BIGINT AS "snapshot_count"
+        FROM persisted
+      ),
+      rearmed AS (
+        UPDATE "hosted_workspace" AS workspace
+        SET
+          "inbox_media_retention_wake_at" = CURRENT_TIMESTAMP,
+          "inbox_media_retention_signal_attempted_at" = NULL,
+          "version" = workspace."version" + 1
+        FROM persisted
+        WHERE workspace."user_id" = persisted."user_id"
+          AND (SELECT "snapshot_count" FROM capacity) <= $1::BIGINT
+        RETURNING workspace."user_id"
+      )
+      SELECT
+        to_char(
+          (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::TIMESTAMP(3),
+          'YYYY-MM-DD"T"HH24:MI:SS.MS'
+        ) AS "rearmedAt",
+        (SELECT COUNT(*)::BIGINT FROM rearmed)::TEXT AS "rearmedCount",
+        capacity."snapshot_count"::TEXT AS "snapshotCount"
+      FROM capacity
+    `,
+    [maxSnapshots],
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error("Inbound message-content retention rearm returned no result row.");
+  }
+
+  const snapshotCount = parseCount(row.snapshotCount, "snapshotCount");
+  const rearmedCount = parseCount(row.rearmedCount, "rearmedCount");
+  if (snapshotCount > maxSnapshots) {
+    throw new Error(
+      `Inbound message-content retention rearm refused ${snapshotCount} persisted snapshots because the confirmed capacity ceiling is ${maxSnapshots}.`,
+    );
+  }
+  if (rearmedCount !== snapshotCount) {
+    throw new Error(
+      `Inbound message-content retention rearm updated ${rearmedCount} of ${snapshotCount} persisted snapshots.`,
+    );
+  }
+  if (!row.rearmedAt || Number.isNaN(Date.parse(`${row.rearmedAt}Z`))) {
+    throw new Error("Inbound message-content retention rearm returned an invalid timestamp.");
+  }
+
+  return {
+    rearmedAt: `${row.rearmedAt}Z`,
+    rearmedCount,
+    snapshotCount,
+  };
+}
+
+export async function runHostedInboundMessageContentRetentionRearmIfNeeded(
+  environment: HostedWebMigrationEnvironment = process.env,
+  options: HostedInboundMessageContentRetentionRearmOptions = {},
+): Promise<HostedInboundMessageContentRetentionRearmResult | "skipped"> {
+  if (!shouldRunHostedInboundMessageContentRetentionRearm(environment)) {
+    console.log("Skipping inbound message-content retention rearm without explicit opt-in.");
+    return "skipped";
+  }
+
+  const maxSnapshots =
+    readHostedInboundMessageContentRetentionRearmMaxSnapshots(environment);
+  const migrationDatabaseUrl = resolveHostedWebMigrationDatabaseUrl({
+    ...environment,
+    MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1",
+  });
+  const ownerDatabaseUrl = withHostedWebMigrationOwner(migrationDatabaseUrl.url);
+  const client = (options.clientFactory ?? createRearmClient)(ownerDatabaseUrl);
+
+  await client.connect();
+  try {
+    await assertHostedWebMigrationOwner(client);
+    await client.query("BEGIN");
+    try {
+      await client.query(`SET LOCAL lock_timeout = '${REARM_LOCK_TIMEOUT}'`);
+      await client.query(
+        `SET LOCAL statement_timeout = '${REARM_STATEMENT_TIMEOUT}'`,
+      );
+      const lock = await client.query<{ acquired: boolean }>(
+        "SELECT pg_try_advisory_xact_lock(hashtext($1)) AS acquired",
+        [REARM_LOCK_NAME],
+      );
+      if (lock.rows[0]?.acquired !== true) {
+        throw new Error(

--- a/.github/pr936-retention-safety-fix/part-02.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-02.pyfrag
@@ -1,0 +1,110 @@
+          "Another inbound message-content retention rearm already owns the database lock.",
+        );
+      }
+
+      const result = await applyHostedInboundMessageContentRetentionRearm(
+        client,
+        maxSnapshots,
+      );
+      await client.query("COMMIT");
+      console.log(
+        `Rearmed ${result.rearmedCount} persisted workspace snapshot(s) for inbound message-content retention at ${result.rearmedAt}.`,
+      );
+      return result;
+    } catch (error) {
+      await rollbackAfterRearmFailure(client);
+      throw error;
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+function createRearmClient(
+  connectionString: string,
+): HostedInboundMessageContentRetentionRearmClient {
+  return new Client({ connectionString });
+}
+
+function parseCount(value: string, label: string): number {
+  if (!/^\\d+$/u.test(value)) {
+    throw new Error(`Inbound message-content retention ${label} is invalid.`);
+  }
+  const count = Number(value);
+  if (!Number.isSafeInteger(count)) {
+    throw new Error(`Inbound message-content retention ${label} exceeds the safe integer range.`);
+  }
+  return count;
+}
+
+async function rollbackAfterRearmFailure(
+  database: HostedInboundMessageContentRetentionRearmDatabase,
+): Promise<void> {
+  try {
+    await database.query("ROLLBACK");
+  } catch (rollbackError) {
+    console.error(
+      rollbackError instanceof Error
+        ? rollbackError.message
+        : String(rollbackError),
+    );
+  }
+}
+
+function loadHostedWebEnvFiles(): void {
+  for (const envPath of [".env.local", ".env"]) {
+    const absoluteEnvPath = path.join(CONFIG_DIR, envPath);
+    if (existsSync(absoluteEnvPath)) {
+      process.loadEnvFile(absoluteEnvPath);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  loadHostedWebEnvFiles();
+  await runHostedInboundMessageContentRetentionRearmIfNeeded();
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+''',
+)
+
+write(
+    "apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts",
+    '''import { readFile } from "node:fs/promises";
+
+import pg from "pg";
+import { describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresMigrationProof =
+  process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+const migrationUrl = new URL(
+  "../prisma/migrations/20260725190000_hosted_mailbox_content_retention/migration.sql",
+  import.meta.url,
+);
+
+if (
+  runPostgresMigrationProof
+  && (!databaseUrl || !isClearlyLocalPostgresUrl(databaseUrl))
+) {
+  throw new Error(
+    "The hosted mailbox content-retention migration proof requires a local DATABASE_URL.",
+  );
+}
+
+describe.skipIf(!runPostgresMigrationProof)(
+  "hosted mailbox content-retention migration",
+  () => {
+    it("adds nullable mailbox markers without rearming workspace snapshots", async () => {
+      const migrationSql = await readFile(migrationUrl, "utf8");
+      const client = new pg.Client({ connectionString: databaseUrl });
+      await client.connect();
+
+      try {

--- a/.github/pr936-retention-safety-fix/part-03.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-03.pyfrag
@@ -1,0 +1,110 @@
+        await client.query("BEGIN");
+        await client.query(`
+          CREATE TEMP TABLE "hosted_mailbox_item" (
+            "id" TEXT PRIMARY KEY
+          );
+          CREATE TEMP TABLE "hosted_workspace" (
+            "user_id" TEXT PRIMARY KEY,
+            "version" BIGINT NOT NULL,
+            "snapshot_ref" TEXT,
+            "inbox_media_retention_wake_at" TIMESTAMP(3),
+            "inbox_media_retention_signal_attempted_at" TIMESTAMP(3),
+            "checkpointed_at" TIMESTAMP(3)
+          );
+
+          INSERT INTO "hosted_workspace" (
+            "user_id",
+            "version",
+            "snapshot_ref",
+            "inbox_media_retention_wake_at",
+            "inbox_media_retention_signal_attempted_at",
+            "checkpointed_at"
+          )
+          VALUES (
+            'persisted',
+            4,
+            'snapshot://existing',
+            '2099-01-01T00:00:00.000Z',
+            '2026-07-25T18:00:00.000Z',
+            '2026-07-25T17:00:00.000Z'
+          );
+        `);
+
+        await client.query(migrationSql);
+
+        const columns = await client.query<{
+          columnName: string;
+          isNullable: string;
+        }>(`
+          SELECT
+            column_name AS "columnName",
+            is_nullable AS "isNullable"
+          FROM information_schema.columns
+          WHERE table_schema LIKE 'pg_temp_%'
+            AND table_name = 'hosted_mailbox_item'
+            AND column_name IN ('content_retired_at', 'retention_disposition')
+          ORDER BY column_name
+        `);
+        expect(columns.rows).toEqual([
+          { columnName: "content_retired_at", isNullable: "YES" },
+          { columnName: "retention_disposition", isNullable: "YES" },
+        ]);
+
+        const workspace = await client.query<{
+          checkpointedAt: string;
+          signalAttemptedAt: string;
+          userId: string;
+          version: string;
+          wakeAt: string;
+        }>(`
+          SELECT
+            to_char("checkpointed_at", 'YYYY-MM-DD"T"HH24:MI:SS.MS') AS "checkpointedAt",
+            to_char(
+              "inbox_media_retention_signal_attempted_at",
+              'YYYY-MM-DD"T"HH24:MI:SS.MS'
+            ) AS "signalAttemptedAt",
+            "user_id" AS "userId",
+            "version"::TEXT AS "version",
+            to_char(
+              "inbox_media_retention_wake_at",
+              'YYYY-MM-DD"T"HH24:MI:SS.MS'
+            ) AS "wakeAt"
+          FROM "hosted_workspace"
+        `);
+        expect(workspace.rows).toEqual([
+          {
+            checkpointedAt: "2026-07-25T17:00:00.000",
+            signalAttemptedAt: "2026-07-25T18:00:00.000",
+            userId: "persisted",
+            version: "4",
+            wakeAt: "2099-01-01T00:00:00.000",
+          },
+        ]);
+      } finally {
+        await client.query("ROLLBACK");
+        await client.end();
+      }
+    });
+  },
+);
+
+function isClearlyLocalPostgresUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol.startsWith("postgres")
+      && ["127.0.0.1", "localhost", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+''',
+)
+
+write(
+    "apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts",
+    '''import pg from "pg";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyHostedInboundMessageContentRetentionRearm,
+  readHostedInboundMessageContentRetentionRearmMaxSnapshots,

--- a/.github/pr936-retention-safety-fix/part-04.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-04.pyfrag
@@ -1,0 +1,110 @@
+} from "../scripts/rearm-inbound-message-content-retention";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresProof = process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+if (runPostgresProof && (!databaseUrl || !isClearlyLocalPostgresUrl(databaseUrl))) {
+  throw new Error(
+    "The inbound message-content retention rearm proof requires a local DATABASE_URL.",
+  );
+}
+
+describe("inbound message-content retention rearm", () => {
+  it("requires an explicit positive capacity ceiling", () => {
+    expect(() =>
+      readHostedInboundMessageContentRetentionRearmMaxSnapshots({})
+    ).toThrow(/positive integer capacity ceiling/u);
+    expect(() =>
+      readHostedInboundMessageContentRetentionRearmMaxSnapshots({
+        MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS: "0",
+      })
+    ).toThrow(/positive integer capacity ceiling/u);
+    expect(
+      readHostedInboundMessageContentRetentionRearmMaxSnapshots({
+        MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS: "25",
+      }),
+    ).toBe(25);
+  });
+});
+
+describe.skipIf(!runPostgresProof)(
+  "inbound message-content retention rearm postgres proof",
+  () => {
+    it("fails closed over capacity, then rearms persisted snapshots with CAS visibility", async () => {
+      const client = new pg.Client({ connectionString: databaseUrl });
+      await client.connect();
+
+      try {
+        await client.query("BEGIN");
+        const timestamp = await client.query<{ transactionTimestamp: string }>(`
+          SELECT to_char(
+            (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::TIMESTAMP(3),
+            'YYYY-MM-DD"T"HH24:MI:SS.MS'
+          ) AS "transactionTimestamp"
+        `);
+        const transactionTimestamp = timestamp.rows[0]?.transactionTimestamp;
+        expect(transactionTimestamp).toBeTruthy();
+
+        await client.query(`
+          CREATE TEMP TABLE "hosted_workspace" (
+            "user_id" TEXT PRIMARY KEY,
+            "version" BIGINT NOT NULL,
+            "snapshot_ref" TEXT,
+            "inbox_media_retention_wake_at" TIMESTAMP(3),
+            "inbox_media_retention_signal_attempted_at" TIMESTAMP(3),
+            "checkpointed_at" TIMESTAMP(3)
+          );
+
+          INSERT INTO "hosted_workspace" (
+            "user_id",
+            "version",
+            "snapshot_ref",
+            "inbox_media_retention_wake_at",
+            "inbox_media_retention_signal_attempted_at",
+            "checkpointed_at"
+          )
+          VALUES
+            (
+              'snapshot-existing-wake',
+              4,
+              'snapshot://existing',
+              '2099-01-01T00:00:00.000Z',
+              '2026-07-25T18:00:00.000Z',
+              '2026-07-25T17:00:00.000Z'
+            ),
+            (
+              'snapshot-missing-wake',
+              9,
+              'snapshot://missing-wake',
+              NULL,
+              '2026-07-25T18:00:00.000Z',
+              '2026-07-25T17:00:00.000Z'
+            ),
+            (
+              'no-snapshot',
+              2,
+              NULL,
+              '2099-01-01T00:00:00.000Z',
+              '2026-07-25T18:00:00.000Z',
+              '2026-07-25T17:00:00.000Z'
+            );
+        `);
+
+        await expect(
+          applyHostedInboundMessageContentRetentionRearm(client, 1),
+        ).rejects.toThrow(/refused 2 persisted snapshots/u);
+
+        const unchanged = await readWorkspaceRows(client);
+        expect(unchanged.map(({ version }) => version)).toEqual(["2", "4", "9"]);
+
+        const result = await applyHostedInboundMessageContentRetentionRearm(
+          client,
+          2,
+        );
+        expect(result).toEqual({
+          rearmedAt: `${transactionTimestamp}Z`,
+          rearmedCount: 2,
+          snapshotCount: 2,
+        });
+
+        const staleCheckpoint = await client.query(`

--- a/.github/pr936-retention-safety-fix/part-05.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-05.pyfrag
@@ -1,0 +1,110 @@
+          UPDATE "hosted_workspace"
+          SET
+            "inbox_media_retention_wake_at" = NULL,
+            "checkpointed_at" = '2026-07-26T15:00:00.000Z',
+            "version" = "version" + 1
+          WHERE "user_id" = 'snapshot-missing-wake'
+            AND "version" = 9
+        `);
+        expect(staleCheckpoint.rowCount).toBe(0);
+
+        expect(await readWorkspaceRows(client)).toEqual([
+          {
+            checkpointedAt: "2026-07-25T17:00:00.000",
+            signalAttemptedAt: "2026-07-25T18:00:00.000",
+            userId: "no-snapshot",
+            version: "2",
+            wakeAt: "2099-01-01T00:00:00.000",
+          },
+          {
+            checkpointedAt: "2026-07-25T17:00:00.000",
+            signalAttemptedAt: null,
+            userId: "snapshot-existing-wake",
+            version: "5",
+            wakeAt: transactionTimestamp,
+          },
+          {
+            checkpointedAt: "2026-07-25T17:00:00.000",
+            signalAttemptedAt: null,
+            userId: "snapshot-missing-wake",
+            version: "10",
+            wakeAt: transactionTimestamp,
+          },
+        ]);
+      } finally {
+        await client.query("ROLLBACK");
+        await client.end();
+      }
+    });
+  },
+);
+
+async function readWorkspaceRows(client: pg.Client): Promise<Array<{
+  checkpointedAt: string | null;
+  signalAttemptedAt: string | null;
+  userId: string;
+  version: string;
+  wakeAt: string | null;
+}>> {
+  const rows = await client.query<{
+    checkpointedAt: string | null;
+    signalAttemptedAt: string | null;
+    userId: string;
+    version: string;
+    wakeAt: string | null;
+  }>(`
+    SELECT
+      to_char(
+        "checkpointed_at",
+        'YYYY-MM-DD"T"HH24:MI:SS.MS'
+      ) AS "checkpointedAt",
+      to_char(
+        "inbox_media_retention_signal_attempted_at",
+        'YYYY-MM-DD"T"HH24:MI:SS.MS'
+      ) AS "signalAttemptedAt",
+      "user_id" AS "userId",
+      "version"::TEXT AS "version",
+      to_char(
+        "inbox_media_retention_wake_at",
+        'YYYY-MM-DD"T"HH24:MI:SS.MS'
+      ) AS "wakeAt"
+    FROM "hosted_workspace"
+    ORDER BY "user_id"
+  `);
+  return rows.rows;
+}
+
+function isClearlyLocalPostgresUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol.startsWith("postgres")
+      && ["127.0.0.1", "localhost", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+''',
+)
+
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''      skip_predeploy_e2e:
+        description: Skip predeploy hosted-local E2E gates
+        required: true
+        default: false
+        type: boolean
+''',
+    '''      skip_predeploy_e2e:
+        description: Skip predeploy hosted-local E2E gates
+        required: true
+        default: false
+        type: boolean
+      rearm_inbound_message_content_retention:
+        description: After a successful immediate production smoke, re-arm persisted snapshots for phase-one message-content retention
+        required: true
+        default: false
+        type: boolean
+      inbound_message_content_retention_max_snapshots:
+        description: Confirmed maximum persisted-snapshot count that the existing five-per-hour retention owner can safely drain
+        required: false
+        default: "0"

--- a/.github/pr936-retention-safety-fix/part-06.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-06.pyfrag
@@ -1,0 +1,110 @@
+        type: string
+''',
+)
+
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''       - name: Verify checked-out deploy commit
+         run: |
+           set -euo pipefail
+           checked_out_sha="$(git rev-parse HEAD)"
+           echo "Deploy commit SHA: ${checked_out_sha}"
+           echo "Expected GitHub SHA: ${GITHUB_SHA}"
+           if [[ "${checked_out_sha}" != "${GITHUB_SHA}" ]]; then
+             echo "Checked-out commit does not match the validated deploy commit." >&2
+             exit 1
+           fi
+'''.replace('       -', '      -'),
+    '''      - name: Verify checked-out deploy commit
+        run: |
+          set -euo pipefail
+          checked_out_sha="$(git rev-parse HEAD)"
+          echo "Deploy commit SHA: ${checked_out_sha}"
+          echo "Expected GitHub SHA: ${GITHUB_SHA}"
+          if [[ "${checked_out_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "Checked-out commit does not match the validated deploy commit." >&2
+            exit 1
+          fi
+
+      - name: Validate inbound-message content-retention rearm
+        if: ${{ inputs.rearm_inbound_message_content_retention }}
+        shell: bash
+        env:
+          RETENTION_REARM_CONTAINER_ROLLOUT: ${{ inputs.container_rollout }}
+          RETENTION_REARM_DEPLOY_WORKER: ${{ inputs.deploy_worker && 'true' || 'false' }}
+          RETENTION_REARM_ENVIRONMENT: ${{ inputs.environment }}
+          RETENTION_REARM_MAX_SNAPSHOTS: ${{ inputs.inbound_message_content_retention_max_snapshots }}
+          RETENTION_REARM_SKIP_PREDEPLOY_E2E: ${{ inputs.skip_predeploy_e2e && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if [[ "${RETENTION_REARM_ENVIRONMENT}" != "production" ]]; then
+            echo "Inbound-message content-retention rearm is production-only." >&2
+            exit 1
+          fi
+          if [[ "${RETENTION_REARM_DEPLOY_WORKER}" != "true" ]]; then
+            echo "Retention rearm requires deploying and smoking the Worker in the same job." >&2
+            exit 1
+          fi
+          if [[ "${RETENTION_REARM_CONTAINER_ROLLOUT}" != "immediate" ]]; then
+            echo "Retention rearm requires container_rollout=immediate." >&2
+            exit 1
+          fi
+          if [[ "${RETENTION_REARM_SKIP_PREDEPLOY_E2E}" != "false" ]]; then
+            echo "Retention rearm cannot skip the predeploy E2E gates." >&2
+            exit 1
+          fi
+          if ! [[ "${RETENTION_REARM_MAX_SNAPSHOTS}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Retention rearm requires a positive confirmed snapshot-capacity ceiling." >&2
+            exit 1
+          fi
+''',
+)
+
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''      - name: Smoke test deployed endpoints
+        if: ${{ inputs.deploy_worker }}
+        env:
+          HOSTED_EXECUTION_SMOKE_VERSION_ID: ${{ steps.deploy.outputs.smoke_version_id }}
+          HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: ${{ secrets.HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK }}
+        run: pnpm --dir apps/cloudflare deploy:smoke
+''',
+    '''      - name: Smoke test deployed endpoints
+        if: ${{ inputs.deploy_worker }}
+        env:
+          HOSTED_EXECUTION_SMOKE_VERSION_ID: ${{ steps.deploy.outputs.smoke_version_id }}
+          HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: ${{ secrets.HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK }}
+        run: pnpm --dir apps/cloudflare deploy:smoke
+
+      - name: Rearm inbound-message content retention snapshots
+        if: ${{ inputs.rearm_inbound_message_content_retention }}
+        env:
+          DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}
+          MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS: ${{ inputs.inbound_message_content_retention_max_snapshots }}
+          MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1"
+          MURPH_RUN_INBOUND_MESSAGE_CONTENT_RETENTION_REARM: "1"
+        run: >-
+          pnpm --dir apps/web exec tsx
+          scripts/rearm-inbound-message-content-retention.ts
+''',
+)
+
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''          DEPLOY_SUMMARY_FINAL_VERSION_TRAFFIC: ${{ steps.deploy.outputs.final_version_traffic || 'not-deployed' }}
+          DEPLOY_SUMMARY_SMOKE_USER_ID: ${{ inputs.smoke_user_id || 'not-set' }}
+''',
+    '''          DEPLOY_SUMMARY_FINAL_VERSION_TRAFFIC: ${{ steps.deploy.outputs.final_version_traffic || 'not-deployed' }}
+          DEPLOY_SUMMARY_RETENTION_REARM: ${{ inputs.rearm_inbound_message_content_retention && 'requested-after-smoke' || 'not-requested' }}
+          DEPLOY_SUMMARY_RETENTION_REARM_MAX_SNAPSHOTS: ${{ inputs.inbound_message_content_retention_max_snapshots }}
+          DEPLOY_SUMMARY_SMOKE_USER_ID: ${{ inputs.smoke_user_id || 'not-set' }}
+''',
+)
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''            printf -- '- Deployed versions: `%s`\\n' "${DEPLOY_SUMMARY_FINAL_VERSION_TRAFFIC}"
+            printf -- '- Smoke user id: `%s`\\n' "${DEPLOY_SUMMARY_SMOKE_USER_ID}"
+''',
+    '''            printf -- '- Deployed versions: `%s`\\n' "${DEPLOY_SUMMARY_FINAL_VERSION_TRAFFIC}"
+            printf -- '- Message-content retention rearm: `%s`\\n' "${DEPLOY_SUMMARY_RETENTION_REARM}"
+            printf -- '- Confirmed retention snapshot ceiling: `%s`\\n' "${DEPLOY_SUMMARY_RETENTION_REARM_MAX_SNAPSHOTS}"

--- a/.github/pr936-retention-safety-fix/part-07.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-07.pyfrag
@@ -1,0 +1,101 @@
+            printf -- '- Smoke user id: `%s`\\n' "${DEPLOY_SUMMARY_SMOKE_USER_ID}"
+''',
+)
+
+replace_once(
+    "apps/cloudflare/test/deploy-automation.test.ts",
+    '''      "skip_predeploy_e2e:",
+      "description: Skip predeploy hosted-local E2E gates",
+''',
+    '''      "skip_predeploy_e2e:",
+      "description: Skip predeploy hosted-local E2E gates",
+      "rearm_inbound_message_content_retention:",
+      "description: After a successful immediate production smoke, re-arm persisted snapshots for phase-one message-content retention",
+      "inbound_message_content_retention_max_snapshots:",
+      "name: Validate inbound-message content-retention rearm",
+      "name: Rearm inbound-message content retention snapshots",
+      "DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}",
+      'MURPH_RUN_INBOUND_MESSAGE_CONTENT_RETENTION_REARM: "1"',
+      "scripts/rearm-inbound-message-content-retention.ts",
+''',
+)
+replace_once(
+    "apps/cloudflare/test/deploy-automation.test.ts",
+    '''    expect(smokeMaxWaitMs).toBeLessThan(deployTimeoutMinutes * 60 * 1000);
+
+    expect(readWorkflowJobBlock(workflow, "codex-cache-prefix-gate")).toContain(
+''',
+    '''    expect(smokeMaxWaitMs).toBeLessThan(deployTimeoutMinutes * 60 * 1000);
+    expect(workflow.indexOf("name: Smoke test deployed endpoints")).toBeLessThan(
+      workflow.indexOf("name: Rearm inbound-message content retention snapshots"),
+    );
+
+    expect(readWorkflowJobBlock(workflow, "codex-cache-prefix-gate")).toContain(
+''',
+)
+
+replace_once(
+    "apps/cloudflare/DEPLOY.md",
+    '''1. Deploy the Cloudflare Worker and stamping-capable runner bundle with
+   `container_rollout=immediate`. Drain old warm bundles, prove the deployed
+   fingerprint, and verify that newly written user transcript entries carry
+   `contentReceivedAt`. This Worker/runner version is also the rollout floor:
+   its ambiguous-completion recovery requires both a workspace-version advance
+   and a changed checkpoint timestamp before it releases a runtime fence.
+2. Before the Web migration, count persisted workspace snapshots and compare
+   the aggregate with the existing retention-cron capacity of five snapshots
+   per successful hourly run plus an explicit full-run signal-failure
+   allowance. Stop if that queue cannot drain safely in the rollout window; do
+   not add a second dispatcher as part of this release.
+3. Record the verified runner-convergence instant, then deploy Web with the
+   additive mailbox retention columns. The phase-one migration re-arms every
+   persisted workspace snapshot once, advances the workspace CAS version, and
+   leaves checkpoint time unchanged. A runtime that read the pre-rearm version
+   must conflict and retry instead of clearing the wake; the Worker must not
+   treat that migration-only version advance as runtime progress. Monitor the
+   existing cron until no due snapshot remains; each restored runtime scrubs
+   receipt-backed captures, parser output, projections, inputs, and stamped
+   transcripts while preserving every unstamped legacy transcript entry.
+   Phase one is incomplete until the queue reaches zero.
+4. Keep legacy unstamped transcript entries intact for 14 complete days after
+''',
+    '''1. Merge and allow the normal Vercel production predeploy to add the two
+   nullable mailbox-retirement columns. That migration is expand-only and must
+   not wake or version any workspace, so it is safe while the prior runner is
+   still draining.
+2. Count persisted workspace snapshots and compare the aggregate with the
+   existing retention-cron capacity of five snapshots per successful hourly
+   run plus an explicit full-run signal-failure allowance. Choose a hard
+   capacity ceiling at or above the observed count and below the proven drain
+   budget. Stop if the queue cannot drain safely; do not add a second dispatcher
+   as part of this release.
+3. From the exact protected `main` commit, dispatch the Cloudflare production
+   workflow with `deploy_worker=true`, `container_rollout=immediate`,
+   `skip_predeploy_e2e=false`,
+   `rearm_inbound_message_content_retention=true`, and the confirmed capacity
+   ceiling. The workflow first deploys and smokes the stamping-capable runner;
+   only after that smoke succeeds does the same production job take the direct
+   database lock and re-arm persisted snapshots. A failed deploy, failed smoke,
+   missing direct database secret, or exceeded capacity leaves every workspace
+   untouched.
+4. Record the successful post-smoke rearm instant as runner convergence. The
+   rearm advances the existing workspace CAS version, clears the prior signal
+   attempt, and leaves checkpoint time unchanged. A runtime that read the
+   pre-rearm version must conflict and retry instead of clearing the wake; the
+   Worker must not treat that version-only advance as runtime progress. Monitor
+   the existing cron until no due snapshot remains; each restored runtime
+   scrubs receipt-backed captures, parser output, projections, inputs, and
+   stamped transcripts while preserving every unstamped legacy transcript
+   entry. Phase one is incomplete until the queue reaches zero.
+5. Keep legacy unstamped transcript entries intact for 14 complete days after
+''',
+)
+replace_once(
+    "apps/cloudflare/DEPLOY.md",
+    '''5. Only after both gates, ship a separate phase-two migration that
+''',
+    '''6. Only after both gates, ship a separate phase-two migration that
+''',
+)
+
+print("Applied PR #936 retention rollout safety fix.")

--- a/.github/pr936-retention-safety-fix/part-08.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-08.pyfrag
@@ -1,0 +1,104 @@
+
+replace_once(
+    "apps/web/scripts/rearm-inbound-message-content-retention.ts",
+    '''export async function runHostedInboundMessageContentRetentionRearmIfNeeded(
+''',
+    '''export async function assertHostedInboundMessageContentRetentionSchema(
+  database: HostedInboundMessageContentRetentionRearmDatabase,
+): Promise<void> {
+  const result = await database.query<{
+    columnName: string;
+    isNullable: string;
+  }>(`
+    SELECT
+      column_name AS "columnName",
+      is_nullable AS "isNullable"
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'hosted_mailbox_item'
+      AND column_name IN ('content_retired_at', 'retention_disposition')
+    ORDER BY column_name
+  `);
+  const expected = [
+    { columnName: "content_retired_at", isNullable: "YES" },
+    { columnName: "retention_disposition", isNullable: "YES" },
+  ];
+  if (JSON.stringify(result.rows) !== JSON.stringify(expected)) {
+    throw new Error(
+      "Inbound message-content retention mailbox columns are missing or incompatible; deploy the expand-only Web migration before rearming snapshots.",
+    );
+  }
+}
+
+export async function runHostedInboundMessageContentRetentionRearmIfNeeded(
+''',
+)
+
+replace_once(
+    "apps/web/scripts/rearm-inbound-message-content-retention.ts",
+    '''      if (lock.rows[0]?.acquired !== true) {
+        throw new Error(
+          "Another inbound message-content retention rearm already owns the database lock.",
+        );
+      }
+
+      const result = await applyHostedInboundMessageContentRetentionRearm(
+''',
+    '''      if (lock.rows[0]?.acquired !== true) {
+        throw new Error(
+          "Another inbound message-content retention rearm already owns the database lock.",
+        );
+      }
+      await assertHostedInboundMessageContentRetentionSchema(client);
+
+      const result = await applyHostedInboundMessageContentRetentionRearm(
+''',
+)
+
+replace_once(
+    "apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts",
+    '''import {
+  applyHostedInboundMessageContentRetentionRearm,
+  readHostedInboundMessageContentRetentionRearmMaxSnapshots,
+} from "../scripts/rearm-inbound-message-content-retention";
+''',
+    '''import {
+  applyHostedInboundMessageContentRetentionRearm,
+  assertHostedInboundMessageContentRetentionSchema,
+  readHostedInboundMessageContentRetentionRearmMaxSnapshots,
+} from "../scripts/rearm-inbound-message-content-retention";
+''',
+)
+
+replace_once(
+    "apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts",
+    '''  it("requires an explicit positive capacity ceiling", () => {
+''',
+    '''  it("refuses to rearm before the expand-only mailbox schema is present", async () => {
+    await expect(
+      assertHostedInboundMessageContentRetentionSchema({
+        async query() {
+          return { rows: [] };
+        },
+      }),
+    ).rejects.toThrow(/deploy the expand-only Web migration/u);
+
+    await expect(
+      assertHostedInboundMessageContentRetentionSchema({
+        async query() {
+          return {
+            rows: [
+              { columnName: "content_retired_at", isNullable: "YES" },
+              { columnName: "retention_disposition", isNullable: "YES" },
+            ],
+          };
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("requires an explicit positive capacity ceiling", () => {
+''',
+)
+
+print("Added pre-rearm mailbox schema proof.")

--- a/.github/pr936-retention-safety-fix/part-08.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-08.pyfrag
@@ -80,7 +80,7 @@ replace_once(
         async query() {
           return { rows: [] };
         },
-      }),
+      } as never),
     ).rejects.toThrow(/deploy the expand-only Web migration/u);
 
     await expect(
@@ -93,7 +93,7 @@ replace_once(
             ],
           };
         },
-      }),
+      } as never),
     ).resolves.toBeUndefined();
   });
 

--- a/.github/pr936-retention-safety-fix/part-09.pyfrag
+++ b/.github/pr936-retention-safety-fix/part-09.pyfrag
@@ -1,0 +1,124 @@
+
+replace_once(
+    ".github/workflows/deploy-cloudflare-hosted.yml",
+    '''      - name: Rearm inbound-message content retention snapshots
+        if: ${{ inputs.rearm_inbound_message_content_retention }}
+        env:
+          DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}
+          MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS: ${{ inputs.inbound_message_content_retention_max_snapshots }}
+          MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1"
+          MURPH_RUN_INBOUND_MESSAGE_CONTENT_RETENTION_REARM: "1"
+        run: >-
+          pnpm --dir apps/web exec tsx
+          scripts/rearm-inbound-message-content-retention.ts
+''',
+    '''      - name: Wait for prior runner containers to become impossible
+        if: ${{ inputs.rearm_inbound_message_content_retention }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          generated_config="apps/cloudflare/.deploy/wrangler.generated.jsonc"
+          rollout_grace_seconds="$(node - "${generated_config}" <<'NODE'
+          const fs = require("node:fs");
+          const configPath = process.argv[2];
+          const text = fs.readFileSync(configPath, "utf8");
+          const runnerStart = text.indexOf('"class_name": "RunnerContainer"');
+          const smokeStart = text.indexOf('"class_name": "DeploySmokeRunnerContainer"');
+          if (runnerStart < 0 || smokeStart <= runnerStart) {
+            throw new Error("Generated deploy config is missing the user runner container block.");
+          }
+          const runnerBlock = text.slice(runnerStart, smokeStart);
+          const match = runnerBlock.match(/"rollout_active_grace_period"\s*:\s*(\d+)/u);
+          if (!match) {
+            throw new Error("Generated deploy config is missing the user runner rollout grace.");
+          }
+          const value = Number(match[1]);
+          if (!Number.isSafeInteger(value) || value < 0 || value > 3600) {
+            throw new Error("Generated user runner rollout grace is outside the audited bound.");
+          }
+          process.stdout.write(String(value));
+          NODE
+          )"
+          # Cloudflare sends SIGTERM only after the configured active grace and
+          # permits up to 15 more minutes before SIGKILL. Waiting through both
+          # bounds plus one minute of scheduling headroom makes it impossible
+          # for a pre-retention image to accept the newly rearmed wake.
+          shutdown_backstop_seconds=900
+          scheduling_headroom_seconds=60
+          convergence_wait_seconds=$((
+            rollout_grace_seconds
+            + shutdown_backstop_seconds
+            + scheduling_headroom_seconds
+          ))
+          echo "Waiting ${convergence_wait_seconds}s for complete RunnerContainer convergence."
+          sleep "${convergence_wait_seconds}"
+
+      - name: Rearm inbound-message content retention snapshots
+        if: ${{ inputs.rearm_inbound_message_content_retention }}
+        env:
+          DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}
+          MURPH_INBOUND_MESSAGE_CONTENT_RETENTION_MAX_SNAPSHOTS: ${{ inputs.inbound_message_content_retention_max_snapshots }}
+          MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1"
+          MURPH_RUN_INBOUND_MESSAGE_CONTENT_RETENTION_REARM: "1"
+        run: >-
+          pnpm --dir apps/web exec tsx
+          scripts/rearm-inbound-message-content-retention.ts
+''',
+)
+
+replace_once(
+    "apps/cloudflare/test/deploy-automation.test.ts",
+    '''      "name: Rearm inbound-message content retention snapshots",
+      "DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}",
+''',
+    '''      "name: Wait for prior runner containers to become impossible",
+      'shutdown_backstop_seconds=900',
+      'scheduling_headroom_seconds=60',
+      'rollout_active_grace_period',
+      "name: Rearm inbound-message content retention snapshots",
+      "DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}",
+''',
+)
+
+replace_once(
+    "apps/cloudflare/test/deploy-automation.test.ts",
+    '''    expect(workflow.indexOf("name: Smoke test deployed endpoints")).toBeLessThan(
+      workflow.indexOf("name: Rearm inbound-message content retention snapshots"),
+    );
+''',
+    '''    expect(workflow.indexOf("name: Smoke test deployed endpoints")).toBeLessThan(
+      workflow.indexOf("name: Wait for prior runner containers to become impossible"),
+    );
+    expect(
+      workflow.indexOf("name: Wait for prior runner containers to become impossible"),
+    ).toBeLessThan(
+      workflow.indexOf("name: Rearm inbound-message content retention snapshots"),
+    );
+''',
+)
+
+replace_once(
+    "apps/cloudflare/DEPLOY.md",
+    '''   workflow with `deploy_worker=true`, `container_rollout=immediate`,
+   `skip_predeploy_e2e=false`,
+   `rearm_inbound_message_content_retention=true`, and the confirmed capacity
+   ceiling. The workflow first deploys and smokes the stamping-capable runner;
+   only after that smoke succeeds does the same production job take the direct
+   database lock and re-arm persisted snapshots. A failed deploy, failed smoke,
+   missing direct database secret, or exceeded capacity leaves every workspace
+   untouched.
+''',
+    '''   workflow with `deploy_worker=true`, `container_rollout=immediate`,
+   `skip_predeploy_e2e=false`,
+   `rearm_inbound_message_content_retention=true`, and the confirmed capacity
+   ceiling. The workflow first deploys and smokes the stamping-capable runner,
+   then waits through the generated user-runner active grace, Cloudflare's full
+   15-minute SIGTERM-to-SIGKILL backstop, and scheduling headroom. Only after a
+   pre-retention runner image can no longer accept work does the same production
+   job take the direct database lock and re-arm persisted snapshots. A failed
+   deploy, failed smoke, malformed rollout config, missing direct database
+   secret, or exceeded capacity leaves every workspace untouched.
+''',
+)
+
+print("Added full Cloudflare runner-convergence gate.")

--- a/.github/workflows/pr936-merge-resolution.yml
+++ b/.github/workflows/pr936-merge-resolution.yml
@@ -65,14 +65,28 @@ jobs:
           fetch-depth: 0
           path: murph
 
-      - name: Apply audited rollout fix
+      - name: Merge current main and apply audited rollout fix
         shell: bash
         run: |
           set -euo pipefail
           cd murph
           expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          expected_main="d9fa35dd037fb60219c2a693de6832058ef30773"
           if [[ "$(git rev-parse HEAD)" != "${expected_head}" ]]; then
             echo "PR #936 moved; refusing to apply a stale safety patch." >&2
+            exit 1
+          fi
+          git fetch origin main
+          if [[ "$(git rev-parse origin/main)" != "${expected_main}" ]]; then
+            echo "main moved; refusing to verify against a stale base." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git merge --no-commit --no-ff origin/main
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            echo "Unexpected conflicts while integrating current main." >&2
+            git diff --name-only --diff-filter=U >&2
             exit 1
           fi
           cat ../helper/.github/pr936-retention-safety-fix/part-*.pyfrag > "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
@@ -134,7 +148,7 @@ jobs:
           set -euo pipefail
           cd murph
           expected_head="8f98e7a667567956156907663cad4d203e91b153"
-          expected_main="9ec9db90390e8dd2f7968905e9fcf97e1eeb11a2"
+          expected_main="d9fa35dd037fb60219c2a693de6832058ef30773"
           git fetch origin main message-retention-14d
           if [[ "$(git rev-parse origin/message-retention-14d)" != "${expected_head}" ]]; then
             echo "PR #936 advanced during verification; refusing to overwrite it." >&2
@@ -144,8 +158,6 @@ jobs:
             echo "main advanced during verification; refusing to push against a stale base." >&2
             exit 1
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
             .github/workflows/deploy-cloudflare-hosted.yml \
             apps/cloudflare/DEPLOY.md \
@@ -155,7 +167,15 @@ jobs:
             apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts \
             apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
           git diff --cached --check
-          git commit -m "Make retention rollout fail closed"
+          git commit -m "Merge current main and make retention rollout fail closed"
+          if [[ "$(git rev-parse HEAD^1)" != "${expected_head}" ]]; then
+            echo "Unexpected first merge parent." >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD^2)" != "${expected_main}" ]]; then
+            echo "Unexpected second merge parent." >&2
+            exit 1
+          fi
           git push origin HEAD:message-retention-14d
 
       - name: Report verification result

--- a/.github/workflows/pr936-merge-resolution.yml
+++ b/.github/workflows/pr936-merge-resolution.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - agent/pr936-retention-safety-fix-20260727
+      - agent/pr936-merge-audit-20260727
 
 concurrency:
   group: pr936-retention-safety-fix

--- a/.github/workflows/pr936-merge-resolution.yml
+++ b/.github/workflows/pr936-merge-resolution.yml
@@ -1,0 +1,177 @@
+name: PR 936 Merge Resolution
+
+on:
+  push:
+    branches:
+      - agent/pr936-retention-safety-fix-20260727
+
+concurrency:
+  group: pr936-retention-safety-fix
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  fix:
+    name: Apply, verify, and push retention rollout safety fix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: murph_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d murph_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Report verification run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body="PR #936 retention-safety verification started: ${RUN_URL} (run ${GITHUB_RUN_ID}, attempt ${GITHUB_RUN_ATTEMPT})."
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/1056/comments" \
+            --data "$(node -e 'process.stdout.write(JSON.stringify({body: process.argv[1]}))' "${body}")" \
+            >/dev/null
+
+      - name: Check out safety-fix helper
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: agent/pr936-retention-safety-fix-20260727
+          path: helper
+          persist-credentials: false
+
+      - name: Check out PR 936 head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: message-retention-14d
+          fetch-depth: 0
+          path: murph
+
+      - name: Apply audited rollout fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd murph
+          expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          if [[ "$(git rev-parse HEAD)" != "${expected_head}" ]]; then
+            echo "PR #936 moved; refusing to apply a stale safety patch." >&2
+            exit 1
+          fi
+          cat ../helper/.github/pr936-retention-safety-fix/part-*.pyfrag > "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
+          python "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
+          git diff --check
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: murph/.nvmrc
+          cache: pnpm
+          cache-dependency-path: murph/pnpm-lock.yaml
+
+      - name: Install exact dependencies
+        working-directory: murph
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Web generated state
+        working-directory: murph
+        run: pnpm --dir apps/web prisma:generate
+
+      - name: Run Postgres migration and rearm proofs
+        working-directory: murph
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/murph_test
+          MURPH_TEST_POSTGRES_CONCURRENCY: "1"
+        run: >-
+          pnpm exec vitest run
+          --config apps/web/vitest.workspace.ts
+          --no-coverage
+          apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
+          apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts
+          apps/web/test/hosted-retention-cleanup.test.ts
+          apps/web/test/hosted-orchestration-signal-runtime.test.ts
+
+      - name: Run deploy workflow guard
+        working-directory: murph
+        run: >-
+          pnpm exec vitest run
+          --config apps/cloudflare/vitest.node.workspace.ts
+          --no-coverage
+          apps/cloudflare/test/deploy-automation.test.ts
+
+      - name: Typecheck affected apps
+        working-directory: murph
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/web typecheck
+          pnpm --dir apps/cloudflare typecheck
+
+      - name: Commit and push verified safety fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd murph
+          expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          expected_main="9ec9db90390e8dd2f7968905e9fcf97e1eeb11a2"
+          git fetch origin main message-retention-14d
+          if [[ "$(git rev-parse origin/message-retention-14d)" != "${expected_head}" ]]; then
+            echo "PR #936 advanced during verification; refusing to overwrite it." >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse origin/main)" != "${expected_main}" ]]; then
+            echo "main advanced during verification; refusing to push against a stale base." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            .github/workflows/deploy-cloudflare-hosted.yml \
+            apps/cloudflare/DEPLOY.md \
+            apps/cloudflare/test/deploy-automation.test.ts \
+            apps/web/prisma/migrations/20260725190000_hosted_mailbox_content_retention/migration.sql \
+            apps/web/scripts/rearm-inbound-message-content-retention.ts \
+            apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts \
+            apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
+          git diff --cached --check
+          git commit -m "Make retention rollout fail closed"
+          git push origin HEAD:message-retention-14d
+
+      - name: Report verification result
+        if: ${{ always() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body="PR #936 retention-safety verification finished with ${JOB_STATUS}: ${RUN_URL} (run ${GITHUB_RUN_ID}, attempt ${GITHUB_RUN_ATTEMPT})."
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/1056/comments" \
+            --data "$(node -e 'process.stdout.write(JSON.stringify({body: process.argv[1]}))' "${body}")" \
+            >/dev/null

--- a/.github/workflows/pr936-retention-safety-fix.yml
+++ b/.github/workflows/pr936-retention-safety-fix.yml
@@ -4,12 +4,21 @@ on:
   push:
     branches:
       - agent/pr936-retention-safety-fix-20260727
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   fix:
+    if: ${{ github.event_name == 'push' || github.head_ref == 'agent/pr936-retention-safety-fix-20260727' }}
     name: Apply, verify, and push retention rollout safety fix
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -134,5 +143,3 @@ jobs:
           git diff --cached --check
           git commit -m "Make retention rollout fail closed"
           git push origin HEAD:message-retention-14d
-
-# Triggered after the helper PR was opened so the branch workflow is visible.

--- a/.github/workflows/pr936-retention-safety-fix.yml
+++ b/.github/workflows/pr936-retention-safety-fix.yml
@@ -12,8 +12,13 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: pr936-retention-safety-fix
+  cancel-in-progress: true
+
 permissions:
   contents: write
+  issues: write
   pull-requests: read
 
 jobs:
@@ -37,6 +42,23 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
+      - name: Report verification run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body="PR #936 retention-safety verification started: ${RUN_URL} (run ${GITHUB_RUN_ID}, attempt ${GITHUB_RUN_ATTEMPT})."
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/1056/comments" \
+            --data "$(node -e 'process.stdout.write(JSON.stringify({body: process.argv[1]}))' "${body}")" \
+            >/dev/null
+
       - name: Check out safety-fix helper
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -143,3 +165,22 @@ jobs:
           git diff --cached --check
           git commit -m "Make retention rollout fail closed"
           git push origin HEAD:message-retention-14d
+
+      - name: Report verification result
+        if: ${{ always() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body="PR #936 retention-safety verification finished with ${JOB_STATUS}: ${RUN_URL} (run ${GITHUB_RUN_ID}, attempt ${GITHUB_RUN_ATTEMPT})."
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/1056/comments" \
+            --data "$(node -e 'process.stdout.write(JSON.stringify({body: process.argv[1]}))' "${body}")" \
+            >/dev/null

--- a/.github/workflows/pr936-retention-safety-fix.yml
+++ b/.github/workflows/pr936-retention-safety-fix.yml
@@ -1,0 +1,136 @@
+name: PR 936 Retention Safety Fix
+
+on:
+  push:
+    branches:
+      - agent/pr936-retention-safety-fix-20260727
+
+permissions:
+  contents: write
+
+jobs:
+  fix:
+    name: Apply, verify, and push retention rollout safety fix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: murph_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d murph_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Check out safety-fix helper
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: agent/pr936-retention-safety-fix-20260727
+          path: helper
+          persist-credentials: false
+
+      - name: Check out PR 936 head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: message-retention-14d
+          fetch-depth: 0
+          path: murph
+
+      - name: Apply audited rollout fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd murph
+          expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          if [[ "$(git rev-parse HEAD)" != "${expected_head}" ]]; then
+            echo "PR #936 moved; refusing to apply a stale safety patch." >&2
+            exit 1
+          fi
+          cat ../helper/.github/pr936-retention-safety-fix/part-*.pyfrag > "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
+          python "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
+          git diff --check
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: murph/.nvmrc
+          cache: pnpm
+          cache-dependency-path: murph/pnpm-lock.yaml
+
+      - name: Install exact dependencies
+        working-directory: murph
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Web generated state
+        working-directory: murph
+        run: pnpm --dir apps/web prisma:generate
+
+      - name: Run Postgres migration and rearm proofs
+        working-directory: murph
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/murph_test
+          MURPH_TEST_POSTGRES_CONCURRENCY: "1"
+        run: >-
+          pnpm exec vitest run
+          --config apps/web/vitest.workspace.ts
+          --no-coverage
+          apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
+          apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts
+          apps/web/test/hosted-retention-cleanup.test.ts
+          apps/web/test/hosted-orchestration-signal-runtime.test.ts
+
+      - name: Run deploy workflow guard
+        working-directory: murph
+        run: >-
+          pnpm exec vitest run
+          --config apps/cloudflare/vitest.node.workspace.ts
+          --no-coverage
+          apps/cloudflare/test/deploy-automation.test.ts
+
+      - name: Typecheck affected apps
+        working-directory: murph
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/web typecheck
+          pnpm --dir apps/cloudflare typecheck
+
+      - name: Commit and push verified safety fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd murph
+          expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          expected_main="9ec9db90390e8dd2f7968905e9fcf97e1eeb11a2"
+          git fetch origin main message-retention-14d
+          if [[ "$(git rev-parse origin/message-retention-14d)" != "${expected_head}" ]]; then
+            echo "PR #936 advanced during verification; refusing to overwrite it." >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse origin/main)" != "${expected_main}" ]]; then
+            echo "main advanced during verification; refusing to push against a stale base." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            .github/workflows/deploy-cloudflare-hosted.yml \
+            apps/cloudflare/DEPLOY.md \
+            apps/cloudflare/test/deploy-automation.test.ts \
+            apps/web/prisma/migrations/20260725190000_hosted_mailbox_content_retention/migration.sql \
+            apps/web/scripts/rearm-inbound-message-content-retention.ts \
+            apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts \
+            apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
+          git diff --cached --check
+          git commit -m "Make retention rollout fail closed"
+          git push origin HEAD:message-retention-14d

--- a/.github/workflows/pr936-retention-safety-fix.yml
+++ b/.github/workflows/pr936-retention-safety-fix.yml
@@ -73,14 +73,28 @@ jobs:
           fetch-depth: 0
           path: murph
 
-      - name: Apply audited rollout fix
+      - name: Merge current main and apply audited rollout fix
         shell: bash
         run: |
           set -euo pipefail
           cd murph
           expected_head="8f98e7a667567956156907663cad4d203e91b153"
+          expected_main="d9fa35dd037fb60219c2a693de6832058ef30773"
           if [[ "$(git rev-parse HEAD)" != "${expected_head}" ]]; then
             echo "PR #936 moved; refusing to apply a stale safety patch." >&2
+            exit 1
+          fi
+          git fetch origin main
+          if [[ "$(git rev-parse origin/main)" != "${expected_main}" ]]; then
+            echo "main moved; refusing to verify against a stale base." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git merge --no-commit --no-ff origin/main
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            echo "Unexpected conflicts while integrating current main." >&2
+            git diff --name-only --diff-filter=U >&2
             exit 1
           fi
           cat ../helper/.github/pr936-retention-safety-fix/part-*.pyfrag > "${RUNNER_TEMP}/pr936-retention-safety-fix.py"
@@ -142,7 +156,7 @@ jobs:
           set -euo pipefail
           cd murph
           expected_head="8f98e7a667567956156907663cad4d203e91b153"
-          expected_main="9ec9db90390e8dd2f7968905e9fcf97e1eeb11a2"
+          expected_main="d9fa35dd037fb60219c2a693de6832058ef30773"
           git fetch origin main message-retention-14d
           if [[ "$(git rev-parse origin/message-retention-14d)" != "${expected_head}" ]]; then
             echo "PR #936 advanced during verification; refusing to overwrite it." >&2
@@ -152,8 +166,6 @@ jobs:
             echo "main advanced during verification; refusing to push against a stale base." >&2
             exit 1
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
             .github/workflows/deploy-cloudflare-hosted.yml \
             apps/cloudflare/DEPLOY.md \
@@ -163,7 +175,15 @@ jobs:
             apps/web/test/hosted-inbound-message-content-retention-rearm-postgres.test.ts \
             apps/web/test/hosted-mailbox-content-retention-migration-postgres.test.ts
           git diff --cached --check
-          git commit -m "Make retention rollout fail closed"
+          git commit -m "Merge current main and make retention rollout fail closed"
+          if [[ "$(git rev-parse HEAD^1)" != "${expected_head}" ]]; then
+            echo "Unexpected first merge parent." >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD^2)" != "${expected_main}" ]]; then
+            echo "Unexpected second merge parent." >&2
+            exit 1
+          fi
           git push origin HEAD:message-retention-14d
 
       - name: Report verification result

--- a/.github/workflows/pr936-retention-safety-fix.yml
+++ b/.github/workflows/pr936-retention-safety-fix.yml
@@ -134,3 +134,5 @@ jobs:
           git diff --cached --check
           git commit -m "Make retention rollout fail closed"
           git push origin HEAD:message-retention-14d
+
+# Triggered after the helper PR was opened so the branch workflow is visible.


### PR DESCRIPTION
Temporary same-repository helper used only to apply and verify the fail-closed rollout correction for PR #936. The workflow checks out the exact PR head, changes the Prisma migration to expand-only, moves snapshot rearming behind the successful immediate Cloudflare production smoke, runs Postgres destructive-path proofs plus affected typechecks, and pushes the verified commit directly to PR #936. No helper files will be merged; this PR will be closed after the target branch is updated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787793387&installation_model_id=19880&pr_number=1056&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1056&signature=81ffdd69ab71d5ed92f31614b8e6028f2edb2d0000690cda441b744a97935cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->