### PR TITLE
Give the wearable connection failure notice a way out

### DIFF
--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -380,6 +380,11 @@ export function ConnectSourcesGrid({
           <ConnectCallbackErrorNotice
             errorCode={visibleNotice.errorCode}
             message={visibleNotice.message}
+            onSignIn={
+              !authenticated && visibleNotice.errorCode === "CALLBACK_SESSION_REQUIRED"
+                ? openAuthDialog
+                : null
+            }
             sourceLabel={visibleNotice.sourceLabel}
             title={visibleNotice.title}
           />

--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/src/components/hosted-onboarding/client-api";
 import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { ConnectCallbackErrorNotice } from "@/src/components/device-sync/connect-callback-error-notice";
 import { Input } from "@/src/components/ui/input";
 import { DeviceSyncSetupGuideDialog } from "@/app/(dashboard)/home/device-sync-completion-dialog";
 import type { DeviceSyncCompletionContactAction } from "@/src/lib/device-sync/connect-completion-types";
@@ -376,10 +377,12 @@ export function ConnectSourcesGrid({
             <AlertDescription>{visibleNotice.message}</AlertDescription>
           </Alert>
         ) : (
-          <Alert variant="destructive">
-            <AlertTitle>Unable to finish connection</AlertTitle>
-            <AlertDescription>{visibleNotice.message}</AlertDescription>
-          </Alert>
+          <ConnectCallbackErrorNotice
+            errorCode={visibleNotice.errorCode}
+            message={visibleNotice.message}
+            sourceLabel={visibleNotice.sourceLabel}
+            title={visibleNotice.title}
+          />
         )
       ) : null}
 

--- a/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
@@ -134,13 +134,31 @@ export function createConnectCallbackNotice(
     };
   }
 
+  // Error callbacks are taken straight from query params, so only a catalog
+  // source and a recognizable code shape may reach the prefilled support mail.
+  // Anything else is unverified text and is dropped rather than quoted back.
+  const catalogSource = findCallbackSource({
+    connectSource: input.connectSource,
+    connectTarget: input.connectTarget,
+    provider: input.provider,
+    sources,
+  });
+
   return {
-    errorCode: input.errorCode,
+    errorCode: normalizeConnectCallbackErrorReference(input.errorCode),
     kind: "error",
-    sourceLabel,
+    sourceLabel: catalogSource?.name ?? null,
     title: "Unable to finish connection",
     message: describeDeviceSyncCallbackError(sourceLabel, input.errorCode),
   };
+}
+
+const CONNECT_CALLBACK_ERROR_REFERENCE_PATTERN = /^[A-Z][A-Z0-9_]{2,63}$/u;
+
+function normalizeConnectCallbackErrorReference(errorCode: string | null): string | null {
+  return errorCode && CONNECT_CALLBACK_ERROR_REFERENCE_PATTERN.test(errorCode)
+    ? errorCode
+    : null;
 }
 
 export function stripConnectCallbackParams() {

--- a/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-helpers.ts
@@ -135,7 +135,9 @@ export function createConnectCallbackNotice(
   }
 
   return {
+    errorCode: input.errorCode,
     kind: "error",
+    sourceLabel,
     title: "Unable to finish connection",
     message: describeDeviceSyncCallbackError(sourceLabel, input.errorCode),
   };
@@ -287,6 +289,10 @@ function describeDeviceSyncCallbackError(providerLabel: string, errorCode: strin
       return `${providerLabel} was not connected this time. You can try again whenever you're ready.`;
     case "OAUTH_STATE_INVALID":
       return `${providerLabel} gave us an expired or invalid return from the last attempt. Start a fresh connection and try again.`;
+    case "CALLBACK_PROOF_INVALID":
+      return `That return link did not match the browser you started in, so nothing was connected. Start ${providerLabel} again from this page.`;
+    case "CALLBACK_SESSION_REQUIRED":
+      return `You were signed out before ${providerLabel} finished connecting. Log in, then start the connection again.`;
     default:
       return `We could not finish connecting ${providerLabel}. Try again when you're ready.`;
   }

--- a/apps/web/app/(dashboard)/connect/connect-page-types.ts
+++ b/apps/web/app/(dashboard)/connect/connect-page-types.ts
@@ -47,7 +47,9 @@ export type ConnectIntentRecoveryRequest = {
 };
 
 export type ConnectCallbackNotice = {
+  errorCode?: string | null;
   kind: "error" | "success" | "warning";
   message: string;
+  sourceLabel?: string | null;
   title: string;
 } | null;

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -143,6 +143,7 @@ import {
   DESIGN_USAGE_MISSION_CONTACT_OPTION,
 } from "./group-usage-funding-study";
 import { HostedUsageTopUpDialog } from "@/src/components/settings/hosted-usage-top-up-dialog";
+import { ConnectCallbackErrorNotice } from "@/src/components/device-sync/connect-callback-error-notice";
 import { HostedAccountDeletionStatus } from "@/src/components/settings/hosted-data-privacy-settings";
 import { GarminHistoricalDataDialog } from "../(dashboard)/connect/connect-page-dialogs";
 import {
@@ -1257,6 +1258,25 @@ export function ComponentsContent() {
           <div className="flex flex-col gap-4">
             <Alert><AlertTitle>Experiment in progress</AlertTitle><AlertDescription>Day 15 of 28. Next session scheduled for this evening.</AlertDescription></Alert>
             <Alert variant="destructive"><AlertTitle>Oura disconnected</AlertTitle><AlertDescription>Reconnect your ring to continue tracking metrics.</AlertDescription></Alert>
+          </div>
+        </Section>
+
+        <Separator />
+
+        <Section title="Connect Callback Error Notice">
+          <div className="flex flex-col gap-4" inert>
+            <ConnectCallbackErrorNotice
+              errorCode="CALLBACK_PROOF_INVALID"
+              message="That return link did not match the browser you started in, so nothing was connected. Start Oura again from this page."
+              sourceLabel="Oura"
+              title="Unable to finish connection"
+            />
+            <ConnectCallbackErrorNotice
+              errorCode="CALLBACK_SESSION_REQUIRED"
+              message="You were signed out before Oura finished connecting. Log in, then start the connection again."
+              sourceLabel="Oura"
+              title="Unable to finish connection"
+            />
           </div>
         </Section>
 

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1274,6 +1274,7 @@ export function ComponentsContent() {
             <ConnectCallbackErrorNotice
               errorCode="CALLBACK_SESSION_REQUIRED"
               message="You were signed out before Oura finished connecting. Log in, then start the connection again."
+              onSignIn={() => {}}
               sourceLabel="Oura"
               title="Unable to finish connection"
             />

--- a/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
+++ b/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
@@ -64,8 +64,9 @@ function buildConnectCallbackSupportBody({
   errorCode: string | null;
   sourceLabel: string | null;
 }): string {
-  // Support needs the failing source and code to answer without a round trip;
-  // both are product labels, never member data.
+  // Support needs the failing source and code to answer without a round trip.
+  // createConnectCallbackNotice only passes a catalog-resolved source name and a
+  // Murph error code here, so raw callback query text cannot reach this draft.
   return [
     `I could not finish connecting ${sourceLabel ?? "a device"} in Murph.`,
     "",

--- a/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
+++ b/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
@@ -1,0 +1,63 @@
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { buttonVariants } from "@/src/components/ui/button";
+import { ContactSupportAction } from "@/src/components/support/contact-support-action";
+import { cn } from "@/src/lib/utils";
+
+export const CONNECT_CALLBACK_ERROR_SUPPORT_SUBJECT = "Murph device connection help";
+
+export function ConnectCallbackErrorNotice({
+  errorCode = null,
+  message,
+  sourceLabel = null,
+  title,
+}: {
+  errorCode?: string | null;
+  message: string;
+  sourceLabel?: string | null;
+  title: string;
+}) {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{message}</AlertDescription>
+      {/* The actions sit outside the description so the Alert's link styling
+          does not underline them into looking like inline links. */}
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <ContactSupportAction
+          body={buildConnectCallbackSupportBody({ errorCode, sourceLabel })}
+          className="w-full justify-center sm:w-auto"
+          subject={CONNECT_CALLBACK_ERROR_SUPPORT_SUBJECT}
+        >
+          Email support
+        </ContactSupportAction>
+        <a
+          className={cn(
+            buttonVariants({ variant: "outline" }),
+            "w-full justify-center font-semibold sm:w-auto",
+          )}
+          href="/home"
+        >
+          Go to home
+        </a>
+      </div>
+    </Alert>
+  );
+}
+
+function buildConnectCallbackSupportBody({
+  errorCode,
+  sourceLabel,
+}: {
+  errorCode: string | null;
+  sourceLabel: string | null;
+}): string {
+  // Support needs the failing source and code to answer without a round trip;
+  // both are product labels, never member data.
+  return [
+    `I could not finish connecting ${sourceLabel ?? "a device"} in Murph.`,
+    "",
+    "What happened:",
+    "",
+    `Reference: ${errorCode ?? "unknown"}`,
+  ].join("\n");
+}

--- a/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
+++ b/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
-import { buttonVariants } from "@/src/components/ui/button";
+import { Button, buttonVariants } from "@/src/components/ui/button";
 import { ContactSupportAction } from "@/src/components/support/contact-support-action";
 import { cn } from "@/src/lib/utils";
 
@@ -8,11 +8,13 @@ const CONNECT_CALLBACK_ERROR_SUPPORT_SUBJECT = "Murph device connection help";
 export function ConnectCallbackErrorNotice({
   errorCode = null,
   message,
+  onSignIn = null,
   sourceLabel = null,
   title,
 }: {
   errorCode?: string | null;
   message: string;
+  onSignIn?: (() => void) | null;
   sourceLabel?: string | null;
   title: string;
 }) {
@@ -23,6 +25,17 @@ export function ConnectCallbackErrorNotice({
       {/* The actions sit outside the description so the Alert's link styling
           does not underline them into looking like inline links. */}
       <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        {/* When the failure was a lost session, signing in is the actual
+            recovery, so it leads and support drops to a fallback. */}
+        {onSignIn ? (
+          <Button
+            className="w-full justify-center font-semibold sm:w-auto"
+            onClick={onSignIn}
+            variant="default"
+          >
+            Log in
+          </Button>
+        ) : null}
         <ContactSupportAction
           body={buildConnectCallbackSupportBody({ errorCode, sourceLabel })}
           className="w-full justify-center sm:w-auto"

--- a/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
+++ b/apps/web/src/components/device-sync/connect-callback-error-notice.tsx
@@ -3,7 +3,7 @@ import { buttonVariants } from "@/src/components/ui/button";
 import { ContactSupportAction } from "@/src/components/support/contact-support-action";
 import { cn } from "@/src/lib/utils";
 
-export const CONNECT_CALLBACK_ERROR_SUPPORT_SUBJECT = "Murph device connection help";
+const CONNECT_CALLBACK_ERROR_SUPPORT_SUBJECT = "Murph device connection help";
 
 export function ConnectCallbackErrorNotice({
   errorCode = null,

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -3785,6 +3785,72 @@ test("ConnectPage shows fallback callback errors with the original source label"
   assert.match(markup, /We could not finish connecting Garmin\./);
 });
 
+test("ConnectPage offers support and home recovery on callback failures", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      connectSource: "garmin",
+      deviceSyncError: "CALLBACK_FAILED",
+      deviceSyncProvider: "junction",
+      deviceSyncStatus: "error",
+    }),
+  }));
+
+  assert.match(markup, /Email support/);
+  assert.match(markup, /Go to home/);
+  assert.match(markup, /href="mailto:support@withmurph\.ai\?/u);
+  // Support needs the failing source and code without asking the member.
+  assert.match(markup, /subject=Murph\+device\+connection\+help/u);
+  assert.match(markup, /Garmin/u);
+  assert.match(markup, /CALLBACK_FAILED/u);
+  assert.match(markup, /href="\/home"/u);
+});
+
+test("ConnectPage explains a callback that lost its initiating browser", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      connectSource: "oura",
+      deviceSyncError: "CALLBACK_PROOF_INVALID",
+      deviceSyncProvider: "oura",
+      deviceSyncStatus: "error",
+    }),
+  }));
+
+  assert.match(markup, /That return link did not match the browser you started in/);
+  assert.match(markup, /nothing was connected/);
+  assert.match(markup, /Email support/);
+});
+
+test("ConnectPage explains a callback that arrived signed out", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      connectSource: "oura",
+      deviceSyncError: "CALLBACK_SESSION_REQUIRED",
+      deviceSyncProvider: "oura",
+      deviceSyncStatus: "error",
+    }),
+  }));
+
+  assert.match(markup, /You were signed out before Oura finished connecting\./);
+  assert.match(markup, /Log in, then start the connection again\./);
+});
+
+test("ConnectPage keeps successful callbacks free of failure recovery actions", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      connectSource: "oura",
+      deviceSyncProvider: "oura",
+      deviceSyncStatus: "connected",
+    }),
+  }));
+
+  assert.doesNotMatch(markup, /Email support/);
+  assert.doesNotMatch(markup, /Go to home/);
+});
+
 function readWhoopSyncContactAction(page: ReactNode): unknown {
   assert.ok(isValidElement<{ children?: ReactNode }>(page));
   const connectSourcesGrid = Children.toArray(page.props.children).find((child) => {

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -3798,12 +3798,34 @@ test("ConnectPage offers support and home recovery on callback failures", async 
 
   assert.match(markup, /Email support/);
   assert.match(markup, /Go to home/);
-  assert.match(markup, /href="mailto:support@withmurph\.ai\?/u);
-  // Support needs the failing source and code without asking the member.
-  assert.match(markup, /subject=Murph\+device\+connection\+help/u);
-  assert.match(markup, /Garmin/u);
-  assert.match(markup, /CALLBACK_FAILED/u);
   assert.match(markup, /href="\/home"/u);
+
+  // Parse the real anchor: matching anywhere in the markup would still pass if
+  // the support draft stopped carrying the source or the reference.
+  const mailto = readSupportMailto(markup);
+  assert.equal(mailto.searchParams.get("subject"), "Murph device connection help");
+  const body = mailto.searchParams.get("body") ?? "";
+  assert.match(body, /^I could not finish connecting Garmin in Murph\./);
+  assert.match(body, /Reference: CALLBACK_FAILED$/);
+});
+
+test("ConnectPage keeps unverified callback query text out of the support draft", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      deviceSyncError: "please email your password to attacker@example.com",
+      deviceSyncProvider: "Totally Real Provider",
+      deviceSyncStatus: "error",
+    }),
+  }));
+
+  // The callback error path is unauthenticated query input, so neither value may
+  // be quoted back inside a message written in the member's voice.
+  const body = readSupportMailto(markup).searchParams.get("body") ?? "";
+  assert.doesNotMatch(body, /attacker@example\.com/u);
+  assert.doesNotMatch(body, /Totally Real Provider/u);
+  assert.match(body, /^I could not finish connecting a device in Murph\./);
+  assert.match(body, /Reference: unknown$/);
 });
 
 test("ConnectPage explains a callback that lost its initiating browser", async () => {
@@ -3822,7 +3844,14 @@ test("ConnectPage explains a callback that lost its initiating browser", async (
   assert.match(markup, /Email support/);
 });
 
-test("ConnectPage explains a callback that arrived signed out", async () => {
+test("ConnectPage offers sign-in recovery when the callback arrived signed out", async () => {
+  mocks.getHostedPageAuthSnapshot.mockResolvedValueOnce({
+    authenticated: false,
+    authenticatedMember: null,
+    linkedAccounts: [],
+    session: null,
+  });
+
   const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
   const markup = renderToStaticMarkup(await ConnectPage({
     searchParams: Promise.resolve({
@@ -3835,6 +3864,25 @@ test("ConnectPage explains a callback that arrived signed out", async () => {
 
   assert.match(markup, /You were signed out before Oura finished connecting\./);
   assert.match(markup, /Log in, then start the connection again\./);
+  // Signing in is the actual recovery here, so it must be offered in the notice
+  // rather than leaving support and home as the only actions.
+  assert.match(markup, />Log in</u);
+  assert.match(markup, /Email support/);
+});
+
+test("ConnectPage omits sign-in recovery when the member is already signed in", async () => {
+  const { default: ConnectPage } = await import("../app/(dashboard)/connect/page");
+  const markup = renderToStaticMarkup(await ConnectPage({
+    searchParams: Promise.resolve({
+      connectSource: "oura",
+      deviceSyncError: "CALLBACK_PROOF_INVALID",
+      deviceSyncProvider: "oura",
+      deviceSyncStatus: "error",
+    }),
+  }));
+
+  assert.doesNotMatch(markup, />Log in</u);
+  assert.match(markup, /Email support/);
 });
 
 test("ConnectPage keeps successful callbacks free of failure recovery actions", async () => {
@@ -3850,6 +3898,12 @@ test("ConnectPage keeps successful callbacks free of failure recovery actions", 
   assert.doesNotMatch(markup, /Email support/);
   assert.doesNotMatch(markup, /Go to home/);
 });
+
+function readSupportMailto(markup: string): URL {
+  const match = markup.match(/href="(mailto:[^"]+)"/u);
+  assert.ok(match, "expected a support mailto anchor in the rendered markup");
+  return new URL(match[1].replaceAll("&amp;", "&"));
+}
 
 function readWhoopSyncContactAction(page: ReactNode): unknown {
   assert.ok(isValidElement<{ children?: ReactNode }>(page));


### PR DESCRIPTION
## Why this PR exists

PR #1252 routed every failed wearable callback to the Connect page's error
notice, which was an improvement over the dead-end HTML it replaced but is
still just a red box with a sentence in it. A member who gets there has already
finished signing in at the provider, so the failure is both surprising and
late. This PR gives that notice the two exits people actually want: email
support, or leave for home.

## User goal / user-visible behavior

When a wearable connection fails on the return from the provider, the notice on
`/connect` now offers **Email support** (a prefilled message that already names
the source and carries the failure reference) and **Go to home**. When the
failure was a lost session, a **Log in** action leads, because signing in is the
actual recovery. Two of the failure reasons also explain themselves properly
instead of falling back to generic wording.

## User experience

- Entry point: the redirect from the provider callback lands on `/connect` with
  `deviceSyncStatus=error`.
- Immediate feedback: the same destructive notice, now with a title, a plain
  explanation, and two actions directly under it.
- Interaction economy: no new screen or step. The actions are inert markup
  until tapped; the sources grid below is unchanged, so retrying in place is
  still the closest action. `Log in` reuses the existing auth dialog opener
  already held by this page rather than adding a route or dialog.
- Terminal delivery / recovery: **Log in** (signed-out session failures only)
  opens the existing auth dialog in place. **Email support** opens a mail
  client with the subject and body prefilled, so the member does not have to
  describe the failure or find the address. **Go to home** leaves the failed
  flow for `/home`. No action is required; the notice remains dismissible by
  retrying.
- Copy: `CALLBACK_PROOF_INVALID` now says the return link did not match the
  browser they started in and that nothing was connected;
  `CALLBACK_SESSION_REQUIRED` now says they were signed out before the source
  finished connecting and should log in first. Both previously fell through to
  the generic "We could not finish connecting X."
- Direct journey evidence: six new server-render tests parse the real support
  anchor and assert its decoded subject and body, assert the `/home` link and
  both new copy strings, assert that a signed-out session failure offers
  `Log in` while a signed-in failure does not, assert that crafted callback
  query text never reaches the support draft, and assert that a *successful*
  callback shows none of the recovery actions.
- Rendered evidence: hosted desktop and mobile screenshots below, captured from
  the running app on the real failure URL and from the design catalog.

## Invariants the PR must preserve

- The callback route contract from #1252 is untouched: no redirect target,
  error code, cookie behavior, or OAuth-state handling changes here. This is
  presentation only.
- The support mailto carries only values Murph itself owns: a source name that
  resolved against the configured source catalog, and a failure reference that
  matches Murph's internal error-code shape. Unrecognized codes and unknown
  providers are dropped (`a device` / `unknown`) rather than quoted back,
  because the error callback is unauthenticated query input. No member
  identifier, email, token, state value, or provider payload is placed in the
  mail body, the markup, or the URL.
- Success and warning notices keep their existing appearance and gain no
  failure actions.
- The error notice remains one Alert in the same position in the page flow, so
  nothing below it shifts.

## Non-obvious affected surfaces

- `ConnectCallbackNotice` gains two optional fields (`errorCode`,
  `sourceLabel`). The connect-intent presentation path also produces notices of
  this type and simply leaves them unset, which renders the actions with a
  generic support body rather than failing.
- The actions render outside `AlertDescription` on purpose: that element styles
  every descendant anchor as an underlined inline link, which made both buttons
  read as text links. Anything later moved back inside it will regress that.
- The visible failure sentence still uses the pre-existing label resolution,
  which can format an unknown provider for display. That behavior predates this
  PR and is unchanged; only the support draft is restricted to catalog-resolved
  values.

## Architecture and reuse

- **Existing systems reused:** the existing `ContactSupportAction` component
  (address, mailto construction, styling), `buttonVariants` for the secondary
  action, the existing `Alert` primitives, and the existing
  `createConnectCallbackNotice` -> notice-render path.
- **New logic:** one presentational component plus a support-body builder, and
  two added cases in the existing error-copy switch.
- **New abstractions:** none beyond the single component; it exists so the
  design catalog and the production page render the same markup instead of the
  page holding one-off JSX, which the catalog rule requires.
- **Complexity intentionally avoided:** no dialog, no support-ticket API, no
  client state, no new route, and no change to the callback route or its error
  codes.

## Hot reply path impact

Not applicable. This is a browser presentation change on `/connect` and touches
no assistant, messaging, or runtime path.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool schema, provider wrapper, or
  request assembly changed.
- Group Murph: Not applicable.

## ReviewGPT specialist findings and triage

The preliminary specialist pass at `60edfe95e423` returned four findings.

1. **Material, product experience: the support draft quoted unverified callback
   query text.** Accepted and fixed. The error callback is unauthenticated
   query input, so a crafted `/connect?deviceSyncStatus=error&...` URL could
   place arbitrary text into a mail body written in the member's voice. The
   notice now receives a source label only when it resolves against the source
   catalog, and a reference only when it matches Murph's error-code shape.
2. **Material, product experience: the actions did not perform the known
   recovery.** Accepted in part. For `CALLBACK_SESSION_REQUIRED` neither action
   performed the required sign-in, so `Log in` is now the primary action for
   that state. The other half of the finding (a "restart this source" primary
   for proof/state failures, with post-auth source continuity) is **not**
   adopted: the sources grid on the same page already owns starting a source,
   the copy points the member at it, and duplicating that owner in the alert
   would add a second start path plus auth-continuity machinery for a case the
   page already handles.
3. **Medium, coverage: the mailto assertions matched anywhere in the markup.**
   Accepted and fixed. The tests now extract the support anchor, decode it, and
   assert the exact subject and body, so the draft losing the source or
   reference fails the test.
4. **Low, coverage: the session-required test ran authenticated.** Accepted and
   fixed. That test now renders with a signed-out auth snapshot and asserts the
   `Log in` recovery, with a signed-in counterpart asserting its absence.

The pass offered a coverage patch artifact; it was not applied. The coverage
findings are addressed with tests written and verified here instead.

## Preliminary specialist lenses

- **Product experience: applicable.** Visible copy and the available actions on
  a failure surface change. Intended outcome, recovery ownership, and direct
  proof are described above.
- **Prompt: not applicable.** No prompt, instruction, or tool description
  changed.
- **Frontend: applicable.** A new shared component, new catalog entry, and
  changed rendered states; desktop and mobile evidence attached.
- **Coverage: applicable.** Executable render behavior changed; the connect page
  suite covers the new actions, the decoded mailto contents, the untrusted-input
  case, signed-out and signed-in recovery, both new copy strings, and the
  success-path negative case. Focused Vitest: 84/84 passed on the connect page
  suite; `apps/web` typecheck and changed-file ESLint passed.

## Change-shape breakdown

Classification rule: production TS/TSX including the design catalog is source;
Vitest files are tests. No docs, config, binary, or generated files are in the
diff.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 135 | 4 |
| Tests/fixtures | 120 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **255** | **4** |

The growth over the first pushed head is the specialist remediation above:
input bounding, the sign-in action, and their tests.

## Design proof

- Design page: `/design?tab=components#connect-callback-error-notice` (new
  "Connect Callback Error Notice" section showing both failure states)
- Desktop screenshot: ![Desktop design catalog entry for the connect callback error notice](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/9c363409-afb5-4538-4498-eb15c26fd100/designproof)
- Mobile screenshot: ![Mobile design catalog entry for the connect callback error notice](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e3ccdb13-d0a2-4f87-a390-410eee000000/designproof)
- Desktop screenshot (production surface, signed-out session failure): ![Desktop Connect page failure notice leading with Log in, then support and home](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/fc260a6a-590d-41f8-db7c-25bc13300000/designproof)
- Mobile screenshot (production surface, signed-out session failure): ![Mobile Connect page failure notice with full-width stacked actions](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/0fc065ed-a1ce-42a8-05d1-c5d5a28b3c00/designproof)
- Desktop screenshot (production surface, signed-in proof failure): ![Desktop Connect page failure notice with support and home actions](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/d2a37e81-8d16-45ad-92a2-771c39071700/designproof)
- Mobile screenshot (production surface, signed-in proof failure): ![Mobile Connect page failure notice with full-width stacked actions](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/8517f504-f0b3-462d-76a4-a14263050c00/designproof)

## Deployment skew / compatibility

Not applicable. Web-only presentation change with no deploy boundary: no
Cloudflare, runner, schema, or contract surface is touched, and the callback
route it renders for already ships on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
