### PR TITLE
Keep Environment voice processing status live

### DIFF
--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -278,7 +278,9 @@ export default function EnvironmentPageClient({
             baselineValues: valuesSignature,
             status: "processing",
           });
-          void refresh({ background: true });
+          void requestEnvironmentVoiceProcessingRecheck().finally(() =>
+            refresh({ background: true }).catch(() => undefined)
+          );
         }}
       />
       {hasEnvironmentData ? (
@@ -342,6 +344,15 @@ async function readEnvironmentVoiceProcessingStatus(): Promise<boolean | null> {
     return null;
   }
   return null;
+}
+
+async function requestEnvironmentVoiceProcessingRecheck(): Promise<void> {
+  const response = await fetch("/api/environment/voice", {
+    method: "PATCH",
+  });
+  if (!response.ok) {
+    throw new Error("Environment voice processing recheck failed.");
+  }
 }
 
 function EnvironmentShell({

--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -13,7 +13,7 @@ import {
   normalizeHabitatCityOrRegion,
 } from "@murphai/contracts";
 import Image from "next/image";
-import { ArrowRight, ShieldCheck } from "lucide-react";
+import { ArrowRight, LoaderCircle, ShieldCheck } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
@@ -47,6 +47,7 @@ const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 } as const;
 const EMPTY_HABITAT_VALUES: HabitatValues = {};
 const EMPTY_HABITAT_SCENE = resolveHabitatScene(EMPTY_HABITAT_VALUES);
 const VOICE_REFRESH_INTERVAL_MS = 2_000;
+const VOICE_REFRESH_DELAYED_INTERVAL_MS = 10_000;
 const VOICE_REFRESH_WINDOW_MS = 2 * 60 * 1_000;
 
 export type VoiceRefreshState =
@@ -87,6 +88,8 @@ export default function EnvironmentPageClient({
     useState<VoiceRefreshState>({ status: "idle" });
   const checkedInitialVoiceProcessingRef = useRef(false);
   const initialVoiceProcessingCheckRef = useRef(0);
+  const voiceRefreshBaselineRef = useRef<string | null>(null);
+  const voiceRefreshStartedAtRef = useRef<number | null>(null);
   const values = useMemo(
     () => (client ? selectEnvironmentHabitatValues(client) : {}),
     [client],
@@ -115,6 +118,8 @@ export default function EnvironmentPageClient({
     displayedVoiceRefreshState.status === "processing" ||
     displayedVoiceRefreshState.status === "delayed";
   const onVoiceAccepted = useCallback(() => {
+    voiceRefreshBaselineRef.current = valuesSignature;
+    voiceRefreshStartedAtRef.current = Date.now();
     setVoiceRefreshState({
       baselineValues: valuesSignature,
       status: "processing",
@@ -136,6 +141,8 @@ export default function EnvironmentPageClient({
       }
       checkedInitialVoiceProcessingRef.current = true;
       if (processing === true) {
+        voiceRefreshBaselineRef.current = valuesSignature;
+        voiceRefreshStartedAtRef.current = Date.now();
         setVoiceRefreshState((current) =>
           current.status === "idle"
             ? {
@@ -154,18 +161,16 @@ export default function EnvironmentPageClient({
   }, [status, valuesSignature]);
 
   useEffect(() => {
-    if (voiceRefreshState.status !== "processing") {
+    if (
+      voiceRefreshState.status !== "processing"
+      && voiceRefreshState.status !== "delayed"
+    ) {
       return;
     }
     let cancelled = false;
-    const startedAt = Date.now();
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const poll = async () => {
       if (cancelled) {
-        return;
-      }
-      if (Date.now() - startedAt >= VOICE_REFRESH_WINDOW_MS) {
-        setVoiceRefreshState({ status: "delayed" });
         return;
       }
       const processing = await readEnvironmentVoiceProcessingStatus();
@@ -180,11 +185,32 @@ export default function EnvironmentPageClient({
                 baselineValues: current.baselineValues,
                 status: "completed",
               }
+            : current.status === "delayed"
+              ? {
+                  baselineValues:
+                    voiceRefreshBaselineRef.current ?? valuesSignature,
+                  status: "completed",
+                }
             : current,
         );
         return;
       }
-      timeoutId = setTimeout(() => void poll(), VOICE_REFRESH_INTERVAL_MS);
+      if (
+        voiceRefreshState.status === "processing"
+        && Date.now() - (
+          voiceRefreshStartedAtRef.current ?? Date.now()
+        ) >= VOICE_REFRESH_WINDOW_MS
+      ) {
+        voiceRefreshBaselineRef.current = voiceRefreshState.baselineValues;
+        setVoiceRefreshState({ status: "delayed" });
+        return;
+      }
+      timeoutId = setTimeout(
+        () => void poll(),
+        voiceRefreshState.status === "delayed"
+          ? VOICE_REFRESH_DELAYED_INTERVAL_MS
+          : VOICE_REFRESH_INTERVAL_MS,
+      );
     };
     timeoutId = setTimeout(() => void poll(), VOICE_REFRESH_INTERVAL_MS);
     return () => {
@@ -193,7 +219,7 @@ export default function EnvironmentPageClient({
         clearTimeout(timeoutId);
       }
     };
-  }, [refresh, voiceRefreshState]);
+  }, [refresh, valuesSignature, voiceRefreshState]);
 
   if (status === "loading") {
     return (
@@ -246,6 +272,8 @@ export default function EnvironmentPageClient({
       <EnvironmentVoiceRefreshNotice
         state={displayedVoiceRefreshState}
         onCheckAgain={() => {
+          voiceRefreshBaselineRef.current = valuesSignature;
+          voiceRefreshStartedAtRef.current = Date.now();
           setVoiceRefreshState({
             baselineValues: valuesSignature,
             status: "processing",
@@ -614,7 +642,13 @@ export function EnvironmentVoiceRefreshNotice({
   if (state.status === "processing") {
     return (
       <Alert aria-live="polite">
-        <AlertTitle>Murph is processing your recording</AlertTitle>
+        <AlertTitle className="flex items-center gap-2">
+          <LoaderCircle
+            aria-hidden="true"
+            className="size-4 animate-spin text-primary motion-reduce:animate-none"
+          />
+          Murph is processing your recording
+        </AlertTitle>
         <AlertDescription>
           This report will refresh automatically when the clear facts are ready.
         </AlertDescription>
@@ -639,7 +673,13 @@ export function EnvironmentVoiceRefreshNotice({
   }
   return (
     <Alert aria-live="polite">
-      <AlertTitle>Murph is taking longer than usual</AlertTitle>
+      <AlertTitle className="flex items-center gap-2">
+        <LoaderCircle
+          aria-hidden="true"
+          className="size-4 animate-spin text-primary motion-reduce:animate-none"
+        />
+        Murph is taking longer than usual
+      </AlertTitle>
       <AlertDescription>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <span>

--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -15,6 +15,7 @@ import {
 import Image from "next/image";
 import { ArrowRight, LoaderCircle, ShieldCheck } from "lucide-react";
 
+import { MurphContactDialog } from "@/src/components/murph/murph-contact-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
 import { PageHeader } from "@/src/components/ui/page-header";
@@ -74,9 +75,9 @@ const EMPTY_CATEGORY_SUMMARIES: Readonly<Record<string, string>> = {
 };
 
 export default function EnvironmentPageClient({
-  contactAction,
+  contactOptions,
 }: {
-  contactAction: MurphContactOption | null;
+  contactOptions: readonly MurphContactOption[];
 }) {
   const {
     client,
@@ -290,14 +291,14 @@ export default function EnvironmentPageClient({
           notes={notes}
           grade={grade}
           coverage={coverage}
-          contactAction={contactAction}
+          contactOptions={contactOptions}
           conditions={conditions}
           onVoiceAccepted={onVoiceAccepted}
           voiceCaptureDisabled={voiceCaptureDisabled}
         />
       ) : (
         <EnvironmentEmptyState
-          contactAction={contactAction}
+          contactOptions={contactOptions}
           onVoiceAccepted={onVoiceAccepted}
           processing={voiceCaptureDisabled}
           script={voiceScript}
@@ -380,12 +381,12 @@ function EnvironmentShell({
 }
 
 export function EnvironmentEmptyState({
-  contactAction,
+  contactOptions,
   onVoiceAccepted,
   processing = false,
   script = buildEnvironmentVoiceScript(EMPTY_HABITAT_VALUES),
 }: {
-  contactAction: MurphContactOption | null;
+  contactOptions: readonly MurphContactOption[];
   onVoiceAccepted?: () => void;
   processing?: boolean;
   script?: EnvironmentVoiceScript;
@@ -430,17 +431,11 @@ export function EnvironmentEmptyState({
                     : "Update by voice"
               }
             />
-            {contactAction ? (
-              <a
-                href={contactAction.href}
-                target={contactAction.target}
-                rel={contactAction.rel}
-                className="inline-flex min-h-11 items-center gap-1.5 text-base font-medium text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground sm:min-h-0 sm:text-sm"
-              >
-                Prefer typing? Use chat
-                <ArrowRight className="size-4 shrink-0" aria-hidden="true" />
-              </a>
-            ) : null}
+            <EnvironmentChatAction
+              contactOptions={contactOptions}
+              label="Prefer typing? Use chat"
+              presentation="link"
+            />
           </div>
 
           <p className="mt-7 max-w-[58ch] text-pretty text-base text-muted-foreground sm:text-sm">
@@ -488,7 +483,7 @@ function EnvironmentReport({
   notes,
   grade,
   coverage,
-  contactAction,
+  contactOptions,
   conditions,
   onVoiceAccepted,
   voiceCaptureDisabled,
@@ -498,11 +493,12 @@ function EnvironmentReport({
   notes: ReturnType<typeof deriveCategoryNote>[];
   grade: ReturnType<typeof overallGrade>;
   coverage: ReturnType<typeof resolveEnvironmentCoverage>;
-  contactAction: MurphContactOption | null;
+  contactOptions: readonly MurphContactOption[];
   conditions: { outdoorAir: string; weather: string };
   onVoiceAccepted: () => void;
   voiceCaptureDisabled: boolean;
 }) {
+  const contactAction = contactOptions[0] ?? null;
   const nextChecks = buildNextChecks(scene, notes);
   const noteByCategoryId = new Map(notes.map((note) => [note.id, note]));
   const voiceScript = buildEnvironmentVoiceScript(values);
@@ -524,7 +520,7 @@ function EnvironmentReport({
       />
 
       <EnvironmentCaptureCard
-        contactAction={contactAction}
+        contactOptions={contactOptions}
         coverage={coverage.coverage}
         known={coverage.known}
         script={voiceScript}
@@ -554,14 +550,14 @@ function EnvironmentReport({
 }
 
 export function EnvironmentCaptureCard({
-  contactAction,
+  contactOptions,
   coverage,
   known,
   script,
   onVoiceAccepted,
   processing = false,
 }: {
-  contactAction: MurphContactOption | null;
+  contactOptions: readonly MurphContactOption[];
   coverage: number;
   known: number;
   script: EnvironmentVoiceScript;
@@ -618,25 +614,87 @@ export function EnvironmentCaptureCard({
           }
           triggerVariant={updating ? "outline" : "default"}
         />
-        {contactAction ? (
-          <Button
-            size="default"
-            variant="ghost"
-            render={
-              <a
-                href={contactAction.href}
-                target={contactAction.target}
-                rel={contactAction.rel}
-              />
-            }
-            nativeButton={false}
-          >
-            {updating ? "Update in chat" : "Chat instead"}
-            <ArrowRight className="size-4" aria-hidden="true" />
-          </Button>
-        ) : null}
+        <EnvironmentChatAction
+          contactOptions={contactOptions}
+          label={updating ? "Update in chat" : "Chat instead"}
+          presentation="button"
+        />
       </div>
     </section>
+  );
+}
+
+function EnvironmentChatAction({
+  contactOptions,
+  label,
+  presentation,
+}: {
+  contactOptions: readonly MurphContactOption[];
+  label: string;
+  presentation: "button" | "link";
+}) {
+  if (contactOptions.length === 0) {
+    return null;
+  }
+
+  const content = (
+    <>
+      {label}
+      <ArrowRight className="size-4 shrink-0" aria-hidden="true" />
+    </>
+  );
+  const contactAction = contactOptions[0];
+
+  if (contactOptions.length === 1 && contactAction) {
+    if (presentation === "link") {
+      return (
+        <a
+          href={contactAction.href}
+          target={contactAction.target}
+          rel={contactAction.rel}
+          className="inline-flex min-h-11 items-center gap-1.5 text-base font-medium text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground sm:min-h-0 sm:text-sm"
+        >
+          {content}
+        </a>
+      );
+    }
+    return (
+      <Button
+        size="default"
+        variant="ghost"
+        render={
+          <a
+            href={contactAction.href}
+            target={contactAction.target}
+            rel={contactAction.rel}
+          />
+        }
+        nativeButton={false}
+      >
+        {content}
+      </Button>
+    );
+  }
+
+  return (
+    <MurphContactDialog
+      options={contactOptions}
+      trigger={(open) =>
+        presentation === "link" ? (
+          <button
+            type="button"
+            className="inline-flex min-h-11 items-center gap-1.5 text-base font-medium text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground sm:min-h-0 sm:text-sm"
+            onClick={open}
+          >
+            {content}
+          </button>
+        ) : (
+          <Button size="default" variant="ghost" onClick={open}>
+            {content}
+          </Button>
+        )
+      }
+    />
   );
 }
 

--- a/apps/web/app/(dashboard)/environment/page.tsx
+++ b/apps/web/app/(dashboard)/environment/page.tsx
@@ -20,23 +20,21 @@ export const metadata: Metadata = createMurphPageMetadata({
 });
 
 export default async function EnvironmentPage() {
-  const contactAction = await resolveEnvironmentContactAction();
-  return <EnvironmentPageClient contactAction={contactAction} />;
+  const contactOptions = await resolveEnvironmentContactOptions();
+  return <EnvironmentPageClient contactOptions={contactOptions} />;
 }
 
-async function resolveEnvironmentContactAction() {
+async function resolveEnvironmentContactOptions() {
   try {
     const options = await resolveHostedMurphContactOptions({
       message: {
         body: "I want to update what you know about my home environment.",
       },
     });
-    return (
-      options.find(
-        (option) => option.kind === "text" || option.kind === "telegram",
-      ) ?? null
+    return options.filter(
+      (option) => option.kind === "text" || option.kind === "telegram",
     );
   } catch {
-    return null;
+    return [];
   }
 }

--- a/apps/web/app/api/environment/voice/route.ts
+++ b/apps/web/app/api/environment/voice/route.ts
@@ -25,7 +25,10 @@ import {
   HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
   lockHostedMemberRow,
 } from "@/src/lib/hosted-onboarding/shared";
-import { signalHostedMailboxAppendRuntime } from "@/src/lib/hosted-orchestration/signal-runtime";
+import {
+  signalHostedMailboxAppendRuntime,
+  signalHostedRuntimeRecheckRuntime,
+} from "@/src/lib/hosted-orchestration/signal-runtime";
 import { resolveHostedRuntimeAiUsageGate } from "@/src/lib/hosted-orchestration/runtime-usage-decision";
 import { readRawBodyBuffer } from "@/src/lib/http";
 import { getPrisma } from "@/src/lib/prisma";
@@ -41,6 +44,21 @@ export const GET = withJsonError(async (request: Request) => {
     userId: auth.member.id,
   });
   return jsonOk({ processing });
+});
+
+export const PATCH = withJsonError(async (request: Request) => {
+  assertHostedOnboardingMutationOrigin(request);
+  const auth = await requireActiveHostedAppSessionFromRequest(request);
+  const processing = await hasPendingHostedEnvironmentVoiceMailboxItem({
+    userId: auth.member.id,
+  });
+  if (processing) {
+    await signalHostedRuntimeRecheckRuntime({ userId: auth.member.id });
+  }
+  return jsonOk({
+    processing,
+    recheckRequested: processing,
+  });
 });
 
 export const POST = withJsonError(async (request: Request) => {

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -868,11 +868,18 @@ export function ComponentsContent() {
               will build without showing empty scores or missing facts.
             </p>
             <EnvironmentEmptyState
-              contactAction={{
-                href: "sms:+15555550100?body=I%20want%20to%20update%20what%20you%20know%20about%20my%20home%20environment.",
-                kind: "text",
-                label: "Text Murph",
-              }}
+              contactOptions={[
+                {
+                  href: "sms:+15555550100?body=I%20want%20to%20update%20what%20you%20know%20about%20my%20home%20environment.",
+                  kind: "text",
+                  label: "Messages",
+                },
+                {
+                  href: "https://t.me/withmurph_bot",
+                  kind: "telegram",
+                  label: "Telegram",
+                },
+              ]}
             />
           </Section>
         </div>
@@ -890,7 +897,7 @@ export function ComponentsContent() {
               built only from facts Murph still does not know.
             </p>
             <EnvironmentCaptureCard
-              contactAction={null}
+              contactOptions={[]}
               coverage={70}
               known={21}
               script={DESIGN_ENVIRONMENT_GAP_SCRIPT}

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -909,7 +909,8 @@ export function ComponentsContent() {
             <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
               The open report keeps ownership after upload: processing,
               updated, no-clear-facts, and delayed recovery remain visible
-              without requiring a reload.
+              without requiring a reload. Processing stays animated, and the
+              delayed action rechecks the existing accepted job.
             </p>
             <div className="grid gap-4">
               <EnvironmentVoiceRefreshNotice

--- a/apps/web/app/design/environment-progress-study.tsx
+++ b/apps/web/app/design/environment-progress-study.tsx
@@ -5,11 +5,18 @@ import {
 } from "../(dashboard)/environment/environment-page-client";
 import type { EnvironmentVoiceScript } from "../(dashboard)/environment/environment-voice-script";
 
-const DESIGN_CONTACT_ACTION = {
-  href: "sms:+15555550100",
-  kind: "text" as const,
-  label: "Text Murph",
-};
+const DESIGN_CONTACT_OPTIONS = [
+  {
+    href: "sms:+15555550100",
+    kind: "text" as const,
+    label: "Messages",
+  },
+  {
+    href: "https://t.me/withmurph_bot",
+    kind: "telegram" as const,
+    label: "Telegram",
+  },
+];
 
 const GAP_SCRIPTS: Readonly<Record<10 | 30 | 70, EnvironmentVoiceScript>> = {
   10: gapScript([
@@ -61,11 +68,11 @@ export function EnvironmentProgressStudy() {
       inert
     >
       <StudyState label="0% · First walkthrough">
-        <EnvironmentEmptyState contactAction={DESIGN_CONTACT_ACTION} />
+        <EnvironmentEmptyState contactOptions={DESIGN_CONTACT_OPTIONS} />
       </StudyState>
       <StudyState label="10% · Build the core picture">
         <EnvironmentCaptureCard
-          contactAction={DESIGN_CONTACT_ACTION}
+          contactOptions={DESIGN_CONTACT_OPTIONS}
           coverage={10}
           known={3}
           script={GAP_SCRIPTS[10]}
@@ -73,7 +80,7 @@ export function EnvironmentProgressStudy() {
       </StudyState>
       <StudyState label="30% · Continue from known facts">
         <EnvironmentCaptureCard
-          contactAction={DESIGN_CONTACT_ACTION}
+          contactOptions={DESIGN_CONTACT_OPTIONS}
           coverage={30}
           known={9}
           script={GAP_SCRIPTS[30]}
@@ -81,7 +88,7 @@ export function EnvironmentProgressStudy() {
       </StudyState>
       <StudyState label="70% · Ask only for remaining gaps">
         <EnvironmentCaptureCard
-          contactAction={DESIGN_CONTACT_ACTION}
+          contactOptions={DESIGN_CONTACT_OPTIONS}
           coverage={70}
           known={21}
           script={GAP_SCRIPTS[70]}
@@ -89,7 +96,7 @@ export function EnvironmentProgressStudy() {
       </StudyState>
       <StudyState label="100% · Free-form update">
         <EnvironmentCaptureCard
-          contactAction={DESIGN_CONTACT_ACTION}
+          contactOptions={DESIGN_CONTACT_OPTIONS}
           coverage={100}
           known={30}
           script={UPDATE_SCRIPT}

--- a/apps/web/src/components/dashboard/sidebar-chat-contact-dialog.tsx
+++ b/apps/web/src/components/dashboard/sidebar-chat-contact-dialog.tsx
@@ -1,158 +1,39 @@
 "use client";
 
-import {
-  Check,
-  ChevronRight,
-  Copy,
-  ExternalLink,
-  Mail,
-  MessageCircle,
-  Send,
-} from "lucide-react";
-import { useState } from "react";
+import { MessageCircle } from "lucide-react";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/src/components/ui/dialog";
+import { MurphContactDialog } from "@/src/components/murph/murph-contact-dialog";
 import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/src/components/ui/sidebar";
-import type {
-  MurphContactKind,
-  MurphContactOption,
-} from "@/src/lib/murph-contact-routing";
+import type { MurphContactOption } from "@/src/lib/murph-contact-routing";
 import {
   SIDEBAR_NAV_ICON_CLASS,
   SIDEBAR_NAV_ITEM_CLASS,
 } from "./sidebar-nav-classes";
-
-const CONTACT_OPTION_ICONS = {
-  email: Mail,
-  telegram: Send,
-  text: MessageCircle,
-} as const;
 
 export function SidebarChatWithMurphContactDialog({
   options,
 }: {
   options: MurphContactOption[];
 }) {
-  const [open, setOpen] = useState(false);
-  const [copiedKind, setCopiedKind] = useState<MurphContactKind | null>(null);
-
-  const copyOptionValue = async (option: MurphContactOption) => {
-    if (!option.copyValue) {
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(option.copyValue);
-    } catch {
-      return;
-    }
-
-    setCopiedKind(option.kind);
-    setTimeout(() => {
-      setCopiedKind((kind) => (kind === option.kind ? null : kind));
-    }, 2000);
-  };
-
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton
-        size="lg"
-        className={SIDEBAR_NAV_ITEM_CLASS}
-        aria-label="Chat with Murph"
-        onClick={() => setOpen(true)}
-      >
-        <MessageCircle className={SIDEBAR_NAV_ICON_CLASS} />
-        Chat with Murph
-      </SidebarMenuButton>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-md p-6 md:p-7">
-          <DialogHeader className="pr-10">
-            <DialogTitle className="text-xl font-bold tracking-tight text-foreground">
-              Chat with Murph
-            </DialogTitle>
-            <DialogDescription>
-              Pick how you want to reach Murph.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-2">
-            {options.map((option) => {
-              const Icon = CONTACT_OPTION_ICONS[option.kind];
-              const opensInNewTab = option.target === "_blank";
-              const copied = copiedKind === option.kind;
-              const hasWebmail = Boolean(option.webmail);
-
-              return (
-                <div
-                  key={option.kind}
-                  className="overflow-hidden rounded-lg border border-border bg-card"
-                >
-                  <div className="relative flex items-center pr-3 transition-colors hover:bg-accent/55">
-                    <a
-                      href={option.href}
-                      target={option.target}
-                      rel={option.rel}
-                      aria-label={`Chat with Murph in ${option.label}${
-                        opensInNewTab ? " (opens in a new tab)" : ""
-                      }`}
-                      className={`flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-sm font-medium text-foreground outline-none after:absolute after:inset-0 after:content-[''] focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-ring ${
-                        hasWebmail
-                          ? "rounded-t-lg after:rounded-t-lg"
-                          : "rounded-lg after:rounded-lg"
-                      }`}
-                      onClick={() => setOpen(false)}
-                    >
-                      <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                      <span className="min-w-0 truncate">{option.label}</span>
-                    </a>
-                    {option.copyValue ? (
-                      <button
-                        type="button"
-                        className="relative z-10 mr-2 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                        aria-label={
-                          copied ? "Copied" : `Copy ${option.label} contact info`
-                        }
-                        title={copied ? "Copied" : `Copy ${option.label}`}
-                        onClick={() => void copyOptionValue(option)}
-                      >
-                        {copied ? (
-                          <Check className="size-3.5" aria-hidden="true" />
-                        ) : (
-                          <Copy className="size-3.5" aria-hidden="true" />
-                        )}
-                      </button>
-                    ) : null}
-                    <ChevronRight
-                      className="size-4 shrink-0 text-muted-foreground"
-                      aria-hidden="true"
-                    />
-                  </div>
-                  {option.webmail ? (
-                    <a
-                      href={option.webmail.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="relative z-10 flex w-full items-center gap-1.5 rounded-t-none rounded-b-lg border-t border-border bg-muted/40 px-11 py-2 text-xs font-medium text-muted-foreground transition-colors outline-none hover:bg-accent/55 hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-                      onClick={() => setOpen(false)}
-                    >
-                      Open in {option.webmail.label}
-                      <ExternalLink className="size-3 shrink-0" aria-hidden="true" />
-                    </a>
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <MurphContactDialog
+        options={options}
+        trigger={(open) => (
+          <SidebarMenuButton
+            size="lg"
+            className={SIDEBAR_NAV_ITEM_CLASS}
+            aria-label="Chat with Murph"
+            onClick={open}
+          >
+            <MessageCircle className={SIDEBAR_NAV_ICON_CLASS} />
+            Chat with Murph
+          </SidebarMenuButton>
+        )}
+      />
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/murph/murph-contact-dialog.tsx
+++ b/apps/web/src/components/murph/murph-contact-dialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import {
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Mail,
+  MessageCircle,
+  Send,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import type {
+  MurphContactKind,
+  MurphContactOption,
+} from "@/src/lib/murph-contact-routing";
+
+const CONTACT_OPTION_ICONS = {
+  email: Mail,
+  telegram: Send,
+  text: MessageCircle,
+} as const;
+
+export function MurphContactDialog({
+  options,
+  trigger,
+}: {
+  options: readonly MurphContactOption[];
+  trigger: (open: () => void) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copiedKind, setCopiedKind] = useState<MurphContactKind | null>(null);
+
+  const copyOptionValue = async (option: MurphContactOption) => {
+    if (!option.copyValue) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(option.copyValue);
+    } catch {
+      return;
+    }
+
+    setCopiedKind(option.kind);
+    setTimeout(() => {
+      setCopiedKind((kind) => (kind === option.kind ? null : kind));
+    }, 2000);
+  };
+
+  return (
+    <>
+      {trigger(() => setOpen(true))}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md p-6 md:p-7">
+          <DialogHeader className="pr-10">
+            <DialogTitle className="text-xl font-bold tracking-tight text-foreground">
+              Chat with Murph
+            </DialogTitle>
+            <DialogDescription>
+              Pick how you want to reach Murph.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            {options.map((option) => {
+              const Icon = CONTACT_OPTION_ICONS[option.kind];
+              const opensInNewTab = option.target === "_blank";
+              const copied = copiedKind === option.kind;
+              const hasWebmail = Boolean(option.webmail);
+
+              return (
+                <div
+                  key={option.kind}
+                  className="overflow-hidden rounded-lg border border-border bg-card"
+                >
+                  <div className="relative flex items-center pr-3 transition-colors hover:bg-accent/55">
+                    <a
+                      href={option.href}
+                      target={option.target}
+                      rel={option.rel}
+                      aria-label={`Chat with Murph in ${option.label}${
+                        opensInNewTab ? " (opens in a new tab)" : ""
+                      }`}
+                      className={`flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-sm font-medium text-foreground outline-none after:absolute after:inset-0 after:content-[''] focus-visible:after:ring-2 focus-visible:after:ring-inset focus-visible:after:ring-ring ${
+                        hasWebmail
+                          ? "rounded-t-lg after:rounded-t-lg"
+                          : "rounded-lg after:rounded-lg"
+                      }`}
+                      onClick={() => setOpen(false)}
+                    >
+                      <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                      <span className="min-w-0 truncate">{option.label}</span>
+                    </a>
+                    {option.copyValue ? (
+                      <button
+                        type="button"
+                        className="relative z-10 mr-2 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label={
+                          copied ? "Copied" : `Copy ${option.label} contact info`
+                        }
+                        title={copied ? "Copied" : `Copy ${option.label}`}
+                        onClick={() => void copyOptionValue(option)}
+                      >
+                        {copied ? (
+                          <Check className="size-3.5" aria-hidden="true" />
+                        ) : (
+                          <Copy className="size-3.5" aria-hidden="true" />
+                        )}
+                      </button>
+                    ) : null}
+                    <ChevronRight
+                      className="size-4 shrink-0 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  {option.webmail ? (
+                    <a
+                      href={option.webmail.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="relative z-10 flex w-full items-center gap-1.5 rounded-t-none rounded-b-lg border-t border-border bg-muted/40 px-11 py-2 text-xs font-medium text-muted-foreground transition-colors outline-none hover:bg-accent/55 hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                      onClick={() => setOpen(false)}
+                    >
+                      Open in {option.webmail.label}
+                      <ExternalLink className="size-3 shrink-0" aria-hidden="true" />
+                    </a>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/test/environment-capture-card.test.tsx
+++ b/apps/web/test/environment-capture-card.test.tsx
@@ -44,7 +44,7 @@ const UPDATE_SCRIPT: EnvironmentVoiceScript = {
 test("partial reports offer to fill only what is missing", async () => {
   const rendered = await renderClientComponent(
     createElement(EnvironmentCaptureCard, {
-      contactAction: null,
+      contactOptions: [],
       coverage: 30,
       known: 9,
       script: GAP_SCRIPT,
@@ -65,7 +65,7 @@ test("partial reports offer to fill only what is missing", async () => {
 test("complete reports offer a free-form update instead of more questions", async () => {
   const rendered = await renderClientComponent(
     createElement(EnvironmentCaptureCard, {
-      contactAction: null,
+      contactOptions: [],
       coverage: 100,
       known: 30,
       script: UPDATE_SCRIPT,
@@ -85,7 +85,7 @@ test("complete reports offer a free-form update instead of more questions", asyn
 test("an empty-looking profile still respects previously declined facts", async () => {
   const rendered = await renderClientComponent(
     createElement(EnvironmentEmptyState, {
-      contactAction: null,
+      contactOptions: [],
       script: GAP_SCRIPT,
     }),
     {
@@ -100,6 +100,43 @@ test("an empty-looking profile still respects previously declined facts", async 
     const bodyText = rendered.window.document.body.textContent ?? "";
     assert.match(bodyText, /Continue the walkthrough/);
     assert.doesNotMatch(bodyText, /Start the 2-minute walkthrough/);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("chat instead uses the channel picker when several chat channels are connected", async () => {
+  const rendered = await renderClientComponent(
+    createElement(EnvironmentCaptureCard, {
+      contactOptions: [
+        {
+          href: "sms:+15550100001",
+          kind: "text",
+          label: "Messages",
+        },
+        {
+          href: "https://t.me/withmurph_bot",
+          kind: "telegram",
+          label: "Telegram",
+          rel: "noopener noreferrer",
+          target: "_blank",
+        },
+      ],
+      coverage: 30,
+      known: 9,
+      script: GAP_SCRIPT,
+    }),
+  );
+
+  try {
+    const chatButton = [...rendered.container.querySelectorAll("button")].find(
+      (candidate) => candidate.textContent?.includes("Chat instead"),
+    );
+    assert.ok(chatButton);
+
+    assert.equal(chatButton.tagName, "BUTTON");
+    assert.equal(chatButton.closest("a"), null);
+    assert.equal(rendered.container.querySelector('a[href^="sms:"]'), null);
   } finally {
     await rendered.cleanup();
   }

--- a/apps/web/test/environment-voice-refresh.test.tsx
+++ b/apps/web/test/environment-voice-refresh.test.tsx
@@ -184,7 +184,10 @@ test("keeps checking after processing takes longer than two minutes", async () =
   mocks.refresh.mockClear();
   const originalFetch = globalThis.fetch;
   let processing = true;
-  const fetchMock = vi.fn(async () => Response.json({ processing }));
+  const fetchMock = vi.fn(async (
+    _input: string | URL | Request,
+    _init?: RequestInit,
+  ) => Response.json({ processing }));
   globalThis.fetch = fetchMock;
   const rendered = await renderClientComponent(
     createElement(EnvironmentPageClient, { contactAction: null }),
@@ -209,10 +212,22 @@ test("keeps checking after processing takes longer than two minutes", async () =
       /Murph is taking longer than usual/,
     );
     const callsAtDelay = fetchMock.mock.calls.length;
+    const checkAgain = Array.from(
+      rendered.window.document.querySelectorAll("button"),
+    ).find((button) => button.textContent?.includes("Check again"));
+    assert.ok(checkAgain instanceof rendered.window.HTMLButtonElement);
+
+    await act(async () => {
+      checkAgain.click();
+      await Promise.resolve();
+    });
+    assert.ok(fetchMock.mock.calls.some(([input, init]) =>
+      input === "/api/environment/voice" && init?.method === "PATCH"
+    ));
 
     processing = false;
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(2_000);
     });
 
     assert.ok(fetchMock.mock.calls.length > callsAtDelay);

--- a/apps/web/test/environment-voice-refresh.test.tsx
+++ b/apps/web/test/environment-voice-refresh.test.tsx
@@ -58,7 +58,7 @@ test("keeps processing through intermediate checkpoints until the voice job fini
   );
   globalThis.fetch = fetchMock;
   const rendered = await renderClientComponent(
-    createElement(EnvironmentPageClient, { contactAction: null }),
+    createElement(EnvironmentPageClient, { contactOptions: [] }),
     {
       location: {
         hash: "",
@@ -96,7 +96,7 @@ test("keeps processing through intermediate checkpoints until the voice job fini
 
     mocks.vault.workspaceVersion = "workspace-v2";
     await rendered.rerender(
-      createElement(EnvironmentPageClient, { contactAction: null }),
+      createElement(EnvironmentPageClient, { contactOptions: [] }),
     );
     assert.match(
       rendered.window.document.body.textContent ?? "",
@@ -138,7 +138,7 @@ test("restores server-side processing state after the page is reopened", async (
     createElement(
       StrictMode,
       null,
-      createElement(EnvironmentPageClient, { contactAction: null }),
+      createElement(EnvironmentPageClient, { contactOptions: [] }),
     ),
     {
       location: {
@@ -190,7 +190,7 @@ test("keeps checking after processing takes longer than two minutes", async () =
   ) => Response.json({ processing }));
   globalThis.fetch = fetchMock;
   const rendered = await renderClientComponent(
-    createElement(EnvironmentPageClient, { contactAction: null }),
+    createElement(EnvironmentPageClient, { contactOptions: [] }),
     {
       location: {
         hash: "",

--- a/apps/web/test/environment-voice-refresh.test.tsx
+++ b/apps/web/test/environment-voice-refresh.test.tsx
@@ -178,3 +178,51 @@ test("restores server-side processing state after the page is reopened", async (
     await rendered.cleanup();
   }
 });
+
+test("keeps checking after processing takes longer than two minutes", async () => {
+  vi.useFakeTimers();
+  mocks.refresh.mockClear();
+  const originalFetch = globalThis.fetch;
+  let processing = true;
+  const fetchMock = vi.fn(async () => Response.json({ processing }));
+  globalThis.fetch = fetchMock;
+  const rendered = await renderClientComponent(
+    createElement(EnvironmentPageClient, { contactAction: null }),
+    {
+      location: {
+        hash: "",
+        href: "https://local.withmurph.ai/environment",
+        origin: "https://local.withmurph.ai",
+        pathname: "/environment",
+        search: "",
+      },
+    },
+  );
+
+  try {
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1_000);
+    });
+    assert.match(
+      rendered.window.document.body.textContent ?? "",
+      /Murph is taking longer than usual/,
+    );
+    const callsAtDelay = fetchMock.mock.calls.length;
+
+    processing = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    assert.ok(fetchMock.mock.calls.length > callsAtDelay);
+    assert.match(
+      rendered.window.document.body.textContent ?? "",
+      /The report was not updated/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    await rendered.cleanup();
+  }
+});

--- a/apps/web/test/environment-voice-route.test.ts
+++ b/apps/web/test/environment-voice-route.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   requireActiveHostedAppSessionFromRequest: vi.fn(),
   resolveHostedRuntimeAiUsageGate: vi.fn(),
   signalHostedMailboxAppendRuntime: vi.fn(),
+  signalHostedRuntimeRecheckRuntime: vi.fn(),
   stageEnvironmentVoice: vi.fn(),
 }));
 
@@ -58,6 +59,7 @@ vi.mock("@/src/lib/hosted-onboarding/shared", () => ({
 }));
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
   signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
+  signalHostedRuntimeRecheckRuntime: mocks.signalHostedRuntimeRecheckRuntime,
 }));
 vi.mock("@/src/lib/hosted-orchestration/runtime-usage-decision", () => ({
   resolveHostedRuntimeAiUsageGate: mocks.resolveHostedRuntimeAiUsageGate,
@@ -66,7 +68,7 @@ vi.mock("@/src/lib/prisma", () => ({
   getPrisma: () => ({ $transaction: transaction }),
 }));
 
-import { GET, POST } from "../app/api/environment/voice/route";
+import { GET, PATCH, POST } from "../app/api/environment/voice/route";
 
 describe("environment voice upload route", () => {
   beforeEach(() => {
@@ -116,6 +118,42 @@ describe("environment voice upload route", () => {
     expect(
       mocks.hasPendingHostedEnvironmentVoiceMailboxItem,
     ).toHaveBeenCalledWith({ userId: "member_123" });
+  });
+
+  it("rechecks the existing runtime only while a recording is pending", async () => {
+    mocks.hasPendingHostedEnvironmentVoiceMailboxItem.mockResolvedValue(true);
+    const request = new Request(
+      "https://local.withmurph.ai/api/environment/voice",
+      { method: "PATCH" },
+    );
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      processing: true,
+      recheckRequested: true,
+    });
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(
+      request,
+    );
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      userId: "member_123",
+    });
+  });
+
+  it("does not wake the runtime when no environment recording is pending", async () => {
+    const response = await PATCH(new Request(
+      "https://local.withmurph.ai/api/environment/voice",
+      { method: "PATCH" },
+    ));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      processing: false,
+      recheckRequested: false,
+    });
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
   });
 
   it("stages an authenticated recording, appends one mailbox wake, and signals runtime", async () => {


### PR DESCRIPTION
## Why this PR exists

The Environment page stopped checking a voice recording after two minutes. If processing finished later, the member could remain on a stale “processing” screen until a manual reload, even though the page promised to refresh automatically.

## User-visible outcome

- The page checks every two seconds during the normal processing window.
- After two minutes it switches to the existing “taking longer” state but keeps checking every ten seconds.
- “Check again” now re-signals the existing hosted runtime when the accepted mailbox item is still pending; it does not upload or admit the recording again.
- The report updates automatically when the canonical Habitat write is ready.
- Processing and delayed states show a restrained spinner, with a reduced-motion fallback.
- A second recording remains disabled while the first one is pending.
- Environment chat actions now show the existing channel picker when both Messages and Telegram are connected; a single connected channel still opens directly.

## Invariants

- The upload, mailbox, runtime, checkpoint, and audio-deletion paths are unchanged.
- The browser does not invent completion; `/api/environment/voice` remains the status source of truth.
- No recording, transcript, or Habitat fact is copied into frontend state beyond the existing status and report projection.

## Architecture and reuse

- **Existing systems reused:** the Environment page continues to read the authenticated `/api/environment/voice` pending status, refresh the existing Browser Vault projection, use the existing `runtime_recheck_requested` signal, render the existing Environment Alert and design-catalog studies, and use the same contact picker as the dashboard sidebar.
- **New logic:** the polling loop slows from two seconds to ten seconds instead of terminating, and the authenticated same-origin `PATCH /api/environment/voice` method checks for a pending recording before re-signaling its existing runtime.
- **New abstractions:** the existing sidebar contact picker presentation is extracted into one shared client component so Environment and the sidebar cannot drift. The spinner uses the installed Lucide icon set and Tailwind motion utilities.
- **Complexity intentionally avoided:** no new endpoint path, mailbox item, queue, persisted state, dependency, service, audio upload, health payload, or compatibility path.

## Preliminary specialist lenses

- **Product experience: applicable.** The intended outcome is that a member can leave the page open and reliably see a delayed voice job finish without re-recording. Direct evidence: the focused component test advances beyond two minutes, confirms continued polling, then confirms the completed report state.
- **Prompt: not applicable.** No prompt or model-facing instruction changed.
- **Frontend: applicable.** The processing and delayed status treatment changes, using the existing Environment progress component and design-catalog study.
- **Coverage: applicable.** The focused refresh test proves polling continues after the former timeout and that “Check again” requests a recheck. Route tests prove a recheck is emitted only for an authenticated pending recording. Focused local tests and Web typecheck pass; exact-head CI is pending.

## Focused verification

- `pnpm exec vitest --config apps/web/vitest.config.ts run apps/web/test/environment-capture-card.test.tsx apps/web/test/environment-voice-refresh.test.tsx apps/web/test/environment-voice-route.test.ts apps/web/test/sidebar-chat-contact-dialog.test.tsx` — 21 tests passed.
- `pnpm --dir apps/web typecheck:prepared` — passed after local Prisma and Health Commons generation.
- `pnpm test:diff --base origin/main --head HEAD` — passed.
- `git diff --check` — passed.

Exact pushed head: `c0c63d1902df41e0efd492c754e2f2f1cb29e28d`.

## Design proof

- Design page: [`/design?tab=components#environment-voice-refresh-notice-component`](https://local.withmurph.ai:3443/design?tab=components#environment-voice-refresh-notice-component)
- Desktop screenshot: ![Environment processing desktop](https://raw.githubusercontent.com/cobuildwithus/murph/ef28af9c72ab9e74a115e99fadaa362ae8af2d1c/agent-docs/assets/pr-proof/environment-progressive-capture/desktop.png)
- Mobile screenshot: ![Environment processing mobile](https://raw.githubusercontent.com/cobuildwithus/murph/ef28af9c72ab9e74a115e99fadaa362ae8af2d1c/agent-docs/assets/pr-proof/environment-progressive-capture/mobile.png)

The layout is unchanged from the catalog proof above. This hotfix adds motion to the existing processing marker; the static images establish the component and responsive layout, while the focused test establishes the delayed-state transition and continued polling.

## Change shape

Classification is based on file ownership and authored content in `origin/main...HEAD`.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 378 | 213 |
| Tests/fixtures | 145 | 7 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **523** | **220** |

## Deployment concerns

Web-only change. It is compatible with the already deployed Environment API and Cloudflare runtime; no coordinated deployment or migration is required. After deployment, confirm a pending job transitions to delayed after two minutes and clears automatically when `/api/environment/voice` reports completion.
