### PR TITLE
Reset usage when members upgrade plans

### DIFF
--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -36,6 +36,7 @@ import {
   getHostedBillingPlanCodeForPlan,
   getHostedDefaultBillingPlanCode,
   getHostedFamilyAiUsageMonthlyAllowanceForPlan,
+  isHostedBillingPlanImmediateUpgrade,
   parseHostedBillingPlanCode,
   parseHostedBillingPhase,
   parseHostedPlanCode,
@@ -1783,6 +1784,14 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
         })
       )
     );
+  const resetForPlanUpgrade = shouldResetHostedAiUsageForPlanUpgrade({
+    billingRef: input.billingRef,
+    currentBillingPlanCode,
+    currentLimitUsdMicros: current.limitUsdMicros,
+    currentPeriodEnd: current.periodEnd,
+    currentPeriodStart: current.periodStart,
+    resolved,
+  });
 
   if (periodMatches) {
     const blockedAt = resolveHostedAiUsageAllowanceBlockedAt({
@@ -1822,13 +1831,15 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
     };
   }
 
-  const blockedAt = resolveHostedAiUsageAllowanceBlockedAt({
-    blockedAt: current.blockedAt,
-    limitUsdMicros: resolved.limitUsdMicros,
-    now: input.now,
-    spentUsdMicros: current.spentUsdMicros,
-    usageCreditBalanceUsdMicros: input.usageCreditBalanceUsdMicros,
-  });
+  const blockedAt = resetForPlanUpgrade
+    ? null
+    : resolveHostedAiUsageAllowanceBlockedAt({
+        blockedAt: current.blockedAt,
+        limitUsdMicros: resolved.limitUsdMicros,
+        now: input.now,
+        spentUsdMicros: current.spentUsdMicros,
+        usageCreditBalanceUsdMicros: input.usageCreditBalanceUsdMicros,
+      });
   const upgraded = await input.tx.hostedAiUsagePeriod.update({
     where: {
       memberId_periodStart: {
@@ -1841,6 +1852,7 @@ async function ensureHostedAiUsageAllowancePeriodTx(input: {
       blockedAt,
       limitUsdMicros: resolved.limitUsdMicros,
       periodEnd: resolved.periodEnd,
+      ...(resetForPlanUpgrade ? { spentUsdMicros: 0n } : {}),
       updatedAt: input.now,
     },
     select: {
@@ -1932,17 +1944,25 @@ async function readHostedAiUsageAllowancePeriodTx(input: {
           resolved,
         })
       );
+    const resetForPlanUpgrade = shouldResetHostedAiUsageForPlanUpgrade({
+      billingRef: input.billingRef,
+      currentBillingPlanCode,
+      currentLimitUsdMicros: current.limitUsdMicros,
+      currentPeriodEnd: current.periodEnd,
+      currentPeriodStart: current.periodStart,
+      resolved,
+    });
     const limitUsdMicros = periodMatches ? current.limitUsdMicros : resolved.limitUsdMicros;
 
     return {
       kind: "period",
       allowanceSource: resolved.allowanceSource,
       billingPlanCode: periodMatches ? currentBillingPlanCode : resolved.billingPlanCode,
-      blockedAt: current.blockedAt,
+      blockedAt: resetForPlanUpgrade ? null : current.blockedAt,
       limitUsdMicros,
       periodEnd: periodMatches ? current.periodEnd : resolved.periodEnd,
       periodStart: periodMatches ? current.periodStart : resolved.periodStart,
-      spentUsdMicros: current.spentUsdMicros,
+      spentUsdMicros: resetForPlanUpgrade ? 0n : current.spentUsdMicros,
       usageCreditBalanceUsdMicros: input.usageCreditBalanceUsdMicros,
       usageCreditLedgerVersion: input.usageCreditLedgerVersion,
     };
@@ -1960,6 +1980,48 @@ async function readHostedAiUsageAllowancePeriodTx(input: {
     usageCreditBalanceUsdMicros: input.usageCreditBalanceUsdMicros,
     usageCreditLedgerVersion: input.usageCreditLedgerVersion,
   };
+}
+
+function shouldResetHostedAiUsageForPlanUpgrade(input: {
+  billingRef: HostedAiUsageAllowanceBillingRef | null;
+  currentBillingPlanCode: HostedBillingPlanCode;
+  currentLimitUsdMicros: bigint;
+  currentPeriodEnd: Date;
+  currentPeriodStart: Date;
+  resolved: Extract<HostedAiUsageAllowancePeriodResolution, { kind: "period" }>;
+}): boolean {
+  if (
+    input.resolved.allowanceSource !== "direct_paid_member_plan" &&
+    input.resolved.allowanceSource !== "family_sponsored_plan"
+  ) {
+    return false;
+  }
+
+  if (isHostedBillingPlanImmediateUpgrade({
+    currentPlanCode: input.currentBillingPlanCode,
+    targetPlanCode: input.resolved.billingPlanCode,
+  })) {
+    return true;
+  }
+
+  if (input.resolved.allowanceSource !== "direct_paid_member_plan") {
+    return false;
+  }
+
+  // Trial and paid Pulse share a plan code. Retained trial bounds identify the
+  // old row without mistaking an ordinary paid allowance change for conversion.
+  return (
+    input.currentBillingPlanCode === "launch_monthly" &&
+    input.resolved.billingPlanCode === "launch_monthly" &&
+    parseHostedBillingCheckoutOffer(input.billingRef?.currentCheckoutOffer)
+      === HOSTED_PULSE_TRIAL_OFFER &&
+    input.billingRef?.currentTrialStartedAt?.getTime()
+      === input.currentPeriodStart.getTime() &&
+    input.billingRef?.currentTrialEndsAt?.getTime()
+      === input.currentPeriodEnd.getTime() &&
+    input.currentLimitUsdMicros === HOSTED_PULSE_TRIAL_USAGE_LIMIT_USD_MICROS &&
+    input.resolved.limitUsdMicros > input.currentLimitUsdMicros
+  );
 }
 
 function shouldPreserveExistingPaidPeriodLimit(input: {

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -3003,13 +3003,14 @@ describe("resolveHostedAiUsageGate", () => {
     });
   });
 
-  it("still reconciles an actual plan change during the current period", async () => {
+  it("resets current-period spend when Pulse upgrades to Edge", async () => {
     const update = vi.fn(async (args: {
       data: {
         billingPlanCode: string;
         blockedAt: Date | null;
         limitUsdMicros: bigint;
         periodEnd: Date;
+        spentUsdMicros?: bigint;
       };
     }) => ({
       billingPlanCode: args.data.billingPlanCode,
@@ -3017,12 +3018,13 @@ describe("resolveHostedAiUsageGate", () => {
       limitUsdMicros: args.data.limitUsdMicros,
       periodEnd: args.data.periodEnd,
       periodStart: new Date("2026-03-01T00:00:00.000Z"),
-      spentUsdMicros: 6_000_000n,
+      spentUsdMicros: args.data.spentUsdMicros ?? 6_000_000n,
     }));
     const prisma = createGatePrisma({
       billingPlanCode: "launch_edge_monthly",
       findUniquePeriod: {
         billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-03-28T12:00:00.000Z"),
         limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
         periodEnd: new Date("2026-04-01T00:00:00.000Z"),
         periodStart: new Date("2026-03-01T00:00:00.000Z"),
@@ -3042,15 +3044,166 @@ describe("resolveHostedAiUsageGate", () => {
       allowed: true,
       billingPlanCode: "launch_edge_monthly",
       limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
-      remainingUsdMicros: 10_000_000n,
-      spentUsdMicros: 6_000_000n,
+      remainingUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+      spentUsdMicros: 0n,
     });
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         billingPlanCode: "launch_edge_monthly",
+        blockedAt: null,
         limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+        spentUsdMicros: 0n,
       }),
     }));
+  });
+
+  it("resets trial spend when a same-period Pulse Trial converts to paid Pulse", async () => {
+    const periodStart = new Date("2026-04-01T12:00:00.000Z");
+    const paidPeriodEnd = new Date("2026-05-01T12:00:00.000Z");
+    const update = vi.fn(async (args: {
+      data: {
+        billingPlanCode: string;
+        blockedAt: Date | null;
+        limitUsdMicros: bigint;
+        periodEnd: Date;
+        spentUsdMicros?: bigint;
+      };
+    }) => ({
+      billingPlanCode: args.data.billingPlanCode,
+      blockedAt: args.data.blockedAt,
+      limitUsdMicros: args.data.limitUsdMicros,
+      periodEnd: args.data.periodEnd,
+      periodStart,
+      spentUsdMicros: args.data.spentUsdMicros ?? 4_000_000n,
+    }));
+    const prisma = createGatePrisma({
+      billingPhase: "paid",
+      checkoutOffer: "pulse_trial_7d",
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-04-07T12:00:00.000Z"),
+        limitUsdMicros: 4_500_000n,
+        periodEnd: new Date("2026-04-08T12:00:00.000Z"),
+        periodStart,
+        spentUsdMicros: 4_000_000n,
+      },
+      periodEnd: paidPeriodEnd,
+      periodStart,
+      pulseTrialPolicyVersion: "pulse-trial-2026-06-30-v2",
+      pulseTrialRedeemedAt: periodStart,
+      spentUsdMicros: 4_000_000n,
+      trialEndsAt: new Date("2026-04-08T12:00:00.000Z"),
+      trialStartedAt: periodStart,
+      update,
+    });
+
+    await expect(resolveHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-04-08T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+      periodEnd: paidPeriodEnd,
+      remainingUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+      spentUsdMicros: 0n,
+    });
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        billingPlanCode: "launch_monthly",
+        blockedAt: null,
+        limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+        periodEnd: paidPeriodEnd,
+        spentUsdMicros: 0n,
+      }),
+    }));
+  });
+
+  it("does not reset an ordinary paid Pulse allowance change", async () => {
+    const periodStart = new Date("2026-04-08T12:00:00.000Z");
+    const periodEnd = new Date("2026-05-08T12:00:00.000Z");
+    const update = vi.fn(async (args: {
+      data: {
+        billingPlanCode: string;
+        blockedAt: Date | null;
+        limitUsdMicros: bigint;
+        periodEnd: Date;
+        spentUsdMicros?: bigint;
+      };
+    }) => ({
+      billingPlanCode: args.data.billingPlanCode,
+      blockedAt: args.data.blockedAt,
+      limitUsdMicros: args.data.limitUsdMicros,
+      periodEnd: args.data.periodEnd,
+      periodStart,
+      spentUsdMicros: args.data.spentUsdMicros ?? 4_000_000n,
+    }));
+    const prisma = createGatePrisma({
+      billingPhase: "paid",
+      checkoutOffer: "pulse_trial_7d",
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        limitUsdMicros: 4_500_000n,
+        periodEnd,
+        periodStart,
+        spentUsdMicros: 4_000_000n,
+      },
+      periodEnd,
+      periodStart,
+      pulseTrialPolicyVersion: "pulse-trial-2026-06-30-v2",
+      pulseTrialRedeemedAt: new Date("2026-04-01T12:00:00.000Z"),
+      spentUsdMicros: 4_000_000n,
+      trialEndsAt: periodStart,
+      trialStartedAt: new Date("2026-04-01T12:00:00.000Z"),
+      update,
+    });
+
+    await expect(resolveHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-04-09T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+      remainingUsdMicros: 2_400_000n,
+      spentUsdMicros: 4_000_000n,
+    });
+    const updateData = (update.mock.calls[0]?.[0] as {
+      data?: Record<string, unknown>;
+    } | undefined)?.data;
+    expect(updateData).not.toHaveProperty("spentUsdMicros");
+  });
+
+  it("preserves spend after the upgraded Edge period is already reconciled", async () => {
+    const update = vi.fn();
+    const prisma = createGatePrisma({
+      billingPlanCode: "launch_edge_monthly",
+      findUniquePeriod: {
+        billingPlanCode: "launch_edge_monthly",
+        limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+        periodEnd: new Date("2026-04-01T00:00:00.000Z"),
+        periodStart: new Date("2026-03-01T00:00:00.000Z"),
+        spentUsdMicros: 2_000_000n,
+      },
+      limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+      spentUsdMicros: 2_000_000n,
+      update,
+    });
+
+    await expect(resolveHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-03-29T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      billingPlanCode: "launch_edge_monthly",
+      limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+      remainingUsdMicros: 14_000_000n,
+      spentUsdMicros: 2_000_000n,
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -3251,6 +3404,82 @@ describe("resolveHostedAiUsageGate", () => {
 });
 
 describe("readHostedAiUsageGate", () => {
+  it("shows zero spend immediately when Pulse upgrades to Edge", async () => {
+    const prisma = createGatePrisma({
+      billingPlanCode: "launch_edge_monthly",
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-03-28T12:00:00.000Z"),
+        limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+        periodEnd: new Date("2026-04-01T00:00:00.000Z"),
+        periodStart: new Date("2026-03-01T00:00:00.000Z"),
+        spentUsdMicros: 6_000_000n,
+      },
+      periodEnd: new Date("2026-04-01T00:00:00.000Z"),
+      periodStart: new Date("2026-03-01T00:00:00.000Z"),
+      spentUsdMicros: 6_000_000n,
+    });
+
+    await expect(readHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-03-29T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      billingPlanCode: "launch_edge_monthly",
+      limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+      remainingUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+      spentUsdMicros: 0n,
+    });
+
+    expect(prisma.hostedAiUsagePeriod.createMany).not.toHaveBeenCalled();
+    expect(prisma.hostedAiUsagePeriod.update).not.toHaveBeenCalled();
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("shows zero spend immediately when a Pulse Trial converts to paid Pulse", async () => {
+    const periodStart = new Date("2026-04-01T12:00:00.000Z");
+    const paidPeriodEnd = new Date("2026-05-01T12:00:00.000Z");
+    const prisma = createGatePrisma({
+      billingPhase: "paid",
+      checkoutOffer: "pulse_trial_7d",
+      findUniquePeriod: {
+        billingPlanCode: "launch_monthly",
+        blockedAt: new Date("2026-04-07T12:00:00.000Z"),
+        limitUsdMicros: 4_500_000n,
+        periodEnd: new Date("2026-04-08T12:00:00.000Z"),
+        periodStart,
+        spentUsdMicros: 4_000_000n,
+      },
+      periodEnd: paidPeriodEnd,
+      periodStart,
+      pulseTrialPolicyVersion: "pulse-trial-2026-06-30-v2",
+      pulseTrialRedeemedAt: periodStart,
+      spentUsdMicros: 4_000_000n,
+      trialEndsAt: new Date("2026-04-08T12:00:00.000Z"),
+      trialStartedAt: periodStart,
+    });
+
+    await expect(readHostedAiUsageGate({
+      memberId: "member_123",
+      now: "2026-04-08T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({
+      allowed: true,
+      billingPlanCode: "launch_monthly",
+      limitUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+      periodEnd: paidPeriodEnd,
+      remainingUsdMicros: DIRECT_PULSE_ALLOWANCE_USD_MICROS,
+      spentUsdMicros: 0n,
+    });
+
+    expect(prisma.hostedAiUsagePeriod.createMany).not.toHaveBeenCalled();
+    expect(prisma.hostedAiUsagePeriod.update).not.toHaveBeenCalled();
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
   it("honors manual usage-period counter resets on the read-first gate", async () => {
     const aggregate = vi.fn(async () => ({
       _max: {
@@ -3824,7 +4053,8 @@ describe("readHostedAiUsageGateSnapshots", () => {
       decision: {
         allowed: true,
         limitUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
-        remainingUsdMicros: 6_000_000n,
+        remainingUsdMicros: DIRECT_EDGE_ALLOWANCE_USD_MICROS,
+        spentUsdMicros: 0n,
       },
       periodPersistedAt: periodUpdatedAt,
     });


### PR DESCRIPTION
## What changed

- Reset the active included-usage balance to $0 when a member moves to a higher plan, including Pulse → Edge.
- Reset Pulse Trial usage when the trial converts to paid Pulse. Normal conversions start a new zeroed Stripe period; a guarded same-period fallback covers event-ordering edge cases.
- Apply the reset immediately in read-only usage views and durably on the next locked allowance reconciliation.
- Clear stale usage blocks while preserving raw usage history, purchased usage credits, and credit-ledger state.
- Keep reconciliation idempotent, so webhook retries do not reset usage again. Same-plan allowance changes and downgrades continue preserving spend.

## Validation

- `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hosted-execution-usage-allowance.test.ts` — 112 passed
- `pnpm --dir apps/web typecheck` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472259&installation_model_id=19880&pr_number=1291&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1291&signature=193de380966f1f05077e99a85a466d5b9664474d71445ac489fc360d5e29ec4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->