### PR TITLE
Preserve image presence in assistant history

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-28-image-response-transcript-presence.md
+++ b/agent-docs/exec-plans/active/2026-07-28-image-response-transcript-presence.md
@@ -69,3 +69,9 @@ Updated: 2026-07-28
 - Required local `product-experience-review`: two material findings were
   accepted and fixed (pre-steer image responses and long-history truncation);
   targeted re-review returned `NO FINDINGS` with no material evidence gaps.
+- Preliminary `completion-specialists` ReviewGPT: one medium coverage finding
+  was accepted for the supported image-only/empty-text branch. Its attached
+  patch was downloaded from the owned review thread, inspected as test-only,
+  and applied deliberately; the focused runtime lane then passed all four image
+  and media-only cases. The substantive preliminary pass is not rerun by
+  workflow contract.

--- a/agent-docs/exec-plans/active/2026-07-28-image-response-transcript-presence.md
+++ b/agent-docs/exec-plans/active/2026-07-28-image-response-transcript-presence.md
@@ -1,0 +1,71 @@
+# Image response transcript presence
+
+Status: active
+Created: 2026-07-28
+Updated: 2026-07-28
+
+## Goal
+
+- Preserve a content-free image-presence fact in assistant transcript history
+  when a response contains both text and image media.
+
+## Success criteria
+
+- A later assistant turn can distinguish an image-bearing prior response from a
+  text-only response without retaining media URLs or alt text.
+- Text-only and voice-memo transcript behavior remains unchanged.
+- Focused regression coverage fails on the prior behavior and passes with the
+  correction.
+- Required verification, preliminary specialist review, final ReviewGPT, and
+  CI complete on the exact pushed PR head.
+
+## Scope
+
+- In scope: assistant response transcript projection and focused
+  assistant-engine tests.
+- Out of scope: image generation lifecycle, provider delivery receipts,
+  database schema, Cloudflare orchestration, and outbound message copy.
+
+## Constraints
+
+- Keep the transcript fact content-free and independent of provider URLs or
+  model-authored media descriptions.
+- Do not claim provider delivery; record only that the assistant response
+  included image media.
+- Add no queue, scheduler, persisted product-state owner, or dependency.
+
+## Tasks
+
+1. Add a focused failing regression for a text response with image media.
+2. Implement the smallest transcript projection correction.
+3. Run focused tests, typecheck, and canonical affected-path verification.
+4. Complete required specialist and final PR review gates with exact-head CI.
+
+## Decisions
+
+- Reuse the existing assistant transcript as the owner of prior assistant
+  response context.
+- Append one fixed image-presence marker; never copy media metadata into
+  transcript history.
+
+## Verification
+
+- Production evidence: image generation completed; automatic reply dispatch was
+  provider-accepted and delivery-receipted without failure. A later fresh model
+  turn started before that receipt and received text-only assistant history,
+  proving the failure was history projection rather than transport.
+- The focused final-response regression failed before the source correction.
+- Focused image-presence, preceding-response, media-only, and bounded-history
+  tests passed.
+- `pnpm --dir packages/assistant-engine typecheck` passed.
+- `pnpm test:diff packages/assistant-engine/src/assistant/local-service.ts
+  packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+  packages/assistant-engine/test/assistant-codex-turn-planning.test.ts` passed
+  every affected typecheck and the full Assistant Engine suite (180 files,
+  2,802 tests); the unrelated reverse-dependent CLI phase became irreversibly
+  red under concurrent shared-host verification with eight 60-second CLI
+  command/session timeouts and ten Health Commons experiment failures, so the
+  task-owned run was stopped rather than collecting redundant failures.
+- Required local `product-experience-review`: two material findings were
+  accepted and fixed (pre-steer image responses and long-history truncation);
+  targeted re-review returned `NO FINDINGS` with no material evidence gaps.

--- a/agent-docs/exec-plans/completed/2026-07-28-image-response-transcript-presence.md
+++ b/agent-docs/exec-plans/completed/2026-07-28-image-response-transcript-presence.md
@@ -1,6 +1,6 @@
 # Image response transcript presence
 
-Status: active
+Status: completed
 Created: 2026-07-28
 Updated: 2026-07-28
 
@@ -45,8 +45,8 @@ Updated: 2026-07-28
 
 - Reuse the existing assistant transcript as the owner of prior assistant
   response context.
-- Append one fixed image-presence marker; never copy media metadata into
-  transcript history.
+- Prefix one fixed image-presence marker so bounded fresh-thread history keeps
+  the fact; never copy media metadata into transcript history.
 
 ## Verification
 
@@ -61,11 +61,23 @@ Updated: 2026-07-28
 - `pnpm test:diff packages/assistant-engine/src/assistant/local-service.ts
   packages/assistant-engine/test/assistant-local-service-runtime.test.ts
   packages/assistant-engine/test/assistant-codex-turn-planning.test.ts` passed
-  every affected typecheck and the full Assistant Engine suite (180 files,
-  2,802 tests); the unrelated reverse-dependent CLI phase became irreversibly
-  red under concurrent shared-host verification with eight 60-second CLI
-  command/session timeouts and ten Health Commons experiment failures, so the
-  task-owned run was stopped rather than collecting redundant failures.
+  every affected typecheck and the full Assistant Engine suite after the
+  coverage remediation (180 files, 2,803 passed, 8 skipped); the unrelated
+  reverse-dependent CLI phase became irreversibly red under concurrent
+  shared-host verification with eight 60-second CLI command/session timeouts
+  and ten Health Commons experiment failures, so the task-owned run was stopped
+  rather than collecting redundant failures.
+- Canonical remote `pnpm verify:acceptance` passed the affected suites, the
+  reverse-dependent CLI files that failed on the shared host, and the broad
+  typecheck/web/Cloudflare lanes. It exited red only on the unrelated
+  setup-assistant Venice wizard timing test; that unchanged test passed
+  immediately in isolation.
+- The exact-head hosted image-delivery E2E was replayed locally twice, including
+  once with CI-equivalent streamed logging. All three direct, async-completion,
+  and upload-failure cases passed both times. The separate unchanged web
+  handoff-timeout test that failed in CI also passed in isolation.
+- An unchanged-head CI rerun then passed the complete Codex media and provider
+  egress E2E leg, including the automatic async image-completion scenario.
 - Required local `product-experience-review`: two material findings were
   accepted and fixed (pre-steer image responses and long-history truncation);
   targeted re-review returned `NO FINDINGS` with no material evidence gaps.
@@ -75,3 +87,4 @@ Updated: 2026-07-28
   and applied deliberately; the focused runtime lane then passed all four image
   and media-only cases. The substantive preliminary pass is not rerun by
   workflow contract.
+Completed: 2026-07-28

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -66,6 +66,9 @@ import {
   resolveAssistantSession,
 } from '../store.js'
 import {
+  stripAssistantImageResponseTranscriptMarker,
+} from '../response-media.js'
+import {
   writeAssistantChatErrorArtifacts,
 } from './artifacts.js'
 import {
@@ -4056,7 +4059,7 @@ async function isRecentSelfAuthoredAssistantEcho(input: {
       }
 
       textCandidates.push({
-        message: entry.text,
+        message: stripAssistantImageResponseTranscriptMarker(entry.text),
         messageTime: entryTime,
       })
     }

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -1595,8 +1595,8 @@ export async function sendAssistantMessageLocal(
             })
           }
         }
-        const precedingResponses = precedingResponseSegments.map((segment) =>
-          resolveAssistantPersistedReplyText({
+        const precedingResponses = precedingResponseSegments.map((segment) => {
+          const response = resolveAssistantPersistedReplyText({
             messageInput: applyAssistantReplyDeliveryContext({
               context: segment.deliveryContext ?? null,
               input: currentInput,
@@ -1605,7 +1605,11 @@ export async function sendAssistantMessageLocal(
             session: currentSession,
             sharedPlan,
           })
-        )
+          return resolveAssistantProviderTranscriptText({
+            media: segment.media,
+            response,
+          }) ?? response
+        })
         const providerResumeStateAction =
           resolveAssistantProviderResumeStateAction({
             codexThreadId: providerResult.codexThreadId ?? null,
@@ -2446,14 +2450,17 @@ function resolveAssistantProviderTranscriptText(input: {
   }
 
   const response = normalizeNullableString(input.response)
-  if (response !== null) {
-    return response
-  }
-
+  const imagePresence = (input.media ?? []).some(
+    (item) => item.kind === 'image',
+  )
+    ? '[This response included an image attachment.]'
+    : null
   const mediaTranscriptText = buildAssistantResponseMediaTranscriptText(
     input.media,
   )
-  return mediaTranscriptText ?? input.response
+  return [imagePresence, response ?? mediaTranscriptText]
+    .filter((text): text is string => text !== null)
+    .join('\n\n') || input.response
 }
 
 function buildAssistantResponseMediaTranscriptText(

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -23,6 +23,9 @@ import { resolveAssistantOperatorDefaults } from '@murphai/operator-config/opera
 import {
   normalizeAssistantDeliveryError,
 } from './outbox.js'
+import {
+  ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER,
+} from './response-media.js'
 import { recordAssistantDiagnosticEvent } from './diagnostics.js'
 import { refreshAssistantStatusSnapshotLocal } from './status.js'
 import {
@@ -2453,7 +2456,7 @@ function resolveAssistantProviderTranscriptText(input: {
   const imagePresence = (input.media ?? []).some(
     (item) => item.kind === 'image',
   )
-    ? '[This response included an image attachment.]'
+    ? ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER
     : null
   const mediaTranscriptText = buildAssistantResponseMediaTranscriptText(
     input.media,

--- a/packages/assistant-engine/src/assistant/response-media.ts
+++ b/packages/assistant-engine/src/assistant/response-media.ts
@@ -3,7 +3,20 @@ import {
   type AssistantResponseMedia,
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
+
+export const ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER =
+  '[This response included an image attachment.]'
+const ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_PREFIX =
+  `${ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER}\n\n`
 const MAX_ASSISTANT_RESPONSE_MEDIA = 40
+
+export function stripAssistantImageResponseTranscriptMarker(
+  text: string,
+): string {
+  return text.startsWith(ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_PREFIX)
+    ? text.slice(ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_PREFIX.length)
+    : text
+}
 
 export function normalizeAssistantResponseMediaList(
   values: readonly unknown[] | null | undefined,

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -34,6 +34,9 @@ import {
   type AssistantInputAttachmentDescriptor,
   upsertAssistantInputEvent,
 } from '../src/assistant/input-store.ts'
+import {
+  ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER,
+} from '../src/assistant/response-media.ts'
 import type { AssistantAutomationOperationScope } from '../src/assistant/automation/operation-scope.ts'
 import { createTempVaultContext } from './test-helpers.ts'
 
@@ -7700,6 +7703,77 @@ describe('assistant auto-reply runtime', () => {
           occurredAt: '2026-04-08T00:00:00.000Z',
           source: 'linq',
           text: 'same text',
+          threadId: 'thread-1',
+        }),
+      ),
+    ])
+
+    if (!context) {
+      throw new Error('expected reply context')
+    }
+
+    const result = await reply.processAssistantAutoReplyGroup({
+      allowSelfAuthored: true,
+      context,
+      enabledChannels: ['linq'],
+      inboxServices,
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault: '/tmp/assistant-automation-vault',
+    })
+
+    expect(result).toMatchObject({
+      advanceCursor: true,
+      failed: 0,
+      nextWakeAt: null,
+      replied: 0,
+      skipped: 1,
+      stopScanning: false,
+    })
+    expect(replyMocks.prepareAssistantAutoReplyInput).toHaveBeenCalledOnce()
+    expect(replyMocks.sendAssistantMessage).not.toHaveBeenCalled()
+  })
+
+  it('skips self-authored image captions whose transcript includes the image-presence marker', async () => {
+    replyMocks.resolveAssistantSession.mockResolvedValue({
+      created: false,
+      session: {
+        lastTurnAt: '2026-04-08T00:00:01.000Z',
+        sessionId: 'session-image-echo',
+      },
+    })
+    replyMocks.listAssistantTranscriptEntries.mockResolvedValue([
+      createTranscriptEntry({
+        createdAt: '2026-04-08T00:00:01.000Z',
+        text: [
+          ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER,
+          'The image is ready.',
+        ].join('\n\n'),
+      }),
+    ])
+    const inboxServices = createInboxServices({
+      show: vi.fn().mockResolvedValue(
+        createShowResult(
+          createCaptureDetail({
+            actorIsSelf: true,
+            occurredAt: '2026-04-08T00:00:00.000Z',
+            source: 'linq',
+            text: 'The image is ready.',
+            threadId: 'thread-1',
+          }),
+        ),
+      ),
+    })
+    const reply = await vi.importActual<typeof import('../src/assistant/automation/reply.ts')>(
+      '../src/assistant/automation/reply.ts',
+    )
+    const context = reply.createAssistantAutoReplyGroupContext([
+      createReplyGroupItem(
+        createCaptureSummary({
+          actorIsSelf: true,
+          occurredAt: '2026-04-08T00:00:00.000Z',
+          source: 'linq',
+          text: 'The image is ready.',
           threadId: 'thread-1',
         }),
       ),

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -3662,6 +3662,65 @@ describe('assistant Codex turn planning', () => {
     }
   })
 
+  it('keeps image presence inside bounded fresh-thread history', async () => {
+    planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
+    planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)
+    planningMocks.resolveCodexAssistantTargetCapabilities.mockReturnValue({
+      supportsNativeResume: false,
+    })
+    const vault = await mkdtemp(
+      path.join(os.tmpdir(), 'assistant-route-plan-image-history-'),
+    )
+    const session = createSession({
+      turnCount: 1,
+    })
+    const imagePresence = '[This response included an image attachment.]'
+
+    try {
+      await appendAssistantTranscriptEntries(vault, session.sessionId, [
+        {
+          kind: 'assistant',
+          text: `${imagePresence}\n\n${'x'.repeat(6_000)}`,
+        },
+      ])
+
+      const plan = await resolveAssistantRouteTurnPlan({
+        executionContext: null,
+        input: {
+          ...createMessageInput(),
+          vault,
+        },
+        profile: {
+          promptProfile: 'conversation',
+          threadScope: 'session-thread',
+          toolProfile: 'provider-turn',
+        },
+        promptTimeContext: {
+          currentLocalDate: '2026-05-04',
+          currentTimeZone: 'Asia/Kuala_Lumpur',
+        },
+        route: createRoute(),
+        session,
+        sharedPlan: createPrivateSharedPlan(),
+      })
+
+      expect(plan.conversationHistoryMessages).toEqual([
+        {
+          content: expect.stringMatching(
+            /^\[This response included an image attachment\.\]/u,
+          ),
+          role: 'assistant',
+        },
+      ])
+      const content = plan.conversationHistoryMessages?.[0]?.content
+      const contentBytes =
+        typeof content === 'string' ? Buffer.byteLength(content, 'utf8') : 0
+      expect(contentBytes).toBeLessThanOrEqual(4_000)
+    } finally {
+      await rm(vault, { force: true, recursive: true })
+    }
+  })
+
   it('does not replay an oversized committed current user prompt', async () => {
     planningMocks.readAssistantCliSurfaceBootstrapContext.mockResolvedValue('bootstrap contract')
     planningMocks.readAssistantContextSnapshotPrompt.mockResolvedValue(null)

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -527,6 +527,105 @@ test('sendAssistantMessageLocal delivers media-only provider replies', async () 
   })
 })
 
+test('sendAssistantMessageLocal preserves image presence beside transcript text', async () => {
+  const session = createAssistantSession()
+  const imageMedia: AssistantResponseMedia = {
+    alt: 'Generated image',
+    kind: 'image',
+    source: null,
+    url: 'https://cdn.example.test/assistant/generated.png',
+  }
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    providerOutcome: {
+      kind: 'succeeded',
+      providerTurn: {
+        onboardingGuidanceInjected: false,
+        codexContinuation: { kind: 'explicit-structured-history' },
+        codexThreadId: 'provider-thread-image-with-text',
+        response: 'The image is ready.',
+        responseDeliveryContextOrdinal: 0,
+        transcriptResponse: 'The image is ready.',
+        responseMedia: [imageMedia],
+        route: { routeId: 'route-image-with-text' },
+        session,
+      },
+    },
+    session,
+  })
+
+  await sendAssistantMessageLocal({
+    deliverResponse: true,
+    executionContext: {
+      hosted: null,
+    },
+    prompt: 'Create an image',
+    vault: '/vaults/test',
+  })
+
+  expect(
+    mocks.finalizeAssistantTurnArtifacts.mock.calls[0]?.[0]
+      ?.assistantTranscriptText,
+  ).toBe(
+    '[This response included an image attachment.]\n\nThe image is ready.',
+  )
+  expect(mocks.dispatchAssistantReply.mock.calls[0]?.[0]?.media).toEqual([
+    imageMedia,
+  ])
+})
+
+test('sendAssistantMessageLocal preserves image presence for preceding replies', async () => {
+  const session = createAssistantSession()
+  const imageMedia: AssistantResponseMedia = {
+    alt: 'Generated image',
+    kind: 'image',
+    source: null,
+    url: 'https://cdn.example.test/assistant/preceding.png',
+  }
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    plan: createDirectSharedPlan(),
+    providerOutcome: {
+      kind: 'succeeded',
+      providerTurn: {
+        onboardingGuidanceInjected: false,
+        codexContinuation: { kind: 'explicit-structured-history' },
+        precedingResponseSegments: [
+          {
+            deliveryContextOrdinal: 0,
+            media: [imageMedia],
+            response: 'The first image is ready.',
+          },
+        ],
+        response: 'The follow-up is ready.',
+        responseDeliveryContextOrdinal: 0,
+        transcriptResponse: 'The follow-up is ready.',
+        route: { routeId: 'route-preceding-image-with-text' },
+        session,
+      },
+    },
+    session,
+  })
+
+  await sendAssistantMessageLocal({
+    deliverResponse: true,
+    prompt: 'Create an image, then refine it',
+    vault: '/vaults/test',
+  })
+
+  expect(
+    mocks.finalizeAssistantTurnArtifacts.mock.calls[0]?.[0]
+      ?.precedingAssistantTranscriptTexts,
+  ).toEqual([
+    '[This response included an image attachment.]\n\nThe first image is ready.',
+  ])
+  expect(mocks.deliverAssistantPrecedingReplies.mock.calls[0]?.[0]?.segments)
+    .toEqual([
+      expect.objectContaining({
+        media: [imageMedia],
+        response: 'The first image is ready.',
+      }),
+    ])
+})
+
 test('sendAssistantMessageLocal keeps manual chat on the session Codex thread', async () => {
   const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule()
 

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -527,6 +527,51 @@ test('sendAssistantMessageLocal delivers media-only provider replies', async () 
   })
 })
 
+test('sendAssistantMessageLocal preserves image presence for media-only image replies', async () => {
+  const session = createAssistantSession()
+  const imageMedia: AssistantResponseMedia = {
+    alt: 'Generated image',
+    kind: 'image',
+    source: null,
+    url: 'https://cdn.example.test/assistant/media-only.png',
+  }
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    providerOutcome: {
+      kind: 'succeeded',
+      providerTurn: {
+        onboardingGuidanceInjected: false,
+        codexContinuation: { kind: 'explicit-structured-history' },
+        codexThreadId: 'provider-thread-image-media-only',
+        response: '',
+        responseDeliveryContextOrdinal: 0,
+        transcriptResponse: '',
+        responseMedia: [imageMedia],
+        route: { routeId: 'route-image-media-only' },
+        session,
+      },
+    },
+    session,
+  })
+
+  await sendAssistantMessageLocal({
+    deliverResponse: true,
+    executionContext: {
+      hosted: null,
+    },
+    prompt: 'Create an image without accompanying text',
+    vault: '/vaults/test',
+  })
+
+  expect(
+    mocks.finalizeAssistantTurnArtifacts.mock.calls[0]?.[0]
+      ?.assistantTranscriptText,
+  ).toBe('[This response included an image attachment.]')
+  expect(mocks.dispatchAssistantReply.mock.calls[0]?.[0]?.response).toBe('')
+  expect(mocks.dispatchAssistantReply.mock.calls[0]?.[0]?.media).toEqual([
+    imageMedia,
+  ])
+})
+
 test('sendAssistantMessageLocal preserves image presence beside transcript text', async () => {
   const session = createAssistantSession()
   const imageMedia: AssistantResponseMedia = {


### PR DESCRIPTION
## Why this PR exists

Automatic image replies were reaching the messaging provider, but the assistant's persisted model-visible history retained only their text. A later fresh turn could therefore contradict successful automatic delivery by reasoning as if the prior reply had no image.

## User goal / user-visible behavior

When an asynchronously generated image reply is automatically sent, later Murph turns should remember that the prior response included an image and should not falsely report that the attachment was absent.

## User experience

The member requests an image and receives the existing immediate progress response. The existing generation-completion wake remains the continuation owner and the result still travels through the original conversation's delivery path with no new action or wait. This change records only that the assistant response included image media, so a concurrent or later fresh model turn has truthful context. Provider acceptance and delivery receipts remain separate transport facts; failure and retry behavior are unchanged.

## Invariants

- Preserve the existing automatic generation wake and outbound media delivery path.
- Do not persist media URLs, source metadata, or alt text in model-visible transcript history.
- Do not claim provider delivery from transcript state; record response inclusion only.
- Preserve text-only and voice-memo transcript behavior.
- Preserve provider-id and timestamp-based self-authored echo suppression.
- Add no schema, queue, state owner, dependency, or compatibility path.

## Non-obvious affected surfaces

- Retained pre-steer assistant responses use the same image-presence projection so concurrent input cannot reintroduce the text-only history gap. Covered by the preceding-response regression.
- The fixed marker precedes response text so the existing 4,000-byte fresh-thread history bound retains it for long replies. Covered by the bounded-history regression.
- Image-only replies with empty text persist the marker while dispatching the original media unchanged. Covered by the specialist-requested media-only image regression.
- Dedicated self-authored messaging lines compare provider-visible caption text when falling back to transcript-based echo detection. A regression covers the image marker plus caption case without a provider message ID, while the existing negative timestamp case still replies.

## Direct scenario evidence

A production timeline showed generation completion, automatic reply dispatch, provider acceptance, and a successful delivery receipt with no transport failure. A subsequent fresh model turn began while delivery was crossing that boundary and received text-only prior-assistant history, isolating the failure to history projection rather than image generation or messaging transport.

## Preliminary specialist lenses

- Prompt: **applicable** — model-visible committed conversation history assembly changes by adding one fixed, content-free fact.
- Frontend: **not applicable** — no `apps/web` UI or rendered state changes.
- Coverage: **applicable** — focused regressions, package typecheck, and the full Assistant Engine suite pass.
- Rendered evidence: not applicable.

Required local `product-experience-review` accepted and drove two scoped corrections, then returned `NO FINDINGS` with no material evidence gaps.

The one substantive preliminary `completion-specialists` pass returned one medium coverage finding for the supported image-only/empty-text branch. The owned `reviewgpt-coverage.patch` was downloaded, inspected as test-only, and applied deliberately; the focused runtime lane passed all four image/media-only cases. No other preliminary finding or patch artifact remains unresolved.

## Final ReviewGPT remediation

Round 1 found that prefixing image-bearing assistant transcript text could break the existing caption-based self-authored echo fallback on dedicated messaging lines. A focused runtime regression reproduced the unsolicited-reply risk before the fix.

The remediation centralizes the fixed marker and strips exactly one leading marker only when projecting transcript-derived echo candidates back to provider-visible text. Provider-message-ID matching, nearest-timestamp selection, and outbox ownership are unchanged.

Retrospective: **not required**. Remediation added 20 authored source lines, below the 500-line threshold, added no owner, state, queue, or lifecycle, and proceeded to correction-verification round 2.\n\nRound 2 correction verification: **PASS** with no findings. Model verification confirmed the requested Pro review model.

Current remediation head: `65dcd6cd0f90d3b3e01597e767e2bb5850e6d2ea`

ReviewGPT first-reviewed head: 2c5a9509bb38f5ec73cce117511445d1945df26d

## Verification

- `pnpm --dir packages/assistant-engine typecheck`
- Focused image-presence, preceding-response, media-only, voice-memo, bounded-history, and self-authored echo regressions
- Full Assistant Engine suite: 180 files passed, 1 file skipped; 2,804 tests passed, 8 skipped
- Exact-head hosted image-delivery E2E twice locally, including CI-equivalent streamed logging: 3 passed
- First-reviewed and current remediation heads both passed the complete Codex media/provider-egress E2E. The current-head first attempt lost the Cloudflare proxy sidecar with exit code 137; an unchanged-head retry passed all scenarios and aggregate gates.
- Canonical `pnpm test:diff` after remediation: all affected, reverse-dependent, typecheck, web, and Cloudflare lanes passed

## Change shape

Classification uses authored production TypeScript as source, test TypeScript as tests/fixtures, the completed execution plan as docs, and keeps config/tooling and generated files separate.

### First-reviewed shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 15 | 8 |
| Tests/fixtures | 203 | 0 |
| Docs | 90 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **308** | **8** |

### Current-head shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 35 | 9 |
| Tests/fixtures | 277 | 0 |
| Docs | 90 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **402** | **9** |

Binary files: none.

## Design proof

Not applicable; this PR has no frontend UI diff.

## Deployment skew / compatibility

This is a backward-compatible Assistant Engine runner-bundle change with no schema, API, protocol, environment, Worker/web, or persisted-state shape change. Warm runner containers on the old bundle may temporarily retain the old text-only history behavior until normal replacement, but mixed versions cannot corrupt delivery or state. No tandem deploy or compatibility machinery is required. Post-deploy proof should exercise an image-bearing reply followed by a fresh turn and confirm that the later turn recognizes the prior image without exposing media metadata.
