### PR TITLE
Align Environment panel with dashboard width

### DIFF
--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -360,7 +360,7 @@ async function requestEnvironmentVoiceProcessingRecheck(): Promise<void> {
   }
 }
 
-function EnvironmentShell({
+export function EnvironmentShell({
   actions,
   children,
 }: {
@@ -478,7 +478,7 @@ export function EnvironmentEmptyState({
   );
 }
 
-function EnvironmentReport({
+export function EnvironmentReport({
   values,
   scene,
   notes,

--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -368,7 +368,7 @@ function EnvironmentShell({
   children: ReactNode;
 }) {
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
+    <div className="flex w-full flex-col gap-10">
       <div className="flex items-end justify-between gap-4">
         <PageHeader
           eyebrow="Habitat"
@@ -442,9 +442,6 @@ export function EnvironmentEmptyState({
             />
           </div>
 
-          <p className="mt-7 max-w-[58ch] text-pretty text-base text-muted-foreground sm:text-sm">
-            Missing answers and optional equipment never lower your grade.
-          </p>
         </div>
 
         <div className="border-t border-border bg-muted/20 px-6 py-7 sm:px-8 sm:py-9 lg:border-l lg:border-t-0 lg:px-8 lg:py-10">

--- a/apps/web/app/design/environment-progress-study.tsx
+++ b/apps/web/app/design/environment-progress-study.tsx
@@ -3,9 +3,20 @@
 import {
   EnvironmentCaptureCard,
   EnvironmentEmptyState,
+  EnvironmentReport,
+  EnvironmentShell,
   EnvironmentVoiceRefreshNotice,
 } from "../(dashboard)/environment/environment-page-client";
+import {
+  deriveCategoryNote,
+  overallGrade,
+} from "../(dashboard)/environment/category-notes";
 import type { EnvironmentVoiceScript } from "../(dashboard)/environment/environment-voice-script";
+import {
+  type HabitatValues,
+  resolveEnvironmentCoverage,
+  resolveHabitatScene,
+} from "../(dashboard)/environment/home-model";
 
 const DESIGN_CONTACT_OPTIONS = [
   {
@@ -19,6 +30,28 @@ const DESIGN_CONTACT_OPTIONS = [
     label: "Telegram",
   },
 ];
+
+const REPORT_DESIGN_VALUES: HabitatValues = {
+  "home-air": {
+    damp_or_mold: "none",
+    smoke_sources: "none",
+    ventilation: "mechanical",
+  },
+  lighting: {
+    daytime_light: "by_window",
+    evening_light: "warm_dim",
+    morning_light_access: "outdoor_routine",
+  },
+  "sleep-environment": {
+    darkness: "blackout",
+    night_noise: "quiet",
+    night_temp_c: 20,
+  },
+  workspace: {
+    breaks: "systematic",
+    screen_at_eye_level: true,
+  },
+};
 
 const GAP_SCRIPTS: Readonly<Record<10 | 30 | 70, EnvironmentVoiceScript>> = {
   10: gapScript([
@@ -62,6 +95,11 @@ const UPDATE_SCRIPT: EnvironmentVoiceScript = {
 };
 
 export function EnvironmentProgressStudy() {
+  const reportScene = resolveHabitatScene(REPORT_DESIGN_VALUES);
+  const reportNotes = reportScene.categories.map((category) =>
+    deriveCategoryNote(category, REPORT_DESIGN_VALUES),
+  );
+
   return (
     <div
       className="flex flex-col gap-10"
@@ -70,7 +108,28 @@ export function EnvironmentProgressStudy() {
       inert
     >
       <StudyState label="0% · Auth-gated first walkthrough">
-        <EnvironmentEmptyState contactOptions={DESIGN_CONTACT_OPTIONS} />
+        <div id="environment-empty-dashboard-shell">
+          <EnvironmentShell>
+            <EnvironmentEmptyState contactOptions={DESIGN_CONTACT_OPTIONS} />
+          </EnvironmentShell>
+        </div>
+      </StudyState>
+      <StudyState label="Populated report · Shared dashboard width">
+        <div id="environment-populated-dashboard-shell">
+          <EnvironmentShell>
+            <EnvironmentReport
+              conditions={{ outdoorAir: "Good", weather: "Clear · 21°C" }}
+              contactOptions={DESIGN_CONTACT_OPTIONS}
+              coverage={resolveEnvironmentCoverage(reportScene)}
+              grade={overallGrade(reportNotes)}
+              notes={reportNotes}
+              onVoiceAccepted={() => {}}
+              scene={reportScene}
+              values={REPORT_DESIGN_VALUES}
+              voiceCaptureDisabled={false}
+            />
+          </EnvironmentShell>
+        </div>
       </StudyState>
       <StudyState label="10% · Build the core picture">
         <EnvironmentCaptureCard

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -175,7 +175,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Environment progressive voice capture">
+      <StudySection title="Environment full-width progressive voice capture">
         <EnvironmentProgressStudy />
       </StudySection>
 

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -267,7 +267,8 @@ test("EnvironmentPage gives zero-data members one clear start and previews the r
   assert.match(markup, /Prefer typing\? Use chat/);
   assert.match(markup, /Murph will turn the clear details/);
   assert.match(markup, /Your report will cover/);
-  assert.match(
+  assert.match(markup, /class="flex w-full flex-col gap-10"/);
+  assert.doesNotMatch(
     markup,
     /Missing answers and optional equipment never lower your grade/,
   );


### PR DESCRIPTION
## Why this PR exists

The Environment zero-data panel was narrower than the rest of the dashboard because the page added its own centered width cap on top of the dashboard shell padding. The helper sentence beneath the actions was also no longer wanted.

## User goal / user-visible behavior

Members see the Environment introduction use the same available content width and horizontal margins as other dashboard pages. The sentence about missing answers and optional equipment is removed.

## User experience

- Entry point: authenticated `/environment` with no saved habitat facts.
- Immediate behavior: the existing introduction, walkthrough action, chat alternative, and report-category preview render unchanged, but the panel fills the dashboard content width.
- Timing and continuation: no asynchronous behavior, state transition, or continuation owner changes.
- Terminal state and recovery: the existing voice and chat actions retain their current destinations and recovery behavior.
- Smallest interaction: no new controls, steps, or choices were added.

## Invariants

- Preserve the dashboard shell as the single owner of page-level horizontal padding.
- Preserve the existing desktop two-column and mobile stacked layouts.
- Preserve the voice-first walkthrough and chat alternative without changing action semantics.
- Keep the production component rendered with synthetic data in the design catalog.

## Architecture and reuse

- Existing systems reused: the existing `DashboardShell` spacing, `EnvironmentShell`, `EnvironmentEmptyState`, `EnvironmentReport`, and `/design?tab=sections` study remain the only owners.
- New logic: none in production; the redundant nested `max-w-6xl` constraint and the requested sentence are deleted, while synthetic catalog data renders the existing populated report for visual proof.
- New abstractions: none, because the existing dashboard shell already owns the shared page width and the Environment component only needed its redundant inner cap removed.
- Complexity intentionally avoided: no new width token, wrapper component, breakpoint, or copy variant was introduced.

## Non-obvious affected surfaces

- The Environment progressive-capture section now renders the real shared shell around both zero-data and populated-report states, and its catalog label names the full-width presentation explicitly.
- The zero-data server-render test now proves the shared-width shell class and absence of the deleted sentence.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/browser-vault-dashboard-pages.test.tsx` (16 passed)
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web exec eslint 'app/(dashboard)/environment/environment-page-client.tsx' app/design/environment-progress-study.tsx app/design/sections-content.tsx test/browser-vault-dashboard-pages.test.tsx`
- `pnpm test:frontend-design-proof` (10 passed)
- Playwright catalog proof at 2048px desktop and 390px mobile: no page errors, the shared shell measured 1184px where the former 1152px cap would bind, the populated report uses the same width, deleted copy is absent, and the responsive layout remains intact.
- Claude Code UI double-check: attempted Fable 5 and stopped on explicit usage-credit exhaustion, per the completion workflow.

## Specialist lenses

- Product experience: applicable; one explanatory sentence is removed at the user's request without changing the action or product promise.
- Frontend: applicable; dashboard width containment changes.
- Coverage: applicable; server-render proof changes with the presentation.
- Prompt: not applicable; no assistant prompt changes.
- Final ReviewGPT gate: not applicable; this is minor frontend containment/copy deletion with no workflow, state, data-flow, or authority change.

## Design proof

- Design page: `/design?tab=sections#environment-progressive-capture`
- Desktop screenshot: ![Desktop zero-data Environment shell](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/29aab561-92d5-4ddb-fb9e-8646b4d80100/designproof)
- Desktop populated-report screenshot: ![Desktop populated Environment shell](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/0d1a0198-f955-4189-1c85-81448927da00/designproof)
- Mobile screenshot: ![Mobile zero-data Environment shell](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/8b7e7e48-093b-4334-6d8d-f0b94dca6600/designproof)

## Change shape

Classification: production and catalog TSX are source; render assertions are tests. No binary files are committed.

- Source: +64 / -8
- Tests: +2 / -1
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
