### PR TITLE
Wait for pending PDF evidence before replying

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
+++ b/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
@@ -71,9 +71,9 @@ Updated: 2026-08-04
 - Direct readback of a descriptor-only `projectionStatus: "pending"` prompt.
 - Pinned Codex App Server complete first-request capture with synthetic direct
   and group PDF fixtures, `gpt-5.6-terra`, low reasoning, code mode, and
-  `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,679 to 30,772 tokens and
-  140,479 to 140,917 bytes (+93 tokens, +0.3031%, +438 bytes); group 26,931
-  to 27,024 tokens and 123,998 to 124,436 bytes (+93 tokens, +0.3453%, +438
+  `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,679 to 30,794 tokens and
+  140,479 to 141,058 bytes (+115 tokens, +0.3748%, +579 bytes); group 26,931
+  to 27,046 tokens and 123,998 to 124,577 bytes (+115 tokens, +0.4270%, +579
   bytes). The complete provider-visible fields were `include`, `input`,
   `parallel_tool_calls`, `text`, and `tool_choice`; only transport controls were
   excluded identically. The temporary capture harness was removed.
@@ -91,3 +91,22 @@ Updated: 2026-08-04
   this task. The PR does not claim prompt wording makes projection readiness a
   runtime guarantee; stronger gating remains a separate product decision.
 - No coverage patch artifact was supplied.
+
+## Corrected-head product purpose verdict
+
+- Irreducible purpose: give a just-arrived attachment a short chance to become
+  readable in the current conversation without delaying ordinary replies or
+  requiring another member message.
+- Smallest selected experience: optional one-line progress, one same-turn local
+  wait bounded at 30 seconds, exact descriptor/new-file matching, then either
+  inspection or a truthful not-yet-available response.
+- Verdict: this is the smallest complete best-effort experience within the
+  explicit prompt-primary constraint. It truthfully avoids promising a runtime
+  readiness or wake guarantee, adds no setup or member choice, and leaves
+  terminal failure and later-message ownership with existing flows.
+- Journey evidence: the assembled prompt regression proves immediate feedback,
+  continuation, evidence, stop, and fallback instructions; the hosted runtime
+  protocol states that successful projection can make raw paths available to
+  the same turn. A real-model delayed-projection journey remains an evidence
+  gap, so the PR is intentionally described as best effort rather than a
+  guaranteed projection barrier.

--- a/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
+++ b/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
@@ -1,0 +1,80 @@
+# Pending attachment progress handling
+
+Status: active
+Created: 2026-08-04
+Updated: 2026-08-04
+
+## Goal
+
+- Let Murph acknowledge an attachment immediately, keep the Codex turn active
+  while projection hydrates, and inspect the readable evidence before giving a
+  substantive answer.
+
+## Success criteria
+
+- Pending attachment context directs Murph to send at most one visible progress
+  update, continue the same turn, and avoid claims or escalation from metadata
+  alone.
+- Completed, failed, quarantined, not-attempted, and text-only prompt behavior
+  remain unchanged.
+- Focused prompt-builder tests and direct assembled-prompt readback pass.
+- Product-experience, prompt, and coverage lenses complete with no unresolved
+  accepted finding; exact-head CI and mergeability are green.
+
+## Scope
+
+- In scope: the pending attachment projection note and focused prompt regression
+  proof.
+- Out of scope: mailbox selection, projection state, queues, polling owners,
+  persisted state, delivery machinery, and provider/runtime lifecycle changes.
+
+## Constraints
+
+- Preserve immediate text-only replies and the existing stage-time handoff to
+  Codex.
+- Reuse `murph.send_progress_update`; add no tool, service, state machine,
+  scheduler, dependency, or runtime branch.
+- Keep the instruction concise, outcome-first, and safe for direct and group
+  conversations without prescribing exact outbound copy.
+- Do not claim attachment inspection until readable evidence exists.
+
+## Risks and mitigations
+
+1. Risk: Murph treats the progress update as a final answer.
+   Mitigation: state explicitly that it must continue the turn and not finalize
+   while the attachment-dependent work is pending.
+2. Risk: the new wording causes repeated status messages.
+   Mitigation: reuse the existing at-most-one progress tool contract.
+3. Risk: the prompt implies availability or successful extraction before proof.
+   Mitigation: require readable evidence and inspection before substantive
+   claims; retain existing terminal unavailable behavior.
+
+## Tasks
+
+1. Update the pending projection guidance at the prompt-builder owner.
+2. Add focused prompt regression assertions for progress, continuation, and the
+   no-premature-final contract.
+3. Run focused tests and direct assembled-prompt readback.
+4. Complete the exact-head preliminary specialist review, CI, parent final
+   review, plan closure, and PR mergeability proof.
+
+## Decisions
+
+- Treat this as prompt-primary product behavior with product-experience, prompt,
+  and coverage lenses in the preliminary specialist ReviewGPT pass.
+- Keep runtime data flow unchanged; evaluate stronger runtime gating only if
+  production evidence shows the prompt contract is insufficient.
+
+## Verification
+
+- `pnpm exec vitest run packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts --no-coverage`
+- Direct readback of a descriptor-only `projectionStatus: "pending"` prompt.
+- Pinned Codex App Server complete first-request capture with synthetic direct
+  and group PDF fixtures, `gpt-5.6-terra`, low reasoning, code mode, and
+  `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,667 to 30,706 tokens and
+  140,486 to 140,684 bytes (+39 tokens, +0.1272%, +198 bytes); group 26,919
+  to 26,958 tokens and 124,005 to 124,203 bytes (+39 tokens, +0.1449%, +198
+  bytes). The complete provider-visible fields were `include`, `input`,
+  `parallel_tool_calls`, `text`, and `tool_choice`; only transport controls were
+  excluded identically. The temporary capture harness was removed.
+- `git diff --check`

--- a/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
+++ b/agent-docs/exec-plans/active/2026-08-04-pending-attachment-progress.md
@@ -71,10 +71,23 @@ Updated: 2026-08-04
 - Direct readback of a descriptor-only `projectionStatus: "pending"` prompt.
 - Pinned Codex App Server complete first-request capture with synthetic direct
   and group PDF fixtures, `gpt-5.6-terra`, low reasoning, code mode, and
-  `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,667 to 30,706 tokens and
-  140,486 to 140,684 bytes (+39 tokens, +0.1272%, +198 bytes); group 26,919
-  to 26,958 tokens and 124,005 to 124,203 bytes (+39 tokens, +0.1449%, +198
+  `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,679 to 30,772 tokens and
+  140,479 to 140,917 bytes (+93 tokens, +0.3031%, +438 bytes); group 26,931
+  to 27,024 tokens and 123,998 to 124,436 bytes (+93 tokens, +0.3453%, +438
   bytes). The complete provider-visible fields were `include`, `input`,
   `parallel_tool_calls`, `text`, and `tool_choice`; only transport controls were
   excluded identically. The temporary capture harness was removed.
 - `git diff --check`
+
+## Preliminary specialist disposition
+
+- Accepted the prompt-level tool/stop-rule finding. Progress delivery is now
+  conditional on tool availability; the same turn uses existing local shell
+  access to check `raw/inbox/**` for a new descriptor-matching file for at most
+  30 seconds, rejects stale or unrelated files, and falls back truthfully.
+- Did not accept the proposed runtime admission gate or its runtime-integration
+  coverage expansion. Those suggestions would replace the explicitly selected
+  prompt-primary, best-effort behavior with new selection/wake behavior outside
+  this task. The PR does not claim prompt wording makes projection readiness a
+  runtime guarantee; stronger gating remains a separate product decision.
+- No coverage patch artifact was supplied.

--- a/agent-docs/exec-plans/completed/2026-08-04-pending-attachment-progress.md
+++ b/agent-docs/exec-plans/completed/2026-08-04-pending-attachment-progress.md
@@ -1,6 +1,6 @@
 # Pending attachment progress handling
 
-Status: active
+Status: completed
 Created: 2026-08-04
 Updated: 2026-08-04
 
@@ -68,7 +68,12 @@ Updated: 2026-08-04
 ## Verification
 
 - `pnpm exec vitest run packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts --no-coverage`
-- Direct readback of a descriptor-only `projectionStatus: "pending"` prompt.
+  passed (49 tests).
+- `pnpm --dir packages/assistant-engine typecheck` passed.
+- `pnpm --filter @murphai/assistant-engine... build` passed for the
+  assistant-engine dependency closure.
+- Direct readback of a descriptor-only `projectionStatus: "pending"` prompt
+  passed through the focused regression.
 - Pinned Codex App Server complete first-request capture with synthetic direct
   and group PDF fixtures, `gpt-5.6-terra`, low reasoning, code mode, and
   `gpt-tokenizer` 3.4.0 `o200k_harmony`: direct 30,679 to 30,794 tokens and
@@ -78,6 +83,9 @@ Updated: 2026-08-04
   `parallel_tool_calls`, `text`, and `tool_choice`; only transport controls were
   excluded identically. The temporary capture harness was removed.
 - `git diff --check`
+- Required GitHub Actions passed on behavior candidate `b1eed8e1970c`,
+  including assistant/platform/CLI coverage, release build and app verification,
+  frontend design proof, artifact checks, and marketing overflow proof.
 
 ## Preliminary specialist disposition
 
@@ -110,3 +118,4 @@ Updated: 2026-08-04
   the same turn. A real-model delayed-projection journey remains an evidence
   gap, so the PR is intentionally described as best effort rather than a
   guaranteed projection barrier.
+Completed: 2026-08-04

--- a/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
+++ b/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
@@ -139,6 +139,7 @@ export function buildAssistantAutoReplyPrompt(
           projectionReasonCode: entry.projection?.reasonCode ?? null,
           projectionStatus: entry.projection?.status ?? null,
         }),
+        projectionStatus: entry.projection?.status ?? null,
         renderedAttachmentSections: entry.attachmentEvidence.attachments
           .map((attachment) => renderAttachmentEvidencePromptSection(attachment))
           .filter((section): section is string => section !== null),
@@ -216,6 +217,7 @@ export async function prepareAssistantAutoReplyInput(
           projectionReasonCode: entry.projection?.reasonCode ?? null,
           projectionStatus: entry.projection?.status ?? null,
         }),
+        projectionStatus: entry.projection?.status ?? null,
         renderedAttachmentSections: entry.attachmentBundles
           .map((attachment) => renderPreparedAttachmentPromptSection(attachment))
           .filter((section): section is string => section !== null),
@@ -536,7 +538,9 @@ function renderAssistantAutoReplyInputSection(input: {
   if (input.correctionContext) {
     sections.push(input.correctionContext)
   }
-  const projectionNote = input.hasAttachmentContext && input.attachmentSections.length === 0
+  const projectionNote = input.hasAttachmentContext && (
+    input.projectionStatus === 'pending' || input.attachmentSections.length === 0
+  )
     ? renderAssistantInputProjectionPromptNote({
         evidenceReasonCode: input.evidenceReasonCode,
         evidenceStatus: input.evidenceStatus,
@@ -584,11 +588,13 @@ function hasAssistantInputAttachmentContext(input: AssistantAutoReplyPromptInput
 
 function buildAssistantAutoReplyAttachmentSections(input: {
   lifecycleSection: string | null
+  projectionStatus: AssistantInputProjectionStatus | null
   renderedAttachmentSections: readonly string[]
 }): string[] {
   if (input.lifecycleSection) {
     const sections = [input.lifecycleSection, ...input.renderedAttachmentSections]
     if (
+      input.projectionStatus !== 'pending' &&
       input.renderedAttachmentSections.length === 0 &&
       input.lifecycleSection.includes('content: unavailable')
     ) {
@@ -1093,7 +1099,7 @@ function renderAssistantInputProjectionPromptNote(input: {
   }
 
   if (input.projectionStatus === 'pending') {
-    return 'attachment evidence is pending; use the staged message text and available metadata only.'
+    return 'attachment evidence is still hydrating. If the request depends on it, immediately call `murph.send_progress_update` once with a brief acknowledgment, then continue the same turn: wait briefly and recheck for readable attachment evidence. Do not finalize, claim inspection, or escalate product feedback solely because hydration is still pending. Once readable, inspect the storedPath and complete the request.'
   }
 
   if (input.projectionStatus === 'not_attempted') {

--- a/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
+++ b/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
@@ -1099,7 +1099,7 @@ function renderAssistantInputProjectionPromptNote(input: {
   }
 
   if (input.projectionStatus === 'pending') {
-    return 'attachment evidence is still hydrating. If the request depends on it and `murph.send_progress_update` is available, call it once with a brief acknowledgment. Keep this turn active for up to 30 seconds total: use brief local shell waits and recheck `raw/inbox/**` for a newly readable file matching this input\'s descriptor metadata; never select an unrelated or stale file. Stop as soon as exact readable evidence appears, then inspect that path and complete the request. If it does not appear within 30 seconds, say the attachment is not yet available. Do not claim inspection or escalate product feedback solely because hydration is still pending.'
+    return 'attachment evidence is still hydrating. If the request does not depend on attachment contents, continue from available context without claiming inspection. If it does depend and `murph.send_progress_update` is available, call it once with a brief acknowledgment. For that attachment-dependent work, keep this turn active for up to 30 seconds total: use brief local shell waits and recheck `raw/inbox/**` for a newly readable file matching this input\'s descriptor metadata; never select an unrelated or stale file. Stop as soon as exact readable evidence appears, then inspect that path and complete the request. If it does not appear within 30 seconds, say the attachment is not yet available. Do not claim inspection or escalate product feedback solely because hydration is still pending.'
   }
 
   if (input.projectionStatus === 'not_attempted') {

--- a/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
+++ b/packages/assistant-engine/src/assistant/automation/prompt-builder.ts
@@ -1099,7 +1099,7 @@ function renderAssistantInputProjectionPromptNote(input: {
   }
 
   if (input.projectionStatus === 'pending') {
-    return 'attachment evidence is still hydrating. If the request depends on it, immediately call `murph.send_progress_update` once with a brief acknowledgment, then continue the same turn: wait briefly and recheck for readable attachment evidence. Do not finalize, claim inspection, or escalate product feedback solely because hydration is still pending. Once readable, inspect the storedPath and complete the request.'
+    return 'attachment evidence is still hydrating. If the request depends on it and `murph.send_progress_update` is available, call it once with a brief acknowledgment. Keep this turn active for up to 30 seconds total: use brief local shell waits and recheck `raw/inbox/**` for a newly readable file matching this input\'s descriptor metadata; never select an unrelated or stale file. Stop as soon as exact readable evidence appears, then inspect that path and complete the request. If it does not appear within 30 seconds, say the attachment is not yet available. Do not claim inspection or escalate product feedback solely because hydration is still pending.'
   }
 
   if (input.projectionStatus === 'not_attempted') {

--- a/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
@@ -1841,16 +1841,19 @@ describe('prepareAssistantAutoReplyInput', () => {
     expect(result.prompt).toContain('- raw evidence: not_attempted')
     expect(result.prompt).not.toContain('- parser output:')
     expect(result.prompt).toContain(
-      'immediately call `murph.send_progress_update` once with a brief acknowledgment',
+      'If the request depends on it and `murph.send_progress_update` is available, call it once with a brief acknowledgment.',
     )
     expect(result.prompt).toContain(
-      'continue the same turn: wait briefly and recheck for readable attachment evidence',
+      'Keep this turn active for up to 30 seconds total',
     )
     expect(result.prompt).toContain(
-      'Do not finalize, claim inspection, or escalate product feedback solely because hydration is still pending.',
+      'recheck `raw/inbox/**` for a newly readable file matching this input\'s descriptor metadata',
     )
     expect(result.prompt).toContain(
-      'Once readable, inspect the storedPath and complete the request.',
+      'If it does not appear within 30 seconds, say the attachment is not yet available.',
+    )
+    expect(result.prompt).toContain(
+      'Do not claim inspection or escalate product feedback solely because hydration is still pending.',
     )
     expect(result.prompt).not.toContain(
       'respond using any other available message context',

--- a/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
@@ -1840,6 +1840,21 @@ describe('prepareAssistantAutoReplyInput', () => {
     expect(result.prompt).toContain('- inbox projection: pending')
     expect(result.prompt).toContain('- raw evidence: not_attempted')
     expect(result.prompt).not.toContain('- parser output:')
+    expect(result.prompt).toContain(
+      'immediately call `murph.send_progress_update` once with a brief acknowledgment',
+    )
+    expect(result.prompt).toContain(
+      'continue the same turn: wait briefly and recheck for readable attachment evidence',
+    )
+    expect(result.prompt).toContain(
+      'Do not finalize, claim inspection, or escalate product feedback solely because hydration is still pending.',
+    )
+    expect(result.prompt).toContain(
+      'Once readable, inspect the storedPath and complete the request.',
+    )
+    expect(result.prompt).not.toContain(
+      'respond using any other available message context',
+    )
     expect(result.prompt).toContain('Attachment 1\nfileName: private-photo.jpg')
     expect(result.prompt).toContain('kind: image')
     expect(result.prompt).toContain('mime: image/jpeg')

--- a/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts
@@ -1841,10 +1841,13 @@ describe('prepareAssistantAutoReplyInput', () => {
     expect(result.prompt).toContain('- raw evidence: not_attempted')
     expect(result.prompt).not.toContain('- parser output:')
     expect(result.prompt).toContain(
-      'If the request depends on it and `murph.send_progress_update` is available, call it once with a brief acknowledgment.',
+      'If the request does not depend on attachment contents, continue from available context without claiming inspection.',
     )
     expect(result.prompt).toContain(
-      'Keep this turn active for up to 30 seconds total',
+      'If it does depend and `murph.send_progress_update` is available, call it once with a brief acknowledgment.',
+    )
+    expect(result.prompt).toContain(
+      'For that attachment-dependent work, keep this turn active for up to 30 seconds total',
     )
     expect(result.prompt).toContain(
       'recheck `raw/inbox/**` for a newly readable file matching this input\'s descriptor metadata',


### PR DESCRIPTION
## Why this PR exists

When an attachment-dependent message reaches Codex before inbox projection has finished, Murph currently treats the attachment as unavailable and may finalize without giving a PDF that becomes available seconds later a chance to hydrate.

## User goal / user-visible behavior

For a pending attachment-dependent request, Murph makes a bounded same-turn attempt to wait for the projected file instead of immediately finalizing from metadata. It acknowledges the wait once when progress delivery is available, checks for exact newly readable evidence for up to 30 seconds, and either inspects that file or truthfully says it is not yet available.

## User experience

The entry point is an ordinary direct or group message with an attachment whose projection is still pending. When `murph.send_progress_update` is available, Murph sends one short progress update, keeps ownership of the same turn, and uses brief local waits to check `raw/inbox/**` for a newly readable file matching the current descriptor metadata. It stops immediately on an exact match and inspects that path before answering. The normal added wait should be the existing few-second projection window and is capped at 30 seconds; text-only and already-readable messages are unchanged.

If no exact match appears within 30 seconds, Murph says the attachment is not yet available and makes no inspection claim. This is deliberately a prompt-primary, best-effort path: it adds no runtime admission gate or later wake guarantee. Existing Codex turn abort, progress-delivery failure, and later-message admission behavior remain authoritative.

## Invariants

- Provider start and text-only replies remain immediate.
- Murph sends at most one pending-attachment progress update when that tool is available and does not treat it as the final answer.
- Murph does not select stale or unrelated files, claim inspection without exact readable evidence, or escalate feedback solely from a transient pending state.
- The pending wait is capped at 30 seconds and has a truthful unavailable fallback.
- Failed, quarantined, succeeded-without-evidence, and not-attempted terminal behavior keeps the existing unavailable-content contract.
- No attachment bytes, private content, or identifiers are added to prompts, tests, logs, or durable docs.

## Non-obvious affected surfaces

- The attachment-section assembler now distinguishes transient `pending` projection from terminal content unavailability. This is necessary so descriptor metadata does not append a contradictory “reply using other context” instruction; the descriptor-only prompt regression proves the pending branch while the existing terminal projection tests remain green.

## Architecture and reuse

- Existing systems reused: the current assistant-input projection status, prompt builder, same-turn Codex shell execution, `raw/inbox/**` attachment path, and optional `murph.send_progress_update` tool.
- New logic: pending attachment projection renders one bounded continuation instruction even when provider descriptors already render, and suppresses the terminal unavailable-content sentence for that transient state.
- New abstractions: none; the existing projection status, prompt-assembly helper, local shell, and raw inbox path are sufficient for this best-effort behavior.
- Complexity intentionally avoided: no queue, polling service, persisted wait state, scheduler, projection admission gate, new tool, dependency, or pre-provider delay.

## Hot reply path impact

- Path status: Touched only after provider start for an attachment-dependent input whose projection is explicitly `pending`; durable acceptance and provider start are unchanged.
- Database calls: None added or moved.
- Network/provider calls: The prompt may select the existing progress tool once, producing its existing conversation delivery and provider continuation. No retry or new endpoint is added; existing progress-delivery failure handling continues the turn.
- Other awaited latency: The model may use brief local shell waits and `raw/inbox/**` rechecks for up to 30 seconds inside the active turn. Non-pending and text-only paths add zero waits.
- Before/after proof: the focused assembled-prompt regression proves the pending path gains a conditional progress call, exact evidence rule, 30-second stop, and truthful fallback while losing the contradictory terminal-unavailable instruction; the complete first-request capture proves provider start remains the same request boundary.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 30,679 | 30,794 | +115 | +0.3748% | 140,479 | 141,058 | +579 |
| Group Murph | 26,931 | 27,046 | +115 | +0.4270% | 123,998 | 124,577 | +579 |

- Assembled instructions: the pending attachment user-input section contributes the full +115-token / +579-byte delta in both runtimes. The changed owner is `packages/assistant-engine/src/assistant/automation/prompt-builder.ts`.
- Tool/schema/generated guidance: unchanged; the same eager dynamic tools, schemas, code-mode guidance, and tool choice are present at base and head.
- Other provider-visible input: unchanged.
- Measurement method: compared base `157fff82a2a5` with corrected candidate `b1eed8e1970c` using identical synthetic direct/group Linq PDF fixtures, the pinned real Codex App Server, `gpt-5.6-terra`, low reasoning, production code mode, and `gpt-tokenizer` 3.4.0 `o200k_harmony`. The complete captured provider-visible object included `include`, `input`, `parallel_tool_calls`, `text`, and `tool_choice`; Codex nests assembled instructions and generated tool declarations in `input`. The base request was reconstructed from the same complete capture by substituting the exactly-once base-rendered pending prompt, preserving every other field. The final parent-review wording adjustment was measured as an exact +22-token / +141-byte substitution inside that captured input, again preserving every other field. Excluded identically as transport controls: `client_metadata`, `model`, `prompt_cache_key`, `reasoning`, `service_tier`, `store`, and `stream`. The temporary capture harness was removed.

## Preliminary specialist lenses

- Product experience: applicable — the change adds optional immediate progress, a bounded same-turn wait, and a truthful fallback; direct evidence is the assembled descriptor-only prompt regression and complete provider-request capture.
- Prompt: applicable — pending projection wording and prompt assembly change.
- Frontend: not applicable — no `apps/web` UI or rendered state changes.
- Coverage: applicable — executable prompt assembly and focused regression assertions changed; local focused tests, package typecheck, behavior-head CI, and final exact-head CI pass.
- Specialist outcome: `FINDINGS`. Accepted the prompt finding that progress must be conditional and waiting needs a real observation path, evidence rule, bound, and fallback; the corrected prompt now supplies those. The proposed runtime admission gate and runtime-integration expansion were not accepted because they replace the explicitly selected prompt-primary, best-effort behavior with new selection/wake semantics outside this task. No patch artifact was supplied.

## Design proof

- Design page: Not applicable; no user-facing Web UI changed.
- Coverage: Not applicable.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: production TypeScript is source, the Vitest file is tests/fixtures, and the execution plan is docs. No config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 2 |
| Tests / fixtures | 21 | 0 |
| Docs | 121 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **150** | **2** |

## Verification

- `pnpm exec vitest run packages/assistant-engine/test/assistant-automation-prompt-builder.test.ts --no-coverage` — 49 tests passed on the corrected prompt.
- `pnpm --dir packages/assistant-engine typecheck` — passed on the corrected prompt.
- Pinned Codex App Server complete first-request capture — passed for synthetic individual and group pending-PDF fixtures; temporary harness removed.
- `pnpm --filter @murphai/assistant-engine... build` — assistant engine and dependency closure built successfully for the initial capture.
- `git diff --check` and scoped identifier/privacy scan — passed.
- Required GitHub Actions — all checks passed on final exact head `fdc3303a1dc4`; the code-bearing behavior candidate `b1eed8e1970c` was independently green before the docs-only plan-closure commit.


