### PR TITLE
Meter native Codex memory without disabling WebSockets

### DIFF
--- a/apps/cloudflare/src/runner-egress-codex-memory-websocket.ts
+++ b/apps/cloudflare/src/runner-egress-codex-memory-websocket.ts
@@ -1,0 +1,444 @@
+import {
+  HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES,
+  hasHostedCodexMemoryBillableUsage,
+  parseHostedCodexMemoryClientFrame,
+  parseHostedCodexMemoryServerFrame,
+  type HostedCodexMemoryUsage,
+  type HostedCodexMemoryProviderRequestOutcome,
+  type HostedCodexMemoryRequestMetadata,
+} from "./runner-egress-codex-memory.ts";
+
+export type HostedCodexMemoryWebSocketMessage = ArrayBuffer | string;
+
+export interface HostedCodexMemorySocketPort {
+  accept(): void;
+  close(code?: number, reason?: string): void;
+  onClose(listener: (event: { code: number; reason: string }) => void): void;
+  onError(listener: () => void): void;
+  onMessage(listener: (data: HostedCodexMemoryWebSocketMessage) => void): void;
+  send(data: HostedCodexMemoryWebSocketMessage): void;
+}
+
+export interface HostedCodexMemoryWebSocketRelayController {
+  drain(): Promise<void>;
+}
+
+export interface HostedCodexMemoryWebSocketCompletion {
+  providerRequestOutcome: HostedCodexMemoryProviderRequestOutcome;
+  requestMetadata: HostedCodexMemoryRequestMetadata;
+  usage: HostedCodexMemoryUsage;
+}
+
+type HostedCodexMemoryWebSocketFailurePhase =
+  | "persistence"
+  | "protocol"
+  | "transport";
+
+const CODEX_MEMORY_PROTOCOL_CLOSE_CODE = 1002;
+const CODEX_MEMORY_INTERNAL_CLOSE_CODE = 1011;
+const CODEX_MEMORY_TOO_LARGE_CLOSE_CODE = 1009;
+const CODEX_MEMORY_PROTOCOL_CLOSE_REASON = "Memory WebSocket protocol error";
+const CODEX_MEMORY_PERSISTENCE_CLOSE_REASON = "Memory usage recording failed";
+const CODEX_MEMORY_RELAY_CLOSE_REASON = "Memory WebSocket relay failed";
+const CODEX_MEMORY_TOO_LARGE_CLOSE_REASON = "Memory WebSocket frame too large";
+
+export function startHostedCodexMemoryWebSocketRelay(input: {
+  defer?: (promise: Promise<void>) => void;
+  downstream: HostedCodexMemorySocketPort;
+  persistUsage(
+    completion: HostedCodexMemoryWebSocketCompletion,
+  ): Promise<void>;
+  reportFailure?: (failure: {
+    phase: HostedCodexMemoryWebSocketFailurePhase;
+  }) => void;
+  upstream: HostedCodexMemorySocketPort;
+}): HostedCodexMemoryWebSocketRelayController {
+  let activeRequest: HostedCodexMemoryRequestMetadata | null = null;
+  let downstreamClosed = false;
+  let upstreamClosed = false;
+  let stopped = false;
+  let queue = Promise.resolve();
+
+  const reportFailure = (
+    phase: HostedCodexMemoryWebSocketFailurePhase,
+  ): void => {
+    try {
+      input.reportFailure?.({ phase });
+    } catch {
+      // Diagnostics must never interfere with relay shutdown.
+    }
+  };
+
+  const closeDownstream = (code: number, reason: string): void => {
+    if (downstreamClosed) return;
+    downstreamClosed = true;
+    safeClose(input.downstream, code, reason);
+  };
+  const closeUpstream = (code: number, reason: string): void => {
+    if (upstreamClosed) return;
+    upstreamClosed = true;
+    safeClose(input.upstream, code, reason);
+  };
+  const fail = (
+    phase: HostedCodexMemoryWebSocketFailurePhase,
+    code: number,
+    reason: string,
+  ): void => {
+    if (stopped) return;
+    stopped = true;
+    reportFailure(phase);
+    closeDownstream(code, reason);
+    closeUpstream(code, reason);
+  };
+  const enqueue = (
+    work: () => Promise<void> | void,
+    runAfterStop = false,
+  ): void => {
+    const next = queue.then(async () => {
+      if (runAfterStop || !stopped) {
+        await work();
+      }
+    });
+    queue = next.catch(() => {
+      fail(
+        "transport",
+        CODEX_MEMORY_INTERNAL_CLOSE_CODE,
+        CODEX_MEMORY_RELAY_CLOSE_REASON,
+      );
+    });
+  };
+  const forwardToUpstream = (
+    data: HostedCodexMemoryWebSocketMessage,
+  ): void => {
+    if (!upstreamClosed) input.upstream.send(data);
+  };
+  const forwardToDownstream = (
+    data: HostedCodexMemoryWebSocketMessage,
+  ): void => {
+    if (!downstreamClosed) input.downstream.send(data);
+  };
+
+  try {
+    input.downstream.accept();
+    input.upstream.accept();
+  } catch {
+    fail(
+      "transport",
+      CODEX_MEMORY_INTERNAL_CLOSE_CODE,
+      CODEX_MEMORY_RELAY_CLOSE_REASON,
+    );
+  }
+
+  input.downstream.onMessage((data) => {
+    enqueue(() => {
+      if (!hasAllowedFrameSize(data)) {
+        fail(
+          "protocol",
+          CODEX_MEMORY_TOO_LARGE_CLOSE_CODE,
+          CODEX_MEMORY_TOO_LARGE_CLOSE_REASON,
+        );
+        return;
+      }
+      if (typeof data === "string") {
+        const frame = parseHostedCodexMemoryClientFrame(data);
+        if (
+          frame.kind === "invalid-response-create"
+          || (frame.kind === "response-create" && activeRequest !== null)
+        ) {
+          fail(
+            "protocol",
+            CODEX_MEMORY_PROTOCOL_CLOSE_CODE,
+            CODEX_MEMORY_PROTOCOL_CLOSE_REASON,
+          );
+          return;
+        }
+        if (frame.kind === "response-create") {
+          activeRequest = frame.metadata;
+        }
+      }
+      forwardToUpstream(data);
+    });
+  });
+
+  input.upstream.onMessage((data) => {
+    if (stopped) return;
+    enqueue(async () => {
+      if (!hasAllowedFrameSize(data)) {
+        fail(
+          "protocol",
+          CODEX_MEMORY_TOO_LARGE_CLOSE_CODE,
+          CODEX_MEMORY_TOO_LARGE_CLOSE_REASON,
+        );
+        return;
+      }
+      if (typeof data !== "string") {
+        forwardToDownstream(data);
+        return;
+      }
+
+      const frame = parseHostedCodexMemoryServerFrame(data);
+      if (frame.kind === "invalid-response-terminal") {
+        fail(
+          "protocol",
+          CODEX_MEMORY_PROTOCOL_CLOSE_CODE,
+          CODEX_MEMORY_PROTOCOL_CLOSE_REASON,
+        );
+        return;
+      }
+      if (frame.kind === "terminal-error") {
+        activeRequest = null;
+        forwardToDownstream(data);
+        return;
+      }
+      if (frame.kind !== "response-terminal") {
+        forwardToDownstream(data);
+        return;
+      }
+      if (activeRequest === null) {
+        fail(
+          "protocol",
+          CODEX_MEMORY_PROTOCOL_CLOSE_CODE,
+          CODEX_MEMORY_PROTOCOL_CLOSE_REASON,
+        );
+        return;
+      }
+
+      const requestMetadata = activeRequest;
+      activeRequest = null;
+      const { providerRequestOutcome, usage } = frame.terminal;
+      if (usage === null) {
+        if (
+          providerRequestOutcome === "succeeded"
+          && requestMetadata.usageRequired
+        ) {
+          fail(
+            "protocol",
+            CODEX_MEMORY_PROTOCOL_CLOSE_CODE,
+            CODEX_MEMORY_PROTOCOL_CLOSE_REASON,
+          );
+          return;
+        }
+        forwardToDownstream(data);
+        return;
+      }
+
+      if (hasHostedCodexMemoryBillableUsage(usage)) {
+        const persistence = input.persistUsage({
+          providerRequestOutcome,
+          requestMetadata,
+          usage,
+        });
+        try {
+          input.defer?.(persistence.catch(() => undefined));
+        } catch {
+          // Lifecycle ownership must not change accounting behavior.
+        }
+        try {
+          await persistence;
+        } catch {
+          if (stopped) {
+            reportFailure("persistence");
+          } else {
+            fail(
+              "persistence",
+              CODEX_MEMORY_INTERNAL_CLOSE_CODE,
+              CODEX_MEMORY_PERSISTENCE_CLOSE_REASON,
+            );
+          }
+          return;
+        }
+      }
+      if (!stopped) {
+        forwardToDownstream(data);
+      }
+    }, true);
+  });
+
+  input.downstream.onClose(({ code, reason }) => {
+    if (downstreamClosed) return;
+    downstreamClosed = true;
+    stopped = true;
+    const close = sanitizePeerClose(code, reason);
+    closeUpstream(close.code, close.reason);
+    safeClose(input.downstream, close.code, close.reason);
+  });
+  input.upstream.onClose(({ code, reason }) => {
+    if (upstreamClosed) return;
+    upstreamClosed = true;
+    const close = sanitizePeerClose(code, reason);
+    // Finish the provider-facing handshake immediately, then preserve message
+    // ordering by closing Codex only after queued terminal accounting completes.
+    safeClose(input.upstream, close.code, close.reason);
+    enqueue(() => {
+      stopped = true;
+      closeDownstream(close.code, close.reason);
+    });
+  });
+  input.downstream.onError(() => {
+    fail(
+      "transport",
+      CODEX_MEMORY_INTERNAL_CLOSE_CODE,
+      CODEX_MEMORY_RELAY_CLOSE_REASON,
+    );
+  });
+  input.upstream.onError(() => {
+    enqueue(() => {
+      fail(
+        "transport",
+        CODEX_MEMORY_INTERNAL_CLOSE_CODE,
+        CODEX_MEMORY_RELAY_CLOSE_REASON,
+      );
+    });
+  });
+
+  return {
+    drain: async () => {
+      await queue;
+    },
+  };
+}
+
+export function relayHostedCodexMemoryWebSocketUpgrade(input: {
+  defer?: (promise: Promise<void>) => void;
+  persistUsage(
+    completion: HostedCodexMemoryWebSocketCompletion,
+  ): Promise<void>;
+  reportFailure?: (failure: {
+    phase: HostedCodexMemoryWebSocketFailurePhase;
+  }) => void;
+  upstreamResponse: Response;
+}): Response {
+  const upstreamSocket = input.upstreamResponse.webSocket;
+  if (input.upstreamResponse.status !== 101 || !upstreamSocket) {
+    return input.upstreamResponse;
+  }
+
+  const pair = new WebSocketPair();
+  const downstreamClient = pair[0];
+  const downstreamServer = pair[1];
+  startHostedCodexMemoryWebSocketRelay({
+    ...(input.defer ? { defer: input.defer } : {}),
+    downstream: adaptCloudflareWebSocket(downstreamServer),
+    persistUsage: input.persistUsage,
+    ...(input.reportFailure ? { reportFailure: input.reportFailure } : {}),
+    upstream: adaptCloudflareWebSocket(upstreamSocket),
+  });
+
+  return new Response(null, {
+    headers: copyWebSocketApplicationHeaders(input.upstreamResponse.headers),
+    status: 101,
+    webSocket: downstreamClient,
+  });
+}
+
+function adaptCloudflareWebSocket(
+  socket: WebSocket,
+): HostedCodexMemorySocketPort {
+  socket.binaryType = "arraybuffer";
+  return {
+    accept: () => {
+      socket.accept({ allowHalfOpen: true });
+    },
+    close: (code, reason) => {
+      socket.close(code, reason);
+    },
+    onClose: (listener) => {
+      socket.addEventListener("close", (event) => {
+        listener({ code: event.code, reason: event.reason });
+      });
+    },
+    onError: (listener) => {
+      socket.addEventListener("error", listener);
+    },
+    onMessage: (listener) => {
+      socket.addEventListener("message", (event) => {
+        listener(event.data as HostedCodexMemoryWebSocketMessage);
+      });
+    },
+    send: (data) => {
+      socket.send(data);
+    },
+  };
+}
+
+function copyWebSocketApplicationHeaders(headers: Headers): Headers {
+  const copied = new Headers(headers);
+  for (const name of [
+    "connection",
+    "content-encoding",
+    "content-length",
+    "sec-websocket-accept",
+    "sec-websocket-extensions",
+    "upgrade",
+  ]) {
+    copied.delete(name);
+  }
+  return copied;
+}
+
+function hasAllowedFrameSize(
+  data: HostedCodexMemoryWebSocketMessage,
+): boolean {
+  if (typeof data !== "string") {
+    return data.byteLength <= HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES;
+  }
+  if (data.length > HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES) {
+    return false;
+  }
+  return new TextEncoder().encode(data).byteLength
+    <= HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES;
+}
+
+function sanitizePeerClose(
+  code: number,
+  reason: string,
+): { code: number; reason: string } {
+  const safeCode = isForwardableCloseCode(code)
+    ? code
+    : CODEX_MEMORY_INTERNAL_CLOSE_CODE;
+  const safeReason = truncateUtf8(reason, 123);
+  return { code: safeCode, reason: safeReason };
+}
+
+function isForwardableCloseCode(code: number): boolean {
+  return (
+    (code >= 1_000
+      && code <= 1_014
+      && code !== 1_004
+      && code !== 1_005
+      && code !== 1_006)
+    || (code >= 3_000 && code <= 4_999)
+  ) && code !== 1_015;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(value).byteLength <= maxBytes) {
+    return value;
+  }
+
+  let result = "";
+  for (const character of value) {
+    if (encoder.encode(result + character).byteLength > maxBytes) {
+      break;
+    }
+    result += character;
+  }
+  return result;
+}
+
+function safeClose(
+  socket: HostedCodexMemorySocketPort,
+  code: number,
+  reason: string,
+): void {
+  try {
+    socket.close(code, reason);
+  } catch {
+    try {
+      socket.close();
+    } catch {
+      // Closing is best effort after the relay has entered a terminal state.
+    }
+  }
+}

--- a/apps/cloudflare/src/runner-egress-codex-memory.ts
+++ b/apps/cloudflare/src/runner-egress-codex-memory.ts
@@ -1,0 +1,364 @@
+const CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata";
+const OPENAI_MEMGEN_REQUEST_HEADER = "x-openai-memgen-request";
+const INVALID_USAGE_TOKEN = Symbol("invalid-usage-token");
+
+export const HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES = 32 * 1024 * 1024;
+
+export type HostedCodexNativeMemoryKind = "consolidation" | "extraction";
+export type HostedCodexMemoryProviderRequestOutcome =
+  | "failed"
+  | "partial"
+  | "succeeded";
+
+export interface HostedCodexMemoryRequestMetadata {
+  usageRequired: boolean;
+  requestedModel: string;
+  serviceTier: string | null;
+}
+
+export interface HostedCodexMemoryUsage {
+  cacheWriteTokens: number | null;
+  cachedInputTokens: number | null;
+  inputTokens: number;
+  occurredAt: string;
+  outputTokens: number;
+  providerRequestId: string;
+  rawUsageJson: Record<string, unknown>;
+  reasoningTokens: number | null;
+  servedModel: string | null;
+  serviceTier: string | null;
+  totalTokens: number;
+}
+
+export interface HostedCodexMemoryTerminalResponse {
+  providerRequestOutcome: HostedCodexMemoryProviderRequestOutcome;
+  usage: HostedCodexMemoryUsage | null;
+}
+
+export type HostedCodexMemoryClientFrame =
+  | { kind: "other" }
+  | {
+      kind: "response-create";
+      metadata: HostedCodexMemoryRequestMetadata;
+    }
+  | { kind: "invalid-response-create" };
+
+export type HostedCodexMemoryServerFrame =
+  | { kind: "other" }
+  | { kind: "terminal-error" }
+  | {
+      kind: "response-terminal";
+      terminal: HostedCodexMemoryTerminalResponse;
+    }
+  | { kind: "invalid-response-terminal" };
+
+/**
+ * Codex marks both native memory phases without Murph inferring intent:
+ * extraction uses request_kind=memory and consolidation uses the dedicated
+ * memgen marker even though its Responses request_kind remains turn.
+ */
+export function readHostedCodexNativeMemoryKind(
+  headers: Headers,
+): HostedCodexNativeMemoryKind | null {
+  if (headers.get(OPENAI_MEMGEN_REQUEST_HEADER)?.trim().toLowerCase() === "true") {
+    return "consolidation";
+  }
+
+  const metadata = headers.get(CODEX_TURN_METADATA_HEADER);
+  if (!metadata) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    return isJsonObject(parsed) && parsed.request_kind === "memory"
+      ? "extraction"
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+
+export function parseHostedCodexMemoryRequestMetadata(
+  body: ArrayBuffer,
+): HostedCodexMemoryRequestMetadata | null {
+  try {
+    return parseRequestMetadata(JSON.parse(new TextDecoder().decode(body)));
+  } catch {
+    return null;
+  }
+}
+
+export function parseHostedCodexMemoryClientFrame(
+  text: string,
+): HostedCodexMemoryClientFrame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { kind: "other" };
+  }
+  if (!isJsonObject(parsed) || parsed.type !== "response.create") {
+    return { kind: "other" };
+  }
+
+  const metadata = parseRequestMetadata(parsed);
+  return metadata
+    ? { kind: "response-create", metadata }
+    : { kind: "invalid-response-create" };
+}
+
+export function parseHostedCodexMemoryServerFrame(
+  text: string,
+): HostedCodexMemoryServerFrame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { kind: "other" };
+  }
+  if (!isJsonObject(parsed)) {
+    return { kind: "other" };
+  }
+  if (parsed.type === "error") {
+    return { kind: "terminal-error" };
+  }
+
+  const providerRequestOutcome = readTerminalProviderRequestOutcome(parsed.type);
+  if (providerRequestOutcome === null) {
+    return { kind: "other" };
+  }
+  const terminal = parseTerminalEvent(parsed, providerRequestOutcome);
+  return terminal
+    ? { kind: "response-terminal", terminal }
+    : { kind: "invalid-response-terminal" };
+}
+
+/**
+ * HTTP and WebSocket traffic share the same terminal Responses schema. The
+ * HTTP path buffers only marked native-memory responses.
+ */
+export function parseHostedCodexMemoryTerminalResponse(
+  body: ArrayBuffer,
+): HostedCodexMemoryTerminalResponse | null {
+  const text = new TextDecoder().decode(body);
+  const events = text.split(/\r?\n\r?\n/u);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]?.trim();
+    if (!event) {
+      continue;
+    }
+    const data = readSseData(event) ?? event;
+    const parsed = parseHostedCodexMemoryServerFrame(data);
+    if (parsed.kind === "response-terminal") {
+      return parsed.terminal;
+    }
+    if (parsed.kind === "invalid-response-terminal") {
+      return null;
+    }
+  }
+  return null;
+}
+
+function parseRequestMetadata(
+  value: unknown,
+): HostedCodexMemoryRequestMetadata | null {
+  if (!isJsonObject(value)) {
+    return null;
+  }
+
+  const requestedModel = readNonEmptyString(value.model);
+  if (!requestedModel) {
+    return null;
+  }
+  if (value.generate !== undefined && typeof value.generate !== "boolean") {
+    return null;
+  }
+
+  return {
+    usageRequired: value.generate !== false,
+    requestedModel,
+    serviceTier: readNonEmptyString(value.service_tier),
+  };
+}
+
+function parseTerminalEvent(
+  event: Record<string, unknown>,
+  providerRequestOutcome: HostedCodexMemoryProviderRequestOutcome,
+): HostedCodexMemoryTerminalResponse | null {
+  const response = event.response;
+  if (!isJsonObject(response)) {
+    return null;
+  }
+  const providerRequestId = readNonEmptyString(response.id);
+  const occurredAt = readProviderOccurredAt(response.created_at);
+  if (!providerRequestId || !occurredAt) {
+    return null;
+  }
+
+  const servedModel = readNonEmptyString(response.model);
+  const serviceTier = readNonEmptyString(response.service_tier);
+  if (response.usage === undefined || response.usage === null) {
+    return {
+      providerRequestOutcome,
+      usage: null,
+    };
+  }
+  if (!isJsonObject(response.usage)) {
+    return null;
+  }
+  const usage = response.usage;
+  const inputTokens = readNonNegativeInteger(usage.input_tokens);
+  const outputTokens = readNonNegativeInteger(usage.output_tokens);
+  const totalTokens = readNonNegativeInteger(usage.total_tokens);
+  if (inputTokens === null || outputTokens === null || totalTokens === null) {
+    return null;
+  }
+
+  const cachedInputTokens = readOptionalNestedUsageToken(
+    usage,
+    "input_tokens_details",
+    "cached_tokens",
+  );
+  const cacheWriteTokens = readOptionalNestedUsageToken(
+    usage,
+    "input_tokens_details",
+    "cache_write_tokens",
+  );
+  const reasoningTokens = readOptionalNestedUsageToken(
+    usage,
+    "output_tokens_details",
+    "reasoning_tokens",
+  );
+  if (
+    cachedInputTokens === INVALID_USAGE_TOKEN
+    || cacheWriteTokens === INVALID_USAGE_TOKEN
+    || reasoningTokens === INVALID_USAGE_TOKEN
+  ) {
+    return null;
+  }
+  if (
+    inputTokens > Number.MAX_SAFE_INTEGER - outputTokens
+    || totalTokens !== inputTokens + outputTokens
+    || (cachedInputTokens ?? 0) > inputTokens
+    || (cacheWriteTokens ?? 0) > inputTokens
+    || (reasoningTokens ?? 0) > outputTokens
+  ) {
+    return null;
+  }
+
+  const rawUsageJson: Record<string, unknown> = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: totalTokens,
+  };
+  if (cachedInputTokens !== null || cacheWriteTokens !== null) {
+    rawUsageJson.input_tokens_details = {
+      ...(cachedInputTokens === null ? {} : { cached_tokens: cachedInputTokens }),
+      ...(cacheWriteTokens === null ? {} : { cache_write_tokens: cacheWriteTokens }),
+    };
+  }
+  if (reasoningTokens !== null) {
+    rawUsageJson.output_tokens_details = { reasoning_tokens: reasoningTokens };
+  }
+
+  return {
+    providerRequestOutcome,
+    usage: {
+      cacheWriteTokens,
+      cachedInputTokens,
+      inputTokens,
+      occurredAt,
+      outputTokens,
+      providerRequestId,
+      rawUsageJson,
+      reasoningTokens,
+      servedModel,
+      serviceTier,
+      totalTokens,
+    },
+  };
+}
+
+export function hasHostedCodexMemoryBillableUsage(
+  usage: HostedCodexMemoryUsage,
+): boolean {
+  return usage.inputTokens > 0
+    || usage.outputTokens > 0
+    || usage.totalTokens > 0
+    || (usage.cachedInputTokens ?? 0) > 0
+    || (usage.cacheWriteTokens ?? 0) > 0
+    || (usage.reasoningTokens ?? 0) > 0;
+}
+
+function readTerminalProviderRequestOutcome(
+  type: unknown,
+): HostedCodexMemoryProviderRequestOutcome | null {
+  if (type === "response.completed") return "succeeded";
+  if (type === "response.incomplete") return "partial";
+  if (type === "response.failed") return "failed";
+  return null;
+}
+
+function readProviderOccurredAt(value: unknown): string | null {
+  if (
+    typeof value !== "number"
+    || !Number.isSafeInteger(value)
+    || value < 0
+  ) {
+    return null;
+  }
+  const milliseconds = value * 1_000;
+  if (!Number.isSafeInteger(milliseconds)) {
+    return null;
+  }
+  const date = new Date(milliseconds);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function readOptionalNestedUsageToken(
+  usage: Record<string, unknown>,
+  detailsKey: string,
+  tokenKey: string,
+): number | null | typeof INVALID_USAGE_TOKEN {
+  const details = usage[detailsKey];
+  if (details === undefined) {
+    return null;
+  }
+  if (!isJsonObject(details)) {
+    return INVALID_USAGE_TOKEN;
+  }
+
+  const value = details[tokenKey];
+  if (value === undefined) {
+    return null;
+  }
+  return readNonNegativeInteger(value) ?? INVALID_USAGE_TOKEN;
+}
+
+function readSseData(event: string): string | null {
+  const dataLines = event
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart());
+  return dataLines.length > 0 ? dataLines.join("\n") : null;
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number"
+      && Number.isSafeInteger(value)
+      && value >= 0
+    ? value
+    : null;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -24,11 +24,15 @@ import {
   HOSTED_RUNTIME_LOG_PATH,
 } from "@murphai/hosted-execution/routes";
 import {
+  buildHostedCodexMemoryUsageRecord,
   buildHostedElevenLabsMusicUsageRecord,
   buildHostedElevenLabsTtsUsageRecord,
   buildHostedTranscriptionUsageRecord,
   buildHostedXaiSearchUsageRecord,
 } from "@murphai/hosted-execution/assistant-usage";
+import {
+  resolveHostedAiUsageTokenPricingBasis,
+} from "@murphai/hosted-execution/runtime-control";
 
 import { readHostedExecutionEnvironment } from "./env.ts";
 import { asWorkerStringEnvironment } from "./worker-contracts.ts";
@@ -92,6 +96,20 @@ import {
   buildHostedCustomInferenceUpstreamRequestBody,
   injectHostedCustomInferenceAuth,
 } from "./runner-egress-custom-inference.ts";
+import {
+  HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES,
+  hasHostedCodexMemoryBillableUsage,
+  parseHostedCodexMemoryTerminalResponse,
+  parseHostedCodexMemoryRequestMetadata,
+  readHostedCodexNativeMemoryKind,
+  type HostedCodexMemoryProviderRequestOutcome,
+  type HostedCodexMemoryRequestMetadata,
+  type HostedCodexMemoryUsage,
+  type HostedCodexNativeMemoryKind,
+} from "./runner-egress-codex-memory.ts";
+import {
+  relayHostedCodexMemoryWebSocketUpgrade,
+} from "./runner-egress-codex-memory-websocket.ts";
 import {
   DEFAULT_ELEVENLABS_API_BASE_URL,
   HOSTED_ELEVENLABS_MAX_BODY_BYTES,
@@ -1420,11 +1438,35 @@ async function maybeHandleOpenAiRequest(input: {
     });
   }
 
+  const nativeMemoryKind = authorization.platformAiUsageAllowed !== false
+    ? readHostedCodexNativeMemoryKind(input.request.headers)
+    : null;
   const token = readRequiredInterceptSecret(input.env.OPENAI_API_KEY, "OPENAI_API_KEY");
   const headers = stripHostedProviderUpstreamHeaders(input.request.headers);
-  headers.set("authorization", `Bearer ${token}`);
+  headers.set("authorization", "Bearer " + token);
   let boundedBody: ArrayBuffer | undefined;
-  if (input.request.method === "POST" && pathnameSuffix === "/v1/images/edits") {
+  let memoryRequestMetadata: HostedCodexMemoryRequestMetadata | null = null;
+  if (
+    nativeMemoryKind
+    && input.request.method === "POST"
+    && pathnameSuffix === "/v1/responses"
+  ) {
+    const body = await readBoundedRequestBody(
+      input.request,
+      HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES,
+    );
+    if (body === null) {
+      return new Response("Payload Too Large", { status: 413 });
+    }
+    memoryRequestMetadata = parseHostedCodexMemoryRequestMetadata(body);
+    if (!memoryRequestMetadata) {
+      return new Response("Invalid Codex memory request.", { status: 400 });
+    }
+    boundedBody = body;
+  } else if (
+    input.request.method === "POST"
+    && pathnameSuffix === "/v1/images/edits"
+  ) {
     const body = await readBoundedRequestBody(
       input.request,
       HOSTED_OPENAI_IMAGES_EDITS_MAX_BODY_BYTES,
@@ -1434,6 +1476,7 @@ async function maybeHandleOpenAiRequest(input: {
     }
     boundedBody = body;
   }
+
   const upstreamRequest = await createHostedRunnerUpstreamRequest(
     input.request,
     createProviderUpstreamUrl(input.url, pathMatch),
@@ -1444,8 +1487,9 @@ async function maybeHandleOpenAiRequest(input: {
     input.request.method,
     pathnameSuffix,
   );
+  let diagnosticPromise: Promise<void> | null = null;
   if (endpointKind) {
-    const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
+    diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
       ctx: input.ctx ?? null,
       endpointKind,
       env: input.env,
@@ -1456,21 +1500,10 @@ async function maybeHandleOpenAiRequest(input: {
     });
     if (typeof input.ctx?.waitUntil === "function") {
       input.ctx.waitUntil(diagnosticPromise);
-    } else {
-      const response = await fetchAuthorizedProviderUpstream({
-        authorization,
-        providerKind: "openai",
-        request: input.request,
-        startedAt,
-        upstreamRequest,
-        upstreamFetchImpl: input.upstreamFetchImpl,
-        url: input.url,
-      });
-      await diagnosticPromise;
-      return response;
     }
   }
-  return await fetchAuthorizedProviderUpstream({
+
+  const response = await fetchAuthorizedProviderUpstream({
     authorization,
     providerKind: "openai",
     request: input.request,
@@ -1479,6 +1512,58 @@ async function maybeHandleOpenAiRequest(input: {
     upstreamFetchImpl: input.upstreamFetchImpl,
     url: input.url,
   });
+  if (diagnosticPromise && typeof input.ctx?.waitUntil !== "function") {
+    await diagnosticPromise;
+  }
+
+  if (
+    nativeMemoryKind
+    && input.request.method === "GET"
+    && pathnameSuffix === "/v1/responses"
+  ) {
+    return relayHostedCodexMemoryWebSocketUpgrade({
+      ...(typeof input.ctx?.waitUntil === "function"
+        ? {
+            defer: (promise) => {
+              input.ctx?.waitUntil?.(promise);
+            },
+          }
+        : {}),
+      persistUsage: async (completion) => {
+        await recordHostedCodexMemoryUsage({
+          apiKeyEnv: "OPENAI_API_KEY",
+          baseUrl: DEFAULT_OPENAI_API_BASE_URL + "/v1",
+          env: input.env,
+          memberId: authorization.userId,
+          providerName: "hosted-openai",
+          providerRequestOutcome: completion.providerRequestOutcome,
+          requestMetadata: completion.requestMetadata,
+          usage: completion.usage,
+        });
+      },
+      reportFailure: ({ phase }) => {
+        reportHostedCodexMemoryUsageFailure({
+          memoryKind: nativeMemoryKind,
+          providerName: "hosted-openai",
+          reason: "websocket_" + phase,
+        });
+      },
+      upstreamResponse: response,
+    });
+  }
+
+  return memoryRequestMetadata && nativeMemoryKind
+    ? await handleHostedCodexMemoryUsageResponse({
+        apiKeyEnv: "OPENAI_API_KEY",
+        baseUrl: DEFAULT_OPENAI_API_BASE_URL + "/v1",
+        env: input.env,
+        memberId: authorization.userId,
+        memoryKind: nativeMemoryKind,
+        providerName: "hosted-openai",
+        requestMetadata: memoryRequestMetadata,
+        response,
+      })
+    : response;
 }
 
 async function maybeHandleVeniceRequest(input: {
@@ -1527,12 +1612,21 @@ async function maybeHandleVeniceRequest(input: {
     });
   }
 
+  const nativeMemoryKind = authorization.platformAiUsageAllowed !== false
+    ? readHostedCodexNativeMemoryKind(input.request.headers)
+    : null;
   const body = await readBoundedRequestBody(
     input.request,
     HOSTED_VENICE_RESPONSES_MAX_BODY_BYTES,
   );
   if (body === null) {
     return new Response("Payload Too Large", { status: 413 });
+  }
+  const memoryRequestMetadata = nativeMemoryKind
+    ? parseHostedCodexMemoryRequestMetadata(body)
+    : null;
+  if (nativeMemoryKind && !memoryRequestMetadata) {
+    return new Response("Invalid Codex memory request.", { status: 400 });
   }
   const upstreamBody = buildHostedVeniceResponsesRequestBody({
     body,
@@ -1554,9 +1648,7 @@ async function maybeHandleVeniceRequest(input: {
     headers,
     { body: upstreamBody },
   );
-  const captureMemoryDiagnostic =
-    authorization.platformAiUsageAllowed !== false
-    && isHostedCodexMemoryRequest(input.request);
+  const captureMemoryDiagnostic = nativeMemoryKind !== null;
   const diagnosticBody = captureMemoryDiagnostic
     ? upstreamRequest.clone()
     : null;
@@ -1615,7 +1707,194 @@ async function maybeHandleVeniceRequest(input: {
       promise: diagnosticPromise,
     });
   }
-  return response;
+  return memoryRequestMetadata && nativeMemoryKind
+    ? await handleHostedCodexMemoryUsageResponse({
+        apiKeyEnv: "VENICE_API_KEY",
+        baseUrl: DEFAULT_VENICE_API_BASE_URL,
+        env: input.env,
+        memberId: authorization.userId,
+        memoryKind: nativeMemoryKind,
+        providerName: "venice",
+        requestMetadata: memoryRequestMetadata,
+        response,
+      })
+    : response;
+}
+
+async function handleHostedCodexMemoryUsageResponse(input: {
+  apiKeyEnv: string;
+  baseUrl: string;
+  env: RunnerOutboundEnvironmentSource;
+  memberId: string | null;
+  memoryKind: HostedCodexNativeMemoryKind;
+  providerName: "hosted-openai" | "venice";
+  requestMetadata: HostedCodexMemoryRequestMetadata;
+  response: Response;
+}): Promise<Response> {
+  if (!input.response.ok) {
+    return input.response;
+  }
+
+  const responseBody = await readBoundedRequestBody(
+    input.response,
+    HOSTED_CODEX_MEMORY_MAX_MESSAGE_BYTES,
+  );
+  if (responseBody === null) {
+    reportHostedCodexMemoryUsageFailure({
+      memoryKind: input.memoryKind,
+      providerName: input.providerName,
+      reason: "response_too_large",
+    });
+    return new Response("Hosted Codex memory response too large.", {
+      status: 502,
+    });
+  }
+
+  const terminal = parseHostedCodexMemoryTerminalResponse(responseBody);
+  if (
+    input.requestMetadata.usageRequired
+    && (
+      terminal === null
+      || (
+        terminal.usage === null
+        && terminal.providerRequestOutcome === "succeeded"
+      )
+    )
+  ) {
+    reportHostedCodexMemoryUsageFailure({
+      memoryKind: input.memoryKind,
+      providerName: input.providerName,
+      reason: "terminal_usage_missing",
+    });
+    return new Response("Hosted Codex memory usage was unavailable.", {
+      status: 502,
+    });
+  }
+
+  if (
+    terminal?.usage
+    && hasHostedCodexMemoryBillableUsage(terminal.usage)
+  ) {
+    try {
+      await recordHostedCodexMemoryUsage({
+        apiKeyEnv: input.apiKeyEnv,
+        baseUrl: input.baseUrl,
+        env: input.env,
+        memberId: input.memberId,
+        providerName: input.providerName,
+        providerRequestOutcome: terminal.providerRequestOutcome,
+        requestMetadata: input.requestMetadata,
+        usage: terminal.usage,
+      });
+    } catch (error) {
+      reportHostedCodexMemoryUsageFailure({
+        error,
+        memoryKind: input.memoryKind,
+        providerName: input.providerName,
+        reason: "persistence_failed",
+      });
+      return new Response("Hosted Codex memory usage recording failed.", {
+        status: 502,
+      });
+    }
+  }
+
+  return rebuildBufferedProviderResponse(input.response, responseBody);
+}
+
+async function recordHostedCodexMemoryUsage(input: {
+  apiKeyEnv: string;
+  baseUrl: string;
+  env: RunnerOutboundEnvironmentSource;
+  memberId: string | null;
+  providerName: "hosted-openai" | "venice";
+  providerRequestOutcome: HostedCodexMemoryProviderRequestOutcome;
+  requestMetadata: HostedCodexMemoryRequestMetadata;
+  usage: HostedCodexMemoryUsage;
+}): Promise<void> {
+  if (!input.memberId) {
+    throw new TypeError("Hosted Codex memory usage recording requires a member id.");
+  }
+
+  const environment = readHostedExecutionEnvironment(
+    asWorkerStringEnvironment(input.env),
+  );
+  const record = buildHostedCodexMemoryUsageRecord({
+    apiKeyEnv: input.apiKeyEnv,
+    baseUrl: input.baseUrl,
+    cacheWriteTokens: input.usage.cacheWriteTokens,
+    cachedInputTokens: input.usage.cachedInputTokens,
+    inputTokens: input.usage.inputTokens,
+    memberId: input.memberId,
+    occurredAt: input.usage.occurredAt,
+    outputTokens: input.usage.outputTokens,
+    providerName: input.providerName,
+    providerRequestId: input.usage.providerRequestId,
+    providerRequestOutcome: input.providerRequestOutcome,
+    rawUsageJson: input.usage.rawUsageJson,
+    reasoningTokens: input.usage.reasoningTokens,
+    requestedModel: input.requestMetadata.requestedModel,
+    // Venice exposes its translated provider id. The canonical request model
+    // remains the priceable identity for that provider.
+    servedModel: input.providerName === "venice"
+      ? null
+      : input.usage.servedModel,
+    tokenPricingBasis: resolveHostedAiUsageTokenPricingBasis({
+      model: input.requestMetadata.requestedModel,
+      providerName: input.providerName,
+      serviceTier: input.usage.serviceTier
+        ?? input.requestMetadata.serviceTier,
+    }),
+    totalTokens: input.usage.totalTokens,
+  });
+  await recordHostedRuntimeUsageRecord({
+    boundUserId: input.memberId,
+    fetchImpl: fetch,
+    record,
+    timeoutMs: environment.webControlTimeoutMs,
+    transport: {
+      callbackSigning: environment.webCallbackSigning,
+      mode: "direct",
+      webControlBaseUrl: environment.hostedWebBaseUrl,
+      workspaceCheckpointBridge: null,
+    },
+  });
+}
+
+function rebuildBufferedProviderResponse(
+  response: Response,
+  body: ArrayBuffer,
+): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  headers.delete("content-length");
+  return new Response(body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function reportHostedCodexMemoryUsageFailure(input: {
+  error?: unknown;
+  memoryKind: HostedCodexNativeMemoryKind;
+  providerName: "hosted-openai" | "venice";
+  reason: string;
+}): void {
+  emitHostedExecutionStructuredLog({
+    component: "runner",
+    details: {
+      ...(input.error === undefined
+        ? {}
+        : buildHostedExecutionSafeErrorDetails(input.error)),
+      memoryKind: input.memoryKind,
+      providerKind: input.providerName + "_codex_memory",
+      reason: input.reason,
+    },
+    level: "warn",
+    message: "Hosted Codex memory usage accounting failed closed.",
+    phase: "wake.running",
+  });
 }
 
 async function maybeHandleElevenLabsRequest(input: {
@@ -2004,22 +2283,6 @@ function readVeniceCacheDiagnosticEndpointKind(
   return pathnameSuffix === "/responses/compact"
     ? "responses_compact"
     : "responses";
-}
-
-function isHostedCodexMemoryRequest(request: Request): boolean {
-  const header = request.headers.get(
-    OPENAI_CACHE_DIAGNOSTIC_CODEX_TURN_METADATA_HEADER,
-  )?.trim();
-  if (!header) {
-    return false;
-  }
-  try {
-    const parsed = JSON.parse(header);
-    return isHostedOpenAiDiagnosticRecord(parsed)
-      && parsed.request_kind === "memory";
-  } catch {
-    return false;
-  }
 }
 
 function readHostedResponsesRequestModelKind(body: ArrayBuffer): string | null {

--- a/apps/cloudflare/test/runner-egress-codex-memory-websocket.test.ts
+++ b/apps/cloudflare/test/runner-egress-codex-memory-websocket.test.ts
@@ -1,0 +1,415 @@
+import { expect, test, vi } from "vitest";
+
+import {
+  startHostedCodexMemoryWebSocketRelay,
+  type HostedCodexMemorySocketPort,
+  type HostedCodexMemoryWebSocketCompletion,
+  type HostedCodexMemoryWebSocketMessage,
+} from "../src/runner-egress-codex-memory-websocket.ts";
+
+class FakeSocket implements HostedCodexMemorySocketPort {
+  readonly closes: Array<{ code?: number; reason?: string }> = [];
+  readonly sent: HostedCodexMemoryWebSocketMessage[] = [];
+  accepts = 0;
+  private readonly closeListeners: Array<
+    (event: { code: number; reason: string }) => void
+  > = [];
+  private readonly errorListeners: Array<() => void> = [];
+  private readonly messageListeners: Array<
+    (data: HostedCodexMemoryWebSocketMessage) => void
+  > = [];
+
+  accept(): void {
+    this.accepts += 1;
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({
+      ...(code === undefined ? {} : { code }),
+      ...(reason === undefined ? {} : { reason }),
+    });
+  }
+
+  onClose(listener: (event: { code: number; reason: string }) => void): void {
+    this.closeListeners.push(listener);
+  }
+
+  onError(listener: () => void): void {
+    this.errorListeners.push(listener);
+  }
+
+  onMessage(
+    listener: (data: HostedCodexMemoryWebSocketMessage) => void,
+  ): void {
+    this.messageListeners.push(listener);
+  }
+
+  send(data: HostedCodexMemoryWebSocketMessage): void {
+    this.sent.push(data);
+  }
+
+  emitClose(code = 1_000, reason = ""): void {
+    for (const listener of this.closeListeners) {
+      listener({ code, reason });
+    }
+  }
+
+  emitError(): void {
+    for (const listener of this.errorListeners) {
+      listener();
+    }
+  }
+
+  emitMessage(data: HostedCodexMemoryWebSocketMessage): void {
+    for (const listener of this.messageListeners) {
+      listener(data);
+    }
+  }
+}
+
+const createdAt = 1_775_000_000;
+
+function createFrame(input?: {
+  generate?: boolean;
+  model?: string;
+  serviceTier?: string;
+}): string {
+  return JSON.stringify({
+    ...(input?.generate === undefined ? {} : { generate: input.generate }),
+    model: input?.model ?? "gpt-5.6-terra",
+    ...(input?.serviceTier === undefined
+      ? {}
+      : { service_tier: input.serviceTier }),
+    type: "response.create",
+  });
+}
+
+function completedFrame(input?: {
+  id?: string;
+  type?: "response.completed" | "response.failed" | "response.incomplete";
+  usage?: Record<string, unknown> | null;
+}): string {
+  const usage = input && "usage" in input
+    ? input.usage
+    : {
+        input_tokens: 100,
+        input_tokens_details: {
+          cache_write_tokens: 5,
+          cached_tokens: 40,
+        },
+        output_tokens: 20,
+        output_tokens_details: { reasoning_tokens: 4 },
+        total_tokens: 120,
+      };
+  return JSON.stringify({
+    response: {
+      created_at: createdAt,
+      id: input?.id ?? "resp_memory_1",
+      model: "gpt-5.6-terra-2026-07-30",
+      service_tier: "priority",
+      usage,
+    },
+    type: input?.type ?? "response.completed",
+  });
+}
+
+function setup(input?: {
+  persistUsage?: Parameters<
+    typeof startHostedCodexMemoryWebSocketRelay
+  >[0]["persistUsage"];
+}) {
+  const downstream = new FakeSocket();
+  const upstream = new FakeSocket();
+  const persistUsage = input?.persistUsage ?? vi.fn(async () => undefined);
+  const deferred: Promise<void>[] = [];
+  const reportFailure = vi.fn();
+  const controller = startHostedCodexMemoryWebSocketRelay({
+    defer: (promise) => {
+      deferred.push(promise);
+    },
+    downstream,
+    persistUsage,
+    reportFailure,
+    upstream,
+  });
+  return {
+    controller,
+    deferred,
+    downstream,
+    persistUsage,
+    reportFailure,
+    upstream,
+  };
+}
+
+test("accepts both sockets and relays ordinary text and binary frames", async () => {
+  const { controller, deferred, downstream, upstream } = setup();
+  const clientText = JSON.stringify({ type: "session.update" });
+  const serverText = JSON.stringify({ type: "response.output_text.delta" });
+  const binary = new Uint8Array([1, 2, 3]).buffer;
+
+  downstream.emitMessage(clientText);
+  upstream.emitMessage(serverText);
+  upstream.emitMessage(binary);
+  await controller.drain();
+
+  expect(downstream.accepts).toBe(1);
+  expect(upstream.accepts).toBe(1);
+  expect(upstream.sent).toEqual([clientText]);
+  expect(downstream.sent).toEqual([serverText, binary]);
+  expect(deferred).toHaveLength(0);
+});
+
+test("persists exact usage before forwarding a billable completion", async () => {
+  let resolvePersistence: (() => void) | undefined;
+  const persistUsage = vi.fn(() => new Promise<void>((resolve) => {
+    resolvePersistence = resolve;
+  }));
+  const { controller, deferred, downstream, upstream } = setup({ persistUsage });
+  const request = createFrame({ serviceTier: "flex" });
+  const completed = completedFrame();
+
+  downstream.emitMessage(request);
+  await controller.drain();
+  upstream.emitMessage(completed);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(upstream.sent).toEqual([request]);
+  expect(downstream.sent).not.toContain(completed);
+  expect(deferred).toHaveLength(1);
+  expect(persistUsage).toHaveBeenCalledWith({
+    providerRequestOutcome: "succeeded",
+    requestMetadata: {
+      usageRequired: true,
+      requestedModel: "gpt-5.6-terra",
+      serviceTier: "flex",
+    },
+    usage: expect.objectContaining({
+      cacheWriteTokens: 5,
+      cachedInputTokens: 40,
+      occurredAt: new Date(createdAt * 1_000).toISOString(),
+      providerRequestId: "resp_memory_1",
+      serviceTier: "priority",
+    }),
+  });
+
+  resolvePersistence?.();
+  await controller.drain();
+  expect(downstream.sent).toContain(completed);
+});
+
+test("skips empty warmups and records warmups only when the provider reports work", async () => {
+  const { controller, downstream, persistUsage, upstream } = setup();
+
+  downstream.emitMessage(createFrame({ generate: false }));
+  upstream.emitMessage(completedFrame({ usage: null }));
+  await controller.drain();
+  expect(persistUsage).not.toHaveBeenCalled();
+
+  downstream.emitMessage(createFrame({ generate: false }));
+  upstream.emitMessage(completedFrame({
+    id: "resp_warmup_work",
+    usage: {
+      input_tokens: 1,
+      output_tokens: 0,
+      total_tokens: 1,
+    },
+  }));
+  await controller.drain();
+
+  expect(persistUsage).toHaveBeenCalledTimes(1);
+  expect(downstream.sent).toHaveLength(2);
+});
+
+test("meters sequential generated responses on one memory connection", async () => {
+  const persistUsage = vi.fn(async (
+    _completion: HostedCodexMemoryWebSocketCompletion,
+  ) => undefined);
+  const { controller, downstream, upstream } = setup({ persistUsage });
+
+  for (const id of ["resp_memory_1", "resp_memory_2"]) {
+    downstream.emitMessage(createFrame());
+    upstream.emitMessage(completedFrame({ id }));
+    await controller.drain();
+  }
+
+  expect(persistUsage).toHaveBeenCalledTimes(2);
+  expect(persistUsage.mock.calls.map(([value]) => (
+    value.usage.providerRequestId
+  ))).toEqual(["resp_memory_1", "resp_memory_2"]);
+});
+
+test("meters a failed response before accepting the next request", async () => {
+  const persistUsage = vi.fn(async (
+    _completion: HostedCodexMemoryWebSocketCompletion,
+  ) => undefined);
+  const { controller, downstream, upstream } = setup({ persistUsage });
+  const failed = completedFrame({
+    id: "resp_failed",
+    type: "response.failed",
+  });
+
+  downstream.emitMessage(createFrame());
+  upstream.emitMessage(failed);
+  downstream.emitMessage(createFrame());
+  upstream.emitMessage(completedFrame());
+  await controller.drain();
+
+  expect(persistUsage).toHaveBeenCalledTimes(2);
+  expect(persistUsage.mock.calls.map(([completion]) => (
+    completion.providerRequestOutcome
+  ))).toEqual(["failed", "succeeded"]);
+  expect(downstream.sent).toContain(failed);
+});
+
+test("fails closed when persistence rejects", async () => {
+  const { controller, downstream, reportFailure, upstream } = setup({
+    persistUsage: vi.fn(async () => {
+      throw new Error("sensitive database error");
+    }),
+  });
+  const completed = completedFrame();
+
+  downstream.emitMessage(createFrame());
+  upstream.emitMessage(completed);
+  await controller.drain();
+
+  expect(downstream.sent).not.toContain(completed);
+  expect(downstream.closes).toContainEqual({
+    code: 1_011,
+    reason: "Memory usage recording failed",
+  });
+  expect(upstream.closes).toContainEqual({
+    code: 1_011,
+    reason: "Memory usage recording failed",
+  });
+  expect(reportFailure).toHaveBeenCalledWith({
+    phase: "persistence",
+  });
+  expect(JSON.stringify(reportFailure.mock.calls)).not.toContain("sensitive");
+});
+
+test("fails closed on overlapping requests or an unpaired completion", async () => {
+  const overlapping = setup();
+  overlapping.downstream.emitMessage(createFrame());
+  overlapping.downstream.emitMessage(createFrame());
+  await overlapping.controller.drain();
+  expect(overlapping.downstream.closes[0]?.code).toBe(1_002);
+  expect(overlapping.upstream.closes[0]?.code).toBe(1_002);
+
+  const unpaired = setup();
+  unpaired.upstream.emitMessage(completedFrame());
+  await unpaired.controller.drain();
+  expect(unpaired.downstream.closes[0]?.code).toBe(1_002);
+  expect(unpaired.upstream.closes[0]?.code).toBe(1_002);
+});
+
+test("mirrors close frames and sanitizes reserved close codes", async () => {
+  const clientClose = setup();
+  clientClose.downstream.emitClose(1_000, "done");
+  expect(clientClose.upstream.closes).toEqual([
+    { code: 1_000, reason: "done" },
+  ]);
+  expect(clientClose.downstream.closes).toEqual([
+    { code: 1_000, reason: "done" },
+  ]);
+
+  const providerClose = setup();
+  providerClose.upstream.emitClose(1_006, "abnormal");
+  await providerClose.controller.drain();
+  expect(providerClose.downstream.closes).toEqual([
+    { code: 1_011, reason: "abnormal" },
+  ]);
+  expect(providerClose.upstream.closes).toEqual([
+    { code: 1_011, reason: "abnormal" },
+  ]);
+});
+
+test("forwards an accounted terminal before a provider-initiated close", async () => {
+  let resolvePersistence: (() => void) | undefined;
+  const persistUsage = vi.fn(() => new Promise<void>((resolve) => {
+    resolvePersistence = resolve;
+  }));
+  const { controller, downstream, upstream } = setup({ persistUsage });
+  const completed = completedFrame();
+
+  downstream.emitMessage(createFrame());
+  await controller.drain();
+  upstream.emitMessage(completed);
+  await Promise.resolve();
+  await Promise.resolve();
+  upstream.emitClose(1_000, "provider done");
+
+  expect(persistUsage).toHaveBeenCalledTimes(1);
+  expect(downstream.sent).not.toContain(completed);
+  expect(downstream.closes).toHaveLength(0);
+  expect(upstream.closes).toEqual([{ code: 1_000, reason: "provider done" }]);
+
+  resolvePersistence?.();
+  await controller.drain();
+  expect(downstream.sent).toContain(completed);
+  expect(downstream.closes).toEqual([
+    { code: 1_000, reason: "provider done" },
+  ]);
+});
+
+test("reports a pending write failure after the client disconnects", async () => {
+  let rejectPersistence: ((reason: Error) => void) | undefined;
+  const persistUsage = vi.fn(() => new Promise<void>((_resolve, reject) => {
+    rejectPersistence = reject;
+  }));
+  const { controller, downstream, reportFailure, upstream } = setup({
+    persistUsage,
+  });
+  const completed = completedFrame();
+
+  downstream.emitMessage(createFrame());
+  await controller.drain();
+  upstream.emitMessage(completed);
+  await Promise.resolve();
+  await Promise.resolve();
+  downstream.emitClose(1_000, "client gone");
+  rejectPersistence?.(new Error("private write failure"));
+  await controller.drain();
+
+  expect(downstream.sent).not.toContain(completed);
+  expect(reportFailure).toHaveBeenCalledWith({ phase: "persistence" });
+});
+
+test("finishes a pending write but does not forward after the client closes", async () => {
+  let resolvePersistence: (() => void) | undefined;
+  const persistUsage = vi.fn(() => new Promise<void>((resolve) => {
+    resolvePersistence = resolve;
+  }));
+  const { controller, downstream, upstream } = setup({ persistUsage });
+  const completed = completedFrame();
+
+  downstream.emitMessage(createFrame());
+  await controller.drain();
+  upstream.emitMessage(completed);
+  await Promise.resolve();
+  await Promise.resolve();
+  downstream.emitClose(1_000, "client gone");
+  resolvePersistence?.();
+  await controller.drain();
+
+  expect(persistUsage).toHaveBeenCalledTimes(1);
+  expect(downstream.sent).not.toContain(completed);
+  expect(upstream.closes).toEqual([{ code: 1_000, reason: "client gone" }]);
+});
+
+test("accounts for a queued terminal when the client closes immediately", async () => {
+  const { controller, downstream, persistUsage, upstream } = setup();
+  const completed = completedFrame();
+
+  downstream.emitMessage(createFrame());
+  await controller.drain();
+  upstream.emitMessage(completed);
+  downstream.emitClose(1_000, "client gone");
+  await controller.drain();
+
+  expect(persistUsage).toHaveBeenCalledTimes(1);
+  expect(downstream.sent).not.toContain(completed);
+  expect(upstream.closes).toEqual([{ code: 1_000, reason: "client gone" }]);
+});

--- a/apps/cloudflare/test/runner-egress-codex-memory.test.ts
+++ b/apps/cloudflare/test/runner-egress-codex-memory.test.ts
@@ -1,0 +1,253 @@
+import { expect, test } from "vitest";
+
+import {
+  hasHostedCodexMemoryBillableUsage,
+  parseHostedCodexMemoryClientFrame,
+  parseHostedCodexMemoryRequestMetadata,
+  parseHostedCodexMemoryServerFrame,
+  parseHostedCodexMemoryTerminalResponse,
+  readHostedCodexNativeMemoryKind,
+} from "../src/runner-egress-codex-memory.ts";
+
+const encoder = new TextEncoder();
+const createdAt = 1_775_000_000;
+
+function terminalEvent(input?: {
+  type?: "response.completed" | "response.failed" | "response.incomplete";
+  usage?: Record<string, unknown> | null;
+}): string {
+  const usage = input && "usage" in input
+    ? input.usage
+    : {
+        input_tokens: 1_500,
+        input_tokens_details: {
+          cache_write_tokens: 50,
+          cached_tokens: 700,
+        },
+        output_tokens: 180,
+        output_tokens_details: { reasoning_tokens: 40 },
+        total_tokens: 1_680,
+      };
+  return JSON.stringify({
+    response: {
+      created_at: createdAt,
+      id: "resp_memory_123",
+      model: "gpt-5.6-terra-2026-07-30",
+      service_tier: "flex",
+      usage,
+    },
+    type: input?.type ?? "response.completed",
+  });
+}
+
+test("classifies both native memory phases without matching ordinary turns", () => {
+  const extraction = new Headers({
+    "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+  });
+  const consolidation = new Headers({
+    "x-codex-turn-metadata": JSON.stringify({ request_kind: "turn" }),
+    "x-openai-memgen-request": "true",
+  });
+
+  expect(readHostedCodexNativeMemoryKind(extraction)).toBe("extraction");
+  expect(readHostedCodexNativeMemoryKind(consolidation)).toBe("consolidation");
+  expect(readHostedCodexNativeMemoryKind(new Headers({
+    "x-codex-turn-metadata": JSON.stringify({ request_kind: "turn" }),
+  }))).toBeNull();
+  expect(readHostedCodexNativeMemoryKind(new Headers({
+    "x-codex-turn-metadata": "not-json",
+  }))).toBeNull();
+});
+
+test("reads model, tier, and warmup intent from HTTP and WebSocket requests", () => {
+  const body = encoder.encode(JSON.stringify({
+    generate: false,
+    model: "gpt-5.6-terra",
+    service_tier: "flex",
+  })).buffer as ArrayBuffer;
+  expect(parseHostedCodexMemoryRequestMetadata(body)).toEqual({
+    requestedModel: "gpt-5.6-terra",
+    serviceTier: "flex",
+    usageRequired: false,
+  });
+  expect(parseHostedCodexMemoryClientFrame(JSON.stringify({
+    model: "gpt-5.6-terra",
+    type: "response.create",
+  }))).toEqual({
+    kind: "response-create",
+    metadata: {
+      requestedModel: "gpt-5.6-terra",
+      serviceTier: null,
+      usageRequired: true,
+    },
+  });
+  expect(parseHostedCodexMemoryClientFrame(JSON.stringify({
+    type: "response.create",
+  }))).toEqual({ kind: "invalid-response-create" });
+  expect(parseHostedCodexMemoryClientFrame(JSON.stringify({
+    type: "response.output_text.delta",
+  }))).toEqual({ kind: "other" });
+});
+
+test("normalizes exact terminal usage and the provider timestamp", () => {
+  const parsed = parseHostedCodexMemoryServerFrame(terminalEvent());
+  expect(parsed).toEqual({
+    kind: "response-terminal",
+    terminal: {
+      providerRequestOutcome: "succeeded",
+      usage: {
+        cacheWriteTokens: 50,
+        cachedInputTokens: 700,
+        inputTokens: 1_500,
+        occurredAt: new Date(createdAt * 1_000).toISOString(),
+        outputTokens: 180,
+        providerRequestId: "resp_memory_123",
+        rawUsageJson: {
+          input_tokens: 1_500,
+          input_tokens_details: {
+            cache_write_tokens: 50,
+            cached_tokens: 700,
+          },
+          output_tokens: 180,
+          output_tokens_details: { reasoning_tokens: 40 },
+          total_tokens: 1_680,
+        },
+        reasoningTokens: 40,
+        servedModel: "gpt-5.6-terra-2026-07-30",
+        serviceTier: "flex",
+        totalTokens: 1_680,
+      },
+    },
+  });
+  if (parsed.kind !== "response-terminal" || parsed.terminal.usage === null) {
+    throw new TypeError("Expected terminal usage.");
+  }
+  expect(hasHostedCodexMemoryBillableUsage(parsed.terminal.usage)).toBe(true);
+});
+
+test("reads the same terminal schema from bounded HTTP SSE", () => {
+  const body = encoder.encode([
+    "event: response.output_text.delta",
+    "data: " + JSON.stringify({
+      delta: "memory",
+      type: "response.output_text.delta",
+    }),
+    "",
+    "event: response.completed",
+    "data: " + terminalEvent(),
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\r\n"));
+
+  expect(
+    parseHostedCodexMemoryTerminalResponse(body.buffer as ArrayBuffer),
+  ).toEqual({
+    providerRequestOutcome: "succeeded",
+    usage: expect.objectContaining({
+      cacheWriteTokens: 50,
+      occurredAt: new Date(createdAt * 1_000).toISOString(),
+      providerRequestId: "resp_memory_123",
+      serviceTier: "flex",
+    }),
+  });
+});
+
+test("meters usage on incomplete and failed terminal responses", () => {
+  for (const [type, providerRequestOutcome] of [
+    ["response.incomplete", "partial"],
+    ["response.failed", "failed"],
+  ] as const) {
+    const parsed = parseHostedCodexMemoryServerFrame(terminalEvent({ type }));
+    expect(parsed.kind).toBe("response-terminal");
+    if (parsed.kind !== "response-terminal") {
+      throw new TypeError("Expected a terminal response.");
+    }
+    expect(parsed.terminal.providerRequestOutcome).toBe(providerRequestOutcome);
+    expect(parsed.terminal.usage?.totalTokens).toBe(1_680);
+  }
+});
+
+test("permits usage-free terminals but rejects malformed terminal usage", () => {
+  expect(parseHostedCodexMemoryServerFrame(
+    terminalEvent({ usage: null }),
+  )).toEqual({
+    kind: "response-terminal",
+    terminal: {
+      providerRequestOutcome: "succeeded",
+      usage: null,
+    },
+  });
+  expect(parseHostedCodexMemoryServerFrame(JSON.stringify({
+    response: {
+      created_at: -1,
+      id: "resp_bad",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    },
+    type: "response.completed",
+  }))).toEqual({ kind: "invalid-response-terminal" });
+  expect(parseHostedCodexMemoryServerFrame(JSON.stringify({
+    response: {
+      created_at: createdAt,
+      id: "resp_bad",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 0,
+        total_tokens: 0,
+      },
+    },
+    type: "response.completed",
+  }))).toEqual({ kind: "invalid-response-terminal" });
+
+  for (const usage of [
+    {
+      input_tokens: 20,
+      input_tokens_details: { cached_tokens: -1 },
+      output_tokens: 2,
+      total_tokens: 22,
+    },
+    {
+      input_tokens: 20,
+      input_tokens_details: { cache_write_tokens: "12" },
+      output_tokens: 2,
+      total_tokens: 22,
+    },
+    {
+      input_tokens: 20,
+      input_tokens_details: null,
+      output_tokens: 2,
+      total_tokens: 22,
+    },
+    {
+      input_tokens: 20,
+      output_tokens: 2,
+      output_tokens_details: { reasoning_tokens: 2.5 },
+      total_tokens: 22,
+    },
+    {
+      input_tokens: 20,
+      output_tokens: 2,
+      total_tokens: 21,
+    },
+    {
+      input_tokens: 20,
+      input_tokens_details: { cached_tokens: 21 },
+      output_tokens: 2,
+      total_tokens: 22,
+    },
+    {
+      input_tokens: 20,
+      output_tokens: 2,
+      output_tokens_details: { reasoning_tokens: 3 },
+      total_tokens: 22,
+    },
+  ]) {
+    expect(parseHostedCodexMemoryServerFrame(
+      terminalEvent({ usage }),
+    )).toEqual({ kind: "invalid-response-terminal" });
+  }
+});

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2560,6 +2560,7 @@ describe("hostedRunnerIntercept", () => {
     const response = await hostedRunnerIntercept(
       new Request("https://api.venice.ai/api/v1/responses", {
         body: JSON.stringify({
+          generate: false,
           input: [{
             content: [{ text: sensitivePromptText, type: "input_text" }],
             role: "user",
@@ -2767,6 +2768,7 @@ describe("hostedRunnerIntercept", () => {
     const response = await hostedRunnerIntercept(
       new Request("https://api.venice.ai/api/v1/responses", {
         body: JSON.stringify({
+          generate: false,
           input: "synthetic memory request",
           model: "gpt-5.6-luna",
           stream: true,
@@ -2837,6 +2839,7 @@ describe("hostedRunnerIntercept", () => {
         hostedRunnerIntercept(
           new Request("https://api.venice.ai/api/v1/responses", {
             body: JSON.stringify({
+              generate: false,
               input: "synthetic memory request",
               model: "gpt-5.6-terra",
               stream: true,
@@ -2979,6 +2982,7 @@ describe("hostedRunnerIntercept", () => {
       const response = await hostedRunnerIntercept(
         new Request("https://api.venice.ai/api/v1/responses", {
           body: JSON.stringify({
+            generate: false,
             input: "synthetic memory request",
             model: "gpt-5.6-terra",
             stream: true,
@@ -5307,6 +5311,204 @@ describe("hostedRunnerIntercept", () => {
     );
     expect(tooLargeDiagnostic.inputType).toBeUndefined();
     expect(tooLargeDiagnostic.inputNestedMetricBytes).toBeUndefined();
+  });
+
+  it.each([
+    ["response.completed", "succeeded"],
+    ["response.incomplete", "partial"],
+    ["response.failed", "failed"],
+  ] as const)("records exact native Codex memory usage for %s", async (
+    terminalType,
+    expectedOutcome,
+  ) => {
+    const providerCreatedAt = 1_775_000_000;
+    const completedEvent = `data: ${JSON.stringify({
+      response: {
+        created_at: providerCreatedAt,
+        id: "resp_memory_123",
+        model: "gpt-5.6-terra-2026-07-30",
+        service_tier: "flex",
+        usage: {
+          input_tokens: 1_500,
+          input_tokens_details: {
+            cache_write_tokens: 50,
+            cached_tokens: 700,
+          },
+          output_tokens: 180,
+          output_tokens_details: { reasoning_tokens: 40 },
+          total_tokens: 1_680,
+        },
+      },
+      type: terminalType,
+    })}\n\n`;
+    const fetchMock = vi.fn<typeof fetch>(async (request) => {
+      const url = request instanceof Request ? request.url : String(request);
+      return url.startsWith("https://api.openai.com/")
+        ? new Response(completedEvent, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          })
+        : Response.json({
+            recorded: true,
+            usageId: "usage_memory_1",
+          });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.openai.com/v1/responses", {
+        body: JSON.stringify({
+          input: "extract durable operator memories",
+          model: "gpt-5.6-terra",
+          service_tier: "flex",
+          stream: true,
+        }),
+        headers: {
+          ...BOUND_USER_WRITE_FENCE_WITH_BEARER_SENTINEL_HEADERS,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        HOSTED_WEB_BASE_URL: "https://web.example.test",
+        OPENAI_API_KEY: "openai-worker-secret",
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    await expect(response.text()).resolves.toBe(completedEvent);
+    const usageCall = fetchMock.mock.calls.find(([request]) => {
+      const url = request instanceof Request ? request.url : String(request);
+      return url.endsWith("/api/internal/hosted-execution/usage/record");
+    });
+    expect(usageCall).toBeDefined();
+    const payload = JSON.parse(String(usageCall?.[1]?.body)) as {
+      usage: Record<string, unknown>;
+    };
+    expect(payload.usage).toEqual(expect.objectContaining({
+      cacheWriteTokens: 50,
+      cachedInputTokens: 700,
+      credentialSource: "platform",
+      featureKey: "codex-native-memory",
+      inputTokens: 1_500,
+      memberId: "member_123",
+      occurredAt: new Date(providerCreatedAt * 1_000).toISOString(),
+      outputTokens: 180,
+      provider: "codex-cli",
+      providerName: "hosted-openai",
+      providerRequestId: "resp_memory_123",
+      providerRequestOutcome: expectedOutcome,
+      reasoningTokens: 40,
+      requestedModel: "gpt-5.6-terra",
+      servedModel: "gpt-5.6-terra-2026-07-30",
+      tokenPricingBasis: "openai-flex",
+      totalTokens: 1_680,
+      triggerKind: "codex-native-memory",
+    }));
+    expect(payload.usage.rawUsageJson).toEqual({
+      input_tokens: 1_500,
+      input_tokens_details: {
+        cache_write_tokens: 50,
+        cached_tokens: 700,
+      },
+      output_tokens: 180,
+      output_tokens_details: { reasoning_tokens: 40 },
+      total_tokens: 1_680,
+    });
+  });
+
+  it("fails native memory completion closed when durable usage recording fails", async () => {
+    const providerCompletion = `data: ${JSON.stringify({
+      response: {
+        created_at: 1_775_000_000,
+        id: "resp_memory_failed_record",
+        model: "gpt-5.6-luna",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 2,
+          total_tokens: 12,
+        },
+      },
+      type: "response.completed",
+    })}\n\n`;
+    const fetchMock = vi.fn<typeof fetch>(async (request) => {
+      const url = request instanceof Request ? request.url : String(request);
+      if (url.startsWith("https://api.openai.com/")) {
+        return new Response(providerCompletion, { status: 200 });
+      }
+      return new Response("unavailable", { status: 503 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.openai.com/v1/responses", {
+        body: JSON.stringify({
+          model: "gpt-5.6-luna",
+          stream: true,
+        }),
+        headers: {
+          ...BOUND_USER_WRITE_FENCE_WITH_BEARER_SENTINEL_HEADERS,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        HOSTED_WEB_BASE_URL: "https://web.example.test",
+        OPENAI_API_KEY: "openai-worker-secret",
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.text()).resolves.not.toContain(
+      "resp_memory_failed_record",
+    );
+  });
+
+  it("does not double-record ordinary OpenAI turns at egress", async () => {
+    const completedEvent = `data: ${JSON.stringify({
+      response: {
+        created_at: 1_775_000_000,
+        id: "resp_turn_123",
+        usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+      },
+      type: "response.completed",
+    })}\n\n`;
+    const fetchMock = vi.fn<typeof fetch>(async (request) => {
+      const url = request instanceof Request ? request.url : String(request);
+      return url.startsWith("https://api.openai.com/")
+        ? new Response(completedEvent, { status: 200 })
+        : new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.openai.com/v1/responses", {
+        body: JSON.stringify({ model: "gpt-5.6-terra", stream: true }),
+        headers: {
+          ...BOUND_USER_WRITE_FENCE_WITH_BEARER_SENTINEL_HEADERS,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "turn" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        HOSTED_WEB_BASE_URL: "https://web.example.test",
+        OPENAI_API_KEY: "openai-worker-secret",
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    await expect(response.text()).resolves.toBe(completedEvent);
+    expect(fetchMock.mock.calls.some(([request]) => {
+      const url = request instanceof Request ? request.url : String(request);
+      return url.endsWith("/api/internal/hosted-execution/usage/record");
+    })).toBe(false);
   });
 
   it("rejects OpenAI paths outside the explicit hosted runner policy", async () => {

--- a/apps/cloudflare/test/workers/runner-egress-codex-memory-websocket.test.ts
+++ b/apps/cloudflare/test/workers/runner-egress-codex-memory-websocket.test.ts
@@ -1,0 +1,124 @@
+import { expect, test, vi } from "vitest";
+
+import {
+  relayHostedCodexMemoryWebSocketUpgrade,
+} from "../../src/runner-egress-codex-memory-websocket.ts";
+
+const createdAt = 1_775_000_000;
+
+function nextClose(socket: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("close", (event) => {
+      resolve({ code: event.code, reason: event.reason });
+    }, { once: true });
+    socket.addEventListener("error", () => {
+      reject(new Error("WebSocket failed while closing."));
+    }, { once: true });
+  });
+}
+
+function nextMessage(socket: WebSocket): Promise<string | ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data === "string" || event.data instanceof ArrayBuffer) {
+        resolve(event.data);
+      } else {
+        reject(new TypeError("Unexpected WebSocket frame type."));
+      }
+    }, { once: true });
+    socket.addEventListener("error", () => {
+      reject(new Error("WebSocket failed."));
+    }, { once: true });
+  });
+}
+
+test("terminates only the two relay legs and preserves application headers", async () => {
+  const upstreamPair = new WebSocketPair();
+  const upstreamClient = upstreamPair[0];
+  const provider = upstreamPair[1];
+  provider.binaryType = "arraybuffer";
+  provider.accept({ allowHalfOpen: true });
+
+  const persistUsage = vi.fn(async () => undefined);
+  const response = relayHostedCodexMemoryWebSocketUpgrade({
+    persistUsage,
+    upstreamResponse: new Response(null, {
+      headers: {
+        connection: "Upgrade",
+        "openai-model": "gpt-5.6-luna",
+        "sec-websocket-accept": "opaque",
+        "sec-websocket-extensions": "permessage-deflate",
+        upgrade: "websocket",
+        "x-reasoning-included": "true",
+      },
+      status: 101,
+      webSocket: upstreamClient,
+    }),
+  });
+
+  expect(response.status).toBe(101);
+  expect(response.headers.get("connection")).toBeNull();
+  expect(response.headers.get("sec-websocket-accept")).toBeNull();
+  expect(response.headers.get("sec-websocket-extensions")).toBeNull();
+  expect(response.headers.get("upgrade")).toBeNull();
+  expect(response.headers.get("openai-model")).toBe("gpt-5.6-luna");
+  expect(response.headers.get("x-reasoning-included")).toBe("true");
+
+  const client = response.webSocket;
+  expect(client).not.toBeNull();
+  if (!client) throw new TypeError("Expected relayed WebSocket.");
+  client.binaryType = "arraybuffer";
+  client.accept({ allowHalfOpen: true });
+
+  const request = JSON.stringify({
+    model: "gpt-5.6-luna",
+    service_tier: "flex",
+    type: "response.create",
+  });
+  const providerMessage = nextMessage(provider);
+  client.send(request);
+  await expect(providerMessage).resolves.toBe(request);
+
+  const completed = JSON.stringify({
+    response: {
+      created_at: createdAt,
+      id: "resp_memory_worker",
+      model: "gpt-5.6-luna-2026-07-30",
+      service_tier: "flex",
+      usage: {
+        input_tokens: 10,
+        input_tokens_details: {
+          cache_write_tokens: 2,
+          cached_tokens: 4,
+        },
+        output_tokens: 3,
+        total_tokens: 13,
+      },
+    },
+    type: "response.completed",
+  });
+  const clientMessage = nextMessage(client);
+  provider.send(completed);
+  await expect(clientMessage).resolves.toBe(completed);
+  expect(persistUsage).toHaveBeenCalledWith({
+    providerRequestOutcome: "succeeded",
+    requestMetadata: {
+      usageRequired: true,
+      requestedModel: "gpt-5.6-luna",
+      serviceTier: "flex",
+    },
+    usage: expect.objectContaining({
+      cacheWriteTokens: 2,
+      providerRequestId: "resp_memory_worker",
+    }),
+  });
+
+  provider.addEventListener("close", (event) => {
+    provider.close(event.code, event.reason);
+  }, { once: true });
+  const clientClosed = nextClose(client);
+  const providerClosed = nextClose(provider);
+  client.close(1_000, "done");
+  await expect(clientClosed).resolves.toEqual({ code: 1_000, reason: "done" });
+  await expect(providerClosed).resolves.toEqual({ code: 1_000, reason: "done" });
+});

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -6,6 +6,10 @@ import {
   resolveAssistantSkillsRoot,
 } from "@murphai/assistant-engine/assistant-skill-assets";
 import {
+  HOSTED_ASSISTANT_LUNA_MODEL,
+  HOSTED_ASSISTANT_TERRA_MODEL,
+} from "@murphai/hosted-execution/assistant-model";
+import {
   buildMurphGroupReadPermissionProfileTomlLines,
   buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines,
   buildMurphMemberMemoryMaintenancePermissionProfileTomlLines,
@@ -583,6 +587,14 @@ export function buildHostedCodexConfigToml(input: {
     : input.provider.id;
   const customInferenceProvider =
     input.provider.id === HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID;
+  const useConfiguredMemoryModel = input.chatGptAuth === true
+    || customInferenceProvider;
+  const memoryExtractModel = useConfiguredMemoryModel
+    ? input.model
+    : HOSTED_ASSISTANT_LUNA_MODEL;
+  const memoryConsolidationModel = useConfiguredMemoryModel
+    ? input.model
+    : HOSTED_ASSISTANT_TERRA_MODEL;
   const autoCompactTokenLimit = input.contextWindowTokens === null
       || input.contextWindowTokens === undefined
     ? DEFAULT_HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT
@@ -660,12 +672,19 @@ export function buildHostedCodexConfigToml(input: {
     `multi_agent_mode_hint_text = ${tomlString(HOSTED_CODEX_MULTI_AGENT_MODE_HINT_TEXT)}`,
     `subagent_usage_hint_text = ${tomlString(HOSTED_CODEX_SUBAGENT_USAGE_HINT_TEXT)}`,
     "",
-    "# Codex-native memories are operator memory only. Murph product memory",
-    "# remains canonical in the vault; snapshots keep the Codex home allowlist",
-    "# narrow instead of recursively preserving every generated memory artifact.",
+    "# Codex-native operator memory remains enabled. Platform-funded generation",
+    "# is pinned to Murph's Luna/Terra policy and metered from exact terminal usage.",
+    "# Member-owned credentials and endpoints follow the configured foreground model.",
+    "# Murph product memory remains canonical in the vault.",
     "[memories]",
     `use_memories = ${HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.useMemories}`,
     `generate_memories = ${HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.generateMemories}`,
+    ...(memoryExtractModel
+      ? [`extract_model = ${tomlString(memoryExtractModel)}`]
+      : []),
+    ...(memoryConsolidationModel
+      ? [`consolidation_model = ${tomlString(memoryConsolidationModel)}`]
+      : []),
     `disable_on_external_context = ${HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.disableOnExternalContext}`,
     `min_rollout_idle_hours = ${HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.minRolloutIdleHours}`,
     `max_rollouts_per_startup = ${HOSTED_CODEX_OPERATOR_MEMORY_CONFIG.maxRolloutsPerStartup}`,

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -17,6 +17,10 @@ import {
   MURPH_ASSISTANT_SKILLS_ROOT_ENV,
 } from "@murphai/assistant-engine/assistant-skill-assets";
 import {
+  HOSTED_ASSISTANT_LUNA_MODEL,
+  HOSTED_ASSISTANT_TERRA_MODEL,
+} from "@murphai/hosted-execution/assistant-model";
+import {
   MURPH_GROUP_READ_PERMISSION_PROFILE,
   MURPH_GROUP_ROOM_MODEL_MAINTENANCE_PERMISSION_PROFILE,
   MURPH_MEMBER_MEMORY_MAINTENANCE_PERMISSION_PROFILE,
@@ -179,6 +183,17 @@ test("hosted Codex runtime config writes Venice Responses config without secret 
   assert.match(config, /wire_api = "responses"/u);
   assert.doesNotMatch(config, /^supports_websockets = true$/mu);
   assert.doesNotMatch(config, /signed-venice-egress-credential/u);
+  assert.match(
+    config,
+    new RegExp(`^extract_model = "${HOSTED_ASSISTANT_LUNA_MODEL}"$`, "mu"),
+  );
+  assert.match(
+    config,
+    new RegExp(
+      `^consolidation_model = "${HOSTED_ASSISTANT_TERRA_MODEL}"$`,
+      "mu",
+    ),
+  );
 });
 
 test("hosted Codex runtime config preserves capabilities with custom inference", async () => {
@@ -215,7 +230,10 @@ test("hosted Codex runtime config preserves capabilities with custom inference",
   assert.match(config, /\[features\]\nplugins = false\nmemories = true/u);
   assert.match(config, /\[features\.multi_agent_v2\]\nenabled = true/u);
   assert.match(config, /^max_concurrent_threads_per_session = 4$/mu);
-  assert.match(config, /\[memories\]\nuse_memories = true\ngenerate_memories = true/u);
+  assert.match(
+    config,
+    /\[memories\]\nuse_memories = true\ngenerate_memories = true\nextract_model = "murph-custom-r7"\nconsolidation_model = "murph-custom-r7"/u,
+  );
   assert.equal(
     new Set<string>(HOSTED_CODEX_SHELL_ENVIRONMENT_INCLUDE_ONLY)
       .has("MURPH_CUSTOM_INFERENCE_API_KEY"),
@@ -325,7 +343,7 @@ test("hosted Codex runtime config writes OpenAI Responses config without secret 
   assert.doesNotMatch(config, /This mode remains active until/u);
   assert.match(
     config,
-    /\[memories\]\nuse_memories = true\ngenerate_memories = true\ndisable_on_external_context = false\nmin_rollout_idle_hours = 1\nmax_rollouts_per_startup = 1\nmax_rollout_age_days = 10\nmin_rate_limit_remaining_percent = 25\nmax_raw_memories_for_consolidation = 128\nmax_unused_days = 30/u,
+    /\[memories\]\nuse_memories = true\ngenerate_memories = true\nextract_model = "gpt-5\.6-luna"\nconsolidation_model = "gpt-5\.6-terra"\ndisable_on_external_context = false\nmin_rollout_idle_hours = 1\nmax_rollouts_per_startup = 1\nmax_rollout_age_days = 10\nmin_rate_limit_remaining_percent = 25\nmax_raw_memories_for_consolidation = 128\nmax_unused_days = 30/u,
   );
   assert.doesNotMatch(config, /^plugins = true$/mu);
   assert.match(config, /\[skills\]\ninclude_instructions = false/u);
@@ -601,6 +619,7 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
   const result = await prepareHostedCodexRuntimeEnvironment({
     operatorHomeRoot,
     runtimeEnv: {
+      HOSTED_ASSISTANT_MODEL: "gpt-5.6-sol",
       HOSTED_ASSISTANT_PROVIDER: "openai",
       [HOSTED_RUNTIME_CODEX_CHATGPT_AUTH_JSON_ENV]: encodeChatGptCodexAuthEnvValue(chatGptAuthJson),
       NODE_ENV: "development",
@@ -634,6 +653,8 @@ test("hosted Codex runtime config uses ChatGPT subscription auth in local dev", 
   assert.match(config, /^stream_max_retries = 0$/mu);
   assert.doesNotMatch(config, /chatgpt-access-token/u);
   assert.match(config, /model_reasoning_effort = "low"/u);
+  assert.match(config, /^extract_model = "gpt-5\.6-sol"$/mu);
+  assert.match(config, /^consolidation_model = "gpt-5\.6-sol"$/mu);
   assert.match(config, /\[history\]\npersistence = "none"/u);
   assert.match(config, /\[shell_environment_policy\]/u);
   assertHostedCodexConfigDisablesLoginShellAtTopLevel(config);
@@ -1626,12 +1647,15 @@ test("hosted Codex config TOML omits credential values and runtime authority hea
       `multi_agent_mode_hint_text = ${JSON.stringify(EXPECTED_MULTI_AGENT_MODE_HINT)}`,
       `subagent_usage_hint_text = ${JSON.stringify(EXPECTED_SUBAGENT_USAGE_HINT)}`,
       "",
-      "# Codex-native memories are operator memory only. Murph product memory",
-      "# remains canonical in the vault; snapshots keep the Codex home allowlist",
-      "# narrow instead of recursively preserving every generated memory artifact.",
+      "# Codex-native operator memory remains enabled. Platform-funded generation",
+      "# is pinned to Murph's Luna/Terra policy and metered from exact terminal usage.",
+      "# Member-owned credentials and endpoints follow the configured foreground model.",
+      "# Murph product memory remains canonical in the vault.",
       "[memories]",
       "use_memories = true",
       "generate_memories = true",
+      "extract_model = \"gpt-5.6-luna\"",
+      "consolidation_model = \"gpt-5.6-terra\"",
       "disable_on_external_context = false",
       "min_rollout_idle_hours = 1",
       "max_rollouts_per_startup = 1",
@@ -1716,6 +1740,8 @@ test("hosted Codex config keeps skill instructions disabled while enabling opera
   assert.match(config, /^max_concurrent_threads_per_session = 4$/mu);
   assert.match(config, /\[memories\]\nuse_memories = true/u);
   assert.match(config, /^generate_memories = true$/mu);
+  assert.match(config, /^extract_model = "gpt-5\.6-luna"$/mu);
+  assert.match(config, /^consolidation_model = "gpt-5\.6-terra"$/mu);
   assert.match(config, /^disable_on_external_context = false$/mu);
   assert.match(config, /^max_rollouts_per_startup = 1$/mu);
   assert.match(config, /^check_for_update_on_startup = false$/mu);

--- a/packages/hosted-execution/src/assistant-usage.ts
+++ b/packages/hosted-execution/src/assistant-usage.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomUUID } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 
 export const ASSISTANT_USAGE_SCHEMA = "murph.assistant-usage.v1";
 export const ASSISTANT_IDLE_COMPACTION_USAGE_ESTIMATE_SOURCE_PATH =
@@ -28,7 +28,12 @@ const ASSISTANT_USAGE_RAW_TOKEN_KEYS = new Set<string>([
   "total_tokens",
 ]);
 const ASSISTANT_USAGE_RAW_DETAIL_TOKEN_KEYS = new Map<string, ReadonlySet<string>>([
-  ["input_tokens_details", new Set(["cached_tokens", "image_tokens", "text_tokens"])],
+  ["input_tokens_details", new Set([
+    "cache_write_tokens",
+    "cached_tokens",
+    "image_tokens",
+    "text_tokens",
+  ])],
   ["output_tokens_details", new Set(["image_tokens", "reasoning_tokens", "text_tokens"])],
   ["prompt_tokens_details", new Set(["cached_tokens"])],
 ]);
@@ -575,6 +580,73 @@ export function buildHostedElevenLabsMusicUsageRecord(input: {
     }),
     usageExtractionSourcePath: "elevenlabs.music.compose",
     usageExtractionVersion: "elevenlabs-music-v1",
+  });
+}
+
+// Exact usage for Codex-native memory work intercepted outside the foreground
+// app-server turn. Provider response ids make re-observation idempotent while
+// the provider timestamp keeps the immutable record stable across retries.
+export function buildHostedCodexMemoryUsageRecord(input: {
+  apiKeyEnv: string;
+  baseUrl: string;
+  cacheWriteTokens: number | null;
+  cachedInputTokens: number | null;
+  inputTokens: number;
+  memberId: string;
+  occurredAt: string;
+  outputTokens: number;
+  providerName: string;
+  providerRequestId: string;
+  providerRequestOutcome: AssistantProviderRequestOutcome;
+  rawUsageJson: Record<string, unknown>;
+  reasoningTokens: number | null;
+  requestedModel: string;
+  servedModel?: string | null;
+  tokenPricingBasis?: AssistantUsageTokenPricingBasis;
+  totalTokens: number;
+}): AssistantUsageRecord {
+  const digest = createHash("sha256")
+    .update("murph.hosted-codex-memory-usage.v1")
+    .update("\0")
+    .update(input.memberId)
+    .update("\0")
+    .update(input.providerName)
+    .update("\0")
+    .update(input.providerRequestId)
+    .digest("hex")
+    .slice(0, 32);
+  const turnId = `turn_codex_memory_${digest}`;
+
+  return parseAssistantUsageRecord({
+    apiKeyEnv: input.apiKeyEnv,
+    attemptCount: 1,
+    baseUrl: input.baseUrl,
+    cacheWriteTokens: input.cacheWriteTokens,
+    cachedInputTokens: input.cachedInputTokens,
+    credentialSource: "platform",
+    featureKey: "codex-native-memory",
+    inputTokens: input.inputTokens,
+    memberId: input.memberId,
+    occurredAt: input.occurredAt,
+    outputTokens: input.outputTokens,
+    provider: "codex-cli",
+    providerName: input.providerName,
+    providerRequestId: input.providerRequestId,
+    providerRequestOutcome: input.providerRequestOutcome,
+    rawUsageJson: input.rawUsageJson,
+    reasoningTokens: input.reasoningTokens,
+    requestedModel: input.requestedModel,
+    schema: ASSISTANT_USAGE_SCHEMA,
+    servedModel: input.servedModel ?? null,
+    sessionId: turnId,
+    surface: "hosted-runner",
+    tokenPricingBasis: input.tokenPricingBasis ?? "standard",
+    totalTokens: input.totalTokens,
+    triggerKind: "codex-native-memory",
+    turnId,
+    usageId: createAssistantUsageId({ attemptCount: 1, turnId }),
+    usageExtractionSourcePath: "codex.responses.terminal",
+    usageExtractionVersion: "codex-native-memory-v1",
   });
 }
 

--- a/packages/hosted-execution/test/assistant-usage.test.ts
+++ b/packages/hosted-execution/test/assistant-usage.test.ts
@@ -9,6 +9,7 @@ import {
   ASSISTANT_TURN_PROFILE_MAX_TOOLS,
   ASSISTANT_USAGE_SCHEMA,
   buildAssistantMaintenanceUsageRecord,
+  buildHostedCodexMemoryUsageRecord,
   buildHostedElevenLabsTtsUsageRecord,
   buildHostedTranscriptionUsageRecord,
   buildHostedXaiSearchUsageRecord,
@@ -82,6 +83,63 @@ test("maintenance usage records parse, attribute, and dedupe like turn usage", (
       },
     }).turnId,
     record.turnId,
+  );
+});
+
+test("native Codex memory usage is exact and replay-idempotent", () => {
+  const input = {
+    apiKeyEnv: "OPENAI_API_KEY",
+    baseUrl: "https://api.openai.com/v1",
+    cacheWriteTokens: 50,
+    cachedInputTokens: 700,
+    inputTokens: 1_500,
+    memberId: "member_123",
+    occurredAt: "2026-04-01T12:00:00.000Z",
+    outputTokens: 180,
+    providerName: "hosted-openai",
+    providerRequestId: "resp_memory_123",
+    providerRequestOutcome: "succeeded" as const,
+    rawUsageJson: {
+      input_tokens: 1_500,
+      input_tokens_details: {
+        cache_write_tokens: 50,
+        cached_tokens: 700,
+      },
+      output_tokens: 180,
+      output_tokens_details: { reasoning_tokens: 40 },
+      total_tokens: 1_680,
+    },
+    reasoningTokens: 40,
+    requestedModel: "gpt-5.6-terra",
+    servedModel: "gpt-5.6-terra-2026-07-30",
+    tokenPricingBasis: "openai-flex" as const,
+    totalTokens: 1_680,
+  };
+
+  const record = buildHostedCodexMemoryUsageRecord(input);
+  assert.deepEqual(parseAssistantUsageRecord({ ...record }), record);
+  assert.match(record.turnId, /^turn_codex_memory_[0-9a-f]{32}$/u);
+  assert.equal(record.usageId, `${record.turnId}.attempt-1`);
+  assert.equal(record.occurredAt, input.occurredAt);
+  assert.equal(record.credentialSource, "platform");
+  assert.equal(record.provider, "codex-cli");
+  assert.equal(record.providerName, "hosted-openai");
+  assert.equal(record.providerRequestId, "resp_memory_123");
+  assert.equal(record.providerRequestOutcome, "succeeded");
+  assert.equal(record.requestedModel, "gpt-5.6-terra");
+  assert.equal(record.servedModel, "gpt-5.6-terra-2026-07-30");
+  assert.equal(record.tokenPricingBasis, "openai-flex");
+  assert.equal(record.cacheWriteTokens, 50);
+  assert.deepEqual(record.rawUsageJson, input.rawUsageJson);
+
+  const duplicate = buildHostedCodexMemoryUsageRecord(input);
+  assert.deepEqual(duplicate, record);
+  assert.notEqual(
+    buildHostedCodexMemoryUsageRecord({
+      ...input,
+      providerRequestId: "resp_memory_456",
+    }).usageId,
+    record.usageId,
   );
 });
 


### PR DESCRIPTION
## What changed

- Keep Codex-native memory generation enabled.
- Preserve WebSockets. Only native-memory upgrades identified by Codex's own markers enter the isolated relay; ordinary Responses WebSockets remain the existing direct pass-through.
- Meter both native phases:
  - extraction: `x-codex-turn-metadata.request_kind = "memory"`
  - consolidation: `x-openai-memgen-request: true`
- Share one pure terminal-event parser across HTTP/SSE and WebSocket paths.
- Persist exact provider-reported usage before forwarding completed, incomplete, or failed terminal responses that contain billable work.
- Make model ownership explicit:
  - platform-funded OpenAI/Venice memory is pinned to Luna extraction and Terra consolidation;
  - ChatGPT-auth and custom-inference memory follow the configured foreground model.

## Architecture and reuse

- **Existing systems reused:** provider authorization, pricing resolution, `AssistantUsageRecord`, and the existing durable usage-record port.
- **New logic:** pure native-memory classification/terminal normalization plus a relay activated only for marked memory WebSockets.
- **New abstractions:** one small socket-port seam makes the relay deterministic to test without adding provider or billing knowledge to transport.
- **Complexity intentionally avoided:** no `426` transport fallback, second ledger, external work queue, telemetry-ingestion path, foreground-traffic interception, or general-purpose WebSocket proxy.

The transport layer has no extraction/consolidation behavior. That distinction remains at the interceptor policy/logging boundary. HTTP and Venice reuse the same terminal normalization.

## Accounting guarantees

- Usage IDs are deterministic from member, provider, and provider response ID.
- `occurredAt` comes from provider `response.created_at`, keeping replayed observations immutable-identical.
- Cache-write tokens use the Responses schema at `usage.input_tokens_details.cache_write_tokens`.
- Provider outcomes are preserved: completed → `succeeded`, incomplete → `partial`, failed → `failed`.
- Positive usage on every terminal outcome is persisted before Codex receives that terminal event.
- A generated successful response with missing/malformed usage fails closed.
- Present-but-malformed token details and contradictory aggregate counts fail closed.
- A failed usage write prevents terminal delivery, so unaccounted memory output is not committed.
- Ordinary foreground turns are excluded to avoid double accounting.

## WebSocket behavior

- No `426` fallback is introduced.
- Both Worker-side sockets use half-open mode and explicitly complete both sides of the close handshake.
- Text and binary frames are relayed unchanged; inspection is limited to bounded terminal/request JSON frames.
- Hop-by-hop and extension-negotiation headers are removed at the terminated boundary while application headers are preserved.
- Empty `generate: false` warmups are skipped; any provider-reported positive work is still accounted for.
- Sequential consolidation/tool-loop responses on one connection are metered independently.
- A provider terminal observed before client close still finishes accounting; post-close forwarding remains suppressed.

## Validation

- 40 focused Node tests pass across protocol parsing, relay ordering/failure behavior, failed/incomplete outcomes, usage normalization/idempotency, and existing assistant-usage contracts.
- Strict TypeScript checks pass for the parser, relay, Workers adapter test, and usage record builder.
- Added a Workers-runtime `WebSocketPair` test, including a one-sided close handshake.
- Rebased onto `main` at `095050b1d9a0fc9a2e59e5e1f16750581ce85dee`.

## Scope

This PR meters native memory generation while preserving its transport. Persistence of Codex's SQLite-native memory state across hosted shutdown remains a separate pre-existing lifecycle concern; this change does not snapshot a live SQLite database.