### PR TITLE
Update group sponsorship note label

### DIFF
--- a/apps/web/app/design/group-usage-funding-study.tsx
+++ b/apps/web/app/design/group-usage-funding-study.tsx
@@ -256,7 +256,8 @@ function GroupUsageFundingStudy() {
         />
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
           The amount dialog authorizes one contribution at a time. Optional
-          fields use a quiet sage border-only focus state.
+          sponsor details open behind Add a note and use a quiet sage
+          border-only focus state.
         </p>
       </div>
       <PersonalUsageCreditState

--- a/apps/web/src/components/hosted-groups/group-sponsorship-dialog.tsx
+++ b/apps/web/src/components/hosted-groups/group-sponsorship-dialog.tsx
@@ -108,7 +108,7 @@ function GroupSponsorshipDialog({
                 />
               }
             >
-              Make it funny (optional)
+              Add a note (optional)
               <ChevronDownIcon data-icon="inline-end" aria-hidden="true" />
             </CollapsibleTrigger>
             <CollapsibleContent className="h-auto">

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -531,7 +531,7 @@ test("freezes optional sponsorship copy with the selected group offer", async ()
   );
 
   try {
-    assert.match(rendered.container.textContent ?? "", /Make it funny/);
+    assert.match(rendered.container.textContent ?? "", /Add a note/);
     assert.ok(rendered.container.querySelector(".h-auto"));
     await clickRadio(rendered.container, rendered.window, "usage_5_usd");
     assert.equal(
@@ -763,7 +763,7 @@ test(
     );
 
     try {
-      assert.doesNotMatch(rendered.container.textContent ?? "", /Make it funny/);
+      assert.doesNotMatch(rendered.container.textContent ?? "", /Add a note/);
       assert.equal(
         rendered.container.querySelector("#group-sponsor-alias"),
         null,


### PR DESCRIPTION
## Why this PR exists

The group sponsorship amount dialog currently frames all optional sponsor details as comedic customization. That framing is narrower than the disclosed controls, which include a note, a public alias, and an offer-dependent temporary running bit.

## User-visible goal and behavior

Change the optional disclosure label from “Make it funny (optional)” to “Add a note (optional).” The existing disclosure contents and interaction remain unchanged.

### User experience

A participant enters through **Sponsor this chat**, selects an amount, and can open **Add a note (optional)** for the same existing sponsor details. Payment authority, permissions, timing, validation, and recovery behavior are unchanged.

## Invariants

- Sponsorship remains an explicit, one-contribution-at-a-time action.
- Optional sponsor details remain optional and available only to authorized participants.
- The label does not change payment processing, offer selection, or hosted-group access rules.
- The design catalog renders the production component with synthetic props only.

## Non-obvious affected surfaces

None.

## Architecture and reuse

- **Existing systems reused:** The existing `GroupSponsorshipDialog`, hosted-usage dialog tests, and group usage funding design study.
- **New logic:** None; this changes one static disclosure label and its assertions.
- **New abstractions:** None; the shared production component remains the single owner.
- **Complexity intentionally avoided:** No new state, branching, component, or compatibility layer.

## Runtime applicability

- **Hot reply path:** Not applicable; this is static browser UI copy.
- **Murph initial provider input:** Not applicable in either runtime; no prompt, provider request, or tool surface changed.

## Preliminary specialist lenses

- **Product experience:** Applicable because this is semantic action-framing copy. Local review: no findings.
- **Prompt:** Not applicable; no prompt or assistant instruction changed.
- **Frontend:** Applicable because the label is rendered in `apps/web`; desktop and mobile design-catalog proof captured.
- **Coverage:** Applicable; authorized visibility and unauthorized absence assertions were updated and the focused test passes.
- **Exact-head CI:** Pending.

## Verification

- `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hosted-usage-top-up-dialog.test.tsx` — 90 tests passed
- `pnpm --dir apps/web typecheck` — passed
- `pnpm test:frontend-design-proof` — 10 tests passed
- `git diff --check` — passed
- Stale-copy search — no remaining `Make it funny` text in `apps/web`
- Claude UI double-check — attempted, but unavailable due to explicit usage-credit exhaustion

## Design proof

Route: `/design?tab=sections#group-usage-funding`

- [Desktop 1440×1000](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1cf39359-be12-4cfa-883b-d40afc9e5000/public)
- [Mobile 390×844](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/8b07b29f-5835-483f-3936-bdd6f42c0c00/public)

## Change shape

| Class | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 2 |
| Tests | 2 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787981533&installation_model_id=19880&pr_number=1163&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1163&signature=9427797cf177b64cc3f3f807b43ccfc110a16088c87de6824a6efd93131dc7f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->