### PR TITLE
Model optional physical-note tool availability in hosted E2E

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -235,6 +235,7 @@ export function expectAdvertisedMurphDynamicTools(
     imessageContactAvailable?: boolean;
     messageTargetingAvailable?: boolean;
     newsletterAvailable?: boolean;
+    physicalNotesAvailable?: boolean;
     phoneCallsAvailable?: boolean;
     progressUpdatesAvailable?: boolean;
     responseCardAvailable?: boolean;
@@ -288,6 +289,13 @@ export function expectAdvertisedMurphDynamicTools(
       if (
         options.newsletterAvailable !== true
         && name === "murph.newsletter"
+      ) {
+        return false;
+      }
+
+      if (
+        options.physicalNotesAvailable !== true
+        && name === "murph.send_physical_note"
       ) {
         return false;
       }

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -514,6 +514,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
       && name !== "murph.select_reply_target"
       && name !== "murph.create_phone_call"
       && name !== "murph.newsletter"
+      && name !== "murph.send_physical_note"
       && name !== "murph.send_vault_file"
       && name !== "murph.ask_grok"
       && name !== "murph.attach_response_card"
@@ -528,6 +529,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     expect(allToolNames).toContain("murph.create_phone_call");
     expect(allToolNames).toContain("murph.group_room_model");
     expect(allToolNames).toContain("murph.imessage_contact");
+    expect(allToolNames).toContain("murph.send_physical_note");
     expect(allToolNames).toContain("murph.send_progress_update");
     expect(allToolNames).toContain("murph.ask_grok");
     expect(allToolNames).toContain("murph.attach_response_card");
@@ -559,6 +561,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
         imessageContactAvailable: true,
         messageTargetingAvailable: true,
         newsletterAvailable: true,
+        physicalNotesAvailable: true,
         phoneCallsAvailable: true,
         progressUpdatesAvailable: true,
         responseCardAvailable: true,


### PR DESCRIPTION
## Why this PR exists

Private hosted integration exposed a stale public E2E helper assumption: `send_physical_note` is default-off unless the runtime platform enables physical notes, but the helper expected it in every provider advertisement. Two unrelated scenarios therefore failed before testing their own behavior.

## User goal / user-visible behavior

No product behavior changes. Hosted integration should assert the tools the production runtime actually enables and continue reaching the Telegram and media-delivery journeys it is meant to verify. Failures still occur if an enabled physical-note runtime omits the tool.

## Invariants

- Optional production tools remain fail-closed and are not advertised without their runtime port.
- A scenario that explicitly enables physical notes can require `send_physical_note`.
- No production source, prompt, deployment configuration, or runtime behavior changes.

## Non-obvious affected surfaces

The shared hosted-local provider-advertisement helper is used by several full-stack E2E scenarios. Physical notes now follow its existing availability-option pattern for connected apps, computer tools, phone calls, vault-file sending, and other optional capabilities.

## Architecture and reuse

- **Existing systems reused:** The shared hosted-local advertisement helper and its existing availability-option pattern.
- **New logic:** One test-only physical-notes availability option and filter.
- **New abstractions:** None were introduced because the existing shared helper already owns optional tool-advertisement expectations.
- **Complexity intentionally avoided:** No new helper, dependency, runtime seam, or production configuration.

## Preliminary specialist lenses

- Product experience: not applicable; no product behavior changes.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: applicable and sufficient; the unit test proves both default-off and explicitly-enabled expectations. Preliminary specialist review passed with no findings.

## Verification

- Focused helper test: 1 file, 22 tests passed.
- Cloudflare typecheck passed.
- Diff hygiene and private-identifier/credential scan passed.
- Exact-head CI: all checks passed on the pushed head.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 11 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

## Hot reply path / provider input / design proof

Not applicable; this is test-only and has no rendered UI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788434457&installation_model_id=19880&pr_number=1282&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1282&signature=f4e2d6683ccfda7fee6057e79fb66c3574696ce61a2c31c830e807ef7d28e609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
