### PR TITLE
fix(cloudflare): preserve usage denial semantics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-04-hosted-usage-denial-direct-wake.md
+++ b/agent-docs/exec-plans/completed/2026-08-04-hosted-usage-denial-direct-wake.md
@@ -1,0 +1,67 @@
+# Hosted usage-denial direct-wake recovery
+
+## Goal
+
+Fix the hosted direct-wake race where a managed AI usage denial observed during
+fresh invocation preparation is recorded as a transport `runtime_error` even
+though Web has already classified the mailbox as product-blocked work.
+
+Success criteria:
+
+- Managed provider egress remains fail-closed when the latest workspace
+  projection denies platform AI usage.
+- A racing payloadless direct wake releases without recording a runtime
+  failure, consuming mailbox work, or calling the assistant provider.
+- The focused usage-limit hosted-local scenario and the private hosted
+  integration matrix pass on the corrected public head.
+
+## Constraints
+
+- Preserve Web as the usage-policy owner and Cloudflare as the execution
+  adapter.
+- Keep Temporal signals and workflow state pointer-only.
+- Reuse the existing denied-mailbox empty-prefix and write-fenced provider
+  egress behavior; do not add another scheduler, queue, response kind, or
+  usage-policy projection.
+- Keep diagnostics metadata-only and preserve unrelated checkout changes.
+
+## Approach
+
+1. Add focused controller proof that a fresh direct wake with
+   `platformAiUsageAllowed: false` runs under a denied fence and completes
+   without persisting a transport failure.
+2. Replace the early managed-route preparation throw with the existing
+   deny-bound write-fence path so the runtime can observe the canonical empty
+   mailbox prefix and release cleanly while provider egress stays blocked.
+3. Update the preparation-level contract test to assert the denied allowance
+   is bound to the active fence.
+4. Run focused Cloudflare tests and typecheck, then the hosted usage-limit
+   scenario when feasible.
+5. Commit, open the public PR, complete required review/CI gates, merge, and
+   rerun the private protected-deploy PR integration against corrected public
+   main.
+
+## Verification
+
+- Focused invocation/controller unit tests.
+- Cloudflare typecheck.
+- Hosted-local usage-limit ambiguous-send E2E when the local harness is
+  available.
+- Preliminary specialist ReviewGPT coverage pass.
+- Final ReviewGPT cross-cutting gate and exact-head CI.
+- Private hosted integration matrix after the public fix merges.
+
+## State
+
+Implemented and locally verified:
+
+- `pnpm --dir apps/cloudflare typecheck`
+- Four focused Cloudflare test files: 348 tests passed.
+- `pnpm hosted-local e2e usage-limit-ambiguous-send --no-bundle`: 2 tests
+  passed against the local Postgres, Temporal, hosted-web, Worker, and runner
+  stack after supplying the existing external worker package.
+
+Public PR review/CI and the private integration rerun remain pending.
+Status: completed
+Updated: 2026-08-04
+Completed: 2026-08-04

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1588,11 +1588,14 @@ ownership remains the only authority to invoke or commit runtime work. The Tempo
 caller sends its existing ensure-processing HTTP timeout as an internal header.
 An expected managed AI usage denial observed by the workspace read is not a
 transport preparation failure. Cloudflare binds the denied allowance to the
-fresh write fence and lets the existing mailbox adapter expose its unchanged
-empty denied prefix so the invocation releases cleanly; the same fence rejects
-all metered provider egress if the runtime reaches one unexpectedly. This keeps
-a racing payloadless direct wake from manufacturing `runtime_error` state while
-Web and Temporal remain the usage-policy and durable-reconciliation owners.
+fresh write fence and narrows a default invocation to the existing
+`system_mailbox` path, which imports eligible model-free system work and exits
+before foreground assistant admission; the same fence rejects all metered
+provider egress if the runtime reaches one unexpectedly. Explicit media
+retention remains model-free, and custom inference keeps its selected route.
+This keeps a racing payloadless direct wake from manufacturing `runtime_error`
+state or mutating restored assistant recovery while Web and Temporal remain the
+usage-policy and durable-reconciliation owners.
 Cloudflare treats that value as an operational hint only: the foreground
 pre-accept budget is clamped by Cloudflare's configured web-control timeout, and
 workspace read/readiness steps are capped by the remaining budget. Accepted

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1590,8 +1590,10 @@ An expected managed AI usage denial observed by the workspace read is not a
 transport preparation failure. Cloudflare binds the denied allowance to the
 fresh write fence and narrows a default invocation to the existing
 `system_mailbox` path, which imports eligible model-free system work and exits
-before foreground assistant admission; the same fence rejects all metered
-provider egress if the runtime reaches one unexpectedly. Explicit media
+before foreground assistant admission. It binds that effective processing mode
+into the same fence so controller priority, preemption, and the container job
+cannot diverge; the fence also rejects all metered provider egress if the runtime
+reaches one unexpectedly. Explicit media
 retention remains model-free, and custom inference keeps its selected route.
 This keeps a racing payloadless direct wake from manufacturing `runtime_error`
 state or mutating restored assistant recovery while Web and Temporal remain the

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1586,6 +1586,13 @@ readiness is overlapped, a failed preparation may still leave a best-effort
 warm shell behind; write-fence
 ownership remains the only authority to invoke or commit runtime work. The Temporal
 caller sends its existing ensure-processing HTTP timeout as an internal header.
+An expected managed AI usage denial observed by the workspace read is not a
+transport preparation failure. Cloudflare binds the denied allowance to the
+fresh write fence and lets the existing mailbox adapter expose its unchanged
+empty denied prefix so the invocation releases cleanly; the same fence rejects
+all metered provider egress if the runtime reaches one unexpectedly. This keeps
+a racing payloadless direct wake from manufacturing `runtime_error` state while
+Web and Temporal remain the usage-policy and durable-reconciliation owners.
 Cloudflare treats that value as an operational hint only: the foreground
 pre-accept budget is clamped by Cloudflare's configured web-control timeout, and
 workspace read/readiness steps are capped by the remaining budget. Accepted

--- a/apps/cloudflare/src/user-runner/runner-state-store.ts
+++ b/apps/cloudflare/src/user-runner/runner-state-store.ts
@@ -231,6 +231,7 @@ export class RunnerStateStore {
   async bindWriteFenceInvocationFacts(input: {
     customInferenceEnvelope: string | null;
     platformAiUsageAllowed: boolean | null;
+    processingMode?: RunnerRuntimeProcessingMode | null;
     token: RunnerWriteFenceToken;
     workspaceVersion: string;
   }): Promise<RunnerWriteFenceToken> {
@@ -248,9 +249,13 @@ export class RunnerStateStore {
       : input.platformAiUsageAllowed
         ? 1
         : 0;
+    if (input.processingMode !== undefined) {
+      meta.active_reason = readRunnerRuntimeProcessingMode(input.processingMode);
+    }
     this.writeMetaRowSync(meta);
     return {
       ...input.token,
+      processingMode: readRunnerRuntimeProcessingMode(meta.active_reason),
       workspaceVersion: meta.active_workspace_version,
     };
   }

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -228,6 +228,7 @@ export class RuntimeInvocationService {
         })
       : null;
     let platformAiUsageAllowed: boolean | null = null;
+    let invocationProcessingMode = input.input.processingMode ?? null;
     if (hostedAssistantCustomInferenceOverride) {
       if (typeof workspaceRead.platformAiUsageAllowed !== "boolean") {
         throw new Error(
@@ -238,11 +239,15 @@ export class RuntimeInvocationService {
     } else if (workspaceRead.platformAiUsageAllowed === false) {
       // A payloadless direct wake can win the race with Temporal's usage-block
       // reconciliation. Keep that expected product block out of transport
-      // failure state: the mailbox adapter will expose the canonical empty
-      // denied prefix, while the bound fence rejects every metered provider
-      // egress if the invocation reaches one unexpectedly. Retention-only work
-      // can also proceed because it needs no model call.
+      // failure state and keep restored assistant work out of provider-failure
+      // handling: the existing system-mailbox path exits before foreground
+      // assistant admission, while the bound fence rejects every metered
+      // provider egress if one is reached unexpectedly. Explicit retention-only
+      // work can also proceed because it needs no model call.
       platformAiUsageAllowed = false;
+      if ((invocationProcessingMode ?? "default") === "default") {
+        invocationProcessingMode = "system_mailbox";
+      }
     }
     const customInferenceEnvelope = customInferenceTarget
       ? await sealHostedInferenceRuntimeTarget({
@@ -268,7 +273,7 @@ export class RuntimeInvocationService {
         workspaceRead.hostedAssistantProviderOverride ?? null,
       hostedAssistantReasoningEffortOverride:
         workspaceRead.hostedAssistantReasoningEffortOverride ?? null,
-      processingMode: input.input.processingMode ?? null,
+      processingMode: invocationProcessingMode,
       token,
       userId: input.input.userId,
       workspace: workspaceRead.workspace,

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -258,6 +258,7 @@ export class RuntimeInvocationService {
     const token = await this.input.stateStore.bindWriteFenceInvocationFacts({
       customInferenceEnvelope,
       platformAiUsageAllowed,
+      processingMode: invocationProcessingMode,
       token: input.token,
       workspaceVersion,
     });

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -236,15 +236,12 @@ export class RuntimeInvocationService {
       }
       platformAiUsageAllowed = workspaceRead.platformAiUsageAllowed;
     } else if (workspaceRead.platformAiUsageAllowed === false) {
-      if (input.input.processingMode !== "inbox_media_retention") {
-        throw new Error(
-          "Hosted managed inference was no longer allowed during invocation preparation.",
-        );
-      }
-      // Inbox media retention deletes expired private media without any model
-      // call, so a denied managed allowance must not block it. Binding the
-      // denial into the write fence keeps every metered provider egress
-      // rejected for the run anyway.
+      // A payloadless direct wake can win the race with Temporal's usage-block
+      // reconciliation. Keep that expected product block out of transport
+      // failure state: the mailbox adapter will expose the canonical empty
+      // denied prefix, while the bound fence rejects every metered provider
+      // egress if the invocation reaches one unexpectedly. Retention-only work
+      // can also proceed because it needs no model call.
       platformAiUsageAllowed = false;
     }
     const customInferenceEnvelope = customInferenceTarget

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -507,7 +507,7 @@ describe("hosted runner container identity", () => {
     })).resolves.toEqual(runtimeTarget);
   });
 
-  it("rejects a managed route when allowance changed after reconciliation", async () => {
+  it("binds a denied managed allowance to the fresh runtime fence", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const durable = createRunnerDurableState();
@@ -532,16 +532,24 @@ describe("hosted runner container identity", () => {
       userId: TEST_USER_ID,
     });
 
-    await expect(service.prepareWithFence({
+    const prepared = await service.prepareWithFence({
       input: {
         orchestrationAttemptId: "orchestration_attempt_managed_denied",
         userId: TEST_USER_ID,
       },
       token,
-    })).rejects.toThrow(
-      "Hosted managed inference was no longer allowed during invocation preparation.",
-    );
+    });
     expect(invokedContainerNames).toEqual([]);
+    if (!prepared.token.providerEgressToken) {
+      throw new Error("Expected a provider egress token on the active fence.");
+    }
+    await expect(stateStore.validateProviderEgressToken({
+      providerEgressToken: prepared.token.providerEgressToken,
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      owns: true,
+      platformAiUsageAllowed: false,
+    });
   });
 
   it("lets inbox media retention run under a denied allowance while metered egress stays blocked", async () => {
@@ -568,7 +576,8 @@ describe("hosted runner container identity", () => {
       userId: TEST_USER_ID,
     });
 
-    // Modes that can reach a model stay blocked under a denied allowance.
+    // System-mailbox work uses the same denied provider-egress fence as the
+    // default runtime path.
     await expect(service.prepareWithFence({
       input: {
         orchestrationAttemptId: "orchestration_attempt_system_mailbox_denied",
@@ -576,9 +585,9 @@ describe("hosted runner container identity", () => {
         userId: TEST_USER_ID,
       },
       token,
-    })).rejects.toThrow(
-      "Hosted managed inference was no longer allowed during invocation preparation.",
-    );
+    })).resolves.toMatchObject({
+      workspaceVersion: "0",
+    });
 
     await expect(service.prepareWithFence({
       input: {

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -461,6 +461,7 @@ describe("hosted runner container identity", () => {
     const service = createRuntimeInvocationService({
       hostedAssistantCustomInferenceOverride: override,
       invokedContainerNames: [],
+      platformAiUsageAllowed: false,
       runnerRuntimeEnvSource,
       stateStore,
       state: durable.state,
@@ -480,6 +481,7 @@ describe("hosted runner container identity", () => {
     const forwardedEnv = prepared.job.runtime?.forwardedEnv;
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(prepared.job.request.processingMode).toBeUndefined();
     expect(forwardedEnv).toMatchObject({
       HOSTED_ASSISTANT_CONTEXT_WINDOW_TOKENS: "131072",
       HOSTED_ASSISTANT_MODEL: "murph-custom-r7",
@@ -507,7 +509,7 @@ describe("hosted runner container identity", () => {
     })).resolves.toEqual(runtimeTarget);
   });
 
-  it("binds a denied managed allowance to the fresh runtime fence", async () => {
+  it("narrows a denied managed default wake to model-free system mailbox work", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const durable = createRunnerDurableState();
@@ -540,6 +542,7 @@ describe("hosted runner container identity", () => {
       token,
     });
     expect(invokedContainerNames).toEqual([]);
+    expect(prepared.job.request.processingMode).toBe("system_mailbox");
     if (!prepared.token.providerEgressToken) {
       throw new Error("Expected a provider egress token on the active fence.");
     }

--- a/apps/cloudflare/test/runner-state-store-write-fence.test.ts
+++ b/apps/cloudflare/test/runner-state-store-write-fence.test.ts
@@ -95,6 +95,35 @@ describe("RunnerStateStore write-fence state", () => {
     await expect(store.readWriteFenceToken()).resolves.toBeNull();
   });
 
+  it("binds the effective invocation mode to the active write fence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    const { db, store } = createHarness();
+    await store.bindUser("member_123");
+    const token = await store.beginWriteFence({
+      runnerContainerName: "member_123",
+      userId: "member_123",
+    });
+
+    const pinned = await store.bindWriteFenceInvocationFacts({
+      customInferenceEnvelope: null,
+      platformAiUsageAllowed: false,
+      processingMode: "system_mailbox",
+      token,
+      workspaceVersion: "9",
+    });
+
+    expect(pinned.processingMode).toBe("system_mailbox");
+    expect(readActiveReason(db)).toBe("system_mailbox");
+    const restartedStore = new RunnerStateStore(createDurableObjectState(db));
+    await expect(restartedStore.readWriteFenceToken()).resolves.toMatchObject({
+      attemptId: token.attemptId,
+      processingMode: "system_mailbox",
+      userId: "member_123",
+      workspaceVersion: "9",
+    } satisfies Partial<RunnerWriteFenceToken>);
+  });
+
   it("pins one custom target envelope to the active fence and clears it with that fence", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1966,6 +1966,69 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("preempts a denied normalized invocation when foreground usage resumes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const firstInvocationResult = createDeferred<HostedWorkspaceInvocationResult>();
+    const abortWorkspaceInvocation = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
+    >(async () => "accepted");
+    let platformAiUsageAllowed = false;
+    const { flushWaitUntil, invoke, runner, sql } = createRunnerHarness({
+      abortWorkspaceInvocation,
+      invocationResults: [
+        firstInvocationResult.promise,
+        { nextWakeAt: null, status: "idle" },
+      ],
+      platformAiUsageAllowed: () => platformAiUsageAllowed,
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-denied-background-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledOnce();
+      expect(invoke.mock.calls[0]?.[0].job.request.processingMode).toBe(
+        "system_mailbox",
+      );
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_reason: "system_mailbox",
+      });
+    });
+
+    platformAiUsageAllowed = true;
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-restored-foreground-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "replaced",
+      kind: "runtime_processing_accepted",
+    });
+
+    const firstRequest = invoke.mock.calls[0]?.[0].job.request;
+    if (!firstRequest) {
+      throw new Error("Expected the denied background invocation request.");
+    }
+    expect(abortWorkspaceInvocation).toHaveBeenCalledWith({
+      attemptId: firstRequest.attemptId,
+      leaseGeneration: firstRequest.leaseGeneration,
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(invoke.mock.calls[1]?.[0].job.request.processingMode).toBeUndefined();
+    });
+
+    firstInvocationResult.resolve({ nextWakeAt: null, status: "idle" });
+    await flushWaitUntil();
+  });
+
   it("returns timeout retry cadence and clears the fresh fence when startup readiness times out", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -5480,7 +5543,7 @@ function createRunnerHarness(input: {
   onStatusRead?: () => Promise<void> | void;
   onStorageList?: (input: { prefix?: string }) => Promise<void> | void;
   onWorkspaceRead?: (input: { timeoutMs: number }) => Promise<void> | void;
-  platformAiUsageAllowed?: boolean;
+  platformAiUsageAllowed?: boolean | (() => boolean);
   readActiveRuntimeUserFence?: HostedExecutionContainerStubLike["readActiveRuntimeUserFence"];
   ownerReleaseResponse?: () => Promise<Response> | Response;
   runtimeLogResponse?: () => Promise<Response> | Response;
@@ -5824,7 +5887,7 @@ function installWebControlResponses(
     readMailboxLag?: () => HostedRuntimeWebStatusResponse["mailboxLag"];
     runtimeLogResponse?: () => Promise<Response> | Response;
     ownerReleaseResponse?: () => Promise<Response> | Response;
-    platformAiUsageAllowed?: boolean;
+    platformAiUsageAllowed?: boolean | (() => boolean);
   } = {},
 ): void {
   mocks.fetchHostedExecutionWebControlPlaneResponse.mockImplementation(
@@ -5839,7 +5902,12 @@ function installWebControlResponses(
           fetchedAt: FIXED_NOW,
           ...(hooks.platformAiUsageAllowed === undefined
             ? {}
-            : { platformAiUsageAllowed: hooks.platformAiUsageAllowed }),
+            : {
+                platformAiUsageAllowed:
+                  typeof hooks.platformAiUsageAllowed === "function"
+                    ? hooks.platformAiUsageAllowed()
+                    : hooks.platformAiUsageAllowed,
+              }),
           workspace,
         });
       }
@@ -6147,6 +6215,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
   active_attempt_id: string | null;
   active_expires_at: null;
   active_generation: number;
+  active_reason: string | null;
   active_started_at: string | null;
   active_workspace_version: string | null;
   backoff_until: null;
@@ -6159,6 +6228,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
     active_attempt_id: string | null;
     active_expires_at: null;
     active_generation: number;
+    active_reason: string | null;
     active_started_at: string | null;
     active_workspace_version: string | null;
     backoff_until: null;
@@ -6170,6 +6240,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
     `SELECT active_attempt_id,
             NULL AS active_expires_at,
             active_generation,
+            active_reason,
             active_started_at,
             active_workspace_version,
             NULL AS backoff_until,

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1931,6 +1931,38 @@ describe("HostedUserRunner execution coordination", () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
+  it("completes a racing managed-usage denial without recording a runtime failure", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => ({ kind: "ready" }));
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureReadyForProcessing,
+      platformAiUsageAllowed: false,
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-orchestration-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledOnce();
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        failure_count: 0,
+        last_error_code: null,
+        wake_at: null,
+      });
+    });
+  });
+
   it("returns timeout retry cadence and clears the fresh fence when startup readiness times out", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -5445,6 +5477,7 @@ function createRunnerHarness(input: {
   onStatusRead?: () => Promise<void> | void;
   onStorageList?: (input: { prefix?: string }) => Promise<void> | void;
   onWorkspaceRead?: (input: { timeoutMs: number }) => Promise<void> | void;
+  platformAiUsageAllowed?: boolean;
   readActiveRuntimeUserFence?: HostedExecutionContainerStubLike["readActiveRuntimeUserFence"];
   ownerReleaseResponse?: () => Promise<Response> | Response;
   runtimeLogResponse?: () => Promise<Response> | Response;
@@ -5575,6 +5608,7 @@ function createRunnerHarness(input: {
     onStatusRead: input.onStatusRead,
     onOwnerReleased: input.onOwnerReleased,
     onWorkspaceRead: input.onWorkspaceRead,
+    platformAiUsageAllowed: input.platformAiUsageAllowed,
     runtimeLogResponse: input.runtimeLogResponse,
     ownerReleaseResponse: input.ownerReleaseResponse,
   });
@@ -5787,6 +5821,7 @@ function installWebControlResponses(
     readMailboxLag?: () => HostedRuntimeWebStatusResponse["mailboxLag"];
     runtimeLogResponse?: () => Promise<Response> | Response;
     ownerReleaseResponse?: () => Promise<Response> | Response;
+    platformAiUsageAllowed?: boolean;
   } = {},
 ): void {
   mocks.fetchHostedExecutionWebControlPlaneResponse.mockImplementation(
@@ -5799,6 +5834,9 @@ function installWebControlResponses(
         await hooks.onWorkspaceRead?.({ timeoutMs: input.timeoutMs });
         return jsonResponse({
           fetchedAt: FIXED_NOW,
+          ...(hooks.platformAiUsageAllowed === undefined
+            ? {}
+            : { platformAiUsageAllowed: hooks.platformAiUsageAllowed }),
           workspace,
         });
       }
@@ -6110,6 +6148,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
   active_workspace_version: string | null;
   backoff_until: null;
   failure_count: number;
+  last_error_code: string | null;
   last_invocation_at: string | null;
   wake_at: null;
 } {
@@ -6121,6 +6160,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
     active_workspace_version: string | null;
     backoff_until: null;
     failure_count: number;
+    last_error_code: string | null;
     last_invocation_at: string | null;
     wake_at: null;
   }>(
@@ -6131,6 +6171,7 @@ function readRunnerMeta(sql: TestSqlStorageLike): {
             active_workspace_version,
             NULL AS backoff_until,
             failure_count,
+            last_error_code,
             last_invocation_at,
             NULL AS wake_at
      FROM runner_meta

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1954,6 +1954,9 @@ describe("HostedUserRunner execution coordination", () => {
 
     await vi.waitFor(() => {
       expect(invoke).toHaveBeenCalledOnce();
+      expect(invoke.mock.calls[0]?.[0].job.request.processingMode).toBe(
+        "system_mailbox",
+      );
       expect(readRunnerMeta(sql)).toMatchObject({
         active_attempt_id: null,
         failure_count: 0,


### PR DESCRIPTION
## Why this exists

A payloadless Cloudflare direct wake can race with Web and Temporal after managed AI usage has been denied. Fresh invocation preparation treated that expected product block as a container transport failure, cleared the write fence, and persisted `runtime_error` instead of completing the already-blocked reconciliation cleanly.

## User-visible goal

Keep an exhausted-usage mailbox safely accepted and blocked without manufacturing a runtime failure or retry churn. Accepted input remains durable, no assistant/conversation work is consumed, and no metered provider call is allowed while usage is denied. Web owns immediate blocked feedback and Temporal owns continuation after a usage-state change; the Cloudflare invocation terminates cleanly without admitting restored assistant work or scheduling transport recovery.

## Invariants

- Web remains the usage-policy owner and Temporal remains the durable reconciliation owner.
- The fresh Cloudflare write fence binds `platformAiUsageAllowed=false`.
- A denied managed default wake uses the existing model-free `system_mailbox` path and exits before assistant admission.
- The write fence, controller, and container job agree on the effective processing mode.
- Metered provider egress remains fail-closed.
- Explicit system-mailbox work and media retention remain available; custom inference keeps its member-funded selected route.
- No new scheduler, queue, response kind, runtime mode, or usage-policy projection is introduced.

## Non-obvious affected surfaces

- Payloadless direct wakes that race the durable usage-block reconciliation.
- Restored pending-input indexes, due assistant wakes, background assistant/cron admission, and assistant retry or terminal-suppression checkpoint ownership are intentionally kept unreachable by normalizing the denied default job before runtime admission.
- Controller priority and preemption after managed usage is restored while a normalized invocation remains active.
- Managed/default and system-mailbox processing modes.
- Inbox media retention remains allowed because it does not use managed inference.
- Custom inference remains selected because member-funded core inference is not blocked by the managed model allowance.
- Provider-egress authorization remains denied by the same invocation fence.

## Architecture and reuse

- **Existing systems reused:** The workspace usage projection, write-fenced provider-egress authorization, invocation-facts fence binding, controller preemption, and existing system-mailbox early-return path that imports model-free work and exits before assistant admission.
- **New logic:** Managed denied default invocation preparation binds the denial and effective `system_mailbox` mode to the fresh fence before constructing the matching runner job. Explicit system-mailbox, media-retention, and custom-inference routes remain unchanged.
- **New abstractions:** None. The existing invocation-facts binding remains the single owner for persisted facts learned during preparation.
- **Complexity intentionally avoided:** No retry policy, scheduler state, queue, response variant, duplicated usage decision, or new runtime mode was added.

## Verification

- Red proof before correction 1: denied default jobs had no processing mode in both controller and preparation tests.
- Red proof before correction 2: a denied normalized job was `system_mailbox` while its active fence remained `default`.
- `pnpm --dir apps/cloudflare typecheck`
- Four focused Cloudflare test files: 350 tests passed.
- Real assistant-runtime system-mailbox entrypoint test: passed and throws if assistant admission starts.
- `pnpm hosted-local e2e usage-limit-ambiguous-send` with a freshly rebuilt bundle: 2 tests passed against local Postgres, Temporal, hosted web, Worker, and runner.
- `git diff --check`
- Privacy scan of all changed files: passed.
- Exact-head CI: pending on the corrected head.
- Formatting check was unavailable because this repository does not install a Prettier binary.

## Review status

- Preliminary specialists: PASS, no findings or evidence gaps.
- Final round 1 on `cea35ae0915253d601e3ce9afef7e3c640d0ca93`: one accepted original-PR finding. A denied default job could restore older pending assistant work and drive it into provider-failure handling.
- Correction 1 on `fb7955071b055211bff7a30fad5d42fe857fd042`: normalize only managed denied default jobs to existing `system_mailbox` semantics before runner admission, while retaining the denied fence.
- Final round 2: one accepted review-induced finding. Correction 1 updated the container job but left the durable fence at `default`, so restored foreground work could take the wrong controller path and then hit a container processing-mode mismatch.
- Correction 2 on `6a20902f64d5802ad96334dfd68d57f27a629f3d`: bind the effective invocation mode through the existing invocation-facts update so the durable fence, controller, preemption decision, returned token, and container job agree.
- Remediation authored-source delta from the first-reviewed head: +16 / -5. No new owner, mode, state machine, queue, or retry mechanism.

## Review anomaly retrospective

- **Original requirement:** An expected managed-usage denial during a racing fresh Cloudflare wake must finish without provider access, restored assistant admission, or synthetic transport failure state.
- **First-reviewed shape:** Bound the denied allowance and returned cleanly, but left the denied default job on the full assistant path.
- **Round-1 correction:** Reused the existing model-free `system_mailbox` job mode to close assistant admission.
- **Round-2 anomaly:** That correction changed only the outgoing job; the persisted fence still advertised `default`, splitting coupled lifecycle truth between controller and container.
- **Current shape and decision:** Keep the correction, but persist the same effective mode through the existing invocation-facts owner. This removes the divergence without adding state, an owner, a mode, or compatibility machinery. A lifecycle regression now proves an active normalized invocation is correctly preempted by a foreground/default ensure after usage is restored.

## Change shape

ReviewGPT first-reviewed head: cea35ae0915253d601e3ce9afef7e3c640d0ca93

First-reviewed baseline:

- Source: +6 / -9
- Tests: +59 / -9
- Docs/plans: +74 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
- Total: +139 / -18

Current corrected head:

- Source: +18 / -10
- Tests: +165 / -9
- Docs/plans: +79 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
- Total: +262 / -19

## Design proof

Not applicable: no user-facing frontend surface changed.

## Review lenses

- Product experience: applicable to blocked mailbox recovery and retry timing. Direct journey evidence is the full hosted-local usage-limit ambiguous-send scenario.
- Coverage: applicable; focused state-store and lifecycle regressions, real system-mailbox runtime proof, and exact hosted-local E2E included.
- Prompt review: not applicable.
- Frontend review: not applicable.