### PR TITLE
Keep Linq provider reasons presence-only

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/http.ts
+++ b/apps/web/src/lib/hosted-onboarding/http.ts
@@ -27,7 +27,6 @@ const HOSTED_ONBOARDING_DEVELOPMENT_STACK_MAX_LENGTH = 6_000;
 const HOSTED_ONBOARDING_DEVELOPMENT_LOG_MAX_DEPTH = 3;
 const HOSTED_ONBOARDING_DEVELOPMENT_LOG_MAX_ENTRIES = 20;
 const HOSTED_ONBOARDING_PERSISTED_ERROR_TOKEN_MAX_LENGTH = 128;
-const HOSTED_ONBOARDING_PROVIDER_REASON_MAX_LENGTH = 256;
 const HOSTED_ONBOARDING_SENSITIVE_LOG_KEY_PATTERN =
   /authorization|secret|token|password|cookie|set-cookie|api[-_]?key/iu;
 const HOSTED_ONBOARDING_SAFE_DOMAIN_ERROR_DETAIL_KEYS = new Set([
@@ -291,22 +290,6 @@ export function sanitizeHostedOnboardingPersistedErrorMessage(
   return sanitizeHostedOnboardingLogString(value, 1)
     ? HOSTED_ONBOARDING_REDACTED_ERROR_MESSAGE
     : null;
-}
-
-// The boundary between this and `sanitizeHostedOnboardingPersistedErrorMessage`
-// is who authored the string. Our own exception text can carry anything the
-// runtime touched, so it keeps presence only. A reason lifted from a provider's
-// webhook payload is a bounded diagnostic and the operator's only evidence for
-// why a send failed, so it keeps its wording; collapsing it to `[redacted]`
-// made every message_failed alert unactionable. Value patterns are still
-// scrubbed: secrets, URLs, emails, phone numbers, and paths.
-export function sanitizeHostedOnboardingProviderReason(
-  value: string | null | undefined,
-): string | null {
-  return sanitizeHostedOnboardingLogString(
-    value,
-    HOSTED_ONBOARDING_PROVIDER_REASON_MAX_LENGTH,
-  );
 }
 
 function isHostedOnboardingDevelopmentLoggingEnabled(): boolean {

--- a/apps/web/src/lib/hosted-onboarding/linq-provider-events.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-provider-events.ts
@@ -16,7 +16,7 @@ import {
 } from "./linq";
 import {
   sanitizeHostedOnboardingLogString,
-  sanitizeHostedOnboardingProviderReason,
+  sanitizeHostedOnboardingPersistedErrorMessage,
 } from "./http";
 import { toHostedOnboardingLogIdSuffix } from "./logging";
 import {
@@ -873,7 +873,7 @@ function normalizeSafeProviderToken(value: string | null): string | null {
 }
 
 function normalizeProviderFreeText(value: string | null): string | null {
-  return sanitizeHostedOnboardingProviderReason(normalizeNullableString(value));
+  return sanitizeHostedOnboardingPersistedErrorMessage(normalizeNullableString(value));
 }
 
 function readProviderStatusValue(value: unknown): string | null {

--- a/apps/web/test/hosted-onboarding-linq-alert-email.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-alert-email.test.ts
@@ -64,12 +64,13 @@ describe("sendPendingHostedLinqAlertsBestEffort", () => {
     });
 
     const text = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)).text as string;
-    // Without these the alert says only that a send failed, which is what made
-    // the original message_failed alerts impossible to act on.
-    expect(text).toContain("Failure code: 30007");
-    expect(text).toContain("Failure reason: carrier filtered the message");
-    expect(text).toContain("Provider reason: recipient carrier rejected the send");
+    // What makes the alert actionable is the masked line plus the bounded
+    // provider code. The reason fields stay presence-only, so the email must
+    // never carry provider prose.
     expect(text).toContain("Line: ***0000");
+    expect(text).toContain("Failure code: 30007");
+    expect(text).toContain("Failure reason: [redacted]");
+    expect(text).not.toContain("carrier filtered the message");
   });
 
   it("marks alerts failed without throwing when Resend rejects the send", async () => {
@@ -186,10 +187,9 @@ function createAlertEmailPrismaFixture(input?: {
         eventIdSuffix: "led_123",
         eventType: "message.failed",
         failureCode: "30007",
-        failureReason: "carrier filtered the message",
+        failureReason: "[redacted]",
         line: "***0000",
         providerCreatedAt: "2026-03-26T12:00:00.000Z",
-        providerReason: "recipient carrier rejected the send",
       },
       eventId: "evt_failed_123",
       id: "hla_message_failed_123",

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -284,9 +284,7 @@ describe("hosted Linq observability stores", () => {
           eventId: createHostedLinqProviderEventLookupKey("evt_failed_123"),
           eventType: "message.failed",
           failureCode: "30007",
-          // The provider's wording is the operator's evidence for why the send
-          // failed, so it survives; the phone number inside it does not.
-          failureReason: "carrier filtered <redacted-phone> provider_msg_123 private text",
+          failureReason: "[redacted]",
         }),
         skipDuplicates: true,
       }),
@@ -299,7 +297,7 @@ describe("hosted Linq observability stores", () => {
         data: expect.objectContaining({
           healthStatus: "warning",
           lastFailureCode: "30007",
-          lastFailureReason: "carrier filtered <redacted-phone> provider_msg_123 private text",
+          lastFailureReason: "[redacted]",
           lastReceiptEventId: createHostedLinqProviderEventLookupKey("evt_failed_123"),
           totalFailedCount: { increment: 1 },
         }),
@@ -309,7 +307,7 @@ describe("hosted Linq observability stores", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           failureCode: "30007",
-          failureReason: "carrier filtered <redacted-phone> provider_msg_123 private text",
+          failureReason: "[redacted]",
           status: "failed",
         }),
         where: expect.objectContaining({

--- a/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
@@ -230,15 +230,60 @@ describe("parseHostedLinqProviderEvent", () => {
       deliveryStatus: "failed",
       eventType: "message.failed",
       failureCode: "30007",
-      failureReason: "carrier filtered <redacted-phone> provider_msg_123 private text",
+      failureReason: "[redacted]",
       phoneNumberRole: "line",
     });
+    expect(JSON.stringify(failed)).not.toContain("provider_msg_123");
     expect(JSON.stringify(failed)).not.toContain("+15551234567");
-    // `data.message` is chat text, not a failure reason: it must never be
-    // promoted into the reason, and the payload copies stay shape-only.
-    expect(JSON.stringify(failed)).not.toContain("raw chat text");
-    expect(JSON.stringify(failed?.payloadSanitizedJson)).not.toContain("provider_msg_123");
-    expect(JSON.stringify(failed?.payloadShapeJson)).not.toContain("provider_msg_123");
+    expect(JSON.stringify(failed)).not.toContain("private text");
+    expect(JSON.stringify(failed?.payloadSanitizedJson)).not.toContain("raw chat text");
+    expect(JSON.stringify(failed?.payloadShapeJson)).not.toContain("raw chat text");
+  });
+
+  it("keeps provider reason text out of the parsed event whatever the provider embeds", () => {
+    // Pattern-based scrubbing cannot recognize these: a national-format phone
+    // number, a schemeless URL, a person's name, and a health statement all
+    // survive `sanitizeJsonLogString`. Presence-only redaction is what actually
+    // holds the boundary, so assert against the leak vectors directly.
+    const leaky = [
+      "undeliverable to 415-555-2671",
+      "see www.example.test/help",
+      "blocked after member reported chest pain",
+      "recipient handle rejected the send",
+    ];
+
+    for (const reason of leaky) {
+      const failed = parseHostedLinqProviderEvent({
+        event: buildGenericEvent({
+          data: {
+            error: { code: "30007", message: reason },
+            message_id: "msg_failed_leak",
+            phone_number: "+15550000000",
+          },
+          eventType: "message.failed",
+        }),
+      });
+      const status = parseHostedLinqProviderEvent({
+        event: buildGenericEvent({
+          data: {
+            phone_number: "+15550000000",
+            reason,
+            status: "flagged",
+          },
+          eventType: "phone_number.status_updated",
+        }),
+      });
+
+      expect(failed?.failureReason).toBe("[redacted]");
+      expect(status?.providerReason).toBe("[redacted]");
+      for (const parsed of [failed, status]) {
+        const serialized = JSON.stringify(parsed);
+        expect(serialized).not.toContain("415-555-2671");
+        expect(serialized).not.toContain("www.example.test");
+        expect(serialized).not.toContain("chest pain");
+        expect(serialized).not.toContain("recipient handle");
+      }
+    }
   });
 
   it("parses reaction events for join-offer dispatch without persisting raw handles", () => {
@@ -430,7 +475,7 @@ describe("parseHostedLinqProviderEvent", () => {
     expect(persistedSanitizedPayload).not.toContain("private nested provider text");
   });
 
-  it("keeps free-form provider status reasons but scrubs contact details", () => {
+  it("redacts free-form provider status reasons before persistence", () => {
     const parsed = parseHostedLinqProviderEvent({
       event: buildGenericEvent({
         data: {
@@ -444,15 +489,11 @@ describe("parseHostedLinqProviderEvent", () => {
 
     expect(parsed).toMatchObject({
       eventType: "phone_number.status_updated",
-      providerReason: "carrier review for <redacted-phone> provider_msg_123",
+      providerReason: "[redacted]",
       providerStatus: "flagged",
     });
-    // The reason keeps its wording so an operator can act on it; the phone
-    // number inside it is still scrubbed, and the raw payload copies below
-    // remain shape-only.
     expect(JSON.stringify(parsed)).not.toContain("+15551234567");
-    expect(JSON.stringify(parsed?.payloadShapeJson)).not.toContain("provider_msg_123");
-    expect(JSON.stringify(parsed?.payloadSanitizedJson)).not.toContain("provider_msg_123");
+    expect(JSON.stringify(parsed)).not.toContain("provider_msg_123");
   });
 
   it("keeps phone-number service and reputation status independent", () => {


### PR DESCRIPTION
## Why this PR exists

PR #1268 merged while its ReviewGPT preliminary pass was still running. That pass returned a confirmed high-severity finding against the merged code, so this PR corrects it on `main`.

#1268 made provider-authored failure and status reasons persist and email their original wording, on the theory that a provider-authored string is safer than our own exception text. That reasoning was wrong, and this PR removes it.

## User goal / user-visible behavior

The operator receiving a Linq operational alert still gets what makes it actionable — the masked line, the provider failure code, and the service/reputation statuses — with no provider prose in the email or the database. A member's content, name, or phone number can never appear in an operational alert because a provider happened to echo it into a reason string.

## User experience

No member-facing surface changes. The operator alert email loses the two free-text reason values added by #1268 and keeps everything else, including the `Line:` row that #1268 added and this PR preserves:

```
Kind: message_failed
Line: *** 0351
Failure code: 4001
Failure reason: [redacted]
Provider created at: 2026-08-02T05:35:19.507Z
```

Entry point, timing, delivery ownership, retry, and recovery behavior are all unchanged.

## Invariants the PR must preserve

- Provider-authored free text never reaches a persisted column or the alert email. Presence-only redaction is the boundary; pattern scrubbing is not.
- The masked line, failure code, provider status, service status, and reputation status remain available to the operator — these are bounded tokens, already safe.
- The `Line:` fallback from #1268 keeps working: an alert whose provider payload carries no phone number still names the line resolved by the delivery receipt.
- Raw payloads stay shape-only; `payloadSanitizedJson` and `payloadShapeJson` gain no payload values.
- Alert claiming stays exactly-once per provider event.

## Non-obvious affected surfaces

- **`hosted_linq_delivery.failure_reason` and `hosted_linq_line.last_failure_reason`.** Neither has a write site in this diff, but both are fed from the parsed provider event, so reverting the parser reverts them to `[redacted]` too. That is the intent. Regression proof: `records failed provider events, updates projections, and claims one event-scoped alert`.
- **Rows written between #1268's deploy and this one.** Any row persisted in that window may hold readable provider wording. The window is small and the volume is low — one `message.failed` in the last 30 days of production data — but the rows are not retroactively scrubbed by this PR. Flagged rather than automated: see the deferred-work note below.

## Architecture and reuse

- Existing systems reused: `sanitizeHostedOnboardingPersistedErrorMessage`, the presence-only sanitizer that already governed these two fields before #1268 and still governs every other persisted error message in `hosted-onboarding`. Reverting to it means the codebase has one policy for untrusted free text again instead of two.
- New logic: None. This diff only removes an exception and strengthens assertions.
- New abstractions: None, and one is deleted — `sanitizeHostedOnboardingProviderReason` and its length constant are gone. The distinction it encoded (provider-authored versus our own text) is not a safety property, so naming it made an unsafe boundary look principled.
- Complexity intentionally avoided: No classifier over provider reasons, no first-party code-to-copy mapping, and no allowlist vocabulary. Linq's code vocabulary is not documented in this repo, so any mapping would be invented rather than derived, and it would need maintenance on every new provider code. The bounded failure code the operator already receives is sufficient to look the failure up.

## Hot reply path impact

`Not applicable.` The changed code runs on provider webhook ingest for `message.failed` and `phone_number.status_updated` only; `resolveHostedLinqAlertKind` returns `null` for `message.received`, so the inbound conversation path is untouched. Nothing here affects durable acceptance of a conversation message, provider start, or reply handoff.

## Murph initial provider input impact

`Not applicable` for both individual and group Murph. No prompt file, prompt builder, tool definition, tool schema, deferred-tool metadata, skill, model configuration, or provider-request assembly is touched.

## Preliminary specialist lenses

- **Product experience — applicable.** Intended outcome: an operational alert that is actionable without exposing member-private content. Direct evidence: the alert email retains the masked line and bounded failure code and drops only unbounded provider prose, proven by `carries the failure reason, provider reason, and line into the email body`.
- **Prompt — not applicable.** No prompt text or builder is touched.
- **Frontend — not applicable.** No `apps/web` UI diff.
- **Coverage — applicable.** Focused local proof at head `7c030ef13b`: 67 test files / 1415 tests green across all Linq, http, Stripe, and webhook suites, plus clean `tsc --noEmit` and eslint. New test `keeps provider reason text out of the parsed event whatever the provider embeds` asserts the boundary against a national-format phone number, a schemeless URL, a health statement, and a handle reference — the four vectors `sanitizeJsonLogString` provably does not catch. Exact-head CI: `pending`.

## Change-shape breakdown

Classification rule: by path — `apps/web/src/**` is source, `apps/web/test/**` is tests/fixtures. No binary, generated, docs, or config files in this diff.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 2 | 19 |
| Tests/fixtures | 64 | 25 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **66** | **44** |

## Design proof for user-facing frontend UI

`Not applicable.` No user-facing frontend UI diff.

## Deployment skew / compatibility

`Not applicable` as a skew risk. Web-only; no deploy boundary, runner bundle, worker/container shape, credential, or schema changes. Both columns are already nullable `text`, so rows written under #1268's behavior coexist with rows written after this one. Nothing reads either column for control flow. Fully reversible by revert.

## Deliberately deferred

Rows persisted between #1268's deploy and this one are not scrubbed here. Given the measured volume (one `message.failed` in 30 days) a bounded manual cleanup is proportionate; a migration or reconciliation pass would be more machinery than the exposure warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ReviewGPT first-reviewed head: 7c030ef13b2fd5fca1bf676cde29ec43c179dc06
