### PR TITLE
Ratchet runner budget and stabilize media E2E

### DIFF
--- a/.github/workflows/cloudflare-hosted-e2e.yml
+++ b/.github/workflows/cloudflare-hosted-e2e.yml
@@ -116,7 +116,7 @@ jobs:
   # and reset their full-stack state between scenarios.
   hosted-scenarios:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner || 'ubuntu-24.04' }}
     timeout-minutes: ${{ matrix.timeoutMinutes || 25 }}
     needs: runner-bundle
     strategy:
@@ -124,6 +124,7 @@ jobs:
       matrix:
         include:
           - name: Codex media + provider egress E2E
+            runner: blacksmith-4vcpu-ubuntu-2404
             slug: codex-media-provider-egress
             scenarios: codex-image-media-delivery openai-egress-authority provider-egress-token-bridge warm-reuse-egress
           - name: Linq reminder + onboarding follow-up E2E

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -64,7 +64,12 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // closure while remaining within the reviewed total budget. Ratchet the static
 // baseline to that combined measurement and retain the established small-growth
 // tolerances.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_856_451 + 32_768;
+//
+// Linq group-line recovery adds authored code to the existing runner chunks
+// without adding a forbidden boot input. The 2026-07-30 assemblies measured
+// 9,889,299B on Linux and 9,936,771B on macOS. Ratchet the total baseline to the
+// higher cross-platform measurement and retain the established 32KB allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_936_771 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_649_331;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_117_894;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -564,7 +564,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_649_331 + 48_000,
       staticClosureBytes: 8_117_894 + 96_000,
-      totalBytes: 9_856_451 + 32_768,
+      totalBytes: 9_936_771 + 32_768,
     });
   });
 

--- a/packages/cli/test/cloudflare-hosted-e2e-workflow-guards.test.ts
+++ b/packages/cli/test/cloudflare-hosted-e2e-workflow-guards.test.ts
@@ -134,6 +134,12 @@ describe('cloudflare hosted e2e workflow guards', () => {
     ])
     expect(workflow).not.toContain('for scenario in ${{ matrix.scenarios }}; do')
     expect(workflow).toContain('pnpm hosted-local e2e "${scenarios[@]}" --no-bundle')
+    expect(workflow).toContain("runs-on: ${{ matrix.runner || 'ubuntu-24.04' }}")
+    expect(workflow).toContain([
+      '          - name: Codex media + provider egress E2E',
+      '            runner: blacksmith-4vcpu-ubuntu-2404',
+      '            slug: codex-media-provider-egress',
+    ].join('\n'))
     expect(workflow).toContain(
       'apps/web/test/hosted-production-500-regressions-postgres.test.ts',
     )


### PR DESCRIPTION
## Why

Current public `main` adds the reviewed Linq group-line recovery path to existing runner chunks. The hosted runner assembly exceeds the stale cross-platform total-byte baseline even though the entry, static-closure, and forbidden-import guards still pass.

The media/provider E2E shard also exposed a capacity boundary: three standard-runner attempts starved the 5-second post-commit handoff while the same full matrix passed on the existing Blacksmith 4-vCPU lane. The shard needs the established higher-capacity runner so the stress proof measures product behavior rather than runner starvation.

This PR supersedes #1168 because `main` moved to a new root commit while that fully green PR was open. The scoped four-file patch was transplanted normally and verified byte-for-byte identical; the unrelated histories are not joined.

## User-visible goal and UX

Restore truthful hosted-runner verification and a stable hosted-E2E gate for the current production code. There is no user-facing UI change.

## Invariants

- Keep the 32 KB reviewed-growth allowance rather than widening it.
- Preserve the entry-chunk, static boot-closure, and forbidden-import guards.
- Use the higher observed cross-platform assembly measurement as the baseline.
- Move only the resource-intensive media/provider shard; the other hosted-E2E shards retain their existing runner.
- Do not join or manufacture history across the replaced public root.

## Architecture and reuse

- Existing systems reused: the current esbuild metafile budget owner, its direct boundary test, and the already-approved Blacksmith 4-vCPU runner class used by hosted deployment gates.
- New logic: ratchet the measured cross-platform total-byte baseline and select that runner only for the media/provider matrix entry.
- New abstractions: none; existing budget and workflow owners remain in place.
- Complexity intentionally avoided: no runtime exception, platform-specific budget, widened tolerance, duplicated job, test retry, compatibility layer, or cross-history merge was added.

## Specialist lenses

- Product experience: not applicable; no journey or product behavior changes.
- Prompt: not applicable.
- Frontend: not applicable; no rendered evidence is required.
- Coverage: applicable. Direct proof covers the runner-bundle boundary and the workflow runner selection.
- Preliminary specialist result on the identical patch: PASS with no findings and no patch artifact.

## Change breakdown

ReviewGPT first-reviewed head: d39f811b8cfa5da724889807f3f4beaa5474f990

- Source: +6 / -1
- Tests: +7 / -1
- Docs: +0 / -0
- Config/tooling: +2 / -1
- Generated/other: +0 / -0

## Verification

- Patch identity against superseded PR #1168: byte-for-byte identical.
- Runner-bundle budget suite: 34 passed.
- Full hosted-local runner assembly: passed on macOS at 9,936,771 bytes under the new 9,969,539-byte ceiling.
- Workflow guard: 3 passed; workflow YAML parsed.
- Private exact-ref hosted integration: all 11 shards passed against the identical public patch.
- Prior final ReviewGPT rounds on the identical patch: PASS with no findings.
- Prior exact-patch CI: all 28 checks passed, including both required hosted-E2E gates.
- Exact-head CI on the replacement root: pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787988620&installation_model_id=19880&pr_number=1172&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1172&signature=966dab355bceda82a427a6ba123c02a742fb25e003d754764f296d56915d7c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
