### PR TITLE
Publish the July 31 changelog

### DIFF
--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -63,6 +63,163 @@ export interface ChangelogPage {
 
 const RAW_CHANGELOG_EDITIONS = [
   {
+    id: "2026-07-31",
+    publishedOn: "2026-07-31",
+    title: "A clearer view of home, stronger follow-through",
+    summary:
+      "Environment turns what Murph knows about your home into a private report and one-memo walkthrough. Group access, link previews, reminders, usage, Venice replies, and delegated work all get clearer or more reliable paths.",
+    items: [
+      {
+        id: "private-environment-report",
+        kind: "feature",
+        priority: 5,
+        title: "See how your environment supports you",
+        summary:
+          "The new Environment page turns saved facts about sleep, air, light, recovery, and workspace into a private report with category notes, live local conditions, and an A–E audit once enough scoreable conditions are known.",
+        details:
+          "Missing or skipped facts never lower the grade, and optional equipment never counts against it. Each result explains what is known, what needs attention, and the next useful check.",
+        relevanceTags: ["environment", "sleep", "workspace", "context"],
+        sourcePullRequests: [573],
+        tryIt: {
+          href: "/environment",
+          label: "Open Environment",
+        },
+      },
+      {
+        id: "environment-voice-walkthrough",
+        kind: "feature",
+        priority: 5,
+        title: "Build the report with one voice memo",
+        summary:
+          "Walk Murph through five short topics in one recording. Murph privately extracts clear facts about your home and workspace, saves them to your vault, and refreshes the open report when processing finishes.",
+        details:
+          "A partial report asks only about useful missing details, while a complete report switches to a free-form update. Precise addresses are rejected, ambiguous details stay unknown, and the transcript is not added to conversation history.",
+        relevanceTags: ["environment", "voice", "privacy", "context"],
+        sourcePullRequests: [573],
+      },
+      {
+        id: "native-link-previews",
+        kind: "feature",
+        priority: 5,
+        title: "Links can arrive as native previews",
+        summary:
+          "In a supported existing chat, a reply with text or media followed by one HTTPS link can send the content first and the link as a native preview.",
+        details:
+          "A link-only reply can use one native link when it does not need a reply anchor. If the preview is definitively rejected, Murph sends the exact link as text, and retries preserve content that was already accepted.",
+        relevanceTags: ["imessage", "links", "messaging", "reliability"],
+        sourcePullRequests: [1110],
+      },
+      {
+        id: "family-owner-usage-topups",
+        kind: "feature",
+        priority: 5,
+        title: "Family owners can add usage for themselves",
+        summary:
+          "An active Family owner can choose Add usage from their own AI-usage row and select $5, $10, or $25 through the existing Family checkout.",
+        details:
+          "A fulfilled purchase starts a fresh display window at 0% used, and only later usage moves the meter. Each payment return stays with its exact owner or member surface instead of creating competing confirmations.",
+        relevanceTags: ["family", "billing", "usage", "settings"],
+        sourcePullRequests: [1198],
+      },
+      {
+        id: "group-access-across-channels",
+        kind: "feature",
+        priority: 5,
+        title: "Group access offers fit the current chat",
+        summary:
+          "A group can ask Murph to create or extend access through one action. Supported iMessage groups keep the native reaction path, while SMS, Telegram, scheduled turns, and standalone requests get the existing first-party link.",
+        details:
+          "Murph chooses the presentation from the trusted route, includes one usable access surface, and returns a truthful unavailable result when the route cannot be proven.",
+        relevanceTags: ["groups", "sharing", "imessage", "telegram"],
+        sourcePullRequests: [1184],
+      },
+      {
+        id: "one-shot-reminders-survive-restart",
+        kind: "improvement",
+        priority: 5,
+        title: "One-time reminders keep their place",
+        summary:
+          "A one-time reminder created near its scheduled minute now keeps a durable wake with the saved schedule, so ending or restarting the creating session cannot strand an active reminder.",
+        details:
+          "The current reply confirms the saved reminder without waiting on the best-effort wake signal. The scheduled message keeps its existing route, timing, and delivery checks.",
+        relevanceTags: ["reminders", "automations", "reliability", "messaging"],
+        sourcePullRequests: [1209],
+      },
+      {
+        id: "venice-tool-compatible-replies",
+        kind: "improvement",
+        priority: 5,
+        title: "Venice replies keep Murph's tools",
+        summary:
+          "Members who choose Venice can now receive Murph's normal tool-enabled reply instead of seeing typing end when the provider rejects the request shape.",
+        details:
+          "The model choice, tools, conversation, and delivery path stay the same. Murph translates only the exact supported tool envelope and rejects malformed or conflicting metadata before provider entry.",
+        relevanceTags: ["assistant", "models", "venice", "reliability"],
+        sourcePullRequests: [1200],
+      },
+      {
+        id: "core-member-plan-name",
+        kind: "improvement",
+        priority: 4,
+        title: "The direct member plan is now Core",
+        summary:
+          "Eligible group members now see Core in Settings, trial continuation, billing recovery, usage-limit messages, Clubs pricing, and private plan answers.",
+        details:
+          "Only the name changed. Core remains $3.50 per month with the same included usage, eligibility, billing transitions, assistant capability, and group continuity.",
+        relevanceTags: ["plans", "billing", "settings", "groups"],
+        sourcePullRequests: [1206],
+      },
+      {
+        id: "usage-referrals-stay-current",
+        kind: "improvement",
+        priority: 4,
+        title: "Usage says what remains and what is still moving",
+        summary:
+          "The usage meter now answers how much capacity remains, while waiting, active, final-checking, and reward-pending referrals stay in the current list until they are complete.",
+        details:
+          "A quiet Details row holds each referral's requirements and selection date. Only completed referrals and usage purchases move into History.",
+        relevanceTags: ["usage", "referrals", "settings", "accessibility"],
+        sourcePullRequests: [1194],
+      },
+      {
+        id: "safe-group-stakes",
+        kind: "improvement",
+        priority: 4,
+        title: "Safe group stakes keep their edge",
+        summary:
+          "Murph now judges a proposed group dare by the concrete act, so an ordinary timed stake or playful consequence can stay intact when it is safe and consensual.",
+        details:
+          "The wording alone does not trigger a veto. Real hazards, coercion, impairment, contraindications, or pressure through distress still get the narrow boundary they require.",
+        relevanceTags: ["groups", "challenges", "humor", "safety"],
+        sourcePullRequests: [1201],
+      },
+      {
+        id: "experiment-progress-cards-fail-soft",
+        kind: "improvement",
+        priority: 4,
+        title: "Experiment progress cards fail soft",
+        summary:
+          "Hosted experiment progress cards now keep rendering when optional biomarker-direction context is unavailable, using neutral mover sentiment instead of failing the whole request.",
+        details:
+          "The card visibly says when direction context was unavailable, and the same accessible description travels with the private image in supported iMessage and Telegram delivery.",
+        relevanceTags: ["experiments", "progress", "accessibility", "reliability"],
+        sourcePullRequests: [1208],
+      },
+      {
+        id: "delegated-work-before-blocker",
+        kind: "improvement",
+        priority: 4,
+        title: "Murph moves the work forward before asking",
+        summary:
+          "When you ask Murph to handle, choose, decide, or figure something out, it now completes everything useful that is independent of a blocker before asking for more input.",
+        details:
+          "If a texting reply still needs a decision-changing fact, Murph asks one highest-value question at the end. Delegation still cannot create new permission to spend, contact, publish, schedule, or take another external action.",
+        relevanceTags: ["assistant", "planning", "decisions", "conversation"],
+        sourcePullRequests: [1214],
+      },
+    ],
+  },
+  {
     id: "2026-07-30",
     publishedOn: "2026-07-30",
     title: "More ways through, less waiting around",

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -67,7 +67,7 @@ const RAW_CHANGELOG_EDITIONS = [
     publishedOn: "2026-07-31",
     title: "A clearer view of home, stronger follow-through",
     summary:
-      "Environment turns what Murph knows about your home into a private report and one-memo walkthrough. Group access, link previews, reminders, usage, Venice replies, and delegated work all get clearer or more reliable paths.",
+      "Environment turns what Murph knows about your home into a private report and one-memo walkthrough. Group funding and access, link previews, reminders, usage, Venice replies, and delegated work all get clearer or more reliable paths.",
     items: [
       {
         id: "private-environment-report",
@@ -132,6 +132,18 @@ const RAW_CHANGELOG_EDITIONS = [
           "Murph chooses the presentation from the trusted route, includes one usable access surface, and returns a truthful unavailable result when the route cannot be proven.",
         relevanceTags: ["groups", "sharing", "imessage", "telegram"],
         sourcePullRequests: [1184],
+      },
+      {
+        id: "fund-groups-at-any-capacity",
+        kind: "feature",
+        priority: 5,
+        title: "Fund a group whenever you choose",
+        summary:
+          "Anyone in an active hosted group can open its first-party funding page at any capacity. Unsponsored groups open monthly sponsorship, while other participants in sponsored groups can add a one-time contribution.",
+        details:
+          "An explicit request to fund, sponsor, contribute, or get the funding link no longer detours into referrals or claims that a healthy group needs funding. The active payer can manage sponsorship on the same page, and every payment still requires explicit confirmation and Stripe reconciliation.",
+        relevanceTags: ["groups", "funding", "usage", "billing"],
+        sourcePullRequests: [1207],
       },
       {
         id: "one-shot-reminders-survive-restart",

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -57,13 +57,14 @@ describe("ChangelogPage", () => {
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
     );
 
+    expect(markup).toContain("A clearer view of home, stronger follow-through");
     expect(markup).toContain("More ways through, less waiting around");
     expect(markup).toContain("Corrections that carry forward");
     expect(markup).toContain("A first text that goes somewhere");
     expect(markup).toContain("Reminders on your time, not ours");
     expect(markup).toContain("Group memory, clearer recovery");
     expect(markup).toContain("A Murph that knows when to speak");
-    expect(markup).toContain("Group chats that read the room");
+    expect(markup).not.toContain("Group chats that read the room");
     expect(markup).not.toContain(
       "Updated documents, honest reactions, usage you can see",
     );
@@ -83,9 +84,9 @@ describe("ChangelogPage", () => {
     expect(markup).not.toContain("Better answers, better instincts");
     expect(markup).not.toContain("Murph referees your group challenge");
     expect(markup).toContain('aria-label="Changelog pages"');
-    expect(markup).toContain('href="/changelog?edition=2026-07-23"');
+    expect(markup).toContain('href="/changelog?edition=2026-07-24"');
     expect(markup).toContain(
-      'href="/changelog?edition=2026-07-30#capped-monthly-group-sponsorship"',
+      'href="/changelog?edition=2026-07-31#private-environment-report"',
     );
     expect(markup).toContain("Older");
     expect(markup).not.toContain(">Newer<");
@@ -98,9 +99,10 @@ describe("ChangelogPage", () => {
 
     expect(markup).toContain("Ask about X");
     expect(markup).toContain("Turn it up");
+    expect(markup).toContain("Open Environment");
+    expect(markup).toContain('href="/environment"');
     expect(markup).toContain("Explore club challenges");
     expect(markup).toContain('href="/clubs"');
-    expect(markup).toMatch(/Ask what(?:&#x27;|')s new/u);
     expect(
       mocks.resolveHostedMurphContactOptions.mock.calls.map(([input]) => input),
     ).toEqual(
@@ -115,12 +117,6 @@ describe("ChangelogPage", () => {
           message: {
             body: "Turn up my Unhinged setting a little.",
             subject: "Try it: Ask Murph to loosen up",
-          },
-        },
-        {
-          message: {
-            body: "What changed in Murph this week?",
-            subject: "Try it: Ask Murph what changed",
           },
         },
       ]),

--- a/apps/web/test/changelog-routes.test.ts
+++ b/apps/web/test/changelog-routes.test.ts
@@ -24,7 +24,7 @@ describe("changelog routes", () => {
   it("publishes every item from the two newest editions with canonical links", async () => {
     const response = await getChangelogFeed(
       new Request(
-        "https://join.example.test/api/changelog?from=2026-07-29&to=2026-07-31&featureLimit=100&improvementLimit=25",
+        "https://join.example.test/api/changelog?from=2026-07-30&to=2026-08-01&featureLimit=100&improvementLimit=25",
       ),
     );
     const body = await response.json();
@@ -37,11 +37,23 @@ describe("changelog routes", () => {
     expect(response.status).toBe(200);
     expect(items).toHaveLength(30);
     expect(items.map((item) => item.publishedOn)).toEqual([
+      ...Array.from({ length: 12 }, () => "2026-07-31"),
       ...Array.from({ length: 18 }, () => "2026-07-30"),
-      ...Array.from({ length: 12 }, () => "2026-07-29"),
     ]);
     expect(items.map((item) => item.id)).toEqual(
       expect.arrayContaining([
+        "private-environment-report",
+        "environment-voice-walkthrough",
+        "native-link-previews",
+        "family-owner-usage-topups",
+        "group-access-across-channels",
+        "one-shot-reminders-survive-restart",
+        "venice-tool-compatible-replies",
+        "core-member-plan-name",
+        "usage-referrals-stay-current",
+        "safe-group-stakes",
+        "experiment-progress-cards-fail-soft",
+        "delegated-work-before-blocker",
         "capped-monthly-group-sponsorship",
         "usage-credit-without-message-estimates",
         "usage-options-together",
@@ -50,12 +62,6 @@ describe("changelog routes", () => {
         "animated-gif-filmstrips",
         "ios-app-link-in-chat",
         "homepage-auth-stays-usable",
-        "post-onboarding-choice-point",
-        "additive-group-challenge-scorecards",
-        "dense-reminders-become-conversation",
-        "telegram-imessage-contact-handoff",
-        "imessage-edits-become-corrections",
-        "clubs-challenge-pilot-page",
       ]),
     );
     for (const item of items) {

--- a/apps/web/test/changelog-routes.test.ts
+++ b/apps/web/test/changelog-routes.test.ts
@@ -35,9 +35,9 @@ describe("changelog routes", () => {
     }>;
 
     expect(response.status).toBe(200);
-    expect(items).toHaveLength(30);
+    expect(items).toHaveLength(31);
     expect(items.map((item) => item.publishedOn)).toEqual([
-      ...Array.from({ length: 12 }, () => "2026-07-31"),
+      ...Array.from({ length: 13 }, () => "2026-07-31"),
       ...Array.from({ length: 18 }, () => "2026-07-30"),
     ]);
     expect(items.map((item) => item.id)).toEqual(
@@ -47,6 +47,7 @@ describe("changelog routes", () => {
         "native-link-previews",
         "family-owner-usage-topups",
         "group-access-across-channels",
+        "fund-groups-at-any-capacity",
         "one-shot-reminders-survive-restart",
         "venice-tool-compatible-replies",
         "core-member-plan-name",

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -151,13 +151,68 @@ describe("changelog registry", () => {
     });
   });
 
-  it("publishes the complete July 20 through July 30 shipment set", () => {
+  it("keeps the July 31 Environment claims private and evidence-aware", () => {
+    const items = new Map(
+      listPublishedChangelogItems().map((item) => [item.id, item]),
+    );
+
+    expect(items.get("private-environment-report")).toMatchObject({
+      sourcePullRequests: [573],
+      details: expect.stringContaining("optional equipment never counts against it"),
+      tryIt: {
+        href: "/environment",
+        label: "Open Environment",
+      },
+    });
+    expect(items.get("environment-voice-walkthrough")).toMatchObject({
+      sourcePullRequests: [573],
+      details: expect.stringContaining("Precise addresses are rejected"),
+    });
+  });
+
+  it("keeps the July 31 reliability and permission claims bounded", () => {
+    const items = new Map(
+      listPublishedChangelogItems().map((item) => [item.id, item]),
+    );
+
+    expect(items.get("group-access-across-channels")).toMatchObject({
+      sourcePullRequests: [1184],
+      details: expect.stringContaining("trusted route"),
+    });
+    expect(items.get("one-shot-reminders-survive-restart")).toMatchObject({
+      sourcePullRequests: [1209],
+      details: expect.stringContaining("best-effort wake signal"),
+    });
+    expect(items.get("delegated-work-before-blocker")).toMatchObject({
+      sourcePullRequests: [1214],
+      details: expect.stringContaining("cannot create new permission"),
+    });
+  });
+
+  it("publishes the complete July 20 through July 31 shipment set", () => {
     expect(
-      listChangelogEditions().slice(0, 11).map((edition) => ({
+      listChangelogEditions().slice(0, 12).map((edition) => ({
         id: edition.id,
         itemIds: edition.items.map((item) => item.id),
       })),
     ).toEqual([
+      {
+        id: "2026-07-31",
+        itemIds: [
+          "private-environment-report",
+          "environment-voice-walkthrough",
+          "native-link-previews",
+          "family-owner-usage-topups",
+          "group-access-across-channels",
+          "one-shot-reminders-survive-restart",
+          "venice-tool-compatible-replies",
+          "core-member-plan-name",
+          "usage-referrals-stay-current",
+          "safe-group-stakes",
+          "experiment-progress-cards-fail-soft",
+          "delegated-work-before-blocker",
+        ],
+      },
       {
         id: "2026-07-30",
         itemIds: [
@@ -466,8 +521,8 @@ describe("changelog registry", () => {
   it("keeps the default archive window to seven calendar days", () => {
     const firstPage = resolveChangelogPage(1);
     expect(firstPage?.editions).toHaveLength(7);
-    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-07-30");
-    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-24");
+    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-07-31");
+    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-25");
   });
 
   it("resolves only known canonical edition cursors", () => {

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -179,6 +179,10 @@ describe("changelog registry", () => {
       sourcePullRequests: [1184],
       details: expect.stringContaining("trusted route"),
     });
+    expect(items.get("fund-groups-at-any-capacity")).toMatchObject({
+      sourcePullRequests: [1207],
+      details: expect.stringContaining("explicit confirmation"),
+    });
     expect(items.get("one-shot-reminders-survive-restart")).toMatchObject({
       sourcePullRequests: [1209],
       details: expect.stringContaining("best-effort wake signal"),
@@ -204,6 +208,7 @@ describe("changelog registry", () => {
           "native-link-previews",
           "family-owner-usage-topups",
           "group-access-across-channels",
+          "fund-groups-at-any-capacity",
           "one-shot-reminders-survive-restart",
           "venice-tool-compatible-replies",
           "core-member-plan-name",


### PR DESCRIPTION
## Why this PR exists

The public changelog stops at July 30 even though 13 member-facing changes have shipped since the last changelog cutoff. This publishes a concise, evidence-backed July 31 edition and omits internal-only monitoring, routing, and digest work.

## User goal / user-visible behavior

Members can read the latest shipped changes in the changelog archive and API feed, including Environment, group funding and access, native link previews, reminder reliability, usage and referral clarity, Venice compatibility, and stronger delegated follow-through.

## User experience

Opening /changelog shows the July 31 edition first, with the newest seven calendar days on the first page and an updated Older cursor. The Environment item links directly to the existing Environment page. Content renders immediately through the existing archive; there is no new asynchronous flow or recovery state.

## Invariants the PR must preserve

- Every claim remains bounded by a merged source PR recorded on the item.
- Private Environment facts, funding state, billing details, and messaging routes keep their existing access controls; the changelog exposes no member data.
- The archive remains reverse chronological with seven calendar days per page, and the API feed retains its existing limits and canonical item links.
- Internal operator-only changes are not presented as member-facing releases.

## Non-obvious affected surfaces

- The changelog API feed now includes all 13 July 31 items; the focused route test proves their canonical links and inclusive date window.
- Adding a calendar edition shifts the default archive boundary and Older cursor by one day; the page and registry tests prove the new boundary.

## Architecture and reuse

- **Existing systems reused:** the typed changelog registry, archive page, pagination, API feed, item anchors, source-PR metadata, and existing Environment route.
- **New logic:** one static July 31 edition and the matching expected registry, feed, and pagination facts.
- **New abstractions:** none; the existing edition and item contracts already represent the release without another owner.
- **Complexity intentionally avoided:** no new component, route, state, dependency, generator, or release pipeline.

## Hot reply path impact

Not applicable. This changes only static changelog data and focused tests; the Foreground Reply Critical Path is untouched.

## Murph initial provider input impact

- **Individual Murph:** Not applicable; no prompt, tool, schema, skill, model, or provider-request assembly changed.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Product experience — applicable:** the intended outcome is a current, scannable release archive; server-rendered page tests prove the new first edition, direct Environment action, and archive cursor. ReviewGPT was skipped at the requester's direction.
- **Prompt — not applicable:** no provider-visible prompt or tool surface changed.
- **Frontend — not applicable:** no component, layout, styling, interaction, or responsive state changed; the edition uses the existing changelog presentation.
- **Coverage — applicable:** 35 focused changelog tests and the hosted-Web typecheck passed locally. Exact-head GitHub Actions passed, including the aggregate release gate.

## Change-shape breakdown

Authored changelog registry data is source; files under apps/web/test are tests. There are no binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 169 | 0 |
| Tests / fixtures | 86 | 23 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **255** | **23** |

## Design proof

Not applicable. The PR changes release copy in the existing changelog presentation, not user-interface structure or styling.

## Verification

- Focused hosted-Web Vitest: 3 files, 35 tests passed.
- Hosted-Web typecheck passed.
- git diff --check passed.
- Diff privacy scan passed.
- ReviewGPT intentionally skipped per requester instruction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098934&installation_model_id=19880&pr_number=1229&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1229&signature=3a1c43d2803ae344862f12702b2526729663926a09da9af7637ca22085b1f311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->