### PR TITLE
Withdrawn: Exclude Flex automations from reply-latency alerts

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-07-27
+Last verified: 2026-07-28
 
 ## Current Guardrails
 
@@ -73,6 +73,10 @@ Last verified: 2026-07-27
 - Foreground inbox/parser-backed daemon runs should favor restartable connectors with bounded backoff over permanently dead watch loops, while still keeping low-level restart behavior opt-in and always bounded by the owning abort signal.
 - Networked assistant/provider/channel calls should set explicit timeouts, propagate caller abort signals, and only auto-retry request shapes that are replay-safe or rate-limit directed.
 - The hosted reply-latency operator alert remains one singleton incident owner.
+  Provider-start telemetry explicitly labels Flex turns, and the monitor
+  excludes those traces from completed-reply and unresolved-work health.
+  Missing or non-Flex labels remain alert-eligible; the monitor does not infer
+  tier from the best-effort usage ledger.
   Outbound paging requires the shared Resend operational-email sender and
   recipients plus a valid IANA operator timezone; it never falls back to
   Linq/iMessage. It suppresses sends from 11 PM through 7 AM local time and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1,6 +1,6 @@
 # Hosted Mailbox Runtime Protocol
 
-Last verified: 2026-07-27
+Last verified: 2026-07-28
 
 ## Decision
 
@@ -904,7 +904,12 @@ process. Its ingress `acceptedAt` value copies the mailbox row's PostgreSQL
 from `acceptedAt` includes the remainder of the append transaction and must not
 be labeled row-insert or commit latency. The web-owned `provider_started` field
 means the runtime observed a local Codex `turn/start`; it is not evidence of an
-upstream OpenAI request or first token. The runtime may also emit metadata-only
+upstream OpenAI request or first token. The same event carries the resolved
+`flex` service-tier label when that execution policy applies; missing tier
+metadata remains non-Flex for alert eligibility. Deploy the Web reader before
+the updated runner producer. The new reader accepts missing labels, while an
+old reader safely drops the unknown phase metadata but cannot exclude the Flex
+trace. The runtime may also emit metadata-only
 `assistant_milestone` events for Linq typing request start/acceptance and the
 first locally observed Codex output/text. It projects
 `terminal_non_reply_committed` only from the assistant engine's existing durable
@@ -2087,9 +2092,11 @@ provider payloads, secrets, local paths, or direct personal identifiers.
 Web runs one Vercel-authenticated reply-latency monitor every five minutes over
 the existing `HostedIngressLatencyTrace`, accepted `HostedLinqDelivery`, and
 conversation `consumed_at` facts. The fixed product boundary is 30 seconds. A
-recent accepted delivery at or above that boundary is anomalous. A trace at or
-above the boundary with no accepted delivery and no durable consumed evidence
-is provisionally resolved only when it has valid
+provider-start trace explicitly labeled `flex` is excluded from completed and
+unresolved alert health without joining the best-effort usage ledger. A recent
+non-Flex accepted delivery at or above the boundary is anomalous. A non-Flex
+trace at or above the boundary with no accepted delivery and no durable
+consumed evidence is provisionally resolved only when it has valid
 `terminal_non_reply_committed` evidence and the runtime's latest
 checkpoint-publication expectation has not elapsed. The expectation includes
 the configured idle window plus the bounded idle-maintenance, snapshot

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -659,8 +659,11 @@ Hosted onboarding extras:
   and `HOSTED_LINQ_ALERT_EMAILS`. The historical Linq-prefixed email names are
   shared operational configuration; the latency path never sends through or
   falls back to Linq/iMessage. The monitor uses the fixed 30-second product
-  boundary, sends one email per continuous incident, suppresses sends from 11
-  PM through 7 AM operator-local time, and adds up to ten minutes of stable
+  boundary for non-Flex work; provider-start traces explicitly labeled `flex`
+  are excluded from both completed and unresolved alert health. Missing or
+  non-Flex labels remain eligible. The monitor sends one email per continuous
+  incident, suppresses sends from 11 PM through 7 AM operator-local time, and
+  adds up to ten minutes of stable
   wake/retry jitter. Provider attempts therefore stay at least ten minutes
   apart and spread across more than one five-minute cron tick. A fresh health
   and operator-time recheck before provider admission makes no attempt-state

--- a/apps/web/src/lib/hosted-runtime-latency/alert-monitor.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/alert-monitor.ts
@@ -6,6 +6,9 @@ import {
   formatTimeZoneDateTimeParts,
   normalizeIanaTimeZone,
 } from "@murphai/contracts";
+import type {
+  HostedRuntimeProviderServiceTier,
+} from "@murphai/hosted-execution/runtime-control";
 import { Prisma, type HostedLinqAlert, type PrismaClient } from "@prisma/client";
 
 import { hostedOnboardingError, isHostedOnboardingError } from "../hosted-onboarding/errors";
@@ -57,6 +60,7 @@ export interface HostedRuntimeLatencyHealthRow {
   checkpointPublicationExpectedBy: Date | null;
   consumedAt: Date | null;
   deliveryAcceptedAt: Date | null;
+  providerServiceTier: HostedRuntimeProviderServiceTier | null;
   terminalNonReplyCommittedAt: Date | null;
 }
 
@@ -237,6 +241,8 @@ export async function readHostedRuntimeLatencyHealth(input: {
         readHostedRuntimeCheckpointPublicationExpectedBy(row.phaseBreakdownJson),
       consumedAt: row.mailboxItem.consumedAt,
       deliveryAcceptedAt: row.linqDelivery?.acceptedAt ?? null,
+      providerServiceTier:
+        readHostedRuntimeProviderServiceTier(row.phaseBreakdownJson),
       terminalNonReplyCommittedAt:
         readHostedRuntimeTerminalNonReplyCommittedAt(row.phaseBreakdownJson),
     })),
@@ -259,6 +265,9 @@ export function summarizeHostedRuntimeLatencyRows(input: {
   let unresolvedReplyCount = 0;
 
   for (const row of input.rows) {
+    if (row.providerServiceTier === "flex") {
+      continue;
+    }
     const acceptedAtMs = row.acceptedAt.getTime();
     const checkpointPublicationExpectedByMs =
       row.checkpointPublicationExpectedBy?.getTime() ?? null;
@@ -350,6 +359,19 @@ function readHostedRuntimeCheckpointPublicationExpectedBy(
     value,
     "checkpointPublicationExpectedByEpochMs",
   );
+}
+
+function readHostedRuntimeProviderServiceTier(
+  value: unknown,
+): HostedRuntimeProviderServiceTier | null {
+  if (!isHostedRuntimeLatencyPhaseRecord(value)) {
+    return null;
+  }
+  const provider = value.provider;
+  if (!isHostedRuntimeLatencyPhaseRecord(provider)) {
+    return null;
+  }
+  return provider.serviceTier === "flex" ? "flex" : null;
 }
 
 function readHostedRuntimeAssistantEpochDate(

--- a/apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
@@ -74,6 +74,36 @@ describe("hosted runtime latency health", () => {
     expect(health.unresolvedReplyCount).toBe(0);
   });
 
+  it("excludes Flex-tier replies and unresolved traces from alert health", () => {
+    const health = summarizeHostedRuntimeLatencyRows({
+      now,
+      rows: [
+        latencyRow({
+          acceptedAt: "2026-07-26T15:58:00.000Z",
+          deliveryAcceptedAt: "2026-07-26T15:59:00.000Z",
+          providerServiceTier: "flex",
+        }),
+        latencyRow({
+          acceptedAt: "2026-07-26T15:59:00.000Z",
+          providerServiceTier: "flex",
+        }),
+        latencyRow({
+          acceptedAt: "2026-07-26T15:59:00.000Z",
+          deliveryAcceptedAt: "2026-07-26T15:59:31.000Z",
+        }),
+      ],
+    });
+
+    expect(health).toMatchObject({
+      anomalous: true,
+      maxCompletedReplyLatencyMs: 31_000,
+      oldestUnresolvedAgeMs: null,
+      recentCompletedReplyCount: 1,
+      recentSlowReplyCount: 1,
+      unresolvedReplyCount: 0,
+    });
+  });
+
   it("treats an explicit terminal non-reply as resolved before mailbox checkpointing", () => {
     const health = summarizeHostedRuntimeLatencyRows({
       now,
@@ -199,6 +229,37 @@ describe("hosted runtime latency health", () => {
 });
 
 describe("hosted runtime latency alert monitor", () => {
+  it("reads the Flex tier from stored provider-start telemetry", async () => {
+    const fixture = createMonitorPrismaFixture([
+      latencyRow({
+        acceptedAt: "2026-07-26T15:58:00.000Z",
+        deliveryAcceptedAt: "2026-07-26T15:59:00.000Z",
+        providerServiceTier: "flex",
+      }),
+      latencyRow({
+        acceptedAt: "2026-07-26T15:59:00.000Z",
+        deliveryAcceptedAt: "2026-07-26T15:59:10.000Z",
+      }),
+    ]);
+
+    const result = await runHostedRuntimeLatencyAlertMonitor({
+      env: {},
+      now,
+      prisma: fixture.prisma,
+    });
+
+    expect(result).toMatchObject({
+      configured: false,
+      health: {
+        anomalous: false,
+        recentCompletedReplyCount: 1,
+        recentSlowReplyCount: 0,
+        unresolvedReplyCount: 0,
+      },
+      outcome: "disabled",
+    });
+  });
+
   it("derives terminal non-replies from the stored latency phase breakdown", async () => {
     const fixture = createMonitorPrismaFixture([
       latencyRow({
@@ -1143,6 +1204,7 @@ function latencyRow(input: {
   checkpointPublicationExpectedBy?: string | null;
   consumedAt?: string | null;
   deliveryAcceptedAt?: string | null;
+  providerServiceTier?: "flex" | null;
   terminalNonReplyCommittedAt?: string | null;
 }): HostedRuntimeLatencyHealthRow {
   return {
@@ -1154,6 +1216,7 @@ function latencyRow(input: {
     deliveryAcceptedAt: input.deliveryAcceptedAt
       ? instant(input.deliveryAcceptedAt)
       : null,
+    providerServiceTier: input.providerServiceTier ?? null,
     terminalNonReplyCommittedAt: input.terminalNonReplyCommittedAt
       ? instant(input.terminalNonReplyCommittedAt)
       : null,
@@ -1182,22 +1245,35 @@ function createMonitorPrismaFixture(
         consumedAt: row.consumedAt,
       },
       phaseBreakdownJson:
-        row.terminalNonReplyCommittedAt || row.checkpointPublicationExpectedBy
+        row.terminalNonReplyCommittedAt
+        || row.checkpointPublicationExpectedBy
+        || row.providerServiceTier
         ? {
-            assistant: {
-              ...(row.terminalNonReplyCommittedAt
-                ? {
-                    terminalNonReplyCommittedAtEpochMs:
-                      row.terminalNonReplyCommittedAt.getTime(),
-                  }
-                : {}),
-              ...(row.checkpointPublicationExpectedBy
-                ? {
-                    checkpointPublicationExpectedByEpochMs:
-                      row.checkpointPublicationExpectedBy.getTime(),
-                  }
-                : {}),
-            },
+            ...(row.terminalNonReplyCommittedAt || row.checkpointPublicationExpectedBy
+              ? {
+                  assistant: {
+                    ...(row.terminalNonReplyCommittedAt
+                      ? {
+                          terminalNonReplyCommittedAtEpochMs:
+                            row.terminalNonReplyCommittedAt.getTime(),
+                        }
+                      : {}),
+                    ...(row.checkpointPublicationExpectedBy
+                      ? {
+                          checkpointPublicationExpectedByEpochMs:
+                            row.checkpointPublicationExpectedBy.getTime(),
+                        }
+                      : {}),
+                  },
+                }
+              : {}),
+            ...(row.providerServiceTier
+              ? {
+                  provider: {
+                    serviceTier: row.providerServiceTier,
+                  },
+                }
+              : {}),
             schemaVersion: 1,
           }
         : null,

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -1761,7 +1761,12 @@ describe("hosted runtime latency dashboard store", () => {
       authenticatedUserId: "member_latency_1",
       phaseBreakdown: {
         schemaVersion: 1,
-        provider: { sessionResolveMs: 11, promptBuildMs: 22, admissionMs: 33 },
+        provider: {
+          sessionResolveMs: 11,
+          promptBuildMs: 22,
+          admissionMs: 33,
+          serviceTier: "flex",
+        },
       },
       prisma,
       providerRequestOrdinal: 0,
@@ -1804,7 +1809,12 @@ describe("hosted runtime latency dashboard store", () => {
         foregroundWaitResolvedAtEpochMs: 1_777_000_001_010,
         foregroundImportStartedAtEpochMs: 1_777_000_001_011,
       },
-      provider: { sessionResolveMs: 11, promptBuildMs: 22, admissionMs: 33 },
+      provider: {
+        sessionResolveMs: 11,
+        promptBuildMs: 22,
+        admissionMs: 33,
+        serviceTier: "flex",
+      },
     });
 
     // Idempotent provider re-send preserves the populated provider sub-object.
@@ -1824,6 +1834,8 @@ describe("hosted runtime latency dashboard store", () => {
     trace = prisma.readTrace();
     expect((trace?.phaseBreakdownJson as { provider: { sessionResolveMs: number } }).provider.sessionResolveMs)
       .toBe(11);
+    expect((trace?.phaseBreakdownJson as { provider: { serviceTier: string } }).provider.serviceTier)
+      .toBe("flex");
     expect((trace?.phaseBreakdownJson as { schemaVersion: number }).schemaVersion).toBe(1);
   });
 

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -21,7 +21,10 @@ import {
   isAssistantProviderConnectionLostError,
   isAssistantProviderStalledError,
 } from '../provider-failure-diagnostics.js'
-import type { AssistantProviderRequestStartTiming } from '../providers/types.js'
+import type {
+  AssistantProviderRequestStartTiming,
+  AssistantProviderServiceTier,
+} from '../providers/types.js'
 import type { AssistantProviderTraceEvent } from '../provider-traces.js'
 import type { AssistantProviderProgressEvent } from '../provider-progress.js'
 import type {
@@ -1965,6 +1968,9 @@ async function executeAssistantAutoReply(input: {
               : { preProviderSetupMs: event.preProviderSetupMs }),
             ...(event.promptBuildMs === undefined ? {} : { promptBuildMs: event.promptBuildMs }),
             providerRequestOrdinal: event.providerRequestOrdinal,
+            ...(event.serviceTier === undefined
+              ? {}
+              : { serviceTier: event.serviceTier }),
             ...(event.sessionResolveMs === undefined
               ? {}
               : { sessionResolveMs: event.sessionResolveMs }),
@@ -1998,6 +2004,7 @@ export type AssistantAutoReplyProviderRequestStartHook = (event: {
   preProviderSetupMs?: number
   promptBuildMs?: number
   providerRequestOrdinal: number
+  serviceTier?: AssistantProviderServiceTier | null
   sessionResolveMs?: number
   source: string
   startedAt: string

--- a/packages/assistant-engine/src/assistant/codex-turn-runner.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn-runner.ts
@@ -219,6 +219,7 @@ export async function executeCodexTurnWithRecovery(input: {
   }) => Promise<AssistantProviderAcceptedInputsRelease | void>
   onProviderRequestStarted?: (event: {
     providerRequestOrdinal: number | null
+    serviceTier?: AssistantProviderServiceTier | null
     startedAt: string
   } & AssistantProviderRequestStartTiming) => Promise<void> | void
   plan: AssistantTurnSharedPlan
@@ -396,6 +397,7 @@ async function executeAssistantCodexAttempt(input: {
   executionPlan: AssistantCodexTurnExecutionPlan
   onProviderRequestStarted?: ((event: {
     providerRequestOrdinal: number | null
+    serviceTier?: AssistantProviderServiceTier | null
     startedAt: string
   } & AssistantProviderRequestStartTiming) => Promise<void> | void) | null
   providerRequestOrdinal: number | null
@@ -538,6 +540,7 @@ async function executeAssistantCodexAttempt(input: {
             event: {
               ...event,
               providerRequestOrdinal: input.providerRequestOrdinal,
+              serviceTier,
             },
             hook: input.onProviderRequestStarted ?? null,
           })
@@ -744,10 +747,12 @@ function normalizeAssistantProviderAttemptMetadata(
 function notifyProviderRequestStartedBestEffort(input: {
   event: {
     providerRequestOrdinal: number | null
+    serviceTier?: AssistantProviderServiceTier | null
     startedAt: string
   } & AssistantProviderRequestStartTiming
   hook?: ((event: {
     providerRequestOrdinal: number | null
+    serviceTier?: AssistantProviderServiceTier | null
     startedAt: string
   } & AssistantProviderRequestStartTiming) => Promise<void> | void) | null
 }): void {

--- a/packages/assistant-engine/src/assistant/service-contracts.ts
+++ b/packages/assistant-engine/src/assistant/service-contracts.ts
@@ -92,6 +92,7 @@ export type AssistantProviderRequestStartHook = (event: {
   preProviderSetupMs?: number
   promptBuildMs?: number
   providerRequestOrdinal: number
+  serviceTier?: AssistantProviderServiceTier | null
   sessionResolveMs?: number
   startedAt: string
   turnLockWaitMs?: number

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -4048,6 +4048,7 @@ describe('assistant auto-reply runtime', () => {
       onProviderRequestStarted?: (event: {
         acceptedInputIds: readonly string[]
         providerRequestOrdinal: number
+        serviceTier?: 'flex' | null
         startedAt: string
       }) => void
     }
@@ -4059,12 +4060,14 @@ describe('assistant auto-reply runtime', () => {
     sendInput.onProviderRequestStarted?.({
       acceptedInputIds: context.inputIds,
       providerRequestOrdinal: 0,
+      serviceTier: 'flex',
       startedAt: '2026-04-08T00:10:00.000Z',
     })
     expect(onProviderRequestStarted).toHaveBeenCalledWith(expect.objectContaining({
       assistantInputIds: context.inputIds,
       autoReplyHistory: historyMetrics,
       providerRequestOrdinal: 0,
+      serviceTier: 'flex',
     }))
     expect(historyReader.readMetrics).toHaveBeenCalledOnce()
     expect(evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence).toHaveBeenCalledOnce()

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -1032,6 +1032,7 @@ describe('Codex model catalog', () => {
 
   it('drops unsupported rich user parts and keeps flex for supported hosted OpenAI routes', async () => {
     const providerScopeEvents: string[] = []
+    const providerRequestStarted = vi.fn()
     const flexCatalog = await createHostedCodexFlexCatalog({ model: 'gpt-5.6-terra' })
     const route = createRoute({
       providerOptions: {
@@ -1069,8 +1070,11 @@ describe('Codex model catalog', () => {
       supportsReasoningEffort: true,
     })
     providerMocks.executeCodexAssistantTurnAttemptFromInput.mockImplementation(
-      async () => {
+      async (providerInput) => {
         providerScopeEvents.push('provider')
+        await providerInput.onProviderRequestStarted?.({
+          startedAt: '2026-04-29T00:00:01.000Z',
+        })
         return createProviderAttemptResult()
       },
     )
@@ -1135,6 +1139,7 @@ describe('Codex model catalog', () => {
             providerScopeEvents.push('released')
           }
         },
+        onProviderRequestStarted: providerRequestStarted,
         plan: createSharedPlan(),
         providerRequestOrdinal: 1,
         resolvedSession: session,
@@ -1156,6 +1161,11 @@ describe('Codex model catalog', () => {
     expect(timeoutSpy).toHaveBeenCalledWith(600_000)
     expect(providerInput?.abortSignal).not.toBe(upstreamAbort.signal)
     expect(providerInput?.abortSignal?.aborted).toBe(false)
+    expect(providerRequestStarted).toHaveBeenCalledWith({
+      providerRequestOrdinal: 1,
+      serviceTier: 'flex',
+      startedAt: '2026-04-29T00:00:01.000Z',
+    })
     upstreamAbort.abort()
     expect(providerInput?.abortSignal?.aborted).toBe(true)
     expect(

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -1844,6 +1844,7 @@ describe('Codex model catalog', () => {
   })
 
   it('drops flex service tier for hosted OpenAI routes without catalog evidence', async () => {
+    const providerRequestStarted = vi.fn()
     const route = createRoute({
       providerOptions: {
         model: 'gpt-5.6-terra',
@@ -1865,8 +1866,13 @@ describe('Codex model catalog', () => {
       supportedUserMessageContentTypes: ['text', 'image'],
       supportsReasoningEffort: true,
     })
-    providerMocks.executeCodexAssistantTurnAttemptFromInput.mockResolvedValue(
-      createProviderAttemptResult(),
+    providerMocks.executeCodexAssistantTurnAttemptFromInput.mockImplementation(
+      async (providerInput) => {
+        await providerInput.onProviderRequestStarted?.({
+          startedAt: '2026-04-29T00:00:01.000Z',
+        })
+        return createProviderAttemptResult()
+      },
     )
     providerTurnRunnerMocks.buildCodexTurnExecutionPlan.mockResolvedValue({
       activeTurnSteering: null,
@@ -1922,6 +1928,7 @@ describe('Codex model catalog', () => {
 
     await executeCodexTurnWithRecovery({
       input,
+      onProviderRequestStarted: providerRequestStarted,
       plan: createSharedPlan(),
       providerRequestOrdinal: 1,
       resolvedSession: session,
@@ -1934,6 +1941,11 @@ describe('Codex model catalog', () => {
       providerMocks.executeCodexAssistantTurnAttemptFromInput.mock.calls[0]?.[0]
     expect(providerInput?.serviceTier).toBeNull()
     expect(providerInput?.abortSignal).toBe(upstreamAbort.signal)
+    expect(providerRequestStarted).toHaveBeenCalledWith({
+      providerRequestOrdinal: 1,
+      serviceTier: null,
+      startedAt: '2026-04-29T00:00:01.000Z',
+    })
   })
 
   it('drops flex service tier for hosted routes on unsupported model providers', async () => {

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -2013,6 +2013,7 @@ test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProvi
       codexAppServerThreadResumeMs: 9,
       codexAppServerWarmReuseMs: 0,
       providerRequestOrdinal: 0,
+      serviceTier: 'flex',
       startedAt: '2026-06-09T00:00:00.000Z',
     })
     return {
@@ -2046,6 +2047,7 @@ test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProvi
     codexAppServerWarmReuseMs: number
     preProviderSetupMs: number
     promptBuildMs: number
+    serviceTier: 'flex'
     sessionResolveMs: number
     turnLockWaitMs: number
   }
@@ -2055,6 +2057,7 @@ test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProvi
   expect(event.codexAppServerSpawnReadyMs).toBe(1)
   expect(event.codexAppServerThreadResumeMs).toBe(9)
   expect(event.codexAppServerWarmReuseMs).toBe(0)
+  expect(event.serviceTier).toBe('flex')
   expect(typeof event.sessionResolveMs).toBe('number')
   expect(typeof event.promptBuildMs).toBe('number')
   expect(typeof event.admissionMs).toBe('number')

--- a/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
@@ -763,6 +763,7 @@ function recordHostedAssistantProviderStartLatencyTraceBestEffort(input: {
   promptBuildMs?: number;
   providerRequestOrdinal: number;
   runtimeAttemptId?: string | null;
+  serviceTier?: "flex" | null;
   sessionResolveMs?: number;
   source: string;
   startedAt: string;
@@ -812,6 +813,9 @@ function recordHostedAssistantProviderStartLatencyTraceBestEffort(input: {
     ...(input.preProviderSetupMs === undefined
       ? {}
       : { preProviderSetupMs: input.preProviderSetupMs }),
+    ...(input.serviceTier === "flex"
+      ? { serviceTier: input.serviceTier }
+      : {}),
   };
 
   void recordHostedAssistantProviderStartLatencyTraceWithRetry(input.latencyTracePort, {

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -3735,6 +3735,7 @@ describe("runHostedAssistantAutomationLane", () => {
     automationPassInput.onProviderRequestStarted?.({
       assistantInputIds: ["input_2"],
       providerRequestOrdinal: 0,
+      serviceTier: null,
       source: "telegram",
       startedAt: "2026-04-08T00:00:02.000Z",
     });

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -3655,6 +3655,7 @@ describe("runHostedAssistantAutomationLane", () => {
       codexAppServerThreadResumeMs: 9,
       codexAppServerWarmReuseMs: 0,
       providerRequestOrdinal: 0,
+      serviceTier: "flex",
       source: "linq",
       startedAt: "2026-04-08T00:00:01.000Z",
     });
@@ -3680,6 +3681,7 @@ describe("runHostedAssistantAutomationLane", () => {
             codexAppServerSpawnReadyMs: 1,
             codexAppServerThreadResumeMs: 9,
             codexAppServerWarmReuseMs: 0,
+            serviceTier: "flex",
           },
           schemaVersion: 1,
         },

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -40,6 +40,7 @@ import {
   HOSTED_RUNTIME_LATENCY_TRACE_ASSISTANT_INPUT_MAX_IDS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_KEYS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS,
+  HOSTED_RUNTIME_PROVIDER_SERVICE_TIERS,
   HOSTED_RUNTIME_LATENCY_TRACE_MILESTONES,
   HOSTED_MAILBOX_FETCH_CURSOR_MODES,
   HOSTED_MAILBOX_KINDS,
@@ -5046,6 +5047,15 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
       ...requireOptionalNonNegativeInteger(provider, "admissionMs", providerLabel),
       ...requireOptionalNonNegativeInteger(provider, "preProviderSetupMs", providerLabel),
       ...requireOptionalNonNegativeInteger(provider, "linqEgressGuardMs", providerLabel),
+      ...(provider.serviceTier === undefined
+        ? {}
+        : {
+            serviceTier: parseAllowedString(
+              provider.serviceTier,
+              `${providerLabel}.serviceTier`,
+              HOSTED_RUNTIME_PROVIDER_SERVICE_TIERS,
+            ),
+          }),
     };
   }
 

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -1740,6 +1740,11 @@ export type HostedRuntimeAssistantMilestone =
 export type HostedRuntimeLatencyTraceMilestone =
   (typeof HOSTED_RUNTIME_LATENCY_TRACE_MILESTONES)[number];
 
+export const HOSTED_RUNTIME_PROVIDER_SERVICE_TIERS = ["flex"] as const;
+
+export type HostedRuntimeProviderServiceTier =
+  (typeof HOSTED_RUNTIME_PROVIDER_SERVICE_TIERS)[number];
+
 export interface HostedRuntimeLatencyPhaseBreakdown {
   schemaVersion: number;
   // Control-plane orchestration stamps before the runner-container DO starts
@@ -1864,6 +1869,7 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
     admissionMs?: number;
     preProviderSetupMs?: number;
     linqEgressGuardMs?: number;
+    serviceTier?: HostedRuntimeProviderServiceTier;
   };
 }
 
@@ -1994,6 +2000,7 @@ export const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS: Record<
     "admissionMs",
     "preProviderSetupMs",
     "linqEgressGuardMs",
+    "serviceTier",
   ],
 } as const;
 
@@ -2242,6 +2249,12 @@ function isHostedRuntimeLatencyPhaseBreakdownLeafSafe(
     return typeof value === "string"
       && value.length <= 20
       && /^(?:0|[1-9]\d*)$/u.test(value);
+  }
+  if (phase === "provider" && leafKey === "serviceTier") {
+    return typeof value === "string"
+      && HOSTED_RUNTIME_PROVIDER_SERVICE_TIERS.includes(
+        value as HostedRuntimeProviderServiceTier,
+      );
   }
   if (HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_BOOLEAN_LEAF_KEY_SET.has(`${phase}.${leafKey}`)) {
     return typeof value === "boolean";

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -1472,6 +1472,7 @@ describe("hosted runtime control contracts", () => {
         admissionMs: 4,
         preProviderSetupMs: 5,
         linqEgressGuardMs: 6,
+        serviceTier: "flex",
       },
     };
     expect(parseHostedRuntimeLatencyTraceRequest({
@@ -1504,6 +1505,7 @@ describe("hosted runtime control contracts", () => {
       { sessionResolveMs: { secret: 1 } }, // object leaf
       { sessionResolveMs: [1, 2, 3] }, // array leaf
       { codexAppServerWarmReuseMs: "0" }, // numeric leaf must stay numeric
+      { serviceTier: "priority" }, // only the explicit Flex tier is supported
       { networkToken: 1 }, // unknown sub key
     ]) {
       const parsed = parseHostedRuntimeLatencyTraceRequest({


### PR DESCRIPTION
## Withdrawn

Live aggregate evidence and the exact-head final audit proved the proposed owner path was incorrect.

The reported slow completed replies were `automation_auto_reply` turns priced on the standard tier; no Flex usage overlapped those reply windows. The production operation that currently selects Flex is scheduled cron automation. Scheduled turns have no inbound mailbox item or `HostedIngressLatencyTrace`, so they are already outside this ingress reply-latency monitor and cannot directly contribute a completed reply to it.

The proposed telemetry started in the inbound auto-reply path, which does not select Flex, making its suppression branch unreachable in production. Extending the design would require synthetic cross-owner correlation and could hide real standard-tier reply latency, so the patch is intentionally not shipping.

Final ReviewGPT round 1 finding: accepted. Resolution: withdraw the patch and preserve the existing monitor boundary.
