### PR TITLE
Fix email-only Family invite acceptance

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-29-email-family-invite-phone-optional.md
+++ b/agent-docs/exec-plans/active/2026-07-29-email-family-invite-phone-optional.md
@@ -1,0 +1,35 @@
+Goal (incl. success criteria):
+- Let a member with a verified email accept an email-bound Family invite without supplying a phone number.
+- Keep phone verification required before Murph assigns a new Linq/iMessage home line.
+- Success means a focused regression test reproduces the current failure, the smallest activation-routing correction passes it, and existing phone, existing-thread, and Telegram behavior remains covered.
+
+Constraints/Assumptions:
+- The Family product contract already authorizes web acceptance through a matching verified email.
+- Family acceptance and activation remain one transaction; do not split them or add retry/state machinery.
+- Do not weaken invite identity binding or allow email identity to authorize a phone/iMessage sender.
+- Reuse an existing Linq thread when one is already bound; otherwise activate email-only members without a signup welcome route.
+
+Key decisions:
+- Prove the failure at the activation boundary before editing production code.
+- Correct route selection rather than catching or suppressing the downstream phone-required error.
+
+State:
+- In progress.
+
+Done:
+- Traced the email-bound web accept route through Family membership activation.
+- Confirmed a verified email lookup is incorrectly treated as sufficient reason to attempt a new Linq home-line assignment.
+
+Now:
+- Add a focused activation regression test for a verified-email-only member with no existing messaging route.
+
+Next:
+- Implement the narrow routing correction, run focused proof, and complete the required product, specialist, CI, and final ReviewGPT gates.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- apps/web/src/lib/hosted-onboarding/member-activation.ts
+- apps/web/test/hosted-onboarding-member-activation.test.ts
+- pnpm test:diff <touched paths>

--- a/agent-docs/exec-plans/completed/2026-07-29-email-family-invite-phone-optional.md
+++ b/agent-docs/exec-plans/completed/2026-07-29-email-family-invite-phone-optional.md
@@ -14,17 +14,26 @@ Key decisions:
 - Correct route selection rather than catching or suppressing the downstream phone-required error.
 
 State:
-- In progress.
+- Complete.
 
 Done:
 - Traced the email-bound web accept route through Family membership activation.
 - Confirmed a verified email lookup is incorrectly treated as sufficient reason to attempt a new Linq home-line assignment.
+- Add a focused activation regression test for a verified-email-only member with no existing messaging route.
+- Corrected activation route selection so a phone-less member only enters Linq route resolution when an existing home or pending thread can be reused.
+- Preserved phone verification before new home-line assignment, existing-thread reuse, Telegram routing, atomic activation, and the canonical activation event.
+- Proved the focused regression failed before the production change and passed afterward.
+- Passed the combined Family acceptance suite and the full affected `apps/web` diff verification.
+- Completed product-experience review with no findings.
+- Accepted the preliminary coverage finding and added activation-boundary tests for established and pending email-handle Linq threads.
+- Passed the preliminary remediation proof: 77 focused tests, scoped ESLint, and `git diff --check`.
+- Completed the parent final diff review with no remaining findings.
 
 Now:
-- Add a focused activation regression test for a verified-email-only member with no existing messaging route.
+- Archive this completed plan and continue the immutable final ReviewGPT and exact-head CI gates.
 
 Next:
-- Implement the narrow routing correction, run focused proof, and complete the required product, specialist, CI, and final ReviewGPT gates.
+- None.
 
 Open questions (UNCONFIRMED if needed):
 - None.
@@ -33,3 +42,6 @@ Working set (files/ids/commands):
 - apps/web/src/lib/hosted-onboarding/member-activation.ts
 - apps/web/test/hosted-onboarding-member-activation.test.ts
 - pnpm test:diff <touched paths>
+Status: completed
+Updated: 2026-07-29
+Completed: 2026-07-29

--- a/apps/web/src/lib/hosted-onboarding/member-activation.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-activation.ts
@@ -381,16 +381,12 @@ async function resolveHostedMemberActivationWelcomeLinqRoute(input: {
     input.member.routing?.linqChatId
     || input.member.routing?.pendingLinqChatId,
   );
-  const hasTelegramRoute = Boolean(
-    input.member.routing?.telegramThreadId
-    || input.member.routing?.telegramUserId,
-  );
 
   if (
     !input.member.identity?.phoneNumber
     && (
       !linqContactLookupKey
-      || (hasTelegramRoute && !hasReusableLinqThread)
+      || !hasReusableLinqThread
     )
   ) {
     return {

--- a/apps/web/test/hosted-onboarding-member-activation.test.ts
+++ b/apps/web/test/hosted-onboarding-member-activation.test.ts
@@ -570,6 +570,90 @@ describe("hosted onboarding member activation", () => {
     });
   });
 
+  it.each([
+    {
+      name: "an established Linq thread",
+      routing: {
+        linqChatId: "chat_home_email",
+        linqHomeLineAssignedAt: new Date("2026-06-18T11:00:00.000Z"),
+        linqRecipientPhone: null,
+        memberId: "member_123",
+        pendingLinqChatId: null,
+        pendingLinqParticipantContact: null,
+        pendingLinqRecipientPhone: null,
+        telegramThreadId: null,
+        telegramUserId: null,
+        telegramUserLookupKey: null,
+      },
+    },
+    {
+      name: "a pending email-handle Linq thread",
+      routing: {
+        linqChatId: null,
+        linqHomeLineAssignedAt: null,
+        linqRecipientPhone: null,
+        memberId: "member_123",
+        pendingLinqChatId: "chat_pending_email",
+        pendingLinqParticipantContact: {
+          kind: "email" as const,
+          lookupKey: "hbidx:email:v1:lookup",
+          observedAt: new Date("2026-06-18T11:00:00.000Z"),
+          value: "member@example.com",
+        },
+        pendingLinqRecipientPhone: null,
+        telegramThreadId: null,
+        telegramUserId: null,
+        telegramUserLookupKey: null,
+      },
+    },
+  ])("reuses $name for verified-email-only family members", async ({ routing }) => {
+    const member = makeMemberSnapshot({
+      core: {
+        billingStatus: HostedBillingStatus.canceled,
+      },
+      emailAuthorization: {
+        directPublicSender: null,
+        memberId: "member_123",
+        stripeCheckoutEmail: null,
+        verifiedEmail: {
+          address: "member@example.com",
+          lookupKey: "hbidx:email:v1:lookup",
+          verifiedAt: new Date("2026-06-18T12:00:00.000Z"),
+        },
+      },
+      identity: {
+        phoneLookupKey: null,
+        phoneNumber: null,
+        phoneNumberVerifiedAt: null,
+      },
+      routing,
+    });
+    setActivationMemberSnapshot(member);
+
+    await expect(activateHostedMemberForFamilySponsorshipTx({
+      memberId: member.core.id,
+      occurredAt: new Date("2026-06-18T12:00:00.000Z"),
+      prisma: makeTransactionHarness({
+        accountGroupMemberships: [{
+          group: { billingStatus: HostedBillingStatus.active, suspendedAt: null },
+          status: "active",
+        }],
+        billingStatus: HostedBillingStatus.canceled,
+        suspendedAt: null,
+        threadContainer: null,
+      }) as never,
+      sourceEventId: `family-invite:${routing.linqChatId ?? routing.pendingLinqChatId}`,
+    })).resolves.toMatchObject({
+      activated: true,
+      memberId: "member_123",
+    });
+
+    expect(mocks.resolveHostedMemberActivationLinqRoute).toHaveBeenCalledWith({
+      member,
+      prisma: expect.anything(),
+    });
+  });
+
   it("uses caller-prepared roots for family sponsorship without the legacy bridge", async () => {
     const member = makeMemberSnapshot({
       core: {

--- a/apps/web/test/hosted-onboarding-member-activation.test.ts
+++ b/apps/web/test/hosted-onboarding-member-activation.test.ts
@@ -512,6 +512,64 @@ describe("hosted onboarding member activation", () => {
     });
   });
 
+  it("activates verified-email-only family members without assigning a Linq home line", async () => {
+    const member = makeMemberSnapshot({
+      core: {
+        billingStatus: HostedBillingStatus.canceled,
+      },
+      emailAuthorization: {
+        directPublicSender: null,
+        memberId: "member_123",
+        stripeCheckoutEmail: null,
+        verifiedEmail: {
+          address: "member@example.com",
+          lookupKey: "hbidx:email:v1:lookup",
+          verifiedAt: new Date("2026-06-18T12:00:00.000Z"),
+        },
+      },
+      identity: {
+        phoneLookupKey: null,
+        phoneNumber: null,
+        phoneNumberVerifiedAt: null,
+      },
+      routing: null,
+    });
+    setActivationMemberSnapshot(member);
+
+    await expect(activateHostedMemberForFamilySponsorshipTx({
+      memberId: member.core.id,
+      occurredAt: new Date("2026-06-18T12:00:00.000Z"),
+      prisma: makeTransactionHarness({
+        accountGroupMemberships: [{
+          group: { billingStatus: HostedBillingStatus.active, suspendedAt: null },
+          status: "active",
+        }],
+        billingStatus: HostedBillingStatus.canceled,
+        suspendedAt: null,
+        threadContainer: null,
+      }) as never,
+      sourceEventId: "family-invite:email-only",
+    })).resolves.toMatchObject({
+      activated: true,
+      memberId: "member_123",
+    });
+
+    expect(mocks.resolveHostedMemberActivationLinqRoute).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+      envelope: expect.objectContaining({
+        kind: "member.activated",
+        memberChannels: {
+          email: true,
+          linq: false,
+          telegram: false,
+        },
+        signupWelcome: null,
+      }),
+      tx: expect.anything(),
+    });
+  });
+
   it("uses caller-prepared roots for family sponsorship without the legacy bridge", async () => {
     const member = makeMemberSnapshot({
       core: {


### PR DESCRIPTION
## Why this PR exists

A person invited to Murph Family through a verified email could create an account but the final acceptance transaction failed because activation tried to assign a new Linq/iMessage home line without a phone number.

## User goal / user-visible behavior

A matching verified email can accept and activate an email-bound Family membership without supplying a phone number. Phone verification remains required before Murph assigns a new Linq/iMessage home line.

ReviewGPT first-reviewed head: 2c72b785235ffd4a37d4ab11ccc1e5e1e2a2fc95

## User experience

The invitee signs in with the email address that received the invite and taps **Accept invite**. The existing synchronous request continues to show `Joining...`, then the normal `You're in. Welcome to Murph.` success state. Membership and activation remain one transaction. When the member has no phone and no existing eligible messaging thread, activation records the email-only member state without queueing an undeliverable signup welcome. The member can connect a phone later. Identity mismatch, inactive invite, capacity, and other existing failures remain fail-closed and use the current error recovery.

## Root cause and change

The activation welcome selector treated a verified email lookup key as sufficient reason to enter new Linq home-line assignment even when there was no reusable Linq thread. The downstream line owner correctly rejected the missing verified phone, which rolled back the Family acceptance transaction.

The fix only enters Linq route resolution for a phone-less member when both an identity lookup and an existing home or pending Linq thread are available. An existing Telegram thread remains eligible through the unchanged welcome-route builder. When neither reusable route exists, activation proceeds with no messaging welcome route. Focused regression tests cover the exact email-only Family case and both preserved Linq-thread shapes.

## Invariants

- A matching verified email may claim only its email-bound invite.
- Email identity never authorizes a phone/iMessage sender or a new Linq home-line assignment.
- Existing bound Linq threads may still be reused for phone-less email-handle members.
- Family membership and activation remain atomic.
- Activation still appends the canonical `member.activated` mailbox event.
- No retry owner, persisted field, queue, compatibility path, or new state machine is added.

## Non-obvious affected surfaces

- Hosted member activation welcome routing: necessary because Family acceptance reuses the shared activation owner. Regression proof is `hosted-onboarding-member-activation.test.ts`, including the phone-less no-thread, established-thread, pending-thread, phone, and Telegram cases.
- Signup welcome delivery: email-only members without an existing messaging route now intentionally have `signupWelcome: null`; the activation event still reports `{ email: true, linq: false, telegram: false }`.

## Architecture and reuse

- Existing systems reused: The existing Family acceptance transaction, hosted member activation owner, verified identity lookup, activation mailbox event, and current welcome-route selector remain the single path.
- New logic: A phone-less member enters Linq route resolution only when an identity lookup and an existing home or pending Linq thread are both available. Existing Telegram routing remains unchanged; with no reusable messaging route, activation succeeds without a welcome route.
- New abstractions: None; the existing activation branch is sufficient and the regression is covered in its current test suite.
- Complexity intentionally avoided: No table, queue, service, compatibility layer, retry owner, persisted field, or new state machine was added.

## Hot reply path impact

Not applicable. This changes synchronous Family web acceptance/activation, not durable acceptance of a current conversation message through provider start and durable reply handoff. It adds no database or provider call.

## Murph initial provider input impact

Not applicable. No prompt, model input, tool description, or provider-visible assistant context changes.

## Product-experience review

`NO FINDINGS`. The smallest complete experience is preserved: matching verified email acceptance succeeds immediately, no false iMessage authority is created, the existing success/error feedback remains unchanged, and phone connection stays a later optional step.

## Preliminary specialist lenses

- Prompt: **not applicable** — no prompt or tool-description changes.
- Frontend: **not applicable** — no UI source, state model, copy, or layout changes.
- Coverage: **applicable** — executable activation routing changed; the one accepted coverage finding was resolved with activation-boundary proof for established and pending email-handle Linq threads.
- Rendered evidence: **not applicable** — no frontend diff.
- Focused remediation proof: 77/77 tests passed across activation and Linq home routing; scoped ESLint and `git diff --check` passed.
- Patch artifact disposition: the suggested external patch was not available locally; the finding was independently verified and implemented as a scoped test-only commit.
- Exact-head CI status: **pending**.

## Verification

- Before fix: the new regression failed because `resolveHostedMemberActivationLinqRoute` was called for a verified-email-only member with no thread.
- After fix: focused activation test file — 23/23 passed before review remediation.
- Family acceptance path — 182/182 passed.
- `pnpm test:diff apps/web/src/lib/hosted-onboarding/member-activation.ts apps/web/test/hosted-onboarding-member-activation.test.ts` — passed, including dependency and boundary guards, TypeScript 7, 7402 passed / 225 skipped web tests, lint with no errors, dev smoke, and production Next build.
- Preliminary remediation command over activation and Linq home-routing tests — 77/77 passed.
- Scoped ESLint and `git diff --check` — passed.
- Final ReviewGPT round 1 — `ROUND_OUTCOME: PASS`, no qualifying findings.

## Change shape

Classification: production TypeScript is source; Vitest files are tests; the completed execution plan is docs; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 5 |
| Tests / fixtures | 142 | 0 |
| Docs | 47 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **190** | **5** |

## Design proof

Not applicable; no user-facing frontend code changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787952676&installation_model_id=19880&pr_number=1139&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1139&signature=c0537a7615f1aaed5c651629ec0bd28b541722aba9c4acccbb29a16d72f046dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->