### PR TITLE
Keep consent handoff terminal until navigation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-30-consent-auth-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-consent-auth-handoff.md
@@ -1,0 +1,78 @@
+# Keep consent handoff terminal until navigation commits
+
+Status: completed
+Created: 2026-07-30
+Updated: 2026-07-30
+
+## Goal
+
+- After launch consent succeeds, keep the authenticated handoff terminal until
+  the owning navigation or route refresh replaces the dialog. The stale login
+  form must never reappear between consent and the destination.
+
+## Success criteria
+
+- A regression test proves that a successful downstream completion leaves the
+  consent handoff mounted and cannot reveal stale auth controls.
+- A failed downstream completion remains retryable without repeating consent
+  writes.
+- Declining consent still resets the panel for a fresh authentication attempt.
+- Focused web tests, web typecheck, frontend design proof, and desktop/mobile
+  browser evidence pass.
+- Exact-head CI and required ReviewGPT gates are green or any external blocker
+  is reported with evidence.
+
+## Scope
+
+- In scope: hosted auth panel consent-to-navigation state ownership, focused
+  regression coverage, and the existing design-catalog auth study.
+- Out of scope: provider authentication behavior, consent persistence, session
+  issuance, redirect destination policy, or new UI styling.
+
+## Constraints
+
+- Technical constraints: preserve retry after handoff failure, prevent duplicate
+  completion callbacks, and use the existing consent card as the only terminal
+  state owner.
+- Product/process constraints: preserve auth, launch-consent, invite, and
+  initial-visit routing invariants; use the frontend worktree/PR lane.
+
+## Risks and mitigations
+
+1. Risk: an embedded auth consumer expects the login form to reappear after a
+   successful completion callback.
+   Mitigation: inspect every callback; all current consumers navigate or refresh,
+   while failure remains the explicit retry path.
+2. Risk: retaining the consent state invokes completion twice.
+   Mitigation: clear only the pending completion ref after success and cover a
+   late requirement-change callback.
+
+## Tasks
+
+1. Add a failing regression assertion to the existing hosted-auth-panel journey.
+2. Keep the accepted consent handoff mounted after downstream completion.
+3. Expose the terminal handoff state in the existing design catalog study.
+4. Run focused tests, typecheck, design proof, and browser verification.
+5. Commit, publish a PR, and complete CI plus preliminary/final ReviewGPT gates.
+
+## Decisions
+
+- Keep the existing callback contract. Successful callbacks already own terminal
+  navigation or refresh; the panel should not invent a second post-success state.
+- Do not reset completion state on success. Reset remains decline-only because
+  decline is the sole supported path back into authentication in the same panel.
+
+## Verification
+
+- Passed: focused hosted auth, consent, and dialog-provider Vitest coverage
+  (52 tests); full `apps/web` typecheck; focused ESLint; frontend design-proof
+  script tests; and `git diff --check`.
+- Direct regression proof: the new assertion failed before the fix because the
+  phone auth form remounted, then passed after the consent state remained owned
+  through the completion handoff.
+- Browser verification gap: the isolated local web server reached ready state,
+  but no controllable browser was attached to this session, so desktop/mobile
+  screenshots and the dependent visual double-check could not run locally.
+- Remaining: committed-range design-proof validation, exact-head CI, and
+  preliminary/final ReviewGPT.
+Completed: 2026-07-30

--- a/apps/web/app/design/consent-content.tsx
+++ b/apps/web/app/design/consent-content.tsx
@@ -93,6 +93,16 @@ export function ConsentContent() {
                 variant="legal"
               />
             </div>
+            <div className="flex flex-col gap-3" inert>
+              <PreviewLabel>Accepted · opening destination</PreviewLabel>
+              <HostedLaunchConsentPrompt
+                documents={DESIGN_LAUNCH_DOCUMENTS}
+                handoffPending
+                mode="panel"
+                onContinue={() => {}}
+                onDecline={() => {}}
+              />
+            </div>
             <div className="flex flex-col gap-3">
               <PreviewLabel>Retryable error</PreviewLabel>
               <HostedLaunchConsentPrompt

--- a/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
@@ -263,7 +263,6 @@ export function HostedAuthPanel({
     if (onCompleted) {
       await onCompleted(result.payload);
       pendingAuthCompletionRef.current = null;
-      setPendingAuthCompletion(null);
       return;
     }
 

--- a/apps/web/test/hosted-auth-panel.test.ts
+++ b/apps/web/test/hosted-auth-panel.test.ts
@@ -1475,6 +1475,8 @@ test("HostedAuthPanel phone signup completion pauses on launch consent before re
   });
   expect(onCompleted).toHaveBeenCalledTimes(1);
   expect(assign).not.toHaveBeenCalled();
+  expect(container.textContent).toContain("Hosted legal consent card");
+  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeNull();
 
   await act(async () => {
     mocks.legalConsentCardProps?.onRequirementChange?.(false);
@@ -1484,7 +1486,7 @@ test("HostedAuthPanel phone signup completion pauses on launch consent before re
   expect(assign).not.toHaveBeenCalled();
 });
 
-test("HostedAuthPanel keeps consent mounted until downstream completion succeeds", async () => {
+test("HostedAuthPanel keeps consent mounted through downstream completion retry", async () => {
   const onCompleted = vi.fn()
     .mockRejectedValueOnce(new Error("Could not finish sign in."))
     .mockResolvedValueOnce(undefined);
@@ -1528,8 +1530,8 @@ test("HostedAuthPanel keeps consent mounted until downstream completion succeeds
   });
 
   expect(onCompleted).toHaveBeenCalledTimes(2);
-  expect(container.textContent).not.toContain("Hosted legal consent card");
-  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeTruthy();
+  expect(container.textContent).toContain("Hosted legal consent card");
+  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeNull();
 });
 
 function setInputValue(
@@ -1641,5 +1643,6 @@ test("HostedAuthPanel keeps Decline terminal when a late status result says cons
     joinUrl: "/join/second-invite-code",
     stage: "active",
   });
-  expect(container.textContent).not.toContain("Hosted legal consent card");
+  expect(container.textContent).toContain("Hosted legal consent card");
+  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeNull();
 });


### PR DESCRIPTION
## Why this PR exists

After launch consent succeeds, the hosted auth dialog can briefly reveal its stale login controls before the destination navigation commits. Consent completion should remain a terminal handoff.

## User goal / user-visible behavior

A person who accepts launch consent stays on the accepted consent state while Murph opens the authenticated destination. The phone, email, and alternate-login controls never reappear during that handoff.

## User experience

- Entry point: a person completes hosted authentication and reaches the existing launch-consent prompt.
- Immediate feedback: accepting consent keeps the prompt mounted and changes its action to the existing disabled `Continuing...` state.
- Timing and continuation: the existing completion callback owns the immediate cross-document navigation or route refresh; no new wait, screen, or action is introduced.
- Destination: existing signup, login, invite, and initial-visit routing remain unchanged.
- Recovery: a downstream completion failure leaves consent visible and retryable without rewriting already accepted scopes; declining still signs out and returns the same mounted panel to a fresh auth attempt.
- Local rendered evidence: the real terminal handoff state was added to the consent design catalog. Interactive desktop/mobile capture is blocked because no controllable browser is attached to the current session.

## Invariants

- First-party app session issuance and consent persistence remain server-owned and unchanged.
- A successful completion callback owns terminal navigation or refresh; the auth panel does not invent a second post-success transition.
- Failed handoff remains retryable, late consent-status callbacks cannot complete twice, and decline remains the only reset path back to authentication in the same panel.
- Signup, login, invite, accessible-stage, and initial-visit destination policy remain unchanged.

## Non-obvious affected surfaces

- Embedded group, family, sidebar, and homepage auth dialogs share the same completion contract. Every current successful callback navigates or refreshes; the focused hosted-auth-panel regression proves the shared panel cannot remount stale auth controls.
- Consent design catalog: adds the existing real `HostedLaunchConsentPrompt` terminal handoff state with synthetic props and inert controls.

## Preliminary specialist lenses

- Product experience: Applicable — the intended outcome is one continuous consent-to-destination journey. Direct journey evidence is the focused regression that failed before the fix and passed after it; rendered browser evidence is currently blocked by the missing controllable browser.
- Prompt: Not applicable — no prompt, tool description, schema, or provider input changed.
- Frontend: Applicable — the real accepted-handoff state is at `/design?tab=consent#launch-consent`; desktop/mobile screenshot artifacts are pending because this session has no controllable browser.
- Coverage: Applicable — 52 focused hosted auth, legal-consent, and dialog-provider tests pass locally; all executable exact-head CI lanes are green, while the design-proof lane is blocked on the missing screenshot URLs.

## Architecture and reuse

- Existing systems reused: the hosted auth panel completion callback, pending-completion ref, legal consent card, and its existing accepted-handoff presentation.
- New logic: none; one premature state reset is removed so the existing terminal owner stays mounted through navigation.
- New abstractions: no abstraction was added because the existing completion and consent contracts are sufficient.
- Complexity intentionally avoided: no timeout, second navigation owner, extra state machine, dependency, provider change, or session workaround.

## Hot reply path impact

Not applicable — this changes only the hosted web authentication dialog after consent; no conversation acceptance, provider start, or durable reply handoff path changes.

## Murph initial provider input impact

| Runtime | Impact |
| --- | --- |
| Individual Murph | Not applicable — no provider-visible instruction, tool, schema, wrapper, or assembly surface changed. |
| Group Murph | Not applicable — no provider-visible instruction, tool, schema, wrapper, or assembly surface changed. |

## Design proof

- Design page: `/design?tab=consent#launch-consent`
- State: accepted launch consent remains mounted with the disabled `Continuing...` action until destination handoff.
- Desktop screenshot: Blocked locally — no controllable browser is attached to this session.
- Mobile screenshot: Blocked locally — no controllable browser is attached to this session.

## Change-shape breakdown

Classification rule: production and design-catalog component files are source; Vitest is tests; the archived execution plan is docs. No binaries or generated files are committed.

ReviewGPT first-reviewed head: 9813c8e2e43f7263a0bcecc60a87a48f87146f85

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 1 |
| Tests / fixtures | 7 | 4 |
| Docs | 78 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **95** | **5** |

## Verification

- Focused regression first failed on the stale auth form, then passed after the fix.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-auth-panel.test.ts apps/web/test/hosted-legal-consent-card.test.ts apps/web/test/auth-dialog-provider.test.tsx` — 52 passed.
- Focused ESLint on the three changed web files — passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm test:frontend-design-proof` — 10 passed.
- `git diff --check` — passed.
- Exact-head CI: all executable build, typecheck, test, coverage, artifact, and overflow lanes passed; frontend design proof failed only for the required hosted desktop/mobile screenshots.
- Final ReviewGPT round 1: `ROUND_OUTCOME: PASS` with no findings at `9813c8e2e43f7263a0bcecc60a87a48f87146f85`; the review also recorded the rendered-evidence gap.
- Preliminary specialist ReviewGPT: blocked because the applicable frontend lens requires desktop/mobile evidence paths and the current session has no controllable browser.