### PR TITLE
Finish retained phone-transfer recovery and ReviewGPT bump

### DIFF
--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -131,14 +131,12 @@ head. The response must contain `SPECIALIST_REVIEW_COMPLETE` and one of
 `SPECIALIST_OUTCOME: PASS`, `SPECIALIST_OUTCOME: FINDINGS`, or
 `SPECIALIST_OUTCOME: INVALID`. Apply the same exact-turn, attachment, configured
 model, and owned-target checks used by the final gate. Because this is a narrow,
-lens-scoped pass, its minimum trustworthy duration is 4 minutes rather than the
-final gate's default 7.5-minute floor. A marked response below 4 minutes does not
-count. The current ReviewGPT package may conservatively reject any marked
-concrete-model response below 7.5 minutes; a specialist response at or above 4
-minutes may still count after local inspection confirms the exact turn,
-attachment, requested model selection, completion marker, and substantive lens
-coverage. Record the elapsed time, lane/model evidence, and acceptance reason;
-the package's missing attestation sidecar is expected for this manual exception.
+lens-scoped pass, its minimum trustworthy duration is 5 minutes rather than the
+final gate's default 7.5-minute floor. A marked response below 5 minutes does not
+count. The ReviewGPT package enforces that same five-minute minimum for marked
+concrete-model responses. Duration alone is not sufficient: confirm the exact
+turn, attachment, requested model selection, completion marker, and substantive
+lens coverage, then record the elapsed time and lane/model evidence.
 An `INVALID` result is a tooling/evidence failure: correct the gap and retry the
 same preliminary pass. A `PASS` or `FINDINGS` result is the one substantive
 specialist pass; do not split or rerun it by lens.
@@ -342,10 +340,9 @@ requires it or the current user explicitly asks for it.
    confirms the exact turn, attachment, requested model selection, completion
    marker, and a substantive review proportionate to the requested scope. Record
    the elapsed time, selected lane/model evidence, artifact-quality judgment,
-   and acceptance reason in the round handoff. The current ReviewGPT package may
-   conservatively fail such a near-threshold run and omit its model-verification
-   sidecar; that diagnostic status alone does not invalidate a documented manual
-   acceptance. Responses at or above 7.5 minutes still require all ordinary
+   and acceptance reason in the round handoff. ReviewGPT's package-level
+   five-minute attestation threshold does not replace this stricter final-gate
+   judgment. Responses at or above 7.5 minutes still require all ordinary
    evidence checks and are not trusted by duration alone.
 
    If a too-fast response is not accepted under this narrow exception, preserve

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -31,6 +31,7 @@ import {
   WebmailIcon,
 } from "@/src/components/settings/hosted-email-murph-contact-dialog";
 import {
+  HostedPhonePrivyHandOffStatus,
   HostedPhoneLinkAction,
   HostedPhoneLinkCardPresentation,
 } from "@/src/components/settings/hosted-phone-settings";
@@ -565,6 +566,8 @@ export function ComponentsContent() {
   const [inlineContactAvatarId, setInlineContactAvatarId] = useState("hooded");
   const [phoneInputCountryCode, setPhoneInputCountryCode] = useState("US");
   const [phoneInputValue, setPhoneInputValue] = useState("");
+  const [phoneTransferSupportDialogOpen, setPhoneTransferSupportDialogOpen] =
+    useState(false);
   const [whoopCompletionPreviewKey, setWhoopCompletionPreviewKey] = useState(0);
   const [whoopCapacityPreviewOpen, setWhoopCapacityPreviewOpen] = useState(false);
   const [whoopCapacityNoContactPreviewOpen, setWhoopCapacityNoContactPreviewOpen] =
@@ -1821,6 +1824,29 @@ export function ComponentsContent() {
                 />
               </div>
             ))}
+          </div>
+          <div className="space-y-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              Settings support-required dialog
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => setPhoneTransferSupportDialogOpen(true)}
+            >
+              Preview terminal dialog
+            </Button>
+            {phoneTransferSupportDialogOpen
+              ? (
+                  <HostedPhonePrivyHandOffStatus
+                    errorMessage="That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely."
+                    isLinking={false}
+                    isRetryAllowed={false}
+                    isSyncing={false}
+                    onAborted={() => setPhoneTransferSupportDialogOpen(false)}
+                    onRetry={() => {}}
+                  />
+                )
+              : null}
           </div>
         </Section>
 

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1687,7 +1687,7 @@ export function ComponentsContent() {
             Settings repairs that projection directly. A declined transfer
             closes quietly, and a failed save retries without reopening Privy.
             Existing phone accounts use the same surface for replacement.
-            Support-required conflicts offer both retry and a direct email
+            Support-required conflicts stop retrying and leave one direct email
             action without putting account identifiers in the message.
             Privacy-safe lifecycle diagnostics observe these states without
             changing any rendered state or action.
@@ -1764,6 +1764,7 @@ export function ComponentsContent() {
           >
             {[
               {
+                disabled: false,
                 errorMessage: null,
                 label: "Resting",
                 state: "resting",
@@ -1771,11 +1772,22 @@ export function ComponentsContent() {
                 statusTone: "neutral" as const,
               },
               {
+                disabled: false,
                 errorMessage: null,
                 label: "Saved status",
                 state: "status",
                 statusMessage: "Phone saved.",
                 statusTone: "success" as const,
+              },
+              {
+                disabled: true,
+                errorMessage:
+                  "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
+                label: "Support required",
+                state: "support-required",
+                statusMessage:
+                  "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
+                statusTone: "destructive" as const,
               },
             ].map((preview) => (
               <div
@@ -1789,6 +1801,7 @@ export function ComponentsContent() {
                 <HostedContactChannelChoice
                   phone={
                     <HostedPhoneLinkCardPresentation
+                      disabled={preview.disabled}
                       errorMessage={preview.errorMessage}
                       isChangeFlow={false}
                       isLinking={false}

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1767,6 +1767,7 @@ export function ComponentsContent() {
                 disabled: false,
                 errorMessage: null,
                 label: "Resting",
+                showPhoneAction: true,
                 state: "resting",
                 statusMessage: null,
                 statusTone: "neutral" as const,
@@ -1775,6 +1776,7 @@ export function ComponentsContent() {
                 disabled: false,
                 errorMessage: null,
                 label: "Saved status",
+                showPhoneAction: true,
                 state: "status",
                 statusMessage: "Phone saved.",
                 statusTone: "success" as const,
@@ -1784,6 +1786,7 @@ export function ComponentsContent() {
                 errorMessage:
                   "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
                 label: "Support required",
+                showPhoneAction: false,
                 state: "support-required",
                 statusMessage:
                   "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
@@ -1806,6 +1809,7 @@ export function ComponentsContent() {
                       isChangeFlow={false}
                       isLinking={false}
                       isSyncing={false}
+                      showPhoneAction={preview.showPhoneAction}
                       statusMessage={preview.statusMessage}
                       statusTone={preview.statusTone}
                       onClick={() => {}}

--- a/apps/web/src/components/settings/hosted-phone-settings.tsx
+++ b/apps/web/src/components/settings/hosted-phone-settings.tsx
@@ -8,6 +8,7 @@ import {
 import { PhoneIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { HostedOnboardingApiError } from "@/src/components/hosted-onboarding/client-api";
 import { finalizeHostedPhoneLink } from "@/src/components/hosted-onboarding/hosted-phone-auth-support";
 import {
   ContactSupportAction,
@@ -47,6 +48,7 @@ export function HostedPhoneSettings(props: {
   const { user: privyUser } = useUser();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLinking, setIsLinking] = useState(false);
+  const [isRetryAllowed, setIsRetryAllowed] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const accountTransferPendingRef = useRef(false);
@@ -167,6 +169,11 @@ export function HostedPhoneSettings(props: {
         reportDiagnostic("sync_succeeded");
       }
     } catch (error) {
+      if (isTerminalHostedPhoneLinkError(error)) {
+        pendingSyncExpectationRef.current = null;
+        pendingSyncOperationRef.current = null;
+        setIsRetryAllowed(false);
+      }
       reportDiagnostic("sync_failed", {
         detailCode: "other",
       });
@@ -278,6 +285,7 @@ export function HostedPhoneSettings(props: {
 
   async function handleLinkPhone() {
     setErrorMessage(null);
+    setIsRetryAllowed(true);
     setSuccessMessage(null);
 
     const pendingExpectation = pendingSyncExpectationRef.current;
@@ -369,6 +377,7 @@ export function HostedPhoneSettings(props: {
       <HostedPhonePrivyHandOffStatus
         errorMessage={errorMessage}
         isLinking={isLinking}
+        isRetryAllowed={isRetryAllowed}
         isSyncing={isSyncing}
         onAborted={props.onAborted}
         onRetry={handleLinkPhone}
@@ -378,7 +387,7 @@ export function HostedPhoneSettings(props: {
 
   return (
     <HostedPhoneLinkCardPresentation
-      disabled={isBusy}
+      disabled={isBusy || !isRetryAllowed}
       errorMessage={errorMessage}
       isChangeFlow={shouldUpdatePhone}
       isLinking={isLinking}
@@ -413,12 +422,14 @@ function HostedPhoneSupportAction({
 function HostedPhonePrivyHandOffStatus({
   errorMessage,
   isLinking,
+  isRetryAllowed,
   isSyncing,
   onAborted,
   onRetry,
 }: {
   errorMessage: string | null;
   isLinking: boolean;
+  isRetryAllowed: boolean;
   isSyncing: boolean;
   onAborted?: () => void;
   onRetry: () => void;
@@ -443,15 +454,19 @@ function HostedPhonePrivyHandOffStatus({
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-3">
-            <Button
-              type="button"
-              size="xl"
-              className="w-full"
-              disabled={isLinking || isSyncing}
-              onClick={onRetry}
-            >
-              Try again
-            </Button>
+            {isRetryAllowed
+              ? (
+                  <Button
+                    type="button"
+                    size="xl"
+                    className="w-full"
+                    disabled={isLinking || isSyncing}
+                    onClick={onRetry}
+                  >
+                    Try again
+                  </Button>
+                )
+              : null}
             <HostedPhoneSupportAction errorMessage={errorMessage} />
           </div>
         </DialogContent>
@@ -565,4 +580,11 @@ function toPhoneLinkErrorMessage(error: unknown): string {
   }
 
   return toErrorMessage(error, "We could not link that phone number.");
+}
+
+function isTerminalHostedPhoneLinkError(error: unknown): boolean {
+  return (
+    error instanceof HostedOnboardingApiError
+    && error.code === "PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE"
+  );
 }

--- a/apps/web/src/components/settings/hosted-phone-settings.tsx
+++ b/apps/web/src/components/settings/hosted-phone-settings.tsx
@@ -420,7 +420,7 @@ function HostedPhoneSupportAction({
   );
 }
 
-function HostedPhonePrivyHandOffStatus({
+export function HostedPhonePrivyHandOffStatus({
   errorMessage,
   isLinking,
   isRetryAllowed,

--- a/apps/web/src/components/settings/hosted-phone-settings.tsx
+++ b/apps/web/src/components/settings/hosted-phone-settings.tsx
@@ -392,6 +392,7 @@ export function HostedPhoneSettings(props: {
       isChangeFlow={shouldUpdatePhone}
       isLinking={isLinking}
       isSyncing={isSyncing}
+      showPhoneAction={isRetryAllowed}
       statusMessage={statusMessage}
       statusTone={statusTone}
       onClick={handleLinkPhone}
@@ -515,6 +516,7 @@ export function HostedPhoneLinkCardPresentation(props: {
   isChangeFlow: boolean;
   isLinking: boolean;
   isSyncing: boolean;
+  showPhoneAction?: boolean;
   statusMessage: string | null;
   statusTone: "neutral" | "success" | "destructive";
   onClick: () => void;
@@ -525,13 +527,17 @@ export function HostedPhoneLinkCardPresentation(props: {
           when a message appears, so it stays tight to the action it reports
           on rather than reading as a gap below the card's primary CTA. */}
       <div className="space-y-2">
-        <HostedPhoneLinkAction
-          disabled={props.disabled}
-          isChangeFlow={props.isChangeFlow}
-          isLinking={props.isLinking}
-          isSyncing={props.isSyncing}
-          onClick={props.onClick}
-        />
+        {props.showPhoneAction === false
+          ? null
+          : (
+              <HostedPhoneLinkAction
+                disabled={props.disabled}
+                isChangeFlow={props.isChangeFlow}
+                isLinking={props.isLinking}
+                isSyncing={props.isSyncing}
+                onClick={props.onClick}
+              />
+            )}
 
         <SettingsStatusLine
           message={props.statusMessage}

--- a/apps/web/src/lib/hosted-onboarding/privy-phone-transfer-retirement.ts
+++ b/apps/web/src/lib/hosted-onboarding/privy-phone-transfer-retirement.ts
@@ -29,9 +29,9 @@ import { acquireHostedLinqParticipantPhoneLockTx } from "./linq-participant-cont
 import { normalizePhoneNumber } from "./phone";
 import {
   readHostedPrivyUserByIdIfExists,
-  resolveHostedPrivyIdentityFromVerifiedUser,
   type HostedPrivyIdentity,
 } from "./privy";
+import { resolveHostedPrivyLinkedAccountState } from "./privy-shared";
 import {
   HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
   lockHostedMemberRow,
@@ -134,7 +134,7 @@ export async function readHostedPrivyPhoneTransferProof(input: {
     // account because it carries other login methods, so it will never be
     // deleted and retrying can never resolve anything.
     const survivingSourcePhoneNumber =
-      resolveHostedPrivyIdentityFromVerifiedUser(sourcePrivyUser).phone?.number;
+      resolveHostedPrivyLinkedAccountState(sourcePrivyUser).phone?.number;
     const survivingSourceStillHoldsPhone = Boolean(
       survivingSourcePhoneNumber
       && normalizePhoneNumber(survivingSourcePhoneNumber)

--- a/apps/web/test/hosted-onboarding-privy-phone-transfer-retirement.test.ts
+++ b/apps/web/test/hosted-onboarding-privy-phone-transfer-retirement.test.ts
@@ -40,9 +40,6 @@ vi.mock("@/src/lib/hosted-onboarding/linq-participant-contact", () => ({
 vi.mock("@/src/lib/hosted-onboarding/privy", () => ({
   readHostedPrivyUserByIdIfExists:
     mocks.readHostedPrivyUserByIdIfExists,
-  // Provider users are stubbed as their own resolved identity shape so a
-  // test can state exactly which phone a surviving source still holds.
-  resolveHostedPrivyIdentityFromVerifiedUser: (user: unknown) => user,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/shared", () => ({
@@ -107,8 +104,14 @@ describe("Privy phone-transfer source retirement", () => {
     it("asks the member to wait while the source still holds the phone", async () => {
       stubPhoneOwner();
       mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue({
-        phone: { number: PHONE_NUMBER },
-        userId: SOURCE_PRIVY_USER_ID,
+        id: SOURCE_PRIVY_USER_ID,
+        linkedAccounts: [
+          {
+            latest_verified_at: 1,
+            phone_number: PHONE_NUMBER,
+            type: "phone",
+          },
+        ],
       });
 
       await expect(readProof()).rejects.toMatchObject({
@@ -117,12 +120,25 @@ describe("Privy phone-transfer source retirement", () => {
       });
     });
 
-    it("stops retrying once the source keeps its own sign-in without the phone", async () => {
+    it("stops retrying once the source keeps other sign-ins without the phone", async () => {
       stubPhoneOwner();
       mocks.readHostedPrivyUserByIdIfExists.mockResolvedValue({
-        email: { address: "owner@example.com" },
-        phone: null,
-        userId: SOURCE_PRIVY_USER_ID,
+        id: SOURCE_PRIVY_USER_ID,
+        linkedAccounts: [
+          {
+            address: "owner@example.com",
+            latest_verified_at: 1,
+            type: "email",
+          },
+          {
+            telegram_user_id: "telegram-source-a",
+            type: "telegram",
+          },
+          {
+            telegram_user_id: "telegram-source-b",
+            type: "telegram",
+          },
+        ],
       });
 
       await expect(readProof()).rejects.toMatchObject({

--- a/apps/web/test/settings-phone-settings.test.ts
+++ b/apps/web/test/settings-phone-settings.test.ts
@@ -1,6 +1,8 @@
 import { act, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { HostedOnboardingApiError } from "@/src/components/hosted-onboarding/client-api";
+
 import { renderClientComponent } from "./render-client-component";
 
 type LinkAccountCallbacks = {
@@ -860,6 +862,49 @@ describe("HostedPhoneSettings", () => {
     expect(supportLink?.getAttribute("href")).toContain("subject=Help+linking+my+phone");
     expect(supportLink?.getAttribute("href")).not.toContain("privy-user-a");
     expect(mocks.finalizeHostedPhoneLink).not.toHaveBeenCalled();
+  });
+
+  it("offers support without retrying a terminal transferred-source conflict", async () => {
+    mocks.providerPhoneNumber = "+15550100002";
+    mocks.finalizeHostedPhoneLink.mockRejectedValue(new HostedOnboardingApiError({
+      code: "PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE",
+      message:
+        "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
+      retryable: false,
+    }));
+    const { HostedPhoneSettings } = await import("@/src/components/settings/hosted-phone-settings");
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedPhoneSettings, {
+        initialPhoneNumber: null,
+      }),
+    );
+    cleanupRender = cleanup;
+
+    await act(async () => {
+      findButton(container, "Change phone")?.dispatchEvent(
+        new Event("click", { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        "That phone moved from another Murph account",
+      );
+    });
+
+    const phoneButton = findButton(container, "Change phone");
+    expect(phoneButton?.disabled).toBe(true);
+    expect(container.textContent).toContain("Contact support");
+    expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
+    expect(mocks.linkPhone).not.toHaveBeenCalled();
+    expect(mocks.updatePhone).not.toHaveBeenCalled();
+
+    await act(async () => {
+      phoneButton?.dispatchEvent(new Event("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
   });
 
   it("does not infer an update flow from linked-account projections alone", async () => {

--- a/apps/web/test/settings-phone-settings.test.ts
+++ b/apps/web/test/settings-phone-settings.test.ts
@@ -893,18 +893,11 @@ describe("HostedPhoneSettings", () => {
       );
     });
 
-    const phoneButton = findButton(container, "Change phone");
-    expect(phoneButton?.disabled).toBe(true);
+    expect(findButton(container, "Change phone")).toBeUndefined();
     expect(container.textContent).toContain("Contact support");
     expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
     expect(mocks.linkPhone).not.toHaveBeenCalled();
     expect(mocks.updatePhone).not.toHaveBeenCalled();
-
-    await act(async () => {
-      phoneButton?.dispatchEvent(new Event("click", { bubbles: true }));
-      await Promise.resolve();
-    });
-    expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
   });
 
   it("does not infer an update flow from linked-account projections alone", async () => {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.117",
+    "@cobuild/review-gpt": "^0.5.122",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -939,13 +939,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.117')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.122')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.117'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.122'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1007,7 +1007,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptDriver).toContain('`CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain('`Nested CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain(
-      'const MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS = 7.5 * 60 * 1000;',
+      'const MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS = 5 * 60 * 1000;',
     )
     const solTarget: ReviewGptModelPickerTarget = {
       desiredVersion: '5-6',
@@ -1098,9 +1098,9 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(reviewGptReadme).toContain('the exact turn committed by this run')
     expect(reviewGptReadme).toContain('An ephemeral per-run nonce')
-    expect(reviewGptReadme).toContain('after at least 7.5 minutes of observed generation')
+    expect(reviewGptReadme).toContain('after at least 5 minutes of observed generation')
     expect(reviewGptReadme).toContain(
-      'A marked concrete-model response that completes in under 7.5 minutes fails closed as untrusted',
+      'A marked concrete-model response that completes in under 5 minutes fails closed as untrusted',
     )
     expect(reviewGptDriver).toContain('REVIEW_GPT_TURN_NONCE:')
     expect(reviewGptDriver).not.toContain("value.includes('MODEL_CONFIRMATION:')")
@@ -1162,6 +1162,7 @@ describe('monorepo release flow coverage audit', () => {
         '  let ownedTargetId = pageTargetId;',
         '  let operationError = null;',
         '  let completedResponseCapture = null;',
+        '  let waitedAttachmentCleanupPending = false;',
         '  let releasePageFocusEmulation = async () => {};',
         '  try {',
       ].join('\n'),
@@ -1463,7 +1464,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(prReviewGptLoop).toContain('ReviewGPT first-reviewed head: <full-sha>')
     expect(prReviewGptLoop).toContain('`ROUND_OUTCOME: INVALID`')
     expect(prReviewGptLoop).toContain(
-      'its minimum trustworthy duration is 4 minutes',
+      'its minimum trustworthy duration is 5 minutes',
     )
     expect(prReviewGptLoop).toContain(
       'Treat 7.5 minutes as the default final-gate trust floor',
@@ -1967,7 +1968,7 @@ describe('monorepo release flow coverage audit', () => {
         'gpt-5.6-sol',
         extractedConfirmation,
         '',
-        7.5 * 60 * 1000 - 1,
+        5 * 60 * 1000 - 1,
       ),
     ).toContain('confirmed model UNKNOWN, expected gpt-5.6-sol')
     expect(
@@ -1975,7 +1976,7 @@ describe('monorepo release flow coverage audit', () => {
         'gpt-5.6-sol',
         extractedConfirmation,
         '',
-        7.5 * 60 * 1000,
+        5 * 60 * 1000,
       ),
     ).toBe('')
     expect(
@@ -1983,7 +1984,7 @@ describe('monorepo release flow coverage audit', () => {
         'gpt-5.6-sol',
         extractedConfirmation,
         'gpt-5-5-pro',
-        7.5 * 60 * 1000,
+        5 * 60 * 1000,
       ),
     ).toContain('DOM reported model gpt-5-5-pro, expected gpt-5.6-sol')
 
@@ -2196,7 +2197,7 @@ describe('monorepo release flow coverage audit', () => {
         elapsedFallbackSnapshot,
         true,
         committedUserTurnSignature,
-        7.5 * 60 * 1000 - 1,
+        5 * 60 * 1000 - 1,
       ),
     ).toMatchObject({ evidence: null, failure: expect.stringContaining('confirmed model UNKNOWN') })
     expect(
@@ -2205,7 +2206,7 @@ describe('monorepo release flow coverage audit', () => {
         elapsedFallbackSnapshot,
         true,
         committedUserTurnSignature,
-        7.5 * 60 * 1000,
+        5 * 60 * 1000,
       ),
     ).toEqual({ evidence: null, failure: '' })
 
@@ -2239,24 +2240,24 @@ describe('monorepo release flow coverage audit', () => {
     ).toMatchObject({ evidence: null })
   })
 
-  it('fails closed marked concrete-model responses below seven and a half minutes', () => {
+  it('fails closed marked concrete-model responses below five minutes', () => {
     const harness = loadReviewGptOpenTargetHarness(1)
 
     expect(
       harness.markedResponseDurationFailure('gpt-5.6-sol', 'ROUND_OUTCOME:', 37_000),
-    ).toContain('after 37s, below the 7.5m minimum')
+    ).toContain('after 37s, below the 5m minimum')
     expect(
       harness.markedResponseDurationFailure(
         'gpt-5.6-sol',
         'ROUND_OUTCOME:',
-        7.5 * 60 * 1000 - 1,
+        5 * 60 * 1000 - 1,
       ),
     ).toContain('The response is untrusted and was not attested.')
     expect(
       harness.markedResponseDurationFailure(
         'gpt-5.6-sol',
         'ROUND_OUTCOME:',
-        7.5 * 60 * 1000,
+        5 * 60 * 1000,
       ),
     ).toBe('')
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       '@cobuild/review-gpt':
-        specifier: ^0.5.117
-        version: 0.5.117(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.122
+        version: 0.5.122(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1329,8 +1329,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.117':
-    resolution: {integrity: sha512-s2/qIU2+l5n5R/sQ9ORB0YfHtV4dWKfqHzGLMXNdfP540hy7ozY1d+jeoZBg7+JCJtAEddCRoni/nfTqdNmR+A==}
+  '@cobuild/review-gpt@0.5.122':
+    resolution: {integrity: sha512-+STlVUmDLiLvVK6W0tBpSznVHIMspov7VXZrCfUpsN+jj7RBAfJ3QtTB4HU2Gqea2E5dwFZa6ORo3AMHh1XLMA==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10262,7 +10262,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)': {}
 
-  '@cobuild/review-gpt@0.5.117(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.122(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.117'
+  - '@cobuild/review-gpt@0.5.122'
   - '@onkernel/sdk@0.76.0'
   - '@openai/codex@0.145.0||0.145.0-darwin-arm64||0.145.0-darwin-x64||0.145.0-linux-arm64||0.145.0-linux-x64||0.145.0-win32-arm64||0.145.0-win32-x64'
   - '@temporalio/activity@1.16.3'


### PR DESCRIPTION
## Why this PR exists

The merged phone-transfer follow-up still left two production bugs, and Murph still pinned the ReviewGPT release whose managed composer no longer worked:

- reading a surviving source account's phone went through the full Privy identity resolver, so unrelated Telegram ambiguity could replace the intended phone-transfer support error;
- the support-only transfer state retained its sync expectation and still rendered a phone action, leaving an impossible manual retry path;
- the repository still resolved `@cobuild/review-gpt` 0.5.117 instead of the repaired 0.5.122 release.

## User goal and product experience

An authenticated member whose phone moved away from a still-active source account sees one terminal explanation and one support action. Murph does not keep asking them to retry an operation that cannot converge. Genuinely in-flight provider transfers and transient Murph save failures retain their existing retry paths.

- Initiating actor: an authenticated member linking or replacing a phone.
- Entry point: Settings or the shared join phone-link surface.
- Immediate feedback: provider progress while the move is in flight; a support-only explanation when the provider retained the old account.
- Continuation owner: Murph retries only propagation and transient save states.
- Terminal recovery: the existing support email action; no source-account or phone identifier is put in the message.

## Invariants

- Privy remains the authority for current phone ownership.
- The surviving-source read inspects only linked-phone state and cannot fail on unrelated Telegram state.
- A terminal source conflict clears the exact pending sync expectation before rendering.
- Transient post-provider save failures keep the exact expectation and never reopen Privy.
- No source account is mutated on the terminal path.
- Dependency policy controls remain enabled; the lockfile and release-age exception move together.

## Direct evidence

- The real linked-account selector is exercised with a surviving source containing two conflicting Telegram accounts and no phone; the phone-specific support code wins.
- The component regression proves the terminal state removes the phone action, leaves support available, and does not issue a second sync or reopen Privy. Browser catalog proof separately verifies the real Settings dialog has no Try again control and retains support and close affordances.
- Production aggregate inspection found no persisted member or web-session write in the bounded incident window. Historical request logs no longer cover that window, so the pre-write email/Privy handoff remains an evidence gap and this PR does not guess at an unrelated auth fix.

## Preliminary specialist lenses

- Product experience: applicable — terminal recovery and action priority change. Intended outcome and direct journey evidence are described above.
- Prompt: not applicable — no model prompt, tool description, or provider-input assembly changed.
- Frontend: applicable — the support-required shared card and Settings dialog remove the impossible phone action. Packaged evidence: `.artifacts/review-gpt/pr-1267-phone-transfer-desktop.png` and `.artifacts/review-gpt/pr-1267-phone-transfer-dialog-desktop.png` at 1440 CSS px / 2x; `.artifacts/review-gpt/pr-1267-phone-transfer-mobile.png` and `.artifacts/review-gpt/pr-1267-phone-transfer-dialog-mobile.png` at 390 CSS px / 3x.
- Coverage: applicable — executable retry and selector behavior changed. Focused Vitest passed 83 tests; hosted-web typecheck and scoped ESLint passed. Exact-head CI is pending.

ReviewGPT first-reviewed head: a60c537f04e85080c275ddcb8846d1bd488f3e64

## Verification

- Focused Vitest: five phone-transfer, selector, sync, and component suites; 83 tests passed.
- ReviewGPT release-contract audit: 40 tests passed; 1 intentional skip.
- Hosted Web typecheck: passed.
- Scoped ESLint across the changed web source, test, and catalog files: passed.
- Dependency policy guard: passed.
- Ignored build scripts: reviewed; no new build-script approval.
- Installed ReviewGPT CLI: reports 0.5.122.
- Dependency audit: fails on the repository's existing advisory baseline. The old and new ReviewGPT lock entries resolve the same `repomix` 1.16.0 graph, including the reported transitive advisories; this bump does not change that graph.

## Design proof

- Design page: [Phone Account Linking component catalog](/design?tab=components#phone-account-linking), “Support required”.
- Desktop screenshot: ![Desktop support-required phone-transfer state without a phone retry action](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/7a7d4dfc-d7d2-43fa-8932-a8a46449de00/designproof)
- Mobile screenshot: ![Mobile support-required phone-transfer state without a phone retry action](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1a1f5ebc-11d7-4de1-774e-6a4aa77cac00/designproof)
- Desktop screenshot (Settings dialog): ![Desktop support-required Settings phone dialog with support and close actions](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/ebc339a0-4f30-4911-6202-b8704e206400/designproof)
- Mobile screenshot (Settings dialog): ![Mobile support-required Settings phone dialog with support and close actions](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/0598999a-86af-4d8c-25d6-9d33f0297600/designproof)

All four delivered images were inspected at native resolution. They use synthetic catalog props and contain no member data.

## Architecture and reuse

- Existing systems reused: the shared Privy linked-account selector, `HostedOnboardingApiError`, the existing pending sync expectation, support action, and real phone-link presentation component.
- New logic: one code-specific terminal-state bit clears retained retry state and removes the two existing retry controls.
- New abstractions: no new owner or service; one optional presentation prop exposes whether the existing phone action should render.
- Complexity intentionally avoided: no account merge, retry manager, provider mutation, or new state owner; the fix narrows the read and deletes an impossible action.

## Change-shape breakdown

Classification is by base-to-head path: authored application/catalog files are source, test files are tests/fixtures, manifest and workspace policy files are config/tooling, and the generated lockfile is generated/other. No binary files are in the diff.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 92 | 21 |
| Tests/fixtures | 79 | 24 |
| Docs | 9 | 12 |
| Config/tooling | 2 | 2 |
| Generated/other | 5 | 5 |
| **Total** | **187** | **64** |

## Deployment skew / compatibility

Web-only and backward compatible. The server code already emits the terminal code on main; deploying this client correction later only removes the stale manual retry. The dependency bump affects local/review tooling, not production runtime.

## Non-obvious affected surfaces

The 0.5.122 ReviewGPT release bundles its managed-composer repair with review-evidence timing changes used repository-wide:

- the package-level marked-response and unknown-model fallback floor moves from 7.5 minutes to 5 minutes;
- the preliminary specialist floor moves from 4 minutes to 5 minutes and no longer needs the former manual exception;
- Murph deliberately retains its stricter final-gate policy: responses below 6.5 minutes are rejected, and 7.5 minutes remains the default trust floor.

Adopting these bundled timing changes is necessary to consume the published composer repair because 0.5.122 is the repaired release and no narrower repaired package version exists. The release-contract audit provides boundary proof for modelConfirmationFailure, modelAttestationForSnapshot, and markedResponseDurationFailure: five minutes minus one millisecond fails and five minutes succeeds. The operating-contract assertions separately preserve the final-gate 6.5-minute rejection boundary and 7.5-minute default.