### PR TITLE
perf(hosted): overlap conditional mailbox reads

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
+++ b/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
@@ -1,0 +1,70 @@
+# Hosted mailbox fetch latency deletion
+
+Status: active
+Created: 2026-08-06
+Updated: 2026-08-06
+
+## Goal
+
+- Reduce the established cold-start mailbox-import interval by deleting stale
+  database protocol work and removing one unnecessary serialized query without
+  changing mailbox ordering, access, AI gating, routing, or replay behavior.
+
+## Success criteria
+
+- The read-only mailbox projection executes as one direct query rather than an
+  interactive transaction around one statement.
+- No-op, system-only, and consumed-replay projections do not read group running
+  state that the runtime cannot use.
+- For a fresh conversation, the existing AI-usage gate and fail-soft group
+  running-state read execute concurrently after active-access and projection.
+- Focused behavior tests, Web typecheck, docs checks, and an RTT-sensitive local
+  benchmark pass. No deployment or merge occurs.
+
+## Invariants
+
+- Active-access authorization remains before mailbox payload hydration.
+- Mixed conversation/system ordering, replay floors, usage denial, and group
+  authorization semantics remain unchanged.
+- The authoritative post-restore mailbox watermark fetch remains in place; do
+  not reintroduce the unsafe pre-restore result that could hide concurrent
+  appends.
+- Add no schema, wire contract, state owner, cache, service, dependency, or
+  compatibility layer.
+
+## Tasks
+
+1. Prove the transaction wrapper is orphaned and map current query ordering.
+2. Implement the smallest route/store deletion and conditional concurrency.
+3. Add focused access, conditional-read, failure, ordering, and concurrency
+   coverage.
+4. Measure at least 30 before/after samples under a controlled database RTT and
+   exercise the hosted-local path without treating it as production evidence.
+5. Run required verification, open an unmerged PR, and complete specialist,
+   final ReviewGPT, and exact-head CI gates.
+
+## Evidence
+
+- Production unique established-cold traces place foreground import start to
+  payload-decode start at about 0.60-0.70 seconds p50; payload decode itself is
+  outside this candidate.
+- Local state, routing, and warm SQL execution are sub-millisecond. Existing
+  telemetry cannot split network, Vercel, Prisma transaction protocol, and
+  access/usage round trips, so this PR will claim only locally measured
+  protocol-turn savings until deployed evidence exists.
+
+## Verification log
+
+- PASS: 131 focused Web tests covering mailbox projection and internal routes.
+- PASS: direct root-client projection performs one `$queryRaw` and never enters
+  `$transaction`; mutation owners retain their existing transaction helper.
+- PASS: no-work, system-only, and consumed-replay batches skip both AI usage and
+  group-state reads; fresh conversation coverage interlocks the two reads to
+  prove they start concurrently. Usage denial returns without waiting for a
+  deliberately unresolved optional group read.
+- PASS: Web prepared typecheck, docs drift, and `git diff --check`.
+- PASS: 30-sample protocol model with 100 ms injected database/network RTT:
+  serial baseline p50 406 ms / p90 416 ms; deletion/concurrency candidate p50
+  101 ms / p90 103 ms; modeled p50 reduction 305 ms. This is an exact
+  three-round-trip sensitivity model, not production or loopback endpoint
+  evidence.

--- a/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
+++ b/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
@@ -1,4 +1,4 @@
-# Hosted mailbox fetch latency deletion
+# Hosted mailbox fetch latency overlap
 
 Status: active
 Created: 2026-08-06
@@ -6,14 +6,14 @@ Updated: 2026-08-06
 
 ## Goal
 
-- Reduce the established cold-start mailbox-import interval by deleting stale
-  database protocol work and removing one unnecessary serialized query without
+- Reduce the established cold-start mailbox-import interval by skipping
+  unnecessary work and removing one serialized query without
   changing mailbox ordering, access, AI gating, routing, or replay behavior.
 
 ## Success criteria
 
-- The read-only mailbox projection executes as one direct query rather than an
-  interactive transaction around one statement.
+- The read-only mailbox projection retains its existing 15-second interactive
+  transaction boundary.
 - No-op, system-only, and consumed-replay projections do not read group running
   state that the runtime cannot use.
 - For a fresh conversation, the existing AI-usage gate and fail-soft group
@@ -34,8 +34,8 @@ Updated: 2026-08-06
 
 ## Tasks
 
-1. Prove the transaction wrapper is orphaned and map current query ordering.
-2. Implement the smallest route/store deletion and conditional concurrency.
+1. Map current query ordering and preserve its interactive transaction boundary.
+2. Implement the smallest conditional-read and concurrency change.
 3. Add focused access, conditional-read, failure, ordering, and concurrency
    coverage.
 4. Measure at least 30 before/after samples under a controlled database RTT and
@@ -56,15 +56,25 @@ Updated: 2026-08-06
 ## Verification log
 
 - PASS: 131 focused Web tests covering mailbox projection and internal routes.
-- PASS: direct root-client projection performs one `$queryRaw` and never enters
-  `$transaction`; mutation owners retain their existing transaction helper.
+- PASS: the root-client projection retains its single `$queryRaw` inside the
+  Prisma client's 15-second interactive transaction boundary.
+- FALSIFIED: a real local PostgreSQL relation-lock proof showed that Prisma's
+  interactive timeout does not cancel an already blocked statement; the query
+  stayed blocked until the lock was released and then surfaced `P2028`. The
+  retained boundary is therefore fail-closed after an overlong statement, not
+  a PostgreSQL statement-cancellation mechanism.
 - PASS: no-work, system-only, and consumed-replay batches skip both AI usage and
   group-state reads; fresh conversation coverage interlocks the two reads to
   prove they start concurrently. Usage denial returns without waiting for a
   deliberately unresolved optional group read.
 - PASS: Web prepared typecheck, docs drift, and `git diff --check`.
-- PASS: 30-sample protocol model with 100 ms injected database/network RTT:
-  serial baseline p50 406 ms / p90 416 ms; deletion/concurrency candidate p50
-  101 ms / p90 103 ms; modeled p50 reduction 305 ms. This is an exact
-  three-round-trip sensitivity model, not production or loopback endpoint
-  evidence.
+- RETIRED after specialist review: the original 30-sample protocol model with
+  100 ms injected database/network RTT predicted a 305 ms p50 reduction by
+  deleting the transaction protocol turns and overlapping one optional read.
+  The transaction deletion also removed the Prisma client's 15-second
+  execution deadline, so it was rejected. Only the conditional-read and
+  concurrency portion remains.
+- PASS: revised 30-sample 100 ms RTT sensitivity model for only the two reads
+  retained by a fresh conversation: serial p50 207 ms, overlapped p50 102 ms,
+  modeled p50 reduction 105 ms. This is a protocol sensitivity model, not
+  production or loopback endpoint evidence.

--- a/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
+++ b/agent-docs/exec-plans/active/2026-08-06-mailbox-fetch-latency.md
@@ -78,3 +78,8 @@ Updated: 2026-08-06
   retained by a fresh conversation: serial p50 207 ms, overlapped p50 102 ms,
   modeled p50 reduction 105 ms. This is a protocol sensitivity model, not
   production or loopback endpoint evidence.
+- PASS: preliminary specialist remediation restored the transaction boundary
+  and strengthened the non-null optional group-bit concurrency assertion.
+- PASS: final ReviewGPT round 2 found no qualifying findings on the substantive
+  candidate. A clean base-only rebase onto current `main` followed; the exact
+  rebased candidate again passed 131 focused tests and Web prepared typecheck.

--- a/agent-docs/exec-plans/completed/2026-08-06-mailbox-fetch-latency.md
+++ b/agent-docs/exec-plans/completed/2026-08-06-mailbox-fetch-latency.md
@@ -1,6 +1,6 @@
 # Hosted mailbox fetch latency overlap
 
-Status: active
+Status: completed
 Created: 2026-08-06
 Updated: 2026-08-06
 
@@ -83,3 +83,11 @@ Updated: 2026-08-06
 - PASS: final ReviewGPT round 2 found no qualifying findings on the substantive
   candidate. A clean base-only rebase onto current `main` followed; the exact
   rebased candidate again passed 131 focused tests and Web prepared typecheck.
+- REJECTED in the parent final review: the allowed-path overlap starts the
+  optional group projection before the required AI-usage decision. That
+  projection can perform multiple database reads plus secure-box decryption,
+  while the denial path throws without joining the in-flight work. Waiting for
+  it would slow denied requests, and adding cancellation or lifecycle machinery
+  is not justified by a 105 ms injected-RTT model. PR #1362 was therefore
+  closed without merge or deployment.
+Completed: 2026-08-06

--- a/apps/web/app/api/internal/hosted-mailbox/fetch/route.ts
+++ b/apps/web/app/api/internal/hosted-mailbox/fetch/route.ts
@@ -60,20 +60,39 @@ export const POST = withJsonError(async (request: Request) => {
     now: fetchedAt,
     userId,
   });
-  const usageRunningLow = await requireHostedRuntimeMailboxAiUsageAccess({
+  const requiresAiUsageAccess = hostedMailboxItemsRequireAiUsageAccess({
     consumedSeqByLane: projection.consumedSeqByLane,
-    items: projection.items,
+    items: projection.items.map((item) => ({
+      consumedAt: item.consumedAt ?? null,
+      lane: item.lane,
+      laneSeq: item.laneSeq,
+      payloadInlineCiphertext: item.payloadInlineCiphertext ?? null,
+      payloadRef: item.payloadRef ?? null,
+    })),
     lanes: body.lanes,
-    maxSeqByLane: projection.maxSeqByLane,
-    prisma,
-    userId,
   });
-  // Sponsorship color is optional; it must never block ordinary mailbox work.
-  const groupRunningBit = await readHostedActiveGroupRunningBit({
-    now: fetchedAt,
-    prisma,
-    runtimeMemberId: userId,
-  }).catch(() => null);
+  let usageRunningLow = false;
+  let groupRunningBit: Awaited<
+    ReturnType<typeof readHostedActiveGroupRunningBit>
+  > = null;
+  if (requiresAiUsageAccess) {
+    // Start the fail-soft sponsorship read beside the required usage gate. If
+    // usage is denied, preserve that failure without waiting for optional data.
+    const groupRunningBitPromise = readHostedActiveGroupRunningBit({
+      now: fetchedAt,
+      prisma,
+      runtimeMemberId: userId,
+    }).catch(() => null);
+    usageRunningLow = await requireHostedRuntimeMailboxAiUsageAccess({
+      consumedSeqByLane: projection.consumedSeqByLane,
+      items: projection.items,
+      lanes: body.lanes,
+      maxSeqByLane: projection.maxSeqByLane,
+      prisma,
+      userId,
+    });
+    groupRunningBit = await groupRunningBitPromise;
+  }
 
   return jsonOk(parseHostedMailboxFetchResponse({
     ...(usageRunningLow ? { conversationUsageStatus: "low" as const } : {}),
@@ -98,20 +117,6 @@ async function requireHostedRuntimeMailboxAiUsageAccess(input: {
 }): Promise<boolean> {
   // Gate the whole fetch batch: runtime imports lanes together, and all-or-nothing
   // watermarks are simpler than returning partial lane output around denied AI work.
-  if (!hostedMailboxItemsRequireAiUsageAccess({
-    consumedSeqByLane: input.consumedSeqByLane,
-    items: input.items.map((item) => ({
-      consumedAt: item.consumedAt ?? null,
-      lane: item.lane,
-      laneSeq: item.laneSeq,
-      payloadInlineCiphertext: item.payloadInlineCiphertext ?? null,
-      payloadRef: item.payloadRef ?? null,
-    })),
-    lanes: input.lanes,
-  })) {
-    return false;
-  }
-
   const gate = await resolveHostedRuntimeAiUsageGate({
     mode: "read_first",
     userId: input.userId,

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -844,37 +844,10 @@ export async function fetchHostedRuntimeMailboxProjection(input: {
 }): Promise<FetchHostedRuntimeMailboxProjectionResult> {
   const prisma = input.prisma ?? getPrisma();
   const now = input.now ?? new Date();
-
-  if (isHostedMailboxRootClient(prisma)) {
-    return prisma.$transaction((tx) =>
-      fetchHostedRuntimeMailboxProjectionTx({
-        ...input,
-        now,
-        tx,
-      })
-    );
-  }
-
-  return fetchHostedRuntimeMailboxProjectionTx({
-    ...input,
-    now,
-    tx: prisma,
-  });
-}
-
-async function fetchHostedRuntimeMailboxProjectionTx(input: {
-  cursorMode?: HostedMailboxFetchCursorMode | null;
-  lanes: readonly HostedMailboxRuntimeFetchLaneCursor[];
-  limitPerLane: number;
-  now: Date | string;
-  tx: HostedMailboxMutationTx;
-  userId: string;
-}): Promise<FetchHostedRuntimeMailboxProjectionResult> {
-  const prisma = input.tx;
   const userId = requireNonEmptyString(input.userId, "Hosted mailbox userId");
   const limitPerLane = normalizeHostedMailboxFetchLimit(input.limitPerLane);
   const fetchedAt = normalizeHostedMailboxDate(
-    input.now ?? new Date(),
+    now,
     "Hosted mailbox fetch date",
   );
   const retainedAt = new Date(fetchedAt.getTime() - HOSTED_MAILBOX_RETENTION_MS);

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -844,10 +844,37 @@ export async function fetchHostedRuntimeMailboxProjection(input: {
 }): Promise<FetchHostedRuntimeMailboxProjectionResult> {
   const prisma = input.prisma ?? getPrisma();
   const now = input.now ?? new Date();
+
+  if (isHostedMailboxRootClient(prisma)) {
+    return prisma.$transaction((tx) =>
+      fetchHostedRuntimeMailboxProjectionTx({
+        ...input,
+        now,
+        tx,
+      })
+    );
+  }
+
+  return fetchHostedRuntimeMailboxProjectionTx({
+    ...input,
+    now,
+    tx: prisma,
+  });
+}
+
+async function fetchHostedRuntimeMailboxProjectionTx(input: {
+  cursorMode?: HostedMailboxFetchCursorMode | null;
+  lanes: readonly HostedMailboxRuntimeFetchLaneCursor[];
+  limitPerLane: number;
+  now: Date | string;
+  tx: HostedMailboxMutationTx;
+  userId: string;
+}): Promise<FetchHostedRuntimeMailboxProjectionResult> {
+  const prisma = input.tx;
   const userId = requireNonEmptyString(input.userId, "Hosted mailbox userId");
   const limitPerLane = normalizeHostedMailboxFetchLimit(input.limitPerLane);
   const fetchedAt = normalizeHostedMailboxDate(
-    now,
+    input.now,
     "Hosted mailbox fetch date",
   );
   const retainedAt = new Date(fetchedAt.getTime() - HOSTED_MAILBOX_RETENTION_MS);

--- a/apps/web/test/hosted-mailbox-store.test.ts
+++ b/apps/web/test/hosted-mailbox-store.test.ts
@@ -2809,9 +2809,13 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
       requestedLane: "conversation",
     };
     const queryRaw = vi.fn(async () => [sourceRow]);
-    const transaction = vi.fn();
-    const prisma = Object.assign(Object.create(null), {
+    const tx = Object.assign(Object.create(null), {
       $queryRaw: queryRaw,
+    });
+    const transaction = vi.fn(async (
+      operation: (transactionClient: typeof tx) => Promise<unknown>,
+    ) => operation(tx));
+    const prisma = Object.assign(Object.create(null), {
       $transaction: transaction,
     }) as never;
 
@@ -2823,7 +2827,7 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
       userId: sourceUserId,
     });
 
-    expect(transaction).not.toHaveBeenCalled();
+    expect(transaction).toHaveBeenCalledTimes(1);
     expect(queryRaw).toHaveBeenCalledTimes(1);
     expect(result.items).toMatchObject([{
       consumedAt: sourceRow.itemConsumedAt.toISOString(),

--- a/apps/web/test/hosted-mailbox-store.test.ts
+++ b/apps/web/test/hosted-mailbox-store.test.ts
@@ -2763,7 +2763,6 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
   it("keeps runtime mailbox projection read-only when a Linq route changed", async () => {
     restoreDefaultHostedSecureBoxTestCodec();
     const sourceUserId = "member_personal";
-    const containerUserId = "member_container";
     const sourceWake = {
       eventId: "evt_group_transition",
       kind: "conversation.message",
@@ -2809,131 +2808,10 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
       maxUpdatedAt: new Date("2026-04-26T00:00:02.000Z"),
       requestedLane: "conversation",
     };
-    const emptySourceProjection = {
-      consumedSeq: 0n,
-      itemConsumedAt: null,
-      itemCreatedAt: null,
-      itemDedupeKey: null,
-      itemExpiresAt: null,
-      itemId: null,
-      itemKind: null,
-      itemLane: null,
-      itemLaneSeq: null,
-      itemOccurredAt: null,
-      itemPayloadBytes: null,
-      itemPayloadHash: null,
-      itemPayloadInlineCiphertext: null,
-      itemPayloadRef: null,
-      itemPayloadSchema: null,
-      itemUpdatedAt: null,
-      itemUserId: null,
-      maxSeq: 0n,
-      maxUpdatedAt: null,
-      requestedLane: "conversation",
-    };
-    const queryRaw = vi.fn(async (...args: unknown[]) => {
-      switch (queryRaw.mock.calls.length) {
-        case 1:
-          return [sourceRow];
-        case 2:
-          return [{ seq: 1n }];
-        case 3: {
-          const values = args.slice(1);
-          return [buildHostedMailboxItemRow({
-            createdAt: FIXED_NOW,
-            dedupeKey: String(values[4]),
-            expiresAt: values[12] as Date | null,
-            id: String(values[0]),
-            kind: String(values[5]),
-            lane: String(values[2]),
-            laneSeq: values[3] as bigint,
-            occurredAt: values[6] as Date,
-            payloadBytes: values[10] as number,
-            payloadHash: values[11] as string,
-            payloadInlineCiphertext: values[8] as string,
-            payloadRef: values[9] as string | null,
-            payloadSchema: String(values[7]),
-            updatedAt: FIXED_NOW,
-            userId: String(values[1]),
-          })];
-        }
-        case 4:
-          return [emptySourceProjection];
-        default:
-          throw new Error("Unexpected hosted mailbox rehome query.");
-      }
-    });
-    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
-    const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
-    const routeTimestamp = new Date("2026-04-01T00:00:00.000Z");
-    const tx = Object.assign(Object.create(null), {
-      $executeRaw: vi.fn().mockResolvedValue(1),
-      $queryRaw: queryRaw,
-      hostedMailboxItem: {
-        deleteMany,
-        findUnique: vi.fn().mockResolvedValue(null),
-        updateMany,
-      },
-      hostedMailboxPayload: {
-        create: vi.fn(),
-        findUnique: vi.fn().mockResolvedValue(null),
-      },
-      hostedRuntimeLog: {
-        create: vi.fn(async (args: { data: Record<string, unknown> }) => ({
-          at: args.data.at as Date,
-          attemptId: args.data.attemptId as string | null,
-          checkpointVersion: args.data.checkpointVersion as bigint | null,
-          component: String(args.data.component),
-          createdAt: FIXED_NOW,
-          errorCode: args.data.errorCode as string | null,
-          eventCode: String(args.data.eventCode),
-          id: String(args.data.id),
-          leaseGeneration: args.data.leaseGeneration as bigint | null,
-          level: String(args.data.level),
-          mailboxLane: args.data.mailboxLane as string | null,
-          mailboxSeqEnd: args.data.mailboxSeqEnd as bigint | null,
-          mailboxSeqStart: args.data.mailboxSeqStart as bigint | null,
-          outboxIntentRef: args.data.outboxIntentRef as string | null,
-          phase: String(args.data.phase),
-          redactedJson: args.data.redactedJson,
-          userId: String(args.data.userId),
-          workspaceVersion: args.data.workspaceVersion as bigint | null,
-        })),
-      },
-      hostedThreadRoute: {
-        findFirst: vi.fn().mockResolvedValue({
-          containerMemberId: containerUserId,
-        }),
-        findMany: vi.fn().mockResolvedValue([{
-          channel: "linq",
-          container: {
-            member: {
-              billingStatus: "inactive",
-              createdAt: routeTimestamp,
-              id: containerUserId,
-              suspendedAt: null,
-              updatedAt: routeTimestamp,
-            },
-            owner: {
-              accountGroupMemberships: [],
-              billingStatus: "active",
-              createdAt: routeTimestamp,
-              id: "member_owner",
-              suspendedAt: null,
-              updatedAt: routeTimestamp,
-            },
-          },
-          containerMemberId: containerUserId,
-        }]),
-      },
-      hostedWorkspace: {
-        upsert: vi.fn().mockResolvedValue(null),
-      },
-    });
-    const transaction = vi.fn(async (
-      operation: (transactionClient: typeof tx) => Promise<unknown>,
-    ) => operation(tx));
+    const queryRaw = vi.fn(async () => [sourceRow]);
+    const transaction = vi.fn();
     const prisma = Object.assign(Object.create(null), {
+      $queryRaw: queryRaw,
       $transaction: transaction,
     }) as never;
 
@@ -2945,7 +2823,7 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
       userId: sourceUserId,
     });
 
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
     expect(queryRaw).toHaveBeenCalledTimes(1);
     expect(result.items).toMatchObject([{
       consumedAt: sourceRow.itemConsumedAt.toISOString(),
@@ -2953,11 +2831,6 @@ describe("fetchHostedRuntimeMailboxProjection", () => {
       payloadInlineCiphertext: sourceCiphertext,
       userId: sourceUserId,
     }]);
-    expect(deleteMany).not.toHaveBeenCalled();
-    expect(updateMany).not.toHaveBeenCalled();
-    expect(tx.hostedMailboxPayload.findUnique).not.toHaveBeenCalled();
-    expect(tx.hostedThreadRoute.findFirst).not.toHaveBeenCalled();
-    expect(tx.hostedThreadRoute.findMany).not.toHaveBeenCalled();
   });
 
   it("returns lane sentinels and rejects duplicate lane projections before querying", async () => {

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -1129,7 +1129,12 @@ describe("hosted runtime internal web routes", () => {
       resolveGroupReadStarted?.();
       resolveGroupReadStarted = null;
       await usageStarted;
-      return null;
+      return {
+        expiresAt: "2026-04-27T00:00:00.000Z",
+        publicAlias: "Recovery Group",
+        requestedBit: "Keep the reply concise.",
+        schema: "murph.group-sponsorship-bit.v1" as const,
+      };
     });
 
     const response = await mailboxFetchRoute.POST(jsonRequest(
@@ -1149,6 +1154,12 @@ describe("hosted runtime internal web routes", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       conversationUsageStatus: "low",
+      groupRunningBit: {
+        expiresAt: "2026-04-27T00:00:00.000Z",
+        publicAlias: "Recovery Group",
+        requestedBit: "Keep the reply concise.",
+        schema: "murph.group-sponsorship-bit.v1",
+      },
       items: [expect.objectContaining({ id: "mailbox_item_low" })],
     });
     expect(

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -617,6 +617,7 @@ describe("hosted runtime internal web routes", () => {
       },
     ]);
     expect(payload.items).toHaveLength(0);
+    expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
   });
 
   it("anchors legacy conversation fetches at the consumed floor without rewinding system", async () => {
@@ -776,6 +777,7 @@ describe("hosted runtime internal web routes", () => {
       "mailbox_browser_vault_denied_replay",
     ]);
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
+    expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
   });
 
   it("fetches the fresh tail when local import is ahead of consume", async () => {
@@ -928,6 +930,7 @@ describe("hosted runtime internal web routes", () => {
       "mailbox_item_consumed_context_001",
     ]);
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
+    expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
   });
 
   it("does not AI-gate fresh conversation tombstones when access is denied", async () => {
@@ -1073,6 +1076,14 @@ describe("hosted runtime internal web routes", () => {
   });
 
   it("projects low usage only with an allowed conversation mailbox batch", async () => {
+    let resolveUsageStarted: (() => void) | null = null;
+    const usageStarted = new Promise<void>((resolve) => {
+      resolveUsageStarted = resolve;
+    });
+    let resolveGroupReadStarted: (() => void) | null = null;
+    const groupReadStarted = new Promise<void>((resolve) => {
+      resolveGroupReadStarted = resolve;
+    });
     mocks.readHostedMailboxConsumedSeqByLane.mockResolvedValueOnce([
       {
         consumedSeq: "11",
@@ -1105,9 +1116,20 @@ describe("hosted runtime internal web routes", () => {
         maxSeq: "12",
       },
     ]);
-    mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValueOnce({
-      status: "allowed",
-      usageRunningLow: true,
+    mocks.resolveHostedRuntimeAiUsageGate.mockImplementationOnce(async () => {
+      resolveUsageStarted?.();
+      resolveUsageStarted = null;
+      await groupReadStarted;
+      return {
+        status: "allowed",
+        usageRunningLow: true,
+      };
+    });
+    mocks.readHostedActiveGroupRunningBit.mockImplementationOnce(async () => {
+      resolveGroupReadStarted?.();
+      resolveGroupReadStarted = null;
+      await usageStarted;
+      return null;
     });
 
     const response = await mailboxFetchRoute.POST(jsonRequest(
@@ -1132,6 +1154,7 @@ describe("hosted runtime internal web routes", () => {
     expect(
       mocks.tryMarkHostedMailboxConversationAiUsageDenied,
     ).not.toHaveBeenCalled();
+    expect(mocks.readHostedActiveGroupRunningBit).toHaveBeenCalledTimes(1);
   });
 
   it("rejects conversation mailbox items when the AI usage gate denies runtime consumption", async () => {
@@ -1170,6 +1193,9 @@ describe("hosted runtime internal web routes", () => {
     mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValueOnce({
       status: "denied",
     });
+    mocks.readHostedActiveGroupRunningBit.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
 
     const response = await mailboxFetchRoute.POST(jsonRequest(
       "/api/internal/hosted-mailbox/fetch",
@@ -1190,6 +1216,7 @@ describe("hosted runtime internal web routes", () => {
       mode: "read_first",
       userId: "member_routes_1",
     });
+    expect(mocks.readHostedActiveGroupRunningBit).toHaveBeenCalledTimes(1);
     expect(
       mocks.tryMarkHostedMailboxConversationAiUsageDenied,
     ).toHaveBeenCalledWith({
@@ -1243,6 +1270,7 @@ describe("hosted runtime internal web routes", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
+    expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
   });
 
   it("does not AI-gate non-manual system mailbox consumption", async () => {
@@ -1289,6 +1317,7 @@ describe("hosted runtime internal web routes", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
+    expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
   });
 
   it("gates the whole mixed mailbox fetch batch when any item needs the AI usage gate", async () => {


### PR DESCRIPTION
## Why this PR exists

Established hosted cold starts spend about 0.60-0.70 seconds p50 between foreground mailbox import start and payload decode start. Fresh-conversation mailbox fetches serialized an optional group-state read after the required AI-usage gate, while no-op, system-only, and consumed-replay fetches performed that optional read even though the runtime could not use it.

## User goal / user-visible behavior

Members should reach the first provider response sooner after an established-workspace cold start, with identical mailbox contents, ordering, gating, routing, reply behavior, and recovery.

There is no new UI or member action. No-op, system-only, and consumed-replay mailbox fetches stop reading group state that the runtime cannot use. Fresh-conversation fetches retain both the required AI-usage decision and optional group projection, but start those reads together.

## Invariants

- Active member/container access remains authorized before mailbox projection or payload hydration.
- The single mixed conversation/system projection retains its existing Prisma interactive-transaction boundary, exact lane ordering, replay floors, retention behavior, and payload metadata.
- Fresh conversation work remains all-or-nothing behind the AI-usage gate. Denial still marks the same range and returns 403.
- The optional group projection remains fail-soft and is returned only where the runtime can consume it.
- Usage denial does not wait for optional group data.
- The authoritative mailbox fetch remains after workspace restore; this does not reintroduce the unsafe pre-restore result that could hide concurrent appends.

## Architecture and reuse

- The route computes the existing fresh-conversation predicate once. False skips both downstream reads; true starts the existing group read beside the existing usage gate.
- `fetchHostedRuntimeMailboxProjection` remains one `$queryRaw` inside the Prisma client's existing interactive transaction when called with the root client; transaction-client callers keep using their current transaction.
- No schema, wire contract, persisted state, cache, queue, service, dependency, timeout owner, or compatibility path was added.
- Obsolete transaction-era Linq rehome test scaffolding was deleted while retaining direct proof that the projection is read-only.

## Hot reply path impact

- Before a fresh conversation: AI usage completed, then group state was read.
- After: both reads start together; the required usage result remains authoritative. On denial, the route returns without waiting for optional group data.
- Before no-op/system/replay work: group state was still read after the no-op usage predicate.
- After: neither downstream read runs.

Production telemetry establishes the 0.60-0.70 second owner interval but does not split its remote round trips. A revised 30-sample protocol model with 100 ms injected RTT measured 207 ms p50 for the two reads in series and 102 ms p50 when overlapped, a 105 ms modeled p50 reduction. This is a protocol sensitivity result, not a production latency claim.

## Murph initial provider input impact

- Individual Murph: no prompt, model, tool/schema, provider input, or selection behavior changes.
- Group Murph: the same optional running-bit projection is preserved for fresh conversation work; only its query timing and irrelevant-query omission change.

## Review findings and remediation

- Preliminary specialist ReviewGPT found that deleting the projection's interactive transaction removed an existing 15-second fail-closed boundary. The transaction was restored.
- A real local PostgreSQL relation-lock proof showed that Prisma does not cancel an already blocked SQL statement at that timeout; the query stayed blocked until lock release and then surfaced `P2028`. This PR therefore makes no statement-cancellation claim.
- Specialist coverage requested proof that concurrent optional data still reaches the response. The interlocked concurrency test now returns a non-null group bit and asserts its exact response projection.
- Product experience: applicable; the intended outcome is a shorter cold reply with unchanged mailbox and denial behavior.
- Prompt and frontend: not applicable; provider-visible content and rendered UI are unchanged.

ReviewGPT context sensitivity: sensitive

Reason: this changes query ordering around active access, AI usage denial, group authorization, and the product-critical foreground mailbox path.

ReviewGPT first-reviewed head: e48c6bc71a10f5991054fe0164dc5e7026cede0f

ReviewGPT final substantive head: 61995dbc8ba8cfdb3e94086264a96309af0a10a4

Current head: 7d160f04701f22abacb69184b55dd88653c509c8 (base-only rebase plus explanatory review record)

## Change-shape breakdown

Classification rule: route/store `.ts` files are source, `test/**` files are tests/fixtures, the execution plan is docs, and no config/tooling or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 31 | 26 |
| Tests/fixtures | 44 | 127 |
| Docs | 85 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **160** | **153** |

## Design proof

Not applicable; this PR has no user-facing frontend UI.

## Verification

- 131 focused Web mailbox store and internal-route tests
- Web prepared typecheck
- `pnpm docs:drift`
- `git diff --check`
- Scoped identifier and home-path privacy scan
- 30-sample 100 ms RTT protocol sensitivity model
- Real local PostgreSQL relation-lock falsification probe; intentionally not retained as a passing test because it disproved statement cancellation
- Preliminary specialist ReviewGPT completed with both findings resolved
- Final ReviewGPT round 2 passed with no qualifying findings on the substantive candidate
- Clean base-only rebase onto current `main`; 131 focused tests and Web prepared typecheck passed again on the rebased candidate
- Exact-head CI is pending

## Deployment

No deployment was performed. This is Web-only, preserves the request/response contract, and has no rolling-version requirement.
