### PR TITLE
Restore member attribution for product feedback

### DIFF
--- a/apps/web/app/api/internal/hosted-execution/product-feedback/record/route.ts
+++ b/apps/web/app/api/internal/hosted-execution/product-feedback/record/route.ts
@@ -6,7 +6,6 @@ import {
   requireHostedCloudflareCallbackJsonRequest,
 } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
 import {
-  isHostedProductSupportEscalationFeedback,
   recordHostedProductFeedback,
 } from "@/src/lib/hosted-execution/product-feedback";
 import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
@@ -24,8 +23,6 @@ export const POST = withJsonError(async (request: Request) => {
 
   return jsonOk(await recordHostedProductFeedback({
     feedback: body.feedback,
-    ...(isHostedProductSupportEscalationFeedback(body.feedback)
-      ? { memberId: userId }
-      : {}),
+    memberId: userId,
   }));
 });

--- a/apps/web/src/lib/hosted-execution/product-feedback-digest.ts
+++ b/apps/web/src/lib/hosted-execution/product-feedback-digest.ts
@@ -6,6 +6,7 @@ import {
 } from "@murphai/contracts";
 import {
   HOSTED_PRODUCT_FEEDBACK_KINDS,
+  HOSTED_PRODUCT_SUPPORT_ESCALATION_PREFIX,
   type HostedProductFeedbackKind,
 } from "@murphai/hosted-execution/runtime-control";
 
@@ -134,9 +135,14 @@ export async function readHostedProductFeedbackDigestBatch(input: {
     kind: {
       in: [...HOSTED_PRODUCT_FEEDBACK_KINDS],
     },
-    // Member-linked support-escalation rows stay out of the digest audience;
-    // their anonymous detail rows carry the issue text instead.
-    memberId: null,
+    // Ordinary feedback is member-linked again and remains visible here. The
+    // reserved support marker stays out because its separate anonymous detail
+    // row carries the actionable issue summary.
+    NOT: {
+      summary: {
+        startsWith: HOSTED_PRODUCT_SUPPORT_ESCALATION_PREFIX,
+      },
+    },
     summary: {
       not: null,
     },

--- a/apps/web/src/lib/hosted-execution/product-feedback.ts
+++ b/apps/web/src/lib/hosted-execution/product-feedback.ts
@@ -20,10 +20,10 @@ import { getPrisma } from "@/src/lib/prisma";
 
 export const HOSTED_PRODUCT_SUPPORT_EMAIL = "support@withmurph.ai";
 export const HOSTED_PRODUCT_SUPPORT_EMAILS_PER_MEMBER_UTC_DAY_MAX = 3;
-// The member-linked row and outbound email carry only this server-authored
-// text. Model-authored free text is best-effort de-identified and may retain
-// semantic private details, so it is persisted exclusively on the anonymous
-// path (see the detail row below), never beside member identity.
+// The support alert and its member-linked marker carry only server-authored
+// text because that path deliberately sends identity to an operator. Ordinary
+// stored feedback may be linked to a private member, but stays bounded and
+// sanitized and is never emailed beside that identity by this service.
 export const HOSTED_PRODUCT_SUPPORT_ESCALATION_RECORD_SUMMARY =
   "Support escalation: member-requested product support escalation.";
 
@@ -58,7 +58,9 @@ export async function recordHostedProductFeedback(input: {
     return await persistHostedProductFeedback({
       feedback,
       feedbackId,
-      memberId: input.memberId ?? null,
+      memberId: await resolveOrdinaryHostedProductFeedbackMemberId(
+        input.memberId,
+      ),
     });
   }
   if (!isHostedProductSupportEscalationFeedback(feedback)) {
@@ -253,6 +255,25 @@ export function buildHostedProductFeedbackId(input: {
     .digest("hex")
     .slice(0, 32);
   return `product_feedback_${digest}`;
+}
+
+async function resolveOrdinaryHostedProductFeedbackMemberId(
+  memberId: string | null | undefined,
+): Promise<string | null> {
+  const normalizedMemberId = memberId?.trim();
+  if (!normalizedMemberId) {
+    return null;
+  }
+
+  // Group callbacks are bound to a synthetic hosted member row, not the human
+  // speaker who expressed the feedback. Keep those rows anonymous rather than
+  // making the synthetic runtime look like a messageable person.
+  const threadContainer = await getPrisma().hostedThreadContainer.findUnique({
+    select: { memberId: true },
+    where: { memberId: normalizedMemberId },
+  });
+
+  return threadContainer ? null : normalizedMemberId;
 }
 
 async function persistHostedProductFeedback(input: {

--- a/apps/web/test/hosted-product-feedback-digest.test.ts
+++ b/apps/web/test/hosted-product-feedback-digest.test.ts
@@ -174,7 +174,11 @@ describe("hosted product feedback digest", () => {
       kind: {
         in: ["feature_interest", "feature_request", "frustration"],
       },
-      memberId: null,
+      NOT: {
+        summary: {
+          startsWith: "Support escalation:",
+        },
+      },
       summary: {
         not: null,
       },

--- a/apps/web/test/hosted-product-feedback-route.test.ts
+++ b/apps/web/test/hosted-product-feedback-route.test.ts
@@ -1,7 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  isHostedProductSupportEscalationFeedback: vi.fn(),
   recordHostedProductFeedback: vi.fn(),
   requireHostedCloudflareCallbackJsonRequest: vi.fn(),
 }));
@@ -12,8 +11,6 @@ vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-execution/product-feedback", () => ({
-  isHostedProductSupportEscalationFeedback:
-    mocks.isHostedProductSupportEscalationFeedback,
   recordHostedProductFeedback: mocks.recordHostedProductFeedback,
 }));
 
@@ -38,22 +35,13 @@ describe("hosted product feedback record route", () => {
         userId: "member_123",
       }),
     );
-    mocks.isHostedProductSupportEscalationFeedback.mockImplementation(
-      (feedback: {
-        kind: string;
-        relatedChangelogItemIds: string[];
-        summary: string;
-      }) => feedback.kind === "frustration"
-        && feedback.relatedChangelogItemIds.length === 0
-        && feedback.summary.startsWith("Support escalation:"),
-    );
     mocks.recordHostedProductFeedback.mockResolvedValue({
       feedbackId: "product_feedback_123",
       recorded: true,
     });
   });
 
-  it("keeps ordinary bounded feedback anonymous", async () => {
+  it("links ordinary bounded feedback to the authenticated member", async () => {
     const feedback = {
       idempotencyKey: "a".repeat(64),
       kind: "feature_interest",
@@ -78,6 +66,7 @@ describe("hosted product feedback record route", () => {
     );
     expect(mocks.recordHostedProductFeedback).toHaveBeenCalledWith({
       feedback,
+      memberId: "member_123",
     });
     await expect(response.json()).resolves.toEqual({
       feedbackId: "product_feedback_123",
@@ -85,7 +74,7 @@ describe("hosted product feedback record route", () => {
     });
   });
 
-  it("links an explicit support escalation to the authenticated member", async () => {
+  it("keeps explicit support escalation attribution on the same boundary", async () => {
     const feedback = {
       idempotencyKey: "b".repeat(64),
       kind: "frustration",
@@ -109,27 +98,5 @@ describe("hosted product feedback record route", () => {
       feedback,
       memberId: "member_123",
     });
-  });
-
-  it("does not attach member identity to a prefixed non-support shape", async () => {
-    const feedback = {
-      idempotencyKey: "c".repeat(64),
-      kind: "feature_request",
-      relatedChangelogItemIds: [],
-      summary: "Support escalation: add a support dashboard.",
-    };
-    const response = await route.POST(
-      new Request(
-        "https://join.example.test/api/internal/hosted-execution/product-feedback/record",
-        {
-          body: JSON.stringify({ feedback }),
-          headers: { "content-type": "application/json" },
-          method: "POST",
-        },
-      ),
-    );
-
-    expect(response.status).toBe(200);
-    expect(mocks.recordHostedProductFeedback).toHaveBeenCalledWith({ feedback });
   });
 });

--- a/apps/web/test/hosted-product-feedback-service.test.ts
+++ b/apps/web/test/hosted-product-feedback-service.test.ts
@@ -3,12 +3,16 @@ import { HOSTED_PRODUCT_FEEDBACK_SUMMARY_MAX_LENGTH } from "@murphai/hosted-exec
 
 const prismaMocks = vi.hoisted(() => ({
   createMany: vi.fn(),
+  findThreadContainer: vi.fn(),
 }));
 
 vi.mock("@/src/lib/prisma", () => ({
   getPrisma: () => ({
     hostedProductFeedback: {
       createMany: prismaMocks.createMany,
+    },
+    hostedThreadContainer: {
+      findUnique: prismaMocks.findThreadContainer,
     },
   }),
 }));
@@ -22,6 +26,7 @@ import {
 describe("recordHostedProductFeedback", () => {
   beforeEach(() => {
     prismaMocks.createMany.mockReset();
+    prismaMocks.findThreadContainer.mockReset().mockResolvedValue(null);
   });
 
   it("stores anonymous feedback by default and is idempotent by runtime key", async () => {
@@ -50,6 +55,7 @@ describe("recordHostedProductFeedback", () => {
     expect(first.feedbackId).toBe(second.feedbackId);
     expect(first.recorded).toBe(true);
     expect(second.recorded).toBe(false);
+    expect(prismaMocks.findThreadContainer).not.toHaveBeenCalled();
     expect(prismaMocks.createMany).toHaveBeenCalledTimes(2);
     expect(prismaMocks.createMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
       data: [
@@ -63,7 +69,7 @@ describe("recordHostedProductFeedback", () => {
     }));
   });
 
-  it("does not encode an optional member link into the feedback id", async () => {
+  it("links a private member without encoding the member id into the feedback id", async () => {
     const insertedIds = new Set<string>();
     prismaMocks.createMany.mockImplementation(async (args: {
       data: Array<{ id: string }>;
@@ -90,6 +96,10 @@ describe("recordHostedProductFeedback", () => {
     expect(first.feedbackId).toBe(second.feedbackId);
     expect(first.recorded).toBe(true);
     expect(second.recorded).toBe(false);
+    expect(prismaMocks.findThreadContainer).toHaveBeenCalledWith({
+      select: { memberId: true },
+      where: { memberId: "member_explicitly_linked" },
+    });
     expect(prismaMocks.createMany).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -106,6 +116,31 @@ describe("recordHostedProductFeedback", () => {
         ],
       }),
     );
+  });
+
+  it("keeps synthetic group-runtime feedback anonymous", async () => {
+    prismaMocks.findThreadContainer.mockResolvedValue({
+      memberId: "member_group_runtime",
+    });
+    prismaMocks.createMany.mockResolvedValue({ count: 1 });
+
+    await expect(recordHostedProductFeedback({
+      feedback: makeFeedback({
+        idempotencyKey: "e".repeat(64),
+      }),
+      memberId: "member_group_runtime",
+    })).resolves.toMatchObject({
+      recorded: true,
+    });
+
+    expect(prismaMocks.findThreadContainer).toHaveBeenCalledWith({
+      select: { memberId: true },
+      where: { memberId: "member_group_runtime" },
+    });
+    expect(prismaMocks.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: [expect.objectContaining({ memberId: null })],
+      skipDuplicates: true,
+    }));
   });
 
   it("accepts product feedback without changelog ids", async () => {


### PR DESCRIPTION
## Why

Ordinary hosted product feedback still arrives through a signed, runtime-bound callback, but the callback currently discards its authenticated member id before persistence. That makes actionable direct-member feedback impossible to reconnect to the person who reported it after the product issue is fixed.

## What changed

- Pass the signed callback's authenticated `userId` into ordinary product-feedback persistence, not only the reserved support-escalation path.
- Keep identity server-owned: the model/runtime payload still cannot provide or select a member id.
- Link feedback only when the callback belongs to a private member runtime. Group Murph runs are bound to synthetic member rows rather than a reliably identified human speaker, so those rows remain anonymous instead of recording a misleading contact target.
- Keep newly attributed ordinary feedback in the existing daily digest while continuing to suppress the generic `Support escalation:` marker row; its separate anonymous detail row remains the actionable digest entry.
- Add callback, persistence, synthetic-group, and digest query-shape regressions.

## Data and privacy behavior

- No schema migration is needed. `HostedProductFeedback.memberId` already exists, remains nullable for group feedback and intentionally anonymous support-detail rows, and retains its existing member relation/account-deletion behavior.
- This restores attribution for new direct-member feedback after deployment. The July 31 anonymization cleared historical links, so old member associations cannot be reconstructed from the retained rows.
- The stored summary remains the existing bounded, product-only, sanitizer-processed summary; raw conversation text is not persisted. This intentionally changes the prior policy for ordinary feedback by allowing that sanitized summary to sit beside a private member id so the team can follow up after fixing the issue.
- Feedback ids remain derived from the runtime idempotency key rather than member identity.
- The daily digest continues to send summaries only; it does not add member ids to email.

## Architecture and reuse

- **Existing systems reused:** The signed Cloudflare callback remains the sole identity authority, and the change reuses the existing `HostedProductFeedback.memberId` relation, feedback sanitizer, idempotency key owner, account-deletion behavior, and digest pipeline.
- **New logic:** Ordinary feedback now resolves the callback member as a private member or synthetic group runtime before persistence; private members are linked and synthetic group runtimes remain anonymous, while the digest excludes only the generic support marker.
- **New abstractions:** No new abstraction is introduced; one narrow resolver centralizes the already-existing private-versus-group runtime check inside the product-feedback service.
- **Complexity intentionally avoided:** There is no migration, backfill, second identity source, model-authored member field, queue, new table, group-speaker inference, or separate follow-up system.

## Validation

- Focused callback-route regression
- Focused persistence regressions for private and synthetic group runtimes
- Focused product-feedback digest regression
- Hosted Web typecheck and repository checks through CI
