### PR TITLE
Expose server clock on companion sync status

### DIFF
--- a/agent-docs/product-specs/companion-app-mvp.md
+++ b/agent-docs/product-specs/companion-app-mvp.md
@@ -286,8 +286,11 @@ verification (existing `@privy-io/node`):
    existing Privy verification is the auth boundary.
 2. `GET /api/device-sync/companion/status`
    — last data receipt overall and per resource (sleep / workouts / heart
-   rate / respiratory), sourced from the existing pipeline. This is what the
-   Connect screen renders.
+   rate / respiratory), sourced from the existing pipeline, plus server
+   `observedAt` for the snapshot. Native clients use that server clock for
+   setup age, receipt freshness, and relative-time copy; a fresh connection
+   requires a receipt that strictly advances the receipt observed immediately
+   before the explicit connect. This is what the Connect screen renders.
 3. `POST /api/device-sync/companion/health-metadata`
    — accepts schema version 1 with 1–200 records, exact lower-case SHA-256
    record identities, required non-negative safe-integer sync versions, and

--- a/agent-docs/product-specs/companion-app.md
+++ b/agent-docs/product-specs/companion-app.md
@@ -148,12 +148,17 @@ and missing-consent states render distinct recovery guidance.
 
 The Android home screen treats
 `GET /api/device-sync/companion/status?sourceProviderSlug=health_connect` as
-sync truth. Webhook receipt rows retain a normalized source slug only when the
-provider-owned webhook parser identifies the source of an actual data-bearing
-event. Data-less historical completions, lifecycle events, and legacy rows keep
-that field null. Source-scoped status filters both connected-source availability
-and receipt timestamps, so those null-source rows intentionally do not satisfy
-Android status.
+sync truth. The response's server `observedAt` owns setup age, receipt
+freshness, and relative-time copy; the phone wall clock never does. When a
+refresh is unavailable, Android may retain the cached projection for context
+only if it labels the surface **Last checked online** and suppresses the frozen
+waiting, synced, delayed, needs-attention, and relative-time claims until one
+explicit check succeeds. Webhook receipt rows retain a normalized source slug
+only when the provider-owned webhook parser identifies the source of an actual
+data-bearing event. Data-less historical completions, lifecycle events, and
+legacy rows keep that field null. Source-scoped status filters both
+connected-source availability and receipt timestamps, so those null-source rows
+intentionally do not satisfy Android status.
 
 The client keeps its Junction resource request centralized and starts with four
 minimum-necessary groups: sleep, workouts, steps, and active calories. The

--- a/apps/web/src/lib/device-sync/companion.ts
+++ b/apps/web/src/lib/device-sync/companion.ts
@@ -482,6 +482,7 @@ export interface CompanionDeviceSyncResourceStatus {
 
 export interface CompanionDeviceSyncStatusResponse {
   lastDataReceivedAt: string | null;
+  observedAt: string;
   resources: Record<string, CompanionDeviceSyncResourceStatus>;
 }
 
@@ -496,6 +497,9 @@ export interface CompanionDeviceSyncStatusResponse {
  *   such as `provider.connection.created` carry no resource and are excluded.
  * - `lastDataReceivedAt` is the max of those per-resource receipt times, so it
  *   only reflects actual data webhooks, never connection lifecycle events.
+ * - `observedAt` is the server time for this status snapshot. Native clients
+ *   use it for setup age and receipt freshness so device clock changes cannot
+ *   create or suppress a synced state.
  * - Resource keys additionally include resources Junction reports available
  *   for connected sources (`device_connection_source.resourceAvailabilitySummary`,
  *   projected by the reconcile floor), with `lastReceivedAt: null` until the
@@ -510,6 +514,7 @@ export interface CompanionDeviceSyncStatusResponse {
  */
 export async function readCompanionDeviceSyncStatus(input: {
   memberId: string;
+  now?: () => Date;
   sourceProviderSlug?: string | null;
   store: PrismaDeviceSyncControlPlaneStore;
 }): Promise<CompanionDeviceSyncStatusResponse> {
@@ -629,6 +634,7 @@ export async function readCompanionDeviceSyncStatus(input: {
 
   return {
     lastDataReceivedAt,
+    observedAt: (input.now?.() ?? new Date()).toISOString(),
     resources,
   };
 }

--- a/apps/web/test/device-sync-companion-routes.test.ts
+++ b/apps/web/test/device-sync-companion-routes.test.ts
@@ -1199,6 +1199,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: null,
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {},
       });
       expect(mocks.listRecentConnectionWebhookSignals).not.toHaveBeenCalled();
@@ -1263,6 +1264,7 @@ describe("device sync companion routes", () => {
         // Lifecycle events such as provider.connection.created never count as
         // received data; only resource-bearing webhook receipts do.
         lastDataReceivedAt: "2026-06-11T08:00:00.000Z",
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {
           heartrate: { lastReceivedAt: "2026-06-11T06:30:00.000Z" },
           sleep: { lastReceivedAt: "2026-06-11T08:00:00.000Z" },
@@ -1309,6 +1311,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: "2026-07-25T18:00:00.000Z",
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {
           workouts: { lastReceivedAt: "2026-07-25T18:00:00.000Z" },
         },
@@ -1357,6 +1360,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: null,
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {},
       });
     });
@@ -1392,6 +1396,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: "2026-07-25T19:00:00.000Z",
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {
           workouts: { lastReceivedAt: "2026-07-25T19:00:00.000Z" },
         },
@@ -1426,6 +1431,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: "2026-07-25T18:00:00.000Z",
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {
           workouts: { lastReceivedAt: "2026-07-25T18:00:00.000Z" },
         },
@@ -1448,6 +1454,7 @@ describe("device sync companion routes", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({
         lastDataReceivedAt: null,
+        observedAt: "2026-07-09T12:00:00.000Z",
         resources: {},
       });
       expect(mocks.listConnectionSources).not.toHaveBeenCalled();

--- a/apps/web/test/prisma-store-connection-sources.test.ts
+++ b/apps/web/test/prisma-store-connection-sources.test.ts
@@ -670,10 +670,12 @@ describe("PrismaDeviceSyncControlPlaneStore connection source projection", () =>
     });
     await expect(readCompanionDeviceSyncStatus({
       memberId: "member_1",
+      now: () => new Date("2026-07-25T20:00:00.000Z"),
       sourceProviderSlug: "health_connect",
       store,
     })).resolves.toEqual({
       lastDataReceivedAt: acceptedAt,
+      observedAt: "2026-07-25T20:00:00.000Z",
       resources: {
         workouts: { lastReceivedAt: acceptedAt },
       },


### PR DESCRIPTION
## Why this PR exists

Android's companion sync status previously compared backend receipt timestamps against the phone's wall clock. A manually wrong or corrected device clock could therefore create a false “Synced” state or suppress a legitimate one.

## User-visible goal

Android should show waiting, synced, delayed, and attention states from one clock domain. The backend supplies its own observation time, and Android labels an unavailable cached projection **Last checked online** rather than presenting frozen state as current.

## User experience

- Entry: Android reads the existing Health Connect-scoped companion status endpoint.
- Immediate feedback: a current response drives ordinary sync status; a failed refresh shows cached context only as **Last checked online**.
- Timing/continuation owner: the backend response owns snapshot time; Android persists only the last server observation alongside its receipt baseline.
- Recovery: one explicit check restores normal classification after the next successful server response.

## Invariants

- Backend receipt timestamps remain the only evidence that health data arrived.
- `observedAt` is additive; existing iOS and older Android decoders may ignore it.
- No health values, provider payloads, device clock values, or new database state are stored.
- A fresh Android connection requires a receipt strictly newer than both the receipt observed immediately before explicit connect and that response's server `observedAt`; the observation remains the floor when no receipt exists.
- Existing source-scoped receipt invalidation and disconnected-source filtering remain unchanged.
- Cached state never renders a frozen waiting, synced, delayed, attention, or relative-time claim as current.

## Non-obvious affected surfaces

- `GET /api/device-sync/companion/status` adds required server `observedAt` to the response.
- The shared companion MVP contract documents the server clock and strict pre-connect receipt baseline.
- The canonical Android product contract documents the stale-snapshot presentation.
- Android PR #1 at `9c997ab13fd6450afdafa6fd67af47edb34baba9` implements and verifies the decoder, lifecycle, UI behavior, and atomic setup-authorization snapshot.

## Architecture and reuse

- Existing systems reused: the companion status read model remains the sole owner of sync-status responses and receipt evidence.
- New logic: the completed status snapshot is stamped with server time through an injectable `now` used for deterministic tests.
- New abstractions: none; this is one additive response field on the existing read path.
- Complexity intentionally avoided: no table, migration, queue, compatibility layer, service, or new dependency is added.

## Verification

- Focused companion route/store Vitest suites: 110 tests passed.
- Web TypeScript: passed.
- Scoped ESLint for all changed TypeScript/tests: passed.
- Exact-head GitHub CI: fully green, including release app verification, package coverage, and design proof.
- Android counterpart exact head: full 112-task Debug/Release test, lint, APK, and manifest verification passed.
- Android final exact-head correction review: PASS, no unresolved or newly introduced Medium-or-higher findings.

## Preliminary specialist lenses

- Product experience: applicable — one finding accepted and resolved by the canonical Android contract plus Android stale-snapshot implementation and regression.
- Prompt: not applicable — no prompts, tool descriptions, or provider assembly changed.
- Frontend: not applicable — no user-facing Web UI changed.
- Coverage: applicable — exact route/store expectations prove the server field; Android tests prove failure-to-stale-to-current recovery.

## Parent product revalidation

The end-to-end journey is now complete: a current server response may classify sync only when its receipt is after the final server-clock setup floor; a failed refresh retains context without a live claim; one successful check restores normal status. This preserves honest feedback under both phone clock changes and offline/server failure.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 0 |
| Tests/fixtures | 9 | 0 |
| Docs | 16 | 8 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **31** | **8** |

ReviewGPT first-reviewed head: `710fb2d949213eb542715140f79463e83b382c7f`
Current remediation head: `ee912fd8f1ac03ce8e9c4c332caab179cc99b43a`

## Review evidence

- Final round 1 on the immutable first head: PASS, no findings.
- Preliminary specialist pass: one product-experience finding accepted and resolved.
- Final correction round 2 on the remediation head: PASS, no findings.

## Deployment concerns

Deploy this API follow-up before releasing Android PR #1. The backend addition is compatible with already-released clients; Android-first skew would make the new client reject the old status shape as invalid.
