### PR TITLE
feat(web): log launch consent declines

### DIFF
--- a/agent-docs/exec-plans/active/2026-07-30-log-launch-consent-declines.md
+++ b/agent-docs/exec-plans/active/2026-07-30-log-launch-consent-declines.md
@@ -1,0 +1,51 @@
+# Log Launch Consent Declines
+
+Status: active
+Created: 2026-07-30
+
+## Goal
+
+- Persist a privacy-safe consent audit event when an authenticated person
+  declines the launch consent prompt.
+- Preserve the existing terminal sign-out behavior even if the scoped audit
+  write is temporarily unavailable.
+
+## Success criteria
+
+- Each currently ungranted launch scope receives a durable `declined` consent
+  event tied to the authenticated member and current document versions.
+- Retrying the same browser-session decline does not create duplicate events.
+- The decline endpoint remains same-origin protected, accepts no member or
+  scope authority from the browser, and clears the app session independently
+  of the scoped audit write.
+- The consent-specific session revoke reason preserves a coarse durable refusal
+  fact when scoped audit storage is unavailable.
+- Focused service, route, client, and interaction tests pass together with the
+  scoped typecheck and required PR review gates.
+
+## Constraints
+
+- Store no phone number, contact detail, document content, or free-form browser
+  metadata.
+- Reuse `HostedConsentEvent`; do not add a schema, telemetry service, or second
+  consent owner.
+- Derive pending launch scopes and document versions on the server.
+- Preserve the existing consent prompt and its explicit decline recovery.
+
+## Working set
+
+- `apps/web/src/lib/legal/consent.ts`
+- `apps/web/app/api/legal/consent/decline/route.ts`
+- `apps/web/src/components/hosted-onboarding/hosted-app-session-client.ts`
+- `apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx`
+- Focused consent, route, client, and auth-panel tests
+
+## Verification plan
+
+- Focused Vitest over the consent service, consent routes, app-session client,
+  and auth-panel interaction.
+- Scoped `apps/web` typecheck.
+- Direct route scenario proving server-derived scopes, idempotent recording,
+  and consent-specific session revocation.
+- Preliminary ReviewGPT coverage/frontend lenses, local product-experience
+  review, parent final review, final ReviewGPT, and exact-head CI.

--- a/apps/web/app/api/legal/consent/decline/route.ts
+++ b/apps/web/app/api/legal/consent/decline/route.ts
@@ -1,0 +1,29 @@
+import { recordHostedLaunchConsentDecline } from "@/src/lib/legal/consent";
+import {
+  requireHostedAppSessionFromRequest,
+  revokeHostedAppSessionFromRequest,
+} from "@/src/lib/hosted-onboarding/app-session";
+import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
+import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
+import { getPrisma } from "@/src/lib/prisma";
+
+export const POST = withJsonError(async (request: Request) => {
+  assertHostedOnboardingMutationOrigin(request);
+  const auth = await requireHostedAppSessionFromRequest(request);
+
+  const [, clearCookie] = await Promise.all([
+    recordHostedLaunchConsentDecline({
+      memberId: auth.member.id,
+      prisma: getPrisma(),
+      sessionId: auth.sessionId,
+      source: "homepage-auth-dialog",
+    }).catch(() => undefined),
+    revokeHostedAppSessionFromRequest({
+      reason: "consent_declined",
+      request,
+    }),
+  ]);
+  const response = jsonOk({ ok: true });
+  response.headers.append("Set-Cookie", clearCookie);
+  return response;
+});

--- a/apps/web/app/design/consent-content.tsx
+++ b/apps/web/app/design/consent-content.tsx
@@ -63,9 +63,15 @@ export function ConsentContent() {
       <Separator />
 
       <section className="flex scroll-mt-24 flex-col gap-6" id="launch-consent">
-        <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
-          Launch consent
-        </h2>
+        <div className="flex flex-col gap-2">
+          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            Launch consent
+          </h2>
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Decline records the current unaccepted launch scopes, then signs the
+            person out without advancing onboarding.
+          </p>
+        </div>
         <div className="grid items-start gap-8 lg:grid-cols-2">
           <PreviewFrame label="Onboarding dialog">
             <HostedLaunchConsentPrompt

--- a/apps/web/src/components/hosted-onboarding/hosted-app-session-client.ts
+++ b/apps/web/src/components/hosted-onboarding/hosted-app-session-client.ts
@@ -12,6 +12,25 @@ import { reloadCurrentHostedAuthDocument } from "./hosted-auth-navigation";
 export async function logoutHostedAppSession(input: {
   logoutPrivy?: () => Promise<void> | void;
 } = {}): Promise<void> {
+  return endHostedAppSession({
+    ...input,
+    url: "/api/hosted-onboarding/session/logout",
+  });
+}
+
+export async function declineHostedLaunchConsent(input: {
+  logoutPrivy?: () => Promise<void> | void;
+} = {}): Promise<void> {
+  return endHostedAppSession({
+    ...input,
+    url: "/api/legal/consent/decline",
+  });
+}
+
+async function endHostedAppSession(input: {
+  logoutPrivy?: () => Promise<void> | void;
+  url: string;
+}): Promise<void> {
   publishBrowserVaultSessionEnding();
   let receivedReplacementHeaders = false;
 
@@ -24,7 +43,7 @@ export async function logoutHostedAppSession(input: {
         publishBrowserVaultSessionInvalidation();
       },
       signal: AbortSignal.timeout(BROWSER_VAULT_SESSION_ENDING_LEASE_MS),
-      url: "/api/hosted-onboarding/session/logout",
+      url: input.url,
     });
   } catch (error) {
     if (!receivedReplacementHeaders) {

--- a/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
@@ -18,7 +18,10 @@ import { isHostedOnboardingAccessibleStage } from "@/src/lib/hosted-onboarding/s
 import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
 import { cn } from "@/src/lib/utils";
 import type { HostedAuthCompletionResult } from "./hosted-auth-completion";
-import { logoutHostedAppSession } from "./hosted-app-session-client";
+import {
+  declineHostedLaunchConsent,
+  logoutHostedAppSession,
+} from "./hosted-app-session-client";
 import { navigateHostedAuthRedirect } from "./hosted-auth-navigation";
 
 import {
@@ -274,9 +277,9 @@ export function HostedAuthPanel({
     consentDeclinedRef.current = true;
     setConsentDeclinePending(true);
     try {
-      await logoutHostedAppSession({ logoutPrivy: logout });
+      await declineHostedLaunchConsent({ logoutPrivy: logout });
     } catch {
-      // logoutHostedAppSession owns recovery: it revalidates authority by
+      // The session-ending client owns recovery: it revalidates authority by
       // reloading the document, and the fail-closed gate reappears if the
       // session survived. Nothing rendered here would outlive that reload.
       // The decline did not take effect, so it does not keep terminal priority.

--- a/apps/web/src/lib/legal/consent.ts
+++ b/apps/web/src/lib/legal/consent.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 import {
   type HostedConsentGrant,
@@ -102,7 +102,7 @@ export type HostedConsentDocumentId = typeof HOSTED_CONSENT_DOCUMENTS[number]["i
 export type HostedConsentScope = typeof HOSTED_CONSENT_SCOPES[number]["scope"];
 export type HostedConsentLaunchScope = Extract<HostedConsentScope, `launch.${string}`>;
 export type HostedConsentGrantStatus = "granted" | "revoked";
-export type HostedConsentEventAction = "accepted" | "granted" | "revoked";
+export type HostedConsentEventAction = "accepted" | "declined" | "granted" | "revoked";
 
 const HOSTED_LAUNCH_SCOPES: readonly HostedConsentLaunchScope[] = ["launch.legal", "launch.health-data"];
 
@@ -252,6 +252,54 @@ export async function recordHostedLaunchRequiredConsent(input: {
     scope: input.scope,
     source: input.source,
   });
+}
+
+export async function recordHostedLaunchConsentDecline(input: {
+  memberId: string;
+  now?: Date;
+  prisma: PrismaClient;
+  sessionId: string;
+  source?: string;
+}): Promise<HostedConsentLaunchScope[]> {
+  const source = normalizeConsentSource(input.source);
+  const now = input.now ?? new Date();
+
+  return input.prisma.$transaction(async (tx) => {
+    const grants = await tx.hostedConsentGrant.findMany({
+      orderBy: [{ scope: "asc" }],
+      where: { memberId: input.memberId },
+    });
+    const status = buildHostedConsentStatus({
+      grants: grants.map(projectHostedConsentGrant),
+      now,
+    });
+    const declinedScopes = status.launchScopes
+      .filter((scope) => !scope.granted)
+      .map((scope) => scope.scope);
+
+    if (declinedScopes.length === 0) {
+      return [];
+    }
+
+    await tx.hostedConsentEvent.createMany({
+      data: declinedScopes.map((scope) => ({
+        action: "declined",
+        createdAt: now,
+        documentVersionsJson: buildCurrentHostedConsentDocumentVersions(scope),
+        id: buildHostedConsentDeclineEventId({
+          memberId: input.memberId,
+          scope,
+          sessionId: input.sessionId,
+        }),
+        memberId: input.memberId,
+        scope,
+        source,
+      })),
+      skipDuplicates: true,
+    });
+
+    return declinedScopes;
+  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
 }
 
 export async function grantHostedOptionalFeatureConsent(input: {
@@ -738,4 +786,22 @@ function normalizeBoundedString(input: {
 
 function generateHostedConsentEventId(): string {
   return `hbce_${randomBytes(12).toString("base64url")}`;
+}
+
+function buildHostedConsentDeclineEventId(input: {
+  memberId: string;
+  scope: HostedConsentLaunchScope;
+  sessionId: string;
+}): string {
+  const digest = createHash("sha256")
+    .update("murph.hosted-consent-decline.v1")
+    .update("\0")
+    .update(input.memberId)
+    .update("\0")
+    .update(input.sessionId)
+    .update("\0")
+    .update(input.scope)
+    .digest("base64url")
+    .slice(0, 24);
+  return `hbce_${digest}`;
 }

--- a/apps/web/test/hosted-app-session-client.test.ts
+++ b/apps/web/test/hosted-app-session-client.test.ts
@@ -67,6 +67,30 @@ describe("logoutHostedAppSession", () => {
     });
   });
 
+  it("uses the consent-decline endpoint before best-effort Privy logout", async () => {
+    const logoutPrivy = vi.fn().mockResolvedValue(undefined);
+    mocks.requestHostedOnboardingJson.mockImplementation(async (input: {
+      onSuccessfulResponseHeaders?: () => void;
+    }) => {
+      input.onSuccessfulResponseHeaders?.();
+      return { ok: true };
+    });
+    const { declineHostedLaunchConsent } = await import(
+      "@/src/components/hosted-onboarding/hosted-app-session-client"
+    );
+
+    await declineHostedLaunchConsent({ logoutPrivy });
+
+    expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith({
+      method: "POST",
+      onSuccessfulResponseError: mocks.reloadCurrentHostedAuthDocument,
+      onSuccessfulResponseHeaders: expect.any(Function),
+      signal: expect.any(AbortSignal),
+      url: "/api/legal/consent/decline",
+    });
+    expect(logoutPrivy).toHaveBeenCalledTimes(1);
+  });
+
   it("does not replay destructive logout when ambient authority changes after a transport failure", async () => {
     const events: string[] = [];
     let ambientMember = "member_A";

--- a/apps/web/test/hosted-auth-panel.test.ts
+++ b/apps/web/test/hosted-auth-panel.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
     preferredScope?: string;
     source?: string;
   } | null,
+  declineHostedLaunchConsent: vi.fn(),
   logoutHostedAppSession: vi.fn(),
   sendCode: vi.fn(),
   usePrivy: vi.fn(),
@@ -79,6 +80,7 @@ vi.mock("@/src/components/hosted-onboarding/hosted-auth-completion", () => ({
 }));
 
 vi.mock("@/src/components/hosted-onboarding/hosted-app-session-client", () => ({
+  declineHostedLaunchConsent: mocks.declineHostedLaunchConsent,
   logoutHostedAppSession: mocks.logoutHostedAppSession,
 }));
 
@@ -176,6 +178,11 @@ let cleanupRender: (() => Promise<void>) | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.declineHostedLaunchConsent.mockImplementation(
+    async ({ logoutPrivy }: { logoutPrivy?: () => Promise<void> | void }) => {
+      await logoutPrivy?.();
+    },
+  );
   mocks.logoutHostedAppSession.mockImplementation(
     async ({ logoutPrivy }: { logoutPrivy?: () => Promise<void> | void }) => {
       await logoutPrivy?.();
@@ -1232,7 +1239,7 @@ test("HostedAuthPanel can require launch consent after homepage login completion
   });
 });
 
-test("HostedAuthPanel returns to auth without recording consent when launch consent is declined", async () => {
+test("HostedAuthPanel records the launch decline and returns to auth", async () => {
   const logout = vi.fn().mockResolvedValue(undefined);
   const onViewChange = vi.fn();
   mocks.usePrivy.mockReturnValue({
@@ -1267,9 +1274,10 @@ test("HostedAuthPanel returns to auth without recording consent when launch cons
   });
 
   expect(logout).toHaveBeenCalledTimes(1);
-  expect(mocks.logoutHostedAppSession).toHaveBeenCalledWith({
+  expect(mocks.declineHostedLaunchConsent).toHaveBeenCalledWith({
     logoutPrivy: logout,
   });
+  expect(mocks.logoutHostedAppSession).not.toHaveBeenCalled();
   expect(assign).not.toHaveBeenCalled();
   expect(container.textContent).not.toContain("Hosted legal consent card");
   expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeTruthy();
@@ -1285,7 +1293,7 @@ test("HostedAuthPanel leaves the gate mounted and Decline usable when sign-out f
     logout,
     ready: true,
   });
-  mocks.logoutHostedAppSession.mockRejectedValueOnce(
+  mocks.declineHostedLaunchConsent.mockRejectedValueOnce(
     new Error("Sign-out unavailable."),
   );
 
@@ -1326,7 +1334,7 @@ test("HostedAuthPanel leaves the gate mounted and Decline usable when sign-out f
   });
 
   await vi.waitFor(() => {
-    expect(mocks.logoutHostedAppSession).toHaveBeenCalledTimes(2);
+    expect(mocks.declineHostedLaunchConsent).toHaveBeenCalledTimes(2);
     expect(logout).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Hosted legal consent card");
   });
@@ -1557,7 +1565,7 @@ test("HostedAuthPanel keeps Decline terminal when a late status result says cons
       redirectUrl: "/home",
     });
   let releaseLogout: (() => void) | null = null;
-  mocks.logoutHostedAppSession.mockImplementationOnce(
+  mocks.declineHostedLaunchConsent.mockImplementationOnce(
     () =>
       new Promise<void>((resolve) => {
         releaseLogout = () => resolve();
@@ -1588,7 +1596,7 @@ test("HostedAuthPanel keeps Decline terminal when a late status result says cons
     declineButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
   });
 
-  expect(mocks.logoutHostedAppSession).toHaveBeenCalledTimes(1);
+  expect(mocks.declineHostedLaunchConsent).toHaveBeenCalledTimes(1);
 
   // The status retry the member started before declining now resolves to a
   // fully granted status while the authoritative logout is still in flight.

--- a/apps/web/test/legal-consent-routes.test.ts
+++ b/apps/web/test/legal-consent-routes.test.ts
@@ -9,8 +9,10 @@ const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   grantHostedOptionalFeatureConsent: vi.fn(),
   readHostedConsentStatus: vi.fn(),
+  recordHostedLaunchConsentDecline: vi.fn(),
   recordHostedLaunchRequiredConsent: vi.fn(),
   requirePrivyMemberAuth: vi.fn(),
+  revokeHostedAppSessionFromRequest: vi.fn(),
   revokeHostedOptionalFeatureConsent: vi.fn(),
   prismaClient: {
     label: "test-prisma",
@@ -23,6 +25,7 @@ vi.mock("@/src/lib/prisma", () => ({
 
 vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
   requireHostedAppSessionFromRequest: mocks.requirePrivyMemberAuth,
+  revokeHostedAppSessionFromRequest: mocks.revokeHostedAppSessionFromRequest,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/csrf", () => ({
@@ -38,6 +41,7 @@ vi.mock("@/src/lib/legal/consent", async () => {
     ...actual,
     grantHostedOptionalFeatureConsent: mocks.grantHostedOptionalFeatureConsent,
     readHostedConsentStatus: mocks.readHostedConsentStatus,
+    recordHostedLaunchConsentDecline: mocks.recordHostedLaunchConsentDecline,
     recordHostedLaunchRequiredConsent: mocks.recordHostedLaunchRequiredConsent,
     revokeHostedOptionalFeatureConsent: mocks.revokeHostedOptionalFeatureConsent,
   };
@@ -45,16 +49,19 @@ vi.mock("@/src/lib/legal/consent", async () => {
 
 type HostedConsentStatusRouteModule = typeof import("../app/api/legal/consent/status/route");
 type HostedConsentAcceptRouteModule = typeof import("../app/api/legal/consent/accept/route");
+type HostedConsentDeclineRouteModule = typeof import("../app/api/legal/consent/decline/route");
 type HostedConsentRevokeRouteModule = typeof import("../app/api/legal/consent/revoke/route");
 
 let consentStatusRoute: HostedConsentStatusRouteModule;
 let consentAcceptRoute: HostedConsentAcceptRouteModule;
+let consentDeclineRoute: HostedConsentDeclineRouteModule;
 let consentRevokeRoute: HostedConsentRevokeRouteModule;
 
 const memberAuth = {
   member: {
     id: "member_123",
   },
+  sessionId: "session_123",
 };
 
 const currentStatus = {
@@ -72,9 +79,10 @@ const currentStatus = {
 
 describe("legal consent routes", () => {
   beforeAll(async () => {
-    [consentStatusRoute, consentAcceptRoute, consentRevokeRoute] = await Promise.all([
+    [consentStatusRoute, consentAcceptRoute, consentDeclineRoute, consentRevokeRoute] = await Promise.all([
       import("../app/api/legal/consent/status/route"),
       import("../app/api/legal/consent/accept/route"),
+      import("../app/api/legal/consent/decline/route"),
       import("../app/api/legal/consent/revoke/route"),
     ]);
   });
@@ -85,7 +93,14 @@ describe("legal consent routes", () => {
     mocks.assertHostedOnboardingMutationOrigin.mockImplementation(() => {});
     mocks.requirePrivyMemberAuth.mockResolvedValue(memberAuth);
     mocks.readHostedConsentStatus.mockResolvedValue(currentStatus);
+    mocks.recordHostedLaunchConsentDecline.mockResolvedValue([
+      "launch.legal",
+      "launch.health-data",
+    ]);
     mocks.recordHostedLaunchRequiredConsent.mockResolvedValue(currentStatus);
+    mocks.revokeHostedAppSessionFromRequest.mockResolvedValue(
+      "murph-session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+    );
     mocks.grantHostedOptionalFeatureConsent.mockResolvedValue(currentStatus);
     mocks.revokeHostedOptionalFeatureConsent.mockResolvedValue(currentStatus);
   });
@@ -172,6 +187,78 @@ describe("legal consent routes", () => {
       source: "hosted onboarding",
     });
     expect(mocks.grantHostedOptionalFeatureConsent).not.toHaveBeenCalled();
+  });
+
+  it("records server-derived launch declines and revokes the authenticated session", async () => {
+    const request = new Request("https://join.example.test/api/legal/consent/decline", {
+      headers: {
+        origin: "https://join.example.test",
+      },
+      method: "POST",
+    });
+
+    const response = await consentDeclineRoute.POST(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toBe(
+      "murph-session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+    );
+    expect(mocks.recordHostedLaunchConsentDecline).toHaveBeenCalledWith({
+      memberId: "member_123",
+      prisma: mocks.prismaClient,
+      sessionId: "session_123",
+      source: "homepage-auth-dialog",
+    });
+    expect(mocks.revokeHostedAppSessionFromRequest).toHaveBeenCalledWith({
+      reason: "consent_declined",
+      request,
+    });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("still revokes the app session when the scoped decline audit is unavailable", async () => {
+    mocks.recordHostedLaunchConsentDecline.mockRejectedValueOnce(
+      new Error("audit unavailable"),
+    );
+    const request = new Request("https://join.example.test/api/legal/consent/decline", {
+      headers: {
+        origin: "https://join.example.test",
+      },
+      method: "POST",
+    });
+
+    const response = await consentDeclineRoute.POST(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toBe(
+      "murph-session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+    );
+    expect(mocks.revokeHostedAppSessionFromRequest).toHaveBeenCalledWith({
+      reason: "consent_declined",
+      request,
+    });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects launch decline before auth when the hosted origin guard fails", async () => {
+    mocks.assertHostedOnboardingMutationOrigin.mockImplementation(() => {
+      throw hostedOnboardingError({
+        code: "HOSTED_ONBOARDING_ORIGIN_REQUIRED",
+        httpStatus: 403,
+        message: "Hosted browser mutation routes require an Origin header.",
+      });
+    });
+
+    const response = await consentDeclineRoute.POST(
+      new Request("https://join.example.test/api/legal/consent/decline", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.requirePrivyMemberAuth).not.toHaveBeenCalled();
+    expect(mocks.recordHostedLaunchConsentDecline).not.toHaveBeenCalled();
+    expect(mocks.revokeHostedAppSessionFromRequest).not.toHaveBeenCalled();
   });
 
   it("rejects consent mutations before auth when the hosted origin guard fails", async () => {

--- a/apps/web/test/legal-consent.test.ts
+++ b/apps/web/test/legal-consent.test.ts
@@ -10,6 +10,7 @@ import {
   hasHostedHistoricalLaunchConsent,
   parseHostedConsentAcceptRequest,
   parseHostedConsentRevokeRequest,
+  recordHostedLaunchConsentDecline,
   type HostedConsentGrantSnapshot,
 } from "@/src/lib/legal/consent";
 
@@ -114,6 +115,124 @@ describe("hosted legal consent registry", () => {
     })).toEqual({
       scope: "feature.connected-health-source",
       source: "settings",
+    });
+  });
+
+  it("records pending launch scopes as idempotent privacy-safe decline events", async () => {
+    const createdBatches: unknown[] = [];
+    const createMany = vi.fn().mockImplementation(async (input: unknown) => {
+      createdBatches.push(input);
+      return { count: 2 };
+    });
+    const tx = {
+      hostedConsentEvent: { createMany },
+      hostedConsentGrant: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as Parameters<typeof recordHostedLaunchConsentDecline>[0]["prisma"];
+    const input = {
+      memberId: "member_1",
+      now: new Date("2026-07-30T17:00:00.000Z"),
+      prisma,
+      sessionId: "session_1",
+      source: "homepage-auth-dialog",
+    };
+
+    await expect(recordHostedLaunchConsentDecline(input)).resolves.toEqual([
+      "launch.legal",
+      "launch.health-data",
+    ]);
+    await expect(recordHostedLaunchConsentDecline(input)).resolves.toEqual([
+      "launch.legal",
+      "launch.health-data",
+    ]);
+
+    expect(createdBatches).toHaveLength(2);
+    const firstBatch = createdBatches[0] as {
+      data: Array<Record<string, unknown>>;
+      skipDuplicates: boolean;
+    };
+    const secondBatch = createdBatches[1] as typeof firstBatch;
+    expect(firstBatch.skipDuplicates).toBe(true);
+    expect(firstBatch.data).toEqual([
+      {
+        action: "declined",
+        createdAt: new Date("2026-07-30T17:00:00.000Z"),
+        documentVersionsJson: {
+          "health-ai-safety-disclosure": "2026-07-23",
+          "privacy-policy": "2026-07-23",
+          "terms-of-service": "2026-07-23",
+        },
+        id: expect.stringMatching(/^hbce_[A-Za-z0-9_-]{24}$/u),
+        memberId: "member_1",
+        scope: "launch.legal",
+        source: "homepage-auth-dialog",
+      },
+      {
+        action: "declined",
+        createdAt: new Date("2026-07-30T17:00:00.000Z"),
+        documentVersionsJson: {
+          "consumer-health-data-notice": "2026-07-23",
+        },
+        id: expect.stringMatching(/^hbce_[A-Za-z0-9_-]{24}$/u),
+        memberId: "member_1",
+        scope: "launch.health-data",
+        source: "homepage-auth-dialog",
+      },
+    ]);
+    expect(secondBatch.data.map((event) => event.id)).toEqual(
+      firstBatch.data.map((event) => event.id),
+    );
+    expect(firstBatch.data.every((event) => !("metadataJson" in event))).toBe(true);
+  });
+
+  it("does not record a decline for a launch scope that is already granted", async () => {
+    const createMany = vi.fn().mockResolvedValue({ count: 1 });
+    const tx = {
+      hostedConsentEvent: { createMany },
+      hostedConsentGrant: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            createdAt: new Date("2026-07-30T16:00:00.000Z"),
+            documentVersionsJson: buildCurrentHostedConsentDocumentVersions("launch.legal"),
+            grantedAt: new Date("2026-07-30T16:00:00.000Z"),
+            lastEventId: "hbce_accepted",
+            memberId: "member_1",
+            revokedAt: null,
+            scope: "launch.legal",
+            source: "homepage-auth-dialog",
+            status: "granted",
+            updatedAt: new Date("2026-07-30T16:00:00.000Z"),
+          },
+        ]),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as Parameters<typeof recordHostedLaunchConsentDecline>[0]["prisma"];
+
+    await expect(recordHostedLaunchConsentDecline({
+      memberId: "member_1",
+      now: new Date("2026-07-30T17:00:00.000Z"),
+      prisma,
+      sessionId: "session_1",
+      source: "homepage-auth-dialog",
+    })).resolves.toEqual(["launch.health-data"]);
+
+    expect(createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          action: "declined",
+          documentVersionsJson: {
+            "consumer-health-data-notice": "2026-07-23",
+          },
+          scope: "launch.health-data",
+        }),
+      ],
+      skipDuplicates: true,
     });
   });
 

--- a/docs/legal-consent-implementation.md
+++ b/docs/legal-consent-implementation.md
@@ -1,6 +1,6 @@
 # Legal Consent Implementation
 
-Last verified: 2026-07-28
+Last verified: 2026-07-30
 
 ## Purpose
 
@@ -32,12 +32,20 @@ The hosted consent API routes are:
 
 - `GET /api/legal/consent/status`
 - `POST /api/legal/consent/accept`
+- `POST /api/legal/consent/decline`
 - `POST /api/legal/consent/revoke`
 - `GET /api/device-sync/companion/legal-consent`
 - `POST /api/device-sync/companion/legal-consent`
 
 All routes require authenticated hosted member context. Launch-required consent can be accepted but not revoked through the revoke endpoint. Optional feature scopes can be granted and revoked independently.
-The `POST` accept and revoke routes also enforce hosted mutation-origin checks before writing consent state.
+The `POST` accept, decline, and revoke routes also enforce hosted
+mutation-origin checks before writing consent state. Decline records one
+`declined` event for each currently ungranted launch scope and ends the current
+hosted app session with the coarse `consent_declined` reason. The event ids are
+deterministic for the member, session, and scope, so retrying the same decline
+does not duplicate the audit history. Session termination remains authoritative
+if the scoped event write is temporarily unavailable; the session reason
+preserves the refusal outcome without keeping the person signed in.
 The companion route uses Privy bearer authentication with no cookie fallback
 and accepts only the two launch scopes. It reads and writes the same consent
 tables and current server-side document registry as the browser routes. The
@@ -104,4 +112,8 @@ available while those health-data bridges are paused.
 
 ## Privacy Notes
 
-Consent events store document versions and coarse source labels only. They do not store raw IP addresses, user agents, prompts, health payloads, or legal document text. If future requirements need stronger provenance, add minimized, documented fields rather than storing raw request metadata.
+Consent events store document versions and coarse source labels only. Decline
+events add no request metadata or free-form client input. Consent events do not
+store raw IP addresses, user agents, prompts, health payloads, contact details,
+or legal document text. If future requirements need stronger provenance, add
+minimized, documented fields rather than storing raw request metadata.


### PR DESCRIPTION
## Why this PR exists

People who decline launch health consent previously looked like ordinary logouts, so the consent audit could not distinguish an explicit refusal. This records a privacy-minimized decline against the authenticated member without adding a second telemetry or consent owner.

## User goal / user-visible behavior

A person can select **Decline** on the launch consent prompt, have that refusal recorded for each currently unaccepted launch scope, and return signed out without advancing onboarding. Operations can distinguish the refusal from a generic logout through existing hosted consent/session records.

## User experience

The existing Decline action keeps its pending feedback while one same-origin request records server-derived scope events and ends the current hosted app session concurrently. On success, browser-vault authority is invalidated, Privy cleanup runs best-effort, and the person returns to signed-out auth.

If scoped consent-event storage is temporarily unavailable, refusal still wins: the session ends with `consent_declined`, preserving a coarse durable refusal fact. If authoritative session termination fails, existing reload/revalidation recovery lets the fail-closed consent gate reappear. No extra screen, choice, or background continuation is introduced. Desktop/mobile catalog evidence shows the existing onboarding, legal-update, retryable-error, and terminal-error states unchanged.

## Invariants

- Refusal never grants, revokes, or advances consent state.
- Member, session, missing scopes, document versions, and source are server-derived.
- Decline remains same-origin and hosted-session authenticated.
- Same member/session/scope retries are idempotent.
- Sign-out is prioritized when the scoped audit insert is unavailable.
- No phone number, contact detail, IP address, user agent, document content, health payload, or free-form browser metadata is stored.
- Existing browser-vault invalidation and best-effort Privy cleanup remain intact.

## Non-obvious affected surfaces

- Hosted app-session termination reuses one private client helper for ordinary logout and consent decline. Focused client/auth-panel tests prove the semantic endpoint split and reload recovery.
- `HostedConsentEvent.action` admits `declined`; the existing database column is a string, so no schema or migration changes. Service tests prove scope derivation, current document snapshots, minimized fields, and retry identity.
- The hosted session uses `consent_declined` rather than generic `logout`. Route tests prove server-owned identity/reason, cookie clearing, origin guard, and audit-failure fallback.
- `/design?tab=consent` documents the behavior while rendering the real production consent component with synthetic props only.

## Architecture and reuse

- **Existing systems reused:** `HostedConsentEvent`, `HostedConsentGrant`, hosted app-session revocation, the same-origin guard, browser-vault invalidation, and the existing consent card.
- **New logic:** one decline recorder derives missing launch scopes/current document versions and creates deterministic member/session/scope event IDs; one route coordinates audit and consent-specific session revocation.
- **New abstractions:** no new service, schema, dependency, telemetry owner, or UI component; a small private session-ending client helper reuses the logout contract.
- **Complexity intentionally avoided:** no raw request metadata, decline grant table, queue, retry worker, reconciliation process, compatibility shim, or client-submitted scope list.

## Hot reply path impact

Not applicable. This changes only authenticated Web consent decline and adds nothing to inbound acceptance through provider start or reply handoff.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-visible prompt, tool, schema, model, or assembly changed.
- Group Murph: Not applicable — no provider-visible prompt, tool, schema, model, or assembly changed.

## Preliminary specialist lenses

- Prompt: not applicable — no prompt surface changed.
- Frontend: applicable — packaged desktop/mobile evidence covers onboarding consent, legal update, retryable error, and terminal error states on `/design?tab=consent`.
- Coverage: applicable — merged-head focused proof passed 4 files / 54 tests, Web typecheck and touched Web ESLint passed, and exact-head CI passed after one unchanged rerun of an unrelated Codex-media/Linq timeout.

## Product and UI review

Product review initially found that audit failure could block refusal and leave the person signed in. That finding was accepted and fixed before merge: audit persistence cannot block session revocation. Follow-up product review returned `ACCEPTED`. The required Claude UI check returned `NO FINDINGS`; production consent-card visuals did not change.

## Preliminary ReviewGPT outcome

The required specialist pass completed after this PR had already merged. It found no production defect. Its request for a new browser/database integration harness was rejected as disproportionate because the unchanged production card, panel, client, route, consent transaction, late-completion behavior, rendered evidence, product review, and exact-head CI already establish the stable owner boundaries.

Three additional failure/idempotency assertions were accepted as useful coverage. They are isolated in tests/plan-cleanup follow-up PR #1188; they were not part of this merged diff.

## Design proof

- Design page: `/design?tab=consent` → **Launch consent**
- Desktop: ![Consent states on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1bf3db16-9461-4adc-c825-d26a1f914700/public)
- Mobile: ![Consent states on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/7baca240-5445-4906-c1b1-f255b76e6600/public)

## Change-shape breakdown

Classification is path-based: production/design-catalog TypeScript is source; `test/**` files are tests/fixtures; the active execution plan and legal-consent guide are docs. No config/tooling, generated, or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 132 | 9 |
| Tests / fixtures | 245 | 7 |
| Docs | 66 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **443** | **19** |

## Verification

- Focused consent service, route, app-session client, and auth-panel Vitest: 4 files / 54 tests passed on the merged head.
- `pnpm --filter @murphai/hosted-web typecheck`: passed.
- Touched Web TypeScript/TSX ESLint: passed.
- `git diff --check` and scoped privacy/identifier scan: passed.
- Product-experience follow-up: `ACCEPTED`.
- Claude UI double-check: `NO FINDINGS`.
- Exact-head GitHub Actions: passed after one unchanged rerun of a transient, unrelated Codex-media/Linq expected-request timeout.

## Deployment skew / compatibility

Web-only; no schema migration, Cloudflare/runtime contract, environment variable, or cross-deploy dependency. Existing consent actions and session revoke reasons are stored strings, so ordinary Web rollout and rollback remain compatible.