### PR TITLE
Stack onboarding tone options vertically

### DIFF
--- a/apps/web/app/design/persona-onboarding-study.tsx
+++ b/apps/web/app/design/persona-onboarding-study.tsx
@@ -17,7 +17,7 @@ export function PersonaOnboardingStudy() {
         The production onboarding step for choosing how Murph shows up. It
         starts with one main personality, adds an optional supporting
         personality, then offers every voice with tailored recommendations
-        first.
+        first and finishes with vertically stacked tone samples.
       </p>
 
       <div className="mt-5 flex flex-col gap-5 rounded-xl border border-border bg-card p-5 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -182,7 +182,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Persona onboarding">
+      <StudySection title="Persona onboarding with stacked tone samples">
         <PersonaOnboardingStudy />
       </StudySection>
 

--- a/apps/web/src/components/murph/murph-persona-picker.tsx
+++ b/apps/web/src/components/murph/murph-persona-picker.tsx
@@ -338,7 +338,7 @@ export function MurphPersonaPicker({
     >
       <fieldset disabled={saving}>
         <legend className="sr-only">Murph tone</legend>
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-3">
           <ToneChoiceCard
             disabled={saving}
             groupId={toneGroupId}

--- a/apps/web/src/components/murph/murph-persona-picker.tsx
+++ b/apps/web/src/components/murph/murph-persona-picker.tsx
@@ -501,7 +501,7 @@ export function MurphPersonaPicker({
               ? "min(44rem, calc(100dvh - 2rem))"
               : undefined,
           maxWidth: "calc(100vw - 2rem)",
-          width: "52rem",
+          width: step === "tone" ? "42rem" : "52rem",
         }}
         className="flex min-w-0 max-h-[calc(100dvh-2rem)] flex-col gap-5 overflow-hidden p-6"
       >

--- a/apps/web/test/murph-persona-picker.test.tsx
+++ b/apps/web/test/murph-persona-picker.test.tsx
@@ -381,6 +381,10 @@ test("MurphPersonaPicker constrains its desktop dialog and left-aligns the subti
     assert.match(step.className, /min-w-0/u);
     assert.match(step.className, /overflow-x-hidden/u);
     assert.match(description.className, /text-left/u);
+    await clickControlContaining(rendered, "Continue");
+    await clickControlContaining(rendered, "Continue");
+    await clickControlContaining(rendered, "Continue");
+    assert.equal(dialog.style.width, "42rem");
   } finally {
     await rendered.cleanup();
   }

--- a/apps/web/test/murph-persona-picker.test.tsx
+++ b/apps/web/test/murph-persona-picker.test.tsx
@@ -156,6 +156,12 @@ test("MurphPersonaPicker saves the selected persona, voice, and tone atomically"
     });
     await clickControlContaining(rendered, "Continue");
     assert.match(rendered.container.textContent ?? "", /Pick Murph’s tone/u);
+    const toneOptions = rendered.container.querySelector(
+      "[data-persona-picker-step='tone'] fieldset > div",
+    );
+    assert.ok(toneOptions instanceof rendered.window.HTMLElement);
+    assert.ok(toneOptions.classList.contains("flex"));
+    assert.ok(toneOptions.classList.contains("flex-col"));
     await clickControlContaining(rendered, "Casual");
     await clickControlContaining(rendered, "Continue");
 


### PR DESCRIPTION
## Why this PR exists

The final persona-onboarding step currently spreads its two tone samples across desktop columns. This PR stacks the Formal and Casual choices vertically and gives that simple two-option step a more compact desktop dialog.

## User goal / user-visible behavior

On Step 4, users see two full-width tone sample cards in one vertical sequence inside a focused 42rem desktop dialog, then select either card and continue exactly as before. Mobile remains full-width.

## User experience

The entry point remains Step 4 of the existing persona picker, after the user chooses personality and voice. The two existing choices, labels, samples, selected state, Back action, and Continue action are unchanged. The final step changes from two columns to one stack and narrows to fit that simpler content, while Steps 1–3 retain their existing 52rem target width. There are no new words, actions, choices, screens, waits, asynchronous continuations, destinations, or recovery paths. Selection feedback remains immediate, and saving still begins only when Continue is pressed.

The real production picker was exercised through Steps 1–4 from `/design?tab=sections#onboarding-persona-picker`. At 1440×1000, the tone dialog measured 672 px wide and both cards measured 624 px wide; at 390×844, the full-width drawer remained 390 px with 358 px cards. Both viewports had zero horizontal overflow, and the mobile Back/Continue footer remained visible.

## Invariants the PR must preserve

- Tone selection remains a single accessible radio group with one selected value.
- Existing Formal/Casual copy, selection styling, focus treatment, and save behavior remain unchanged.
- Steps 1–3 retain the wider desktop dialog required by their denser choice grids.
- The tone step remains usable without clipping or horizontal overflow at desktop and mobile widths.
- The design catalog continues to render the real production component against synthetic data only.

## Non-obvious affected surfaces

None.

## Architecture and reuse

- **Existing systems reused:** The existing `MurphPersonaPicker`, `ToneChoiceCard`, responsive drawer/dialog shell, Tailwind spacing tokens, and persona-onboarding design study remain the sole owners.
- **New logic:** The tone-choice wrapper uses the established `flex flex-col gap-3` list pattern, and the existing desktop dialog width style selects 42rem only for the tone step while retaining 52rem elsewhere.
- **New abstractions:** No abstraction was added because the existing step state and dialog style boundary are sufficient.
- **Complexity intentionally avoided:** No duplicate component, breakpoint condition, new state, animation, CSS override, or dependency was introduced.

## Hot reply path impact

Not applicable. This is a client-side onboarding layout change and does not touch the Foreground Reply Critical Path, database calls, provider calls, or durable reply handoff.

## Murph initial provider input impact

- **Individual Murph:** Not applicable. No prompt, tool/schema, skill, model configuration, request builder, provider adapter, or provider-visible wrapper changed.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Product experience:** Not applicable. The user purpose, copy, actions, choices, state transitions, timing, and recovery behavior are unchanged; the direct journey proof covers the existing Step 1→4 flow.
- **Prompt:** Not applicable. No assistant/provider prompt or messaging surface changed.
- **Frontend:** Applicable. `desktop.png` proves the compact Step 4 dialog at 1440×1000, and `mobile.png` proves the unchanged Step 4 drawer at 390×844; both are embedded below from redacted synthetic catalog data.
- **Coverage:** Applicable. Focused component coverage passed with 7 tests, including regression assertions for the vertical wrapper, the retained 52rem content-step width, and the 42rem tone-step width; exact-head GitHub Actions completed successfully.

## Change-shape breakdown

Classification rule: production component and design-catalog files are source; component regressions are tests/fixtures; no binary or generated file is included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 4 |
| Tests/fixtures | 10 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **14** | **4** |

## Verification

- `pnpm exec vitest run apps/web/test/murph-persona-picker.test.tsx --config apps/web/vitest.workspace.ts --no-coverage` — 7 passed.
- `pnpm --dir apps/web typecheck` with the isolated worktree database — passed on the new head.
- Scoped ESLint for the changed files — passed.
- `pnpm test:frontend-design-proof` — 10 passed.
- Live PR-body frontend design-proof checker — passed on the exact PR head.
- Playwright Step 1→4 desktop/mobile scenario with exact 672 px desktop tone width, stacked-card geometry, and no-overflow assertions — passed.
- Claude Code Fable UI double-check — rerun after the compact-width refinement; `NO FINDINGS`.
- Preliminary ReviewGPT specialist pass — `PASS`, no findings, no patch artifact. Per the completion workflow, the substantive preliminary pass was not rerun for the later bounded presentation refinement.
- Exact-head GitHub Actions — 12 successful, 1 skipped, and no failures; the isolated private-media expiry flake passed on a failed-job rerun after a 10/10 local reproduction.

## Design proof

- Design page: `/design?tab=sections#onboarding-persona-picker`
- Desktop screenshot: ![Compact desktop persona tone dialog with vertically stacked options](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/aa671c5c-b5d1-477c-9ee5-d4a906823300/public)
- Mobile screenshot: ![Mobile persona tone options stacked vertically](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/832bd5c3-c4d1-4091-2092-ac6a0d61b800/public)

