### PR TITLE
fix(hosted): bound Assistant Ask wake handoff

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -560,6 +560,12 @@ Last verified: 2026-07-30
   pinned to the original target and membership generation; expiry is the
   existing ten-minute mailbox deadline, with no second lease, timer, status
   row, or delivery ledger.
+- Cloudflare may exact-replay one Assistant Ask control request within the
+  original request deadline after a replay-safe transport ambiguity or HTTP
+  `5xx`. This applies only to group `ask`, `ask_member`, `ask_current_sender`,
+  and the dedicated `prepare` / `complete` control requests, whose stable
+  identities make identical replay idempotent. Caller cancellation, exhausted
+  deadlines, authority failures, and other `4xx` responses do not replay.
 - Assistant Ask request and completion appends first signal the existing Temporal
   workflow, then may issue the shared payloadless, no-retry direct
   `ensure-processing` latency hint. Temporal acceptance failure starts no direct

--- a/agent-docs/exec-plans/active/2026-07-30-assistant-ask-handoff-port.md
+++ b/agent-docs/exec-plans/active/2026-07-30-assistant-ask-handoff-port.md
@@ -52,6 +52,32 @@ Created: 2026-07-30
 - Exact pushed-head CI, preliminary completion-specialists ReviewGPT, parent
   final review, and final ReviewGPT rounds.
 
+Completed local proof:
+
+- Focused Web: 4 files, 137 tests passed; Web prepared typecheck and targeted
+  lint passed.
+- Focused Cloudflare plus shared transport: 5 files, 159 tests passed;
+  Cloudflare typecheck passed.
+- Assistant Engine current-turn boundary: full 240-test runtime file passed;
+  Assistant Engine typecheck passed.
+- Assistant Runtime group-context boundary: 20 tests passed; Assistant Runtime
+  typecheck passed.
+- Hosted-local `temporal-orchestration` full-stack E2E: 2 tests passed against
+  the real local Web, Cloudflare runner, database, and managed Temporal stack.
+- Signed loopback direct scenarios proved one exact replay after HTTP `503` and
+  no second POST after foreground cancellation.
+
+Preliminary specialist disposition:
+
+- Accepted the cancellation finding and propagated the existing foreground
+  signal through Assistant Engine, the current-turn runtime wrapper, and the
+  Cloudflare group-tool port. Regression and direct proof now cover the
+  canceled retry boundary.
+- Addressed the requested cross-runtime evidence with the existing hosted-local
+  Temporal scenario plus the existing Web ordering, signed control transport,
+  and Assistant Ask completion integration boundaries. No test-only Temporal
+  controls or parallel orchestration harness were added.
+
 ## Deployment
 
 - Web and Cloudflare control-flow change only; no schema, wire-shape, or

--- a/agent-docs/exec-plans/active/2026-07-30-assistant-ask-handoff-port.md
+++ b/agent-docs/exec-plans/active/2026-07-30-assistant-ask-handoff-port.md
@@ -1,0 +1,60 @@
+# Assistant Ask bounded handoff port
+
+Status: active
+Created: 2026-07-30
+
+## Goal
+
+- Port the bounded Assistant Ask mailbox wake handoff from the stale PR onto
+  current `main`.
+- Return request or completion success only after Temporal accepts the durable
+  mailbox signal.
+- Replay an exact, idempotent Assistant Ask control request once when a
+  retryable response or response-body failure makes the result ambiguous.
+
+## Proven cause
+
+- Web commits the encrypted mailbox item, then schedules the Temporal signal
+  with `after()` and swallows signaling failure.
+- The HTTP caller can therefore observe success before any durable wake owner
+  accepts the work.
+- Current `main` has added a separate Assistant Ask control port and the
+  `ask_current_sender` action since the original patch was written.
+
+## Constraints
+
+- Keep the encrypted mailbox as the only durable Assistant Ask queue and
+  operation state.
+- Keep Temporal as the sole durable wake and reconciliation owner.
+- Start the payload-free direct Cloudflare wake only after Temporal accepts the
+  signal, and keep it best effort.
+- Retry only exact request shapes whose stable mailbox identities make replay
+  idempotent; do not add a queue, receipt, scheduler, or persisted retry state.
+- Propagate the caller abort signal and keep all attempts inside one existing
+  control-plane timeout budget.
+
+## Approach
+
+1. Replace the deferred wake scheduler with one bounded, awaited handoff.
+2. Await it at the request and completion HTTP boundaries.
+3. Extend the current Cloudflare web-control transport with one optional exact
+   replay under a shared deadline and bounded response-body reads.
+4. Enable exact replay for all current idempotent Assistant Ask request and
+   completion adapters, including `ask_current_sender`.
+5. Add focused failure, ordering, timeout, and exact-replay regressions.
+
+## Verification
+
+- Focused Web tests for mailbox handoff, group-tool request routes, and the
+  Assistant Ask completion route.
+- Focused Cloudflare tests for all current Ask adapters and transport response
+  ambiguity cases.
+- Exact pushed-head CI, preliminary completion-specialists ReviewGPT, parent
+  final review, and final ReviewGPT rounds.
+
+## Deployment
+
+- Web and Cloudflare control-flow change only; no schema, wire-shape, or
+  persisted-state change.
+- Determine and document the safe deploy order and temporary skew behavior
+  before final handoff.

--- a/agent-docs/exec-plans/completed/2026-07-30-assistant-ask-handoff-port.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-assistant-ask-handoff-port.md
@@ -1,6 +1,6 @@
 # Assistant Ask bounded handoff port
 
-Status: active
+Status: completed
 Created: 2026-07-30
 
 ## Goal
@@ -78,9 +78,29 @@ Preliminary specialist disposition:
   and Assistant Ask completion integration boundaries. No test-only Temporal
   controls or parallel orchestration harness were added.
 
+Parent product-experience revalidation:
+
+- Pass. The corrected flow keeps the existing entry point and destination,
+  makes acceptance truthful at the durable Temporal boundary, preserves the
+  mailbox as reconciliation truth, and ties replay cancellation to the
+  initiating turn.
+- The stable owner-boundary tests, hosted-local Temporal scenario, and signed
+  loopback replay/cancellation scenarios directly prove the changed behavior.
+  A new monolithic scenario would require test-only orchestration controls and
+  would not add material product confidence for this patch.
+
+Parent final review:
+
+- No remaining findings. Retry is opt-in for stable Assistant Ask identities,
+  shares one deadline, excludes caller cancellation and non-`5xx` responses,
+  and does not change unrelated control requests.
+
 ## Deployment
 
 - Web and Cloudflare control-flow change only; no schema, wire-shape, or
   persisted-state change.
-- Determine and document the safe deploy order and temporary skew behavior
-  before final handoff.
+- Deploy Cloudflare and roll the runner revision first, then deploy Web. The
+  Cloudflare-first compatibility window accepts old Web behavior; Web-first
+  would omit the new exact-replay recovery from warm old runners.
+Updated: 2026-07-30
+Completed: 2026-07-30

--- a/apps/cloudflare/src/runtime-platform/assistant-ask-port.ts
+++ b/apps/cloudflare/src/runtime-platform/assistant-ask-port.ts
@@ -27,6 +27,7 @@ export function createHostedRuntimeAssistantAskPort(input: {
         description: "Hosted Assistant Ask control",
         fetchImpl: input.fetchImpl,
         path: HOSTED_RUNTIME_ASSISTANT_ASK_CONTROL_PATH,
+        replayOnceOnRetryableFailure: true,
         sensitiveResponseBody: {
           maxBytes: HOSTED_RUNTIME_ASSISTANT_ASK_RESPONSE_MAX_BYTES,
         },

--- a/apps/cloudflare/src/runtime-platform/group-tool-port.ts
+++ b/apps/cloudflare/src/runtime-platform/group-tool-port.ts
@@ -42,6 +42,7 @@ export function createHostedRuntimeGroupToolPort(input: {
         description: "Hosted group tool",
         fetchImpl: input.fetchImpl,
         path: buildHostedRuntimeGroupToolPath(),
+        replayOnceOnRetryableFailure: isHostedAssistantAskGroupToolRequest(request),
         ...(isParticipantDisplayNameRead
           ? {
               sensitiveResponseBody: {
@@ -62,6 +63,16 @@ export function createHostedRuntimeGroupToolPort(input: {
       }
     },
   };
+}
+
+function isHostedAssistantAskGroupToolRequest(
+  request: Parameters<
+    NonNullable<HostedRuntimePlatform["groupToolPort"]>["request"]
+  >[0],
+): boolean {
+  return request.action === "ask"
+    || request.action === "ask_current_sender"
+    || request.action === "ask_member";
 }
 
 function buildHostedRuntimeGroupToolPath(): string {

--- a/apps/cloudflare/src/runtime-platform/group-tool-port.ts
+++ b/apps/cloudflare/src/runtime-platform/group-tool-port.ts
@@ -27,7 +27,7 @@ export function createHostedRuntimeGroupToolPort(input: {
   transport: HostedWebControlTransport;
 }): NonNullable<HostedRuntimePlatform["groupToolPort"]> {
   return {
-    async request(request) {
+    async request(request, context) {
       const isParticipantDisplayNameRead =
         request.action === "read_participant_display_names";
       const timeoutMs = isParticipantDisplayNameRead
@@ -36,6 +36,13 @@ export function createHostedRuntimeGroupToolPort(input: {
           HOSTED_RUNTIME_GROUP_PARTICIPANT_DISPLAY_NAME_SOFT_TIMEOUT_MS,
         )
         : input.timeoutMs;
+      let signal = context?.signal;
+      if (isParticipantDisplayNameRead) {
+        const timeoutSignal = AbortSignal.timeout(timeoutMs);
+        signal = signal
+          ? AbortSignal.any([signal, timeoutSignal])
+          : timeoutSignal;
+      }
       const payload = await fetchHostedWebControlPlaneJson({
         body: request,
         boundUserId: input.boundUserId,
@@ -49,9 +56,9 @@ export function createHostedRuntimeGroupToolPort(input: {
                 maxBytes:
                   HOSTED_RUNTIME_GROUP_PARTICIPANT_DISPLAY_NAME_RESPONSE_MAX_BYTES,
               },
-              signal: AbortSignal.timeout(timeoutMs),
             }
           : {}),
+        signal,
         timeoutMs,
         transport: input.transport,
       });

--- a/apps/cloudflare/src/runtime-platform/web-control-transport.ts
+++ b/apps/cloudflare/src/runtime-platform/web-control-transport.ts
@@ -26,6 +26,7 @@ import {
   HostedRuntimeControlPlaneFetchError,
   HOSTED_REPLAY_SAFE_READ_RETRY_ATTEMPTS,
   combineAbortSignalsWithCleanup,
+  isRetryableHostedRuntimeReplaySafeReadTransportError,
   isRetryableHostedWebControlReadError,
   shouldPreserveHostedRuntimeFetchError,
   sleepHostedReplaySafeReadRetryDelay,
@@ -49,6 +50,25 @@ export type HostedWebControlTransport =
   | {
     mode: "proxy";
   };
+
+interface HostedWebControlPlaneJsonRequest {
+  acceptedStatuses?: readonly number[];
+  body?: unknown;
+  boundUserId: string;
+  description: string;
+  fetchImpl: typeof fetch;
+  headers?: Headers;
+  method?: "GET" | "POST";
+  path: string;
+  replayOnceOnRetryableFailure?: boolean;
+  sensitiveResponseBody?: {
+    maxBytes: number;
+  };
+  signal?: AbortSignal | null;
+  timeoutMs: number;
+  transport: HostedWebControlTransport;
+}
+
 export class HostedWebControlPlaneResponseError extends Error {
   readonly code: string | undefined;
   readonly context: {
@@ -162,22 +182,38 @@ function assertReplaySafeHostedWebControlRetryPath(path: string): void {
   }
 }
 
-export async function fetchHostedWebControlPlaneJson(input: {
-  acceptedStatuses?: readonly number[];
-  body?: unknown;
-  boundUserId: string;
-  description: string;
-  fetchImpl: typeof fetch;
-  headers?: Headers;
-  method?: "GET" | "POST";
-  path: string;
-  sensitiveResponseBody?: {
-    maxBytes: number;
-  };
-  signal?: AbortSignal | null;
-  timeoutMs: number;
-  transport: HostedWebControlTransport;
-}): Promise<unknown> {
+export async function fetchHostedWebControlPlaneJson(
+  input: HostedWebControlPlaneJsonRequest,
+): Promise<unknown> {
+  if (input.replayOnceOnRetryableFailure !== true) {
+    return await fetchHostedWebControlPlaneJsonAttempt(input);
+  }
+
+  const deadlineMs = Date.now() + input.timeoutMs;
+  try {
+    return await fetchHostedWebControlPlaneJsonAttempt({
+      ...input,
+      timeoutMs: Math.max(0, deadlineMs - Date.now()),
+    });
+  } catch (error) {
+    if (
+      input.signal?.aborted
+      || !isRetryableHostedWebControlExactReplayError(error)
+      || Date.now() >= deadlineMs
+    ) {
+      throw error;
+    }
+  }
+
+  return await fetchHostedWebControlPlaneJsonAttempt({
+    ...input,
+    timeoutMs: Math.max(0, deadlineMs - Date.now()),
+  });
+}
+
+async function fetchHostedWebControlPlaneJsonAttempt(
+  input: HostedWebControlPlaneJsonRequest,
+): Promise<unknown> {
   if (
     input.sensitiveResponseBody
     && (
@@ -196,6 +232,7 @@ export async function fetchHostedWebControlPlaneJson(input: {
   });
   const body = input.body === undefined ? undefined : JSON.stringify(input.body);
   const requestStartedAt = Date.now();
+  const requestDeadlineMs = requestStartedAt + input.timeoutMs;
   const requestLogDetails = buildHostedWebControlRequestLogDetails({
     body,
     description: input.description,
@@ -323,7 +360,10 @@ export async function fetchHostedWebControlPlaneJson(input: {
     maxBytes: input.sensitiveResponseBody?.maxBytes,
     response,
     signal: input.signal ?? null,
-    timeoutMs: input.timeoutMs,
+    streamBody: input.replayOnceOnRetryableFailure === true,
+    timeoutMs: input.replayOnceOnRetryableFailure === true
+      ? Math.max(0, requestDeadlineMs - Date.now())
+      : input.timeoutMs,
   });
   const acceptedStatus = input.acceptedStatuses?.includes(response.status) ?? false;
   if (!response.ok && !acceptedStatus) {
@@ -393,38 +433,43 @@ async function readHostedWebControlPlaneResponseText(input: {
   maxBytes: number | undefined;
   response: Response;
   signal: AbortSignal | null;
+  streamBody: boolean;
   timeoutMs: number;
 }): Promise<string> {
   const maxBytes = input.maxBytes;
-  if (maxBytes === undefined) {
+  if (maxBytes === undefined && !input.streamBody) {
     return await input.response.text();
   }
 
-  const contentLengthText = input.response.headers.get("content-length")?.trim() ?? "";
-  const contentLength = /^\d+$/u.test(contentLengthText)
-    ? Number(contentLengthText)
-    : null;
-  if (
-    contentLength !== null
-    && Number.isSafeInteger(contentLength)
-    && contentLength > maxBytes
-  ) {
-    try {
-      await input.response.body?.cancel();
-    } catch {
-      // The fixed-size rejection below is the authoritative failure.
+  if (maxBytes !== undefined) {
+    const contentLengthText =
+      input.response.headers.get("content-length")?.trim() ?? "";
+    const contentLength = /^\d+$/u.test(contentLengthText)
+      ? Number(contentLengthText)
+      : null;
+    if (
+      contentLength !== null
+      && Number.isSafeInteger(contentLength)
+      && contentLength > maxBytes
+    ) {
+      try {
+        await input.response.body?.cancel();
+      } catch {
+        // The fixed-size rejection below is the authoritative failure.
+      }
+      throw createHostedWebControlPlaneResponseTooLargeError({
+        description: input.description,
+        maxBytes,
+      });
     }
-    throw createHostedWebControlPlaneResponseTooLargeError({
-      description: input.description,
-      maxBytes,
-    });
   }
 
   if (!input.response.body) {
     return "";
   }
 
-  const chunks: Uint8Array[] = [];
+  const decoder = new TextDecoder();
+  let text = "";
   let totalBytes = 0;
   for await (const chunk of readHostedRuntimeResponseBodyChunks({
     body: input.response.body,
@@ -433,22 +478,23 @@ async function readHostedWebControlPlaneResponseText(input: {
     timeoutMs: input.timeoutMs,
   })) {
     totalBytes += chunk.byteLength;
-    if (totalBytes > maxBytes) {
+    if (maxBytes !== undefined && totalBytes > maxBytes) {
       throw createHostedWebControlPlaneResponseTooLargeError({
         description: input.description,
         maxBytes,
       });
     }
-    chunks.push(chunk);
+    text += decoder.decode(chunk, { stream: true });
   }
+  text += decoder.decode();
+  return text;
+}
 
-  const bytes = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
+function isRetryableHostedWebControlExactReplayError(error: unknown): boolean {
+  if (error instanceof HostedWebControlPlaneResponseError) {
+    return error.status >= 500 && error.status <= 599;
   }
-  return new TextDecoder().decode(bytes);
+  return isRetryableHostedRuntimeReplaySafeReadTransportError(error);
 }
 
 function createHostedWebControlPlaneResponseTooLargeError(input: {

--- a/apps/cloudflare/test/assistant-ask-port-replay.test.ts
+++ b/apps/cloudflare/test/assistant-ask-port-replay.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  HostedRuntimeAssistantAskControlRequest,
+  HostedRuntimeAssistantAskControlResponse,
+} from "@murphai/hosted-execution/runtime-control";
+
+import { createHostedRuntimeAssistantAskPort } from "../src/runtime-platform/assistant-ask-port.ts";
+import {
+  HostedWebControlPlaneResponseError,
+} from "../src/runtime-platform/web-control-transport.ts";
+
+const replaySafeRequests = [
+  {
+    action: "prepare",
+    request: { action: "prepare", requestId: "aask_req_one" },
+    response: {
+      action: "prepare",
+      question: "What is today's workout?",
+      status: "ready",
+      targetLabel: "100 Club",
+    },
+  },
+  {
+    action: "complete",
+    request: {
+      action: "complete",
+      requestId: "aask_req_one",
+      result: { answer: "Three sets of squats.", outcome: "answered" },
+    },
+    response: { action: "complete", status: "completed" },
+  },
+] as const satisfies readonly {
+  action: string;
+  request: HostedRuntimeAssistantAskControlRequest;
+  response: HostedRuntimeAssistantAskControlResponse;
+}[];
+
+describe("hosted Assistant Ask control exact replay", () => {
+  it.each(replaySafeRequests)(
+    "exact-replays the same $action request when a successful response body is lost",
+    async ({ request, response }) => {
+      const requestBodies: BodyInit[] = [];
+      const fetchImpl = vi.fn<typeof fetch>(async (_request, init) => {
+        if (init?.body) {
+          requestBodies.push(init.body);
+        }
+        return requestBodies.length === 1
+          ? createLostBodyResponse(200)
+          : createJsonResponse(response);
+      });
+      const port = createHostedRuntimeAssistantAskPort({
+        boundUserId: "member-bound",
+        fetchImpl,
+        timeoutMs: 5_000,
+        transport: { mode: "proxy" },
+      });
+
+      await expect(port.request(request)).resolves.toEqual(response);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(requestBodies).toEqual([
+        JSON.stringify(request),
+        JSON.stringify(request),
+      ]);
+    },
+  );
+
+  it("exact-replays a committed completion after a complete 5xx response", async () => {
+    const { request, response } = replaySafeRequests[1];
+    const responses = [
+      createJsonResponse({ error: "temporarily unavailable" }, 503),
+      createJsonResponse(response),
+    ];
+    const fetchImpl = vi.fn<typeof fetch>(async () => responses.shift()!);
+    const port = createHostedRuntimeAssistantAskPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(request)).resolves.toEqual(response);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay a request rejected by Web authority", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      createJsonResponse({ error: "unauthorized" }, 401)
+    );
+    const port = createHostedRuntimeAssistantAskPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(replaySafeRequests[0].request)).rejects.toBeInstanceOf(
+      HostedWebControlPlaneResponseError,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay after the caller cancels the request", async () => {
+    const abortController = new AbortController();
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      abortController.abort(new DOMException("caller cancelled", "AbortError"));
+      return createLostBodyResponse(200);
+    });
+    const port = createHostedRuntimeAssistantAskPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(
+      replaySafeRequests[0].request,
+      { signal: abortController.signal },
+    )).rejects.toThrow();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createJsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function createLostBodyResponse(status: number): Response {
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.error(new TypeError("Response body lost."));
+    },
+  }), { status });
+}

--- a/apps/cloudflare/test/assistant-ask-port.test.ts
+++ b/apps/cloudflare/test/assistant-ask-port.test.ts
@@ -79,6 +79,7 @@ describe("Hosted Assistant Ask control-plane port", () => {
       description: "Hosted Assistant Ask control",
       fetchImpl: expect.any(Function),
       path: HOSTED_RUNTIME_ASSISTANT_ASK_CONTROL_PATH,
+      replayOnceOnRetryableFailure: true,
       sensitiveResponseBody: { maxBytes: 16_384 },
       signal,
       timeoutMs: 5_000,

--- a/apps/cloudflare/test/group-tool-port-replay.test.ts
+++ b/apps/cloudflare/test/group-tool-port-replay.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  HostedRuntimeGroupToolRequest,
+  HostedRuntimeGroupToolResponse,
+} from "@murphai/hosted-execution/runtime-control";
+
+import { createHostedRuntimeGroupToolPort } from "../src/runtime-platform/group-tool-port.ts";
+import {
+  HostedWebControlPlaneResponseError,
+} from "../src/runtime-platform/web-control-transport.ts";
+
+const replaySafeRequests = [
+  {
+    action: "ask",
+    request: {
+      action: "ask",
+      groupLabel: "100 Club",
+      originAssistantInputId: `ain_${"a".repeat(32)}`,
+      originSessionId: "session_private",
+      question: "What exercises are scheduled today?",
+    },
+    response: {
+      action: "ask",
+      result: { status: "accepted", targetLabel: "100 Club" },
+    },
+  },
+  {
+    action: "ask_member",
+    request: {
+      action: "ask_member",
+      grantId: "grant_sleep",
+      origin: {
+        assistantInputId: `ain_${"b".repeat(32)}`,
+        kind: "accepted_input",
+        sessionId: "session_group",
+      },
+      question: "How has the grantor been sleeping lately?",
+    },
+    response: {
+      action: "ask_member",
+      result: { status: "accepted" },
+    },
+  },
+  {
+    action: "ask_current_sender",
+    request: {
+      action: "ask_current_sender",
+      origin: {
+        assistantInputId: `ain_${"c".repeat(32)}`,
+        kind: "accepted_input",
+        sessionId: "session_group",
+      },
+    },
+    response: {
+      action: "ask_current_sender",
+      result: { status: "accepted" },
+    },
+  },
+] as const satisfies readonly {
+  action: string;
+  request: HostedRuntimeGroupToolRequest;
+  response: HostedRuntimeGroupToolResponse;
+}[];
+
+describe("hosted group tool exact replay", () => {
+  it.each(replaySafeRequests)(
+    "exact-replays the same $action request when a successful response body is lost",
+    async ({ request, response }) => {
+      const requestBodies: BodyInit[] = [];
+      const fetchImpl = vi.fn<typeof fetch>(async (_request, init) => {
+        if (init?.body) {
+          requestBodies.push(init.body);
+        }
+        return requestBodies.length === 1
+          ? createLostBodyResponse(200)
+          : createJsonResponse(response);
+      });
+      const port = createHostedRuntimeGroupToolPort({
+        boundUserId: "member-bound",
+        fetchImpl,
+        timeoutMs: 5_000,
+        transport: { mode: "proxy" },
+      });
+
+      await expect(port.request(request)).resolves.toEqual(response);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(requestBodies).toEqual([
+        JSON.stringify(request),
+        JSON.stringify(request),
+      ]);
+    },
+  );
+
+  it("exact-replays the same Ask after consuming a complete 5xx response", async () => {
+    const { request, response } = replaySafeRequests[0];
+    const responses = [
+      createJsonResponse({ error: "temporarily unavailable" }, 503),
+      createJsonResponse(response),
+    ];
+    const requestBodies: BodyInit[] = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (_request, init) => {
+      if (init?.body) {
+        requestBodies.push(init.body);
+      }
+      return responses.shift()!;
+    });
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(request)).resolves.toEqual(response);
+    expect(requestBodies).toEqual([
+      JSON.stringify(request),
+      JSON.stringify(request),
+    ]);
+  });
+
+  it("returns the second post-header failure after exactly one replay", async () => {
+    const firstFailure = new TypeError("First response body lost.");
+    const secondFailure = new TypeError("Second response body lost.");
+    const responses = [
+      createLostBodyResponse(200, firstFailure),
+      createLostBodyResponse(200, secondFailure),
+    ];
+    const fetchImpl = vi.fn<typeof fetch>(async () => responses.shift()!);
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(replaySafeRequests[0].request)).rejects.toMatchObject({
+      cause: secondFailure,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a stalled body when the original total deadline expires", async () => {
+    let canceled = false;
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          canceled = true;
+        },
+        pull() {
+          // Remain pending until the original request deadline cancels the reader.
+        },
+      }),
+      { status: 200 },
+    ));
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 50,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(replaySafeRequests[0].request)).rejects.toThrow();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(canceled).toBe(true);
+  });
+
+  it("does not replay an Ask rejected by Web authority", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      createJsonResponse({ error: "unauthorized" }, 401)
+    );
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(replaySafeRequests[0].request)).rejects.toBeInstanceOf(
+      HostedWebControlPlaneResponseError,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay an unrelated group action after a lost body", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => createLostBodyResponse(200));
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request({ action: "read_current" })).rejects.toBeInstanceOf(
+      TypeError,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createJsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function createLostBodyResponse(
+  status: number,
+  error: Error = new TypeError("Response body lost."),
+): Response {
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.error(error);
+    },
+  }), { status });
+}

--- a/apps/cloudflare/test/group-tool-port-replay.test.ts
+++ b/apps/cloudflare/test/group-tool-port-replay.test.ts
@@ -182,6 +182,26 @@ describe("hosted group tool exact replay", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not replay an Ask after the initiating turn is canceled", async () => {
+    const abortController = new AbortController();
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      abortController.abort(new DOMException("turn cancelled", "AbortError"));
+      return createJsonResponse({ error: "temporarily unavailable" }, 503);
+    });
+    const port = createHostedRuntimeGroupToolPort({
+      boundUserId: "member-bound",
+      fetchImpl,
+      timeoutMs: 5_000,
+      transport: { mode: "proxy" },
+    });
+
+    await expect(port.request(
+      replaySafeRequests[0].request,
+      { signal: abortController.signal },
+    )).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not replay an unrelated group action after a lost body", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => createLostBodyResponse(200));
     const port = createHostedRuntimeGroupToolPort({

--- a/apps/web/app/api/internal/hosted-execution/assistant-asks/runtime/route.ts
+++ b/apps/web/app/api/internal/hosted-execution/assistant-asks/runtime/route.ts
@@ -14,7 +14,7 @@ import {
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
 import {
-  scheduleHostedMailboxWakeAfterResponse,
+  handoffHostedMailboxWake,
 } from "@/src/lib/hosted-orchestration/mailbox-wake";
 import { readRawBodyBuffer } from "@/src/lib/http";
 
@@ -46,9 +46,10 @@ export const POST = withJsonError(async (request: Request) => {
     request: requestBody,
   });
   if (result.mailboxWake) {
-    scheduleHostedMailboxWakeAfterResponse({
+    await handoffHostedMailboxWake({
       ...result.mailboxWake,
       directWakeSource: "assistant-ask-completion",
+      signal: request.signal,
     });
   }
   return jsonOk(result.response);

--- a/apps/web/app/api/internal/hosted-execution/groups/tool/route.ts
+++ b/apps/web/app/api/internal/hosted-execution/groups/tool/route.ts
@@ -24,7 +24,7 @@ import {
 } from "@/src/lib/hosted-execution/environment";
 import { jsonError, jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
 import {
-  scheduleHostedMailboxWakeAfterResponse,
+  handoffHostedMailboxWake,
 } from "@/src/lib/hosted-orchestration/mailbox-wake";
 import {
   readHostedVaultShareSupportedProjectionScopeKeysFromRequest,
@@ -47,12 +47,12 @@ export const POST = withJsonError(async (request: Request) => {
     await handleHostedRuntimeGroupTool({
       memberId,
       request: body,
-      scheduleMailboxWake: (wake) => {
-        scheduleHostedMailboxWakeAfterResponse({
+      scheduleMailboxWake: (wake) =>
+        handoffHostedMailboxWake({
           ...wake,
           directWakeSource: "assistant-ask-request",
-        });
-      },
+          signal: request.signal,
+        }),
     }),
     supportedProjectionScopeKeys,
   );

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -195,7 +195,7 @@ export async function handleHostedRuntimeGroupTool(input: {
   scheduleMailboxWake?: (input: {
     expectedUserId: string;
     mailboxItemId: string;
-  }) => void;
+  }) => Promise<void>;
 }): Promise<HostedRuntimeGroupToolResponse> {
   if (input.request.action === "ask") {
     const admission = await requestHostedGroupAssistantAsk({
@@ -206,7 +206,7 @@ export async function handleHostedRuntimeGroupTool(input: {
       question: input.request.question,
     });
     if (admission.mailboxWake) {
-      input.scheduleMailboxWake?.(admission.mailboxWake);
+      await input.scheduleMailboxWake?.(admission.mailboxWake);
     }
     return { action: "ask", result: admission.result };
   }
@@ -217,7 +217,7 @@ export async function handleHostedRuntimeGroupTool(input: {
       origin: input.request.origin,
     });
     if (admission.mailboxWake) {
-      input.scheduleMailboxWake?.(admission.mailboxWake);
+      await input.scheduleMailboxWake?.(admission.mailboxWake);
     }
     return { action: "ask_current_sender", result: admission.result };
   }
@@ -230,7 +230,7 @@ export async function handleHostedRuntimeGroupTool(input: {
       question: input.request.question,
     });
     if (admission.mailboxWake) {
-      input.scheduleMailboxWake?.(admission.mailboxWake);
+      await input.scheduleMailboxWake?.(admission.mailboxWake);
     }
     return { action: "ask_member", result: admission.result };
   }

--- a/apps/web/src/lib/hosted-orchestration/mailbox-wake.ts
+++ b/apps/web/src/lib/hosted-orchestration/mailbox-wake.ts
@@ -4,34 +4,37 @@ import {
   startHostedDirectRuntimeWakeBestEffort,
   type HostedDirectRuntimeWakeSource,
 } from "../hosted-execution/direct-runtime-wake";
+import {
+  createHostedPostCommitDeadline,
+  waitForHostedPostCommitOperation,
+} from "../hosted-onboarding/bounded-post-commit";
 import { signalHostedMailboxAppendRuntime } from "./signal-runtime";
 
-export function scheduleHostedMailboxWakeAfterResponse(input: {
+export async function handoffHostedMailboxWake(input: {
   directWakeSource: HostedDirectRuntimeWakeSource;
   expectedUserId: string;
   mailboxItemId: string;
-}): void {
-  const task = async () => {
-    try {
-      await signalHostedMailboxAppendRuntime({
-        expectedUserId: input.expectedUserId,
-        mailboxItemId: input.mailboxItemId,
-      });
-    } catch {
-      // The durable mailbox item remains reconciliation truth when signaling
-      // is unavailable. A direct wake must never bypass Temporal acceptance.
-      return;
-    }
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}): Promise<void> {
+  const deadlineMs = createHostedPostCommitDeadline(input.timeoutMs);
+  await waitForHostedPostCommitOperation({
+    deadlineMs,
+    operation: (abortSignal) => signalHostedMailboxAppendRuntime({
+      abortSignal,
+      expectedUserId: input.expectedUserId,
+      mailboxItemId: input.mailboxItemId,
+    }),
+    signal: input.signal,
+  });
 
-    await startHostedDirectRuntimeWakeBestEffort({
-      source: input.directWakeSource,
-      userId: input.expectedUserId,
-    });
-  };
-
+  const directWake = startHostedDirectRuntimeWakeBestEffort({
+    source: input.directWakeSource,
+    userId: input.expectedUserId,
+  });
   try {
-    after(task);
+    after(() => directWake);
   } catch {
-    void task();
+    void directWake;
   }
 }

--- a/apps/web/test/hosted-assistant-ask-runtime-route.test.ts
+++ b/apps/web/test/hosted-assistant-ask-runtime-route.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   handleHostedRuntimeAssistantAskControl: vi.fn(),
+  handoffHostedMailboxWake: vi.fn(),
   requireHostedCloudflareCallbackRequest: vi.fn(),
-  scheduleHostedMailboxWakeAfterResponse: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
@@ -15,8 +15,7 @@ vi.mock("@/src/lib/hosted-groups/group-assistant-ask", () => ({
     mocks.handleHostedRuntimeAssistantAskControl,
 }));
 vi.mock("@/src/lib/hosted-orchestration/mailbox-wake", () => ({
-  scheduleHostedMailboxWakeAfterResponse:
-    mocks.scheduleHostedMailboxWakeAfterResponse,
+  handoffHostedMailboxWake: mocks.handoffHostedMailboxWake,
 }));
 
 import { POST } from "@/app/api/internal/hosted-execution/assistant-asks/runtime/route";
@@ -41,6 +40,7 @@ function runtimeRequest(body: unknown, input: { includeFence?: boolean } = {}) {
 describe("Hosted Assistant Ask runtime route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.handoffHostedMailboxWake.mockResolvedValue(undefined);
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue(
       "member-group-runtime",
     );
@@ -97,7 +97,39 @@ describe("Hosted Assistant Ask runtime route", () => {
     });
   });
 
-  it("wakes only the committed private completion after responding", async () => {
+  it("wakes only the committed private completion before responding", async () => {
+    mocks.handleHostedRuntimeAssistantAskControl.mockResolvedValue({
+      mailboxWake: {
+        expectedUserId: "member-personal",
+        mailboxItemId: "aask_done_one",
+      },
+      response: { action: "complete", status: "completed" },
+    });
+
+    const request = runtimeRequest({
+      action: "complete",
+      requestId: "aask_req_one",
+      result: { answer: "Three sets of squats.", outcome: "answered" },
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      action: "complete",
+      status: "completed",
+    });
+    expect(mocks.handoffHostedMailboxWake).toHaveBeenCalledWith({
+      directWakeSource: "assistant-ask-completion",
+      expectedUserId: "member-personal",
+      mailboxItemId: "aask_done_one",
+      signal: request.signal,
+    });
+  });
+
+  it("does not acknowledge a committed completion when its durable handoff rejects", async () => {
+    mocks.handoffHostedMailboxWake.mockRejectedValueOnce(
+      new Error("Temporal unavailable"),
+    );
     mocks.handleHostedRuntimeAssistantAskControl.mockResolvedValue({
       mailboxWake: {
         expectedUserId: "member-personal",
@@ -112,15 +144,12 @@ describe("Hosted Assistant Ask runtime route", () => {
       result: { answer: "Three sets of squats.", outcome: "answered" },
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      action: "complete",
-      status: "completed",
-    });
-    expect(mocks.scheduleHostedMailboxWakeAfterResponse).toHaveBeenCalledWith({
-      directWakeSource: "assistant-ask-completion",
-      expectedUserId: "member-personal",
-      mailboxItemId: "aask_done_one",
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal error.",
+      },
     });
   });
 

--- a/apps/web/test/hosted-group-tool-route.test.ts
+++ b/apps/web/test/hosted-group-tool-route.test.ts
@@ -12,9 +12,9 @@ import {
 } from "@/src/lib/hosted-groups/group-assistant-ask";
 
 const mocks = vi.hoisted(() => ({
+  handoffHostedMailboxWake: vi.fn(),
   handleTool: vi.fn(),
   requireJsonCallback: vi.fn(),
-  scheduleHostedMailboxWakeAfterResponse: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
@@ -25,8 +25,7 @@ vi.mock("@/src/lib/hosted-groups/group-tool", () => ({
   handleHostedRuntimeGroupTool: mocks.handleTool,
 }));
 vi.mock("@/src/lib/hosted-orchestration/mailbox-wake", () => ({
-  scheduleHostedMailboxWakeAfterResponse:
-    mocks.scheduleHostedMailboxWakeAfterResponse,
+  handoffHostedMailboxWake: mocks.handoffHostedMailboxWake,
 }));
 
 type RouteModule = typeof import(
@@ -44,6 +43,7 @@ describe("hosted group tool route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.handoffHostedMailboxWake.mockResolvedValue(undefined);
     mocks.requireJsonCallback.mockImplementation(async (
       request: Request,
       options: { maxBodyBytes: number },
@@ -161,7 +161,7 @@ describe("hosted group tool route", () => {
       question: "What exercises are scheduled today?",
     };
     mocks.handleTool.mockImplementationOnce(async (input) => {
-      input.scheduleMailboxWake({
+      await input.scheduleMailboxWake({
         expectedUserId: "member-group-runtime",
         mailboxItemId: "aask_req_direct_wake",
       });
@@ -183,10 +183,128 @@ describe("hosted group tool route", () => {
     const response = await route.POST(request);
 
     expect(response.status).toBe(200);
-    expect(mocks.scheduleHostedMailboxWakeAfterResponse).toHaveBeenCalledWith({
+    expect(mocks.handoffHostedMailboxWake).toHaveBeenCalledWith({
       directWakeSource: "assistant-ask-request",
       expectedUserId: "member-group-runtime",
       mailboxItemId: "aask_req_direct_wake",
+      signal: request.signal,
     });
   });
+
+  it("does not acknowledge an accepted Ask when its durable handoff rejects", async () => {
+    mocks.handoffHostedMailboxWake.mockRejectedValueOnce(
+      new Error("Temporal unavailable"),
+    );
+    const originAssistantInputId = `ain_${"a".repeat(32)}`;
+    const body = {
+      action: "ask",
+      groupLabel: "100 Club",
+      originAssistantInputId,
+      originSessionId: "session_private",
+      question: "What exercises are scheduled today?",
+    };
+    mocks.handleTool.mockImplementationOnce(async (input) => {
+      await input.scheduleMailboxWake({
+        expectedUserId: "member-group-runtime",
+        mailboxItemId: "aask_req_direct_wake",
+      });
+      return {
+        action: "ask",
+        requestId: "aask_req_direct_wake",
+        status: "accepted",
+      };
+    });
+    const request = new Request(
+      `https://join.example.test${HOSTED_RUNTIME_GROUP_TOOL_PATH}`,
+      {
+        body: JSON.stringify(body),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+
+    const response = await route.POST(request);
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get(HOSTED_RUNTIME_ASSISTANT_ASK_REQUEST_ID_HEADER))
+      .toBe(createHostedAssistantAskRequestId({
+        memberId: "member_group_runtime",
+        originAssistantInputId,
+      }));
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal error.",
+      },
+    });
+  });
+
+  it.each([
+    {
+      body: {
+        action: "ask_member",
+        grantId: "grant_sleep",
+        origin: {
+          assistantInputId: `ain_${"b".repeat(32)}`,
+          kind: "accepted_input",
+          sessionId: "session_group",
+        },
+        question: "How has the grantor been sleeping lately?",
+      },
+      expectedUserId: "member-grantor",
+      mailboxItemId: "aask_req_disclosure_one",
+      responseAction: "ask_member",
+    },
+    {
+      body: {
+        action: "ask_current_sender",
+        origin: {
+          assistantInputId: `ain_${"c".repeat(32)}`,
+          kind: "accepted_input",
+          sessionId: "session_group",
+        },
+      },
+      expectedUserId: "member-sender",
+      mailboxItemId: "aask_req_current_sender",
+      responseAction: "ask_current_sender",
+    },
+  ])(
+    "does not acknowledge an accepted $responseAction when its durable handoff rejects",
+    async ({ body, expectedUserId, mailboxItemId, responseAction }) => {
+      mocks.handoffHostedMailboxWake.mockRejectedValueOnce(
+        new Error("Temporal unavailable"),
+      );
+      mocks.handleTool.mockImplementationOnce(async (input) => {
+        await input.scheduleMailboxWake({ expectedUserId, mailboxItemId });
+        return {
+          action: responseAction,
+          result: { status: "accepted" },
+        };
+      });
+      const request = new Request(
+        `https://join.example.test${HOSTED_RUNTIME_GROUP_TOOL_PATH}`,
+        {
+          body: JSON.stringify(body),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+
+      const response = await route.POST(request);
+
+      expect(response.status).toBe(500);
+      expect(mocks.handoffHostedMailboxWake).toHaveBeenCalledWith({
+        directWakeSource: "assistant-ask-request",
+        expectedUserId,
+        mailboxItemId,
+        signal: request.signal,
+      });
+      await expect(response.json()).resolves.toEqual({
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Internal error.",
+        },
+      });
+    },
+  );
 });

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -561,6 +561,30 @@ describe("handleHostedRuntimeGroupTool", () => {
     });
   });
 
+  it("does not acknowledge a personal ask when its durable mailbox handoff rejects", async () => {
+    const signalError = new Error("Temporal unavailable");
+    const scheduleMailboxWake = vi.fn().mockRejectedValue(signalError);
+    mocks.requestHostedGroupAssistantAsk.mockResolvedValue({
+      mailboxWake: {
+        expectedUserId: "member_group_runtime",
+        mailboxItemId: "aask_req_one",
+      },
+      result: { status: "accepted", targetLabel: "100 Club" },
+    });
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_self",
+      request: {
+        action: "ask",
+        groupLabel: "100 Club",
+        originAssistantInputId: `ain_${"a".repeat(32)}`,
+        originSessionId: "session_private",
+        question: "What is today's workout?",
+      },
+      scheduleMailboxWake,
+    })).rejects.toBe(signalError);
+  });
+
   it("dispatches an exact current-sender ask and schedules only its personal wake", async () => {
     const scheduleMailboxWake = vi.fn();
     const origin = {
@@ -591,6 +615,34 @@ describe("handleHostedRuntimeGroupTool", () => {
       groupRuntimeMemberId: "member_group_runtime",
       origin,
     });
+    expect(scheduleMailboxWake).toHaveBeenCalledWith({
+      expectedUserId: "member_sender",
+      mailboxItemId: "aask_req_current_sender",
+    });
+  });
+
+  it("does not acknowledge a current-sender ask when its durable mailbox handoff rejects", async () => {
+    const signalError = new Error("Temporal unavailable");
+    const scheduleMailboxWake = vi.fn().mockRejectedValue(signalError);
+    const origin = {
+      assistantInputId: `ain_${"c".repeat(32)}`,
+      kind: "accepted_input" as const,
+      sessionId: "session_group",
+    };
+    mocks.requestHostedGroupCurrentSenderAssistantAsk.mockResolvedValue({
+      mailboxWake: {
+        expectedUserId: "member_sender",
+        mailboxItemId: "aask_req_current_sender",
+      },
+      result: { status: "accepted" },
+    });
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_group_runtime",
+      request: { action: "ask_current_sender", origin },
+      scheduleMailboxWake,
+    })).rejects.toBe(signalError);
+
     expect(scheduleMailboxWake).toHaveBeenCalledWith({
       expectedUserId: "member_sender",
       mailboxItemId: "aask_req_current_sender",
@@ -635,6 +687,38 @@ describe("handleHostedRuntimeGroupTool", () => {
       },
       question: "How has the grantor been sleeping lately?",
     });
+    expect(scheduleMailboxWake).toHaveBeenCalledWith({
+      expectedUserId: "member_grantor",
+      mailboxItemId: "aask_req_disclosure_one",
+    });
+  });
+
+  it("does not acknowledge a grant-bound ask when its durable mailbox handoff rejects", async () => {
+    const signalError = new Error("Temporal unavailable");
+    const scheduleMailboxWake = vi.fn().mockRejectedValue(signalError);
+    mocks.requestHostedGroupMemberAssistantAsk.mockResolvedValue({
+      mailboxWake: {
+        expectedUserId: "member_grantor",
+        mailboxItemId: "aask_req_disclosure_one",
+      },
+      result: { status: "accepted" },
+    });
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_group_runtime",
+      request: {
+        action: "ask_member",
+        grantId: "grant_sleep",
+        origin: {
+          assistantInputId: `ain_${"b".repeat(32)}`,
+          kind: "accepted_input",
+          sessionId: "session_group",
+        },
+        question: "How has the grantor been sleeping lately?",
+      },
+      scheduleMailboxWake,
+    })).rejects.toBe(signalError);
+
     expect(scheduleMailboxWake).toHaveBeenCalledWith({
       expectedUserId: "member_grantor",
       mailboxItemId: "aask_req_disclosure_one",

--- a/apps/web/test/hosted-mailbox-wake.test.ts
+++ b/apps/web/test/hosted-mailbox-wake.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   after: vi.fn(),
@@ -22,16 +22,17 @@ vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
 }));
 
 import {
-  scheduleHostedMailboxWakeAfterResponse,
+  handoffHostedMailboxWake,
 } from "@/src/lib/hosted-orchestration/mailbox-wake";
 
-describe("hosted mailbox direct wake scheduler", () => {
+describe("hosted mailbox wake handoff", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.after.mockImplementation((task: () => Promise<void>) => {
-      void task();
-    });
     mocks.startHostedDirectRuntimeWakeBestEffort.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("starts the direct latency hint only after Temporal accepts durable signaling", async () => {
@@ -49,42 +50,93 @@ describe("hosted mailbox direct wake scheduler", () => {
       },
     );
 
-    scheduleHostedMailboxWakeAfterResponse({
+    const handoff = handoffHostedMailboxWake({
       directWakeSource: "assistant-ask-completion",
       expectedUserId: "member-private",
       mailboxItemId: "aask_done_one",
     });
 
-    expect(mocks.after).toHaveBeenCalledTimes(1);
+    expect(mocks.after).not.toHaveBeenCalled();
     expect(mocks.startHostedDirectRuntimeWakeBestEffort).not.toHaveBeenCalled();
     acceptTemporal();
-    await vi.waitFor(() => {
-      expect(mocks.startHostedDirectRuntimeWakeBestEffort).toHaveBeenCalledWith({
-        source: "assistant-ask-completion",
-        userId: "member-private",
-      });
+    await handoff;
+    expect(mocks.startHostedDirectRuntimeWakeBestEffort).toHaveBeenCalledWith({
+      source: "assistant-ask-completion",
+      userId: "member-private",
     });
+    expect(mocks.after).toHaveBeenCalledWith(expect.any(Function));
     expect(order).toEqual(["temporal", "direct"]);
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
       expectedUserId: "member-private",
       mailboxItemId: "aask_done_one",
     });
   });
 
-  it("never bypasses a rejected Temporal signal", async () => {
+  it("rejects the handoff and never schedules a direct wake when Temporal rejects", async () => {
     mocks.signalHostedMailboxAppendRuntime.mockRejectedValueOnce(
       new Error("Temporal unavailable"),
     );
 
-    scheduleHostedMailboxWakeAfterResponse({
+    await expect(handoffHostedMailboxWake({
       directWakeSource: "assistant-ask-request",
       expectedUserId: "member-group-runtime",
       mailboxItemId: "aask_req_one",
-    });
+    })).rejects.toThrow("Temporal unavailable");
 
-    await vi.waitFor(() => {
-      expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
-    });
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.after).not.toHaveBeenCalled();
     expect(mocks.startHostedDirectRuntimeWakeBestEffort).not.toHaveBeenCalled();
+  });
+
+  it("aborts an unsettled Temporal handoff before the caller budget expires", async () => {
+    vi.useFakeTimers();
+    let temporalSignal: AbortSignal | undefined;
+    let resolveTemporal!: () => void;
+    mocks.signalHostedMailboxAppendRuntime.mockImplementationOnce(
+      (input: { abortSignal?: AbortSignal }) => {
+        temporalSignal = input.abortSignal;
+        return new Promise<void>((resolve) => {
+          resolveTemporal = resolve;
+        });
+      },
+    );
+
+    const handoff = handoffHostedMailboxWake({
+      directWakeSource: "assistant-ask-request",
+      expectedUserId: "member-group-runtime",
+      mailboxItemId: "aask_req_timeout",
+      timeoutMs: 25,
+    });
+    const rejection = expect(handoff).rejects.toThrow(
+      "Hosted post-commit handoff timed out",
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+    expect(temporalSignal?.aborted).toBe(true);
+    resolveTemporal();
+    await Promise.resolve();
+    expect(mocks.after).not.toHaveBeenCalled();
+    expect(mocks.startHostedDirectRuntimeWakeBestEffort).not.toHaveBeenCalled();
+  });
+
+  it("does not wait for the best-effort direct wake before completing handoff", async () => {
+    mocks.signalHostedMailboxAppendRuntime.mockResolvedValueOnce({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:member-private",
+    });
+    mocks.startHostedDirectRuntimeWakeBestEffort.mockReturnValueOnce(
+      new Promise<void>(() => {}),
+    );
+
+    await expect(handoffHostedMailboxWake({
+      directWakeSource: "assistant-ask-completion",
+      expectedUserId: "member-private",
+      mailboxItemId: "aask_done_one",
+    })).resolves.toBeUndefined();
+
+    expect(mocks.startHostedDirectRuntimeWakeBestEffort).toHaveBeenCalledTimes(1);
+    expect(mocks.after).toHaveBeenCalledWith(expect.any(Function));
   });
 });

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -4080,9 +4080,10 @@ async function executeGroupTool(input: {
       { action: 'preflight_set_chat_avatar' }
     >
     try {
-      const preflightResult = await groupTool.request({
-        action: 'preflight_set_chat_avatar',
-      })
+      const preflightResult = await groupTool.request(
+        { action: 'preflight_set_chat_avatar' },
+        { signal: input.abortSignal },
+      )
       if (preflightResult.action !== 'preflight_set_chat_avatar') {
         return groupAvatarUnavailableToolResult(
           'group_avatar_preflight_unavailable',
@@ -4305,7 +4306,9 @@ async function executeGroupTool(input: {
   }
 
   try {
-    const result = await groupTool.request(request)
+    const result = await groupTool.request(request, {
+      signal: input.abortSignal,
+    })
     const modelResult = groupToolModelResult(result)
     const payload = generatedAvatarCapture
       ? { ...modelResult, generatedImage: generatedAvatarCapture }

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -4080,10 +4080,10 @@ async function executeGroupTool(input: {
       { action: 'preflight_set_chat_avatar' }
     >
     try {
-      const preflightResult = await groupTool.request(
-        { action: 'preflight_set_chat_avatar' },
-        { signal: input.abortSignal },
-      )
+      const preflightRequest = { action: 'preflight_set_chat_avatar' } as const
+      const preflightResult = input.abortSignal
+        ? await groupTool.request(preflightRequest, { signal: input.abortSignal })
+        : await groupTool.request(preflightRequest)
       if (preflightResult.action !== 'preflight_set_chat_avatar') {
         return groupAvatarUnavailableToolResult(
           'group_avatar_preflight_unavailable',
@@ -4306,9 +4306,9 @@ async function executeGroupTool(input: {
   }
 
   try {
-    const result = await groupTool.request(request, {
-      signal: input.abortSignal,
-    })
+    const result = input.abortSignal
+      ? await groupTool.request(request, { signal: input.abortSignal })
+      : await groupTool.request(request)
     const modelResult = groupToolModelResult(result)
     const payload = generatedAvatarCapture
       ? { ...modelResult, generatedImage: generatedAvatarCapture }

--- a/packages/assistant-engine/src/assistant/execution-context.ts
+++ b/packages/assistant-engine/src/assistant/execution-context.ts
@@ -283,6 +283,7 @@ export interface AssistantHostedAssistantConfigurationTool {
 export interface AssistantHostedGroupTool {
   request(
     request: HostedRuntimeGroupToolRequest,
+    context?: { signal?: AbortSignal | null },
   ): Promise<HostedRuntimeGroupToolResponse>
 }
 

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -19505,6 +19505,7 @@ describe('steered final segments', () => {
   async function runScriptedSteeredFinalSegmentsTurn(
     steps: Array<Record<string, unknown> | ScriptedSteeredFinalStep>,
     input: {
+      abortSignal?: CodexAppServerTurnInput['abortSignal']
       authorizeAcceptedMessageTarget?:
         CodexAppServerTurnInput['authorizeAcceptedMessageTarget']
       hostedToolContext?: CodexAppServerTurnInput['hostedToolContext']
@@ -19738,6 +19739,7 @@ describe('steered final segments', () => {
 
     return await executeCodexAppServerTurn({
       approvalPolicy: 'never',
+      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
       authorizeAcceptedMessageTarget:
         input.authorizeAcceptedMessageTarget ?? null,
       codexCommand: 'codex',
@@ -19788,8 +19790,12 @@ describe('steered final segments', () => {
       },
     }
     const groupTool = {
-      request: vi.fn(async () => response),
+      request: vi.fn(async (
+        _request: unknown,
+        _context?: { signal?: AbortSignal | null },
+      ) => response),
     }
+    const abortController = new AbortController()
 
     const result = await runScriptedSteeredFinalSegmentsTurn([
       {
@@ -19803,10 +19809,21 @@ describe('steered final segments', () => {
         message: 'You belong to Sunday runners.',
       }),
     ], {
+      abortSignal: abortController.signal,
       hostedToolContext: createHostedToolContext({ groupTool }),
     })
 
-    expect(groupTool.request).toHaveBeenCalledWith({ action: 'list_memberships' })
+    expect(groupTool.request).toHaveBeenCalledWith(
+      { action: 'list_memberships' },
+      { signal: expect.any(AbortSignal) },
+    )
+    const forwardedSignal = groupTool.request.mock.calls[0]?.[1]?.signal
+    if (!forwardedSignal) {
+      throw new Error('Expected current-turn abort signal at group-tool boundary.')
+    }
+    expect(forwardedSignal.aborted).toBe(false)
+    abortController.abort(new DOMException('turn cancelled', 'AbortError'))
+    expect(forwardedSignal.aborted).toBe(true)
     expect(result.finalMessage).toBe('You belong to Sunday runners.')
   })
 

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -497,6 +497,7 @@ export interface HostedRuntimeAssistantPersonalizationToolPort {
 export interface HostedRuntimeGroupToolPort {
   request(
     request: HostedRuntimeGroupToolRequest,
+    context?: { signal?: AbortSignal | null },
   ): Promise<HostedRuntimeGroupToolResponse>;
 }
 

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -345,7 +345,11 @@ export function createHostedGroupToolWithCurrentTurnContext(input: {
   const emailIngressPresent = input.groupEmailIngress === true
     || (input.emailDeliveryContexts?.length ?? 0) > 0;
   return {
-    async request(request) {
+    async request(request, context) {
+      const forwardRequest = (forwardedRequest: HostedRuntimeGroupToolRequest) =>
+        context
+          ? input.groupToolPort.request(forwardedRequest, context)
+          : input.groupToolPort.request(forwardedRequest);
       if (
         emailIngressPresent
         && request.action !== "read_current"
@@ -367,7 +371,7 @@ export function createHostedGroupToolWithCurrentTurnContext(input: {
               linqDeliveryContexts: input.linqDeliveryContexts,
               telegramSenderHandles: input.telegramSenderHandles ?? [],
             });
-        return await input.groupToolPort.request({
+        return await forwardRequest({
           ...sharedReadRequest,
           ...senderHandles,
         });
@@ -405,7 +409,7 @@ export function createHostedGroupToolWithCurrentTurnContext(input: {
               action: request.action,
               policyCode: request.policyCode,
             };
-        return await input.groupToolPort.request({
+        return await forwardRequest({
           ...referralRequest,
           ...senderHandles,
           ...(request.action !== "cancel_usage_referral"
@@ -422,7 +426,7 @@ export function createHostedGroupToolWithCurrentTurnContext(input: {
         && request.action !== "set_chat_avatar"
         && request.action !== "share_contact_card"
       ) {
-        return await input.groupToolPort.request(request);
+        return await forwardRequest(request);
       }
       const linqThread = resolveHostedGroupToolLinqThreadContext(
         input.linqDeliveryContexts,
@@ -430,7 +434,7 @@ export function createHostedGroupToolWithCurrentTurnContext(input: {
           ? "imessage_or_sms"
           : "imessage_only",
       );
-      return await input.groupToolPort.request(
+      return await forwardRequest(
         linqThread ? { ...request, linqThread } : request,
       );
     },

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -44,6 +44,32 @@ function buildEmailDeliveryContext(
 }
 
 describe("createHostedGroupToolWithCurrentTurnContext", () => {
+  it("forwards current-turn cancellation through Assistant Ask requests", async () => {
+    const request = vi.fn().mockResolvedValue({
+      action: "ask_current_sender",
+      result: { status: "accepted" },
+    });
+    const groupTool = createHostedGroupToolWithCurrentTurnContext({
+      groupToolPort: { request },
+      linqDeliveryContexts: [],
+    });
+    const signal = new AbortController().signal;
+    const askRequest = {
+      action: "ask_current_sender" as const,
+      origin: {
+        assistantInputId: `ain_${"a".repeat(32)}`,
+        kind: "accepted_input" as const,
+        sessionId: "session_group",
+      },
+    };
+
+    await expect(groupTool.request(askRequest, { signal })).resolves.toEqual({
+      action: "ask_current_sender",
+      result: { status: "accepted" },
+    });
+    expect(request).toHaveBeenCalledExactlyOnceWith(askRequest, { signal });
+  });
+
   it("injects the exact current sender into referral actions", async () => {
     const request = vi.fn().mockResolvedValue({
       action: "arm_usage_referral",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1497,7 +1497,7 @@ describe('monorepo release flow coverage audit', () => {
       'For prompt-primary changes, apply the prompt lens inside the preliminary specialist ReviewGPT pass',
     )
     expect(agentsGuide).toContain('isolated regression test or explanatory doc')
-    expect(agentsGuide).toContain('later rounds verify only remediation deltas')
+    expect(agentsGuide).toContain('later rounds verify remediation deltas')
     expect(agentWorkflowRouting).toContain('final-ReviewGPT-eligible PR-lane work')
     expect(agentWorkflowRouting).toContain('scope-anomaly signal')
     expect(prReviewGptLoop).toContain('final cross-cutting gate for eligible work')
@@ -1552,9 +1552,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(completionWorkflow).toContain(
       'pass replaces the four former local `product-experience-review`,',
     )
-    expect(completionWorkflow).toContain(
-      'never combine this final gate with local `deep-review`',
-    )
+    expect(completionWorkflow).toMatch(/do not also run local\s+`deep-review`/u)
     expect(completionWorkflow).not.toContain(
       'Run local `deep-review` too only when the user explicitly asks',
     )


### PR DESCRIPTION
## Why this PR exists

Assistant Ask could return success after committing its mailbox item but before Temporal accepted the durable wake. If that signal failed, the failure was swallowed and the requested answer could wait for later reconciliation or an unrelated inbound event.

## User goal / user-visible behavior

When someone asks another Murph assistant for information, the request should either enter the existing durable processing path or fail honestly. A successful request or completion now means Temporal accepted the mailbox wake; a retryable ambiguous control response gets one exact replay so an already-committed result is recovered without creating duplicate work.

## User experience

- Entry point: the existing `ask`, `ask_member`, or `ask_current_sender` group tool. No new screen, control, or user step is added.
- Immediate feedback: the existing accepted response is returned only after the encrypted mailbox append commits and Temporal accepts its pointer-only signal, bounded by the existing 5-second post-commit handoff deadline for each HTTP attempt.
- Continuation: Temporal remains the durable wake and reconciliation owner. Only after it accepts the signal does Web start the existing payload-free direct Cloudflare wake as a best-effort latency hint.
- Completion: the target assistant still answers through the existing request/completion mailbox lifecycle, and the originating runtime still delivers the result to the exact initiating conversation and audience.
- Failure/recovery: signal failure, timeout, or caller cancellation returns an error instead of false success. Cloudflare may replay the identical idempotent control request once after HTTP 5xx or a replay-safe response-body ambiguity, within the original request deadline. Authority/other 4xx failures, caller cancellation, and exhausted deadlines do not replay. The committed mailbox item remains the existing reconciliation truth.

## Preliminary specialist lenses

- Product experience: **applicable** — asynchronous acknowledgement, continuation ownership, timing, cancellation, and recovery change.
- Prompt: **not applicable** — no prompt, tool description, or instruction text changes.
- Frontend: **not applicable** — no user-facing Web presentation changes.
- Coverage: **applicable** — executable failure/retry behavior and its regression proof change.

The preliminary ReviewGPT pass found that the group-tool replay boundary did not yet receive the initiating turn's cancellation signal. That finding was accepted and fixed through the Assistant Engine, current-turn runtime wrapper, and Cloudflare group-tool port, with focused and signed-loopback regression proof. Its request for one monolithic cross-runtime test was addressed with the existing hosted-local Temporal scenario plus stable Web ordering, Assistant Ask completion, and signed HTTP replay/cancellation boundaries; adding a second test-only orchestration system was not justified. No generated patch artifact was applied.

Parent product-experience revalidation: **PASS**. The corrected flow keeps the same entry point and exact destination, makes acceptance truthful at the durable owner boundary, preserves the mailbox as reconciliation truth, ties replay cancellation to the initiating turn, and adds no user step or state owner.

## Invariants

- The encrypted mailbox remains the only durable Assistant Ask queue and operation state.
- Temporal remains the sole durable wake/reconciliation owner; the direct Cloudflare wake never runs before Temporal acceptance and remains best effort.
- Exact replay is limited to request shapes with stable identities and idempotent first-commit-wins behavior.
- Replay keeps the original target, origin, membership generation, question/answer, and deadline; it never re-resolves or creates replacement work.
- Caller cancellation, exhausted deadlines, authority failures, and other 4xx responses fail without replay.
- No raw mailbox payload, hidden identity, routing identifier, credential, or private response body is added to logs or errors.

## Non-obvious affected surfaces

- Shared Cloudflare Web control transport: gains an opt-in exact-replay mode and bounded response-body reader only for opted-in calls. Existing non-Assistant-Ask calls retain their prior single-attempt and timeout behavior. Proof: `runner-platform`, `group-tool-port`, and focused replay suites.
- Assistant Ask completion control: the dedicated `prepare` and `complete` port opts into exact replay because both operations already revalidate stable request/completion identities. Proof: focused Assistant Ask port replay suite.
- Current-sender Ask: included alongside `ask` and `ask_member` because it now exists on current `main` and uses the same deterministic mailbox lifecycle. Proof: parameterized group-tool replay and Web route tests.
- Current-turn cancellation: the existing Assistant Engine abort signal is forwarded through the runtime context into the Cloudflare group-tool control request. It prevents a second POST after the initiating turn is canceled. Proof: Assistant Engine, runtime wrapper, Cloudflare port, and signed-loopback cancellation tests.
- Web request/completion routes: now await the handoff and propagate the incoming request abort signal, so a signaling failure becomes HTTP 500 rather than a false HTTP 200. Proof: focused route and mailbox-handoff tests.
- Base workflow coverage: the newly merged parallel-ReviewGPT docs changed two exact phrases without updating their CLI coverage assertions. The isolated test expectations now follow the current durable wording; no production behavior changes. Proof: focused 41-case release-script coverage audit.

## Architecture and reuse

- Existing systems reused: encrypted Assistant Ask mailbox items, deterministic request/completion identities, Temporal mailbox signaling, the shared bounded post-commit helper, request abort signals, and the payload-free direct runtime wake.
- New logic: one opt-in exact replay after HTTP 5xx or a precisely classified replay-safe transport ambiguity, with both attempts sharing the original timeout budget.
- New abstractions: none; the existing Web control transport receives one optional flag, and the existing mailbox wake helper becomes awaited.
- Complexity intentionally avoided: no queue, receipt table, lease, scheduler, retry worker, status lifecycle, compatibility shim, dependency, or additional persisted state.

## Hot reply path impact

- Path status: **Touched** — Assistant Ask tool execution occurs after provider start and before the originating reply is durably handed off.
- Database calls: none added, but the existing mailbox-checkpoint read and active-access/workspace ensure operations reached by Temporal signaling move from deferred `after()` work onto the awaited request/completion path.
- Network/provider calls: the existing Temporal signal moves from deferred work onto the awaited path, with one 5-second post-commit handoff bound per HTTP attempt. For opted-in Cloudflare-to-Web Assistant Ask controls, one identical retry may occur after 5xx or replay-safe response ambiguity, so an ambiguous first response can produce two serial handoffs and two `signalWithStart` attempts (up to roughly 10 seconds plus request overhead) within the shared 30-second control deadline. The direct Cloudflare wake still starts only after signal acceptance and is not awaited.
- Other awaited latency: successful acceptance now includes Temporal signal latency; failure is bounded and surfaced instead of returning false success.
- Before/after proof: ordering, rejection, timeout, route failure, exact-request replay, and initiating-turn cancellation assertions in the focused suites; real signed loopback scenarios cover replay and cancellation over HTTP.

## Murph initial provider input impact

Not applicable — no prompt assembly, provider-visible instructions, tool schemas/descriptions, deferred-tool metadata, history wrappers, or model configuration changed.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: Not applicable — no user-facing Web UI changed.
- Coverage: Not applicable.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

ReviewGPT first-reviewed head: abcf6d542ce3ae5c3835f553c6fcb524024f3948

Classification rule: runtime and route implementations are Source; `*.test.ts` files are Tests / fixtures; reliability guidance and the completed execution plan are Docs. No config, tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 165 | 87 |
| Tests / fixtures | 735 | 36 |
| Docs | 112 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1012** | **123** |

## Verification

- Focused Web: 4 files, 137 tests passed; prepared typecheck and targeted changed-file ESLint passed.
- Focused Cloudflare plus shared transport: 5 files, 159 tests passed; Cloudflare typecheck passed.
- Assistant Engine current-turn boundary: full 240-test runtime file passed; Assistant Engine typecheck passed.
- Assistant Engine CI remediation: both group-tool suites plus the full current-turn runtime suite passed, 312 tests total; the change preserves one-argument calls when no turn signal exists.
- CLI workflow coverage alignment: focused release-script coverage audit passed, 40 tests with 1 expected skip.
- Assistant Runtime group-context boundary: 20 tests passed; Assistant Runtime typecheck passed.
- Hosted-local `temporal-orchestration` full-stack E2E: 2 tests passed against the real local Web, Cloudflare runner, isolated database, and managed Temporal stack.
- Signed loopback replay scenario: the server consumed a real signed request, returned HTTP 503, then received one byte-identical replay and returned the accepted `ask_current_sender` result — passed.
- Signed loopback cancellation scenario: the server received one real signed request, the initiating signal was canceled before its 503 response, and no second POST occurred — passed.
- `git diff --check` and changed-content privacy scan — passed.
- Final ReviewGPT round 1: `PASS` with no findings on the reviewed patch head; concrete Pro-model verification recorded.
- Base-updated exact-head GitHub Actions: all applicable checks passed; merge state clean.

## Deployment concerns

Deploy Cloudflare first and immediately roll the runner bundle/container revision so all warm runtimes understand exact replay, then deploy Web. Cloudflare-first skew is safe because old Web behavior remains accepted by the new caller. Web-first skew can expose old runners to the new honest 5xx without exact replay recovery, so avoid that order. After Web deploy, smoke one request and one completion and confirm metadata-only logs show no replay for 4xx responses. No schema or wire-shape migration is required.
