### PR TITLE
Stop retrying a phone transfer the provider already finished

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/privy-phone-transfer-retirement.ts
+++ b/apps/web/src/lib/hosted-onboarding/privy-phone-transfer-retirement.ts
@@ -29,6 +29,7 @@ import { acquireHostedLinqParticipantPhoneLockTx } from "./linq-participant-cont
 import { normalizePhoneNumber } from "./phone";
 import {
   readHostedPrivyUserByIdIfExists,
+  resolveHostedPrivyIdentityFromVerifiedUser,
   type HostedPrivyIdentity,
 } from "./privy";
 import {
@@ -126,12 +127,34 @@ export async function readHostedPrivyPhoneTransferProof(input: {
     },
   );
   if (sourcePrivyUser) {
+    // A surviving source account means one of two very different things.
+    // While it still holds the phone the provider has not finished moving
+    // it, so retrying is the correct advice. Once the phone is gone from it
+    // the move is already complete and the provider deliberately kept the
+    // account because it carries other login methods, so it will never be
+    // deleted and retrying can never resolve anything.
+    const survivingSourcePhoneNumber =
+      resolveHostedPrivyIdentityFromVerifiedUser(sourcePrivyUser).phone?.number;
+    const survivingSourceStillHoldsPhone = Boolean(
+      survivingSourcePhoneNumber
+      && normalizePhoneNumber(survivingSourcePhoneNumber)
+        === normalizePhoneNumber(phoneNumber),
+    );
+    if (survivingSourceStillHoldsPhone) {
+      throw hostedOnboardingError({
+        code: "PRIVY_PHONE_NOT_READY",
+        httpStatus: 409,
+        message:
+          "Privy is still finishing the phone transfer. Wait a moment and try again.",
+        retryable: true,
+      });
+    }
+
     throw hostedOnboardingError({
-      code: "PRIVY_PHONE_NOT_READY",
+      code: "PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE",
       httpStatus: 409,
       message:
-        "Privy is still finishing the phone transfer. Wait a moment and try again.",
-      retryable: true,
+        "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
     });
   }
 

--- a/apps/web/test/hosted-onboarding-privy-phone-transfer-retirement.test.ts
+++ b/apps/web/test/hosted-onboarding-privy-phone-transfer-retirement.test.ts
@@ -40,6 +40,9 @@ vi.mock("@/src/lib/hosted-onboarding/linq-participant-contact", () => ({
 vi.mock("@/src/lib/hosted-onboarding/privy", () => ({
   readHostedPrivyUserByIdIfExists:
     mocks.readHostedPrivyUserByIdIfExists,
+  // Provider users are stubbed as their own resolved identity shape so a
+  // test can state exactly which phone a surviving source still holds.
+  resolveHostedPrivyIdentityFromVerifiedUser: (user: unknown) => user,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/shared", () => ({
@@ -51,6 +54,7 @@ import {
   acquireHostedPrivyPhoneTransferPhoneLocksTx,
   assertHostedPrivyPhoneTransferSourceRetirementFenceTx,
   prepareHostedPrivyPhoneTransferSourceRetirementTx,
+  readHostedPrivyPhoneTransferProof,
 } from "@/src/lib/hosted-onboarding/privy-phone-transfer-retirement";
 import {
   buildHostedBrowserVaultRefreshRuntimeControlEvent,
@@ -78,6 +82,65 @@ describe("Privy phone-transfer source retirement", () => {
     mocks.acquireHostedLinqParticipantPhoneLockTx.mockResolvedValue(undefined);
     mocks.lockHostedMemberRow.mockResolvedValue(undefined);
     mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue(null);
+  });
+
+  describe("surviving provider source accounts", () => {
+    function stubPhoneOwner() {
+      mocks.lookupHostedMemberIdentityByPhoneNumber.mockResolvedValue({
+        core: { id: SOURCE_MEMBER_ID },
+        identity: { privyUserId: SOURCE_PRIVY_USER_ID },
+      });
+    }
+
+    function readProof() {
+      return readHostedPrivyPhoneTransferProof({
+        identity: {
+          phone: { number: PHONE_NUMBER, verifiedAt: 1 },
+          telegram: null,
+          userId: TARGET_PRIVY_USER_ID,
+        },
+        memberId: TARGET_MEMBER_ID,
+        prisma: {} as never,
+      });
+    }
+
+    it("asks the member to wait while the source still holds the phone", async () => {
+      stubPhoneOwner();
+      mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue({
+        phone: { number: PHONE_NUMBER },
+        userId: SOURCE_PRIVY_USER_ID,
+      });
+
+      await expect(readProof()).rejects.toMatchObject({
+        code: "PRIVY_PHONE_NOT_READY",
+        retryable: true,
+      });
+    });
+
+    it("stops retrying once the source keeps its own sign-in without the phone", async () => {
+      stubPhoneOwner();
+      mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue({
+        email: { address: "owner@example.com" },
+        phone: null,
+        userId: SOURCE_PRIVY_USER_ID,
+      });
+
+      await expect(readProof()).rejects.toMatchObject({
+        code: "PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE",
+        retryable: false,
+      });
+    });
+
+    it("returns transfer proof once the provider released the source", async () => {
+      stubPhoneOwner();
+      mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue(null);
+
+      await expect(readProof()).resolves.toEqual({
+        phoneNumber: PHONE_NUMBER,
+        sourceMemberId: SOURCE_MEMBER_ID,
+        sourcePrivyUserId: SOURCE_PRIVY_USER_ID,
+      });
+    });
   });
 
   it("fences an exact pristine not-started signup scaffold", async () => {


### PR DESCRIPTION
## Why this PR exists

**Required.** A member linking a phone that another Murph account owns could be
told to wait and try again forever. `readHostedPrivyPhoneTransferProof` treated
any surviving source provider account as an unfinished transfer. That is only
true while the provider is still moving the number. When the source account
carries other login methods, the provider keeps it on purpose and will never
release it, so the retryable message could never come true and the member had no
path forward.

This was found while proving out the automatic-source-retirement fixes that
landed earlier today; it is the last known state in that flow that cannot
resolve itself.

## User goal / user-visible behavior

**Required.** A member adding a phone that moved from another account either
completes, waits on a genuinely in-flight provider move, or is told plainly that
the other account is still active and support is the way through.

- Source still holds the number at the provider: unchanged retryable
  "wait a moment and try again".
- Source no longer holds the number but still exists: new terminal message,
  "That phone moved from another Murph account that is still active with its
  own sign-in. Contact support to reconcile it safely."
- Source released by the provider: unchanged, the transfer proceeds.

## User experience

**Required.** The terminal case renders through the existing phone-link error
surface. Because the copy contains "contact support",
`shouldShowContactSupportAction` shows the email action beside **Try again**
with no client change. The error is not marked retryable and its code is absent
from `isRetryableHostedPhoneLinkError`, so the client stops its own retry loop
rather than re-driving a request that cannot succeed.

## Invariants

**Required.**

- Provider identity stays the only authority for who owns a phone; Murph reads
  the surviving account rather than inferring from its own projection.
- Both phone numbers are compared through `normalizePhoneNumber`, so formatting
  differences cannot classify a held number as released.
- No account state is written on either path. The terminal case ends the request
  before any lock, census, billing call, or deletion.
- The retryable wait keeps its exact prior code, status, and copy, so existing
  client retry behavior for in-flight transfers is untouched.

## Non-obvious affected surfaces

**Required.**

- `isRetryableHostedPhoneLinkError` in `hosted-phone-auth-support.ts` gates
  client auto-retry on an allow-list of codes. The new code is deliberately not
  added, which is what stops the loop.
- `shouldShowContactSupportAction` keys off message text, not error code, so the
  support action appears without touching the component.
- The join island and Settings share this route, so both surfaces get the new
  terminal state.

## Preliminary specialist lenses

**Required.** Product experience: the copy names what happened and what to do
without exposing the other account's identity. Prompt: not applicable, no model
surface changes. Frontend: no component changes; behavior comes from existing
error routing, verified by reading both gates. Coverage: three tests pin the
three provider outcomes, including the previously unpinned released-source path.

## Change shape

| Row | Detail |
| --- | --- |
| Intent | Convert an unresolvable retry loop into a distinct terminal state |
| Surface | `readHostedPrivyPhoneTransferProof` phone-transfer discovery |
| Mechanism | Compare the surviving source account's own phone against the transferred number |
| Proof | 8,381 tests green including three new provider-outcome tests |
| Risk | Terminal path is read-only and cannot delete or bill; retryable path byte-identical |

## Design proof

**Not applicable.** No `apps/web` UI markup, styling, or layout changes. The new
state renders through the existing phone-link error surface, which already has
design catalog coverage under `#phone-account-linking`.

## Deployment skew

**Not applicable.** Web-only change with no contract, schema, or runner boundary
involved. The new error code is produced and consumed within the same deploy.

## Architecture and reuse

- **Existing systems reused:** the provider identity read
  (`readHostedPrivyUserByIdIfExists`), its identity resolver
  (`resolveHostedPrivyIdentityFromVerifiedUser`), the shared
  `normalizePhoneNumber` comparison, and the existing `hostedOnboardingError`
  transport that already routes code, status, and retryability to the client.
- **New logic:** one discriminator, whether the surviving source account still
  holds the transferred number, which selects between the existing retryable
  wait and a new terminal state.
- **New abstractions:** none. Adding a helper or a state enum here would wrap a
  single boolean comparison that is read once, so the check stays inline next to
  the branch it explains.
- **Complexity intentionally avoided:** Murph does not attempt to reconcile a
  surviving account by clearing its stale phone projection. That would mutate a
  still-reachable account on provider evidence alone, so the fail-closed report
  is preferred until an owner decides.

## Known limitation left for a human decision

When the source account survives with its own sign-in, this PR stops at support
rather than reconciling automatically. Murph could instead clear the stale phone
from the source member's projection and complete the link, since the provider
has already moved the number. That mutates a still-reachable account, so it is
deliberately not done here without an owner decision.


ReviewGPT first-reviewed head: e4055e4e11783c3bf296d9ad84e567fbc990895e
