### PR TITLE
Keep physical-note return addresses platform-owned

### DIFF
--- a/agent-docs/product-specs/physical-notes.md
+++ b/agent-docs/product-specs/physical-notes.md
@@ -11,8 +11,9 @@ Murph can mail one expressive, US-only physical note from a direct conversation
 or a hosted group. GPT Image generates the complete color artwork page, including
 any handwriting, illustration, and a small `murph ai` mark. Murph may show the
 artwork first when a draft or choice is useful, but an explicit send request with
-a complete address may continue through generation and mailing without an extra
-preview round trip.
+a complete recipient address may continue through generation and mailing without
+an extra preview round trip. The platform supplies Murph's fixed return address;
+it is never collected from the person sending the note.
 
 Each hosted member receives one complimentary note under the versioned
 `physical-note-v1` offer. A hosted group receives its own complimentary note
@@ -79,16 +80,25 @@ remaining capacity, and no second balance owner is needed.
 
 ## Provider boundary
 
-Web alone holds `LOB_API_KEY` and the configured return-address id. Lob receives
-one color US Letter request using First Class mail, `insert_blank_page`, and a
-provider idempotency key equal to the physical-note id. The generated artwork is
-wrapped only in deterministic letter-sized transport HTML with the required
-print-safe margin; visual expression remains model-owned.
+Web alone holds `LOB_API_KEY` and the configured return-address id. The assistant
+and tool schema accept only the recipient address. Lob receives one color US
+Letter request using First Class mail, `insert_blank_page`, and a provider
+idempotency key equal to the physical-note id. The generated artwork is wrapped
+only in deterministic letter-sized transport HTML with the required print-safe
+margin; visual expression remains model-owned.
 
-Test keys may render proofs. A `live_` key is rejected unless
-`LOB_PHYSICAL_NOTES_LIVE_ENABLED=true`. The charged amount comes from
-`LOB_PHYSICAL_NOTE_COST_USD_MICROS` and its explicit pricing version, not from a
-scraped public rate.
+USPS Secure Destruction is an account-level Lob setting rather than a per-letter
+API field. Operators enable it in the Lob account before live sending so eligible
+undeliverable First Class notes are destroyed instead of returned to Murph's
+mailbox. The runtime keeps every note on First Class mail, and a `live_` key is
+rejected unless both `LOB_PHYSICAL_NOTES_LIVE_ENABLED=true` and
+`LOB_USPS_SECURE_DESTRUCTION_CONFIRMED=true` are present. The confirmation flag
+does not change the Lob account; it records that an operator already enabled the
+account setting.
+
+Test keys may render proofs without the two live-account confirmations. The
+charged amount comes from `LOB_PHYSICAL_NOTE_COST_USD_MICROS` and its explicit
+pricing version, not from a scraped public rate.
 
 Cloudflare exposes the composable tool only when the non-secret platform
 capability `HOSTED_PHYSICAL_NOTES_ENABLED=true` is set. This flag must be enabled
@@ -119,8 +129,10 @@ and postal-service retention remain governed by those providers.
 
 Deploy the Prisma migration and Web route/service first, with live sending off.
 Then deploy Cloudflare and the assistant runtime/tool surface with
-`HOSTED_PHYSICAL_NOTES_ENABLED` still off. Verify at least one Lob test-mode
-proof before enabling the Cloudflare capability, and enable live sending only
-after that proof passes. The older runtime simply lacks the tool during a
-Web-first compatibility window; a new runtime against an old Web deployment
+`HOSTED_PHYSICAL_NOTES_ENABLED` still off. Configure Lob's fixed Murph return
+address and enable USPS Secure Destruction in the Lob account. Verify at least
+one Lob test-mode proof before enabling the Cloudflare capability. Set
+`LOB_USPS_SECURE_DESTRUCTION_CONFIRMED=true` only after the account setting is
+active, then enable live sending. The older runtime simply lacks the tool during
+a Web-first compatibility window; a new runtime against an old Web deployment
 would expose a route that does not exist and is therefore the unsafe order.

--- a/apps/web/src/lib/physical-notes/config.ts
+++ b/apps/web/src/lib/physical-notes/config.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+type PhysicalNoteEnvironment = Readonly<
+  Record<string, string | undefined>
+>;
+
+export interface PhysicalNoteConfig {
+  apiKey: string;
+  costUsdMicros: bigint;
+  fromAddressId: string;
+  pricingVersion: string;
+}
+
+export function readPhysicalNoteConfig(
+  env: PhysicalNoteEnvironment = process.env,
+): PhysicalNoteConfig | null {
+  const apiKey = readEnv(env, "LOB_API_KEY");
+  const fromAddressId = readEnv(env, "LOB_FROM_ADDRESS_ID");
+  const pricingVersion = readEnv(env, "LOB_PHYSICAL_NOTE_PRICING_VERSION");
+  const costText = readEnv(env, "LOB_PHYSICAL_NOTE_COST_USD_MICROS");
+  if (!apiKey || !fromAddressId || !pricingVersion || !costText) {
+    return null;
+  }
+  // Lob exposes USPS Secure Destruction as an account setting, not a letter
+  // API field. This flag records the operator's completed account setup.
+  if (
+    apiKey.startsWith("live_")
+    && (
+      !isEnabled(env, "LOB_PHYSICAL_NOTES_LIVE_ENABLED")
+      || !isEnabled(env, "LOB_USPS_SECURE_DESTRUCTION_CONFIRMED")
+    )
+  ) {
+    return null;
+  }
+  const cost = Number(costText);
+  if (!Number.isSafeInteger(cost) || cost <= 0) {
+    return null;
+  }
+  return {
+    apiKey,
+    costUsdMicros: BigInt(cost),
+    fromAddressId,
+    pricingVersion,
+  };
+}
+
+function isEnabled(
+  env: PhysicalNoteEnvironment,
+  name: string,
+): boolean {
+  return readEnv(env, name)?.toLowerCase() === "true";
+}
+
+function readEnv(
+  env: PhysicalNoteEnvironment,
+  name: string,
+): string | null {
+  const value = env[name]?.trim();
+  return value || null;
+}

--- a/apps/web/src/lib/physical-notes/service.ts
+++ b/apps/web/src/lib/physical-notes/service.ts
@@ -33,6 +33,7 @@ import { getPrisma } from "../prisma";
 import { readHostedAiUsageGate } from "../hosted-execution/usage-allowance";
 import { recordHostedAiUsageRecords } from "../hosted-execution/usage";
 import { buildHostedLobPhysicalNoteUsageRecord } from "../hosted-execution/usage-lob";
+import { readPhysicalNoteConfig } from "./config";
 import {
   createLobPhysicalNoteRuntime,
   type LobPhysicalNoteRuntime,
@@ -40,13 +41,6 @@ import {
 
 const COMPLIMENTARY_OFFER_CODE = "physical-note-v1";
 const REPLAY_WINDOW_MS = 23 * 60 * 60 * 1_000;
-
-interface PhysicalNoteConfig {
-  apiKey: string;
-  costUsdMicros: bigint;
-  fromAddressId: string;
-  pricingVersion: string;
-}
 
 export async function createHostedPhysicalNote(input: HostedPhysicalNoteSendRequest & {
   memberId: string;
@@ -429,32 +423,6 @@ async function recordPaidPhysicalNoteUsageTx(input: {
   });
 }
 
-function readPhysicalNoteConfig(): PhysicalNoteConfig | null {
-  const apiKey = readEnv("LOB_API_KEY");
-  const fromAddressId = readEnv("LOB_FROM_ADDRESS_ID");
-  const pricingVersion = readEnv("LOB_PHYSICAL_NOTE_PRICING_VERSION");
-  const costText = readEnv("LOB_PHYSICAL_NOTE_COST_USD_MICROS");
-  if (!apiKey || !fromAddressId || !pricingVersion || !costText) {
-    return null;
-  }
-  if (
-    apiKey.startsWith("live_")
-    && process.env.LOB_PHYSICAL_NOTES_LIVE_ENABLED?.trim().toLowerCase() !== "true"
-  ) {
-    return null;
-  }
-  const cost = Number(costText);
-  if (!Number.isSafeInteger(cost) || cost <= 0) {
-    return null;
-  }
-  return {
-    apiKey,
-    costUsdMicros: BigInt(cost),
-    fromAddressId,
-    pricingVersion,
-  };
-}
-
 async function markHostedPhysicalNoteFailed(input: {
   memberId: string;
   noteId: string;
@@ -518,11 +486,6 @@ function toResponse(
 
 function createPhysicalNoteId(): string {
   return `hpn_${randomUUID().replaceAll("-", "")}`;
-}
-
-function readEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  return value || null;
 }
 
 function unavailableResponse(): HostedPhysicalNoteSendResponse {

--- a/apps/web/test/physical-notes-config.test.ts
+++ b/apps/web/test/physical-notes-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readPhysicalNoteConfig,
+} from "../src/lib/physical-notes/config";
+
+const BASE_ENV = {
+  LOB_FROM_ADDRESS_ID: "adr_from_test",
+  LOB_PHYSICAL_NOTE_COST_USD_MICROS: "250000",
+  LOB_PHYSICAL_NOTE_PRICING_VERSION: "lob-test-v1",
+} as const;
+
+describe("physical-note provider configuration", () => {
+  it("allows Lob test proofs without live-account confirmations", () => {
+    expect(readPhysicalNoteConfig({
+      ...BASE_ENV,
+      LOB_API_KEY: "test_physical_notes",
+    })).toEqual({
+      apiKey: "test_physical_notes",
+      costUsdMicros: 250_000n,
+      fromAddressId: "adr_from_test",
+      pricingVersion: "lob-test-v1",
+    });
+  });
+
+  it("fails live sending closed until secure destruction is confirmed", () => {
+    const liveEnv = {
+      ...BASE_ENV,
+      LOB_API_KEY: "live_physical_notes",
+    };
+
+    expect(readPhysicalNoteConfig(liveEnv)).toBeNull();
+    expect(readPhysicalNoteConfig({
+      ...liveEnv,
+      LOB_PHYSICAL_NOTES_LIVE_ENABLED: "true",
+    })).toBeNull();
+    expect(readPhysicalNoteConfig({
+      ...liveEnv,
+      LOB_USPS_SECURE_DESTRUCTION_CONFIRMED: "true",
+    })).toBeNull();
+    expect(readPhysicalNoteConfig({
+      ...liveEnv,
+      LOB_PHYSICAL_NOTES_LIVE_ENABLED: " TRUE ",
+      LOB_USPS_SECURE_DESTRUCTION_CONFIRMED: " true ",
+    })).toEqual({
+      apiKey: "live_physical_notes",
+      costUsdMicros: 250_000n,
+      fromAddressId: "adr_from_test",
+      pricingVersion: "lob-test-v1",
+    });
+  });
+});

--- a/packages/assistant-engine/skills/physical-notes/SKILL.md
+++ b/packages/assistant-engine/skills/physical-notes/SKILL.md
@@ -11,6 +11,8 @@ the mail. The product is one US-only, one-artwork-page, color First Class note.
 ## Compose with the existing primitives
 
 1. Collect one complete US recipient address and enough intent to make the note.
+   Murph's fixed return address is platform configuration. Never ask the person
+   for a return address, invent one, or place one in tool arguments or artwork.
 2. Call `murph.generate_image` with portrait size `1024x1536`, JPEG output,
    high quality, and the exact current authorizing message as `message_ref`.
    The generated image is the complete expressive page.
@@ -51,8 +53,9 @@ Include these print constraints in the prompt:
   branding inside the artwork;
 - large enough lettering and contrast to remain legible in print.
 
-The address belongs only in `murph.send_physical_note`; never place it in the
-image prompt.
+The recipient address belongs only in `murph.send_physical_note`; never place
+it in the image prompt. Trusted server code supplies the platform return
+address.
 
 ## Authority and safety
 
@@ -62,8 +65,9 @@ and any later Murph-time cost.
 
 Do not send bulk or repeated mail, international mail, anonymous threats,
 harassment, fraud, impersonation, doxxing, illegal content, or a note that
-claims to come from an uninvolved real person. Ask one concise question when
-the address or send intent is incomplete.
+claims to come from an uninvolved real person. Ask one concise question only
+when the recipient address or send intent is incomplete. Never ask for a return
+address.
 
 Treat tool results literally:
 

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/physical-notes.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/physical-notes.ts
@@ -67,6 +67,7 @@ export const MURPH_SEND_PHYSICAL_NOTE_TOOL = {
     'On a trusted hosted image-completion turn whose generation was launched with the exact authorizing message_ref, omit image_ref, image_sha256, and message_ref so runtime code binds the exact generated image and request automatically.',
     'When a generated note was intentionally shown first and a person later says to send it, provide the exact image_ref and image_sha256 from that trusted completion plus the exact message_ref approving the send in the current turn. Runtime code re-reads and verifies the private vault bytes and exact accepted input.',
     'When the originating user already explicitly asked Murph to mail the note and supplied a complete US address, call this tool automatically after generation finishes; showing or attaching the image first is optional, not required.',
+    "The server supplies Murph's fixed return address. Never ask the person for a return address, invent one, or include one in the tool arguments or artwork.",
     'Do not call for a draft-only request, an incomplete address, bulk mail, an international address, impersonation, threats, harassment, fraud, or illegal content.',
     'The server decides whether the note is complimentary and computes any Murph-time cost. Never claim acceptance until this tool reports accepted.',
   ].join(' '),
@@ -96,6 +97,8 @@ export const MURPH_SEND_PHYSICAL_NOTE_TOOL = {
       to: {
         type: 'object',
         additionalProperties: false,
+        description:
+          "One recipient address only. Trusted server code supplies Murph's fixed return address.",
         properties: {
           name: { type: 'string', minLength: 1, maxLength: 40 },
           address_line1: { type: 'string', minLength: 1, maxLength: 64 },

--- a/packages/assistant-engine/test/assistant-physical-note-return-address.test.ts
+++ b/packages/assistant-engine/test/assistant-physical-note-return-address.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MURPH_SEND_PHYSICAL_NOTE_TOOL,
+  readPhysicalNoteDynamicToolRequest,
+} from '../src/assistant-codex/dynamic-tools/physical-notes.js'
+
+const RECIPIENT = {
+  address_line1: '123 Main St',
+  city: 'Atlanta',
+  name: 'Sam',
+  postal_code: '30308',
+  state: 'GA',
+}
+
+describe('physical-note return address ownership', () => {
+  it('keeps the return address in trusted platform configuration', () => {
+    expect(MURPH_SEND_PHYSICAL_NOTE_TOOL.description).toContain(
+      'Never ask the person for a return address',
+    )
+    expect(
+      MURPH_SEND_PHYSICAL_NOTE_TOOL.inputSchema.properties.to.description,
+    ).toContain("server code supplies Murph's fixed return address")
+    expect(MURPH_SEND_PHYSICAL_NOTE_TOOL.inputSchema.properties)
+      .not.toHaveProperty('from')
+
+    expect(readPhysicalNoteDynamicToolRequest({
+      arguments: {
+        from: 'user supplied return address',
+        to: RECIPIENT,
+      },
+      tool: MURPH_SEND_PHYSICAL_NOTE_TOOL.name,
+    })).toMatchObject({
+      kind: 'invalid-physical-note-arguments',
+    })
+  })
+})


### PR DESCRIPTION
## Why

Murph currently has enough information to send a physical note, but can still ask the person for a return address. That is unnecessary: Web already owns the fixed Lob `from` address through `LOB_FROM_ADDRESS_ID`.

Lob exposes USPS Secure Destruction as an account-level setting rather than a per-letter API field. Live physical-note mail should therefore stay disabled until an operator has enabled that Lob setting and explicitly confirmed the setup.

## What changed

- Tell the always-visible tool metadata and deferred physical-note skill that the return address is platform-owned and must never be requested, invented, added to artwork, or included in tool arguments.
- Keep the tool schema recipient-only and add a focused regression proving a model-supplied `from` field is rejected.
- Extract the small Lob physical-note configuration reader from the service.
- Fail live Lob configuration closed unless both:
  - `LOB_PHYSICAL_NOTES_LIVE_ENABLED=true`
  - `LOB_USPS_SECURE_DESTRUCTION_CONFIRMED=true`
- Keep test-mode Lob proofs available without live-account confirmations.
- Document that the new confirmation flag does not toggle Lob; it records that an operator already enabled USPS Secure Destruction in the Lob account.

## Architecture and reuse

- **Existing systems reused:** The existing `murph.generate_image` continuation, strict `murph.send_physical_note` recipient schema, Web-owned `LOB_FROM_ADDRESS_ID`, Lob First Class adapter, live-send kill switch, idempotency, and ordinary physical-note accounting remain their current owners.
- **New logic:** One additional live-configuration condition requires an operator confirmation that the account-level USPS Secure Destruction setting is enabled, and assistant instructions explicitly forbid collecting a return address.
- **New abstractions:** A small pure physical-note configuration reader is extracted from the existing service so the live-account invariant can be tested directly; it introduces no new runtime, workflow, state owner, or provider adapter.
- **Complexity intentionally avoided:** The patch does not add a fake address, a per-user return address, a per-letter Secure Destruction field Lob does not support, another database row, a second mail path, or a dashboard integration that pretends to toggle the account setting.

## Resulting flow

```text
person supplies recipient address
  -> Murph generates the note
  -> murph.send_physical_note receives recipient only
  -> Web binds LOB_FROM_ADDRESS_ID
  -> Lob sends First Class mail
  -> account-level USPS Secure Destruction handles eligible undeliverable mail
```

No fake or user-provided return address is introduced, and no per-letter setting is invented that Lob does not support.

## Deployment

1. Configure the fixed Murph/company return address in Lob and set `LOB_FROM_ADDRESS_ID`.
2. Enable USPS Secure Destruction in the Lob account.
3. Set `LOB_USPS_SECURE_DESTRUCTION_CONFIRMED=true` only after step 2 is complete.
4. Keep `LOB_PHYSICAL_NOTES_LIVE_ENABLED` off until the usual test-mode proof passes, then enable live sending.

## Verification

The current head is green:

- Release build/typecheck, package-boundary checks, artifact hygiene, and doc gardening.
- Assistant, platform, CLI, fixture, and cross-platform host coverage.
- Release app verification.
- Repo Hygiene.
- Cloudflare Runner Permission Sandbox.
- Web Viewport Overflow.
- Frontend Design Proof.
- Vercel status check.


## Review gates

- **Product-experience lens: applicable.** The user-visible assistant journey changes by eliminating return-address collection; focused evidence is the assistant return-address regression and strict tool-schema rejection.
- **Prompt lens: applicable.** Tool metadata and the deferred physical-note skill change; focused evidence is `packages/assistant-engine/test/assistant-physical-note-return-address.test.ts`.
- **Frontend lens: not applicable.** No user-facing `apps/web` UI or rendered state changes.
- **Coverage lens: applicable.** Executable configuration behavior and prompt/tool behavior change; focused evidence is the new Web configuration test and assistant regression.

**Product outcome:** A person supplies only the recipient address; Murph uses the fixed platform return address and live Lob sends fail closed unless the operator has confirmed account-level USPS Secure Destruction.

**Immediate feedback, timing, continuation, and recovery:** Existing physical-note continuation and status behavior remain unchanged. Missing or unconfirmed live provider configuration remains unavailable before provider entry; test-mode proof remains available.

**Non-obvious affected surfaces:** Hosted assistant instruction/tool assembly and Web provider-configuration admission. No frontend rendering, persistence owner, provider adapter, billing flow, or per-letter Lob field changes.

**Exact-head proof:** Focused tests previously passed on the authored patch. Required CI is pending on the base-merge-only head `19d7c5a6ed16093163bce1ee2e7579d4582721cf`.

ReviewGPT first-reviewed head: 19d7c5a6ed16093163bce1ee2e7579d4582721cf

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 72 | 42 |
| Tests | 89 | 0 |
| Docs | 28 | 16 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
