### PR TITLE
docs(web): publish August 1 through 4 changelog

### DIFF
--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -80,10 +80,6 @@ const RAW_CHANGELOG_EDITIONS = [
           "Murph verifies a public HTTPS endpoint, encrypts its connection details, and never silently falls back to a managed model if the custom route fails. Murph's health tools and other hosted services keep their existing funding and privacy boundaries.",
         relevanceTags: ["assistant", "models", "settings", "privacy"],
         sourcePullRequests: [1202],
-        tryIt: {
-          href: "/settings",
-          label: "Open model settings",
-        },
       },
       {
         id: "health-data-consent-controls",
@@ -97,7 +93,7 @@ const RAW_CHANGELOG_EDITIONS = [
         relevanceTags: ["privacy", "consent", "health-data", "settings"],
         sourcePullRequests: [1215],
         tryIt: {
-          href: "/settings",
+          href: "/settings/data-privacy",
           label: "Open privacy settings",
         },
       },

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -340,7 +340,7 @@ const RAW_CHANGELOG_EDITIONS = [
         summary:
           "Murph can turn a generated image and an explicitly approved message into one complimentary physical note from an eligible conversation.",
         details:
-          "Sending requires the postal destination and exact message authority. The address, artwork, note, and image prompt do not get saved as plaintext conversation memory, and a retry cannot silently create another claim.",
+          "Sending requires the postal destination and exact message authority. The physical-note delivery record does not store the postal address, artwork, note text, or image prompt; conversation history follows Murph's existing retention rules, and a retry cannot silently create another claim.",
         relevanceTags: ["notes", "mail", "images", "privacy"],
         sourcePullRequests: [1199, 1248],
       },

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -63,6 +63,462 @@ export interface ChangelogPage {
 
 const RAW_CHANGELOG_EDITIONS = [
   {
+    id: "2026-08-04",
+    publishedOn: "2026-08-04",
+    title: "More control over data, models, and connections",
+    summary:
+      "You can bring a compatible model endpoint, pause health-data processing, ask for a nutrition card, disconnect one wearable source, and get clearer recovery across usage, device sync, physical notes, photos, and follow-up timing.",
+    items: [
+      {
+        id: "custom-inference-endpoint",
+        kind: "feature",
+        priority: 5,
+        title: "Bring your own model endpoint",
+        summary:
+          "Settings now lets you use Murph's managed models or a compatible custom endpoint for core replies in your personal conversation.",
+        details:
+          "Murph verifies a public HTTPS endpoint, encrypts its connection details, and never silently falls back to a managed model if the custom route fails. Murph's health tools and other hosted services keep their existing funding and privacy boundaries.",
+        relevanceTags: ["assistant", "models", "settings", "privacy"],
+        sourcePullRequests: [1202],
+        tryIt: {
+          href: "/settings",
+          label: "Open model settings",
+        },
+      },
+      {
+        id: "health-data-consent-controls",
+        kind: "feature",
+        priority: 5,
+        title: "Pause health-data processing",
+        summary:
+          "Health data use in Settings now includes a consent-withdrawal flow that pauses health-data processing without locking you out of Settings, export, or account deletion.",
+        details:
+          "A confirmation explains the effect before anything changes. Processing stays paused until you explicitly choose to use Murph again and renew consent, including across wearable sync and assistant runtime paths.",
+        relevanceTags: ["privacy", "consent", "health-data", "settings"],
+        sourcePullRequests: [1215],
+        tryIt: {
+          href: "/settings",
+          label: "Open privacy settings",
+        },
+      },
+      {
+        id: "daily-nutrition-cards",
+        kind: "feature",
+        priority: 5,
+        title: "Ask for today's nutrition card",
+        summary:
+          "In a private conversation, you can ask for a daily nutrition card with the current totals for calories, protein, carbohydrates, fat, and fiber.",
+        details:
+          "When the date and data are clear, the card can also show an exact saved goal and status. Missing goals stay missing, uncertain dates fall back to a normal reply, and group or unrelated scheduled turns do not produce the card.",
+        relevanceTags: ["nutrition", "imessage", "goals", "health-data"],
+        sourcePullRequests: [1104, 1280],
+        tryIt: {
+          label: "Ask for today's nutrition card",
+          prompt: "Show me today's nutrition card.",
+        },
+      },
+      {
+        id: "single-source-wearable-disconnect",
+        kind: "feature",
+        priority: 5,
+        title: "Disconnect one wearable source at a time",
+        summary:
+          "The Connections page can now remove one selected wearable source without disconnecting your other sources or deleting their history.",
+        details:
+          "The chosen source keeps its imported history but stops future sync. A failed removal stays recoverable, and reconnect-required cards now expose the same source-specific action.",
+        relevanceTags: ["wearables", "connect", "settings", "privacy"],
+        sourcePullRequests: [1274],
+        tryIt: {
+          href: "/connect",
+          label: "Manage connections",
+        },
+      },
+      {
+        id: "database-first-nutrition-estimates",
+        kind: "improvement",
+        priority: 5,
+        title: "Food estimates start with label data",
+        summary:
+          "Murph now looks up a nutrition label or food-database match for each identifiable part of a meal before estimating its nutrients.",
+        details:
+          "Portions still come from the photo and conversation, while sauces, fats, drinks, and exact supplement labels stay explicit. A general estimate is used only when database and official-source lookup cannot resolve the food.",
+        relevanceTags: ["nutrition", "meals", "images", "health-data"],
+        sourcePullRequests: [1278],
+      },
+      {
+        id: "physical-note-address-completion",
+        kind: "improvement",
+        priority: 5,
+        title: "Physical notes need fewer address follow-ups",
+        summary:
+          "When you provide a destination for an approved physical note, Murph can temporarily complete a missing city, state, or ZIP code from the address you supplied.",
+        details:
+          "The lookup cannot discover where someone lives, saved prompts and notes never gain the address, and Murph's platform-owned return address stays separate from the recipient destination.",
+        relevanceTags: ["notes", "mail", "privacy", "assistant"],
+        sourcePullRequests: [1261, 1266],
+      },
+      {
+        id: "capacity-without-message-estimates",
+        kind: "improvement",
+        priority: 4,
+        title: "Capacity answers stay in percentages and dates",
+        summary:
+          "Murph no longer turns remaining AI capacity into a guessed number of messages, even when you ask how many replies are left.",
+        details:
+          "Usage answers use the known percentage, reset date, trial date, or day-level forecast instead. They do not pretend that differently sized requests consume a predictable message count.",
+        relevanceTags: ["usage", "billing", "assistant", "settings"],
+        sourcePullRequests: [1265],
+      },
+      {
+        id: "venice-provider-rate-usage",
+        kind: "improvement",
+        priority: 4,
+        title: "Venice usage reflects its provider rate",
+        summary:
+          "Replies sent through Venice now consume included AI capacity at the underlying provider rate instead of using the managed-model price.",
+        details:
+          "Settings explains that this choice can use capacity faster. The change applies to new usage only and does not reprice earlier replies.",
+        relevanceTags: ["assistant", "models", "venice", "usage"],
+        sourcePullRequests: [1277],
+      },
+      {
+        id: "device-sync-artifact-retries",
+        kind: "improvement",
+        priority: 4,
+        title: "Device sync retries transient write failures",
+        summary:
+          "A temporary failure while saving a replay-safe device-sync artifact now retries through the existing sync job instead of ending the import immediately.",
+        details:
+          "Only safe transient writes retry. Permanent errors still stop with their specific failure, and the retry does not create a second import or duplicate user action.",
+        relevanceTags: ["wearables", "sync", "reliability", "health-data"],
+        sourcePullRequests: [1269],
+      },
+      {
+        id: "foreground-after-checkpoint-wake",
+        kind: "improvement",
+        priority: 4,
+        title: "New messages keep priority after a wake",
+        summary:
+          "A newly accepted message now keeps foreground priority when it arrives just after Murph wakes from a saved checkpoint.",
+        details:
+          "The change is invisible when timing is normal. In the race it fixes, the new message reaches the ordinary reply path instead of waiting behind restored background work.",
+        relevanceTags: ["messaging", "assistant", "reliability", "performance"],
+        sourcePullRequests: [1273],
+      },
+      {
+        id: "group-photo-reference-reuse",
+        kind: "improvement",
+        priority: 4,
+        title: "Group photo references carry forward",
+        summary:
+          "Murph now keeps a bounded room index of captions, positions, and corrections for recent group photos, then checks it before asking for another upload.",
+        details:
+          "References stay tied to the conversation and do not use face recognition. Corrections can update which known photo the group means without turning the image into an identity record.",
+        relevanceTags: ["groups", "images", "memory", "privacy"],
+        sourcePullRequests: [1289],
+      },
+      {
+        id: "usage-denials-preserve-pending-work",
+        kind: "improvement",
+        priority: 4,
+        title: "Usage limits no longer turn into runtime errors",
+        summary:
+          "When managed AI usage is exhausted, accepted work stays safely pending instead of being mislabeled as a runtime failure during a background wake.",
+        details:
+          "Murph does not consume the conversation or call a metered model while access is denied. The existing usage message explains the block, and the existing continuation path can resume after capacity changes.",
+        relevanceTags: ["usage", "reliability", "assistant", "messaging"],
+        sourcePullRequests: [1283],
+      },
+    ],
+  },
+  {
+    id: "2026-08-03",
+    publishedOn: "2026-08-03",
+    title: "Connected apps recover with a clearer next step",
+    summary:
+      "Large connected-app results now stay bounded and useful, so Murph can narrow the request or explain the real failure without losing the conversation.",
+    items: [
+      {
+        id: "connected-app-results-stay-in-turn",
+        kind: "improvement",
+        priority: 5,
+        title: "Oversized app results can be narrowed in place",
+        summary:
+          "When a connected app returns more data than one reply can safely use, Murph now compacts the result and can narrow or retry the request in the same turn.",
+        details:
+          "A genuinely failed app call keeps its specific safe error instead of looking like an oversized success. Raw service responses stay outside the model conversation.",
+        relevanceTags: ["connected-apps", "assistant", "reliability", "privacy"],
+        sourcePullRequests: [1259],
+      },
+    ],
+  },
+  {
+    id: "2026-08-02",
+    publishedOn: "2026-08-02",
+    title: "Recovery that stops at the right moment",
+    summary:
+      "Phone transfer, group signup, contact setup, and physical-note delivery now recover from partial completion without repeating work that already succeeded.",
+    items: [
+      {
+        id: "phone-transfer-recovery",
+        kind: "improvement",
+        priority: 5,
+        title: "Phone transfer recovery recognizes success",
+        summary:
+          "Linking or changing your phone now repairs incomplete local setup while recognizing when the external transfer already finished.",
+        details:
+          "Murph stops retrying a terminal transfer, preserves the correct home-line route, retires a disposable source account only when it is safe, and shows the existing contact-support path when automatic repair cannot finish.",
+        relevanceTags: ["phone", "settings", "onboarding", "reliability"],
+        sourcePullRequests: [1191, 1255, 1267],
+      },
+      {
+        id: "unknown-group-signup-recovery",
+        kind: "feature",
+        priority: 5,
+        title: "An unknown group can start with signup",
+        summary:
+          "When someone who is not active yet messages Murph in a supported group, the group can receive one first-party signup link instead of reaching a dead end.",
+        details:
+          "The page handles signup only and does not let anyone claim a room or choose an owner. After activation, the next ordinary message continues through the existing group route without duplicate capacity or follow-up claims.",
+        relevanceTags: ["groups", "signup", "onboarding", "messaging"],
+        sourcePullRequests: [1221, 1257],
+      },
+      {
+        id: "physical-note-claim-recovery",
+        kind: "improvement",
+        priority: 5,
+        title: "Physical-note sends recover after partial completion",
+        summary:
+          "A physical note that was approved but stranded between claim and delivery can now resume without consuming a second complimentary send.",
+        details:
+          "Clear refusals explain whether the note needs approval, an address, or remaining eligibility. A retry reuses the existing claim and preserves the exact approved message.",
+        relevanceTags: ["notes", "mail", "reliability", "privacy"],
+        sourcePullRequests: [1260],
+      },
+      {
+        id: "contact-card-line-recovery",
+        kind: "improvement",
+        priority: 4,
+        title: "Contact setup does not stall on one unusable line",
+        summary:
+          "Contact-card setup now moves past an unusable unowned line and distinguishes that case from a complete line-inventory outage.",
+        details:
+          "A healthy available line can still finish setup. If no trustworthy inventory can be loaded, Murph surfaces the outage for recovery instead of silently choosing or retrying the wrong line.",
+        relevanceTags: ["contacts", "phone", "onboarding", "reliability"],
+        sourcePullRequests: [1244, 1253],
+      },
+    ],
+  },
+  {
+    id: "2026-08-01",
+    publishedOn: "2026-08-01",
+    title: "More ways to finish what you started",
+    summary:
+      "Environment reports can finish and print, physical notes can leave the chat, support can receive a private escalation, and group, signup, reminder, connection, and reply flows keep more of their context.",
+    items: [
+      {
+        id: "environment-processing-and-print",
+        kind: "feature",
+        priority: 5,
+        title: "Finish, revisit, and print your Environment report",
+        summary:
+          "The Environment page now keeps checking a voice memo until processing finishes, reports progress without a manual reload, and offers a private print view beside Share.",
+        details:
+          "Signed-out members return to Environment after login. On iOS, the microphone-permission handoff keeps the walkthrough mounted, and moving the page to the background safely ends an active recording.",
+        relevanceTags: ["environment", "voice", "privacy", "accessibility"],
+        sourcePullRequests: [1228, 1238, 1251],
+        tryIt: {
+          href: "/environment",
+          label: "Open Environment",
+        },
+      },
+      {
+        id: "physical-notes-from-chat",
+        kind: "feature",
+        priority: 5,
+        title: "Send a physical note from your conversation",
+        summary:
+          "Murph can turn a generated image and an explicitly approved message into one complimentary physical note from an eligible conversation.",
+        details:
+          "Sending requires the postal destination and exact message authority. The address, artwork, note, and image prompt do not get saved as plaintext conversation memory, and a retry cannot silently create another claim.",
+        relevanceTags: ["notes", "mail", "images", "privacy"],
+        sourcePullRequests: [1199, 1248],
+      },
+      {
+        id: "direct-product-support-escalation",
+        kind: "feature",
+        priority: 5,
+        title: "Ask Murph to escalate to product support",
+        summary:
+          "In a verified private conversation, an explicit request for product support can queue a de-identified escalation to the support team.",
+        details:
+          "Murph does not promise a ticket number or response time. Group conversations receive the support email and a direction to continue privately, and the site footer now exposes the same direct support address.",
+        relevanceTags: ["support", "assistant", "privacy", "settings"],
+        sourcePullRequests: [1247],
+      },
+      {
+        id: "calendar-aware-reminder-availability",
+        kind: "feature",
+        priority: 5,
+        title: "Reminders can respect busy calendar time",
+        summary:
+          "A reminder with skip-when-busy or calendar-only availability can now use the busy timestamps from your connected calendar to decide whether to send.",
+        details:
+          "Calendar titles, attendees, locations, and descriptions never enter the model. If availability cannot be checked safely, the ordinary reminder sends instead of silently disappearing.",
+        relevanceTags: ["reminders", "calendar", "privacy", "automations"],
+        sourcePullRequests: [1204],
+      },
+      {
+        id: "one-action-challenge-entry",
+        kind: "feature",
+        priority: 5,
+        title: "One clear reaction can enter a challenge",
+        summary:
+          "A recent native reaction can now confirm the exact unchanged terms of a group challenge and move that participant into the finalized challenge in one action.",
+        details:
+          "The shortcut applies only when the participant, scope, terms, and timing all match. Ambiguous or changed terms still require the existing explicit confirmation.",
+        relevanceTags: ["groups", "challenges", "reactions", "consent"],
+        sourcePullRequests: [1217],
+      },
+      {
+        id: "group-reactions-shape-room-memory",
+        kind: "improvement",
+        priority: 5,
+        title: "Group reactions now shape room memory",
+        summary:
+          "Supported group reactions now become durable room evidence even when nobody sends another message afterward.",
+        details:
+          "Adds, removals, custom reactions, and bounded reaction summaries can help Murph learn what lands in the room without triggering a reply by themselves. Reaction evidence stays out of private member memory.",
+        relevanceTags: ["groups", "reactions", "memory", "privacy"],
+        sourcePullRequests: [1212],
+      },
+      {
+        id: "group-casing-room-tone",
+        kind: "feature",
+        priority: 4,
+        title: "A group can set Murph's casing style",
+        summary:
+          "A persistent request for sentence case or capitalization now moves the room toward a formal tone, while a persistent lowercase request moves it toward casual.",
+        details:
+          "A one-reply formatting request stays temporary. The preference belongs to the room rather than changing a participant's private conversation style.",
+        relevanceTags: ["groups", "tone", "personalization", "conversation"],
+        sourcePullRequests: [1239],
+      },
+      {
+        id: "signup-handoffs-stay-on-course",
+        kind: "improvement",
+        priority: 5,
+        title: "Signup returns to the place that invited you",
+        summary:
+          "Native companion signup now reuses the hosted onboarding flow, and a first web sign-in still reaches the welcome handoff even when texting created the member record earlier.",
+        details:
+          "Reacting to an eligible group invite can open one link-free private signup conversation. Consent and activation remain required, and returning members keep their existing destination instead of being sent through first-visit setup again.",
+        relevanceTags: ["signup", "onboarding", "groups", "mobile"],
+        sourcePullRequests: [1222, 1226, 1243],
+      },
+      {
+        id: "wearable-connect-finish-and-recover",
+        kind: "improvement",
+        priority: 5,
+        title: "Wearable connection returns finish itself",
+        summary:
+          "After you approve a wearable connection, the callback now completes automatically and returns to the Connections result without an extra confirmation screen.",
+        details:
+          "If setup fails, the notice explains what happened and offers the relevant next action: log in, try again, or contact support. The signed-out and successful paths keep their original destination.",
+        relevanceTags: ["wearables", "connect", "onboarding", "reliability"],
+        sourcePullRequests: [1252, 1256],
+        tryIt: {
+          href: "/connect",
+          label: "Open Connections",
+        },
+      },
+      {
+        id: "late-followups-stay-eligible",
+        kind: "improvement",
+        priority: 5,
+        title: "Late follow-ups still get their turn",
+        summary:
+          "A follow-up that arrives too late to affect the current answer now stays pending for the next ordinary reply instead of being recorded as already handled.",
+        details:
+          "Optional delegated work can also finish after the first reply and return when it is relevant to the next message. Neither path delays the current answer or invents a second background conversation.",
+        relevanceTags: ["assistant", "conversation", "reliability", "delegation"],
+        sourcePullRequests: [1218, 1219],
+      },
+      {
+        id: "image-errors-explain-the-failure",
+        kind: "improvement",
+        priority: 4,
+        title: "Image failures explain what happened",
+        summary:
+          "A failed image generation or group-avatar delivery now returns a safe, useful reason through the original conversation instead of ending with a vague failure.",
+        details:
+          "Documented service errors keep their actionable category without exposing raw responses. Murph does not automatically repeat an image request that may have already been accepted.",
+        relevanceTags: ["images", "groups", "reliability", "messaging"],
+        sourcePullRequests: [1216, 1227],
+      },
+      {
+        id: "bounded-onboarding-followup",
+        kind: "improvement",
+        priority: 4,
+        title: "Onboarding gets one useful follow-up",
+        summary:
+          "After signup, Murph can send one bounded follow-up with a single easy question when the conversation still needs a natural next step.",
+        details:
+          "The attempt is spread away from the signup moment, never retries forever, and does not turn into a nag sequence when you do not answer.",
+        relevanceTags: ["onboarding", "conversation", "messaging", "reliability"],
+        sourcePullRequests: [1203],
+      },
+      {
+        id: "daily-wrong-line-redirect",
+        kind: "improvement",
+        priority: 4,
+        title: "The wrong direct chat can point home again",
+        summary:
+          "If you message an old or non-home Murph line directly, that chat can send one short redirect per day with your current home number.",
+        details:
+          "The reminder is link-free, appears only after a new inbound message, and does not create scheduled outreach from the wrong line.",
+        relevanceTags: ["phone", "messaging", "onboarding", "reliability"],
+        sourcePullRequests: [1224],
+      },
+      {
+        id: "dashboard-refresh-stays-in-place",
+        kind: "improvement",
+        priority: 4,
+        title: "Dashboard refresh stays on the current page",
+        summary:
+          "Returning focus to the dashboard now refreshes account data in the background while keeping the current page mounted.",
+        details:
+          "The update no longer jumps through a blank or replacement state when the existing screen is already usable.",
+        relevanceTags: ["dashboard", "settings", "performance", "accessibility"],
+        sourcePullRequests: [1235],
+      },
+      {
+        id: "faster-first-imessage-reply",
+        kind: "improvement",
+        priority: 4,
+        title: "The first iMessage reply starts sooner",
+        summary:
+          "Murph now prewarms the reply service for instant-start conversations and begins the typing hint after durable work is accepted.",
+        details:
+          "The hint stops on failure and does not count as a message. The actual reply keeps the existing durable delivery path.",
+        relevanceTags: ["imessage", "performance", "messaging", "reliability"],
+        sourcePullRequests: [1246],
+      },
+      {
+        id: "higher-group-daily-text-capacity",
+        kind: "improvement",
+        priority: 4,
+        title: "Active group chats have more daily room",
+        summary:
+          "The daily safeguard for supported group chats now allows up to 400 inbound texts, twice the previous limit.",
+        details:
+          "The higher limit applies to group activity only. Personal-chat safeguards and the existing handling after the group limit remain unchanged.",
+        relevanceTags: ["groups", "messaging", "usage", "reliability"],
+        sourcePullRequests: [],
+      },
+    ],
+  },
+  {
     id: "2026-07-31",
     publishedOn: "2026-07-31",
     title: "A clearer view of home, stronger follow-through",

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -106,8 +106,9 @@ describe("ChangelogPage", () => {
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
     );
 
-    expect(markup).toContain("Open model settings");
+    expect(markup).not.toContain("Open model settings");
     expect(markup).toContain("Open privacy settings");
+    expect(markup).toContain('href="/settings/data-privacy"');
     expect(markup).toContain("Ask for today&#x27;s nutrition card");
     expect(markup).toContain("Manage connections");
     expect(markup).toContain("Open Environment");

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -90,6 +90,13 @@ describe("ChangelogPage", () => {
     expect(markup).toContain(
       'href="/changelog?edition=2026-08-04#custom-inference-endpoint"',
     );
+    expect(markup).toContain(
+      "The physical-note delivery record does not store the postal address",
+    );
+    expect(markup).toContain(
+      "conversation history follows Murph&#x27;s existing retention rules",
+    );
+    expect(markup).not.toContain("plaintext conversation memory");
     expect(markup).toContain("Older");
     expect(markup).not.toContain(">Newer<");
   });

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -57,14 +57,16 @@ describe("ChangelogPage", () => {
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
     );
 
+    expect(markup).toContain("More control over data, models, and connections");
+    expect(markup).toContain(
+      "Connected apps recover with a clearer next step",
+    );
+    expect(markup).toContain("Recovery that stops at the right moment");
+    expect(markup).toContain("More ways to finish what you started");
     expect(markup).toContain("A clearer view of home, stronger follow-through");
     expect(markup).toContain("More ways through, less waiting around");
     expect(markup).toContain("Corrections that carry forward");
-    expect(markup).toContain("A first text that goes somewhere");
-    expect(markup).toContain("Reminders on your time, not ours");
-    expect(markup).toContain("Group memory, clearer recovery");
-    expect(markup).toContain("A Murph that knows when to speak");
-    expect(markup).not.toContain("Group chats that read the room");
+    expect(markup).not.toContain("A first text that goes somewhere");
     expect(markup).not.toContain(
       "Updated documents, honest reactions, usage you can see",
     );
@@ -84,9 +86,9 @@ describe("ChangelogPage", () => {
     expect(markup).not.toContain("Better answers, better instincts");
     expect(markup).not.toContain("Murph referees your group challenge");
     expect(markup).toContain('aria-label="Changelog pages"');
-    expect(markup).toContain('href="/changelog?edition=2026-07-24"');
+    expect(markup).toContain('href="/changelog?edition=2026-07-28"');
     expect(markup).toContain(
-      'href="/changelog?edition=2026-07-31#private-environment-report"',
+      'href="/changelog?edition=2026-08-04#custom-inference-endpoint"',
     );
     expect(markup).toContain("Older");
     expect(markup).not.toContain(">Newer<");
@@ -97,26 +99,22 @@ describe("ChangelogPage", () => {
       await ChangelogPage({ searchParams: Promise.resolve({}) }),
     );
 
-    expect(markup).toContain("Ask about X");
-    expect(markup).toContain("Turn it up");
+    expect(markup).toContain("Open model settings");
+    expect(markup).toContain("Open privacy settings");
+    expect(markup).toContain("Ask for today&#x27;s nutrition card");
+    expect(markup).toContain("Manage connections");
     expect(markup).toContain("Open Environment");
     expect(markup).toContain('href="/environment"');
-    expect(markup).toContain("Explore club challenges");
-    expect(markup).toContain('href="/clubs"');
+    expect(markup).toContain("Open Connections");
+    expect(markup).toContain('href="/connect"');
     expect(
       mocks.resolveHostedMurphContactOptions.mock.calls.map(([input]) => input),
     ).toEqual(
       expect.arrayContaining([
         {
           message: {
-            body: "What are people on X saying about zone 2 training this week?",
-            subject: "Try it: Ask Grok what people are saying on X",
-          },
-        },
-        {
-          message: {
-            body: "Turn up my Unhinged setting a little.",
-            subject: "Try it: Ask Murph to loosen up",
+            body: "Show me today's nutrition card.",
+            subject: "Try it: Ask for today's nutrition card",
           },
         },
       ]),
@@ -131,9 +129,15 @@ describe("ChangelogPage", () => {
   });
 
   it("renders explanatory visuals for the major new features", async () => {
-    const markup = renderToStaticMarkup(
-      await ChangelogPage({ searchParams: Promise.resolve({}) }),
-    );
+    const [latestPage, olderPage] = await Promise.all([
+      ChangelogPage({ searchParams: Promise.resolve({}) }),
+      ChangelogPage({
+        searchParams: Promise.resolve({ edition: "2026-07-28" }),
+      }),
+    ]);
+    const markup = [latestPage, olderPage]
+      .map((page) => renderToStaticMarkup(page))
+      .join("\n");
 
     expect(markup).toContain("Add usage");
     expect(markup).toContain("Add to Contacts");

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -193,13 +193,99 @@ describe("changelog registry", () => {
     });
   });
 
-  it("publishes the complete July 20 through July 31 shipment set", () => {
+  it("keeps the August 1 through August 4 privacy and recovery claims bounded", () => {
+    const items = new Map(
+      listPublishedChangelogItems().map((item) => [item.id, item]),
+    );
+
+    expect(items.get("custom-inference-endpoint")).toMatchObject({
+      sourcePullRequests: [1202],
+      details: expect.stringContaining("never silently falls back"),
+    });
+    expect(items.get("health-data-consent-controls")).toMatchObject({
+      sourcePullRequests: [1215],
+      summary: expect.stringContaining("without locking you out"),
+    });
+    expect(items.get("daily-nutrition-cards")).toMatchObject({
+      sourcePullRequests: [1104, 1280],
+      details: expect.stringContaining("Missing goals stay missing"),
+    });
+    expect(items.get("physical-note-address-completion")).toMatchObject({
+      sourcePullRequests: [1261, 1266],
+      details: expect.stringContaining("cannot discover where someone lives"),
+    });
+    expect(items.get("phone-transfer-recovery")).toMatchObject({
+      sourcePullRequests: [1191, 1255, 1267],
+      details: expect.stringContaining("stops retrying a terminal transfer"),
+    });
+    expect(items.get("calendar-aware-reminder-availability")).toMatchObject({
+      sourcePullRequests: [1204],
+      details: expect.stringContaining("never enter the model"),
+    });
+    expect(items.get("group-reactions-shape-room-memory")).toMatchObject({
+      sourcePullRequests: [1212],
+      details: expect.stringContaining("out of private member memory"),
+    });
+  });
+
+  it("publishes the complete July 20 through August 4 shipment set", () => {
     expect(
-      listChangelogEditions().slice(0, 12).map((edition) => ({
+      listChangelogEditions().slice(0, 16).map((edition) => ({
         id: edition.id,
         itemIds: edition.items.map((item) => item.id),
       })),
     ).toEqual([
+      {
+        id: "2026-08-04",
+        itemIds: [
+          "custom-inference-endpoint",
+          "health-data-consent-controls",
+          "daily-nutrition-cards",
+          "single-source-wearable-disconnect",
+          "database-first-nutrition-estimates",
+          "physical-note-address-completion",
+          "capacity-without-message-estimates",
+          "venice-provider-rate-usage",
+          "device-sync-artifact-retries",
+          "foreground-after-checkpoint-wake",
+          "group-photo-reference-reuse",
+          "usage-denials-preserve-pending-work",
+        ],
+      },
+      {
+        id: "2026-08-03",
+        itemIds: ["connected-app-results-stay-in-turn"],
+      },
+      {
+        id: "2026-08-02",
+        itemIds: [
+          "phone-transfer-recovery",
+          "unknown-group-signup-recovery",
+          "physical-note-claim-recovery",
+          "contact-card-line-recovery",
+        ],
+      },
+      {
+        id: "2026-08-01",
+        itemIds: [
+          "environment-processing-and-print",
+          "physical-notes-from-chat",
+          "direct-product-support-escalation",
+          "calendar-aware-reminder-availability",
+          "one-action-challenge-entry",
+          "group-reactions-shape-room-memory",
+          "group-casing-room-tone",
+          "signup-handoffs-stay-on-course",
+          "wearable-connect-finish-and-recover",
+          "late-followups-stay-eligible",
+          "image-errors-explain-the-failure",
+          "bounded-onboarding-followup",
+          "daily-wrong-line-redirect",
+          "dashboard-refresh-stays-in-place",
+          "faster-first-imessage-reply",
+          "higher-group-daily-text-capacity",
+        ],
+      },
       {
         id: "2026-07-31",
         itemIds: [
@@ -526,8 +612,8 @@ describe("changelog registry", () => {
   it("keeps the default archive window to seven calendar days", () => {
     const firstPage = resolveChangelogPage(1);
     expect(firstPage?.editions).toHaveLength(7);
-    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-07-31");
-    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-25");
+    expect(firstPage?.editions[0]?.publishedOn).toBe("2026-08-04");
+    expect(firstPage?.editions.at(-1)?.publishedOn).toBe("2026-07-29");
   });
 
   it("resolves only known canonical edition cursors", () => {

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -202,9 +202,14 @@ describe("changelog registry", () => {
       sourcePullRequests: [1202],
       details: expect.stringContaining("never silently falls back"),
     });
+    expect(items.get("custom-inference-endpoint")?.tryIt).toBeUndefined();
     expect(items.get("health-data-consent-controls")).toMatchObject({
       sourcePullRequests: [1215],
       summary: expect.stringContaining("without locking you out"),
+      tryIt: {
+        href: "/settings/data-privacy",
+        label: "Open privacy settings",
+      },
     });
     expect(items.get("daily-nutrition-cards")).toMatchObject({
       sourcePullRequests: [1104, 1280],

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -214,6 +214,15 @@ describe("changelog registry", () => {
       sourcePullRequests: [1261, 1266],
       details: expect.stringContaining("cannot discover where someone lives"),
     });
+    expect(items.get("physical-notes-from-chat")).toMatchObject({
+      sourcePullRequests: [1199, 1248],
+      details: expect.stringContaining(
+        "conversation history follows Murph's existing retention rules",
+      ),
+    });
+    expect(items.get("physical-notes-from-chat")?.details).not.toContain(
+      "plaintext conversation memory",
+    );
     expect(items.get("phone-transfer-recovery")).toMatchObject({
       sourcePullRequests: [1191, 1255, 1267],
       details: expect.stringContaining("stops retrying a terminal transfer"),


### PR DESCRIPTION
## Why this PR exists

The public changelog stopped at July 31 even though four more days of member-visible features and improvements have shipped. This PR publishes that missing release history and leaves internal-only migrations, logging, tests, and build work out of the public record.

## User goal / user-visible behavior

Members can open `/changelog` and see the material August 1 through August 4 shipments in reverse chronological order, with bounded explanations, source PR attribution, useful try-it actions, stable permalinks, and the existing older-edition archive.

## User experience

The entry point remains the public changelog. The server-rendered page immediately shows the latest seven dated editions, now August 4 through July 29, and the existing `Older` action opens the July 28 window. Four new editions cover member control over models, consent, nutrition, and connections; physical-note launch and recovery; Environment, signup, support, reminder, group, and reply improvements; and the shipped reliability fixes that materially change a member's experience.

There is no new screen, loading state, background continuation, or user decision. The longest normal wait is the existing page load. Entry try-it controls keep the current Settings, Connections, Environment, or private-conversation handoff. A Playwright journey rendered the real page at 1440px desktop and 390px mobile widths, found the August 4 edition and representative entries, and proved the archive now continues at July 28.

## Invariants the PR must preserve

- Every new claim stays bounded to shipped member-visible behavior and names its source PRs when the work landed through a PR.
- Internal service details, raw errors, private member data, and operator-only work stay out of published copy.
- Changelog edition and item IDs remain unique; existing IDs, dates, permalinks, pagination, and historical copy remain stable.
- Privacy, consent, billing, health-data, and action-authority wording does not promise more than the merged implementation provides.
- The update adds no persisted state, route, component, runtime behavior, or deployment dependency.

## Non-obvious affected surfaces

- **Archive pagination:** four new dated editions move the page-one boundary from July 25 to July 29 and page two to July 28. The rendered page and registry tests pin both boundaries and the first new permalink.
- **Try-it handoff:** the newest page adds the resumable Data & privacy entry, Connections, Environment, and one private nutrition-card prompt. The custom-model note has no public action because no intent-preserving model-settings entry exists. The page and registry tests pin those decisions and the exact prefilled message.
- **Physical-note privacy semantics:** the public entry distinguishes the address-free delivery record from ordinary conversation history, which continues to follow Murph's existing retention rules. Registry and rendered-page assertions pin that boundary and reject the prior overstatement.
- **Changelog preview metadata:** the existing preview builder now naturally selects the newest August items. Metadata and route tests continue to derive those cards from the registry instead of duplicating IDs.

## Architecture and reuse

- **Existing systems reused:** the typed changelog registry, existing edition/item schema, server-rendered archive page, pagination helpers, try-it resolver, card metadata builder, and real changelog design study.
- **New logic:** four immutable edition records and focused expectations for their exact item sets, claims, newest archive window, try-it controls, and shifted visual-test boundary.
- **New abstractions:** none. The current `ChangelogEdition` and `ChangelogItem` contracts already express every release note and attribution needed here.
- **Complexity intentionally avoided:** no release generator, dependency, new visual map, duplicate page, state owner, or runtime fetch was added; the public record remains static typed content.

## Hot reply path impact

Not applicable. The diff changes static changelog content and its tests only; it adds no work between conversation acceptance, provider start, or durable reply handoff.

## Murph initial provider input impact

- **Individual Murph:** Not applicable. No prompt builder, instruction, tool schema, skill, model mode, or provider-request assembly changed.
- **Group Murph:** Not applicable for the same reason. The one try-it string is member-facing prefilled message copy, not an assistant instruction or provider wrapper.

## Preliminary specialist lenses

- **Product experience: applicable.** The outcome is a complete, plain-language public record of member-visible shipments since July 31. Direct evidence is the desktop/mobile Playwright journey through `/changelog`, including the newest edition, representative entries, and the July 28 archive continuation.
- **Prompt: not applicable.** No assistant prompt, instruction stack, tool description, skill, or provider-input assembly changed.
- **Frontend: applicable.** The hosted design-proof links below show the real corrected physical-note card at 1440px/2x and 390px/3x. Review packages also include current-head model-card, privacy-action, top/newest-edition, and archive-navigation captures at both widths.
- **Coverage: applicable.** The focused registry, route, and rendered-page suites pass 36 tests; hosted-web typecheck and scoped ESLint pass. Exact-head GitHub Actions rerun on the remediation head concurrently with review.

## Change-shape breakdown

Classification rule: `apps/web/src/lib/changelog.ts` is authored source; `apps/web/test/**` is tests/fixtures. No docs, config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 452 | 0 |
| Tests/fixtures | 138 | 26 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **590** | **26** |

## Design proof

- Design page: [Changelog archive study](https://withmurph.ai/design?tab=sections#changelog-archive)
- Desktop screenshot: ![Desktop physical-note changelog card](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/a8a86297-b48c-471d-235e-ae60cdf6ec00/designproof)
- Mobile screenshot: ![Mobile physical-note changelog card](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/23212fd7-eaff-4ca9-b879-3beb7adb3300/designproof)

Both local captures and hosted variants were inspected at native resolution. They show the real public changelog item with the corrected retention copy and contain no private data.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/changelog.test.ts apps/web/test/changelog-page.test.tsx apps/web/test/changelog-routes.test.ts` (36 tests passed)
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web exec eslint src/lib/changelog.ts test/changelog.test.ts test/changelog-page.test.tsx`
- `pnpm test:frontend-design-proof` (10 tests passed)
- desktop/mobile Playwright journey through `/changelog` and `/design?tab=sections`
- `git diff --check` and new-copy em-dash scan

The separate Fable UI double-check was attempted after rendered evidence stabilized and stopped at explicit usage-credit exhaustion, as required by the completion workflow.

## Deployment skew / compatibility

Not applicable. This is static web content with no schema, API, Worker, runner, provider, or persisted-state contract change.

## Review gate

ReviewGPT first-reviewed head: 092449e05e54dc264e519432e8c027702bda4c41

Final round 1 found that one physical-note sentence overstated conversation non-retention. Head `051a479ad63a` replaced that promise with the actual delivery-record boundary, pinned it in registry and rendered-page tests, and passed correction round 2. The valid preliminary specialist pass then found that two public Settings actions lost signed-out intent. Current head `7d52f0c524e2` routes privacy through the existing resumable `/settings/data-privacy` entry, omits the model action until an equivalent entry exists, and pins both decisions in focused tests. The first round-3 response required the retrospective below and current-head action evidence; the same-head retry passed with no qualifying findings after verifying both fixes, the existing auth-resume owner, the focused tests, and the four current action captures.

### Round-3 anomaly retrospective

- **Original requirement:** publish one truthful, member-visible changelog record for all August 1–4 shipments since the July 31 update, reusing the existing typed registry, archive page, and action handoffs.
- **First-reviewed shape:** `092449e05e54` added 456 source lines and 116/26 test lines across four editions and 33 items. It introduced no route, state, runtime owner, dependency, or schema, but one privacy sentence was too broad and two Settings actions used a generic destination.
- **Current shape and review attribution:** `7d52f0c524e2` has 452 source additions and 138/26 test lines. Since the first review, remediation is +2/-6 source and +23/-1 tests: round 1 narrowed the physical-note storage claim; the specialist pass deleted the unsupported model action and rerouted privacy through the existing resumable entry. The two findings have distinct mechanisms—public retention wording versus signed-out destination intent—and no mechanism repeated.
- **Concepts and ownership:** no owner, state machine, route, queue, compatibility path, or abstraction was added. The registry remains the only changelog source of truth, `/settings/data-privacy` remains the auth-resume owner, and the unsupported model-action concept was deleted.
- **Decision:** continue this PR as one static-content change. The source patch shrank, both corrections stay within existing owners, and splitting one four-day public release record would add coordination without reducing product or architectural risk. No redesign or further machinery is justified.
