### PR TITLE
Improve calorie estimates with database-first nutrition lookups

### DIFF
--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -49,7 +49,7 @@ Treat every calorie or macro estimate as two separate questions:
 Do not let vision or memory answer both. For every numeric meal estimate—including
 interactive meal logs, user-sent photos, automatic-meal-capture enrichment, and
 scheduled closeouts—resolve nutrient density from the hosted food-label database
-whenever each material component is identifiable. Use the photo, description,
+for every identifiable material component. Use the photo, description,
 and conversation to estimate identity, quantity, and preparation; use returned
 label or USDA facts for calories and macros. If another meal skill says to
 estimate visible ingredients or portions, that means estimate those quantities

--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -39,17 +39,54 @@ Ask at most one question, and only when the missing detail materially changes sa
 - Do not estimate or surface calories or macros for intuitive-eating contexts, eating-disorder risk, or number-sensitive users. In symptom or digestion work, keep numbers secondary to the focus rather than leading with them.
 - Structured label facts may remain available when useful; surface the details relevant to the user's request alongside the default totals.
 
-## Resolve exact labels only when they matter
+## Ground numeric estimates in label and USDA data
 
-When nutrition, ingredients, allergens, or exact product identity could change
-the answer or saved record, use `vault-cli food search-labels` for one item or
-`vault-cli food search-labels-batch` for several before estimating from memory
-or searching the web. Use `--generic` for ordinary ingredients where a USDA
-generic row is preferable; use normal lookup for branded, packaged, menu, UPC,
-or exact-FDC searches. Increase the default result limit only when the first
-match is ambiguous or missing a likely variant. If the database is unavailable
-or incomplete, use an official label/manufacturer/menu source or a clearly
-marked estimate with assumptions.
+Treat every calorie or macro estimate as two separate questions:
+
+1. Which nutrient density or exact label facts apply?
+2. How much was actually eaten, including preparation and additions?
+
+Do not let vision or memory answer both. For every numeric meal estimate—including
+interactive meal logs, user-sent photos, automatic-meal-capture enrichment, and
+scheduled closeouts—resolve nutrient density from the hosted food-label database
+whenever each material component is identifiable. Use the photo, description,
+and conversation to estimate identity, quantity, and preparation; use returned
+label or USDA facts for calories and macros. If another meal skill says to
+estimate visible ingredients or portions, that means estimate those quantities
+and preparation assumptions, not nutrient density from memory.
+
+Before calculating a meal total:
+
+- Enumerate the material components separately. Count discrete pieces or slices
+  when visible, and include cooking oil, butter, dressing, sauce, cheese,
+  toppings, and caloric drinks when they are visible, named, or strongly implied
+  by the preparation. Do not silently assume restaurant or prepared food has no
+  added fat.
+- Use `vault-cli food search-labels` for one item or
+  `vault-cli food search-labels-batch` for several before estimating from memory
+  or searching the web. Use `--generic` for ordinary ingredients where a USDA
+  generic row is preferable; use normal lookup for branded, packaged, menu, UPC,
+  or exact-FDC searches. Because `--generic` applies to the whole batch, split a
+  mixed meal into at most two lookups: one generic USDA batch and one normal
+  branded/menu/package batch.
+- Prefer an exact visible or user-named product, restaurant item, variant, UPC,
+  or FDC id over a nearby generic substitute. Never merge nutrition from
+  similarly named variants without evidence that they are the same item.
+- Read the returned serving basis before scaling. Determine whether nutrition is
+  per labeled serving, per stated gram amount, or per 100 g, then scale it to the
+  estimated amount actually eaten. A database serving is not evidence that the
+  user ate exactly one serving.
+- Sum component estimates only after that scaling. Give a central estimate plus
+  a useful range when portion size, preparation, hidden fat, or exact identity
+  could materially move the total. Avoid fake precision; set confidence from
+  the weakest material identity, quantity, or preparation assumption.
+
+Increase the default result limit only when the first match is ambiguous or
+missing a likely variant. If the database is unavailable or incomplete, use an
+official label, manufacturer, or restaurant menu source. Only after those fail
+may you use a clearly marked memory-based estimate with the assumptions and
+material uncertainty stated. Never invent an exact label or imply that a visual
+portion estimate was database-measured.
 
 For a fridge or pantry photo, enumerate distinct visible products and resolve
 them in one batch. Summarize only relevant nutrition, ingredient, allergen, and
@@ -57,8 +94,9 @@ uncertainty flags. Do not create recurring food records from a scan unless the
 user asks.
 
 When an exact label matters to a meal, preserve serving size and returned label
-nutrition on the meal with label-based provenance. For a user-approved recurring
-or pantry item, save or update the food record with serving, ingredients,
+nutrition on the meal with label-based provenance. For USDA generic rows, use
+database provenance and retain the lookup id or source detail used for scaling.
+For a user-approved recurring or pantry item, save or update the food record with serving, ingredients,
 nutrition, and the label lookup id in provenance so it can be found again.
 
 Treat contaminant observations as exact-product lab context only. Never infer

--- a/packages/assistant-engine/skills/micronutrients-supplements/SKILL.md
+++ b/packages/assistant-engine/skills/micronutrients-supplements/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: micronutrients-supplements
-description: Use for vitamin D iron ferritin B12 magnesium omega 3 creatine supplement evidence dosing testing and safety questions.
+description: Use for vitamin D iron ferritin B12 magnesium omega 3 creatine supplement evidence product labels dosing testing and safety questions.
 ---
 
 # Micronutrients And Supplements
@@ -52,13 +52,33 @@ Ask: "Are you trying to correct a known low lab, improve a symptom/performance t
 
 ## Resolve and preserve supplement labels
 
-Use `vault-cli supplement search-labels` for one product or `vault-cli
-supplement search-labels-batch` for several before web lookup. Increase the
-default result limit only when the first result is ambiguous, generic, or
-missing a likely variant. Use a returned serving, dose, or amount instead of
-asking the user to restate it. If the database is unavailable or incomplete,
-prefer an official manufacturer label or another primary source and state the
-gap.
+For every named supplement product, brand, exact dose, serving, ingredient-panel
+question, product image or list, and create or update request, use
+`vault-cli supplement search-labels` for one product or
+`vault-cli supplement search-labels-batch` for several before relying on memory
+or web search. Batch a multi-product stack instead of looking up each item
+serially. Skip exact-product lookup only for a genuinely generic evidence
+question where product identity, serving, formulation, and market status cannot
+change the answer.
+
+Match the exact variant before using returned facts. Prefer agreement on product
+name, brand or manufacturer, serving, UPC, and other available identifiers; do
+not merge nearby formulas, flavors, strengths, or historical labels. Use a
+returned serving, dose, or amount instead of asking the user to restate it, but
+never treat a search result as proof that it is the product the user owns when
+material identifiers conflict or remain ambiguous.
+
+The hosted corpus can include NIH DSLD, DailyMed, and first-party manufacturer
+label records. Preserve and, when relevant, name the actual returned source.
+Never describe a database match as FDA approval, and never treat label presence
+as proof of efficacy, purity, third-party testing, current availability, or
+safety for this user.
+
+Increase the default result limit only when the first result is ambiguous,
+generic, or missing a likely variant. If a returned serving, amount, or
+ingredient field is absent or source-null, do not infer it from a nearby product
+or marketing text. Prefer an official manufacturer label or another primary
+source and state the unresolved gap.
 
 When saving known label facts, preserve the full active ingredient panel with
 repeated `vault-cli supplement save --ingredient` JSON-object flags and save the

--- a/packages/assistant-engine/skills/micronutrients-supplements/SKILL.md
+++ b/packages/assistant-engine/skills/micronutrients-supplements/SKILL.md
@@ -55,7 +55,8 @@ Ask: "Are you trying to correct a known low lab, improve a symptom/performance t
 For every named supplement product, brand, exact dose, serving, ingredient-panel
 question, product image or list, and create or update request, use
 `vault-cli supplement search-labels` for one product or
-`vault-cli supplement search-labels-batch` for several before relying on memory
+`vault-cli
+supplement search-labels-batch` for several before relying on memory
 or web search. Batch a multi-product stack instead of looking up each item
 serially. Skip exact-product lookup only for a genuinely generic evidence
 question where product identity, serving, formulation, and market status cannot

--- a/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
@@ -27,7 +27,7 @@ describe('assistant nutrition source grounding', () => {
     )
     expect(food).toContain('Do not let vision or memory answer both.')
     expect(food).toContain(
-      'For every numeric meal estimate—including interactive meal logs, user-sent photos, automatic-meal-capture enrichment, and scheduled closeouts—resolve nutrient density from the hosted food-label database',
+      'For every numeric meal estimate—including interactive meal logs, user-sent photos, automatic-meal-capture enrichment, and scheduled closeouts—resolve nutrient density from the hosted food-label database for every identifiable material component.',
     )
     expect(food).toContain(
       'use returned label or USDA facts for calories and macros',

--- a/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, ' ').trim()
+}
+
+describe('assistant nutrition source grounding', () => {
+  it('uses USDA and label facts for nutrient density before visual estimation', async () => {
+    const skillsRoot = resolveAssistantSkillsRoot()
+    const [foodJournal, automaticMealCapture] = await Promise.all([
+      readFile(path.join(skillsRoot, 'food-journal', 'SKILL.md'), 'utf8'),
+      readFile(
+        path.join(skillsRoot, 'automatic-meal-capture', 'SKILL.md'),
+        'utf8',
+      ),
+    ])
+    const food = compact(foodJournal)
+    const automatic = compact(automaticMealCapture)
+
+    expect(food).toContain(
+      'Treat every calorie or macro estimate as two separate questions:',
+    )
+    expect(food).toContain('Do not let vision or memory answer both.')
+    expect(food).toContain(
+      'For every numeric meal estimate—including interactive meal logs, user-sent photos, automatic-meal-capture enrichment, and scheduled closeouts—resolve nutrient density from the hosted food-label database',
+    )
+    expect(food).toContain(
+      'use returned label or USDA facts for calories and macros',
+    )
+    expect(food).toContain(
+      'Because `--generic` applies to the whole batch, split a mixed meal into at most two lookups: one generic USDA batch and one normal branded/menu/package batch.',
+    )
+    expect(food).toContain(
+      'A database serving is not evidence that the user ate exactly one serving.',
+    )
+    expect(food).toContain(
+      'Do not silently assume restaurant or prepared food has no added fat.',
+    )
+    expect(food).toContain(
+      'Only after those fail may you use a clearly marked memory-based estimate',
+    )
+    expect(automatic).toContain(
+      'Read `$MURPH_ASSISTANT_SKILLS_ROOT/food-journal/SKILL.md` before estimating nutrition',
+    )
+  })
+
+  it('looks up exact supplement products without implying FDA approval', async () => {
+    const supplementSkill = compact(
+      await readFile(
+        path.join(
+          resolveAssistantSkillsRoot(),
+          'micronutrients-supplements',
+          'SKILL.md',
+        ),
+        'utf8',
+      ),
+    )
+
+    expect(supplementSkill).toContain(
+      'For every named supplement product, brand, exact dose, serving, ingredient-panel question, product image or list, and create or update request',
+    )
+    expect(supplementSkill).toContain(
+      '`vault-cli supplement search-labels-batch` for several before relying on memory or web search',
+    )
+    expect(supplementSkill).toContain(
+      'Batch a multi-product stack instead of looking up each item serially.',
+    )
+    expect(supplementSkill).toContain(
+      'Skip exact-product lookup only for a genuinely generic evidence question',
+    )
+    expect(supplementSkill).toContain(
+      'The hosted corpus can include NIH DSLD, DailyMed, and first-party manufacturer label records.',
+    )
+    expect(supplementSkill).toContain(
+      'Never describe a database match as FDA approval',
+    )
+    expect(supplementSkill).toContain(
+      'If a returned serving, amount, or ingredient field is absent or source-null, do not infer it',
+    )
+  })
+})


### PR DESCRIPTION
## Why

The resident system prompt already routes meal capture/calorie estimation to `food-journal` and supplement labels/dosing to `micronutrients-supplements`. The gap was inside those owning skills: food-label lookup was conditional on an exact label “mattering,” so vision or memory could supply both nutrient density and portion size, and supplement lookup was not explicit for every named product or stack.

## What changed

- Require the hosted food-label database for every numeric meal estimate when material components are identifiable.
- Separate nutrient-density evidence from portion/preparation estimation: labels and USDA FoodData Central supply calories/macros; photos and conversation supply quantity and preparation assumptions.
- Split mixed meals into at most two batched lookups: USDA generic ingredients with `--generic`, and branded/menu/package items without it.
- Scale returned serving or per-100 g values to the estimated amount actually eaten instead of treating a database serving as the consumed serving.
- Explicitly account for pieces, cooking fats, sauces, dressings, toppings, and caloric drinks; use a central estimate plus a range when uncertainty is material.
- Fall back to memory only after the database and an official label/manufacturer/menu source fail, with provenance and uncertainty stated.
- Require supplement-label lookup for every named product, exact dose/serving/ingredient panel, product image/list, stack, and save/update flow; match exact variants and never fill missing fields from nearby products.
- Describe the supplement corpus accurately as potentially including NIH DSLD, DailyMed, and manufacturer-label records rather than implying every match is an FDA approval.
- Add a focused regression test that also verifies automatic meal capture delegates nutrition estimation to `food-journal`.

## Architecture and reuse

- Existing systems reused: Keeps the resident skill router, the existing `food-journal` and `automatic-meal-capture` handoff, USDA FoodData Central food search, and supplement-label search commands; no new service or storage path is introduced.
- New logic: Tightens owner-skill orchestration so nutrient density is database-backed per identifiable component while portion and preparation remain explicit estimates, and requires exact supplement lookups for named products and stacks.
- New abstractions: Adds no runtime abstraction; the only new structure is a focused contract test that normalizes skill Markdown whitespace and asserts the existing skill boundary.
- Complexity intentionally avoided: Does not add a second calorie engine, duplicate CLI guidance in the resident system prompt, change persisted schemas, or introduce new lookup APIs.

## Validation

Added `assistant-nutrition-source-grounding.test.ts` to lock the database-first calorie workflow, serving-size scaling, generic/branded batch split, automatic-capture handoff, exact supplement lookup, and non-approval language. There are no user-facing web UI changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788412412&installation_model_id=19880&pr_number=1278&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1278&signature=a8fcf7698791b46ec46dc13e354996aaaf45afbd1ab46f9b697ce164cfa3f0e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->