### PR TITLE
Make image generation acknowledgements confident

### DIFF
--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -3333,7 +3333,7 @@ function renderHostedImageGenerationLaunchResult(input: {
   status: 'pending' | 'queued' | null
 }): string {
   if (input.launch === 'started') {
-    return 'image generation started in the background. briefly and confidently tell the user you are making it now and will send it here in a separate message when it is ready. for a simple request, you may say it usually takes about a minute, without promising an exact deadline. until a trusted hosted image completion result arrives, keep treating later user questions steered into this live turn as pending. keep the acknowledgement to that current-status-and-next-step shape without qualifications or internal processing details'
+    return 'image generation started in the background. briefly and confidently tell the user you are making it now and that the result should come back here in a separate message when it is ready. for a simple request, you may say it usually takes about a minute, without promising an exact deadline. until a trusted hosted image completion result arrives, keep treating later user questions steered into this live turn as pending. keep the acknowledgement to that current-status-and-expected-next-step shape; omit internal processing details'
   }
   if (input.launch === 'already-started') {
     return 'no new image was started because this exact image operation was already accepted. do not infer its current state from another pending or queued image in the conversation, and do not claim it failed or restarted; rely only on the earlier tool result, trusted completion evidence, or conversation history'

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -3333,7 +3333,7 @@ function renderHostedImageGenerationLaunchResult(input: {
   status: 'pending' | 'queued' | null
 }): string {
   if (input.launch === 'started') {
-    return 'image generation started in the background. tell the user it is still generating and that, if it succeeds, the completed image should return here in a separate message. until a trusted hosted image completion result arrives, keep treating later user questions steered into this live turn as pending. do not claim that it already attached, failed, or restarted, and do not guarantee success before completion'
+    return 'image generation started in the background. briefly and confidently tell the user you are making it now and will send it here in a separate message when it is ready. for a simple request, you may say it usually takes about a minute, without promising an exact deadline. until a trusted hosted image completion result arrives, keep treating later user questions steered into this live turn as pending. keep the acknowledgement to that current-status-and-next-step shape without qualifications or internal processing details'
   }
   if (input.launch === 'already-started') {
     return 'no new image was started because this exact image operation was already accepted. do not infer its current state from another pending or queued image in the conversation, and do not claim it failed or restarted; rely only on the earlier tool result, trusted completion evidence, or conversation history'

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -576,8 +576,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
     }
     return [
       'Trusted hosted image status: an earlier image request in this conversation is still in progress.',
-      '- no failure has been reported. if generation succeeds, the completed image should return here separately; do not guarantee success before completion.',
-      '- if the user asks where it is, say that it is still in progress; do not claim it attached, failed, or restarted.',
+      '- if the user asks where it is, say that it is still in progress and will return here separately when it is ready. state only the current status and next step until trusted completion evidence arrives.',
       '- do not call `murph.generate_image` while this status is present, even for a different image. if asked for another image, say that request was not started and ask the user to wait for this result first.',
     ].join('\n')
   })()

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -576,7 +576,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
     }
     return [
       'Trusted hosted image status: an earlier image request in this conversation is still in progress.',
-      '- if the user asks where it is, say that it is still in progress and will return here separately when it is ready. state only the current status and next step until trusted completion evidence arrives.',
+      '- if the user asks where it is, say that it is still in progress and should return here separately when it is ready. state only the current status and expected next step until trusted completion evidence arrives.',
       '- do not call `murph.generate_image` while this status is present, even for a different image. if asked for another image, say that request was not started and ask the user to wait for this result first.',
     ].join('\n')
   })()

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -858,10 +858,11 @@ describe('assistant Codex turn planning', () => {
       'do not call `murph.generate_image` while this status is present, even for a different image',
     )
     expect(plan.systemPrompt).toContain(
-      'will return here separately when it is ready',
+      'should return here separately when it is ready',
     )
     expect(plan.systemPrompt).not.toContain('if generation succeeds')
     expect(plan.systemPrompt).not.toContain('do not guarantee success')
+    expect(plan.systemPrompt).not.toContain('will return here separately')
     expect(plan.systemPrompt).not.toContain('it failed')
 
     imageStatus = 'queued'

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -857,7 +857,11 @@ describe('assistant Codex turn planning', () => {
     expect(plan.systemPrompt).toContain(
       'do not call `murph.generate_image` while this status is present, even for a different image',
     )
-    expect(plan.systemPrompt).toContain('do not guarantee success')
+    expect(plan.systemPrompt).toContain(
+      'will return here separately when it is ready',
+    )
+    expect(plan.systemPrompt).not.toContain('if generation succeeds')
+    expect(plan.systemPrompt).not.toContain('do not guarantee success')
     expect(plan.systemPrompt).not.toContain('it failed')
 
     imageStatus = 'queued'

--- a/packages/assistant-engine/test/dynamic-tools-generate-image.test.ts
+++ b/packages/assistant-engine/test/dynamic-tools-generate-image.test.ts
@@ -159,12 +159,14 @@ describe('murph.generate_image dynamic tool schema', () => {
     expect(result.rpcResult).toMatchObject({
       success: true,
       contentItems: [{
-        text: expect.stringContaining('tell the user it is still generating'),
+        text: expect.stringContaining(
+          'will send it here in a separate message when it is ready',
+        ),
       }],
     })
     expect(result.rpcResult).toMatchObject({
       contentItems: [{
-        text: expect.stringContaining('if it succeeds'),
+        text: expect.stringContaining('usually takes about a minute'),
       }],
     })
     expect(result.rpcResult).toMatchObject({
@@ -176,7 +178,12 @@ describe('murph.generate_image dynamic tool schema', () => {
     })
     expect(result.rpcResult).not.toMatchObject({
       contentItems: [{
-        text: expect.stringContaining('will appear'),
+        text: expect.stringContaining('if it succeeds'),
+      }],
+    })
+    expect(result.rpcResult).not.toMatchObject({
+      contentItems: [{
+        text: expect.stringContaining('do not guarantee success'),
       }],
     })
     await vi.waitFor(() => {

--- a/packages/assistant-engine/test/dynamic-tools-generate-image.test.ts
+++ b/packages/assistant-engine/test/dynamic-tools-generate-image.test.ts
@@ -160,7 +160,7 @@ describe('murph.generate_image dynamic tool schema', () => {
       success: true,
       contentItems: [{
         text: expect.stringContaining(
-          'will send it here in a separate message when it is ready',
+          'should come back here in a separate message when it is ready',
         ),
       }],
     })
@@ -184,6 +184,11 @@ describe('murph.generate_image dynamic tool schema', () => {
     expect(result.rpcResult).not.toMatchObject({
       contentItems: [{
         text: expect.stringContaining('do not guarantee success'),
+      }],
+    })
+    expect(result.rpcResult).not.toMatchObject({
+      contentItems: [{
+        text: expect.stringContaining('will send it here'),
       }],
     })
     await vi.waitFor(() => {


### PR DESCRIPTION
## Why this PR exists

Murph currently answers an accepted direct image request with an awkward success caveat, even though the trusted background completion path already owns terminal success or failure. The acknowledgement should be brief, confident, and useful without exposing internal processing language.

## User goal / user-visible behavior

After a user directly asks Murph to create an image, Murph says it is making the image and that the result should come back here separately when ready. For a simple request it may say this usually takes about a minute, without promising either delivery or an exact deadline and without adding “if it succeeds.”

## User experience

- Entry: the user directly asks for an image and the existing hosted image launcher accepts the background job.
- Immediate feedback: Murph gives only current status and the expected next step. The intended shape is: “I’m making it now—it should come back here separately when it’s ready. Simple requests usually take about a minute.”
- Timing: simple generations usually take about a minute; complex or reference-image work can take more than two minutes, and the existing provider timeout remains 240 seconds.
- Continuation owner: the existing invocation-local image-generation job owns provider work and independently sends the trusted terminal result to the initiating route.
- Completion/recovery: the image returns separately to the same conversation without an unrelated new inbound message. Existing trusted completion/failure handling remains authoritative; this PR changes only acknowledgement and pending-status guidance.
- Local product-experience review: `NO FINDINGS` after remediation. The reviewer noted that deterministic tests prove prompt construction rather than a live model’s exact sentence; the preliminary ReviewGPT prompt lens provides the independent prompt-behavior review.

## Invariants

- A started background job remains pending until trusted hosted completion evidence arrives.
- Later status questions do not cause a duplicate image-generation call.
- Only trusted terminal evidence may claim that the image attached, failed, or completed.
- Completion remains a separate message to the initiating route; provider execution, timeout, attachment privacy, and failure handling are unchanged.

## Non-obvious affected surfaces

- The later-turn pending-image system context is aligned with the initial acknowledgement so it reports current status and next step without reintroducing the success caveat. Regression proof: `assistant-codex-turn-planning.test.ts`.

## Hot reply path impact

Not applicable. No database, network/provider, or other awaited operation is added or moved; the existing provider turn receives different locally assembled guidance, so before/after call counts and latency are unchanged.

## Murph runtime system prompt impact

Deterministic method: render `resolveAssistantRouteTurnPlan` at base `862bafab79` and head `40b889e93776c5e891d1dfe42a84907bcddc3940` with identical pending-image fixtures, once with a direct audience and once with a Telegram group audience; count `systemPrompt.length`. The changed layer is the pending hosted-image context in `packages/assistant-engine/src/assistant/codex-turn/planning.ts`. The launch-result guidance in `packages/assistant-engine/src/assistant-codex/dynamic-tools.ts` is tool-result content and is covered separately.

| Runtime | Base chars | Head chars | Delta | Change |
| --- | ---: | ---: | ---: | ---: |
| Individual Murph | 61,711 | 61,659 | -52 | -0.084% |
| Group Murph | 40,317 | 40,265 | -52 | -0.129% |

## Preliminary specialist lenses

- Prompt: applicable — tool-result and system-prompt instructions change acknowledgement behavior.
- Frontend: not applicable — no `apps/web` UI or rendered state changes.
- Coverage: applicable — `NODE_OPTIONS=--max-old-space-size=6144 pnpm --dir packages/assistant-engine test:coverage` passed 180 files / 2,817 tests with 89.91% statements, 82.55% branches, 94.19% functions, and 89.94% lines. The canonical `pnpm test:diff <four changed paths>` also passed all affected typechecks and the assistant-engine, assistant-cli, assistant-runtime, assistantd, and setup-cli suites, but remained red on unrelated pre-existing `packages/cli` integration timeouts and experiment-journal assertions reproduced on a clean one-shot Testbox.
- ReviewGPT disposition: accepted its one medium prompt finding that unconditional “will send” language overpromised invocation-local delivery. Remediated to a confident current status plus the expected “should come back” outcome, with focused negative assertions against both the old caveat and the unconditional promise. Per the preliminary-gate workflow, the accepted finding was resolved and verified locally without rerunning the preliminary pass.

## Change shape

Classification: production TypeScript is source; Vitest files are tests/fixtures; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 3 |
| Tests/fixtures | 21 | 4 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **23** | **7** |

## Design proof

Not applicable. This PR changes conversational prompt behavior and has no frontend UI diff.

## Rollout

No Web/Worker compatibility change. The behavior takes effect in runner processes built from this head; use the normal Cloudflare runner deployment with immediate container rollout so warm processes do not retain the old prompt bundle.
