### PR TITLE
fix(web): dedupe Linq email-recovery capacity claims

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-transport.ts
@@ -1376,6 +1376,14 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
       if (existingRoute) {
         return { status: "already_completed" };
       }
+      const persistedIntent =
+        await readHostedLinqDeliveryProviderDispatchIntentTx({
+          idempotencyKey: groupEmailRecoveryEffect.effectId,
+          prisma,
+        });
+      if (persistedIntent?.providerCorrelated) {
+        return { status: "already_completed" };
+      }
       const incomingLineState = await readHostedLinqIncomingLineState({
         phoneNumberLookupKeys: createHostedPhoneLookupKeyReadCandidates(
           groupEmailRecoveryEffect.payload.assignedRecipientPhone,
@@ -1386,26 +1394,31 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
         return { status: "target_unauthorized" };
       }
       // Private email recovery opens a brand-new conversation from the managed
-      // line, so it claims the same per-line daily new-conversation budget as
-      // every other proactive path. Without this a single sender could open one
-      // new conversation per group chat and burn the line's reputation.
-      const recoveryLine = await prisma.hostedLinqLine.findUnique({
-        select: { maxNewConversationsPerDay: true },
-        where: {
-          phoneNumberLookupKey: incomingLineState.phoneNumberLookupKey,
-        },
-      });
-      if (
-        !recoveryLine
-        || !await claimHostedLinqProactiveConversationCapacityTx({
-          dayUtc: startOfUtcDay(new Date(input.startedAtMs)),
-          limit: resolveHostedLinqSignupWelcomeDailyLimit(recoveryLine),
-          phoneNumberLookupKey: incomingLineState.phoneNumberLookupKey,
-          prisma,
-          requiredHealthStatus: "healthy",
-        })
-      ) {
-        return { status: "target_unauthorized" };
+      // line, so the first unresolved attempt claims the same per-line daily
+      // new-conversation budget as every other proactive path. The chat lock
+      // serializes this lookup with the delivery claim below; a retry that
+      // already has a durable intent must reuse the original reservation rather
+      // than burn another slot without opening another conversation.
+      if (!persistedIntent) {
+        const recoveryLine = await prisma.hostedLinqLine.findUnique({
+          select: { maxNewConversationsPerDay: true },
+          where: {
+            phoneNumberLookupKey: incomingLineState.phoneNumberLookupKey,
+          },
+        });
+        if (
+          !recoveryLine
+          || !await claimHostedLinqProactiveConversationCapacityTx({
+            dayUtc: startOfUtcDay(new Date(input.startedAtMs)),
+            limit: resolveHostedLinqSignupWelcomeDailyLimit(recoveryLine),
+            phoneNumberLookupKey: incomingLineState.phoneNumberLookupKey,
+            prisma,
+            requiredHealthStatus: "healthy",
+          })
+        ) {
+          return { status: "target_unauthorized" };
+        }
+        recoveryCapacityClaimed = true;
       }
     }
 
@@ -1449,7 +1462,7 @@ async function prepareHostedLinqSideEffectProviderDispatch(input: {
     });
     if (recoveryCapacityClaimed && !claim.claimed) {
       throw new Error(
-        "Hosted Linq group-line recovery delivery conflicted after reserving line capacity.",
+        "Hosted Linq recovery delivery conflicted after reserving line capacity.",
       );
     }
     if (claim.claimed) {

--- a/apps/web/test/hosted-onboarding-linq-transport.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-transport.test.ts
@@ -3659,6 +3659,112 @@ describe("hosted Linq webhook transport", () => {
       }
     });
 
+    it("does not spend another line slot for a correlated private recovery replay", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(dispatchNow);
+      const lookupKey = arrangeAssignableRecoveryLine();
+      const { line, prisma } = createHostedLinqLineCapacityPrisma({
+        maxNewConversationsPerDay: 10,
+        phoneNumberLookupKey: lookupKey,
+        proactiveConversationCount: 3,
+        proactiveConversationDayUtc: dispatchDayUtc,
+      });
+      const effect = buildGroupEmailRecoveryEffect(
+        "event-group-email-correlated-replay",
+      );
+      vi.mocked(readHostedLinqDeliveryProviderDispatchIntentTx)
+        .mockResolvedValueOnce({
+          groupJoinOutreachId: null,
+          groupJoinReplyOccurredAt: null,
+          id: "hld_group_email_correlated",
+          lastProviderEventId: "provider-event-correlated",
+          phoneNumberLookupKey: lookupKey,
+          providerCorrelated: true,
+          sourceRef: effect.effectId,
+          status: "accepted",
+          targetKind: "participant",
+          template: "group_email_recovery",
+        });
+
+      try {
+        await expect(drainHostedLinqSideEffectsDirect({
+          prisma: prisma as never,
+          sideEffects: [effect],
+        })).resolves.toEqual({
+          sentCount: 0,
+          skipped: [{
+            effectId: effect.effectId,
+            reason: "notice_already_claimed",
+            template: "group_email_recovery",
+          }],
+        });
+
+        expect(prisma.hostedLinqLine.updateMany).not.toHaveBeenCalled();
+        expect(claimHostedLinqDeliveryProviderDispatchTx).not.toHaveBeenCalled();
+        expect(createHostedLinqChat).not.toHaveBeenCalled();
+        expect(line.proactiveConversationCount).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reuses the original line slot while a private recovery is in flight", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(dispatchNow);
+      const lookupKey = arrangeAssignableRecoveryLine();
+      const retryAt = new Date("2026-03-27T12:15:00.000Z");
+      const { line, prisma } = createHostedLinqLineCapacityPrisma({
+        maxNewConversationsPerDay: 10,
+        phoneNumberLookupKey: lookupKey,
+        proactiveConversationCount: 3,
+        proactiveConversationDayUtc: dispatchDayUtc,
+      });
+      const effect = buildGroupEmailRecoveryEffect(
+        "event-group-email-in-flight-replay",
+      );
+      vi.mocked(readHostedLinqDeliveryProviderDispatchIntentTx)
+        .mockResolvedValueOnce({
+          groupJoinOutreachId: null,
+          groupJoinReplyOccurredAt: null,
+          id: "hld_group_email_in_flight",
+          lastProviderEventId: null,
+          phoneNumberLookupKey: lookupKey,
+          providerCorrelated: false,
+          sourceRef: effect.effectId,
+          status: "attempted",
+          targetKind: "participant",
+          template: "group_email_recovery",
+        });
+      vi.mocked(claimHostedLinqDeliveryProviderDispatchTx)
+        .mockResolvedValueOnce({
+          claimed: false,
+          id: "hld_group_email_in_flight",
+          retryAt,
+        });
+
+      try {
+        await expect(drainHostedLinqSideEffectsDirect({
+          prisma: prisma as never,
+          sideEffects: [effect],
+        })).resolves.toEqual({
+          sentCount: 0,
+          skipped: [{
+            effectId: effect.effectId,
+            reason: "notice_in_flight",
+            retryAt,
+            template: "group_email_recovery",
+          }],
+        });
+
+        expect(prisma.hostedLinqLine.updateMany).not.toHaveBeenCalled();
+        expect(claimHostedLinqDeliveryProviderDispatchTx).toHaveBeenCalledTimes(1);
+        expect(createHostedLinqChat).not.toHaveBeenCalled();
+        expect(line.proactiveConversationCount).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("skips a recovery link whose token expired before dispatch without spending line budget", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(dispatchNow);


### PR DESCRIPTION
## Why

Follow-up audit of merged #1221 found one concrete replay bug in private iCloud/email group recovery.

The transport reserved a Linq line's daily **new-conversation** slot before its durable delivery claim decided that the same recovery effect was already provider-correlated or still in flight. A webhook replay or repeated same-day unknown-email message could therefore consume another slot without creating another conversation, eventually suppressing legitimate proactive sends.

## Fix

- Read the durable recovery intent while holding the existing group-chat ownership lock.
- Return immediately for provider-correlated deliveries.
- Reuse the original capacity reservation for unresolved/in-flight retries.
- Reserve capacity only when no delivery intent exists yet.
- Reuse the existing transaction rollback guard so a fresh reservation cannot survive a lost delivery-claim race.
- Keep the implementation inside the existing transport transaction; no schema, queue, or new abstraction.

## Architecture and reuse

- **Existing systems reused:** The fix reuses the existing group-chat advisory lock, durable Linq delivery intent, proactive line-capacity counter, provider-dispatch claim, and transaction rollback boundary.
- **New logic:** Private email recovery reads its existing delivery intent before reserving capacity, treats provider-correlated delivery as complete, and reuses the first reservation while an attempt remains unresolved.
- **New abstractions:** No new abstraction is introduced because the invariant belongs in the existing transport preparation transaction alongside the line-capacity and delivery claims.
- **Complexity intentionally avoided:** No schema change, reservation table, compensating decrement, queue, retry coordinator, or separate recovery service was added; the behavior remains inside the existing transaction.

## Regression coverage

- A correlated private-recovery replay does not increment line capacity or call Linq.
- An in-flight private-recovery replay does not increment line capacity or call Linq.
- Existing fresh-send, expired-token, line-health, and capacity-limit coverage remains intact.

## Audit notes

I also rechecked the recovery token boundary, authenticated/CSRF-protected redemption, exact email + group + recipient-line binding, route locks, conflict handling, day-scoped retry identity, first-contact admission, signup handoff, existing-home-route behavior, and privacy-key rotation compatibility. I found no other concrete correctness or security defect in those paths.

## Verification

- Focused `hosted-onboarding-linq-transport.test.ts` suite passed on the patched tree.
- Hosted web TypeScript check passed on the patched tree.
- Branch is one commit, two files, directly on current `main`.
