### PR TITLE
Add Venice memory request diagnostics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-04-memory-provider-observability.md
+++ b/agent-docs/exec-plans/completed/2026-08-04-memory-provider-observability.md
@@ -1,0 +1,47 @@
+# Memory Provider Observability
+
+## Goal
+
+Make hosted Codex memory-model traffic reconstructable from Murph's existing
+redacted runtime-log database, especially when Venice is selected, without
+persisting prompts, responses, vault content, credentials, or raw Codex
+session/thread/turn identifiers.
+
+## Constraints
+
+- Reuse `runner.provider_egress_diagnostic` and the existing signed runtime-log
+  callback; do not add a database, queue, or second observability owner.
+- Keep provider egress and assistant execution fail-open with respect to
+  diagnostic capture.
+- Record only bounded request shape, allowlisted provider/model metadata,
+  response status/timing, and keyed identifier fingerprints.
+- Preserve OpenAI diagnostic behavior and unrelated work.
+
+## Plan
+
+1. Generalize the existing Responses request diagnostic so Venice can use the
+   same bounded request-shape and cache-prefix evidence as OpenAI.
+2. Add Venice request routing and response-header metadata, including canonical
+   and upstream model kinds, HTTP outcome, elapsed time, retry count, and a
+   validated provider correlation id.
+3. Add HMAC-only Codex session/thread/turn/window correlation fields when the
+   hosted log fingerprint secret is configured.
+4. Add focused Cloudflare tests for memory classification, repeated-turn
+   correlation, provider routing, response metadata, and redaction.
+5. Update the hosted runtime-log contract docs, run focused tests and
+   typecheck, review the diff, then complete the PR verification workflow.
+
+## Verification
+
+- `pnpm --dir apps/cloudflare test:node apps/cloudflare/test/runner-egress-intercept.test.ts`
+  passed (219 tests).
+- `pnpm --dir apps/cloudflare typecheck` passed.
+- `pnpm logs:guard` passed.
+- `bash scripts/workspace-verify.sh test:diff ...` passed, including 2,190
+  Cloudflare node tests and 3 Worker tests.
+- `git diff --check` and the scoped identifier/privacy review passed.
+- Exact-head CI and the required ReviewGPT gates remain part of the PR
+  completion workflow after this plan is archived and committed.
+Status: completed
+Updated: 2026-08-04
+Completed: 2026-08-04

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -18,6 +18,9 @@ import {
   type HostedExecutionStructuredLogDetails,
 } from "@murphai/hosted-execution";
 import {
+  HOSTED_ASSISTANT_VENICE_PROVIDER_MODELS,
+} from "@murphai/hosted-execution/assistant-model";
+import {
   HOSTED_RUNTIME_LOG_PATH,
 } from "@murphai/hosted-execution/routes";
 import {
@@ -215,9 +218,12 @@ const OPENAI_CACHE_DIAGNOSTIC_MODEL_KINDS = new Set([
   "o3-mini",
   "o4-mini",
 ]);
+const VENICE_CACHE_DIAGNOSTIC_MODEL_KINDS: ReadonlySet<string> = new Set(
+  Object.values(HOSTED_ASSISTANT_VENICE_PROVIDER_MODELS),
+);
 export const HOSTED_OPENAI_CACHE_DIAGNOSTIC_EVENT_CODE =
   "runner.provider_egress_diagnostic";
-const HOSTED_OPENAI_CACHE_DIAGNOSTIC_VERSION = 1;
+const HOSTED_OPENAI_CACHE_DIAGNOSTIC_VERSION = 2;
 const OPENAI_CACHE_DIAGNOSTIC_CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata";
 const OPENAI_CACHE_DIAGNOSTIC_MAX_JSON_BYTES = 6 * 1024 * 1024;
 const OPENAI_CACHE_DIAGNOSTIC_MAX_FULL_FINGERPRINT_BYTES = 256 * 1024;
@@ -413,6 +419,7 @@ const HOSTED_PLATFORM_METERED_PROVIDER_KINDS = new Set([
 ]);
 
 export type HostedOpenAiCacheDiagnosticEndpointKind = "responses" | "responses_compact";
+type HostedResponsesDiagnosticProviderKind = "openai" | "venice";
 type HostedRunnerDiagnosticScalar = boolean | null | number | string;
 export type HostedRunnerDiagnosticJson = Record<
   string,
@@ -1541,19 +1548,63 @@ async function maybeHandleVeniceRequest(input: {
   headers.set("authorization", `Bearer ${token}`);
   headers.set("content-type", "application/json");
 
-  return await fetchAuthorizedProviderUpstream({
-    authorization,
+  const upstreamRequest = await createHostedRunnerUpstreamRequest(
+    input.request,
+    createProviderUpstreamUrl(input.url, pathMatch),
+    headers,
+    { body: upstreamBody },
+  );
+  const diagnosticBody = upstreamRequest.clone();
+  const canonicalModelKind = readHostedResponsesRequestModelKind(body);
+  let response: Response;
+  try {
+    response = await fetchAuthorizedProviderUpstream({
+      authorization,
+      providerKind: "venice",
+      request: input.request,
+      startedAt,
+      upstreamRequest,
+      url: input.url,
+    });
+  } catch (error) {
+    const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
+      canonicalModelKind,
+      ctx: input.ctx ?? null,
+      endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
+      env: input.env,
+      providerKind: "venice",
+      providerResponseTtfbMs: Date.now() - startedAt,
+      providerTransportFailed: true,
+      request: input.request,
+      upstreamRequestBody: diagnosticBody,
+      userId: authorization.userId,
+      writeFence: authorization.writeFence,
+    });
+    await scheduleOrAwaitHostedProviderDiagnostic({
+      ctx: input.ctx ?? null,
+      promise: diagnosticPromise,
+    });
+    throw error;
+  }
+
+  const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
+    canonicalModelKind,
+    ctx: input.ctx ?? null,
+    endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
+    env: input.env,
     providerKind: "venice",
+    providerResponseTtfbMs: Date.now() - startedAt,
     request: input.request,
-    startedAt,
-    upstreamRequest: await createHostedRunnerUpstreamRequest(
-      input.request,
-      createProviderUpstreamUrl(input.url, pathMatch),
-      headers,
-      { body: upstreamBody },
-    ),
-    url: input.url,
+    response,
+    upstreamRequestBody: diagnosticBody,
+    userId: authorization.userId,
+    writeFence: authorization.writeFence,
   });
+  await scheduleOrAwaitHostedProviderDiagnostic({
+    ctx: input.ctx ?? null,
+    promise: diagnosticPromise,
+  });
+  return response;
 }
 
 async function maybeHandleElevenLabsRequest(input: {
@@ -1936,6 +1987,25 @@ function readOpenAiCacheDiagnosticEndpointKind(
   return null;
 }
 
+function readVeniceCacheDiagnosticEndpointKind(
+  pathnameSuffix: string,
+): HostedOpenAiCacheDiagnosticEndpointKind {
+  return pathnameSuffix === "/responses/compact"
+    ? "responses_compact"
+    : "responses";
+}
+
+function readHostedResponsesRequestModelKind(body: ArrayBuffer): string | null {
+  try {
+    const parsed = JSON.parse(OPENAI_CACHE_DIAGNOSTIC_TEXT_DECODER.decode(body));
+    return isHostedOpenAiDiagnosticRecord(parsed)
+      ? readStringRecordProperty(parsed, "model")
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 async function readDeploySmokeLiveModelTurnOpenAiModel(input: {
   pathnameSuffix: string;
   request: Request;
@@ -1956,11 +2026,31 @@ async function readDeploySmokeLiveModelTurnOpenAiModel(input: {
   );
 }
 
+async function scheduleOrAwaitHostedProviderDiagnostic(input: {
+  ctx: HostedRunnerOutboundContext | null;
+  promise: Promise<void>;
+}): Promise<void> {
+  if (typeof input.ctx?.waitUntil !== "function") {
+    await input.promise;
+    return;
+  }
+  try {
+    input.ctx.waitUntil(input.promise);
+  } catch {
+    await input.promise;
+  }
+}
+
 async function emitHostedRunnerOpenAiCacheDiagnostic(input: {
+  canonicalModelKind?: string | null;
   ctx: HostedRunnerOutboundContext | null;
   endpointKind: HostedOpenAiCacheDiagnosticEndpointKind;
   env: RunnerOutboundEnvironmentSource;
+  providerKind?: HostedResponsesDiagnosticProviderKind;
+  providerResponseTtfbMs?: number;
+  providerTransportFailed?: boolean;
   request: Request;
+  response?: Response;
   upstreamRequestBody: HostedRunnerDiagnosticBodySource;
   userId: string | null;
   writeFence: HostedProviderEgressWriteFenceMetadata | null;
@@ -1969,13 +2059,22 @@ async function emitHostedRunnerOpenAiCacheDiagnostic(input: {
   try {
     const requestBytes = new Uint8Array(await input.upstreamRequestBody.arrayBuffer());
     diagnostic = await buildHostedOpenAiCacheDiagnostic({
+      canonicalModelKind: input.canonicalModelKind ?? null,
       endpointKind: input.endpointKind,
       fingerprintSecret: readOpenAiCacheDiagnosticFingerprintSecret(input.env),
       method: input.request.method,
+      providerKind: input.providerKind ?? "openai",
       requestBytes,
       turnMetadataHeader: input.request.headers.get(
         OPENAI_CACHE_DIAGNOSTIC_CODEX_TURN_METADATA_HEADER,
       ),
+    });
+    appendProviderResponseDiagnostics({
+      diagnostic,
+      providerKind: input.providerKind ?? "openai",
+      providerResponseTtfbMs: input.providerResponseTtfbMs,
+      providerTransportFailed: input.providerTransportFailed ?? false,
+      response: input.response,
     });
   } catch (error) {
     emitHostedExecutionStructuredLog({
@@ -1983,10 +2082,11 @@ async function emitHostedRunnerOpenAiCacheDiagnostic(input: {
       details: {
         diagnosticCaptured: false,
         endpointKind: input.endpointKind,
+        providerKind: input.providerKind ?? "openai",
       },
       error,
       level: "warn",
-      message: "Hosted runner OpenAI cache diagnostic capture failed.",
+      message: "Hosted runner provider request diagnostic capture failed.",
       phase: "wake.running",
     });
     return;
@@ -2001,7 +2101,7 @@ async function emitHostedRunnerOpenAiCacheDiagnostic(input: {
       runtimeLogScheduled,
       ...diagnostic,
     },
-    message: "Hosted runner OpenAI cache diagnostic captured.",
+    message: "Hosted runner provider request diagnostic captured.",
     phase: "wake.running",
   });
 
@@ -2020,20 +2120,23 @@ async function emitHostedRunnerOpenAiCacheDiagnostic(input: {
       component: "runner",
       details: {
         endpointKind: input.endpointKind,
+        providerKind: input.providerKind ?? "openai",
         runtimeLogScheduled,
       },
       error,
       level: "warn",
-      message: "Hosted runner OpenAI cache diagnostic runtime-log write failed.",
+      message: "Hosted runner provider request diagnostic runtime-log write failed.",
       phase: "wake.running",
     });
   });
 }
 
 export async function buildHostedOpenAiCacheDiagnostic(input: {
+  canonicalModelKind?: string | null;
   endpointKind: HostedOpenAiCacheDiagnosticEndpointKind;
   fingerprintSecret?: string | null;
   method: string;
+  providerKind?: HostedResponsesDiagnosticProviderKind;
   requestBytes: Uint8Array;
   turnMetadataHeader?: string | null;
 }): Promise<HostedRunnerDiagnosticJson> {
@@ -2047,11 +2150,12 @@ export async function buildHostedOpenAiCacheDiagnostic(input: {
     jsonType: "unknown",
     jsonValid: false,
     methodKind: readOpenAiDiagnosticMethodKind(input.method),
-    providerKind: "openai",
+    providerKind: input.providerKind ?? "openai",
     requestBytes: input.requestBytes.byteLength,
   };
-  appendCodexTurnMetadataDiagnostics({
+  await appendCodexTurnMetadataDiagnostics({
     diagnostic,
+    fingerprintKey,
     turnMetadataHeader: input.turnMetadataHeader ?? null,
   });
 
@@ -2082,7 +2186,13 @@ export async function buildHostedOpenAiCacheDiagnostic(input: {
   }
 
   diagnostic.requestFieldCount = Object.keys(parsed).length;
-  diagnostic.modelKind = readOpenAiDiagnosticModelKind(readStringRecordProperty(parsed, "model"));
+  const requestModel = readStringRecordProperty(parsed, "model");
+  diagnostic.modelKind = readOpenAiDiagnosticModelKind(
+    input.canonicalModelKind ?? requestModel,
+  );
+  if ((input.providerKind ?? "openai") === "venice") {
+    diagnostic.upstreamModelKind = readVeniceDiagnosticModelKind(requestModel);
+  }
   diagnostic.cacheRetentionKind = readOpenAiCacheRetentionKind(parsed.prompt_cache_retention);
 
   const cacheNamespace = readStringRecordProperty(parsed, "prompt_cache_key");
@@ -2141,6 +2251,62 @@ export async function buildHostedOpenAiCacheDiagnostic(input: {
   return diagnostic;
 }
 
+function appendProviderResponseDiagnostics(input: {
+  diagnostic: HostedRunnerDiagnosticJson;
+  providerKind: HostedResponsesDiagnosticProviderKind;
+  providerResponseTtfbMs?: number;
+  providerTransportFailed: boolean;
+  response?: Response;
+}): void {
+  if (input.providerResponseTtfbMs !== undefined) {
+    input.diagnostic.providerResponseTtfbMs = Math.max(
+      0,
+      Math.trunc(input.providerResponseTtfbMs),
+    );
+  }
+  if (input.providerTransportFailed) {
+    input.diagnostic.providerResponseOutcomeKind = "transport_error";
+    return;
+  }
+  if (!input.response) {
+    return;
+  }
+
+  input.diagnostic.providerResponseOk = input.response.ok;
+  input.diagnostic.providerResponseOutcomeKind = input.response.ok
+    ? "accepted"
+    : "rejected";
+  input.diagnostic.providerResponseStatus = input.response.status;
+  input.diagnostic.providerResponseContentKind = readResponseContentKind(
+    input.response.headers.get("content-type"),
+  );
+
+  if (input.providerKind !== "venice") {
+    return;
+  }
+  const cloudflareRay = readSafeCloudflareRay(input.response.headers.get("cf-ray"));
+  if (cloudflareRay) {
+    input.diagnostic.providerResponseCloudflareRay = cloudflareRay;
+  }
+  const responseModelKind = readVeniceDiagnosticModelKind(
+    input.response.headers.get("x-venice-model-id"),
+  );
+  input.diagnostic.providerResponseModelKind = responseModelKind;
+  const requestModelKind = input.diagnostic.upstreamModelKind;
+  input.diagnostic.providerResponseModelMatchesRequest =
+    typeof requestModelKind === "string"
+    && requestModelKind !== "missing"
+    && requestModelKind !== "other"
+    && responseModelKind === requestModelKind;
+
+  const retryCount = readBoundedProviderRetryCount(
+    input.response.headers.get("x-retry-count"),
+  );
+  if (retryCount !== null) {
+    input.diagnostic.providerResponseRetryCount = retryCount;
+  }
+}
+
 async function writeHostedRunnerOpenAiCacheDiagnosticRuntimeLog(input: {
   diagnostic: HostedRunnerDiagnosticJson;
   env: RunnerOutboundEnvironmentSource;
@@ -2161,7 +2327,11 @@ async function writeHostedRunnerOpenAiCacheDiagnosticRuntimeLog(input: {
           component: "runner",
           eventCode: HOSTED_OPENAI_CACHE_DIAGNOSTIC_EVENT_CODE,
           ...(writeFence ? { leaseGeneration: writeFence.leaseGeneration } : {}),
-          level: "debug",
+          level:
+            input.diagnostic.providerResponseOutcomeKind === "rejected"
+              || input.diagnostic.providerResponseOutcomeKind === "transport_error"
+              ? "warn"
+              : "debug",
           phase: "fetch",
           redactedJson: input.diagnostic,
           ...(writeFence?.workspaceVersion ? { workspaceVersion: writeFence.workspaceVersion } : {}),
@@ -2186,7 +2356,7 @@ async function writeHostedRunnerOpenAiCacheDiagnosticRuntimeLog(input: {
   );
 
   if (!response.ok) {
-    throw new Error(`Hosted OpenAI cache diagnostic runtime-log write returned HTTP ${response.status}.`);
+    throw new Error(`Hosted provider request diagnostic runtime-log write returned HTTP ${response.status}.`);
   }
   await drainHostedRunnerMetadataResponse(response);
 }
@@ -2236,7 +2406,13 @@ async function appendFingerprintDiagnostics(input: {
 }
 
 async function appendSensitiveIdentifierFingerprint(input: {
-  fieldPrefix: "cacheNamespace" | "previousResponse";
+  fieldPrefix:
+    | "cacheNamespace"
+    | "codexSession"
+    | "codexThread"
+    | "codexTurn"
+    | "codexWindow"
+    | "previousResponse";
   fingerprintKey: CryptoKey | null;
   output: HostedRunnerDiagnosticJson;
   value: string;
@@ -2278,6 +2454,25 @@ function readOpenAiDiagnosticModelKind(value: string | null): string {
     return "missing";
   }
   return OPENAI_CACHE_DIAGNOSTIC_MODEL_KINDS.has(normalized) ? normalized : "other";
+}
+
+function readVeniceDiagnosticModelKind(value: string | null): string {
+  const normalized = value?.split(":", 1)[0]?.trim() ?? "";
+  if (!normalized) {
+    return "missing";
+  }
+  return VENICE_CACHE_DIAGNOSTIC_MODEL_KINDS.has(normalized)
+    ? normalized
+    : "other";
+}
+
+function readBoundedProviderRetryCount(value: string | null): number | null {
+  const normalized = value?.trim() ?? "";
+  if (!/^\d{1,3}$/u.test(normalized)) {
+    return null;
+  }
+  const parsed = Number(normalized);
+  return parsed <= 100 ? parsed : null;
 }
 
 function readOpenAiCacheRetentionKind(value: unknown): string {
@@ -2328,10 +2523,11 @@ function readStringRecordProperty(record: Record<string, unknown>, key: string):
   return normalized.length > 0 ? normalized : null;
 }
 
-function appendCodexTurnMetadataDiagnostics(input: {
+async function appendCodexTurnMetadataDiagnostics(input: {
   diagnostic: HostedRunnerDiagnosticJson;
+  fingerprintKey: CryptoKey | null;
   turnMetadataHeader: string | null;
-}): void {
+}): Promise<void> {
   const header = input.turnMetadataHeader?.trim();
   if (!header) {
     return;
@@ -2356,6 +2552,43 @@ function appendCodexTurnMetadataDiagnostics(input: {
     output: input.diagnostic,
     value: parsed.request_kind,
   });
+
+  const sessionId = readStringRecordProperty(parsed, "session_id");
+  if (sessionId) {
+    await appendSensitiveIdentifierFingerprint({
+      fieldPrefix: "codexSession",
+      fingerprintKey: input.fingerprintKey,
+      output: input.diagnostic,
+      value: sessionId,
+    });
+  }
+  const threadId = readStringRecordProperty(parsed, "thread_id");
+  if (threadId) {
+    await appendSensitiveIdentifierFingerprint({
+      fieldPrefix: "codexThread",
+      fingerprintKey: input.fingerprintKey,
+      output: input.diagnostic,
+      value: threadId,
+    });
+  }
+  const turnId = readStringRecordProperty(parsed, "turn_id");
+  if (turnId) {
+    await appendSensitiveIdentifierFingerprint({
+      fieldPrefix: "codexTurn",
+      fingerprintKey: input.fingerprintKey,
+      output: input.diagnostic,
+      value: turnId,
+    });
+  }
+  const windowId = readStringRecordProperty(parsed, "window_id");
+  if (windowId) {
+    await appendSensitiveIdentifierFingerprint({
+      fieldPrefix: "codexWindow",
+      fingerprintKey: input.fingerprintKey,
+      output: input.diagnostic,
+      value: windowId,
+    });
+  }
 
   const compaction = parsed.compaction;
   if (!isHostedOpenAiDiagnosticRecord(compaction)) {

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -1554,8 +1554,13 @@ async function maybeHandleVeniceRequest(input: {
     headers,
     { body: upstreamBody },
   );
-  const diagnosticBody = upstreamRequest.clone();
-  const canonicalModelKind = readHostedResponsesRequestModelKind(body);
+  const captureMemoryDiagnostic = isHostedCodexMemoryRequest(input.request);
+  const diagnosticBody = captureMemoryDiagnostic
+    ? upstreamRequest.clone()
+    : null;
+  const canonicalModelKind = captureMemoryDiagnostic
+    ? readHostedResponsesRequestModelKind(body)
+    : null;
   let response: Response;
   try {
     response = await fetchAuthorizedProviderUpstream({
@@ -1567,6 +1572,29 @@ async function maybeHandleVeniceRequest(input: {
       url: input.url,
     });
   } catch (error) {
+    if (diagnosticBody) {
+      const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
+        canonicalModelKind,
+        ctx: input.ctx ?? null,
+        endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
+        env: input.env,
+        providerKind: "venice",
+        providerResponseTtfbMs: Date.now() - startedAt,
+        providerTransportFailed: true,
+        request: input.request,
+        upstreamRequestBody: diagnosticBody,
+        userId: authorization.userId,
+        writeFence: authorization.writeFence,
+      });
+      await scheduleOrAwaitHostedProviderDiagnostic({
+        ctx: input.ctx ?? null,
+        promise: diagnosticPromise,
+      });
+    }
+    throw error;
+  }
+
+  if (diagnosticBody) {
     const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
       canonicalModelKind,
       ctx: input.ctx ?? null,
@@ -1574,8 +1602,8 @@ async function maybeHandleVeniceRequest(input: {
       env: input.env,
       providerKind: "venice",
       providerResponseTtfbMs: Date.now() - startedAt,
-      providerTransportFailed: true,
       request: input.request,
+      response,
       upstreamRequestBody: diagnosticBody,
       userId: authorization.userId,
       writeFence: authorization.writeFence,
@@ -1584,26 +1612,7 @@ async function maybeHandleVeniceRequest(input: {
       ctx: input.ctx ?? null,
       promise: diagnosticPromise,
     });
-    throw error;
   }
-
-  const diagnosticPromise = emitHostedRunnerOpenAiCacheDiagnostic({
-    canonicalModelKind,
-    ctx: input.ctx ?? null,
-    endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
-    env: input.env,
-    providerKind: "venice",
-    providerResponseTtfbMs: Date.now() - startedAt,
-    request: input.request,
-    response,
-    upstreamRequestBody: diagnosticBody,
-    userId: authorization.userId,
-    writeFence: authorization.writeFence,
-  });
-  await scheduleOrAwaitHostedProviderDiagnostic({
-    ctx: input.ctx ?? null,
-    promise: diagnosticPromise,
-  });
   return response;
 }
 
@@ -1993,6 +2002,22 @@ function readVeniceCacheDiagnosticEndpointKind(
   return pathnameSuffix === "/responses/compact"
     ? "responses_compact"
     : "responses";
+}
+
+function isHostedCodexMemoryRequest(request: Request): boolean {
+  const header = request.headers.get(
+    OPENAI_CACHE_DIAGNOSTIC_CODEX_TURN_METADATA_HEADER,
+  )?.trim();
+  if (!header) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(header);
+    return isHostedOpenAiDiagnosticRecord(parsed)
+      && parsed.request_kind === "memory";
+  } catch {
+    return false;
+  }
 }
 
 function readHostedResponsesRequestModelKind(body: ArrayBuffer): string | null {

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -1554,13 +1554,16 @@ async function maybeHandleVeniceRequest(input: {
     headers,
     { body: upstreamBody },
   );
-  const captureMemoryDiagnostic = isHostedCodexMemoryRequest(input.request);
+  const captureMemoryDiagnostic =
+    authorization.platformAiUsageAllowed !== false
+    && isHostedCodexMemoryRequest(input.request);
   const diagnosticBody = captureMemoryDiagnostic
     ? upstreamRequest.clone()
     : null;
   const canonicalModelKind = captureMemoryDiagnostic
     ? readHostedResponsesRequestModelKind(body)
     : null;
+  const providerStartedAt = Date.now();
   let response: Response;
   try {
     response = await fetchAuthorizedProviderUpstream({
@@ -1579,14 +1582,13 @@ async function maybeHandleVeniceRequest(input: {
         endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
         env: input.env,
         providerKind: "venice",
-        providerResponseTtfbMs: Date.now() - startedAt,
         providerTransportFailed: true,
         request: input.request,
         upstreamRequestBody: diagnosticBody,
         userId: authorization.userId,
         writeFence: authorization.writeFence,
       });
-      await scheduleOrAwaitHostedProviderDiagnostic({
+      scheduleHostedProviderDiagnostic({
         ctx: input.ctx ?? null,
         promise: diagnosticPromise,
       });
@@ -1601,14 +1603,14 @@ async function maybeHandleVeniceRequest(input: {
       endpointKind: readVeniceCacheDiagnosticEndpointKind(pathMatch.pathnameSuffix),
       env: input.env,
       providerKind: "venice",
-      providerResponseTtfbMs: Date.now() - startedAt,
+      providerResponseTtfbMs: Date.now() - providerStartedAt,
       request: input.request,
       response,
       upstreamRequestBody: diagnosticBody,
       userId: authorization.userId,
       writeFence: authorization.writeFence,
     });
-    await scheduleOrAwaitHostedProviderDiagnostic({
+    scheduleHostedProviderDiagnostic({
       ctx: input.ctx ?? null,
       promise: diagnosticPromise,
     });
@@ -2051,19 +2053,32 @@ async function readDeploySmokeLiveModelTurnOpenAiModel(input: {
   );
 }
 
-async function scheduleOrAwaitHostedProviderDiagnostic(input: {
+function scheduleHostedProviderDiagnostic(input: {
   ctx: HostedRunnerOutboundContext | null;
   promise: Promise<void>;
-}): Promise<void> {
-  if (typeof input.ctx?.waitUntil !== "function") {
-    await input.promise;
-    return;
+}): void {
+  if (typeof input.ctx?.waitUntil === "function") {
+    try {
+      input.ctx.waitUntil(input.promise);
+      return;
+    } catch {
+      // Production container interception has no lifecycle owner. If an
+      // optional scheduler rejects synchronously, use the same best-effort
+      // detached fallback without extending the provider-response budget.
+    }
   }
-  try {
-    input.ctx.waitUntil(input.promise);
-  } catch {
-    await input.promise;
-  }
+  void input.promise.catch((error: unknown) => {
+    emitHostedExecutionStructuredLog({
+      component: "runner",
+      details: {
+        ...buildHostedExecutionSafeErrorDetails(error),
+        providerKind: "venice",
+      },
+      level: "warn",
+      message: "Hosted runner provider request diagnostic detached task failed.",
+      phase: "wake.running",
+    });
+  });
 }
 
 async function emitHostedRunnerOpenAiCacheDiagnostic(input: {

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2717,6 +2717,42 @@ describe("hostedRunnerIntercept", () => {
     expect(JSON.stringify(runtimeLogBody)).not.toContain(privateTransportDetail);
   });
 
+  it("does not persist Venice provider diagnostics for foreground turns", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: "synthetic foreground request",
+          model: "gpt-5.6-sol",
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "turn" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential: async (input) =>
+          createProviderEgressCredentialValidationResult(input),
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(new URL(readFetchTargetUrl(fetchMock.mock.calls[0]?.[0])).hostname)
+      .toBe("api.venice.ai");
+  });
+
   it("normalizes Responses Lite tools before Venice upstream egress", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2520,6 +2520,203 @@ describe("hostedRunnerIntercept", () => {
     });
   });
 
+  it("persists redacted Venice memory-request routing and correlation diagnostics", async () => {
+    const sensitiveProviderResponse = "private-provider-response-segment";
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        return Response.json({ loggedCount: 1 });
+      }
+      return new Response(sensitiveProviderResponse, {
+        headers: {
+          "cf-ray": "230b030023ae2822-SJC",
+          "content-type": "text/event-stream; charset=utf-8",
+          "x-retry-count": "2",
+          "x-venice-balance-usd": "private-balance-header",
+          "x-venice-host-name": "private-provider-host-header",
+          "x-venice-model-id": "openai-gpt-56-terra",
+          "x-venice-model-name": "private-provider-model-name",
+          "x-venice-model-router": "private-provider-router-header",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const validateRuntimeProviderEgressCredential = vi.fn(async (input: {
+      providerKind: string;
+      runnerContainerName: string;
+      userId: string;
+    }) => createProviderEgressCredentialValidationResult(input));
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+    const sensitiveSessionId = "session-sensitive-memory-diagnostic-id";
+    const sensitiveThreadId = "thread-sensitive-memory-diagnostic-id";
+    const sensitiveTurnId = "turn-sensitive-memory-diagnostic-id";
+    const sensitiveWindowId = "window-sensitive-memory-diagnostic-id";
+    const sensitiveCacheKey = "cache-sensitive-memory-diagnostic-key";
+    const sensitivePromptText = "private-memory-prompt-segment ".repeat(240);
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: [{
+            content: [{ text: sensitivePromptText, type: "input_text" }],
+            role: "user",
+            type: "message",
+          }],
+          model: "gpt-5.6-terra",
+          prompt_cache_key: sensitiveCacheKey,
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({
+            request_kind: "memory",
+            session_id: sensitiveSessionId,
+            thread_id: sensitiveThreadId,
+            turn_id: sensitiveTurnId,
+            window_id: sensitiveWindowId,
+          }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        HOSTED_LOG_FINGERPRINT_SECRET: "diagnostic-fingerprint-secret",
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential,
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(200);
+
+    const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
+    expect(runtimeLogCall).toBeDefined();
+    const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
+      entries?: Array<{
+        eventCode?: string;
+        redactedJson?: Record<string, unknown>;
+      }>;
+    };
+    expect(parseHostedRuntimeLogRequest(runtimeLogBody).entries).toHaveLength(1);
+    const entry = runtimeLogBody.entries?.[0];
+    expect(entry?.eventCode).toBe(HOSTED_OPENAI_CACHE_DIAGNOSTIC_EVENT_CODE);
+    expect(entry?.redactedJson).toEqual(expect.objectContaining({
+      codexRequestKind: "memory",
+      codexSessionFingerprintPresent: true,
+      codexThreadFingerprintPresent: true,
+      codexTurnFingerprintPresent: true,
+      codexTurnMetadataStatus: "valid",
+      codexWindowFingerprintPresent: true,
+      endpointKind: "responses",
+      modelKind: "gpt-5.6-terra",
+      providerKind: "venice",
+      providerResponseCloudflareRay: "230b030023ae2822-SJC",
+      providerResponseContentKind: "text",
+      providerResponseModelKind: "openai-gpt-56-terra",
+      providerResponseModelMatchesRequest: true,
+      providerResponseOk: true,
+      providerResponseOutcomeKind: "accepted",
+      providerResponseRetryCount: 2,
+      providerResponseStatus: 200,
+      upstreamModelKind: "openai-gpt-56-terra",
+    }));
+    expect(entry?.redactedJson?.providerResponseTtfbMs)
+      .toEqual(expect.any(Number));
+    expect(entry?.redactedJson?.codexSessionFingerprint)
+      .toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+    expect(entry?.redactedJson?.codexThreadFingerprint)
+      .toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+    expect(entry?.redactedJson?.codexTurnFingerprint)
+      .toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+    expect(entry?.redactedJson?.codexWindowFingerprint)
+      .toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+    expect(Object.keys(entry?.redactedJson ?? {}).length).toBeLessThanOrEqual(96);
+    const captureCall = mocks.emitHostedExecutionStructuredLog.mock.calls.find(([log]) =>
+      log.message === "Hosted runner provider request diagnostic captured."
+    );
+    expect(captureCall?.[0].details).toEqual(expect.objectContaining({
+      providerKind: "venice",
+      runtimeLogScheduled: false,
+    }));
+
+    const serializedLogs = JSON.stringify(runtimeLogBody);
+    expect(serializedLogs).not.toContain(sensitiveSessionId);
+    expect(serializedLogs).not.toContain(sensitiveThreadId);
+    expect(serializedLogs).not.toContain(sensitiveTurnId);
+    expect(serializedLogs).not.toContain(sensitiveWindowId);
+    expect(serializedLogs).not.toContain(sensitiveCacheKey);
+    expect(serializedLogs).not.toContain("private-memory-prompt-segment");
+    expect(serializedLogs).not.toContain(sensitiveProviderResponse);
+    expect(serializedLogs).not.toContain("private-balance-header");
+    expect(serializedLogs).not.toContain("private-provider-host-header");
+    expect(serializedLogs).not.toContain("private-provider-model-name");
+    expect(serializedLogs).not.toContain("private-provider-router-header");
+    expect(serializedLogs).not.toContain("diagnostic-fingerprint-secret");
+    expect(serializedLogs).not.toContain("venice-worker-secret");
+  });
+
+  it("persists a warning diagnostic when Venice memory egress fails in transport", async () => {
+    const privateTransportDetail = "private Venice socket failure detail";
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        return Response.json({ loggedCount: 1 });
+      }
+      throw new Error(privateTransportDetail);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    await expect(hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: "synthetic memory request",
+          model: "gpt-5.6-luna",
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential: async (input) =>
+          createProviderEgressCredentialValidationResult(input),
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    )).rejects.toThrow(privateTransportDetail);
+
+    const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
+    expect(runtimeLogCall).toBeDefined();
+    const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
+      entries?: Array<{
+        level?: string;
+        redactedJson?: Record<string, unknown>;
+      }>;
+    };
+    expect(parseHostedRuntimeLogRequest(runtimeLogBody).entries).toHaveLength(1);
+    expect(runtimeLogBody.entries?.[0]).toEqual(expect.objectContaining({
+      level: "warn",
+      redactedJson: expect.objectContaining({
+        codexRequestKind: "memory",
+        modelKind: "gpt-5.6-luna",
+        providerKind: "venice",
+        providerResponseOutcomeKind: "transport_error",
+        upstreamModelKind: "openai-gpt-56-luna",
+      }),
+    }));
+    expect(JSON.stringify(runtimeLogBody)).not.toContain(privateTransportDetail);
+  });
+
   it("normalizes Responses Lite tools before Venice upstream egress", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
     vi.stubGlobal("fetch", fetchMock);
@@ -3942,6 +4139,62 @@ describe("hostedRunnerIntercept", () => {
       .not.toContain(sensitiveThreadId);
   });
 
+  it("groups repeated Codex memory requests with stable keyed fingerprints", async () => {
+    const sharedSessionId = "session-shared-memory-correlation-id";
+    const sharedThreadId = "thread-shared-memory-correlation-id";
+    const firstTurnId = "turn-first-memory-correlation-id";
+    const secondTurnId = "turn-second-memory-correlation-id";
+    const otherThreadId = "thread-other-memory-correlation-id";
+    const requestBytes = TEST_TEXT_ENCODER.encode(JSON.stringify({
+      input: [],
+      model: "gpt-5.6-terra",
+    }));
+    const buildDiagnostic = (input: {
+      threadId: string;
+      turnId: string;
+    }) => buildHostedOpenAiCacheDiagnostic({
+      endpointKind: "responses",
+      fingerprintSecret: "diagnostic-fingerprint-secret",
+      method: "POST",
+      requestBytes,
+      turnMetadataHeader: JSON.stringify({
+        request_kind: "memory",
+        session_id: sharedSessionId,
+        thread_id: input.threadId,
+        turn_id: input.turnId,
+        window_id: `${input.threadId}:1`,
+      }),
+    });
+
+    const first = await buildDiagnostic({
+      threadId: sharedThreadId,
+      turnId: firstTurnId,
+    });
+    const second = await buildDiagnostic({
+      threadId: sharedThreadId,
+      turnId: secondTurnId,
+    });
+    const other = await buildDiagnostic({
+      threadId: otherThreadId,
+      turnId: secondTurnId,
+    });
+
+    expect(first.codexRequestKind).toBe("memory");
+    expect(first.codexSessionFingerprint).toBe(second.codexSessionFingerprint);
+    expect(first.codexThreadFingerprint).toBe(second.codexThreadFingerprint);
+    expect(first.codexThreadFingerprint).not.toBe(other.codexThreadFingerprint);
+    expect(first.codexTurnFingerprint).not.toBe(second.codexTurnFingerprint);
+    for (const diagnostic of [first, second, other]) {
+      parseDiagnosticRuntimeLog(diagnostic);
+    }
+    const serialized = JSON.stringify([first, second, other]);
+    expect(serialized).not.toContain(sharedSessionId);
+    expect(serialized).not.toContain(sharedThreadId);
+    expect(serialized).not.toContain(firstTurnId);
+    expect(serialized).not.toContain(secondTurnId);
+    expect(serialized).not.toContain(otherThreadId);
+  });
+
   it("records OpenAI cache diagnostics under the fence validated by a provider token", async () => {
     const waitUntilPromises: Promise<unknown>[] = [];
     const fetchMock = vi.fn<typeof fetch>(async (target) => {
@@ -4091,7 +4344,7 @@ describe("hostedRunnerIntercept", () => {
       }),
     }));
     const captureCall = mocks.emitHostedExecutionStructuredLog.mock.calls.find(([entry]) =>
-      entry.message === "Hosted runner OpenAI cache diagnostic captured."
+      entry.message === "Hosted runner provider request diagnostic captured."
     );
     expect(captureCall?.[0].details).toEqual(expect.objectContaining({
       runtimeLogScheduled: false,

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2597,12 +2597,14 @@ describe("hostedRunnerIntercept", () => {
     const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
       entries?: Array<{
         eventCode?: string;
+        level?: string;
         redactedJson?: Record<string, unknown>;
       }>;
     };
     expect(parseHostedRuntimeLogRequest(runtimeLogBody).entries).toHaveLength(1);
     const entry = runtimeLogBody.entries?.[0];
     expect(entry?.eventCode).toBe(HOSTED_OPENAI_CACHE_DIAGNOSTIC_EVENT_CODE);
+    expect(entry?.level).toBe("debug");
     expect(entry?.redactedJson).toEqual(expect.objectContaining({
       codexRequestKind: "memory",
       codexSessionFingerprintPresent: true,
@@ -2610,6 +2612,7 @@ describe("hostedRunnerIntercept", () => {
       codexTurnFingerprintPresent: true,
       codexTurnMetadataStatus: "valid",
       codexWindowFingerprintPresent: true,
+      diagnosticVersion: 2,
       endpointKind: "responses",
       modelKind: "gpt-5.6-terra",
       providerKind: "venice",
@@ -2656,6 +2659,134 @@ describe("hostedRunnerIntercept", () => {
     expect(serializedLogs).not.toContain("private-provider-router-header");
     expect(serializedLogs).not.toContain("diagnostic-fingerprint-secret");
     expect(serializedLogs).not.toContain("venice-worker-secret");
+  });
+
+  it("returns rejected Venice memory responses unchanged and persists bounded warning metadata", async () => {
+    const rejectedBody = "synthetic provider rejection";
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        return Response.json({ loggedCount: 1 });
+      }
+      return new Response(rejectedBody, {
+        headers: {
+          "cf-ray": "not-a-valid-ray",
+          "content-type": "application/json",
+          "x-retry-count": "101",
+          "x-venice-model-id": "unallowlisted-provider-model",
+        },
+        status: 429,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: "synthetic memory request",
+          model: "gpt-5.6-terra",
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential: async (input) =>
+          createProviderEgressCredentialValidationResult(input),
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.text()).toBe(rejectedBody);
+    const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
+    expect(runtimeLogCall).toBeDefined();
+    const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
+      entries?: Array<{
+        level?: string;
+        redactedJson?: Record<string, unknown>;
+      }>;
+    };
+    expect(parseHostedRuntimeLogRequest(runtimeLogBody).entries).toHaveLength(1);
+    expect(runtimeLogBody.entries?.[0]).toEqual(expect.objectContaining({
+      level: "warn",
+      redactedJson: expect.objectContaining({
+        providerKind: "venice",
+        providerResponseContentKind: "json",
+        providerResponseModelKind: "other",
+        providerResponseOk: false,
+        providerResponseOutcomeKind: "rejected",
+        providerResponseStatus: 429,
+      }),
+    }));
+    expect(runtimeLogBody.entries?.[0]?.redactedJson)
+      .not.toHaveProperty("providerResponseCloudflareRay");
+    expect(runtimeLogBody.entries?.[0]?.redactedJson)
+      .not.toHaveProperty("providerResponseRetryCount");
+    expect(JSON.stringify(runtimeLogBody)).not.toContain("unallowlisted-provider-model");
+  });
+
+  it("keeps successful Venice memory responses intact when background diagnostic persistence fails", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      return url.hostname === "web.example.test"
+        ? new Response("unavailable", { status: 500 })
+        : new Response("provider response", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: "synthetic memory request",
+          model: "gpt-5.6-luna",
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential: async (input) =>
+          createProviderEgressCredentialValidationResult(input),
+        validateRuntimeWriteFence: async () => true,
+      }),
+      {
+        containerId: "opaque-container-id",
+        waitUntil: (promise) => {
+          waitUntilPromises.push(Promise.resolve(promise));
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("provider response");
+    expect(waitUntilPromises).toHaveLength(1);
+    await Promise.all(waitUntilPromises);
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ providerKind: "venice" }),
+        level: "warn",
+        message: "Hosted runner provider request diagnostic runtime-log write failed.",
+      }),
+    );
   });
 
   it("persists a warning diagnostic when Venice memory egress fails in transport", async () => {
@@ -2717,12 +2848,22 @@ describe("hostedRunnerIntercept", () => {
     expect(JSON.stringify(runtimeLogBody)).not.toContain(privateTransportDetail);
   });
 
-  it("does not persist Venice provider diagnostics for foreground turns", async () => {
+  it.each([
+    ["foreground", JSON.stringify({ request_kind: "turn" })],
+    ["untagged", null],
+  ])("does not persist Venice provider diagnostics for %s turns", async (_kind, metadata) => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
     vi.stubGlobal("fetch", fetchMock);
     const credential = await createTestProviderEgressCredential({
       providerKind: "venice",
     });
+    const headers = new Headers({
+      authorization: `Bearer ${credential}`,
+      "content-type": "application/json",
+    });
+    if (metadata) {
+      headers.set("x-codex-turn-metadata", metadata);
+    }
 
     const response = await hostedRunnerIntercept(
       new Request("https://api.venice.ai/api/v1/responses", {
@@ -2731,11 +2872,7 @@ describe("hostedRunnerIntercept", () => {
           model: "gpt-5.6-sol",
           stream: true,
         }),
-        headers: {
-          authorization: `Bearer ${credential}`,
-          "content-type": "application/json",
-          "x-codex-turn-metadata": JSON.stringify({ request_kind: "turn" }),
-        },
+        headers,
         method: "POST",
       }),
       createInterceptEnv({

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -2521,6 +2521,7 @@ describe("hostedRunnerIntercept", () => {
   });
 
   it("persists redacted Venice memory-request routing and correlation diagnostics", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
     const sensitiveProviderResponse = "private-provider-response-segment";
     const fetchMock = vi.fn<typeof fetch>(async (target) => {
       const url = new URL(readFetchTargetUrl(target));
@@ -2587,10 +2588,17 @@ describe("hostedRunnerIntercept", () => {
         validateRuntimeProviderEgressCredential,
         validateRuntimeWriteFence: async () => true,
       }),
-      { containerId: "opaque-container-id" },
+      {
+        containerId: "opaque-container-id",
+        waitUntil: (promise) => {
+          waitUntilPromises.push(Promise.resolve(promise));
+        },
+      },
     );
 
     expect(response.status).toBe(200);
+    expect(waitUntilPromises).toHaveLength(1);
+    await Promise.all(waitUntilPromises);
 
     const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
     expect(runtimeLogCall).toBeDefined();
@@ -2642,7 +2650,7 @@ describe("hostedRunnerIntercept", () => {
     );
     expect(captureCall?.[0].details).toEqual(expect.objectContaining({
       providerKind: "venice",
-      runtimeLogScheduled: false,
+      runtimeLogScheduled: true,
     }));
 
     const serializedLogs = JSON.stringify(runtimeLogBody);
@@ -2662,6 +2670,7 @@ describe("hostedRunnerIntercept", () => {
   });
 
   it("returns rejected Venice memory responses unchanged and persists bounded warning metadata", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
     const rejectedBody = "synthetic provider rejection";
     const fetchMock = vi.fn<typeof fetch>(async (target) => {
       const url = new URL(readFetchTargetUrl(target));
@@ -2703,11 +2712,18 @@ describe("hostedRunnerIntercept", () => {
           createProviderEgressCredentialValidationResult(input),
         validateRuntimeWriteFence: async () => true,
       }),
-      { containerId: "opaque-container-id" },
+      {
+        containerId: "opaque-container-id",
+        waitUntil: (promise) => {
+          waitUntilPromises.push(Promise.resolve(promise));
+        },
+      },
     );
 
     expect(response.status).toBe(429);
     expect(await response.text()).toBe(rejectedBody);
+    expect(waitUntilPromises).toHaveLength(1);
+    await Promise.all(waitUntilPromises);
     const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
     expect(runtimeLogCall).toBeDefined();
     const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
@@ -2789,7 +2805,261 @@ describe("hostedRunnerIntercept", () => {
     );
   });
 
+  it("returns Venice memory responses before detached diagnostic persistence settles", async () => {
+    let markRuntimeLogStarted: (() => void) | undefined;
+    const runtimeLogStarted = new Promise<void>((resolve) => {
+      markRuntimeLogStarted = resolve;
+    });
+    let finishRuntimeLog: ((response: Response) => void) | undefined;
+    let runtimeLogSettled = false;
+    const pendingRuntimeLog = new Promise<Response>((resolve) => {
+      finishRuntimeLog = (response) => {
+        runtimeLogSettled = true;
+        resolve(response);
+      };
+    });
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        markRuntimeLogStarted?.();
+        return await pendingRuntimeLog;
+      }
+      return new Response("provider response", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const response = await Promise.race([
+        hostedRunnerIntercept(
+          new Request("https://api.venice.ai/api/v1/responses", {
+            body: JSON.stringify({
+              input: "synthetic memory request",
+              model: "gpt-5.6-terra",
+              stream: true,
+            }),
+            headers: {
+              authorization: `Bearer ${credential}`,
+              "content-type": "application/json",
+              "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+            },
+            method: "POST",
+          }),
+          createInterceptEnv({
+            VENICE_API_KEY: "venice-worker-secret",
+            validateRuntimeProviderEgressCredential: async (input) =>
+              createProviderEgressCredentialValidationResult(input),
+            validateRuntimeWriteFence: async () => true,
+          }),
+          { containerId: "opaque-container-id" },
+        ),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error("Venice response delivery waited for diagnostic persistence"));
+          }, 1_000);
+        }),
+      ]);
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("provider response");
+      expect(runtimeLogSettled).toBe(false);
+      await runtimeLogStarted;
+      expect(runtimeLogSettled).toBe(false);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      finishRuntimeLog?.(Response.json({ loggedCount: 1 }));
+    }
+    await pendingRuntimeLog;
+    await Promise.resolve();
+  });
+
+  it("propagates Venice transport errors before detached diagnostic persistence settles", async () => {
+    const privateTransportDetail = "private Venice transport ordering detail";
+    let markRuntimeLogStarted: (() => void) | undefined;
+    const runtimeLogStarted = new Promise<void>((resolve) => {
+      markRuntimeLogStarted = resolve;
+    });
+    let finishRuntimeLog: ((response: Response) => void) | undefined;
+    let runtimeLogSettled = false;
+    const pendingRuntimeLog = new Promise<Response>((resolve) => {
+      finishRuntimeLog = (response) => {
+        runtimeLogSettled = true;
+        resolve(response);
+      };
+    });
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        markRuntimeLogStarted?.();
+        return await pendingRuntimeLog;
+      }
+      throw new Error(privateTransportDetail);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const outcome = await Promise.race([
+        hostedRunnerIntercept(
+          new Request("https://api.venice.ai/api/v1/responses", {
+            body: JSON.stringify({
+              input: "synthetic memory request",
+              model: "gpt-5.6-luna",
+              stream: true,
+            }),
+            headers: {
+              authorization: `Bearer ${credential}`,
+              "content-type": "application/json",
+              "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+            },
+            method: "POST",
+          }),
+          createInterceptEnv({
+            VENICE_API_KEY: "venice-worker-secret",
+            validateRuntimeProviderEgressCredential: async (input) =>
+              createProviderEgressCredentialValidationResult(input),
+            validateRuntimeWriteFence: async () => true,
+          }),
+          { containerId: "opaque-container-id" },
+        ).then(
+          () => ({ error: null, kind: "resolved" as const }),
+          (error: unknown) => ({ error, kind: "rejected" as const }),
+        ),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error("Venice transport error waited for diagnostic persistence"));
+          }, 1_000);
+        }),
+      ]);
+
+      expect(outcome.kind).toBe("rejected");
+      if (!(outcome.error instanceof Error)) {
+        throw new TypeError("Expected the Venice transport failure to remain an Error.");
+      }
+      expect(outcome.error.message).toBe(privateTransportDetail);
+      expect(runtimeLogSettled).toBe(false);
+      await runtimeLogStarted;
+      expect(runtimeLogSettled).toBe(false);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      finishRuntimeLog?.(Response.json({ loggedCount: 1 }));
+    }
+    await pendingRuntimeLog;
+    await Promise.resolve();
+  });
+
+  it("measures Venice response-header latency from upstream dispatch", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
+    let nowMs = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const fetchMock = vi.fn<typeof fetch>(async (target) => {
+      const url = new URL(readFetchTargetUrl(target));
+      if (url.hostname === "web.example.test") {
+        return Response.json({ loggedCount: 1 });
+      }
+      nowMs += 37;
+      return new Response("provider response", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    try {
+      const response = await hostedRunnerIntercept(
+        new Request("https://api.venice.ai/api/v1/responses", {
+          body: JSON.stringify({
+            input: "synthetic memory request",
+            model: "gpt-5.6-terra",
+            stream: true,
+          }),
+          headers: {
+            authorization: `Bearer ${credential}`,
+            "content-type": "application/json",
+            "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+          },
+          method: "POST",
+        }),
+        createInterceptEnv({
+          VENICE_API_KEY: "venice-worker-secret",
+          validateRuntimeProviderEgressCredential: async (input) => {
+            nowMs += 5_000;
+            return createProviderEgressCredentialValidationResult(input);
+          },
+          validateRuntimeWriteFence: async () => true,
+        }),
+        {
+          containerId: "opaque-container-id",
+          waitUntil: (promise) => {
+            waitUntilPromises.push(Promise.resolve(promise));
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await Promise.all(waitUntilPromises);
+      const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
+      const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
+        entries?: Array<{ redactedJson?: Record<string, unknown> }>;
+      };
+      expect(runtimeLogBody.entries?.[0]?.redactedJson?.providerResponseTtfbMs)
+        .toBe(37);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("does not attribute Murph-local AI usage denial to Venice", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("unexpected"));
+    vi.stubGlobal("fetch", fetchMock);
+    const credential = await createTestProviderEgressCredential({
+      providerKind: "venice",
+    });
+
+    const response = await hostedRunnerIntercept(
+      new Request("https://api.venice.ai/api/v1/responses", {
+        body: JSON.stringify({
+          input: "synthetic memory request",
+          model: "gpt-5.6-terra",
+          stream: true,
+        }),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json",
+          "x-codex-turn-metadata": JSON.stringify({ request_kind: "memory" }),
+        },
+        method: "POST",
+      }),
+      createInterceptEnv({
+        VENICE_API_KEY: "venice-worker-secret",
+        validateRuntimeProviderEgressCredential: async (input) => ({
+          ...createProviderEgressCredentialValidationResult(input),
+          platformAiUsageAllowed: false,
+        }),
+        validateRuntimeWriteFence: async () => true,
+      }),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "HOSTED_PLATFORM_AI_USAGE_DENIED" },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("persists a warning diagnostic when Venice memory egress fails in transport", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
     const privateTransportDetail = "private Venice socket failure detail";
     const fetchMock = vi.fn<typeof fetch>(async (target) => {
       const url = new URL(readFetchTargetUrl(target));
@@ -2823,9 +3093,16 @@ describe("hostedRunnerIntercept", () => {
           createProviderEgressCredentialValidationResult(input),
         validateRuntimeWriteFence: async () => true,
       }),
-      { containerId: "opaque-container-id" },
+      {
+        containerId: "opaque-container-id",
+        waitUntil: (promise) => {
+          waitUntilPromises.push(Promise.resolve(promise));
+        },
+      },
     )).rejects.toThrow(privateTransportDetail);
 
+    expect(waitUntilPromises).toHaveLength(1);
+    await Promise.all(waitUntilPromises);
     const runtimeLogCall = findFetchCall(fetchMock, "web.example.test");
     expect(runtimeLogCall).toBeDefined();
     const runtimeLogBody = JSON.parse(String(runtimeLogCall?.[1]?.body ?? "{}")) as {
@@ -2845,6 +3122,8 @@ describe("hostedRunnerIntercept", () => {
         upstreamModelKind: "openai-gpt-56-luna",
       }),
     }));
+    expect(runtimeLogBody.entries?.[0]?.redactedJson)
+      .not.toHaveProperty("providerResponseTtfbMs");
     expect(JSON.stringify(runtimeLogBody)).not.toContain(privateTransportDetail);
   });
 

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -44,6 +44,32 @@ The isolated database does not store the raw hosted member id and has no
 cross-database foreign key. Attempt ids and other existing redacted operational
 correlation fields retain their current contract and limits.
 
+### Provider request diagnostics
+
+`runner.provider_egress_diagnostic` is the bounded provider-request trace for
+hosted OpenAI and Venice Responses traffic. Version 2 records request and input
+byte counts, allowlisted shape/model kinds, cache-key presence, and keyed prefix
+fingerprints. Venice rows additionally record the canonical Murph model, the
+allowlisted upstream Venice model id, response-header latency, HTTP outcome,
+validated `CF-RAY`, bounded provider retry count, and whether the provider's
+reported model matches the requested route. `providerResponseTtfbMs` measures
+time through response headers, not full streamed-generation latency.
+
+Codex `session_id`, `thread_id`, `turn_id`, and `window_id` values are never
+stored. When `HOSTED_LOG_FINGERPRINT_SECRET` is configured, the Worker records
+only context-separated HMAC-SHA256 fingerprints so repeated `request_kind`
+`memory` calls can be grouped within the retention window. Without the secret,
+the diagnostic records fingerprint availability only. Provider request and
+response bodies, prompts, messages, tool arguments/results, arbitrary response
+headers, account balances, credentials, paths, vault content, and direct member
+identifiers remain excluded.
+
+The row is observability only and remains failure-isolated from provider egress.
+Container egress persists it through the existing awaited callback fallback
+when a Cloudflare `waitUntil` scheduler is unavailable. Non-OK and
+transport-error diagnostics use warning retention, while
+accepted and request-only diagnostics use debug retention.
+
 ## Append and deletion serialization
 
 Every append runs in one short transaction:

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -67,10 +67,14 @@ identifiers remain excluded.
 
 The row is observability only and remains failure-isolated from provider egress.
 Venice foreground and untagged calls do not create these rows. Container egress
-persists tagged memory rows through the existing awaited callback fallback when
-a Cloudflare `waitUntil` scheduler is unavailable. Non-OK and transport-error
-diagnostics use warning retention, while accepted and request-only diagnostics
-use debug retention.
+schedules tagged memory rows with Cloudflare `waitUntil` when available and
+otherwise starts a best-effort detached callback, which can be lost if the
+invocation ends. Diagnostic persistence never delays a provider response or
+transport error. Non-OK and transport-error diagnostics use warning retention,
+while accepted and request-only diagnostics use debug retention. Venice response
+status and response-header latency are recorded only after upstream dispatch;
+Murph-local platform-usage denials do not produce Venice response rows, and
+transport failures omit response-header latency.
 
 ## Append and deletion serialization
 

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -47,13 +47,14 @@ correlation fields retain their current contract and limits.
 ### Provider request diagnostics
 
 `runner.provider_egress_diagnostic` is the bounded provider-request trace for
-hosted OpenAI and Venice Responses traffic. Version 2 records request and input
-byte counts, allowlisted shape/model kinds, cache-key presence, and keyed prefix
-fingerprints. Venice rows additionally record the canonical Murph model, the
-allowlisted upstream Venice model id, response-header latency, HTTP outcome,
-validated `CF-RAY`, bounded provider retry count, and whether the provider's
-reported model matches the requested route. `providerResponseTtfbMs` measures
-time through response headers, not full streamed-generation latency.
+hosted OpenAI Responses traffic and Venice Responses calls explicitly tagged by
+Codex as `request_kind: memory`. Version 2 records request and input byte counts,
+allowlisted shape/model kinds, cache-key presence, and keyed prefix fingerprints.
+Venice memory rows additionally record the canonical Murph model, the allowlisted
+upstream Venice model id, response-header latency, HTTP outcome, validated
+`CF-RAY`, bounded provider retry count, and whether the provider's reported model
+matches the requested route. `providerResponseTtfbMs` measures time through
+response headers, not full streamed-generation latency.
 
 Codex `session_id`, `thread_id`, `turn_id`, and `window_id` values are never
 stored. When `HOSTED_LOG_FINGERPRINT_SECRET` is configured, the Worker records
@@ -65,10 +66,11 @@ headers, account balances, credentials, paths, vault content, and direct member
 identifiers remain excluded.
 
 The row is observability only and remains failure-isolated from provider egress.
-Container egress persists it through the existing awaited callback fallback
-when a Cloudflare `waitUntil` scheduler is unavailable. Non-OK and
-transport-error diagnostics use warning retention, while
-accepted and request-only diagnostics use debug retention.
+Venice foreground and untagged calls do not create these rows. Container egress
+persists tagged memory rows through the existing awaited callback fallback when
+a Cloudflare `waitUntil` scheduler is unavailable. Non-OK and transport-error
+diagnostics use warning retention, while accepted and request-only diagnostics
+use debug retention.
 
 ## Append and deletion serialization
 


### PR DESCRIPTION
## Why this PR exists

A Venice-routed hosted memory incident produced substantial provider usage without enough durable Murph-side evidence to reconstruct the individual Codex memory requests. This PR makes a future recurrence attributable at the provider boundary without storing member content or raw Codex identifiers.

## User goal / user-visible behavior

After this ships, an operator can switch a test member to Venice and use successfully captured rows to determine whether Codex issued repeated memory calls, which canonical and upstream model handled each call, whether request input grew or reused stable prefixes, and how Venice responded. There is no end-user UI or messaging change.

## User experience

No user-facing flow changes. The operator-facing result is a bounded, best-effort `runner.provider_egress_diagnostic` row for Venice Responses calls explicitly tagged by Codex as `request_kind: memory`; accepted rows use debug retention and rejected or transport-failed rows use warning retention. Logging failure is isolated from provider egress and never delays a provider response or error.

## Invariants

- Never persist prompts, responses, messages, tool payloads, vault content, credentials, balances, raw member ids, or raw Codex session/thread/turn/window ids.
- Preserve Venice request routing, body normalization, streaming, and error behavior.
- Keep ordinary foreground Venice turns free of the new diagnostic callback.
- Reuse the existing signed runtime-log callback, parser limits, retention, and deletion ownership.
- Diagnostic capture must remain failure-isolated and off the provider-delivery path.
- Attribute response status and response-header latency only after a real Venice dispatch; never label a Murph-local usage denial as a Venice response.

## Non-obvious affected surfaces

- **OpenAI provider diagnostics:** the shared diagnostic format advances to version 2 and can include the same allowlisted, HMAC-only Codex correlation fields. Existing OpenAI request routing is unchanged. Regression proof: the focused interceptor suite remains green.
- **Hosted runtime-log ingestion:** Venice memory rows use the existing event code and signed Web callback; no schema, event owner, or retention mechanism changes. Without a lifecycle scheduler the callback is deliberately best-effort and potentially lossy so observability cannot delay provider delivery. Regression proof: the emitted payload passes the production request parser and the log-safety guard.
- **Foreground Venice egress:** ordinary and untagged turns explicitly skip the new durable callback. Regression proof: the focused test asserts a foreground turn performs exactly one fetch, to Venice.

## Architecture and reuse

- **Existing systems reused:** the hosted egress interceptor, provider authorization/write fence, signed runtime-log callback, redacted JSON parser, retention rules, and configured log fingerprint secret.
- **New logic:** bounded request-shape and prefix fingerprints, allowlisted Venice response metadata, canonical/upstream model comparison, response-header latency, and context-separated HMAC fingerprints for Codex memory correlation.
- **New abstractions:** one small lifecycle-scheduling helper centralizes `waitUntil` use and the already-established best-effort detached fallback; the existing diagnostic builder remains the single request-shape owner.
- **Complexity intentionally avoided:** no new database table, queue, billing poller, response-body buffering, prompt capture, session owner, or model-specific state machine.

## Hot reply path impact

Not applicable. New Venice persistence is gated to `x-codex-turn-metadata.request_kind === "memory"`; a focused test proves a `request_kind: turn` call performs no diagnostic callback, while ordering tests prove tagged memory responses and transport errors are released before detached persistence settles. Existing OpenAI diagnostic scheduling behavior is unchanged.

## Murph initial provider input impact

- **Individual Murph:** Not applicable. No prompt builder, tool/schema surface, model/tool mode, or provider-visible request field changes; the interceptor observes the already-finalized request and forwards the same normalized Venice body and headers.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Product experience:** not applicable — this is operator observability with no user journey change; direct evidence is the parsed durable row and foreground no-callback test.
- **Prompt:** not applicable — no authored or assembled provider-visible prompt/input changes.
- **Frontend:** not applicable — no frontend files or rendered states change.
- **Coverage:** applicable — 227 focused interceptor tests, Cloudflare typecheck, and the log guard pass locally. The preliminary specialist finding was accepted and resolved with rejected-response, callback-failure, and untagged-request boundary tests. Final-round findings were accepted and resolved with delivery-ordering, upstream-timing, transport-field, and local-denial tests. Exact-head CI is green, and final correction round 2 passed with no findings.

## Change-shape breakdown

Classification is by file role in the base-to-head text diff; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 298 | 25 |
| Tests/fixtures | 706 | 1 |
| Docs | 79 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1083** | **26** |

## Design proof

Not applicable; there is no user-facing frontend diff.

## Deployment skew / compatibility

This is a Cloudflare-only code change that reuses the existing Web runtime-log endpoint and permissive bounded `redactedJson` contract; no Vercel, schema, runner bundle, environment-name, or credential-shape change is required. Warm hosted containers continue sending the already-supported Codex metadata header, and the Worker decides whether to emit a row, so no immediate container rollout is needed. Current incident evidence showed one explicitly Venice-routed member, bounding realistic exposure to that member's memory calls during the test. The change is reversible by redeploying the prior Worker. Post-deploy proof is one tagged memory call followed by a bounded runtime-log query confirming the canonical/upstream model, outcome, correlation fingerprints, and request growth fields.

ReviewGPT first-reviewed head: cb9297435893bd4bc9f78e2fd0d8b03cb92e0633
