### PR TITLE
feat(web): add status page footer link

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -12,6 +12,7 @@ import { HowItWorksSection } from "@/src/components/homepage/how-it-works-sectio
 import { DEFAULT_MURPH_HEADSHOT } from "@/src/components/homepage/murph-headshot-avatar";
 import { PersonasSection } from "@/src/components/homepage/personas-section";
 import { SecurityTeaserSection } from "@/src/components/homepage/security-teaser-section";
+import { SiteFooter } from "@/src/components/homepage/site-footer";
 import { TogetherSection } from "@/src/components/homepage/together-section";
 import { ModelProviderSecuritySection } from "@/src/components/security/model-provider-security-section";
 import { HostedAssistantModelSettings } from "@/src/components/settings/hosted-assistant-model-settings";
@@ -208,6 +209,18 @@ export function SectionsContent() {
         >
           <TogetherSection />
           <AsksGridSection />
+        </div>
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Homepage footer">
+        <div
+          data-design-section="homepage-footer"
+          className="-mx-5 sm:-mx-8 lg:-mx-12"
+          inert
+        >
+          <SiteFooter />
         </div>
       </StudySection>
 

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -220,7 +220,7 @@ export function SectionsContent() {
           className="-mx-5 sm:-mx-8 lg:-mx-12"
           inert
         >
-          <SiteFooter />
+          <SiteFooter id="design-site-footer-preview" />
         </div>
       </StudySection>
 

--- a/apps/web/src/components/homepage/site-footer.tsx
+++ b/apps/web/src/components/homepage/site-footer.tsx
@@ -34,6 +34,11 @@ const footerLinks = {
   murph: [
     { label: "Clubs", href: "/clubs", external: false },
     { label: "Changelog", href: "/changelog", external: false },
+    {
+      label: "Status",
+      href: "https://status.withmurph.ai",
+      external: true,
+    },
     { label: "Design", href: "/design", external: false },
     { label: "Security", href: "/security", external: false },
     {

--- a/apps/web/src/components/homepage/site-footer.tsx
+++ b/apps/web/src/components/homepage/site-footer.tsx
@@ -60,9 +60,9 @@ const footerLinks = {
   ],
 };
 
-export function SiteFooter() {
+export function SiteFooter({ id = "site-footer" }: { id?: string }) {
   return (
-    <footer id="site-footer" className="border-t border-[rgba(196,168,130,0.25)] bg-[#f5f0e8] px-6 sm:px-10 lg:px-16">
+    <footer id={id} className="border-t border-[rgba(196,168,130,0.25)] bg-[#f5f0e8] px-6 sm:px-10 lg:px-16">
       <div className="mx-auto max-w-[1080px]">
         {/* Logo + link columns */}
         <div className="flex flex-col gap-10 py-10 sm:flex-row sm:justify-between">

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -113,6 +113,8 @@ test("design page routes the biomarker studies through the dedicated sections ta
   );
   expect(sectionsMarkup).toContain("Homepage experiment flow");
   expect(sectionsMarkup).toContain("Homepage personas");
+  expect(sectionsMarkup).toContain("Homepage footer");
+  expect(sectionsMarkup).toContain('data-design-section="homepage-footer"');
   expect(sectionsMarkup).toContain("Changelog archive edition");
   expect(sectionsMarkup).toContain('data-design-study="changelog-archive"');
   expect(sectionsMarkup).toContain("A week that closes its own loops");

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -94,6 +94,7 @@ import {
   BIOMARKER_STUDY_GROUPS,
 } from "@/src/components/biomarkers/biomarker-design-data";
 import { DesignPage } from "@/app/design/design-page";
+import DesignRoute from "@/app/design/page";
 
 beforeEach(() => {
   navigationMocks.replace.mockReset();
@@ -234,6 +235,18 @@ test("design page routes the biomarker studies through the dedicated sections ta
   expect(groupFundingStudySource).toContain(
     'mode="one_time"',
   );
+});
+
+test("design sections keep the route footer as the sole canonical footer target", async () => {
+  const route = await DesignRoute({
+    searchParams: Promise.resolve({ tab: "sections" }),
+  });
+  const routeMarkup = renderToStaticMarkup(route);
+
+  expect(routeMarkup.match(/id="site-footer"/g)).toHaveLength(1);
+  expect(routeMarkup).toContain('id="design-site-footer-preview"');
+  expect(routeMarkup).toContain('data-design-section="homepage-footer"');
+  expect(routeMarkup).toContain("inert=");
 });
 
 test("biomarker preparing study reassures members and previews the index structure", () => {

--- a/apps/web/test/consumer-health-data-privacy-policy.test.ts
+++ b/apps/web/test/consumer-health-data-privacy-policy.test.ts
@@ -121,3 +121,12 @@ test("SiteFooter exposes the consumer health data notice link in the legal nav c
   assert.match(markup, /href="\/consumer-health-data-privacy-policy"/u);
   assert.match(markup, /Consumer Health Data/u);
 });
+
+test("SiteFooter exposes the public status page in the product nav column", () => {
+  const markup = renderToStaticMarkup(createElement(SiteFooter));
+
+  assert.match(markup, /aria-label="Product links"/u);
+  assert.match(markup, /href="https:\/\/status\.withmurph\.ai"/u);
+  assert.match(markup, />Status<\/a>/u);
+  assert.match(markup, /href="https:\/\/status\.withmurph\.ai" target="_blank" rel="noreferrer"/u);
+});


### PR DESCRIPTION
## Why

The public incident.io page is live at `status.withmurph.ai`, but members cannot discover it from Murph's primary site navigation.

## User-visible goal / UX

Add a quiet `Status` link to the existing homepage footer's Murph column. It opens the hosted status page in a new tab and preserves the footer's current visual hierarchy, responsiveness, and legal content.

## Invariants

- the footer points only to the verified HTTPS custom domain
- the link uses the existing external-link behavior with `target="_blank"` and `rel="noreferrer"`
- no new footer abstraction or duplicate presentation is introduced
- the design catalog renders the real production `SiteFooter` with synthetic, inert context

## Architecture and reuse

- **Existing systems reused:** the existing `SiteFooter` link collection, external-link rendering, and design-catalog `StudySection`.
- **New logic:** one external link entry, a preview-specific footer ID for the design catalog, and focused assertions for the link and full-route DOM identity.
- **New abstractions:** None; the existing footer data structure and catalog study already own this behavior.
- **Complexity intentionally avoided:** no status widget, API client, runtime dependency, bespoke footer variant, or duplicated catalog markup.

## Design proof

- Design page: `/design?tab=sections` → `Homepage footer`
- Desktop screenshot: [![Desktop footer status link](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/bf88bd87-c00a-4b34-c385-e646f7d90c00/designproof)](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/bf88bd87-c00a-4b34-c385-e646f7d90c00/designproof)
- Mobile screenshot: [![Mobile footer status link](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/acbcf9e9-177d-491c-e82c-ecc38463a500/designproof)](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/acbcf9e9-177d-491c-e82c-ecc38463a500/designproof)
- Claude UI double-check: attempted with Fable; explicit usage-credit exhaustion, recorded as a non-blocking gap under the completion workflow.

## Preliminary specialist lenses

- Product experience: Applicable — adds a new member-visible navigation action.
- Prompt: Not applicable — no prompt, tool description, or provider input changed.
- Frontend: Applicable — changes the production homepage footer and its responsive catalog rendering.
- Coverage: Applicable — focused footer and design-catalog assertions changed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 20 | 2 |
| Tests / fixtures | 24 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **44** | **2** |

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/consumer-health-data-privacy-policy.test.ts apps/web/test/biomarker-design-studies.test.tsx` — 14 passed
- `pnpm --dir apps/web typecheck` — passed
- scoped ESLint — passed
- desktop 1440 CSS px / DSF2 and mobile 390 CSS px / DSF3 production-component renders inspected
- browser DOM proof at 1440×900 and 390×844 — one canonical footer ID, one inert preview ID, correct status URL
- `git diff --check` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cobuildwithus/codesmith/murph/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788553516&installation_model_id=19880&pr_number=1328&repository=cobuildwithus%2Fmurph&return_to=https%3A%2F%2Fgithub.com%2Fcobuildwithus%2Fmurph%2Fpull%2F1328&signature=8bac1e12d7912911849507ca56b91f9eb5b17ef4b8a7ecba73d307dde65d21e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->