### PR TITLE
Disable paid Blacksmith Testbox spend by default

### DIFF
--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -56,6 +56,13 @@ through `scripts/verification-dispatch.mjs`:
   either CLI is unavailable. No remote failure silently duplicates work
   locally. The `:local` package aliases exist only for executor diagnosis
   because canonical automatic execution is already local.
+- The `crabbox` executor is the only lane that creates paid Blacksmith spend, so
+  it is disabled by default and fails closed with a message naming the free
+  alternatives. A single deliberate invocation accepts the cost by also setting
+  `MURPH_ALLOW_TESTBOX_SPEND=1`. The flag is per-invocation on purpose: do not
+  export it into a shell profile, a worktree env file, or an agent's ambient
+  environment, because that silently restores the unbounded lane. It gates only
+  the paid executor and never widens `local` or `ssh`.
 - The Testbox hydration workflow must exist on the repository default branch
   before GitHub accepts a delegated `workflow_dispatch`. The change that first
   introduces or moves `.github/workflows/crabbox-bounded.yml` therefore uses
@@ -199,16 +206,26 @@ offering the Mac by disabling Remote Login or removing its authorized key.
 Measure time spent waiting for the exclusive local shared-host slot separately
 from active verification time. If a required canonical command has waited 10
 continuous minutes without acquiring that slot, stop only the exact waiting
-process tree owned by the current task and rerun the same command through
-Crabbox:
+process tree owned by the current task and rerun the same command on a free
+executor first. Prefer the dedicated SSH worker when it is configured and idle,
+because it runs the same canonical command without creating spend:
 
 ```bash
-MURPH_VERIFY_EXECUTOR=crabbox pnpm test:diff <path ...>
-MURPH_VERIFY_EXECUTOR=crabbox pnpm verify:acceptance
+MURPH_VERIFY_EXECUTOR=ssh pnpm test:diff <path ...>
+MURPH_VERIFY_EXECUTOR=ssh pnpm verify:acceptance
 ```
 
-If the dedicated SSH worker is configured and idle, it may run that same
-canonical command without creating spend. Otherwise the paid forced executor
+Only when no free executor can run the command does the paid Testbox lane
+apply, and it must be opted into per invocation:
+
+```bash
+MURPH_ALLOW_TESTBOX_SPEND=1 MURPH_VERIFY_EXECUTOR=crabbox pnpm test:diff <path ...>
+MURPH_ALLOW_TESTBOX_SPEND=1 MURPH_VERIFY_EXECUTOR=crabbox pnpm verify:acceptance
+```
+
+Report the spend when you take that lane: name the Testbox ID and the reason no
+free executor was usable. A slow local slot is a reason to wait or to use the
+SSH worker, not by itself a reason to spend. The paid forced executor
 creates a fresh one-shot Testbox through the fully pinned route. Crabbox stops
 every newly acquired delegated Testbox when the one-shot command exits unless
 `--keep` is passed; the dispatcher never passes `--keep` or

--- a/scripts/verification-dispatch.mjs
+++ b/scripts/verification-dispatch.mjs
@@ -62,6 +62,21 @@ export function parseVerificationRequest(argv) {
   return { commandArgs, verificationCommand };
 }
 
+function assertTestboxSpendAllowed(env) {
+  if (
+    readBooleanFlag(
+      env.MURPH_ALLOW_TESTBOX_SPEND,
+      "MURPH_ALLOW_TESTBOX_SPEND",
+    )
+  ) {
+    return;
+  }
+
+  throw new Error(
+    "MURPH_VERIFY_EXECUTOR=crabbox creates paid Blacksmith Testbox spend and is disabled by default. Run the canonical command with MURPH_VERIFY_EXECUTOR=local, or route it to the free dedicated worker with MURPH_VERIFY_EXECUTOR=ssh. Set MURPH_ALLOW_TESTBOX_SPEND=1 on a single deliberate invocation to accept the spend.",
+  );
+}
+
 function assertSafeBlacksmithRoutingInputs(env) {
   const leaseId = readOptionalValue(
     env.MURPH_CRABBOX_LEASE_ID,
@@ -121,6 +136,7 @@ export function resolveVerificationExecutor({
   }
 
   if (requestedExecutor === "crabbox") {
+    assertTestboxSpendAllowed(env);
     assertSafeBlacksmithRoutingInputs(env);
   } else {
     readSshRoutingInputs(env);

--- a/scripts/verification-dispatch.test.ts
+++ b/scripts/verification-dispatch.test.ts
@@ -81,13 +81,42 @@ describe("verification dispatcher", () => {
     }, true)).toContain("never forwards Vercel development credentials");
   });
 
+  it("disables paid Blacksmith Testbox spend unless a single run opts in", () => {
+    expect(resolveExecutorFailure({
+      MURPH_VERIFY_EXECUTOR: "crabbox",
+    }, true)).toContain("creates paid Blacksmith Testbox spend and is disabled by default");
+
+    expect(resolveExecutorFailure({
+      MURPH_ALLOW_TESTBOX_SPEND: "0",
+      MURPH_VERIFY_EXECUTOR: "crabbox",
+    }, true)).toContain("creates paid Blacksmith Testbox spend and is disabled by default");
+
+    expect(resolveExecutorFailure({
+      MURPH_ALLOW_TESTBOX_SPEND: "yes",
+      MURPH_VERIFY_EXECUTOR: "crabbox",
+    }, true)).toContain("MURPH_ALLOW_TESTBOX_SPEND must be 0 or 1.");
+
+    // The opt-in is scoped to the paid lane; it never widens the free executors.
+    expect(resolveExecutor({
+      MURPH_ALLOW_TESTBOX_SPEND: "1",
+      MURPH_VERIFY_EXECUTOR: "local",
+    }, true)).toMatchObject({ executor: "local", reason: "explicit" });
+
+    expect(resolveExecutor({
+      MURPH_ALLOW_TESTBOX_SPEND: "1",
+      MURPH_VERIFY_EXECUTOR: "crabbox",
+    }, true)).toMatchObject({ executor: "crabbox", reason: "explicit" });
+  });
+
   it("rejects coordinator pools and fails closed when an explicit remote stack is unavailable", () => {
     expect(resolveExecutorFailure({
+      MURPH_ALLOW_TESTBOX_SPEND: "1",
       MURPH_CRABBOX_POOL: "pool",
       MURPH_VERIFY_EXECUTOR: "crabbox",
     }, true)).toContain("does not use Crabbox pools");
 
     expect(resolveExecutor({
+      MURPH_ALLOW_TESTBOX_SPEND: "1",
       MURPH_VERIFY_EXECUTOR: "crabbox",
     }, true)).toMatchObject({
       executor: "crabbox",
@@ -95,6 +124,7 @@ describe("verification dispatcher", () => {
     });
 
     expect(resolveExecutorFailure({
+      MURPH_ALLOW_TESTBOX_SPEND: "1",
       MURPH_VERIFY_EXECUTOR: "crabbox",
     }, false)).toContain("Crabbox and Blacksmith CLIs are unavailable");
 
@@ -262,6 +292,7 @@ describe("verification dispatcher", () => {
           CRABBOX_CONFIG: "/tmp/attacker-controlled-crabbox.yaml",
           CUSTOM_PROVIDER_TOKEN: "must-not-reach-crabbox",
           GITHUB_TOKEN: "must-not-reach-crabbox",
+          MURPH_ALLOW_TESTBOX_SPEND: "1",
           MURPH_CRABBOX_NO_FORWARD: "must-not-reach-crabbox",
           MURPH_CRABBOX_PROFILE: "attacker-controlled-profile",
           MURPH_VERIFY_EXECUTOR: "crabbox",
@@ -325,6 +356,7 @@ describe("verification dispatcher", () => {
           CRABBOX_ENV_ALLOW: "OPENAI_API_KEY,VERCEL_OIDC_TOKEN",
           CUSTOM_PROVIDER_TOKEN: "must-not-reach-crabbox",
           GITHUB_TOKEN: "must-not-reach-crabbox",
+          MURPH_ALLOW_TESTBOX_SPEND: "1",
           MURPH_CRABBOX_LEASE_ID: "lease-1",
           MURPH_CRABBOX_NO_FORWARD: "must-not-reach-crabbox",
           MURPH_VERIFY_EXECUTOR: "crabbox",
@@ -851,6 +883,7 @@ describe("verification dispatcher", () => {
         env: {
           ...insideWorkspaceArtifactLockEnvironment(process.env),
           HOME: path.join(tempRoot, "home"),
+          MURPH_ALLOW_TESTBOX_SPEND: "1",
           MURPH_VERIFY_EXECUTOR: "crabbox",
           PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
         },
@@ -1291,6 +1324,7 @@ describe("verification dispatcher", () => {
           encoding: "utf8",
           env: {
             ...insideWorkspaceArtifactLockEnvironment(process.env),
+            MURPH_ALLOW_TESTBOX_SPEND: "1",
             MURPH_VERIFY_EXECUTOR: "crabbox",
             PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
           },
@@ -1322,6 +1356,7 @@ describe("verification dispatcher", () => {
         encoding: "utf8",
         env: {
           ...insideWorkspaceArtifactLockEnvironment(process.env),
+          MURPH_ALLOW_TESTBOX_SPEND: "1",
           MURPH_VERIFY_EXECUTOR: "crabbox",
           PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
         },
@@ -1367,6 +1402,7 @@ describe("verification dispatcher", () => {
         encoding: "utf8",
         env: {
           ...insideWorkspaceArtifactLockEnvironment(process.env),
+          MURPH_ALLOW_TESTBOX_SPEND: "1",
           MURPH_VERIFY_EXECUTOR: "crabbox",
           PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
         },
@@ -1663,6 +1699,7 @@ function withoutVerificationRoutingEnvironment(
   const sanitized = { ...environment };
   delete sanitized.CI;
   delete sanitized.CODEX_THREAD_ID;
+  delete sanitized.MURPH_ALLOW_TESTBOX_SPEND;
   delete sanitized.MURPH_CRABBOX_BLACKSMITH;
   delete sanitized.MURPH_CRABBOX_LEASE_ID;
   delete sanitized.MURPH_CRABBOX_POOL;


### PR DESCRIPTION
## Why this PR exists

The `crabbox` executor is the only verification lane that creates paid Blacksmith
Testbox spend, and nothing gated it. Any invocation that set
`MURPH_VERIFY_EXECUTOR=crabbox` dispatched a fresh 16-vCPU Testbox on demand.
Over Jul 27-31 that produced 95 dispatched runs and 965 billed 16-vCPU minutes,
93 of them ending `cancelled`, with no ceiling other than the per-run 10-minute
idle timeout and the 50-minute hydration cap. The lane should stay available; it
should not be reachable by habit.

## User goal / user-visible behavior

The "user" here is a repo operator or agent running canonical verification. Once
this ships, requesting the paid lane without opting in fails immediately with a
message naming the two free executors, so the expensive path can no longer be
taken by reflex or by an ambient environment value. A deliberate one-off run
still reaches a Testbox by adding `MURPH_ALLOW_TESTBOX_SPEND=1`. Automatic
routing is untouched and was already local, so no default workflow changes.

## User experience

No product surface is involved. The operator path is: run
`MURPH_VERIFY_EXECUTOR=crabbox pnpm test:diff <path ...>`, get an immediate
synchronous failure with exit 1 and a single stderr line naming `local`, `ssh`,
and the opt-in flag. The timing class is immediate and there is no asynchronous
continuation to own: the check runs before any Crabbox or Blacksmith CLI probe
and before the Git-candidate and sync work, so a blocked request performs no
network call and creates nothing to clean up. Recovery is stated in the failure
text itself, so the next action needs no separate lookup. Re-running with the
flag reaches the pre-existing routing unchanged.

Both directions were exercised on the PR head:

- blocked (default): exit 1, message emitted, no provider contact
- opted in: resolves `{"executor":"crabbox","reason":"explicit"}`

## Invariants the PR must preserve

- The paid lane fails closed. An absent, `0`, or malformed flag never reaches a
  Testbox.
- Policy fails before plumbing. The spend check precedes CLI availability
  probing, so a blocked request cannot contact Blacksmith at all.
- The gate is scoped to `crabbox`. It never widens or alters `local`, `ssh`,
  `auto`, CI, or already-remote routing.
- `auto` stays local. This PR does not change automatic executor selection.
- The flag is not forwarded to the provider. The Crabbox CLI environment remains
  the existing `SAFE_CRABBOX_CLI_ENVIRONMENT_NAMES` allowlist, which
  `MURPH_ALLOW_TESTBOX_SPEND` is not on.
- Existing crabbox fail-closed contracts keep their current error precedence and
  messages: pool rejection, lease rejection, CLI unavailability, and the
  Vercel-development-environment exclusion.
- Boolean parsing stays strict. Only `0` and `1` are accepted; anything else is
  an error rather than a silent falsey read.

## Non-obvious affected surfaces

- **The ten-minute local admission fallback** in
  `agent-docs/operations/verification-and-runtime.md`. It previously offered the
  paid Testbox as the fallback and described the free SSH worker as one the
  operator "may" use. It now routes to `ssh` first and treats the paid lane as a
  last resort that must state why no free executor was usable. This is necessary
  because that documented path is what produced the observed run volume; landing
  the code gate alone would leave the guidance still pointing at the paid lane.
  Regression proof: docs-only, no automated proof; the code gate is what
  enforces the outcome.
- **`withoutVerificationRoutingEnvironment`** in the dispatcher test helper now
  also strips `MURPH_ALLOW_TESTBOX_SPEND`. Necessary so that an operator who
  exports the flag into their shell cannot make the end-to-end dispatcher tests
  pass for the wrong reason. Regression proof: the new default-blocked assertion
  in the same suite fails if the flag leaks in from the ambient environment.

## Architecture and reuse

- **Existing systems reused:** `resolveVerificationExecutor` stays the single
  executor admission point; the new check uses the existing strict
  `readBooleanFlag` helper and the established fail-closed `throw` convention, so
  the error surfaces through the dispatcher's existing exit-1 path with no new
  error handling or exit code.
- **New logic:** One guard, `assertTestboxSpendAllowed`, called as the first
  statement in the existing `crabbox` branch. It is the only behavior change in
  the diff; everything else is docs and tests.
- **New abstractions:** None, and none were warranted. The executor branch
  already had an established place for per-executor admission assertions —
  `assertSafeBlacksmithRoutingInputs` sits directly beside it — so the guard
  follows that existing contract instead of introducing a policy layer.
- **Complexity intentionally avoided:** No spend budget, run counter, persisted
  ledger, rate limit, or config file. A per-invocation boolean removes the
  accidental path, whereas any stateful accounting would add a durable state
  owner to what is otherwise a pure, synchronous admission check.

## Hot reply path impact

Not applicable. The change is confined to `scripts/verification-dispatch.mjs`, a
developer verification entrypoint invoked from a shell or CI and imported by no
runtime code, so it touches no part of the Foreground Reply Critical Path defined
in `docs/contracts/00-invariants.md`.

## Murph initial provider input impact

Not applicable for both individual and group Murph. The diff changes no prompt
builder or prompt text, no tool definition, argument schema, availability, or
deferral, no skill rendered into instructions, no Codex version or configuration,
no model tool mode, and no provider-request assembly. The only changed executable
file is a verification dispatcher outside the assistant runtime, so no
provider-visible input is assembled differently and no measurement applies.

## Preliminary specialist lenses

- **Product experience:** not applicable. No user-facing product surface,
  journey, copy, action, or state changes; the only behavior change is an
  operator-facing CLI admission check.
- **Prompt:** not applicable. No prompt file, builder, or provider-visible
  instruction changed.
- **Frontend:** not applicable. No `apps/web` presentation, component, route, or
  asset changed, so the frontend lens and its rendered-evidence requirement do
  not trigger and no redacted desktop/mobile files were packaged.
- **Coverage:** applicable. Focused local proof is the repo-tools suite run
  against the exact PR head (30 files, 461 tests, exit 0), plus a direct
  end-to-end check of both gate directions. Exact-head CI status at open:
  `pending`.

## Change-shape breakdown

Classification rule: production runtime source under `apps/` and `packages/`
counts as source; `scripts/` is config/tooling; `agent-docs/` is docs; `*.test.ts`
is tests/fixtures regardless of directory. No binary files. No generated code.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests/fixtures | 37 | 0 |
| Docs | 23 | 6 |
| Config/tooling | 16 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **76** | **6** |

## Design proof for user-facing frontend UI

Not applicable. No user-facing `apps/web` UI changed, so there is no `/design`
catalog surface to link and no rendered state to screenshot.

## Deployment skew

Not applicable. Nothing in the diff ships to a deployed runtime: the dispatcher
runs only from a developer shell or CI, the doc is repo guidance, and the test
executes in CI. There is no deploy boundary, migration, or version-skew window.

## Verification

- `npx vitest run --config scripts/vitest.config.ts --no-coverage` on the PR head
  in an isolated worktree: 30 files, 461 tests passed, exit 0.
- `tsc --noEmit` on the changed test file: exit 0.
- Direct gate proof on the PR head: default request exits 1 with the spend
  message and no provider contact; opted-in request resolves to the `crabbox`
  executor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788294801&installation_model_id=19880&pr_number=1264&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1264&signature=1114739302ba12090791d7196ff5544fec6e9816d6b1be6705a7169caa300c93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->