### PR TITLE
Prepare hosted Temporal for Murph Cloud extraction

### DIFF
--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -32,7 +32,7 @@ Temporal worker and its idempotent schedule setup from one sibling or absolute
 package directory:
 
 ```bash
-MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=../murph-hosted/packages/hosted-orchestrator-temporal \
+MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=../murph-cloud/packages/hosted-orchestrator-temporal \
   pnpm dev
 ```
 

--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -25,6 +25,25 @@ pnpm hosted-local run -- pnpm --dir apps/cloudflare test:workers
 
 Root `pnpm dev` is a thin alias for `pnpm hosted-local up`.
 
+## External Temporal worker package
+
+Hosted-local keeps Web and Cloudflare in this checkout, but it can start the
+Temporal worker and its idempotent schedule setup from one sibling or absolute
+package directory:
+
+```bash
+MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=../murph-hosted/packages/hosted-orchestrator-temporal \
+  pnpm dev
+```
+
+The setting changes only the package directory passed to `pnpm --dir` for
+`temporal:worker` and `temporal:ensure-device-sync-reconciler-schedule`. The
+Temporal address, namespace, task queue, and signed Web/Cloudflare HTTP
+contracts remain unchanged. When it is unset or blank, hosted-local uses the
+existing in-repo `packages/hosted-orchestrator-temporal` package. This keeps one
+canonical local entrypoint without a submodule, source mirror, or second
+orchestration path.
+
 ## Local web origin
 
 The hosted web app binds to `http://127.0.0.1:3000` by default. Telegram's

--- a/packages/hosted-local-harness/src/dev-hosted-local/temporal.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/temporal.ts
@@ -43,6 +43,10 @@ const LOCAL_TEMPORAL_CLI_ENV_CLEARANCE_NAMES = [
 ] as const;
 const EXTERNAL_SCHEDULE_ENSURE_OPT_IN_ENV =
   "MURPH_DEV_TEMPORAL_ALLOW_EXTERNAL_SCHEDULE_ENSURE";
+const DEFAULT_HOSTED_LOCAL_TEMPORAL_WORKER_PACKAGE_DIR =
+  "packages/hosted-orchestrator-temporal";
+const HOSTED_LOCAL_TEMPORAL_WORKER_PACKAGE_DIR_ENV =
+  "MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR";
 
 export interface HostedLocalTemporalRuntime {
   address: string;
@@ -81,6 +85,13 @@ export function buildHostedLocalTemporalRuntimeEnv(input: {
   };
 }
 
+export function resolveHostedLocalTemporalWorkerPackageDir(
+  source: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  return source[HOSTED_LOCAL_TEMPORAL_WORKER_PACKAGE_DIR_ENV]?.trim()
+    || DEFAULT_HOSTED_LOCAL_TEMPORAL_WORKER_PACKAGE_DIR;
+}
+
 export async function startHostedLocalTemporalRuntime(input: {
   abortSignal?: AbortSignal;
   cloudflareHostedControlBaseUrl: string;
@@ -105,6 +116,9 @@ export async function startHostedLocalTemporalRuntime(input: {
   }
 
   const address = resolveHostedLocalTemporalAddress(input);
+  const temporalWorkerPackageDir = resolveHostedLocalTemporalWorkerPackageDir(
+    input.env,
+  );
   const cloudflareHostedControlBaseUrl = normalizeHostedLocalClientBaseUrl(
     input.cloudflareHostedControlBaseUrl,
   );
@@ -178,6 +192,7 @@ export async function startHostedLocalTemporalRuntime(input: {
     })) {
       await ensureHostedLocalDeviceSyncReconcilerSchedule({
         env: temporalRuntimeEnv,
+        packageDir: temporalWorkerPackageDir,
         signal: input.abortSignal,
       });
       throwIfAbortSignalAborted(input.abortSignal);
@@ -186,7 +201,7 @@ export async function startHostedLocalTemporalRuntime(input: {
     workerProcess = spawnChildProcess(
       "temporal-worker",
       "pnpm",
-      ["--dir", "packages/hosted-orchestrator-temporal", "temporal:worker"],
+      ["--dir", temporalWorkerPackageDir, "temporal:worker"],
       temporalRuntimeEnv,
       {
         pipeOutput: input.pipeOutput,
@@ -227,11 +242,12 @@ export async function startHostedLocalTemporalRuntime(input: {
 
 async function ensureHostedLocalDeviceSyncReconcilerSchedule(input: {
   env: NodeJS.ProcessEnv;
+  packageDir: string;
   signal?: AbortSignal;
 }): Promise<void> {
   await runCommand("pnpm", [
     "--dir",
-    "packages/hosted-orchestrator-temporal",
+    input.packageDir,
     "temporal:ensure-device-sync-reconciler-schedule",
   ], {
     cwd: repoRoot,

--- a/packages/hosted-local-harness/test/dev-hosted-local/temporal-worker-package-dir.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/temporal-worker-package-dir.test.ts
@@ -17,7 +17,7 @@ describe("hosted-local Temporal worker package directory", () => {
   it("accepts one trimmed external package directory", () => {
     expect(resolveHostedLocalTemporalWorkerPackageDir({
       MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR:
-        "  ../murph-hosted/packages/hosted-orchestrator-temporal  ",
-    })).toBe("../murph-hosted/packages/hosted-orchestrator-temporal");
+        "  ../murph-cloud/packages/hosted-orchestrator-temporal  ",
+    })).toBe("../murph-cloud/packages/hosted-orchestrator-temporal");
   });
 });

--- a/packages/hosted-local-harness/test/dev-hosted-local/temporal-worker-package-dir.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/temporal-worker-package-dir.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveHostedLocalTemporalWorkerPackageDir,
+} from "../../src/dev-hosted-local/temporal.ts";
+
+describe("hosted-local Temporal worker package directory", () => {
+  it("keeps the in-repo worker as the default", () => {
+    expect(resolveHostedLocalTemporalWorkerPackageDir({})).toBe(
+      "packages/hosted-orchestrator-temporal",
+    );
+    expect(resolveHostedLocalTemporalWorkerPackageDir({
+      MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR: "   ",
+    })).toBe("packages/hosted-orchestrator-temporal");
+  });
+
+  it("accepts one trimmed external package directory", () => {
+    expect(resolveHostedLocalTemporalWorkerPackageDir({
+      MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR:
+        "  ../murph-hosted/packages/hosted-orchestrator-temporal  ",
+    })).toBe("../murph-hosted/packages/hosted-orchestrator-temporal");
+  });
+});

--- a/packages/hosted-local-harness/test/dev-hosted-local/temporal.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/temporal.test.ts
@@ -269,8 +269,9 @@ describe("hosted-local Temporal lifecycle", () => {
     expect(terminateChildProcessAndWaitMock).toHaveBeenCalledTimes(1);
   });
 
-  it("ensures the schedule before starting an opted-in external-mode worker with the worker env", async () => {
+  it("uses one configured package directory for opted-in schedule setup and worker startup", async () => {
     const { startHostedLocalTemporalRuntime } = await import("../../src/dev-hosted-local/temporal.ts");
+    const externalPackageDir = "../murph-cloud/packages/hosted-orchestrator-temporal";
 
     const runtime = await startHostedLocalTemporalRuntime({
       cloudflareHostedControlBaseUrl: "http://0.0.0.0:8787",
@@ -289,6 +290,7 @@ describe("hosted-local Temporal lifecycle", () => {
         HOSTED_TEMPORAL_API_KEY: "remote-secret",
         HOSTED_TEMPORAL_TLS_ENABLED: "true",
         MURPH_DEV_TEMPORAL_ALLOW_EXTERNAL_SCHEDULE_ENSURE: "1",
+        MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR: `  ${externalPackageDir}  `,
       },
       hostedWebBaseUrl: "http://localhost:3000",
     });
@@ -298,7 +300,7 @@ describe("hosted-local Temporal lifecycle", () => {
       "pnpm",
       [
         "--dir",
-        "packages/hosted-orchestrator-temporal",
+        externalPackageDir,
         "temporal:ensure-device-sync-reconciler-schedule",
       ],
       expect.objectContaining({
@@ -321,7 +323,7 @@ describe("hosted-local Temporal lifecycle", () => {
     expect(spawnChildProcessMock).toHaveBeenCalledWith(
       "temporal-worker",
       "pnpm",
-      ["--dir", "packages/hosted-orchestrator-temporal", "temporal:worker"],
+      ["--dir", externalPackageDir, "temporal:worker"],
       expect.objectContaining({
         CLOUDFLARE_HOSTED_CONTROL_BASE_URL: "http://127.0.0.1:8787",
         HOSTED_TEMPORAL_ADDRESS: "temporal.example.test:7233",


### PR DESCRIPTION
## Why this PR exists

Murph's hosted Temporal worker is the cleanest first implementation surface to move into the private [`cobuildwithus/murph-cloud`](https://github.com/cobuildwithus/murph-cloud) repository: it owns orchestration policy and production worker operation, while Web and Cloudflare already communicate with it through the public `@murphai/hosted-execution` contract.

A physical move to a sibling private repository should not require a second local stack, a submodule, source mirroring, or a redesign of the Temporal workflow. This PR adds the one public-side seam needed to keep `pnpm dev` canonical after that move.

## User goal / user-visible behavior

There is no member-facing product or messaging change.

For developers, hosted-local still starts the existing in-repo Temporal package by default. An operator with a sibling Murph Cloud checkout may set:

```bash
MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=../murph-cloud/packages/hosted-orchestrator-temporal pnpm dev
```

The same configured package directory is then used for both the idempotent device-sync schedule setup and the Temporal worker process.

## Architecture and reuse

- **Existing systems reused:** The canonical `pnpm hosted-local` / `pnpm dev` entrypoint, existing `pnpm --dir` process boundary, existing Temporal address/namespace/task-queue contracts, signed Web/Cloudflare HTTP boundaries, and existing Temporal lifecycle tests all remain authoritative.
- **New logic:** One small resolver reads and trims `MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR`, falls back to the current in-repo package, and supplies that single value to schedule setup and worker startup.
- **New abstractions:** No new service, package loader, protocol, repository adapter, or orchestration interface is introduced; the change is one configuration seam over the process calls that already exist.
- **Complexity intentionally avoided:** No submodule, source mirror, duplicate dev stack, Git dependency, second scheduler, workflow rewrite, or contract fork is added.

## Invariants

- One hosted-local entrypoint remains authoritative: `pnpm hosted-local` / `pnpm dev`.
- Schedule setup and worker startup cannot drift onto different package directories.
- Blank or missing configuration uses the current in-repo package.
- Temporal remains pointer-only orchestration; Web remains product-state owner and Cloudflare remains execution owner.
- This PR does not move or change the replay-sensitive workflow implementation.
- The public implementation remains the production owner until Murph Cloud consumes a released public contract and the replacement worker is proven healthy.

## Non-obvious surfaces

- **Hot reply path:** unchanged; only the local process package directory is configurable.
- **Provider input impact:** none.
- **Deployment skew:** none for this preparation PR. The later hard cut must deploy and prove Murph Cloud before removing the public worker/deploy owner.

## Preliminary specialist lenses

- **Prompt:** not applicable; no prompt or instruction behavior changed.
- **Frontend:** not applicable; no user-facing web UI changed.
- **Coverage:** applicable. Focused tests cover missing, blank, and external sibling package paths, while existing lifecycle tests cover the two Temporal process calls that consume the resolved directory.
- **Preliminary specialist result:** one coverage finding accepted and resolved by proving the same trimmed external directory reaches schedule setup and worker startup.
- **Current exact-head CI:** green on `3aa1b681269d628840060c1b1bf43b03286e62af`, including release/typecheck, application verification, repository hygiene, hosted runner/web builds, Temporal E2E, and the full hosted E2E matrix.
- **Final ReviewGPT result:** pass with no findings on the exact head above.

## Design proof

Not applicable. No frontend surface changed.

## Verification

- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts --no-coverage test/dev-hosted-local/temporal.test.ts test/dev-hosted-local/temporal-worker-package-dir.test.ts --maxWorkers 1 --no-file-parallelism` — 16 passed.
- `pnpm --dir packages/hosted-local-harness typecheck` — passed.
- `git diff --check` and privacy scan — passed.
- Exact-head GitHub Actions — passed after one same-head rerun of an unrelated pre-existing 1 ms timeout flake in `apps/web`; no extraction files or behavior were changed for the rerun.

## Change shape

Classification rule: runtime harness implementation is counted as config/tooling; `*.test.ts` is tests; Markdown is docs. No binary or generated files.

- Source: +0 / -0
- Tests: +28 / -3
- Docs: +19 / -0
- Config/tooling: +18 / -2
- Generated/other: +0 / -0
- Total: +65 / -5

## Follow-up boundary

The private `cobuildwithus/murph-cloud` repository now exists. Its first implementation surface is the unchanged Temporal package plus Render deployment ownership, consuming an exact released `@murphai/hosted-execution` version. The extraction must preserve workflow names, task queue, schedule id, patch ids, and command order. Only after the private worker builds against that released contract, passes the public full-stack E2E, and polls production healthily should a separate hard-cut PR remove the public worker implementation and deployment owner.

## Final ReviewGPT baseline

ReviewGPT first-reviewed head: 3aa1b681269d628840060c1b1bf43b03286e62af

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 28 | 3 |
| Docs | 19 | 0 |
| Config/tooling | 18 | 2 |
| Generated/other | 0 | 0 |
| Total | 65 | 5 |