### PR TITLE
Make group usage success feel rewarding

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -378,6 +378,16 @@ narrow screens, preserve visible focus and selection states, and render the
 production components on both the Components and Sections tabs of `/design`
 for review.
 
+When group funding is fulfilled, switch from the payment-status composition to
+one confident success hierarchy: a compact sage confirmation mark and mono
+`NICE ONE` label, the Fraunces headline `This group has more Murph`, one
+sentence confirming that the contribution is ready, then a warm-divider handoff
+to **Open Messages**. State that Messages opens without a group deep link and
+the member must choose the group. Do not repeat the confirmation in a bordered
+status card, keep payment-pending copy visible, invent an amount, or add
+celebration graphics. Once fulfillment is verified, do not carry frozen sponsor
+details or their payment-recovery instructions into the success receipt.
+
 ### Spinner
 Use the shared `Spinner` for compact pending feedback inside buttons or beside a
 short status label. Pair it with a disabled control and visible action copy such

--- a/agent-docs/exec-plans/active/2026-07-29-usage-success-redesign.md
+++ b/agent-docs/exec-plans/active/2026-07-29-usage-success-redesign.md
@@ -1,0 +1,94 @@
+# Make usage top-up success feel rewarding and on-brand
+
+Status: active
+Created: 2026-07-29
+Updated: 2026-07-29
+
+## Goal
+
+- Make the fulfilled group usage top-up state feel rewarding, specific, and
+  recognizably Murph while preserving the existing payment, polling, dismissal,
+  and Messages handoff behavior.
+
+## Success criteria
+
+- The fulfilled group state no longer repeats the same confirmation in a
+  bordered status card or shows payment-pending copy after fulfillment.
+- The hierarchy clearly communicates payment completion, the added group
+  capacity, and the honest next step into Messages.
+- Personal and Family fulfilled states remain correct and usable.
+- The real production component is reviewable on the design catalog's section
+  study at desktop and mobile widths.
+- Focused tests, web typecheck, frontend design proof, browser proof, required
+  product/frontend review, exact-head CI, and the scoped commit/PR path complete.
+
+## Scope
+
+- In scope: fulfilled presentation and copy in the existing hosted usage top-up
+  dialog owner, its focused tests, the existing group usage funding design
+  study, and the durable design-system description.
+- Out of scope: payment state transitions, Stripe or billing behavior, top-up
+  amounts, Messages deep-link behavior, new imagery, new dependencies, and
+  unrelated dialog states.
+
+## Constraints
+
+- Technical constraints: keep the current `HostedUsageTopUpDialog` state owner
+  and shared button/dialog primitives; do not add a second success component or
+  state machine.
+- Product/process constraints: warm precision rather than gamified celebration;
+  no false promise that `sms:` can deep-link to the group; preserve keyboard
+  focus, accessible status meaning, responsive layout, and the worktree/PR
+  review gates for user-facing frontend work.
+
+## Risks and mitigations
+
+1. Risk: stronger copy could imply a specific amount or exact chat destination
+   that the fulfilled payload cannot prove.
+   Mitigation: celebrate only the verified fulfilled state, keep the copy
+   amount-neutral, and say that Messages opens so the member can choose the
+   group.
+2. Risk: styling the shared dialog could regress personal, Family, or
+   nonterminal states.
+   Mitigation: branch only on the existing fulfilled confirmation predicate and
+   keep focused assertions for every scope.
+
+## Tasks
+
+1. Redesign the existing fulfilled presentation and tighten its scope-specific
+   copy without changing payment state.
+2. Update focused tests and the existing design-catalog study for the exact
+   fulfilled group state.
+3. Run focused verification and desktop/mobile browser proof, then resolve the
+   required product, frontend, and second-model reviews.
+4. Complete the scoped commit, PR, preliminary ReviewGPT pass, exact-head CI,
+   final parent review, and mergeability proof.
+
+## Decisions
+
+- Use the existing modal because it closes a provider-owned payment handoff and
+  returns the member to conversation; the problem is its success composition,
+  not the presence of a modal.
+- Skip generated imagery. This compact product state has sufficient brand
+  character in the existing typography, paper palette, and one affirmative
+  sage signal.
+- Hide frozen sponsor recovery details only after fulfillment is verified.
+  Nonterminal recovery keeps its original details and actions; the terminal
+  receipt cannot show an impossible cancellation instruction.
+
+## Verification
+
+- Commands to run: focused hosted usage dialog Vitest; web typecheck; frontend
+  design-proof guard; `git diff --check`; desktop and mobile browser capture on
+  `/design?tab=sections`.
+- Expected outcomes: fulfilled group copy and hierarchy are exact, `sms:` and
+  dismissal behavior are unchanged, all focused tests and type checks pass, and
+  rendered evidence is legible and balanced at both viewports.
+- Completed locally: 90 focused dialog tests, web typecheck, scoped ESLint,
+  full Web lint with no errors, 10 frontend design-proof tests, and desktop and
+  mobile catalog proof with no overflow.
+- Product-experience review found one stale frozen-recovery detail during the
+  pending-to-fulfilled transition. The owner-minimal fix and regression proof
+  were implemented locally; the required re-review returned `NO FINDINGS`.
+- The Claude Code UI double-check stopped on explicit Fable usage-credit
+  exhaustion, so no second-model pass is claimed.

--- a/agent-docs/exec-plans/completed/2026-07-29-usage-success-redesign.md
+++ b/agent-docs/exec-plans/completed/2026-07-29-usage-success-redesign.md
@@ -1,6 +1,6 @@
 # Make usage top-up success feel rewarding and on-brand
 
-Status: active
+Status: completed
 Created: 2026-07-29
 Updated: 2026-07-29
 
@@ -92,3 +92,11 @@ Updated: 2026-07-29
   were implemented locally; the required re-review returned `NO FINDINGS`.
 - The Claude Code UI double-check stopped on explicit Fable usage-credit
   exhaustion, so no second-model pass is claimed.
+- Preliminary ReviewGPT inspected the exact pushed review candidate with the
+  frontend and coverage lenses, returned `SPECIALIST_OUTCOME: PASS`, found no
+  issues, and attached no coverage patch.
+- The parent final review found no remaining product, state, accessibility, or
+  proof gap. The later cross-cutting ReviewGPT gate is not applicable because
+  the final change is minor frontend presentation polish with no workflow,
+  state-model, data-flow, authority, payment, or runtime change.
+Completed: 2026-07-29

--- a/apps/web/app/design/group-usage-funding-study.tsx
+++ b/apps/web/app/design/group-usage-funding-study.tsx
@@ -137,11 +137,12 @@ function GroupUsageFundingStudy() {
         data-design-state="usage-added-follow-up"
       >
         <p className="text-sm text-muted-foreground">
-          After a group payment completes, the confirmation offers Open
-          Messages — there is no deep link back into the group thread, so it
-          opens the Messages app. Personal and Family top-ups keep the Text
-          Murph action: one channel renders a direct link; several channels
-          render inline rows in the same dialog.
+          After a group payment completes, the confirmation makes the added
+          capacity unmistakable, then offers Open Messages. Messages cannot
+          deep-link to the group thread, so the handoff says to choose the
+          group. Personal and Family top-ups keep the Text Murph action: one
+          channel renders a direct link; several channels render inline rows in
+          the same dialog.
         </p>
         <div className="flex flex-wrap gap-2">
           <Button
@@ -180,6 +181,11 @@ function GroupUsageFundingStudy() {
             }}
             deferTerminalRefreshUntilClose
             customizationAllowed
+            frozenSponsorship={{
+              publicAlias: "Sunday sleep crew",
+              runningBitRequest: "Keep the recovery jokes going.",
+              sponsorMessage: "More room for the group.",
+            }}
             initialOpen
             offers={[]}
             payerMemberId={DESIGN_PAYER_MEMBER_ID}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -178,7 +178,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Group usage funding and top-up follow-up">
+      <StudySection title="Group usage funding, recovery, and fulfilled receipt">
         <GroupUsageFundingStudy />
       </StudySection>
 

--- a/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
+++ b/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
@@ -289,14 +289,17 @@ function readStatusContent(input: {
 
   switch (input.status) {
     case "fulfilled":
-      return content(
-        "Usage added",
-        input.scope === "group"
-          ? "This group's available usage has been updated."
-          : input.scope === "family" && input.targetLabel
-            ? `The available usage for ${input.targetLabel} has been updated.`
-          : "Your available usage has been updated.",
-      );
+      return input.scope === "group"
+        ? content(
+            "This group has more Murph",
+            "Your contribution landed. The group has more room to talk.",
+          )
+        : content(
+            "Usage added",
+            input.scope === "family" && input.targetLabel
+              ? `The available usage for ${input.targetLabel} has been updated.`
+              : "Your available usage has been updated.",
+          );
     case "expired":
       return content("Checkout canceled", "Checkout canceled. No usage was added.");
     case "payment_failed":

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { CircleAlertIcon, MessageCircle } from "lucide-react";
+import { CheckIcon, CircleAlertIcon, MessageCircle } from "lucide-react";
 
 import { MurphContactChannelRows } from "@/src/components/murph/murph-contact-channel-rows";
 import { MurphContactLink } from "@/src/components/murph/murph-contact-link";
@@ -203,14 +203,39 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
       ) : null}
       <DialogContent
         ref={dialogContentRef}
-        className="max-h-[calc(100dvh-2rem)] gap-7 overflow-y-auto border border-border bg-popover p-6 sm:max-w-xl sm:p-8"
+        className={cn(
+          "max-h-[calc(100dvh-2rem)] gap-7 overflow-y-auto border border-border bg-popover p-6 sm:max-w-xl sm:p-8",
+          showGroupMessagesAction && "sm:max-w-2xl sm:gap-8 sm:p-10",
+        )}
         initialFocus={titleRef}
       >
-        <DialogHeader className="pr-10">
+        <DialogHeader className={cn("pr-10", showGroupMessagesAction && "gap-4")}>
+          {showGroupMessagesAction && statusContent ? (
+            <div
+              className="flex items-center gap-3"
+              role="status"
+              aria-live="polite"
+              aria-label={`${statusContent.title}. ${statusContent.message}`}
+            >
+              <span
+                className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                aria-hidden="true"
+              >
+                <CheckIcon className="size-5 stroke-[2.5]" />
+              </span>
+              <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-primary">
+                Nice one
+              </span>
+            </div>
+          ) : null}
           <DialogTitle
             ref={titleRef}
             tabIndex={-1}
-            className="text-3xl font-semibold leading-[1.1] tracking-tight outline-none"
+            className={cn(
+              "text-3xl font-semibold leading-[1.1] tracking-tight outline-none",
+              showGroupMessagesAction &&
+                "max-w-lg text-[2.5rem] leading-[1.02] tracking-[-0.035em] sm:text-5xl",
+            )}
           >
             {statusContent
               ? `${statusContent.title}${familyTarget && !purchase?.targetConflict ? ` for ${familyTarget}` : ""}`
@@ -222,9 +247,17 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                     ? `Choose an amount for ${familyTarget}`
                     : "Choose an amount"}
           </DialogTitle>
-          <DialogDescription className="max-w-md text-base leading-6">
+          <DialogDescription
+            className={cn(
+              "max-w-md text-base leading-6",
+              showGroupMessagesAction &&
+                "max-w-lg text-[1.0625rem] leading-7 text-muted-foreground",
+            )}
+          >
             {purchase
-              ? purchase.targetConflict
+              ? showGroupMessagesAction && statusContent
+                ? statusContent.message
+                : purchase.targetConflict
                 ? "Manage the unfinished checkout before starting one for this usage destination."
                 : purchase.selectionConflict
                   ? purchase.selectionConflict === "sponsorship"
@@ -247,18 +280,47 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
 
         {purchase && statusContent ? (
           <div className="flex flex-col gap-5">
-            <div
-              className="rounded-2xl border border-border bg-muted/30 p-5"
-              role="status"
-              aria-live="polite"
-            >
-              <p className="text-pretty text-sm leading-6 text-foreground">
-                {statusContent.message}
-              </p>
-            </div>
-            {props.renderPurchaseDetails}
+            {!showGroupMessagesAction ? (
+              <div
+                className="rounded-2xl border border-border bg-muted/30 p-5"
+                role="status"
+                aria-live="polite"
+              >
+                <p className="text-pretty text-sm leading-6 text-foreground">
+                  {statusContent.message}
+                </p>
+              </div>
+            ) : null}
+            {showGroupMessagesAction ? null : props.renderPurchaseDetails}
             <FieldError>{purchase.checkoutError}</FieldError>
             <div className="flex flex-col gap-2">
+              {showGroupMessagesAction ? (
+                <div className="grid gap-5 border-y border-border py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:py-6">
+                  <div className="space-y-1.5">
+                    <p className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                      Back to the chat
+                    </p>
+                    <p className="text-pretty text-sm leading-6 text-foreground">
+                      Messages will open. Choose this group to keep going.
+                    </p>
+                  </div>
+                  {/* Messages has no deep link into an existing group thread, so
+                  the group follow-up can only open the app itself. */}
+                  <a
+                    href="sms:"
+                    className={cn(
+                      buttonVariants({ size: "xl" }),
+                      "w-full sm:w-auto",
+                    )}
+                  >
+                    <MessageCircle
+                      className="size-4 shrink-0"
+                      aria-hidden="true"
+                    />
+                    Open Messages
+                  </a>
+                </div>
+              ) : null}
               {canResume ? (
                 <Button
                   type="button"
@@ -329,17 +391,6 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                   Check again
                 </Button>
               ) : null}
-              {showGroupMessagesAction ? (
-                // Messages has no deep link into an existing group thread, so
-                // the group follow-up can only open the app itself.
-                <a
-                  href="sms:"
-                  className={cn(buttonVariants({ size: "lg" }), "w-full")}
-                >
-                  <MessageCircle className="size-4 shrink-0" aria-hidden="true" />
-                  Open Messages
-                </a>
-              ) : null}
               {showContactAction ? (
                 contactOptions.length === 1 ? (
                   <MurphContactLink
@@ -366,10 +417,12 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                 type="button"
                 variant="ghost"
                 size="lg"
-                className="w-full"
+                className={cn(
+                  showGroupMessagesAction ? "mt-3 self-center px-8" : "w-full",
+                )}
                 onClick={() => controller.handleOpenChange(false)}
               >
-                Close
+                {showGroupMessagesAction ? "Done" : "Close"}
               </Button>
             </div>
           </div>

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -109,7 +109,9 @@ test("design page routes the biomarker studies through the dedicated sections ta
   expect(sectionsMarkup.match(/Illustrative examples\./g)).toHaveLength(2);
   expect(sectionsMarkup).toContain("Biomarker preparing state");
   expect(sectionsMarkup).toContain("Biomarker index");
-  expect(sectionsMarkup).toContain("Group usage funding and top-up follow-up");
+  expect(sectionsMarkup).toContain(
+    "Group usage funding, recovery, and fulfilled receipt",
+  );
   expect(sectionsMarkup).toContain("Overall AI usage and fulfilled top-up");
   expect(sectionsMarkup).toContain("Biomarker result detail");
   expect(sectionsMarkup).toContain("Biomarker reference context");

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -1596,6 +1596,78 @@ test("restarts polling when a frozen retry advances the same purchase", async ()
   }
 });
 
+test("removes frozen sponsor recovery details once group usage is fulfilled", async () => {
+  const status = deferred<unknown>();
+  mocks.requestHostedOnboardingJson.mockReturnValueOnce(status.promise);
+  const { GroupSponsorshipDialog } = await import(
+    "@/src/components/hosted-groups/group-sponsorship-dialog"
+  );
+  const rendered = await renderClientComponent(
+    createElement(GroupSponsorshipDialog, {
+      payerMemberId: TEST_PAYER_MEMBER_ID,
+      activePurchase: {
+        offerCode: "usage_10_usd",
+        purchaseId: "hucp_group_frozen_fulfilled",
+        retryAllowed: true,
+        status: "reconciling",
+      },
+      customizationAllowed: false,
+      frozenSponsorship: {
+        publicAlias: "Sunday sleep crew",
+        runningBitRequest: "Keep the recovery jokes going.",
+        sponsorMessage: "More room for the group.",
+      },
+      offers: [],
+    }),
+    {
+      location: { href: "https://example.test/groups/fund/group_join_code_1234" },
+      requireButton: false,
+    },
+  );
+
+  try {
+    await clickButton(rendered.container, rendered.window, "Check payment");
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Your original sponsor details are still attached/,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Cancel this payment before changing them\./,
+    );
+
+    await act(async () => {
+      status.resolve({
+        purchaseId: "hucp_group_frozen_fulfilled",
+        status: "fulfilled",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.match(
+      rendered.container.textContent ?? "",
+      /This group has more Murph/,
+    );
+    assert.doesNotMatch(
+      rendered.container.textContent ?? "",
+      /original sponsor details|Cancel this payment/,
+    );
+    const contactLink = rendered.container.querySelector("a");
+    assert.ok(contactLink);
+    assert.equal(contactLink.textContent, "Open Messages");
+    assert.equal(contactLink.getAttribute("href"), "sms:");
+    assert.equal(
+      rendered.container.querySelectorAll('[role="status"]').length,
+      1,
+    );
+    await clickButton(rendered.container, rendered.window, "Done");
+    assert.equal(rendered.container.querySelector('[role="dialog"]'), null);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
 test("preserves a frozen retry key across status-only recovery", async () => {
   let statusReadCount = 0;
   mocks.requestHostedOnboardingJson.mockImplementation(async (request: {
@@ -4138,17 +4210,29 @@ test("offers Open Messages on a fulfilled group top-up return", async () => {
       await Promise.resolve();
     });
 
-    assert.match(rendered.container.textContent ?? "", /Usage added/);
+    assert.match(rendered.container.textContent ?? "", /Nice one/);
     assert.match(
       rendered.container.textContent ?? "",
-      /This group's available usage has been updated\./,
+      /This group has more Murph/,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Your contribution landed\. The group has more room to talk\./,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Messages will open\. Choose this group to keep going\./,
     );
     const contactLink = rendered.container.querySelector("a");
     assert.ok(contactLink);
     assert.equal(contactLink.textContent, "Open Messages");
     assert.equal(contactLink.getAttribute("href"), "sms:");
     assert.doesNotMatch(rendered.container.textContent ?? "", /Text Murph/);
-    assert.equal(buttonByText(rendered.container, "Close").disabled, false);
+    assert.equal(buttonByText(rendered.container, "Done").disabled, false);
+    assert.equal(
+      rendered.container.querySelectorAll('[role="status"]').length,
+      1,
+    );
   } finally {
     await rendered.cleanup();
   }


### PR DESCRIPTION
## Why this PR exists

The fulfilled group usage dialog looked like another payment status box instead
of a satisfying receipt. This gives the verified success state a confident,
Murph-specific hierarchy and a clearer return to the conversation.

## User goal / user-visible behavior

After a group contribution is fulfilled, the contributor sees one rewarding
confirmation that the group has more room to talk, then can open Messages or
dismiss the receipt. The handoff remains honest that Messages opens at the app
level and the contributor must choose the group.

## User experience

The existing group funding entry point, provider checkout, return handling, and
status polling are unchanged. While payment is nonterminal, the existing
recovery details and actions remain available. As soon as the existing status
owner verifies `fulfilled`, the dialog switches to one live success receipt,
removes stale recovery instructions, presents **Open Messages** as the only
primary action, and offers **Done** as a quiet dismissal.

Payment/provider timing, retries, cancellation, and refresh ownership are
unchanged by this PR. Failure and recovery states retain their existing UI; the
new hierarchy appears only after verified fulfillment. The next experience is
immediate and user-directed: **Open Messages** launches `sms:`, and the helper
copy tells the contributor to choose the group because Messages has no group
deep link.

Desktop and mobile catalog renders prove the final fulfilled state with frozen
recovery data supplied, no stale recovery copy, no horizontal overflow, one
status region, the preserved `sms:` link, and a working **Done** dismissal. The
required product-experience review returned `NO FINDINGS` after one accepted
stale-recovery finding was fixed. The Claude Code UI double-check was attempted
with Fable and stopped on explicit usage-credit exhaustion, so no second-model
pass is claimed.

## Invariants the PR must preserve

- The celebratory receipt appears only after the existing owner verifies
  `fulfilled`; it must not imply success while payment is pending or failed.
- Frozen sponsor details and cancellation guidance remain available for
  nonterminal recovery, then disappear from the terminal receipt.
- **Open Messages** remains `sms:` and must not claim to deep-link into the
  group thread.
- Personal and Family fulfilled states, checkout payloads, payment polling,
  cancellation, retries, refresh behavior, and credit fulfillment remain
  unchanged.
- The success state retains one accessible live status and remains contained at
  desktop and mobile widths.

## Non-obvious affected surfaces

- The group-only fulfilled status copy changes in the shared top-up status
  contract. Focused assertions preserve the existing Personal and Family copy.
- Frozen sponsorship recovery details are suppressed only in the verified group
  terminal state. A pending-to-fulfilled wrapper test proves the details remain
  visible before fulfillment and disappear afterward.
- The existing group usage funding section study now supplies synthetic frozen
  sponsorship data, and `DESIGN.md` records the terminal success hierarchy.
  Frontend design-proof tests guard the catalog contract.

## Architecture and reuse

- **Existing systems reused:** The existing `HostedUsageTopUpDialog`,
  `GroupSponsorshipDialog`, shared Dialog/Button primitives, status contract,
  design-catalog study, and focused test suite remain the owners.
- **New logic:** The established fulfilled-group predicate selects the stronger
  presentation and omits nonterminal recovery details once fulfillment is
  verified.
- **New abstractions:** No abstraction was added because the existing status
  predicate and render slot already express the correct owner boundary.
- **Complexity intentionally avoided:** No new state, component, animation
  system, dependency, payment branch, deep-link claim, or duplicated success
  flow was introduced.

## Hot reply path impact

Not applicable. This PR changes only the Web group-funding receipt and adds no
database, network, provider, or other awaited operation to the Foreground Reply
Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool, schema, skill,
  provider-request builder, or provider-visible wrapper changed.
- Group Murph: Not applicable. No prompt, tool, schema, skill, provider-request
  builder, or provider-visible wrapper changed.

## Preliminary specialist lenses

- **Prompt:** Not applicable — no prompt or provider-visible instruction
  surface changed.
- **Frontend:** Applicable —
  `audit-packages/usage-success-desktop.png` shows the fulfilled group receipt
  at 1440x1000 and `audit-packages/usage-success-mobile.png` shows it at
  390x844, both with synthetic frozen sponsorship data supplied.
- **Coverage:** Applicable —
  `apps/web/test/hosted-usage-top-up-dialog.test.tsx` passes all 90 focused
  tests, including the pending-to-fulfilled frozen-details regression;
  exact-head GitHub Actions are pending and will run concurrently with the
  preliminary pass.

## Change-shape breakdown

Classification rule: production and design-catalog TypeScript is source;
Vitest assertions are tests/fixtures; `DESIGN.md` and the completed execution plan
are docs. No config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 105 | 43 |
| Tests / fixtures | 87 | 3 |
| Docs | 112 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **304** | **46** |

## Verification

- Focused hosted usage dialog suite — 90 passed.
- Web typecheck — passed.
- Scoped ESLint — passed.
- Full Web lint — 0 errors; 22 pre-existing warnings outside the changed
  surface.
- Frontend design-proof contract — 10 passed.
- Desktop and 390 px mobile catalog interaction proof — passed with no
  overflow, one status region, preserved `sms:`, and working dismissal.
- Product-experience review — `NO FINDINGS` after the accepted frozen-recovery
  correction.
- Preliminary ReviewGPT frontend/coverage pass — `SPECIALIST_OUTCOME: PASS`,
  zero findings, no coverage patch.
- Final ReviewGPT gate — not applicable; this is minor frontend presentation
  polish with no workflow, state-model, data-flow, authority, payment, or
  runtime change.
- Claude Code UI double-check — attempted with Fable; stopped on explicit
  usage-credit exhaustion.
- `git diff --check` and identifier/privacy scan — passed.
- Required exact-head GitHub Actions — pending.

## Design proof

- Design page: [Group usage funding section](/design?tab=sections#group-usage-funding)
- Desktop screenshot: ![Desktop fulfilled group usage receipt](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/caeeb2a2-f9e7-4e78-b06d-afa3bbb71500/public)
- Mobile screenshot: ![Mobile fulfilled group usage receipt](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/957af17c-72a4-4ce5-03a0-0c8c55d8a700/public)
