### PR TITLE
Chart message growth over time

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -225,10 +225,14 @@ with **Total messages sent**, a thin sage cumulative line seeded from the
 established historical base, and **Messages sent per day**, restrained sage
 bars for completed UTC days. Both derive from the existing daily growth
 snapshots. Shift each snapshot's prior-day counts onto the date when the
-messages occurred, leave legacy unknown counts as chart gaps rather than zeros,
-and state that the daily total combines inbound messages across supported
-channels with tracked Linq replies. Keep acquisition and revenue snapshots as
-the second chart row.
+messages occurred and always preserve the exact 30 completed-day UTC spine.
+Leave absent snapshots and legacy unknown counts as chart gaps rather than
+zeros. Once tracking has begun, an unavailable day also ends the exact
+cumulative line until the missing evidence is reconciled; later known daily
+bars may still render. State that the daily total combines inbound messages
+across supported channels with tracked Linq replies. Give each keyboard-enabled
+chart one visible focus surface named by its heading. Keep acquisition and
+revenue snapshots as the second chart row.
 
 ### Measured Biomarker Index
 On `/biomarkers`, device-derived reading rows lead in a flat full-width notebook

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -220,6 +220,16 @@ an affected WAU or MAU with `At least`, explain the private evidence retirement
 in the supporting copy, and withhold a week-over-week rate when either compared
 window is incomplete.
 
+Follow the scorecard with the existing two-column chart grid. Lead that grid
+with **Total messages sent**, a thin sage cumulative line seeded from the
+established historical base, and **Messages sent per day**, restrained sage
+bars for completed UTC days. Both derive from the existing daily growth
+snapshots. Shift each snapshot's prior-day counts onto the date when the
+messages occurred, leave legacy unknown counts as chart gaps rather than zeros,
+and state that the daily total combines inbound messages across supported
+channels with tracked Linq replies. Keep acquisition and revenue snapshots as
+the second chart row.
+
 ### Measured Biomarker Index
 On `/biomarkers`, device-derived reading rows lead in a flat full-width notebook
 band bracketed by warm one-pixel rules. Do not wrap that band in a rounded card

--- a/agent-docs/exec-plans/active/2026-07-31-growth-message-volume-charts.md
+++ b/agent-docs/exec-plans/active/2026-07-31-growth-message-volume-charts.md
@@ -1,0 +1,41 @@
+# Growth message-volume charts
+
+Status: active
+Created: 2026-07-31
+
+## Outcome
+
+- Let the operator see cumulative hosted message volume and messages per UTC day on `/ops/growth` so movement over time is immediately legible.
+- Keep the existing acquisition, revenue, and weekly scorecard behavior intact.
+
+## Ownership and evidence
+
+- `HostedGrowthDailySnapshot` already owns prior-day inbound and outbound message counts.
+- `HOSTED_MESSAGE_VOLUME_BASE` already represents untracked pre-snapshot history for the public lifetime total.
+- The gap is presentation and a bounded read projection: the dashboard currently drops the two message-count fields before rendering its chart series.
+
+## Plan
+
+1. Derive a bounded message series from the existing daily snapshots, with the message date shifted to the prior UTC day and cumulative totals seeded from the existing historical base.
+2. Add cumulative and per-day charts to the existing `GrowthCharts` component using the current Recharts and chart-token system.
+3. Render the real chart composition with synthetic data in the existing growth design study.
+4. Add focused projection and rendering regressions, then run scoped hosted-web checks and desktop/mobile browser proof.
+5. Commit, push a pull request, complete the required specialist and UI review gates, and require green exact-head CI.
+
+## Invariants
+
+- Do not add a schema, persistence owner, cron, or provider call.
+- Do not count mailbox rows or delivery rows differently from the existing snapshot and public message-volume definitions.
+- Keep unknown legacy snapshot counts honest rather than displaying them as a known zero.
+- Keep the series bounded and the operator page free of member or message identifiers.
+- Preserve responsive readability and the existing warm-paper chart vocabulary.
+
+## Verification
+
+- Focused hosted growth metric and rendering tests.
+- Hosted-web TypeScript and lint checks for touched files.
+- Frontend design-proof guard.
+- Desktop and mobile Playwright proof from `/design?tab=sections`.
+- Preliminary `completion-specialists` ReviewGPT pass with product-experience, frontend, and coverage lenses.
+- Claude Code UI double-check while credits are available.
+- Exact-head required CI and parent final review.

--- a/agent-docs/exec-plans/completed/2026-07-31-growth-message-volume-charts.md
+++ b/agent-docs/exec-plans/completed/2026-07-31-growth-message-volume-charts.md
@@ -1,6 +1,6 @@
 # Growth message-volume charts
 
-Status: active
+Status: completed
 Created: 2026-07-31
 
 ## Outcome
@@ -39,3 +39,5 @@ Created: 2026-07-31
 - Preliminary `completion-specialists` ReviewGPT pass with product-experience, frontend, and coverage lenses.
 - Claude Code UI double-check while credits are available.
 - Exact-head required CI and parent final review.
+Updated: 2026-07-31
+Completed: 2026-07-31

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import {
   Area,
   AreaChart,
@@ -61,6 +61,9 @@ const revenueChartConfig = {
   },
 } satisfies ChartConfig;
 
+const interactiveChartClassName =
+  "mt-4 h-64 w-full rounded-sm has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-ring";
+
 interface GrowthChartsProps {
   dailySeries: HostedGrowthDailyPoint[];
   messageSeries: HostedGrowthMessagePoint[];
@@ -68,6 +71,11 @@ interface GrowthChartsProps {
 }
 
 export function GrowthCharts(input: GrowthChartsProps) {
+  const titleIdPrefix = useId().replace(/:/gu, "");
+  const totalMessagesTitleId = `${titleIdPrefix}-total-messages`;
+  const dailyMessagesTitleId = `${titleIdPrefix}-daily-messages`;
+  const acquisitionTitleId = `${titleIdPrefix}-acquisition`;
+  const revenueTitleId = `${titleIdPrefix}-revenue`;
   const revenueSeries = input.snapshotSeries.map((point) => ({
     date: point.date,
     mrrUsd: point.mrrUsdCents / 100,
@@ -78,19 +86,24 @@ export function GrowthCharts(input: GrowthChartsProps) {
     <div className="grid gap-4 xl:grid-cols-2">
       <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
-          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+          <h3
+            className="font-serif text-lg font-semibold tracking-tight text-foreground"
+            id={totalMessagesTitleId}
+          >
             Total messages sent
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
-            Cumulative hosted messages sent through each completed UTC day.
+            Cumulative hosted messages through each completed UTC day.
+            Unavailable history is left blank.
           </p>
         </div>
         <ChartContainer
-          className="mt-4 h-64 w-full"
+          className={interactiveChartClassName}
           config={totalMessagesChartConfig}
         >
           <LineChart
             accessibilityLayer
+            aria-labelledby={totalMessagesTitleId}
             data={input.messageSeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >
@@ -139,19 +152,24 @@ export function GrowthCharts(input: GrowthChartsProps) {
 
       <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
-          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+          <h3
+            className="font-serif text-lg font-semibold tracking-tight text-foreground"
+            id={dailyMessagesTitleId}
+          >
             Messages sent per day
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
             Daily inbound messages plus tracked Linq replies, by UTC date.
+            Unavailable days are left blank.
           </p>
         </div>
         <ChartContainer
-          className="mt-4 h-64 w-full"
+          className={interactiveChartClassName}
           config={dailyMessagesChartConfig}
         >
           <BarChart
             accessibilityLayer
+            aria-labelledby={dailyMessagesTitleId}
             data={input.messageSeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >
@@ -195,7 +213,10 @@ export function GrowthCharts(input: GrowthChartsProps) {
 
       <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
-          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+          <h3
+            className="font-serif text-lg font-semibold tracking-tight text-foreground"
+            id={acquisitionTitleId}
+          >
             Acquisition
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
@@ -203,11 +224,12 @@ export function GrowthCharts(input: GrowthChartsProps) {
           </p>
         </div>
         <ChartContainer
-          className="mt-4 h-64 w-full"
+          className={interactiveChartClassName}
           config={acquisitionChartConfig}
         >
           <AreaChart
             accessibilityLayer
+            aria-labelledby={acquisitionTitleId}
             data={input.dailySeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >
@@ -258,7 +280,10 @@ export function GrowthCharts(input: GrowthChartsProps) {
 
       <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
-          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+          <h3
+            className="font-serif text-lg font-semibold tracking-tight text-foreground"
+            id={revenueTitleId}
+          >
             Revenue snapshots
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
@@ -266,11 +291,12 @@ export function GrowthCharts(input: GrowthChartsProps) {
           </p>
         </div>
         <ChartContainer
-          className="mt-4 h-64 w-full"
+          className={interactiveChartClassName}
           config={revenueChartConfig}
         >
           <LineChart
             accessibilityLayer
+            aria-labelledby={revenueTitleId}
             data={revenueSeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import type { ReactNode } from "react";
 import {
   Area,
   AreaChart,
+  Bar,
+  BarChart,
   CartesianGrid,
   Line,
   LineChart,
@@ -18,8 +21,23 @@ import {
 } from "@/src/components/ui/chart";
 import type {
   HostedGrowthDailyPoint,
+  HostedGrowthMessagePoint,
   HostedGrowthSnapshotPoint,
 } from "@/src/lib/hosted-ops/growth-metrics";
+
+const totalMessagesChartConfig = {
+  totalMessages: {
+    color: "#7A8C6E",
+    label: "Total messages sent",
+  },
+} satisfies ChartConfig;
+
+const dailyMessagesChartConfig = {
+  messagesPerDay: {
+    color: "#7A8C6E",
+    label: "Messages sent per day",
+  },
+} satisfies ChartConfig;
 
 const acquisitionChartConfig = {
   newMembers: {
@@ -45,6 +63,7 @@ const revenueChartConfig = {
 
 interface GrowthChartsProps {
   dailySeries: HostedGrowthDailyPoint[];
+  messageSeries: HostedGrowthMessagePoint[];
   snapshotSeries: HostedGrowthSnapshotPoint[];
 }
 
@@ -57,7 +76,114 @@ export function GrowthCharts(input: GrowthChartsProps) {
 
   return (
     <div className="grid gap-4 xl:grid-cols-2">
-      <div className="rounded-xl border border-border/70 bg-card/90 p-5">
+      <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
+        <div className="flex flex-col gap-1">
+          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+            Total messages sent
+          </h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Cumulative hosted messages sent through each completed UTC day.
+          </p>
+        </div>
+        <ChartContainer
+          className="mt-4 h-64 w-full"
+          config={totalMessagesChartConfig}
+        >
+          <LineChart
+            accessibilityLayer
+            data={input.messageSeries}
+            margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
+          >
+            <CartesianGrid
+              stroke="var(--color-border)"
+              strokeDasharray="3 3"
+              strokeOpacity={0.55}
+              vertical={false}
+            />
+            <XAxis
+              axisLine={false}
+              dataKey="date"
+              minTickGap={24}
+              tickFormatter={formatShortDate}
+              tickLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              axisLine={false}
+              domain={["auto", "auto"]}
+              tickFormatter={formatCompactNumber}
+              tickLine={false}
+              width={44}
+            />
+            <ChartTooltip
+              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
+              cursor={{ stroke: "var(--color-border)", strokeDasharray: "3 3" }}
+            />
+            <Line
+              connectNulls={false}
+              dataKey="totalMessages"
+              dot={false}
+              name="Total messages sent"
+              stroke="var(--color-totalMessages)"
+              strokeWidth={2}
+              type="monotone"
+            />
+          </LineChart>
+        </ChartContainer>
+      </div>
+
+      <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
+        <div className="flex flex-col gap-1">
+          <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
+            Messages sent per day
+          </h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Daily inbound messages plus tracked Linq replies, by UTC date.
+          </p>
+        </div>
+        <ChartContainer
+          className="mt-4 h-64 w-full"
+          config={dailyMessagesChartConfig}
+        >
+          <BarChart
+            accessibilityLayer
+            data={input.messageSeries}
+            margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
+          >
+            <CartesianGrid
+              stroke="var(--color-border)"
+              strokeDasharray="3 3"
+              strokeOpacity={0.55}
+              vertical={false}
+            />
+            <XAxis
+              axisLine={false}
+              dataKey="date"
+              minTickGap={24}
+              tickFormatter={formatShortDate}
+              tickLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              axisLine={false}
+              tickLine={false}
+              width={36}
+            />
+            <ChartTooltip
+              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
+              cursor={{ fill: "var(--color-muted)", fillOpacity: 0.35 }}
+            />
+            <Bar
+              dataKey="messagesPerDay"
+              fill="var(--color-messagesPerDay)"
+              name="Messages sent per day"
+              radius={[3, 3, 0, 0]}
+            />
+          </BarChart>
+        </ChartContainer>
+      </div>
+
+      <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
           <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
             Acquisition
@@ -71,6 +197,7 @@ export function GrowthCharts(input: GrowthChartsProps) {
           config={acquisitionChartConfig}
         >
           <AreaChart
+            accessibilityLayer
             data={input.dailySeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >
@@ -94,7 +221,7 @@ export function GrowthCharts(input: GrowthChartsProps) {
               width={32}
             />
             <ChartTooltip
-              content={<ChartTooltipContent />}
+              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
               cursor={{ stroke: "var(--color-border)", strokeDasharray: "3 3" }}
             />
             <Area
@@ -119,7 +246,7 @@ export function GrowthCharts(input: GrowthChartsProps) {
         </ChartContainer>
       </div>
 
-      <div className="rounded-xl border border-border/70 bg-card/90 p-5">
+      <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
         <div className="flex flex-col gap-1">
           <h3 className="font-serif text-lg font-semibold tracking-tight text-foreground">
             Revenue snapshots
@@ -133,6 +260,7 @@ export function GrowthCharts(input: GrowthChartsProps) {
           config={revenueChartConfig}
         >
           <LineChart
+            accessibilityLayer
             data={revenueSeries}
             margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
           >
@@ -156,7 +284,7 @@ export function GrowthCharts(input: GrowthChartsProps) {
               width={32}
             />
             <ChartTooltip
-              content={<ChartTooltipContent />}
+              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
               cursor={{ stroke: "var(--color-border)", strokeDasharray: "3 3" }}
             />
             <Line
@@ -188,4 +316,15 @@ function formatShortDate(value: string): string {
     month: "short",
     timeZone: "UTC",
   }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
+function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 1,
+    notation: "compact",
+  }).format(value);
+}
+
+function formatTooltipDate(value: ReactNode): string {
+  return typeof value === "string" ? formatShortDate(value) : "";
 }

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -116,7 +116,12 @@ export function GrowthCharts(input: GrowthChartsProps) {
               width={44}
             />
             <ChartTooltip
-              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
+              content={(
+                <ChartTooltipContent
+                  className="min-w-52"
+                  labelFormatter={formatTooltipDate}
+                />
+              )}
               cursor={{ stroke: "var(--color-border)", strokeDasharray: "3 3" }}
             />
             <Line
@@ -170,7 +175,12 @@ export function GrowthCharts(input: GrowthChartsProps) {
               width={36}
             />
             <ChartTooltip
-              content={<ChartTooltipContent labelFormatter={formatTooltipDate} />}
+              content={(
+                <ChartTooltipContent
+                  className="min-w-52"
+                  labelFormatter={formatTooltipDate}
+                />
+              )}
               cursor={{ fill: "var(--color-muted)", fillOpacity: 0.35 }}
             />
             <Bar

--- a/apps/web/app/(dashboard)/ops/growth/page.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/page.tsx
@@ -75,6 +75,7 @@ export default async function HostedOpsGrowthPage() {
 
       <GrowthCharts
         dailySeries={dashboard.dailySeries}
+        messageSeries={dashboard.messageSeries}
         snapshotSeries={dashboard.snapshotSeries}
       />
 

--- a/apps/web/app/design/growth-scorecard-study.tsx
+++ b/apps/web/app/design/growth-scorecard-study.tsx
@@ -2,6 +2,42 @@ import {
   GrowthScorecard,
   type GrowthScorecardProps,
 } from "../(dashboard)/ops/growth/growth-scorecard";
+import { GrowthCharts } from "../(dashboard)/ops/growth/growth-charts";
+
+const GROWTH_DATES = Array.from({ length: 30 }, (_, index) => {
+  const date = new Date(Date.UTC(2026, 6, index + 1));
+  return date.toISOString().slice(0, 10);
+});
+
+const DAILY_MESSAGE_VOLUMES = GROWTH_DATES.map(
+  (_, index) => 58 + ((index * 17) % 83),
+);
+const MESSAGE_TRACKING_START_INDEX = 8;
+const MESSAGE_SERIES = GROWTH_DATES.map((date, index) => ({
+  date,
+  messagesPerDay: index < MESSAGE_TRACKING_START_INDEX
+    ? null
+    : DAILY_MESSAGE_VOLUMES[index] ?? 0,
+  totalMessages: index < MESSAGE_TRACKING_START_INDEX
+    ? null
+    : 5_240 + DAILY_MESSAGE_VOLUMES
+      .slice(MESSAGE_TRACKING_START_INDEX, index + 1)
+      .reduce((sum, value) => sum + value, 0),
+}));
+
+const DAILY_SERIES = GROWTH_DATES.map((date, index) => ({
+  date,
+  newMembers: 2 + ((index * 3) % 8),
+  trialStarts: 1 + ((index * 2) % 5),
+}));
+
+const SNAPSHOT_SERIES = GROWTH_DATES.map((date, index) => ({
+  coveredMembers: 82 + index * 3,
+  date,
+  mrrUsdCents: 14_400 + index * 320,
+  payingCustomers: 54 + Math.floor(index * 0.8),
+  trialingMembers: 16 + (index % 7),
+}));
 
 const STUDY_INPUT = {
   activeUsers: {
@@ -92,6 +128,16 @@ export function GrowthScorecardStudy() {
       data-design-study="ops-weekly-growth-compass"
       id="ops-weekly-growth-compass"
     >
+      <div id="growth-message-volume-charts">
+        <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Thirty-day movement
+        </div>
+        <GrowthCharts
+          dailySeries={DAILY_SERIES}
+          messageSeries={MESSAGE_SERIES}
+          snapshotSeries={SNAPSHOT_SERIES}
+        />
+      </div>
       <StudyState id="target-hit" label="Target hit" mrrWowPercent={10.8} />
       <StudyState id="below-target" label="Below target" mrrWowPercent={6.2} />
       <StudyState

--- a/apps/web/app/design/growth-scorecard-study.tsx
+++ b/apps/web/app/design/growth-scorecard-study.tsx
@@ -1,4 +1,8 @@
 import {
+  buildHostedGrowthMessageSeries,
+  type HostedGrowthMessageSnapshot,
+} from "@/src/lib/hosted-ops/growth-message-series";
+import {
   GrowthScorecard,
   type GrowthScorecardProps,
 } from "../(dashboard)/ops/growth/growth-scorecard";
@@ -10,20 +14,38 @@ const GROWTH_DATES = Array.from({ length: 30 }, (_, index) => {
 });
 
 const DAILY_MESSAGE_VOLUMES = GROWTH_DATES.map(
-  (_, index) => 58 + ((index * 17) % 83),
+  (_, index) => index === 14 ? 0 : 58 + ((index * 17) % 83),
 );
 const MESSAGE_TRACKING_START_INDEX = 8;
-const MESSAGE_SERIES = GROWTH_DATES.map((date, index) => ({
-  date,
-  messagesPerDay: index < MESSAGE_TRACKING_START_INDEX
-    ? null
-    : DAILY_MESSAGE_VOLUMES[index] ?? 0,
-  totalMessages: index < MESSAGE_TRACKING_START_INDEX
-    ? null
-    : 5_240 + DAILY_MESSAGE_VOLUMES
-      .slice(MESSAGE_TRACKING_START_INDEX, index + 1)
-      .reduce((sum, value) => sum + value, 0),
-}));
+const MISSING_TRACKED_MESSAGE_INDEX = 24;
+const MESSAGE_SNAPSHOTS = GROWTH_DATES
+  .slice(MESSAGE_TRACKING_START_INDEX - 1)
+  .flatMap((messageDate, relativeIndex) => {
+    const messageIndex = relativeIndex + MESSAGE_TRACKING_START_INDEX - 1;
+    if (messageIndex === MISSING_TRACKED_MESSAGE_INDEX) {
+      return [];
+    }
+    const snapshotDate = new Date(`${messageDate}T00:00:00.000Z`);
+    snapshotDate.setUTCDate(snapshotDate.getUTCDate() + 1);
+    const messages = DAILY_MESSAGE_VOLUMES[messageIndex] ?? 0;
+    const trackingAvailable = messageIndex >= MESSAGE_TRACKING_START_INDEX;
+
+    return [{
+      inboundMessagesPriorDay: trackingAvailable
+        ? Math.floor(messages * 0.45)
+        : null,
+      outboundMessagesPriorDay: trackingAvailable
+        ? messages - Math.floor(messages * 0.45)
+        : null,
+      snapshotDate,
+    } satisfies HostedGrowthMessageSnapshot];
+  });
+const MESSAGE_SERIES = buildHostedGrowthMessageSeries({
+  messagesBeforeSeries: 5_240,
+  snapshots: MESSAGE_SNAPSHOTS,
+  trackingEstablishedBeforeSeries: false,
+  windowEnd: new Date("2026-07-31T12:00:00.000Z"),
+});
 
 const DAILY_SERIES = GROWTH_DATES.map((date, index) => ({
   date,

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -292,7 +292,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Ops weekly growth compass with complete and retention-limited sender evidence">
+      <StudySection title="Ops weekly growth compass with message-volume history and retention-limited sender evidence">
         <GrowthScorecardStudy />
       </StudySection>
 

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -293,7 +293,9 @@ export function SectionsContent() {
       <Separator />
 
       <StudySection title="Ops weekly growth compass with message-volume history and retention-limited sender evidence">
-        <GrowthScorecardStudy />
+        <div inert>
+          <GrowthScorecardStudy />
+        </div>
       </StudySection>
 
       <Separator />

--- a/apps/web/e2e/ops-growth-message-charts.spec.ts
+++ b/apps/web/e2e/ops-growth-message-charts.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+
+const VIEWPORTS = [
+  { height: 900, label: "desktop", width: 1440 },
+  { height: 844, label: "mobile", width: 390 },
+] as const;
+
+const CHART_NAMES = [
+  "Total messages sent",
+  "Messages sent per day",
+  "Acquisition",
+  "Revenue snapshots",
+] as const;
+
+function isLoopbackUrl(rawUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rawUrl);
+    return hostname === "127.0.0.1"
+      || hostname === "localhost"
+      || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`growth message charts expose truthful keyboard states on ${viewport.label}`, async ({
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    await page.setViewportSize(viewport);
+    await page.route("**/*", (route) => {
+      if (isLoopbackUrl(route.request().url())) {
+        route.continue();
+      } else {
+        route.abort();
+      }
+    });
+
+    const response = await page.goto(
+      "/design?tab=sections#ops-weekly-growth-compass",
+      { waitUntil: "load" },
+    );
+    expect(response?.status(), "growth study should respond 200").toBe(200);
+
+    const study = page.locator("#ops-weekly-growth-compass");
+    const interactionBoundary = study.locator("..");
+    await expect(study).toBeVisible();
+    await page.evaluate(async () => {
+      await document.fonts?.ready;
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      );
+    });
+    await page.waitForFunction(() => {
+      const chartSurface = document.querySelector(
+        "#ops-weekly-growth-compass .recharts-surface",
+      );
+      return chartSurface
+        ? Object.keys(chartSurface).some((key) => key.startsWith("__reactFiber$"))
+        : false;
+    });
+    await interactionBoundary.evaluate((element) =>
+      element.removeAttribute("inert")
+    );
+
+    const chartCards = study.locator(
+      "#growth-message-volume-charts > div.grid > div",
+    );
+    const chartSurfaces = chartCards.locator(
+      '.recharts-surface[role="application"][tabindex="0"]',
+    );
+    await expect(chartCards).toHaveCount(4);
+    await expect(chartSurfaces).toHaveCount(4);
+
+    for (const [index, name] of CHART_NAMES.entries()) {
+      await expect(chartSurfaces.nth(index)).toHaveAccessibleName(name);
+    }
+
+    const dailyTooltip = chartCards.nth(1).locator(
+      ".recharts-tooltip-wrapper",
+    );
+    await chartSurfaces.nth(1).focus();
+    await expect(dailyTooltip).toBeHidden();
+
+    await chartSurfaces.nth(1).focus();
+    await page.keyboard.press("Shift+Tab");
+    const chartSurfaceCount = await chartSurfaces.count();
+    for (let index = 0; index < chartSurfaceCount; index += 1) {
+      await expect(chartSurfaces.nth(index)).toBeFocused();
+      const focusStyle = await chartCards
+        .nth(index)
+        .locator('[data-slot="chart"]')
+        .evaluate((element) => {
+          const style = window.getComputedStyle(element);
+          return {
+            outlineStyle: style.outlineStyle,
+            outlineWidth: Number.parseFloat(style.outlineWidth),
+          };
+        });
+      expect(focusStyle.outlineStyle).not.toBe("none");
+      expect(focusStyle.outlineWidth).toBeGreaterThanOrEqual(2);
+      await page.keyboard.press("Tab");
+    }
+    await expect(chartSurfaces.last()).not.toBeFocused();
+
+    await chartSurfaces.nth(1).focus();
+    for (let index = 0; index < 14; index += 1) {
+      await page.keyboard.press("ArrowRight");
+    }
+    await expect(dailyTooltip).toBeVisible();
+    await expect(dailyTooltip).toContainText("Jul 15");
+    await expect(dailyTooltip).toContainText("Messages sent per day");
+    await expect(dailyTooltip).toContainText("0");
+
+    await page.emulateMedia({ forcedColors: "active" });
+    await chartSurfaces.nth(1).focus();
+    await page.keyboard.press("Shift+Tab");
+    const forcedColorFocus = await chartCards
+      .first()
+      .locator('[data-slot="chart"]')
+      .evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return {
+          outlineStyle: style.outlineStyle,
+          outlineWidth: Number.parseFloat(style.outlineWidth),
+        };
+      });
+    expect(forcedColorFocus.outlineStyle).not.toBe("none");
+    expect(forcedColorFocus.outlineWidth).toBeGreaterThanOrEqual(2);
+  });
+}

--- a/apps/web/src/lib/hosted-ops/growth-message-series.ts
+++ b/apps/web/src/lib/hosted-ops/growth-message-series.ts
@@ -1,0 +1,90 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MESSAGE_SERIES_DAYS = 30;
+
+export interface HostedGrowthMessageSnapshot {
+  inboundMessagesPriorDay: number | null;
+  outboundMessagesPriorDay: number | null;
+  snapshotDate: Date;
+}
+
+export interface HostedGrowthMessagePoint {
+  date: string;
+  messagesPerDay: number | null;
+  totalMessages: number | null;
+}
+
+export function buildHostedGrowthMessageSeries(input: {
+  messagesBeforeSeries: number;
+  snapshots: HostedGrowthMessageSnapshot[];
+  trackingEstablishedBeforeSeries: boolean;
+  windowEnd: Date;
+}): HostedGrowthMessagePoint[] {
+  const lastSnapshotDate = startOfUtcDay(input.windowEnd);
+  const firstSnapshotDate = addUtcDays(
+    lastSnapshotDate,
+    -(MESSAGE_SERIES_DAYS - 1),
+  );
+  const snapshotsByDate = new Map(
+    input.snapshots.map((snapshot) => [
+      formatUtcDateKey(snapshot.snapshotDate),
+      snapshot,
+    ]),
+  );
+  let totalMessages = input.messagesBeforeSeries;
+  let cumulativeAvailable = true;
+  let cumulativeStarted = input.trackingEstablishedBeforeSeries;
+
+  return Array.from({ length: MESSAGE_SERIES_DAYS }, (_, index) => {
+    const snapshotDate = addUtcDays(firstSnapshotDate, index);
+    const snapshot = snapshotsByDate.get(formatUtcDateKey(snapshotDate));
+    const inboundMessages = snapshot?.inboundMessagesPriorDay ?? null;
+    const outboundMessages = snapshot?.outboundMessagesPriorDay ?? null;
+    const messagesPerDay = snapshot === undefined
+      || inboundMessages === null
+      || outboundMessages === null
+      ? null
+      : inboundMessages + outboundMessages;
+
+    if (messagesPerDay === null) {
+      if (cumulativeStarted) {
+        cumulativeAvailable = false;
+      }
+
+      return {
+        date: formatUtcDateKey(addUtcDays(snapshotDate, -1)),
+        messagesPerDay: null,
+        totalMessages: null,
+      };
+    }
+
+    if (!cumulativeStarted) {
+      cumulativeStarted = true;
+      cumulativeAvailable = true;
+    }
+    if (cumulativeAvailable) {
+      totalMessages += messagesPerDay;
+    }
+
+    return {
+      date: formatUtcDateKey(addUtcDays(snapshotDate, -1)),
+      messagesPerDay,
+      totalMessages: cumulativeAvailable ? totalMessages : null,
+    };
+  });
+}
+
+function addUtcDays(value: Date, days: number): Date {
+  return new Date(value.getTime() + days * MS_PER_DAY);
+}
+
+function formatUtcDateKey(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function startOfUtcDay(value: Date): Date {
+  return new Date(Date.UTC(
+    value.getUTCFullYear(),
+    value.getUTCMonth(),
+    value.getUTCDate(),
+  ));
+}

--- a/apps/web/src/lib/hosted-ops/growth-metrics.ts
+++ b/apps/web/src/lib/hosted-ops/growth-metrics.ts
@@ -36,8 +36,15 @@ import {
   createHostedLinqParticipantContactLookupKeyReadCandidates,
   type HostedLinqParticipantContactKind,
 } from "@/src/lib/hosted-onboarding/linq-participant-contact";
+import {
+  buildHostedGrowthMessageSeries,
+  type HostedGrowthMessagePoint,
+} from "@/src/lib/hosted-ops/growth-message-series";
 import { HOSTED_MESSAGE_VOLUME_BASE } from "@/src/lib/message-volume";
 import { getPrisma } from "@/src/lib/prisma";
+
+export { buildHostedGrowthMessageSeries } from "@/src/lib/hosted-ops/growth-message-series";
+export type { HostedGrowthMessagePoint } from "@/src/lib/hosted-ops/growth-message-series";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DAILY_SERIES_DAYS = 30;
@@ -182,12 +189,6 @@ export interface HostedGrowthDailyPoint {
   date: string;
   newMembers: number;
   trialStarts: number;
-}
-
-export interface HostedGrowthMessagePoint {
-  date: string;
-  messagesPerDay: number | null;
-  totalMessages: number | null;
 }
 
 export interface HostedGrowthSnapshotPoint {
@@ -467,28 +468,6 @@ export function buildDailyGrowthSeries(input: {
   }
 
   return Array.from(counts.values());
-}
-
-export function buildHostedGrowthMessageSeries(input: {
-  messagesBeforeSeries: number;
-  snapshots: HostedGrowthSnapshotRow[];
-}): HostedGrowthMessagePoint[] {
-  let totalMessages = input.messagesBeforeSeries;
-
-  return input.snapshots.map((snapshot) => {
-    const inboundMessages = snapshot.inboundMessagesPriorDay;
-    const outboundMessages = snapshot.outboundMessagesPriorDay;
-    totalMessages += (inboundMessages ?? 0) + (outboundMessages ?? 0);
-    const messagesPerDay = inboundMessages === null || outboundMessages === null
-      ? null
-      : inboundMessages + outboundMessages;
-
-    return {
-      date: formatUtcDateKey(addUtcDays(snapshot.snapshotDate, -1)),
-      messagesPerDay,
-      totalMessages: messagesPerDay === null ? null : totalMessages,
-    };
-  });
 }
 
 export function buildWeeklyGrowthRows(input: {
@@ -1120,6 +1099,10 @@ export async function readHostedGrowthDashboard(
       },
     }),
     prisma.hostedGrowthDailySnapshot.aggregate({
+      _count: {
+        inboundMessagesPriorDay: true,
+        outboundMessagesPriorDay: true,
+      },
       _sum: {
         inboundMessagesPriorDay: true,
         outboundMessagesPriorDay: true,
@@ -1325,6 +1308,10 @@ export async function readHostedGrowthDashboard(
         (messagesBeforeSeries._sum.inboundMessagesPriorDay ?? 0) +
         (messagesBeforeSeries._sum.outboundMessagesPriorDay ?? 0),
       snapshots,
+      trackingEstablishedBeforeSeries:
+        messagesBeforeSeries._count.inboundMessagesPriorDay > 0
+        && messagesBeforeSeries._count.outboundMessagesPriorDay > 0,
+      windowEnd: now,
     }),
     mrrWowPercent: comparableSnapshot === null
       ? null

--- a/apps/web/src/lib/hosted-ops/growth-metrics.ts
+++ b/apps/web/src/lib/hosted-ops/growth-metrics.ts
@@ -184,6 +184,12 @@ export interface HostedGrowthDailyPoint {
   trialStarts: number;
 }
 
+export interface HostedGrowthMessagePoint {
+  date: string;
+  messagesPerDay: number | null;
+  totalMessages: number | null;
+}
+
 export interface HostedGrowthSnapshotPoint {
   coveredMembers: number;
   date: string;
@@ -227,6 +233,7 @@ export interface HostedGrowthDashboard {
   };
   current: HostedGrowthCurrentMetrics;
   dailySeries: HostedGrowthDailyPoint[];
+  messageSeries: HostedGrowthMessagePoint[];
   mrrWowPercent: number | null;
   newMembers: {
     today: number;
@@ -460,6 +467,28 @@ export function buildDailyGrowthSeries(input: {
   }
 
   return Array.from(counts.values());
+}
+
+export function buildHostedGrowthMessageSeries(input: {
+  messagesBeforeSeries: number;
+  snapshots: HostedGrowthSnapshotRow[];
+}): HostedGrowthMessagePoint[] {
+  let totalMessages = input.messagesBeforeSeries;
+
+  return input.snapshots.map((snapshot) => {
+    const inboundMessages = snapshot.inboundMessagesPriorDay;
+    const outboundMessages = snapshot.outboundMessagesPriorDay;
+    totalMessages += (inboundMessages ?? 0) + (outboundMessages ?? 0);
+    const messagesPerDay = inboundMessages === null || outboundMessages === null
+      ? null
+      : inboundMessages + outboundMessages;
+
+    return {
+      date: formatUtcDateKey(addUtcDays(snapshot.snapshotDate, -1)),
+      messagesPerDay,
+      totalMessages: messagesPerDay === null ? null : totalMessages,
+    };
+  });
 }
 
 export function buildWeeklyGrowthRows(input: {
@@ -1032,6 +1061,7 @@ export async function readHostedGrowthDashboard(
     memberRows,
     rawTrialStartRows,
     snapshots,
+    messagesBeforeSeries,
     matureStarted,
     matureConverted,
     growthAggregate,
@@ -1086,6 +1116,17 @@ export async function readHostedGrowthDashboard(
         snapshotDate: {
           gte: dailyStart,
           lte: todayStart,
+        },
+      },
+    }),
+    prisma.hostedGrowthDailySnapshot.aggregate({
+      _sum: {
+        inboundMessagesPriorDay: true,
+        outboundMessagesPriorDay: true,
+      },
+      where: {
+        snapshotDate: {
+          lt: dailyStart,
         },
       },
     }),
@@ -1279,6 +1320,12 @@ export async function readHostedGrowthDashboard(
     }),
     current,
     dailySeries,
+    messageSeries: buildHostedGrowthMessageSeries({
+      messagesBeforeSeries: HOSTED_MESSAGE_VOLUME_BASE +
+        (messagesBeforeSeries._sum.inboundMessagesPriorDay ?? 0) +
+        (messagesBeforeSeries._sum.outboundMessagesPriorDay ?? 0),
+      snapshots,
+    }),
     mrrWowPercent: comparableSnapshot === null
       ? null
       : calculatePercentChange(current.mrrUsdCents, comparableSnapshot.mrrUsdCents),

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -172,6 +172,10 @@ describe("hosted ops growth metrics", () => {
       trackedFulfilledUsageTopUps: 0,
     });
     mocks.hostedGrowthDailySnapshot.aggregate.mockResolvedValue({
+      _count: {
+        inboundMessagesPriorDay: 0,
+        outboundMessagesPriorDay: 0,
+      },
       _max: {
         snapshotDate: null,
       },
@@ -680,45 +684,71 @@ describe("hosted ops growth metrics", () => {
     expect(calculatePercentChange(6, 3)).toBe(100);
   });
 
-  it("builds cumulative and daily message points on the day messages occurred", () => {
+  it("preserves the 30-day message spine, known zeroes, and unavailable gaps", () => {
     const points = buildHostedGrowthMessageSeries({
       messagesBeforeSeries: 5_000,
       snapshots: [
         {
-          ...snapshotRow("2026-07-05", 2_800),
+          ...snapshotRow("2026-07-08", 2_800),
           inboundMessagesPriorDay: null,
           outboundMessagesPriorDay: null,
         },
         {
-          ...snapshotRow("2026-07-06", 2_900),
+          ...snapshotRow("2026-07-10", 2_900),
           inboundMessagesPriorDay: 42,
           outboundMessagesPriorDay: 57,
         },
         {
-          ...snapshotRow("2026-07-07", 3_000),
+          ...snapshotRow("2026-07-11", 2_900),
+          inboundMessagesPriorDay: 0,
+          outboundMessagesPriorDay: 0,
+        },
+        {
+          ...snapshotRow("2026-07-13", 3_000),
           inboundMessagesPriorDay: 51,
           outboundMessagesPriorDay: 63,
         },
       ],
+      trackingEstablishedBeforeSeries: false,
+      windowEnd: new Date("2026-07-31T12:00:00.000Z"),
     });
 
-    expect(points).toEqual([
-      {
-        date: "2026-07-04",
-        messagesPerDay: null,
-        totalMessages: null,
-      },
-      {
-        date: "2026-07-05",
-        messagesPerDay: 99,
-        totalMessages: 5_099,
-      },
-      {
-        date: "2026-07-06",
-        messagesPerDay: 114,
-        totalMessages: 5_213,
-      },
-    ]);
+    expect(points).toHaveLength(30);
+    expect(points.map((point) => point.date)).toEqual(
+      Array.from({ length: 30 }, (_, index) =>
+        `2026-07-${String(index + 1).padStart(2, "0")}`
+      ),
+    );
+    expect(points[0]).toEqual({
+      date: "2026-07-01",
+      messagesPerDay: null,
+      totalMessages: null,
+    });
+    expect(points[6]).toEqual({
+      date: "2026-07-07",
+      messagesPerDay: null,
+      totalMessages: null,
+    });
+    expect(points[8]).toEqual({
+      date: "2026-07-09",
+      messagesPerDay: 99,
+      totalMessages: 5_099,
+    });
+    expect(points[9]).toEqual({
+      date: "2026-07-10",
+      messagesPerDay: 0,
+      totalMessages: 5_099,
+    });
+    expect(points[10]).toEqual({
+      date: "2026-07-11",
+      messagesPerDay: null,
+      totalMessages: null,
+    });
+    expect(points[11]).toEqual({
+      date: "2026-07-12",
+      messagesPerDay: 114,
+      totalMessages: null,
+    });
   });
 
   it("seeds the dashboard message series from earlier snapshot history", async () => {
@@ -726,14 +756,30 @@ describe("hosted ops growth metrics", () => {
     queueCurrentMetricMocks();
     mocks.hostedMember.findMany.mockResolvedValueOnce([]);
     mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
-    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce([
-      {
-        ...snapshotRow("2026-07-06", 2_900),
-        inboundMessagesPriorDay: 42,
-        outboundMessagesPriorDay: 57,
-      },
-    ]);
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce(
+      Array.from({ length: 30 }, (_, index) => {
+        const snapshotDate = addUtcDays(
+          new Date("2026-06-07T00:00:00.000Z"),
+          index,
+        );
+        const row = snapshotRow(
+          snapshotDate.toISOString().slice(0, 10),
+          2_900,
+        );
+        return index === 29
+          ? {
+              ...row,
+              inboundMessagesPriorDay: 42,
+              outboundMessagesPriorDay: 57,
+            }
+          : row;
+      }),
+    );
     mocks.hostedGrowthDailySnapshot.aggregate.mockResolvedValueOnce({
+      _count: {
+        inboundMessagesPriorDay: 1,
+        outboundMessagesPriorDay: 1,
+      },
       _sum: {
         inboundMessagesPriorDay: 300,
         outboundMessagesPriorDay: 200,
@@ -745,14 +791,22 @@ describe("hosted ops growth metrics", () => {
 
     const dashboard = await readHostedGrowthDashboard(now);
 
-    expect(dashboard.messageSeries).toEqual([
-      {
-        date: "2026-07-05",
-        messagesPerDay: 99,
-        totalMessages: HOSTED_MESSAGE_VOLUME_BASE + 599,
-      },
-    ]);
+    expect(dashboard.messageSeries).toHaveLength(30);
+    expect(dashboard.messageSeries[0]).toEqual({
+      date: "2026-06-06",
+      messagesPerDay: 0,
+      totalMessages: HOSTED_MESSAGE_VOLUME_BASE + 500,
+    });
+    expect(dashboard.messageSeries.at(-1)).toEqual({
+      date: "2026-07-05",
+      messagesPerDay: 99,
+      totalMessages: HOSTED_MESSAGE_VOLUME_BASE + 599,
+    });
     expect(mocks.hostedGrowthDailySnapshot.aggregate).toHaveBeenCalledWith({
+      _count: {
+        inboundMessagesPriorDay: true,
+        outboundMessagesPriorDay: true,
+      },
       _sum: {
         inboundMessagesPriorDay: true,
         outboundMessagesPriorDay: true,

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/lib/hosted-onboarding/linq-participant-contact";
 import {
   addUtcDays,
+  buildHostedGrowthMessageSeries,
   buildTrialCohortRows,
   calculateHostedGrowthCurrentMetrics,
   calculateHostedTrialMetrics,
@@ -169,6 +170,15 @@ describe("hosted ops growth metrics", () => {
     });
     mocks.hostedGrowthAggregate.findUniqueOrThrow.mockResolvedValue({
       trackedFulfilledUsageTopUps: 0,
+    });
+    mocks.hostedGrowthDailySnapshot.aggregate.mockResolvedValue({
+      _max: {
+        snapshotDate: null,
+      },
+      _sum: {
+        inboundMessagesPriorDay: null,
+        outboundMessagesPriorDay: null,
+      },
     });
     mocks.hostedMember.count.mockResolvedValue(0);
     mocks.requireActiveHostedAppSession.mockResolvedValue({
@@ -549,6 +559,8 @@ describe("hosted ops growth metrics", () => {
     const markup = renderToStaticMarkup(await growthPage.default());
 
     expect(markup).toContain("MRR growth per week");
+    expect(markup).toContain("Total messages sent");
+    expect(markup).toContain("Messages sent per day");
     expect(markup).toMatch(
       /Weekly active users<\/div><div[^>]*>6 WAU<\/div><div[^>]*>9 MAU across personal \+ group chats<\/div>/u,
     );
@@ -666,6 +678,91 @@ describe("hosted ops growth metrics", () => {
   it("returns no percent change when the previous window is zero", () => {
     expect(calculatePercentChange(4, 0)).toBeNull();
     expect(calculatePercentChange(6, 3)).toBe(100);
+  });
+
+  it("builds cumulative and daily message points on the day messages occurred", () => {
+    const points = buildHostedGrowthMessageSeries({
+      messagesBeforeSeries: 5_000,
+      snapshots: [
+        {
+          ...snapshotRow("2026-07-05", 2_800),
+          inboundMessagesPriorDay: null,
+          outboundMessagesPriorDay: null,
+        },
+        {
+          ...snapshotRow("2026-07-06", 2_900),
+          inboundMessagesPriorDay: 42,
+          outboundMessagesPriorDay: 57,
+        },
+        {
+          ...snapshotRow("2026-07-07", 3_000),
+          inboundMessagesPriorDay: 51,
+          outboundMessagesPriorDay: 63,
+        },
+      ],
+    });
+
+    expect(points).toEqual([
+      {
+        date: "2026-07-04",
+        messagesPerDay: null,
+        totalMessages: null,
+      },
+      {
+        date: "2026-07-05",
+        messagesPerDay: 99,
+        totalMessages: 5_099,
+      },
+      {
+        date: "2026-07-06",
+        messagesPerDay: 114,
+        totalMessages: 5_213,
+      },
+    ]);
+  });
+
+  it("seeds the dashboard message series from earlier snapshot history", async () => {
+    const now = new Date("2026-07-06T12:00:00.000Z");
+    queueCurrentMetricMocks();
+    mocks.hostedMember.findMany.mockResolvedValueOnce([]);
+    mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce([
+      {
+        ...snapshotRow("2026-07-06", 2_900),
+        inboundMessagesPriorDay: 42,
+        outboundMessagesPriorDay: 57,
+      },
+    ]);
+    mocks.hostedGrowthDailySnapshot.aggregate.mockResolvedValueOnce({
+      _sum: {
+        inboundMessagesPriorDay: 300,
+        outboundMessagesPriorDay: 200,
+      },
+    });
+    mocks.hostedMemberBillingRef.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+
+    const dashboard = await readHostedGrowthDashboard(now);
+
+    expect(dashboard.messageSeries).toEqual([
+      {
+        date: "2026-07-05",
+        messagesPerDay: 99,
+        totalMessages: HOSTED_MESSAGE_VOLUME_BASE + 599,
+      },
+    ]);
+    expect(mocks.hostedGrowthDailySnapshot.aggregate).toHaveBeenCalledWith({
+      _sum: {
+        inboundMessagesPriorDay: true,
+        outboundMessagesPriorDay: true,
+      },
+      where: {
+        snapshotDate: {
+          lt: new Date("2026-06-07T00:00:00.000Z"),
+        },
+      },
+    });
   });
 
   it("counts distinct senders across personal chats and group containers", async () => {


### PR DESCRIPTION
## Why this PR exists

The internal growth page shows acquisition and revenue movement, but it drops
the message-volume history already captured in the daily growth snapshots. An
operator needs to see both cumulative message growth and daily message activity
without introducing another metric owner.

## User goal / user-visible behavior

On `/ops/growth`, the operator sees **Total messages sent** as a cumulative
30-day line and **Messages sent per day** as daily bars ahead of the existing
acquisition and revenue charts. Dates represent completed UTC days. Pre-tracking
legacy days remain visible as gaps rather than false zeroes.
If a day is missing after tracking starts, later known daily bars still render,
but the cumulative line stops until that missing evidence is reconciled.

## User experience

- Entry point: an authorized operator opens the existing growth page.
- Immediate feedback: the two message charts render with the rest of the
  dashboard; hover and keyboard chart navigation expose the date and value.
- Timing/continuation: this is a synchronous dashboard read with no new queue,
  cron, workflow, or continuation owner.
- Completion/recovery: the current page-level auth and data error boundaries
  remain unchanged. Unknown or absent counts render as gaps, not invented data.

## Architecture and reuse

- Existing systems reused: `HostedGrowthDailySnapshot` remains the sole durable
  owner, while the existing `GrowthCharts`, Recharts primitives, chart tokens,
  and growth design study render the result.
- New logic: one bounded aggregate seeds an exact 30 completed-day UTC spine
  from older snapshot history plus `HOSTED_MESSAGE_VOLUME_BASE`, then the
  existing prior-day inbound and tracked Linq outbound counts are projected
  onto the date when the messages occurred.
- New abstractions: one typed message-series projection helper keeps UTC date
  alignment, leading legacy gaps, known zeroes, missing tracked days, and
  cumulative arithmetic independently testable.
- Complexity intentionally avoided: no schema, persistence owner, dependency,
  provider read, scheduled work, queue, or duplicate message-count query was
  added.

## Invariants

- Preserve the existing inbound and outbound counting definitions.
- Keep the query bounded and free of member/message identifiers.
- Do not represent unknown legacy values as known zeroes.
- Do not carry a cumulative total across an unavailable tracked day.
- Preserve acquisition, revenue, scorecard, auth, and error behavior.
- Keep the chart grid responsive and keyboard-accessible.

## Non-obvious affected surfaces

- The acquisition and revenue tooltips now use the same short UTC-date format
  as the new charts, and both existing charts opt into Recharts' accessibility
  layer for consistent keyboard behavior.
- The cumulative Y axis uses its observed data band so movement remains legible
  as the lifetime total grows.
- No cross-deploy compatibility window exists: all behavior is owned by the
  hosted web app and reads an unchanged schema.

## Verification

- `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hosted-ops-growth.test.ts` — 33 tests passed.
- `pnpm --dir apps/web typecheck:prepared` — passed.
- Scoped ESLint across all touched app/test files — passed.
- `pnpm test:frontend-design-proof` — 10 tests passed.
- Focused Playwright proof passed at 1440 × 900 and 390 × 844. It verifies the
  exact sparse-data state, known zero-day tooltip, four chart names, sequential
  keyboard navigation, a visible focus outline, focus exit, and forced-colors
  focus behavior.
- Fable UI review ran review-only. Accepted findings added the legacy gap state,
  uniform tooltip dates, solid graphical contrast, the auto-scaled cumulative
  axis, consistent accessibility layers, and the shared 2px stroke. A proposed
  null-tooltip fix was rejected after direct Recharts source inspection proved
  its default `filterNull` removes null entries before rendering.
- Exact-head tooltip proof exposed and resolved crowded label/value spacing in
  the two new message tooltips.
- The preliminary specialist pass found three material gaps: collapsed sparse
  dates, unnamed/unfocused keyboard surfaces, and missing boundary coverage.
  The exact 30-day spine, named focus frames, and focused Vitest/Playwright
  regressions resolve all three. Product-purpose revalidation confirms the
  operator can still read movement over time while unavailable evidence remains
  explicit.

Exact-head broad CI: passed after a clean base-only rebase onto current `main`.
Host matrices, build/typecheck, app verification, fixture and package coverage,
viewport Playwright, design proof, release checks, and repository hygiene are
green.

## Preliminary specialist lenses

- Product experience: **applicable** — the visible message-history elements and
  their unavailable-data semantics are new. The specialist finding is resolved
  by the exact 30-day spine and cumulative stop after a tracked gap.
- Prompt: **not applicable** — no prompt, tool description, instruction stack,
  or provider-visible assembly changed.
- Frontend: **applicable** — rendered evidence is packaged as
  `audit-packages/growth-message-charts-desktop-final.png`,
  `audit-packages/growth-message-charts-mobile-final.png`, and
  `audit-packages/growth-message-charts-tooltip-final.png`, with separate
  keyboard-focus proof for the new named focus frame.
- Coverage: **applicable** — focused projection and browser tests prove the UTC
  shift, exact spine, leading and tracked gaps, known zero, historical seed,
  bounded aggregate, chart names, keyboard order, and focus visibility.

## Provider-visible input impact

- OpenAI/Codex: Not applicable; no provider-visible prompt or tool surface
  changed.
- Anthropic/Claude: Not applicable; no provider-visible prompt or tool surface
  changed.

## Change shape

Classification: production TypeScript/TSX is source; Vitest changes are tests;
`DESIGN.md` and the execution plan are docs; no binary or generated file is in
the patch.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 380 | 10 |
| Tests / fixtures | 283 | 0 |
| Docs | 57 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **720** | **10** |

## Design proof

- Design page: `/design?tab=sections#ops-weekly-growth-compass`
- Desktop screenshot: ![Desktop growth message charts](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/cfd1e71c-b2c2-4aa3-4a07-b6f2db15ed00/designproof)
- Mobile screenshot: ![Mobile growth message charts](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/f070ca67-52d7-4ffb-063d-136dae291000/designproof)
- Tooltip screenshot: ![Daily message tooltip](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/f4bb345d-77c7-4ade-d30e-9ddb643f4500/designproof)
- Keyboard-focus screenshot: ![Keyboard focus on the total-message chart](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/77a07806-6f96-4c1d-5313-a435acaebe00/designproof)

These redacted exact-head renders exercise the real design-study component at
1440 and 390 CSS-pixel viewports, a hovered daily bar, and the keyboard focus
frame. No screenshot binaries are committed.

## Review route

The preliminary product/frontend/coverage specialist pass applies. The final
cross-cutting ReviewGPT gate does not: this is a bounded single-owner web
projection with no auth, billing, privacy, health-safety, schema, persistence,
runtime-boundary, ordering, retry, concurrency, or public API change.
