### PR TITLE
Fix delegated Blacksmith verification lifecycle

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-28-blacksmith-delegated-lifecycle.md
+++ b/agent-docs/exec-plans/active/2026-07-28-blacksmith-delegated-lifecycle.md
@@ -1,0 +1,39 @@
+# Blacksmith Delegated Lifecycle Repair
+
+## Goal
+
+Restore canonical Crabbox-backed Blacksmith verification by removing the
+unsupported generic lifecycle flag from the delegated provider invocation.
+
+## Constraints
+
+- Preserve the pinned Blacksmith provider, organization, ref, workflow, job,
+  trusted entrypoint, idle timeout, TTL, and secret-scrubbed environment.
+- Keep fresh one-shot behavior: no retained Testbox ID, `--keep`, or
+  `--keep-on-failure`.
+- Do not forward local environment values or credentials into Blacksmith.
+- Keep the correction limited to the dispatcher, its focused contract test, and
+  the owning verification documentation.
+
+## Plan
+
+1. Remove only the unsupported `--stop-after always` dispatcher arguments.
+2. Make the focused fake-provider test reject that flag and prove the retained
+   fresh, non-kept delegated invocation.
+3. Document Blacksmith's delegated lifecycle ownership and retained cleanup
+   bounds.
+4. Run focused and canonical verification, complete ReviewGPT review, and land
+   the change through the normal PR lane.
+
+## Verification
+
+- Focused verification-dispatch Vitest coverage.
+- `node --check scripts/verification-dispatch.mjs`
+- `pnpm test:diff` for the touched tooling, test, and documentation paths.
+- Preliminary specialist ReviewGPT and parent final review.
+
+## State
+
+Active. Minimal dispatcher, contract-test, and owner-documentation changes are
+implemented. Syntax checks, the 15-test focused contract suite, and canonical
+repo-internal `test:diff` (436 tests) pass. PR review is next.

--- a/agent-docs/exec-plans/completed/2026-07-28-blacksmith-delegated-lifecycle.md
+++ b/agent-docs/exec-plans/completed/2026-07-28-blacksmith-delegated-lifecycle.md
@@ -34,6 +34,12 @@ unsupported generic lifecycle flag from the delegated provider invocation.
 
 ## State
 
-Active. Minimal dispatcher, contract-test, and owner-documentation changes are
-implemented. Syntax checks, the 15-test focused contract suite, and canonical
-repo-internal `test:diff` (436 tests) pass. PR review is next.
+Complete. Minimal dispatcher, contract-test, and owner-documentation changes
+are implemented. Syntax checks, the 15-test focused contract suite, and
+canonical repo-internal `test:diff` (436 tests) pass. Preliminary specialist
+ReviewGPT returned `PASS` with no findings or patch artifact after checking the
+exact pushed head. Parent final review found no residual scope, safety, or proof
+gap.
+Status: completed
+Updated: 2026-07-28
+Completed: 2026-07-28

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -52,11 +52,14 @@ MURPH_VERIFY_EXECUTOR=crabbox pnpm verify:acceptance
 ```
 
 The forced executor creates a fresh one-shot Testbox through the fully pinned
-route. Its invocation always requests cleanup, a 10-minute idle timeout, and a
-45-minute maximum lease lifetime; the hydration workflow has a 50-minute
-last-resort ceiling. Do not leave the local waiter running concurrently, forward
-local environment values, bypass the canonical command, warm a lease separately,
-or return automatically to another unbounded local wait.
+route. Blacksmith owns the delegated run lifecycle and stops a fresh, non-kept
+Testbox after the command exits, so the invocation does not pass Crabbox's
+generic `--stop-after` flag. A 10-minute idle timeout and 45-minute maximum lease
+lifetime remain provider-side cleanup bounds; the hydration workflow has a
+50-minute last-resort ceiling. Do not leave the local waiter running
+concurrently, forward local environment values, bypass the canonical command,
+warm a lease separately, or return automatically to another unbounded local
+wait.
 Before delegation, satisfy the Git-state admission boundary, including fully
 staging any new non-ignored source or documentation file. If Crabbox cannot run
 because its CLIs, authentication, or capacity are unavailable, fail closed and

--- a/scripts/verification-dispatch.mjs
+++ b/scripts/verification-dispatch.mjs
@@ -142,8 +142,6 @@ export function buildCrabboxInvocation(request) {
     CRABBOX_IDLE_TIMEOUT,
     "--ttl",
     CRABBOX_TTL,
-    "--stop-after",
-    "always",
     "--label",
     `murph ${request.verificationCommand}`,
     "--timing-json",

--- a/scripts/verification-dispatch.test.ts
+++ b/scripts/verification-dispatch.test.ts
@@ -135,6 +135,12 @@ describe("verification dispatcher", () => {
         `  printf "%s\\n" "\${OPENAI_API_KEY-unset}" "\${STRIPE_SECRET_KEY-unset}" "\${GITHUB_TOKEN-unset}" "\${CUSTOM_PROVIDER_TOKEN-unset}" "\${CI-unset}" "\${NODE_OPTIONS-unset}" "\${CRABBOX_ENV_ALLOW-unset}" "\${CRABBOX_CONFIG-unset}" "\${MURPH_CRABBOX_PROFILE-unset}" "\${MURPH_CRABBOX_NO_FORWARD-unset}" > ${shellQuote(crabboxProbeCapturePath)}`,
         "  exit 0",
         "fi",
+        'for arg in "$@"; do',
+        '  if [ "$arg" = "--stop-after" ]; then',
+        '    printf "%s\\n" "blacksmith-testbox delegates run execution; --stop-after is not supported" >&2',
+        "    exit 2",
+        "  fi",
+        "done",
         `printf "%s\\n" "$@" > ${shellQuote(capturePath)}`,
         `printf "%s" "\${CRABBOX_ENV_ALLOW-unset}" > ${shellQuote(envCapturePath)}`,
         `printf "%s\\n" "\${OPENAI_API_KEY-unset}" "\${STRIPE_SECRET_KEY-unset}" "\${GITHUB_TOKEN-unset}" "\${CUSTOM_PROVIDER_TOKEN-unset}" "\${CI-unset}" "\${NODE_OPTIONS-unset}" > ${shellQuote(secretCapturePath)}`,
@@ -201,7 +207,9 @@ describe("verification dispatcher", () => {
     expect(flagValue(args, "--blacksmith-job")).toBe("hydrate");
     expect(flagValue(args, "--idle-timeout")).toBe("10m");
     expect(flagValue(args, "--ttl")).toBe("45m");
-    expect(flagValue(args, "--stop-after")).toBe("always");
+    expect(args).not.toContain("--stop-after");
+    expect(args).not.toContain("--keep");
+    expect(args).not.toContain("--keep-on-failure");
     expect(args).not.toContain("--id");
     expect(args).not.toContain("--pool");
     expect(args).not.toContain("--pool-return");


### PR DESCRIPTION
## Why this PR exists

Canonical Crabbox-backed verification currently fails before provisioning because delegated `blacksmith-testbox` execution rejects the generic `--stop-after` flag.

## User goal / user-visible behavior

Internal-only tooling change: an explicitly forced canonical verification command can provision a fresh Blacksmith Testbox and run to completion again. There is no product UX change. The command reports dispatcher selection immediately, then Blacksmith owns execution and terminal cleanup; provider/auth/capacity failures continue to fail closed with no local duplicate.

## Invariants

- Preserve the pinned provider, organization, ref, workflow, job, and trusted entrypoint.
- Preserve the 10-minute idle and 45-minute TTL cleanup bounds.
- Preserve fresh one-shot behavior with no ID, `--keep`, or `--keep-on-failure`.
- Keep the delegated environment scrubbed; no local credentials reach Blacksmith.

## Non-obvious affected surfaces

- Canonical `pnpm test:diff` and `pnpm verify:acceptance` calls when `MURPH_VERIFY_EXECUTOR=crabbox` is explicitly selected. The spawned-process contract test proves routing pins, cleanup bounds, fresh execution, and secret scrubbing.
- Blacksmith Testbox lifecycle ownership documentation. The focused fake provider rejects the same unsupported flag as the real delegated provider.

## Verification

- `node --check scripts/verification-dispatch.mjs`
- `node --experimental-strip-types --check scripts/verification-dispatch.test.ts`
- Focused dispatcher contract: 15/15 tests passed.
- Canonical `pnpm test:diff ...`: 30 files / 436 tests passed; dependency policy passed.

## Preliminary specialist lenses

- Coverage: applicable. Canonical `pnpm test:diff ...` passed; ReviewGPT found the spawned-process contract test directly covers the regression and retained invariants.
- Prompt: not applicable; no prompt surface changed.
- Frontend: not applicable; no rendered surface changed and no rendered evidence is required.
- Specialist outcome: PASS with no findings and no patch artifact at the exact candidate head.

## Change shape

Classification is by path and role; the execution plan and owner runbook are docs, the dispatcher is config/tooling, and the Vitest file is tests. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 9 | 1 |
| Docs | 53 | 5 |
| Config / tooling | 0 | 2 |
| Generated / other | 0 | 0 |
| **Total** | **62** | **8** |

ReviewGPT first-reviewed head: 19d2c3f334bf1b8ef5d46c339d61b881f97eb3f0