### PR TITLE
Keep onboarding steps on a horizontal track

### DIFF
--- a/apps/web/app/design/home-onboarding-steps-study.tsx
+++ b/apps/web/app/design/home-onboarding-steps-study.tsx
@@ -1,0 +1,39 @@
+import { ArrowRight } from "lucide-react";
+
+import {
+  getOnboardingStepActionClass,
+  OnboardingSteps,
+} from "@/src/components/home/onboarding-steps";
+
+function StudyAction({
+  children,
+  primary = false,
+}: {
+  children: string;
+  primary?: boolean;
+}) {
+  return (
+    <a
+      className={getOnboardingStepActionClass(primary)}
+      href="/design?tab=sections"
+    >
+      {children}
+      <ArrowRight className="size-4" />
+    </a>
+  );
+}
+
+export function HomeOnboardingStepsStudy() {
+  return (
+    <div
+      data-design-section="home-onboarding-steps"
+      id="home-onboarding-steps"
+      inert
+    >
+      <OnboardingSteps
+        messageMurphAction={<StudyAction primary>Message</StudyAction>}
+        uploadLabsAction={<StudyAction>Sync</StudyAction>}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -25,6 +25,7 @@ import { FamilyInviteJoinStudy } from "./family-invite-join-study";
 import { GroupJoinStudy } from "./group-join-study";
 import { GrowthScorecardStudy } from "./growth-scorecard-study";
 import { HomeLoadStateStudy } from "./home-load-state-study";
+import { HomeOnboardingStepsStudy } from "./home-onboarding-steps-study";
 import { PersonaOnboardingStudy } from "./persona-onboarding-study";
 import { PulseTrialBillingContinuationStudy } from "./pulse-trial-billing-continuation-study";
 import { SettingsAuthRequiredStudy } from "./settings-auth-required-study";
@@ -212,6 +213,12 @@ export function SectionsContent() {
 
       <StudySection title="Home partial-load recovery">
         <HomeLoadStateStudy />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Home onboarding steps">
+        <HomeOnboardingStepsStudy />
       </StudySection>
 
       <Separator />

--- a/apps/web/e2e/viewport-overflow.spec.ts
+++ b/apps/web/e2e/viewport-overflow.spec.ts
@@ -146,6 +146,114 @@ for (const route of ROUTES) {
   }
 }
 
+test("home onboarding steps keep equal cards across dashboard widths", async ({
+  page,
+}) => {
+  test.setTimeout(300_000);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.route("**/*", (route) => {
+    if (isLoopbackUrl(route.request().url())) {
+      route.continue();
+    } else {
+      route.abort();
+    }
+  });
+
+  const response = await page.goto(
+    "/design?tab=sections#home-onboarding-steps",
+    { waitUntil: "load" },
+  );
+  expect(response?.status(), "onboarding study should respond 200").toBe(200);
+
+  const study = page.locator(
+    '[data-design-section="home-onboarding-steps"]',
+  );
+  const track = study.locator("[data-onboarding-steps]");
+  await expect(track).toBeVisible();
+
+  for (const viewportWidth of [1023, 1024, 1050, 1280, 1440] as const) {
+    await page.setViewportSize({ width: viewportWidth, height: 900 });
+    const dashboardContentWidth = viewportWidth - 256 - 112;
+    await study.evaluate((element, width) => {
+      element.style.maxWidth = `${width}px`;
+      element.style.width = `${width}px`;
+    }, dashboardContentWidth);
+    await page.evaluate(async () => {
+      await document.fonts?.ready;
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      );
+    });
+
+    const layout = await track.evaluate((element, tolerance) => {
+      const cards = Array.from(
+        element.querySelectorAll<HTMLElement>("[data-onboarding-step]"),
+      );
+      const trackRect = element.getBoundingClientRect();
+      const measureCards = () => {
+        const withinTrack = (rect: DOMRect) =>
+          rect.left >= trackRect.left - tolerance
+          && rect.right <= trackRect.right + tolerance;
+        return {
+          actionsContained: cards.every((card) => {
+            const cardRect = card.getBoundingClientRect();
+            const actionRect = card.querySelector<HTMLElement>(
+              "a, button",
+            )?.getBoundingClientRect();
+            return Boolean(
+              actionRect
+              && actionRect.left >= cardRect.left - tolerance
+              && actionRect.right <= cardRect.right + tolerance,
+            );
+          }),
+          visibleCards: cards.filter((card) =>
+            withinTrack(card.getBoundingClientRect())
+          ).length,
+          widths: cards.map((card) => card.getBoundingClientRect().width),
+        };
+      };
+
+      element.scrollLeft = 0;
+      const start = measureCards();
+      element.scrollLeft = element.scrollWidth - element.clientWidth;
+      const end = measureCards();
+
+      return {
+        actionsContained: start.actionsContained,
+        clientWidth: element.clientWidth,
+        display: window.getComputedStyle(element).display,
+        documentOverflow:
+          document.documentElement.scrollWidth
+          - document.documentElement.clientWidth,
+        endVisibleCards: end.visibleCards,
+        maxCardWidthDelta:
+          Math.max(...start.widths) - Math.min(...start.widths),
+        scrollWidth: element.scrollWidth,
+        startVisibleCards: start.visibleCards,
+      };
+    }, OVERFLOW_TOLERANCE_PX);
+
+    expect(layout.documentOverflow).toBeLessThanOrEqual(OVERFLOW_TOLERANCE_PX);
+
+    if (viewportWidth < 1024) {
+      expect(layout.display).toBe("grid");
+      expect(layout.scrollWidth).toBeLessThanOrEqual(
+        layout.clientWidth + OVERFLOW_TOLERANCE_PX,
+      );
+      continue;
+    }
+
+    expect(layout.display).toBe("flex");
+    expect(layout.scrollWidth).toBeGreaterThan(layout.clientWidth);
+    expect(layout.maxCardWidthDelta).toBeLessThanOrEqual(
+      OVERFLOW_TOLERANCE_PX,
+    );
+    expect(layout.actionsContained).toBe(true);
+    expect(layout.startVisibleCards).toBe(3);
+    expect(layout.endVisibleCards).toBe(3);
+  }
+});
+
 test("clubs stays reachable through the global navigation at every breakpoint", async ({
   page,
 }) => {

--- a/apps/web/src/components/home/onboarding-steps.tsx
+++ b/apps/web/src/components/home/onboarding-steps.tsx
@@ -138,7 +138,7 @@ export function OnboardingSteps({
         return (
           <div
             key={step.id}
-            className={`group flex flex-col justify-between rounded-2xl border p-7 transition-colors duration-300 lg:flex-none ${desktopCardWidthClass} ${isPrimary ? "border-primary/35 bg-primary/12 hover:border-primary/45" : "border-border/50 bg-[rgba(255,252,246,0.9)] hover:border-[#7a8c6e]/25"}`}
+            className={`group flex flex-col justify-between rounded-2xl border p-7 transition-colors duration-300 lg:min-w-0 lg:flex-none ${desktopCardWidthClass} ${isPrimary ? "border-primary/35 bg-primary/12 hover:border-primary/45" : "border-border/50 bg-[rgba(255,252,246,0.9)] hover:border-[#7a8c6e]/25"}`}
             data-onboarding-step={step.id}
           >
             <div>

--- a/apps/web/src/components/home/onboarding-steps.tsx
+++ b/apps/web/src/components/home/onboarding-steps.tsx
@@ -93,11 +93,16 @@ export function OnboardingSteps({
   // cannot prompt for on its own.
   const primaryStepId = messageMurphAction ? "message" : "devices";
 
-  const gridColsClass =
-    visibleSteps.length >= 3 ? "sm:grid-cols-2 xl:grid-cols-3" : "sm:grid-cols-2";
+  const desktopCardWidthClass =
+    visibleSteps.length >= 3
+      ? "lg:basis-[calc((100%-2.5rem)/3)]"
+      : "lg:basis-[calc((100%-1.25rem)/2)]";
 
   return (
-    <div className={`grid gap-5 ${gridColsClass}`}>
+    <div
+      className="grid gap-5 sm:grid-cols-2 lg:flex lg:overflow-x-auto lg:pb-2"
+      data-onboarding-steps
+    >
       {visibleSteps.map((step, i) => {
         const Icon = step.icon;
         const isPrimary = step.id === primaryStepId;
@@ -133,7 +138,8 @@ export function OnboardingSteps({
         return (
           <div
             key={step.id}
-            className={`group flex flex-col justify-between rounded-2xl border p-7 transition-colors duration-300 ${isPrimary ? "border-primary/35 bg-primary/12 hover:border-primary/45" : "border-border/50 bg-[rgba(255,252,246,0.9)] hover:border-[#7a8c6e]/25"}`}
+            className={`group flex flex-col justify-between rounded-2xl border p-7 transition-colors duration-300 lg:flex-none ${desktopCardWidthClass} ${isPrimary ? "border-primary/35 bg-primary/12 hover:border-primary/45" : "border-border/50 bg-[rgba(255,252,246,0.9)] hover:border-[#7a8c6e]/25"}`}
+            data-onboarding-step={step.id}
           >
             <div>
               <div className="mb-6 flex items-start justify-between">

--- a/apps/web/test/onboarding-steps.test.ts
+++ b/apps/web/test/onboarding-steps.test.ts
@@ -116,3 +116,20 @@ test("OnboardingSteps leads with the message card and takes the primary style", 
     markup.indexOf("border-primary/35") < markup.indexOf("Connect devices"),
   );
 });
+
+test("OnboardingSteps keeps four desktop cards on one horizontal track", async () => {
+  const { OnboardingSteps } = await import("@/src/components/home/onboarding-steps");
+  const markup = renderToStaticMarkup(createElement(OnboardingSteps, {
+    messageMurphAction: createElement("a", { href: "/message" }, "Message"),
+  }));
+
+  assert.match(markup, /data-onboarding-steps="true"/);
+  assert.match(markup, /lg:flex/);
+  assert.match(markup, /lg:overflow-x-auto/);
+  assert.doesNotMatch(markup, /xl:grid-cols-3/);
+  assert.equal(markup.match(/data-onboarding-step=/gu)?.length, 4);
+  assert.equal(
+    markup.match(/lg:basis-\[calc\(\(100%-2\.5rem\)\/3\)\]/gu)?.length,
+    4,
+  );
+});

--- a/apps/web/test/onboarding-steps.test.ts
+++ b/apps/web/test/onboarding-steps.test.ts
@@ -128,6 +128,7 @@ test("OnboardingSteps keeps four desktop cards on one horizontal track", async (
   assert.match(markup, /lg:overflow-x-auto/);
   assert.doesNotMatch(markup, /xl:grid-cols-3/);
   assert.equal(markup.match(/data-onboarding-step=/gu)?.length, 4);
+  assert.equal(markup.match(/lg:min-w-0/gu)?.length, 4);
   assert.equal(
     markup.match(/lg:basis-\[calc\(\(100%-2\.5rem\)\/3\)\]/gu)?.length,
     4,


### PR DESCRIPTION
## Why this PR exists

The home welcome surface can show four onboarding steps, but its desktop layout was limited to three grid columns. The fourth card should stay in the same row and remain reachable through horizontal scrolling.

## User goal / user-visible behavior

Members see one stable onboarding track on desktop: three equal cards are visible at once and the fourth is available by scrolling horizontally. Mobile keeps the existing single-column stack.

## User experience

The entry point remains the existing home welcome surface. Cards render immediately with the same order, hierarchy, copy, actions, and destinations; only desktop containment changes. There are no new waits, asynchronous owners, failure states, or recovery steps. The rendered design study proves the 1440px row at both scroll positions and the 390px stacked layout without horizontal overflow.

## Invariants the PR must preserve

- Onboarding step ordering, visibility rules, primary-action priority, copy, and destinations remain unchanged.
- Desktop cards stay equal-width, non-shrinking, and on one row.
- Mobile remains a single-column layout with no horizontal overflow.
- The design catalog renders the real production component against synthetic props only.

## Non-obvious affected surfaces

- The `/design?tab=sections#home-onboarding-steps` catalog gains a study of the real component so the responsive states remain reviewable. Regression proof: `pnpm test:frontend-design-proof`.
- No shared state owner, workflow, API, persistence, auth, messaging, or deploy/runtime boundary changes.

## Architecture and reuse

- **Existing systems reused:** The existing `OnboardingSteps` component, its current responsive breakpoint, and the design catalog's section-study pattern.
- **New logic:** A length-derived desktop flex basis keeps up to three equal cards visible while additional cards overflow on the same horizontal track.
- **New abstractions:** No production abstraction was added; the component's existing props and visibility filtering are sufficient.
- **Complexity intentionally avoided:** No carousel state, JavaScript resize observer, pagination control, dependency, duplicated production markup, or new state owner.

## Hot reply path impact

Not applicable. This is presentation-only web UI and does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- **Individual Murph:** Not applicable. No prompt, tool definition, schema, skill, model configuration, request builder, or provider-visible wrapper changes.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Prompt:** Not applicable; no provider-facing or assistant prompt surface changes.
- **Frontend:** Applicable. `audit-packages/welcome-horizontal-scroll-desktop.png` and `audit-packages/welcome-horizontal-scroll-desktop-scrolled.png` prove the 1440×1000 start/end scroll states; the two `welcome-horizontal-scroll-desktop-boundary-*` files prove the 1024px expanded-sidebar boundary; `audit-packages/welcome-horizontal-scroll-mobile.png` proves the 390×844 stacked state.
- **Coverage:** Applicable. Focused proof is `apps/web/test/onboarding-steps.test.ts` (6/6 passing) plus the computed-layout Playwright case across 1023, 1024, 1050, 1280, and 1440px (1/1 passing), with exact-head CI pending.

Product-decision review is not applicable because the diff is implementation-only responsive containment: actions, copy, state, timing, and workflow are unchanged. The Claude Fable UI check was attempted and ended at explicit usage-credit exhaustion. The separate final ReviewGPT gate is exempt under the minor responsive-containment rule; the preliminary frontend and coverage lenses still apply.

## Verification

- `pnpm --dir apps/web typecheck`
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/onboarding-steps.test.ts` — 6/6 passed
- `VIEWPORT_OVERFLOW_PORT=3178 pnpm --dir apps/web exec playwright test e2e/viewport-overflow.spec.ts --grep 'home onboarding steps'` — 1/1 passed against the isolated worktree server
- Focused ESLint on all five changed files
- `pnpm test:frontend-design-proof` — 10/10 passed
- `git diff --check origin/main...HEAD`
- Direct rendered metrics: roomy desktop has four equal 381px cards; the 1024px expanded-sidebar boundary has four equal 205.33px cards with all actions contained and three complete cards at each scroll endpoint; mobile is a one-column 350px grid with no overflow.

## Preliminary specialist resolution

ReviewGPT returned one frontend and one coverage finding around the same mechanism: `min-width:auto` let the longest CTA widen the fourth card at the 1024px dashboard boundary, while the original class-emission test could not detect computed geometry. Both were accepted. The production correction is `lg:min-w-0`; the new Playwright case proves equal widths, action containment, document containment, and three fully visible cards at both endpoints across five boundary widths. No patch artifact was returned.

## Change-shape breakdown

Classification counts authored component and design-catalog code as source, the focused regression file as tests, and keeps generated output separate. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 56 | 4 |
| Tests/fixtures | 126 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **182** | **4** |

## Design proof

- Design page: [local onboarding-steps study](http://localhost:3178/design?tab=sections#home-onboarding-steps)
- Desktop screenshot: ![Desktop start](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/ceb86203-1cdc-48fc-53bd-4416c175c000/public) ![Desktop end](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/a2ed8960-c493-4d21-7e4e-953cc63a4300/public) ![Desktop boundary start](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/ca1bb1ad-97af-4c5f-61f6-66a1cc5a2b00/public) ![Desktop boundary end](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/12e3a01e-550e-4ac8-4d15-160ec2633600/public)
- Mobile screenshot: ![Mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/47bd107e-a6c3-4848-cba7-be8a30544300/public)

## Deployment skew / compatibility

Not applicable. This PR changes only one web component's responsive CSS and its review/test surfaces; there is no cross-deploy contract or persisted-state skew.
