### PR TITLE
Retry transient hosted artifact writes for device sync

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -293,6 +293,11 @@ Last verified: 2026-07-31
   for the private message.
 - Foreground inbox/parser-backed daemon runs should favor restartable connectors with bounded backoff over permanently dead watch loops, while still keeping low-level restart behavior opt-in and always bounded by the owning abort signal.
 - Networked assistant/provider/channel calls should set explicit timeouts, propagate caller abort signals, and only auto-retry request shapes that are replay-safe or rate-limit directed.
+- Hosted artifact uploads are content-addressed and replay-safe. Transport failures
+  plus HTTP 408, 429, and 5xx responses carry typed retryability into the existing
+  device-sync job owner, which requeues with its normal bounded backoff. Write-fence
+  and authority failures, other HTTP responses, malformed data, and unclassified
+  errors remain terminal; the runtime must not create a second artifact retry queue.
 - Junction Link setup remains retryable but inert before proof-verified callback
   completion. Webhooks for an active `pending_link` or `link_returned` account
   release their trace claim and return a retryable not-ready response; they do

--- a/agent-docs/exec-plans/active/2026-08-03-device-sync-artifact-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-03-device-sync-artifact-retry.md
@@ -1,0 +1,44 @@
+# Device-sync artifact retry correctness
+
+## Goal
+
+Prevent transient hosted artifact-store failures from killing otherwise replay-safe device-sync jobs, while preserving fail-closed behavior for validation, authorization, and programming errors.
+
+## Proven production symptom
+
+- Hosted runtime logs recorded transient artifact upload transport failures on device-sync resource and backfill jobs.
+- The device-sync service normalized those generic errors as non-retryable `SYNC_JOB_FAILED`, so the affected jobs were dropped.
+- Junction profile-summary 404 responses already skip only that optional resource; they are not part of this fix.
+- Source-less Junction SDK accounts are an intentional pre-provider state. Any retry-loop change must preserve webhook admission and initial historical recovery after a provider is selected.
+
+## Success criteria
+
+- Hosted artifact upload transport timeouts, connection failures, and retryable HTTP responses reach device-sync as a stable retryable error.
+- Device-sync jobs remain queued with backoff after those failures instead of becoming dead.
+- Non-retryable HTTP responses, malformed data, and unexpected programming errors retain their existing terminal behavior.
+- No provider payload, credential, member identifier, or local path enters diagnostics or fixtures.
+- Source-less SDK behavior changes only if a focused test proves history can be restarted from existing durable source/webhook state.
+
+## Implementation
+
+1. Add focused failing tests at the hosted importer/device-sync boundary.
+2. Add the smallest boundary translation needed to preserve retry metadata.
+3. Evaluate the source-less historical retry loop and either make a proven safe simplification or leave it unchanged with the reason recorded.
+4. Run focused package tests and typechecks plus a direct retry-state scenario.
+5. Push an exact candidate, run required CI and ReviewGPT gates, resolve accepted findings, and close this plan with the final scoped commit.
+
+## Verification
+
+- The hosted importer regression proves a retryable artifact write leaves the
+  device-sync job queued, while a terminal write leaves it dead with the same
+  stable error code.
+- Cloudflare artifact-store coverage proves transport, 408, 429, and 5xx
+  failures are retryable; 422 is terminal; existing authority rejection
+  coverage remains green.
+- The existing Junction profile test proves summary-profile 404 is imported as
+  a one-shot optional skip instead of failing the sync.
+- The existing SDK sign-in suite proves source-less setup remains
+  `source_confirmed`, seeds initial jobs, and schedules reconciliation. Production
+  evidence showed successful job completion without current errors, so this
+  intentional pre-provider recovery state is unchanged.
+- Focused package tests and both affected package typechecks pass locally.

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -205,6 +205,12 @@ writes, provider effects, and mailbox payload decode authorize the current
 runner by runtime-kind write-fence identity (`attemptId`, `generation`, and
 `userId`). The transport still carries the generation in the historical
 `leaseGeneration` header until the 2026-05-25 compatibility deletion.
+Artifact objects are addressed by their content hash, so retrying the same PUT is
+replay-safe. The Worker classifies transport failures and HTTP 408, 429, and 5xx
+responses as retryable; a hosted device-sync import preserves that classification
+for its existing job backoff owner. Authority/header failures and other HTTP
+responses remain terminal, and artifact transport does not own an independent
+retry loop.
 External provider egress must not send exact runtime authority headers to
 third-party provider origins. Runtime provider fetches instead carry the
 bound-user header plus a short-lived opaque provider-egress token from the

--- a/apps/cloudflare/src/runtime-platform/artifact-store.ts
+++ b/apps/cloudflare/src/runtime-platform/artifact-store.ts
@@ -1,6 +1,7 @@
 import { emitHostedExecutionStructuredLog } from "@murphai/hosted-execution";
 import {
   HostedRuntimeArtifactReadError,
+  HostedRuntimeArtifactWriteError,
   type HostedRuntimePlatform,
 } from "@murphai/assistant-runtime/hosted-runtime-contracts";
 
@@ -20,6 +21,7 @@ import {
 import {
   HOSTED_REPLAY_SAFE_READ_RETRY_ATTEMPTS,
   HostedRuntimeControlPlaneFetchError,
+  shouldPreserveHostedRuntimeFetchError,
   shouldRetryHostedRuntimeReplaySafeRead,
   sleepHostedReplaySafeReadRetryDelay,
 } from "./control-plane-fetch.ts";
@@ -138,7 +140,13 @@ export function createCloudflareArtifactStore(input: {
         phase: "checkpoint",
         userId: null,
       });
-      throw error;
+      if (shouldPreserveHostedRuntimeFetchError(error)) {
+        throw error;
+      }
+      throw new HostedRuntimeArtifactWriteError({
+        cause: error,
+        retryable: true,
+      });
     }
 
     emitHostedExecutionStructuredLog({
@@ -156,7 +164,17 @@ export function createCloudflareArtifactStore(input: {
       phase: "checkpoint",
       userId: null,
     });
-    assertHostedOk(response, "Hosted artifact upload");
+    try {
+      assertHostedOk(response, "Hosted artifact upload");
+    } catch (error) {
+      if (shouldPreserveHostedRuntimeFetchError(error)) {
+        throw error;
+      }
+      throw new HostedRuntimeArtifactWriteError({
+        cause: error,
+        retryable: isRetryableHostedArtifactWriteStatus(response.status),
+      });
+    }
     emitHostedExecutionStructuredLog({
       component: "hosted.runtime.artifact-store",
       details: {
@@ -408,6 +426,10 @@ export function createCloudflareArtifactStore(input: {
       await putArtifactOnce({ bytes, sha256 });
     },
   };
+}
+
+function isRetryableHostedArtifactWriteStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
 }
 
 function assertHostedArtifactFetchLive(

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -36,6 +36,7 @@ import {
 } from "@murphai/assistant-runtime/hosted-checkpoint-bridge";
 import {
   HostedRuntimeArtifactReadError,
+  HostedRuntimeArtifactWriteError,
 } from "@murphai/assistant-runtime/hosted-runtime-contracts";
 import {
   HOSTED_RUNTIME_EMAIL_EGRESS_RECIPIENT_PATH,
@@ -7107,6 +7108,58 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(serializedLogs).not.toContain("member_123");
     expect(serializedLogs).not.toContain("runtime_write_123");
     expect(serializedLogs).not.toContain("temporary failure");
+  });
+
+  it.each([
+    { retryable: true, status: 408 },
+    { retryable: true, status: 429 },
+    { retryable: true, status: 503 },
+    { retryable: false, status: 422 },
+  ])("classifies artifact upload HTTP $status failures", async ({
+    retryable,
+    status,
+  }) => {
+    const fetchMock = vi.fn(async () => new Response(null, { status }));
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    let rejectedError: unknown;
+    try {
+      await platform.artifactStore.put({
+        bytes: new Uint8Array([1, 2, 3]),
+        sha256: "a".repeat(64),
+      });
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    expect(rejectedError).toBeInstanceOf(HostedRuntimeArtifactWriteError);
+    expect(rejectedError).toMatchObject({ retryable });
+  });
+
+  it("classifies artifact upload transport failures as retryable", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("fetch failed");
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    let rejectedError: unknown;
+    try {
+      await platform.artifactStore.put({
+        bytes: new Uint8Array([1, 2, 3]),
+        sha256: "a".repeat(64),
+      });
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    expect(rejectedError).toBeInstanceOf(HostedRuntimeArtifactWriteError);
+    expect(rejectedError).toMatchObject({ retryable: true });
   });
 
   it("validates the workspace lease immediately before web checkpoint callbacks", async () => {

--- a/packages/assistant-runtime/src/device-sync-service.ts
+++ b/packages/assistant-runtime/src/device-sync-service.ts
@@ -4,6 +4,7 @@ import { DEVICE_SYNC_DB_RELATIVE_PATH } from "@murphai/runtime-state/node/runtim
 import { buildJunctionProviderSourceInstanceKey } from "@murphai/device-syncd/connect-config";
 
 import {
+  createDefaultImporterPort,
   createDeviceSyncService,
   SqliteDeviceSyncStore,
 } from "@murphai/device-syncd/service";
@@ -13,8 +14,14 @@ import type {
   CreateDeviceSyncServiceInput,
   DeviceSyncService,
 } from "@murphai/device-syncd/service";
-import type { ProviderJobConnectionSource } from "@murphai/device-syncd/types";
-import type { HostedRuntimeDeviceSyncPort } from "./hosted-runtime/platform.ts";
+import type {
+  DeviceSyncImporterPort,
+  ProviderJobConnectionSource,
+} from "@murphai/device-syncd/types";
+import {
+  HostedRuntimeArtifactWriteError,
+  type HostedRuntimeDeviceSyncPort,
+} from "./hosted-runtime/platform.ts";
 
 const storeByService = new WeakMap<DeviceSyncService, SqliteDeviceSyncStore>();
 
@@ -29,9 +36,12 @@ export function createHostedRuntimeDeviceSyncService(
   );
 
   try {
-    const { deviceSyncPort, ...serviceInput } = input;
+    const { deviceSyncPort, importer, ...serviceInput } = input;
     const service = createDeviceSyncService({
       ...serviceInput,
+      importer: createHostedRuntimeDeviceSyncImporter(
+        importer ?? createDefaultImporterPort(),
+      ),
       ...(deviceSyncPort
         ? {
             listConnectionSourcesForJob: async (sourceInput) =>
@@ -50,6 +60,29 @@ export function createHostedRuntimeDeviceSyncService(
     store.close();
     throw error;
   }
+}
+
+function createHostedRuntimeDeviceSyncImporter(
+  importer: DeviceSyncImporterPort,
+): DeviceSyncImporterPort {
+  return {
+    async importDeviceProviderSnapshot(input) {
+      try {
+        return await importer.importDeviceProviderSnapshot(input);
+      } catch (error) {
+        if (!(error instanceof HostedRuntimeArtifactWriteError)) {
+          throw error;
+        }
+        throw deviceSyncError({
+          cause: error,
+          code: "HOSTED_DEVICE_SYNC_ARTIFACT_WRITE_FAILED",
+          httpStatus: error.retryable ? 503 : 500,
+          message: "Hosted device-sync artifact persistence failed. Retry shortly.",
+          retryable: error.retryable,
+        });
+      }
+    },
+  };
 }
 
 async function listHostedJobConnectionSources(input: {

--- a/packages/assistant-runtime/src/hosted-runtime-contracts.ts
+++ b/packages/assistant-runtime/src/hosted-runtime-contracts.ts
@@ -67,6 +67,7 @@ export type {
 export {
   HOSTED_RUNTIME_ARTIFACT_READ_PURPOSES,
   HostedRuntimeArtifactReadError,
+  HostedRuntimeArtifactWriteError,
 } from "./hosted-runtime/platform.ts";
 export {
   HOSTED_SHARED_CHANNEL_PLATFORM_ENV_NAMES,

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -160,6 +160,21 @@ export class HostedRuntimeArtifactReadError extends Error {
   }
 }
 
+export class HostedRuntimeArtifactWriteError extends Error {
+  readonly retryable: boolean;
+
+  constructor(input: { cause: unknown; retryable: boolean }) {
+    super(
+      input.cause instanceof Error
+        ? input.cause.message
+        : "Hosted runtime artifact write failed.",
+      { cause: input.cause },
+    );
+    this.name = "HostedRuntimeArtifactWriteError";
+    this.retryable = input.retryable;
+  }
+}
+
 export interface HostedRuntimeAssistantConfigurationToolPort {
   request(
     request: HostedRuntimeAssistantConfigurationControlRequest,

--- a/packages/assistant-runtime/test/device-sync-service.test.ts
+++ b/packages/assistant-runtime/test/device-sync-service.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   closeStore: vi.fn(),
+  createDefaultImporterPort: vi.fn(),
   createDeviceSyncService: vi.fn(),
   SqliteDeviceSyncStore: vi.fn(),
 }));
 
 vi.mock("@murphai/device-syncd/service", () => ({
+  createDefaultImporterPort: mocks.createDefaultImporterPort,
   createDeviceSyncService: mocks.createDeviceSyncService,
   SqliteDeviceSyncStore: mocks.SqliteDeviceSyncStore,
 }));
@@ -17,6 +19,9 @@ import { createHostedRuntimeDeviceSyncService } from "../src/device-sync-service
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.createDefaultImporterPort.mockReturnValue({
+    importDeviceProviderSnapshot: vi.fn(),
+  });
   mocks.SqliteDeviceSyncStore.mockImplementation(function MockSqliteDeviceSyncStore() {
     return {
       close: mocks.closeStore,

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -46,7 +46,10 @@ import {
   reconcileHostedDeviceSyncControlPlaneState,
   syncHostedDeviceSyncControlPlaneState,
 } from "../src/hosted-device-sync-runtime.ts";
-import type { HostedRuntimeDeviceSyncPort } from "../src/hosted-runtime/platform.ts";
+import {
+  HostedRuntimeArtifactWriteError,
+  type HostedRuntimeDeviceSyncPort,
+} from "../src/hosted-runtime/platform.ts";
 import { recordHostedDeviceSyncDirtyPostCheckpointRecord } from "../src/hosted-runtime/system-mailbox.ts";
 import {
   createHostedRuntimeResolvedConfig,
@@ -1544,6 +1547,77 @@ describe("hosted device-sync runtime", () => {
         [{
           code: "HOSTED_DEVICE_SYNC_SOURCE_STATE_UNAVAILABLE",
           retryable: true,
+        }],
+      );
+    } finally {
+      closeHostedRuntimeDeviceSyncService(service);
+      await cleanup();
+    }
+  });
+
+  test.each([
+    { expectedStatus: "queued", retryable: true },
+    { expectedStatus: "dead", retryable: false },
+  ] as const)("hosted artifact write failures preserve retryable=$retryable for device-sync jobs", async ({
+    expectedStatus,
+    retryable,
+  }) => {
+    const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
+      `hosted-device-sync-artifact-write-${retryable ? "retryable" : "terminal"}-`,
+    );
+    await mkdir(vaultRoot, { recursive: true });
+    const provider = createFakeProvider({
+      jobExecutor: {
+        async executeJob(context) {
+          await context.importSnapshot({ provider: "demo" });
+          return {};
+        },
+      },
+    });
+    const service = createHostedRuntimeDeviceSyncService({
+      config: {
+        publicBaseUrl: "https://sync.example.test/device-sync",
+        stateDatabasePath: path.join(vaultRoot, ".runtime", "device-syncd.sqlite"),
+        vaultRoot,
+      },
+      importer: {
+        async importDeviceProviderSnapshot() {
+          throw new HostedRuntimeArtifactWriteError({
+            cause: new Error("Hosted artifact upload failed."),
+            retryable,
+          });
+        },
+      },
+      providers: [provider],
+      secret: DEVICE_SYNC_SECRET,
+    });
+
+    try {
+      const begin = await service.startConnection({ provider: "demo" });
+      const connected = await service.handleOAuthCallback({
+        code: "artifact-write-classification",
+        provider: "demo",
+        state: begin.state,
+      });
+      const job = getStore(service).enqueueJob({
+        accountId: connected.account.id,
+        availableAt: "2026-07-30T00:00:00.000Z",
+        kind: "reconcile",
+        payload: {},
+        provider: "demo",
+      });
+
+      await service.runWorkerOnce();
+
+      assert.equal(getStore(service).getJobById(job.id)?.status, expectedStatus);
+      assert.deepEqual(
+        service.listJobFailureDiagnostics().map((diagnostic) => ({
+          code: diagnostic.code,
+          retryable: diagnostic.retryable,
+        })),
+        [{
+          code: "HOSTED_DEVICE_SYNC_ARTIFACT_WRITE_FAILED",
+          retryable,
         }],
       );
     } finally {


### PR DESCRIPTION
## Why this PR exists

Transient hosted artifact uploads were reaching device-sync as unclassified terminal errors. Production resource and backfill jobs could therefore be dropped even though the content-addressed write and job are replay-safe.

## User goal / user-visible behavior

A wearable sync interrupted by a temporary artifact-store timeout, network failure, rate limit, or server error resumes through the existing device-sync job backoff instead of silently stopping.

## User experience

No UI changes. The existing connection and sync flow remains the entry point; successful work behaves identically. On a qualifying transient artifact-write failure, the existing device-sync job owner records the stable failure and retries after its normal backoff without requiring another member action. Permanent validation, authorization, and programming failures remain terminal.

## Invariants

- Artifact retries are admitted only for content-addressed replay-safe writes.
- Write-fence and authority failures remain fail-closed.
- HTTP 408, 429, and 5xx plus transport failures are retryable; other HTTP and unclassified failures remain terminal.
- The existing device-sync job store remains the sole durable retry owner.
- Provider payloads, credentials, member identifiers, and artifact hashes do not enter new diagnostics.

## Non-obvious affected surfaces

- Shared Cloudflare hosted artifact store: emits a typed write error so downstream owners can preserve retryability. Regression proof covers transport and HTTP classifications plus the existing authority-rejection path.
- Hosted assistant-runtime device-sync importer: translates only that typed error into the existing DeviceSyncError contract. Regression proof asserts queued versus dead job state and stable diagnostics.
- Junction optional profile and SDK pre-provider lifecycle: unchanged. Existing focused tests prove profile 404 is a one-shot optional skip and source-less SDK setup seeds recovery work.

## Architecture and reuse

- **Existing systems reused:** content-addressed artifact PUTs, DeviceSyncError, and the existing bounded device-sync job backoff/store.
- **New logic:** one typed artifact-write error, status classification at the Cloudflare transport owner, and a narrow hosted importer translation.
- **New abstractions:** only the write-side counterpart to the existing HostedRuntimeArtifactReadError contract; no new service or state owner.
- **Complexity intentionally avoided:** no transport retry loop, queue, persisted flag, schema change, or provider-specific branch.

## Hot reply path impact

Not applicable. The change is limited to background hosted artifact persistence during device-sync imports and does not alter the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, model configuration, request builder, or provider-visible wrapper changed.
- Group Murph: Not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: **applicable** — intended outcome is automatic recovery from transient sync persistence failure; direct evidence is the queued-versus-dead hosted device-sync regression.
- Prompt: **not applicable** — no provider-visible instructions or tool contracts changed.
- Frontend: **not applicable** — no UI or rendered state changed; no rendered evidence is required.
- Coverage: **applicable** — focused Cloudflare artifact classification (145 tests), assistant runtime (85 tests across two files), Junction SDK lifecycle (6 tests), and profile-404 skip (1 focused test) pass locally; exact-head CI is pending.

## Change shape

Classification rule: authored runtime TypeScript is source; Vitest files are tests/fixtures; Markdown is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 76 | 5 |
| Tests/fixtures | 128 | 1 |
| Docs | 55 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **259** | **6** |

ReviewGPT first-reviewed head: c63c3b3f692ce2b6838f12b66abcd61e2fcb7468

## Current head after CI-only test correction

Current head: 49930ea811a434df2d8ffd55fbc355b5a4eeb03d

The only change since the immutable first-reviewed head is five test-mock lines required by platform coverage; production behavior is unchanged.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 76 | 5 |
| Tests/fixtures | 133 | 1 |
| Docs | 55 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **264** | **6** |
