### PR TITLE
fix(cloudflare): reconcile R2 CopyObject connection resets

### DIFF
--- a/apps/cloudflare/R2_BUNDLES_ENAM_ONLINE_CUTOVER.md
+++ b/apps/cloudflare/R2_BUNDLES_ENAM_ONLINE_CUTOVER.md
@@ -231,15 +231,21 @@ Continue with step 6 while that exact process waits. A timing-only rehearsal
 must omit this flag; if it exits with destination-only churn, keep that
 destination as rehearsal evidence only and never restart copying into it.
 
-CopyObject has two narrow recovery cases:
+CopyObject has three narrow recovery cases:
 
 1. The initial request allows one additional attempt only when the first
    built-in-fetch rejection is a `TypeError` whose direct cause code is
    `UND_ERR_CONNECT_TIMEOUT`, proving that the failed connection attempt never
    reached the server.
-2. After the terminal response body is fully drained, exactly HTTP `500`
-   enters one reconciliation path. Cloudflare documents `500 InternalError` as
-   retryable, and R2's direct S3 reads are strongly consistent:
+2. An initial built-in-fetch `TypeError` whose direct cause code is exactly
+   `ECONNRESET` enters identity reconciliation instead of a blind retry. The
+   reset does not prove whether R2 committed the create-only request, so the
+   copier uses the same strong destination/source HEAD proof and one-second
+   same-key recovery floor described below.
+3. After the terminal response body is fully drained, exactly HTTP `500`
+   enters the same identity reconciliation path. Cloudflare documents `500
+   InternalError` as retryable, and R2's direct S3 reads are strongly
+   consistent:
    [error codes](https://developers.cloudflare.com/r2/api/error-codes/) and
    [consistency model](https://developers.cloudflare.com/r2/reference/consistency/).
    The copier HEADs the destination and source and requires the planned ETag
@@ -250,18 +256,19 @@ CopyObject has two narrow recovery cases:
    recovery attempt does not use or reset the pre-connect retry wrapper. R2
    permits only [one write per second to the same object key](https://developers.cloudflare.com/r2/platform/limits/),
    so the copier establishes a one-second recovery-not-before deadline after
-   the first `500` body drains, performs the reconciliation HEADs during that
-   interval, and waits any remaining time before the recovery PUT.
+   the ambiguous failure, performs the reconciliation HEADs during that
+   interval, and waits any remaining time before the recovery PUT. For HTTP
+   `500`, that deadline starts only after the first response body drains.
 
-The single HTTP `500` recovery accepts only a successful response or `412`,
-then the ordinary destination and source HEAD validation runs again. A second
-`404`, `500`, `429`, `503`, other HTTP response, redirect, socket or transport
-failure, or response-body failure is terminal. A body failure on the first
-`500`, failed reconciliation HEAD, missing or changed source, or conflicting
-destination is also terminal without a recovery PUT.
-Every other first-attempt terminal HTTP response, redirect, socket failure, and
+The single ambiguous-outcome recovery accepts only a successful response or
+`412`, then the ordinary destination and source HEAD validation runs again. A
+second `404`, `500`, `429`, `503`, other HTTP response, redirect, socket or
+transport failure, or response-body failure is terminal. A body failure on the
+first `500`, failed reconciliation HEAD, missing or changed source, or
+conflicting destination is also terminal without a recovery PUT. Every other
+first-attempt terminal HTTP response, redirect, socket failure, and
 response-body failure keeps its existing terminal one-shot behavior. No PUT is
-allowed after the single HTTP `500` recovery attempt; when the initial
+allowed after the single ambiguous-outcome recovery attempt; when the initial
 pre-connect retry was used, this still caps the sequence at three raw fetch
 calls while only two could have reached R2.
 

--- a/apps/cloudflare/R2_BUNDLES_ENAM_ONLINE_CUTOVER.md
+++ b/apps/cloudflare/R2_BUNDLES_ENAM_ONLINE_CUTOVER.md
@@ -238,12 +238,18 @@ CopyObject has three narrow recovery cases:
    `UND_ERR_CONNECT_TIMEOUT`, proving that the failed connection attempt never
    reached the server.
 2. An initial built-in-fetch `TypeError` whose direct cause code is exactly
-   `ECONNRESET` enters identity reconciliation instead of a blind retry. The
-   reset does not prove whether R2 committed the create-only request, so the
-   copier uses the same strong destination/source HEAD proof and one-second
-   same-key recovery floor described below.
+   `ECONNRESET` enters a five-minute observation window instead of a retry.
+   Cloudflare does not publish a maximum R2 CopyObject execution or late-commit
+   duration, so elapsed time cannot prove that an absent copy is safe to
+   replay. After the observation window, the copier performs strong destination
+   and source HEADs. An exact destination plus exact source proves the original
+   request committed and may continue. An absent destination, missing or
+   changed source, or conflicting destination is terminal and quarantines the
+   destination without another PUT. The window improves the chance of observing
+   a committed original request; correctness never depends on it being a
+   server-side execution bound.
 3. After the terminal response body is fully drained, exactly HTTP `500`
-   enters the same identity reconciliation path. Cloudflare documents `500
+   enters a separate identity reconciliation path. Cloudflare documents `500
    InternalError` as retryable, and R2's direct S3 reads are strongly
    consistent:
    [error codes](https://developers.cloudflare.com/r2/api/error-codes/) and
@@ -289,8 +295,10 @@ validation. That is the source-active copy proof; do not launch a separate
 read-only process afterward because its intentionally fresh provenance must
 distrust clean destination-only churn from the completed process.
 
-Only if the process crashes or a CopyObject result is ambiguous, wait out the
-request bound and run the strict source-active read-only audit:
+Only if the process crashes or a CopyObject result is ambiguous, preserve the
+destination as quarantine evidence. A later strict source-active read-only
+audit is diagnostic only and cannot authorize reuse because Cloudflare does not
+publish a maximum late-commit bound:
 
 Run without `--apply`:
 

--- a/apps/cloudflare/scripts/r2-bundles-online-copy.ts
+++ b/apps/cloudflare/scripts/r2-bundles-online-copy.ts
@@ -1040,14 +1040,30 @@ function createOnlineCopyClient(environment: MigrationEnvironment): OnlineCopyCl
         key: input.entry.key,
         method: "PUT",
       };
-      const response = await fetchR2CopyObjectWithPreconnectRetry(environment, request);
-      await response.arrayBuffer();
-      if (response.status === 500) {
+      let response: Response;
+      try {
+        response = await fetchR2CopyObjectWithPreconnectRetry(environment, request);
+      } catch (error) {
+        if (!isExactConnectionReset(error)) throw error;
         const recoveryNotBefore = performance.now() + R2_SAME_KEY_WRITE_INTERVAL_MS;
-        return await reconcileR2CopyObjectHttp500({
+        return await reconcileR2CopyObjectAmbiguousOutcome({
           destination: input.destination,
           entry: input.entry,
           environment,
+          failureLabel: "connection reset",
+          recoveryNotBefore,
+          request,
+          source: input.source,
+        });
+      }
+      await response.arrayBuffer();
+      if (response.status === 500) {
+        const recoveryNotBefore = performance.now() + R2_SAME_KEY_WRITE_INTERVAL_MS;
+        return await reconcileR2CopyObjectAmbiguousOutcome({
+          destination: input.destination,
+          entry: input.entry,
+          environment,
+          failureLabel: "HTTP 500",
           recoveryNotBefore,
           request,
           source: input.source,
@@ -1084,10 +1100,11 @@ function createOnlineCopyClient(environment: MigrationEnvironment): OnlineCopyCl
   };
 }
 
-async function reconcileR2CopyObjectHttp500(input: {
+async function reconcileR2CopyObjectAmbiguousOutcome(input: {
   destination: string;
   entry: R2ObjectInventoryEntry;
   environment: MigrationEnvironment;
+  failureLabel: "connection reset" | "HTTP 500";
   recoveryNotBefore: number;
   request: R2CopyRequestInput;
   source: string;
@@ -1099,19 +1116,19 @@ async function reconcileR2CopyObjectHttp500(input: {
   );
   if (destinationHead && !sameHeadIdentity(input.entry, destinationHead)) {
     throw new Error(
-      "R2 CopyObject HTTP 500 reconciliation found a conflicting destination identity.",
+      `R2 CopyObject ${input.failureLabel} reconciliation found a conflicting destination identity.`,
     );
   }
 
   const sourceHead = await headR2Object(input.environment, input.source, input.entry.key);
   if (!sourceHead) {
     throw new Error(
-      "R2 CopyObject HTTP 500 reconciliation found the planned source object missing.",
+      `R2 CopyObject ${input.failureLabel} reconciliation found the planned source object missing.`,
     );
   }
   if (!sameHeadIdentity(input.entry, sourceHead)) {
     throw new Error(
-      "R2 CopyObject HTTP 500 reconciliation found the planned source identity changed.",
+      `R2 CopyObject ${input.failureLabel} reconciliation found the planned source identity changed.`,
     );
   }
   if (destinationHead) return "destination_exists";
@@ -1122,7 +1139,8 @@ async function reconcileR2CopyObjectHttp500(input: {
   if (recoveryResponse.status === 412) return "destination_exists";
   if (!recoveryResponse.ok) {
     throw new Error(
-      `R2 create-only CopyObject recovery failed with HTTP ${recoveryResponse.status}.`,
+      `R2 create-only CopyObject ${input.failureLabel} recovery failed with HTTP `
+      + `${recoveryResponse.status}.`,
     );
   }
   return "copied";
@@ -1178,6 +1196,15 @@ function isExactUndiciConnectTimeout(error: unknown): boolean {
     && cause !== null
     && "code" in cause
     && cause.code === "UND_ERR_CONNECT_TIMEOUT";
+}
+
+function isExactConnectionReset(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
+  const cause = error.cause;
+  return typeof cause === "object"
+    && cause !== null
+    && "code" in cause
+    && cause.code === "ECONNRESET";
 }
 
 async function fetchR2WithOneRetry(

--- a/apps/cloudflare/scripts/r2-bundles-online-copy.ts
+++ b/apps/cloudflare/scripts/r2-bundles-online-copy.ts
@@ -32,6 +32,7 @@ const lifecycleConfigPath = path.join(appDir, "r2-bundles-lifecycle.json");
 
 const COPY_CONCURRENCY = 16;
 const COPY_OBJECT_MAX_BYTES_EXCLUSIVE = 5_000_000_000;
+const COPY_OBJECT_RESET_OBSERVATION_MS = 300_000;
 const R2_SAME_KEY_WRITE_INTERVAL_MS = 1_000;
 const MIGRATION_ACCESS_KEY_ENV = "R2_MIGRATION_ACCESS_KEY_ID";
 const MIGRATION_SECRET_KEY_ENV = "R2_MIGRATION_SECRET_ACCESS_KEY";
@@ -1045,25 +1046,23 @@ function createOnlineCopyClient(environment: MigrationEnvironment): OnlineCopyCl
         response = await fetchR2CopyObjectWithPreconnectRetry(environment, request);
       } catch (error) {
         if (!isExactConnectionReset(error)) throw error;
-        const recoveryNotBefore = performance.now() + R2_SAME_KEY_WRITE_INTERVAL_MS;
-        return await reconcileR2CopyObjectAmbiguousOutcome({
+        await waitUntilPerformanceTime(
+          performance.now() + COPY_OBJECT_RESET_OBSERVATION_MS,
+        );
+        return await reconcileR2CopyObjectConnectionReset({
           destination: input.destination,
           entry: input.entry,
           environment,
-          failureLabel: "connection reset",
-          recoveryNotBefore,
-          request,
           source: input.source,
         });
       }
       await response.arrayBuffer();
       if (response.status === 500) {
         const recoveryNotBefore = performance.now() + R2_SAME_KEY_WRITE_INTERVAL_MS;
-        return await reconcileR2CopyObjectAmbiguousOutcome({
+        return await reconcileR2CopyObjectHttp500({
           destination: input.destination,
           entry: input.entry,
           environment,
-          failureLabel: "HTTP 500",
           recoveryNotBefore,
           request,
           source: input.source,
@@ -1100,11 +1099,47 @@ function createOnlineCopyClient(environment: MigrationEnvironment): OnlineCopyCl
   };
 }
 
-async function reconcileR2CopyObjectAmbiguousOutcome(input: {
+async function reconcileR2CopyObjectConnectionReset(input: {
   destination: string;
   entry: R2ObjectInventoryEntry;
   environment: MigrationEnvironment;
-  failureLabel: "connection reset" | "HTTP 500";
+  source: string;
+}): Promise<"destination_exists"> {
+  const destinationHead = await headR2Object(
+    input.environment,
+    input.destination,
+    input.entry.key,
+  );
+  if (destinationHead && !sameHeadIdentity(input.entry, destinationHead)) {
+    throw new Error(
+      "R2 CopyObject connection reset reconciliation found a conflicting destination identity.",
+    );
+  }
+
+  const sourceHead = await headR2Object(input.environment, input.source, input.entry.key);
+  if (!sourceHead) {
+    throw new Error(
+      "R2 CopyObject connection reset reconciliation found the planned source object missing.",
+    );
+  }
+  if (!sameHeadIdentity(input.entry, sourceHead)) {
+    throw new Error(
+      "R2 CopyObject connection reset reconciliation found the planned source identity changed.",
+    );
+  }
+  if (!destinationHead) {
+    throw new Error(
+      "R2 CopyObject connection reset remained uncommitted after the observation window; "
+      + "quarantine this destination.",
+    );
+  }
+  return "destination_exists";
+}
+
+async function reconcileR2CopyObjectHttp500(input: {
+  destination: string;
+  entry: R2ObjectInventoryEntry;
+  environment: MigrationEnvironment;
   recoveryNotBefore: number;
   request: R2CopyRequestInput;
   source: string;
@@ -1116,37 +1151,37 @@ async function reconcileR2CopyObjectAmbiguousOutcome(input: {
   );
   if (destinationHead && !sameHeadIdentity(input.entry, destinationHead)) {
     throw new Error(
-      `R2 CopyObject ${input.failureLabel} reconciliation found a conflicting destination identity.`,
+      "R2 CopyObject HTTP 500 reconciliation found a conflicting destination identity.",
     );
   }
 
   const sourceHead = await headR2Object(input.environment, input.source, input.entry.key);
   if (!sourceHead) {
     throw new Error(
-      `R2 CopyObject ${input.failureLabel} reconciliation found the planned source object missing.`,
+      "R2 CopyObject HTTP 500 reconciliation found the planned source object missing.",
     );
   }
   if (!sameHeadIdentity(input.entry, sourceHead)) {
     throw new Error(
-      `R2 CopyObject ${input.failureLabel} reconciliation found the planned source identity changed.`,
+      "R2 CopyObject HTTP 500 reconciliation found the planned source identity changed.",
     );
   }
   if (destinationHead) return "destination_exists";
 
-  await waitForR2SameKeyWriteInterval(input.recoveryNotBefore);
+  await waitUntilPerformanceTime(input.recoveryNotBefore);
   const recoveryResponse = await fetchR2Once(input.environment, input.request);
   await recoveryResponse.arrayBuffer();
   if (recoveryResponse.status === 412) return "destination_exists";
   if (!recoveryResponse.ok) {
     throw new Error(
-      `R2 create-only CopyObject ${input.failureLabel} recovery failed with HTTP `
+      "R2 create-only CopyObject HTTP 500 recovery failed with HTTP "
       + `${recoveryResponse.status}.`,
     );
   }
   return "copied";
 }
 
-async function waitForR2SameKeyWriteInterval(notBefore: number): Promise<void> {
+async function waitUntilPerformanceTime(notBefore: number): Promise<void> {
   while (true) {
     const remaining = notBefore - performance.now();
     if (remaining <= 0) return;

--- a/apps/cloudflare/test/r2-bundles-online-copy.test.ts
+++ b/apps/cloudflare/test/r2-bundles-online-copy.test.ts
@@ -649,57 +649,20 @@ describe("R2 online immutable copy", () => {
     expect(copySuccessResponse.bodyUsed).toBe(true);
   });
 
-  it("accepts an ECONNRESET when strong HEADs prove the copy already committed", async () => {
-    const boundaryNamespace = createHostedStorageNamespaceId("member_1");
-    const eligible = entry(
-      `users/${boundaryNamespace}/workspace-snapshots/reset-committed.snapshot.enc`,
-      { etag: '"14141414141414141414141414141414"', size: 12 },
-    );
-    let putAttempts = 0;
-    const headPaths: string[] = [];
-    const fixture = createProductionCopyFixture(
-      eligible,
-      async (request, init, state) => {
-        const url = new URL(String(request));
-        if (init?.method === "PUT") {
-          putAttempts += 1;
-          state.destinationInventory = [marker(), eligible];
-          throw connectionReset();
-        }
-        if (init?.method === "HEAD") {
-          headPaths.push(url.pathname);
-          return exactHeadResponse(eligible);
-        }
-        throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
-      },
-    );
-
-    await fixture.run();
-
-    expect(putAttempts).toBe(1);
-    expect(headPaths).toEqual([
-      `/${destinationBucket}/${eligible.key}`,
-      `/${sourceBucket}/${eligible.key}`,
-      `/${destinationBucket}/${eligible.key}`,
-      `/${sourceBucket}/${eligible.key}`,
-    ]);
-  });
-
-  it("retries one uncommitted ECONNRESET with the identical create-only request", async () => {
+  it("waits through the reset observation window before accepting a committed copy", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-30T00:00:00.000Z"));
     try {
       const boundaryNamespace = createHostedStorageNamespaceId("member_1");
       const eligible = entry(
-        `users/${boundaryNamespace}/workspace-snapshots/reset-recovery.snapshot.enc`,
-        { etag: '"15151515151515151515151515151515"', size: 12 },
+        `users/${boundaryNamespace}/workspace-snapshots/reset-committed.snapshot.enc`,
+        { etag: '"14141414141414141414141414141414"', size: 12 },
       );
-      const copyHeaders: Record<string, string | null>[] = [];
-      const putTimes: number[] = [];
       let putAttempts = 0;
-      let markSourceHeadObserved!: () => void;
-      const sourceHeadObserved = new Promise<void>((resolve) => {
-        markSourceHeadObserved = resolve;
+      const headPaths: string[] = [];
+      let markFirstPutObserved!: () => void;
+      const firstPutObserved = new Promise<void>((resolve) => {
+        markFirstPutObserved = resolve;
       });
       const fixture = createProductionCopyFixture(
         eligible,
@@ -707,21 +670,72 @@ describe("R2 online immutable copy", () => {
           const url = new URL(String(request));
           if (init?.method === "PUT") {
             putAttempts += 1;
-            putTimes.push(Date.now());
-            copyHeaders.push(criticalCopyHeaders(init));
-            if (putAttempts === 1) throw connectionReset();
             state.destinationInventory = [marker(), eligible];
-            return new Response("<CopyObjectResult />", { status: 200 });
+            markFirstPutObserved();
+            throw connectionReset();
           }
           if (init?.method === "HEAD") {
+            headPaths.push(url.pathname);
+            return exactHeadResponse(eligible);
+          }
+          throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+        },
+      );
+
+      const runPromise = fixture.run();
+      await firstPutObserved;
+      await vi.advanceTimersByTimeAsync(299_999);
+      expect(putAttempts).toBe(1);
+      expect(headPaths).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1);
+      await runPromise;
+
+      expect(putAttempts).toBe(1);
+      expect(headPaths).toEqual([
+        `/${destinationBucket}/${eligible.key}`,
+        `/${sourceBucket}/${eligible.key}`,
+        `/${destinationBucket}/${eligible.key}`,
+        `/${sourceBucket}/${eligible.key}`,
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("observes a delayed reset commit after the same-key floor without replaying it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-30T00:00:00.000Z"));
+    try {
+      const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+      const eligible = entry(
+        `users/${boundaryNamespace}/workspace-snapshots/reset-delayed-commit.snapshot.enc`,
+        { etag: '"15151515151515151515151515151515"', size: 12 },
+      );
+      let putAttempts = 0;
+      const headPaths: string[] = [];
+      let markFirstPutObserved!: () => void;
+      const firstPutObserved = new Promise<void>((resolve) => {
+        markFirstPutObserved = resolve;
+      });
+      const fixture = createProductionCopyFixture(
+        eligible,
+        async (request, init, state) => {
+          const url = new URL(String(request));
+          if (init?.method === "PUT") {
+            putAttempts += 1;
+            markFirstPutObserved();
+            setTimeout(() => {
+              state.destinationInventory = [marker(), eligible];
+            }, 2_000);
+            throw connectionReset();
+          }
+          if (init?.method === "HEAD") {
+            headPaths.push(url.pathname);
             if (
               url.pathname === `/${destinationBucket}/${eligible.key}`
               && !state.destinationInventory.includes(eligible)
             ) {
               return new Response(null, { status: 404 });
-            }
-            if (url.pathname === `/${sourceBucket}/${eligible.key}`) {
-              markSourceHeadObserved();
             }
             return exactHeadResponse(eligible);
           }
@@ -730,54 +744,131 @@ describe("R2 online immutable copy", () => {
       );
 
       const runPromise = fixture.run();
-      await sourceHeadObserved;
-      await vi.advanceTimersByTimeAsync(999);
+      await firstPutObserved;
+      await vi.advanceTimersByTimeAsync(299_999);
       expect(putAttempts).toBe(1);
+      expect(headPaths).toEqual([]);
       await vi.advanceTimersByTimeAsync(1);
       await runPromise;
 
-      expect(putAttempts).toBe(2);
-      expect(putTimes).toEqual([
-        new Date("2026-07-30T00:00:00.000Z").getTime(),
-        new Date("2026-07-30T00:00:01.000Z").getTime(),
+      expect(putAttempts).toBe(1);
+      expect(headPaths).toEqual([
+        `/${destinationBucket}/${eligible.key}`,
+        `/${sourceBucket}/${eligible.key}`,
+        `/${destinationBucket}/${eligible.key}`,
+        `/${sourceBucket}/${eligible.key}`,
       ]);
-      expect(copyHeaders[1]).toEqual(copyHeaders[0]);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("fails ECONNRESET reconciliation when the planned source is missing", async () => {
-    const boundaryNamespace = createHostedStorageNamespaceId("member_1");
-    const eligible = entry(
-      `users/${boundaryNamespace}/workspace-snapshots/reset-missing-source.snapshot.enc`,
-      { etag: '"16161616161616161616161616161616"', size: 12 },
-    );
-    let putAttempts = 0;
-    const fixture = createProductionCopyFixture(eligible, async (request, init) => {
-      const url = new URL(String(request));
-      if (init?.method === "PUT") {
-        putAttempts += 1;
-        throw connectionReset();
-      }
-      if (
-        init?.method === "HEAD"
-        && url.pathname === `/${destinationBucket}/${eligible.key}`
-      ) {
-        return new Response(null, { status: 404 });
-      }
-      if (init?.method === "HEAD" && url.pathname === `/${sourceBucket}/${eligible.key}`) {
-        return new Response(null, { status: 404 });
-      }
-      throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
-    });
+  it("never replays an uncommitted ECONNRESET after the observation window", async () => {
+    vi.useFakeTimers();
+    try {
+      const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+      const eligible = entry(
+        `users/${boundaryNamespace}/workspace-snapshots/reset-uncommitted.snapshot.enc`,
+        { etag: '"17171717171717171717171717171717"', size: 12 },
+      );
+      let putAttempts = 0;
+      let markFirstPutObserved!: () => void;
+      const firstPutObserved = new Promise<void>((resolve) => {
+        markFirstPutObserved = resolve;
+      });
+      const fixture = createProductionCopyFixture(eligible, async (request, init) => {
+        const url = new URL(String(request));
+        if (init?.method === "PUT") {
+          putAttempts += 1;
+          markFirstPutObserved();
+          throw connectionReset();
+        }
+        if (
+          init?.method === "HEAD"
+          && url.pathname === `/${destinationBucket}/${eligible.key}`
+        ) {
+          return new Response(null, { status: 404 });
+        }
+        if (init?.method === "HEAD") return exactHeadResponse(eligible);
+        throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+      });
 
-    await expect(fixture.run()).rejects.toThrow(
-      "connection reset reconciliation found the planned source object missing",
-    );
+      const runPromise = fixture.run();
+      const caughtRun = runPromise.catch((error: unknown) => error);
+      await firstPutObserved;
+      await vi.advanceTimersByTimeAsync(300_000);
+      const error = await caughtRun;
+      expect(error).toBeInstanceOf(Error);
+      if (!(error instanceof Error)) {
+        throw new TypeError("expected the uncommitted reset to reject with an Error");
+      }
+      expect(error.message).toContain(
+        "connection reset remained uncommitted after the observation window",
+      );
 
-    expect(putAttempts).toBe(1);
-    expect(fixture.fetchMock).toHaveBeenCalledTimes(3);
+      expect(putAttempts).toBe(1);
+      expect(fixture.fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("quarantines a delayed reset commit when the source was deleted", async () => {
+    vi.useFakeTimers();
+    try {
+      const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+      const eligible = entry(
+        `users/${boundaryNamespace}/workspace-snapshots/reset-deleted-source.snapshot.enc`,
+        { etag: '"18181818181818181818181818181818"', size: 12 },
+      );
+      let putAttempts = 0;
+      let sourceDeleted = false;
+      let markFirstPutObserved!: () => void;
+      const firstPutObserved = new Promise<void>((resolve) => {
+        markFirstPutObserved = resolve;
+      });
+      const fixture = createProductionCopyFixture(
+        eligible,
+        async (request, init, state) => {
+          const url = new URL(String(request));
+          if (init?.method === "PUT") {
+            putAttempts += 1;
+            markFirstPutObserved();
+            setTimeout(() => {
+              state.destinationInventory = [marker(), eligible];
+            }, 2_000);
+            setTimeout(() => {
+              sourceDeleted = true;
+            }, 3_000);
+            throw connectionReset();
+          }
+          if (init?.method === "HEAD") {
+            if (url.pathname === `/${sourceBucket}/${eligible.key}` && sourceDeleted) {
+              return new Response(null, { status: 404 });
+            }
+            return exactHeadResponse(eligible);
+          }
+          throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+        },
+      );
+
+      const runPromise = fixture.run();
+      const caughtRun = runPromise.catch((error: unknown) => error);
+      await firstPutObserved;
+      await vi.advanceTimersByTimeAsync(300_000);
+      const error = await caughtRun;
+      expect(error).toBeInstanceOf(Error);
+      if (!(error instanceof Error)) {
+        throw new TypeError("expected the deleted-source reset to reject with an Error");
+      }
+      expect(error.message).toContain(
+        "connection reset reconciliation found the planned source object missing",
+      );
+
+      expect(putAttempts).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("accepts one HTTP 500 when strong HEADs prove the copy already committed", async () => {

--- a/apps/cloudflare/test/r2-bundles-online-copy.test.ts
+++ b/apps/cloudflare/test/r2-bundles-online-copy.test.ts
@@ -542,7 +542,16 @@ describe("R2 online immutable copy", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("never retries a connect-timeout-shaped body failure after response headers", async () => {
+  it.each([
+    {
+      failure: undiciConnectTimeout,
+      label: "connect-timeout-shaped",
+    },
+    {
+      failure: connectionReset,
+      label: "connection-reset-shaped",
+    },
+  ])("never retries a $label body failure after response headers", async ({ failure }) => {
     const boundaryNamespace = createHostedStorageNamespaceId("member_1");
     const eligible = entry(
       `users/${boundaryNamespace}/workspace-snapshots/post-response-body-failure.snapshot.enc`,
@@ -561,7 +570,7 @@ describe("R2 online immutable copy", () => {
       }
       return new Response(new ReadableStream({
         start(controller) {
-          controller.error(undiciConnectTimeout());
+          controller.error(failure());
         },
       }), { status: 200 });
     });
@@ -1184,6 +1193,12 @@ describe("R2 online immutable copy", () => {
         throw new TypeError("fetch failed", {
           cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
         });
+      },
+    },
+    {
+      label: "exact connection reset",
+      outcome: () => {
+        throw connectionReset();
       },
     },
     {

--- a/apps/cloudflare/test/r2-bundles-online-copy.test.ts
+++ b/apps/cloudflare/test/r2-bundles-online-copy.test.ts
@@ -74,6 +74,14 @@ function undiciConnectTimeout(): TypeError {
   });
 }
 
+function connectionReset(): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    }),
+  });
+}
+
 function options(overrides: Partial<R2BundlesOnlineCopyOptions> = {}): R2BundlesOnlineCopyOptions {
   return {
     apply: false,
@@ -630,6 +638,137 @@ describe("R2 online immutable copy", () => {
     expect(putAttempts).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(copySuccessResponse.bodyUsed).toBe(true);
+  });
+
+  it("accepts an ECONNRESET when strong HEADs prove the copy already committed", async () => {
+    const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+    const eligible = entry(
+      `users/${boundaryNamespace}/workspace-snapshots/reset-committed.snapshot.enc`,
+      { etag: '"14141414141414141414141414141414"', size: 12 },
+    );
+    let putAttempts = 0;
+    const headPaths: string[] = [];
+    const fixture = createProductionCopyFixture(
+      eligible,
+      async (request, init, state) => {
+        const url = new URL(String(request));
+        if (init?.method === "PUT") {
+          putAttempts += 1;
+          state.destinationInventory = [marker(), eligible];
+          throw connectionReset();
+        }
+        if (init?.method === "HEAD") {
+          headPaths.push(url.pathname);
+          return exactHeadResponse(eligible);
+        }
+        throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+      },
+    );
+
+    await fixture.run();
+
+    expect(putAttempts).toBe(1);
+    expect(headPaths).toEqual([
+      `/${destinationBucket}/${eligible.key}`,
+      `/${sourceBucket}/${eligible.key}`,
+      `/${destinationBucket}/${eligible.key}`,
+      `/${sourceBucket}/${eligible.key}`,
+    ]);
+  });
+
+  it("retries one uncommitted ECONNRESET with the identical create-only request", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-30T00:00:00.000Z"));
+    try {
+      const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+      const eligible = entry(
+        `users/${boundaryNamespace}/workspace-snapshots/reset-recovery.snapshot.enc`,
+        { etag: '"15151515151515151515151515151515"', size: 12 },
+      );
+      const copyHeaders: Record<string, string | null>[] = [];
+      const putTimes: number[] = [];
+      let putAttempts = 0;
+      let markSourceHeadObserved!: () => void;
+      const sourceHeadObserved = new Promise<void>((resolve) => {
+        markSourceHeadObserved = resolve;
+      });
+      const fixture = createProductionCopyFixture(
+        eligible,
+        async (request, init, state) => {
+          const url = new URL(String(request));
+          if (init?.method === "PUT") {
+            putAttempts += 1;
+            putTimes.push(Date.now());
+            copyHeaders.push(criticalCopyHeaders(init));
+            if (putAttempts === 1) throw connectionReset();
+            state.destinationInventory = [marker(), eligible];
+            return new Response("<CopyObjectResult />", { status: 200 });
+          }
+          if (init?.method === "HEAD") {
+            if (
+              url.pathname === `/${destinationBucket}/${eligible.key}`
+              && !state.destinationInventory.includes(eligible)
+            ) {
+              return new Response(null, { status: 404 });
+            }
+            if (url.pathname === `/${sourceBucket}/${eligible.key}`) {
+              markSourceHeadObserved();
+            }
+            return exactHeadResponse(eligible);
+          }
+          throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+        },
+      );
+
+      const runPromise = fixture.run();
+      await sourceHeadObserved;
+      await vi.advanceTimersByTimeAsync(999);
+      expect(putAttempts).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await runPromise;
+
+      expect(putAttempts).toBe(2);
+      expect(putTimes).toEqual([
+        new Date("2026-07-30T00:00:00.000Z").getTime(),
+        new Date("2026-07-30T00:00:01.000Z").getTime(),
+      ]);
+      expect(copyHeaders[1]).toEqual(copyHeaders[0]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails ECONNRESET reconciliation when the planned source is missing", async () => {
+    const boundaryNamespace = createHostedStorageNamespaceId("member_1");
+    const eligible = entry(
+      `users/${boundaryNamespace}/workspace-snapshots/reset-missing-source.snapshot.enc`,
+      { etag: '"16161616161616161616161616161616"', size: 12 },
+    );
+    let putAttempts = 0;
+    const fixture = createProductionCopyFixture(eligible, async (request, init) => {
+      const url = new URL(String(request));
+      if (init?.method === "PUT") {
+        putAttempts += 1;
+        throw connectionReset();
+      }
+      if (
+        init?.method === "HEAD"
+        && url.pathname === `/${destinationBucket}/${eligible.key}`
+      ) {
+        return new Response(null, { status: 404 });
+      }
+      if (init?.method === "HEAD" && url.pathname === `/${sourceBucket}/${eligible.key}`) {
+        return new Response(null, { status: 404 });
+      }
+      throw new Error(`Unexpected online-copy fetch method: ${init?.method ?? "GET"}`);
+    });
+
+    await expect(fixture.run()).rejects.toThrow(
+      "connection reset reconciliation found the planned source object missing",
+    );
+
+    expect(putAttempts).toBe(1);
+    expect(fixture.fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("accepts one HTTP 500 when strong HEADs prove the copy already committed", async () => {


### PR DESCRIPTION
## Why this PR exists

An isolated live R2 copy rehearsal proved that Node's built-in fetch can reject a create-only CopyObject request with an exact `ECONNRESET`. The request outcome is ambiguous: R2 may or may not have committed the object. Cloudflare does not publish a maximum R2 CopyObject execution or late-commit duration, so elapsed time cannot make replay safe.

## User goal / user-visible behavior

Large online R2 copies can preserve progress when strong reads prove that the original reset-hidden request committed. If the destination remains absent, the command stops and quarantines the destination without issuing a second PUT. There is no end-user UI or interaction change; this affects the operator-only migration command.

## User experience

No user-facing effect. Production remains online. The copier's source credential is read-only, while ordinary OC writers remain active until the later explicit drain. An exact committed reset outcome is reconciled internally after a five-minute observation window; any absent or unresolved identity stops the command and requires a fresh quarantined-destination rebooking.

## Invariants

- OC remains the read-only source; the copier never issues a source write.
- Destination writes remain create-only and preserve the source ETag condition.
- There is no replay after `ECONNRESET`, because Cloudflare publishes no server-side late-commit bound.
- Reset reconciliation waits five minutes before strong destination and source HEADs.
- An exact destination plus exact source proves the original request committed and may continue.
- An absent destination, missing or changed source, conflicting destination, or HEAD failure is terminal and quarantines the destination.
- HTTP 500 keeps its separate, fully drained response and one paced recovery behavior.
- No delete or overwrite path is introduced.

## Non-obvious affected surfaces

- R2 CopyObject transport recovery: necessary because the live S3-compatible fetch boundary produced `ECONNRESET`; deterministic tests prove committed, delayed-commit, absent, and source-delete outcomes.
- HTTP 500 recovery: split back into its own helper and retains the prior identity, pacing, and one-recovery contract.
- ENAM online-cutover runbook: documents that the observation window improves liveness but is not a server-execution proof, and that abnormal-stop audits are diagnostic only.

## Architecture and reuse

- **Existing systems reused:** Existing create-only request signing, strong destination/source HEAD checks, post-copy identity validation, and HTTP 500 same-key pacing.
- **New logic:** A narrow direct-cause `ECONNRESET` classifier waits through a bounded observation window, then accepts only the already-committed original request.
- **New abstractions:** No new service, state owner, queue, journal, lock, or retry framework. Reset and HTTP 500 reconciliation are two small functions because their safe terminal contracts differ.
- **Complexity intentionally avoided:** No invented timeout-based idempotency, general transport retry policy, resume state, overwrite fallback, or destination cleanup path.

## Hot reply path impact

Not applicable. The change is isolated to an operator-run Cloudflare R2 migration script and does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, provider adapter, model configuration, skill rendering, or request-assembly surface changed.
- Group Murph: Not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: **not applicable** — no product-owned journey, semantic copy, required action, visible feedback, or user recovery flow changes.
- Prompt: **not applicable** — no prompt or provider-visible instruction surface changes.
- Frontend: **not applicable** — no `apps/web` UI or rendered state changes; no visual evidence is required.
- Coverage: **applicable** — focused proof is `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/r2-bundles-online-copy.test.ts` (68/68 passed) plus `pnpm --dir apps/cloudflare typecheck` (passed). Exact-head CI status: **passed**.

The preliminary specialist pass returned one coverage finding at `5e208489fa0`: exact reset behavior after response headers and on the sole recovery attempt lacked direct proof. The accepted test-only correction landed in `abbe68b98fc`; the inaccessible optional patch artifact was not used.

Final ReviewGPT round 1 then returned one accepted high finding: the one-second reset replay could race a still-running original request and later recreate deleted data. The correction at `72a946026a8f` removes reset replay entirely, waits before reconciliation, accepts only an exact original commit, and adds delayed-commit and source-delete regressions. Final ReviewGPT correction round 2 passed with no findings. Retrospective: not required; this is round 2, adds no state owner or new lifecycle, and the remediation source churn is below the threshold.

## Verification

- Focused copier tests: 68/68 passed.
- Cloudflare TypeScript: passed.
- Exact-head GitHub Actions: passed.
- Final ReviewGPT correction round 2: passed with no findings.
- `git diff --check`: passed.
- Privacy identifier scan of changed files: passed.

Tests cover an immediate reset-hidden commit, a delayed commit after the former one-second floor with no replay, an absent post-window destination with no replay, a delayed commit whose source was deleted, a post-header reset that cannot retry, and a reset on HTTP 500 recovery that cannot issue a third PUT.

## Change-shape breakdown

Classification rule: authored runtime TypeScript is source; Vitest files are tests/fixtures; authored Markdown is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 66 | 4 |
| Tests/fixtures | 247 | 2 |
| Docs | 32 | 17 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **345** | **23** |

ReviewGPT first-reviewed head: abbe68b98fc8e5ff99dfcfe3a9e4c619edc4a7c1