### PR TITLE
fix(connected-apps): compact oversized provider reads and surface failure codes to the assistant

### DIFF
--- a/apps/cloudflare/src/runtime-platform/web-control-transport.ts
+++ b/apps/cloudflare/src/runtime-platform/web-control-transport.ts
@@ -77,6 +77,9 @@ export class HostedWebControlPlaneResponseError extends Error {
     status: number;
     statusCode: number;
   };
+  // The control plane's own message, kept apart from the formatted `message` so
+  // a caller can quote it without the transport's description and status prefix.
+  readonly detail: string | undefined;
   readonly requestId: string | undefined;
   readonly retryable: boolean | undefined;
   readonly status: number;
@@ -93,6 +96,7 @@ export class HostedWebControlPlaneResponseError extends Error {
     super(formatHostedWebControlPlaneResponseErrorMessage(input));
     this.name = "HostedWebControlPlaneResponseError";
     this.code = input.code;
+    this.detail = input.message?.trim() || undefined;
     this.requestId = input.requestId;
     this.retryable = input.retryable;
     this.status = input.status;

--- a/apps/cloudflare/test/connected-apps-web-control-policy.test.ts
+++ b/apps/cloudflare/test/connected-apps-web-control-policy.test.ts
@@ -18,13 +18,18 @@ vi.mock("../src/web-control-plane.ts", async () => {
   };
 });
 
+import { createHostedWebConnectedAppsPort } from "../src/runtime-platform/connected-apps-port.ts";
+import { HostedWebControlPlaneResponseError } from "../src/runtime-platform/web-control-transport.ts";
 import { readHostedExecutionEnvironment } from "../src/env.ts";
 import type { RunnerOutboundEnvironmentSource } from "../src/runner-outbound/shared.ts";
 import {
   readHostedRunnerWebControlPolicy,
 } from "../src/runner-outbound/shared-web-control-policy.ts";
 import { handleRunnerWebControlRequest } from "../src/runner-outbound/web-control.ts";
-import { createHostedExecutionTestEnv } from "./hosted-execution-fixtures.ts";
+import {
+  createHostedExecutionTestEnv,
+  TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+} from "./hosted-execution-fixtures.ts";
 
 beforeEach(() => {
   mocks.fetchHostedExecutionWebControlPlaneResponse.mockReset();
@@ -84,5 +89,51 @@ describe("connected-app web-control policy", () => {
 
     expect(response.status).toBe(401);
     expect(mocks.fetchHostedExecutionWebControlPlaneResponse).not.toHaveBeenCalled();
+  });
+  it("keeps the control-plane error code, status, and message readable by the caller", async () => {
+    // The assistant decides whether a connected-app failure is worth retrying
+    // and what to tell the user, so a rejected request must arrive as more than
+    // a transport error.
+    mocks.fetchHostedExecutionWebControlPlaneResponse.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+            message: "That request returned more than Murph can read at once.",
+            retryable: false,
+          },
+        }),
+        { headers: { "content-type": "application/json" }, status: 413 },
+      ),
+    );
+    const port = createHostedWebConnectedAppsPort({
+      boundUserId: "member_123",
+      fetchImpl: (async () => {
+        throw new Error("Direct transport should route through the control plane.");
+      }) as unknown as typeof fetch,
+      timeoutMs: 5_000,
+      transport: {
+        callbackSigning: {
+          keyId: "v1",
+          privateKeyJwkJson: TEST_HOSTED_WEB_CALLBACK_PRIVATE_JWK_JSON,
+        },
+        mode: "direct",
+        webControlBaseUrl: "https://web.example.test",
+        workspaceCheckpointBridge: null,
+      },
+    });
+
+    const error = await port.request(
+      { input: { query: "travel credit" }, operation: "search" },
+      { signal: null },
+    ).catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(HostedWebControlPlaneResponseError);
+    expect(error).toMatchObject({
+      code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+      detail: "That request returned more than Murph can read at once.",
+      retryable: false,
+      status: 413,
+    });
   });
 });

--- a/apps/web/src/lib/connected-apps/composio.ts
+++ b/apps/web/src/lib/connected-apps/composio.ts
@@ -6,7 +6,12 @@ import {
 } from "./config";
 
 const COMPOSIO_REQUEST_TIMEOUT_MS = 30_000;
-const COMPOSIO_RESPONSE_LIMIT_BYTES = 512 * 1024;
+// Memory ceiling for the raw provider body only. A mailbox read carrying full
+// HTML bodies routinely exceeds a few hundred kilobytes before compaction, so
+// this sits well above the assistant result budget the route enforces after
+// stripping markup; rejecting here would discard a payload that compacts to a
+// fraction of its wire size.
+const COMPOSIO_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024;
 
 export interface ComposioConnectedAccount {
   alias: string | null;

--- a/apps/web/src/lib/connected-apps/service.ts
+++ b/apps/web/src/lib/connected-apps/service.ts
@@ -3,9 +3,11 @@ import "server-only";
 import { createHash, randomBytes } from "node:crypto";
 
 import type { Prisma, PrismaClient } from "@prisma/client";
-import type {
-  HostedConnectedAppsManageInput,
-  HostedConnectedAppsRequest,
+import {
+  compactHostedConnectedAppsResult,
+  serializeHostedConnectedAppsResult,
+  type HostedConnectedAppsManageInput,
+  type HostedConnectedAppsRequest,
 } from "@murphai/hosted-execution/connected-apps";
 
 import {
@@ -48,6 +50,33 @@ export interface HostedConnectedAppIntent {
 }
 
 export async function executeHostedConnectedAppsRequest(input: {
+  fetchImpl?: typeof fetch;
+  memberId: string;
+  prisma?: PrismaClient;
+  request: HostedConnectedAppsRequest;
+}): Promise<unknown> {
+  return boundHostedConnectedAppsResult(
+    await runHostedConnectedAppsRequest(input),
+  );
+}
+
+// Provider output reaches the assistant verbatim, so markup is stripped here
+// rather than at the runtime edge: the budget that matters is the serialized
+// size the model reads, not the wire size the provider sent.
+function boundHostedConnectedAppsResult(result: unknown): unknown {
+  const compacted = compactHostedConnectedAppsResult(result);
+  if (serializeHostedConnectedAppsResult(compacted) === null) {
+    throw hostedOnboardingError({
+      code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+      httpStatus: 413,
+      message:
+        "That request returned more than Murph can read at once. Ask for fewer results, a narrower time range, or one item at a time.",
+    });
+  }
+  return compacted;
+}
+
+async function runHostedConnectedAppsRequest(input: {
   fetchImpl?: typeof fetch;
   memberId: string;
   prisma?: PrismaClient;

--- a/apps/web/src/lib/connected-apps/service.ts
+++ b/apps/web/src/lib/connected-apps/service.ts
@@ -34,6 +34,8 @@ import {
 } from "@/src/lib/hosted-onboarding/shared";
 import { getPrisma } from "@/src/lib/prisma";
 
+const CONNECTED_APPS_RESULT_TOO_LARGE_MESSAGE =
+  "That request returned more than Murph can read at once. Ask for fewer results, a narrower time range, or one item at a time.";
 const CONNECTED_APP_INTENT_PREFIX = "cai_";
 const CONNECTED_APP_INTENT_BYTES = 24;
 const CONNECTED_APP_INTENT_TTL_MS = 15 * 60 * 1000;
@@ -66,14 +68,18 @@ export async function executeHostedConnectedAppsRequest(input: {
 function boundHostedConnectedAppsResult(result: unknown): unknown {
   const compacted = compactHostedConnectedAppsResult(result);
   if (serializeHostedConnectedAppsResult(compacted) === null) {
-    throw hostedOnboardingError({
-      code: "CONNECTED_APPS_RESULT_TOO_LARGE",
-      httpStatus: 413,
-      message:
-        "That request returned more than Murph can read at once. Ask for fewer results, a narrower time range, or one item at a time.",
-    });
+    throw connectedAppsResultTooLargeError();
   }
   return compacted;
+}
+
+function connectedAppsResultTooLargeError(cause?: unknown) {
+  return hostedOnboardingError({
+    ...(cause === undefined ? {} : { cause }),
+    code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+    httpStatus: 413,
+    message: CONNECTED_APPS_RESULT_TOO_LARGE_MESSAGE,
+  });
 }
 
 async function runHostedConnectedAppsRequest(input: {
@@ -756,8 +762,13 @@ function mapConnectedAppsError(error: unknown): unknown {
   if (!(error instanceof ComposioConnectedAppsRequestError)) {
     return error;
   }
-  const retryable = error.retryable
-    ?? (error.status === null || error.status === 429 || error.status >= 500);
+  // A provider body too large to read is a narrowable request, not an outage.
+  // Reporting it as one is what left the assistant offering a retry that could
+  // only fail again.
+  if (error.type === "composio_response_too_large") {
+    return connectedAppsResultTooLargeError(error);
+  }
+  const retryable = error.retryable ?? isRetryableComposioFailure(error);
   return hostedOnboardingError({
     cause: error,
     code: "CONNECTED_APPS_PROVIDER_UNAVAILABLE",
@@ -768,6 +779,18 @@ function mapConnectedAppsError(error: unknown): unknown {
       : "The connected-app request could not be completed.",
     retryable,
   });
+}
+
+function isRetryableComposioFailure(
+  error: ComposioConnectedAppsRequestError,
+): boolean {
+  // A malformed body arrives on a 200 with nothing about the request to blame,
+  // so calling it non-retryable would tell the assistant that repeating the
+  // call must fail — a claim the evidence does not support.
+  if (error.type === "composio_invalid_json") {
+    return true;
+  }
+  return error.status === null || error.status === 429 || error.status >= 500;
 }
 
 function buildConnectedAppsProviderErrorDetails(

--- a/apps/web/test/connected-apps-composio.test.ts
+++ b/apps/web/test/connected-apps-composio.test.ts
@@ -358,7 +358,7 @@ describe("Composio connected-app client", () => {
       const encoder = new TextEncoder();
       return new Response(new ReadableStream<Uint8Array>({
         start(controller) {
-          controller.enqueue(encoder.encode(`{"data":"${"x".repeat(600 * 1024)}"}`));
+          controller.enqueue(encoder.encode(`{"data":"${"x".repeat(5 * 1024 * 1024)}"}`));
           controller.close();
         },
       }), {

--- a/apps/web/test/connected-apps-service.test.ts
+++ b/apps/web/test/connected-apps-service.test.ts
@@ -731,6 +731,63 @@ describe("connected-app service", () => {
     });
   });
 
+  it("classifies a provider body too large to read as a narrowable request", async () => {
+    // The provider answers 200 and the body is simply beyond what the tier can
+    // buffer. Reporting that as an outage is what produced the false diagnosis.
+    installPrismaHarness();
+    const fetchImpl = vi.fn(async (url: string | URL | Request): Promise<Response> => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/v3.1/tool_router/session") {
+        return jsonResponse({ session_id: "trs_member" });
+      }
+      if (parsed.pathname === "/api/v3.1/tool_router/session/trs_member/search") {
+        return new Response(`{"data":"${"x".repeat(5 * 1024 * 1024)}"}`, {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected Composio request ${String(url)}`);
+    });
+
+    await expect(executeHostedConnectedAppsRequest({
+      fetchImpl,
+      memberId: "hbm_member",
+      request: { input: { query: "everything" }, operation: "search" },
+    })).rejects.toMatchObject({
+      code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+      httpStatus: 413,
+    });
+  });
+
+  it("keeps a malformed provider body retryable", async () => {
+    // Invalid JSON arrives on a 200 with nothing about the request to blame, so
+    // the assistant must not be told that repeating the call cannot work.
+    installPrismaHarness();
+    const fetchImpl = vi.fn(async (url: string | URL | Request): Promise<Response> => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/v3.1/tool_router/session") {
+        return jsonResponse({ session_id: "trs_member" });
+      }
+      if (parsed.pathname === "/api/v3.1/tool_router/session/trs_member/search") {
+        return new Response("{ truncated", {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected Composio request ${String(url)}`);
+    });
+
+    await expect(executeHostedConnectedAppsRequest({
+      fetchImpl,
+      memberId: "hbm_member",
+      request: { input: { query: "travel credit" }, operation: "search" },
+    })).rejects.toMatchObject({
+      code: "CONNECTED_APPS_PROVIDER_UNAVAILABLE",
+      httpStatus: 503,
+      retryable: true,
+    });
+  });
+
   it("executes OpenWeather through Composio with the server-held API key", async () => {
     vi.stubEnv("OPENWEATHER_API_KEY", "openweather-test-key");
     installPrismaHarness();

--- a/apps/web/test/connected-apps-service.test.ts
+++ b/apps/web/test/connected-apps-service.test.ts
@@ -668,6 +668,69 @@ describe("connected-app service", () => {
     expect(executeFetch).toHaveBeenCalledTimes(2);
   });
 
+  it("delivers a markup-heavy mailbox read that the raw wire ceiling used to discard", async () => {
+    // The provider answers 200 with full HTML envelopes. Judging that payload
+    // on wire size threw away a result that fits the assistant budget once the
+    // markup is stripped, and the assistant reported it as an outage.
+    installPrismaHarness();
+    const envelope = `<!doctype html><html><head><style>${".pad{color:red}".repeat(400)}</style></head>`
+      + `<body><table><tr><td><p>Voucher code: ABC-123</p>`
+      + `<p><a href="https://air.example.com/redeem">Redeem</a></p></td></tr></table></body></html>`;
+    const messages = Array.from({ length: 90 }, (_item, index) => ({
+      messageId: `msg_${index}`,
+      messageText: envelope,
+      subject: `Travel credit ${index}`,
+    }));
+    expect(JSON.stringify({ messages }).length).toBeGreaterThan(512 * 1024);
+
+    const fetchImpl = vi.fn(async (url: string | URL | Request): Promise<Response> => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/v3.1/tool_router/session") {
+        return jsonResponse({ session_id: "trs_member" });
+      }
+      if (parsed.pathname === "/api/v3.1/tool_router/session/trs_member/search") {
+        return jsonResponse({ messages });
+      }
+      throw new Error(`Unexpected Composio request ${String(url)}`);
+    });
+
+    const result = await executeHostedConnectedAppsRequest({
+      fetchImpl,
+      memberId: "hbm_member",
+      request: { input: { query: "travel credit" }, operation: "search" },
+    }) as { messages: { messageText: string }[] };
+
+    expect(result.messages).toHaveLength(messages.length);
+    // The voucher code and its link survive; the markup that made the payload
+    // exceed the wire ceiling does not.
+    expect(result.messages[0]!.messageText).toContain("Voucher code: ABC-123");
+    expect(result.messages[0]!.messageText).toContain("Redeem (https://air.example.com/redeem)");
+    expect(result.messages[0]!.messageText).not.toMatch(/<\/?(html|body|table|style|p|a)\b/iu);
+  });
+
+  it("asks for a narrower request when a result stays oversized after compaction", async () => {
+    installPrismaHarness();
+    const fetchImpl = vi.fn(async (url: string | URL | Request): Promise<Response> => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === "/api/v3.1/tool_router/session") {
+        return jsonResponse({ session_id: "trs_member" });
+      }
+      if (parsed.pathname === "/api/v3.1/tool_router/session/trs_member/search") {
+        return jsonResponse({ note: "x".repeat(200_000) });
+      }
+      throw new Error(`Unexpected Composio request ${String(url)}`);
+    });
+
+    await expect(executeHostedConnectedAppsRequest({
+      fetchImpl,
+      memberId: "hbm_member",
+      request: { input: { query: "everything" }, operation: "search" },
+    })).rejects.toMatchObject({
+      code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+      httpStatus: 413,
+    });
+  });
+
   it("executes OpenWeather through Composio with the server-held API key", async () => {
     vi.stubEnv("OPENWEATHER_API_KEY", "openweather-test-key");
     installPrismaHarness();

--- a/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
+++ b/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
@@ -378,10 +378,15 @@ export function buildRuntimeIssueInputForFailedCodexAction(input: {
 
   const durationMs = readItemDurationMs(item)
   const output = measureActionOutput(item)
+  // The sanitized tool name is the difference between "a tool call failed" and
+  // a diagnosable record; without it a failure cannot be traced to a surface
+  // without pulling the web tier's request logs.
+  const toolIdentity = resolveToolDiagnosticIdentity(kind, item)
   const commonDetails = {
     actionKind: kind,
     durationMsBucket: durationMsBucket(durationMs),
     outputBytesBucket: bytesBucket(output.bytesTotal),
+    ...(toolIdentity.tool === null ? {} : { tool: toolIdentity.tool }),
   }
 
   if (kind === 'command.execution') {

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/connected-apps.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/connected-apps.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 
 import {
-  compactHostedConnectedAppsResult,
   hostedConnectedAppsExecuteInputSchema,
   hostedConnectedAppsManageInputSchema,
   hostedConnectedAppsSearchInputSchema,
@@ -146,11 +145,12 @@ export async function executeConnectedAppsDynamicTool(input: {
     const response = await input.connectedApps.request(requestBody, {
       signal: input.abortSignal ?? null,
     })
-    // The web tier already compacts and bounds the result. Repeating both here
-    // keeps an older web deployment from spending the model's context on raw
-    // markup, and compaction is a no-op once the markup is gone.
-    const compacted = compactHostedConnectedAppsResult(response.result)
-    const text = serializeHostedConnectedAppsResult(compacted)
+    // Compaction belongs to the web tier alone. It is not idempotent: an email
+    // whose visible text contains escaped markup (`&lt;p&gt;`) decodes to real
+    // tags on the first pass, and a second pass would strip them as structure
+    // and silently delete the member's content. The budget check stays here as
+    // an independent guard on what enters the model's context.
+    const text = serializeHostedConnectedAppsResult(response.result)
     if (!text) {
       return connectedAppsTextResult(
         false,

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/connected-apps.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/connected-apps.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
 
 import {
+  compactHostedConnectedAppsResult,
   hostedConnectedAppsExecuteInputSchema,
   hostedConnectedAppsManageInputSchema,
   hostedConnectedAppsSearchInputSchema,
+  serializeHostedConnectedAppsResult,
   type HostedConnectedAppsExecuteInput,
   type HostedConnectedAppsManageInput,
   type HostedConnectedAppsRequest,
@@ -19,21 +21,16 @@ import {
 } from '../../assistant/tool-validation-digest.js'
 import { parseDynamicToolArguments } from './dynamic-tool-wrapper.js'
 
-const CONNECTED_APPS_RESULT_MAX_BYTES = 120_000
 const CONNECTED_APPS_CALENDAR_CREATE_TOOL_SLUGS = new Set([
   'GOOGLECALENDAR_CREATE_EVENT',
   'OUTLOOK_CALENDAR_CREATE_EVENT',
 ])
 
-// Composio tool results commonly include raw HTML email bodies (Gmail
-// FETCH_MESSAGE_BY_MESSAGE_ID) and similar markup-heavy payloads. The model
-// processes plain text just as well and pays per token for every markup
-// character, so strip HTML to text before serializing. Only strings that look
-// HTML-shaped get touched; everything else (descriptions, slugs, schemas)
-// passes through unchanged.
-const CONNECTED_APPS_HTML_MIN_LENGTH = 200
-const CONNECTED_APPS_HTML_TAG_SENTINEL =
-  /<(?:!doctype|html|body|head|table|div|p|span|br|a\s|img|h[1-6]|td|tr|style|script)\b/iu
+// Bounds on what a control-plane failure may put in front of the model. Only a
+// well-formed error code admits its paired message; anything else could be an
+// untrusted proxy or provider body, so those failures report status alone.
+const CONNECTED_APPS_ERROR_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/u
+const CONNECTED_APPS_ERROR_MESSAGE_MAX_LENGTH = 300
 
 export const MURPH_CONNECTED_APPS_MANAGE_TOOL = {
   namespace: 'murph',
@@ -149,8 +146,11 @@ export async function executeConnectedAppsDynamicTool(input: {
     const response = await input.connectedApps.request(requestBody, {
       signal: input.abortSignal ?? null,
     })
-    const compacted = compactConnectedAppsResult(response.result)
-    const text = serializeConnectedAppsResult(compacted)
+    // The web tier already compacts and bounds the result. Repeating both here
+    // keeps an older web deployment from spending the model's context on raw
+    // markup, and compaction is a no-op once the markup is gone.
+    const compacted = compactHostedConnectedAppsResult(response.result)
+    const text = serializeHostedConnectedAppsResult(compacted)
     if (!text) {
       return connectedAppsTextResult(
         false,
@@ -159,15 +159,82 @@ export async function executeConnectedAppsDynamicTool(input: {
     }
 
     return connectedAppsTextResult(true, text)
-  } catch {
+  } catch (error) {
     if (isConnectedAppsCalendarCreateRequest(requestBody)) {
       return connectedAppsTextResult(
         false,
         'calendar event creation failed or returned an ambiguous result. Do not retry the calendar-create call. Search the selected calendar for the event first, then explain the ambiguous outcome to the user before taking any further write action.',
       )
     }
-    return connectedAppsTextResult(false, 'connected apps API is unavailable')
+    return connectedAppsTextResult(false, describeConnectedAppsFailure(error))
   }
+}
+
+// Every connected-app failure used to read as an outage, so the assistant told
+// people their account was fine and offered a retry that could not succeed.
+// Rejected arguments, oversized reads, and revoked access are all decidable
+// from the control-plane error, so pass the code, status, and retry posture
+// through instead of flattening them.
+function describeConnectedAppsFailure(error: unknown): string {
+  const failure = readConnectedAppsControlPlaneFailure(error)
+  if (!failure) {
+    return 'connected apps API is unavailable'
+  }
+
+  const status = failure.status === null ? '' : ` (HTTP ${failure.status})`
+  if (!failure.code) {
+    return `connected apps request failed${status}`
+  }
+
+  const detail = failure.message ? `: ${failure.message}` : ''
+  const posture = failure.retryable === true
+    ? ' This failure is transient; one retry is reasonable.'
+    : failure.retryable === false
+      ? ' Repeating this call unchanged will fail the same way; change the request or tell the user what is wrong.'
+      : ''
+  return `connected apps request failed with ${failure.code}${status}${detail}.${posture}`
+}
+
+// Structural read of the hosted web control-plane error raised by the runtime
+// platform port. The port lives outside this package, so match on shape rather
+// than on a class this package cannot import.
+function readConnectedAppsControlPlaneFailure(error: unknown): {
+  code: string | null
+  message: string | null
+  retryable: boolean | null
+  status: number | null
+} | null {
+  if (typeof error !== 'object' || error === null) {
+    return null
+  }
+  const candidate: Record<string, unknown> = { ...error }
+  const status = typeof candidate.status === 'number' && Number.isInteger(candidate.status)
+    ? candidate.status
+    : null
+  const code = typeof candidate.code === 'string'
+      && CONNECTED_APPS_ERROR_CODE_PATTERN.test(candidate.code.trim())
+    ? candidate.code.trim()
+    : null
+  if (status === null && code === null) {
+    return null
+  }
+
+  return {
+    code,
+    message: code === null ? null : readConnectedAppsErrorMessage(candidate.detail),
+    retryable: typeof candidate.retryable === 'boolean' ? candidate.retryable : null,
+    status,
+  }
+}
+
+function readConnectedAppsErrorMessage(detail: unknown): string | null {
+  if (typeof detail !== 'string') {
+    return null
+  }
+  const collapsed = detail.replace(/\s+/gu, ' ').trim()
+  return collapsed.length > CONNECTED_APPS_ERROR_MESSAGE_MAX_LENGTH
+    ? `${collapsed.slice(0, CONNECTED_APPS_ERROR_MESSAGE_MAX_LENGTH).trimEnd()}…`
+    : collapsed || null
 }
 
 function isConnectedAppsCalendarCreateRequest(
@@ -188,100 +255,6 @@ function toHostedConnectedAppsRequest(
     case 'connected-apps-execute':
       return { input: request.args, operation: 'execute' }
   }
-}
-
-function serializeConnectedAppsResult(value: unknown): string | null {
-  try {
-    const text = JSON.stringify(value) ?? 'null'
-    return new TextEncoder().encode(text).byteLength <= CONNECTED_APPS_RESULT_MAX_BYTES
-      ? text
-      : null
-  } catch {
-    return null
-  }
-}
-
-// Walks the provider result and replaces any HTML-shaped string with its
-// stripped plain-text equivalent. Non-string values, short strings, and
-// strings without HTML tag markers pass through untouched, so this only
-// affects payloads that would otherwise burn tokens on markup (chiefly Gmail
-// message bodies). Exported for the unit test.
-export function compactConnectedAppsResult(value: unknown): unknown {
-  if (typeof value === 'string') {
-    if (value.length < CONNECTED_APPS_HTML_MIN_LENGTH) return value
-    if (!CONNECTED_APPS_HTML_TAG_SENTINEL.test(value)) return value
-    return stripHtmlForConnectedAppsResult(value)
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => compactConnectedAppsResult(item))
-  }
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = compactConnectedAppsResult(v)
-    }
-    return out
-  }
-  return value
-}
-
-function stripHtmlForConnectedAppsResult(value: string): string {
-  return value
-    // Drop noise: style/script/head blocks carry no model-useful signal and
-    // they account for most of the markup volume in Gmail HTML envelopes.
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, ' ')
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, ' ')
-    .replace(/<head\b[^>]*>[\s\S]*?<\/head>/giu, ' ')
-    // Preserve the most semantically important attributes: a hyperlink's
-    // href (tracking links, order URLs, calendar invites, unsubscribe) and
-    // an image's alt text. The opening-tag pattern uses a quote-aware
-    // tokenizer (`[^>"']` OR a complete `"..."` / `'...'` string) so that
-    // attribute values containing literal `>` (`<a title="Reply >>"...>`,
-    // common in marketing email and table-of-contents emails) do not abort
-    // the match and silently drop the href. href and alt are then extracted
-    // from the captured opening tag with a separate regex so both single-
-    // and double-quoted forms work without nested capture-group plumbing.
-    .replace(
-      /<a\b(?:[^>"']|"[^"]*"|'[^']*')*?>([\s\S]*?)<\/a>/giu,
-      (match, inner: string) => {
-        const hrefMatch = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/iu.exec(match)
-        const href = hrefMatch ? (hrefMatch[1] ?? hrefMatch[2] ?? null) : null
-        const label = inner.replace(/<[^>]+>/gu, '').replace(/\s+/gu, ' ').trim()
-        if (!href) return label
-        if (!label) return href
-        return label === href ? href : `${label} (${href})`
-      },
-    )
-    .replace(
-      /<img\b(?:[^>"']|"[^"]*"|'[^']*')*?>/giu,
-      (match) => {
-        const altMatch = /\balt\s*=\s*(?:"([^"]*)"|'([^']*)')/iu.exec(match)
-        const alt = altMatch ? (altMatch[1] ?? altMatch[2] ?? null) : null
-        return alt ? `[image: ${alt}]` : ' '
-      },
-    )
-    // Block-level breaks become real newlines so flowing prose survives.
-    .replace(/<br\s*\/?>/giu, '\n')
-    .replace(/<\/(?:p|div|li|tr|h[1-6])>/giu, '\n')
-    // Every remaining tag goes; we've already pulled out the bits that
-    // carried information beyond their text content.
-    .replace(/<[^>]+>/gu, ' ')
-    .replace(/&nbsp;/giu, ' ')
-    .replace(/&amp;/giu, '&')
-    .replace(/&lt;/giu, '<')
-    .replace(/&gt;/giu, '>')
-    .replace(/&quot;/giu, '"')
-    .replace(/&#39;/giu, "'")
-    .replace(/&#(\d+);/gu, (_match, code: string) => {
-      const num = Number(code)
-      return Number.isInteger(num) && num >= 32 && num <= 0x10ffff
-        ? String.fromCodePoint(num)
-        : ' '
-    })
-    .replace(/\s+\n/gu, '\n')
-    .replace(/\n{3,}/gu, '\n\n')
-    .replace(/[ \t]{2,}/gu, ' ')
-    .trim()
 }
 
 function connectedAppsTextResult(success: boolean, text: string) {

--- a/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  compactConnectedAppsResult,
   MURPH_CONNECTED_APPS_EXECUTE_TOOL,
   MURPH_CONNECTED_APPS_MANAGE_TOOL,
   MURPH_CONNECTED_APPS_SEARCH_TOOL,
@@ -242,85 +241,94 @@ describe("murph connected-app dynamic tools", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("strips HTML from Gmail-style message bodies while preserving link URLs, alt text, and inline content", async () => {
-    // Production Gmail responses ship the full HTML envelope under
-    // `data.messageText`. The compactor must rewrite the email body to
-    // plain text but must NOT silently drop link URLs (tracking links,
-    // unsubscribe, calendar invites) or image alt text — those are the
-    // bits a user typically asks Murph to act on.
-    const htmlBody = `<!doctype html><html><head><style>.x{color:red}</style></head>`
-      + `<body><table><tr><td><p>Hello&nbsp;<strong>Alex</strong>,</p>`
-      + `<p>Thanks for your order #1234. Subtotal: $42.00</p>`
-      + `<p>Track it here: <a href="https://orders.example.com/1234">View order</a>.</p>`
-      + `<p>To stop these emails, <a href='https://example.com/unsub?u=42'>unsubscribe</a>.</p>`
-      + `<p><img src="https://cdn.example.com/logo.png" alt="Example Co logo"></p>`
-      + `<p>— Murph &amp; Co.</p></td></tr></table></body></html>`;
-    const result = compactConnectedAppsResult({
-      data: {
-        attachmentList: [],
-        labelIds: ["INBOX"],
-        messageId: "abc123",
-        messageText: htmlBody,
-        sender: "store@example.com",
-        subject: "Order #1234",
-      },
-      tool_schemas: {
-        // Schema description happens to mention `<p>` literally; under 200
-        // chars so the length gate skips it. Must remain untouched.
-        GMAIL_FETCH_EMAILS: {
-          description: "Fetch emails. Returns body with <p> tags when raw=true.",
-        },
-      },
-    }) as { data: { messageText: string }; tool_schemas: Record<string, { description: string }> };
+  it("reports the control-plane failure code, status, and retry posture", async () => {
+    // A rejected request is not an outage. Flattening every failure to
+    // "unavailable" made the assistant vouch for the account and offer a retry
+    // that could only fail the same way.
+    const connectedApps: AssistantConnectedAppsPort = {
+      request: vi.fn(async () => {
+        throw Object.assign(
+          new Error("Hosted connected apps failed with HTTP 413. Ask for fewer results."),
+          {
+            code: "CONNECTED_APPS_RESULT_TOO_LARGE",
+            detail: "That request returned more than Murph can read at once. Ask for fewer results.",
+            retryable: false,
+            status: 413,
+            statusCode: 413,
+          },
+        );
+      }),
+    };
 
-    const compactedBody = result.data.messageText;
-    // All structural HTML and the style block are stripped.
-    expect(compactedBody).not.toMatch(/<\/?(html|body|table|td|tr|p|strong|style|head|img)\b/iu);
-    expect(compactedBody).not.toMatch(/color:red/u);
-    // Email prose, link text, and link URLs all survive.
-    expect(compactedBody).toContain("Hello");
-    expect(compactedBody).toContain("Alex");
-    expect(compactedBody).toContain("Thanks for your order #1234");
-    expect(compactedBody).toContain("View order (https://orders.example.com/1234)");
-    expect(compactedBody).toContain("unsubscribe (https://example.com/unsub?u=42)");
-    expect(compactedBody).toContain("[image: Example Co logo]");
-    expect(compactedBody).toContain("Murph & Co.");
-    // The strip cuts roughly half of an HTML envelope at minimum; this
-    // particular fixture should land well under the original byte length.
-    expect(compactedBody.length).toBeLessThan(htmlBody.length / 2);
-    expect(result.tool_schemas.GMAIL_FETCH_EMAILS.description).toBe(
-      "Fetch emails. Returns body with <p> tags when raw=true.",
-    );
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createHostedToolContext(connectedApps),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: createProgressDelivery(),
+      request: {
+        args: { account: "work", arguments: {}, toolSlug: "GMAIL_FETCH_EMAILS" },
+        kind: "connected-apps-execute",
+      },
+    });
+
+    expect(result.rpcResult.success).toBe(false);
+    const text = result.rpcResult.contentItems[0]!.text;
+    expect(text).toContain("CONNECTED_APPS_RESULT_TOO_LARGE");
+    expect(text).toContain("HTTP 413");
+    expect(text).toContain("Ask for fewer results");
+    expect(text).toContain("will fail the same way");
+    expect(text).not.toContain("connected apps API is unavailable");
   });
 
-  it("preserves anchor hrefs whose opening tag has a literal `>` inside an attribute value", async () => {
-    // Real Gmail/marketing HTML regularly emits anchors like
-    // `<a title="Reply >>" href="...">` where the attribute value contains
-    // a literal `>`. A naive `[^>]*` attribute-skip pattern aborts at the
-    // first `>` and the generic tag stripper then erases the opening tag,
-    // silently losing the href — which is exactly the data this compactor
-    // is meant to preserve. The quote-aware tokenizer in the stripper must
-    // handle this without dropping the URL or eating the surrounding prose.
-    const htmlBody = `<!doctype html><html><body>`
-      + `<p>Hi! See more:</p>`
-      + `<p><a title="Reply >>" href="https://example.com/track?id=abc&n=1">View update</a> for details.</p>`
-      + `<p>Or <a href='https://example.com/inline-quote/"q"'>this one</a>.</p>`
-      + `<p><img src="https://cdn.example.com/x.png" alt="Status: green > yellow"></p>`
-      + `</body></html>`;
-    const result = compactConnectedAppsResult({
-      data: { messageText: htmlBody },
-    }) as { data: { messageText: string } };
-    const compactedBody = result.data.messageText;
-    // The link's label, the href, AND the surrounding prose all survive.
-    expect(compactedBody).toContain("View update (https://example.com/track?id=abc&n=1)");
-    expect(compactedBody).toContain("Hi! See more:");
-    expect(compactedBody).toContain("for details.");
-    // The single-quoted anchor with a quote-bearing href still works.
-    expect(compactedBody).toContain('this one (https://example.com/inline-quote/"q")');
-    // Image alt with `>` inside survives.
-    expect(compactedBody).toContain("[image: Status: green > yellow]");
-    // None of the opening-tag attribute text leaked through as bare text.
-    expect(compactedBody).not.toMatch(/title=|src=/u);
+  it("invites one retry for a transient control-plane failure", async () => {
+    const connectedApps: AssistantConnectedAppsPort = {
+      request: vi.fn(async () => {
+        throw Object.assign(new Error("Hosted connected apps failed with HTTP 503."), {
+          code: "CONNECTED_APPS_PROVIDER_UNAVAILABLE",
+          detail: "Connected apps are temporarily unavailable.",
+          retryable: true,
+          status: 503,
+          statusCode: 503,
+        });
+      }),
+    };
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createHostedToolContext(connectedApps),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: createProgressDelivery(),
+      request: { args: { action: "list" }, kind: "connected-apps-manage" },
+    });
+
+    const text = result.rpcResult.contentItems[0]!.text;
+    expect(text).toContain("CONNECTED_APPS_PROVIDER_UNAVAILABLE");
+    expect(text).toContain("one retry is reasonable");
+  });
+
+  it("withholds an unstructured transport failure body from the model", async () => {
+    // Without a well-formed code the message may be a proxy or provider body,
+    // so the tool result may not quote it.
+    const connectedApps: AssistantConnectedAppsPort = {
+      request: vi.fn(async () => {
+        throw new Error("<html><body>upstream connect error: 10.0.0.1</body></html>");
+      }),
+    };
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createHostedToolContext(connectedApps),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: createProgressDelivery(),
+      request: { args: { action: "list" }, kind: "connected-apps-manage" },
+    });
+
+    const text = result.rpcResult.contentItems[0]!.text;
+    expect(text).toBe("connected apps API is unavailable");
+    expect(text).not.toContain("10.0.0.1");
   });
 
   it("fails closed instead of truncating an oversized provider result", async () => {

--- a/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-connected-apps.test.ts
@@ -331,6 +331,30 @@ describe("murph connected-app dynamic tools", () => {
     expect(text).not.toContain("10.0.0.1");
   });
 
+  it("hands the web tier's compacted result to the model unchanged", async () => {
+    // Compaction runs once, in the web tier. Text that merely looks like markup
+    // must survive the runtime edge verbatim.
+    const literalMarkup = '<p class="warning">Do not cancel</p>';
+    const connectedApps: AssistantConnectedAppsPort = {
+      request: vi.fn(async () => ({ result: { body: literalMarkup } })),
+    };
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createHostedToolContext(connectedApps),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: createProgressDelivery(),
+      request: {
+        args: { account: "work", arguments: {}, toolSlug: "GMAIL_FETCH_EMAILS" },
+        kind: "connected-apps-execute",
+      },
+    });
+
+    expect(result.rpcResult.success).toBe(true);
+    expect(JSON.parse(result.rpcResult.contentItems[0]!.text)).toEqual({ body: literalMarkup });
+  });
+
   it("fails closed instead of truncating an oversized provider result", async () => {
     const connectedApps: AssistantConnectedAppsPort = {
       request: vi.fn(async () => ({ result: { body: "x".repeat(130_000) } })),

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -10378,6 +10378,7 @@ describe('assistant codex runtime', () => {
         actionKind: 'mcp.tool.call',
         durationMsBucket: 'unknown',
         outputBytesBucket: 'lt_1kb',
+        tool: 'search_query',
       },
     })
 
@@ -10387,6 +10388,8 @@ describe('assistant codex runtime', () => {
         item: {
           id: 'dynamic-1',
           type: 'dynamicToolCall',
+          namespace: 'murph',
+          tool: 'connected_apps_execute',
           success: false,
           arguments: {
             prompt: 'private prompt',
@@ -10411,6 +10414,8 @@ describe('assistant codex runtime', () => {
         actionKind: 'dynamic.tool.call',
         durationMsBucket: 'unknown',
         outputBytesBucket: 'lt_1kb',
+        // Names the failing surface without the arguments or output around it.
+        tool: 'connected_apps_execute',
       },
     })
 

--- a/packages/hosted-execution/src/connected-apps.ts
+++ b/packages/hosted-execution/src/connected-apps.ts
@@ -206,12 +206,18 @@ function stripHtmlForHostedConnectedAppsResult(value: string): string {
     .replace(/<[^>]+>/gu, " ")
     .replace(/&nbsp;/giu, " ")
     .replace(/&amp;/giu, "&")
-    .replace(/&lt;/giu, "<")
-    .replace(/&gt;/giu, ">")
     .replace(/&quot;/giu, '"')
     .replace(/&#39;/giu, "'")
+    // Angle brackets stay escaped. Decoding them would let an email whose
+    // visible text quotes markup ("&lt;p&gt;Do not cancel&lt;/p&gt;") come out
+    // of this function looking like structure, and a later pass over that
+    // output would then strip the member's own words as if they were tags.
+    // Leaving the entities intact costs the model nothing and keeps compaction
+    // safe to apply more than once.
     .replace(/&#(\d+);/gu, (_match, code: string) => {
       const num = Number(code);
+      if (num === 0x3c) return "&lt;";
+      if (num === 0x3e) return "&gt;";
       return Number.isInteger(num) && num >= 32 && num <= 0x10ffff
         ? String.fromCodePoint(num)
         : " ";

--- a/packages/hosted-execution/src/connected-apps.ts
+++ b/packages/hosted-execution/src/connected-apps.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 
 export const HOSTED_CONNECTED_APPS_PATH = "/api/internal/connected-apps";
 
+// Serialized budget for a connected-app result handed to the assistant. The web
+// tier compacts provider output and enforces this before responding, so an
+// oversized read turns into actionable guidance instead of a discarded payload.
+export const HOSTED_CONNECTED_APPS_RESULT_MAX_BYTES = 120_000;
+
+// Composio tool results commonly include raw HTML email bodies (Gmail
+// FETCH_MESSAGE_BY_MESSAGE_ID) and similar markup-heavy payloads. The model
+// processes plain text just as well and pays per token for every markup
+// character, so strip HTML to text before serializing. Only strings that look
+// HTML-shaped get touched; everything else (descriptions, slugs, schemas)
+// passes through unchanged.
+const HOSTED_CONNECTED_APPS_HTML_MIN_LENGTH = 200;
+const HOSTED_CONNECTED_APPS_HTML_TAG_SENTINEL =
+  /<(?:!doctype|html|body|head|table|div|p|span|br|a\s|img|h[1-6]|td|tr|style|script)\b/iu;
+
 export const hostedConnectedAppsToolkitSchema = z
   .string()
   .trim()
@@ -107,6 +122,105 @@ export const hostedConnectedAppsResponseSchema = z
     result: z.unknown(),
   })
   .strict();
+
+// Walks the provider result and replaces any HTML-shaped string with its
+// stripped plain-text equivalent. Non-string values, short strings, and
+// strings without HTML tag markers pass through untouched, so this only
+// affects payloads that would otherwise burn tokens on markup (chiefly Gmail
+// message bodies).
+export function compactHostedConnectedAppsResult(value: unknown): unknown {
+  if (typeof value === "string") {
+    if (value.length < HOSTED_CONNECTED_APPS_HTML_MIN_LENGTH) return value;
+    if (!HOSTED_CONNECTED_APPS_HTML_TAG_SENTINEL.test(value)) return value;
+    return stripHtmlForHostedConnectedAppsResult(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => compactHostedConnectedAppsResult(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = compactHostedConnectedAppsResult(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Serializes a compacted result and fails closed when it exceeds the assistant
+// budget. Truncating would hand the model a half-read mailbox it cannot detect,
+// so callers turn `null` into an explicit narrow-the-request instruction.
+export function serializeHostedConnectedAppsResult(value: unknown): string | null {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? "null";
+  } catch {
+    return null;
+  }
+  return new TextEncoder().encode(text).byteLength
+      <= HOSTED_CONNECTED_APPS_RESULT_MAX_BYTES
+    ? text
+    : null;
+}
+
+function stripHtmlForHostedConnectedAppsResult(value: string): string {
+  return value
+    // Drop noise: style/script/head blocks carry no model-useful signal and
+    // they account for most of the markup volume in Gmail HTML envelopes.
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+    .replace(/<head\b[^>]*>[\s\S]*?<\/head>/giu, " ")
+    // Preserve the most semantically important attributes: a hyperlink's
+    // href (tracking links, order URLs, calendar invites, unsubscribe) and
+    // an image's alt text. The opening-tag pattern uses a quote-aware
+    // tokenizer (`[^>"']` OR a complete `"..."` / `'...'` string) so that
+    // attribute values containing literal `>` (`<a title="Reply >>"...>`,
+    // common in marketing email and table-of-contents emails) do not abort
+    // the match and silently drop the href. href and alt are then extracted
+    // from the captured opening tag with a separate regex so both single-
+    // and double-quoted forms work without nested capture-group plumbing.
+    .replace(
+      /<a\b(?:[^>"']|"[^"]*"|'[^']*')*?>([\s\S]*?)<\/a>/giu,
+      (match, inner: string) => {
+        const hrefMatch = /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/iu.exec(match);
+        const href = hrefMatch ? (hrefMatch[1] ?? hrefMatch[2] ?? null) : null;
+        const label = inner.replace(/<[^>]+>/gu, "").replace(/\s+/gu, " ").trim();
+        if (!href) return label;
+        if (!label) return href;
+        return label === href ? href : `${label} (${href})`;
+      },
+    )
+    .replace(
+      /<img\b(?:[^>"']|"[^"]*"|'[^']*')*?>/giu,
+      (match) => {
+        const altMatch = /\balt\s*=\s*(?:"([^"]*)"|'([^']*)')/iu.exec(match);
+        const alt = altMatch ? (altMatch[1] ?? altMatch[2] ?? null) : null;
+        return alt ? `[image: ${alt}]` : " ";
+      },
+    )
+    // Block-level breaks become real newlines so flowing prose survives.
+    .replace(/<br\s*\/?>/giu, "\n")
+    .replace(/<\/(?:p|div|li|tr|h[1-6])>/giu, "\n")
+    // Every remaining tag goes; we've already pulled out the bits that
+    // carried information beyond their text content.
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/&nbsp;/giu, " ")
+    .replace(/&amp;/giu, "&")
+    .replace(/&lt;/giu, "<")
+    .replace(/&gt;/giu, ">")
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;/giu, "'")
+    .replace(/&#(\d+);/gu, (_match, code: string) => {
+      const num = Number(code);
+      return Number.isInteger(num) && num >= 32 && num <= 0x10ffff
+        ? String.fromCodePoint(num)
+        : " ";
+    })
+    .replace(/\s+\n/gu, "\n")
+    .replace(/\n{3,}/gu, "\n\n")
+    .replace(/[ \t]{2,}/gu, " ")
+    .trim();
+}
 
 export type HostedConnectedAppsManageInput = z.infer<
   typeof hostedConnectedAppsManageInputSchema

--- a/packages/hosted-execution/test/connected-apps.test.ts
+++ b/packages/hosted-execution/test/connected-apps.test.ts
@@ -1,12 +1,121 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  compactHostedConnectedAppsResult,
   HOSTED_CONNECTED_APPS_PATH,
   hostedConnectedAppsExecuteInputSchema,
   hostedConnectedAppsRequestSchema,
+  serializeHostedConnectedAppsResult,
 } from "../src/connected-apps.ts";
 
 describe("hosted connected-app contracts", () => {
+  it("strips HTML from Gmail-style message bodies while preserving link URLs, alt text, and inline content", () => {
+    // Production Gmail responses ship the full HTML envelope under
+    // `data.messageText`. The compactor must rewrite the email body to
+    // plain text but must NOT silently drop link URLs (tracking links,
+    // unsubscribe, calendar invites) or image alt text — those are the
+    // bits a user typically asks Murph to act on.
+    const htmlBody = `<!doctype html><html><head><style>.x{color:red}</style></head>`
+      + `<body><table><tr><td><p>Hello&nbsp;<strong>Alex</strong>,</p>`
+      + `<p>Thanks for your order #1234. Subtotal: $42.00</p>`
+      + `<p>Track it here: <a href="https://orders.example.com/1234">View order</a>.</p>`
+      + `<p>To stop these emails, <a href='https://example.com/unsub?u=42'>unsubscribe</a>.</p>`
+      + `<p><img src="https://cdn.example.com/logo.png" alt="Example Co logo"></p>`
+      + `<p>— Murph &amp; Co.</p></td></tr></table></body></html>`;
+    const result = compactHostedConnectedAppsResult({
+      data: {
+        attachmentList: [],
+        labelIds: ["INBOX"],
+        messageId: "abc123",
+        messageText: htmlBody,
+        sender: "store@example.com",
+        subject: "Order #1234",
+      },
+      tool_schemas: {
+        // Schema description happens to mention `<p>` literally; under 200
+        // chars so the length gate skips it. Must remain untouched.
+        GMAIL_FETCH_EMAILS: {
+          description: "Fetch emails. Returns body with <p> tags when raw=true.",
+        },
+      },
+    }) as { data: { messageText: string }; tool_schemas: Record<string, { description: string }> };
+
+    const compactedBody = result.data.messageText;
+    // All structural HTML and the style block are stripped.
+    expect(compactedBody).not.toMatch(/<\/?(html|body|table|td|tr|p|strong|style|head|img)\b/iu);
+    expect(compactedBody).not.toMatch(/color:red/u);
+    // Email prose, link text, and link URLs all survive.
+    expect(compactedBody).toContain("Hello");
+    expect(compactedBody).toContain("Alex");
+    expect(compactedBody).toContain("Thanks for your order #1234");
+    expect(compactedBody).toContain("View order (https://orders.example.com/1234)");
+    expect(compactedBody).toContain("unsubscribe (https://example.com/unsub?u=42)");
+    expect(compactedBody).toContain("[image: Example Co logo]");
+    expect(compactedBody).toContain("Murph & Co.");
+    // The strip cuts roughly half of an HTML envelope at minimum; this
+    // particular fixture should land well under the original byte length.
+    expect(compactedBody.length).toBeLessThan(htmlBody.length / 2);
+    expect(result.tool_schemas.GMAIL_FETCH_EMAILS.description).toBe(
+      "Fetch emails. Returns body with <p> tags when raw=true.",
+    );
+  });
+
+  it("preserves anchor hrefs whose opening tag has a literal `>` inside an attribute value", () => {
+    // Real Gmail/marketing HTML regularly emits anchors like
+    // `<a title="Reply >>" href="...">` where the attribute value contains
+    // a literal `>`. A naive `[^>]*` attribute-skip pattern aborts at the
+    // first `>` and the generic tag stripper then erases the opening tag,
+    // silently losing the href — which is exactly the data this compactor
+    // is meant to preserve. The quote-aware tokenizer in the stripper must
+    // handle this without dropping the URL or eating the surrounding prose.
+    const htmlBody = `<!doctype html><html><body>`
+      + `<p>Hi! See more:</p>`
+      + `<p><a title="Reply >>" href="https://example.com/track?id=abc&n=1">View update</a> for details.</p>`
+      + `<p>Or <a href='https://example.com/inline-quote/"q"'>this one</a>.</p>`
+      + `<p><img src="https://cdn.example.com/x.png" alt="Status: green > yellow"></p>`
+      + `</body></html>`;
+    const result = compactHostedConnectedAppsResult({
+      data: { messageText: htmlBody },
+    }) as { data: { messageText: string } };
+    const compactedBody = result.data.messageText;
+    // The link's label, the href, AND the surrounding prose all survive.
+    expect(compactedBody).toContain("View update (https://example.com/track?id=abc&n=1)");
+    expect(compactedBody).toContain("Hi! See more:");
+    expect(compactedBody).toContain("for details.");
+    // The single-quoted anchor with a quote-bearing href still works.
+    expect(compactedBody).toContain('this one (https://example.com/inline-quote/"q")');
+    // Image alt with `>` inside survives.
+    expect(compactedBody).toContain("[image: Status: green > yellow]");
+    // None of the opening-tag attribute text leaked through as bare text.
+    expect(compactedBody).not.toMatch(/title=|src=/u);
+  });
+
+  it("bounds a compacted result to the assistant budget", () => {
+    expect(serializeHostedConnectedAppsResult({ body: "x".repeat(10) })).not.toBeNull();
+    expect(serializeHostedConnectedAppsResult({ body: "x".repeat(130_000) })).toBeNull();
+  });
+
+  it("keeps a markup-heavy mailbox read inside the budget after compaction", () => {
+    // A mailbox read whose raw envelopes exceed the old 512 KB wire ceiling
+    // still has to reach the model: the markup, not the content, is what makes
+    // it large. Rejecting it on wire size discarded a result that fits.
+    const envelope = `<!doctype html><html><head><style>${".pad{color:red}".repeat(400)}</style></head>`
+      + `<body><table><tr><td><p>Order confirmed. Total: $42.00</p>`
+      + `<p>Details: <a href="https://orders.example.com/1">View</a></p></td></tr></table></body></html>`;
+    const raw = {
+      data: {
+        messages: Array.from({ length: 90 }, (_item, index) => ({
+          messageId: `msg_${index}`,
+          messageText: envelope,
+          subject: `Order ${index}`,
+        })),
+      },
+    };
+
+    expect(JSON.stringify(raw).length).toBeGreaterThan(512 * 1024);
+    expect(serializeHostedConnectedAppsResult(compactHostedConnectedAppsResult(raw))).not.toBeNull();
+  });
+
   it("keeps one stable internal route", () => {
     expect(HOSTED_CONNECTED_APPS_PATH).toBe("/api/internal/connected-apps");
   });

--- a/packages/hosted-execution/test/connected-apps.test.ts
+++ b/packages/hosted-execution/test/connected-apps.test.ts
@@ -90,22 +90,22 @@ describe("hosted connected-app contracts", () => {
     expect(compactedBody).not.toMatch(/title=|src=/u);
   });
 
-  it("does not treat its own output as markup on a second pass", () => {
-    // Compaction is deliberately single-pass. An email whose visible text
-    // quotes markup decodes to real tags here, so running the compactor over
-    // its own output would strip that text as structure and silently delete
-    // the member's content.
+  it("survives a second pass so mixed-version callers cannot corrupt content", () => {
+    // A deployment window can leave an older caller compacting a result the web
+    // tier already compacted. That second pass must not read the member's own
+    // quoted markup as structure and delete it.
     const quoted = `<!doctype html><html><body><p>Use this exact block:</p>`
       + `<p>&lt;p class="warning"&gt;Do not cancel&lt;/p&gt;</p>`
+      + `<p>And this one: &#60;span&#62;keep me&#60;/span&#62;</p>`
       + `<p>Paste it verbatim.</p>${"<p>filler copy for length</p>".repeat(20)}</body></html>`;
     const once = compactHostedConnectedAppsResult({ body: quoted }) as { body: string };
 
-    expect(once.body).toContain('<p class="warning">Do not cancel</p>');
+    expect(once.body).toContain("Do not cancel");
+    expect(once.body).toContain("keep me");
     expect(once.body).toContain("Paste it verbatim.");
 
     const twice = compactHostedConnectedAppsResult(once) as { body: string };
-    expect(twice.body).not.toBe(once.body);
-    expect(twice.body).not.toContain("Do not cancel</p>");
+    expect(twice.body).toBe(once.body);
   });
 
   it("bounds a compacted result to the assistant budget", () => {

--- a/packages/hosted-execution/test/connected-apps.test.ts
+++ b/packages/hosted-execution/test/connected-apps.test.ts
@@ -90,6 +90,24 @@ describe("hosted connected-app contracts", () => {
     expect(compactedBody).not.toMatch(/title=|src=/u);
   });
 
+  it("does not treat its own output as markup on a second pass", () => {
+    // Compaction is deliberately single-pass. An email whose visible text
+    // quotes markup decodes to real tags here, so running the compactor over
+    // its own output would strip that text as structure and silently delete
+    // the member's content.
+    const quoted = `<!doctype html><html><body><p>Use this exact block:</p>`
+      + `<p>&lt;p class="warning"&gt;Do not cancel&lt;/p&gt;</p>`
+      + `<p>Paste it verbatim.</p>${"<p>filler copy for length</p>".repeat(20)}</body></html>`;
+    const once = compactHostedConnectedAppsResult({ body: quoted }) as { body: string };
+
+    expect(once.body).toContain('<p class="warning">Do not cancel</p>');
+    expect(once.body).toContain("Paste it verbatim.");
+
+    const twice = compactHostedConnectedAppsResult(once) as { body: string };
+    expect(twice.body).not.toBe(once.body);
+    expect(twice.body).not.toContain("Do not cancel</p>");
+  });
+
   it("bounds a compacted result to the assistant budget", () => {
     expect(serializeHostedConnectedAppsResult({ body: "x".repeat(10) })).not.toBeNull();
     expect(serializeHostedConnectedAppsResult({ body: "x".repeat(130_000) })).toBeNull();


### PR DESCRIPTION
## Why this PR exists

A member asked Murph to search their email. The provider answered `200 OK`, but the response body exceeded the web tier's raw wire ceiling and was discarded, and the runtime tool reported the failure to the assistant as the single string `connected apps API is unavailable`. Murph then told the member their account was fine, called it a temporary service bug, and offered a retry that could only fail the same way.

Both halves are defects: a mailbox read is large because of markup, not because of content, and a rejected request is not an outage.

## User goal / user-visible behavior

Asking Murph to search connected email returns the result instead of an apology. When a request genuinely returns too much, Murph says so and narrows the search rather than reporting an outage and offering a doomed retry.

## User experience

Entry point is an ordinary chat message ("search my email for X"). Murph runs a connected-app search and read; the read now succeeds where markup-heavy mailboxes previously failed. Timing class is unchanged — the same single provider round trip, bounded by the existing 30s client timeout.

Failure paths change:

- Too much data returned: Murph receives `CONNECTED_APPS_RESULT_TOO_LARGE` with the instruction to ask for fewer results, a narrower time range, or one item at a time. It narrows and retries within the same turn instead of ending the conversation on an outage claim.
- Genuine provider outage: Murph receives `retryable: true` and the "one retry is reasonable" posture, matching the retry it already offers.
- Rejected request (bad arguments, revoked access, inactive account): Murph receives the code and the reason and can tell the member what is actually wrong.

No asynchronous continuation and no new screen. Not a frontend change, so there is no rendered evidence to record.

## Invariants the PR must preserve

- No untrusted provider or proxy body text reaches the model through an error path. Only a well-formed error code (`^[A-Z][A-Z0-9_]{0,63}$`) admits its paired control-plane message; anything else reports status alone. Covered by `withholds an unstructured transport failure body from the model`.
- The assistant result stays bounded. The compacted result is capped at 120 KB before the web tier responds, and the runtime keeps its own identical budget as a second gate.
- Oversized results fail closed, never truncated. A silently half-read mailbox is undetectable to the model; both budget checks return an explicit narrow-the-request instruction.
- Compaction never deletes member content. It runs once, in the web tier, and is safe to repeat: angle brackets stay escaped so an email quoting markup cannot be re-read as structure by a second pass. Covered by `survives a second pass so mixed-version callers cannot corrupt content`.
- Raising the raw read ceiling remains a memory guard, not an assistant budget. 4 MB bounds what the web tier buffers; it is never what the model receives.
- Calendar-create failures keep their existing non-retryable ambiguous-outcome wording, which takes precedence over the new generic failure description.

## Non-obvious affected surfaces

- `HostedWebControlPlaneResponseError` gains a `detail` field (`apps/cloudflare/src/runtime-platform/web-control-transport.ts`). Necessary because the class formats `message` as `"<description> failed with HTTP <status>. <body message>"`; quoting that to the model would duplicate the status and leak the internal transport description. `detail` keeps the control plane's own message verbatim. Additive only — every existing field and the formatted `message` are unchanged. Proof: `keeps the control-plane error code, status, and message readable by the caller` in `apps/cloudflare/test/connected-apps-web-control-policy.test.ts`, which drives the real class through the real port.
- Failed dynamic and MCP tool-call runtime issues now record the sanitized tool name (`packages/assistant-engine/src/assistant-codex/action-diagnostics.ts`). Necessary because `hosted_assistant_runtime_issue` previously recorded only action kind and duration/output buckets for these failures, so a failed call could not be attributed to a surface without the web tier's request logs. Reuses the existing `resolveToolDiagnosticIdentity` allowlist, so only an identifier-shaped name is stored — never arguments or output. Proof: the extended `builds privacy-safe runtime issues for failed Codex action events`, whose existing assertions still verify no prompt, stdout, stderr, or output text is encoded.
- `executeHostedConnectedAppsRequest` now compacts every operation's result, including `manage`. Compaction is a no-op walk on markup-free payloads; the existing management tests cover the unchanged shapes.

## Architecture and reuse

- **Existing systems reused:** `@murphai/hosted-execution/connected-apps` already had both consumers as dependents, so it became the compaction owner without a new package or dependency edge. The oversize failure reuses `hostedOnboardingError` and the existing `{error: {code, message, retryable}}` body that the transport already parses into `code`/`retryable`; no new error channel was introduced.
- **New logic:** Web-tier compaction and budget enforcement before responding (`boundHostedConnectedAppsResult`); a control-plane failure description that reports code, status, and retry posture; the `detail` field carrying the unformatted control-plane message.
- **New abstractions:** None. The compaction function moved from the runtime tool into the shared contract package it already imported; the runtime tool now calls the same function instead of a private copy. The structural failure reader is a local function, not a shared abstraction, because the runtime tool is its only consumer and the error class lives in an app the package cannot import.
- **Complexity intentionally avoided:** No retry, queue, chunking, pagination layer, or streaming path was added — the fix is a budget applied at the layer that owns the assistant's context, plus an error that already existed being allowed through. Compaction runs in exactly one place rather than defensively at both tiers, and deploy-window safety comes from making the transform repeatable instead of from version negotiation.

## Hot reply path impact

`Not applicable.` The change is confined to connected-app tool calls made during a provider turn. It adds no database call, network call, or awaited operation to durable acceptance of a current conversation message, provider start, or durable reply handoff. Compaction runs in the web tier on a payload already buffered in memory; it replaces a byte-length check that ran on the same payload.

## Murph initial provider input impact

`Not applicable` for both individual and group Murph. No prompt file, tool description, argument schema, tool availability, deferral metadata, Codex version, or provider-request assembly changed. The three connected-app tool definitions in `dynamic-tools/connected-apps.ts` are byte-identical to base; the diff in that file touches result and failure handling, which is tool-call output within a turn, not provider input.

## Preliminary specialist lenses

- **Product experience** — `applicable`. Intended outcome: a member asking Murph to search their email gets the result, and when a request truly returns too much, gets a narrower search instead of a false outage report and a doomed retry offer. Direct journey evidence: the production incident is reproduced as a test — `delivers a markup-heavy mailbox read that the raw wire ceiling used to discard` builds a mailbox payload over the old ceiling and asserts the voucher code and its link survive; `reports the control-plane failure code, status, and retry posture` asserts the assistant no longer sees "unavailable" for a rejected request. Gap: no live end-to-end run against the provider, since the Composio credential is production-only.
- **Prompt** — `not applicable`. No prompt text, tool description, or schema changed.
- **Frontend** — `not applicable`. No `apps/web` UI diff; the change is a route/service boundary and a runtime tool.
- **Coverage** — `applicable`. Focused local proof: `apps/web/test/connected-apps-{service,composio,internal-route}.test.ts` (38 passed), `packages/assistant-engine/test/assistant-codex-connected-apps.test.ts` + `packages/hosted-execution/test/connected-apps.test.ts` (18 passed), `packages/assistant-engine/test/assistant-codex-runtime.test.ts` (240 passed), `apps/cloudflare/test/connected-apps-web-control-policy.test.ts` (4 passed); typecheck green for `apps/web`, `apps/cloudflare`, `@murphai/assistant-engine`, and `@murphai/hosted-execution`. Exact-head CI: `pending`.

## Change-shape breakdown

Classification rule: any path under a `test/` directory counts as tests/fixtures; everything else under `src/` counts as source. No docs, config/tooling, or generated files are touched, and there are no binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 242 | 112 |
| Tests/fixtures | 315 | 79 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **557** | **191** |

Source deletions are dominated by the compaction helper moving out of `dynamic-tools/connected-apps.ts` (108 lines) into `packages/hosted-execution/src/connected-apps.ts`; test movement is the matching relocation of its two unit tests.

## Design proof for user-facing frontend UI

`Not applicable.` No user-facing frontend UI diff.

## Deployment skew / compatibility

This PR changes both sides of the web/Worker deploy boundary. Each side is independently correct, and the compaction transform is repeatable, so neither ordering can corrupt content.

- **Deploy order: `apps/web` first. The Cloudflare deploy is deliberately not part of this rollout.**
- **Web new, runner old (the intended and indefinite steady state here):** the size fix is fully live — the member-visible bug this PR exists for is fixed by the web deploy alone. The old runner still compacts the already-compacted result; that second pass is a no-op because angle brackets are left escaped, and it applies the identical 120 KB budget. The new oversize 413 reaches the old runner's bare catch and still reads as `connected apps API is unavailable`, which is exactly today's behavior and no worse. The error-surfacing and diagnostics improvements stay dormant until Cloudflare deploys.
- **Web old, runner new (only if the order is reversed):** the runner reports the code and status correctly, but the oversized read still fails because the old web tier rejects it on wire size, and results arrive uncompacted within the same 120 KB budget. Degraded, not broken.
- **Worker/container skew:** warm `RunnerContainer` processes on the previous bundle behave exactly as the "runner old" case above. No `container_rollout=immediate` is required, and no tandem deploy window is needed.
- **Persisted state:** none changed. No migration, no schema change, no new env var, no credential shape change.
- **Reversibility:** fully reversible by revert. The only persisted side effect arrives with the Cloudflare deploy: a new optional `tool` key inside `hosted_assistant_runtime_issue.details_json`, which is additive JSON that existing readers ignore.
- **Post-deploy checks (web):** confirm `POST /api/internal/connected-apps` returns 200 for a mailbox search that previously produced `composio_response_too_large`; confirm `CONNECTED_APPS_RESULT_TOO_LARGE` appears only for genuinely large requests. Deferred until the Cloudflare deploy: confirm new `CODEX_DYNAMIC_TOOL_CALL_FAILED` rows carry a `tool` key in `details_json`.
