### PR TITLE
Fix PlanetScale PgBouncer timeouts for hosted runtime logs

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-29-runtime-log-pgbouncer-timeout.md
+++ b/agent-docs/exec-plans/active/2026-07-29-runtime-log-pgbouncer-timeout.md
@@ -1,0 +1,63 @@
+# Runtime-log PgBouncer timeout compatibility
+
+Status: active
+
+## Outcome
+
+Make the dedicated hosted runtime-log database usable through PlanetScale's
+transaction-mode PgBouncer endpoint, then complete the production cutover
+without moving application traffic to direct Postgres.
+
+## Proven cause
+
+- The isolated database, schema, indexes, credentials, direct endpoint, and
+  pooled/direct database identity are healthy.
+- The first dedicated-mode production canary failed before SQL execution with
+  PostgreSQL protocol code `08P01`.
+- A matching probe succeeds through the pooled endpoint when the node-postgres
+  `statement_timeout` startup parameter is absent, and succeeds through the
+  direct endpoint when that parameter is present.
+- PlanetScale PgBouncer rejects unallowlisted startup parameters. Ignoring
+  `statement_timeout` would silently discard the intended server-side bound,
+  while direct application traffic would give up the required serverless
+  pooling boundary.
+
+## Invariants
+
+- Production runtime traffic continues through the pooled endpoint; the direct
+  endpoint remains migration and administration only.
+- The server cancels runtime-log statements after at most ten seconds.
+- The driver has a slightly longer client-side query timeout so normal server
+  cancellation wins first.
+- Production migration preflight proves the pooled runtime role has the
+  required server-side timeout before a deployment can proceed.
+- Dedicated write failure never falls back to the primary database.
+- Account-deletion locking, compatibility reads, retention, and the fourteen-day
+  primary tail remain unchanged.
+
+## Steps
+
+1. Replace the rejected startup parameter with a client-side query timeout and
+   add a pooled-role server-timeout preflight.
+2. Add focused regression coverage and update the operator contract.
+3. Run scoped verification and the required completion review gates.
+4. Commit, push, open the PR, resolve ReviewGPT and CI, and merge.
+5. Deploy in primary mode, drain prior requests, cut over only the storage mode,
+   and verify both database write paths plus runtime health.
+
+## Evidence
+
+- No open PR, active execution plan, or active worktree overlaps the changed
+  runtime-log database paths or this PgBouncer compatibility fix.
+- The installed `pg` client serializes `statement_timeout` into startup
+  configuration while enforcing `query_timeout` with a client-side timer.
+- Focused Vitest proof passes all 18 runtime-log write and migration tests.
+- The Web TypeScript project passes typechecking.
+- A local PostgreSQL scenario confirms the preflight interval predicate accepts
+  the required ten-second role setting.
+- The production runtime role has been configured with the ten-second
+  server-side timeout while application storage remains in primary mode.
+- Preliminary specialist review, final review, exact-head CI, final ReviewGPT,
+  merge, deploy, drain, cutover, and post-cutover verification remain pending.
+
+Updated: 2026-07-29

--- a/agent-docs/exec-plans/active/2026-07-29-runtime-log-pgbouncer-timeout.md
+++ b/agent-docs/exec-plans/active/2026-07-29-runtime-log-pgbouncer-timeout.md
@@ -57,7 +57,12 @@ without moving application traffic to direct Postgres.
   the required ten-second role setting.
 - The production runtime role has been configured with the ten-second
   server-side timeout while application storage remains in primary mode.
-- Preliminary specialist review, final review, exact-head CI, final ReviewGPT,
-  merge, deploy, drain, cutover, and post-cutover verification remain pending.
+- Preliminary ReviewGPT returned one accepted coverage finding: the existing
+  real-PostgreSQL lane depended on ambient timeout configuration and did not
+  exercise the rejected timeout boundaries through production SQL.
+- The reviewed test-only coverage patch was inspected, dry-run, applied, and
+  proved with all eight real-PostgreSQL runtime-log concurrency tests passing.
+- Parent final review, exact-head CI, final ReviewGPT, merge, deploy, drain,
+  cutover, and post-cutover verification remain pending.
 
 Updated: 2026-07-29

--- a/agent-docs/exec-plans/completed/2026-07-29-runtime-log-pgbouncer-timeout.md
+++ b/agent-docs/exec-plans/completed/2026-07-29-runtime-log-pgbouncer-timeout.md
@@ -1,6 +1,6 @@
 # Runtime-log PgBouncer timeout compatibility
 
-Status: active
+Status: completed
 
 ## Outcome
 
@@ -62,7 +62,11 @@ without moving application traffic to direct Postgres.
   exercise the rejected timeout boundaries through production SQL.
 - The reviewed test-only coverage patch was inspected, dry-run, applied, and
   proved with all eight real-PostgreSQL runtime-log concurrency tests passing.
-- Parent final review, exact-head CI, final ReviewGPT, merge, deploy, drain,
-  cutover, and post-cutover verification remain pending.
+- Parent final review found no remaining correctness, scope, privacy, or proof
+  gaps, and the branch rebases cleanly onto the latest non-overlapping `main`.
+- Repository implementation and local verification are complete. Exact-head CI,
+  final ReviewGPT, merge, deploy, drain, cutover, and post-cutover verification
+  remain external completion gates for the current PR and rollout.
 
 Updated: 2026-07-29
+Completed: 2026-07-29

--- a/apps/web/scripts/run-runtime-log-migrate-deploy.ts
+++ b/apps/web/scripts/run-runtime-log-migrate-deploy.ts
@@ -55,6 +55,8 @@ export type HostedRuntimeLogEndpointProbeClientFactory = (
   databaseUrl: string,
 ) => HostedRuntimeLogEndpointProbeClient;
 
+const HOSTED_RUNTIME_LOG_MAX_STATEMENT_TIMEOUT_MS = 10_000;
+
 export const hostedRuntimeLogMigrateDeployCommand = {
   args: [
     "--dir",
@@ -195,6 +197,19 @@ async function verifyHostedRuntimeLogPooledDirectIdentity(
     leftConnected = true;
     await right.connect();
     rightConnected = true;
+    const timeoutProbe = await left.query(
+      `SELECT (
+        current_setting('statement_timeout')::interval > interval '0 seconds'
+        AND current_setting('statement_timeout')::interval
+          <= ($1::bigint * interval '1 millisecond')
+      ) AS "configured"`,
+      [HOSTED_RUNTIME_LOG_MAX_STATEMENT_TIMEOUT_MS],
+    );
+    if (timeoutProbe.rows[0]?.configured !== true) {
+      throw new Error(
+        "HOSTED_RUNTIME_LOG_DATABASE_URL must use a role with statement_timeout set to a positive value no greater than 10 seconds.",
+      );
+    }
     await left.query("BEGIN");
     leftTransaction = true;
     await left.query(

--- a/apps/web/src/lib/hosted-runtime-log/database.ts
+++ b/apps/web/src/lib/hosted-runtime-log/database.ts
@@ -9,7 +9,7 @@ const DEFAULT_HOSTED_RUNTIME_LOG_DATABASE_POOL_MAX = 5;
 const MAX_HOSTED_RUNTIME_LOG_DATABASE_POOL_MAX = 10;
 const HOSTED_RUNTIME_LOG_DATABASE_CONNECTION_TIMEOUT_MS = 3_000;
 const HOSTED_RUNTIME_LOG_DATABASE_IDLE_TIMEOUT_MS = 30_000;
-const HOSTED_RUNTIME_LOG_DATABASE_STATEMENT_TIMEOUT_MS = 10_000;
+const HOSTED_RUNTIME_LOG_DATABASE_QUERY_TIMEOUT_MS = 12_000;
 
 const globalForHostedRuntimeLogDatabase = globalThis as typeof globalThis & {
   __murphHostedRuntimeLogPool?: PgPool;
@@ -131,7 +131,11 @@ export function getHostedRuntimeLogPool(): PgPool {
     connectionTimeoutMillis: HOSTED_RUNTIME_LOG_DATABASE_CONNECTION_TIMEOUT_MS,
     idleTimeoutMillis: HOSTED_RUNTIME_LOG_DATABASE_IDLE_TIMEOUT_MS,
     max,
-    statement_timeout: HOSTED_RUNTIME_LOG_DATABASE_STATEMENT_TIMEOUT_MS,
+    // PlanetScale's transaction-mode PgBouncer rejects statement_timeout as a
+    // startup parameter. Migration preflight verifies the runtime role's
+    // server-side 10-second bound; this slightly longer client timeout covers
+    // transport failures after PostgreSQL has had time to cancel the query.
+    query_timeout: HOSTED_RUNTIME_LOG_DATABASE_QUERY_TIMEOUT_MS,
   });
   attachDatabasePool(hostedRuntimeLogPool);
   hostedRuntimeLogPool.on("error", (error: Error) => {

--- a/apps/web/test/hosted-runtime-log-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-runtime-log-postgres-concurrency.test.ts
@@ -56,6 +56,7 @@ describe.skipIf(!runPostgresProof)("isolated runtime-log deletion fence", () => 
     });
     await admin.connect();
     await admin.query(`CREATE DATABASE "${testDatabaseName}"`);
+    await setTestDatabaseStatementTimeout(admin, testDatabaseName, "10s");
 
     pool = new PgPool({
       connectionString: postgresDatabaseUrl(primaryDatabaseUrl, testDatabaseName),
@@ -100,6 +101,37 @@ describe.skipIf(!runPostgresProof)("isolated runtime-log deletion fence", () => 
     })).rejects.toThrow(
       /same PostgreSQL cluster as DIRECT_DATABASE_URL/u,
     );
+  });
+
+  it("rejects disabled and over-budget statement timeouts with PostgreSQL", async () => {
+    const postgresAdmin = requireClient(admin);
+    const runtimeDatabaseUrl = postgresDatabaseUrl(
+      primaryDatabaseUrl,
+      testDatabaseName,
+    );
+
+    try {
+      for (const timeout of ["0", "10001ms"] as const) {
+        await setTestDatabaseStatementTimeout(
+          postgresAdmin,
+          testDatabaseName,
+          timeout,
+        );
+        await expect(verifyHostedRuntimeLogDatabaseEndpoints({
+          directDatabaseUrl: runtimeDatabaseUrl,
+          primaryDirectDatabaseUrl: primaryDatabaseUrl,
+          runtimeDatabaseUrl,
+        })).rejects.toThrow(
+          /statement_timeout set to a positive value no greater than 10 seconds/u,
+        );
+      }
+    } finally {
+      await setTestDatabaseStatementTimeout(
+        postgresAdmin,
+        testDatabaseName,
+        "10s",
+      );
+    }
   });
 
   it("keeps pre-change cleanup receipts until isolated deletion is complete", async () => {
@@ -490,6 +522,13 @@ function randomToken(): string {
   return randomUUID().replaceAll("-", "");
 }
 
+function requireClient(value: Client | null): Client {
+  if (!value) {
+    throw new Error("Runtime-log test client is unavailable.");
+  }
+  return value;
+}
+
 function requireDatabase(
   value: HostedRuntimeLogSqlDatabase | null,
 ): HostedRuntimeLogSqlDatabase {
@@ -504,6 +543,19 @@ function requirePool(value: Pool | null): Pool {
     throw new Error("Runtime-log test pool is unavailable.");
   }
   return value;
+}
+
+async function setTestDatabaseStatementTimeout(
+  client: Client,
+  databaseName: string,
+  timeout: "0" | "10s" | "10001ms",
+): Promise<void> {
+  if (!/^[a-z0-9_]+$/u.test(databaseName)) {
+    throw new TypeError("Runtime-log test database name is invalid.");
+  }
+  await client.query(
+    `ALTER DATABASE "${databaseName}" SET statement_timeout = '${timeout}'`,
+  );
 }
 
 function postgresDatabaseUrl(baseUrl: string, databaseName: string): string {

--- a/apps/web/test/hosted-runtime-log-write.test.ts
+++ b/apps/web/test/hosted-runtime-log-write.test.ts
@@ -18,6 +18,7 @@ import {
   HOSTED_RUNTIME_LOG_DATABASE_MUST_NOT_ALIAS_PRIMARY_MESSAGE,
   HOSTED_RUNTIME_LOG_DATABASE_URL_REQUIRED_MESSAGE,
   HOSTED_RUNTIME_LOG_STORAGE_MODE_REQUIRED_MESSAGE,
+  getHostedRuntimeLogPool,
   isHostedRuntimeLogDatabaseConfigured,
   readHostedRuntimeLogStorageMode,
 } from "@/src/lib/hosted-runtime-log/database";
@@ -94,6 +95,25 @@ describe("hosted runtime log write routing", () => {
       "isolated database unavailable",
     );
     expect(mocks.recordLegacyHostedRuntimeLogs).not.toHaveBeenCalled();
+  });
+
+  it("keeps PgBouncer startup parameters free of statement_timeout", async () => {
+    vi.stubEnv(
+      "HOSTED_RUNTIME_LOG_DATABASE_URL",
+      "postgresql://runtime.test:6432/runtime_logs",
+    );
+
+    const pool = getHostedRuntimeLogPool();
+    const options = Reflect.get(pool, "options");
+
+    expect(options).toMatchObject({
+      connectionTimeoutMillis: 3_000,
+      idleTimeoutMillis: 30_000,
+      max: 5,
+      query_timeout: 12_000,
+    });
+    expect(options).not.toHaveProperty("statement_timeout");
+    await pool.end();
   });
 });
 

--- a/apps/web/test/runtime-log-migration.test.ts
+++ b/apps/web/test/runtime-log-migration.test.ts
@@ -195,6 +195,27 @@ describe("hosted runtime log database migration", () => {
     ]))).rejects.toThrow(/same PostgreSQL cluster as DIRECT_DATABASE_URL/u);
   });
 
+  it("requires a bounded server-side timeout on the pooled runtime role", async () => {
+    const clients = [
+      new RuntimeLogProbeClient(undefined, undefined, false),
+      new RuntimeLogProbeClient(),
+    ];
+
+    await expect(verifyHostedRuntimeLogDatabaseEndpoints({
+      directDatabaseUrl: "postgresql://logs-direct.test/runtime_logs",
+      primaryDirectDatabaseUrl: "postgresql://primary-direct.test/murph",
+      runtimeDatabaseUrl: "postgresql://logs-pool.test/runtime_logs",
+    }, () => {
+      const client = clients.shift();
+      if (!client) {
+        throw new Error("Unexpected runtime-log topology probe client.");
+      }
+      return client;
+    })).rejects.toThrow(
+      /statement_timeout set to a positive value no greater than 10 seconds/u,
+    );
+  });
+
   it("fails closed when PostgreSQL cannot prove the cluster identity", async () => {
     await expect(verifyHostedRuntimeLogDatabaseEndpoints({
       directDatabaseUrl: "postgresql://logs-direct.test/runtime_logs",
@@ -307,6 +328,7 @@ class RuntimeLogProbeClient implements HostedRuntimeLogEndpointProbeClient {
   constructor(
     private readonly tryLockAcquired?: boolean,
     private readonly systemIdentifier?: string,
+    private readonly statementTimeoutConfigured = true,
   ) {}
 
   async connect(): Promise<void> {
@@ -325,6 +347,11 @@ class RuntimeLogProbeClient implements HostedRuntimeLogEndpointProbeClient {
       throw new Error("Runtime-log probe query ran before connect.");
     }
     this.queries.push({ text, values });
+    if (text.includes("current_setting('statement_timeout')")) {
+      return {
+        rows: [{ configured: this.statementTimeoutConfigured }],
+      };
+    }
     if (text.includes("pg_try_advisory_xact_lock")) {
       if (this.tryLockAcquired === undefined) {
         throw new Error("Runtime-log probe client has no try-lock result.");

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -119,6 +119,24 @@ HOSTED_RUNTIME_LOG_DATABASE_URL
 HOSTED_RUNTIME_LOG_DATABASE_POOL_MAX=5
 ```
 
+The dedicated runtime login role must enforce the server-side query bound:
+
+```sql
+ALTER ROLE <runtime-role> SET statement_timeout = '10s';
+```
+
+The migration preflight verifies that the pooled endpoint reports a positive
+`statement_timeout` no greater than ten seconds. The node-postgres pool uses a
+slightly longer twelve-second client query timeout and deliberately does not
+send `statement_timeout` as a startup parameter: PlanetScale's
+[transaction-mode PgBouncer](https://planetscale.com/docs/postgres/connecting/pgbouncer)
+rejects unallowlisted startup parameters. This follows PlanetScale's
+[connection-resilience guidance](https://planetscale.com/docs/postgres/connection-resilience):
+enforce the database timeout at the role and keep the client timeout slightly
+longer. Do not add `statement_timeout` to PgBouncer's
+`ignore_startup_parameters`, because that would accept the connection while
+silently discarding the server-side bound.
+
 Migration traffic:
 
 ```text
@@ -164,7 +182,8 @@ verifies the canonical schema owner before invoking Prisma.
 
 ## Deployment
 
-1. Provision the isolated Postgres project or cluster and its direct migration
+1. Provision the isolated Postgres project or cluster, its dedicated runtime
+   role with the ten-second `statement_timeout`, and its direct migration
    endpoint.
 2. Set the runtime/direct URLs, pool size, and
    `HOSTED_RUNTIME_LOG_STORAGE=primary` in Vercel production.


### PR DESCRIPTION
## Why this PR exists

The dedicated hosted runtime-log cutover introduced by #1109 is blocked because node-postgres serializes its `statement_timeout` pool option into the PostgreSQL startup packet, while PlanetScale's transaction-mode PgBouncer rejects that unallowlisted startup parameter. The database, role, schema, and pooled/direct topology are otherwise healthy.

## User goal / user-visible behavior

Hosted runtime logs can be moved to their isolated PlanetScale Postgres database through the pooled application endpoint, without routing serverless traffic to the direct endpoint or weakening query time bounds.

## User experience

No user-facing UI or interaction changes. This is an operational compatibility correction for diagnostic log persistence; the existing runtime-log API behavior and failure semantics stay the same.

## Invariants the PR must preserve

- Application traffic uses the pooled endpoint; the direct endpoint remains migration/administration only.
- The runtime role enforces a positive server-side `statement_timeout` no greater than 10 seconds, while the driver uses a slightly longer 12-second client timeout.
- Dedicated write failures never fall back to primary storage.
- Pooled/direct identity proof, physical-cluster isolation proof, account-deletion locks, retention, merged reads, and the 14-day primary compatibility tail remain unchanged.
- Migration preflight fails closed if the runtime role does not expose the required server timeout.

## Non-obvious affected surfaces

- **Vercel migration preflight:** it now checks the pooled role's effective `statement_timeout` before Prisma migrations. Focused proof: `apps/web/test/runtime-log-migration.test.ts` and the real-Postgres proof in `apps/web/test/hosted-runtime-log-postgres-concurrency.test.ts`.
- **Runtime pool initialization:** it replaces a startup parameter with node-postgres's client-side query timer. Focused proof: `apps/web/test/hosted-runtime-log-write.test.ts` and installed `pg` source inspection.
- **Deployment contract:** the operator guide now requires the role-level timeout and links the relevant PlanetScale PgBouncer/resilience guidance. Regression proof: documentation readback plus migration preflight tests.

## Architecture and reuse

- **Existing systems reused:** the existing node-postgres pool, PlanetScale transaction-mode PgBouncer endpoint, migration topology preflight, and role-level PostgreSQL settings remain the owners.
- **New logic:** one preflight predicate proves the runtime role's effective server timeout is positive and at most 10 seconds; the pool uses the existing `query_timeout` option at 12 seconds.
- **New abstractions:** none; the existing pool configuration and migration verifier are the sufficient ownership boundaries.
- **Complexity intentionally avoided:** no direct-endpoint application fallback, PgBouncer ignore list, retry layer, queue, dual-write, service, or new state owner.

## Hot reply path impact

Not applicable. The change affects diagnostic runtime-log persistence and deployment preflight; it adds no database, network, provider, retry, or fallback work to the Foreground Reply Critical Path.

## Murph initial provider input impact

- **Individual Murph:** Not applicable; no prompt, tool schema, provider adapter, model configuration, or request-assembly surface changed.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Prompt:** not applicable; no prompt or provider-visible instruction surface changed.
- **Frontend:** not applicable; no user-facing UI or presentation changed, so rendered evidence is not required.
- **Coverage:** applicable; executable runtime pool and migration preflight behavior changed. Focused local proof: the two-file runtime-log unit suite (18/18 passing), the real-Postgres runtime-log concurrency suite (8/8 passing), Web typecheck (passing), and focused ESLint (passing). Current exact-head CI status: pending.

Preliminary specialist outcome: `FINDINGS`. One accepted coverage finding identified that the real-Postgres lane depended on ambient timeout configuration and did not execute the rejected timeout boundaries through production SQL. The assistant-owned test-only patch was downloaded from the exact review thread, fully inspected, confirmed to touch only `apps/web/test/hosted-runtime-log-postgres-concurrency.test.ts`, dry-run, applied, and verified. No prompt or frontend finding was reported.

Parent final review: `PASS` with zero remaining findings after walking the pool construction, migration cleanup paths, real-Postgres timeout boundaries, logging call sites, and deployment contract.

ReviewGPT first-reviewed head: 9c53d2698a9e93204dfd79639f5dab07c7df4c75

Current PR head: aee94429049f059e839b0088b19f6dbb5c030047

Base-only update: after the round-one `PASS`, the branch was rebased normally onto `4d64817d7ea2538098b6862226bf8b328f8ae18e` with no conflicts or manual resolution. The PR patch and five-category change shape are unchanged; per the ReviewGPT base-update-only exception, the reviewed verdict remains applicable and CI is rerunning on the current head.

## Change-shape breakdown

Classification is by repository role: production TypeScript is source; Vitest files are tests/fixtures; Markdown operator and completed execution-plan files are docs; no config/tooling or generated files changed. This is the immutable round-one shape for the first-reviewed head above and remains the current patch shape.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 2 |
| Tests/fixtures | 99 | 0 |
| Docs | 92 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **212** | **3** |

Binary files: none.

## Design proof

Not applicable; this PR has no user-facing frontend UI diff.

## Verification

- Focused runtime-log Vitest: 2 files, 18 tests passed.
- Real-Postgres runtime-log concurrency proof: 1 file, 8 tests passed; exactly 10 seconds reaches the existing physical-cluster check, while disabled and 10,001 ms are rejected by the production preflight SQL.
- Web typecheck: passed.
- Focused ESLint on all changed TypeScript files: passed.
- `git diff --check`: passed on the current rebased head.
- Installed `pg@8.20.0` source confirms `statement_timeout` enters `getStartupConf()`, while `query_timeout` is enforced by the client query timer.
- Current-main merge base and upstream overlap check: clean through `2561e73f6ae9f3ea4dcbba20ba77be6cc32441fd`; newly merged work changes unrelated R2 copy, assistant sponsorship-copy, Cloudflare alerting, voice memo, and newsletter surfaces.

## Rollout

Production remains in `HOSTED_RUNTIME_LOG_STORAGE=primary` until this PR is reviewed, green, merged, and deployed. Then drain older Web deployments for the established 300-second prior-function window, flip only the storage mode to `dedicated`, and verify dedicated inserts, zero new primary log inserts, retention, merged reads, error rates, and account deletion while retaining both dedicated URLs and the primary compatibility tail.