### PR TITLE
fix(web): normalize account deletion KMS keys

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
+++ b/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
@@ -39,10 +39,18 @@ Success criteria:
 
 ## Verification
 
-- Pending.
+- Focused KMS and account-deletion Vitest suites passed on current `origin/main`
+  with 31 tests.
+- Hosted web typecheck passed.
+- Scoped ESLint passed for the two source files and two focused test files.
+- A read-only production-faithful check proved that the pending receipt's
+  numeric `CryptoKeyVersion` resource normalizes to its parent `CryptoKey`
+  without decrypting the payload or invoking provider cleanup.
+- The required local product-experience review returned `NO FINDINGS`; no
+  rendered proof applies because this change has no frontend presentation.
 
 ## State
 
-Implementation in progress.
+Implementation and focused verification complete. PR completion gates pending.
 Status: active
 Updated: 2026-07-30

--- a/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
+++ b/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
@@ -1,0 +1,48 @@
+# Account Deletion KMS Resource Name Repair
+
+## Goal
+
+Restore durable hosted account-deletion cleanup by using the parent Google Cloud
+KMS `CryptoKey` for decrypt operations while preserving fail-closed retries and
+supporting the existing version-named cleanup receipt without a data migration.
+
+Success criteria:
+
+- New cleanup receipts persist a validated parent `CryptoKey` name.
+- Existing receipts that contain a numeric `CryptoKeyVersion` name normalize to
+  the parent key in memory before decrypting.
+- Malformed or mismatched resource names fail before provider I/O and retain
+  retry ownership.
+- Focused KMS and account-deletion tests cover the real Google response shape,
+  the existing receipt shape, and malformed names.
+
+## Constraints
+
+- Do not manually retry or modify production cleanup state.
+- Do not weaken account-deletion, privacy, lease, or retry invariants.
+- Do not add a migration, dependency, compatibility service, or provider-state
+  mutation.
+- Treat the ReviewGPT patch as behavioral intent and inspect every change before
+  landing it.
+- Keep identifiers, credentials, and private provider data out of repository
+  artifacts and logs.
+
+## Plan
+
+1. Apply and inspect the ReviewGPT-authored patch in the isolated task worktree.
+2. Validate KMS resource parsing and reduce the patch if existing abstractions
+   already own the behavior.
+3. Run focused KMS and account-deletion tests plus the required web typecheck.
+4. Run the required preliminary and final review gates on exact pushed heads,
+   resolve accepted findings, and require green CI.
+5. Close the plan, commit the scoped result, and complete the PR workflow.
+
+## Verification
+
+- Pending.
+
+## State
+
+Implementation in progress.
+Status: active
+Updated: 2026-07-30

--- a/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
+++ b/agent-docs/exec-plans/active/2026-07-30-account-deletion-kms-resource-name.md
@@ -40,7 +40,7 @@ Success criteria:
 ## Verification
 
 - Focused KMS and account-deletion Vitest suites passed on current `origin/main`
-  with 31 tests.
+  with 32 tests.
 - Hosted web typecheck passed.
 - Scoped ESLint passed for the two source files and two focused test files.
 - A read-only production-faithful check proved that the pending receipt's
@@ -48,6 +48,10 @@ Success criteria:
   without decrypting the payload or invoking provider cleanup.
 - The required local product-experience review returned `NO FINDINGS`; no
   rendered proof applies because this change has no frontend presentation.
+- The preliminary ReviewGPT specialist pass returned one accepted low-severity
+  coverage finding. Its test-only patch was inspected, path-scoped, applied,
+  and verified; encrypt now has direct proof that a version resource is rejected
+  before provider I/O.
 
 ## State
 

--- a/agent-docs/exec-plans/completed/2026-07-30-account-deletion-kms-resource-name.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-account-deletion-kms-resource-name.md
@@ -52,9 +52,16 @@ Success criteria:
   coverage finding. Its test-only patch was inspected, path-scoped, applied,
   and verified; encrypt now has direct proof that a version resource is rejected
   before provider I/O.
+- Parent final review walked every KMS encrypt/decrypt caller, the cleanup
+  fanout, retry ownership, and rolling-deploy compatibility and found no
+  remaining issue.
 
 ## State
 
-Implementation and focused verification complete. PR completion gates pending.
-Status: active
+Implementation, focused verification, preliminary remediation, and parent final
+review complete. Exact-head CI and the final ReviewGPT gate continue after plan
+closure under the PR workflow.
+Status: completed
 Updated: 2026-07-30
+Completed: 2026-07-30
+Completed: 2026-07-30

--- a/apps/web/src/lib/hosted-crypto/gcp-kms.ts
+++ b/apps/web/src/lib/hosted-crypto/gcp-kms.ts
@@ -11,6 +11,10 @@ const LOCAL_KMS_IV_BYTES = 12;
 const LOCAL_KMS_KEY_BYTES = 32;
 const DEFAULT_STS_TOKEN_URI = "https://sts.googleapis.com/v1/token";
 const DEFAULT_IAM_CREDENTIALS_API_ROOT = "https://iamcredentials.googleapis.com/v1";
+const GCP_KMS_CRYPTO_KEY_NAME_PATTERN =
+  /^projects\/[A-Za-z0-9][A-Za-z0-9._:-]*\/locations\/[A-Za-z0-9_-]+\/keyRings\/[A-Za-z0-9_-]+\/cryptoKeys\/[A-Za-z0-9_-]+$/u;
+const GCP_KMS_CRYPTO_KEY_VERSION_NAME_PATTERN =
+  /^(projects\/[A-Za-z0-9][A-Za-z0-9._:-]*\/locations\/[A-Za-z0-9_-]+\/keyRings\/[A-Za-z0-9_-]+\/cryptoKeys\/[A-Za-z0-9_-]+)\/cryptoKeyVersions\/[1-9][0-9]*$/u;
 // One deadline owns the complete token + KMS operation. Callers may abort
 // earlier. Provider failures are fail-closed and are never retried here.
 export const HOSTED_GCP_KMS_OPERATION_TIMEOUT_MS = 10_000;
@@ -176,7 +180,7 @@ class HostedLocalGcpKmsClient implements HostedGcpKmsClient {
   ) {}
 
   async encrypt(input: GcpKmsEncryptInput): Promise<{ ciphertext: string; keyName: string }> {
-    const keyName = requireKmsResourceName(input.keyName, "Local KMS Encrypt keyName");
+    const keyName = requireKmsCryptoKeyName(input.keyName, "Local KMS Encrypt keyName");
     const iv = crypto.getRandomValues(new Uint8Array(LOCAL_KMS_IV_BYTES));
     const key = await this.importWrapKey(["encrypt"]);
     const ciphertext = new Uint8Array(
@@ -203,7 +207,7 @@ class HostedLocalGcpKmsClient implements HostedGcpKmsClient {
   }
 
   async decrypt(input: GcpKmsDecryptInput): Promise<{ plaintext: Uint8Array }> {
-    const keyName = requireKmsResourceName(input.keyName, "Local KMS Decrypt keyName");
+    const keyName = normalizeKmsCryptoKeyName(input.keyName, "Local KMS Decrypt keyName");
     if (!input.ciphertext.startsWith(LOCAL_KMS_CIPHERTEXT_PREFIX)) {
       throw new TypeError("Local KMS ciphertext must use the local-kms-v1 envelope.");
     }
@@ -311,29 +315,40 @@ class HostedGcpKmsJsonClient implements HostedGcpKmsClient {
   }
 
   async encrypt(input: GcpKmsEncryptInput): Promise<{ ciphertext: string; keyName: string }> {
+    const keyName = requireKmsCryptoKeyName(input.keyName, "GCP KMS Encrypt keyName");
     const response = await this.call<GcpEncryptResponse>({
       body: {
         additionalAuthenticatedData: encodeBase64(utf8(input.additionalAuthenticatedData)),
         plaintext: encodeBase64(input.plaintext),
       },
       operation: "cloudkms/encrypt",
-      resource: `${requireKmsResourceName(input.keyName, "GCP KMS Encrypt keyName")}:encrypt`,
+      resource: `${keyName}:encrypt`,
       signal: input.signal,
     });
+    const responseKeyName = requireKmsCryptoKeyVersionParentName(
+      response.name,
+      "GCP KMS Encrypt name",
+    );
+    if (responseKeyName !== keyName) {
+      throw new Error(
+        "GCP KMS Encrypt response key version did not match the requested CryptoKey.",
+      );
+    }
     return {
       ciphertext: requireNonEmptyString(response.ciphertext, "GCP KMS Encrypt ciphertext"),
-      keyName: requireNonEmptyString(response.name ?? input.keyName, "GCP KMS Encrypt name"),
+      keyName,
     };
   }
 
   async decrypt(input: GcpKmsDecryptInput): Promise<{ plaintext: Uint8Array }> {
+    const keyName = normalizeKmsCryptoKeyName(input.keyName, "GCP KMS Decrypt keyName");
     const response = await this.call<GcpDecryptResponse>({
       body: {
         additionalAuthenticatedData: encodeBase64(utf8(input.additionalAuthenticatedData)),
         ciphertext: requireNonEmptyString(input.ciphertext, "GCP KMS Decrypt ciphertext"),
       },
       operation: "cloudkms/decrypt",
-      resource: `${requireKmsResourceName(input.keyName, "GCP KMS Decrypt keyName")}:decrypt`,
+      resource: `${keyName}:decrypt`,
       signal: input.signal,
     });
     return {
@@ -706,6 +721,41 @@ function getGoogleCloudErrorReason(parsed: unknown, response: Response): string 
 
 async function sha256(value: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(value)));
+}
+
+export function normalizeGcpKmsCryptoKeyName(value: string): string {
+  return normalizeKmsCryptoKeyName(value, "GCP KMS keyName");
+}
+
+function normalizeKmsCryptoKeyName(value: string, label: string): string {
+  const trimmed = requireNonEmptyString(value, label);
+  if (GCP_KMS_CRYPTO_KEY_NAME_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  const versionMatch = GCP_KMS_CRYPTO_KEY_VERSION_NAME_PATTERN.exec(trimmed);
+  if (versionMatch) {
+    return versionMatch[1]!;
+  }
+  throw new TypeError(
+    `${label} must be a CryptoKey or CryptoKeyVersion resource name.`,
+  );
+}
+
+function requireKmsCryptoKeyName(value: string, label: string): string {
+  const trimmed = requireNonEmptyString(value, label);
+  if (!GCP_KMS_CRYPTO_KEY_NAME_PATTERN.test(trimmed)) {
+    throw new TypeError(`${label} must be a CryptoKey resource name.`);
+  }
+  return trimmed;
+}
+
+function requireKmsCryptoKeyVersionParentName(value: unknown, label: string): string {
+  const trimmed = requireNonEmptyString(value, label);
+  const versionMatch = GCP_KMS_CRYPTO_KEY_VERSION_NAME_PATTERN.exec(trimmed);
+  if (!versionMatch) {
+    throw new TypeError(`${label} must be a CryptoKeyVersion resource name.`);
+  }
+  return versionMatch[1]!;
 }
 
 function requireKmsResourceName(value: string, label: string): string {

--- a/apps/web/src/lib/hosted-privacy/account-deletion-cleanup.ts
+++ b/apps/web/src/lib/hosted-privacy/account-deletion-cleanup.ts
@@ -7,6 +7,7 @@ import type {
 } from "@prisma/client";
 
 import { getHostedWebCryptoConfig } from "../hosted-crypto/env";
+import { normalizeGcpKmsCryptoKeyName } from "../hosted-crypto/gcp-kms";
 import {
   deleteHostedRunnerUserDataBestEffort,
   type HostedRunnerUserDataDeletionBestEffortResult,
@@ -130,7 +131,7 @@ export async function prepareHostedAccountDeletionCleanup(input: {
     cloudflareCompletedAt: null,
     environment: cryptoConfig.env,
     id,
-    kmsKeyName: encrypted.keyName,
+    kmsKeyName: normalizeGcpKmsCryptoKeyName(encrypted.keyName),
     nextAttemptAt: input.now,
     payloadCiphertext: encrypted.ciphertext,
     privyCompletedAt: privyUserId === null ? input.now : null,
@@ -418,7 +419,7 @@ async function decryptCleanupPayload(
       id: cleanup.id,
     }),
     ciphertext: cleanup.payloadCiphertext,
-    keyName: cleanup.kmsKeyName,
+    keyName: normalizeGcpKmsCryptoKeyName(cleanup.kmsKeyName),
     signal,
   });
   return parseCleanupPayload(

--- a/apps/web/test/hosted-account-deletion-cleanup.test.ts
+++ b/apps/web/test/hosted-account-deletion-cleanup.test.ts
@@ -136,6 +136,7 @@ describe("hosted account deletion cleanup", () => {
       keyName: KMS_KEY_NAME,
     }));
     expect(mocks.deleteHostedRunnerUserDataBestEffort).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteHostedRuntimeLogDataForUsers).toHaveBeenCalledTimes(1);
     expect(mocks.deleteHostedPrivyUser).toHaveBeenCalledTimes(1);
     expect(deleteStripeCustomer).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/test/hosted-account-deletion-cleanup.test.ts
+++ b/apps/web/test/hosted-account-deletion-cleanup.test.ts
@@ -41,6 +41,7 @@ import {
 
 const KMS_KEY_NAME =
   "projects/test/locations/global/keyRings/test/cryptoKeys/account-cleanup";
+const KMS_KEY_VERSION_NAME = `${KMS_KEY_NAME}/cryptoKeyVersions/7`;
 
 beforeEach(() => {
   vi.useRealTimers();
@@ -79,6 +80,10 @@ beforeEach(() => {
 describe("hosted account deletion cleanup", () => {
   it("encrypts only the identifiers needed for cleanup with receipt-bound AAD", async () => {
     const now = new Date("2026-07-26T18:00:00.000Z");
+    mocks.kmsEncrypt.mockImplementationOnce(async (input: { plaintext: Uint8Array }) => ({
+      ciphertext: Buffer.from(input.plaintext).toString("base64"),
+      keyName: KMS_KEY_VERSION_NAME,
+    }));
     const cleanup = await prepareHostedAccountDeletionCleanup({
       now,
       privyUserId: "privy_user_1",
@@ -102,6 +107,70 @@ describe("hosted account deletion cleanup", () => {
       stripeCustomerIds: ["cus_1"],
     });
     expect(cleanup.payloadCiphertext).not.toContain("privy_user_1");
+    expect(cleanup.kmsKeyName).toBe(KMS_KEY_NAME);
+  });
+
+  it("repairs a legacy versioned KMS receipt before provider cleanup starts", async () => {
+    const store = new CleanupStore();
+    const now = new Date("2026-07-26T18:00:00.000Z");
+    const deleteStripeCustomer = vi.fn(async () => ({ deleted: true }));
+    mocks.getHostedOnboardingStripe.mockReturnValue({
+      customers: { del: deleteStripeCustomer },
+    });
+    const prepared = await createCleanup(store, now, {
+      privyUserId: "privy_user_1",
+      stripeCustomerIds: ["cus_1"],
+    });
+    if (!store.row) {
+      throw new Error("Expected a persisted cleanup receipt.");
+    }
+    store.row = { ...store.row, kmsKeyName: KMS_KEY_VERSION_NAME };
+
+    await expect(runHostedAccountDeletionCleanup({
+      cleanupId: prepared.id,
+      now,
+      prisma: store.prisma as never,
+    })).resolves.toMatchObject({ cleanupPending: false });
+
+    expect(mocks.kmsDecrypt).toHaveBeenCalledWith(expect.objectContaining({
+      keyName: KMS_KEY_NAME,
+    }));
+    expect(mocks.deleteHostedRunnerUserDataBestEffort).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteHostedPrivyUser).toHaveBeenCalledTimes(1);
+    expect(deleteStripeCustomer).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on malformed persisted KMS resource names", async () => {
+    const store = new CleanupStore();
+    const now = new Date("2026-07-26T18:00:00.000Z");
+    const prepared = await createCleanup(store, now, {
+      privyUserId: "privy_user_1",
+      stripeCustomerIds: ["cus_1"],
+    });
+    if (!store.row) {
+      throw new Error("Expected a persisted cleanup receipt.");
+    }
+    store.row = {
+      ...store.row,
+      kmsKeyName: `${KMS_KEY_NAME}/cryptoKeyVersions/latest`,
+    };
+
+    await expect(runHostedAccountDeletionCleanup({
+      cleanupId: prepared.id,
+      now,
+      prisma: store.prisma as never,
+    })).rejects.toThrow(/CryptoKey or CryptoKeyVersion resource name/u);
+
+    expect(mocks.kmsDecrypt).not.toHaveBeenCalled();
+    expect(mocks.deleteHostedRunnerUserDataBestEffort).not.toHaveBeenCalled();
+    expect(mocks.deleteHostedPrivyUser).not.toHaveBeenCalled();
+    expect(mocks.getHostedOnboardingStripe).not.toHaveBeenCalled();
+    expect(store.row).toMatchObject({
+      attemptCount: 1,
+      lastErrorCode: "TypeError",
+      leaseToken: null,
+    });
+    expect(store.row?.nextAttemptAt.getTime()).toBeGreaterThan(now.getTime());
   });
 
   it("persists target progress and retries only unfinished targets", async () => {

--- a/apps/web/test/hosted-crypto-gcp-kms.test.ts
+++ b/apps/web/test/hosted-crypto-gcp-kms.test.ts
@@ -11,6 +11,8 @@ vi.mock("@vercel/oidc", () => ({
 const LOCAL_KMS_API_ROOT = "local://murph-hosted-kms";
 const LOCAL_KMS_KEY_NAME =
   "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/web-wrap";
+const LOCAL_KMS_KEY_VERSION_NAME =
+  `${LOCAL_KMS_KEY_NAME}/cryptoKeyVersions/7`;
 const LOCAL_SIGN_KEY_VERSION =
   "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/authority-sign/cryptoKeyVersions/1";
 const LOCAL_MAC_KEY_VERSION =
@@ -153,7 +155,7 @@ describe("hosted crypto GCP Workload Identity Federation", () => {
       )) {
         return jsonResponse({
           ciphertext: "encrypted-root-key",
-          name: LOCAL_KMS_KEY_NAME,
+          name: LOCAL_KMS_KEY_VERSION_NAME,
         });
       }
 
@@ -198,6 +200,78 @@ describe("hosted crypto GCP Workload Identity Federation", () => {
       scope: ["https://www.googleapis.com/auth/cloudkms"],
     });
     expect(readBearerToken(kmsRequest?.headers)).toBe("kms-service-account-token");
+  });
+
+  it("uses only exact CryptoKey or CryptoKeyVersion resource names for decrypt", async () => {
+    const plaintext = new Uint8Array([4, 5, 6]);
+    const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({
+      plaintext: Buffer.from(plaintext).toString("base64"),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createHostedGcpKmsClientFromEnv({
+      HOSTED_CRYPTO_ALLOW_STATIC_GCP_ACCESS_TOKEN_FOR_DEV: "1",
+      HOSTED_CRYPTO_ENV: "dev",
+      HOSTED_CRYPTO_GCP_ACCESS_TOKEN: "ya29.static-token",
+      HOSTED_CRYPTO_GCP_KMS_API_ROOT: "https://kms.example.test/v1",
+      NODE_ENV: "test",
+    });
+
+    await expect(client.decrypt({
+      additionalAuthenticatedData: "domain=control",
+      ciphertext: "encrypted-root-key",
+      keyName: LOCAL_KMS_KEY_VERSION_NAME,
+    })).resolves.toEqual({ plaintext });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://kms.example.test/v1/${LOCAL_KMS_KEY_NAME}:decrypt`,
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    for (const keyName of [
+      `${LOCAL_KMS_KEY_NAME}/cryptoKeyVersions/latest`,
+      `${LOCAL_KMS_KEY_NAME}:decrypt`,
+      `${LOCAL_KMS_KEY_VERSION_NAME}/extra`,
+    ]) {
+      await expect(client.decrypt({
+        additionalAuthenticatedData: "domain=control",
+        ciphertext: "encrypted-root-key",
+        keyName,
+      })).rejects.toThrow(/CryptoKey or CryptoKeyVersion resource name/u);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed or mismatched EncryptResponse key version names", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({
+        ciphertext: "encrypted-root-key",
+        name: `${LOCAL_KMS_KEY_NAME}/cryptoKeyVersions/latest`,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        ciphertext: "encrypted-root-key",
+        name:
+          "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/other/cryptoKeyVersions/1",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createHostedGcpKmsClientFromEnv({
+      HOSTED_CRYPTO_ALLOW_STATIC_GCP_ACCESS_TOKEN_FOR_DEV: "1",
+      HOSTED_CRYPTO_ENV: "dev",
+      HOSTED_CRYPTO_GCP_ACCESS_TOKEN: "ya29.static-token",
+      HOSTED_CRYPTO_GCP_KMS_API_ROOT: "https://kms.example.test/v1",
+      NODE_ENV: "test",
+    });
+    const input = {
+      additionalAuthenticatedData: "domain=control",
+      keyName: LOCAL_KMS_KEY_NAME,
+      plaintext: new Uint8Array([1, 2, 3]),
+    };
+
+    await expect(client.encrypt(input)).rejects.toThrow(
+      /must be a CryptoKeyVersion resource name/u,
+    );
+    await expect(client.encrypt(input)).rejects.toThrow(
+      /did not match the requested CryptoKey/u,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("redacts raw Google provider messages from token exchange failures", async () => {

--- a/apps/web/test/hosted-crypto-gcp-kms.test.ts
+++ b/apps/web/test/hosted-crypto-gcp-kms.test.ts
@@ -240,6 +240,28 @@ describe("hosted crypto GCP Workload Identity Federation", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects a CryptoKeyVersion as an encrypt parent before provider I/O", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({
+      ciphertext: "unexpected",
+      name: LOCAL_KMS_KEY_VERSION_NAME,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createHostedGcpKmsClientFromEnv({
+      HOSTED_CRYPTO_ALLOW_STATIC_GCP_ACCESS_TOKEN_FOR_DEV: "1",
+      HOSTED_CRYPTO_ENV: "dev",
+      HOSTED_CRYPTO_GCP_ACCESS_TOKEN: "ya29.static-token",
+      HOSTED_CRYPTO_GCP_KMS_API_ROOT: "https://kms.example.test/v1",
+      NODE_ENV: "test",
+    });
+
+    await expect(client.encrypt({
+      additionalAuthenticatedData: "domain=control",
+      keyName: LOCAL_KMS_KEY_VERSION_NAME,
+      plaintext: new Uint8Array([1, 2, 3]),
+    })).rejects.toThrow(/must be a CryptoKey resource name/u);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed or mismatched EncryptResponse key version names", async () => {
     const fetchMock = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(jsonResponse({


### PR DESCRIPTION
## Why this PR exists

Hosted account-deletion cleanup persisted the `CryptoKeyVersion` name returned by Google KMS encryption, then used that version resource with `cryptoKeys.decrypt`, which accepts only the parent `CryptoKey`. Cleanup therefore failed before any external target could run.

## User goal / user-visible behavior

A member can delete their account once and have Murph durably complete the remaining runtime and provider cleanup without further action, including for already persisted version-named receipts.

## User experience

The existing account-deletion entry point and immediate feedback do not change. Canonical deletion remains immediate; the encrypted FK-free receipt owns any remaining work. The immediate attempt or existing retention retry owner decrypts the receipt, runs runtime-log, Cloudflare, Stripe, and Privy cleanup, and removes the receipt only after convergence. Malformed key names continue to fail closed, release the lease, and retain scheduled recovery. No new screen, copy, choice, or user action is introduced.

The required local product-experience review returned `NO FINDINGS`; rendered proof is not applicable because no frontend presentation changed.

## Invariants the PR must preserve

- Receipt payload identifiers remain KMS-encrypted and bound to the receipt AAD.
- Decrypt starts before provider fanout; malformed resources cause no provider I/O.
- Existing numeric `CryptoKeyVersion` receipts remain recoverable without a migration or manual state mutation.
- Lease release, attempt accounting, bounded backoff, per-target progress, and delete-after-convergence semantics remain unchanged.
- KMS encrypt responses must identify a numeric version belonging to the requested parent key.

## Non-obvious affected surfaces

- Shared hosted GCP KMS encrypt/decrypt client: it now validates exact parent/version resource shapes and returns the parent key after encryption. Covered by the focused KMS suite.
- Local hosted KMS client: it uses the same parent/version normalization contract so local proof matches production behavior. Covered by the focused KMS suite.
- Hosted account-deletion cleanup: new receipts store the parent key and existing version-named receipts normalize in memory before decrypt. Covered by the cleanup coordinator suite across runtime logs, Cloudflare, Stripe, and Privy.

## Architecture and reuse

- **Existing systems reused:** the existing KMS client, encrypted cleanup receipt, lease owner, target completion timestamps, and retention retry loop remain the only owners.
- **New logic:** two strict resource-shape validators derive a parent `CryptoKey` from either an exact parent name or a numeric `CryptoKeyVersion` name and verify the encryption response belongs to the requested key.
- **New abstractions:** one exported normalization function exposes the shared KMS boundary to the cleanup receipt; no service, state owner, dependency, or persisted schema is added.
- **Complexity intentionally avoided:** no data migration, manual retry path, reconciliation job, provider mutation, fallback alias handling, or compatibility service is introduced.

## Hot reply path impact

Not applicable. This change is confined to hosted account-deletion cleanup and does not alter the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, model mode, adapter, or provider-request assembly changed.
- Group Murph: Not applicable; no prompt, tool schema, model mode, adapter, or provider-request assembly changed.

## Preliminary specialist lenses

- Prompt: **not applicable** — no model-visible instructions, tools, or schemas changed.
- Frontend: **not applicable** — no UI or presentation changed; no rendered evidence applies.
- Coverage: **applicable** — focused KMS and account-deletion Vitest suites pass 32/32, web typecheck passes, scoped ESLint passes, and a redacted read-only production-shape check confirms the persisted version resource normalizes to its parent key. Exact-head CI is green.

The preliminary specialist pass returned `SPECIALIST_OUTCOME: FINDINGS` with one accepted low-severity coverage gap: no direct proof that encrypt rejects a version resource before provider I/O. The returned test-only patch was inspected, confirmed to touch only the focused KMS test, applied, and verified. No prompt or frontend findings were returned, and the preliminary pass was not rerun after substantive remediation.

## Final review and CI

- Parent final review found no remaining issues across KMS callers, cleanup fanout, retry ownership, and rolling compatibility.
- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with zero findings at `b1371cfcb6d826712ce0bcd68f4f76e2f59e910e`.
- Exact-head CI completed with 27 successful checks, one non-required skipped integration, and no pending or failing checks.
- A merge-tree check against current `origin/main` is clean; GitHub reports the PR mergeable.

## Change-shape breakdown

ReviewGPT first-reviewed head: b1371cfcb6d826712ce0bcd68f4f76e2f59e910e

Classification uses repository paths: runtime `.ts` files are source, Vitest files are tests/fixtures, the completed execution plan is docs, and no generated output is included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 58 | 7 |
| Tests/fixtures | 167 | 1 |
| Docs | 67 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **292** | **8** |

Binary files: none.

## Design proof

Not applicable; there is no user-facing frontend UI diff.

## Deployment skew / compatibility

This is a web-only deploy and requires no Cloudflare or container tandem rollout. During a rolling Vercel deploy, older code may still create a version-named receipt, which the new code accepts. New code stores a parent key name, which the prior decrypt path already accepts, so rollback is also compatible. Post-deploy proof is the next ordinary cleanup retry completing without `GoogleCloudApiError`; no force retry is required.