### PR TITLE
Keep consent refresh label inside its button

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-28-web-consent-refresh-label.md
+++ b/agent-docs/exec-plans/active/2026-07-28-web-consent-refresh-label.md
@@ -1,0 +1,54 @@
+# Web consent refresh label
+
+Status: active
+Created: 2026-07-28
+Updated: 2026-07-28
+
+## Goal
+
+- Keep the dashboard consent dialog's accepted handoff state readable inside its existing primary button at narrow and wide viewports.
+
+## Success criteria
+
+- The accepted handoff uses a concise loading label that fits the existing button constraint.
+- The button remains disabled and exposes its existing busy state while the dashboard reload handoff is pending.
+- Consent authority, persistence, retry, routing, and reload behavior remain unchanged.
+- The production component, design-catalog study, focused regression, canonical verification, and required frontend reviews agree on the final state.
+
+## Scope
+
+- In scope: the dashboard consent gate's accepted pending label, its existing design-catalog study, and focused assertions.
+- Out of scope: consent APIs, document versions, state ownership, retry behavior, dashboard reload timing, dialog layout, and shared button sizing.
+
+## Constraints
+
+- Reuse the existing `HostedLegalConsentCard` pending-label seam.
+- Prefer a copy correction over layout or shared-component changes.
+- Preserve unrelated working-tree work.
+
+## Tasks
+
+1. Prove the overflow cause from the production component and shared button constraint.
+2. Replace the dashboard-specific pending label with concise existing-pattern copy.
+3. Update the existing design-catalog study and focused regression.
+4. Run focused and canonical verification plus desktop/mobile catalog proof.
+5. Complete required product, Claude, and preliminary ReviewGPT reviews.
+6. Commit, open the PR, verify CI and mergeability, then close the plan for handoff.
+
+## Decisions
+
+- Keep the current button width and state model; the dashboard-specific label is the only oversized element.
+- Use `Refreshing...`, matching the component's existing `Saving...` and `Continuing...` pending-copy pattern.
+
+## Verification
+
+- Focused Vitest: 1 file passed, 8 tests passed.
+- Canonical `pnpm test:diff` passed, including the full hosted-web suite,
+  typecheck, lint, development smoke check, and production build.
+- Frontend design-proof guard: 10 tests passed.
+- Production-component catalog proof passed at 1440×1000 desktop and 390×844
+  mobile viewports; the accepted handoff label was visible, disabled, and
+  `aria-busy="true"` without overflow.
+- Product-experience review: no findings and no evidence gaps.
+- Claude Fable UI review: blocked by explicit usage-credit exhaustion.
+- Preliminary ReviewGPT specialist pass: pending on the pushed PR head.

--- a/agent-docs/exec-plans/completed/2026-07-28-web-consent-refresh-label.md
+++ b/agent-docs/exec-plans/completed/2026-07-28-web-consent-refresh-label.md
@@ -1,6 +1,6 @@
 # Web consent refresh label
 
-Status: active
+Status: completed
 Created: 2026-07-28
 Updated: 2026-07-28
 
@@ -51,4 +51,8 @@ Updated: 2026-07-28
   `aria-busy="true"` without overflow.
 - Product-experience review: no findings and no evidence gaps.
 - Claude Fable UI review: blocked by explicit usage-credit exhaustion.
-- Preliminary ReviewGPT specialist pass: pending on the pushed PR head.
+- Preliminary ReviewGPT specialist pass: one PR-metadata finding, accepted and
+  resolved by using the design-proof labels required by the repository guard;
+  the implementation and coverage lenses had no finding, no patch artifact was
+  returned, and the actual frontend design-proof guard then passed.
+Completed: 2026-07-28

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -356,7 +356,7 @@ export function ComponentsContent() {
             data-design-dashboard-legal-composition="true"
           >
             <HostedLegalConsentCard
-              acceptedPendingLabel="Refreshing your dashboard"
+              acceptedPendingLabel="Refreshing..."
               acceptScope={acceptDesignDashboardConsentScope}
               initialStatus={DESIGN_DASHBOARD_CONSENT_STATUS}
               launchDescription="We updated Murph's legal documents. Accept the current versions to get your full dashboard back."

--- a/apps/web/src/components/legal/dashboard-legal-consent-gate.tsx
+++ b/apps/web/src/components/legal/dashboard-legal-consent-gate.tsx
@@ -51,7 +51,7 @@ export function DashboardLegalConsentGate({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <HostedLegalConsentCard
-          acceptedPendingLabel="Refreshing your dashboard"
+          acceptedPendingLabel="Refreshing..."
           acceptScope={acceptScope}
           initialStatus={initialStatus}
           launchDescription={description}

--- a/apps/web/test/dashboard-legal-consent-gate.test.tsx
+++ b/apps/web/test/dashboard-legal-consent-gate.test.tsx
@@ -149,7 +149,9 @@ test("dashboard consent reloads the exact route once after the accepted handoff"
     await flushPromises();
   });
 
-  expect(continueButton.textContent).toContain("Refreshing your dashboard");
+  expect(continueButton.textContent).toBe("Refreshing...");
+  expect(continueButton.disabled).toBe(true);
+  expect(continueButton.getAttribute("aria-busy")).toBe("true");
   expect(rendered.reload).not.toHaveBeenCalled();
 
   await act(async () => {
@@ -232,7 +234,7 @@ test("dashboard consent keeps a failed save retryable and continues after retry"
     await flushPromises();
   });
 
-  expect(continueButton.textContent).toContain("Refreshing your dashboard");
+  expect(continueButton.textContent).toBe("Refreshing...");
   await act(async () => {
     await vi.advanceTimersByTimeAsync(100);
   });


### PR DESCRIPTION
## Why this PR exists

After dashboard legal consent is accepted, the compact primary button currently changes to a long loading label that overflows. This PR keeps the accepted handoff clear and readable without changing consent behavior.

## User goal / user-visible behavior

A member can accept the required dashboard consent and see a concise Refreshing... state that fits the existing button while Murph reloads the dashboard.

## User experience

The entry point remains the legal-consent dialog on /home. The existing Consent action records the required consent, then the same button immediately becomes disabled and busy with Refreshing... while the existing owner reloads the current authenticated route after its 100 ms handoff. There are no new screens, choices, or actions. A consent-save network failure retains the existing retry behavior; routing, consent authority, and reload recovery are unchanged. Desktop and mobile catalog renders show the complete accepted-handoff state without overflow.

Product-experience review verdict: NO FINDINGS and no evidence gaps.

## Invariants the PR must preserve

- Consent scope, persistence, authority, and document versions are unchanged.
- The accepted handoff remains disabled and exposes aria-busy=true.
- Existing save failure, retry, current-route reload, and dashboard access behavior remain unchanged.
- The design catalog renders the same production component and label as /home.

## Non-obvious affected surfaces

- The existing Dashboard legal update design-catalog study mirrors the production label so visual proof cannot drift. The desktop/mobile Playwright scenario exercises the real component with synthetic status data.

## Preliminary specialist lenses

- Prompt: not applicable; no prompt or instruction text changed.
- Frontend: applicable; audit-packages/consent-refresh-desktop.png and audit-packages/consent-refresh-mobile.png show the accepted handoff at 1440x1000 and 390x844.
- Coverage: applicable; canonical pnpm test:diff passed for the production component, catalog study, and focused regression.

Preliminary ReviewGPT reviewed candidate 13152c23bc86. It found one PR-metadata issue: the design-proof list labels did not match the repository guard. The labels were corrected, the actual guard passed, no implementation or coverage finding remained, and no patch artifact was returned.

## Verification

- Focused Vitest: 1 file passed, 8 tests passed, including the post-review rerun.
- Canonical pnpm test:diff: passed, including 565 Vitest files / 7,367 tests, TypeScript, lint with zero errors, development smoke, and the production build.
- Frontend design-proof guard: 10 tests passed; the actual PR guard also passed after the metadata correction.
- Playwright catalog proof: 2 desktop/mobile scenarios passed; the refined mobile capture also passed.
- Product-experience review: NO FINDINGS.
- Preliminary completion-specialists ReviewGPT: one accepted PR-metadata finding resolved; no implementation or coverage findings and no patch artifact.
- Claude Fable UI double-check: explicit usage-credit exhaustion; no Claude pass is claimed.
- git diff --check: passed.

## Change-shape breakdown

Classification: authored production and catalog TSX are source; Vitest assertions are tests; the completed execution plan is docs; no binaries are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 4 | 2 |
| Docs | 58 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 64 | 4 |

## Design proof

The captures use synthetic catalog data only.

- Design page: [Dashboard legal update](https://murph.ai/design?tab=components)
- Desktop screenshot: ![Dashboard consent refreshing on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e7f786a7-3fee-4cff-bca4-bd26c1079400/public)
- Mobile screenshot: ![Dashboard consent refreshing on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e4553a69-f878-4e69-d99d-418e2efbaa00/public)
