### PR TITLE
Let group casing requests update Murph's room tone

### DIFF
--- a/agent-docs/product-specs/murph-tone-and-voice.md
+++ b/agent-docs/product-specs/murph-tone-and-voice.md
@@ -1,6 +1,6 @@
 # How Murph Talks
 
-Last verified: 2026-07-24
+Last verified: 2026-08-01
 Status: Implemented for persona-first onboarding, personal Settings, hosted mailbox handoff, prompt style, voice memo default resolution, supervisor-run preview generation, private conversational controls, room-owned hosted Linq group controls, and the conversational-only Unhinged dial
 
 ## Product Contract
@@ -21,6 +21,8 @@ Tone and voice appear during the hosted first visit and under **How Murph talks*
 Unhinged is conversational-only. It has no first-visit step and no Settings row, and the browser `POST /api/settings/assistant-style` route rejects it; the only way to change it is to ask Murph in conversation, which uses `murph.assistant_style`. It scales how much Murph self-censors its own style and how much edgy, crude, or adult-flavored latitude it takes among clearly consenting adults. It never changes safety, truth, privacy, consent, authority, tool access, or notification cadence.
 
 An authenticated hosted Linq group may change all six controls conversationally, but those choices belong to that room's Murph runtime and have no separate web UI.
+
+Reply casing is an interpretation of Tone, not a seventh stored control. When a member is clearly asking how Murph should write its replies, requests to capitalize, use normal or standard capitalization, use sentence case, or stop writing in lowercase select `formal`; requests to write in lowercase select `casual`. Private chats and authenticated hosted Linq groups both persist the choice through `murph.personalization`; group writes remain room-owned and begin on a later turn.
 
 The first-visit sequence is the four-step Murph personality picker:
 

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -580,7 +580,7 @@ export const MURPH_PERSONALIZATION_TOOL = {
   namespace: 'murph',
   name: 'personalization',
   description:
-    'Read the current hosted conversation runtime\'s effective Murph tone, voice, and model context, or atomically update tone and voice. In a private chat this is the member\'s Murph; in a group chat this is the synthetic room Murph and never a participant\'s private settings. Use murph.assistant_configuration for model, provider, or reasoning changes only when that separate tool is available.',
+    'Read the current hosted conversation runtime\'s effective Murph tone, voice, and model context, or atomically update tone and voice. Reply casing maps to the existing tone field: capitalize, standard capitalization, or sentence case means formal; lowercase means casual. Treat a request about how Murph should keep writing as an update rather than an unsupported setting; a one-reply formatting request does not persist. In a private chat this is the member\'s Murph; in a group chat this is the synthetic room Murph and never a participant\'s private settings. Use murph.assistant_configuration for model, provider, or reasoning changes only when that separate tool is available.',
   inputSchema: {
     oneOf: [
       {

--- a/packages/assistant-engine/test/assistant-personalization-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-personalization-tool.test.ts
@@ -30,6 +30,21 @@ describe('assistant personalization tool', () => {
     expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
       'never a participant',
     )
+    expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
+      'Reply casing maps to the existing tone field',
+    )
+    expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
+      'sentence case means formal',
+    )
+    expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
+      'lowercase means casual',
+    )
+    expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
+      'rather than an unsupported setting',
+    )
+    expect(MURPH_PERSONALIZATION_TOOL.description).toContain(
+      'a one-reply formatting request does not persist',
+    )
     expect(JSON.stringify(MURPH_PERSONALIZATION_TOOL.inputSchema)).not.toContain(
       'memberId',
     )


### PR DESCRIPTION
## Summary

- map reply-casing language onto the existing tone IDs owned by `murph.personalization`
- treat capitalization and sentence-case requests as `formal`, and lowercase requests as `casual`
- keep one-reply formatting requests ephemeral instead of persisting them
- document the contract and cover the personalization tool description with a regression test

## Why

Hosted Linq groups already own a synthetic Murph tone preference. The gap was interpretation: language such as “capitalize” was treated as a separate unsupported setting instead of the existing `formal` tone.

This deliberately does not add a seventh preference, a database field, or another mutation path.

## Architecture and reuse

- **Existing systems reused:** Reuses the callback-bound `murph.personalization` tool, its existing `casual` / `formal` tone IDs, and the existing room-owned hosted Linq personalization persistence path.
- **New logic:** Adds a narrow semantic alias contract so persistent casing requests map to the existing tone update, while explicitly one-reply formatting requests remain temporary.
- **New abstractions:** No new abstraction is introduced; casing remains an interpretation of Tone rather than a separate preference.
- **Complexity intentionally avoided:** Avoids a new schema field, migration, API, room-state owner, mutation path, or resident system-prompt expansion.

## Verification

- `pnpm exec vitest run packages/assistant-engine/test/assistant-personalization-tool.test.ts packages/assistant-engine/test/model-behavior.test.ts --no-coverage`
- 2 test files passed; 76 tests passed
