### PR TITLE
fix(cloudflare): ratchet runner bundle budget

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -115,7 +115,13 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // transcript, and Linq delivery paths without adding a forbidden boot input.
 // Linux CI measured an 8,540,082B static closure on 2026-08-05; retain the
 // established allowance above that reviewed measurement.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_186_925 + 32_768;
+//
+// Restoring the disabled native-memory provider relay, diagnostics, and usage
+// accounting extends existing runner chunks without adding a forbidden boot
+// input. Linux CI measured 10,222,098B total and macOS measured 10,273,401B
+// total on 2026-08-06; retain the established allowance above the higher
+// cross-platform measurement.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_273_401 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_699_250;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_540_082;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -564,7 +564,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_699_250 + 48_000,
       staticClosureBytes: 8_540_082 + 96_000,
-      totalBytes: 10_186_925 + 32_768,
+      totalBytes: 10_273_401 + 32_768,
     });
   });
 


### PR DESCRIPTION
## Why this PR exists

The production Cloudflare deploy for the disabled native-memory infrastructure restoration was blocked because the restored, intended runner code exceeded the prior total bundle-size ratchet by 2,405 bytes on Linux.

## User goal / user-visible behavior

Allow the already-merged infrastructure to deploy while Venice and Codex native-memory generation remain disabled by configuration.

## User experience

No user-facing effect. This changes only the runner assembly budget; it does not enable either inference choice or native memory.

## Invariants

- Keep the Venice and native-memory feature settings unchanged and disabled.
- Preserve the independent entry-chunk, static-closure, and forbidden-input guards.
- Preserve the established 32 KiB allowance above a measured cross-platform baseline.
- Add no runtime state, provider behavior, or deployment bypass.

## Preliminary specialist lenses

- Product experience: not applicable — no product-owned journey, feedback, recovery, or interaction changes.
- Prompt: not applicable — no prompt, instruction, tool description, or provider-visible input changes.
- Frontend: not applicable — no `apps/web` UI changes.
- Coverage: applicable — the change updates deploy-gate proof scaffolding and its exact unit-test lock.
- Product outcome and actors: operators can deploy the already-merged dormant infrastructure; end users see no behavior change.
- Entry point, timing, feedback, continuation, terminal destination, permission, and recovery: not applicable to product experience; the production deploy workflow remains the existing owner and fails closed at bundle assembly.
- Focused local proof: 34 focused unit tests, Cloudflare typecheck, and full runner-bundle assembly passed at the measured cross-platform ceiling.
- Current exact-head CI status: pending at review launch.
- Rendered evidence: not applicable.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: This is a production deploy-gate correction for the hosted runtime bundle.

ReviewGPT first-reviewed head: 709c83021d88bc51607647810937b09095cc060e

## Non-obvious affected surfaces

- Cloudflare production predeploy assembly: proved by a full local `runner:bundle` build at 10,273,401 bytes against the 10,306,169-byte budget.

## Architecture and reuse

- Existing systems reused: The existing measured bundle ratchet and its unit-test lock.
- New logic: None; only the measured total baseline changes.
- New abstractions: None; the existing budget owner is sufficient.
- Complexity intentionally avoided: No runtime branch, deploy bypass, alternate bundle, or feature-specific exception.

## Hot reply path impact

- Path status: Not applicable — no runtime code changes.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable; the emitted runner code is unchanged.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: Not applicable.
- Coverage: No UI changes.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: The bundle budget script is config/tooling; its lock test is tests. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config / tooling | 7 | 1 |
| Generated / other | 0 | 0 |
| **Total** | **8** | **2** |

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts --no-coverage` — 34 tests passed.
- `pnpm --dir apps/cloudflare typecheck` — passed.
- `pnpm --dir apps/cloudflare runner:bundle` — passed; entry, static closure, total budget, parity probes, and assembly all succeeded.
- `git diff --check` — passed.
