### PR TITLE
Scrub national-format phone numbers and schemeless URLs

### DIFF
--- a/apps/web/src/lib/http.ts
+++ b/apps/web/src/lib/http.ts
@@ -592,10 +592,13 @@ export function sanitizeJsonLogString(
     .replace(/\bwhsec_[A-Z0-9]+\b/giu, "<redacted-secret>")
     .replace(/\bfile:\/\/\S+/giu, "<redacted-path>")
     .replace(/\bhttps?:\/\/\S+/giu, "<redacted-url>")
+    // Email must resolve before the schemeless-URL rule below. A `www.`-prefixed
+    // domain is legal in an address, so matching the URL first would consume the
+    // domain and strand the identifying local part (`alice@<redacted-url>`).
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu, "<redacted-email>")
     // A scheme is a formatting choice, not a sensitivity boundary: `www.host/x`
     // leaks exactly what `https://www.host/x` would.
     .replace(/\bwww\.\S+/giu, "<redacted-url>")
-    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu, "<redacted-email>")
     .replace(/\+\d[\d().\s-]{7,}\d/gu, "<redacted-phone>")
     // Same number without the country prefix. External text we do not control
     // (provider failure reasons especially) writes phone numbers in national

--- a/apps/web/src/lib/http.ts
+++ b/apps/web/src/lib/http.ts
@@ -592,8 +592,17 @@ export function sanitizeJsonLogString(
     .replace(/\bwhsec_[A-Z0-9]+\b/giu, "<redacted-secret>")
     .replace(/\bfile:\/\/\S+/giu, "<redacted-path>")
     .replace(/\bhttps?:\/\/\S+/giu, "<redacted-url>")
+    // A scheme is a formatting choice, not a sensitivity boundary: `www.host/x`
+    // leaks exactly what `https://www.host/x` would.
+    .replace(/\bwww\.\S+/giu, "<redacted-url>")
     .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu, "<redacted-email>")
     .replace(/\+\d[\d().\s-]{7,}\d/gu, "<redacted-phone>")
+    // Same number without the country prefix. External text we do not control
+    // (provider failure reasons especially) writes phone numbers in national
+    // format far more often than E.164, so matching only `+` left the common
+    // case readable. Over-matching a phone-shaped identifier here is the safe
+    // direction: only the number is replaced, not the surrounding wording.
+    .replace(/(?:\(\d{3}\)\s*|\b\d{3}[.\s-])\d{3}[.\s-]\d{4}\b/gu, "<redacted-phone>")
     .replace(/(^|[\s(])\/[^\s)]+/gu, "$1<redacted-path>")
     .replace(/\b[A-Z]:\\[^\s]+/gu, "<redacted-path>");
 

--- a/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-events.test.ts
@@ -241,6 +241,48 @@ describe("parseHostedLinqProviderEvent", () => {
     expect(JSON.stringify(failed?.payloadShapeJson)).not.toContain("provider_msg_123");
   });
 
+  it("masks contact identifiers a provider embeds in a failure or status reason", () => {
+    // The reason keeps its wording, so every contact shape the provider can
+    // write has to be masked on the way through the parser — this is the last
+    // point before the value is persisted and emailed.
+    const failed = parseHostedLinqProviderEvent({
+      event: buildGenericEvent({
+        data: {
+          error: {
+            code: "30007",
+            message: "bounced for alice@www.example.test at 415-555-2671, see www.example.test/help",
+          },
+          message_id: "msg_failed_contacts",
+          phone_number: "+15550000000",
+        },
+        eventType: "message.failed",
+      }),
+    });
+    const status = parseHostedLinqProviderEvent({
+      event: buildGenericEvent({
+        data: {
+          phone_number: "+15550000000",
+          reason: "review requested by alice@www.example.test at 415-555-2671",
+          status: "flagged",
+        },
+        eventType: "phone_number.status_updated",
+      }),
+    });
+
+    expect(failed?.failureReason).toBe(
+      "bounced for <redacted-email> at <redacted-phone>, see <redacted-url>",
+    );
+    expect(status?.providerReason).toBe(
+      "review requested by <redacted-email> at <redacted-phone>",
+    );
+    for (const parsed of [failed, status]) {
+      const serialized = JSON.stringify(parsed);
+      expect(serialized).not.toContain("alice");
+      expect(serialized).not.toContain("example.test");
+      expect(serialized).not.toContain("415-555-2671");
+    }
+  });
+
   it("parses reaction events for join-offer dispatch without persisting raw handles", () => {
     const parsed = parseHostedLinqProviderEvent({
       event: buildGenericEvent({

--- a/apps/web/test/http.test.ts
+++ b/apps/web/test/http.test.ts
@@ -562,6 +562,21 @@ describe("json route helper factory", () => {
       .toBe("see <redacted-url> for details");
   });
 
+  it("redacts a whole email address whose domain is www-prefixed", () => {
+    // Ordering regression: if the schemeless-URL rule runs first it consumes the
+    // domain and strands the local part, which is usually the identifying half.
+    for (const address of [
+      "alice@www.example.test",
+      "alice+tag@www.example.test",
+      "alice@mail.www.example.test",
+    ]) {
+      const sanitized = httpModule.sanitizeJsonLogString(`provider rejected ${address}`);
+      expect(sanitized).toBe("provider rejected <redacted-email>");
+      expect(sanitized).not.toContain("alice");
+      expect(sanitized).not.toContain("example.test");
+    }
+  });
+
   it("keeps non-contact numerics readable so diagnostics stay useful", () => {
     // Over-redaction would defeat the purpose of keeping provider reasons.
     for (const value of [

--- a/apps/web/test/http.test.ts
+++ b/apps/web/test/http.test.ts
@@ -546,6 +546,35 @@ describe("json route helper factory", () => {
     });
   });
 
+  it("redacts national-format phone numbers and schemeless URLs while keeping the surrounding wording", () => {
+    // These are the shapes external text actually uses. Matching only `+`
+    // phones and `https://` URLs left them readable in persisted diagnostics
+    // and operational alert emails.
+    expect(httpModule.sanitizeJsonLogString("carrier filtered 415-555-2671 for spam"))
+      .toBe("carrier filtered <redacted-phone> for spam");
+    expect(httpModule.sanitizeJsonLogString("blocked (415) 555-2671 at gateway"))
+      .toBe("blocked <redacted-phone> at gateway");
+    expect(httpModule.sanitizeJsonLogString("415.555.2671 unreachable"))
+      .toBe("<redacted-phone> unreachable");
+    expect(httpModule.sanitizeJsonLogString("415 555 2671 unreachable"))
+      .toBe("<redacted-phone> unreachable");
+    expect(httpModule.sanitizeJsonLogString("see www.example.test/help for details"))
+      .toBe("see <redacted-url> for details");
+  });
+
+  it("keeps non-contact numerics readable so diagnostics stay useful", () => {
+    // Over-redaction would defeat the purpose of keeping provider reasons.
+    for (const value of [
+      "failed at 2026-08-04 with code 30007",
+      "retry after 1.2.3 seconds",
+      "carrier filtered the message",
+      "spam score 0.87 exceeded threshold",
+      "error code 4001 from gateway",
+    ]) {
+      expect(httpModule.sanitizeJsonLogString(value)).toBe(value);
+    }
+  });
+
   it("redacts complete authorization and cookie header values from log strings", () => {
     expect(httpModule.sanitizeJsonLogString("Authorization: Bearer auth-fixture-token, status=401"))
       .toBe("Authorization: <redacted-secret>");


### PR DESCRIPTION
## Why this PR exists

`sanitizeJsonLogString` matched only `+`-prefixed phone numbers and `https://` URLs. A number written `415-555-2671` and a link written `www.example.test/help` passed through untouched into persisted diagnostics and operational alert emails. A country prefix and a URL scheme are formatting choices, not sensitivity boundaries.

This became load-bearing in #1268, which made Linq provider failure and status reasons keep their wording so an operator can act on them. External providers write phone numbers in national format far more often than E.164, so the common case was the unprotected one.

## User goal / user-visible behavior

An operator reading a Linq alert email still gets the provider's actual explanation of why a send failed, but a phone number or link inside that explanation is masked. Nothing a member can see changes.

## User experience

No member-facing surface changes. The only visible difference is inside operator alert emails and persisted diagnostics, and it is deliberately narrow — the number is replaced, not the sentence:

```
before:  carrier filtered 415-555-2671 for spam
after:   carrier filtered <redacted-phone> for spam

before:  see www.example.test/help for details
after:   see <redacted-url> for details
```

Entry point, timing, delivery, retry, and recovery behavior are unchanged.

## Invariants the PR must preserve

- Contact identifiers in untrusted text are masked regardless of formatting: `+1…`, `415-555-2671`, `(415) 555-2671`, `415.555.2671`, `415 555 2671`, `https://…`, and `www.…` all redact.
- Redaction stays substring-scoped. The surrounding diagnostic wording survives, because a reason nobody can read is what this whole line of work set out to fix.
- Non-contact numerics stay readable: dates, semantic versions, decimal scores, and provider error codes must not be redacted.
- Every existing redaction (secrets, bearer tokens, emails, file paths, Windows paths) keeps working unchanged. In particular an email address must resolve as one complete token before the schemeless-URL rule, so a `www.`-prefixed domain cannot strand the local part.

## Non-obvious affected surfaces

- **Every caller of `sanitizeJsonLogString` repo-wide.** This is the shared log/diagnostic scrubber, not a Linq-local helper, so the tightening applies to all hosted-onboarding persisted errors, device-sync diagnostics, assistant runtime observability, and route logging. That breadth is the point — the same blind spot existed everywhere. Regression proof: the full `apps/web` workspace suite, 636 files / 8540 tests, green at this head.
- **Deliberate over-matching on phone shape.** A non-phone identifier formatted `NNN-NNN-NNNN` will be redacted. In a diagnostic string that is the safe direction, and the second new test pins the shapes that must *not* be caught so the over-match stays bounded.

## Architecture and reuse

- Existing systems reused: `sanitizeJsonLogString` itself. The two new patterns sit directly beside their existing counterparts — the schemeless-URL rule after the `https?://` rule, the national-phone rule after the `+`-phone rule — so all redaction policy stays in one function with one ordering.
- New logic: Two regex replacements, plus one ordering constraint — email resolves before the schemeless-URL rule. No new branching, options, or call-site changes.
- New abstractions: None, and none was warranted. The existing function already is the abstraction for "scrub untrusted text before it is persisted or emailed"; this fills gaps in its coverage rather than adding a second mechanism beside it.
- Complexity intentionally avoided: No phone-number parsing library, no locale or region configuration, and no per-caller sensitivity levels. A library would add a dependency and runtime cost to a hot logging path for a bounded set of formats, and per-caller levels would reintroduce exactly the "this caller's text is safer" reasoning that caused the original gap.

## Hot reply path impact

`Not applicable.` `sanitizeJsonLogString` runs on diagnostic and log strings, not on durable acceptance of a conversation message, provider start, or reply handoff. No database, network, or awaited operation is added anywhere; the change is two additional regex passes over strings already being scanned by eleven other redaction replacements (twelve `replace` passes counting whitespace normalization).

## Murph initial provider input impact

`Not applicable` for both individual and group Murph. No prompt file, prompt builder, tool definition, tool schema, deferred-tool metadata, skill, model configuration, or provider-request assembly is touched.

## Preliminary specialist lenses

- **Product experience — applicable.** Intended outcome: operator alerts that stay diagnosable while masking contact identifiers. Direct evidence: the before/after strings above, pinned by `redacts national-format phone numbers and schemeless URLs while keeping the surrounding wording` and `keeps non-contact numerics readable so diagnostics stay useful`.
- **Prompt — not applicable.** No prompt text or builder is touched.
- **Frontend — not applicable.** No `apps/web` UI diff.
- **Coverage — applicable.** Focused local proof at head `76cb1809d7`: full `apps/web` workspace green (636 files / 8540 tests), clean `tsc --noEmit`, clean eslint. Four new tests: the two redaction directions, an email-ordering regression over plain/tagged/nested-domain addresses, and a provider-event test driving the real parser path with an email, a national-format phone number, and a schemeless URL in one reason. Exact-head CI: all 13 checks green.

## Change-shape breakdown

Classification rule: by path — `apps/web/src/**` is source, `apps/web/test/**` is tests/fixtures. No binary, generated, docs, or config files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 12 | 0 |
| Tests/fixtures | 86 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **98** | **0** |

## Design proof for user-facing frontend UI

`Not applicable.` No user-facing frontend UI diff.

## Deployment skew / compatibility

`Not applicable` as a skew risk. Web-only, no deploy boundary, runner bundle, worker/container shape, credential, or schema change. The function is pure and its output is only ever written to diagnostics; rows written before and after this deploy coexist, and nothing reads those strings for control flow. Fully reversible by revert.

## Deliberately deferred

Names and free-form prose (for example a health statement a provider echoes into a reason) are not pattern-detectable and still pass through. That residual exposure is a known, accepted property of keeping provider wording readable; this PR closes the two mechanically detectable vectors and does not claim to close that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round record

- **Round 2** (head `76cb1809d7`) — `ROUND_OUTCOME: PASS`, no qualifying findings; the accepted correction was confirmed effective across the full webhook-to-email path. It flagged three bookkeeping errors in this body (change-shape counts, a stale test total, and a miscount of existing redaction passes); all three were verified against the diff and corrected here, with no code change.
- **Round 1** (head `2e5fe43ffd`) — 1 High finding, accepted: the new `www.` rule preceded the email rule, so `alice@www.example.test` sanitized to `alice@<redacted-url>` and stranded the identifying local part. Reproduced before fixing. Landed the reviewer's smallest correction in `76cb1809d7` — move the email replacement ahead of the schemeless-URL replacement — plus the two regressions it asked for. No other finding.

ReviewGPT first-reviewed head: 2e5fe43ffd1f21ded0c98034978d2f269398993f
