### PR TITLE
Preserve foreground priority across checkpoint races

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-04-foreground-priority-full-stack-e2e.md
+++ b/agent-docs/exec-plans/completed/2026-08-04-foreground-priority-full-stack-e2e.md
@@ -1,0 +1,68 @@
+# Foreground priority full-stack hosted-local proof
+
+## Goal
+
+Add a deterministic hosted-local full-stack regression that proves durably
+accepted conversation input cannot lose foreground admission to a new
+interruptible checkpoint attempt.
+
+The proof must cross the real local hosted boundaries: Web acceptance and
+mailbox persistence, runtime signaling, Cloudflare coordination, runner
+checkpointing, mailbox import, provider start, and accepted Linq delivery.
+
+## Success criteria
+
+- Reproduce the exact snapshot-interruption race whose first foreground probe
+  is empty before the later causal conversation row and wake become visible.
+- Prove with typed ordering evidence that the accepted conversation is imported
+  and reaches provider start before any retry snapshot begins.
+- Cover the canonical-publication exception: once publication is
+  non-interruptible it may finish, but the accepted conversation must be the
+  immediate continuation before another checkpoint attempt.
+- Preserve existing proofs that ordinary empty wakes do not indefinitely defer
+  durability and that system-only work, shutdown, and provider handoff keep
+  their established authority.
+- Avoid timing thresholds as the primary correctness oracle; use deterministic
+  test-owned barriers and bounded waits only for liveness.
+
+## Constraints
+
+- Reuse the hosted-local harness, real test database, Worker/Durable Object,
+  runner bundle, provider stub, and Linq stub.
+- Keep every control test-only and fail-closed behind existing hosted-local
+  control admission.
+- Add no production scheduler, queue, persisted state, polling owner,
+  correlation protocol, or product behavior.
+- Prefer one composable barrier or observation seam over phase-specific test
+  machinery.
+- Keep diagnostics and fixtures synthetic, bounded, and free of private user
+  evidence.
+
+## Approach
+
+1. Have ChatGPT Pro inspect the merged fix and current hosted-local harness, then
+   return a scoped patch implementing the smallest complete full-stack proof.
+2. Treat the patch as intent: inspect its authority boundary, remove accidental
+   complexity, and verify the exact race locally.
+3. Run focused package tests and typechecks, then the required PR review and CI
+   gates.
+
+## State
+
+Implementation and focused verification complete.
+
+- The observer records a bounded, typed per-user sequence across snapshot
+  start, checkpoint start/commit, mailbox fetch completion, and provider start.
+- Test-only barriers deterministically hold an interrupted snapshot start, its
+  exact rearm conversation probe, or a committed canonical publication.
+- The runtime now rearms an interrupted idle checkpoint even when a parallel
+  foreground waiter consumed the optional wake-notification timestamp, and the
+  regression covers that seedless interruption directly.
+- The registered scenario runs its production-floor and ordering profiles in
+  separate Vitest processes because hosted crypto state is process-scoped.
+- Focused unit, harness, Cloudflare control, typecheck, bundle, and exact
+  hosted-local scenario checks pass; commit, PR, CI, and required review gates
+  remain.
+Status: completed
+Updated: 2026-08-04
+Completed: 2026-08-04

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -323,8 +323,14 @@ never reads production feedback or enters Resend.
   and separately stages system-mailbox, retention-only, stale-owner, and active
   foreground contention. Each real signed Linq inbound must produce exactly one
   accepted outbound Linq request within 30 seconds while any staged background
-  checkpoint remains held. Its separately named workflow leg makes this latency
-  invariant visible without replacing the two aggregate required checks.
+  checkpoint remains held. The same scenario command then starts a clean Vitest
+  process with a 10-second idle floor and typed, bounded ordering observation.
+  That process proves a later durable conversation reaches mailbox import and
+  provider start before an interrupted idle snapshot can retry, and proves the
+  same foreground continuation after a committed canonical publication. The
+  two process profiles cannot share process-scoped hosted crypto state. Its
+  separately named workflow leg makes these invariants visible without
+  replacing the two aggregate required checks.
 - `apps/web/test/hosted-runtime-latency-alert-{monitor,cron}.test.ts` locks the
   same exact 30-second boundary for completed and still-unresolved Linq traces,
   excludes chronologically valid AI usage-denied traces before grouping while

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -100,7 +100,11 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // closure, and 10,119,605B total on 2026-08-01. No forbidden subsystem
 // entered the boot graph. Ratchet each baseline to the merged measurement and
 // retain the established allowances.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_119_605 + 32_768;
+//
+// The hosted-local foreground-priority regression adds bounded test-only
+// ordering observations to the runner entrypoint. macOS assembly measured
+// 10,159,135B total on 2026-08-05; retain the established allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_159_135 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_699_250;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_442_983;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/src/hosted-local-test/foreground-priority-ordering.ts
+++ b/apps/cloudflare/src/hosted-local-test/foreground-priority-ordering.ts
@@ -1,0 +1,515 @@
+import {
+  HOSTED_RUNTIME_MAILBOX_FETCH_PATH,
+  HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH,
+} from "@murphai/hosted-execution/routes";
+
+import {
+  HOSTED_RUNNER_BOUND_USER_ID_HEADER,
+} from "../runner-outbound/headers.ts";
+import type {
+  RunnerOutboundEnvironmentSource,
+} from "../runner-outbound.ts";
+
+export interface HostedLocalForegroundPriorityOrderingOutboundContext {
+  containerId?: string;
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+export type HostedLocalForegroundPriorityOrderingOutboundHandler = (
+  request: Request,
+  env: RunnerOutboundEnvironmentSource,
+  ctx: HostedLocalForegroundPriorityOrderingOutboundContext,
+) => Promise<Response>;
+
+export type HostedLocalForegroundPriorityOrderingBarrierTarget =
+  | "canonical_post_commit"
+  | "empty_conversation_probe"
+  | "none";
+
+export type HostedLocalForegroundPriorityOrderingBarrierState =
+  | "armed"
+  | "disabled"
+  | "entered"
+  | "released";
+
+export type HostedLocalForegroundPriorityOrderingEvent =
+  | {
+      kind: "assistant_provider_started";
+      ordinal: number;
+    }
+  | {
+      kind: "canonical_checkpoint_committed";
+      ordinal: number;
+    }
+  | {
+      kind: "workspace_checkpoint_started";
+      ordinal: number;
+      reason:
+        | "canonical_runtime_commit"
+        | "idle_shutdown"
+        | "other"
+        | null;
+    }
+  | {
+      conversationItemCount: number | null;
+      conversationLaneRequested: boolean | null;
+      conversationSeqEnd: string | null;
+      kind: "mailbox_fetch_finished";
+      ordinal: number;
+      probeKind:
+        | "checkpoint_interrupt"
+        | "checkpoint_interrupt_rearm"
+        | "other"
+        | "runtime_wake"
+        | null;
+      responseStatus: number;
+    }
+  | {
+      kind: "snapshot_started";
+      ordinal: number;
+    };
+
+export interface HostedLocalForegroundPriorityOrderingObservationState {
+  barrierState: HostedLocalForegroundPriorityOrderingBarrierState;
+  barrierTarget: HostedLocalForegroundPriorityOrderingBarrierTarget;
+  events: HostedLocalForegroundPriorityOrderingEvent[];
+  state: "armed" | "unarmed";
+  truncated: boolean;
+}
+
+export type HostedLocalForegroundPriorityOrderingControlInput =
+  | {
+      action: "arm";
+      barrierTarget?: HostedLocalForegroundPriorityOrderingBarrierTarget;
+      userId: string;
+    }
+  | {
+      action: "clear" | "record-provider-start" | "release" | "status";
+      userId: string;
+    };
+
+export type HostedLocalForegroundPriorityOrderingControlResult =
+  | HostedLocalForegroundPriorityOrderingObservationState
+  | { cleared: boolean; ok: true }
+  | { ok: true }
+  | { ok: true; released: boolean };
+
+export type HostedLocalForegroundPriorityOrderingSurface =
+  | "snapshot-store"
+  | "web-control";
+
+type HostedLocalForegroundPriorityOrderingEventInput =
+  HostedLocalForegroundPriorityOrderingEvent extends infer Event
+    ? Event extends { ordinal: number }
+      ? Omit<Event, "ordinal">
+      : never
+    : never;
+
+interface HostedLocalForegroundPriorityOrderingBarrier {
+  release(): void;
+  released: Promise<void>;
+  state: HostedLocalForegroundPriorityOrderingBarrierState;
+  target: HostedLocalForegroundPriorityOrderingBarrierTarget;
+}
+
+interface HostedLocalForegroundPriorityOrderingObservation {
+  barrier: HostedLocalForegroundPriorityOrderingBarrier;
+  events: HostedLocalForegroundPriorityOrderingEvent[];
+  truncated: boolean;
+}
+
+const HOSTED_LOCAL_FOREGROUND_PRIORITY_ORDERING_EVENT_LIMIT = 64;
+const foregroundPriorityOrderingObservations =
+  new Map<string, HostedLocalForegroundPriorityOrderingObservation>();
+
+export function armForegroundPriorityOrderingObservation(
+  userId: string,
+  barrierTarget: HostedLocalForegroundPriorityOrderingBarrierTarget = "none",
+): void {
+  const normalizedUserId = normalizeForegroundPriorityOrderingUserId(userId);
+  if (foregroundPriorityOrderingObservations.has(normalizedUserId)) {
+    throw new Error(
+      "A hosted-local foreground-priority ordering observation is already armed for this user.",
+    );
+  }
+
+  foregroundPriorityOrderingObservations.set(normalizedUserId, {
+    barrier: createForegroundPriorityOrderingBarrier(barrierTarget),
+    events: [],
+    truncated: false,
+  });
+}
+
+export function clearForegroundPriorityOrderingObservation(userId: string): boolean {
+  const normalizedUserId = normalizeForegroundPriorityOrderingUserId(userId);
+  const observation = foregroundPriorityOrderingObservations.get(normalizedUserId);
+  if (!observation) {
+    return false;
+  }
+
+  foregroundPriorityOrderingObservations.delete(normalizedUserId);
+  releaseForegroundPriorityOrderingBarrierState(observation.barrier);
+  return true;
+}
+
+export function readForegroundPriorityOrderingObservation(
+  userId: string,
+): HostedLocalForegroundPriorityOrderingObservationState {
+  const observation = foregroundPriorityOrderingObservations.get(
+    normalizeForegroundPriorityOrderingUserId(userId),
+  );
+  if (!observation) {
+    return {
+      barrierState: "disabled",
+      barrierTarget: "none",
+      events: [],
+      state: "unarmed",
+      truncated: false,
+    };
+  }
+
+  return {
+    barrierState: observation.barrier.state,
+    barrierTarget: observation.barrier.target,
+    events: observation.events.map((event) => ({ ...event })),
+    state: "armed",
+    truncated: observation.truncated,
+  };
+}
+
+export function releaseForegroundPriorityOrderingBarrier(userId: string): boolean {
+  const observation = foregroundPriorityOrderingObservations.get(
+    normalizeForegroundPriorityOrderingUserId(userId),
+  );
+  return observation
+    ? releaseForegroundPriorityOrderingBarrierState(observation.barrier)
+    : false;
+}
+
+export function recordForegroundPriorityAssistantProviderStart(userId: string): void {
+  const normalizedUserId = normalizeForegroundPriorityOrderingUserId(userId);
+  if (!foregroundPriorityOrderingObservations.has(normalizedUserId)) {
+    throw new Error(
+      "Hosted-local foreground-priority provider start requires an armed observation.",
+    );
+  }
+  recordForegroundPriorityOrderingEvent(normalizedUserId, {
+    kind: "assistant_provider_started",
+  });
+}
+
+export function wrapForegroundPriorityOrderingObservationForTest(
+  handler: HostedLocalForegroundPriorityOrderingOutboundHandler,
+  surface: HostedLocalForegroundPriorityOrderingSurface,
+): HostedLocalForegroundPriorityOrderingOutboundHandler {
+  return async (request, env, ctx) => {
+    const userId = request.headers.get(HOSTED_RUNNER_BOUND_USER_ID_HEADER)?.trim() ?? "";
+    if (userId.length === 0 || !foregroundPriorityOrderingObservations.has(userId)) {
+      return await handler(request, env, ctx);
+    }
+
+    switch (surface) {
+      case "snapshot-store":
+        return await observeForegroundPrioritySnapshotRequest(
+          userId,
+          request,
+          () => handler(request, env, ctx),
+        );
+      case "web-control":
+        return await observeForegroundPriorityWebControlRequest(
+          userId,
+          request,
+          () => handler(request, env, ctx),
+        );
+    }
+  };
+}
+
+async function observeForegroundPrioritySnapshotRequest(
+  userId: string,
+  request: Request,
+  run: () => Promise<Response>,
+): Promise<Response> {
+  const pathname = new URL(request.url).pathname;
+  if (request.method === "POST" && pathname === "/workspace-snapshots/start") {
+    recordForegroundPriorityOrderingEvent(userId, { kind: "snapshot_started" });
+  }
+  return await run();
+}
+
+async function observeForegroundPriorityWebControlRequest(
+  userId: string,
+  request: Request,
+  run: () => Promise<Response>,
+): Promise<Response> {
+  const pathname = new URL(request.url).pathname;
+  if (request.method !== "POST") {
+    return await run();
+  }
+
+  if (pathname === HOSTED_RUNTIME_MAILBOX_FETCH_PATH) {
+    const requestSummary = await readMailboxFetchRequestSummary(request);
+    const response = await run();
+    const summary = await readMailboxFetchConversationSummary(response);
+    recordForegroundPriorityOrderingEvent(userId, {
+      ...summary,
+      ...requestSummary,
+      kind: "mailbox_fetch_finished",
+      responseStatus: response.status,
+    });
+    if (
+      response.ok
+      && requestSummary.conversationLaneRequested === true
+      && requestSummary.probeKind === "checkpoint_interrupt_rearm"
+      && summary.conversationItemCount === 0
+      && foregroundPriorityOrderingObservationHasEvent(
+        userId,
+        "snapshot_started",
+      )
+    ) {
+      await enterForegroundPriorityOrderingBarrier(
+        userId,
+        "empty_conversation_probe",
+      );
+    }
+    return response;
+  }
+
+  if (pathname !== HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH) {
+    return await run();
+  }
+  const reason = await readWorkspaceCheckpointReason(request);
+  recordForegroundPriorityOrderingEvent(userId, {
+    kind: "workspace_checkpoint_started",
+    reason,
+  });
+  const response = await run();
+  if (
+    reason === "canonical_runtime_commit"
+    && response.ok
+    && await isForegroundPriorityCommittedCanonicalCheckpointResponse(response)
+  ) {
+    recordForegroundPriorityOrderingEvent(userId, {
+      kind: "canonical_checkpoint_committed",
+    });
+    await enterForegroundPriorityOrderingBarrier(
+      userId,
+      "canonical_post_commit",
+    );
+  }
+  return response;
+}
+
+async function readWorkspaceCheckpointReason(request: Request): Promise<
+  | "canonical_runtime_commit"
+  | "idle_shutdown"
+  | "other"
+  | null
+> {
+  const body: unknown = await request.clone().json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null;
+  }
+  const reason = "reason" in body ? body.reason : null;
+  if (reason === "canonical_runtime_commit" || reason === "idle_shutdown") {
+    return reason;
+  }
+  return typeof reason === "string" && reason.trim().length > 0
+    ? "other"
+    : null;
+}
+
+function recordForegroundPriorityOrderingEvent(
+  userId: string,
+  event: HostedLocalForegroundPriorityOrderingEventInput,
+): void {
+  const observation = foregroundPriorityOrderingObservations.get(userId);
+  if (!observation) {
+    return;
+  }
+  if (observation.events.length >= HOSTED_LOCAL_FOREGROUND_PRIORITY_ORDERING_EVENT_LIMIT) {
+    observation.truncated = true;
+    return;
+  }
+
+  observation.events.push({
+    ...event,
+    ordinal: observation.events.length + 1,
+  } as HostedLocalForegroundPriorityOrderingEvent);
+}
+
+function foregroundPriorityOrderingObservationHasEvent(
+  userId: string,
+  kind: HostedLocalForegroundPriorityOrderingEvent["kind"],
+): boolean {
+  return foregroundPriorityOrderingObservations.get(userId)?.events.some(
+    (event) => event.kind === kind,
+  ) ?? false;
+}
+
+async function readMailboxFetchRequestSummary(
+  request: Request,
+): Promise<{
+  conversationLaneRequested: boolean | null;
+  probeKind:
+    | "checkpoint_interrupt"
+    | "checkpoint_interrupt_rearm"
+    | "other"
+    | "runtime_wake"
+    | null;
+}> {
+  const body: unknown = await request.clone().json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { conversationLaneRequested: null, probeKind: null };
+  }
+  const lanes = "lanes" in body && Array.isArray(body.lanes)
+    ? body.lanes
+    : null;
+  if (lanes === null) {
+    return { conversationLaneRequested: null, probeKind: null };
+  }
+  const requestId = "requestId" in body && typeof body.requestId === "string"
+    ? body.requestId
+    : null;
+  return {
+    conversationLaneRequested: lanes.some((lane) =>
+      lane
+      && typeof lane === "object"
+      && !Array.isArray(lane)
+      && "lane" in lane
+      && lane.lane === "conversation"
+    ),
+    probeKind: classifyForegroundPriorityOrderingProbeKind(requestId),
+  };
+}
+
+function classifyForegroundPriorityOrderingProbeKind(
+  requestId: string | null,
+):
+  | "checkpoint_interrupt"
+  | "checkpoint_interrupt_rearm"
+  | "other"
+  | "runtime_wake"
+  | null {
+  if (requestId === null) {
+    return null;
+  }
+  if (requestId.includes(":checkpoint-interrupt-rearm-")) {
+    return "checkpoint_interrupt_rearm";
+  }
+  if (requestId.includes(":checkpoint-interrupt-")) {
+    return "checkpoint_interrupt";
+  }
+  return requestId.includes(":runtime-wake:") ? "runtime_wake" : "other";
+}
+
+async function readMailboxFetchConversationSummary(response: Response): Promise<{
+  conversationItemCount: number | null;
+  conversationSeqEnd: string | null;
+}> {
+  const body: unknown = await response.clone().json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { conversationItemCount: null, conversationSeqEnd: null };
+  }
+  const items = "items" in body && Array.isArray(body.items) ? body.items : null;
+  if (items === null) {
+    return { conversationItemCount: null, conversationSeqEnd: null };
+  }
+
+  let conversationItemCount = 0;
+  let conversationSeqEnd: bigint | null = null;
+  for (const item of items) {
+    if (
+      !item
+      || typeof item !== "object"
+      || Array.isArray(item)
+      || !("lane" in item)
+      || item.lane !== "conversation"
+    ) {
+      continue;
+    }
+    conversationItemCount += 1;
+    const laneSeq = "laneSeq" in item
+      ? readForegroundPriorityOrderingSeq(item.laneSeq)
+      : null;
+    if (laneSeq !== null && (conversationSeqEnd === null || laneSeq > conversationSeqEnd)) {
+      conversationSeqEnd = laneSeq;
+    }
+  }
+
+  return {
+    conversationItemCount,
+    conversationSeqEnd: conversationSeqEnd?.toString() ?? null,
+  };
+}
+
+function readForegroundPriorityOrderingSeq(value: unknown): bigint | null {
+  if (typeof value === "string" && /^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    return BigInt(value);
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return BigInt(value);
+  }
+  return null;
+}
+
+function createForegroundPriorityOrderingBarrier(
+  target: HostedLocalForegroundPriorityOrderingBarrierTarget,
+): HostedLocalForegroundPriorityOrderingBarrier {
+  let release = () => {};
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    release,
+    released,
+    state: target === "none" ? "disabled" : "armed",
+    target,
+  };
+}
+
+async function enterForegroundPriorityOrderingBarrier(
+  userId: string,
+  target: Exclude<HostedLocalForegroundPriorityOrderingBarrierTarget, "none">,
+): Promise<void> {
+  const barrier = foregroundPriorityOrderingObservations.get(userId)?.barrier;
+  if (!barrier || barrier.target !== target || barrier.state !== "armed") {
+    return;
+  }
+  barrier.state = "entered";
+  await barrier.released;
+}
+
+function releaseForegroundPriorityOrderingBarrierState(
+  barrier: HostedLocalForegroundPriorityOrderingBarrier,
+): boolean {
+  if (barrier.state === "disabled" || barrier.state === "released") {
+    return false;
+  }
+  barrier.state = "released";
+  barrier.release();
+  return true;
+}
+
+function normalizeForegroundPriorityOrderingUserId(userId: string): string {
+  const normalizedUserId = userId.trim();
+  if (normalizedUserId.length === 0) {
+    throw new TypeError(
+      "Hosted-local foreground-priority ordering observation requires a user id.",
+    );
+  }
+  return normalizedUserId;
+}
+
+async function isForegroundPriorityCommittedCanonicalCheckpointResponse(
+  response: Response,
+): Promise<boolean> {
+  const body: unknown = await response.clone().json().catch(() => null);
+  return Boolean(
+    body
+      && typeof body === "object"
+      && !Array.isArray(body)
+      && "checkpointed" in body
+      && body.checkpointed === true,
+  );
+}

--- a/apps/cloudflare/src/hosted-local-test/runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/runner-container.ts
@@ -31,6 +31,16 @@ import type {
 import {
   asWorkerStringEnvironment,
 } from "../worker-contracts.ts";
+import {
+  armForegroundPriorityOrderingObservation,
+  clearForegroundPriorityOrderingObservation,
+  readForegroundPriorityOrderingObservation,
+  recordForegroundPriorityAssistantProviderStart,
+  releaseForegroundPriorityOrderingBarrier,
+  wrapForegroundPriorityOrderingObservationForTest,
+  type HostedLocalForegroundPriorityOrderingControlInput,
+  type HostedLocalForegroundPriorityOrderingControlResult,
+} from "./foreground-priority-ordering.ts";
 
 export interface HostedLocalTestRunnerOutboundContext {
   containerId?: string;
@@ -70,6 +80,41 @@ export class RunnerContainer extends BaseRunnerContainer {
   ): Promise<{ ok: true }> {
     armCanonicalCheckpointPublicationBarrier(input.userId);
     return { ok: true };
+  }
+
+  async armIdleSnapshotStartBarrierForTest(
+    input: { userId: string },
+  ): Promise<{ ok: true }> {
+    armIdleSnapshotStartBarrier(input.userId);
+    return { ok: true };
+  }
+
+  async foregroundPriorityOrderingControlForTest(
+    input: HostedLocalForegroundPriorityOrderingControlInput,
+  ): Promise<HostedLocalForegroundPriorityOrderingControlResult> {
+    switch (input.action) {
+      case "arm":
+        armForegroundPriorityOrderingObservation(
+          input.userId,
+          input.barrierTarget ?? "none",
+        );
+        return { ok: true };
+      case "clear":
+        return {
+          cleared: clearForegroundPriorityOrderingObservation(input.userId),
+          ok: true,
+        };
+      case "record-provider-start":
+        recordForegroundPriorityAssistantProviderStart(input.userId);
+        return { ok: true };
+      case "release":
+        return {
+          ok: true,
+          released: releaseForegroundPriorityOrderingBarrier(input.userId),
+        };
+      case "status":
+        return readForegroundPriorityOrderingObservation(input.userId);
+    }
   }
 
   async armSnapshotPublicationCorruptionForTest(
@@ -189,7 +234,7 @@ export type HostedLocalShutdownCheckpointPublicationBarrierState =
 
 interface HostedLocalShutdownCheckpointPublicationBarrier {
   entered: boolean;
-  reason: "canonical_runtime_commit" | "idle_shutdown";
+  target: "canonical_runtime_commit" | "idle_shutdown" | "snapshot_start";
   release(): void;
   released: Promise<void>;
 }
@@ -310,9 +355,13 @@ export function armCanonicalCheckpointPublicationBarrier(userId: string): void {
   armCheckpointPublicationBarrier(userId, "canonical_runtime_commit");
 }
 
+export function armIdleSnapshotStartBarrier(userId: string): void {
+  armCheckpointPublicationBarrier(userId, "snapshot_start");
+}
+
 function armCheckpointPublicationBarrier(
   userId: string,
-  reason: "canonical_runtime_commit" | "idle_shutdown",
+  target: "canonical_runtime_commit" | "idle_shutdown" | "snapshot_start",
 ): void {
   const normalizedUserId = normalizeShutdownCheckpointPublicationBarrierUserId(userId);
   if (shutdownCheckpointPublicationBarriers.has(normalizedUserId)) {
@@ -327,7 +376,7 @@ function armCheckpointPublicationBarrier(
   });
   shutdownCheckpointPublicationBarriers.set(normalizedUserId, {
     entered: false,
-    reason,
+    target,
     release,
     released,
   });
@@ -369,7 +418,7 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
       !barrier
       || !await isCheckpointPublicationRequestForReason(
         request,
-        barrier.reason,
+        barrier.target,
       )
     ) {
       return await handler(request, env, ctx);
@@ -379,7 +428,7 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
     emitHostedExecutionStructuredLog({
       component: "runner",
       details: {
-        barrierKind: `${barrier.reason}_checkpoint_publication`,
+        barrierKind: `${barrier.target}_checkpoint_publication`,
       },
       message:
         "Hosted-local test paused checkpoint publication before the real checkpoint commit.",
@@ -401,10 +450,17 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
 
 async function isCheckpointPublicationRequestForReason(
   request: Request,
-  reason: "canonical_runtime_commit" | "idle_shutdown",
+  target: "canonical_runtime_commit" | "idle_shutdown" | "snapshot_start",
 ): Promise<boolean> {
   if (
-    reason === "canonical_runtime_commit"
+    target === "snapshot_start"
+    && request.method === "POST"
+    && new URL(request.url).pathname === "/workspace-snapshots/start"
+  ) {
+    return true;
+  }
+  if (
+    target === "canonical_runtime_commit"
     && await isCanonicalRuntimeCheckpointRequest(request)
   ) {
     return true;
@@ -424,7 +480,7 @@ async function isCheckpointPublicationRequestForReason(
     && typeof checkpointRequest === "object"
     && !Array.isArray(checkpointRequest)
     && "reason" in checkpointRequest
-    && checkpointRequest.reason === reason,
+    && checkpointRequest.reason === target,
   );
 }
 
@@ -662,12 +718,18 @@ const hostedLocalTestOutboundByHost: typeof HOSTED_RUNNER_OUTBOUND_BY_HOST = {
   [CLOUDFLARE_HOSTED_TRANSCRIBE_HOST]: (request, env, ctx) =>
     transcribeHandler(request, env.AI ? env : { ...env, AI: hostedLocalTestAiBinding }, ctx),
   [CLOUDFLARE_HOSTED_RUNTIME_HOSTS.webControlPlane]:
-    wrapShutdownCheckpointPublicationBarrierForTest(
-      wrapCanonicalCheckpointLostAckForTest(webControlPlaneHandler),
+    wrapForegroundPriorityOrderingObservationForTest(
+      wrapShutdownCheckpointPublicationBarrierForTest(
+        wrapCanonicalCheckpointLostAckForTest(webControlPlaneHandler),
+      ),
+      "web-control",
     ),
   [CLOUDFLARE_HOSTED_RUNTIME_HOSTS.workspaceSnapshotStore]:
-    wrapShutdownCheckpointPublicationBarrierForTest(
-      wrapSnapshotPublicationCorruptionForTest(workspaceSnapshotStoreHandler),
+    wrapForegroundPriorityOrderingObservationForTest(
+      wrapShutdownCheckpointPublicationBarrierForTest(
+        wrapSnapshotPublicationCorruptionForTest(workspaceSnapshotStoreHandler),
+      ),
+      "snapshot-store",
     ),
   [CLOUDFLARE_HOSTED_RUNTIME_HOSTS.effectsPort]: effectsPortHandler,
   [HOSTED_LOCAL_LINQ_ATTACHMENT_UPLOAD_HOST]: handleHostedLocalLinqAttachmentUpload,

--- a/apps/cloudflare/src/worker/route-handlers/test-runner.ts
+++ b/apps/cloudflare/src/worker/route-handlers/test-runner.ts
@@ -7,6 +7,9 @@ import {
   jsonError,
   notFound,
 } from "../../json.ts";
+import type {
+  HostedLocalForegroundPriorityOrderingControlInput,
+} from "../../hosted-local-test/foreground-priority-ordering.ts";
 import {
   resolveHostedExecutionRunnerContainerName,
 } from "../../runner-container.ts";
@@ -59,6 +62,9 @@ interface HostedLocalTestRunnerContainerStubLike {
   armCanonicalCheckpointPublicationBarrierForTest?(
     input: { userId: string },
   ): Promise<{ ok: true }>;
+  armIdleSnapshotStartBarrierForTest?(
+    input: { userId: string },
+  ): Promise<{ ok: true }>;
   armSnapshotPublicationCorruptionForTest?(
     input: { userId: string },
   ): Promise<{ ok: true }>;
@@ -70,6 +76,9 @@ interface HostedLocalTestRunnerContainerStubLike {
   ): Promise<{ ok: true }>;
   dropActiveOperationForTest?(input: { userId: string }): Promise<{ ok: true }>;
   expireActivityForTest?(input: { userId: string }): Promise<{ ok: true }>;
+  foregroundPriorityOrderingControlForTest?(
+    input: HostedLocalForegroundPriorityOrderingControlInput,
+  ): Promise<unknown>;
   readShutdownCheckpointPublicationBarrierForTest?(
     input: { userId: string },
   ): Promise<{ state: "armed" | "entered" | "unarmed" }>;
@@ -79,6 +88,17 @@ interface HostedLocalTestRunnerContainerStubLike {
   releaseShutdownCheckpointPublicationBarrierForTest?(
     input: { userId: string },
   ): Promise<{ ok: true; released: boolean }>;
+}
+
+function hasHostedLocalTestRunnerContainerForegroundPriorityOrderingControl(
+  stub: object,
+): stub is HostedLocalTestRunnerContainerStubLike & {
+  foregroundPriorityOrderingControlForTest(
+    input: HostedLocalForegroundPriorityOrderingControlInput,
+  ): Promise<unknown>;
+} {
+  return "foregroundPriorityOrderingControlForTest" in stub
+    && typeof stub.foregroundPriorityOrderingControlForTest === "function";
 }
 
 function hasHostedLocalTestRunnerContainerGeneratedImageProviderBarrierControl(
@@ -116,6 +136,7 @@ function hasHostedLocalTestRunnerContainerShutdownCheckpointPublicationBarrierCo
 ): stub is HostedLocalTestRunnerContainerStubLike & Required<Pick<
   HostedLocalTestRunnerContainerStubLike,
   | "armCanonicalCheckpointPublicationBarrierForTest"
+  | "armIdleSnapshotStartBarrierForTest"
   | "armShutdownCheckpointPublicationBarrierForTest"
   | "beginShutdownCheckpointGracefulStopForTest"
   | "readShutdownCheckpointPublicationBarrierForTest"
@@ -123,6 +144,8 @@ function hasHostedLocalTestRunnerContainerShutdownCheckpointPublicationBarrierCo
 >> {
   return "armCanonicalCheckpointPublicationBarrierForTest" in stub
     && typeof stub.armCanonicalCheckpointPublicationBarrierForTest === "function"
+    && "armIdleSnapshotStartBarrierForTest" in stub
+    && typeof stub.armIdleSnapshotStartBarrierForTest === "function"
     && "armShutdownCheckpointPublicationBarrierForTest" in stub
     && typeof stub.armShutdownCheckpointPublicationBarrierForTest === "function"
     && "beginShutdownCheckpointGracefulStopForTest" in stub
@@ -192,6 +215,22 @@ export const testRunnerRoutes: readonly DeclarativeRoute<WorkerRouteContext>[] =
     ),
     methods: ["POST"],
     name: "test-canonical-checkpoint-lost-ack",
+    wrongMethodResponse: "not-found",
+  },
+  {
+    authorization: "vercel-oidc",
+    beforeMethod(context) {
+      return requireHostedWorkerTestEnvironment(context);
+    },
+    async handle(context, params) {
+      return handleTestForegroundPriorityOrderingRoute(context, params.userId);
+    },
+    match: matchHostedLocalTestUserRoute(
+      "/__test/users/",
+      "/foreground-priority-ordering",
+    ),
+    methods: ["POST"],
+    name: "test-foreground-priority-ordering",
     wrongMethodResponse: "not-found",
   },
   {
@@ -465,6 +504,72 @@ export async function handleTestCanonicalCheckpointLostAckRoute(
   return json(await stub.armCanonicalCheckpointLostAckForTest({ userId }));
 }
 
+export async function handleTestForegroundPriorityOrderingRoute(
+  context: WorkerRouteContext,
+  encodedUserId: string,
+): Promise<Response> {
+  if (!isHostedWorkerTestEnvironment(context.env)) {
+    return notFound();
+  }
+
+  const userId = decodeRouteParam(encodedUserId);
+  const boundUserResponse = requireHostedExecutionBoundUserResponse(
+    context.request,
+    userId,
+    "Hosted execution bound user does not match the test runner user.",
+    "test-runner-bound-user-mismatch",
+    "test-foreground-priority-ordering",
+  );
+  if (boundUserResponse) {
+    return boundUserResponse;
+  }
+
+  const actions = context.url.searchParams.getAll("action");
+  const action = actions.length === 1 ? actions[0] : null;
+  if (
+    context.url.searchParams.size !== 1
+    || (
+      action !== "arm-canonical"
+      && action !== "arm-empty-probe"
+      && action !== "clear"
+      && action !== "provider-start"
+      && action !== "release"
+      && action !== "status"
+    )
+  ) {
+    return jsonError(
+      "Foreground-priority ordering action must be arm-canonical, arm-empty-probe, clear, provider-start, release, or status.",
+      400,
+    );
+  }
+
+  const runnerContainerName = resolveHostedExecutionRunnerContainerName({
+    source: context.env,
+    userId,
+  });
+  const stub = context.env.RUNNER_CONTAINER.getByName(runnerContainerName);
+  if (!hasHostedLocalTestRunnerContainerForegroundPriorityOrderingControl(stub)) {
+    throw new Error(
+      "Hosted runner container foreground-priority ordering test RPC is unavailable.",
+    );
+  }
+
+  if (action === "arm-canonical" || action === "arm-empty-probe") {
+    return json(await stub.foregroundPriorityOrderingControlForTest({
+      action: "arm",
+      barrierTarget: action === "arm-canonical"
+        ? "canonical_post_commit"
+        : "empty_conversation_probe",
+      userId,
+    }));
+  }
+
+  return json(await stub.foregroundPriorityOrderingControlForTest({
+    action: action === "provider-start" ? "record-provider-start" : action,
+    userId,
+  }));
+}
+
 async function handleTestGeneratedImageProviderBarrierRoute(
   context: WorkerRouteContext,
   encodedUserId: string,
@@ -564,13 +669,14 @@ export async function handleTestShutdownCheckpointPublicationBarrierRoute(
     || (
       action !== "arm"
       && action !== "arm-canonical"
+      && action !== "arm-snapshot-start"
       && action !== "shutdown"
       && action !== "status"
       && action !== "release"
     )
   ) {
     return jsonError(
-      "Checkpoint publication barrier action must be arm, arm-canonical, shutdown, status, or release.",
+      "Checkpoint publication barrier action must be arm, arm-canonical, arm-snapshot-start, shutdown, status, or release.",
       400,
     );
   }
@@ -589,6 +695,8 @@ export async function handleTestShutdownCheckpointPublicationBarrierRoute(
   switch (action) {
     case "arm-canonical":
       return json(await stub.armCanonicalCheckpointPublicationBarrierForTest({ userId }));
+    case "arm-snapshot-start":
+      return json(await stub.armIdleSnapshotStartBarrierForTest({ userId }));
     case "arm":
       return json(await stub.armShutdownCheckpointPublicationBarrierForTest({ userId }));
     case "shutdown":

--- a/apps/cloudflare/test/helpers/hosted-local-dev-harness.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-dev-harness.ts
@@ -17,6 +17,10 @@ import {
   HOSTED_EXECUTION_USER_ID_HEADER,
 } from "@murphai/hosted-execution/contracts";
 
+import type {
+  HostedLocalForegroundPriorityOrderingObservationState,
+} from "../../src/hosted-local-test/foreground-priority-ordering.ts";
+
 import { repoRoot } from "../../vitest.shared.js";
 import { resolveHostedLocalDevConfig } from "@murphai/hosted-local-harness/dev-hosted-local/config";
 import {
@@ -46,11 +50,27 @@ export interface HostedLocalDevHarness {
   requestJson<T>(pathname: string, init?: RequestInit): Promise<T>;
   readUserStatus(userId: string): Promise<HostedRunnerStatusResponse>;
   armCanonicalCheckpointLostAckForTest(userId: string): Promise<{ ok: true }>;
+  armForegroundPriorityOrderingObservationForTest(
+    userId: string,
+    barrierTarget:
+      | "canonical_post_commit"
+      | "empty_conversation_probe",
+  ): Promise<{ ok: true }>;
+  clearForegroundPriorityOrderingObservationForTest(
+    userId: string,
+  ): Promise<{ cleared: boolean; ok: true }>;
   armSnapshotPublicationCorruptionForTest(userId: string): Promise<{ ok: true }>;
+  armIdleSnapshotStartBarrierForTest(userId: string): Promise<{ ok: true }>;
   armShutdownCheckpointPublicationBarrierForTest(userId: string): Promise<{ ok: true }>;
   beginShutdownCheckpointGracefulStopForTest(userId: string): Promise<{ ok: true }>;
   expireRunnerActivityForTest(userId: string): Promise<{ ok: true }>;
   dropRunnerActiveOperationForTest(userId: string): Promise<{ ok: true }>;
+  readForegroundPriorityOrderingObservationForTest(
+    userId: string,
+  ): Promise<HostedLocalForegroundPriorityOrderingObservationState>;
+  recordForegroundPriorityAssistantProviderStartForTest(
+    userId: string,
+  ): Promise<{ ok: true }>;
   readShutdownCheckpointPublicationBarrierForTest(
     userId: string,
   ): Promise<{ state: "armed" | "entered" | "unarmed" }>;
@@ -96,6 +116,9 @@ export interface HostedLocalDevHarness {
     },
   ): Promise<HostedRunnerStatusResponse>;
   armGeneratedImageProviderBarrierForTest(userId: string): Promise<{ ok: true }>;
+  releaseForegroundPriorityOrderingBarrierForTest(
+    userId: string,
+  ): Promise<{ ok: true; released: boolean }>;
   releaseGeneratedImageProviderBarrierForTest(userId: string): Promise<{ ok: true }>;
   webBaseUrl: string;
   workerBaseUrl: string;
@@ -219,12 +242,18 @@ export async function startHostedLocalDevHarness(input: {
       },
       armGeneratedImageProviderBarrierForTest,
       armCanonicalCheckpointLostAckForTest,
+      armForegroundPriorityOrderingObservationForTest,
+      clearForegroundPriorityOrderingObservationForTest,
       armSnapshotPublicationCorruptionForTest,
+      armIdleSnapshotStartBarrierForTest,
       armShutdownCheckpointPublicationBarrierForTest,
       beginShutdownCheckpointGracefulStopForTest,
       dropRunnerActiveOperationForTest,
       expireRunnerActivityForTest,
+      readForegroundPriorityOrderingObservationForTest,
+      recordForegroundPriorityAssistantProviderStartForTest,
       readShutdownCheckpointPublicationBarrierForTest,
+      releaseForegroundPriorityOrderingBarrierForTest,
       releaseGeneratedImageProviderBarrierForTest,
       releaseShutdownCheckpointPublicationBarrierForTest,
       runHostedAlarmInvocationForTest: requireTestControls(runHostedAlarmInvocationForTest),
@@ -560,6 +589,96 @@ export async function startHostedLocalDevHarness(input: {
     );
   }
 
+  async function armForegroundPriorityOrderingObservationForTest(
+    userId: string,
+    barrierTarget:
+      | "canonical_post_commit"
+      | "empty_conversation_probe",
+  ): Promise<{ ok: true }> {
+    assertHostedLocalTestControlsAvailable(
+      "armForegroundPriorityOrderingObservationForTest",
+    );
+    const action = barrierTarget === "canonical_post_commit"
+      ? "arm-canonical"
+      : "arm-empty-probe";
+    return await requestForegroundPriorityOrderingControlForTest(
+      userId,
+      action,
+    );
+  }
+
+  async function readForegroundPriorityOrderingObservationForTest(
+    userId: string,
+  ): Promise<HostedLocalForegroundPriorityOrderingObservationState> {
+    assertHostedLocalTestControlsAvailable(
+      "readForegroundPriorityOrderingObservationForTest",
+    );
+    return await requestForegroundPriorityOrderingControlForTest(
+      userId,
+      "status",
+    );
+  }
+
+  async function releaseForegroundPriorityOrderingBarrierForTest(
+    userId: string,
+  ): Promise<{ ok: true; released: boolean }> {
+    assertHostedLocalTestControlsAvailable(
+      "releaseForegroundPriorityOrderingBarrierForTest",
+    );
+    return await requestForegroundPriorityOrderingControlForTest(
+      userId,
+      "release",
+    );
+  }
+
+  async function recordForegroundPriorityAssistantProviderStartForTest(
+    userId: string,
+  ): Promise<{ ok: true }> {
+    assertHostedLocalTestControlsAvailable(
+      "recordForegroundPriorityAssistantProviderStartForTest",
+    );
+    return await requestForegroundPriorityOrderingControlForTest(
+      userId,
+      "provider-start",
+    );
+  }
+
+  async function clearForegroundPriorityOrderingObservationForTest(
+    userId: string,
+  ): Promise<{ cleared: boolean; ok: true }> {
+    assertHostedLocalTestControlsAvailable(
+      "clearForegroundPriorityOrderingObservationForTest",
+    );
+    return await requestForegroundPriorityOrderingControlForTest(
+      userId,
+      "clear",
+    );
+  }
+
+  async function requestForegroundPriorityOrderingControlForTest<T>(
+    userId: string,
+    action:
+      | "arm-canonical"
+      | "arm-empty-probe"
+      | "clear"
+      | "provider-start"
+      | "release"
+      | "status",
+  ): Promise<T> {
+    return await requestJsonForRuntime<T>(
+      `/__test/users/${encodeURIComponent(userId)}`
+        + `/foreground-priority-ordering?action=${action}`,
+      {
+        headers: {
+          [HOSTED_EXECUTION_USER_ID_HEADER]: userId,
+          ...statusHeaders(userId),
+        },
+        method: "POST",
+        signal: AbortSignal.timeout(hostedLocalActivityExpiryTimeoutMs),
+      },
+    );
+  }
+
   async function armGeneratedImageProviderBarrierForTest(
     userId: string,
   ): Promise<{ ok: true }> {
@@ -621,6 +740,16 @@ export async function startHostedLocalDevHarness(input: {
     );
   }
 
+  async function armIdleSnapshotStartBarrierForTest(
+    userId: string,
+  ): Promise<{ ok: true }> {
+    assertHostedLocalTestControlsAvailable("armIdleSnapshotStartBarrierForTest");
+    return await requestShutdownCheckpointPublicationBarrierForTest<{ ok: true }>(
+      userId,
+      "arm-snapshot-start",
+    );
+  }
+
   async function beginShutdownCheckpointGracefulStopForTest(
     userId: string,
   ): Promise<{ ok: true }> {
@@ -652,7 +781,7 @@ export async function startHostedLocalDevHarness(input: {
 
   async function requestShutdownCheckpointPublicationBarrierForTest<T>(
     userId: string,
-    action: "arm" | "release" | "shutdown" | "status",
+    action: "arm" | "arm-snapshot-start" | "release" | "shutdown" | "status",
   ): Promise<T> {
     return await requestJsonForRuntime<T>(
       `/__test/users/${encodeURIComponent(userId)}`

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -10,12 +10,14 @@ import {
   ageHostedRuntimeLatencyAlertForTest,
   appendHostedExecutionWakeForTest,
   normalizeHostedLinqLatencyTracesForTest,
+  queryHostedRuntimeWorkflowForTest,
   readHostedMailboxItemForTest,
   seedHostedWorkspaceCheckpointForTest,
   seedHostedWorkspaceInboxMediaRetentionWakeForTest,
   setLatestHostedLinqReplyLatencyForTest,
   signalHostedMailboxAppendRuntimeForTest,
   signalHostedRuntimeRecheckRuntimeForTest,
+  signalHostedRuntimeWakeRuntimeForTest,
 } from "#hosted-web-testing";
 import {
   buildHostedExecutionAssistantAskCompletedWake,
@@ -41,6 +43,9 @@ import {
   buildHostedExecutionClinicalRecordsSyncRequestedWake,
 } from "@murphai/hosted-execution/clinical-records";
 import {
+  HOSTED_USER_RUNTIME_STATUS_QUERY_NAME,
+} from "@murphai/hosted-execution/orchestration-control";
+import {
   HOSTED_EXECUTION_USER_ID_HEADER,
   type HostedBrowserVaultReplicaRef,
   type HostedExecutionSnapshotRef,
@@ -59,6 +64,10 @@ import {
 import {
   buildAssistantProviderShellCommandCall,
 } from "./helpers/hosted-local-e2e-support.js";
+import type {
+  HostedLocalForegroundPriorityOrderingEvent,
+  HostedLocalForegroundPriorityOrderingObservationState,
+} from "../src/hosted-local-test/foreground-priority-ordering.ts";
 import {
   startHostedLocalFullStackScenario,
   type HostedLocalFullStackScenario,
@@ -85,6 +94,7 @@ const latencyAlertCronSecret = "hosted-local-priority-latency-cron-secret";
 const latencyAlertTimeZone = buildDaytimeTestTimeZone(new Date());
 const productionLikeAssistantModel = "gpt-5.6-terra";
 const productionIdleCheckpointDelayMs = 180_000;
+const orderingIdleCheckpointDelayMs = 10_000;
 const promptReplyDeadlineMs = 30_000;
 const duplicateReplyObservationMs = 3_000;
 const activeTurnDuplicateReplyObservationMs = 22_000;
@@ -99,10 +109,26 @@ interface ProbeIdentity {
   userId: string;
 }
 
+type ForegroundPriorityOrderingEventKind =
+  HostedLocalForegroundPriorityOrderingEvent["kind"];
+type ForegroundPriorityOrderingEventOfKind<
+  Kind extends ForegroundPriorityOrderingEventKind,
+> = Extract<HostedLocalForegroundPriorityOrderingEvent, { kind: Kind }>;
+
 const systemMailboxProbe = createProbeIdentity("system-mailbox");
 const retentionProbe = createProbeIdentity("retention");
 const stuckInvocationProbe = createProbeIdentity("stuck-invocation");
 const activeTurnProbe = createProbeIdentity("active-turn");
+const interruptedSnapshotOrderingProbe = createProbeIdentity(
+  "interrupted-snapshot-ordering",
+);
+const canonicalPublicationOrderingProbe = createProbeIdentity(
+  "canonical-publication-ordering",
+);
+const orderingProbeIdentities = [
+  interruptedSnapshotOrderingProbe,
+  canonicalPublicationOrderingProbe,
+] as const;
 const allProbeIdentities = [
   systemMailboxProbe,
   retentionProbe,
@@ -113,6 +139,8 @@ const allProbeIdentities = [
 let scenario: HostedLocalFullStackScenario | null = null;
 let linqStub: HostedLocalLinqStub | null = null;
 let resendStub: HostedLocalResendStub | null = null;
+let orderingScenario: HostedLocalFullStackScenario | null = null;
+let orderingLinqStub: HostedLocalLinqStub | null = null;
 
 describe.sequential("hosted local foreground reply priority e2e", () => {
   beforeAll(async () => {
@@ -524,6 +552,63 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
   }, 120_000);
 });
 
+// The idle checkpoint delay is process-wide. The scenario registry runs this
+// suite in its own Vitest process so the production-floor latency proofs above
+// remain unchanged while this race reaches a real idle snapshot deterministically.
+describe.sequential("hosted local foreground checkpoint ordering e2e", () => {
+  beforeAll(async () => {
+    orderingLinqStub = await startHostedLocalLinqStub();
+    orderingScenario = await startHostedLocalFullStackScenario({
+      additionalEnv: {
+        HOSTED_ASSISTANT_MODEL: productionLikeAssistantModel,
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        HOSTED_EXECUTION_IDLE_CHECKPOINT_DELAY_MS:
+          String(orderingIdleCheckpointDelayMs),
+        HOSTED_EXECUTION_RUNNER_IDLE_TTL_MS: "300000",
+        HOSTED_ONBOARDING_LINQ_LOCAL_ALLOWED_INBOUND_PHONE_NUMBERS:
+          orderingProbeIdentities.map((identity) => identity.memberPhone).join(","),
+        LINQ_API_BASE_URL: requireOrderingLinqStub().runnerBaseUrl,
+        LINQ_API_TOKEN: "linq-local-ordering-token",
+        LINQ_WEBHOOK_SECRET: linqWebhookSecret,
+        MURPH_DEV_SKIP_HEALTH_COMMONS_WATCH: "1",
+        OPENAI_API_KEY: "stub-local-ordering-openai-key",
+      },
+      assistantProviderStubModelId: productionLikeAssistantModel,
+      faultInjection: true,
+      localDatabaseUrl,
+      persistDirOverride: workerPersistDirOverride,
+      persistDirPrefix: "murph-hosted-local-foreground-ordering-",
+      requiredRunnerEnvProfile: "linq",
+      scenarioLabel: "Local hosted foreground checkpoint ordering e2e",
+      streamLogs: streamDevLogs,
+      testControls: true,
+    });
+  }, 600_000);
+
+  afterAll(async () => {
+    await orderingScenario?.stop();
+    orderingScenario = null;
+    await orderingLinqStub?.stop();
+    orderingLinqStub = null;
+  }, 120_000);
+
+  it("imports later durable input before retrying an interrupted idle snapshot", async () => {
+    await proveInterruptedSnapshotForegroundOrdering({
+      identity: interruptedSnapshotOrderingProbe,
+      linqStub: requireOrderingLinqStub(),
+      scenario: requireOrderingScenario(),
+    });
+  }, 240_000);
+
+  it("continues with durable foreground input after a committed canonical publication", async () => {
+    await proveCanonicalPublicationForegroundOrdering({
+      identity: canonicalPublicationOrderingProbe,
+      linqStub: requireOrderingLinqStub(),
+      scenario: requireOrderingScenario(),
+    });
+  }, 180_000);
+});
+
 function buildDaytimeTestTimeZone(now: Date): string {
   const unwrappedOffsetHours = 12 - now.getUTCHours();
   const offsetHours = unwrappedOffsetHours > 11
@@ -538,17 +623,760 @@ function buildDaytimeTestTimeZone(now: Date): string {
 }
 
 async function seedProbe(identity: ProbeIdentity): Promise<void> {
-  await requireScenario().seedActiveHostedLinqMember({
+  await seedProbeInScenario(requireScenario(), identity);
+}
+
+async function seedProbeInScenario(
+  targetScenario: HostedLocalFullStackScenario,
+  identity: ProbeIdentity,
+): Promise<void> {
+  await targetScenario.seedActiveHostedLinqMember({
     homePhone: identity.homePhone,
     memberId: identity.userId,
     memberPhone: identity.memberPhone,
   });
-  await requireScenario().bindActiveHostedLinqHomeChat({
+  await targetScenario.bindActiveHostedLinqHomeChat({
     chatId: identity.chatId,
     memberId: identity.userId,
     recipientPhone: identity.memberPhone,
   });
-  await seedActivatedWorkspaceCheckpoint(identity.userId);
+  await seedActivatedWorkspaceCheckpointInScenario(
+    targetScenario,
+    identity.userId,
+  );
+}
+
+async function proveInterruptedSnapshotForegroundOrdering(input: {
+  identity: ProbeIdentity;
+  linqStub: HostedLocalLinqStub;
+  scenario: HostedLocalFullStackScenario;
+}): Promise<void> {
+  const { identity, linqStub: targetLinqStub, scenario: targetScenario } = input;
+  await seedProbeInScenario(targetScenario, identity);
+  await armForegroundPriorityOrderingObservation({
+    mode: "empty-probe",
+    scenario: targetScenario,
+    userId: identity.userId,
+  });
+  let checkpointBarrierArmed = false;
+
+  try {
+    await targetScenario.harness.armIdleSnapshotStartBarrierForTest(
+      identity.userId,
+    );
+    checkpointBarrierArmed = true;
+
+    const warmupText = "Prepare one synthetic foreground turn for the idle checkpoint race.";
+    const warmupReply = "Synthetic checkpoint ordering state prepared.";
+    targetScenario.queueAssistantResponses(
+      [{
+        beforeResponse: async () => {
+          await targetScenario.harness
+            .recordForegroundPriorityAssistantProviderStartForTest(identity.userId);
+        },
+        text: warmupReply,
+      }],
+      { matchInputContains: warmupText },
+    );
+    const warmupResponse = await postSignedLinqWebhookForScenario(
+      targetScenario,
+      buildHostedLinqInboundEvent(identity.userId, identity.chatId, {
+        eventId: `evt_priority_ordering_warmup_${runId}`,
+        messageId: `msg_priority_ordering_warmup_${runId}`,
+        text: warmupText,
+      }),
+    );
+    expect(warmupResponse.status).toBe(202);
+    await expect(warmupResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+    const warmupProviderStart = await waitForForegroundPriorityOrderingEvent({
+      kind: "assistant_provider_started",
+      label: "warmup provider start before idle snapshot",
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    await waitForAssistantProviderInputInScenario({
+      expectedText: warmupText,
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+
+    await waitForCheckpointBarrierInScenario(targetScenario, identity.userId);
+    const snapshotStarted = await waitForForegroundPriorityOrderingEvent({
+      afterOrdinal: warmupProviderStart.ordinal,
+      kind: "snapshot_started",
+      label: "interruptible idle snapshot start",
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+
+    const runtimeWakeStateBefore = await readRuntimeWakeObservation({
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    await signalHostedRuntimeWakeRuntimeForTest({
+      environment: targetScenario.runtimeEnv,
+      userId: identity.userId,
+    });
+    await waitForRuntimeWakeExecution({
+      previous: runtimeWakeStateBefore,
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    await expect(
+      targetScenario.harness.readShutdownCheckpointPublicationBarrierForTest(
+        identity.userId,
+      ),
+    ).resolves.toEqual({ state: "entered" });
+
+    await expect(
+      targetScenario.harness.releaseShutdownCheckpointPublicationBarrierForTest(
+        identity.userId,
+      ),
+    ).resolves.toEqual({ ok: true, released: true });
+    checkpointBarrierArmed = false;
+
+    const heldEmptyProbe = await waitForForegroundPriorityOrderingObservation({
+      label: "post-interruption empty foreground mailbox probe",
+      predicate: (observation) =>
+        observation.barrierState === "entered"
+        && observation.barrierTarget === "empty_conversation_probe"
+        && foregroundPriorityOrderingEventsOfKind(
+          observation,
+          "mailbox_fetch_finished",
+        ).some((event) =>
+          event.ordinal > snapshotStarted.ordinal
+          && event.responseStatus === 200
+          && event.conversationLaneRequested === true
+          && event.probeKind === "checkpoint_interrupt_rearm"
+          && event.conversationItemCount === 0
+        ),
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const emptyForegroundProbe = foregroundPriorityOrderingEventsOfKind(
+      heldEmptyProbe,
+      "mailbox_fetch_finished",
+    ).find((event) =>
+      event.ordinal > snapshotStarted.ordinal
+      && event.responseStatus === 200
+      && event.conversationLaneRequested === true
+      && event.probeKind === "checkpoint_interrupt_rearm"
+      && event.conversationItemCount === 0
+    );
+    if (!emptyForegroundProbe) {
+      throw new Error("The held foreground mailbox probe lost its typed event.");
+    }
+    assertForegroundPriorityOrderingObservationHealthy(heldEmptyProbe);
+    assertNoBackgroundCheckpointEventBetween({
+      afterOrdinal: snapshotStarted.ordinal,
+      beforeOrdinal: emptyForegroundProbe.ordinal + 1,
+      label: "immediate empty foreground probe",
+      observation: heldEmptyProbe,
+    });
+
+    const laterText = "Process the synthetic conversation persisted after the empty probe.";
+    const laterReply = "The later synthetic conversation ran before checkpoint retry.";
+    const laterEventId = `evt_priority_ordering_later_${runId}`;
+    const laterReplyPath = replyPathFor(identity);
+    const laterMatcher = matchLinqMessageText(laterReply, targetLinqStub);
+    const laterReplyBaseline = targetLinqStub.countAcceptedSends(
+      laterReplyPath,
+      laterMatcher,
+    );
+    targetScenario.queueAssistantResponses(
+      [{
+        beforeResponse: async () => {
+          await targetScenario.harness
+            .recordForegroundPriorityAssistantProviderStartForTest(identity.userId);
+        },
+        text: laterReply,
+      }],
+      { matchInputContains: laterText },
+    );
+    const laterResponse = await postSignedLinqWebhookForScenario(
+      targetScenario,
+      buildHostedLinqInboundEvent(identity.userId, identity.chatId, {
+        eventId: laterEventId,
+        messageId: `msg_priority_ordering_later_${runId}`,
+        text: laterText,
+      }),
+    );
+    expect(laterResponse.status).toBe(202);
+    await expect(laterResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+    const laterMailboxItem = await readHostedMailboxItemForTest({
+      dedupeKey: laterEventId,
+      environment: targetScenario.runtimeEnv,
+      userId: identity.userId,
+    });
+    expect(laterMailboxItem).toMatchObject({
+      dedupeKey: laterEventId,
+      kind: "conversation.message",
+      lane: "conversation",
+    });
+    if (!laterMailboxItem) {
+      throw new Error("The later foreground webhook did not persist its mailbox row.");
+    }
+    await expect(readForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    )).resolves.toMatchObject({
+      barrierState: "entered",
+      barrierTarget: "empty_conversation_probe",
+    });
+
+    await expect(releaseForegroundPriorityOrderingBarrier({
+      scenario: targetScenario,
+      userId: identity.userId,
+    })).resolves.toEqual({ ok: true, released: true });
+
+    const laterMailboxImport = await waitForForegroundPriorityOrderingEvent({
+      afterOrdinal: emptyForegroundProbe.ordinal,
+      kind: "mailbox_fetch_finished",
+      label: "later durable conversation mailbox import",
+      predicate: (event) =>
+        event.responseStatus === 200
+        && event.conversationLaneRequested === true
+        && (event.conversationItemCount ?? 0) > 0
+        && hostedOrderingSeqAtLeast(
+          event.conversationSeqEnd,
+          laterMailboxItem.laneSeq,
+        ),
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const laterProviderStart = await waitForForegroundPriorityOrderingEvent({
+      afterOrdinal: laterMailboxImport.ordinal,
+      kind: "assistant_provider_started",
+      label: "provider start for later durable conversation",
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const finalObservation = await readForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    );
+    assertForegroundPriorityOrderingObservationHealthy(finalObservation);
+    assertNoBackgroundCheckpointEventBetween({
+      afterOrdinal: emptyForegroundProbe.ordinal,
+      beforeOrdinal: laterProviderStart.ordinal,
+      label: "interrupted idle snapshot retry",
+      observation: finalObservation,
+    });
+
+    await Promise.all([
+      waitForAssistantProviderInputInScenario({
+        expectedText: laterText,
+        scenario: targetScenario,
+        userId: identity.userId,
+      }),
+      waitForAcceptedReplyInScenario({
+        baselineCount: laterReplyBaseline,
+        identity,
+        label: "interrupted snapshot ordering",
+        linqStub: targetLinqStub,
+        matcher: laterMatcher,
+        replyPath: laterReplyPath,
+        scenario: targetScenario,
+      }),
+    ]);
+  } finally {
+    if (checkpointBarrierArmed) {
+      await targetScenario.harness
+        .releaseShutdownCheckpointPublicationBarrierForTest(identity.userId)
+        .catch(() => undefined);
+    }
+    await releaseForegroundPriorityOrderingBarrier({
+      scenario: targetScenario,
+      userId: identity.userId,
+    }).catch(() => undefined);
+    await clearForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    ).catch(() => undefined);
+  }
+}
+
+async function proveCanonicalPublicationForegroundOrdering(input: {
+  identity: ProbeIdentity;
+  linqStub: HostedLocalLinqStub;
+  scenario: HostedLocalFullStackScenario;
+}): Promise<void> {
+  const { identity, linqStub: targetLinqStub, scenario: targetScenario } = input;
+  await seedProbeInScenario(targetScenario, identity);
+  await armForegroundPriorityOrderingObservation({
+    mode: "canonical",
+    scenario: targetScenario,
+    userId: identity.userId,
+  });
+
+  try {
+    const preferencesWake = buildHostedExecutionMemberPreferencesUpdatedWake({
+      eventId: `member.preferences.updated:ordering:${runId}`,
+      memberId: identity.userId,
+      occurredAt: new Date().toISOString(),
+      preferences: {
+        personality: { detail: 6 },
+        tone: "casual",
+      },
+    });
+    const appended = await appendHostedExecutionWakeForTest({
+      environment: targetScenario.runtimeEnv,
+      wake: preferencesWake,
+    });
+    expect(appended.inserted).toBe(true);
+    await signalHostedMailboxAppendRuntimeForTest({
+      environment: targetScenario.runtimeEnv,
+      expectedUserId: identity.userId,
+      mailboxItemId: appended.wake.id,
+    });
+
+    const heldObservation = await waitForForegroundPriorityOrderingObservation({
+      label: "canonical checkpoint post-commit boundary",
+      predicate: (observation) =>
+        observation.barrierState === "entered"
+        && observation.barrierTarget === "canonical_post_commit",
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const canonicalCommit = foregroundPriorityOrderingEventsOfKind(
+      heldObservation,
+      "canonical_checkpoint_committed",
+    ).at(-1);
+    if (!canonicalCommit) {
+      throw new Error("Canonical ordering barrier entered without a committed checkpoint event.");
+    }
+
+    const laterText = "Continue with the synthetic conversation after canonical publication.";
+    const laterReply = "Canonical publication finished before the foreground continuation.";
+    const laterEventId = `evt_priority_canonical_later_${runId}`;
+    const laterReplyPath = replyPathFor(identity);
+    const laterMatcher = matchLinqMessageText(laterReply, targetLinqStub);
+    const laterReplyBaseline = targetLinqStub.countAcceptedSends(
+      laterReplyPath,
+      laterMatcher,
+    );
+    targetScenario.queueAssistantResponses(
+      [{
+        beforeResponse: async () => {
+          await targetScenario.harness
+            .recordForegroundPriorityAssistantProviderStartForTest(identity.userId);
+        },
+        text: laterReply,
+      }],
+      { matchInputContains: laterText },
+    );
+    const laterResponse = await postSignedLinqWebhookForScenario(
+      targetScenario,
+      buildHostedLinqInboundEvent(identity.userId, identity.chatId, {
+        eventId: laterEventId,
+        messageId: `msg_priority_canonical_later_${runId}`,
+        text: laterText,
+      }),
+    );
+    expect(laterResponse.status).toBe(202);
+    await expect(laterResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+    const laterMailboxItem = await readHostedMailboxItemForTest({
+      dedupeKey: laterEventId,
+      environment: targetScenario.runtimeEnv,
+      userId: identity.userId,
+    });
+    expect(laterMailboxItem).toMatchObject({
+      dedupeKey: laterEventId,
+      kind: "conversation.message",
+      lane: "conversation",
+    });
+    if (!laterMailboxItem) {
+      throw new Error("Canonical continuation webhook did not persist its mailbox row.");
+    }
+    await expect(readForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    )).resolves.toMatchObject({
+      barrierState: "entered",
+      barrierTarget: "canonical_post_commit",
+    });
+
+    await expect(releaseForegroundPriorityOrderingBarrier({
+      scenario: targetScenario,
+      userId: identity.userId,
+    })).resolves.toEqual({ ok: true, released: true });
+
+    const laterMailboxImport = await waitForForegroundPriorityOrderingEvent({
+      afterOrdinal: canonicalCommit.ordinal,
+      kind: "mailbox_fetch_finished",
+      label: "canonical continuation mailbox import",
+      predicate: (event) =>
+        event.responseStatus === 200
+        && event.conversationLaneRequested === true
+        && (event.conversationItemCount ?? 0) > 0
+        && hostedOrderingSeqAtLeast(
+          event.conversationSeqEnd,
+          laterMailboxItem.laneSeq,
+        ),
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const laterProviderStart = await waitForForegroundPriorityOrderingEvent({
+      afterOrdinal: laterMailboxImport.ordinal,
+      kind: "assistant_provider_started",
+      label: "canonical continuation provider start",
+      scenario: targetScenario,
+      userId: identity.userId,
+    });
+    const finalObservation = await readForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    );
+    assertForegroundPriorityOrderingObservationHealthy(finalObservation);
+    assertNoBackgroundCheckpointEventBetween({
+      afterOrdinal: canonicalCommit.ordinal,
+      beforeOrdinal: laterProviderStart.ordinal,
+      label: "canonical publication continuation",
+      observation: finalObservation,
+    });
+
+    await Promise.all([
+      waitForAssistantProviderInputInScenario({
+        expectedText: laterText,
+        scenario: targetScenario,
+        userId: identity.userId,
+      }),
+      waitForAcceptedReplyInScenario({
+        baselineCount: laterReplyBaseline,
+        identity,
+        label: "canonical publication ordering",
+        linqStub: targetLinqStub,
+        matcher: laterMatcher,
+        replyPath: laterReplyPath,
+        scenario: targetScenario,
+      }),
+    ]);
+  } finally {
+    await releaseForegroundPriorityOrderingBarrier({
+      scenario: targetScenario,
+      userId: identity.userId,
+    }).catch(() => undefined);
+    await clearForegroundPriorityOrderingObservation(
+      targetScenario,
+      identity.userId,
+    ).catch(() => undefined);
+  }
+}
+
+async function armForegroundPriorityOrderingObservation(input: {
+  mode: "canonical" | "empty-probe";
+  scenario: HostedLocalFullStackScenario;
+  userId: string;
+}): Promise<void> {
+  await expect(
+    input.scenario.harness.armForegroundPriorityOrderingObservationForTest(
+      input.userId,
+      input.mode === "canonical"
+        ? "canonical_post_commit"
+        : "empty_conversation_probe",
+    ),
+  ).resolves.toEqual({ ok: true });
+}
+
+async function readForegroundPriorityOrderingObservation(
+  targetScenario: HostedLocalFullStackScenario,
+  userId: string,
+): Promise<HostedLocalForegroundPriorityOrderingObservationState> {
+  return await targetScenario.harness
+    .readForegroundPriorityOrderingObservationForTest(userId);
+}
+
+async function releaseForegroundPriorityOrderingBarrier(input: {
+  scenario: HostedLocalFullStackScenario;
+  userId: string;
+}): Promise<{ ok: true; released: boolean }> {
+  return await input.scenario.harness
+    .releaseForegroundPriorityOrderingBarrierForTest(input.userId);
+}
+
+async function clearForegroundPriorityOrderingObservation(
+  targetScenario: HostedLocalFullStackScenario,
+  userId: string,
+): Promise<{ cleared: boolean; ok: true }> {
+  return await targetScenario.harness
+    .clearForegroundPriorityOrderingObservationForTest(userId);
+}
+
+function foregroundPriorityOrderingEventsOfKind<
+  Kind extends ForegroundPriorityOrderingEventKind,
+>(
+  observation: HostedLocalForegroundPriorityOrderingObservationState,
+  kind: Kind,
+): Array<ForegroundPriorityOrderingEventOfKind<Kind>> {
+  return observation.events.filter(
+    (event): event is ForegroundPriorityOrderingEventOfKind<Kind> =>
+      event.kind === kind,
+  );
+}
+
+function assertForegroundPriorityOrderingObservationHealthy(
+  observation: HostedLocalForegroundPriorityOrderingObservationState,
+): void {
+  expect(observation.state).toBe("armed");
+  expect(
+    observation.truncated,
+    "Foreground-priority ordering evidence was truncated at its bounded test limit.",
+  ).toBe(false);
+}
+
+function assertNoBackgroundCheckpointEventBetween(input: {
+  afterOrdinal: number;
+  beforeOrdinal: number;
+  label: string;
+  observation: HostedLocalForegroundPriorityOrderingObservationState;
+}): void {
+  const conflictingEvent = input.observation.events.find((event) =>
+    (
+      event.kind === "snapshot_started"
+      || (
+        event.kind === "workspace_checkpoint_started"
+        && event.reason === "idle_shutdown"
+      )
+    )
+    && event.ordinal > input.afterOrdinal
+    && event.ordinal < input.beforeOrdinal
+  );
+  expect(
+    conflictingEvent,
+    `${input.label} let a background idle checkpoint overtake foreground work.`,
+  ).toBeUndefined();
+}
+
+async function waitForForegroundPriorityOrderingObservation(input: {
+  label: string;
+  predicate: (
+    observation: HostedLocalForegroundPriorityOrderingObservationState,
+  ) => boolean;
+  scenario: HostedLocalFullStackScenario;
+  timeoutMs?: number;
+  userId: string;
+}): Promise<HostedLocalForegroundPriorityOrderingObservationState> {
+  const deadlineAt = Date.now() + (input.timeoutMs ?? 90_000);
+  let lastObservation = await readForegroundPriorityOrderingObservation(
+    input.scenario,
+    input.userId,
+  );
+
+  while (Date.now() < deadlineAt) {
+    lastObservation = await readForegroundPriorityOrderingObservation(
+      input.scenario,
+      input.userId,
+    );
+    if (lastObservation.truncated) {
+      throw new Error(await input.scenario.buildFailureMessage(input.userId, [
+        `Foreground-priority ordering trace was truncated while waiting for ${input.label}.`,
+        `last observation: ${JSON.stringify(lastObservation)}`,
+      ]));
+    }
+    if (lastObservation.state === "armed" && input.predicate(lastObservation)) {
+      return lastObservation;
+    }
+    await sleep(100);
+  }
+
+  throw new Error(await input.scenario.buildFailureMessage(input.userId, [
+    `Timed out waiting for ${input.label}.`,
+    `last observation: ${JSON.stringify(lastObservation)}`,
+  ]));
+}
+
+async function waitForForegroundPriorityOrderingEvent<
+  Kind extends ForegroundPriorityOrderingEventKind,
+>(input: {
+  afterOrdinal?: number;
+  kind: Kind;
+  label: string;
+  predicate?: (event: ForegroundPriorityOrderingEventOfKind<Kind>) => boolean;
+  scenario: HostedLocalFullStackScenario;
+  timeoutMs?: number;
+  userId: string;
+}): Promise<ForegroundPriorityOrderingEventOfKind<Kind>> {
+  let matchedEvent: ForegroundPriorityOrderingEventOfKind<Kind> | null = null;
+  await waitForForegroundPriorityOrderingObservation({
+    label: input.label,
+    predicate: (observation) => {
+      matchedEvent = foregroundPriorityOrderingEventsOfKind(
+        observation,
+        input.kind,
+      ).find((event) =>
+        event.ordinal > (input.afterOrdinal ?? 0)
+        && (input.predicate?.(event) ?? true)
+      ) ?? null;
+      return matchedEvent !== null;
+    },
+    scenario: input.scenario,
+    timeoutMs: input.timeoutMs,
+    userId: input.userId,
+  });
+  if (!matchedEvent) {
+    throw new Error(`Foreground-priority ordering event ${input.kind} disappeared.`);
+  }
+  return matchedEvent;
+}
+
+async function waitForCheckpointBarrierInScenario(
+  targetScenario: HostedLocalFullStackScenario,
+  userId: string,
+): Promise<void> {
+  const deadlineAt = Date.now() + 90_000;
+  let lastStatus = await targetScenario.harness.readUserStatus(userId);
+
+  while (Date.now() < deadlineAt) {
+    const barrier =
+      await targetScenario.harness.readShutdownCheckpointPublicationBarrierForTest(
+        userId,
+      );
+    if (barrier.state === "entered") {
+      return;
+    }
+    lastStatus = await targetScenario.harness.readUserStatus(userId);
+    await sleep(250);
+  }
+
+  throw new Error(await targetScenario.buildFailureMessage(userId, [
+    "Timed out waiting for checkpoint publication to enter the test barrier.",
+    `last status: ${JSON.stringify(lastStatus)}`,
+  ]));
+}
+
+async function waitForAssistantProviderInputInScenario(input: {
+  expectedText: string;
+  scenario: HostedLocalFullStackScenario;
+  timeoutMs?: number;
+  userId: string;
+}): Promise<void> {
+  const deadlineAt = Date.now() + (input.timeoutMs ?? 60_000);
+  while (Date.now() < deadlineAt) {
+    if (
+      input.scenario.assistantProviderRequests.some((request) =>
+        request.url === "/v1/responses"
+        && request.body.includes(input.expectedText)
+      )
+    ) {
+      return;
+    }
+    await sleep(100);
+  }
+
+  throw new Error(await input.scenario.buildFailureMessage(input.userId, [
+    "Timed out waiting for the assistant provider transport to include ordered foreground input.",
+  ]));
+}
+
+interface RuntimeWakeObservation {
+  lastExecutionAt: string | null;
+  signalVersion: number;
+}
+
+async function readRuntimeWakeObservation(input: {
+  scenario: HostedLocalFullStackScenario;
+  userId: string;
+}): Promise<RuntimeWakeObservation> {
+  const value = await queryHostedRuntimeWorkflowForTest({
+    environment: input.scenario.runtimeEnv,
+    queryName: HOSTED_USER_RUNTIME_STATUS_QUERY_NAME,
+    workflowId: `hosted-user-runtime:${input.userId}`,
+  });
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Hosted runtime workflow query returned an invalid state.");
+  }
+  const lastExecutionAt: unknown = Reflect.get(value, "lastExecutionAt");
+  const signalVersion: unknown = Reflect.get(value, "signalVersion");
+  if (
+    (lastExecutionAt !== null && typeof lastExecutionAt !== "string")
+    || typeof signalVersion !== "number"
+    || !Number.isSafeInteger(signalVersion)
+    || signalVersion < 0
+  ) {
+    throw new TypeError("Hosted runtime workflow query returned an invalid state.");
+  }
+  return { lastExecutionAt, signalVersion };
+}
+
+async function waitForRuntimeWakeExecution(input: {
+  previous: RuntimeWakeObservation;
+  scenario: HostedLocalFullStackScenario;
+  userId: string;
+}): Promise<void> {
+  const deadlineAt = Date.now() + 30_000;
+  let latest = input.previous;
+  while (Date.now() < deadlineAt) {
+    latest = await readRuntimeWakeObservation(input);
+    if (
+      latest.signalVersion > input.previous.signalVersion
+      && latest.lastExecutionAt !== input.previous.lastExecutionAt
+    ) {
+      return;
+    }
+    await sleep(250);
+  }
+  throw new Error(await input.scenario.buildFailureMessage(input.userId, [
+    "Timed out waiting for the active-runtime wake to reach Cloudflare.",
+    `last Temporal state: ${JSON.stringify(latest)}`,
+  ]));
+}
+
+async function waitForAcceptedReplyInScenario(input: {
+  baselineCount: number;
+  identity: ProbeIdentity;
+  label: string;
+  linqStub: HostedLocalLinqStub;
+  matcher: ObservedLinqRequestMatcher;
+  replyPath: string;
+  scenario: HostedLocalFullStackScenario;
+  timeoutMs?: number;
+}): Promise<ObservedLinqRequest> {
+  const deadlineAt = Date.now() + (input.timeoutMs ?? 60_000);
+  while (Date.now() < deadlineAt) {
+    const matching = input.linqStub.acceptedSendRequests.filter((request) =>
+      request.method === "POST"
+      && request.url === input.replyPath
+      && input.matcher(request)
+    );
+    if (matching.length > input.baselineCount) {
+      expect(
+        matching.length,
+        `${input.label} emitted more than one newly accepted Linq reply.`,
+      ).toBe(input.baselineCount + 1);
+      return matching.at(-1)!;
+    }
+    await sleep(100);
+  }
+
+  throw new Error(await input.scenario.buildFailureMessage(input.identity.userId, [
+    `Timed out waiting for accepted Linq delivery in ${input.label}.`,
+    `accepted reply count: ${
+      input.linqStub.countAcceptedSends(input.replyPath, input.matcher)
+    }`,
+  ]));
+}
+
+function hostedOrderingSeqAtLeast(
+  value: string | null | undefined,
+  floor: string,
+): boolean {
+  if (
+    typeof value !== "string"
+    || !/^(?:0|[1-9][0-9]*)$/u.test(value)
+    || !/^(?:0|[1-9][0-9]*)$/u.test(floor)
+  ) {
+    return false;
+  }
+  return BigInt(value) >= BigInt(floor);
 }
 
 async function sendInboundAndRequirePromptReply(input: {
@@ -924,25 +1752,24 @@ async function waitForAssistantProviderInput(
   userId: string,
   timeoutMs = 30_000,
 ): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (
-      requireScenario().assistantProviderRequests.some((request) =>
-        request.url === "/v1/responses" && request.body.includes(expectedText)
-      )
-    ) {
-      return;
-    }
-    await sleep(250);
-  }
-  throw new Error(await requireScenario().buildFailureMessage(userId, [
-    "Timed out waiting for the real assistant provider transport to include foreground input.",
-  ]));
+  await waitForAssistantProviderInputInScenario({
+    expectedText,
+    scenario: requireScenario(),
+    timeoutMs,
+    userId,
+  });
 }
 
 async function seedActivatedWorkspaceCheckpoint(userId: string): Promise<void> {
+  await seedActivatedWorkspaceCheckpointInScenario(requireScenario(), userId);
+}
+
+async function seedActivatedWorkspaceCheckpointInScenario(
+  targetScenario: HostedLocalFullStackScenario,
+  userId: string,
+): Promise<void> {
   const root = await mkdtemp(
-    path.join(requireScenario().harness.persistDir, "priority-vault-"),
+    path.join(targetScenario.harness.persistDir, "priority-vault-"),
   );
   const operatorHomeRoot = path.join(root, "operator-home");
   const vaultRoot = path.join(root, "vault");
@@ -960,7 +1787,7 @@ async function seedActivatedWorkspaceCheckpoint(userId: string): Promise<void> {
   const hash = sha256HostedBundleHex(snapshot.bundle);
   const checkpoint = await seedHostedWorkspaceCheckpointForTest({
     browserVaultReplicaRef: createBrowserVaultReplicaRef(hash),
-    environment: requireScenario().runtimeEnv,
+    environment: targetScenario.runtimeEnv,
     nextWakeAt: null,
     nextWakeReason: null,
     redactedStatusJson: {
@@ -974,7 +1801,7 @@ async function seedActivatedWorkspaceCheckpoint(userId: string): Promise<void> {
   });
   expect(checkpoint.status).toBe("updated");
 
-  await requireScenario().harness.request(
+  await targetScenario.harness.request(
     `/__test/artifacts?userId=${encodeURIComponent(userId)}&sha256=${hash}`,
     {
       body: new Blob([new Uint8Array(snapshot.bundle)]),
@@ -1319,8 +2146,11 @@ function replyPathFor(identity: ProbeIdentity): string {
   return `/chats/${encodeURIComponent(identity.chatId)}/messages`;
 }
 
-function matchLinqMessageText(expectedText: string): ObservedLinqRequestMatcher {
-  return (request) => requireLinqStub().readObservedMessageText(request) === expectedText;
+function matchLinqMessageText(
+  expectedText: string,
+  targetLinqStub: HostedLocalLinqStub = requireLinqStub(),
+): ObservedLinqRequestMatcher {
+  return (request) => targetLinqStub.readObservedMessageText(request) === expectedText;
 }
 
 function observedLinqLatencyAlertRequests(): ObservedLinqRequest[] {
@@ -1388,6 +2218,13 @@ async function requestLatencyAlertCron(): Promise<Response> {
 }
 
 async function postSignedLinqWebhook(event: Record<string, unknown>): Promise<Response> {
+  return await postSignedLinqWebhookForScenario(requireScenario(), event);
+}
+
+async function postSignedLinqWebhookForScenario(
+  targetScenario: HostedLocalFullStackScenario,
+  event: Record<string, unknown>,
+): Promise<Response> {
   const rawBody = JSON.stringify(event);
   const timestamp = String(Math.floor(Date.now() / 1_000));
   const signature = createHmac("sha256", linqWebhookSecret)
@@ -1395,7 +2232,7 @@ async function postSignedLinqWebhook(event: Record<string, unknown>): Promise<Re
     .digest("hex");
 
   return await fetch(
-    `${requireScenario().harness.webBaseUrl}/api/hosted-onboarding/linq/webhook`,
+    `${targetScenario.harness.webBaseUrl}/api/hosted-onboarding/linq/webhook`,
     {
       body: rawBody,
       headers: {
@@ -1427,6 +2264,20 @@ function requireLinqStub(): HostedLocalLinqStub {
     throw new Error("Hosted foreground reply priority Linq stub was not initialized.");
   }
   return linqStub;
+}
+
+function requireOrderingScenario(): HostedLocalFullStackScenario {
+  if (!orderingScenario) {
+    throw new Error("Hosted foreground checkpoint ordering scenario was not initialized.");
+  }
+  return orderingScenario;
+}
+
+function requireOrderingLinqStub(): HostedLocalLinqStub {
+  if (!orderingLinqStub) {
+    throw new Error("Hosted foreground checkpoint ordering Linq stub was not initialized.");
+  }
+  return orderingLinqStub;
 }
 
 function requireResendStub(): HostedLocalResendStub {

--- a/apps/cloudflare/test/hosted-local-test-runner-container.test.ts
+++ b/apps/cloudflare/test/hosted-local-test-runner-container.test.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 
 import { describe, expect, it, vi } from "vitest";
 import {
+  HOSTED_RUNTIME_MAILBOX_FETCH_PATH,
   HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH,
 } from "@murphai/hosted-execution/routes";
 
@@ -23,6 +24,7 @@ import {
   armCanonicalCheckpointPublicationBarrier,
   armCanonicalCheckpointLostAck,
   armSnapshotPublicationCorruption,
+  armIdleSnapshotStartBarrier,
   armShutdownCheckpointPublicationBarrier,
   HOSTED_LOCAL_LINQ_ATTACHMENT_UPLOAD_HOST,
   readShutdownCheckpointPublicationBarrierState,
@@ -32,6 +34,14 @@ import {
   wrapSnapshotPublicationCorruptionForTest,
   wrapShutdownCheckpointPublicationBarrierForTest,
 } from "../src/hosted-local-test/runner-container.ts";
+import {
+  armForegroundPriorityOrderingObservation,
+  clearForegroundPriorityOrderingObservation,
+  readForegroundPriorityOrderingObservation,
+  recordForegroundPriorityAssistantProviderStart,
+  releaseForegroundPriorityOrderingBarrier,
+  wrapForegroundPriorityOrderingObservationForTest,
+} from "../src/hosted-local-test/foreground-priority-ordering.ts";
 import {
   HOSTED_RUNNER_DEFAULT_OUTBOUND_HOSTS,
   HOSTED_RUNNER_OUTBOUND_BY_HOST,
@@ -68,6 +78,63 @@ function createCanonicalCheckpointRequest(userId: string): Request {
         [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId,
         "content-type": "application/json; charset=utf-8",
       },
+      method: "POST",
+    },
+  );
+}
+
+function createMailboxFetchRequest(
+  userId: string,
+  importedSeq = "0",
+  lanes: readonly { importedSeq: string; lane: string }[] = [
+    { importedSeq, lane: "conversation" },
+    { importedSeq: "0", lane: "system" },
+  ],
+  requestId = "request-foreground-priority-ordering",
+): Request {
+  return new Request(
+    `http://${HOSTED_RUNNER_DEFAULT_OUTBOUND_HOSTS.webControlPlane}`
+      + HOSTED_RUNTIME_MAILBOX_FETCH_PATH,
+    {
+      body: JSON.stringify({
+        lanes,
+        limitPerLane: 25,
+        requestId,
+        userId,
+      }),
+      headers: {
+        [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId,
+        "content-type": "application/json; charset=utf-8",
+      },
+      method: "POST",
+    },
+  );
+}
+
+function createMailboxFetchResponse(
+  userId: string,
+  conversationSeqs: readonly string[],
+): Response {
+  return new Response(JSON.stringify({
+    items: conversationSeqs.map((laneSeq, index) => ({
+      id: `mailbox-synthetic-${index + 1}`,
+      kind: "conversation.message",
+      lane: "conversation",
+      laneSeq,
+      userId,
+    })),
+  }), {
+    headers: { "content-type": "application/json; charset=utf-8" },
+    status: 200,
+  });
+}
+
+function createSnapshotStartRequest(userId: string): Request {
+  return new Request(
+    `http://${HOSTED_RUNNER_DEFAULT_OUTBOUND_HOSTS.workspaceSnapshotStore}`
+      + "/workspace-snapshots/start",
+    {
+      headers: { [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId },
       method: "POST",
     },
   );
@@ -280,6 +347,262 @@ describe("hosted-local test RunnerContainer outbound composition", () => {
       }
     }
     expect(wrapped[HOSTED_LOCAL_LINQ_ATTACHMENT_UPLOAD_HOST]).toBeTypeOf("function");
+  });
+
+  it("records bounded typed ordering at the mailbox, checkpoint, and provider boundaries", async () => {
+    const userId = "member_foreground_priority_ordering_trace";
+    const realHandler = vi.fn(async (request: Request) => {
+      const pathname = new URL(request.url).pathname;
+      if (pathname === HOSTED_RUNTIME_MAILBOX_FETCH_PATH) {
+        return createMailboxFetchResponse(userId, ["3", "4"]);
+      }
+      if (pathname === HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH) {
+        return new Response(JSON.stringify({ checkpointed: true }), {
+          headers: { "content-type": "application/json; charset=utf-8" },
+          status: 200,
+        });
+      }
+      return new Response("accepted", { status: 200 });
+    });
+    const snapshotHandler = wrapForegroundPriorityOrderingObservationForTest(
+      realHandler,
+      "snapshot-store",
+    );
+    const webHandler = wrapForegroundPriorityOrderingObservationForTest(
+      realHandler,
+      "web-control",
+    );
+    armForegroundPriorityOrderingObservation(userId);
+
+    try {
+      await snapshotHandler(
+        createSnapshotStartRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      await webHandler(
+        createMailboxFetchRequest(userId, "2"),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      await webHandler(
+        createCanonicalCheckpointRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      recordForegroundPriorityAssistantProviderStart(userId);
+
+      expect(readForegroundPriorityOrderingObservation(userId)).toEqual({
+        barrierState: "disabled",
+        barrierTarget: "none",
+        events: [
+          { kind: "snapshot_started", ordinal: 1 },
+          {
+            conversationItemCount: 2,
+            conversationLaneRequested: true,
+            conversationSeqEnd: "4",
+            kind: "mailbox_fetch_finished",
+            ordinal: 2,
+            probeKind: "other",
+            responseStatus: 200,
+          },
+          {
+            kind: "workspace_checkpoint_started",
+            ordinal: 3,
+            reason: "canonical_runtime_commit",
+          },
+          { kind: "canonical_checkpoint_committed", ordinal: 4 },
+          { kind: "assistant_provider_started", ordinal: 5 },
+        ],
+        state: "armed",
+        truncated: false,
+      });
+    } finally {
+      clearForegroundPriorityOrderingObservation(userId);
+    }
+  });
+
+  it("rejects provider evidence without an armed observation", () => {
+    expect(() =>
+      recordForegroundPriorityAssistantProviderStart(
+        "member_foreground_priority_unarmed_provider",
+      )
+    ).toThrow(
+      "Hosted-local foreground-priority provider start requires an armed observation.",
+    );
+  });
+
+  it("bounds the foreground-priority ordering trace", () => {
+    const userId = "member_foreground_priority_ordering_bounded";
+    armForegroundPriorityOrderingObservation(userId);
+
+    try {
+      for (let index = 0; index < 65; index += 1) {
+        recordForegroundPriorityAssistantProviderStart(userId);
+      }
+
+      const observation = readForegroundPriorityOrderingObservation(userId);
+      expect(observation.events).toHaveLength(64);
+      expect(observation.events.at(-1)).toEqual({
+        kind: "assistant_provider_started",
+        ordinal: 64,
+      });
+      expect(observation.truncated).toBe(true);
+    } finally {
+      clearForegroundPriorityOrderingObservation(userId);
+    }
+  });
+
+  it("holds the first empty conversation probe after an idle snapshot starts", async () => {
+    const userId = "member_foreground_priority_empty_probe_barrier";
+    const realHandler = vi.fn(async (request: Request) => {
+      const pathname = new URL(request.url).pathname;
+      if (pathname === HOSTED_RUNTIME_MAILBOX_FETCH_PATH) {
+        return createMailboxFetchResponse(userId, []);
+      }
+      return new Response("accepted", { status: 200 });
+    });
+    const snapshotHandler = wrapForegroundPriorityOrderingObservationForTest(
+      realHandler,
+      "snapshot-store",
+    );
+    const webHandler = wrapForegroundPriorityOrderingObservationForTest(
+      realHandler,
+      "web-control",
+    );
+    armForegroundPriorityOrderingObservation(
+      userId,
+      "empty_conversation_probe",
+    );
+
+    try {
+      await expect(webHandler(
+        createMailboxFetchRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      ).then((response) => response.status)).resolves.toBe(200);
+      expect(readForegroundPriorityOrderingObservation(userId)).toMatchObject({
+        barrierState: "armed",
+      });
+
+      await expect(snapshotHandler(
+        createSnapshotStartRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      ).then((response) => response.status)).resolves.toBe(200);
+
+      await expect(webHandler(
+        createMailboxFetchRequest(userId, "0", [
+          { importedSeq: "0", lane: "system" },
+        ]),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      ).then((response) => response.status)).resolves.toBe(200);
+      expect(readForegroundPriorityOrderingObservation(userId)).toMatchObject({
+        barrierState: "armed",
+      });
+
+      const heldEmptyProbe = webHandler(
+        createMailboxFetchRequest(
+          userId,
+          "0",
+          [
+            { importedSeq: "0", lane: "conversation" },
+            { importedSeq: "0", lane: "system" },
+          ],
+          "hosted-invocation:checkpoint-interrupt-rearm-foreground-prefetch:1",
+        ),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      await vi.waitFor(() => {
+        expect(readForegroundPriorityOrderingObservation(userId)).toEqual({
+          barrierState: "entered",
+          barrierTarget: "empty_conversation_probe",
+          events: [
+            {
+              conversationItemCount: 0,
+              conversationLaneRequested: true,
+              conversationSeqEnd: null,
+              kind: "mailbox_fetch_finished",
+              ordinal: 1,
+              probeKind: "other",
+              responseStatus: 200,
+            },
+            { kind: "snapshot_started", ordinal: 2 },
+            {
+              conversationItemCount: 0,
+              conversationLaneRequested: false,
+              conversationSeqEnd: null,
+              kind: "mailbox_fetch_finished",
+              ordinal: 3,
+              probeKind: "other",
+              responseStatus: 200,
+            },
+            {
+              conversationItemCount: 0,
+              conversationLaneRequested: true,
+              conversationSeqEnd: null,
+              kind: "mailbox_fetch_finished",
+              ordinal: 4,
+              probeKind: "checkpoint_interrupt_rearm",
+              responseStatus: 200,
+            },
+          ],
+          state: "armed",
+          truncated: false,
+        });
+      });
+      expect(releaseForegroundPriorityOrderingBarrier(userId)).toBe(true);
+      await expect(heldEmptyProbe.then((response) => response.status)).resolves.toBe(200);
+    } finally {
+      clearForegroundPriorityOrderingObservation(userId);
+    }
+  });
+
+  it("holds canonical acknowledgement only after the real checkpoint commits", async () => {
+    const userId = "member_foreground_priority_canonical_post_commit";
+    const realHandler = vi.fn(async () => new Response(
+      JSON.stringify({ checkpointed: true }),
+      {
+        headers: { "content-type": "application/json; charset=utf-8" },
+        status: 200,
+      },
+    ));
+    const handler = wrapForegroundPriorityOrderingObservationForTest(
+      realHandler,
+      "web-control",
+    );
+    armForegroundPriorityOrderingObservation(userId, "canonical_post_commit");
+
+    try {
+      const heldCommit = handler(
+        createCanonicalCheckpointRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      await vi.waitFor(() => {
+        expect(readForegroundPriorityOrderingObservation(userId)).toEqual({
+          barrierState: "entered",
+          barrierTarget: "canonical_post_commit",
+          events: [
+            {
+              kind: "workspace_checkpoint_started",
+              ordinal: 1,
+              reason: "canonical_runtime_commit",
+            },
+            { kind: "canonical_checkpoint_committed", ordinal: 2 },
+          ],
+          state: "armed",
+          truncated: false,
+        });
+      });
+      expect(realHandler).toHaveBeenCalledOnce();
+      expect(releaseForegroundPriorityOrderingBarrier(userId)).toBe(true);
+      await expect(heldCommit.then((response) => response.status)).resolves.toBe(200);
+    } finally {
+      clearForegroundPriorityOrderingObservation(userId);
+    }
   });
 
   it("accepts supported nonempty private-media PUTs on the hosted-local Linq upload path", async () => {
@@ -694,6 +1017,40 @@ describe("hosted-local test RunnerContainer outbound composition", () => {
       );
       expect(realHandler).toHaveBeenCalledTimes(4);
       expect(releaseShutdownCheckpointPublicationBarrier(userId)).toBe(false);
+    } finally {
+      releaseShutdownCheckpointPublicationBarrier(userId);
+    }
+  });
+
+  it("holds snapshot start at the cancellation-aware boundary", async () => {
+    const userId = "member_idle_snapshot_start_barrier";
+    const realHandler = vi.fn(async () => new Response("snapshot started", { status: 200 }));
+    const handler = wrapShutdownCheckpointPublicationBarrierForTest(realHandler);
+    armIdleSnapshotStartBarrier(userId);
+
+    try {
+      const heldStart = handler(
+        createSnapshotStartRequest(userId),
+        createOutboundEnv(),
+        { containerId: "opaque-container-id" },
+      );
+      await vi.waitFor(() => {
+        expect(readShutdownCheckpointPublicationBarrierState(userId)).toBe("entered");
+      });
+      expect(realHandler).not.toHaveBeenCalled();
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: {
+            barrierKind: "snapshot_start_checkpoint_publication",
+          },
+          userId,
+        }),
+      );
+
+      expect(releaseShutdownCheckpointPublicationBarrier(userId)).toBe(true);
+      await expect(heldStart.then((response) => response.text()))
+        .resolves.toBe("snapshot started");
+      expect(realHandler).toHaveBeenCalledTimes(1);
     } finally {
       releaseShutdownCheckpointPublicationBarrier(userId);
     }

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -248,7 +248,9 @@ describe("cloudflare worker routes", () => {
     expect(workerSource).not.toContain("startStuckInvocationForTest");
     expect(workerSource).not.toContain("readActiveRuntimeFenceForTest");
     expect(workerSource).not.toContain("armCanonicalCheckpointLostAckForTest");
+    expect(workerSource).not.toContain("foregroundPriorityOrderingControlForTest");
     expect(workerSource).not.toContain("armSnapshotPublicationCorruptionForTest");
+    expect(workerSource).not.toContain("armIdleSnapshotStartBarrierForTest");
     expect(workerSource).not.toContain("armShutdownCheckpointPublicationBarrierForTest");
     expect(workerSource).not.toContain("beginShutdownCheckpointGracefulStopForTest");
     expect(workerSource).not.toContain("readShutdownCheckpointPublicationBarrierForTest");
@@ -351,6 +353,7 @@ describe("cloudflare worker routes", () => {
       "test-run-until-idle",
       "test-run-alarm",
       "test-canonical-checkpoint-lost-ack",
+      "test-foreground-priority-ordering",
       "test-arm-generated-image-provider-barrier",
       "test-release-generated-image-provider-barrier",
       "test-snapshot-publication-corruption",
@@ -1287,6 +1290,22 @@ describe("cloudflare worker routes", () => {
       error: "Hosted execution bound user does not match the test runner user.",
     });
 
+    const foregroundPriorityOrderingResponse = await hostedLocalTestWorker.fetch(
+      await signControlRequest(new Request(
+        "https://runner.example.test/__test/users/member_123"
+          + "/foreground-priority-ordering?action=status",
+        { method: "POST" },
+      ), {
+        boundUserId: "member_other",
+      }),
+      env,
+    );
+
+    expect(foregroundPriorityOrderingResponse.status).toBe(401);
+    await expect(foregroundPriorityOrderingResponse.json()).resolves.toEqual({
+      error: "Hosted execution bound user does not match the test runner user.",
+    });
+
     const snapshotPublicationCorruptionResponse = await hostedLocalTestWorker.fetch(
       await signControlRequest(new Request(
         "https://runner.example.test/__test/users/member_123/snapshot-publication-corruption",
@@ -1690,6 +1709,8 @@ describe("cloudflare worker routes", () => {
       vi.fn(async () => ({ ok: true as const }));
     const armCanonicalCheckpointPublicationBarrierForTest =
       vi.fn(async () => ({ ok: true as const }));
+    const armIdleSnapshotStartBarrierForTest =
+      vi.fn(async () => ({ ok: true as const }));
     const beginShutdownCheckpointGracefulStopForTest =
       vi.fn(async () => ({ ok: true as const }));
     const readShutdownCheckpointPublicationBarrierForTest =
@@ -1699,6 +1720,7 @@ describe("cloudflare worker routes", () => {
     const getByName = vi.fn((name: string) => ({
       ...baseRunnerContainerNamespace.getByName(name),
       armCanonicalCheckpointPublicationBarrierForTest,
+      armIdleSnapshotStartBarrierForTest,
       armShutdownCheckpointPublicationBarrierForTest,
       beginShutdownCheckpointGracefulStopForTest,
       readShutdownCheckpointPublicationBarrierForTest,
@@ -1712,7 +1734,13 @@ describe("cloudflare worker routes", () => {
       },
     });
     const request = async (
-      action: "arm" | "arm-canonical" | "release" | "shutdown" | "status",
+      action:
+        | "arm"
+        | "arm-canonical"
+        | "arm-snapshot-start"
+        | "release"
+        | "shutdown"
+        | "status",
     ) =>
       await hostedLocalTestWorker.fetch(
         await signControlRequest(new Request(
@@ -1727,6 +1755,7 @@ describe("cloudflare worker routes", () => {
 
     const armResponse = await request("arm");
     const armCanonicalResponse = await request("arm-canonical");
+    const armSnapshotStartResponse = await request("arm-snapshot-start");
     const statusResponse = await request("status");
     const shutdownResponse = await request("shutdown");
     const releaseResponse = await request("release");
@@ -1735,6 +1764,8 @@ describe("cloudflare worker routes", () => {
     await expect(armResponse.json()).resolves.toEqual({ ok: true });
     expect(armCanonicalResponse.status).toBe(200);
     await expect(armCanonicalResponse.json()).resolves.toEqual({ ok: true });
+    expect(armSnapshotStartResponse.status).toBe(200);
+    await expect(armSnapshotStartResponse.json()).resolves.toEqual({ ok: true });
     expect(statusResponse.status).toBe(200);
     await expect(statusResponse.json()).resolves.toEqual({ state: "entered" });
     expect(shutdownResponse.status).toBe(200);
@@ -1746,6 +1777,9 @@ describe("cloudflare worker routes", () => {
       userId: "member_123",
     });
     expect(armCanonicalCheckpointPublicationBarrierForTest).toHaveBeenCalledWith({
+      userId: "member_123",
+    });
+    expect(armIdleSnapshotStartBarrierForTest).toHaveBeenCalledWith({
       userId: "member_123",
     });
     expect(readShutdownCheckpointPublicationBarrierForTest).toHaveBeenCalledWith({
@@ -1762,6 +1796,77 @@ describe("cloudflare worker routes", () => {
       await signControlRequest(new Request(
         "https://runner.example.test/__test/users/member_123"
           + "/shutdown-checkpoint-publication-barrier?action=arm&extra=1",
+        { method: "POST" },
+      ), {
+        boundUserId: "member_123",
+      }),
+      env,
+    );
+    expect(invalidResponse.status).toBe(400);
+  });
+
+  it("maps the user-scoped foreground-priority ordering controls", async () => {
+    const baseRunnerContainerNamespace = createRunnerContainerNamespace();
+    const foregroundPriorityOrderingControlForTest = vi.fn(
+      async (input: unknown) => input,
+    );
+    const getByName = vi.fn((name: string) => ({
+      ...baseRunnerContainerNamespace.getByName(name),
+      foregroundPriorityOrderingControlForTest,
+    }));
+    const env = createWorkerEnv(createUserRunnerStub(), {
+      MURPH_HOSTED_LOCAL_TEST_ROUTES: "1",
+      NODE_ENV: "test",
+      RUNNER_CONTAINER: {
+        getByName,
+      },
+    });
+    const request = async (action: string) =>
+      await hostedLocalTestWorker.fetch(
+        await signControlRequest(new Request(
+          "https://runner.example.test/__test/users/member_123"
+            + `/foreground-priority-ordering?action=${action}`,
+          { method: "POST" },
+        ), {
+          boundUserId: "member_123",
+        }),
+        env,
+      );
+
+    for (const action of [
+      "arm-canonical",
+      "arm-empty-probe",
+      "clear",
+      "provider-start",
+      "release",
+      "status",
+    ]) {
+      const response = await request(action);
+      expect(response.status).toBe(200);
+    }
+
+    expect(foregroundPriorityOrderingControlForTest.mock.calls).toEqual([
+      [{
+        action: "arm",
+        barrierTarget: "canonical_post_commit",
+        userId: "member_123",
+      }],
+      [{
+        action: "arm",
+        barrierTarget: "empty_conversation_probe",
+        userId: "member_123",
+      }],
+      [{ action: "clear", userId: "member_123" }],
+      [{ action: "record-provider-start", userId: "member_123" }],
+      [{ action: "release", userId: "member_123" }],
+      [{ action: "status", userId: "member_123" }],
+    ]);
+    expect(getByName).toHaveBeenCalledWith(expect.stringContaining("member_123"));
+
+    const invalidResponse = await hostedLocalTestWorker.fetch(
+      await signControlRequest(new Request(
+        "https://runner.example.test/__test/users/member_123"
+          + "/foreground-priority-ordering?action=status&extra=1",
         { method: "POST" },
       ), {
         boundUserId: "member_123",

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -564,7 +564,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_699_250 + 48_000,
       staticClosureBytes: 8_442_983 + 96_000,
-      totalBytes: 10_119_605 + 32_768,
+      totalBytes: 10_159_135 + 32_768,
     });
   });
 

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3050,7 +3050,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         ): void => {
           if (
             input.rearmIdleCheckpointAfterEmptyProbe !== true
-            || input.latencySeed === null
             || !shouldContinue()
           ) {
             return;
@@ -3113,11 +3112,15 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 assistantAskRequestTargetKind: "joined_group" as const,
               }
             : wakeInitialMailboxImportContext;
+        const foregroundProbeRequestIdKind =
+          input.rearmIdleCheckpointAfterEmptyProbe
+            ? `${input.requestIdKind}-rearm`
+            : input.requestIdKind;
         const initialMailboxPrefetch = await createHostedForegroundMailboxPrefetch({
           lanes: HOSTED_FOREGROUND_MAILBOX_PREFETCH_LANES,
           limitPerLane: mailboxBudget.fetchLimitPerLane,
           requestId:
-            `${requestId}:${input.requestIdKind}-foreground-prefetch:${idleWakeOrdinal + 1}`,
+            `${requestId}:${foregroundProbeRequestIdKind}-foreground-prefetch:${idleWakeOrdinal + 1}`,
           runnerInput: baseRunnerInput,
         });
         if (!shouldContinue()) {
@@ -3141,7 +3144,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             initialMailboxImportLanes: lanes,
             initialMailboxPrefetch,
             requestId:
-              `${requestId}:${input.requestIdKind}-foreground-import:${idleWakeOrdinal}`,
+              `${requestId}:${foregroundProbeRequestIdKind}-foreground-import:${idleWakeOrdinal}`,
             signal: importSignal,
             workspace: passWorkspace,
           });
@@ -3241,6 +3244,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           systemImport.importResult.importedCount === 0
           && !systemImport.importResult.blocked.some((item) => item.retryable)
         ) {
+          deferCheckpointAfterEmptyForegroundProbe(systemImport);
           await finishMailboxImportWithoutAssistant(systemImport);
           return false;
         }

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3050,6 +3050,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         ): void => {
           if (
             input.rearmIdleCheckpointAfterEmptyProbe !== true
+            || input.latencySeed === null
             || !shouldContinue()
           ) {
             return;

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -15665,9 +15665,7 @@ describe("hosted workspace runtime entrypoint", () => {
             snapshotAttempt += 1;
             events.push(`snapshot:${snapshotAttempt}:${snapshotInput.reason}`);
             if (snapshotAttempt === 1) {
-              throw new HostedRuntimeCheckpointInterruptedByWakeError({
-                notification: { notifiedAtEpochMs: Date.now() },
-              });
+              throw new HostedRuntimeCheckpointInterruptedByWakeError();
             }
             return {
               snapshotRef: createBundleRef({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -15748,6 +15748,138 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
+  test("rearms after a terminally skipped safe system continuation before a later conversation wake", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-idle-checkpoint-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const mailboxItems = [
+      createMailboxItem({
+        id: "mailbox_item_entrypoint_safe_system_rearm_initial",
+        laneSeq: "1",
+      }),
+    ];
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    let lateWakeTimer: ReturnType<typeof setTimeout> | null = null;
+    let snapshotAttempt = 0;
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_safe_system_rearm",
+            idleCheckpointDelayMs: 250,
+            leaseGeneration: "9",
+            userId: TEST_USER_ID,
+            workspaceVersion: "4",
+          },
+        }),
+        {
+          async createCheckpointSnapshot(snapshotInput) {
+            snapshotAttempt += 1;
+            events.push(`snapshot:${snapshotAttempt}:${snapshotInput.reason}`);
+            if (snapshotAttempt === 1) {
+              mailboxItems.push(createMailboxItem({
+                id: "mailbox_item_entrypoint_safe_system_rearm_system",
+                kind: "runtime.pending-effects-reconcile-requested",
+                lane: "system",
+                laneSeq: "1",
+              }));
+              throw new HostedRuntimeCheckpointInterruptedByWakeError({
+                notification: { notifiedAtEpochMs: Date.now() },
+              });
+            }
+            return {
+              snapshotRef: createBundleRef({
+                hash: `${snapshotAttempt}`.repeat(64).slice(0, 64),
+                key:
+                  "users/bundles/member-synthetic/"
+                  + `runtime-safe-system-rearm-${snapshotAttempt}.bundle.json`,
+                size: 640,
+              }),
+            };
+          },
+          async importItem(item) {
+            events.push(`mailbox.importItem:${item.item.id}`);
+            if (item.item.lane === "system") {
+              lateWakeTimer = setTimeout(() => {
+                mailboxItems.push(createMailboxItem({
+                  id: "mailbox_item_entrypoint_safe_system_rearm_late",
+                  laneSeq: "2",
+                }));
+                runtimeWakeSignal.notify({ notifiedAtEpochMs: Date.now() });
+              }, 100);
+              return {
+                reasonCode: "synthetic_terminal_skip",
+                status: "skipped",
+              };
+            }
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            events,
+            logRequests,
+            mailboxPort: createMailboxPort({
+              events,
+              items: mailboxItems,
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({ version: "4" }),
+            }),
+          }),
+          runtimeWakeSignal,
+          vaultRoot,
+        },
+      );
+
+      assert.deepEqual(events.filter((event) => event.startsWith("snapshot:")), [
+        "snapshot:1:idle_shutdown",
+        "snapshot:2:idle_shutdown",
+      ]);
+      assert.ok(
+        requireEventIndex(
+          events,
+          "mailbox.importItem:mailbox_item_entrypoint_safe_system_rearm_system",
+        ) < requireEventIndex(
+          events,
+          "mailbox.importItem:mailbox_item_entrypoint_safe_system_rearm_late",
+        ),
+        events.join(","),
+      );
+      assert.ok(
+        requireEventIndex(
+          events,
+          "mailbox.importItem:mailbox_item_entrypoint_safe_system_rearm_late",
+        ) < requireEventIndex(events, "snapshot:2:idle_shutdown"),
+        events.join(","),
+      );
+      assert.deepEqual(checkpointRequests.map((request) => request.expectedWorkspaceVersion), [
+        "4",
+      ]);
+      const systemProbeLog = logRequests
+        .flatMap((request) => request.entries)
+        .find((entry) =>
+          entry.eventCode === "mailbox.imported"
+          && entry.redactedJson?.foregroundProbeOutcome === "no_runnable_work"
+          && entry.redactedJson?.fetchedCount === 1
+        );
+      assert.equal(systemProbeLog?.redactedJson?.checkpointDeferred, true);
+      assert.equal(systemProbeLog?.redactedJson?.idleCheckpointTimerRearmed, true);
+      assert.equal(systemProbeLog?.redactedJson?.importedCount, 0);
+      assert.equal(result.redactedStatus?.hostedMailboxConversationImportedSeq, "2");
+      assert.equal(result.redactedStatus?.hostedMailboxSystemImportedSeq, "1");
+      assert.equal(result.status, "idle");
+    } finally {
+      if (lateWakeTimer) {
+        clearTimeout(lateWakeTimer);
+      }
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("successful checkpoint conversation input hints immediately run the foreground path", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-idle-checkpoint-"));
     const events: string[] = [];

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -15665,7 +15665,9 @@ describe("hosted workspace runtime entrypoint", () => {
             snapshotAttempt += 1;
             events.push(`snapshot:${snapshotAttempt}:${snapshotInput.reason}`);
             if (snapshotAttempt === 1) {
-              throw new HostedRuntimeCheckpointInterruptedByWakeError();
+              throw new HostedRuntimeCheckpointInterruptedByWakeError({
+                notification: { notifiedAtEpochMs: Date.now() },
+              });
             }
             return {
               snapshotRef: createBundleRef({

--- a/packages/hosted-local-harness/src/e2e.ts
+++ b/packages/hosted-local-harness/src/e2e.ts
@@ -93,6 +93,11 @@ export interface HostedLocalE2eScenario {
   name: Exclude<HostedLocalE2eScenarioName, "all">;
   requiresParserToolchain?: boolean;
   /**
+   * Run one matching suite per Vitest process when a scenario needs multiple
+   * process-scoped full-stack profiles from the same test file.
+   */
+  vitestProcessTestNamePatterns?: readonly [string, ...string[]];
+  /**
    * Normal hosted E2E scenarios run the production Worker/Runner/UserRunner
    * graph. Set this only for deliberate fault-injection scenarios that need
    * hosted-local test RPCs such as active-operation drop, activity expiry, or
@@ -345,6 +350,10 @@ export const hostedLocalE2eScenarios: readonly HostedLocalE2eScenario[] = [
     file: "apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts",
     name: "foreground-reply-priority",
     testControls: true,
+    vitestProcessTestNamePatterns: [
+      "^hosted local foreground reply priority e2e",
+      "^hosted local foreground checkpoint ordering e2e",
+    ],
   },
 ] as const;
 
@@ -723,25 +732,42 @@ async function runHostedLocalVitestForScenarios(input: {
   label: string;
   scenarios: readonly HostedLocalE2eScenario[];
 }): Promise<void> {
-  await runForegroundCommand({
-    args: [
-      "exec",
-      "vitest",
-      "run",
-      "--config",
-      "apps/cloudflare/vitest.e2e.config.ts",
-      ...input.scenarios.map((scenario) => scenario.file),
-      ...(input.scenarios.length > 1 ? ["--bail", "1"] : []),
-      "--no-coverage",
-    ],
-    command: "pnpm",
-    cwd: hostedLocalHarnessRepoRoot,
-    env: buildHostedLocalVitestScenarioEnv({
-      env: input.env,
-      scenarios: input.scenarios,
-    }),
-    label: input.label,
-  });
+  const testNamePatterns = input.scenarios.length === 1
+    ? input.scenarios[0]?.vitestProcessTestNamePatterns ?? [null]
+    : [null];
+
+  for (let index = 0; index < testNamePatterns.length; index += 1) {
+    const testNamePattern = testNamePatterns[index] ?? null;
+    await runForegroundCommand({
+      args: [
+        "exec",
+        "vitest",
+        "run",
+        "--config",
+        "apps/cloudflare/vitest.e2e.config.ts",
+        ...input.scenarios.map((scenario) => scenario.file),
+        ...(testNamePattern ? ["--testNamePattern", testNamePattern] : []),
+        ...(input.scenarios.length > 1 ? ["--bail", "1"] : []),
+        "--no-coverage",
+      ],
+      command: "pnpm",
+      cwd: hostedLocalHarnessRepoRoot,
+      env: buildHostedLocalVitestScenarioEnv({
+        env: input.env,
+        scenarios: input.scenarios,
+      }),
+      label: testNamePatterns.length > 1
+        ? `${input.label} process ${index + 1}/${testNamePatterns.length}`
+        : input.label,
+    });
+    if (index < testNamePatterns.length - 1) {
+      await cleanupHostedLocalE2eRunnerArtifacts(input.env, {
+        ignoreRunnerCleanupErrors: false,
+        removeRunnerImages: false,
+        runnerCleanupTimeoutMs: SCENARIO_RUNNER_CLEANUP_TIMEOUT_MS,
+      });
+    }
+  }
 }
 
 function foregroundSignalExitCode(signal: NodeJS.Signals): number {

--- a/packages/hosted-local-harness/test/e2e-suite.test.ts
+++ b/packages/hosted-local-harness/test/e2e-suite.test.ts
@@ -138,7 +138,7 @@ describe("hosted-local E2E suite preparation", () => {
     const vitestCalls = runForegroundCommand.mock.calls
       .map(([call]) => call)
       .filter((call) => call.args.includes("vitest"));
-    expect(vitestCalls).toHaveLength(20);
+    expect(vitestCalls).toHaveLength(21);
     expect(vitestCalls[0]).toEqual(expect.objectContaining({
       args: expect.arrayContaining([
         "apps/cloudflare/test/hosted-runtime-checkpoint-baseline-e2e.test.ts",
@@ -411,7 +411,6 @@ describe("hosted-local E2E suite preparation", () => {
       [16, "retryable-outbox-foreground-restart", "hosted-local-retryable-outbox-foreground-restart"],
       [17, "shutdown-checkpoint-conversation-ahead", "hosted-local-shutdown-checkpoint-conversation-ahead"],
       [18, "vault-file-approval-resume", "hosted-local-vault-file-approval-resume"],
-      [19, "foreground-reply-priority", "hosted-local-foreground-reply-priority"],
     ] as const) {
       expect(vitestCalls[index]).toEqual(expect.objectContaining({
         args: expect.arrayContaining([
@@ -433,7 +432,27 @@ describe("hosted-local E2E suite preparation", () => {
       expect(vitestCalls[index]?.env.MURPH_HOSTED_LOCAL_E2E_RUNNER_SMOKE_PROVED_BUILD_ID)
         .toBeUndefined();
     }
-    expect(cleanupHostedRunnerContainers).toHaveBeenCalledTimes(22);
+    for (const [index, processIndex, testNamePattern] of [
+      [19, 1, "^hosted local foreground reply priority e2e"],
+      [20, 2, "^hosted local foreground checkpoint ordering e2e"],
+    ] as const) {
+      expect(vitestCalls[index]).toEqual(expect.objectContaining({
+        args: expect.arrayContaining([
+          "apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts",
+          "--testNamePattern",
+          testNamePattern,
+        ]),
+        command: "pnpm",
+        label:
+          `Hosted local full-stack e2e scenario 20/20 foreground-reply-priority process ${processIndex}/2`,
+      }));
+      expect(vitestCalls[index]?.env).toEqual(expect.objectContaining({
+        MURPH_HOSTED_LOCAL_E2E_TEST_CONTROLS: "1",
+        MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID:
+          expect.stringMatching(/^hosted-local-e2e-/u),
+      }));
+    }
+    expect(cleanupHostedRunnerContainers).toHaveBeenCalledTimes(23);
     expect(cleanupHostedRunnerContainers).toHaveBeenCalledWith(expect.objectContaining({
       ignoreErrors: false,
       scope: "current-build",

--- a/packages/hosted-local-harness/test/hosted-local.test.ts
+++ b/packages/hosted-local-harness/test/hosted-local.test.ts
@@ -127,6 +127,10 @@ describe("hosted-local harness", () => {
       file: "apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts",
       name: "foreground-reply-priority",
       testControls: true,
+      vitestProcessTestNamePatterns: [
+        "^hosted local foreground reply priority e2e",
+        "^hosted local foreground checkpoint ordering e2e",
+      ],
     });
     for (const [name, file] of [
       ["canonical-receipt-lost-ack-recovery", "hosted-local-canonical-receipt-lost-ack-recovery"],


### PR DESCRIPTION
## Why this PR exists

A durably accepted foreground conversation can arrive while the hosted runtime is publishing or retrying an idle checkpoint. We need a production-faithful regression proving that new foreground work always regains admission before another background checkpoint attempt.

## User goal / user-visible behavior

A member who messages Murph while hosted checkpoint work is active still gets that message processed and replied to promptly; they do not need to send another message or wait for a later runtime wake.

## User experience

There is no new UI or interaction. The existing signed inbound is accepted and persisted as before. If it races with checkpoint work, the current runtime imports it, starts the provider, and hands off the reply before attempting another idle checkpoint. A canonical publication that has already committed may finish, after which the foreground continuation runs immediately.

## Invariants the PR must preserve

- Durable foreground conversation input precedes every new interruptible background checkpoint attempt.
- A canonical checkpoint that already committed may complete, but cannot authorize another background checkpoint ahead of later foreground input.
- Empty checkpoint-interruption probes with fresh wake evidence rearm the idle timer without delaying an already-due same-key assistant wake.
- Existing system-work, provider-handoff, shutdown, durability, and reply-latency authority remains intact.
- All deterministic barriers and ordering controls are test-only, bounded, per-user, and fail closed outside hosted-local test mode.

## Non-obvious affected surfaces

- **Hosted runtime idle checkpoint rearm:** rearms after an empty system-lane continuation while preserving the existing checkpoint-before-service rule for an already-due same-key assistant wake. Focused entrypoint regressions and the hosted-local interruption scenario cover both sides.
- **Runner test-control bundle:** adds typed ordering observation and snapshot-start control at existing outbound/test RPC boundaries. The Cloudflare control tests cover admission, action mapping, ordering, truncation, and cleanup.
- **Hosted-local scenario runner:** one scenario invokes two isolated Vitest processes because its 180-second latency profile and 10-second ordering profile cannot safely share process-scoped crypto state. Harness suite tests cover command construction and cleanup.
- **Runner bundle budget:** ratcheted to the measured test-only closure; the policy contract and full bundle assembly are green.

## Architecture and reuse

- **Existing systems reused:** Existing signed Linq ingress, real test Postgres mailbox, Temporal wake, Worker/RunnerContainer topology, snapshot/checkpoint ports, provider stub, Linq stub, and test-control admission own the proof.
- **New logic:** A bounded 64-event per-user observer records snapshot start, checkpoint start/commit, mailbox fetch completion, and provider start; three deterministic barriers hold the exact race boundaries.
- **New abstractions:** One typed observer/control module and one optional scenario-level list of Vitest name patterns compose the required profiles without adding product state or a second scenario/CI contract.
- **Complexity intentionally avoided:** No production queue, scheduler, persisted observer, polling owner, dependency, or compatibility layer was added. Production behavior changes are limited to the existing checkpoint-rearm decision.

## Hot reply path impact

The foreground critical path call count is unchanged. This PR adds no awaited database, network, provider, or logging operation between durable acceptance and provider start. The runtime change is a synchronous idle-timer rearm after an interrupted checkpoint probe; test observation exists only in hosted-local test mode. Before/after awaited call counts are therefore identical. The exact hosted-local scenario proves all five existing 30-second latency cases plus typed mailbox-import/provider ordering across both checkpoint races.

## Murph initial provider input impact

- **Individual Murph:** Not applicable; no prompt, tool/schema, model configuration, Codex wrapper, or provider-request assembly surface changed.
- **Group Murph:** Not applicable for the same reason.

## Preliminary specialist lenses

- **Product experience:** Applicable — the outcome is that a current inbound receives its reply without another user action; the exact signed-Linq hosted-local journey is green.
- **Prompt:** Not applicable — no provider-visible instruction or tool surface changed.
- **Frontend:** Not applicable — no user-facing web UI changed.
- **Coverage:** Applicable — both specialist findings were reproduced and addressed with direct safe-system and Worker route-contract regressions.

## Change-shape breakdown

Classification: runtime/test-control implementations are source; E2E files, test helpers, and test assertions are tests/fixtures; the archived execution plan and testing map are docs; the bundle budget is config/tooling; no generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 750 | 34 |
| Tests/fixtures | 1,626 | 29 |
| Docs | 76 | 2 |
| Config/tooling | 5 | 1 |
| Generated/other | 0 | 0 |
| **Total** | **2,457** | **66** |

## Validation

- Cloudflare Worker/runner test-control contract — 128 passed.
- Focused hosted-local harness registration/orchestration tests — 24 passed.
- Focused empty-conversation, terminally skipped safe-system, and same-key due-wake checkpoint-interruption regressions — 3 passed.
- Runner bundle budget-policy regression — 34 passed.
- Cloudflare runner, assistant-runtime, and hosted-local-harness typechecks — passed.
- `pnpm --filter @murphai/cloudflare-runner runner:bundle:hosted-local` — passed; total 10,159,358 bytes of 10,191,903.
- `pnpm hosted-local e2e foreground-reply-priority --no-bundle` with the sibling Temporal worker package — process 1: 5 passed; process 2: 2 passed.
- Exact-head GitHub Actions — passed.

ReviewGPT first-reviewed head: e6474aba5204489ad245eb379953c76600476968

