### PR TITLE
Correct R2 CopyObject integrity proof

### DIFF
--- a/apps/cloudflare/R2_BUNDLES_ENAM_MIGRATION.md
+++ b/apps/cloudflare/R2_BUNDLES_ENAM_MIGRATION.md
@@ -50,6 +50,12 @@ source moves.
   requests. Each request uses R2's required leading-slash source, the listed
   source ETag as a precondition, metadata `COPY`, and Standard storage. There
   is no `sync` heuristic or multipart path.
+- R2 does not implement `x-amz-checksum-algorithm` for `CopyObject`, and
+  SHA-256 `FULL_OBJECT` is not an implemented R2 checksum combination. For this
+  migration, a destination `ChecksumSHA256` returned after `CopyObject` is
+  diagnostic only. The representative proof streams both objects under their
+  exact ETags and requires both body digests and copied `encryptedsha256`
+  metadata to equal the canonical v2 snapshot reference.
 - Objects at the single-copy limit, non-Standard objects, and multipart or
   non-MD5 ETags fail closed, as does any object still staged under a
   lifecycle-managed prefix.
@@ -336,33 +342,122 @@ pnpm --dir apps/cloudflare deploy:smoke
 
 Before production, require all three proofs:
 
-1. HEAD the same representative v2 snapshot in both buckets and compare
-   length, ETag, custom metadata, supported HTTP metadata, stored SHA-256, and
-   checksum type.
+1. HEAD the same representative v2 snapshot in both buckets. Compare length,
+   ETag, custom metadata, supported HTTP metadata, every returned checksum
+   field other than `ChecksumSHA256`, and checksum type. Then stream both
+   objects under their exact ETags and require each body SHA-256 plus both
+   copied `encryptedsha256` metadata values to equal
+   `snapshotRef.archive.encryptedObjectSha256` from the canonical workspace.
+   Also require the source `ChecksumSHA256` to encode that canonical digest.
+   Do not compare the destination `ChecksumSHA256`: R2 does not implement the
+   checksum-selection field for `CopyObject`, and its reported destination
+   value is not the body-integrity authority for this copy.
 2. Cold-restore that copied snapshot through the staging Worker.
 3. Write and cold-restore a fresh staging checkpoint from ENAM.
 
-Enter the private object key without terminal echo. This emits no key or
-metadata; do not use shell tracing:
+Enter the private object key and the canonical reference's lowercase
+`archive.encryptedObjectSha256` without terminal echo. This emits no key,
+metadata, object bytes, or digest; do not use shell tracing:
 
 ```bash
 (
   set -euo pipefail
+  umask 077
   read -r -s SNAPSHOT_KEY
+  read -r -s EXPECTED_ENCRYPTED_SHA256
+  case "$EXPECTED_ENCRYPTED_SHA256" in
+    (''|*[!0-9a-f]*)
+      echo "Canonical encrypted object SHA-256 must be 64 lowercase hex characters." >&2
+      exit 1
+      ;;
+  esac
+  test "${#EXPECTED_ENCRYPTED_SHA256}" -eq 64
+
   R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
   head_snapshot() {
     AWS_ACCESS_KEY_ID="$R2_MIGRATION_ACCESS_KEY_ID" \
     AWS_SECRET_ACCESS_KEY="$R2_MIGRATION_SECRET_ACCESS_KEY" \
       aws s3api head-object --bucket "$1" --key "$SNAPSHOT_KEY" \
         --checksum-mode ENABLED --endpoint-url "$R2_ENDPOINT" --region auto \
-        --output json --no-cli-pager | \
-      jq -Sc '{CacheControl,ChecksumCRC32,ChecksumCRC32C,ChecksumSHA1,ChecksumSHA256,ChecksumType,ContentDisposition,ContentEncoding,ContentLanguage,ContentLength,ContentType,ETag,Expires,Metadata}'
+        --output json --no-cli-pager | jq -Sc '.'
   }
+  stable_copy_head() {
+    jq -Sc \
+      '{CacheControl,ChecksumCRC32,ChecksumCRC32C,ChecksumSHA1,ChecksumType,ContentDisposition,ContentEncoding,ContentLanguage,ContentLength,ContentType,ETag,Expires,Metadata}'
+  }
+  get_snapshot() {
+    AWS_ACCESS_KEY_ID="$R2_MIGRATION_ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$R2_MIGRATION_SECRET_ACCESS_KEY" \
+      aws s3api get-object --bucket "$1" --key "$SNAPSHOT_KEY" \
+        --if-match "$2" --endpoint-url "$R2_ENDPOINT" --region auto \
+        --no-cli-pager "$3" >/dev/null
+  }
+  hash_file() {
+    node -e '
+      const { createHash } = require("node:crypto");
+      const { createReadStream } = require("node:fs");
+      const hash = createHash("sha256");
+      const stream = createReadStream(process.argv[1]);
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("error", (error) => {
+        console.error(error.message);
+        process.exitCode = 1;
+      });
+      stream.on("end", () => process.stdout.write(hash.digest("hex")));
+    ' "$1"
+  }
+
   SOURCE_HEAD="$(head_snapshot "$PREVIEW_SOURCE_BUCKET")"
   DESTINATION_HEAD="$(head_snapshot "$PREVIEW_DESTINATION_BUCKET")"
   test -n "$SOURCE_HEAD"
   test -n "$DESTINATION_HEAD"
-  test "$SOURCE_HEAD" = "$DESTINATION_HEAD"
+  test "$(stable_copy_head <<<"$SOURCE_HEAD")" \
+    = "$(stable_copy_head <<<"$DESTINATION_HEAD")"
+
+  SOURCE_ETAG="$(jq -er '.ETag | strings | select(length > 0)' <<<"$SOURCE_HEAD")"
+  DESTINATION_ETAG="$(
+    jq -er '.ETag | strings | select(length > 0)' <<<"$DESTINATION_HEAD"
+  )"
+  test "$SOURCE_ETAG" = "$DESTINATION_ETAG"
+
+  SOURCE_METADATA_SHA256="$(
+    jq -er \
+      '.Metadata.encryptedsha256 | ascii_downcase | select(test("^[0-9a-f]{64}$"))' \
+      <<<"$SOURCE_HEAD"
+  )"
+  DESTINATION_METADATA_SHA256="$(
+    jq -er \
+      '.Metadata.encryptedsha256 | ascii_downcase | select(test("^[0-9a-f]{64}$"))' \
+      <<<"$DESTINATION_HEAD"
+  )"
+  test "$SOURCE_METADATA_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"
+  test "$DESTINATION_METADATA_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"
+
+  EXPECTED_CHECKSUM_BASE64="$(
+    node -e \
+      'process.stdout.write(Buffer.from(process.argv[1], "hex").toString("base64"))' \
+      "$EXPECTED_ENCRYPTED_SHA256"
+  )"
+  SOURCE_CHECKSUM_SHA256="$(
+    jq -er '.ChecksumSHA256 | strings | select(length > 0)' <<<"$SOURCE_HEAD"
+  )"
+  test "$SOURCE_CHECKSUM_SHA256" = "$EXPECTED_CHECKSUM_BASE64"
+
+  PROOF_DIR="$(mktemp -d)"
+  trap 'rm -rf -- "$PROOF_DIR"' EXIT
+  get_snapshot "$PREVIEW_SOURCE_BUCKET" "$SOURCE_ETAG" "$PROOF_DIR/source.enc"
+  get_snapshot \
+    "$PREVIEW_DESTINATION_BUCKET" \
+    "$DESTINATION_ETAG" \
+    "$PROOF_DIR/destination.enc"
+  SOURCE_BODY_SHA256="$(hash_file "$PROOF_DIR/source.enc")"
+  DESTINATION_BODY_SHA256="$(hash_file "$PROOF_DIR/destination.enc")"
+  test "$SOURCE_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"
+  test "$DESTINATION_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"
+
+  # Close the HEAD-to-GET race: neither object may change during the proof.
+  test "$(head_snapshot "$PREVIEW_SOURCE_BUCKET")" = "$SOURCE_HEAD"
+  test "$(head_snapshot "$PREVIEW_DESTINATION_BUCKET")" = "$DESTINATION_HEAD"
 )
 ```
 

--- a/apps/cloudflare/R2_BUNDLES_ENAM_MIGRATION.md
+++ b/apps/cloudflare/R2_BUNDLES_ENAM_MIGRATION.md
@@ -386,6 +386,7 @@ metadata, object bytes, or digest; do not use shell tracing:
       '{CacheControl,ChecksumCRC32,ChecksumCRC32C,ChecksumSHA1,ChecksumType,ContentDisposition,ContentEncoding,ContentLanguage,ContentLength,ContentType,ETag,Expires,Metadata}'
   }
   get_snapshot() {
+    AWS_RESPONSE_CHECKSUM_VALIDATION=WHEN_REQUIRED \
     AWS_ACCESS_KEY_ID="$R2_MIGRATION_ACCESS_KEY_ID" \
     AWS_SECRET_ACCESS_KEY="$R2_MIGRATION_SECRET_ACCESS_KEY" \
       aws s3api get-object --bucket "$1" --key "$SNAPSHOT_KEY" \

--- a/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
+++ b/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
@@ -616,6 +616,33 @@ describe("R2 lifecycle parsing", () => {
   });
 });
 
+describe("R2 migration runbook copy proof", () => {
+  it(
+    "anchors copied bytes to the canonical digest without trusting CopyObject checksum reporting",
+    async () => {
+      const runbook = await readFile(
+        new URL("../R2_BUNDLES_ENAM_MIGRATION.md", import.meta.url),
+        "utf8",
+      );
+
+      expect(runbook).toContain(
+        "a destination `ChecksumSHA256` returned after `CopyObject` is",
+      );
+      expect(runbook).toContain("EXPECTED_ENCRYPTED_SHA256");
+      expect(runbook).toContain(".Metadata.encryptedsha256");
+      expect(runbook).toContain("aws s3api get-object");
+      expect(runbook).toContain("--if-match");
+      expect(runbook).toContain(
+        'test "$SOURCE_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"',
+      );
+      expect(runbook).toContain(
+        'test "$DESTINATION_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"',
+      );
+      expect(runbook).not.toContain('test "$SOURCE_HEAD" = "$DESTINATION_HEAD"');
+    },
+  );
+});
+
 describe("R2 inventory verification", () => {
   it("sorts keys bytewise instead of conflating Unicode normalization forms", () => {
     const entries = parseR2ObjectInventoryJson(inventoryJson([
@@ -749,6 +776,7 @@ describe("R2 migration orchestration", () => {
     for (const copy of copies) {
       expect(copy.args).toContain("--copy-source");
       expect(copy.args).toContain("--copy-source-if-match");
+      expect(copy.args).not.toContain("--checksum-algorithm");
       expect(copy.args).toContain("--key");
       expect(copy.args.slice(
         copy.args.indexOf("--metadata-directive"),

--- a/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
+++ b/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
@@ -675,6 +675,7 @@ const FAKE_AWS_FUNCTION = [
   "    return",
   "  fi",
   '  if [[ "$operation" == "get-object" ]]; then',
+  '    [[ "${AWS_RESPONSE_CHECKSUM_VALIDATION:-}" == "WHEN_REQUIRED" ]] || return 27',
   '    [[ "$if_match" == \'"0123456789abcdef0123456789abcdef"\' ]] || return 25',
   '    cp "$RUNBOOK_PROOF_FIXTURE_ROOT/${kind}.body" "$output"',
   "    return",

--- a/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
+++ b/apps/cloudflare/test/deploy-r2-bundles-migration.test.ts
@@ -1,4 +1,8 @@
-import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -616,29 +620,279 @@ describe("R2 lifecycle parsing", () => {
   });
 });
 
+interface RunbookCopyProofScenario {
+  destinationBody?: Buffer;
+  destinationChecksumCrc32?: string;
+  destinationMetadataSha256?: string;
+  expectedSha256Input?: string;
+  finalHeadMutation?: "destination" | "source";
+  sourceBody?: Buffer;
+  sourceChecksumSha256?: string;
+  sourceMetadataSha256?: string;
+}
+
+interface RunbookCopyProofResult {
+  destinationHeadReads: number;
+  exitCode: number;
+  sourceHeadReads: number;
+  stderr: string;
+  stdout: string;
+}
+
+const RUNBOOK_COPY_PROOF_MARKER =
+  "Enter the private object key and the canonical reference's lowercase";
+const FAKE_AWS_FUNCTION = [
+  "aws() {",
+  '  [[ "$1" == "s3api" ]] || return 22',
+  '  local operation="$2"',
+  '  local output="${!#}"',
+  '  local bucket=""',
+  '  local if_match=""',
+  '  while (( $# > 0 )); do',
+  '    case "$1" in',
+  '      --bucket) bucket="$2"; shift 2 ;;',
+  '      --if-match) if_match="$2"; shift 2 ;;',
+  '      *) shift ;;',
+  "    esac",
+  "  done",
+  '  local kind=""',
+  '  if [[ "$bucket" == "$PREVIEW_SOURCE_BUCKET" ]]; then',
+  '    kind="source"',
+  '  elif [[ "$bucket" == "$PREVIEW_DESTINATION_BUCKET" ]]; then',
+  '    kind="destination"',
+  "  else",
+  "    return 23",
+  "  fi",
+  '  if [[ "$operation" == "head-object" ]]; then',
+  '    local count_path="$RUNBOOK_PROOF_FIXTURE_ROOT/${kind}.head-count"',
+  '    local count="$(( $(cat "$count_path") + 1 ))"',
+  '    printf "%s" "$count" > "$count_path"',
+  '    local head_path="$RUNBOOK_PROOF_FIXTURE_ROOT/${kind}.head.json"',
+  '    if (( count > 1 )) && [[ "${RUNBOOK_PROOF_MUTATE_FINAL:-}" == "$kind" ]]; then',
+  '      head_path="$RUNBOOK_PROOF_FIXTURE_ROOT/${kind}.final-head.json"',
+  "    fi",
+  '    cat "$head_path"',
+  "    return",
+  "  fi",
+  '  if [[ "$operation" == "get-object" ]]; then',
+  '    [[ "$if_match" == \'"0123456789abcdef0123456789abcdef"\' ]] || return 25',
+  '    cp "$RUNBOOK_PROOF_FIXTURE_ROOT/${kind}.body" "$output"',
+  "    return",
+  "  fi",
+  "  return 26",
+  "}",
+].join("\n");
+
+function extractRunbookCopyProof(runbook: string): string {
+  const markerIndex = runbook.indexOf(RUNBOOK_COPY_PROOF_MARKER);
+  if (markerIndex < 0) throw new Error("Runbook copy-proof marker is missing.");
+  const start = runbook.indexOf("```bash\n", markerIndex);
+  const end = start < 0 ? -1 : runbook.indexOf("\n```", start + 8);
+  if (start < 0 || end < 0) {
+    throw new Error("Runbook copy-proof block is missing.");
+  }
+  return runbook.slice(start + 8, end);
+}
+
+async function runRunbookCopyProof(
+  scenario: RunbookCopyProofScenario = {},
+): Promise<RunbookCopyProofResult> {
+  const root = await mkdtemp(path.join(tmpdir(), "murph-r2-copy-proof-"));
+  try {
+    const runbook = await readFile(
+      new URL("../R2_BUNDLES_ENAM_MIGRATION.md", import.meta.url),
+      "utf8",
+    );
+    const canonicalBody = Buffer.from("canonical encrypted snapshot fixture");
+    const expectedSha256 = createHash("sha256")
+      .update(canonicalBody)
+      .digest("hex");
+    const sourceHead = {
+      ChecksumCRC32: "AAAAAA==",
+      ChecksumSHA256: scenario.sourceChecksumSha256
+        ?? Buffer.from(expectedSha256, "hex").toString("base64"),
+      ChecksumType: "FULL_OBJECT",
+      ContentLength: canonicalBody.byteLength,
+      ETag: '"0123456789abcdef0123456789abcdef"',
+      Metadata: {
+        encryptedsha256: scenario.sourceMetadataSha256 ?? expectedSha256,
+      },
+    };
+    const destinationHead = {
+      ...sourceHead,
+      ChecksumCRC32: scenario.destinationChecksumCrc32 ?? sourceHead.ChecksumCRC32,
+      ChecksumSHA256: Buffer.alloc(32, 7).toString("base64"),
+      Metadata: {
+        encryptedsha256: scenario.destinationMetadataSha256 ?? expectedSha256,
+      },
+    };
+    const mutatedSourceHead = {
+      ...sourceHead,
+      ETag: '"ffffffffffffffffffffffffffffffff"',
+    };
+    const mutatedDestinationHead = {
+      ...destinationHead,
+      ChecksumSHA256: Buffer.alloc(32, 8).toString("base64"),
+    };
+    await Promise.all([
+      writeFile(
+        path.join(root, "proof.sh"),
+        `${FAKE_AWS_FUNCTION}\n${extractRunbookCopyProof(runbook)}`,
+      ),
+      writeFile(path.join(root, "source.head.json"), JSON.stringify(sourceHead)),
+      writeFile(
+        path.join(root, "destination.head.json"),
+        JSON.stringify(destinationHead),
+      ),
+      writeFile(
+        path.join(root, "source.final-head.json"),
+        JSON.stringify(mutatedSourceHead),
+      ),
+      writeFile(
+        path.join(root, "destination.final-head.json"),
+        JSON.stringify(mutatedDestinationHead),
+      ),
+      writeFile(
+        path.join(root, "source.body"),
+        scenario.sourceBody ?? canonicalBody,
+      ),
+      writeFile(
+        path.join(root, "destination.body"),
+        scenario.destinationBody ?? canonicalBody,
+      ),
+      writeFile(path.join(root, "source.head-count"), "0"),
+      writeFile(path.join(root, "destination.head-count"), "0"),
+    ]);
+
+    const result = await new Promise<{
+      exitCode: number;
+      stderr: string;
+      stdout: string;
+    }>(
+      (resolve, reject) => {
+        const child = spawn("bash", [path.join(root, "proof.sh")], {
+          env: {
+            CLOUDFLARE_ACCOUNT_ID: "fixture-account",
+            PATH: process.env.PATH,
+            PREVIEW_DESTINATION_BUCKET: "destination-bucket",
+            PREVIEW_SOURCE_BUCKET: "source-bucket",
+            R2_MIGRATION_ACCESS_KEY_ID: "fixture-access-key",
+            R2_MIGRATION_SECRET_ACCESS_KEY: "fixture-secret-key",
+            RUNBOOK_PROOF_FIXTURE_ROOT: root,
+            TMPDIR: root,
+            ...(scenario.finalHeadMutation
+              ? { RUNBOOK_PROOF_MUTATE_FINAL: scenario.finalHeadMutation }
+              : {}),
+          },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        let stderr = "";
+        let stdout = "";
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk: string) => {
+          stderr += chunk;
+        });
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk: string) => {
+          stdout += chunk;
+        });
+        child.once("error", reject);
+        child.once("close", (code) => resolve({
+          exitCode: code ?? -1,
+          stderr,
+          stdout,
+        }));
+        child.stdin.on("error", () => undefined);
+        child.stdin.end(
+          `private-key\n${scenario.expectedSha256Input ?? expectedSha256}\n`,
+        );
+      },
+    );
+    return {
+      ...result,
+      destinationHeadReads: Number(
+        await readFile(path.join(root, "destination.head-count"), "utf8"),
+      ),
+      sourceHeadReads: Number(
+        await readFile(path.join(root, "source.head-count"), "utf8"),
+      ),
+    };
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+function tamperedBody(): Buffer {
+  const body = Buffer.from("canonical encrypted snapshot fixture");
+  body[0] = body[0] ^ 1;
+  return body;
+}
+
 describe("R2 migration runbook copy proof", () => {
   it(
-    "anchors copied bytes to the canonical digest without trusting CopyObject checksum reporting",
+    "executes the canonical proof while ignoring only the destination SHA-256",
     async () => {
-      const runbook = await readFile(
-        new URL("../R2_BUNDLES_ENAM_MIGRATION.md", import.meta.url),
-        "utf8",
-      );
+      const result = await runRunbookCopyProof();
 
-      expect(runbook).toContain(
-        "a destination `ChecksumSHA256` returned after `CopyObject` is",
-      );
-      expect(runbook).toContain("EXPECTED_ENCRYPTED_SHA256");
-      expect(runbook).toContain(".Metadata.encryptedsha256");
-      expect(runbook).toContain("aws s3api get-object");
-      expect(runbook).toContain("--if-match");
-      expect(runbook).toContain(
-        'test "$SOURCE_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"',
-      );
-      expect(runbook).toContain(
-        'test "$DESTINATION_BODY_SHA256" = "$EXPECTED_ENCRYPTED_SHA256"',
-      );
-      expect(runbook).not.toContain('test "$SOURCE_HEAD" = "$DESTINATION_HEAD"');
+      expect(result).toMatchObject({
+        destinationHeadReads: 2,
+        exitCode: 0,
+        sourceHeadReads: 2,
+        stderr: "",
+        stdout: "",
+      });
+    },
+  );
+
+  const failureScenarios: Array<{
+    label: string;
+    scenario: RunbookCopyProofScenario;
+  }> = [
+    {
+      label: "uppercase canonical digest input",
+      scenario: { expectedSha256Input: "A".repeat(64) },
+    },
+    {
+      label: "short canonical digest input",
+      scenario: { expectedSha256Input: "a".repeat(63) },
+    },
+    {
+      label: "source checksum",
+      scenario: { sourceChecksumSha256: Buffer.alloc(32, 9).toString("base64") },
+    },
+    {
+      label: "canonical metadata digest",
+      scenario: {
+        destinationMetadataSha256: "b".repeat(64),
+        sourceMetadataSha256: "b".repeat(64),
+      },
+    },
+    {
+      label: "copied metadata parity",
+      scenario: { destinationMetadataSha256: "b".repeat(64) },
+    },
+    { label: "source body digest", scenario: { sourceBody: tamperedBody() } },
+    {
+      label: "destination body digest",
+      scenario: { destinationBody: tamperedBody() },
+    },
+    {
+      label: "another copied checksum",
+      scenario: { destinationChecksumCrc32: "BBBBBB==" },
+    },
+    { label: "source final HEAD", scenario: { finalHeadMutation: "source" } },
+    {
+      label: "destination final HEAD",
+      scenario: { finalHeadMutation: "destination" },
+    },
+  ];
+
+  it.each(failureScenarios)(
+    "fails closed when the $label disagrees",
+    async ({ scenario }) => {
+      const result = await runRunbookCopyProof(scenario);
+
+      expect(result.exitCode).not.toBe(0);
     },
   );
 });


### PR DESCRIPTION
## Why this PR exists

The staging rehearsal showed Cloudflare R2 can report a destination `ChecksumSHA256` after `CopyObject` that does not represent the copied body, even though the ETag, streamed bytes, and copied encrypted-digest metadata are identical. The runbook must not mistake that reporting anomaly for corruption or accept a corrupt copy.

## User goal / user-visible behavior

Internal-only migration safety change: operators can prove a representative copied snapshot against its canonical encrypted archive digest before any Worker cutover. There is no product UI change. The proof fails closed before restore/write validation if either conditional GET, body digest, copied metadata digest, source checksum, or the final HEAD stability check disagrees.

## Invariants

- Never treat the destination `ChecksumSHA256` reported by R2 `CopyObject` as body-integrity authority.
- Anchor the source body, destination body, copied `encryptedsha256` metadata, and source checksum to the canonical snapshot digest.
- Read both objects under exact ETag preconditions and close the HEAD-to-GET race with final HEAD equality.
- Preserve every other metadata/checksum comparison and all existing production migration guards.
- This documentation/test change performs no deployment and mutates no R2 object or production configuration.

## Non-obvious affected surfaces

- The private representative-object integrity proof in the ENAM migration runbook. Regression coverage executes the canonical digest chain and proves that CopyObject checksum-selection is not reintroduced.
- No Worker runtime, Web runtime, database, provider, or deployed configuration changes.

## Verification

- Focused Cloudflare migration suite: 65/65 tests passed, including hermetic execution of the runbook proof across success and ten fail-closed scenarios.
- `git diff --check`: passed.
- Canonical Blacksmith `pnpm test:diff ...`: passed Cloudflare typecheck and 108 test files / 2,025 tests, including all 65 migration tests.

ReviewGPT first-reviewed head: be0f46850cd1cb502ff2a20661cb606e0dfa3ffd

## ReviewGPT remediation

| Round | Current head | Authored growth | Disposition |
| --- | --- | --- | --- |
| 1 | `1adddfab33934f3b4b16eb3ea6cf5170c3a1bf0e` | Docs +1; tests +1 | Accepted the AWS CLI response-checksum finding; both conditional GETs now use command-scoped `WHEN_REQUIRED`, and the executable harness requires it. |

## Preliminary specialist lenses

- Coverage: applicable; ReviewGPT identified that the original token-scan did not execute the proof. Its tests-only patch was inspected, hardened to avoid ambient-environment inheritance, and verified at 65/65 focused tests. Canonical Blacksmith verification passed 108 test files / 2,025 tests on the current head.
- Prompt: not applicable; no prompt surface changed.
- Frontend: not applicable; no rendered surface changed and no rendered evidence is required.

## Change shape

Classification is by path and role; the runbook is docs and its Vitest contract is tests. No source, config, binary, or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 284 | 1 |
| Docs | 104 | 8 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **388** | **9** |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787809262&installation_model_id=19880&pr_number=1074&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1074&signature=f5448a4e37246cd95458027ee8b0a4489914c0db320846c9cab53d2bd85875a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->