### PR TITLE
test(hosted): match card capability recipient

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-linq-support.ts
@@ -135,7 +135,6 @@ export interface HostedLocalLinqStub {
   createCreateChatRequestMatcher(userId: string): ObservedLinqRequestMatcher;
   createIMessageCapabilityRequestMatcher(input: {
     address: string;
-    from: string;
   }): ObservedLinqRequestMatcher;
   listObservedMessageIds(chatId: string): string[];
   observedRequests: ObservedLinqRequest[];
@@ -673,9 +672,9 @@ export async function startHostedLocalLinqStub(input: {
         return parsed?.from === expectedFrom && Array.isArray(to) && to[0] === expectedTo;
       };
     },
-    createIMessageCapabilityRequestMatcher: ({ address, from }) => (request) => {
+    createIMessageCapabilityRequestMatcher: ({ address }) => (request) => {
       const parsed = parseObservedLinqJson(request.body);
-      return parsed?.address === address && parsed.from === from;
+      return parsed?.address === address;
     },
     listObservedMessageIds: (chatId) => [...(observedMessageIdsByChat.get(chatId) ?? [])],
     observedRequests,

--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -354,7 +354,6 @@ describe("hosted local Linq scheduled reminder e2e", () => {
     const capabilityPath = "/capability/check_imessage";
     const capabilityMatcher = requireLinqStub().createIMessageCapabilityRequestMatcher({
       address: memberPhone,
-      from: homePhone,
     });
     const overlapCapabilityBaselineCount = requireLinqStub().countObservedRequests({
       expectedMethod: "POST",


### PR DESCRIPTION
## Why

The production deployment gate for the merged late-input nutrition-card fix observed both the expected iMessage capability request and the native app-card send, but the new regression test timed out because its matcher also required Linq's optional `from` field. Current inbound-thread delivery intentionally carries the exact direct recipient and existing thread without performing a separate home-route lookup.

## User-visible goal and UX

Let the exact deployment proof recognize a native nutrition card delivered to the requesting direct iMessage thread, so the corrected runner can deploy without weakening the same-chat/no-duplicate guarantees.

## Invariants

- Capability proof still matches the exact direct recipient.
- The connected scenario must send exactly one `imessage_app` card to the existing chat.
- The scenario still rejects plaintext duplication and Create Chat fallback.
- No production behavior, state owner, schema, API, or dependency changes.

## Architecture and reuse

- Existing systems reused: the current hosted-local Linq stub, connected scheduled-overlap scenario, inbound delivery context, and Linq capability contract.
- New logic: the existing capability matcher asserts the exact required recipient and no longer asserts Linq's optional `from` field.
- New abstractions: none; the shared matcher becomes smaller.
- Complexity intentionally avoided: no home-route lookup, cache, state owner, compatibility branch, new service, or production code.

## Review lenses

- Product experience: applicable — preserve one native nutrition card in the requesting direct iMessage thread with no plaintext duplicate.
- Prompt: not applicable — no assistant or provider prompt changes.
- Frontend: not applicable — no web or rendered UI changes.
- Coverage: applicable — this changes the connected hosted-local matcher that proves the late-input native-card journey.
- Direct journey evidence: the stopped deployment run observed the recipient capability request and native app-card POST; exact-head Docker proof is pending CI and the next deployment gate.
- Rendered evidence: none; no frontend surface changed.

## Verification

- `pnpm --dir apps/cloudflare typecheck`
- `git diff --check`
- The failed deployment trace observed the exact capability endpoint followed by a native app-card POST; this PR makes the matcher assert the recipient actually present in that request. The full Docker-backed gate will rerun on the PR and again before deployment.

## Change shape

- Source: `+0/-0`
- Tests/fixtures: `+2/-4`
- Docs: `+0/-0`
- Config/tooling: `+0/-0`
- Generated/other: `+0/-0`

## Design proof

Not applicable: test-only change with no UI surface.
