### PR TITLE
fix(hosted): validate Linq inventory snapshots and surface total contact-card outages

### DIFF
--- a/apps/web/prisma/migrations/20260802000000_add_hosted_linq_line_inventory_confirmed_at/migration.sql
+++ b/apps/web/prisma/migrations/20260802000000_add_hosted_linq_line_inventory_confirmed_at/migration.sql
@@ -1,0 +1,9 @@
+-- Additive freshness watermark for validated provider phone-number snapshots.
+-- Nullable with no backfill: rows written before this migration have no
+-- confirmed snapshot, so ownership-gated consumers fail closed until the
+-- next successful inventory sync stamps them.
+ALTER TABLE "hosted_linq_line"
+  ADD COLUMN IF NOT EXISTS "provider_inventory_confirmed_at" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "hosted_linq_line_provider_inventory_confirmed_at_idx"
+  ON "hosted_linq_line" ("provider_inventory_confirmed_at");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1842,6 +1842,12 @@ model HostedLinqLine {
   configuredAt               DateTime? @map("configured_at")
   providerSeenAt             DateTime? @map("provider_seen_at")
   providerPhoneNumberId      String?   @unique @map("provider_phone_number_id")
+  /// Written only when a validated authoritative provider phone-number
+  /// snapshot confirms this row's phone-to-provider-id pairing. Distinct from
+  /// providerSeenAt/providerLastSeenAt, which chat-health and status
+  /// projection also advance, so it is the only trustworthy freshness signal
+  /// for ownership-gated consumers.
+  providerInventoryConfirmedAt DateTime? @map("provider_inventory_confirmed_at")
   providerFirstSeenAt        DateTime? @map("provider_first_seen_at")
   providerLastSeenAt         DateTime? @map("provider_last_seen_at")
   healthStatus               String    @default("unknown") @map("health_status")
@@ -1893,6 +1899,7 @@ model HostedLinqLine {
   @@index([providerServiceStatus])
   @@index([providerReputationStatus])
   @@index([providerLastSeenAt])
+  @@index([providerInventoryConfirmedAt])
   @@index([lastFailedAt])
   @@map("hosted_linq_line")
 }

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -114,6 +114,18 @@ export async function reconcileHostedLinqContactCards(input: {
     }
   }
 
+  // Per-line isolation covers a partially degraded pool; a run where every
+  // line failed is a reconciliation outage and must fail the cron so the
+  // scheduler and alerting see it instead of a silent success.
+  if (result.lineCount > 0 && result.failedLines === result.lineCount) {
+    throw hostedOnboardingError({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+      message: `Linq contact-card reconciliation failed for all ${result.lineCount} line(s).`,
+      httpStatus: 502,
+      retryable: true,
+    });
+  }
+
   return result;
 }
 

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -4,7 +4,10 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
-import { listHostedLinqContactCardLines } from "./linq-line-store";
+import {
+  buildHostedLinqInventoryFreshnessCutoff,
+  listHostedLinqContactCardLines,
+} from "./linq-line-store";
 import { normalizePhoneNumber } from "./phone";
 import {
   getHostedOnboardingEnvironment,
@@ -55,34 +58,27 @@ type LinqContactCardsResponse = {
 
 export async function reconcileHostedLinqContactCards(input: {
   maxLines?: number;
+  observedAt?: Date;
   prisma: HostedLinqContactCardClient;
   signal?: AbortSignal;
 }): Promise<HostedLinqContactCardReconciliation> {
-  const lines = await listHostedLinqConfiguredContactCardLines({
-    maxLines: input.maxLines,
+  const observedAt = input.observedAt ?? new Date();
+
+  // Configured lines are the only ones that can own a member conversation,
+  // so their health is evaluated independently of the combined candidate
+  // list: an unrelated provider-only row must never let a total
+  // configured-line outage read as success. Checked before any provider
+  // request so no call is made for numbers the account no longer owns.
+  await assertHostedLinqConfiguredContactCardPoolHealthy({
+    observedAt,
     prisma: input.prisma,
   });
 
-  // An empty candidate list while configured lines exist means the inventory
-  // has revoked ownership of every configured number — that is a contact-card
-  // outage, not a legitimately empty pool, and must not read as a lineCount:0
-  // success.
-  if (lines.length === 0) {
-    const configuredLineCount = await input.prisma.hostedLinqLine.count({
-      where: {
-        configuredAt: { not: null },
-        phoneNumberEncrypted: { not: null },
-      },
-    });
-    if (configuredLineCount > 0) {
-      throw hostedOnboardingError({
-        code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
-        message: `Linq contact-card reconciliation found ${configuredLineCount} configured line(s) but none with validated inventory backing.`,
-        httpStatus: 502,
-        retryable: true,
-      });
-    }
-  }
+  const lines = await listHostedLinqConfiguredContactCardLines({
+    maxLines: input.maxLines,
+    observedAt,
+    prisma: input.prisma,
+  });
 
   const result: HostedLinqContactCardReconciliation = {
     activeCards: 0,
@@ -224,6 +220,49 @@ export async function updateHostedLinqContactCard(input: {
   return requireHostedLinqContactCard(payload, "update");
 }
 
+/**
+ * Configured lines are the only ones that can own a member conversation, so
+ * the pool is unhealthy whenever configured lines exist but none of them
+ * still carries a fresh, validated inventory confirmation — whether their
+ * ownership was revoked or the inventory owner has been failing long enough
+ * for confirmation to age out. Provider-only rows never satisfy this.
+ */
+async function assertHostedLinqConfiguredContactCardPoolHealthy(input: {
+  observedAt: Date;
+  prisma: HostedLinqContactCardClient;
+}): Promise<void> {
+  const configuredLineCount = await input.prisma.hostedLinqLine.count({
+    where: {
+      configuredAt: { not: null },
+      phoneNumberEncrypted: { not: null },
+    },
+  });
+  if (configuredLineCount === 0) {
+    return;
+  }
+
+  const backedConfiguredLineCount = await input.prisma.hostedLinqLine.count({
+    where: {
+      configuredAt: { not: null },
+      phoneNumberEncrypted: { not: null },
+      providerInventoryConfirmedAt: {
+        gte: buildHostedLinqInventoryFreshnessCutoff(input.observedAt),
+      },
+      providerPhoneNumberId: { not: null },
+    },
+  });
+  if (backedConfiguredLineCount > 0) {
+    return;
+  }
+
+  throw hostedOnboardingError({
+    code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    message: `Linq contact-card reconciliation found ${configuredLineCount} configured line(s) but none with a fresh validated inventory confirmation.`,
+    httpStatus: 502,
+    retryable: true,
+  });
+}
+
 type HostedLinqContactCardOutcome =
   | "activeCards"
   | "createdCards"
@@ -232,6 +271,7 @@ type HostedLinqContactCardOutcome =
 
 async function listHostedLinqConfiguredContactCardLines(input: {
   maxLines?: number;
+  observedAt: Date;
   prisma: HostedLinqContactCardClient;
 }): Promise<Array<{
   phoneNumber: string;
@@ -247,6 +287,7 @@ async function listHostedLinqConfiguredContactCardLines(input: {
   // into a member's saved vCard.
   const lines = await listHostedLinqContactCardLines({
     limit: maxLines,
+    observedAt: input.observedAt,
     prisma: input.prisma,
   });
   return lines.map((line) => ({

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -5,8 +5,8 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
 import {
-  buildHostedLinqInventoryFreshnessCutoff,
   listHostedLinqContactCardLines,
+  readHostedLinqContactCardCandidacySnapshot,
 } from "./linq-line-store";
 import { normalizePhoneNumber } from "./phone";
 import {
@@ -64,21 +64,28 @@ export async function reconcileHostedLinqContactCards(input: {
 }): Promise<HostedLinqContactCardReconciliation> {
   const observedAt = input.observedAt ?? new Date();
 
-  // Configured lines are the only ones that can own a member conversation,
-  // so their health is evaluated independently of the combined candidate
-  // list: an unrelated provider-only row must never let a total
-  // configured-line outage read as success. Checked before any provider
-  // request so no call is made for numbers the account no longer owns.
-  await assertHostedLinqConfiguredContactCardPoolHealthy({
-    observedAt,
-    prisma: input.prisma,
-  });
-
-  const lines = await listHostedLinqConfiguredContactCardLines({
+  // One locked, consistent snapshot of candidacy plus the configured-line
+  // total, so an overlapping revoking health-cron run can never be observed
+  // half-applied and no second unlocked read can disagree with the first.
+  const { configuredLineCount, lines } = await listHostedLinqConfiguredContactCardLines({
     maxLines: input.maxLines,
     observedAt,
     prisma: input.prisma,
   });
+
+  // Configured lines are the only ones that can own a member conversation.
+  // Their health is judged on its own, never satisfied by an unrelated
+  // provider-only row, and checked before any provider request so no call is
+  // made for a number the account no longer owns.
+  const configuredLines = lines.filter((line) => line.isConfigured);
+  if (configuredLineCount > 0 && configuredLines.length === 0) {
+    throw hostedOnboardingError({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+      message: `Linq contact-card reconciliation found ${configuredLineCount} configured line(s) but none with a fresh validated inventory confirmation.`,
+      httpStatus: 502,
+      retryable: true,
+    });
+  }
 
   const result: HostedLinqContactCardReconciliation = {
     activeCards: 0,
@@ -91,6 +98,7 @@ export async function reconcileHostedLinqContactCards(input: {
     updatedCards: 0,
   };
 
+  const usableActiveLineKeys = new Set<string>();
   for (const line of lines) {
     if (line.providerReputationStatus === "AT_RISK") {
       result.atRiskLines += 1;
@@ -112,6 +120,9 @@ export async function reconcileHostedLinqContactCards(input: {
         signal: input.signal,
       });
       result[outcome] += 1;
+      if (outcome !== "inactiveCards") {
+        usableActiveLineKeys.add(line.phoneNumberLookupKey);
+      }
     } catch (error) {
       if (input.signal?.aborted) {
         throw error;
@@ -128,7 +139,21 @@ export async function reconcileHostedLinqContactCards(input: {
   // with zero usable active cards — every line failed or produced an
   // inactive card — leaves the native contact-card share with nothing to
   // send, so it must fail the cron and reach the scheduler and alerting
-  // instead of reporting a silent success.
+  // instead of reporting a silent success. Configured lines are judged
+  // separately, so an active provider-only card can never stand in for the
+  // loss of every line that can actually own a member conversation.
+  const usableConfiguredCards = configuredLines.filter(
+    (line) => usableActiveLineKeys.has(line.phoneNumberLookupKey),
+  ).length;
+  if (configuredLines.length > 0 && usableConfiguredCards === 0) {
+    throw hostedOnboardingError({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+      message: `Linq contact-card reconciliation produced no usable active contact card across ${configuredLines.length} configured line(s) (${result.failedLines} failed, ${result.inactiveCards} inactive overall).`,
+      httpStatus: 502,
+      retryable: true,
+    });
+  }
+
   const usableActiveCards =
     result.activeCards + result.createdCards + result.updatedCards;
   if (result.lineCount > 0 && usableActiveCards === 0) {
@@ -220,49 +245,6 @@ export async function updateHostedLinqContactCard(input: {
   return requireHostedLinqContactCard(payload, "update");
 }
 
-/**
- * Configured lines are the only ones that can own a member conversation, so
- * the pool is unhealthy whenever configured lines exist but none of them
- * still carries a fresh, validated inventory confirmation — whether their
- * ownership was revoked or the inventory owner has been failing long enough
- * for confirmation to age out. Provider-only rows never satisfy this.
- */
-async function assertHostedLinqConfiguredContactCardPoolHealthy(input: {
-  observedAt: Date;
-  prisma: HostedLinqContactCardClient;
-}): Promise<void> {
-  const configuredLineCount = await input.prisma.hostedLinqLine.count({
-    where: {
-      configuredAt: { not: null },
-      phoneNumberEncrypted: { not: null },
-    },
-  });
-  if (configuredLineCount === 0) {
-    return;
-  }
-
-  const backedConfiguredLineCount = await input.prisma.hostedLinqLine.count({
-    where: {
-      configuredAt: { not: null },
-      phoneNumberEncrypted: { not: null },
-      providerInventoryConfirmedAt: {
-        gte: buildHostedLinqInventoryFreshnessCutoff(input.observedAt),
-      },
-      providerPhoneNumberId: { not: null },
-    },
-  });
-  if (backedConfiguredLineCount > 0) {
-    return;
-  }
-
-  throw hostedOnboardingError({
-    code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
-    message: `Linq contact-card reconciliation found ${configuredLineCount} configured line(s) but none with a fresh validated inventory confirmation.`,
-    httpStatus: 502,
-    retryable: true,
-  });
-}
-
 type HostedLinqContactCardOutcome =
   | "activeCards"
   | "createdCards"
@@ -273,11 +255,16 @@ async function listHostedLinqConfiguredContactCardLines(input: {
   maxLines?: number;
   observedAt: Date;
   prisma: HostedLinqContactCardClient;
-}): Promise<Array<{
-  phoneNumber: string;
-  phoneNumberHint: string;
-  providerReputationStatus: string | null;
-}>> {
+}): Promise<{
+  configuredLineCount: number;
+  lines: Array<{
+    isConfigured: boolean;
+    phoneNumber: string;
+    phoneNumberHint: string;
+    phoneNumberLookupKey: string;
+    providerReputationStatus: string | null;
+  }>;
+}> {
   const maxLines = normalizeLineLimit(input.maxLines);
 
   // Provider inventory refresh has exactly one scheduled owner: the
@@ -285,16 +272,21 @@ async function listHostedLinqConfiguredContactCardLines(input: {
   // issuing a second minute-zero inventory fetch, so two crons can never
   // apply provider snapshots out of order and publish a relinquished line
   // into a member's saved vCard.
-  const lines = await listHostedLinqContactCardLines({
+  const snapshot = await readHostedLinqContactCardCandidacySnapshot({
     limit: maxLines,
     observedAt: input.observedAt,
     prisma: input.prisma,
   });
-  return lines.map((line) => ({
-    phoneNumber: line.phoneNumber,
-    phoneNumberHint: line.phoneNumberHint,
-    providerReputationStatus: line.providerReputationStatus,
-  }));
+  return {
+    configuredLineCount: snapshot.configuredLineCount,
+    lines: snapshot.lines.map((line) => ({
+      isConfigured: line.isConfigured,
+      phoneNumber: line.phoneNumber,
+      phoneNumberHint: line.phoneNumberHint,
+      phoneNumberLookupKey: line.phoneNumberLookupKey,
+      providerReputationStatus: line.providerReputationStatus,
+    })),
+  };
 }
 
 async function reconcileHostedLinqContactCardForLine(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -106,13 +106,17 @@ export async function reconcileHostedLinqContactCards(input: {
     }
   }
 
-  // Per-line isolation covers a partially degraded pool; a run where every
-  // line failed is a reconciliation outage and must fail the cron so the
-  // scheduler and alerting see it instead of a silent success.
-  if (result.lineCount > 0 && result.failedLines === result.lineCount) {
+  // Per-line isolation covers a partially degraded pool; a run that ends
+  // with zero usable active cards — every line failed or produced an
+  // inactive card — leaves the native contact-card share with nothing to
+  // send, so it must fail the cron and reach the scheduler and alerting
+  // instead of reporting a silent success.
+  const usableActiveCards =
+    result.activeCards + result.createdCards + result.updatedCards;
+  if (result.lineCount > 0 && usableActiveCards === 0) {
     throw hostedOnboardingError({
       code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
-      message: `Linq contact-card reconciliation failed for all ${result.lineCount} line(s).`,
+      message: `Linq contact-card reconciliation produced no usable active contact card across ${result.lineCount} line(s) (${result.failedLines} failed, ${result.inactiveCards} inactive).`,
       httpStatus: 502,
       retryable: true,
     });

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -271,9 +271,18 @@ async function listHostedLinqConfiguredContactCardLines(input: {
   // into a member's saved vCard.
   const snapshot = await readHostedLinqContactCardCandidacySnapshot({
     limit: maxLines,
+    lockMode: "wait",
     observedAt: input.observedAt,
     prisma: input.prisma,
   });
+  if (!snapshot) {
+    throw hostedOnboardingError({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+      message: "Linq contact-card reconciliation could not read a candidacy snapshot.",
+      httpStatus: 502,
+      retryable: true,
+    });
+  }
   return {
     configuredLineCount: snapshot.configuredLineCount,
     lines: snapshot.lines.map((line) => ({
@@ -538,10 +547,15 @@ export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: 
     // can straddle a committing ownership move and return a line that was
     // just revoked, which this resolver would then embed terminally in a
     // member's saved vCard.
-    const { lines } = await readHostedLinqContactCardCandidacySnapshot({
+    const snapshot = await readHostedLinqContactCardCandidacySnapshot({
       limit: HOSTED_LINQ_CONTACT_CARD_LINE_LIMIT,
+      lockMode: "skip",
       prisma: input.prisma,
     });
+    if (!snapshot) {
+      return null;
+    }
+    const { lines } = snapshot;
     return lines.find((line) =>
       line.phoneNumber !== excludePhoneNumber
       && line.providerServiceStatus !== "FLAGGED"

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -62,6 +62,28 @@ export async function reconcileHostedLinqContactCards(input: {
     maxLines: input.maxLines,
     prisma: input.prisma,
   });
+
+  // An empty candidate list while configured lines exist means the inventory
+  // has revoked ownership of every configured number — that is a contact-card
+  // outage, not a legitimately empty pool, and must not read as a lineCount:0
+  // success.
+  if (lines.length === 0) {
+    const configuredLineCount = await input.prisma.hostedLinqLine.count({
+      where: {
+        configuredAt: { not: null },
+        phoneNumberEncrypted: { not: null },
+      },
+    });
+    if (configuredLineCount > 0) {
+      throw hostedOnboardingError({
+        code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+        message: `Linq contact-card reconciliation found ${configuredLineCount} configured line(s) but none with validated inventory backing.`,
+        httpStatus: 502,
+        retryable: true,
+      });
+    }
+  }
+
   const result: HostedLinqContactCardReconciliation = {
     activeCards: 0,
     atRiskLines: 0,

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -5,10 +5,6 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
 import { listHostedLinqContactCardLines } from "./linq-line-store";
-import {
-  HOSTED_LINQ_PHONE_NUMBER_INVENTORY_SYNC_LIMIT,
-  syncHostedLinqPhoneNumberInventory,
-} from "./linq-phone-number-inventory";
 import { normalizePhoneNumber } from "./phone";
 import {
   getHostedOnboardingEnvironment,
@@ -59,16 +55,12 @@ type LinqContactCardsResponse = {
 
 export async function reconcileHostedLinqContactCards(input: {
   maxLines?: number;
-  observedAt?: Date;
   prisma: HostedLinqContactCardClient;
   signal?: AbortSignal;
 }): Promise<HostedLinqContactCardReconciliation> {
-  const observedAt = input.observedAt ?? new Date();
   const lines = await listHostedLinqConfiguredContactCardLines({
     maxLines: input.maxLines,
-    observedAt,
     prisma: input.prisma,
-    signal: input.signal,
   });
   const result: HostedLinqContactCardReconciliation = {
     activeCards: 0,
@@ -214,9 +206,7 @@ type HostedLinqContactCardOutcome =
 
 async function listHostedLinqConfiguredContactCardLines(input: {
   maxLines?: number;
-  observedAt: Date;
   prisma: HostedLinqContactCardClient;
-  signal?: AbortSignal;
 }): Promise<Array<{
   phoneNumber: string;
   phoneNumberHint: string;
@@ -224,13 +214,11 @@ async function listHostedLinqConfiguredContactCardLines(input: {
 }>> {
   const maxLines = normalizeLineLimit(input.maxLines);
 
-  await syncHostedLinqPhoneNumberInventory({
-    maxLines: HOSTED_LINQ_PHONE_NUMBER_INVENTORY_SYNC_LIMIT,
-    observedAt: input.observedAt,
-    prisma: input.prisma,
-    signal: input.signal,
-  });
-
+  // Provider inventory refresh has exactly one scheduled owner: the
+  // five-minute health cron. Reconciliation reads that projection instead of
+  // issuing a second minute-zero inventory fetch, so two crons can never
+  // apply provider snapshots out of order and publish a relinquished line
+  // into a member's saved vCard.
   const lines = await listHostedLinqContactCardLines({
     limit: maxLines,
     prisma: input.prisma,

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -4,10 +4,7 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
-import {
-  listHostedLinqContactCardLines,
-  readHostedLinqContactCardCandidacySnapshot,
-} from "./linq-line-store";
+import { readHostedLinqContactCardCandidacySnapshot } from "./linq-line-store";
 import { normalizePhoneNumber } from "./phone";
 import {
   getHostedOnboardingEnvironment,
@@ -537,7 +534,11 @@ export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: 
 }): Promise<string | null> {
   const excludePhoneNumber = normalizePhoneNumber(input.excludePhoneNumber);
   try {
-    const lines = await listHostedLinqContactCardLines({
+    // Same locked snapshot the reconciler uses: an unlocked two-query read
+    // can straddle a committing ownership move and return a line that was
+    // just revoked, which this resolver would then embed terminally in a
+    // member's saved vCard.
+    const { lines } = await readHostedLinqContactCardCandidacySnapshot({
       limit: HOSTED_LINQ_CONTACT_CARD_LINE_LIMIT,
       prisma: input.prisma,
     });

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -760,11 +760,32 @@ function mapHostedLinqAssignableHomeLineRows(
   });
 }
 
+/**
+ * Ownership must be re-confirmed by a validated provider snapshot at least
+ * this often for a line to stay contact-card eligible. Sized to three
+ * five-minute health-cron cycles, so a single missed or failed run does not
+ * disqualify the pool while a sustained inventory outage does.
+ */
+export const HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS = 15 * 60 * 1000;
+
+export function buildHostedLinqInventoryFreshnessCutoff(observedAt: Date): Date {
+  return new Date(observedAt.getTime() - HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS);
+}
+
 export async function listHostedLinqContactCardLines(input: {
   limit?: number;
+  observedAt?: Date;
   prisma: HostedLinqLineClient;
 }): Promise<HostedLinqContactCardLine[]> {
   const take = input.limit && input.limit > 0 ? input.limit : undefined;
+  // Ownership is only trustworthy while a recent validated snapshot still
+  // confirms it. Rows written before this watermark existed, and rows whose
+  // confirmation has aged out through repeated failed or malformed inventory
+  // reads, fail closed out of candidacy rather than publishing a possibly
+  // relinquished number.
+  const inventoryConfirmedAfter = buildHostedLinqInventoryFreshnessCutoff(
+    input.observedAt ?? new Date(),
+  );
   // Contact-card candidacy always requires validated inventory backing
   // (providerPhoneNumberId is written only from an authoritative provider
   // snapshot): a configured row whose ownership the inventory has revoked —
@@ -775,6 +796,7 @@ export async function listHostedLinqContactCardLines(input: {
     where: {
       configuredAt: { not: null },
       phoneNumberEncrypted: { not: null },
+      providerInventoryConfirmedAt: { gte: inventoryConfirmedAfter },
       providerPhoneNumberId: { not: null },
     },
     orderBy: [
@@ -803,6 +825,7 @@ export async function listHostedLinqContactCardLines(input: {
       where: {
         configuredAt: null,
         phoneNumberEncrypted: { not: null },
+        providerInventoryConfirmedAt: { gte: inventoryConfirmedAfter },
         providerPhoneNumberId: { not: null },
         providerSeenAt: { not: null },
       },

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -42,6 +42,11 @@ export type HostedLinqAssignableHomeLine = {
 };
 
 export type HostedLinqContactCardLine = {
+  /**
+   * Only configured lines can own a member conversation, so consumers must
+   * be able to judge configured-pool health without re-querying.
+   */
+  isConfigured: boolean;
   phoneNumber: string;
   phoneNumberHint: string;
   phoneNumberLookupKey: string;
@@ -60,6 +65,7 @@ type HostedLinqAssignableHomeLineRow = {
 };
 
 type HostedLinqContactCardLineRow = {
+  configuredAt: Date | null;
   phoneNumberEncrypted: string | null;
   phoneNumberHint: string;
   phoneNumberLookupKey: string;
@@ -772,6 +778,44 @@ export function buildHostedLinqInventoryFreshnessCutoff(observedAt: Date): Date 
   return new Date(observedAt.getTime() - HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS);
 }
 
+/**
+ * One consistent contact-card candidacy snapshot. Reads the configured-line
+ * total and the eligible candidates under the same inventory-wide advisory
+ * lock the snapshot applier uses, so a revoking health-cron run overlapping
+ * the hourly contact-card cron can never be observed half-applied.
+ */
+export async function readHostedLinqContactCardCandidacySnapshot(input: {
+  limit?: number;
+  observedAt?: Date;
+  prisma: PrismaClient | Prisma.TransactionClient;
+}): Promise<{
+  configuredLineCount: number;
+  lines: HostedLinqContactCardLine[];
+}> {
+  const read = async (tx: HostedLinqLineClient) => {
+    await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
+    const configuredLineCount = await tx.hostedLinqLine.count({
+      where: {
+        configuredAt: { not: null },
+        phoneNumberEncrypted: { not: null },
+      },
+    });
+    const lines = await listHostedLinqContactCardLines({
+      ...(input.limit === undefined ? {} : { limit: input.limit }),
+      ...(input.observedAt === undefined ? {} : { observedAt: input.observedAt }),
+      prisma: tx,
+    });
+    return { configuredLineCount, lines };
+  };
+
+  if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
+    const prisma = input.prisma;
+    return prisma.$transaction((tx) => read(tx));
+  }
+
+  return read(input.prisma);
+}
+
 export async function listHostedLinqContactCardLines(input: {
   limit?: number;
   observedAt?: Date;
@@ -806,6 +850,7 @@ export async function listHostedLinqContactCardLines(input: {
     ],
     ...(take ? { take } : {}),
     select: {
+      configuredAt: true,
       phoneNumberEncrypted: true,
       phoneNumberHint: true,
       phoneNumberLookupKey: true,
@@ -835,6 +880,7 @@ export async function listHostedLinqContactCardLines(input: {
       ],
       ...(take ? { take: take - configuredRows.length } : {}),
       select: {
+        configuredAt: true,
         phoneNumberEncrypted: true,
         phoneNumberHint: true,
         phoneNumberLookupKey: true,
@@ -859,6 +905,7 @@ function mapHostedLinqContactCardRows(
       return [];
     }
     return [{
+      isConfigured: row.configuredAt !== null,
       phoneNumber,
       phoneNumberHint: row.phoneNumberHint,
       phoneNumberLookupKey: row.phoneNumberLookupKey,

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -788,12 +788,31 @@ export async function readHostedLinqContactCardCandidacySnapshot(input: {
   limit?: number;
   observedAt?: Date;
   prisma: PrismaClient | Prisma.TransactionClient;
+  /**
+   * `wait` (default) is for background reconciliation, which must observe a
+   * fully applied snapshot. `skip` is for member-facing reads that must never
+   * queue behind an inventory writer: it returns null instead of waiting, so
+   * the caller can serve the primary card and omit the optional backup.
+   */
+  lockMode?: "skip" | "wait";
 }): Promise<{
   configuredLineCount: number;
   lines: HostedLinqContactCardLine[];
-}> {
+} | null> {
   const read = async (tx: HostedLinqLineClient) => {
-    await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
+    if (input.lockMode === "skip") {
+      const acquired = await tx.$queryRaw<Array<{ locked: boolean }>>`
+        SELECT pg_try_advisory_xact_lock(
+          hashtext('hosted_linq_phone_number_inventory'),
+          hashtext('snapshot')
+        ) AS locked
+      `;
+      if (acquired[0]?.locked !== true) {
+        return null;
+      }
+    } else {
+      await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
+    }
     const configuredLineCount = await tx.hostedLinqLine.count({
       where: {
         configuredAt: { not: null },

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -244,6 +244,24 @@ function chooseHostedLinqLineWriteLookupKey(
   return lookupKeyReadCandidates.find((candidate) => existingLookupKeys.has(candidate)) ?? null;
 }
 
+/**
+ * Serializes every multi-phone line writer (provider inventory application
+ * and configured-line synchronization) on one inventory-wide advisory lock.
+ * Without a shared first lock, two writers touching the same phones in
+ * opposite orders can invert their per-phone lock acquisition and deadlock.
+ * Transaction-scoped: callers must already be inside a transaction.
+ */
+export async function acquireHostedLinqInventoryApplyLockTx(input: {
+  prisma: HostedLinqLineClient;
+}): Promise<void> {
+  await input.prisma.$executeRaw`
+    SELECT pg_advisory_xact_lock(
+      hashtext('hosted_linq_phone_number_inventory'),
+      hashtext('snapshot')
+    )
+  `;
+}
+
 export async function syncHostedLinqConfiguredLinesTx(input: {
   /**
    * Additive-rollout compatibility for previous application builds only.
@@ -256,6 +274,7 @@ export async function syncHostedLinqConfiguredLinesTx(input: {
   prisma: HostedLinqLineClient;
 }): Promise<void> {
   const observedAt = input.observedAt ?? new Date();
+  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
   for (const phoneNumber of input.phoneNumbers) {
     await upsertHostedLinqLineForPhoneTx({
       activeMemberLimit: input.activeMemberLimit,

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -765,10 +765,17 @@ export async function listHostedLinqContactCardLines(input: {
   prisma: HostedLinqLineClient;
 }): Promise<HostedLinqContactCardLine[]> {
   const take = input.limit && input.limit > 0 ? input.limit : undefined;
+  // Contact-card candidacy always requires validated inventory backing
+  // (providerPhoneNumberId is written only from an authoritative provider
+  // snapshot): a configured row whose ownership the inventory has revoked —
+  // a moved or relinquished number — must not be maintained or offered as a
+  // member-facing backup, even though configuration still matters to other
+  // consumers such as inbound routing.
   const configuredRows = await input.prisma.hostedLinqLine.findMany({
     where: {
       configuredAt: { not: null },
       phoneNumberEncrypted: { not: null },
+      providerPhoneNumberId: { not: null },
     },
     orderBy: [
       { configuredAt: "desc" },

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -39,7 +39,46 @@ export async function syncHostedLinqPhoneNumberInventory(input: {
     signal: input.signal,
   });
   const observedAt = input.observedAt ?? new Date();
+
+  // The contact-card and health crons both trigger this sync at minute zero,
+  // and the per-phone upsert locks cannot order two whole-snapshot
+  // applications that touch different phones. Apply each validated snapshot
+  // under one inventory-wide advisory lock inside one transaction: concurrent
+  // applications serialize instead of interleaving (so a moved id can never
+  // race the unique provider-id index), and a mid-application failure rolls
+  // the whole replacement back. Two overlapping runs may still commit in
+  // either order; the hourly cadence converges any stale winner on the next
+  // run.
+  if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
+    const prisma = input.prisma;
+    return prisma.$transaction((tx) => applyHostedLinqPhoneNumberInventorySnapshot({
+      lines,
+      observedAt,
+      prisma: tx,
+    }));
+  }
+
+  return applyHostedLinqPhoneNumberInventorySnapshot({
+    lines,
+    observedAt,
+    prisma: input.prisma,
+  });
+}
+
+async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
+  lines: HostedLinqProviderInventoryLine[];
+  observedAt: Date;
+  prisma: HostedLinqInventoryClient;
+}): Promise<{ syncedCount: number }> {
+  const { lines, observedAt } = input;
   let syncedCount = 0;
+
+  await input.prisma.$executeRaw`
+    SELECT pg_advisory_xact_lock(
+      hashtext('hosted_linq_phone_number_inventory'),
+      hashtext('snapshot')
+    )
+  `;
 
   // A validated read is a complete identity snapshot (failed, malformed,
   // over-limit, and identity-lossy reads all throw before this point), so any
@@ -48,9 +87,7 @@ export async function syncHostedLinqPhoneNumberInventory(input: {
   // upserts: relinquished ids stop qualifying as account-owned for
   // ownership-gated consumers (contact-card and backup-number candidacy), and
   // a moved id is released before its new row claims it, so the unique
-  // provider-id index cannot collide. Writes are ordered fail-closed: a crash
-  // between revoke and restore leaves ownership under-claimed, never
-  // over-claimed, and the next hourly sync converges it.
+  // provider-id index cannot collide.
   const confirmedLookupKeysById = new Map<string, Set<string>>();
   for (const line of lines) {
     if (line.providerPhoneNumberId) {

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -112,7 +112,10 @@ async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
     .map((row) => row.phoneNumberLookupKey);
   if (staleLookupKeys.length > 0) {
     await input.prisma.hostedLinqLine.updateMany({
-      data: { providerPhoneNumberId: null },
+      data: {
+        providerInventoryConfirmedAt: null,
+        providerPhoneNumberId: null,
+      },
       where: { phoneNumberLookupKey: { in: staleLookupKeys } },
     });
   }
@@ -124,6 +127,13 @@ async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
       prisma: input.prisma,
       providerPhoneNumberId: line.providerPhoneNumberId,
       source: "provider",
+    });
+    // Freshness watermark for ownership-gated consumers. Stamped only here,
+    // inside the same transaction that applied a validated snapshot, so it
+    // can never be advanced by chat-health or status projection.
+    await input.prisma.hostedLinqLine.updateMany({
+      data: { providerInventoryConfirmedAt: observedAt },
+      where: { phoneNumberLookupKey: storedLine.phoneNumberLookupKey },
     });
     await projectHostedLinqLineProviderStateTx({
       observedAt,

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -1,6 +1,7 @@
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
+import { createHostedPhoneLookupKeyReadCandidates } from "./contact-privacy-core";
 import { hostedOnboardingError } from "./errors";
 import { upsertHostedLinqLineForPhoneTx } from "./linq-line-store";
 import {
@@ -40,23 +41,46 @@ export async function syncHostedLinqPhoneNumberInventory(input: {
   const observedAt = input.observedAt ?? new Date();
   let syncedCount = 0;
 
-  // A successful inventory read is a complete snapshot (failed, malformed,
-  // and over-limit reads all throw before this point), so an id the provider
-  // no longer reports marks a relinquished line. Revoke its inventory backing
-  // so ownership-gated consumers (contact-card and backup-number candidacy)
-  // stop treating it as account-owned; revoke before the upserts so a moved
-  // id cannot collide with the unique provider-id index.
-  await input.prisma.hostedLinqLine.updateMany({
-    data: { providerPhoneNumberId: null },
-    where: {
-      providerPhoneNumberId: {
-        not: null,
-        notIn: lines
-          .map((line) => line.providerPhoneNumberId)
-          .filter((id): id is string => id !== null),
-      },
+  // A validated read is a complete identity snapshot (failed, malformed,
+  // over-limit, and identity-lossy reads all throw before this point), so any
+  // stored phone-to-provider-id pairing the snapshot does not confirm marks a
+  // relinquished or moved line. Revoke exactly those pairings before the
+  // upserts: relinquished ids stop qualifying as account-owned for
+  // ownership-gated consumers (contact-card and backup-number candidacy), and
+  // a moved id is released before its new row claims it, so the unique
+  // provider-id index cannot collide. Writes are ordered fail-closed: a crash
+  // between revoke and restore leaves ownership under-claimed, never
+  // over-claimed, and the next hourly sync converges it.
+  const confirmedLookupKeysById = new Map<string, Set<string>>();
+  for (const line of lines) {
+    if (line.providerPhoneNumberId) {
+      confirmedLookupKeysById.set(
+        line.providerPhoneNumberId,
+        new Set(createHostedPhoneLookupKeyReadCandidates(line.phoneNumber)),
+      );
+    }
+  }
+  const heldRows = await input.prisma.hostedLinqLine.findMany({
+    where: { providerPhoneNumberId: { not: null } },
+    select: {
+      phoneNumberLookupKey: true,
+      providerPhoneNumberId: true,
     },
   });
+  const staleLookupKeys = heldRows
+    .filter((row) => {
+      const confirmed = row.providerPhoneNumberId
+        ? confirmedLookupKeysById.get(row.providerPhoneNumberId)
+        : undefined;
+      return !confirmed || !confirmed.has(row.phoneNumberLookupKey);
+    })
+    .map((row) => row.phoneNumberLookupKey);
+  if (staleLookupKeys.length > 0) {
+    await input.prisma.hostedLinqLine.updateMany({
+      data: { providerPhoneNumberId: null },
+      where: { phoneNumberLookupKey: { in: staleLookupKeys } },
+    });
+  }
 
   for (const line of lines) {
     const storedLine = await upsertHostedLinqLineForPhoneTx({
@@ -121,8 +145,56 @@ export async function listHostedLinqPhoneNumberInventory(input: {
   }
 
   const payload = await response.json();
-  return parseHostedLinqPhoneNumberInventory(payload, {
+  return requireHostedLinqPhoneNumberInventorySnapshot(payload, {
     maxLines: input.maxLines,
+  });
+}
+
+/**
+ * Parse an inventory payload as an authoritative identity snapshot. The
+ * lenient parser tolerates dropped records for display-style consumers, but a
+ * snapshot that feeds ownership reconciliation must not be lossy: a malformed
+ * collection or a record with a missing, invalid, or duplicate identity would
+ * otherwise read as a smaller account and revoke legitimate ownership.
+ */
+export function requireHostedLinqPhoneNumberInventorySnapshot(
+  payload: unknown,
+  input: {
+    maxLines?: number;
+  } = {},
+): HostedLinqProviderInventoryLine[] {
+  if (!isRecord(payload) || !Array.isArray(payload.phone_numbers)) {
+    throw invalidInventorySnapshotError(
+      "Linq phone-number inventory response did not contain a phone_numbers array.",
+    );
+  }
+
+  const lines = parseHostedLinqPhoneNumberInventory(payload, input);
+  if (lines.length !== payload.phone_numbers.length) {
+    throw invalidInventorySnapshotError(
+      "Linq phone-number inventory contained records without a valid unique phone number.",
+    );
+  }
+
+  const seenIds = new Set<string>();
+  for (const line of lines) {
+    if (!line.providerPhoneNumberId || seenIds.has(line.providerPhoneNumberId)) {
+      throw invalidInventorySnapshotError(
+        "Linq phone-number inventory contained records without a valid unique provider id.",
+      );
+    }
+    seenIds.add(line.providerPhoneNumberId);
+  }
+
+  return lines;
+}
+
+function invalidInventorySnapshotError(message: string): Error {
+  return hostedOnboardingError({
+    code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
+    httpStatus: 502,
+    message,
+    retryable: true,
   });
 }
 

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -3,7 +3,10 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { createHostedPhoneLookupKeyReadCandidates } from "./contact-privacy-core";
 import { hostedOnboardingError } from "./errors";
-import { upsertHostedLinqLineForPhoneTx } from "./linq-line-store";
+import {
+  acquireHostedLinqInventoryApplyLockTx,
+  upsertHostedLinqLineForPhoneTx,
+} from "./linq-line-store";
 import {
   projectHostedLinqLineProviderStateTx,
 } from "./linq-provider-health-store";
@@ -73,12 +76,7 @@ async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
   const { lines, observedAt } = input;
   let syncedCount = 0;
 
-  await input.prisma.$executeRaw`
-    SELECT pg_advisory_xact_lock(
-      hashtext('hosted_linq_phone_number_inventory'),
-      hashtext('snapshot')
-    )
-  `;
+  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
 
   // A validated read is a complete identity snapshot (failed, malformed,
   // over-limit, and identity-lossy reads all throw before this point), so any

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -425,6 +425,109 @@ describe("hosted Linq contact card client", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("fails the run when every line yields an inactive card without logging request failures", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
+      syncedCount: 1,
+    });
+    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+      {
+        phoneNumber: "+15550000001",
+        phoneNumberHint: "*** 0001",
+        phoneNumberLookupKey: "lookup:1",
+        providerReputationStatus: "HEALTHY",
+        providerServiceStatus: "ACTIVE",
+      },
+    ]);
+    const prisma = {};
+
+    const fetchMock = vi.fn(async () => createJsonResponse({
+      contact_cards: [
+        {
+          first_name: "Murph",
+          image_url: null,
+          is_active: false,
+          phone_number: "+15550000001",
+        },
+      ],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    });
+
+    // The line responded; it just has no usable active card, so nothing is a
+    // per-line request failure worth logging.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("fails the run when the only non-failing lines yield inactive cards", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
+      syncedCount: 2,
+    });
+    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+      {
+        phoneNumber: "+15550000009",
+        phoneNumberHint: "*** 0009",
+        phoneNumberLookupKey: "lookup:9",
+        providerReputationStatus: null,
+        providerServiceStatus: null,
+      },
+      {
+        phoneNumber: "+15550000001",
+        phoneNumberHint: "*** 0001",
+        phoneNumberLookupKey: "lookup:1",
+        providerReputationStatus: "HEALTHY",
+        providerServiceStatus: "ACTIVE",
+      },
+    ]);
+    const prisma = {};
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+
+      if (url.searchParams.get("phone_number") === "+15550000009" && init?.method === "GET") {
+        return createJsonResponse({
+          error: {
+            code: 2006,
+            message: "You do not have permission to send from this phone number",
+            status: 403,
+          },
+          success: false,
+        }, 403);
+      }
+
+      return createJsonResponse({
+        contact_cards: [
+          {
+            first_name: "Murph",
+            image_url: null,
+            is_active: false,
+            phone_number: "+15550000001",
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    });
+
+    // Both lines attempted; only the real request failure is logged.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
   it("rethrows caller cancellation instead of counting it as a line failure", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -1019,7 +1019,9 @@ describe("fetchMurphHostedLinqContactCardVcfPhoto", () => {
 
 describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
   it("reads the existing projection and returns the first healthy alternate without provider sync", async () => {
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 4,
+      lines: [
       {
         isConfigured: true,
         phoneNumber: "+15550000001",
@@ -1052,7 +1054,8 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const providerFetch = vi.fn(() => {
       throw new Error("Backup selection must not call Linq.");
     });
@@ -1064,8 +1067,8 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
       prisma: prisma as never,
     })).resolves.toBe("+15550000003");
 
-    expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledOnce();
-    expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
+    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledOnce();
+    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
       prisma,
     });

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const linqLineStoreMocks = vi.hoisted(() => ({
   listHostedLinqContactCardLines: vi.fn(),
+  readHostedLinqContactCardCandidacySnapshot: vi.fn(),
 }));
 
 const linqInventoryMocks = vi.hoisted(() => ({
@@ -24,9 +25,9 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
-  buildHostedLinqInventoryFreshnessCutoff: (observedAt: Date) =>
-    new Date(observedAt.getTime() - 15 * 60 * 1000),
   listHostedLinqContactCardLines: linqLineStoreMocks.listHostedLinqContactCardLines,
+  readHostedLinqContactCardCandidacySnapshot:
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-phone-number-inventory", () => ({
@@ -55,6 +56,7 @@ afterEach(() => {
   runtimeMocks.getHostedOnboardingEnvironment.mockReset();
   linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockReset();
   linqLineStoreMocks.listHostedLinqContactCardLines.mockReset();
+  linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockReset();
 
   if (originalFetch) {
     vi.stubGlobal("fetch", originalFetch);
@@ -217,8 +219,11 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
@@ -226,13 +231,15 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000002",
         phoneNumberHint: "*** 0002",
         phoneNumberLookupKey: "lookup:2",
         providerReputationStatus: "AT_RISK",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -298,7 +305,7 @@ describe("hosted Linq contact card client", () => {
     // Inventory refresh has one scheduled owner (the health cron); the
     // contact-card path must only read the projection.
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
-    expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
+    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
       observedAt: expect.any(Date),
       prisma,
@@ -310,8 +317,11 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000009",
         phoneNumberHint: "*** 0009",
         phoneNumberLookupKey: "lookup:9",
@@ -319,13 +329,15 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: null,
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -387,8 +399,11 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
@@ -396,13 +411,15 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000002",
         phoneNumberHint: "*** 0002",
         phoneNumberLookupKey: "lookup:2",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async () => createJsonResponse({
@@ -433,15 +450,19 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 1,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 1,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async () => createJsonResponse({
@@ -474,8 +495,11 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000009",
         phoneNumberHint: "*** 0009",
         phoneNumberLookupKey: "lookup:9",
@@ -483,13 +507,15 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: null,
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -532,12 +558,12 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("fails the run when configured lines exist but none keep validated inventory backing", async () => {
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([]);
     // Two configured lines exist, but none carries a fresh confirmation.
-    const count = vi.fn()
-      .mockResolvedValueOnce(2)
-      .mockResolvedValueOnce(0);
-    const prisma = { hostedLinqLine: { count } };
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [],
+    });
+    const prisma = { hostedLinqLine: { count: vi.fn() } };
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -550,25 +576,15 @@ describe("hosted Linq contact card client", () => {
     // A revoked pool is an outage, not an empty pool: no provider call is
     // made for a number the account no longer owns.
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(count).toHaveBeenNthCalledWith(1, {
-      where: {
-        configuredAt: { not: null },
-        phoneNumberEncrypted: { not: null },
-      },
-    });
-    expect(count).toHaveBeenNthCalledWith(2, {
-      where: {
-        configuredAt: { not: null },
-        phoneNumberEncrypted: { not: null },
-        providerInventoryConfirmedAt: { gte: expect.any(Date) },
-        providerPhoneNumberId: { not: null },
-      },
-    });
+
   });
 
   it("resolves an empty run when no configured lines exist at all", async () => {
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([]);
-    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(0) } };
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 0,
+      lines: [],
+    });
+    const prisma = { hostedLinqLine: { count: vi.fn() } };
     vi.stubGlobal("fetch", vi.fn());
 
     await expect(reconcileHostedLinqContactCards({
@@ -585,13 +601,136 @@ describe("hosted Linq contact card client", () => {
     });
   });
 
+  it("fails the run when an active provider-only card is the only survivor of a configured outage", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 1,
+      lines: [
+        {
+          isConfigured: true,
+          phoneNumber: "+15550000009",
+          phoneNumberHint: "*** 0009",
+          phoneNumberLookupKey: "lookup:9",
+          providerReputationStatus: "HEALTHY",
+          providerServiceStatus: "ACTIVE",
+        },
+        {
+          isConfigured: false,
+          phoneNumber: "+15550000001",
+          phoneNumberHint: "*** 0001",
+          phoneNumberLookupKey: "lookup:1",
+          providerReputationStatus: "HEALTHY",
+          providerServiceStatus: "ACTIVE",
+        },
+      ],
+    });
+    const prisma = { hostedLinqLine: { count: vi.fn() } };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+
+      if (url.searchParams.get("phone_number") === "+15550000009" && init?.method === "GET") {
+        return createJsonResponse({
+          error: {
+            code: 2006,
+            message: "You do not have permission to send from this phone number",
+            status: 403,
+          },
+          success: false,
+        }, 403);
+      }
+
+      // The unconfigured provider-only line still has a healthy active card.
+      return createJsonResponse({
+        contact_cards: [
+          {
+            first_name: "Murph",
+            image_url: null,
+            is_active: true,
+            phone_number: "+15550000001",
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // An active card on a line that cannot own a member conversation must not
+    // stand in for the loss of every configured line.
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("succeeds when a configured line keeps a usable card alongside a failing provider-only line", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 1,
+      lines: [
+        {
+          isConfigured: true,
+          phoneNumber: "+15550000001",
+          phoneNumberHint: "*** 0001",
+          phoneNumberLookupKey: "lookup:1",
+          providerReputationStatus: "HEALTHY",
+          providerServiceStatus: "ACTIVE",
+        },
+        {
+          isConfigured: false,
+          phoneNumber: "+15550000009",
+          phoneNumberHint: "*** 0009",
+          phoneNumberLookupKey: "lookup:9",
+          providerReputationStatus: "HEALTHY",
+          providerServiceStatus: "ACTIVE",
+        },
+      ],
+    });
+    const prisma = { hostedLinqLine: { count: vi.fn() } };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof URL ? input : new URL(String(input));
+
+      if (url.searchParams.get("phone_number") === "+15550000009" && init?.method === "GET") {
+        return createJsonResponse({ success: false }, 403);
+      }
+
+      return createJsonResponse({
+        contact_cards: [
+          {
+            first_name: "Murph",
+            image_url: null,
+            is_active: true,
+            phone_number: "+15550000001",
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      activeCards: 1,
+      failedLines: 1,
+      lineCount: 2,
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
   it("rethrows caller cancellation instead of counting it as a line failure", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 2,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
@@ -599,13 +738,15 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000002",
         phoneNumberHint: "*** 0002",
         phoneNumberLookupKey: "lookup:2",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
     const abortController = new AbortController();
     const abortReason = new Error("cron request aborted");
@@ -630,15 +771,19 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 1,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 1,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -698,15 +843,19 @@ describe("hosted Linq contact card client", () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 1,
     });
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
+      configuredLineCount: 1,
+      lines: [
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
-    ]);
+      ],
+    });
     const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -748,7 +897,7 @@ describe("hosted Linq contact card client", () => {
     // Inventory refresh has one scheduled owner (the health cron); the
     // contact-card path must only read the projection.
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
-    expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
+    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
       observedAt: expect.any(Date),
       prisma,
@@ -872,6 +1021,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
   it("reads the existing projection and returns the first healthy alternate without provider sync", async () => {
     linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
       {
+        isConfigured: true,
         phoneNumber: "+15550000001",
         phoneNumberHint: "*** 0001",
         phoneNumberLookupKey: "lookup:1",
@@ -879,6 +1029,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000002",
         phoneNumberHint: "*** 0002",
         phoneNumberLookupKey: "lookup:2",
@@ -886,6 +1037,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000004",
         phoneNumberHint: "*** 0004",
         phoneNumberLookupKey: "lookup:4",
@@ -893,6 +1045,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
         providerServiceStatus: "FLAGGED",
       },
       {
+        isConfigured: true,
         phoneNumber: "+15550000003",
         phoneNumberHint: "*** 0003",
         phoneNumberLookupKey: "lookup:3",

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -528,6 +528,49 @@ describe("hosted Linq contact card client", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("fails the run when configured lines exist but none keep validated inventory backing", async () => {
+    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([]);
+    const count = vi.fn().mockResolvedValue(2);
+    const prisma = { hostedLinqLine: { count } };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    });
+
+    // A revoked pool is an outage, not an empty pool: no provider call is
+    // made for a number the account no longer owns.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(count).toHaveBeenCalledWith({
+      where: {
+        configuredAt: { not: null },
+        phoneNumberEncrypted: { not: null },
+      },
+    });
+  });
+
+  it("resolves an empty run when no configured lines exist at all", async () => {
+    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([]);
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(0) } };
+    vi.stubGlobal("fetch", vi.fn());
+
+    await expect(reconcileHostedLinqContactCards({
+      prisma: prisma as never,
+    })).resolves.toEqual({
+      activeCards: 0,
+      atRiskLines: 0,
+      createdCards: 0,
+      criticalLines: 0,
+      failedLines: 0,
+      inactiveCards: 0,
+      lineCount: 0,
+      updatedCards: 0,
+    });
+  });
+
   it("rethrows caller cancellation instead of counting it as a line failure", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -385,6 +385,54 @@ describe("hosted Linq contact card client", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("attempts every line but fails the run when all lines fail", async () => {
+    const observedAt = new Date("2026-06-25T12:30:00.000Z");
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
+      syncedCount: 2,
+    });
+    linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([
+      {
+        phoneNumber: "+15550000001",
+        phoneNumberHint: "*** 0001",
+        phoneNumberLookupKey: "lookup:1",
+        providerReputationStatus: "HEALTHY",
+        providerServiceStatus: "ACTIVE",
+      },
+      {
+        phoneNumber: "+15550000002",
+        phoneNumberHint: "*** 0002",
+        phoneNumberLookupKey: "lookup:2",
+        providerReputationStatus: "HEALTHY",
+        providerServiceStatus: "ACTIVE",
+      },
+    ]);
+    const prisma = {};
+
+    const fetchMock = vi.fn(async () => createJsonResponse({
+      error: {
+        code: 2006,
+        message: "You do not have permission to send from this phone number",
+        status: 403,
+      },
+      success: false,
+    }, 403));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(reconcileHostedLinqContactCards({
+      observedAt,
+      prisma: prisma as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
+    });
+
+    // Both lines were still attempted and individually logged before the run
+    // was surfaced as an outage.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    consoleErrorSpy.mockRestore();
+  });
+
   it("rethrows caller cancellation instead of counting it as a line failure", async () => {
     const observedAt = new Date("2026-06-25T12:30:00.000Z");
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -211,8 +211,7 @@ describe("hosted Linq contact card client", () => {
     });
   });
 
-  it("reconciles DB-backed line contact cards after provider inventory sync", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
+  it("reconciles DB-backed line contact cards from the owned-line projection", async () => {
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
     });
@@ -282,7 +281,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
     })).resolves.toEqual({
       activeCards: 1,
@@ -295,11 +293,9 @@ describe("hosted Linq contact card client", () => {
       updatedCards: 0,
     });
 
-    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).toHaveBeenCalledWith(expect.objectContaining({
-      maxLines: 250,
-      observedAt,
-      prisma,
-    }));
+    // Inventory refresh has one scheduled owner (the health cron); the
+    // contact-card path must only read the projection.
+    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
       limit: 50,
       prisma,
@@ -307,7 +303,6 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("keeps reconciling remaining lines when one line fails and counts the failure", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
@@ -366,7 +361,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
     })).resolves.toEqual({
       activeCards: 1,
@@ -386,7 +380,6 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("attempts every line but fails the run when all lines fail", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
@@ -420,7 +413,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
     })).rejects.toMatchObject({
       code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
@@ -434,7 +426,6 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("rethrows caller cancellation instead of counting it as a line failure", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 2,
@@ -466,7 +457,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
       signal: abortController.signal,
     })).rejects.toBe(abortReason);
@@ -477,7 +467,6 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("corrects a non-Murph first name without clearing legacy provider fields", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 1,
     });
@@ -531,7 +520,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
     })).resolves.toEqual({
       activeCards: 0,
@@ -547,7 +535,6 @@ describe("hosted Linq contact card client", () => {
   });
 
   it("keeps legacy provider fields when the contact-card first name is current", async () => {
-    const observedAt = new Date("2026-06-25T12:30:00.000Z");
     linqInventoryMocks.syncHostedLinqPhoneNumberInventory.mockResolvedValue({
       syncedCount: 1,
     });
@@ -586,7 +573,6 @@ describe("hosted Linq contact card client", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(reconcileHostedLinqContactCards({
-      observedAt,
       prisma: prisma as never,
     })).resolves.toEqual({
       activeCards: 1,
@@ -599,11 +585,9 @@ describe("hosted Linq contact card client", () => {
       updatedCards: 0,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).toHaveBeenCalledWith(expect.objectContaining({
-      maxLines: 250,
-      observedAt,
-      prisma,
-    }));
+    // Inventory refresh has one scheduled owner (the health cron); the
+    // contact-card path must only read the projection.
+    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
       limit: 50,
       prisma,

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -307,6 +307,7 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
+      lockMode: "wait",
       observedAt: expect.any(Date),
       prisma,
     });
@@ -899,6 +900,7 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
+      lockMode: "wait",
       observedAt: expect.any(Date),
       prisma,
     });
@@ -1018,6 +1020,17 @@ describe("fetchMurphHostedLinqContactCardVcfPhoto", () => {
 });
 
 describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
+  it("omits the backup instead of waiting when an inventory writer holds the lock", async () => {
+    // The snapshot returns null when the lock is unavailable; the member's
+    // primary card must still be served, just without the optional backup.
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue(null);
+
+    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
+      excludePhoneNumber: "+15550000001",
+      prisma: {} as never,
+    })).resolves.toBeNull();
+  });
+
   it("reads the existing projection and returns the first healthy alternate without provider sync", async () => {
     linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
       configuredLineCount: 4,
@@ -1068,8 +1081,10 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
     })).resolves.toBe("+15550000003");
 
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledOnce();
+    // Member-facing: never waits on an inventory writer.
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
+      lockMode: "skip",
       prisma,
     });
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
@@ -1077,7 +1092,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
   });
 
   it("fails soft to null when the projection read is unavailable", async () => {
-    linqLineStoreMocks.listHostedLinqContactCardLines.mockRejectedValue(
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockRejectedValue(
       new Error("projection unavailable"),
     );
 

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -24,6 +24,8 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
+  buildHostedLinqInventoryFreshnessCutoff: (observedAt: Date) =>
+    new Date(observedAt.getTime() - 15 * 60 * 1000),
   listHostedLinqContactCardLines: linqLineStoreMocks.listHostedLinqContactCardLines,
 }));
 
@@ -231,7 +233,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input instanceof URL ? input : new URL(String(input));
@@ -298,6 +300,7 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
       limit: 50,
+      observedAt: expect.any(Date),
       prisma,
     });
   });
@@ -323,7 +326,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input instanceof URL ? input : new URL(String(input));
@@ -400,7 +403,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async () => createJsonResponse({
       error: {
@@ -439,7 +442,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async () => createJsonResponse({
       contact_cards: [
@@ -487,7 +490,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input instanceof URL ? input : new URL(String(input));
@@ -530,7 +533,10 @@ describe("hosted Linq contact card client", () => {
 
   it("fails the run when configured lines exist but none keep validated inventory backing", async () => {
     linqLineStoreMocks.listHostedLinqContactCardLines.mockResolvedValue([]);
-    const count = vi.fn().mockResolvedValue(2);
+    // Two configured lines exist, but none carries a fresh confirmation.
+    const count = vi.fn()
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(0);
     const prisma = { hostedLinqLine: { count } };
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -544,10 +550,18 @@ describe("hosted Linq contact card client", () => {
     // A revoked pool is an outage, not an empty pool: no provider call is
     // made for a number the account no longer owns.
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(count).toHaveBeenCalledWith({
+    expect(count).toHaveBeenNthCalledWith(1, {
       where: {
         configuredAt: { not: null },
         phoneNumberEncrypted: { not: null },
+      },
+    });
+    expect(count).toHaveBeenNthCalledWith(2, {
+      where: {
+        configuredAt: { not: null },
+        phoneNumberEncrypted: { not: null },
+        providerInventoryConfirmedAt: { gte: expect.any(Date) },
+        providerPhoneNumberId: { not: null },
       },
     });
   });
@@ -592,7 +606,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
     const abortController = new AbortController();
     const abortReason = new Error("cron request aborted");
 
@@ -625,7 +639,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input instanceof URL ? input : new URL(String(input));
@@ -693,7 +707,7 @@ describe("hosted Linq contact card client", () => {
         providerServiceStatus: "ACTIVE",
       },
     ]);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input instanceof URL ? input : new URL(String(input));
@@ -736,6 +750,7 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.listHostedLinqContactCardLines).toHaveBeenCalledWith({
       limit: 50,
+      observedAt: expect.any(Date),
       prisma,
     });
   });
@@ -889,7 +904,7 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
       throw new Error("Backup selection must not call Linq.");
     });
     vi.stubGlobal("fetch", providerFetch);
-    const prisma = {};
+    const prisma = { hostedLinqLine: { count: vi.fn().mockResolvedValue(1) } };
 
     await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
       excludePhoneNumber: "+15550000001",

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -83,6 +83,7 @@ describe("listHostedLinqContactCardLines", () => {
       where: {
         configuredAt: { not: null },
         phoneNumberEncrypted: { not: null },
+        providerInventoryConfirmedAt: { gte: expect.any(Date) },
         providerPhoneNumberId: { not: null },
       },
     }));
@@ -91,6 +92,7 @@ describe("listHostedLinqContactCardLines", () => {
       where: {
         configuredAt: null,
         phoneNumberEncrypted: { not: null },
+        providerInventoryConfirmedAt: { gte: expect.any(Date) },
         providerPhoneNumberId: { not: null },
         providerSeenAt: { not: null },
       },

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -83,6 +83,7 @@ describe("listHostedLinqContactCardLines", () => {
       where: {
         configuredAt: { not: null },
         phoneNumberEncrypted: { not: null },
+        providerPhoneNumberId: { not: null },
       },
     }));
     expect(findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -40,6 +40,7 @@ describe("listHostedLinqContactCardLines", () => {
     const findMany = vi.fn()
       .mockResolvedValueOnce([
         buildLineRow("+15550100001", {
+          configuredAt: new Date("2026-06-30T11:00:00.000Z"),
           providerLastSeenAt: new Date("2026-06-30T12:00:00.000Z"),
           providerReputationStatus: "HEALTHY",
           providerServiceStatus: "ACTIVE",
@@ -65,12 +66,14 @@ describe("listHostedLinqContactCardLines", () => {
       }),
     ).resolves.toMatchObject([
       {
+        isConfigured: true,
         phoneNumber: "+15550100001",
         phoneNumberHint: "*** 0001",
         providerReputationStatus: "HEALTHY",
         providerServiceStatus: "ACTIVE",
       },
       {
+        isConfigured: false,
         phoneNumber: "+15550100002",
         phoneNumberHint: "*** 0002",
         providerReputationStatus: "AT_RISK",
@@ -859,12 +862,14 @@ describe("upsertHostedLinqLineForPhoneTx", () => {
 function buildLineRow(
   phoneNumber: string,
   input: {
+    configuredAt?: Date | null;
     providerLastSeenAt: Date;
     providerReputationStatus: string;
     providerServiceStatus: string;
   },
 ) {
   return {
+    configuredAt: input.configuredAt ?? null,
     phoneNumberEncrypted: encryptHostedLinqLinePhoneNumber(phoneNumber),
     phoneNumberHint: `*** ${phoneNumber.slice(-4)}`,
     phoneNumberLookupKey: `lookup:${phoneNumber}`,

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -16,6 +16,7 @@ import {
   readHostedLinqRecentMessageEffectCountsTx,
   readHostedLinqIncomingLineState,
   readHostedLinqReceiptCorrelatedRecoveryLineTx,
+  syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
 import {
@@ -659,6 +660,57 @@ describe("hosted Linq proactive-conversation capacity", () => {
         phoneNumberLookupKey: "lookup:line-1",
       });
     }
+  });
+});
+
+describe("syncHostedLinqConfiguredLinesTx", () => {
+  it("takes the inventory-wide lock before any per-phone lock, read, or write", async () => {
+    const events: string[] = [];
+    const transactionClient = {
+      $executeRaw: vi.fn().mockImplementation((strings: TemplateStringsArray) => {
+        events.push(
+          strings.join("?").includes("hosted_linq_phone_number_inventory")
+            ? "inventory-lock"
+            : "phone-lock",
+        );
+        return Promise.resolve([]);
+      }),
+      hostedLinqLine: {
+        findMany: vi.fn().mockImplementation(() => {
+          events.push("candidate-read");
+          return Promise.resolve([]);
+        }),
+        upsert: vi.fn().mockImplementation((input: { create: { phoneNumberLookupKey: string } }) => {
+          events.push("write");
+          return Promise.resolve({
+            phoneNumberLookupKey: input.create.phoneNumberLookupKey,
+          });
+        }),
+      },
+    };
+
+    await syncHostedLinqConfiguredLinesTx({
+      activeMemberLimit: null,
+      observedAt: new Date("2026-06-30T12:00:00.000Z"),
+      phoneNumbers: ["+15550100001", "+15550100002"],
+      prisma: transactionClient as never,
+    });
+
+    // Every multi-phone writer must serialize on the shared inventory lock
+    // before touching any per-phone lock, so lock acquisition can never
+    // invert against the provider-inventory writer.
+    expect(events[0]).toBe("inventory-lock");
+    expect(events.filter((event) => event === "inventory-lock")).toHaveLength(1);
+    expect(events.filter((event) => event === "phone-lock")).toHaveLength(2);
+    expect(events).toEqual([
+      "inventory-lock",
+      "phone-lock",
+      "candidate-read",
+      "write",
+      "phone-lock",
+      "candidate-read",
+      "write",
+    ]);
   });
 });
 

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -40,8 +40,10 @@ beforeEach(() => {
 });
 
 import { createHostedPhoneLookupKeyReadCandidates } from "@/src/lib/hosted-onboarding/contact-privacy-core";
+import { resolveMurphHostedLinqContactCardBackupPhoneNumber } from "@/src/lib/hosted-onboarding/linq-contact-card";
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 import {
+  listHostedLinqContactCardLines,
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
@@ -245,6 +247,95 @@ describe.skipIf(!runPostgresProof)(
         await prisma.$disconnect();
       }
     });
+    it("drops a revoked configured line from contact-card candidacy and backup selection", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const phoneOther = buildSyntheticProofPhoneNumber();
+      const otherProviderId = `pg-proof-line-${randomUUID()}`;
+      const proofLookupKeys = [phoneA, phoneB, phoneOther].flatMap(
+        (phone) => createHostedPhoneLookupKeyReadCandidates(phone),
+      );
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        // Phone A is a fully configured sending line that currently holds the
+        // provider id — the strongest candidate the lister can return.
+        const rowA = await upsertHostedLinqLineForPhoneTx({
+          activeMemberLimit: null,
+          observedAt: new Date(),
+          phoneNumber: phoneA,
+          prisma,
+          providerPhoneNumberId: providerId,
+          source: "configured",
+        });
+        await prisma.hostedLinqLine.update({
+          data: { providerPhoneNumberId: providerId },
+          where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
+        });
+
+        // The provider moves that id to phone B and reports one other owned
+        // line, so a healthy backup candidate still exists.
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerId,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+            {
+              id: otherProviderId,
+              phone_number: phoneOther,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: 2 });
+
+        // The revoked configured row must disappear from the real consumers,
+        // not merely lose its ownership column.
+        const candidates = await listHostedLinqContactCardLines({ prisma });
+        expect(candidates.map((line) => line.phoneNumber)).not.toContain(phoneA);
+        expect(candidates.map((line) => line.phoneNumber)).toEqual(
+          expect.arrayContaining([phoneB, phoneOther]),
+        );
+
+        for (const excludePhoneNumber of [phoneB, phoneOther]) {
+          const backup = await resolveMurphHostedLinqContactCardBackupPhoneNumber({
+            excludePhoneNumber,
+            prisma,
+          });
+          expect(backup).not.toBe(phoneA);
+        }
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
     it("blocks a concurrent sync on the inventory-wide advisory lock until the owner commits", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
       const observer = createPrismaClient({ databaseUrl, poolMax: 2 });

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -82,6 +82,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -137,7 +138,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -158,6 +162,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -239,7 +244,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -264,6 +272,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -327,7 +336,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -348,6 +360,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -428,7 +441,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -439,9 +455,8 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("never returns a relinquished line as the member-facing backup mid-move", async () => {
+    it("serves the member backup without waiting on an in-flight ownership move", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
-      const observer = createPrismaClient({ databaseUrl, poolMax: 2 });
       const providerId = `pg-proof-line-${randomUUID()}`;
       const otherProviderId = `pg-proof-line-${randomUUID()}`;
       const phoneA = buildSyntheticProofPhoneNumber();
@@ -455,6 +470,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -526,37 +542,37 @@ describe.skipIf(!runPostgresProof)(
           await moveHold;
         });
 
-        const moveBackendPid = await moveLocked;
-        const backupPromise = resolveMurphHostedLinqContactCardBackupPhoneNumber({
-          excludePhoneNumber: phoneOther,
-          prisma,
-        });
+        await moveLocked;
 
-        // The member-facing resolver must wait for the move rather than read
-        // across it.
-        let blocked = 0;
-        for (let attempt = 0; attempt < 40 && blocked === 0; attempt += 1) {
-          const rows = await observer.$queryRaw<Array<{ blocked: bigint | number }>>`
-            SELECT count(*) AS blocked
-            FROM pg_stat_activity
-            WHERE wait_event_type = 'Lock'
-              AND wait_event = 'advisory'
-              AND ${moveBackendPid} = ANY(pg_blocking_pids(pid))
-          `;
-          blocked = Number(rows[0]?.blocked ?? 0);
-          if (blocked === 0) {
-            await new Promise((resolve) => setTimeout(resolve, 100));
-          }
-        }
-        expect(blocked).toBeGreaterThan(0);
+        // The member-facing resolver must never queue behind the writer: it
+        // resolves while the move is still open, omitting the optional backup
+        // rather than delaying the member's primary card.
+        await expect(Promise.race([
+          resolveMurphHostedLinqContactCardBackupPhoneNumber({
+            excludePhoneNumber: phoneOther,
+            prisma,
+          }),
+          new Promise((_resolve, reject) => {
+            setTimeout(() => reject(new Error("backup resolution blocked on the inventory lock")), 5_000);
+          }),
+        ])).resolves.toBeNull();
 
         releaseMove();
         await moveTransaction;
-        await expect(backupPromise).resolves.not.toBe(phoneA);
+
+        // After the move commits, the relinquished line is never offered and
+        // the new owner is.
+        await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
+          excludePhoneNumber: phoneOther,
+          prisma,
+        })).resolves.toBe(phoneB);
       } finally {
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -564,7 +580,6 @@ describe.skipIf(!runPostgresProof)(
           where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
-        await observer.$disconnect();
       }
     });
 
@@ -579,6 +594,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -660,7 +676,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -685,6 +704,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -739,7 +759,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -768,6 +791,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -813,7 +837,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -844,6 +871,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -896,7 +924,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }
@@ -922,6 +953,7 @@ describe.skipIf(!runPostgresProof)(
         where: { providerPhoneNumberId: { not: null } },
         select: {
           phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
           providerPhoneNumberId: true,
         },
       });
@@ -944,7 +976,10 @@ describe.skipIf(!runPostgresProof)(
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
-            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
             where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
           });
         }

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -43,6 +43,7 @@ import { createHostedPhoneLookupKeyReadCandidates } from "@/src/lib/hosted-onboa
 import { resolveMurphHostedLinqContactCardBackupPhoneNumber } from "@/src/lib/hosted-onboarding/linq-contact-card";
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 import {
+  HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS,
   listHostedLinqContactCardLines,
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
@@ -321,6 +322,107 @@ describe.skipIf(!runPostgresProof)(
           });
           expect(backup).not.toBe(phoneA);
         }
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
+    it("gates candidacy on a fresh validated confirmation before, during, and after inventory outages", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phone = buildSyntheticProofPhoneNumber();
+      const proofLookupKeys = createHostedPhoneLookupKeyReadCandidates(phone);
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        // A pre-rollout row: configured and holding a provider id written by
+        // the former lenient path, with no snapshot confirmation.
+        const row = await upsertHostedLinqLineForPhoneTx({
+          activeMemberLimit: null,
+          observedAt: new Date(),
+          phoneNumber: phone,
+          prisma,
+          providerPhoneNumberId: providerId,
+          source: "configured",
+        });
+        await prisma.hostedLinqLine.update({
+          data: {
+            providerInventoryConfirmedAt: null,
+            providerPhoneNumberId: providerId,
+          },
+          where: { phoneNumberLookupKey: row.phoneNumberLookupKey },
+        });
+
+        const beforeFirstSnapshot = await listHostedLinqContactCardLines({ prisma });
+        expect(beforeFirstSnapshot.map((line) => line.phoneNumber)).not.toContain(phone);
+
+        // A validated snapshot stamps the watermark and makes it eligible.
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerId,
+              phone_number: phone,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: 1 });
+
+        const afterSnapshot = await listHostedLinqContactCardLines({ prisma });
+        expect(afterSnapshot.map((line) => line.phoneNumber)).toContain(phone);
+
+        // Repeated failed and malformed reads leave ownership untouched but
+        // never refresh the watermark, so eligibility ages out on a clock
+        // advanced past the freshness budget.
+        vi.stubGlobal("fetch", vi.fn(async () => new Response("upstream error", { status: 503 })));
+        await expect(syncHostedLinqPhoneNumberInventory({ prisma })).rejects.toMatchObject({
+          code: "LINQ_PHONE_NUMBER_INVENTORY_FAILED",
+        });
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ data: [] }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        })));
+        await expect(syncHostedLinqPhoneNumberInventory({ prisma })).rejects.toMatchObject({
+          code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
+        });
+
+        const stillOwned = await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: row.phoneNumberLookupKey },
+          select: { providerPhoneNumberId: true },
+        });
+        expect(stillOwned?.providerPhoneNumberId).toBe(providerId);
+
+        const pastBudget = new Date(
+          Date.parse(new Date().toISOString())
+          + HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS
+          + 60_000,
+        );
+        const afterStaleness = await listHostedLinqContactCardLines({
+          observedAt: pastBudget,
+          prisma,
+        });
+        expect(afterStaleness.map((line) => line.phoneNumber)).not.toContain(phone);
       } finally {
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -41,7 +41,10 @@ beforeEach(() => {
 
 import { createHostedPhoneLookupKeyReadCandidates } from "@/src/lib/hosted-onboarding/contact-privacy-core";
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
-import { upsertHostedLinqLineForPhoneTx } from "@/src/lib/hosted-onboarding/linq-line-store";
+import {
+  syncHostedLinqConfiguredLinesTx,
+  upsertHostedLinqLineForPhoneTx,
+} from "@/src/lib/hosted-onboarding/linq-line-store";
 import { createPrismaClient } from "@/src/lib/prisma";
 
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
@@ -499,6 +502,83 @@ describe.skipIf(!runPostgresProof)(
               ),
             },
           },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
+    it("races configured-line sync against inventory application in reverse phone order without deadlock", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
+      const providerIdOne = `pg-proof-line-${randomUUID()}`;
+      const providerIdTwo = `pg-proof-line-${randomUUID()}`;
+      const phoneOne = buildSyntheticProofPhoneNumber();
+      const phoneTwo = buildSyntheticProofPhoneNumber();
+      const proofLookupKeys = [phoneOne, phoneTwo].flatMap(
+        (phone) => createHostedPhoneLookupKeyReadCandidates(phone),
+      );
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        // Both multi-phone writers touch the same two phones in opposite
+        // orders; without the shared inventory-wide first lock their
+        // per-phone advisory locks can invert and PostgreSQL aborts one
+        // participant as a deadlock.
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerIdTwo,
+              phone_number: phoneTwo,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+            {
+              id: providerIdOne,
+              phone_number: phoneOne,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(Promise.all([
+          prisma.$transaction((tx) => syncHostedLinqConfiguredLinesTx({
+            activeMemberLimit: null,
+            phoneNumbers: [phoneOne, phoneTwo],
+            prisma: tx,
+          })),
+          syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
+        ])).resolves.toEqual([undefined, { syncedCount: 2 }]);
+
+        const rows = await prisma.hostedLinqLine.findMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
+          select: {
+            configuredAt: true,
+            providerPhoneNumberId: true,
+          },
+        });
+        expect(rows).toHaveLength(2);
+        for (const row of rows) {
+          expect(row.configuredAt).not.toBeNull();
+        }
+        expect(new Set(rows.map((row) => row.providerPhoneNumberId)))
+          .toEqual(new Set([providerIdOne, providerIdTwo]));
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
       }

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
   providerStateControl.failOnCall = 0;
 });
 
+import { createHostedPhoneLookupKeyReadCandidates } from "@/src/lib/hosted-onboarding/contact-privacy-core";
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 import { upsertHostedLinqLineForPhoneTx } from "@/src/lib/hosted-onboarding/linq-line-store";
 import { createPrismaClient } from "@/src/lib/prisma";
@@ -413,6 +414,86 @@ describe.skipIf(!runPostgresProof)(
         }
         await prisma.hostedLinqLine.deleteMany({
           where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
+    it("completes two concurrent maximum-cardinality syncs within the default transaction budget", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
+      const lineCount = 250;
+      const buildBulkSnapshot = (batch: string) => Array.from({ length: lineCount }, (_value, index) => ({
+        id: `pg-proof-${batch}-${index}-${randomUUID()}`,
+        phone_number: `+1555${batch === "one" ? "2" : "3"}${String(100_000 + index)}`,
+        reputation: { status: "HEALTHY" },
+        status: "ACTIVE",
+      }));
+      const snapshotOne = buildBulkSnapshot("one");
+      const snapshotTwo = buildBulkSnapshot("two");
+      const allIds = [...snapshotOne, ...snapshotTwo].map((line) => line.id);
+      const snapshotTwoIds = snapshotTwo.map((line) => line.id);
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        // The follower's transaction lifetime covers both the advisory-lock
+        // wait behind the leader's full apply and its own 250-line apply;
+        // both overlapping minute-zero crons must still finish without
+        // hitting the shared 15s transaction timeout (P2028).
+        let fetchCalls = 0;
+        vi.stubGlobal("fetch", vi.fn(async () => {
+          fetchCalls += 1;
+          return new Response(JSON.stringify({
+            phone_numbers: fetchCalls === 1 ? snapshotOne : snapshotTwo,
+          }), { headers: { "content-type": "application/json" }, status: 200 });
+        }));
+        await expect(Promise.all([
+          syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
+          syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
+        ])).resolves.toEqual([
+          { syncedCount: lineCount },
+          { syncedCount: lineCount },
+        ]);
+
+        const heldAfterRace = await prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: { in: allIds } },
+        });
+        expect(heldAfterRace).toBe(lineCount);
+
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: snapshotTwo,
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: lineCount });
+
+        const finalHeld = await prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: { in: snapshotTwoIds } },
+        });
+        expect(finalHeld).toBe(lineCount);
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: {
+            phoneNumberLookupKey: {
+              in: [...snapshotOne, ...snapshotTwo].flatMap(
+                (line) => createHostedPhoneLookupKeyReadCandidates(line.phone_number),
+              ),
+            },
+          },
         });
         await prisma.$disconnect();
       }

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -1,6 +1,6 @@
 import { randomInt, randomUUID } from "node:crypto";
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingLinqConfig: () => ({
@@ -8,6 +8,36 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
     apiToken: "linq-token",
   }),
 }));
+
+// Pass-through wrapper so the rollback proof can inject a failure mid-way
+// through an otherwise fully real snapshot application.
+const providerStateControl = vi.hoisted(() => ({ calls: 0, failOnCall: 0 }));
+
+vi.mock("@/src/lib/hosted-onboarding/linq-provider-health-store", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/lib/hosted-onboarding/linq-provider-health-store")
+  >();
+  return {
+    ...actual,
+    projectHostedLinqLineProviderStateTx: async (
+      input: Parameters<typeof actual.projectHostedLinqLineProviderStateTx>[0],
+    ) => {
+      providerStateControl.calls += 1;
+      if (
+        providerStateControl.failOnCall > 0
+        && providerStateControl.calls === providerStateControl.failOnCall
+      ) {
+        throw new Error("injected mid-application failure");
+      }
+      return actual.projectHostedLinqLineProviderStateTx(input);
+    },
+  };
+});
+
+beforeEach(() => {
+  providerStateControl.calls = 0;
+  providerStateControl.failOnCall = 0;
+});
 
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 import { upsertHostedLinqLineForPhoneTx } from "@/src/lib/hosted-onboarding/linq-line-store";
@@ -207,6 +237,230 @@ describe.skipIf(!runPostgresProof)(
         }
         await prisma.hostedLinqLine.deleteMany({
           where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+    it("blocks a concurrent sync on the inventory-wide advisory lock until the owner commits", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
+      const observer = createPrismaClient({ databaseUrl, poolMax: 2 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const createdLookupKeys: string[] = [];
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerId,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        let releaseOwner: () => void = () => undefined;
+        const ownerHold = new Promise<void>((resolve) => {
+          releaseOwner = resolve;
+        });
+        let ownerHasLock: () => void = () => undefined;
+        const ownerLocked = new Promise<void>((resolve) => {
+          ownerHasLock = resolve;
+        });
+        const ownerTransaction = prisma.$transaction(async (tx) => {
+          await tx.$executeRaw`
+            SELECT pg_advisory_xact_lock(
+              hashtext('hosted_linq_phone_number_inventory'),
+              hashtext('snapshot')
+            )
+          `;
+          ownerHasLock();
+          await ownerHold;
+        });
+
+        await ownerLocked;
+        const contender = syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        });
+
+        // The production sync must be observably blocked on the advisory lock
+        // while the owner holds it — this assertion fails if the lock is
+        // removed from the sync.
+        let blockedBackends = 0;
+        for (let attempt = 0; attempt < 40 && blockedBackends === 0; attempt += 1) {
+          const rows = await observer.$queryRaw<Array<{ blocked: bigint | number }>>`
+            SELECT count(*) AS blocked
+            FROM pg_stat_activity
+            WHERE wait_event_type = 'Lock'
+              AND wait_event = 'advisory'
+              AND cardinality(pg_blocking_pids(pid)) > 0
+          `;
+          blockedBackends = Number(rows[0]?.blocked ?? 0);
+          if (blockedBackends === 0) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+        }
+        expect(blockedBackends).toBeGreaterThan(0);
+
+        releaseOwner();
+        await ownerTransaction;
+        await expect(contender).resolves.toEqual({ syncedCount: 1 });
+
+        const owners = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: providerId },
+          select: { phoneNumberLookupKey: true },
+        });
+        for (const owner of owners) {
+          createdLookupKeys.push(owner.phoneNumberLookupKey);
+        }
+        expect(owners).toHaveLength(1);
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+        await observer.$disconnect();
+      }
+    });
+
+    it("rolls the whole snapshot application back when a line fails mid-way", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerIdX = `pg-proof-line-${randomUUID()}`;
+      const providerIdY = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const phoneC = buildSyntheticProofPhoneNumber();
+      const createdLookupKeys: string[] = [];
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        const rowA = await upsertHostedLinqLineForPhoneTx({
+          observedAt: new Date(),
+          phoneNumber: phoneA,
+          prisma,
+          providerPhoneNumberId: providerIdX,
+          source: "provider",
+        });
+        createdLookupKeys.push(rowA.phoneNumberLookupKey);
+
+        // Snapshot: new line C first, then X moved from A to B. Failing the
+        // second line's application (after the stale revoke and a full first
+        // line) must roll the entire replacement back.
+        providerStateControl.failOnCall = 2;
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerIdY,
+              phone_number: phoneC,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+            {
+              id: providerIdX,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).rejects.toThrow("injected mid-application failure");
+
+        const rowAAfter = await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
+          select: { providerPhoneNumberId: true },
+        });
+        expect(rowAAfter?.providerPhoneNumberId).toBe(providerIdX);
+        const strayRows = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: providerIdY },
+          select: { phoneNumberLookupKey: true },
+        });
+        expect(strayRows).toHaveLength(0);
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
+    it("applies a maximum-cardinality 250-line snapshot inside the default transaction budget", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const lineCount = 250;
+      const snapshotLines = Array.from({ length: lineCount }, (_value, index) => ({
+        id: `pg-proof-bulk-${index}-${randomUUID()}`,
+        phone_number: `+1555${String(1_000_000 + index)}`,
+        reputation: { status: "HEALTHY" },
+        status: "ACTIVE",
+      }));
+      const snapshotIds = snapshotLines.map((line) => line.id);
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: snapshotLines,
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: lineCount });
+
+        const heldCount = await prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: { in: snapshotIds } },
+        });
+        expect(heldCount).toBe(lineCount);
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { providerPhoneNumberId: { in: snapshotIds } },
         });
         await prisma.$disconnect();
       }

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -109,6 +109,108 @@ describe.skipIf(!runPostgresProof)(
         await prisma.$disconnect();
       }
     });
+    it("serializes concurrent snapshot applications without violating the unique index", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const createdLookupKeys: string[] = [];
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      const buildSnapshotResponse = (phoneNumber: string) => new Response(JSON.stringify({
+        phone_numbers: [
+          {
+            id: providerId,
+            phone_number: phoneNumber,
+            reputation: { status: "HEALTHY" },
+            status: "ACTIVE",
+          },
+        ],
+      }), { headers: { "content-type": "application/json" }, status: 200 });
+
+      try {
+        const rowA = await upsertHostedLinqLineForPhoneTx({
+          observedAt: new Date(),
+          phoneNumber: phoneA,
+          prisma,
+          providerPhoneNumberId: providerId,
+          source: "provider",
+        });
+        createdLookupKeys.push(rowA.phoneNumberLookupKey);
+
+        // One overlapping run still sees the old X→A snapshot while the other
+        // sees the new X→B snapshot; both apply concurrently. The advisory
+        // lock must serialize them so neither hits the unique index, in
+        // either commit order.
+        let fetchCalls = 0;
+        vi.stubGlobal("fetch", vi.fn(async () => {
+          fetchCalls += 1;
+          return buildSnapshotResponse(fetchCalls === 1 ? phoneA : phoneB);
+        }));
+        await expect(Promise.all([
+          syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
+          syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
+        ])).resolves.toEqual([{ syncedCount: 1 }, { syncedCount: 1 }]);
+
+        const ownersAfterRace = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: providerId },
+          select: { phoneNumberLookupKey: true },
+        });
+        for (const owner of ownersAfterRace) {
+          if (!createdLookupKeys.includes(owner.phoneNumberLookupKey)) {
+            createdLookupKeys.push(owner.phoneNumberLookupKey);
+          }
+        }
+        expect(ownersAfterRace).toHaveLength(1);
+
+        // The provider's current truth converges on the next run regardless
+        // of which overlapping snapshot committed last.
+        vi.stubGlobal("fetch", vi.fn(async () => buildSnapshotResponse(phoneB)));
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: 1 });
+
+        const finalOwners = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: providerId },
+          select: {
+            phoneNumberHint: true,
+            phoneNumberLookupKey: true,
+          },
+        });
+        for (const owner of finalOwners) {
+          if (!createdLookupKeys.includes(owner.phoneNumberLookupKey)) {
+            createdLookupKeys.push(owner.phoneNumberLookupKey);
+          }
+        }
+        expect(finalOwners).toHaveLength(1);
+        expect(finalOwners[0]?.phoneNumberHint).toBe(`*** ${phoneB.slice(-4)}`);
+        const releasedRowA = await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
+          select: { providerPhoneNumberId: true },
+        });
+        expect(releasedRowA?.providerPhoneNumberId).toBeNull();
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
   },
 );
 

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -1,0 +1,136 @@
+import { randomInt, randomUUID } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
+  requireHostedOnboardingLinqConfig: () => ({
+    apiBaseUrl: "https://linq.example.test/api/partner/v3",
+    apiToken: "linq-token",
+  }),
+}));
+
+import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
+import { upsertHostedLinqLineForPhoneTx } from "@/src/lib/hosted-onboarding/linq-line-store";
+import { createPrismaClient } from "@/src/lib/prisma";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresProof =
+  process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+if (
+  runPostgresProof
+  && (!databaseUrl || !isClearlyLocalPostgresUrl(databaseUrl))
+) {
+  throw new Error(
+    "The Hosted Linq phone-number inventory proof requires a local DATABASE_URL.",
+  );
+}
+
+describe.skipIf(!runPostgresProof)(
+  "hosted Linq phone-number inventory PostgreSQL proof",
+  () => {
+    it("transfers a moved provider id between rows without violating the unique index", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const observedAt = new Date();
+      const createdLookupKeys: string[] = [];
+
+      // The sync revokes every held pairing its snapshot does not confirm, so
+      // capture unrelated held rows up front and restore them afterwards to
+      // keep this proof independent of other suites sharing the database.
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        const rowA = await upsertHostedLinqLineForPhoneTx({
+          observedAt,
+          phoneNumber: phoneA,
+          prisma,
+          providerPhoneNumberId: providerId,
+          source: "provider",
+        });
+        createdLookupKeys.push(rowA.phoneNumberLookupKey);
+
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerId,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: new Date(),
+          prisma,
+        })).resolves.toEqual({ syncedCount: 1 });
+
+        const owners = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: providerId },
+          select: {
+            phoneNumberHint: true,
+            phoneNumberLookupKey: true,
+          },
+        });
+        for (const owner of owners) {
+          if (!createdLookupKeys.includes(owner.phoneNumberLookupKey)) {
+            createdLookupKeys.push(owner.phoneNumberLookupKey);
+          }
+        }
+        expect(owners).toHaveLength(1);
+        expect(owners[0]?.phoneNumberHint).toBe(`*** ${phoneB.slice(-4)}`);
+        expect(owners[0]?.phoneNumberLookupKey).not.toBe(rowA.phoneNumberLookupKey);
+
+        const releasedRowA = await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
+          select: { providerPhoneNumberId: true },
+        });
+        expect(releasedRowA?.providerPhoneNumberId).toBeNull();
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+  },
+);
+
+function buildSyntheticProofPhoneNumber(): string {
+  return `+1555${String(randomInt(0, 10_000_000)).padStart(7, "0")}`;
+}
+
+function isClearlyLocalPostgresUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+    return false;
+  }
+  const hostOverrides = parsed.searchParams.getAll("host");
+  if (hostOverrides.length > 1) {
+    return false;
+  }
+  const effectiveHost = (hostOverrides[0] || parsed.hostname).toLowerCase();
+  return ["127.0.0.1", "::1", "[::1]", "localhost"].includes(effectiveHost)
+    || effectiveHost.startsWith("/");
+}

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -273,8 +273,8 @@ describe.skipIf(!runPostgresProof)(
         const ownerHold = new Promise<void>((resolve) => {
           releaseOwner = resolve;
         });
-        let ownerHasLock: () => void = () => undefined;
-        const ownerLocked = new Promise<void>((resolve) => {
+        let ownerHasLock: (backendPid: number) => void = () => undefined;
+        const ownerLocked = new Promise<number>((resolve) => {
           ownerHasLock = resolve;
         });
         const ownerTransaction = prisma.$transaction(async (tx) => {
@@ -284,19 +284,24 @@ describe.skipIf(!runPostgresProof)(
               hashtext('snapshot')
             )
           `;
-          ownerHasLock();
+          const pidRows = await tx.$queryRaw<Array<{ pid: number }>>`
+            SELECT pg_backend_pid() AS pid
+          `;
+          ownerHasLock(Number(pidRows[0]?.pid ?? 0));
           await ownerHold;
         });
 
-        await ownerLocked;
+        const ownerBackendPid = await ownerLocked;
+        expect(ownerBackendPid).toBeGreaterThan(0);
         const contender = syncHostedLinqPhoneNumberInventory({
           observedAt: new Date(),
           prisma,
         });
 
         // The production sync must be observably blocked on the advisory lock
-        // while the owner holds it — this assertion fails if the lock is
-        // removed from the sync.
+        // held by this exact owner backend — this assertion fails if the lock
+        // is removed from the sync, and an unrelated suite's advisory waiter
+        // cannot satisfy it.
         let blockedBackends = 0;
         for (let attempt = 0; attempt < 40 && blockedBackends === 0; attempt += 1) {
           const rows = await observer.$queryRaw<Array<{ blocked: bigint | number }>>`
@@ -304,7 +309,7 @@ describe.skipIf(!runPostgresProof)(
             FROM pg_stat_activity
             WHERE wait_event_type = 'Lock'
               AND wait_event = 'advisory'
-              AND cardinality(pg_blocking_pids(pid)) > 0
+              AND ${ownerBackendPid} = ANY(pg_blocking_pids(pid))
           `;
           blockedBackends = Number(rows[0]?.blocked ?? 0);
           if (blockedBackends === 0) {

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -48,6 +48,7 @@ import {
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
+import { encryptHostedLinqLinePhoneNumber } from "@/src/lib/hosted-onboarding/linq-line-phone-codec";
 import { createPrismaClient } from "@/src/lib/prisma";
 
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
@@ -435,6 +436,135 @@ describe.skipIf(!runPostgresProof)(
           where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
+      }
+    });
+
+    it("never returns a relinquished line as the member-facing backup mid-move", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
+      const observer = createPrismaClient({ databaseUrl, poolMax: 2 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const otherProviderId = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const phoneOther = buildSyntheticProofPhoneNumber();
+      const proofLookupKeys = [phoneA, phoneB, phoneOther].flatMap(
+        (phone) => createHostedPhoneLookupKeyReadCandidates(phone),
+      );
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        // Seed A as a confirmed configured owner plus one other owned line,
+        // so backup resolution has a real choice.
+        for (const [phone, id] of [[phoneA, providerId], [phoneOther, otherProviderId]] as const) {
+          const seeded = await upsertHostedLinqLineForPhoneTx({
+            activeMemberLimit: null,
+            observedAt: new Date(),
+            phoneNumber: phone,
+            prisma,
+            providerPhoneNumberId: id,
+            source: "configured",
+          });
+          await prisma.hostedLinqLine.update({
+            data: {
+              providerInventoryConfirmedAt: new Date(),
+              providerPhoneNumberId: id,
+            },
+            where: { phoneNumberLookupKey: seeded.phoneNumberLookupKey },
+          });
+        }
+
+        // Hold the authoritative move X: A→B open under the inventory lock.
+        let releaseMove: () => void = () => undefined;
+        const moveHold = new Promise<void>((resolve) => {
+          releaseMove = resolve;
+        });
+        let movePid: (pid: number) => void = () => undefined;
+        const moveLocked = new Promise<number>((resolve) => {
+          movePid = resolve;
+        });
+        const moveTransaction = prisma.$transaction(async (tx) => {
+          await tx.$executeRaw`
+            SELECT pg_advisory_xact_lock(
+              hashtext('hosted_linq_phone_number_inventory'),
+              hashtext('snapshot')
+            )
+          `;
+          const revokedKeys = createHostedPhoneLookupKeyReadCandidates(phoneA);
+          await tx.hostedLinqLine.updateMany({
+            data: {
+              providerInventoryConfirmedAt: null,
+              providerPhoneNumberId: null,
+            },
+            where: { phoneNumberLookupKey: { in: revokedKeys } },
+          });
+          const claimed = createHostedPhoneLookupKeyReadCandidates(phoneB);
+          await tx.hostedLinqLine.create({
+            data: {
+              assignmentWeight: 100,
+              egressPolicy: "enabled",
+              healthStatus: "unknown",
+              phoneNumberEncrypted: encryptHostedLinqLinePhoneNumber(phoneB),
+              phoneNumberHint: `*** ${phoneB.slice(-4)}`,
+              phoneNumberLookupKey: claimed[0] as string,
+              providerInventoryConfirmedAt: new Date(),
+              providerPhoneNumberId: providerId,
+              providerSeenAt: new Date(),
+              source: "provider",
+            },
+          });
+          const pidRows = await tx.$queryRaw<Array<{ pid: number }>>`
+            SELECT pg_backend_pid() AS pid
+          `;
+          movePid(Number(pidRows[0]?.pid ?? 0));
+          await moveHold;
+        });
+
+        const moveBackendPid = await moveLocked;
+        const backupPromise = resolveMurphHostedLinqContactCardBackupPhoneNumber({
+          excludePhoneNumber: phoneOther,
+          prisma,
+        });
+
+        // The member-facing resolver must wait for the move rather than read
+        // across it.
+        let blocked = 0;
+        for (let attempt = 0; attempt < 40 && blocked === 0; attempt += 1) {
+          const rows = await observer.$queryRaw<Array<{ blocked: bigint | number }>>`
+            SELECT count(*) AS blocked
+            FROM pg_stat_activity
+            WHERE wait_event_type = 'Lock'
+              AND wait_event = 'advisory'
+              AND ${moveBackendPid} = ANY(pg_blocking_pids(pid))
+          `;
+          blocked = Number(rows[0]?.blocked ?? 0);
+          if (blocked === 0) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+        }
+        expect(blocked).toBeGreaterThan(0);
+
+        releaseMove();
+        await moveTransaction;
+        await expect(backupPromise).resolves.not.toBe(phoneA);
+      } finally {
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: { providerPhoneNumberId: heldRow.providerPhoneNumberId },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
+        });
+        await prisma.$disconnect();
+        await observer.$disconnect();
       }
     });
 

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -78,7 +78,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
     })).resolves.toEqual({ syncedCount: 2 });
 
     // line_current keeps its pairing; line_moving is held at a lookup key
@@ -103,7 +103,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     stubInventoryFetch({ phone_numbers: [] });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
     })).resolves.toEqual({ syncedCount: 0 });
 
     expect(updateMany).toHaveBeenCalledWith({
@@ -120,7 +120,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     stubInventoryFetch("upstream error", 503);
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_FAILED",
     });
@@ -140,7 +140,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     stubInventoryFetch(payload);
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
     });
@@ -167,7 +167,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     stubInventoryFetch({ phone_numbers: records });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
     });

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   }),
 }));
 
+import { createHostedPhoneLookupKey } from "@/src/lib/hosted-onboarding/contact-privacy-core";
 import {
   parseHostedLinqPhoneNumberInventory,
   syncHostedLinqPhoneNumberInventory,
@@ -35,18 +36,31 @@ afterEach(() => {
 });
 
 describe("syncHostedLinqPhoneNumberInventory", () => {
-  it("revokes inventory backing from lines absent in a successful snapshot before upserting", async () => {
+  const stubInventoryFetch = (payload: unknown, status = 200) => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      typeof payload === "string" ? payload : JSON.stringify(payload),
+      { headers: { "content-type": "application/json" }, status },
+    )));
+  };
+
+  it("revokes relinquished and moved provider-id pairings before upserting", async () => {
+    const keptLookupKey = createHostedPhoneLookupKey("+15550000001");
     const callOrder: string[] = [];
+    const findMany = vi.fn(async () => [
+      { phoneNumberLookupKey: keptLookupKey, providerPhoneNumberId: "line_current" },
+      { phoneNumberLookupKey: "lookup:moved", providerPhoneNumberId: "line_moving" },
+      { phoneNumberLookupKey: "lookup:relinquished", providerPhoneNumberId: "line_gone" },
+    ]);
     const updateMany = vi.fn(async () => {
       callOrder.push("revoke");
-      return { count: 1 };
+      return { count: 2 };
     });
     lineStoreMocks.upsertHostedLinqLineForPhoneTx.mockImplementation(async () => {
       callOrder.push("upsert");
-      return { phoneNumberLookupKey: "lookup:1" };
+      return { phoneNumberLookupKey: "lookup:any" };
     });
     providerHealthStoreMocks.projectHostedLinqLineProviderStateTx.mockResolvedValue(undefined);
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+    stubInventoryFetch({
       phone_numbers: [
         {
           id: "line_current",
@@ -54,36 +68,111 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
           reputation: { status: "HEALTHY" },
           status: "ACTIVE",
         },
+        {
+          id: "line_moving",
+          phone_number: "+15550000002",
+          reputation: { status: "HEALTHY" },
+          status: "ACTIVE",
+        },
       ],
-    }), { headers: { "content-type": "application/json" }, status: 200 })));
+    });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { updateMany } } as never,
-    })).resolves.toEqual({ syncedCount: 1 });
+      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+    })).resolves.toEqual({ syncedCount: 2 });
 
+    // line_current keeps its pairing; line_moving is held at a lookup key
+    // that is not a candidate for its snapshot phone (a move) and line_gone
+    // is absent from the snapshot, so exactly those two rows are cleared.
+    expect(updateMany).toHaveBeenCalledTimes(1);
     expect(updateMany).toHaveBeenCalledWith({
       data: { providerPhoneNumberId: null },
       where: {
-        providerPhoneNumberId: {
-          not: null,
-          notIn: ["line_current"],
-        },
+        phoneNumberLookupKey: { in: ["lookup:moved", "lookup:relinquished"] },
       },
     });
     expect(callOrder[0]).toBe("revoke");
     expect(callOrder).toContain("upsert");
   });
 
-  it("does not revoke inventory backing when the provider read fails", async () => {
-    const updateMany = vi.fn();
-    vi.stubGlobal("fetch", vi.fn(async () => new Response("upstream error", { status: 503 })));
+  it("clears every held provider id when the provider reports an explicitly empty inventory", async () => {
+    const findMany = vi.fn(async () => [
+      { phoneNumberLookupKey: "lookup:only", providerPhoneNumberId: "line_prior" },
+    ]);
+    const updateMany = vi.fn(async () => ({ count: 1 }));
+    stubInventoryFetch({ phone_numbers: [] });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { hostedLinqLine: { updateMany } } as never,
+      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+    })).resolves.toEqual({ syncedCount: 0 });
+
+    expect(updateMany).toHaveBeenCalledWith({
+      data: { providerPhoneNumberId: null },
+      where: {
+        phoneNumberLookupKey: { in: ["lookup:only"] },
+      },
+    });
+  });
+
+  it("does not revoke inventory backing when the provider read fails", async () => {
+    const findMany = vi.fn();
+    const updateMany = vi.fn();
+    stubInventoryFetch("upstream error", 503);
+
+    await expect(syncHostedLinqPhoneNumberInventory({
+      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_FAILED",
     });
 
+    expect(findMany).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing collection field", {}],
+    ["an aliased collection field", { data: [{ id: "line_1", phone_number: "+15550000001" }] }],
+    ["a non-array collection field", { phone_numbers: "+15550000001" }],
+  ])("rejects %s without touching stored ownership", async (_label, payload) => {
+    const findMany = vi.fn();
+    const updateMany = vi.fn();
+    stubInventoryFetch(payload);
+
+    await expect(syncHostedLinqPhoneNumberInventory({
+      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
+    });
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an invalid phone number", [{ id: "line_1", phone_number: "not-a-phone" }]],
+    ["a duplicate phone number", [
+      { id: "line_1", phone_number: "+15550000001" },
+      { id: "line_2", phone_number: "+1 (555) 000-0001" },
+    ]],
+    ["a missing provider id", [{ phone_number: "+15550000001" }]],
+    ["a duplicate provider id", [
+      { id: "line_1", phone_number: "+15550000001" },
+      { id: "line_1", phone_number: "+15550000002" },
+    ]],
+  ])("rejects a snapshot containing %s without touching stored ownership", async (_label, records) => {
+    const findMany = vi.fn();
+    const updateMany = vi.fn();
+    stubInventoryFetch({ phone_numbers: records });
+
+    await expect(syncHostedLinqPhoneNumberInventory({
+      prisma: { hostedLinqLine: { findMany, updateMany } } as never,
+    })).rejects.toMatchObject({
+      code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
+    });
+
+    expect(findMany).not.toHaveBeenCalled();
     expect(updateMany).not.toHaveBeenCalled();
     expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
   });

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -89,9 +89,11 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     // line_current keeps its pairing; line_moving is held at a lookup key
     // that is not a candidate for its snapshot phone (a move) and line_gone
     // is absent from the snapshot, so exactly those two rows are cleared.
-    expect(updateMany).toHaveBeenCalledTimes(1);
     expect(updateMany).toHaveBeenCalledWith({
-      data: { providerPhoneNumberId: null },
+      data: {
+        providerInventoryConfirmedAt: null,
+        providerPhoneNumberId: null,
+      },
       where: {
         phoneNumberLookupKey: { in: ["lookup:moved", "lookup:relinquished"] },
       },
@@ -112,7 +114,10 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     })).resolves.toEqual({ syncedCount: 0 });
 
     expect(updateMany).toHaveBeenCalledWith({
-      data: { providerPhoneNumberId: null },
+      data: {
+        providerInventoryConfirmedAt: null,
+        providerPhoneNumberId: null,
+      },
       where: {
         phoneNumberLookupKey: { in: ["lookup:only"] },
       },

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -114,6 +114,35 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     });
   });
 
+  it("applies the snapshot inside one owning transaction that takes the inventory lock first", async () => {
+    const callOrder: string[] = [];
+    const tx = {
+      $executeRaw: vi.fn(async () => {
+        callOrder.push("lock");
+        return 0;
+      }),
+      hostedLinqLine: {
+        findMany: vi.fn(async () => {
+          callOrder.push("read-held");
+          return [];
+        }),
+        updateMany: vi.fn(),
+      },
+    };
+    const $transaction = vi.fn(async (callback: (client: unknown) => Promise<unknown>) => {
+      callOrder.push("transaction");
+      return callback(tx);
+    });
+    stubInventoryFetch({ phone_numbers: [] });
+
+    await expect(syncHostedLinqPhoneNumberInventory({
+      prisma: { $transaction, hostedLinqLine: { findMany: vi.fn(), updateMany: vi.fn() } } as never,
+    })).resolves.toEqual({ syncedCount: 0 });
+
+    expect($transaction).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["transaction", "lock", "read-held"]);
+  });
+
   it("does not revoke inventory backing when the provider read fails", async () => {
     const findMany = vi.fn();
     const updateMany = vi.fn();

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -9,6 +9,11 @@ const providerHealthStoreMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
+  acquireHostedLinqInventoryApplyLockTx: async (
+    input: { prisma: { $executeRaw: (...args: unknown[]) => Promise<unknown> } },
+  ) => {
+    await input.prisma.$executeRaw();
+  },
   upsertHostedLinqLineForPhoneTx: lineStoreMocks.upsertHostedLinqLineForPhoneTx,
 }));
 

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -304,7 +304,13 @@ describe("Linq provider health inventory synchronization", () => {
       prisma,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    expect(updateMany).not.toHaveBeenCalled();
+    // The only write is the freshness watermark for the confirmed line;
+    // unknown status values never clear stored provider state.
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    expect(updateMany).toHaveBeenCalledWith({
+      data: { providerInventoryConfirmedAt: expect.any(Date) },
+      where: { phoneNumberLookupKey: "line-key" },
+    });
   });
 
   it("associates inventoried chat health with its resolved sending line", async () => {

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -223,6 +223,7 @@ describe("Linq provider health inventory synchronization", () => {
     const observedAt = new Date("2026-07-29T16:08:00.000Z");
     const updateMany = vi.fn().mockResolvedValue({ count: 1 });
     const prisma = {
+      $executeRaw: vi.fn(),
       hostedLinqLine: {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany,
@@ -275,6 +276,7 @@ describe("Linq provider health inventory synchronization", () => {
   it("does not clear stored provider state from unknown inventory values", async () => {
     const updateMany = vi.fn();
     const prisma = {
+      $executeRaw: vi.fn(),
       hostedLinqLine: {
         findMany: vi.fn().mockResolvedValue([]),
         updateMany,

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -52,6 +52,11 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
+  acquireHostedLinqInventoryApplyLockTx: async (
+    input: { prisma: { $executeRaw: (...args: unknown[]) => Promise<unknown> } },
+  ) => {
+    await input.prisma.$executeRaw();
+  },
   upsertHostedLinqLineForPhoneTx:
     inventoryMocks.upsertHostedLinqLineForPhoneTx,
 }));

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -223,7 +223,10 @@ describe("Linq provider health inventory synchronization", () => {
     const observedAt = new Date("2026-07-29T16:08:00.000Z");
     const updateMany = vi.fn().mockResolvedValue({ count: 1 });
     const prisma = {
-      hostedLinqLine: { updateMany },
+      hostedLinqLine: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany,
+      },
     } as never;
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
@@ -272,7 +275,10 @@ describe("Linq provider health inventory synchronization", () => {
   it("does not clear stored provider state from unknown inventory values", async () => {
     const updateMany = vi.fn();
     const prisma = {
-      hostedLinqLine: { updateMany },
+      hostedLinqLine: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany,
+      },
     } as never;
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
@@ -291,19 +297,7 @@ describe("Linq provider health inventory synchronization", () => {
       prisma,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    // The only direct write is the inventory-membership revoke, which keeps
-    // the snapshot's own line; unknown status values never clear stored
-    // provider state.
-    expect(updateMany).toHaveBeenCalledTimes(1);
-    expect(updateMany).toHaveBeenCalledWith({
-      data: { providerPhoneNumberId: null },
-      where: {
-        providerPhoneNumberId: {
-          not: null,
-          notIn: ["line-future"],
-        },
-      },
-    });
+    expect(updateMany).not.toHaveBeenCalled();
   });
 
   it("associates inventoried chat health with its resolved sending line", async () => {

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -1036,6 +1036,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260730190000_hosted_physical_notes",
       "20260731001500_add_hosted_product_feedback_created_at_index",
       "20260731120000_anonymize_hosted_product_feedback",
+      "20260802000000_add_hosted_linq_line_inventory_confirmed_at",
       "migration_lock.toml",
     ]);
     expect(deviceSyncSignalSourceProviderMigrationSql).toContain(


### PR DESCRIPTION
PR: cobuildwithus/murph#1253 (follow-up hardening to #1244). Pushed head under review: c33d4685a28c8d00658522864f3d132e6d7aa526.

## Why this PR exists

Follow-up hardening to #1244 (contact-card cron killed hourly by a phantom, unowned Linq line). #1244 merged with the first remediation round; a preliminary specialist ReviewGPT round against the interim head then confirmed three residual defects in the merged state: (1) the new inventory-id revoke trusts any HTTP 200 payload, so a malformed response that parses as an empty or smaller inventory mass-revokes legitimate line ownership; (2) a provider id that moves between phone numbers is retained on the old row and collides with the unique provider-id index during the upsert; (3) a run where every line fails reconciliation still returns HTTP 200 to the Vercel cron scheduler, hiding a total contact-card outage. This PR lands those three fixes with their coverage.

## User goal / user-visible behavior

Members keep receiving working "Murph" contact cards and backup numbers: line ownership in the database can only change in response to a validated provider inventory snapshot, one provider id can never wedge the sync or the unique index, and a complete contact-card outage becomes a visible cron failure instead of a silent success.

## User experience

No direct UI or conversation change. Indirect only: contact-card and vCard backup-number candidacy stay correct under provider-side malformed responses, number moves, and outages.

## Invariants the PR must preserve

- The inventory sync only mutates ownership from a validated authoritative snapshot: the payload must carry a `phone_numbers` array and every record must have a valid unique normalized phone number and a valid unique provider id, otherwise the sync throws (`LINQ_PHONE_NUMBER_INVENTORY_INVALID`) with zero writes. An explicit empty array is a legitimate snapshot and clears held ids; a malformed 200 can never mass-revoke ownership.
- Revocation clears exactly the phone-to-provider-id pairings the snapshot does not confirm (relinquished ids and moved ids), before the upserts, so a moved id is released before its new row claims it and the unique provider-id index cannot collide.
- Contact-card candidacy — for both cron reconciliation and the member-facing vCard backup number — requires validated inventory backing on every row, configured or provider-only. A configured line whose ownership the inventory revoked (moved or relinquished) is dropped from candidacy, so it can never be maintained as Murph or embedded under the `backup` label. Configured-line authority for unrelated inbound routing and assignment is untouched.
- Ownership is only trusted while a recent validated snapshot still confirms it. A dedicated `provider_inventory_confirmed_at` watermark is stamped only inside the transaction that applied a validated snapshot (never by chat-health or status projection, which advance `providerSeenAt`/`providerLastSeenAt`) and is cleared alongside revocation. Candidacy and backup selection require a confirmation newer than 15 minutes — three health-cron cycles, so one missed run is tolerated while a sustained inventory outage fails closed.
- Candidacy is read as one consistent snapshot: `readHostedLinqContactCardCandidacySnapshot` takes the same inventory-wide advisory lock the snapshot applier uses and returns the configured-line total plus `isConfigured`-tagged candidates from a single transaction, so the normal minute-zero overlap with the revoking health cron can never be observed half-applied and no second unlocked read can disagree with the first.
- The member-facing backup resolver reads the same consistent snapshot, so an unlocked two-query read can never straddle a committing ownership move and embed a just-revoked number terminally in a saved vCard — but it takes the lock with `pg_try_advisory_xact_lock` and returns null immediately when an inventory writer holds it. "Add Murph to Contacts" therefore never queues behind inventory work: the member always gets the primary card promptly, and only the optional backup line is omitted in that window. Background reconciliation still waits for a fully applied snapshot.
- Configured-line health is judged on its own, from those tags, both before any provider request (configured lines exist but none is eligible → throw) and after the loop (no configured line produced a usable active card → throw). An active card on an unconfigured provider-only row can therefore never stand in for the loss of every line that can actually own a member conversation.
- Provider inventory refresh has exactly one scheduled owner: the five-minute health cron. The hourly contact-card reconciliation no longer issues its own inventory fetch and instead reads the at-most-five-minutes-old ownership projection, so two scheduled fetchers can never apply provider snapshots out of order and publish a relinquished number into a member's terminally saved vCard. The manual line-sync script remains an unscheduled operator path and is covered by the same advisory-lock serialization.
- Every multi-phone line writer acquires the same inventory-wide advisory lock before its first per-phone lock: provider snapshot application and configured-line synchronization share `acquireHostedLinqInventoryApplyLockTx`, so two writers touching the same phones in opposite orders can never invert per-phone lock acquisition and deadlock (previously reachable when a deploy-time configured-line sync overlapped the five-minute health cron).
- Snapshot application is atomic and serialized: when the sync owns the client it applies the whole revoke-plus-upserts replacement inside one Prisma transaction that first takes an inventory-wide `pg_advisory_xact_lock`, so the concurrent minute-zero contact-card and health crons serialize instead of interleaving across phones (the per-phone upsert locks cannot order whole-snapshot applications) and a mid-application failure rolls the entire replacement back. Two overlapping runs may commit in either order; the hourly cadence converges any stale winner on the next run — with no provider-supplied snapshot version, a monotonic fence is not implementable, so serialized application plus hourly convergence is the intended durability contract. The bounded apply phase (a few queries per line, at most 250 lines) fits the repo's 15s transaction budget.
- A run that ends with zero usable active cards — every line failed or produced an inactive card — throws (`LINQ_CONTACT_CARD_RECONCILE_FAILED`) only after all lines were attempted, with only actual per-line request failures logged, so the cron returns non-2xx and alerting sees the outage of the native contact-card share. One usable active card plus failures still resolves with `failedLines` counted; caller cancellation still rethrows untouched.

## Non-obvious affected surfaces

- `syncHostedLinqPhoneNumberInventory` is also invoked by the Linq health cron and the line-sync script; its listing now enforces strict snapshot validation, so previously tolerated malformed payload shapes fail those callers visibly instead of silently syncing nothing. Regression proof: `apps/web/test/hosted-onboarding-linq-provider-health.test.ts`, `apps/web/test/hosted-onboarding-linq-health-cron.test.ts`, `apps/web/test/sync-hosted-linq-lines-script.test.ts` (all green).
- The contact-card cron now returns non-2xx when every line fails reconciliation (previously HTTP 200 with zero successes); the recoverable-alert delivery in the route's `finally` still runs. Regression proof: the new all-failed test in `apps/web/test/hosted-onboarding-linq-contact-card.test.ts` plus the existing cron-route failure test.

## Architecture and reuse

- Existing systems reused: the existing lenient `parseHostedLinqPhoneNumberInventory` stays the single record parser (the strict snapshot check wraps it); revocation reuses `createHostedPhoneLookupKeyReadCandidates` from `contact-privacy-core` as the phone-to-row identity, and the existing `hostedOnboardingError` taxonomy carries both new failure codes.
- New logic: `requireHostedLinqPhoneNumberInventorySnapshot` (structure + identity validation, ~40 lines), a pairing-exact revoke (one `findMany` of held ids + one `updateMany`) replacing the id-set `notIn` revoke, an `applyHostedLinqPhoneNumberInventorySnapshot` helper that runs the replacement inside one owning `$transaction` opened with the inventory-wide advisory lock, and an all-failed guard at the end of `reconcileHostedLinqContactCards`.
- New abstractions: none beyond the one exported validation function; no new types, tables, or services.
- Complexity intentionally avoided: no snapshot-version fence or lease service (the provider supplies no snapshot version; the inventory-wide advisory lock plus hourly convergence covers ordering); no retry/backoff machinery; no schema change; no new alert channel.

## Deployment skew

Additive, nullable column plus index (`hosted_linq_line.provider_inventory_confirmed_at`); no backfill, so old application builds ignore it and rollback is safe. Deliberate fail-closed window: between the migration and the first successful health-cron inventory sync (≤5 minutes), no row carries a confirmation, so the contact-card cron returns 502 and the optional vCard backup line is omitted. The member-facing primary number and the vCard itself are unaffected. Migrations run in the web build step, so web deploys before the first sync stamps the watermark.

## Hot reply path impact

Not applicable. Only internal cron paths (contact-card and health inventory sync) and their unit tests change; nothing on durable message acceptance, provider start, or reply handoff is touched.

## Murph initial provider input impact

Not applicable for both runtimes. No prompt, tool schema, skill, Codex configuration, or provider-request assembly changes.

## Preliminary specialist lenses

- Product experience: applicable — ownership selection controls which numbers appear in member vCards and backup labels; the remediation closes the malformed-snapshot and moved-id paths the prior round flagged. Direct journey evidence: unit proofs listed under coverage; no UI change.
- Prompt: not applicable — no prompt surfaces touched.
- Frontend: not applicable — no `apps/web` UI change.
- Coverage: applicable — focused local proof: `vitest run` over the 8 affected suites (`linq-phone-number-inventory`, `linq-contact-card`, `linq-line-store`, `linq-contact-card-cron`, `linq-contact-card-share`, `linq-provider-health`, `linq-health-cron`, `sync-hosted-linq-lines-script`), 120 tests, all passing, including malformed-shape rejection, identity-violation rejection, explicit-empty clear, moved-id release, all-failed surfacing, all-inactive and failed-plus-inactive outage surfacing, and cancellation passthrough. Preliminary specialist round 1 (head 99a0b9b) returned one coverage finding: the moved-id transfer was proved only against mocked Prisma. Remediated with `apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts`, an opt-in real-PostgreSQL proof in the repo's `MURPH_TEST_POSTGRES_CONCURRENCY=1` convention, now two scenarios: (1) serial moved-id transfer — seed provider id X on phone A, sync a snapshot pairing X with phone B through the real sync and line-store path, assert A's row is nulled, B owns X, and exactly one persisted row owns X; (2) two concurrent syncs applying the old X→A and new X→B snapshots simultaneously both resolve without a unique-index violation, leave exactly one owner, and a following sync converges ownership to B; (3) lock proof — an owner transaction holds the exact inventory advisory lock while the real sync runs, and `pg_stat_activity` filtered to the owner's exact `pg_backend_pid()` in `pg_blocking_pids` proves the sync's backend is blocked by that owner until it commits (fails if the lock is removed, and an unrelated suite's advisory waiter cannot satisfy it); (4) rollback proof — an injected failure after the stale revoke and one fully applied line rejects the sync and leaves the complete pre-transaction ownership state intact; (5) maximum-cardinality proof — a 250-line snapshot applies through the real line-store and provider-state path inside the default 15s transaction budget with all 250 ids held; (6) concurrent maximum-cardinality proof — two overlapping production syncs each applying a full 250-line snapshot under default `createPrismaClient` transaction options both resolve without P2028 (the follower's transaction lifetime covers the lock wait behind the leader's full apply plus its own apply), leave a consistent single-owner state, and a final authoritative snapshot converges ownership. A unit test additionally pins the owning-client path: one `$transaction` whose first statement is the inventory lock. A further real-PostgreSQL scenario races configured-line synchronization against provider-inventory application over the same two phones in reverse input order and proves both complete without deadlock with correct final configured and provider ownership. A deterministic line-store unit test additionally pins the configured-line writer's ordering: exactly one inventory-wide lock acquisition strictly before any per-phone lock, candidate read, or write. A further real-PostgreSQL scenario proves the freshness fence end to end: a pre-rollout row holding an id with no confirmation is ineligible, a validated snapshot makes it eligible, repeated 503 and malformed reads leave ownership intact without refreshing the watermark, and eligibility ages out past the budget. Another holds an authoritative A→B ownership move open under the inventory lock and proves the member-facing resolver returns (backup omitted) within 5s instead of queueing, then asserts the next resolution after commit returns the new owner and never the relinquished line. Another proves the consumer boundary: a configured line holding provider id X, after a validated X→B move, disappears from the real `listHostedLinqContactCardLines` and can never be returned by `resolveMurphHostedLinqContactCardBackupPhoneNumber` (verified regression-sensitive — it fails when the eligibility predicate is reverted). All green locally against a migrated throwaway local database; the postgres suite skips cleanly without the flag. Web lane typecheck and eslint green. Exact-head CI: pending on the current head.

## Change-shape breakdown

Classification rule: lines under `apps/web/src/**` are source; lines under `apps/web/test/**` are tests/fixtures; the Prisma schema and migration SQL are config/tooling; no docs, generated, or binary files are touched.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 350 | 44 |
| Tests/fixtures | 1646 | 70 |
| Docs | 0 | 0 |
| Config/tooling | 16 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2012** | **114** |

## Design proof for user-facing frontend UI

Not applicable — no user-facing frontend UI change (backend cron and library code plus unit tests only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
