### PR TITLE
Preserve independently authorized scheduled reminders

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-05-scheduled-reminder-independent-authority.md
+++ b/agent-docs/exec-plans/completed/2026-08-05-scheduled-reminder-independent-authority.md
@@ -1,0 +1,83 @@
+# Preserve independently authorized scheduled reminders
+
+Status: completed
+Created: 2026-08-05
+Updated: 2026-08-05
+
+## Goal
+
+- Keep an active, independently authorized scheduled reminder deliverable when a
+  related plan has completed, unless the saved automation itself defines that
+  state as a skip condition or current evidence proves the requested action is
+  already complete.
+- Preserve the provider's structured send-or-skip decision in the existing cron
+  run record so a successful no-delivery run is diagnosable without private
+  transcript reconstruction.
+
+## Success criteria
+
+- Ordinary active automations receive an engine-owned authority boundary that
+  prevents a related plan's lifecycle from becoming an invented cancellation.
+- Plan-owned support keeps its existing typed lifecycle and consent gates, and
+  conditional reminders can still skip for conditions stated in their saved
+  instructions or proven completion of the requested action.
+- Cron run records distinguish provider `skip` from a send decision that did
+  not create a delivery effect while remaining readable across older records.
+- Focused contract and cron-runtime tests, package typechecks, exact-head CI,
+  and required ReviewGPT gates pass.
+
+## Scope
+
+- In scope: scheduled-notification execution instructions, cron run-record
+  observability, focused contracts/runtime tests, and matching durable docs.
+- Out of scope: changing production records, adding a scheduler or queue,
+  changing plan lifecycle ownership, replaying the historical occurrence, or
+  persisting private model/tool content.
+
+## Constraints
+
+- Technical constraints: reuse the existing automation and cron-run owners;
+  keep old v1 run records parseable; store only bounded structured metadata.
+- Product/process constraints: preserve wise model silence, explicit consent
+  boundaries, product-critical reminder delivery, and private evidence rules.
+
+## Risks and mitigations
+
+1. Risk: broad anti-skip wording could create noisy reminders after the user
+   already acted.
+   Mitigation: protect only against implicit cancellation from a merely related
+   plan while explicitly retaining saved skip conditions and proven completion.
+2. Risk: a run-record schema addition could reject existing vault history.
+   Mitigation: make the new structured decision nullable/optional on read and
+   write it deterministically for new notification runs.
+
+## Tasks
+
+1. [x] Add failing contract/runtime regressions for independent reminder authority
+   and structured no-delivery decisions.
+2. [x] Implement the smallest execution and run-record changes in current owners.
+3. [x] Update the live automation contract documentation and run focused proof.
+4. [ ] Commit, push, open the PR, and complete exact-head CI plus ReviewGPT gates.
+
+## Decisions
+
+- The historical incident was a provider `skip`, not a delivery failure or
+  lifecycle invalidation; no production mutation is needed for diagnosis.
+- Treat the active automation as the authority. Related records are context,
+  not cancellation authority, unless ownership or the saved instructions say
+  otherwise.
+- Persist decision metadata on `AssistantCronRunRecord`; do not create a new
+  observability store.
+
+## Verification
+
+- Passed `pnpm --filter @murphai/operator-config exec vitest run --config
+  vitest.config.ts --no-coverage test/assistant-cli-contracts.test.ts` (23/23).
+- Passed `pnpm --filter @murphai/assistant-engine exec vitest run --config
+  vitest.config.ts --no-coverage test/assistant-cron-runtime.test.ts` (168/168).
+- Passed package typechecks for `@murphai/operator-config` and
+  `@murphai/assistant-engine`.
+- Passed `git diff --check`.
+- Pending: exact-head PR CI, preliminary completion-specialists ReviewGPT, and
+  final ReviewGPT.
+Completed: 2026-08-05

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -432,10 +432,17 @@ it has been explicitly elevated to a cross-cutting invariant.
   planner, prompt stack, thread policy, skills, and dynamic-tool eligibility.
   Its stored instructions are the turn request; trusted occurrence and delivery
   facts are context, and the send-or-skip JSON object is only a delivery
-  envelope. Trigger origin must not select a second assistant profile or a
-  reduced tool planner. Effects still require the same invocation ports,
-  audience and accepted-input evidence, and owning-boundary validation as any
-  other turn.
+  envelope. An active ordinary automation is independent authority: completion
+  of a merely related plan or experiment cannot silently cancel it unless the
+  stored instructions define that state as a skip condition or current evidence
+  proves the occurrence's requested action already happened. Plan-owned support
+  continues to use its typed owner and consent gates. Trigger origin must not
+  select a second assistant profile or a reduced tool planner. Effects still
+  require the same invocation ports, audience and accepted-input evidence, and
+  owning-boundary validation as any other turn. The existing cron run record
+  stores the scheduled occurrence and structured provider send-or-skip decision;
+  surrounding job and session ids are the bounded record references, while
+  private tool output and reasoning remain excluded.
 - A detached system notification without a valid scheduled occurrence is not a
   user or automation turn. It runs as isolated output-only formatting with no
   conversation history, private context, resume mutation, tools, network, or

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { parseAutomationSupportSeriesTag } from '@murphai/contracts'
 import {
   archiveAutomationIfActiveUntilElapsed,
   isVaultError,
@@ -535,6 +536,7 @@ export async function executeClaimedAssistantCronJob(
   let outcome: AssistantCronRunOutcome = 'failed'
   let reason = 'unhandled'
   let pendingDeliveryIntentId: string | null = null
+  let notificationDecision: AssistantCronRunRecord['notificationDecision'] = null
   let newsletterRecoveryAuthorized = false
   let canonicalSourceDisposition: AssistantCronCanonicalSourceDisposition = 'current'
   let canonicalSourceSkipReason: string | null = null
@@ -886,6 +888,16 @@ export async function executeClaimedAssistantCronJob(
               }
             }
           }
+          const recordNotificationDecision = (
+            decision: AssistantNotificationResult['decision'] | null | undefined,
+          ): void => {
+            if (!decision) {
+              return
+            }
+            notificationDecision = decision.kind === 'skip'
+              ? { kind: 'skip', reasonCode: 'provider_skip' }
+              : { kind: 'send_message', reasonCode: 'provider_send_message' }
+          }
           const notificationInput: Parameters<
             typeof sendAssistantNotificationLocal
           >[0] = {
@@ -904,9 +916,13 @@ export async function executeClaimedAssistantCronJob(
                 }
               : {}),
             beforeProviderAcceptedInputs: assertNotificationStillAuthorized,
-            beforeDelivery: assertNotificationStillAuthorized,
+            beforeDelivery: async (context) => {
+              recordNotificationDecision(context?.decision)
+              await assertNotificationStillAuthorized()
+            },
             beforeToolExecution: assertNotificationStillAuthorized,
             beforeCommit: async (context) => {
+              recordNotificationDecision(context.decision)
               await assertNotificationStillAuthorized()
               await preemptAssistantCronNotificationCommitForForeground({
                 allowTerminalNoDelivery:
@@ -974,6 +990,7 @@ export async function executeClaimedAssistantCronJob(
           }
           const result = await sendAssistantNotificationLocal(notificationInput)
 
+          recordNotificationDecision(result.decision)
           sessionId = result.session.sessionId
           response = result.response ?? result.decision.privateSummary
           const postTurnDeliveryFailure =
@@ -1161,6 +1178,8 @@ export async function executeClaimedAssistantCronJob(
     response: truncateAssistantCronResponse(response),
     responseLength: response?.length ?? 0,
     error: errorText,
+    notificationDecision,
+    scheduledOccurrenceAt: occurrenceAt,
   })
 
   const finalized = await withAssistantCronWriteLock(input.paths, async () => {
@@ -1495,10 +1514,38 @@ function buildAssistantCronExecutionInstructions(
           '- Treat this run as the next valid delivery attempt or check-in; do not claim the prior message reached the user.',
         ].join('\n')
   const supportScope = buildAssistantCronSupportScopeInstructions(job)
+  const independentAuthority =
+    buildAssistantCronIndependentAutomationAuthorityInstructions(job)
 
-  return [job.job.prompt, retryEvidence, supportScope]
+  return [job.job.prompt, retryEvidence, independentAuthority, supportScope]
     .filter((section): section is string => section !== null)
     .join('\n\n')
+}
+
+function buildAssistantCronIndependentAutomationAuthorityInstructions(
+  job: ResolvedAssistantCronJob,
+): string | null {
+  if (
+    job.kind !== 'canonical' ||
+    job.source.kind !== 'automation' ||
+    job.source.status !== 'active' ||
+    job.source.supportKind !== null ||
+    resolveMurphManagedAutomationOwnerScope(job.source.automationId) !== null ||
+    job.source.tags.some((tag) =>
+      parseAutomationSupportSeriesTag(tag) !== null ||
+      tag.startsWith('murph-managed:')
+    )
+  ) {
+    return null
+  }
+
+  return [
+    'Independent automation authority (engine-supplied):',
+    '- This active saved automation is a current user request. Related plans and experiments are context, not cancellation authority.',
+    "- Do not treat a related plan or experiment's completion as cancellation unless the saved instructions explicitly make that state a skip condition.",
+    '- Completion of a broader plan is not proof that this occurrence\'s requested action already happened.',
+    '- You may still skip when the saved instructions authorize that outcome or current evidence proves the requested action already happened.',
+  ].join('\n')
 }
 
 function buildAssistantCronSupportScopeInstructions(

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -342,6 +342,11 @@ beforeEach(() => {
     },
   })
   cronMocks.sendAssistantMessageLocal.mockReset().mockResolvedValue({
+    decision: {
+      kind: 'send_message',
+      privateSummary: 'Prepared scheduled check-in.',
+      text: 'Completed scheduled check-in.',
+    },
     response: 'Completed scheduled check-in.',
     session: {
       sessionId: 'session-default',
@@ -1852,8 +1857,13 @@ describe('assistant cron runtime orchestration', () => {
       runs: [
         expect.objectContaining({
           error: null,
+          notificationDecision: {
+            kind: 'skip',
+            reasonCode: 'provider_skip',
+          },
           outcome: 'no_op',
           reason: 'no_delivery',
+          scheduledOccurrenceAt: '2026-04-08T08:59:30.000Z',
           status: 'succeeded',
         }),
       ],
@@ -2584,7 +2594,7 @@ describe('assistant cron runtime orchestration', () => {
     expect(canonicalAutomation).toBeDefined()
     canonicalAutomation?.tags.push('system:assistant-require-send')
 
-    await runAssistantCronJobNow({
+    const result = await runAssistantCronJobNow({
       job: canonicalJob.jobId,
       vault: vaultRoot,
     })
@@ -2592,11 +2602,64 @@ describe('assistant cron runtime orchestration', () => {
     expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
       expect.objectContaining({
         deliveryDedupeToken: null,
-        instructions: 'Check in for raw-prompt-shape',
+        instructions: expect.stringContaining('Check in for raw-prompt-shape'),
         responsePolicy: { kind: 'require_send' },
         turnTrigger: 'automation-cron',
       }),
     )
+    const providerInput = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0] as
+      | { instructions?: string }
+      | undefined
+    expect(providerInput?.instructions).toContain(
+      'Independent automation authority (engine-supplied):',
+    )
+    expect(providerInput?.instructions).toContain(
+      "Do not treat a related plan or experiment's completion as cancellation",
+    )
+    expect(providerInput?.instructions).toContain(
+      'You may still skip when the saved instructions authorize that outcome or current evidence proves the requested action already happened.',
+    )
+    expect(result.run).toMatchObject({
+      notificationDecision: {
+        kind: 'send_message',
+        reasonCode: 'provider_send_message',
+      },
+      scheduledOccurrenceAt: canonicalJob.state.nextRunAt,
+    })
+  })
+
+  it('keeps an active unowned reminder independent from related plan lifecycle', async () => {
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-independent-reminder-ownership-',
+    )
+    const canonicalJob = await createCanonicalJob(
+      vaultRoot,
+      'garden reminder',
+    )
+
+    const result = await runAssistantCronJobNow({
+      job: canonicalJob.jobId,
+      vault: vaultRoot,
+    })
+
+    expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: expect.stringContaining(
+          'Independent automation authority (engine-supplied):',
+        ),
+        responsePolicy: null,
+      }),
+    )
+    const providerInput = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0] as
+      | { instructions?: string }
+      | undefined
+    expect(providerInput?.instructions).toContain(
+      "Completion of a broader plan is not proof that this occurrence's requested action already happened.",
+    )
+    expect(result.run.notificationDecision).toEqual({
+      kind: 'send_message',
+      reasonCode: 'provider_send_message',
+    })
   })
 
   it.each([
@@ -2668,6 +2731,9 @@ describe('assistant cron runtime orchestration', () => {
       }
       expect(providerInput?.instructions).toContain(
         'this overrides any broader repair or follow-up option above',
+      )
+      expect(providerInput?.instructions).not.toContain(
+        'Independent automation authority (engine-supplied):',
       )
     },
   )
@@ -6331,7 +6397,7 @@ describe('assistant cron runtime orchestration', () => {
         deliveryDedupeToken: expect.stringContaining(
           `assistant-cron|${canonicalJob.jobId}|2026-04-08T09:00:00.000Z`,
         ),
-        instructions: 'First-session prep reminder.',
+        instructions: expect.stringContaining('First-session prep reminder.'),
         turnTrigger: 'automation-cron',
       }),
     )
@@ -6387,7 +6453,7 @@ describe('assistant cron runtime orchestration', () => {
         deliveryDedupeToken: expect.stringContaining(
           `assistant-cron|${canonicalJob.jobId}|2026-04-08T09:00:00.000Z`,
         ),
-        instructions: 'First-session prep reminder.',
+        instructions: expect.stringContaining('First-session prep reminder.'),
         turnTrigger: 'automation-cron',
       }),
     )
@@ -6818,7 +6884,7 @@ describe('assistant cron runtime orchestration', () => {
     expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledOnce()
     expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
       expect.objectContaining({
-        instructions: 'Check in for stale-canonical',
+        instructions: expect.stringContaining('Check in for stale-canonical'),
       }),
     )
 
@@ -9284,7 +9350,9 @@ describe('assistant cron runtime orchestration', () => {
         ),
         deliveryKind: 'thread',
         deliveryTarget: null,
-        instructions: 'Send the red light glasses before bed reminder.',
+        instructions: expect.stringContaining(
+          'Send the red light glasses before bed reminder.',
+        ),
         participantId: null,
         sessionId: null,
         threadId,

--- a/packages/cli/test/assistant-cron.test.ts
+++ b/packages/cli/test/assistant-cron.test.ts
@@ -582,9 +582,15 @@ test('assistant cron manual runs record history and remove completed one-shot jo
   assert.equal(result.removedAfterRun, true)
   assert.equal(result.run.sessionId, 'asst_cron_manual')
   assert.equal(result.run.response, 'Drink water now.')
+  const instructions =
+    cronServiceMocks.sendAssistantMessage.mock.calls[0]?.[0]?.instructions ?? ''
   assert.equal(
-    cronServiceMocks.sendAssistantMessage.mock.calls[0]?.[0]?.instructions,
-    'Remind me to drink water.',
+    instructions.startsWith('Remind me to drink water.\n\n'),
+    true,
+  )
+  assert.match(
+    instructions,
+    /Independent automation authority \(engine-supplied\):/u,
   )
   assert.equal(
     cronServiceMocks.sendAssistantMessage.mock.calls[0]?.[0]?.channel,

--- a/packages/operator-config/src/assistant-cli-contracts.ts
+++ b/packages/operator-config/src/assistant-cli-contracts.ts
@@ -1430,6 +1430,17 @@ function normalizeAssistantCronRunReason(
     : fallback
 }
 
+const assistantCronNotificationDecisionSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('skip'),
+    reasonCode: z.literal('provider_skip'),
+  }).strict(),
+  z.object({
+    kind: z.literal('send_message'),
+    reasonCode: z.literal('provider_send_message'),
+  }).strict(),
+])
+
 export const assistantCronRunRecordSchema = z.preprocess(
   normalizeAssistantCronRunRecordInput,
   z.object({
@@ -1446,6 +1457,9 @@ export const assistantCronRunRecordSchema = z.preprocess(
     response: z.string().nullable(),
     responseLength: z.number().int().nonnegative(),
     error: z.string().nullable(),
+    notificationDecision:
+      assistantCronNotificationDecisionSchema.nullable().optional(),
+    scheduledOccurrenceAt: isoTimestampSchema.optional(),
   })
   .strict(),
 )

--- a/packages/operator-config/test/assistant-cli-contracts.test.ts
+++ b/packages/operator-config/test/assistant-cli-contracts.test.ts
@@ -453,6 +453,31 @@ describe('assistant CLI delivery contracts', () => {
     expect(run.runId).toBe('cronrun_123')
     expect(run.jobId).toBe('cronjob_123')
     expect(run.sessionId).toBe('session_123')
+    expect(run.notificationDecision).toBeUndefined()
+    expect(run.scheduledOccurrenceAt).toBeUndefined()
+
+    expect(assistantCronRunRecordSchema.parse({
+      ...run,
+      notificationDecision: {
+        kind: 'skip',
+        reasonCode: 'provider_skip',
+      },
+      scheduledOccurrenceAt: '2026-04-12T00:00:00.000Z',
+    })).toMatchObject({
+      notificationDecision: {
+        kind: 'skip',
+        reasonCode: 'provider_skip',
+      },
+      scheduledOccurrenceAt: '2026-04-12T00:00:00.000Z',
+    })
+
+    expect(() => assistantCronRunRecordSchema.parse({
+      ...run,
+      notificationDecision: {
+        kind: 'skip',
+        reasonCode: 'provider_send_message',
+      },
+    })).toThrow()
   })
 
   it('rejects the removed assistant cron deliverResponse field', () => {


### PR DESCRIPTION
## Why this PR exists

An active scheduled workout reminder was allowed to end successfully with no delivery because the provider treated completion of a merely related training plan as cancellation authority. The reminder was a separate saved request and should have remained deliverable through its own active range.

## User goal / user-visible behavior

An active ordinary automation remains an independent user request. A related plan or experiment may inform the turn, but its completion does not cancel the automation unless the saved instructions explicitly define that condition or current evidence proves this occurrence's requested action already happened.

The provider still retains useful send-or-skip judgment. This PR narrows only the invalid inference that a broader related lifecycle silently cancels an otherwise active saved automation.

## User experience

The entry point is the next due occurrence of an active ordinary saved automation. The existing scheduled runner owns timing and the existing notification turn owns provider execution and delivery. There is no new screen or foreground feedback state: when the occurrence runs, the provider receives the saved instructions plus the engine-owned authority boundary and either requests the existing delivery path or makes an allowed skip decision.

Successful delivery still reaches the automation's bound conversation. A valid skip still produces no user-facing message. Delivery failures and retries keep their existing behavior. The cron run record now preserves the occurrence and a bounded machine-readable provider decision so an operator can distinguish provider skip from send-without-delivery without reconstructing private content. This PR does not replay or mutate the historical occurrence.

## Invariants

- Keep the active automation, not a merely related plan, as the authority for an ordinary scheduled occurrence.
- Preserve explicit saved skip conditions, proof that this occurrence's requested action already happened, and the model's ability to remain wisely quiet.
- Keep plan-owned support and Murph-managed automations on their existing typed owner, consent, lifecycle, and delivery gates.
- Preserve delivery routing, idempotency, preemption, retry, and occurrence-consumption behavior.
- Persist only bounded decision metadata and the occurrence timestamp; do not persist provider reasoning, tool output, or private notification content in the new fields.
- Keep legacy cron run records readable by the new parser.

## Non-obvious affected surfaces

- **Canonical automation classification:** only active ordinary automation records receive the independent-authority block. Typed support-series tags, non-null support kinds, managed owner ids, and `murph-managed:` tags are excluded. Focused cron-runtime coverage proves ordinary inclusion and plan-owned support exclusion.
- **Cron run persistence:** the existing v1 run record gains optional `scheduledOccurrenceAt` and a strict discriminated `notificationDecision`. Contract tests prove legacy records remain valid and mismatched kind/reason pairs fail closed.
- **No-delivery diagnosis:** the existing `outcome` and `reason` remain authoritative for delivery effect; the new decision records whether the provider selected `skip` or `send_message`, including before a later authorization/preemption failure. Runtime tests prove both decision kinds and scheduled occurrence persistence.
- **Provider instructions:** both individual and group scheduled ordinary automations receive the same engine-owned authority boundary. Complete pinned-App-Server request capture and prompt assertions prove the intended inclusion without changing tool/schema surfaces.

## Architecture and reuse

- Existing systems reused: the canonical automation owner fields and tags, existing cron execution instruction builder, notification decision contract, cron run store, and current delivery/outbox lifecycle.
- New logic: classify active ordinary automations at the scheduled execution boundary, append one trusted authority section, capture the provider's existing structured decision, and persist it with the scheduled occurrence.
- New abstractions: one local instruction-builder helper and one private discriminated schema inside the existing run-record contract; no new service, store, queue, lifecycle, or public package surface.
- Complexity intentionally avoided: no must-send tag expansion, synthetic replay, plan-state synchronization, cancellation manager, second observability table, raw tool-call retention, or provider-rationale persistence.

## Hot reply path impact

- Path status: Not applicable — only off-path scheduled cron notification execution and its run record change.
- Database calls: None added or moved onto the foreground reply path.
- Network/provider calls: None added or moved onto the foreground reply path.
- Other awaited latency: None added or moved onto the foreground reply path.
- Before/after proof: focused cron-runtime tests exercise the changed scheduled path; no current-conversation acceptance or reply-handoff code changes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 33,262 | 33,365 | +103 | +0.3097% | 152,995 | 153,571 | +576 |
| Group Murph | 27,933 | 28,036 | +103 | +0.3687% | 129,168 | 129,744 | +576 |

- Assembled instructions: the full delta in both runtimes is the five-line `Independent automation authority (engine-supplied)` section added by `buildAssistantCronIndependentAutomationAuthorityInstructions` in `packages/assistant-engine/src/assistant/cron/execution.ts`.
- Tool/schema/generated guidance: unchanged. The individual fixture exposed 16 representative Murph dynamic tools and the group fixture exposed 13; pinned Terra code mode rendered their schemas and Codex-generated guidance inside the captured provider input rather than top-level Responses tools.
- Other provider-visible input: unchanged. System/developer layers, scheduled-occurrence context, saved reminder instructions, wrappers, model mode, and representative availability were identical between reconstructed base and head.
- Measurement method: implementation head `e5d6c773fb859b35e5951711514d893adf11ef1d` versus base `e90c68e5bbe5db41cf161a589a6f62c91918ab68`, using the installed pinned Codex App Server, `gpt-5.6-terra`, low reasoning, production code mode, and `gpt-tokenizer` 3.4.0 `o200k_harmony`. A temporary deterministic local Responses stub captured the complete first request for synthetic scheduled individual and group turns. Counts cover canonical JSON for `include`, `input`, `parallel_tool_calls`, `text`, `tool_choice`, and `tools`, including Murph/Codex instructions, code-mode guidance, dynamic-tool declarations, schemas, and other provider-visible wrappers. Only transport/cache/account fields were excluded equally; ephemeral Codex-home/workspace paths and UUIDs were normalized equally. Base was reconstructed by removing the exact new authority block once, asserted once per request; a second capture for each runtime was byte-identical. The current head adds only a CLI assertion for the already-measured instructions and does not change provider-visible input. The temporary harness and capture were removed.

## Preliminary specialist lenses

- Product experience — applicable: the intended outcome is that a separately requested active reminder remains deliverable through its own authority; the direct journey evidence is focused ordinary-automation inclusion, valid skip preservation, and plan-owned support exclusion.
- Prompt — applicable: scheduled provider instructions gain an engine-owned authority boundary while preserving saved skip conditions and proven occurrence completion.
- Frontend — not applicable: no UI, component, route, or rendered state changes.
- Coverage — applicable: the focused Assistant Engine runtime suite passed 168 tests, Operator Config contract suite passed 23 tests, focused CLI cron suite passed 12 tests, both affected source-package typechecks passed, and exact-head GitHub Actions are rerunning after the CLI assertion was aligned with the intended appended instructions.

## Design proof

- Design page: Not applicable; no user-facing `apps/web` UI changes.
- Coverage: Not applicable; no component or section changes.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: executable TypeScript contract/runtime files are source; Vitest files are tests/fixtures; Markdown invariant and completed-plan files are docs. There are no config/tooling, generated, or binary changes. This immutable round-1 baseline is measured from `e90c68e5bbe5db41cf161a589a6f62c91918ab68` to first-reviewed head `e5d6c773fb859b35e5951711514d893adf11ef1d`.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 63 | 2 |
| Tests / fixtures | 99 | 6 |
| Docs | 94 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **256** | **12** |

Current head `2e6d41867d05d6035dbddfe3ced3bff2f4c2809c` adds only the focused CLI regression assertion required by exact-head CI:

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 63 | 2 |
| Tests / fixtures | 105 | 8 |
| Docs | 94 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **262** | **14** |

## Verification

- `pnpm --filter @murphai/operator-config typecheck`
- `pnpm --filter @murphai/operator-config exec vitest run --config vitest.config.ts --no-coverage test/assistant-cli-contracts.test.ts` — 23 passed.
- `pnpm --filter @murphai/assistant-engine typecheck`
- `pnpm --filter @murphai/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-cron-runtime.test.ts` — 168 passed.
- `pnpm --filter @murphai/murph exec vitest run --config vitest.config.ts --no-coverage test/assistant-cron.test.ts` — 12 passed after exact-head CI exposed the stale equality assertion.
- `bash scripts/check-agent-docs-drift.sh`
- `git diff --check`
- `git merge-tree --write-tree HEAD origin/main` — clean synthetic merge tree.
- Pinned real Codex App Server first-request capture passed twice for individual and group fixtures with byte-identical normalized results.
- Privacy scan found no direct identifiers in the committed diff.

## Deployment concerns

This is a Cloudflare-hosted runner/package change only; no Vercel change or tandem deployment is required. The new parser accepts both legacy and enriched v1 run records, so old warm runners may continue writing the legacy shape while new runners read either shape. New runners write fields that the pre-change strict parser does not know, so avoid rolling the Cloudflare runner back below this change after enriched records have been written; use a forward fix that retains the optional fields if rollback is required. Post-deploy, inspect a new scheduled run through the existing secret-safe operator surface and confirm `scheduledOccurrenceAt`, `notificationDecision`, and the existing delivery outcome agree.

ReviewGPT first-reviewed head: e5d6c773fb859b35e5951711514d893adf11ef1d
