### PR TITLE
fix(web): close the unknown Linq group recovery follow-ups

### DIFF
--- a/apps/web/app/api/groups/start/recover/route.ts
+++ b/apps/web/app/api/groups/start/recover/route.ts
@@ -1,3 +1,4 @@
+import { isUniqueViolation } from "@/src/lib/device-sync/prisma-store/prisma-errors";
 import { requireHostedAppSessionFromRequest } from "@/src/lib/hosted-onboarding/app-session";
 import { assertHostedOnboardingMutationOrigin } from "@/src/lib/hosted-onboarding/csrf";
 import { assertHostedMemberNotSuspended } from "@/src/lib/hosted-onboarding/entitlement";
@@ -88,15 +89,26 @@ export const POST = withJsonError(async (request: Request) => {
       throwRecoveryConflict();
     }
 
-    await upsertHostedMemberPendingLinqBindingTx({
-      homeLineAssignedAt: null,
-      linqChatId: recovery.chatId,
-      memberId: session.member.id,
-      participantContact: recovery.participantContact,
-      participantContactObservedAt: recovery.observedAt,
-      prisma: tx,
-      recipientPhone: recovery.recipientPhone,
-    });
+    try {
+      await upsertHostedMemberPendingLinqBindingTx({
+        homeLineAssignedAt: null,
+        linqChatId: recovery.chatId,
+        memberId: session.member.id,
+        participantContact: recovery.participantContact,
+        participantContactObservedAt: recovery.observedAt,
+        prisma: tx,
+        recipientPhone: recovery.recipientPhone,
+      });
+    } catch (error) {
+      // The routing store signals "this contact already belongs to another
+      // member" as a unique-violation. The checks above only see the session
+      // member's own bindings, so this is the same conflict arriving from the
+      // one place that can see every member's — report it as one.
+      if (isUniqueViolation(error)) {
+        throwRecoveryConflict();
+      }
+      throw error;
+    }
     return "linked" as const;
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
 

--- a/apps/web/app/design/group-start-study.tsx
+++ b/apps/web/app/design/group-start-study.tsx
@@ -38,6 +38,14 @@ export function GroupStartStudy() {
 
       <StudyCard>
         <HostedGroupStartFrame
+          icon={<MessageCircle className="size-8" />}
+          title="That address is already set up"
+          body="The Messages address that sent this group message is connected to a different Murph account. Log in to that account and message the group again, or ask someone else in the group to message Murph."
+        />
+      </StudyCard>
+
+      <StudyCard>
+        <HostedGroupStartFrame
           icon={<Check className="size-8" />}
           title="Go back to the group"
           body="Message Murph in that group again. Your next message will connect the chat and Murph will reply there."

--- a/apps/web/src/components/hosted-groups/group-start-client.tsx
+++ b/apps/web/src/components/hosted-groups/group-start-client.tsx
@@ -6,7 +6,10 @@ import { useEffect, useRef, useState } from "react";
 
 import { AuthDialog } from "@/src/components/hosted-onboarding/auth-dialog";
 import { HostedGroupStartFrame } from "./group-start-frame";
-import { requestHostedOnboardingJson } from "@/src/components/hosted-onboarding/client-api";
+import {
+  HostedOnboardingApiError,
+  requestHostedOnboardingJson,
+} from "@/src/components/hosted-onboarding/client-api";
 import { navigateHostedAuthRedirect } from "@/src/components/hosted-onboarding/hosted-auth-navigation";
 import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
 import { isHostedOnboardingAccessibleStage } from "@/src/lib/hosted-onboarding/stage";
@@ -23,10 +26,16 @@ type HostedGroupStartRecoveryResponse = {
 
 type HostedGroupStartRecoveryStatus =
   | "checking"
+  | "conflict"
   | "failed"
   | "idle"
   | "linked"
   | "linking";
+
+// The route reports a cross-account binding as this typed 409. It is terminal
+// for this link, so it gets its own message and no retry action.
+const HOSTED_GROUP_START_RECOVERY_CONFLICT_CODE =
+  "HOSTED_LINQ_GROUP_EMAIL_RECOVERY_CONFLICT";
 
 export function HostedGroupStartClient({
   activeAccess,
@@ -74,9 +83,9 @@ export function HostedGroupStartClient({
           clearHostedGroupStartRecoveryFragment();
           setRecoveryStatus("linked");
         }
-      } catch {
+      } catch (error) {
         if (!cancelled) {
-          setRecoveryStatus("failed");
+          setRecoveryStatus(readHostedGroupStartRecoveryFailure(error));
         }
       }
     });
@@ -94,8 +103,8 @@ export function HostedGroupStartClient({
         await linkRecovery(recoveryToken);
         clearHostedGroupStartRecoveryFragment();
         setRecoveryStatus("linked");
-      } catch {
-        setRecoveryStatus("failed");
+      } catch (error) {
+        setRecoveryStatus(readHostedGroupStartRecoveryFailure(error));
         return;
       }
     }
@@ -130,6 +139,16 @@ export function HostedGroupStartClient({
     );
   }
 
+  if (recoveryStatus === "conflict") {
+    return (
+      <HostedGroupStartFrame
+        icon={<MessageCircle className="size-8" />}
+        title="That address is already set up"
+        body="The Messages address that sent this group message is connected to a different Murph account. Log in to that account and message the group again, or ask someone else in the group to message Murph."
+      />
+    );
+  }
+
   if (recoveryStatus === "failed") {
     return (
       <HostedGroupStartFrame
@@ -152,7 +171,8 @@ export function HostedGroupStartClient({
                 clearHostedGroupStartRecoveryFragment();
                 setRecoveryStatus("linked");
               },
-              () => setRecoveryStatus("failed"),
+              (error: unknown) =>
+                setRecoveryStatus(readHostedGroupStartRecoveryFailure(error)),
             );
           }}
         >
@@ -211,6 +231,15 @@ export function HostedGroupStartClient({
       />
     </HostedGroupStartFrame>
   );
+}
+
+function readHostedGroupStartRecoveryFailure(
+  error: unknown,
+): Extract<HostedGroupStartRecoveryStatus, "conflict" | "failed"> {
+  return error instanceof HostedOnboardingApiError
+    && error.code === HOSTED_GROUP_START_RECOVERY_CONFLICT_CODE
+    ? "conflict"
+    : "failed";
 }
 
 async function linkRecovery(token: string): Promise<void> {

--- a/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
@@ -69,13 +69,6 @@ type HostedLinqFirstContactAdmissionBudgetStore = {
     ...values: readonly unknown[]
   ): Promise<number>;
   hostedLinqFirstContactAdmissionBudget: {
-    count(input: {
-      where: {
-        participantContactLookupKey: {
-          in: string[];
-        };
-      };
-    }): Promise<number>;
     create(input: {
       data: {
         eventId: string;
@@ -105,11 +98,9 @@ type HostedLinqFirstContactAdmissionBudgetStore = {
   hostedLinqFirstContactAdmissionDecision: {
     findMany(input: {
       where: {
-        decision: HostedLinqFirstContactAdmissionDecision["kind"];
         eventId: {
           in: string[];
         };
-        source: HostedLinqFirstContactAdmissionDecision["source"];
       };
     }): Promise<HostedLinqFirstContactAdmissionDecisionRecord[]>;
   };
@@ -371,49 +362,33 @@ export async function claimHostedLinqFirstContactAdmissionBudget(input: {
       },
     },
   });
+  const history = await readHostedLinqFirstContactAdmissionContactHistory({
+    lookupKeyCandidates,
+    tx: input.tx,
+  });
   if (alreadyCounted) {
     return {
-      attemptCount: await input.tx.hostedLinqFirstContactAdmissionBudget.count({
-        where: {
-          participantContactLookupKey: {
-            in: lookupKeyCandidates,
-          },
-        },
-      }),
+      attemptCount: history.chargeableCount,
       kind: "claimed",
     };
   }
 
-  const existingCount = await input.tx.hostedLinqFirstContactAdmissionBudget.count({
-    where: {
-      participantContactLookupKey: {
-        in: lookupKeyCandidates,
-      },
-    },
-  });
   // Admission is a decision about a contact, not about one message. Once any
-  // earlier event for this contact recorded a terminal allow, later events
-  // reuse it instead of spending another lifetime attempt or another
-  // classifier call. Without that, a sender who keeps messaging before they
-  // resolve to a member burns the cap on repeat offers and is then blocked
-  // forever, on this path and on the ordinary direct one. Blocks and
-  // never-completed attempts still count against the cap.
-  const recordedAllow = existingCount > 0
-    ? await readHostedLinqFirstContactAdmissionRecordedContactAllow({
-      lookupKeyCandidates,
-      tx: input.tx,
-    })
-    : null;
-  if (recordedAllow) {
+  // earlier event for this contact recorded a reusable allow, later events
+  // reuse it instead of spending another attempt or another classifier call.
+  // Without that, a sender who keeps messaging before they resolve to a member
+  // burns the cap on repeat offers and is then blocked forever, on this path
+  // and on the ordinary direct one.
+  if (history.reusableAllow) {
     return {
-      decision: recordedAllow,
+      decision: history.reusableAllow,
       kind: "already_allowed",
     };
   }
 
-  if (existingCount >= HOSTED_LINQ_FIRST_CONTACT_ADMISSION_MAX_ATTEMPTS) {
+  if (history.chargeableCount >= HOSTED_LINQ_FIRST_CONTACT_ADMISSION_MAX_ATTEMPTS) {
     return {
-      attemptCount: existingCount,
+      attemptCount: history.chargeableCount,
       kind: "exhausted",
     };
   }
@@ -427,28 +402,40 @@ export async function claimHostedLinqFirstContactAdmissionBudget(input: {
   });
 
   return {
-    attemptCount: existingCount + 1,
+    attemptCount: history.chargeableCount + 1,
     kind: "claimed",
   };
 }
 
 // The budget rows carry the contact key and the decision rows carry the
-// outcome; they join on the event id. Reading them here keeps the contact-key
-// candidates (and their rotation handling) inside this owner instead of
-// leaking the lookup-key rules into callers.
+// outcome; they join on the event id. Reading them together here keeps the
+// contact-key candidates (and their rotation handling) inside this owner
+// instead of leaking the lookup-key rules into callers, and derives both facts
+// the caller needs from one pair of reads.
 //
-// Only a model-source allow is reusable. The other allow this path can persist
-// is the classifier-unavailable fail-open, which is evidence that nobody could
-// check the sender rather than evidence the sender is welcome; reusing it would
-// let one OpenAI outage admit a contact permanently. Reuse answers the contact
-// question ("may Murph answer this stranger at all?") only. Whether an inbound
-// may mint instant-start entitlement stays a property of the exact event that
-// earned its own model allow, which is why nothing is written under a later
-// event id.
-async function readHostedLinqFirstContactAdmissionRecordedContactAllow(input: {
+// `reusableAllow` answers only the contact question, "may Murph answer this
+// stranger at all". Just a model-source allow qualifies: the other allow this
+// path persists is the classifier-unavailable fail-open, which is evidence
+// that nobody could check the sender rather than evidence the sender is
+// welcome, so reusing it would let one outage admit a contact permanently.
+// Whether an inbound may mint instant-start entitlement stays a property of the
+// exact event that earned its own model allow, which is why nothing is ever
+// written under a later event id.
+//
+// `chargeableCount` is the lifetime cap's meaning: attempts that actually spent
+// a classification. A fail-open event never reached the classifier, so charging
+// it would let an outage alone exhaust the contact — four unavailable events
+// would leave the contact with no reusable evidence and no remaining attempts,
+// permanently silent on both the group and direct paths with no repair short of
+// a database edit. Real blocks, model allows, and never-completed attempts all
+// still count, so the spend and abuse bound keeps its meaning.
+async function readHostedLinqFirstContactAdmissionContactHistory(input: {
   lookupKeyCandidates: string[];
   tx: HostedLinqFirstContactAdmissionBudgetStore;
-}): Promise<HostedLinqFirstContactAdmissionDecision | null> {
+}): Promise<{
+  chargeableCount: number;
+  reusableAllow: HostedLinqFirstContactAdmissionDecision | null;
+}> {
   const attempts = await input.tx.hostedLinqFirstContactAdmissionBudget.findMany({
     select: {
       eventId: true,
@@ -460,26 +447,44 @@ async function readHostedLinqFirstContactAdmissionRecordedContactAllow(input: {
     },
   });
   if (attempts.length === 0) {
-    return null;
+    return { chargeableCount: 0, reusableAllow: null };
   }
 
   const records = await input.tx.hostedLinqFirstContactAdmissionDecision.findMany({
     where: {
-      decision: "allow",
       eventId: {
         in: attempts.map(({ eventId }) => eventId),
       },
-      source: "model",
     },
   });
-  for (const record of records) {
-    const decision = parseHostedLinqFirstContactAdmissionDecisionRecord(record);
+  const decisionsByEventId = new Map(
+    records.map((record) => [
+      record.eventId,
+      parseHostedLinqFirstContactAdmissionDecisionRecord(record),
+    ]),
+  );
+
+  let reusableAllow: HostedLinqFirstContactAdmissionDecision | null = null;
+  let chargeableCount = 0;
+  for (const { eventId } of attempts) {
+    const decision = decisionsByEventId.get(eventId) ?? null;
     if (decision?.kind === "allow" && decision.source === "model") {
-      return decision;
+      reusableAllow ??= decision;
+    }
+    if (!isHostedLinqFirstContactAdmissionFailOpenDecision(decision)) {
+      chargeableCount += 1;
     }
   }
 
-  return null;
+  return { chargeableCount, reusableAllow };
+}
+
+// The classifier-unavailable fallback is the only allow this path records
+// without asking the model.
+function isHostedLinqFirstContactAdmissionFailOpenDecision(
+  decision: HostedLinqFirstContactAdmissionDecision | null,
+): boolean {
+  return decision?.kind === "allow" && decision.source === "deterministic";
 }
 
 function buildHostedLinqFirstContactAdmissionOpenAiBody(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
@@ -91,10 +91,34 @@ type HostedLinqFirstContactAdmissionBudgetStore = {
         };
       };
     }): Promise<HostedLinqFirstContactAdmissionBudgetRecord | null>;
+    findMany(input: {
+      select: {
+        eventId: true;
+      };
+      where: {
+        participantContactLookupKey: {
+          in: string[];
+        };
+      };
+    }): Promise<{ eventId: string }[]>;
+  };
+  hostedLinqFirstContactAdmissionDecision: {
+    findMany(input: {
+      where: {
+        decision: HostedLinqFirstContactAdmissionDecision["kind"];
+        eventId: {
+          in: string[];
+        };
+      };
+    }): Promise<HostedLinqFirstContactAdmissionDecisionRecord[]>;
   };
 };
 
 export type HostedLinqFirstContactAdmissionBudgetClaim =
+  | {
+      decision: HostedLinqFirstContactAdmissionDecision;
+      kind: "already_allowed";
+    }
   | {
       attemptCount: number;
       kind: "claimed";
@@ -366,6 +390,26 @@ export async function claimHostedLinqFirstContactAdmissionBudget(input: {
       },
     },
   });
+  // Admission is a decision about a contact, not about one message. Once any
+  // earlier event for this contact recorded a terminal allow, later events
+  // reuse it instead of spending another lifetime attempt or another
+  // classifier call. Without that, a sender who keeps messaging before they
+  // resolve to a member burns the cap on repeat offers and is then blocked
+  // forever, on this path and on the ordinary direct one. Blocks and
+  // never-completed attempts still count against the cap.
+  const recordedAllow = existingCount > 0
+    ? await readHostedLinqFirstContactAdmissionRecordedContactAllow({
+      lookupKeyCandidates,
+      tx: input.tx,
+    })
+    : null;
+  if (recordedAllow) {
+    return {
+      decision: recordedAllow,
+      kind: "already_allowed",
+    };
+  }
+
   if (existingCount >= HOSTED_LINQ_FIRST_CONTACT_ADMISSION_MAX_ATTEMPTS) {
     return {
       attemptCount: existingCount,
@@ -385,6 +429,46 @@ export async function claimHostedLinqFirstContactAdmissionBudget(input: {
     attemptCount: existingCount + 1,
     kind: "claimed",
   };
+}
+
+// The budget rows carry the contact key and the decision rows carry the
+// outcome; they join on the event id. Reading them here keeps the contact-key
+// candidates (and their rotation handling) inside this owner instead of
+// leaking the lookup-key rules into callers.
+async function readHostedLinqFirstContactAdmissionRecordedContactAllow(input: {
+  lookupKeyCandidates: string[];
+  tx: HostedLinqFirstContactAdmissionBudgetStore;
+}): Promise<HostedLinqFirstContactAdmissionDecision | null> {
+  const attempts = await input.tx.hostedLinqFirstContactAdmissionBudget.findMany({
+    select: {
+      eventId: true,
+    },
+    where: {
+      participantContactLookupKey: {
+        in: input.lookupKeyCandidates,
+      },
+    },
+  });
+  if (attempts.length === 0) {
+    return null;
+  }
+
+  const records = await input.tx.hostedLinqFirstContactAdmissionDecision.findMany({
+    where: {
+      decision: "allow",
+      eventId: {
+        in: attempts.map(({ eventId }) => eventId),
+      },
+    },
+  });
+  for (const record of records) {
+    const decision = parseHostedLinqFirstContactAdmissionDecisionRecord(record);
+    if (decision?.kind === "allow") {
+      return decision;
+    }
+  }
+
+  return null;
 }
 
 function buildHostedLinqFirstContactAdmissionOpenAiBody(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-first-contact-admission.ts
@@ -109,6 +109,7 @@ type HostedLinqFirstContactAdmissionBudgetStore = {
         eventId: {
           in: string[];
         };
+        source: HostedLinqFirstContactAdmissionDecision["source"];
       };
     }): Promise<HostedLinqFirstContactAdmissionDecisionRecord[]>;
   };
@@ -435,6 +436,15 @@ export async function claimHostedLinqFirstContactAdmissionBudget(input: {
 // outcome; they join on the event id. Reading them here keeps the contact-key
 // candidates (and their rotation handling) inside this owner instead of
 // leaking the lookup-key rules into callers.
+//
+// Only a model-source allow is reusable. The other allow this path can persist
+// is the classifier-unavailable fail-open, which is evidence that nobody could
+// check the sender rather than evidence the sender is welcome; reusing it would
+// let one OpenAI outage admit a contact permanently. Reuse answers the contact
+// question ("may Murph answer this stranger at all?") only. Whether an inbound
+// may mint instant-start entitlement stays a property of the exact event that
+// earned its own model allow, which is why nothing is written under a later
+// event id.
 async function readHostedLinqFirstContactAdmissionRecordedContactAllow(input: {
   lookupKeyCandidates: string[];
   tx: HostedLinqFirstContactAdmissionBudgetStore;
@@ -459,11 +469,12 @@ async function readHostedLinqFirstContactAdmissionRecordedContactAllow(input: {
       eventId: {
         in: attempts.map(({ eventId }) => eventId),
       },
+      source: "model",
     },
   });
   for (const record of records) {
     const decision = parseHostedLinqFirstContactAdmissionDecisionRecord(record);
-    if (decision?.kind === "allow") {
+    if (decision?.kind === "allow" && decision.source === "model") {
       return decision;
     }
   }

--- a/apps/web/src/lib/hosted-onboarding/linq-group-setup.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-group-setup.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createCipheriv, createDecipheriv, createHmac } from "node:crypto";
 
 import { readHostedAppSessionHmacKey } from "./app-session-config";
+import { resolveHostedLinqDayUtc } from "./linq-daily-state";
 import {
   createHostedLinqParticipantContact,
   type HostedLinqParticipantContact,
@@ -48,25 +49,39 @@ export type HostedLinqGroupEmailRecovery = {
   recipientPhone: string;
 };
 
+// One setup link per group chat per inbound UTC day. Keying on the chat alone
+// would mute a chat forever after a single link: if the wrong person redeems
+// it, or nobody does, the group could never be offered another one. The
+// provider occurrence day keeps webhook retries deduped even when processing
+// crosses midnight.
 export function buildHostedLinqGroupSetupEffectId(input: {
   chatId: string;
+  occurredAt: string | Date;
 }): string {
   const chatId = normalizeHostedLinqGroupChatId(input.chatId);
-  if (!chatId) {
+  const dayUtc = resolveHostedLinqDayUtc(input.occurredAt);
+  if (!chatId || Number.isNaN(dayUtc.getTime())) {
     throw new TypeError(
-      "Hosted Linq group setup requires a non-empty chat id.",
+      "Hosted Linq group setup requires a non-empty chat id and a valid occurrence time.",
     );
   }
 
-  return `linq-group-setup:${sha256Hex(chatId).slice(0, 32)}`;
+  return `linq-group-setup:${sha256Hex(JSON.stringify({
+    chatId,
+    dayUtc: dayUtc.toISOString(),
+  })).slice(0, 32)}`;
 }
 
+// One private recovery link per address per group chat per inbound UTC day,
+// for the same reason as the in-group link above.
 export function buildHostedLinqGroupEmailRecoveryEffectId(input: {
   chatId: string;
+  occurredAt: string | Date;
   participantEmail: string;
   recipientPhone: string;
 }): string {
   const chatId = normalizeHostedLinqGroupChatId(input.chatId);
+  const dayUtc = resolveHostedLinqDayUtc(input.occurredAt);
   const participantContact = createHostedLinqParticipantContact({
     kind: "email",
     value: input.participantEmail,
@@ -74,12 +89,13 @@ export function buildHostedLinqGroupEmailRecoveryEffectId(input: {
   const recipientPhone = normalizePhoneNumber(input.recipientPhone);
   if (
     !chatId
+    || Number.isNaN(dayUtc.getTime())
     || !participantContact
     || participantContact.kind !== "email"
     || !recipientPhone
   ) {
     throw new TypeError(
-      "Hosted Linq group email recovery requires a valid chat, email, and recipient line.",
+      "Hosted Linq group email recovery requires a valid chat, occurrence time, email, and recipient line.",
     );
   }
 
@@ -88,6 +104,7 @@ export function buildHostedLinqGroupEmailRecoveryEffectId(input: {
   // re-send a duplicate private recovery link to the same address.
   return `linq-group-email-recovery:${sha256Hex(JSON.stringify({
     chatId,
+    dayUtc: dayUtc.toISOString(),
     participantEmail: participantContact.value,
     recipientPhone,
   })).slice(0, 32)}`;

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -861,7 +861,9 @@ export async function planHostedOnboardingLinqWebhook(input: {
       ...(input.affirmativeReaction ? { affirmativeReaction: true } : {}),
       context,
       event: input.event,
+      firstContactAdmissionDecision: input.firstContactAdmissionDecision,
       prisma: input.prisma,
+      requireFirstContactAdmission: input.requireFirstContactAdmission,
       threadRouteAccountLookupKeys,
     });
   }
@@ -2527,7 +2529,9 @@ async function planHostedLinqGroupChatWebhook(input: {
   affirmativeReaction?: boolean;
   context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
   event: HostedLinqWebhookEvent;
+  firstContactAdmissionDecision?: HostedLinqFirstContactAdmissionDecision | null;
   prisma: Prisma.TransactionClient;
+  requireFirstContactAdmission?: boolean;
   threadRouteAccountLookupKeys: readonly string[];
 }): Promise<HostedOnboardingLinqDirectPlan> {
   const {
@@ -2667,6 +2671,33 @@ async function planHostedLinqGroupChatWebhook(input: {
         "recipient-line-not-assigned",
         senderIdentityMatch,
         "group-chat-line-unavailable",
+      );
+    }
+
+    // A setup link is a reply to a stranger, so it goes through the same
+    // first-contact admission gate that screens unknown direct senders rather
+    // than running a second, looser policy. The service layer acts on the
+    // returned request and re-plans with the decision.
+    if (
+      sender === null
+      && input.requireFirstContactAdmission === true
+      && input.firstContactAdmissionDecision?.kind !== "allow"
+    ) {
+      return logHostedLinqWebhookPlannerDecisionAndReturn(
+        buildFirstContactAdmissionRequiredPlan({
+          participantContact,
+          request: buildHostedLinqFirstContactAdmissionRequest({
+            context: input.context,
+            event: input.event,
+            participantContact,
+          }),
+        }),
+        buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+          existingMemberActive: false,
+          existingMemberMatch: senderIdentityMatch,
+          reason: "first-contact-admission-required",
+          routeStage: "first-contact-admission-required",
+        }),
       );
     }
 

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -525,7 +525,20 @@ export async function handleHostedOnboardingLinqWebhook(input: {
                 tx: transaction,
               }),
           );
-          if (admissionBudget.kind === "exhausted") {
+          if (admissionBudget.kind === "already_allowed") {
+            // This contact cleared admission on an earlier event, so the offer
+            // is re-planned on the stored allow: no attempt is spent and the
+            // classifier is not asked to re-decide a sender already admitted.
+            firstContactAdmissionDecision =
+              await recordHostedLinqFirstContactAdmissionDecision({
+                decision: admissionBudget.decision,
+                eventId: event.event_id,
+                prisma,
+              });
+            plan = firstContactAdmissionDecision.kind === "block"
+              ? await planAfterBlockedAdmission()
+              : await runPlan();
+          } else if (admissionBudget.kind === "exhausted") {
             plan = await planAfterBlockedAdmission(
               "first-contact-admission-budget-exhausted",
             );

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -526,18 +526,14 @@ export async function handleHostedOnboardingLinqWebhook(input: {
               }),
           );
           if (admissionBudget.kind === "already_allowed") {
-            // This contact cleared admission on an earlier event, so the offer
-            // is re-planned on the stored allow: no attempt is spent and the
-            // classifier is not asked to re-decide a sender already admitted.
-            firstContactAdmissionDecision =
-              await recordHostedLinqFirstContactAdmissionDecision({
-                decision: admissionBudget.decision,
-                eventId: event.event_id,
-                prisma,
-              });
-            plan = firstContactAdmissionDecision.kind === "block"
-              ? await planAfterBlockedAdmission()
-              : await runPlan();
+            // This contact cleared admission on an earlier event, so this one
+            // is planned on that allow: no attempt is spent and the classifier
+            // is not asked to re-decide a sender already admitted. The allow
+            // stays owned by the event that earned it and is never written
+            // under this event id, and instant start is off here: only a
+            // classification of this exact inbound may mint that entitlement.
+            firstContactAdmissionDecision = admissionBudget.decision;
+            plan = await runPlan(false);
           } else if (admissionBudget.kind === "exhausted") {
             plan = await planAfterBlockedAdmission(
               "first-contact-admission-budget-exhausted",

--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -68,6 +68,7 @@ import {
   buildHostedLinqGroupSetupMessage,
   HOSTED_LINQ_GROUP_EMAIL_RECOVERY_TEMPLATE,
   HOSTED_LINQ_GROUP_SETUP_TEMPLATE,
+  openHostedLinqGroupEmailRecoveryToken,
 } from "./linq-group-setup";
 import {
   claimHostedLinqQuotaReplyNotice,
@@ -425,12 +426,14 @@ function buildHostedWebhookLinqMessageEffectId(
   if (input.template === HOSTED_LINQ_GROUP_SETUP_TEMPLATE) {
     return buildHostedLinqGroupSetupEffectId({
       chatId: input.chatId,
+      occurredAt: input.occurredAt,
     });
   }
 
   if (input.template === HOSTED_LINQ_GROUP_EMAIL_RECOVERY_TEMPLATE) {
     return buildHostedLinqGroupEmailRecoveryEffectId({
       chatId: input.threadId,
+      occurredAt: input.occurredAt,
       participantEmail: input.participantContact.value,
       recipientPhone: input.assignedRecipientPhone,
     });
@@ -1348,6 +1351,19 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
     }
 
     if (groupEmailRecoveryEffect) {
+      // The token's lifetime is anchored to the provider's observed send time
+      // so plan retries stay byte-identical for idempotency. A redelivery from
+      // a long backlog can therefore surface a token that is already dead, so
+      // re-open it with the same reader the redeem endpoint uses and skip
+      // rather than open a conversation around a link that cannot work.
+      if (
+        !openHostedLinqGroupEmailRecoveryToken({
+          now: new Date(input.startedAtMs),
+          token: groupEmailRecoveryEffect.payload.recoveryToken,
+        })
+      ) {
+        return { status: "target_unauthorized" };
+      }
       await acquireHostedLinqChatOwnershipLockTx({
         chatId: groupEmailRecoveryEffect.payload.threadId,
         tx: prisma,

--- a/apps/web/test/hosted-group-start-client.test.tsx
+++ b/apps/web/test/hosted-group-start-client.test.tsx
@@ -1,0 +1,98 @@
+import { createElement } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { HostedOnboardingApiError } from "@/src/components/hosted-onboarding/client-api";
+import { renderClientComponent } from "./render-client-component";
+
+const mocks = vi.hoisted(() => ({
+  requestHostedOnboardingJson: vi.fn(),
+}));
+
+vi.mock("@/src/components/hosted-onboarding/client-api", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/components/hosted-onboarding/client-api")
+  >();
+
+  return {
+    ...actual,
+    requestHostedOnboardingJson: mocks.requestHostedOnboardingJson,
+  };
+});
+
+vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
+  AuthDialog() {
+    return null;
+  },
+}));
+
+const RECOVERY_LOCATION = {
+  hash: "#recover=tok_group_start_example",
+  href: "https://join.example.test/groups/start#recover=tok_group_start_example",
+  origin: "https://join.example.test",
+  pathname: "/groups/start",
+  search: "",
+};
+
+let cleanupRender: (() => Promise<void>) | null = null;
+
+afterEach(async () => {
+  if (cleanupRender) {
+    await cleanupRender();
+    cleanupRender = null;
+  }
+  vi.clearAllMocks();
+});
+
+test("explains the cross-account conflict without offering a retry", async () => {
+  mocks.requestHostedOnboardingJson.mockRejectedValue(
+    new HostedOnboardingApiError({
+      code: "HOSTED_LINQ_GROUP_EMAIL_RECOVERY_CONFLICT",
+      message: "That Messages address is already linked to another Murph setup.",
+      retryable: false,
+    }),
+  );
+
+  const { container, cleanup } = await renderStartClient();
+  cleanupRender = cleanup;
+
+  expect(container.textContent).toContain("That address is already set up");
+  expect(container.textContent).toContain("a different Murph account");
+  // The binding conflict is terminal for this link, so retrying it forever is
+  // not offered, and the generic failure copy must not stand in for it.
+  expect(container.querySelector("button")).toBeNull();
+  expect(container.textContent).not.toContain("Try again");
+  expect(container.textContent).not.toContain("That recovery link did not work");
+});
+
+test("keeps the retry action for a recovery failure that can succeed later", async () => {
+  mocks.requestHostedOnboardingJson.mockRejectedValue(
+    new HostedOnboardingApiError({
+      code: null,
+      message: "Something went wrong. Try again.",
+      retryable: true,
+    }),
+  );
+
+  const { container, cleanup } = await renderStartClient();
+  cleanupRender = cleanup;
+
+  expect(container.textContent).toContain("That recovery link did not work");
+  expect(container.querySelector("button")?.textContent).toContain("Try again");
+});
+
+async function renderStartClient() {
+  const { HostedGroupStartClient } = await import(
+    "@/src/components/hosted-groups/group-start-client"
+  );
+
+  return renderClientComponent(
+    createElement(HostedGroupStartClient, {
+      activeAccess: false,
+      authenticated: true,
+    }),
+    {
+      location: RECOVERY_LOCATION,
+      requireButton: false,
+    },
+  );
+}

--- a/apps/web/test/hosted-group-start-recovery-route.test.ts
+++ b/apps/web/test/hosted-group-start-recovery-route.test.ts
@@ -198,6 +198,43 @@ test("accepts an idempotent exact pending Messages setup", async () => {
   expect(mocks.upsertHostedMemberPendingLinqBindingTx).toHaveBeenCalledTimes(1);
 });
 
+test("reports a contact already bound to another member as a conflict", async () => {
+  // The pre-checks above only read the session member's own bindings. The
+  // routing store is the only layer that sees every member's, and it reports
+  // the cross-member collision as a unique violation — the same conflict, so
+  // it must not escape as a 5xx.
+  mocks.upsertHostedMemberPendingLinqBindingTx.mockRejectedValueOnce({
+    code: "P2002",
+  });
+
+  const response = await route.POST(buildRequest());
+
+  expect(response.status).toBe(409);
+  await expect(response.json()).resolves.toMatchObject({
+    error: { code: "HOSTED_LINQ_GROUP_EMAIL_RECOVERY_CONFLICT" },
+  });
+});
+
+test("still fails loudly when the binding upsert fails for an unrelated reason", async () => {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  mocks.upsertHostedMemberPendingLinqBindingTx.mockRejectedValueOnce(
+    new Error("routing store unavailable"),
+  );
+
+  try {
+    const response = await route.POST(buildRequest());
+
+    // A conflict is the only failure the catch may reinterpret; anything else
+    // must keep its original 5xx so the outage stays visible.
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "INTERNAL_ERROR" },
+    });
+  } finally {
+    errorSpy.mockRestore();
+  }
+});
+
 test("rejects an expired or malformed recovery token", async () => {
   mocks.openHostedLinqGroupEmailRecoveryToken.mockReturnValueOnce(null);
 

--- a/apps/web/test/hosted-linq-group-setup.test.ts
+++ b/apps/web/test/hosted-linq-group-setup.test.ts
@@ -114,25 +114,62 @@ describe("Hosted Linq group setup", () => {
     })).toBeNull();
   });
 
-  it("uses stable opaque setup and recovery identities", () => {
+  it("uses stable opaque setup and recovery identities within one UTC day", () => {
     const setupId = buildHostedLinqGroupSetupEffectId({
       chatId: "chat_group_123",
+      occurredAt: "2026-07-31T04:00:00.000Z",
     });
     const recoveryId = buildHostedLinqGroupEmailRecoveryEffectId({
       chatId: "chat_group_123",
-      participantEmail: "person@icloud.com",
+      occurredAt: "2026-07-31T04:00:00.000Z",
+      participantEmail: "person@example.com",
       recipientPhone: "+15550000000",
     });
 
     expect(buildHostedLinqGroupSetupEffectId({
       chatId: "chat_group_123",
+      occurredAt: "2026-07-31T22:15:00.000Z",
     })).toBe(setupId);
     expect(buildHostedLinqGroupEmailRecoveryEffectId({
       chatId: "chat_group_123",
-      participantEmail: "PERSON@ICLOUD.COM",
+      occurredAt: "2026-07-31T22:15:00.000Z",
+      participantEmail: "PERSON@EXAMPLE.COM",
       recipientPhone: "+1 (555) 000-0000",
     })).toBe(recoveryId);
-    expect(`${setupId}:${recoveryId}`).not.toContain("icloud");
+    expect(`${setupId}:${recoveryId}`).not.toContain("example");
     expect(`${setupId}:${recoveryId}`).not.toContain("+1555");
+  });
+
+  it("offers a new setup and recovery identity on the next UTC day", () => {
+    // Keying on the chat alone would mute a group forever after one link: if
+    // the wrong person redeems it, or nobody does, no further link is ever
+    // sent. A day bucket bounds the repeats without making the chat a dead end.
+    const nextDay = { occurredAt: "2026-08-01T00:00:00.000Z" } as const;
+
+    expect(buildHostedLinqGroupSetupEffectId({
+      chatId: "chat_group_123",
+      ...nextDay,
+    })).not.toBe(buildHostedLinqGroupSetupEffectId({
+      chatId: "chat_group_123",
+      occurredAt: "2026-07-31T23:59:59.999Z",
+    }));
+    expect(buildHostedLinqGroupEmailRecoveryEffectId({
+      chatId: "chat_group_123",
+      participantEmail: "person@example.com",
+      recipientPhone: "+15550000000",
+      ...nextDay,
+    })).not.toBe(buildHostedLinqGroupEmailRecoveryEffectId({
+      chatId: "chat_group_123",
+      occurredAt: "2026-07-31T23:59:59.999Z",
+      participantEmail: "person@example.com",
+      recipientPhone: "+15550000000",
+    }));
+  });
+
+  it("rejects an unusable occurrence time", () => {
+    expect(() => buildHostedLinqGroupSetupEffectId({
+      chatId: "chat_group_123",
+      occurredAt: "not-a-time",
+    })).toThrow(TypeError);
   });
 });

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -6657,25 +6657,9 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         }),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(0),
-        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
-          firstContactAdmissionOrder.push("claim");
-          return data;
-        }),
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn(async () => ({ count: 1 })),
-        findUnique: vi.fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValueOnce({
-            confidence: 1,
-            decision: "allow",
-            eventId: "evt_sms_first_contact",
-            source: "deterministic",
-          }),
-      },
+      ...createHostedLinqAdmissionTables({
+        onAttemptCreated: () => firstContactAdmissionOrder.push("claim"),
+      }),
       hostedInvite: {
         create: vi.fn().mockResolvedValue(invite),
         findFirst: vi.fn().mockResolvedValue(null),
@@ -6855,17 +6839,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         update: vi.fn(),
         updateMany: vi.fn(),
       },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findUnique: vi.fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValue({
-            confidence: 0.94,
-            decision: "block",
-            eventId: "evt_wrong_person_first_contact",
-            source: "model",
-          }),
-      },
+      ...createHostedLinqAdmissionTables(),
       hostedMember: {
         create: vi.fn(),
         findUnique: vi.fn()
@@ -6955,16 +6929,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       throw new Error("first-contact admission decision should not be recorded inside the budget transaction");
     });
     const transactionClient = {
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(0),
-        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
-          admissionOrder.push("claim");
-          return data;
-        }),
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
+      hostedLinqFirstContactAdmissionBudget: createHostedLinqAdmissionTables({
+        onAttemptCreated: () => admissionOrder.push("claim"),
+      }).hostedLinqFirstContactAdmissionBudget,
       hostedLinqFirstContactAdmissionDecision: {
         createMany: transactionDecisionCreateMany,
+        findMany: vi.fn().mockResolvedValue([]),
         findUnique: vi.fn().mockResolvedValue(null),
       },
       hostedMember: {
@@ -6991,6 +6961,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       },
       hostedLinqFirstContactAdmissionDecision: {
         createMany: rootDecisionCreateMany,
+        findMany: vi.fn().mockResolvedValue([]),
         findUnique: vi.fn()
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce({
@@ -7174,23 +7145,16 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         update: vi.fn(),
         updateMany: vi.fn(),
       },
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(4),
-        create: vi.fn(),
-        findFirst: vi.fn().mockResolvedValue(null),
-        findMany: vi.fn().mockResolvedValue([
-          { eventId: "evt_first_contact_attempt_1" },
-          { eventId: "evt_first_contact_attempt_2" },
-          { eventId: "evt_first_contact_attempt_3" },
-          { eventId: "evt_first_contact_attempt_4" },
-        ]),
-      },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn(),
-        // None of the four attempts ever recorded a terminal allow.
-        findMany: vi.fn().mockResolvedValue([]),
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
+      // Four attempts that never completed a classification: none of them is a
+      // fail-open, so all four are chargeable and the cap stands.
+      ...createHostedLinqAdmissionTables({
+        attemptEventIds: [
+          "evt_first_contact_attempt_1",
+          "evt_first_contact_attempt_2",
+          "evt_first_contact_attempt_3",
+          "evt_first_contact_attempt_4",
+        ],
+      }),
       hostedMember: {
         create: vi.fn(),
         findUnique: vi.fn().mockResolvedValue(null),
@@ -7225,7 +7189,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     // The locked claim checks same-event idempotency first (findFirst) so
     // transport retries of an already-claimed event can re-run the classifier;
     // only brand-new events for an already-exhausted contact short-circuit on
-    // the total-count read, before model egress or any insert.
+    // the contact-history read, before model egress or any insert.
     expect(prismaMocks.hostedLinqFirstContactAdmissionBudget.findFirst).toHaveBeenCalledWith({
       where: {
         eventId: "evt_first_contact_budget_exhausted",
@@ -7234,7 +7198,10 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         },
       },
     });
-    expect(prismaMocks.hostedLinqFirstContactAdmissionBudget.count).toHaveBeenCalledWith({
+    expect(prismaMocks.hostedLinqFirstContactAdmissionBudget.findMany).toHaveBeenCalledWith({
+      select: {
+        eventId: true,
+      },
       where: {
         participantContactLookupKey: {
           in: expect.arrayContaining([expect.any(String)]),
@@ -7370,6 +7337,223 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       expect(effectId).toMatch(/^linq-group-setup:/u);
     }
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies a contact again once the classifier recovers from an outage that spanned four events", async () => {
+    mocks.hostedOnboardingEnvironment.linqFirstContactAdmissionMode = "enforce";
+    // A launch prefix, so the later direct message is a genuine instant-start
+    // candidate and the entitlement assertions below have teeth.
+    mocks.hostedOnboardingEnvironment.linqInstantStartPhonePrefixes = ["+1"];
+    const classifierUnavailable = () => hostedOnboardingError({
+      code: "LINQ_FIRST_CONTACT_ADMISSION_CLASSIFIER_UNAVAILABLE",
+      details: {
+        operationName: "hosted_linq_first_contact_admission",
+        type: "transport",
+      },
+      httpStatus: 503,
+      message: "Linq first-contact admission classifier is unavailable.",
+      retryable: true,
+    });
+    const outageEventIds = [
+      "evt_outage_group_1",
+      "evt_outage_group_2",
+      "evt_outage_group_3",
+      "evt_outage_group_4",
+    ] as const;
+    outageEventIds.forEach(() => {
+      mocks.classifyHostedLinqFirstContactAdmission.mockRejectedValueOnce(
+        classifierUnavailable(),
+      );
+    });
+
+    const invite = {
+      channel: "linq",
+      id: "invite_after_outage",
+      inviteCode: "code_after_outage",
+      memberId: "member_after_outage",
+      sentAt: null,
+      status: "pending",
+    };
+    const prisma = asPrismaTransactionClient({
+      hostedInvite: {
+        create: vi.fn().mockResolvedValue(invite),
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn().mockResolvedValue(invite),
+        update: vi.fn().mockResolvedValue({
+          id: invite.id,
+          sentAt: new Date("2026-03-30T12:00:01.000Z"),
+        }),
+        updateMany: vi.fn(),
+      },
+      hostedLinqLine: buildManagedInboundHostedLinqLineFixture("+15550000000"),
+      hostedMember: {
+        create: vi.fn().mockResolvedValue({
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.not_started,
+          id: invite.memberId,
+          phoneLookupKey: "+15551112222",
+        }),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      hostedMemberIdentity: {
+        findFirst: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn(),
+      },
+      hostedMemberRouting: {
+        findFirst: vi.fn(),
+        findUnique: vi.fn(),
+        upsert: vi.fn(),
+      },
+      hostedWebhookReceipt: buildHostedWebhookReceiptFixture(),
+    });
+    const groupWebhook = (input: { createdAt: string; eventId: string }) =>
+      handleHostedOnboardingLinqWebhook({
+        prisma,
+        rawBody: buildHostedLinqWebhookBody({
+          createdAt: input.createdAt,
+          data: {
+            chat: {
+              id: "chat_group_123",
+              is_group: true,
+              owner_handle: {
+                handle: "+15550000000",
+                id: "handle_owner_123",
+                is_me: true,
+                service: "iMessage",
+              },
+            },
+            sender_handle: {
+              handle: "+15551112222",
+              id: "handle_group_stranger",
+              service: "iMessage",
+            },
+            sent_at: input.createdAt,
+          },
+          eventId: input.eventId,
+          service: "iMessage",
+        }),
+        signature: null,
+        timestamp: null,
+      });
+
+    // Four events while OpenAI is unreachable. Each fails open, so each records
+    // a deterministic allow that nobody may reuse.
+    for (const [index, eventId] of outageEventIds.entries()) {
+      await expect(groupWebhook({
+        createdAt: `2026-03-2${6 + index}T12:00:00.000Z`,
+        eventId,
+      })).resolves.toMatchObject({
+        ok: true,
+        reason: "sent-group-setup",
+      });
+    }
+
+    // The classifier recovers. The contact must still be reachable: an outage
+    // alone may not spend the lifetime cap.
+    const recoveredEventId = "evt_recovered_group";
+    await expect(groupWebhook({
+      createdAt: "2026-03-30T12:00:00.000Z",
+      eventId: recoveredEventId,
+    })).resolves.toMatchObject({
+      ok: true,
+      reason: "sent-group-setup",
+    });
+    expect(mocks.classifyHostedLinqFirstContactAdmission).toHaveBeenCalledTimes(5);
+    expect(mocks.classifyHostedLinqFirstContactAdmission).toHaveBeenNthCalledWith(5, {
+      request: expect.objectContaining({ eventId: recoveredEventId }),
+      signal: undefined,
+    });
+
+    // The ordinary direct path is reachable for the same contact too, on the
+    // recovered model allow, and it mints no instant-start authority.
+    await expect(handleHostedOnboardingLinqWebhook({
+      prisma,
+      rawBody: buildHostedLinqWebhookBody({
+        createdAt: "2026-03-30T13:00:00.000Z",
+        data: {
+          chat: {
+            id: "chat_123",
+            is_group: false,
+            owner_handle: {
+              handle: "+15550000000",
+              id: "handle_owner_123",
+              is_me: true,
+              service: "iMessage",
+            },
+          },
+          sender_handle: {
+            handle: "+15551112222",
+            id: "handle_direct_stranger",
+            service: "iMessage",
+          },
+          sent_at: "2026-03-30T13:00:00.000Z",
+        },
+        eventId: "evt_recovered_direct",
+        service: "iMessage",
+      }),
+      signature: null,
+      timestamp: null,
+    })).resolves.toMatchObject({
+      inviteCode: invite.inviteCode,
+      ok: true,
+      reason: "sent-signup-link",
+    });
+
+    // A replay of the recovered event reuses its own stored decision: no sixth
+    // classification and no sixth attempt row.
+    await expect(groupWebhook({
+      createdAt: "2026-03-30T12:00:00.000Z",
+      eventId: recoveredEventId,
+    })).resolves.toMatchObject({
+      ok: true,
+      reason: "sent-group-setup",
+    });
+    expect(mocks.classifyHostedLinqFirstContactAdmission).toHaveBeenCalledTimes(5);
+
+    const budgetCreate = requireMock(
+      prisma.hostedLinqFirstContactAdmissionBudget?.create,
+      "hostedLinqFirstContactAdmissionBudget.create",
+    );
+    expect(
+      (budgetCreate.mock.calls as [{ data: { eventId: string } }][])
+        .map(([{ data }]) => data.eventId),
+    ).toEqual([...outageEventIds, recoveredEventId]);
+
+    // Every decision stays owned by the event that earned it: four fail-opens,
+    // one model allow, and nothing at all for the direct message.
+    const decisionCreateMany = requireMock(
+      prisma.hostedLinqFirstContactAdmissionDecision?.createMany,
+      "hostedLinqFirstContactAdmissionDecision.createMany",
+    );
+    expect(
+      (decisionCreateMany.mock.calls as [{ data: { eventId: string; source: string } }][])
+        .map(([{ data }]) => [data.eventId, data.source]),
+    ).toEqual([
+      ...outageEventIds.map((eventId) => [eventId, "deterministic"]),
+      [recoveredEventId, "model"],
+    ]);
+
+    expect(mocks.ensureHostedLinqInstantStartPulseTrialEnrollment).not.toHaveBeenCalled();
+    const inviteCreate = requireMock(
+      prisma.hostedInvite?.create,
+      "hostedInvite.create",
+    );
+    for (const [{ data }] of inviteCreate.mock.calls as [
+      { data: { instantStartAdmissionEventId?: string | null } },
+    ][]) {
+      expect(data.instantStartAdmissionEventId ?? null).toBeNull();
+    }
+    const identityCreateMany = requireMock(
+      prisma.hostedMemberIdentity?.createMany,
+      "hostedMemberIdentity.createMany",
+    );
+    for (const [{ data }] of identityCreateMany.mock.calls as [
+      { data: { phoneNumberVerifiedAt?: Date | null } },
+    ][]) {
+      expect(data.phoneNumberVerifiedAt ?? null).toBeNull();
+    }
   });
 
   it("admits a direct first contact whose contact recorded an allow after the attempt cap filled", async () => {
@@ -7860,22 +8044,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         }),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(0),
-        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => data),
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findUnique: vi.fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValue({
-            confidence: 1,
-            decision: "allow",
-            eventId: "evt_classifier_transport_retry",
-            source: "deterministic",
-          }),
-      },
+      ...createHostedLinqAdmissionTables(),
       hostedInvite: {
         create: vi.fn().mockResolvedValue(invite),
         findFirst: vi.fn().mockResolvedValue(null),
@@ -7970,15 +8139,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         }),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(0),
-        create: vi.fn(),
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn(),
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
+      ...createHostedLinqAdmissionTables(),
       hostedInvite: {
         create: vi.fn(),
         findFirst: vi.fn(),
@@ -8065,26 +8226,17 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         }),
         updateMany: vi.fn(),
       },
-      hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValue(4),
-        create: vi.fn(),
-        findFirst: vi.fn().mockResolvedValue({
+      // The contact is already at the cap, and this event is one of the four
+      // attempts: a transport retry of an already-claimed event still
+      // classifies rather than short-circuiting.
+      ...createHostedLinqAdmissionTables({
+        attemptEventIds: [
           eventId,
-          participantContactKind: "phone",
-          participantContactLookupKey: "blind:v1:retry-contact",
-        }),
-      },
-      hostedLinqFirstContactAdmissionDecision: {
-        createMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findUnique: vi.fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValue({
-            confidence: 1,
-            decision: "allow",
-            eventId,
-            source: "deterministic",
-          }),
-      },
+          "evt_classifier_transport_retry_other_1",
+          "evt_classifier_transport_retry_other_2",
+          "evt_classifier_transport_retry_other_3",
+        ],
+      }),
       hostedMember: {
         create: vi.fn().mockResolvedValue({
           accountGroupMemberships: [],
@@ -12062,33 +12214,11 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
     hostedLinqDailyState.updateMany = vi.fn().mockResolvedValue({ count: 1 });
   }
 
+  const defaultAdmissionTables = createHostedLinqAdmissionTables();
   if (!hostedLinqFirstContactAdmissionDecision?.findUnique || !hostedLinqFirstContactAdmissionDecision?.createMany) {
-    const decisionRecords = new Map<string, Record<string, unknown>>();
     Object.defineProperty(prisma, "hostedLinqFirstContactAdmissionDecision", {
       configurable: true,
-      value: {
-        // `decision.eventId` is the primary key and inserts are
-        // `skipDuplicates`, so the first write for an event wins.
-        createMany: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
-          if (typeof data.eventId !== "string" || decisionRecords.has(data.eventId)) {
-            return { count: 0 };
-          }
-          decisionRecords.set(data.eventId, data);
-          return { count: 1 };
-        }),
-        findMany: vi.fn(async ({ where }: {
-          where: { decision?: string; eventId?: { in?: string[] } };
-        }) => {
-          const eventIds = where.eventId?.in ?? null;
-          return [...decisionRecords.values()].filter((record) =>
-            (where.decision === undefined || record.decision === where.decision)
-            && (!eventIds || eventIds.includes(String(record.eventId)))
-          );
-        }),
-        findUnique: vi.fn(async ({ where }: { where: { eventId: string } }) =>
-          decisionRecords.get(where.eventId) ?? null,
-        ),
-      },
+      value: defaultAdmissionTables.hostedLinqFirstContactAdmissionDecision,
     });
   }
 
@@ -12097,45 +12227,105 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
     || !hostedLinqFirstContactAdmissionBudget?.create
     || !hostedLinqFirstContactAdmissionBudget?.count
   ) {
-    // The budget table is keyed by (contact lookup key, event id) and is read
-    // back within the same webhook run, so the default fixture persists rows
-    // instead of answering a fixed count.
-    const budgetRows: { eventId: string; participantContactLookupKey: string }[] = [];
-    const matchesBudgetContact = (
-      row: { participantContactLookupKey: string },
-      where: { participantContactLookupKey?: { in?: string[] } },
-    ) => (where.participantContactLookupKey?.in ?? []).includes(
-      row.participantContactLookupKey,
-    );
     Object.defineProperty(prisma, "hostedLinqFirstContactAdmissionBudget", {
       configurable: true,
-      value: {
-        count: vi.fn(async ({ where }: {
-          where: { participantContactLookupKey?: { in?: string[] } };
-        }) => budgetRows.filter((row) => matchesBudgetContact(row, where)).length),
-        create: vi.fn(async ({ data }: {
-          data: { eventId: string; participantContactLookupKey: string };
-        }) => {
-          budgetRows.push(data);
-          return data;
-        }),
-        findFirst: vi.fn(async ({ where }: {
-          where: { eventId: string; participantContactLookupKey?: { in?: string[] } };
-        }) =>
-          budgetRows.find((row) =>
-            row.eventId === where.eventId && matchesBudgetContact(row, where)
-          ) ?? null),
-        findMany: vi.fn(async ({ where }: {
-          where: { participantContactLookupKey?: { in?: string[] } };
-        }) =>
-          budgetRows
-            .filter((row) => matchesBudgetContact(row, where))
-            .map(({ eventId }) => ({ eventId }))),
-      },
+      value: defaultAdmissionTables.hostedLinqFirstContactAdmissionBudget,
     });
   }
 
   return prisma as T & HostedOnboardingLinqWebhookPrismaFixture;
+}
+
+type HostedLinqAdmissionDecisionRow = {
+  confidence: number;
+  decision: string;
+  eventId: string;
+  source: string;
+};
+
+/**
+ * One stateful stand-in for the two first-contact admission tables. The claim
+ * derives the contact's chargeable attempt count and its reusable allow by
+ * joining budget rows to decision rows on the event id, so a double that
+ * answers a fixed count cannot express the scenarios these tests describe.
+ * Seed `attemptEventIds` and `decisions` to state the contact's prior history;
+ * everything written during the run is read back the way Postgres would.
+ */
+function createHostedLinqAdmissionTables(input: {
+  attemptEventIds?: readonly string[];
+  decisions?: readonly HostedLinqAdmissionDecisionRow[];
+  onAttemptCreated?: (eventId: string) => void;
+} = {}) {
+  const attempts = (input.attemptEventIds ?? []).map((eventId) => ({
+    eventId,
+    participantContactKind: "phone",
+    participantContactLookupKey: null as string | null,
+  }));
+  const decisions = new Map<string, HostedLinqAdmissionDecisionRow>(
+    (input.decisions ?? []).map((row) => [row.eventId, row]),
+  );
+  // Seeded rows belong to whichever contact the test is exercising, so they
+  // match every lookup-key candidate; rows written during the run carry the
+  // key the claim inserted.
+  const matchesContact = (
+    row: { participantContactLookupKey: string | null },
+    where: { participantContactLookupKey?: { in?: string[] } },
+  ) => row.participantContactLookupKey === null
+    || (where.participantContactLookupKey?.in ?? []).includes(
+      row.participantContactLookupKey,
+    );
+
+  return {
+    hostedLinqFirstContactAdmissionBudget: {
+      count: vi.fn(async ({ where }: {
+        where: { participantContactLookupKey?: { in?: string[] } };
+      }) => attempts.filter((row) => matchesContact(row, where)).length),
+      create: vi.fn(async ({ data }: {
+        data: {
+          eventId: string;
+          participantContactKind: string;
+          participantContactLookupKey: string;
+        };
+      }) => {
+        attempts.push({ ...data });
+        input.onAttemptCreated?.(data.eventId);
+        return data;
+      }),
+      findFirst: vi.fn(async ({ where }: {
+        where: { eventId: string; participantContactLookupKey?: { in?: string[] } };
+      }) =>
+        attempts.find((row) =>
+          row.eventId === where.eventId && matchesContact(row, where)
+        ) ?? null),
+      findMany: vi.fn(async ({ where }: {
+        where: { participantContactLookupKey?: { in?: string[] } };
+      }) =>
+        attempts
+          .filter((row) => matchesContact(row, where))
+          .map(({ eventId }) => ({ eventId }))),
+    },
+    hostedLinqFirstContactAdmissionDecision: {
+      // `decision.eventId` is the primary key and inserts are
+      // `skipDuplicates`, so the first write for an event wins.
+      createMany: vi.fn(async ({ data }: { data: HostedLinqAdmissionDecisionRow }) => {
+        if (decisions.has(data.eventId)) {
+          return { count: 0 };
+        }
+        decisions.set(data.eventId, data);
+        return { count: 1 };
+      }),
+      findMany: vi.fn(async ({ where }: {
+        where: { eventId?: { in?: string[] } };
+      }) => {
+        const eventIds = where.eventId?.in ?? null;
+        return [...decisions.values()].filter((row) =>
+          !eventIds || eventIds.includes(row.eventId)
+        );
+      }),
+      findUnique: vi.fn(async ({ where }: { where: { eventId: string } }) =>
+        decisions.get(where.eventId) ?? null),
+    },
+  };
 }
 
 function createSingleHostedMemberRoutingMock(record: Record<string, unknown>) {

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -7469,6 +7469,156 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(prismaMocks.hostedInvite.create).toHaveBeenCalledTimes(1);
   });
 
+  it("never lends an earlier group allow to a launch-prefix direct first contact as instant-start authority", async () => {
+    mocks.hostedOnboardingEnvironment.linqFirstContactAdmissionMode = "enforce";
+    // The production default prefix list includes +1, so the later direct
+    // message below is a genuine instant-start candidate.
+    mocks.hostedOnboardingEnvironment.linqInstantStartPhonePrefixes = ["+1"];
+
+    const groupAdmissionEventId = "evt_group_offer_model_allow";
+    // The contact's only classification happened on a group message, which may
+    // never mint instant-start entitlement for a different inbound.
+    const budgetRows = [{ eventId: groupAdmissionEventId }];
+    const decisionRows = new Map<string, Record<string, unknown>>([
+      [groupAdmissionEventId, {
+        confidence: 0.9,
+        decision: "allow",
+        eventId: groupAdmissionEventId,
+        source: "model",
+      }],
+    ]);
+    const invite = {
+      channel: "linq",
+      id: "invite_direct_after_group_allow",
+      inviteCode: "code_direct_after_group_allow",
+      memberId: "member_direct_after_group_allow",
+      sentAt: null,
+      status: "pending",
+    };
+    // The admission tables outlive one webhook attempt; the rest of the
+    // fixture is rebuilt per attempt so the retry is a clean redelivery.
+    const budgetCreate = vi.fn(async ({ data }: { data: { eventId: string } }) => {
+      budgetRows.push({ eventId: data.eventId });
+      return data;
+    });
+    const decisionCreateMany = vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      if (typeof data.eventId !== "string" || decisionRows.has(data.eventId)) {
+        return { count: 0 };
+      }
+      decisionRows.set(data.eventId, data);
+      return { count: 1 };
+    });
+    const inviteCreate = vi.fn().mockResolvedValue(invite);
+    const buildDirectAttemptPrisma = () => asPrismaTransactionClient({
+      $queryRaw: vi.fn().mockResolvedValue([]),
+      hostedWebhookReceipt: buildHostedWebhookReceiptFixture(),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn(async () => budgetRows.length),
+        create: budgetCreate,
+        findFirst: vi.fn(async ({ where }: { where: { eventId: string } }) =>
+          budgetRows.find((row) => row.eventId === where.eventId) ?? null),
+        findMany: vi.fn(async () => budgetRows.map(({ eventId }) => ({ eventId }))),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        createMany: decisionCreateMany,
+        findMany: vi.fn(async ({ where }: {
+          where: { decision?: string; eventId?: { in?: string[] } };
+        }) =>
+          [...decisionRows.values()].filter((row) =>
+            (where.decision === undefined || row.decision === where.decision)
+            && (where.eventId?.in ?? []).includes(String(row.eventId))
+          )),
+        findUnique: vi.fn(async ({ where }: { where: { eventId: string } }) =>
+          decisionRows.get(where.eventId) ?? null),
+      },
+      hostedInvite: {
+        create: inviteCreate,
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn().mockResolvedValue(invite),
+        update: vi.fn().mockResolvedValue({
+          id: invite.id,
+          sentAt: new Date("2026-03-26T12:00:01.000Z"),
+        }),
+        updateMany: vi.fn(),
+      },
+      hostedMember: {
+        create: vi.fn().mockResolvedValue({
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.not_started,
+          id: invite.memberId,
+          phoneLookupKey: "+15551234567",
+        }),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+    });
+
+    const attempts = [buildDirectAttemptPrisma(), buildDirectAttemptPrisma()];
+    const directWebhook = (prisma: ReturnType<typeof buildDirectAttemptPrisma>) =>
+      handleHostedOnboardingLinqWebhook({
+        prisma,
+        rawBody: buildHostedLinqWebhookBody({
+          data: {
+            chat: {
+              id: "chat_123",
+              is_group: false,
+              owner_handle: {
+                handle: "+15550000000",
+                id: "handle_owner_123",
+                is_me: true,
+                service: "iMessage",
+              },
+            },
+            parts: [{ type: "text", value: "Limited spots left on our program." }],
+          },
+          eventId: "evt_direct_after_group_allow",
+          service: "iMessage",
+        }),
+        signature: null,
+        timestamp: null,
+      });
+
+    // The delivery attempt and its redelivery must both land on the ordinary
+    // signup link, never on instant start.
+    for (const attempt of attempts) {
+      await expect(directWebhook(attempt)).resolves.toMatchObject({
+        inviteCode: invite.inviteCode,
+        ok: true,
+        reason: "sent-signup-link",
+      });
+    }
+
+    // The earlier allow satisfies the gate without spending an attempt or a
+    // classifier call, and it is never copied onto this event: the model-source
+    // proof stays owned by the event the model actually judged, so no retry can
+    // read instant-start authority back out of the decision table.
+    expect(mocks.classifyHostedLinqFirstContactAdmission).not.toHaveBeenCalled();
+    expect(budgetCreate).not.toHaveBeenCalled();
+    expect(decisionCreateMany).not.toHaveBeenCalled();
+    expect([...decisionRows.keys()]).toEqual([groupAdmissionEventId]);
+    // No instant-start entitlement: no trial enrollment, no admission id on the
+    // invite, and no phone verified off the back of a group classification.
+    expect(mocks.ensureHostedLinqInstantStartPulseTrialEnrollment).not.toHaveBeenCalled();
+    expect(inviteCreate).toHaveBeenCalledTimes(attempts.length);
+    for (const [{ data }] of inviteCreate.mock.calls as [
+      { data: { instantStartAdmissionEventId?: string | null } },
+    ][]) {
+      expect(data.instantStartAdmissionEventId ?? null).toBeNull();
+    }
+    for (const attempt of attempts) {
+      const identityCreateMany = requireMock(
+        attempt.hostedMemberIdentity?.createMany,
+        "hostedMemberIdentity.createMany",
+      );
+      expect(identityCreateMany).toHaveBeenCalled();
+      for (const [call] of identityCreateMany.mock.calls as [
+        { data: { phoneNumberVerifiedAt?: Date | null } },
+      ][]) {
+        expect(call.data.phoneNumberVerifiedAt ?? null).toBeNull();
+      }
+    }
+  });
+
   it("reuses stored classifier blocks for duplicate unknown Linq first contacts", async () => {
     mocks.hostedOnboardingEnvironment.linqFirstContactAdmissionMode = "enforce";
 

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -447,6 +447,7 @@ type HostedLinqProviderEventFixture = {
 
 type HostedLinqFirstContactAdmissionDecisionFixture = {
   createMany?: MockedFunction;
+  findMany?: MockedFunction;
   findUnique?: MockedFunction;
 };
 
@@ -454,6 +455,7 @@ type HostedLinqFirstContactAdmissionBudgetFixture = {
   count?: MockedFunction;
   create?: MockedFunction;
   findFirst?: MockedFunction;
+  findMany?: MockedFunction;
 };
 
 type HostedMemberFixture = {
@@ -7176,9 +7178,17 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         count: vi.fn().mockResolvedValue(4),
         create: vi.fn(),
         findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_first_contact_attempt_1" },
+          { eventId: "evt_first_contact_attempt_2" },
+          { eventId: "evt_first_contact_attempt_3" },
+          { eventId: "evt_first_contact_attempt_4" },
+        ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
         createMany: vi.fn(),
+        // None of the four attempts ever recorded a terminal allow.
+        findMany: vi.fn().mockResolvedValue([]),
         findUnique: vi.fn().mockResolvedValue(null),
       },
       hostedMember: {
@@ -7242,6 +7252,221 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.enqueueHostedExecutionOutbox).not.toHaveBeenCalled();
     expect(mocks.drainHostedExecutionOutboxBestEffort).not.toHaveBeenCalled();
     expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
+  });
+
+  it("keeps offering group setup on later days by reusing one recorded first-contact allow", async () => {
+    mocks.hostedOnboardingEnvironment.linqFirstContactAdmissionMode = "enforce";
+    // The delivery row's idempotency key is the effect id, so a repeat of an
+    // already-claimed effect is the real dedupe: one offer per key.
+    const claimedEffectIds: string[] = [];
+    mocks.claimHostedLinqDeliveryProviderDispatchTx.mockImplementation(
+      async ({ idempotencyKey }: { idempotencyKey: string }) => {
+        if (claimedEffectIds.includes(idempotencyKey)) {
+          return { claimed: false, outcome: "completed" };
+        }
+        claimedEffectIds.push(idempotencyKey);
+        return { claimed: true, id: `hld_group_setup_${claimedEffectIds.length}` };
+      },
+    );
+
+    const prisma = asPrismaTransactionClient({
+      hostedInvite: {
+        create: vi.fn(),
+        findFirst: vi.fn(),
+        update: vi.fn(),
+      },
+      hostedLinqLine: buildManagedInboundHostedLinqLineFixture("+15550000000"),
+      hostedMember: {
+        create: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+      hostedMemberIdentity: {
+        findFirst: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn(),
+      },
+      hostedMemberRouting: {
+        findFirst: vi.fn(),
+        findUnique: vi.fn(),
+        upsert: vi.fn(),
+      },
+      hostedWebhookReceipt: {
+        create: vi.fn().mockResolvedValue({}),
+        findUnique: vi.fn().mockResolvedValue({
+          payloadJson: {
+            eventType: "message.received",
+            receiptAttemptCount: 1,
+            receiptStatus: "processing",
+          },
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    });
+
+    // Four messages on one day plus one the next: more events than the
+    // four-attempt lifetime cap, all from the same unresolved sender.
+    for (
+      const { createdAt, eventId } of [
+        { createdAt: "2026-03-26T12:00:00.000Z", eventId: "evt_group_offer_day1_first" },
+        { createdAt: "2026-03-26T13:00:00.000Z", eventId: "evt_group_offer_day1_second" },
+        { createdAt: "2026-03-26T14:00:00.000Z", eventId: "evt_group_offer_day1_third" },
+        { createdAt: "2026-03-26T15:00:00.000Z", eventId: "evt_group_offer_day1_fourth" },
+        { createdAt: "2026-03-27T12:00:00.000Z", eventId: "evt_group_offer_day2_first" },
+      ]
+    ) {
+      await expect(handleHostedOnboardingLinqWebhook({
+        prisma,
+        rawBody: buildHostedLinqWebhookBody({
+          createdAt,
+          data: {
+            chat: {
+              id: "chat_group_123",
+              is_group: true,
+              owner_handle: {
+                handle: "+15550000000",
+                id: "handle_owner_123",
+                is_me: true,
+                service: "iMessage",
+              },
+            },
+            sender_handle: {
+              handle: "+15551112222",
+              id: "handle_group_stranger",
+              service: "iMessage",
+            },
+            sent_at: createdAt,
+          },
+          eventId,
+          service: "iMessage",
+        }),
+        signature: null,
+        timestamp: null,
+      })).resolves.toMatchObject({
+        ok: true,
+        reason: "sent-group-setup",
+      });
+    }
+
+    // One classifier call and one budget attempt for the contact's lifetime:
+    // every later event re-plans on the stored allow.
+    expect(mocks.classifyHostedLinqFirstContactAdmission).toHaveBeenCalledTimes(1);
+    expect(mocks.classifyHostedLinqFirstContactAdmission).toHaveBeenCalledWith({
+      request: expect.objectContaining({
+        eventId: "evt_group_offer_day1_first",
+      }),
+      signal: undefined,
+    });
+    expect(
+      requireMock(
+        prisma.hostedLinqFirstContactAdmissionBudget?.create,
+        "hostedLinqFirstContactAdmissionBudget.create",
+      ),
+    ).toHaveBeenCalledTimes(1);
+    // The offer itself stays one per chat per UTC day: three same-day repeats
+    // claim nothing new, and the next day earns a fresh link.
+    expect(claimedEffectIds).toHaveLength(2);
+    expect(claimedEffectIds[0]).not.toBe(claimedEffectIds[1]);
+    for (const effectId of claimedEffectIds) {
+      expect(effectId).toMatch(/^linq-group-setup:/u);
+    }
+    expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("admits a direct first contact whose contact recorded an allow after the attempt cap filled", async () => {
+    mocks.hostedOnboardingEnvironment.linqFirstContactAdmissionMode = "enforce";
+
+    const invite = {
+      channel: "linq",
+      id: "invite_after_group_offers",
+      inviteCode: "code_after_group_offers",
+      memberId: "member_after_group_offers",
+      sentAt: null,
+      status: "pending",
+    };
+    const prismaMocks = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
+      hostedWebhookReceipt: {
+        create: vi.fn().mockResolvedValue({}),
+        findUnique: vi.fn().mockResolvedValue({
+          payloadJson: {
+            eventType: "message.received",
+            receiptAttemptCount: 1,
+            receiptStatus: "processing",
+          },
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      hostedLinqFirstContactAdmissionBudget: {
+        // Four group offers already used the contact-global lifetime cap.
+        count: vi.fn().mockResolvedValue(4),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_group_offer_1" },
+          { eventId: "evt_group_offer_2" },
+          { eventId: "evt_group_offer_3" },
+          { eventId: "evt_group_offer_4" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+        // The winning classifier call recorded its allow only after the
+        // concurrent events had already claimed the last attempt slots.
+        findMany: vi.fn().mockResolvedValue([{
+          confidence: 0.93,
+          decision: "allow",
+          eventId: "evt_group_offer_2",
+          source: "model",
+        }]),
+        findUnique: vi.fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue({
+            confidence: 0.93,
+            decision: "allow",
+            eventId: "evt_direct_after_group_offers",
+            source: "model",
+          }),
+      },
+      hostedInvite: {
+        create: vi.fn().mockResolvedValue(invite),
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn().mockResolvedValue(invite),
+        update: vi.fn().mockResolvedValue({
+          id: invite.id,
+          sentAt: new Date("2026-03-26T12:00:01.000Z"),
+        }),
+        updateMany: vi.fn(),
+      },
+      hostedMember: {
+        create: vi.fn().mockResolvedValue({
+          accountGroupMemberships: [],
+          billingStatus: HostedBillingStatus.not_started,
+          id: invite.memberId,
+          phoneLookupKey: "+15551234567",
+        }),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+    };
+    const prisma = asPrismaTransactionClient(prismaMocks);
+
+    await expect(handleHostedOnboardingLinqWebhook({
+      prisma,
+      rawBody: buildHostedLinqWebhookBody({
+        eventId: "evt_direct_after_group_offers",
+      }),
+      signature: null,
+      timestamp: null,
+    })).resolves.toMatchObject({
+      inviteCode: invite.inviteCode,
+      ok: true,
+      reason: "sent-signup-link",
+    });
+
+    expect(mocks.classifyHostedLinqFirstContactAdmission).not.toHaveBeenCalled();
+    expect(prismaMocks.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+    expect(prismaMocks.hostedMember.create).toHaveBeenCalledTimes(1);
+    expect(prismaMocks.hostedInvite.create).toHaveBeenCalledTimes(1);
   });
 
   it("reuses stored classifier blocks for duplicate unknown Linq first contacts", async () => {
@@ -11692,11 +11917,23 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
     Object.defineProperty(prisma, "hostedLinqFirstContactAdmissionDecision", {
       configurable: true,
       value: {
+        // `decision.eventId` is the primary key and inserts are
+        // `skipDuplicates`, so the first write for an event wins.
         createMany: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
-          if (typeof data.eventId === "string") {
-            decisionRecords.set(data.eventId, data);
+          if (typeof data.eventId !== "string" || decisionRecords.has(data.eventId)) {
+            return { count: 0 };
           }
+          decisionRecords.set(data.eventId, data);
           return { count: 1 };
+        }),
+        findMany: vi.fn(async ({ where }: {
+          where: { decision?: string; eventId?: { in?: string[] } };
+        }) => {
+          const eventIds = where.eventId?.in ?? null;
+          return [...decisionRecords.values()].filter((record) =>
+            (where.decision === undefined || record.decision === where.decision)
+            && (!eventIds || eventIds.includes(String(record.eventId)))
+          );
         }),
         findUnique: vi.fn(async ({ where }: { where: { eventId: string } }) =>
           decisionRecords.get(where.eventId) ?? null,
@@ -11710,12 +11947,40 @@ function asPrismaTransactionClient<T extends PrismaFixtureBase>(
     || !hostedLinqFirstContactAdmissionBudget?.create
     || !hostedLinqFirstContactAdmissionBudget?.count
   ) {
+    // The budget table is keyed by (contact lookup key, event id) and is read
+    // back within the same webhook run, so the default fixture persists rows
+    // instead of answering a fixed count.
+    const budgetRows: { eventId: string; participantContactLookupKey: string }[] = [];
+    const matchesBudgetContact = (
+      row: { participantContactLookupKey: string },
+      where: { participantContactLookupKey?: { in?: string[] } },
+    ) => (where.participantContactLookupKey?.in ?? []).includes(
+      row.participantContactLookupKey,
+    );
     Object.defineProperty(prisma, "hostedLinqFirstContactAdmissionBudget", {
       configurable: true,
       value: {
-        count: vi.fn().mockResolvedValue(0),
-        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => data),
-        findFirst: vi.fn().mockResolvedValue(null),
+        count: vi.fn(async ({ where }: {
+          where: { participantContactLookupKey?: { in?: string[] } };
+        }) => budgetRows.filter((row) => matchesBudgetContact(row, where)).length),
+        create: vi.fn(async ({ data }: {
+          data: { eventId: string; participantContactLookupKey: string };
+        }) => {
+          budgetRows.push(data);
+          return data;
+        }),
+        findFirst: vi.fn(async ({ where }: {
+          where: { eventId: string; participantContactLookupKey?: { in?: string[] } };
+        }) =>
+          budgetRows.find((row) =>
+            row.eventId === where.eventId && matchesBudgetContact(row, where)
+          ) ?? null),
+        findMany: vi.fn(async ({ where }: {
+          where: { participantContactLookupKey?: { in?: string[] } };
+        }) =>
+          budgetRows
+            .filter((row) => matchesBudgetContact(row, where))
+            .map(({ eventId }) => ({ eventId }))),
       },
     });
   }

--- a/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
@@ -412,6 +412,10 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
         }),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -438,6 +442,10 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
         }),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -459,6 +467,16 @@ describe("Linq first-contact admission", () => {
         count: vi.fn().mockResolvedValueOnce(4),
         create: vi.fn(),
         findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_attempt_1" },
+          { eventId: "evt_attempt_2" },
+          { eventId: "evt_attempt_3" },
+          { eventId: "evt_attempt_4" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        // Four attempts that never recorded a terminal allow: the cap stands.
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -473,6 +491,170 @@ describe("Linq first-contact admission", () => {
     expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
   });
 
+  it("keeps the cap when every counted attempt for the contact recorded a block", async () => {
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(4),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_blocked_1" },
+          { eventId: "evt_blocked_2" },
+          { eventId: "evt_blocked_3" },
+          { eventId: "evt_blocked_4" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            confidence: 0.96,
+            decision: "block",
+            eventId: "evt_blocked_1",
+            source: "model",
+          },
+          {
+            confidence: 0.98,
+            decision: "block",
+            eventId: "evt_blocked_2",
+            source: "model",
+          },
+        ]),
+      },
+    };
+
+    // Only a terminal allow escapes the cap. Recorded blocks are still spent
+    // attempts, so the contact stays exhausted.
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toEqual({
+      attemptCount: 4,
+      kind: "exhausted",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+  });
+
+  it("reuses a recorded allow from an earlier event instead of spending another attempt", async () => {
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(2),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_earlier_allow" },
+          { eventId: "evt_earlier_unresolved" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([{
+          confidence: 0.87,
+          decision: "allow",
+          eventId: "evt_earlier_allow",
+          source: "model",
+        }]),
+      },
+    };
+
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toEqual({
+      decision: {
+        confidence: 0.87,
+        kind: "allow",
+        source: "model",
+      },
+      kind: "already_allowed",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+  });
+
+  it("reuses a recorded allow that landed after the contact reached the attempt cap", async () => {
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(4),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_race_1" },
+          { eventId: "evt_race_2" },
+          { eventId: "evt_race_3" },
+          { eventId: "evt_race_4" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        // Concurrent events claimed the last slots before the winning
+        // classifier call finished recording its allow.
+        findMany: vi.fn().mockResolvedValue([{
+          confidence: 1,
+          decision: "allow",
+          eventId: "evt_race_3",
+          source: "deterministic",
+        }]),
+      },
+    };
+
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toEqual({
+      decision: {
+        confidence: 1,
+        kind: "allow",
+        source: "deterministic",
+      },
+      kind: "already_allowed",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+  });
+
+  it("reads the recorded allow under every contact key version that still resolves", async () => {
+    mocks.participantContact.readCandidates = ["blind:v2:test-contact", "blind:v1:test-contact"];
+    mocks.participantContact.currentLookupKey = "blind:v2:test-contact";
+
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(1),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([{ eventId: "evt_rotated_allow" }]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([{
+          confidence: 0.91,
+          decision: "allow",
+          eventId: "evt_rotated_allow",
+          source: "model",
+        }]),
+      },
+    };
+
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toMatchObject({
+      kind: "already_allowed",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.findMany).toHaveBeenCalledWith({
+      select: {
+        eventId: true,
+      },
+      where: {
+        participantContactLookupKey: {
+          in: ["blind:v2:test-contact", "blind:v1:test-contact"],
+        },
+      },
+    });
+  });
+
   it("counts a fresh first-contact event as a single new attempt", async () => {
     const tx = {
       $executeRaw: vi.fn().mockResolvedValue(0),
@@ -484,6 +666,10 @@ describe("Linq first-contact admission", () => {
           participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
         }),
         findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([{ eventId: "evt_earlier_attempt" }]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -512,6 +698,10 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: "blind:v1:test-contact",
         }),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -548,6 +738,10 @@ describe("Linq first-contact admission", () => {
           participantContactLookupKey: "blind:v2:test-contact",
         }),
         findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([{ eventId: "evt_rotated_attempt" }]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -599,6 +793,13 @@ describe("Linq first-contact admission", () => {
           callOrder.push("findFirst");
           return null;
         }),
+        findMany: vi.fn(async () => {
+          callOrder.push("findMany");
+          return [];
+        }),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn(async () => []),
       },
     };
 

--- a/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
@@ -594,7 +594,7 @@ describe("Linq first-contact admission", () => {
           confidence: 1,
           decision: "allow",
           eventId: "evt_race_3",
-          source: "deterministic",
+          source: "model",
         }]),
       },
     };
@@ -607,9 +607,44 @@ describe("Linq first-contact admission", () => {
       decision: {
         confidence: 1,
         kind: "allow",
-        source: "deterministic",
+        source: "model",
       },
       kind: "already_allowed",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse a classifier-unavailable fail-open allow", async () => {
+    // A deterministic allow means nobody could check this sender, not that the
+    // sender is welcome. Reusing it would let one classifier outage admit a
+    // contact permanently, so the cap still applies.
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(4),
+        create: vi.fn(),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_unavailable_1" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue([{
+          confidence: 1,
+          decision: "allow",
+          eventId: "evt_unavailable_1",
+          source: "deterministic",
+        }]),
+      },
+    };
+
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toEqual({
+      attemptCount: 4,
+      kind: "exhausted",
     });
     expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
   });

--- a/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts
@@ -412,7 +412,12 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
         }),
-        findMany: vi.fn().mockResolvedValue([]),
+        // This event already holds one of the contact's three attempts.
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: BASE_REQUEST.eventId },
+          { eventId: "evt_earlier_attempt_1" },
+          { eventId: "evt_earlier_attempt_2" },
+        ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
         findMany: vi.fn().mockResolvedValue([]),
@@ -442,7 +447,11 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
         }),
-        findMany: vi.fn().mockResolvedValue([]),
+        // This event's own attempt row plus the one counted after it.
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: BASE_REQUEST.eventId },
+          { eventId: "evt_later_attempt" },
+        ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
         findMany: vi.fn().mockResolvedValue([]),
@@ -617,15 +626,19 @@ describe("Linq first-contact admission", () => {
   it("does not reuse a classifier-unavailable fail-open allow", async () => {
     // A deterministic allow means nobody could check this sender, not that the
     // sender is welcome. Reusing it would let one classifier outage admit a
-    // contact permanently, so the cap still applies.
+    // contact permanently, so the contact's four real attempts still bind.
     const tx = {
       $executeRaw: vi.fn().mockResolvedValue(0),
       hostedLinqFirstContactAdmissionBudget: {
-        count: vi.fn().mockResolvedValueOnce(4),
+        count: vi.fn().mockResolvedValueOnce(5),
         create: vi.fn(),
         findFirst: vi.fn().mockResolvedValueOnce(null),
         findMany: vi.fn().mockResolvedValue([
           { eventId: "evt_unavailable_1" },
+          { eventId: "evt_attempt_1" },
+          { eventId: "evt_attempt_2" },
+          { eventId: "evt_attempt_3" },
+          { eventId: "evt_attempt_4" },
         ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
@@ -638,15 +651,61 @@ describe("Linq first-contact admission", () => {
       },
     };
 
+    // Whether the fail-open row is charged is a separate question; what this
+    // asserts is that it is never handed back as an admission.
+    await expect(claimHostedLinqFirstContactAdmissionBudget({
+      eventId: BASE_REQUEST.eventId,
+      participantContact: BASE_PARTICIPANT_CONTACT,
+      tx,
+    })).resolves.toMatchObject({
+      kind: "exhausted",
+    });
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+  });
+
+  it("does not charge classifier-unavailable attempts against the contact's cap", async () => {
+    // Four events during one OpenAI outage. None of them reached the
+    // classifier, so none of them spent a classification: charging them would
+    // leave the contact with no reusable evidence and no attempts left, silent
+    // on every path until someone edited the database.
+    const tx = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      hostedLinqFirstContactAdmissionBudget: {
+        count: vi.fn().mockResolvedValueOnce(4),
+        create: vi.fn().mockResolvedValueOnce({
+          eventId: BASE_REQUEST.eventId,
+          participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
+          participantContactLookupKey: BASE_PARTICIPANT_CONTACT.lookupKey,
+        }),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_outage_1" },
+          { eventId: "evt_outage_2" },
+          { eventId: "evt_outage_3" },
+          { eventId: "evt_outage_4" },
+        ]),
+      },
+      hostedLinqFirstContactAdmissionDecision: {
+        findMany: vi.fn().mockResolvedValue(
+          [1, 2, 3, 4].map((index) => ({
+            confidence: 1,
+            decision: "allow",
+            eventId: `evt_outage_${index}`,
+            source: "deterministic",
+          })),
+        ),
+      },
+    };
+
     await expect(claimHostedLinqFirstContactAdmissionBudget({
       eventId: BASE_REQUEST.eventId,
       participantContact: BASE_PARTICIPANT_CONTACT,
       tx,
     })).resolves.toEqual({
-      attemptCount: 4,
-      kind: "exhausted",
+      attemptCount: 1,
+      kind: "claimed",
     });
-    expect(tx.hostedLinqFirstContactAdmissionBudget.create).not.toHaveBeenCalled();
+    expect(tx.hostedLinqFirstContactAdmissionBudget.create).toHaveBeenCalledTimes(1);
   });
 
   it("reads the recorded allow under every contact key version that still resolves", async () => {
@@ -733,7 +792,10 @@ describe("Linq first-contact admission", () => {
           participantContactKind: BASE_PARTICIPANT_CONTACT.kind,
           participantContactLookupKey: "blind:v1:test-contact",
         }),
-        findMany: vi.fn().mockResolvedValue([]),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: BASE_REQUEST.eventId },
+          { eventId: "evt_rotated_earlier_attempt" },
+        ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
         findMany: vi.fn().mockResolvedValue([]),
@@ -773,7 +835,10 @@ describe("Linq first-contact admission", () => {
           participantContactLookupKey: "blind:v2:test-contact",
         }),
         findFirst: vi.fn().mockResolvedValueOnce(null),
-        findMany: vi.fn().mockResolvedValue([{ eventId: "evt_rotated_attempt" }]),
+        findMany: vi.fn().mockResolvedValue([
+          { eventId: "evt_rotated_attempt_1" },
+          { eventId: "evt_rotated_attempt_2" },
+        ]),
       },
       hostedLinqFirstContactAdmissionDecision: {
         findMany: vi.fn().mockResolvedValue([]),

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -4747,6 +4747,61 @@ describe("Linq group chat auto-provision", () => {
     expect(plan.firstContactAdmissionRequest).toBeUndefined();
   });
 
+  it("plans one setup and private recovery link per day for an allowed unknown email sender", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000");
+
+    const planUnknownEmailSender = (input: { createdAt: string; eventId: string }) =>
+      planHostedOnboardingLinqWebhook({
+        event: buildLinqMessageReceivedEvent({
+          createdAt: input.createdAt,
+          eventId: input.eventId,
+          sender: "group-stranger@example.com",
+        }),
+        // The contact already cleared admission, so later messages are planned
+        // on the stored allow instead of a fresh classifier decision.
+        firstContactAdmissionDecision: {
+          confidence: 0.9,
+          kind: "allow",
+          source: "model",
+        },
+        prisma: prisma as never,
+        requireFirstContactAdmission: true,
+      });
+
+    const firstOfDay = await planUnknownEmailSender({
+      createdAt: "2026-06-24T12:00:00.000Z",
+      eventId: "evt_group_email_day1_first",
+    });
+    const laterSameDay = await planUnknownEmailSender({
+      createdAt: "2026-06-24T18:00:00.000Z",
+      eventId: "evt_group_email_day1_second",
+    });
+    const nextDay = await planUnknownEmailSender({
+      createdAt: "2026-06-25T09:00:00.000Z",
+      eventId: "evt_group_email_day2_first",
+    });
+
+    for (const plan of [firstOfDay, laterSameDay, nextDay]) {
+      expect(plan.response).toMatchObject({
+        ok: true,
+        reason: "sent-group-setup",
+      });
+      expect(plan.desiredSideEffects.map(({ payload }) => payload.template))
+        .toEqual(["group_setup", "group_email_recovery"]);
+    }
+
+    const effectIds = (plan: typeof firstOfDay) =>
+      plan.desiredSideEffects.map(({ effectId }) => effectId);
+    // Same day dedupes to the one offer already delivered; the next day earns
+    // a fresh in-group link and a fresh private recovery link.
+    expect(effectIds(laterSameDay)).toEqual(effectIds(firstOfDay));
+    expect(effectIds(nextDay)).toHaveLength(2);
+    for (const effectId of effectIds(nextDay)) {
+      expect(effectIds(firstOfDay)).not.toContain(effectId);
+    }
+  });
+
   it("offers the group setup link without an admission request when enforcement is off", async () => {
     const prisma = createStatefulThreadRoutePrisma();
     prisma.seedActiveManagedLinqLine("+15550000000");

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -4673,6 +4673,160 @@ describe("Linq group chat auto-provision", () => {
     expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
   });
 
+  it("screens an unknown group sender through first-contact admission before offering setup", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000");
+    mockSenderLookup(null);
+
+    try {
+      const plan = await planHostedOnboardingLinqWebhook({
+        event: buildLinqMessageReceivedEvent({}),
+        prisma: prisma as never,
+        requireFirstContactAdmission: true,
+      });
+
+      // A setup link is still a reply to a stranger, so the group planner hands
+      // the service layer the same admission request the direct planner does
+      // instead of answering on a second, looser policy.
+      expect(plan.response).toMatchObject({
+        ignored: true,
+        ok: true,
+        reason: "first-contact-admission-required",
+      });
+      expect(plan.firstContactAdmissionRequest).toMatchObject({
+        eventId: "evt_group_123",
+        participantContactKind: "phone",
+        partTypes: ["text"],
+        service: "imessage",
+        text: "How did we sleep?",
+      });
+      expect(plan.firstContactAdmissionParticipantContact).toMatchObject({
+        kind: "phone",
+        value: "+15551112222",
+      });
+      expect(plan.desiredSideEffects).toEqual([]);
+      expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
+
+      const plannerDetails = info.mock.calls.find(
+        ([message]) => message === "Hosted Linq webhook planner decision.",
+      )?.[1];
+      expect(plannerDetails).toMatchObject({
+        existingMemberActive: false,
+        existingMemberMatch: "none",
+        reason: "first-contact-admission-required",
+        routeStage: "first-contact-admission-required",
+      });
+    } finally {
+      info.mockRestore();
+    }
+  });
+
+  it("offers the group setup link once first-contact admission allows the unknown sender", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000");
+    mockSenderLookup(null);
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      firstContactAdmissionDecision: {
+        confidence: 0.9,
+        kind: "allow",
+        source: "model",
+      },
+      prisma: prisma as never,
+      requireFirstContactAdmission: true,
+    });
+
+    expect(plan.response).toMatchObject({
+      ok: true,
+      reason: "sent-group-setup",
+    });
+    expect(plan.desiredSideEffects.map(({ payload }) => payload.template))
+      .toEqual(["group_setup"]);
+    expect(plan.firstContactAdmissionRequest).toBeUndefined();
+  });
+
+  it("offers the group setup link without an admission request when enforcement is off", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000");
+    mockSenderLookup(null);
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      prisma: prisma as never,
+      requireFirstContactAdmission: false,
+    });
+
+    // The gate is opt-in: with enforcement off the unknown sender is answered
+    // exactly as before, and the classifier is never asked for.
+    expect(plan.response).toMatchObject({
+      ok: true,
+      reason: "sent-group-setup",
+    });
+    expect(plan.desiredSideEffects.map(({ payload }) => payload.template))
+      .toEqual(["group_setup"]);
+    expect(plan.firstContactAdmissionRequest).toBeUndefined();
+  });
+
+  it("offers group setup to a known but inactive member without a first-contact admission request", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000");
+    mockSenderLookup({
+      ...senderCore,
+      billingStatus: HostedBillingStatus.paused,
+    });
+    prisma.hostedMember.findUnique.mockResolvedValue({
+      accountGroupMemberships: [],
+      billingStatus: HostedBillingStatus.paused,
+      suspendedAt: null,
+      threadContainer: null,
+    });
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      prisma: prisma as never,
+      requireFirstContactAdmission: true,
+    });
+
+    // Admission screens strangers. A resolved member whose access lapsed is
+    // already known, so gating them would spend classifier budget re-deciding
+    // an identity the database can answer.
+    expect(plan.response).toMatchObject({
+      ok: true,
+      reason: "sent-group-setup",
+    });
+    expect(plan.desiredSideEffects.map(({ payload }) => payload.template))
+      .toEqual(["group_setup"]);
+    expect(plan.firstContactAdmissionRequest).toBeUndefined();
+  });
+
+  it("does not screen an unknown group sender on a line it could not answer on", async () => {
+    const prisma = createStatefulThreadRoutePrisma();
+    prisma.seedActiveManagedLinqLine("+15550000000", {
+      healthStatus: "degraded",
+      providerReputationStatus: "AT_RISK",
+    });
+    mockSenderLookup(null);
+
+    const plan = await planHostedOnboardingLinqWebhook({
+      event: buildLinqMessageReceivedEvent({}),
+      prisma: prisma as never,
+      requireFirstContactAdmission: true,
+    });
+
+    // The gate sits after the assignable-line check, so strangers on lines we
+    // could never reply from stay ignored instead of consuming classifier
+    // budget on a message that has no answer.
+    expect(plan.response).toMatchObject({
+      ignored: true,
+      ok: true,
+      reason: "group-chat-line-unavailable",
+    });
+    expect(plan.firstContactAdmissionRequest).toBeUndefined();
+    expect(plan.desiredSideEffects).toEqual([]);
+  });
+
   it("does not answer a standalone SMS opt-out command in an unknown group", async () => {
     const prisma = createStatefulThreadRoutePrisma();
     prisma.seedActiveManagedLinqLine("+15550000000");

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -228,6 +228,7 @@ import {
   buildHostedLinqGroupLineRecoveryMessage,
   buildHostedLinqGroupLineRecoverySourceRef,
 } from "@/src/lib/hosted-onboarding/linq-group-line-recovery";
+import { issueHostedLinqGroupEmailRecoveryToken } from "@/src/lib/hosted-onboarding/linq-group-setup";
 import {
   createHostedWebhookLinqMessageSideEffect,
   drainHostedLinqSideEffectsDirect,
@@ -3584,15 +3585,27 @@ describe("hosted Linq webhook transport", () => {
       return lookupKey;
     }
 
-    function buildGroupEmailRecoveryEffect(sourceEventId: string) {
+    // Dispatch re-opens the token to reject links that expired while the
+    // webhook sat in a backlog, so this fixture carries a real sealed token
+    // rather than a placeholder.
+    function buildGroupEmailRecoveryEffect(
+      sourceEventId: string,
+      observedAt = "2026-03-27T11:59:00.000Z",
+    ) {
       return createHostedWebhookLinqMessageSideEffect({
         assignedRecipientPhone: recoveryLinePhone,
-        occurredAt: "2026-03-27T11:59:00.000Z",
+        occurredAt: observedAt,
         participantContact: {
           kind: "email",
           value: unknownSenderEmail,
         },
-        recoveryToken: "murph_linq_group_email_v1.token",
+        recoveryToken: issueHostedLinqGroupEmailRecoveryToken({
+          chatId: "chat-group-email-budget",
+          now: new Date(observedAt),
+          observedAt,
+          participantEmail: unknownSenderEmail,
+          recipientPhone: recoveryLinePhone,
+        }),
         sourceEventId,
         template: "group_email_recovery",
         threadId: "chat-group-email-budget",
@@ -3641,6 +3654,84 @@ describe("hosted Linq webhook transport", () => {
             }),
           }),
         );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips a recovery link whose token expired before dispatch without spending line budget", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(dispatchNow);
+      const lookupKey = arrangeAssignableRecoveryLine();
+      const { line, prisma } = createHostedLinqLineCapacityPrisma({
+        maxNewConversationsPerDay: 10,
+        phoneNumberLookupKey: lookupKey,
+        proactiveConversationCount: 3,
+        proactiveConversationDayUtc: dispatchDayUtc,
+      });
+      // Two days of backlog: the token's 24-hour life is anchored to the
+      // provider's observed send time so plan retries stay byte-identical, so a
+      // late redelivery carries a link that is already dead on arrival.
+      const effect = buildGroupEmailRecoveryEffect(
+        "event-group-email-token-expired",
+        "2026-03-25T11:59:00.000Z",
+      );
+
+      try {
+        await expect(drainHostedLinqSideEffectsDirect({
+          prisma: prisma as never,
+          sideEffects: [effect],
+        })).resolves.toEqual({
+          sentCount: 0,
+          skipped: [{
+            effectId: effect.effectId,
+            reason: "notice_target_unauthorized",
+            template: "group_email_recovery",
+          }],
+        });
+
+        expect(createHostedLinqChat).not.toHaveBeenCalled();
+        // Freshness is checked before the capacity claim, so a link that cannot
+        // work never burns a slot the line could have spent on a live one.
+        expect(prisma.hostedLinqLine.updateMany).not.toHaveBeenCalled();
+        expect(line.proactiveConversationCount).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still sends a recovery link whose token is inside its lifetime at dispatch", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(dispatchNow);
+      const lookupKey = arrangeAssignableRecoveryLine();
+      const { line, prisma } = createHostedLinqLineCapacityPrisma({
+        maxNewConversationsPerDay: 10,
+        phoneNumberLookupKey: lookupKey,
+        proactiveConversationCount: 3,
+        proactiveConversationDayUtc: dispatchDayUtc,
+      });
+      // Issued 23.5 hours before dispatch: still inside the window, so the
+      // freshness guard must let an aged-but-live link through rather than
+      // rejecting anything that did not arrive immediately.
+      const effect = buildGroupEmailRecoveryEffect(
+        "event-group-email-token-fresh",
+        "2026-03-26T12:30:00.000Z",
+      );
+
+      try {
+        await expect(drainHostedLinqSideEffectsDirect({
+          prisma: prisma as never,
+          sideEffects: [effect],
+        })).resolves.toEqual({ sentCount: 1, skipped: [] });
+
+        expect(createHostedLinqChat).toHaveBeenCalledWith(
+          expect.objectContaining({
+            from: recoveryLinePhone,
+            idempotencyKey: effect.effectId,
+            to: [unknownSenderEmail],
+          }),
+        );
+        expect(line.proactiveConversationCount).toBe(4);
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION
## Why this PR exists

Unknown-group recovery shipped in #1221 with four known gaps left open. One of them can permanently mute a group chat with no attacker involved, and one lets a stranger reach Murph through a group without passing the screening that the same stranger would face in a direct message. This closes all four before the feature is deployed.

## User goal / user-visible behavior

A group that reaches Murph keeps getting a usable way in. If the first setup link goes to the wrong person or is ignored, the next day's message offers another one instead of leaving the chat silent forever. Strangers reaching Murph through a group are screened the same way strangers reaching it directly are. Nobody receives a recovery link that is already dead, and someone whose Messages address is already claimed by another account sees a clear conflict rather than a generic failure.

## User experience

No new screens or entry points. The recovery journey from #1221 is unchanged; this PR changes when it is offered and how one failure is reported, and adds one new terminal state on the existing `/groups/start` page with two new user-visible strings for the cross-account conflict.

- **Entry point.** Unchanged: an inbound group message on a healthy managed line whose sender is not a recognized active member.
- **What changes for the user.** A group that did not act on its first link is offered another on a later day. Previously the chat was a permanent dead end.
- **Timing class.** For an unresolved sender on an enforcing line, first contact now awaits the existing OpenAI admission classifier (10,000 ms timeout) before setup planning resumes, exactly as an unknown direct sender already does. Once that contact has a recorded *model-source* allow, later events reuse it and add no call. Every other change is a decision inside the existing webhook and dispatch paths and adds no awaited network work.
- **Failure and recovery.** Redeeming a link for an address already set up on another Murph account now returns a typed `409`, and the page renders a terminal conflict state that explains it and offers no retry, because retrying cannot succeed. The other account is never identified. Transient and stale-link failures keep the existing generic message and its Try again action.
- **Rendered evidence.** One new terminal conflict state on `/groups/start`, registered in the existing `/design?tab=sections` study so it is reviewable there.

## Invariants the PR must preserve

- One setup link per group chat per inbound UTC day, and one private recovery link per (address, chat, recipient line, day). Webhook retries within a day must still dedupe to a single send.
- Only a fully unresolved sender is screened by first-contact admission. A known-but-inactive member is not a stranger and must not consume classifier budget.
- Admission screening happens only after the line is known assignable, so strangers arriving on a line Murph cannot answer on never reach the classifier.
- With admission enforcement off — the repository default — no sender is screened and no classifier is called, so group *admission* behaves exactly as before. The two effect identities change unconditionally in both modes, which is the day-bucket fix itself.
- A recovery link that cannot be redeemed is never sent, and never consumes the line's daily new-conversation budget.
- The recover endpoint still fails loudly on errors that are not binding conflicts.

## Non-obvious affected surfaces

- **Effect-id identity for two templates.** `group_setup` and `group_email_recovery` idempotency keys change shape. Nothing is deployed yet — #1221 merged but has not shipped — so no in-flight effect can be orphaned by the change. Regression proof: the stable-within-a-day and distinct-across-days tests in `apps/web/test/hosted-linq-group-setup.test.ts`.
- **Group planner input surface.** `planHostedLinqGroupChatWebhook` now receives `requireFirstContactAdmission` and `firstContactAdmissionDecision`, which the outer planner already had and simply did not thread through. No service-layer change was required, because the service acts on `plan.firstContactAdmissionRequest` generically. Regression proof: the six admission-path tests in `apps/web/test/hosted-onboarding-linq-thread-route.test.ts`, including one pinning the enforcement-off path.
- **Contact-level admission budget is now consumed by group traffic.** `HostedLinqFirstContactAdmissionBudget` is contact-keyed and its four-attempt ceiling is per contact for its lifetime, not per chat or per day; `HostedLinqFirstContactAdmissionDecision` is keyed by `eventId`, and per `agent-docs/SECURITY.md` its instant-start provenance is contractually limited to the exact inbound that earned it. They are therefore two different authorities joined on event id, not one contact-level authority. Group offers draw on the contact-keyed budget only. Group offers therefore draw on the same budget. To keep repeat offers from exhausting it — which would both mute the group permanently and lock that address out of the direct path — a recorded *model-source* allow for the contact is reused instead of spending another attempt or re-running the classifier. Real blocks, model allows, and never-completed attempts all still count; a classifier-unavailable fail-open does not, because it never spent a classification. The inherited allow satisfies the gate for that invocation only: it is never written under the new event id, and the re-plan runs with instant start disabled, so a group classification can never become direct instant-start provenance for member creation, phone verification, or a Stripe-backed trial. Regression proof: the reuse, cap-preservation, key-rotation, later-day re-offer, and later-direct-contact tests in `apps/web/test/hosted-onboarding-linq-first-contact-admission.test.ts` and `hosted-onboarding-linq-dispatch.test.ts`.
- **Cross-domain import.** The recover route imports the exported `isUniqueViolation` from `apps/web/src/lib/device-sync/prisma-store/prisma-errors.ts` rather than adding a sixth local copy of the same predicate. `hosted-execution/internal-request-nonces.ts` already imports it across domains, so this follows existing precedent.

## Architecture and reuse

- **Existing systems reused:** `resolveHostedLinqDayUtc` for day bucketing, matching `buildHostedLinqConversationHomeRedirectEffectId`; the first-contact admission pipeline's builders (`buildFirstContactAdmissionRequiredPlan`, `buildHostedLinqFirstContactAdmissionRequest`) and its existing `runPlan(instantStartAllowed)` seam; `openHostedLinqGroupEmailRecoveryToken`, the reader the redeem endpoint already uses, as the dispatch freshness check; the shared `isUniqueViolation` predicate; the existing `throwRecoveryConflict` domain error; and the existing `HostedGroupStartFrame` for the new conflict state. The service-layer classify-and-replan loop is **not** unchanged: it gains one `already_allowed` branch (net 14 added / 1 removed at first, then reduced) that re-plans on a stored allow through the existing instant-start-disabled seam.
- **New logic:** four guards, a day component in two effect ids, one reused-allow branch in the admission claim, and one terminal conflict state in the client. 266 added source lines total.
- **New abstractions:** none. Each fix was expressible by threading an existing input or calling an existing function, which is why the source diff is small; adding a scheduler, a re-offer state machine, a second admission policy, or a bespoke expiry check would each have been a new concept where an existing one already fit.
- **Complexity intentionally avoided:** no schema migration, no re-offer queue or cron, no separate group-admission policy or classifier, no new error taxonomy, and no token-ownership verification flow. The bearer-token exposure is bounded by the day bucket rather than by adding an email-control challenge, which would have meant a new verification journey for a recovery path.

## Hot reply path impact

Not applicable. All changes sit on the unrouted-group, admission, and side-effect dispatch paths, which by definition carry no current conversation, so none of them touch the Foreground Reply Critical Path defined in `docs/contracts/00-invariants.md`.

Stated plainly because the first version of this section understated it: the admission gate does add one awaited provider call (the existing classifier, 10,000 ms timeout, one per contact until a model allow is recorded) plus four indexed reads on the admission tables for a reused-allow event: the exact-event decision `findUnique`, the budget `findFirst`, the budget `findMany`, and the decision `findMany`. The obsolete `count` was removed, so no path still issues it. All of this is on the unrouted-group path only, which is not the foreground reply path.

## Murph initial provider input impact

Not applicable for both individual and group Murph, in the sense the section measures: no prompt builder, instruction text, dynamic-tool description, schema, tool availability or deferral, skill, Codex version or configuration, model tool mode, or provider-request assembly is touched, so the assembled first provider-visible input for a Murph turn is byte-identical.

Disclosed separately because it is a provider-visible change of a different kind: the pre-existing OpenAI first-contact admission classifier now receives unknown-*group* sender content when enforcement is on. Its request is built by the unchanged `buildHostedLinqFirstContactAdmissionRequest` and carries message text, service, part types, and contact kind. This is new traffic to an existing call, not a new or modified provider request.

## Preliminary specialist lenses

- **Product experience — applicable.** Intended outcome: a group that reaches Murph is never permanently mute. Direct journey evidence: the day-bucket tests prove a second link is offered the next day; the exact gap is that no live end-to-end group send was exercised against a real managed line.
- **Prompt — applicable.** When enforcement is on, an unresolved group sender's message text, service, part types, and contact kind now reach the existing OpenAI first-contact classifier, which previously saw direct traffic only. The request builder, schema, and model are unchanged; only the traffic reaching them is new.
- **Frontend — applicable, with an evidence gap.** `HostedGroupStartClient` gains a terminal conflict state, added to the `/design?tab=sections` study. No redacted desktop/mobile captures were packaged this round, so the lens has no rendered artifact beyond the catalog state.
- **Coverage — applicable.** Focused local proof: `apps/web` typecheck exit 0 and the full `apps/web` suite exit 0 at 8419 tests, up 9 from the 8410 baseline. Every one of the four changes was revert-verified — the product change was mutated, the corresponding test observed failing, and the code restored. Exact-head CI: pending, starting concurrently with this pass.

## Anomaly retrospective (round 3, `RETROSPECTIVE_REQUIRED`)

Triggered by substantive round 3 and by the same mechanism producing the round-2 finding. Decision: **shrink, then explicitly justified continuation.**

**Requirement restated to one position.** A stored admission allow carries two facts on different axes, and conflating them caused all three rounds. On the *contact* axis it answers "may Murph answer this stranger at all" — a property of the contact, where the four-attempt cap exists to bound classifier spend and abuse, not to mute an already-admitted contact forever. On the *event* axis it answers "may this exact inbound mint a member, a verified phone, and a Stripe-backed trial" — which `agent-docs/SECURITY.md` makes deliberately non-transferable. Round 1 fixed the contact axis, round 2 removed the accidental crossing into the event axis, and round 3 narrows what qualifies on the contact axis.

**Which sources qualify for reuse.** Only a `model`-source allow. The only other allow this path persists is the classifier-unavailable fail-open (`source: "deterministic"`), which is evidence that nobody could check the sender rather than evidence the sender is welcome; reusing it would let one OpenAI outage admit a contact permanently. This deletes the question rather than guarding it, and makes the reuse rule strictly smaller.

**Lifetime and downstream effects of reuse.** Reuse satisfies the admission gate for that invocation only. It spends no attempt, calls no classifier, is never written under a later event id, and re-plans with instant start disabled. Instant-start authority therefore remains owned solely by the exact direct inbound that earned its own model allow.

### Second retrospective (round 4, `RETROSPECTIVE_REQUIRED`)

Round 4 showed the three positions above did not jointly satisfy the liveness outcome. Making the fail-open allow non-reusable was right, but its budget row still counted against the cap, so four events during one outage left a contact with no reusable evidence and no attempts — permanently silent on both paths, repairable only by a database edit. That is not hypothetical here: OpenAI credit exhaustion is a recurring incident for this service.

**Who owns classifier unavailability.** The cap bounds *classification spend and abuse*, so it counts attempts that produced a terminal model classification. A fail-open event did not, so it cannot consume one.

Stated precisely, because the shorthand "never reached the classifier" is wrong: the deterministic fallback can also follow a request that did leave the process — quota exhaustion, another non-success response, invalid JSON or output, or a timeout after dispatch. The counting rule distinguishes a terminal *deterministic fallback* from a terminal *model classification*, not whether provider egress began.

- *Does an unavailable-event fallback consume the lifetime budget?* No. It yielded no model decision.
- *Does the exact event still fail open?* Yes — unchanged, pre-existing behaviour, deliberately outside this PR.
- *How does a contact eventually get a real model decision?* Because outage events never consumed attempts, the contact still has its budget when the classifier recovers, without outage evidence ever becoming reusable.
- *How is exact-event-only model authority preserved?* Unchanged: nothing is written under a later event id, and reuse re-plans with instant start disabled.

Real blocks, model allows, and never-completed attempts all still count, so the spend and abuse bound keeps an enforceable meaning. Implementation is a counting rule in the same owner: the claim now derives the reusable allow and the chargeable count from one pair of reads, replacing the separate count and allow-lookup — fewer queries than before, and the now-dead `count` is removed from the store contract. No new owner, table, expiry, reset, or repair path.

**Shape.** First-reviewed head: 89 source additions / 13 deletions across four production files. Current: 266 / 44 across eight. Review remediation added 146 net authored-source lines (177 additions minus 31 deletions under `apps/`, excluding `apps/web/test/`), of which the terminal conflict state and its catalog entry are a product gap the review found rather than machinery the review created. Round 2 was a net source reduction; round 3 adds only a predicate and a comment.

**Why continuation rather than deletion, reversion, or splitting.** No new durable table, queue, scheduler, lease, fence, state machine, lifecycle owner, migration, or reconciliation pass was added in any round. The retained pieces are one result variant on an existing claim function, one branch in an existing service loop, and one render branch in an existing client component — each the smallest expression of an outcome the four original fixes require. Splitting would ship the day-bucket fix without the budget fix that keeps it working, which is the exact permanent-mute defect this PR exists to remove.

## Change-shape breakdown

Classification rule: paths under `apps/web/test/` are tests/fixtures; `agent-docs/` and `*.md` are docs; `.github/` and `scripts/` are config/tooling; everything else under `apps/` is authored source. No binary files, no generated code. Counts from `git diff --numstat origin/main...HEAD`.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 266 | 44 |
| Tests/fixtures | 1495 | 117 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1761** | **161** |

The ratio is deliberate: the behavioral claims here are all about *when* something is withheld, which is cheap to state and expensive to pin.

## Design proof

Catalog surface: [`/design?tab=sections`](https://www.withmurph.ai/design?tab=sections) — the "Unknown iMessage group setup and recovery" study now also renders the terminal cross-account conflict state added here (`apps/web/app/design/group-start-study.tsx`).

Hosted desktop and mobile screenshots were not captured this round, so the Frontend Design Proof check is red on that basis. That check is not in the repository's required status checks, and the omission was explicitly accepted by the repository owner for this line of work. The catalog study is the reviewable surface for the new state.

## Deployment skew / compatibility

Single deploy unit, `apps/web` only. No Cloudflare Worker, runner container, runner bundle, provider egress credential, runtime env, or persisted runtime state shape changes, so there is no warm-container skew window and `container_rollout=immediate` is not required.

The one consideration is effect-id identity. `group_setup` and `group_email_recovery` idempotency keys change shape, so an effect planned by the old code and dispatched by the new code would not dedupe against its predecessor. That window is empty in practice: #1221 is merged but not deployed, so no effect of either template has ever been planned in production. Reversibility is a plain revert. The realistic worst case if that assumption were wrong is one duplicate setup link in a single group chat, which is self-limiting and needs no reconciliation machinery.


ReviewGPT first-reviewed head: b04a5ab1f9886e31755ad606c011749ba0aebfea
