### PR TITLE
Polish settings inference and recovery layouts

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
+++ b/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
@@ -23,7 +23,7 @@ Done:
 - Moved endpoint metadata into a subordinate line, gave Change a 40px hit target, normalized export-dialog spacing inside the reusable production content, and regrouped paused health-data copy into one left-aligned column.
 - Updated the real design studies with stable proof selectors and captured synthetic desktop/mobile states for all three provider labels, export ready, and processing paused.
 - Passed 69 focused component/design tests, hosted Web typecheck, scoped ESLint, the frontend design-proof tests, and native-resolution visual inspection.
-- Confirmed the first remote design-proof failure was metadata-only: the guard requires a top-level catalog registry diff and a relative `/design?tab=…` PR link. Registered the revised headings in both catalog owners; no production behavior changed.
+- Confirmed the first remote design-proof failure was metadata-only: the guard requires a top-level catalog registry diff and a `Design page:` list item containing a visible `/design?tab=…` route. Registered the revised headings in both catalog owners; no production behavior changed.
 
 Now:
 - Commit and push the exact rendered candidate, open the PR, and run the required frontend/product/coverage specialist review plus the Claude UI double-check.

--- a/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
+++ b/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
@@ -1,0 +1,48 @@
+Goal (incl. success criteria):
+- Replace the indirect assistant-provider summary with direct provider-specific copy: `Inference on OpenAI`, `Inference on Venice`, or `Inference on your endpoint`.
+- Clean up the provider summary hierarchy and left-align the export-ready and paused health-data states with consistent vertical spacing at desktop and mobile widths.
+- Success means the real production components and design-catalog studies render the requested hierarchy, focused component tests and typecheck pass, and desktop/mobile catalog captures remain legible.
+
+Constraints/Assumptions:
+- Reuse the existing settings, data-export, health-consent, button, and design-catalog components; add no dependency or abstraction.
+- Preserve current actions, state transitions, accessibility, feature flags, and network behavior.
+- Keep synthetic catalog studies inert and free of real requests.
+
+Key decisions:
+- Treat the provider identity as the summary headline and keep custom endpoint metadata subordinate.
+- Use one left-aligned content column for confirmation and paused states instead of split icon/content geometry.
+- Limit the change to presentation and the requested semantic copy; do not alter settings persistence or privacy behavior.
+
+State:
+- Local implementation complete; PR review and CI pending.
+
+Done:
+- Confirmed the existing custom-inference, export, and health-consent studies and reviewed the supplied desktop states.
+- Loaded the frontend, product, design, verification, completion, and worktree-development guidance.
+- Replaced the provider summary and related settings announcements with direct inference labels for OpenAI, Venice, and the member endpoint.
+- Moved endpoint metadata into a subordinate line, gave Change a 40px hit target, normalized export-dialog spacing inside the reusable production content, and regrouped paused health-data copy into one left-aligned column.
+- Updated the real design studies with stable proof selectors and captured synthetic desktop/mobile states for all three provider labels, export ready, and processing paused.
+- Passed 69 focused component/design tests, hosted Web typecheck, scoped ESLint, the frontend design-proof tests, and native-resolution visual inspection.
+
+Now:
+- Commit and push the exact rendered candidate, open the PR, and run the required frontend/product/coverage specialist review plus the Claude UI double-check.
+
+Next:
+- Resolve any accepted review or CI findings, close the plan through the final scoped commit path, and hand off the live catalog URL.
+
+Open questions (UNCONFIRMED if needed):
+- None blocking; the user explicitly supplied the desired provider-label pattern and alignment direction.
+
+Working set (files/ids/commands):
+- apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+- apps/web/src/components/settings/hosted-data-privacy-settings.tsx
+- apps/web/src/components/settings/hosted-health-data-consent-settings.tsx
+- apps/web/app/design/components-content.tsx
+- apps/web/app/design/settings-custom-inference-study.tsx
+- apps/web/app/design/data-export-study.tsx
+- apps/web/app/design/health-data-consent-study.tsx
+- apps/web/test/hosted-assistant-model-settings.test.tsx
+- apps/web/test/hosted-data-privacy-settings.test.tsx
+- apps/web/test/hosted-health-data-consent-settings.test.tsx
+- pnpm test:frontend-design-proof
+- pnpm --dir apps/web typecheck

--- a/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
+++ b/agent-docs/exec-plans/active/2026-08-04-settings-ui-alignment-polish.md
@@ -23,6 +23,7 @@ Done:
 - Moved endpoint metadata into a subordinate line, gave Change a 40px hit target, normalized export-dialog spacing inside the reusable production content, and regrouped paused health-data copy into one left-aligned column.
 - Updated the real design studies with stable proof selectors and captured synthetic desktop/mobile states for all three provider labels, export ready, and processing paused.
 - Passed 69 focused component/design tests, hosted Web typecheck, scoped ESLint, the frontend design-proof tests, and native-resolution visual inspection.
+- Confirmed the first remote design-proof failure was metadata-only: the guard requires a top-level catalog registry diff and a relative `/design?tab=…` PR link. Registered the revised headings in both catalog owners; no production behavior changed.
 
 Now:
 - Commit and push the exact rendered candidate, open the PR, and run the required frontend/product/coverage specialist review plus the Claude UI double-check.

--- a/agent-docs/exec-plans/completed/2026-08-04-settings-ui-alignment-polish.md
+++ b/agent-docs/exec-plans/completed/2026-08-04-settings-ui-alignment-polish.md
@@ -14,7 +14,7 @@ Key decisions:
 - Limit the change to presentation and the requested semantic copy; do not alter settings persistence or privacy behavior.
 
 State:
-- Local implementation complete; PR review and CI pending.
+- Complete. The implementation, design proof, focused local verification, and exact-head CI are green; no further ReviewGPT runs will be sent per the user's explicit instruction.
 
 Done:
 - Confirmed the existing custom-inference, export, and health-consent studies and reviewed the supplied desktop states.
@@ -24,12 +24,15 @@ Done:
 - Updated the real design studies with stable proof selectors and captured synthetic desktop/mobile states for all three provider labels, export ready, and processing paused.
 - Passed 69 focused component/design tests, hosted Web typecheck, scoped ESLint, the frontend design-proof tests, and native-resolution visual inspection.
 - Confirmed the first remote design-proof failure was metadata-only: the guard requires a top-level catalog registry diff and a `Design page:` list item containing a visible `/design?tab=…` route. Registered the revised headings in both catalog owners; no production behavior changed.
+- Opened draft PR #1292 with hosted desktop/mobile proof for OpenAI, Venice, custom endpoint, export ready, and processing paused.
+- Passed the exact-head GitHub Actions surface: 13 successful checks, including frontend design proof, release build/typecheck, app verification, package coverage, host matrices, repository hygiene, and viewport overflow.
+- Stopped the in-progress preliminary ReviewGPT retry and sent no further reviews after the user's explicit request. The separate automated UI reviewer was unavailable due to exhausted reviewer credits; local native-resolution inspection remains the direct visual proof.
 
 Now:
-- Commit and push the exact rendered candidate, open the PR, and run the required frontend/product/coverage specialist review plus the Claude UI double-check.
+- Archive this plan through the final scoped commit path and hand off the live catalog and PR.
 
 Next:
-- Resolve any accepted review or CI findings, close the plan through the final scoped commit path, and hand off the live catalog URL.
+- None.
 
 Open questions (UNCONFIRMED if needed):
 - None blocking; the user explicitly supplied the desired provider-label pattern and alignment direction.
@@ -47,3 +50,6 @@ Working set (files/ids/commands):
 - apps/web/test/hosted-health-data-consent-settings.test.tsx
 - pnpm test:frontend-design-proof
 - pnpm --dir apps/web typecheck
+Status: completed
+Updated: 2026-08-04
+Completed: 2026-08-04

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1136,7 +1136,7 @@ export function ComponentsContent() {
 
         <Section
           id="assistant-provider-picker"
-          title="Radio Group, Choice Cards & Provider Picker"
+          title="Radio group, choice cards & inference routing"
         >
           <p className="max-w-2xl text-sm text-muted-foreground">
             Compare model choice cards and review the provider privacy and

--- a/apps/web/app/design/data-export-study.tsx
+++ b/apps/web/app/design/data-export-study.tsx
@@ -50,7 +50,10 @@ function DataExportStudyContent() {
           })}
         />
       </div>
-      <div className="rounded-3xl border border-border bg-popover p-6 sm:p-7">
+      <div
+        className="mx-auto w-full max-w-md rounded-3xl border border-border bg-popover p-6 sm:p-7"
+        data-design-state="export-dialog"
+      >
         <HostedDataExportDialogContent
           acknowledgedSensitiveDownload={pending || ready}
           errorMessage={errorMessage}

--- a/apps/web/app/design/health-data-consent-study.tsx
+++ b/apps/web/app/design/health-data-consent-study.tsx
@@ -131,7 +131,7 @@ export function HealthDataConsentWithdrawalFlowStudy() {
       )}
       data-design-section="health-data-consent-withdrawal"
     >
-      <div className="flex min-w-0 flex-col gap-4 border-y border-border py-5">
+      <div className="flex min-w-0 flex-col gap-5 border-y border-border py-5">
         <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
           {presentation === "active" ? "Consent active" : "Consent withdrawn"}
         </p>
@@ -194,7 +194,10 @@ function ConsentStateFrame({
   label: string;
 }) {
   return (
-    <div className="rounded-2xl border border-border bg-background p-5">
+    <div
+      className="rounded-2xl border border-border bg-background p-5"
+      data-design-state={label.toLowerCase().replaceAll(" ", "-")}
+    >
       <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
         {label}
       </p>

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -153,7 +153,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Settings custom inference connection">
+      <StudySection title="Settings custom inference routing and endpoint">
         <SettingsCustomInferenceStudy />
       </StudySection>
 

--- a/apps/web/app/design/settings-custom-inference-study.tsx
+++ b/apps/web/app/design/settings-custom-inference-study.tsx
@@ -9,7 +9,7 @@ export function SettingsCustomInferenceStudy() {
   return (
     <div
       id="settings-custom-inference"
-      className="flex flex-col gap-8"
+      className="mx-auto flex w-full max-w-5xl flex-col gap-8"
       data-design-section="settings-custom-inference"
       inert
     >

--- a/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
+++ b/apps/web/src/components/settings/hosted-assistant-model-settings.tsx
@@ -60,9 +60,9 @@ const VENICE_USAGE_DISCLOSURE =
   "Venice’s higher provider rates use included AI capacity faster.";
 
 /**
- * Where new core replies go. Murph-managed providers and the member's own
- * endpoint are one choice because they answer the same question; the managed
- * provider stays remembered while the endpoint is in use.
+ * Where inference runs. Murph-managed providers and the member's own endpoint
+ * are one choice because they answer the same question; the managed provider
+ * stays remembered while the endpoint is in use.
  */
 export const CUSTOM_INFERENCE_ROUTING = "custom";
 
@@ -199,49 +199,46 @@ export function AssistantProviderSummary({
   const currentName = readRoutingName(currentRouting);
   const draftName = readRoutingName(draftRouting);
   const hasPendingChange = currentRouting !== draftRouting;
+  const displayedName = hasPendingChange ? draftName : currentName;
   const endpointDetail =
     draftRouting === CUSTOM_INFERENCE_ROUTING && connection
       ? `${connection.endpointHost} · ${connection.model}`
       : null;
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1 px-1">
-      <p className="text-sm text-muted-foreground">
-        {hasPendingChange ? (
-          <>
-            Core replies switch to{" "}
-            <span className="font-medium text-foreground">{draftName}</span>{" "}
-            after Save.
-          </>
-        ) : (
-          <>
-            New core replies use{" "}
-            <span className="font-medium text-foreground">{currentName}</span>.
-          </>
-        )}
-        {endpointDetail ? (
-          <span className="ml-1.5 font-mono text-xs [overflow-wrap:anywhere]">
-            {endpointDetail}
-          </span>
-        ) : null}
-      </p>
-      <Button
-        aria-label={
-          hasPendingChange
-            ? `Change where core replies go. Core replies will switch to ${draftName} after Save.`
-            : `Change where core replies go. New core replies use ${currentName}.`
-        }
-        className="text-muted-foreground"
-        disabled={disabled}
-        onClick={onChangeClick}
-        size="xs"
-        type="button"
-        variant="ghost"
-      >
-        Change
-      </Button>
+    <div className="w-full px-1" data-slot="assistant-provider-summary">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0 py-1.5">
+          <p className="text-sm font-medium text-foreground">
+            Inference on {displayedName}
+            {hasPendingChange ? (
+              <span className="font-normal text-muted-foreground"> after Save</span>
+            ) : null}
+          </p>
+          {endpointDetail ? (
+            <p className="mt-1 font-mono text-xs/5 text-muted-foreground [overflow-wrap:anywhere]">
+              {endpointDetail}
+            </p>
+          ) : null}
+        </div>
+        <Button
+          aria-label={
+            hasPendingChange
+              ? `Change inference routing. Inference on ${draftName} after Save.`
+              : `Change inference routing. Inference on ${currentName}.`
+          }
+          className="-my-0.5 -mr-2 min-h-10 px-2 text-muted-foreground"
+          disabled={disabled}
+          onClick={onChangeClick}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          Change
+        </Button>
+      </div>
       {draftRouting === HOSTED_ASSISTANT_VENICE_PROVIDER ? (
-        <p className="basis-full text-xs/5 text-pretty text-muted-foreground">
+        <p className="mt-2 max-w-2xl text-xs/5 text-pretty text-muted-foreground">
           {VENICE_USAGE_DISCLOSURE}
         </p>
       ) : null}
@@ -322,8 +319,8 @@ export function AssistantProviderDialog({
                   }
                 >
                   {routing === CUSTOM_INFERENCE_ROUTING
-                    ? "Selected for core replies"
-                    : "Use for core replies"}
+                    ? "Selected for inference"
+                    : "Use for inference"}
                 </Button>
               ) : null}
             </div>
@@ -335,11 +332,11 @@ export function AssistantProviderDialog({
                 Choose provider
               </DialogTitle>
               <DialogDescription className="max-w-[38ch] text-sm/6">
-                Murph sends core replies here after you save.
+                Inference runs here after you save.
               </DialogDescription>
             </DialogHeader>
             <RadioGroup
-              aria-label="Core reply provider"
+              aria-label="Inference provider"
               className="gap-2"
               value={routing}
               onValueChange={(value) => {
@@ -406,7 +403,7 @@ export function AssistantProviderDialog({
               ) : null}
             </RadioGroup>
             <p className="px-1 text-xs/5 text-pretty text-muted-foreground">
-              The selected provider handles core replies. Image generation,
+              The selected provider handles inference. Image generation,
               voice, search, and other tools still use their specialized
               providers.
             </p>
@@ -637,9 +634,9 @@ function HostedAssistantModelSettingsForm(
       const savedProvider = managed?.provider ?? currentProvider;
       setSaveAnnouncement(
         enteringCustom
-          ? `Saved. New core replies use your endpoint. ${readProductModelName(savedModel)} through ${readProviderName(savedProvider)} stays your managed default.`
+          ? `Saved. Inference on your endpoint. ${readProductModelName(savedModel)} through ${readProviderName(savedProvider)} stays your managed default.`
           : (managed?.dormantSolPreference ?? dormantSolPreference)
-          ? `Saved. New core replies use ${readProductModelName(savedModel)} through ${readProviderName(savedProvider)} while Edge is paused; Sol remains saved.`
+          ? `Saved. Inference on ${readProductModelName(savedModel)} through ${readProviderName(savedProvider)} while Edge is paused; Sol remains saved.`
           : `Saved. ${readProductModelName(savedModel)} through ${readProviderName(savedProvider)} is your default.`,
       );
     } catch (error) {

--- a/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
+++ b/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
@@ -420,10 +420,10 @@ export function HostedDataExportDialogContent({
   pending: boolean;
 }) {
   return (
-    <>
+    <div className="flex flex-col items-stretch gap-6">
       <div className="space-y-2 pr-10">
         <h2
-          className="font-serif text-2xl/7 font-semibold tracking-normal text-foreground"
+          className="font-serif text-2xl/7 font-semibold tracking-normal text-balance text-foreground"
           id="hosted-data-export-title"
         >
           Export your data
@@ -444,7 +444,7 @@ export function HostedDataExportDialogContent({
           {errorMessage}
         </p>
       ) : null}
-      <div className="flex items-start gap-4 text-sm leading-relaxed text-foreground">
+      <div className="flex items-start gap-3 text-sm leading-relaxed text-foreground">
         <Checkbox
           checked={acknowledgedSensitiveDownload}
           className="size-7 shrink-0"
@@ -452,7 +452,7 @@ export function HostedDataExportDialogContent({
           onCheckedChange={onAcknowledgedChange}
         />
         <label
-          className="cursor-pointer"
+          className="cursor-pointer pt-0.5 text-pretty"
           htmlFor="hosted-data-export-acknowledge"
         >
           This export may contain sensitive health data and private notes.
@@ -480,7 +480,7 @@ export function HostedDataExportDialogContent({
           Cancel
         </Button>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/apps/web/src/components/settings/hosted-health-data-consent-settings.tsx
+++ b/apps/web/src/components/settings/hosted-health-data-consent-settings.tsx
@@ -224,58 +224,62 @@ export function HostedHealthDataConsentControl({
   const unavailable = presentation === "unavailable";
 
   return (
-    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-3 border-b border-border pb-4 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
-      {active ? (
-        <ShieldCheck
-          aria-hidden="true"
-          className="mt-0.5 size-[18px] shrink-0 text-muted-foreground"
-          strokeWidth={1.6}
-        />
-      ) : (
-        <ShieldOff
-          aria-hidden="true"
-          className="mt-0.5 size-[18px] shrink-0 text-muted-foreground"
-          strokeWidth={1.6}
-        />
-      )}
-      <div className="min-w-0">
-        <div className="font-serif text-base tracking-tight text-foreground">
-          Health data use
-        </div>
-        <p
-          aria-live="polite"
-          className={`mt-0.5 text-xs leading-5 ${
-            unavailable && errorMessage
-              ? "text-destructive"
-              : "text-muted-foreground"
-          }`}
-        >
-          {active
-            ? "Used to personalize Murph"
-            : paused
-              ? "Processing paused"
-              : presentation === "not-enabled"
-                ? "Not enabled"
-                : statusPending
-                  ? "Checking status..."
-                  : errorMessage ?? "Status unavailable"}
-        </p>
-        {active || paused ? (
-          <div className="mt-2">
-            <Link
-              className="relative inline-flex self-start text-sm font-medium text-primary underline-offset-4 hover:underline before:absolute before:-inset-x-2 before:-inset-y-2 before:content-['']"
-              href="/connect"
-            >
-              {paused ? "Review source disconnections" : "Review or reconnect sources"}
-            </Link>
+    <div className="grid grid-cols-1 items-start gap-4 border-b border-border pb-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+      <div className="flex min-w-0 items-start gap-3">
+        {active ? (
+          <ShieldCheck
+            aria-hidden="true"
+            className="mt-0.5 size-[18px] shrink-0 text-muted-foreground"
+            strokeWidth={1.6}
+          />
+        ) : (
+          <ShieldOff
+            aria-hidden="true"
+            className="mt-0.5 size-[18px] shrink-0 text-muted-foreground"
+            strokeWidth={1.6}
+          />
+        )}
+        <div className="min-w-0">
+          <div className="font-serif text-base tracking-tight text-foreground">
+            Health data use
           </div>
-        ) : null}
+          <p
+            aria-live="polite"
+            className={`mt-0.5 text-xs leading-5 ${
+              unavailable && errorMessage
+                ? "text-destructive"
+                : "text-muted-foreground"
+            }`}
+          >
+            {active
+              ? "Used to personalize Murph"
+              : paused
+                ? "Processing paused"
+                : presentation === "not-enabled"
+                  ? "Not enabled"
+                  : statusPending
+                    ? "Checking status..."
+                    : errorMessage ?? "Status unavailable"}
+          </p>
+          {active || paused ? (
+            <div className="mt-2">
+              <Link
+                className="relative inline-flex min-h-10 items-center self-start text-sm font-medium text-primary underline-offset-4 hover:underline before:absolute before:-inset-x-2 before:content-['']"
+                href="/connect"
+              >
+                {paused ? "Review source disconnections" : "Review or reconnect sources"}
+              </Link>
+            </div>
+          ) : null}
+        </div>
       </div>
       <Button
         className={
-          active
-            ? "col-start-2 justify-self-start sm:col-start-auto sm:justify-self-end"
-            : "col-span-2 w-full sm:col-span-1 sm:w-auto sm:self-start"
+          paused
+            ? "w-full sm:col-span-2"
+            : active
+              ? "ml-[30px] justify-self-start sm:ml-0 sm:justify-self-end"
+              : "w-full sm:w-auto sm:self-start"
         }
         disabled={pending}
         onClick={onAction}

--- a/apps/web/src/components/settings/hosted-inference-connection-settings.tsx
+++ b/apps/web/src/components/settings/hosted-inference-connection-settings.tsx
@@ -67,7 +67,7 @@ interface ConnectionMutationResponse {
 
 /**
  * Endpoint pane of the provider dialog: verify, replace, and delete the one
- * personal connection. Selecting it for core replies is the dialog's job, so a
+ * personal connection. Selecting it for inference is the dialog's job, so a
  * successful verification here deliberately leaves the connection inactive.
  */
 export function HostedInferenceConnectionPane(
@@ -146,7 +146,7 @@ export function HostedInferenceConnectionPane(
       setConfirmDelete(false);
       setStatus({
         message:
-          "Verified and saved. Choose Your endpoint and save to route new core replies to it.",
+          "Verified and saved. Choose Your endpoint and save to route inference to it.",
         tone: "neutral",
       });
       requestAnimationFrame(() => connectionHeadingRef.current?.focus());
@@ -181,7 +181,7 @@ export function HostedInferenceConnectionPane(
       setSecret("");
       setStatus({
         announcement:
-          "Connection deleted. New core replies use Murph-managed inference.",
+          "Connection deleted. Inference is now Murph-managed.",
         message: "Connection deleted.",
         tone: "neutral",
       });
@@ -273,7 +273,7 @@ export function HostedInferenceConnectionPane(
                   id="hosted-inference-delete-description"
                 >
                   {props.selected
-                    ? "Delete the saved endpoint and credential? New core replies will switch to Murph-managed inference."
+                    ? "Delete the saved endpoint and credential? Inference will return to your managed provider."
                     : "Delete the saved endpoint and credential?"}
                 </span>
                 <Button

--- a/apps/web/test/data-export-design-study.test.tsx
+++ b/apps/web/test/data-export-design-study.test.tsx
@@ -47,6 +47,8 @@ test("renders the retained-export ready study from the production content", () =
   const markup = renderToStaticMarkup(createElement(DataExportFlowStudy));
 
   expect(markup).toContain("Download my data");
+  expect(markup).toContain("flex flex-col items-stretch gap-6");
+  expect(markup).toContain("max-w-md");
   expect(markup).not.toContain("Preparing...");
 });
 
@@ -82,4 +84,5 @@ test("renders pending renewed consent from the production prompt", () => {
 
   expect(markup).toContain("Saving...");
   expect(markup).toContain("Use Murph again");
+  expect(markup).toContain("sm:grid-cols-[minmax(0,1fr)_auto]");
 });

--- a/apps/web/test/hosted-assistant-model-settings.test.tsx
+++ b/apps/web/test/hosted-assistant-model-settings.test.tsx
@@ -203,9 +203,9 @@ test("custom inference marks the model cards as the managed default", () => {
     );
     assert.match(markup, /Managed default/u);
     // One control owns where replies go, even when Venice is unavailable.
-    assert.match(markup, /New core replies use/u);
+    assert.match(markup, /Inference on/u);
   }
-  assert.match(withVenice, /New core replies use.*OpenAI/su);
+  assert.match(withVenice, /Inference on OpenAI/u);
 });
 
 test("the routing dialog offers the member's endpoint as a third option", () => {
@@ -236,7 +236,7 @@ test("the routing dialog offers the member's endpoint as a third option", () => 
 
   // A routed endpoint is described where the provider choice lives, so there
   // is no second inference control to reconcile.
-  assert.match(markup, /New core replies use.*your endpoint/su);
+  assert.match(markup, /Inference on your endpoint/u);
   assert.match(markup, /inference\.example\.test · example-model/u);
 });
 
@@ -260,7 +260,7 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
       veniceAvailable: true,
     }),
   );
-  assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
+  assert.match(view.container.textContent ?? "", /Inference on OpenAI/u);
   assert.doesNotMatch(
     view.container.textContent ?? "",
     /higher provider rates use included AI capacity faster/u,
@@ -279,11 +279,11 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   );
   assert.match(
     view.document.body.textContent ?? "",
-    /Murph sends core replies here after you save\./u,
+    /Inference runs here after you save\./u,
   );
   assert.match(
     view.document.body.textContent ?? "",
-    /The selected provider handles core replies\. Image generation, voice, search, and other tools still use their specialized providers\./u,
+    /The selected provider handles inference\. Image generation, voice, search, and other tools still use their specialized providers\./u,
   );
   const providerDialog = view.document.querySelector<HTMLElement>(
     '[role="dialog"]',
@@ -309,7 +309,7 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
   assert.equal(view.document.querySelector('[role="dialog"]'), null);
   assert.match(
     view.container.textContent ?? "",
-    /Core replies switch to Venice after Save\./u,
+    /Inference on Venice after Save/u,
   );
   assert.match(
     view.container.textContent ?? "",
@@ -328,7 +328,7 @@ test("members can switch the provider without changing Terra, Luna, or Sol", asy
     },
     url: "/api/settings/assistant-model",
   });
-  assert.match(view.container.textContent ?? "", /New core replies use Venice\./u);
+  assert.match(view.container.textContent ?? "", /Inference on Venice/u);
   assert.match(
     view.container.textContent ?? "",
     /Venice’s higher provider rates use included AI capacity faster\./u,
@@ -357,7 +357,7 @@ test("a saved Venice provider discloses its higher included-capacity use", () =>
     }),
   );
 
-  assert.match(markup, /New core replies use.*Venice/su);
+  assert.match(markup, /Inference on Venice/u);
   assert.match(
     markup,
     /Venice’s higher provider rates use included AI capacity faster\./u,
@@ -392,7 +392,7 @@ test("one save routes replies to the endpoint and keeps the managed default", as
     }),
   );
 
-  assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
+  assert.match(view.container.textContent ?? "", /Inference on OpenAI/u);
   await act(async () => {
     findButton(view.container, "Change").click();
   });
@@ -408,7 +408,7 @@ test("one save routes replies to the endpoint and keeps the managed default", as
   assert.equal(view.document.querySelector('[role="dialog"]'), null);
   assert.match(
     view.container.textContent ?? "",
-    /Core replies switch to your endpoint after Save\./u,
+    /Inference on your endpoint after Save/u,
   );
   // Selecting is a draft: nothing is durable until the single Save runs.
   expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
@@ -429,11 +429,11 @@ test("one save routes replies to the endpoint and keeps the managed default", as
   });
   assert.match(
     view.container.textContent ?? "",
-    /New core replies use your endpoint\./u,
+    /Inference on your endpoint/u,
   );
   assertHiddenSaveAnnouncement(
     view.container,
-    /Saved\. New core replies use your endpoint\. Terra through OpenAI stays your managed default\./u,
+    /Saved\. Inference on your endpoint\. Terra through OpenAI stays your managed default\./u,
   );
   view.cleanup();
 });
@@ -487,7 +487,7 @@ test("leaving an active endpoint changes the managed provider before routing", a
   });
   assert.match(
     view.container.textContent ?? "",
-    /Core replies switch to Venice after Save\./u,
+    /Inference on Venice after Save/u,
   );
   assert.equal(findButton(view.container, "Save change").disabled, false);
 
@@ -509,7 +509,7 @@ test("leaving an active endpoint changes the managed provider before routing", a
     payload: { mode: "managed" },
     url: "/api/settings/assistant",
   });
-  assert.match(view.container.textContent ?? "", /New core replies use Venice\./u);
+  assert.match(view.container.textContent ?? "", /Inference on Venice/u);
   assert.ok(findButton(view.container, "Save change").disabled);
 
   view.cleanup();
@@ -590,7 +590,7 @@ test("retrying a failed endpoint exit preserves dormant Sol", async () => {
   }
   assertHiddenSaveAnnouncement(
     view.container,
-    /Saved\. New core replies use Terra through Venice while Edge is paused; Sol remains saved\./u,
+    /Saved\. Inference on Terra through Venice while Edge is paused; Sol remains saved\./u,
   );
 
   view.cleanup();
@@ -643,9 +643,9 @@ test("the shown route is derived from the durable connection, not a copy", () =>
     }),
   );
 
-  assert.match(active, /New core replies use.*your endpoint/su);
-  assert.match(replaced, /New core replies use.*OpenAI/su);
-  assert.doesNotMatch(replaced, /New core replies use.*your endpoint/su);
+  assert.match(active, /Inference on your endpoint/u);
+  assert.match(replaced, /Inference on OpenAI/u);
+  assert.doesNotMatch(replaced, /Inference on your endpoint/u);
 });
 
 test("the routing dialog is not inside the settings form", async () => {
@@ -769,7 +769,7 @@ test("closing the provider dialog leaves the draft unchanged", async () => {
   });
 
   assert.equal(view.document.querySelector('[role="dialog"]'), null);
-  assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
+  assert.match(view.container.textContent ?? "", /Inference on OpenAI/u);
   assert.ok(saveButton.disabled);
   expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
 
@@ -810,7 +810,7 @@ test("a model-only save adopts the server's canonical provider", async () => {
     payload: { model: HOSTED_ASSISTANT_LUNA_MODEL },
     url: "/api/settings/assistant-model",
   });
-  assert.match(view.container.textContent ?? "", /New core replies use OpenAI\./u);
+  assert.match(view.container.textContent ?? "", /Inference on OpenAI/u);
   assertHiddenSaveAnnouncement(
     view.container,
     /Saved\. Luna through OpenAI is your default\./u,
@@ -880,7 +880,7 @@ test("a provider-only save preserves a dormant Sol preference", async () => {
   assert.equal(findHiddenSaveAnnouncement(view.container), announcement);
   assert.match(
     announcement.textContent ?? "",
-    /Saved\. New core replies use Terra through Venice while Edge is paused; Sol remains saved\./u,
+    /Saved\. Inference on Terra through Venice while Edge is paused; Sol remains saved\./u,
   );
   assert.equal(findButton(view.container, "Save change").disabled, false);
 
@@ -941,7 +941,7 @@ test("a combined provider and model save preserves both choices for retry", asyn
   );
   assert.match(
     view.container.textContent ?? "",
-    /Core replies switch to Venice after Save\./u,
+    /Inference on Venice after Save/u,
   );
   assert.ok(isRadioChecked(solInput));
   assert.equal(findButton(view.container, "Save change").disabled, false);
@@ -957,7 +957,7 @@ test("a combined provider and model save preserves both choices for retry", asyn
     payload: combinedPayload,
     url: "/api/settings/assistant-model",
   });
-  assert.match(view.container.textContent ?? "", /New core replies use Venice\./u);
+  assert.match(view.container.textContent ?? "", /Inference on Venice/u);
   assertHiddenSaveAnnouncement(
     view.container,
     /Saved\. Sol through Venice is your default\./u,
@@ -1363,7 +1363,7 @@ test("a stale Venice page falls back to OpenAI and removes the unavailable choic
     view.container.textContent ?? "",
     /Venice is no longer available\. Murph will keep using OpenAI\./,
   );
-  assert.doesNotMatch(view.container.textContent ?? "", /Core replies/u);
+  assert.doesNotMatch(view.container.textContent ?? "", /Inference on/u);
   assert.equal(findOptionalButton(view.container, "Change"), undefined);
   assert.ok(findButton(view.container, "Save change").disabled);
 
@@ -1526,7 +1526,7 @@ test("members without active personal access see both provider and model control
     markup,
     /Provider and model choices are read-only until personal Murph access is active\./,
   );
-  assert.match(markup, /New core replies use.*OpenAI/su);
+  assert.match(markup, /Inference on OpenAI/u);
   assert.match(markup, /<button[^>]*disabled=""[^>]*>Change<\/button>/u);
   assert.doesNotMatch(markup, /Choose provider/u);
 });

--- a/apps/web/test/hosted-health-data-consent-settings.test.tsx
+++ b/apps/web/test/hosted-health-data-consent-settings.test.tsx
@@ -122,7 +122,7 @@ test("renders separate active and paused consent controls", async () => {
   expect(active.container.textContent).toContain("Withdraw consent");
   const sourceReviewLink = active.container.querySelector('a[href="/connect"]');
   expect(sourceReviewLink?.textContent).toContain("Review or reconnect sources");
-  expect(sourceReviewLink?.className).toContain("before:-inset-y-2");
+  expect(sourceReviewLink?.className).toContain("min-h-10");
   expect(sourceReviewLink?.parentElement?.className).toContain("mt-2");
   expect(active.container.firstElementChild?.className).toContain("items-start");
 
@@ -140,6 +140,12 @@ test("renders separate active and paused consent controls", async () => {
 
   expect(paused.container.textContent).toContain("Processing paused");
   expect(paused.container.textContent).toContain("Use Murph again");
+  expect(paused.container.firstElementChild?.className).toContain(
+    "sm:grid-cols-[minmax(0,1fr)_auto]",
+  );
+  expect(findButton(paused.container, "Use Murph again").className).toContain(
+    "sm:col-span-2",
+  );
 });
 
 test("renders legacy missing and unavailable consent states without treating either as withdrawn", async () => {

--- a/apps/web/test/hosted-inference-connection-settings.test.tsx
+++ b/apps/web/test/hosted-inference-connection-settings.test.tsx
@@ -229,7 +229,7 @@ describe("hosted inference connection pane", () => {
       );
       assert.doesNotMatch(
         view.container.textContent ?? "",
-        /will switch to Murph-managed inference/u,
+        /Inference will return to your managed provider/u,
       );
     } finally {
       await view.cleanup();

--- a/apps/web/test/hosted-inference-connection-settings.test.tsx
+++ b/apps/web/test/hosted-inference-connection-settings.test.tsx
@@ -174,7 +174,7 @@ describe("hosted inference connection pane", () => {
       assert.deepEqual(connectionChanges, [savedConnection(false)]);
       assert.match(
         view.container.textContent ?? "",
-        /Choose Your endpoint and save to route new core replies to it/u,
+        /Choose Your endpoint and save to route inference to it/u,
       );
       assert.equal(nonEmptyLiveRegions(view.container).length, 1);
     } finally {
@@ -200,7 +200,7 @@ describe("hosted inference connection pane", () => {
       });
       assert.match(
         view.container.textContent ?? "",
-        /New core replies will switch to Murph-managed inference/u,
+        /Inference will return to your managed provider/u,
       );
     } finally {
       await view.cleanup();


### PR DESCRIPTION
## Why this PR exists

The settings design catalog exposed indirect, visually loose status copy around inference routing, data export confirmation, and paused health-data processing. This PR makes those states read as one clear hierarchy without changing their behavior.

## User goal / user-visible behavior

Members can immediately see whether inference runs on OpenAI, Venice, or their own endpoint. The export confirmation and paused health-data controls keep their content left-aligned with consistent vertical spacing on desktop and mobile.

## User experience

- Entry points remain the existing Settings model, data privacy, and health-data controls.
- Inference routing now reads `Inference on OpenAI`, `Inference on Venice`, or `Inference on your endpoint`; a pending selection adds `after Save`.
- Custom endpoint host/model metadata moves to a quiet second line, while Change keeps a 40px hit target.
- Export confirmation content owns one consistent vertical stack inside the production dialog.
- Paused health-data content keeps the icon, heading, status, and recovery link in one left-anchored group, with the existing full-width recovery action below.
- Save, download, consent, retry, failure, and recovery behavior is unchanged; this is immediate presentation feedback with no asynchronous continuation added.

## Invariants

- Inference connection selection and managed-provider persistence remain owned by their existing routes and state.
- Export acknowledgement and sensitive-action authorization remain unchanged.
- Health-data consent authority, withdrawal/resume behavior, and source-disconnection recovery remain unchanged.
- Design studies use synthetic props, remain inert, and make no real requests.

## Non-obvious affected surfaces

- The custom inference delete confirmation and live-region announcement use the same inference terminology. Focused connection-component tests cover both selected and inactive deletion.
- No other production subsystem is affected.

## Architecture and reuse

- **Existing systems reused:** Existing `AssistantProviderSummary`, `HostedDataExportDialogContent`, `HostedHealthDataConsentControl`, shared buttons, design studies, and focused component tests.
- **New logic:** Only provider-specific presentation text and responsive layout classes at the existing component owners.
- **New abstractions:** None; the existing shared production components already own every affected state.
- **Complexity intentionally avoided:** No duplicate status component, layout wrapper, state owner, dependency, animation, or API change.

## Hot reply path impact

Not applicable. This changes Settings presentation only and adds no operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

Not applicable for individual and group Murph. No prompt, tool description/schema, model configuration, or provider-request assembly changed.

## Preliminary specialist lenses

- **Product experience: applicable.** Intended outcome: provider identity and recovery states are readable at a glance. Direct journey evidence is the synthetic Settings catalog at the linked desktop/mobile captures.
- **Prompt: not applicable.** No prompt or provider-visible instruction changed.
- **Frontend: applicable.** Redacted synthetic captures below cover OpenAI, Venice, custom endpoint, export-ready, and processing-paused states at 1440px desktop/2x and 390px mobile/3x.
- **Coverage: applicable.** Focused proof: 69 tests across the five affected component/design suites, hosted Web typecheck, scoped ESLint, and frontend design-proof tests. Exact-head CI passed on the final test-remediation head.

## Preliminary specialist result

- ReviewGPT inspected exact head `112af8b4e0` with all ten rendered-evidence images and returned `SPECIALIST_OUTCOME: FINDINGS`.
- Accepted: the inactive-endpoint deletion test still rejected the removed sentence instead of the current selected-only warning. The assertion now rejects `Inference will return to your managed provider`; the focused suite passes 7/7.
- Rejected: reverting the provider headline to “New core replies use …” directly conflicts with the requested `Inference on OpenAI/Venice/your endpoint` wording. The provider dialog retains the explicit disclosure that image generation, voice, search, and other tools use specialized providers.
- No frontend finding: all supplied desktop/mobile renders were readable without clipping, overflow, hierarchy collapse, or undersized controls.

## Change-shape breakdown

Classification: `apps/web/src` and `apps/web/app/design` are source; `apps/web/test` is tests/fixtures; the execution plan is docs; no config/tooling, generated files, or binaries are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 116 | 109 |
| Tests/fixtures | 39 | 30 |
| Docs | 55 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **210** | **139** |

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-assistant-model-settings.test.tsx apps/web/test/hosted-inference-connection-settings.test.tsx apps/web/test/hosted-data-privacy-settings.test.ts apps/web/test/hosted-health-data-consent-settings.test.tsx apps/web/test/data-export-design-study.test.tsx` — 69 passed.
- `pnpm --dir apps/web typecheck` — passed.
- Scoped ESLint over all touched Web source/test files — passed.
- `pnpm test:frontend-design-proof` — 10 passed.
- Playwright-rendered desktop/mobile catalog captures inspected at native resolution — passed.
- Exact-head GitHub Actions — 13 successful checks, 0 failures on the final test-remediation head.

## Design proof

Catalog routes:
- Design page: `/design?tab=sections#settings-custom-inference`
- [/design?tab=components](/design?tab=components)
- [Custom inference states](http://localhost:3248/design?tab=sections#settings-custom-inference)
- [Export ready](http://localhost:3248/design?tab=sections&study=data-export-ready)
- [Health-data controls](http://localhost:3248/design?tab=components)

OpenAI:
- Desktop screenshot: ![OpenAI inference summary desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/29fa3c39-a2c1-433c-939a-9a48df5f6600/designproof)
- Mobile screenshot: ![OpenAI inference summary mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e48d39fe-0d2c-4eb9-7201-9741d8eac600/designproof)

Venice:
- Desktop screenshot: ![Venice inference summary desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/f4b98925-dc88-4721-3610-029b744fb600/designproof)
- Mobile screenshot: ![Venice inference summary mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/91c5140c-611f-410f-e085-018fe29bde00/designproof)

Custom endpoint:
- Desktop screenshot: ![Custom inference summary desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e64f23f0-0d62-4235-398d-553de943ec00/designproof)
- Mobile screenshot: ![Custom inference summary mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/8174ff4c-c5fe-4a28-b2b6-52171e1bfe00/designproof)

Export ready:
- Desktop screenshot: ![Export ready desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1eeee964-8bd4-431e-e23f-e2d313c96200/designproof)
- Mobile screenshot: ![Export ready mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/f85d9150-8514-4650-46f9-2119ef41ab00/designproof)

Processing paused:
- Desktop screenshot: ![Processing paused desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/af8daaf8-ba1a-4e12-9a3f-b0509c2a9c00/designproof)
- Mobile screenshot: ![Processing paused mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/dada2a28-13f0-4100-50de-5fce4ec00b00/designproof)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472848&installation_model_id=19880&pr_number=1292&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1292&signature=069a01baa37f7744102d522fafa4f21c58fbe729056eb04587139cc1e0587b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->