### PR TITLE
Test terminal auto-open phone transfer recovery

### DIFF
--- a/agent-docs/exec-plans/completed/2026-07-30-phone-link-transfer-reconciliation.md
+++ b/agent-docs/exec-plans/completed/2026-07-30-phone-link-transfer-reconciliation.md
@@ -1,8 +1,8 @@
 # Repair phone-transfer reconciliation
 
-Status: active
+Status: completed
 Created: 2026-07-30
-Updated: 2026-07-30
+Updated: 2026-08-04
 
 ## Goal
 
@@ -86,8 +86,8 @@ Updated: 2026-07-30
    regressions.
 4. [x] Reconcile a provider-confirmed transfer by retiring only a proven unused
    source scaffold through the canonical account-deletion owner.
-5. [ ] Complete scoped verification, parent review, commit, push, and PR evidence.
-6. [ ] Resolve the five-round ReviewGPT cap after exact-head CI and live proof;
+5. [x] Complete scoped verification, parent review, commit, push, and PR evidence.
+6. [x] Resolve the five-round ReviewGPT cap after exact-head CI and live proof;
    do not start round 6 without an explicit continuation decision.
 
 ## Decisions
@@ -124,6 +124,20 @@ Updated: 2026-07-30
 - Final ReviewGPT round 5 found and reproduced a stale old-phone writer that
   could cross source deletion. The dual-phone lock correction is pushed; the
   five-round cap requires an explicit decision before any round 6.
-- Browser proof of the final already-transferred phone reconciliation remains
-  pending.
-- Final parent review, exact-head review, and CI evidence remain pending.
+- The phone-transfer corrections and terminal recovery UI shipped through PRs
+  #1191 and #1267. Four synthetic design-catalog captures cover the shared card
+  and Settings dialog at desktop and mobile viewports without member data.
+- PR #1267 exact-head CI passed every required check. Final ReviewGPT accepted
+  one disclosure-only finding, the PR intent contract was corrected, and the
+  unchanged patch then received `ROUND_OUTCOME: PASS` with verified model
+  evidence.
+- The preliminary specialist pass found no production, product-experience,
+  prompt, or frontend defect. Its sole accepted coverage finding is resolved by
+  a production-path component regression that exercises the auto-open Settings
+  transfer callbacks and proves the terminal dialog has support but no retry.
+  The focused suite passes 19 tests; hosted-web typecheck and scoped lint pass.
+- A bounded read-only production inspection found no persisted member or web
+  session write for the older reported email-to-phone incident. Historical
+  request evidence is unavailable, so no speculative authentication change was
+  made.
+Completed: 2026-08-04

--- a/apps/web/test/settings-phone-settings.test.ts
+++ b/apps/web/test/settings-phone-settings.test.ts
@@ -1,4 +1,4 @@
-import { act, createElement } from "react";
+import { act, createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HostedOnboardingApiError } from "@/src/components/hosted-onboarding/client-api";
@@ -50,6 +50,15 @@ vi.mock("@privy-io/react-auth", () => ({
 
 vi.mock("@/src/components/hosted-onboarding/hosted-phone-auth-support", () => ({
   finalizeHostedPhoneLink: mocks.finalizeHostedPhoneLink,
+}));
+
+vi.mock("@/src/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+    open ? createElement("div", { "data-dialog": "open" }, children) : null,
+  DialogContent: "div",
+  DialogDescription: "p",
+  DialogHeader: "div",
+  DialogTitle: "h2",
 }));
 
 let cleanupRender: (() => Promise<void>) | null = null;
@@ -898,6 +907,58 @@ describe("HostedPhoneSettings", () => {
     expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
     expect(mocks.linkPhone).not.toHaveBeenCalled();
     expect(mocks.updatePhone).not.toHaveBeenCalled();
+  });
+
+  it("makes an auto-open transferred-source conflict terminal after Privy exits", async () => {
+    mocks.providerPhoneNumber = "+15550100001";
+    mocks.finalizeHostedPhoneLink.mockRejectedValue(new HostedOnboardingApiError({
+      code: "PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE",
+      message:
+        "That phone moved from another Murph account that is still active with its own sign-in. Contact support to reconcile it safely.",
+      retryable: false,
+    }));
+    const { HostedPhoneSettings } = await import("@/src/components/settings/hosted-phone-settings");
+    const { cleanup, container } = await renderClientComponent(
+      createElement(HostedPhoneSettings, {
+        autoOpen: true,
+        initialPhoneNumber: "+15550100001",
+      }),
+      { requireButton: false },
+    );
+    cleanupRender = cleanup;
+
+    await vi.waitFor(() => {
+      expect(mocks.updatePhone).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      mocks.updateAccountCallbacks?.onError?.("account_transfer_required", {
+        linkMethod: "sms",
+      });
+      mocks.updateAccountCallbacks?.onError?.("exited_update_flow", {
+        linkMethod: "sms",
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        "That phone moved from another Murph account",
+      );
+    });
+
+    expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledWith({
+      expectation: {
+        kind: "changed-from",
+        phoneNumber: "+15550100001",
+      },
+      onLinked: expect.any(Function),
+    });
+    expect(mocks.finalizeHostedPhoneLink).toHaveBeenCalledTimes(1);
+    expect(mocks.updatePhone).toHaveBeenCalledTimes(1);
+    expect(mocks.linkPhone).not.toHaveBeenCalled();
+    expect(findButton(container, "Try again")).toBeUndefined();
+    expect(container.textContent).toContain("Contact support");
   });
 
   it("does not infer an update flow from linked-account projections alone", async () => {


### PR DESCRIPTION
## Why this PR exists

The retained phone-transfer fix is already on main, but its late preliminary specialist review found that the regression suite covered only the inline card path. Production Settings enters through the auto-open dialog and the real Privy transfer callback sequence, so that exact terminal journey lacked executable proof.

## User goal and product experience

An authenticated member whose phone transfer cannot converge because the source account remains active must see one terminal explanation and one support path, never another retry action. This follow-up adds regression proof only; it does not change the shipped experience.

## Invariants

- The test enters the same auto-open Settings component used in production.
- The provider phone initially matches the saved phone, so Privy launches update exactly once.
- The transfer-required and exited-update callbacks produce an exact changed-from reconciliation expectation.
- The terminal source-conflict code leaves Contact support visible and Try again absent.
- No production source, runtime configuration, schema, dependency, or UI presentation changes.

## Non-obvious affected surfaces

The generic dialog primitive is rendered inline only inside this component test because the Base UI portal does not mount in the Linkedom harness. The real HostedPhoneSettings state machine, Privy callbacks, reconciliation call, terminal error classification, and support/retry actions remain under test. Existing design-catalog browser evidence from PR #1267 continues to cover the real dialog presentation.

## Preliminary specialist lenses

- Product experience: not applicable to this follow-up; no shipped behavior changes.
- Prompt: not applicable.
- Frontend: not applicable; no production UI source changes.
- Coverage: applicable. The completed PR #1267 specialist pass requested this exact production-path regression. Repository policy does not rerun the specialist pass for an isolated accepted regression-test addition.

## Direct evidence

The new test renders HostedPhoneSettings with autoOpen, simulates account_transfer_required followed by exited_update_flow, and makes final reconciliation return PRIVY_PHONE_TRANSFER_SOURCE_STILL_ACTIVE. It asserts the changed-from expectation, one update launch, one reconciliation attempt, no link launch, visible support, and no Try again control.

## Verification

- Focused HostedPhoneSettings Vitest: 19 passed.
- Hosted Web typecheck: passed.
- Scoped ESLint: passed.
- Doc gardening: passed with zero issues.
- Diff check and identifier scan: passed.

## Design proof

Not required for this test-and-plan-only follow-up. PR #1267 already contains inspected desktop and mobile proof for the real shared card and Settings dialog states.

## Architecture and reuse

- Existing systems reused: the existing renderClientComponent harness, HostedPhoneSettings component, Privy callback mocks, and terminal API error contract.
- New logic: one regression test drives the production auto-open update-transfer callback sequence and asserts the exact terminal reconciliation and rendered actions.
- New abstractions: none; the generic dialog shell is mocked locally so the real phone-transfer owner can render inside the existing DOM harness.
- Complexity intentionally avoided: no runtime source, portal implementation, shared test harness, state owner, retry machinery, or compatibility path changed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 62 | 1 |
| Docs | 21 | 7 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **83** | **8** |

## Deployment skew / compatibility

None. This PR changes tests and archives a completed plan only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788428631&installation_model_id=19880&pr_number=1281&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1281&signature=c2d09c5b201568baed18b0b3c4ff2bd380860894f3f1f99bda2fb5b42cfd34bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->