### PR TITLE
test(web): strengthen consent decline coverage

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-30-log-launch-consent-declines.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-log-launch-consent-declines.md
@@ -1,6 +1,6 @@
 # Log Launch Consent Declines
 
-Status: active
+Status: completed
 Created: 2026-07-30
 
 ## Goal
@@ -49,3 +49,5 @@ Created: 2026-07-30
   and consent-specific session revocation.
 - Preliminary ReviewGPT coverage/frontend lenses, local product-experience
   review, parent final review, final ReviewGPT, and exact-head CI.
+Updated: 2026-07-30
+Completed: 2026-07-30

--- a/apps/web/test/hosted-app-session-client.test.ts
+++ b/apps/web/test/hosted-app-session-client.test.ts
@@ -91,6 +91,25 @@ describe("logoutHostedAppSession", () => {
     expect(logoutPrivy).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a successful consent decline terminal when Privy cleanup fails", async () => {
+    const logoutPrivy = vi.fn().mockRejectedValue(new Error("Privy unavailable"));
+    mocks.requestHostedOnboardingJson.mockImplementation(async (input: {
+      onSuccessfulResponseHeaders?: () => void;
+    }) => {
+      input.onSuccessfulResponseHeaders?.();
+      return { ok: true };
+    });
+    const { declineHostedLaunchConsent } = await import(
+      "@/src/components/hosted-onboarding/hosted-app-session-client"
+    );
+
+    await expect(declineHostedLaunchConsent({ logoutPrivy })).resolves.toBeUndefined();
+
+    expect(logoutPrivy).toHaveBeenCalledTimes(1);
+    expect(mocks.publishBrowserVaultSessionInvalidation).toHaveBeenCalledTimes(1);
+    expect(mocks.reloadCurrentHostedAuthDocument).not.toHaveBeenCalled();
+  });
+
   it("does not replay destructive logout when ambient authority changes after a transport failure", async () => {
     const events: string[] = [];
     let ambientMember = "member_A";

--- a/apps/web/test/legal-consent-routes.test.ts
+++ b/apps/web/test/legal-consent-routes.test.ts
@@ -240,6 +240,39 @@ describe("legal consent routes", () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
+  it("fails the decline request when authoritative session revocation is unavailable", async () => {
+    mocks.revokeHostedAppSessionFromRequest.mockRejectedValueOnce(
+      new Error("session store unavailable"),
+    );
+    const request = new Request("https://join.example.test/api/legal/consent/decline", {
+      headers: {
+        origin: "https://join.example.test",
+      },
+      method: "POST",
+    });
+
+    const response = await consentDeclineRoute.POST(request);
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+    expect(mocks.recordHostedLaunchConsentDecline).toHaveBeenCalledWith({
+      memberId: "member_123",
+      prisma: mocks.prismaClient,
+      sessionId: "session_123",
+      source: "homepage-auth-dialog",
+    });
+    expect(mocks.revokeHostedAppSessionFromRequest).toHaveBeenCalledWith({
+      reason: "consent_declined",
+      request,
+    });
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal error.",
+      },
+    });
+  });
+
   it("rejects launch decline before auth when the hosted origin guard fails", async () => {
     mocks.assertHostedOnboardingMutationOrigin.mockImplementation(() => {
       throw hostedOnboardingError({

--- a/apps/web/test/legal-consent.test.ts
+++ b/apps/web/test/legal-consent.test.ts
@@ -135,17 +135,22 @@ describe("hosted legal consent registry", () => {
     } as unknown as Parameters<typeof recordHostedLaunchConsentDecline>[0]["prisma"];
     const input = {
       memberId: "member_1",
-      now: new Date("2026-07-30T17:00:00.000Z"),
       prisma,
       sessionId: "session_1",
       source: "homepage-auth-dialog",
     };
 
-    await expect(recordHostedLaunchConsentDecline(input)).resolves.toEqual([
+    await expect(recordHostedLaunchConsentDecline({
+      ...input,
+      now: new Date("2026-07-30T17:00:00.000Z"),
+    })).resolves.toEqual([
       "launch.legal",
       "launch.health-data",
     ]);
-    await expect(recordHostedLaunchConsentDecline(input)).resolves.toEqual([
+    await expect(recordHostedLaunchConsentDecline({
+      ...input,
+      now: new Date("2026-07-30T17:05:00.000Z"),
+    })).resolves.toEqual([
       "launch.legal",
       "launch.health-data",
     ]);
@@ -186,6 +191,10 @@ describe("hosted legal consent registry", () => {
     expect(secondBatch.data.map((event) => event.id)).toEqual(
       firstBatch.data.map((event) => event.id),
     );
+    expect(secondBatch.data.map((event) => event.createdAt)).toEqual([
+      new Date("2026-07-30T17:05:00.000Z"),
+      new Date("2026-07-30T17:05:00.000Z"),
+    ]);
     expect(firstBatch.data.every((event) => !("metadataJson" in event))).toBe(true);
   });
 


### PR DESCRIPTION
## Why this PR exists

PR #1185 merged while its required specialist review was still finishing. That review suggested three focused assertions; this tests-only follow-up lands the accepted coverage and archives the completed execution plan without changing production behavior.

## User goal / user-visible behavior

No user-visible behavior changes. The already-merged consent-decline flow remains exactly the same; this PR proves its existing failure and retry contracts more explicitly.

## User experience

No UI, copy, interaction, timing, or recovery behavior changes. The underlying merged experience remains: decline records current unaccepted launch scopes when available, prioritizes authoritative session termination, and returns the person signed out. This follow-up only exercises existing boundaries.

## Invariants

- Authoritative hosted-session revocation failure returns an error and never emits a clearing cookie.
- Privy cleanup remains best-effort after successful server-side session termination.
- Retrying the same member/session/scope decline later produces the same deterministic audit event IDs.
- Production code and database behavior remain unchanged.

## Non-obvious affected surfaces

- The completed execution plan moves from `active` to `completed` because PR #1185 merged during the review loop. No operative guidance changes.
- Three existing Web test files gain assertions for already-shipped route, client, and consent-service behavior. Focused Vitest, Web typecheck, and touched-test ESLint prove the current main integration.

## Architecture and reuse

- **Existing systems reused:** the existing legal-consent route, session client, consent-service fixtures, Vitest workspace, and execution-plan archive workflow.
- **New logic:** test assertions only for revocation failure, Privy cleanup failure, and time-separated idempotent retry.
- **New abstractions:** none; the existing test fixtures expose every required seam.
- **Complexity intentionally avoided:** no production code, browser/database harness, dependency, schema, service, queue, or compatibility path is added.

## Hot reply path impact

Not applicable. This is tests and plan archival only; no runtime call path changes.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-visible source changed.
- Group Murph: Not applicable — no provider-visible source changed.

## Preliminary specialist lenses

- Prompt: not applicable — no prompt or provider-visible instruction changed.
- Frontend: not applicable — no user-facing Web UI changed.
- Coverage: applicable — this diff is the accepted tests-only coverage correction from PR #1185’s trusted preliminary pass. Per the repository workflow, that substantive preliminary pass is not rerun for its own correction. The focused current-main run passes 4 files / 56 tests; Web typecheck and touched-test ESLint pass; exact-head CI is green.

## Preliminary finding disposition

The exact ReviewGPT coverage artifact from PR #1185 was downloaded from the owned review thread, inspected in full, confirmed to touch only these three test files, and passed `git apply --check`. Its three assertions were accepted and applied deliberately. The separate suggestion to add a new cross-owner browser/database harness was rejected as disproportionate because it would duplicate existing stable owner boundaries without evidence of a broken production path.

## Design proof

Not applicable. No user-facing frontend UI diff.

## Change-shape breakdown

Classification is path-based: `test/**` files are tests/fixtures and the archived execution plan is docs. There are no source, config/tooling, generated, or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 64 | 3 |
| Docs | 3 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **67** | **4** |

## Verification

- Focused consent route, app-session client, consent service, and auth-panel Vitest on current main: 4 files / 56 tests passed.
- `pnpm --filter @murphai/hosted-web typecheck`: passed.
- Touched-test ESLint: passed.
- `git diff --check`: passed.
- Exact-head CI: all required checks passed.

## Deployment skew / compatibility

Not applicable. This PR changes tests and plan archival only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788030209&installation_model_id=19880&pr_number=1188&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1188&signature=b5427cc715f14c7ef01636e22da75055e7bd8d334baddba9ce46250439f14251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
