### PR TITLE
fix(web): clarify provider storage copy

### DIFF
--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -99,6 +99,13 @@ Last verified: 2026-07-30
   only the two Responses POST paths, canonical product model ids, a bounded
   20 MiB request body, and fixed operator model mappings; it disables Venice's
   added system prompt, web search, and web scraping at the final egress rewrite.
+  Settings may say that Murph disables OpenAI response storage because the
+  direct OpenAI Responses path sends `store: false`, which [disables Responses
+  API storage](https://developers.openai.com/api/docs/guides/migrate-to-responses#4-decide-when-to-use-statefulness).
+  This is an application-state setting, not a zero-data-retention promise:
+  OpenAI documents separate [abuse-monitoring, prompt-cache, and endpoint
+  retention controls](https://developers.openai.com/api/docs/guides/your-data#v1responses),
+  and third-party tools retain data under their own policies.
   Settings may describe Venice as privacy-first and state that Venice stores no
   prompts or replies, matching [Venice's API privacy
   documentation](https://docs.venice.ai/welcome/privacy). Treat that as a

--- a/agent-docs/exec-plans/active/2026-07-30-provider-storage-copy.md
+++ b/agent-docs/exec-plans/active/2026-07-30-provider-storage-copy.md
@@ -1,0 +1,38 @@
+# Clarify Provider Storage Copy
+
+Status: active
+Created: 2026-07-30
+Updated: 2026-07-30
+
+## Goal
+
+- Make the provider picker explain both providers' storage posture in short,
+  parallel language without turning `store: false` into a zero-data-retention
+  promise.
+
+## Success Criteria
+
+- OpenAI says Murph disables response storage.
+- Venice says prompts and replies are not stored in fewer words than the
+  current description.
+- The durable product and security docs bound the OpenAI statement to Responses
+  API application-state storage and preserve the existing Venice boundary.
+- The focused component test and design-catalog study cover the final copy.
+- Desktop and mobile browser proof show that both descriptions remain easy to
+  scan.
+
+## Scope
+
+- Provider-picker copy, its focused component test, the existing design-catalog
+  study, and the matching product/security disclosures.
+- No provider routing, request construction, persistence, availability,
+  billing, or tool-provider behavior changes.
+
+## Verification
+
+- Focused hosted assistant model settings test.
+- Scoped web typecheck and lint.
+- Desktop and mobile design-catalog browser proof.
+- Required product-experience, frontend, coverage, Claude UI, parent, CI, and
+  ReviewGPT gates.
+

--- a/agent-docs/exec-plans/active/2026-07-30-provider-storage-copy.md
+++ b/agent-docs/exec-plans/active/2026-07-30-provider-storage-copy.md
@@ -35,4 +35,3 @@ Updated: 2026-07-30
 - Desktop and mobile design-catalog browser proof.
 - Required product-experience, frontend, coverage, Claude UI, parent, CI, and
   ReviewGPT gates.
-

--- a/agent-docs/exec-plans/completed/2026-07-30-provider-storage-copy.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-provider-storage-copy.md
@@ -1,6 +1,6 @@
 # Clarify Provider Storage Copy
 
-Status: active
+Status: completed
 Created: 2026-07-30
 Updated: 2026-07-30
 
@@ -12,9 +12,10 @@ Updated: 2026-07-30
 
 ## Success Criteria
 
-- OpenAI says Murph disables response storage.
-- Venice says prompts and replies are not stored in fewer words than the
-  current description.
+- OpenAI uses the plain-language line "No chat history saved."
+- Venice uses the compact positioning line "Privacy-first inference."
+- The dialog introduction says Murph uses the selected provider after save
+  without limiting the statement to core replies.
 - The durable product and security docs bound the OpenAI statement to Responses
   API application-state storage and preserve the existing Venice boundary.
 - The focused component test and design-catalog study cover the final copy.
@@ -33,5 +34,15 @@ Updated: 2026-07-30
 - Focused hosted assistant model settings test.
 - Scoped web typecheck and lint.
 - Desktop and mobile design-catalog browser proof.
-- Required product-experience, frontend, coverage, Claude UI, parent, CI, and
-  ReviewGPT gates.
+- The user explicitly waived additional review gates and requested direct
+  merge after the focused verification.
+
+## Completion Evidence
+
+- Focused hosted assistant model settings test: 18 tests passed.
+- Scoped ESLint passed for the component, focused test, and design-catalog
+  study.
+- Web typecheck passed.
+- Desktop and mobile Playwright checks confirmed the final strings and dialog
+  containment.
+Completed: 2026-07-30

--- a/agent-docs/product-specs/hosted-plan-downgrades.md
+++ b/agent-docs/product-specs/hosted-plan-downgrades.md
@@ -38,6 +38,13 @@ turn:
   Venice rollout flag is enabled, an active personal member may choose Venice
   instead. The choice changes core assistant inference only; specialized tools
   can continue to use their own managed providers.
+- Settings may state that Murph disables OpenAI response storage because the
+  direct Responses path sends `store: false`, which [disables Responses API
+  storage](https://developers.openai.com/api/docs/guides/migrate-to-responses#4-decide-when-to-use-statefulness).
+  This does not promise zero data retention: OpenAI separately documents
+  [abuse-monitoring, prompt-cache, and endpoint retention
+  controls](https://developers.openai.com/api/docs/guides/your-data#v1responses),
+  and third-party tools remain subject to their own retention policies.
 - Settings may call Venice privacy-first and state that Venice stores no prompts
   or replies, consistent with [Venice's API privacy
   documentation](https://docs.venice.ai/welcome/privacy). This is a

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -995,8 +995,8 @@ export function ComponentsContent() {
 
         <Section title="Radio Group, Choice Cards & Provider Picker">
           <p className="max-w-2xl text-sm text-muted-foreground">
-            Compare model choice cards and the compact, save-gated provider
-            picker used by assistant settings.
+            Compare model choice cards and review the compact provider-storage
+            disclosures used by assistant settings.
           </p>
           <RadioGroup
             className="grid gap-3 sm:grid-cols-3"

--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -84,7 +84,7 @@ const MODEL_OPTIONS = [
 
 const PROVIDER_OPTIONS = [
   {
-    description: "Direct inference through OpenAI",
+    description: "We disable response storage.",
     logo: {
       height: 180,
       src: "/brand-logos/assistant-providers/openai-light.svg",
@@ -94,7 +94,7 @@ const PROVIDER_OPTIONS = [
     provider: HOSTED_ASSISTANT_OPENAI_PROVIDER,
   },
   {
-    description: "Privacy-first. Venice stores no prompts or replies.",
+    description: "No prompts or replies stored.",
     logo: {
       height: 356,
       src: "/brand-logos/assistant-providers/venice-light.svg",

--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -84,7 +84,7 @@ const MODEL_OPTIONS = [
 
 const PROVIDER_OPTIONS = [
   {
-    description: "We disable response storage.",
+    description: "No chat history saved.",
     logo: {
       height: 180,
       src: "/brand-logos/assistant-providers/openai-light.svg",
@@ -94,7 +94,7 @@ const PROVIDER_OPTIONS = [
     provider: HOSTED_ASSISTANT_OPENAI_PROVIDER,
   },
   {
-    description: "No prompts or replies stored.",
+    description: "Privacy-first inference.",
     logo: {
       height: 356,
       src: "/brand-logos/assistant-providers/venice-light.svg",
@@ -211,7 +211,7 @@ export function AssistantProviderDialog({
             Choose provider
           </DialogTitle>
           <DialogDescription className="max-w-[38ch] text-sm/6">
-            Core replies use this provider after you save.
+            Murph uses this provider after you save.
           </DialogDescription>
         </DialogHeader>
         <RadioGroup

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -194,7 +194,7 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
   assert.doesNotMatch(
     view.container.textContent ?? "",
-    /We disable response storage\./u,
+    /No chat history saved\./u,
   );
   await act(async () => {
     findButton(view.container, "Change").click();
@@ -202,11 +202,15 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   assert.match(view.document.body.textContent ?? "", /Choose provider/u);
   assert.match(
     view.document.body.textContent ?? "",
-    /We disable response storage\./u,
+    /No chat history saved\./u,
   );
   assert.match(
     view.document.body.textContent ?? "",
-    /No prompts or replies stored\./u,
+    /Privacy-first inference\./u,
+  );
+  assert.match(
+    view.document.body.textContent ?? "",
+    /Murph uses this provider after you save\./u,
   );
   assert.match(
     view.document.body.textContent ?? "",

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -194,7 +194,7 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
   assert.doesNotMatch(
     view.container.textContent ?? "",
-    /Direct inference through OpenAI/u,
+    /We disable response storage\./u,
   );
   await act(async () => {
     findButton(view.container, "Change").click();
@@ -202,11 +202,11 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   assert.match(view.document.body.textContent ?? "", /Choose provider/u);
   assert.match(
     view.document.body.textContent ?? "",
-    /Direct inference through OpenAI/u,
+    /We disable response storage\./u,
   );
   assert.match(
     view.document.body.textContent ?? "",
-    /Privacy-first\. Venice stores no prompts or replies\./u,
+    /No prompts or replies stored\./u,
   );
   assert.match(
     view.document.body.textContent ?? "",


### PR DESCRIPTION
## Why

The core-provider picker used uneven privacy copy: Venice had a long storage statement, while OpenAI only described the inference route. This makes the comparison concise and gives members a bounded, plain-language OpenAI storage disclosure.

## User-visible goal and experience

Members opening **Settings → Core provider → Change** now see:

- Dialog intro: “Murph uses this provider after you save.”
- OpenAI: “No chat history saved.”
- Venice: “Privacy-first inference.”

The existing interaction is unchanged: choosing a provider updates the draft immediately, closing the dialog preserves that draft, and Save persists it. Existing recovery and save behavior are unaffected.

## Invariants

- “No chat history saved” describes disabled Responses API application-state storage; it does not claim Zero Data Retention or no provider-side retention of any kind.
- Provider selection, model behavior, request construction, and persistence are unchanged.
- The existing reusable provider picker remains the production and design-catalog source.

## Architecture and reuse

- **Existing systems reused:** The provider picker, settings state, focused component test, and design-catalog study.
- **New logic:** None; this changes static copy, exact test assertions, and bounded durable documentation only.
- **New abstractions:** No new abstractions were needed because the existing provider-option data already owns this copy.
- **Complexity intentionally avoided:** No new runtime branch, state owner, component, dependency, or compatibility layer.

## Review lenses

- Product experience: applicable; this is member-facing comparison copy.
- Prompt behavior: not applicable; no provider-visible prompts, tools, request builders, or model configuration changed.
- Frontend: applicable; the production surface and existing component study were updated together.
- Coverage: applicable; focused assertions protect the final disclosures and dialog introduction.
- Additional specialist and final review gates were waived by the user for this copy-only change.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-assistant-model-settings.test.tsx` — 18 tests passed.
- Scoped ESLint on the component, test, and design-catalog file — passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm test:frontend-design-proof` — 10 tests passed.
- Desktop and mobile Playwright render checks confirmed all final strings and dialog containment.

## Design proof

- Design page: [`/design?tab=components`](/design?tab=components)
- Desktop screenshot: ![Provider storage copy — desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/dd72a00c-13af-4301-aba6-f36a19c10f00/public)
- Mobile screenshot: ![Provider storage copy — mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/edd578b0-94f2-4a81-c517-1e137e221700/public)

## Change shape

| Area | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 5 |
| Tests | 7 | 3 |
| Docs | 62 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **74** | **8** |

## Deployment

No cross-service behavior or deployment-order dependency is introduced. This is web copy, test, catalog, and documentation only.
