### PR TITLE
fix(core): date display-name audit by caller time

### DIFF
--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -129,6 +129,7 @@ export async function setMemoryDisplayName(
       vaultRoot,
       operationType: "memory_upsert",
       summary: `Set memory display name ${next.record.id}`,
+      occurredAt: input.now,
       target: resolveSingletonMarkdownDocumentTarget({
         relativePath: memoryDocumentRelativePath,
         created: !snapshot.exists,


### PR DESCRIPTION
## Why this PR exists

At 2026-08-01T00:00 UTC every repository CI run started failing: `packages/core/test/memory.test.ts > sets the preferred display name as a canonical memory record` fails with `VaultError: Missing required file "audit/2026/2026-07.jsonl"`. The test injects a fixed July `now` into `setMemoryDisplayName` and reads the July audit shard, but the audited write ignored the caller's time and dated the audit record with the wall clock, so the record landed in the August shard. The failure is deterministic for the whole month and blocks the `Release package coverage (platform)` and `Release checks (ubuntu)` gates on every branch, including `main`'s own post-merge runs.

## User goal / user-visible behavior

No user-visible product behavior changes. The vault audit ledger now dates a display-name write by the same caller-supplied time that stamps the memory record itself, so the audit record lands in the shard for the month the operation logically occurred, matching every other audited memory mutation.

## User experience

Not applicable — no rendered surface, copy, timing, or interaction changes. The only observable change is which monthly audit shard receives the ledger row for a display-name write when a caller supplies an explicit operation time.

## Invariants to preserve

- An audited canonical write and its audit ledger row commit together.
- Audit shards are keyed by the operation's logical occurrence time; `updateMemory` and `forgetMemoryRecord` already pass `occurredAt: input.now`, and `setMemoryDisplayName` now matches them.
- Callers that omit `now` keep the existing wall-clock default.

## Architecture and reuse

One line: `setMemoryDisplayName` forwards `occurredAt: input.now` to the existing `writeCanonicalMarkdownDocument` owner, exactly as its sibling `updateMemory` already does. No new abstraction, path, or behavior branch.

Non-obvious affected surfaces: the monthly audit shard selected for display-name writes when the logical time and wall-clock month differ (previously the wall-clock month; now the logical month, consistent with the rest of the memory API).

## Direct journey evidence

- `packages/core/test/memory.test.ts` — the exact suite red on every branch since the UTC month rollover — passes: 10/10, including the previously failing case.
- Full `packages/core` Vitest suite — pass, 768 tests (the CI shard failed 1/768 before this fix).
- `packages/core` TypeScript `--noEmit` — pass.

## Verification

- Focused failing test reproduced red at `origin/main` (`789931e75f`) and green with this change.
- Full core package suite — pass, 768 tests.
- Package typecheck — pass.
- `git diff --check` — pass; the diff is a single added line.

## Preliminary specialist lenses

- Product experience: not applicable — no user-facing change.
- Coverage: applicable — the existing deterministic test now exercises the corrected path; no new test is needed because the failing assertion is itself the regression proof.
- Prompt: not applicable.
- Frontend: not applicable — no rendered UI; design proof not applicable.

## Change shape

| Category | + | - |
| --- | ---: | ---: |
| Authored source | 1 | 0 |
| Tests / direct proof | 0 | 0 |
| Docs / plan | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1** | **0** |

## Deployment skew / compatibility

None. The audit ledger is an append-only local vault file; old and new revisions read shards the same way, and no schema, contract, or durable row shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788137371&installation_model_id=19880&pr_number=1245&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1245&signature=e10b8ca6979d748057ba777840fc1979dd5b0d57d4452fcc9c6f12f7b0796c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->