### PR TITLE
Harden Linq and Telegram hosted egress conformance

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-06-provider-egress-conformance.md
+++ b/agent-docs/exec-plans/active/2026-08-06-provider-egress-conformance.md
@@ -1,0 +1,53 @@
+# Extend hosted provider egress conformance to Telegram
+
+Status: active
+Created: 2026-08-06
+Updated: 2026-08-06
+
+## Goal
+
+- Preserve the exact Linq capability fix at the Worker trust boundary.
+- Prove every Telegram route currently emitted by hosted Murph clients can cross
+  the production Cloudflare interceptor with the expected Worker-owned token and
+  write-fence checks.
+- Keep Telegram polling, webhook administration, and web-control methods outside
+  hosted runner egress.
+
+## Scope
+
+- In scope:
+  - The existing exact Linq `POST /capability/check_imessage` allowlist entry.
+  - A real Linq response-card client-through-interceptor regression.
+  - Real hosted Telegram client calls for `sendMessage`, `sendPhoto`,
+    `sendVoice`, `sendChatAction`, `deleteMessages`,
+    `deleteBusinessMessages`, `setMessageReaction`, `getFile`, and the
+    provider-returned file-download path.
+  - Negative hosted-runner proof for Telegram methods owned by Inboxd polling or
+    web control rather than the runner.
+- Out of scope:
+  - Changing Telegram client behavior, retries, delivery ownership, or payloads.
+  - A shared provider registry, generated firewall, schema, queue, cache,
+    feature flag, or new effect owner.
+  - Inboxd polling transport and web-owned Telegram API calls, which do not
+    traverse the hosted runner interceptor.
+
+## Decisions
+
+- Keep the Cloudflare Worker as the sole egress authority. The conformance test
+  invokes production clients through the production interceptor; client code
+  does not grant itself routes.
+- Do not add HTTP-method restrictions to Telegram Bot API method names. Telegram
+  officially accepts both GET and POST for Bot API methods; the regression still
+  asserts the exact methods Murph's current clients emit.
+- Reuse the existing interceptor route-matrix coverage for direct allowlist
+  testing and add one cross-boundary suite rather than introducing a provider
+  framework.
+
+## Verification
+
+- Cloudflare typecheck.
+- Focused Linq policy, interceptor, and provider-conformance tests.
+- Focused Telegram channel, operator-config runtime, and hosted provider-effect
+  tests covering the same clients used by the conformance suite.
+- Documentation drift/gardening and `git diff --check`.
+- Exact-head required GitHub Actions and final review before closing this plan.

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -80,6 +80,10 @@ import {
   HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
 } from "./runner-injected-credential.ts";
 import {
+  readAllowedHostedLinqOperation,
+  type HostedLinqProviderOperation,
+} from "./runner-egress-linq-policy.ts";
+import {
   isHostedProviderEgressCredential,
   verifyHostedProviderEgressCredential,
 } from "./hosted-provider-egress-credential.ts";
@@ -3761,7 +3765,7 @@ async function maybeHandleLinqRequest(input: {
     return null;
   }
 
-  const providerOperation = readAllowedLinqOperation(
+  const providerOperation = readAllowedHostedLinqOperation(
     input.request.method,
     pathMatch.pathnameSuffix,
   );
@@ -3970,59 +3974,6 @@ function readBearerCredential(headers: Headers): string | null {
 
 function hasHeaderCredentialSentinel(headers: Headers, name: string): boolean {
   return headers.get(name)?.trim() === HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL;
-}
-
-type HostedLinqProviderOperation =
-  | "attachment_create"
-  | "attachment_read"
-  | "chat_create"
-  | "message_delete"
-  | "message_send"
-  | "phone_numbers_list"
-  | "reaction_create"
-  | "read_receipt_send"
-  | "typing_start"
-  | "typing_stop"
-  | "voice_memo_send";
-
-function readAllowedLinqOperation(
-  method: string,
-  pathnameSuffix: string,
-): HostedLinqProviderOperation | null {
-  if (method === "GET" && pathnameSuffix === "/phone_numbers") {
-    return "phone_numbers_list";
-  }
-  if (method === "GET" && /^\/attachments\/[^/]+$/u.test(pathnameSuffix)) {
-    return "attachment_read";
-  }
-  if (method === "POST" && pathnameSuffix === "/attachments") {
-    return "attachment_create";
-  }
-  if (method === "POST" && pathnameSuffix === "/chats") {
-    return "chat_create";
-  }
-  if (method === "POST" && /^\/messages\/[^/]+\/reactions$/u.test(pathnameSuffix)) {
-    return "reaction_create";
-  }
-  if (method === "POST" && /^\/chats\/[^/]+\/voicememo$/u.test(pathnameSuffix)) {
-    return "voice_memo_send";
-  }
-  if (method === "POST" && /^\/chats\/[^/]+\/messages$/u.test(pathnameSuffix)) {
-    return "message_send";
-  }
-  if (method === "POST" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
-    return "typing_start";
-  }
-  if (method === "POST" && /^\/chats\/[^/]+\/read$/u.test(pathnameSuffix)) {
-    return "read_receipt_send";
-  }
-  if (method === "DELETE" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
-    return "typing_stop";
-  }
-  if (method === "DELETE" && /^\/messages\/[^/]+$/u.test(pathnameSuffix)) {
-    return "message_delete";
-  }
-  return null;
 }
 
 function readTelegramSentinelOperation(pathname: string): string | null {

--- a/apps/cloudflare/src/runner-egress-linq-policy.ts
+++ b/apps/cloudflare/src/runner-egress-linq-policy.ts
@@ -1,0 +1,57 @@
+export type HostedLinqProviderOperation =
+  | "attachment_create"
+  | "attachment_read"
+  | "chat_create"
+  | "check_imessage_capability"
+  | "message_delete"
+  | "message_send"
+  | "phone_numbers_list"
+  | "reaction_create"
+  | "read_receipt_send"
+  | "typing_start"
+  | "typing_stop"
+  | "voice_memo_send";
+
+/** Worker-owned Linq allowlist. Provider clients never grant egress. */
+export function readAllowedHostedLinqOperation(
+  method: string,
+  pathnameSuffix: string,
+): HostedLinqProviderOperation | null {
+  if (method === "GET" && pathnameSuffix === "/phone_numbers") {
+    return "phone_numbers_list";
+  }
+  if (method === "GET" && /^\/attachments\/[^/]+$/u.test(pathnameSuffix)) {
+    return "attachment_read";
+  }
+  if (method === "POST" && pathnameSuffix === "/attachments") {
+    return "attachment_create";
+  }
+  if (method === "POST" && pathnameSuffix === "/chats") {
+    return "chat_create";
+  }
+  if (method === "POST" && pathnameSuffix === "/capability/check_imessage") {
+    return "check_imessage_capability";
+  }
+  if (method === "POST" && /^\/messages\/[^/]+\/reactions$/u.test(pathnameSuffix)) {
+    return "reaction_create";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/voicememo$/u.test(pathnameSuffix)) {
+    return "voice_memo_send";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/messages$/u.test(pathnameSuffix)) {
+    return "message_send";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
+    return "typing_start";
+  }
+  if (method === "POST" && /^\/chats\/[^/]+\/read$/u.test(pathnameSuffix)) {
+    return "read_receipt_send";
+  }
+  if (method === "DELETE" && /^\/chats\/[^/]+\/typing$/u.test(pathnameSuffix)) {
+    return "typing_stop";
+  }
+  if (method === "DELETE" && /^\/messages\/[^/]+$/u.test(pathnameSuffix)) {
+    return "message_delete";
+  }
+  return null;
+}

--- a/apps/cloudflare/test/provider-egress-conformance.test.ts
+++ b/apps/cloudflare/test/provider-egress-conformance.test.ts
@@ -1,0 +1,416 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  emitHostedExecutionStructuredLog: vi.fn(),
+}));
+
+vi.mock("@murphai/hosted-execution", async () => {
+  const actual = await vi.importActual<typeof import("@murphai/hosted-execution")>(
+    "@murphai/hosted-execution",
+  );
+  return {
+    ...actual,
+    emitHostedExecutionStructuredLog: mocks.emitHostedExecutionStructuredLog,
+  };
+});
+
+import {
+  sendLinqMessage,
+  sendTelegramImageMessage,
+  sendTelegramMessage,
+  sendTelegramVoiceMemoMessage,
+  startTelegramTypingIndicator,
+} from "@murphai/assistant-engine/assistant-channel-runtime";
+import {
+  downloadHostedProviderTelegramFile,
+  getHostedProviderTelegramFile,
+} from "@murphai/assistant-runtime/hosted-provider-effects";
+import {
+  deleteTelegramMessages,
+  setTelegramMessageReaction,
+} from "@murphai/operator-config/telegram-runtime";
+import {
+  HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+  hostedRunnerIntercept,
+} from "../src/runner-egress-intercept.ts";
+import {
+  HOSTED_RUNTIME_ATTEMPT_ID_HEADER,
+  HOSTED_RUNTIME_LEASE_GENERATION_HEADER,
+  HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER,
+  HOSTED_RUNNER_BOUND_USER_ID_HEADER,
+} from "../src/runner-outbound/headers.ts";
+import type {
+  RunnerOutboundEnvironmentSource,
+} from "../src/runner-outbound.ts";
+import {
+  createHostedExecutionTestEnv,
+} from "./hosted-execution-fixtures.ts";
+
+const WRITE_FENCE_HEADERS = {
+  [HOSTED_RUNTIME_ATTEMPT_ID_HEADER]: "attempt_1",
+  [HOSTED_RUNTIME_LEASE_GENERATION_HEADER]: "7",
+  [HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER]: "4",
+  [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: "member_123",
+} as const;
+
+const TELEGRAM_CLIENT_ROUTES = [
+  { method: "POST", operation: "sendMessage" },
+  { method: "POST", operation: "sendPhoto" },
+  { method: "POST", operation: "sendVoice" },
+  { method: "POST", operation: "sendChatAction" },
+  { method: "POST", operation: "deleteMessages" },
+  { method: "POST", operation: "deleteBusinessMessages" },
+  { method: "POST", operation: "setMessageReaction" },
+  { method: "GET", operation: "getFile" },
+] as const;
+
+const NUTRITION_CARD = {
+  kind: "daily_nutrition",
+  localDate: "2026-08-06",
+  mealCount: 1,
+  totals: {
+    calories: { mealCount: 1, total: 520 },
+    carbsGrams: { mealCount: 1, total: 48 },
+    fatGrams: { mealCount: 1, total: 20 },
+    proteinGrams: { mealCount: 1, total: 42 },
+  },
+} as const;
+
+const ELEVENLABS_MP3_BYTES = new Uint8Array([0xff, 0xfb, 0x90, 0x64]);
+const TELEGRAM_FILE_BYTES = new Uint8Array([1, 2, 3]);
+
+type ForwardedRequest = {
+  body: unknown;
+  headers: Headers;
+  method: string;
+  url: URL;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("hosted provider egress conformance", () => {
+  it("drives the real Linq response-card client through the production interceptor", async () => {
+    const validateRuntimeWriteFence = vi.fn(async () => true);
+    const env = createProviderInterceptEnv(validateRuntimeWriteFence);
+    const forwarded: ForwardedRequest[] = [];
+    vi.stubGlobal("fetch", createProviderUpstreamFetch(forwarded));
+
+    await expect(sendLinqMessage({
+      card: NUTRITION_CARD,
+      directRecipientPhoneNumber: "+15550000001",
+      fromPhoneNumber: "+15550000000",
+      idempotencyKey: "card_egress_conformance_1",
+      message: "Nutrition summary",
+      target: "chat_1",
+      targetKind: "thread",
+      threadIsDirect: true,
+    }, {
+      env: {
+        LINQ_API_TOKEN: HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+      },
+      fetchImplementation: createInterceptingProviderFetch(env),
+    })).resolves.toMatchObject({
+      providerMessageId: "message_1",
+      target: "chat_1",
+    });
+
+    expect(validateRuntimeWriteFence).toHaveBeenCalledTimes(2);
+    expect(forwarded).toHaveLength(2);
+    expect(forwarded[0]).toMatchObject({
+      body: {
+        address: "+15550000001",
+        from: "+15550000000",
+      },
+      method: "POST",
+    });
+    expect(forwarded[0]?.url.pathname)
+      .toBe("/api/partner/v3/capability/check_imessage");
+    expect(forwarded[0]?.headers.get("authorization"))
+      .toBe("Bearer linq-worker-secret");
+    expect(forwarded[1]?.body).toMatchObject({
+      message: {
+        idempotency_key: "card_egress_conformance_1",
+        preferred_service: "iMessage",
+        parts: [{ interactive: false, type: "imessage_app" }],
+      },
+    });
+    expect(forwarded[1]?.url.pathname)
+      .toBe("/api/partner/v3/chats/chat_1/messages");
+    assertAuthorityHeadersStripped(forwarded);
+  });
+
+  it.each([
+    "getMe",
+    "getUpdates",
+    "getWebhookInfo",
+    "deleteWebhook",
+    "getChat",
+    "answerCallbackQuery",
+  ])("keeps Telegram %s outside hosted runner egress", async (operation) => {
+    const validateRuntimeWriteFence = vi.fn(async () => true);
+    const upstreamFetch = vi.fn<typeof fetch>(async () =>
+      new Response("unexpected upstream call"));
+    vi.stubGlobal("fetch", upstreamFetch);
+
+    const response = await hostedRunnerIntercept(
+      new Request(
+        `https://api.telegram.org/bot${HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL}/${operation}`,
+        {
+          headers: WRITE_FENCE_HEADERS,
+          method: "POST",
+        },
+      ),
+      createProviderInterceptEnv(validateRuntimeWriteFence),
+      { containerId: "opaque-container-id" },
+    );
+
+    expect(response.status).toBe(403);
+    expect(validateRuntimeWriteFence).not.toHaveBeenCalled();
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it("drives every hosted Telegram client route through the production interceptor", async () => {
+    const validateRuntimeWriteFence = vi.fn(async () => true);
+    const env = createProviderInterceptEnv(validateRuntimeWriteFence);
+    const forwarded: ForwardedRequest[] = [];
+    vi.stubGlobal("fetch", createProviderUpstreamFetch(forwarded));
+
+    const clientEnv = {
+      ELEVENLABS_API_KEY: "elevenlabs-test-key",
+      TELEGRAM_API_BASE_URL: "https://api.telegram.org",
+      TELEGRAM_BOT_TOKEN: HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+      TELEGRAM_FILE_BASE_URL: "https://api.telegram.org/file",
+    } satisfies NodeJS.ProcessEnv;
+    const fetchImplementation = createInterceptingProviderFetch(env);
+
+    await sendTelegramMessage({
+      message: "hello",
+      target: "123",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+      maxDeliveryAttempts: 1,
+    });
+    await sendTelegramImageMessage({
+      media: [{
+        alt: "photo",
+        kind: "image",
+        source: "conformance",
+        url: "https://images.example.test/photo.jpg",
+      }],
+      message: "photo",
+      target: "123",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+      maxDeliveryAttempts: 1,
+    });
+    await sendTelegramVoiceMemoMessage({
+      filename: "memo",
+      generation: {
+        kind: "elevenlabs_speech",
+        modelId: "eleven_multilingual_v2",
+        outputFormat: "mp3_44100_128",
+        text: "Short memo.",
+        voiceId: "voice_murph",
+      },
+      target: "123",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+      maxDeliveryAttempts: 1,
+    });
+    const typing = await startTelegramTypingIndicator({
+      target: "123",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    });
+    await typing.stop();
+    await deleteTelegramMessages({
+      messageIds: ["101"],
+      target: "123",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    });
+    await deleteTelegramMessages({
+      messageIds: ["102"],
+      target: {
+        businessConnectionId: "business_1",
+        chatId: "123",
+      },
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    });
+    await setTelegramMessageReaction({
+      reaction: "heart",
+      target: "123",
+      targetMessageId: "103",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    });
+    await expect(getHostedProviderTelegramFile({
+      fileId: "file_1",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    })).resolves.toMatchObject({
+      file_id: "file_1",
+      file_path: "photos/file_1.jpg",
+    });
+    await expect(downloadHostedProviderTelegramFile({
+      filePath: "photos/file_1.jpg",
+    }, {
+      env: clientEnv,
+      fetchImplementation,
+    })).resolves.toEqual(TELEGRAM_FILE_BYTES);
+
+    const botPrefix = "/bottelegram-worker-secret/";
+    const botRoutes = forwarded
+      .filter((request) => request.url.pathname.startsWith(botPrefix))
+      .map((request) => ({
+        method: request.method,
+        operation: request.url.pathname.slice(botPrefix.length),
+      }));
+    expect(botRoutes).toEqual(TELEGRAM_CLIENT_ROUTES);
+    expect(
+      forwarded.find((request) => request.url.pathname.endsWith("/getFile"))
+        ?.url.search,
+    ).toBe("?file_id=file_1");
+    expect(forwarded.at(-1)?.url.toString()).toBe(
+      "https://api.telegram.org/file/bottelegram-worker-secret/photos/file_1.jpg",
+    );
+    expect(validateRuntimeWriteFence).toHaveBeenCalledTimes(9);
+    assertAuthorityHeadersStripped(forwarded);
+  });
+});
+
+function createProviderUpstreamFetch(
+  forwarded: ForwardedRequest[],
+): typeof fetch {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const request = input instanceof Request
+      ? input.clone()
+      : new Request(input, init);
+    const url = new URL(request.url);
+    forwarded.push({
+      body: await readForwardedBody(request),
+      headers: request.headers,
+      method: request.method,
+      url,
+    });
+
+    if (url.pathname.endsWith("/capability/check_imessage")) {
+      return Response.json({
+        address: "+15550000001",
+        available: true,
+      });
+    }
+    if (url.pathname.endsWith("/chats/chat_1/messages")) {
+      return Response.json({ message: { id: "message_1" } });
+    }
+    if (url.pathname.startsWith("/file/bottelegram-worker-secret/")) {
+      return new Response(TELEGRAM_FILE_BYTES, {
+        headers: { "content-type": "image/jpeg" },
+      });
+    }
+
+    const operation = url.pathname.split("/").at(-1);
+    if (operation === "getFile") {
+      return Response.json({
+        ok: true,
+        result: {
+          file_id: "file_1",
+          file_path: "photos/file_1.jpg",
+          file_size: TELEGRAM_FILE_BYTES.byteLength,
+          file_unique_id: "unique_1",
+        },
+      });
+    }
+    if (
+      operation === "sendMessage"
+      || operation === "sendPhoto"
+      || operation === "sendVoice"
+    ) {
+      return Response.json({
+        ok: true,
+        result: { message_id: 101 },
+      });
+    }
+    return Response.json({ ok: true, result: true });
+  });
+}
+
+function createInterceptingProviderFetch(
+  env: RunnerOutboundEnvironmentSource,
+): typeof fetch {
+  return async (input, init) => {
+    const request = input instanceof Request
+      ? input
+      : new Request(input, init);
+    if (new URL(request.url).hostname === "api.elevenlabs.io") {
+      return new Response(ELEVENLABS_MP3_BYTES, {
+        headers: { "content-type": "audio/mpeg" },
+      });
+    }
+
+    const headers = new Headers(request.headers);
+    for (const [name, value] of Object.entries(WRITE_FENCE_HEADERS)) {
+      headers.set(name, value);
+    }
+    return await hostedRunnerIntercept(
+      new Request(request, { headers }),
+      env,
+      { containerId: "opaque-container-id" },
+    );
+  };
+}
+
+async function readForwardedBody(request: Request): Promise<unknown> {
+  if (request.body === null) {
+    return null;
+  }
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return await request.clone().json();
+  }
+  return { contentType };
+}
+
+function createProviderInterceptEnv(
+  validateRuntimeWriteFence: (input: {
+    attemptId: string;
+    generation: string;
+    userId: string;
+  }) => Promise<boolean>,
+): RunnerOutboundEnvironmentSource {
+  return {
+    ...createHostedExecutionTestEnv(),
+    LINQ_API_TOKEN: "linq-worker-secret",
+    TELEGRAM_BOT_TOKEN: "telegram-worker-secret",
+    USER_RUNNER: {
+      getByName: () => ({
+        validateRuntimeProviderEgressCredential: async () => ({ owns: false }),
+        validateRuntimeProviderEgressToken: async () => ({ owns: false }),
+        validateRuntimeWriteFence,
+      }),
+    },
+  } as unknown as RunnerOutboundEnvironmentSource;
+}
+
+function assertAuthorityHeadersStripped(
+  requests: readonly ForwardedRequest[],
+): void {
+  for (const request of requests) {
+    expect(request.headers.has(HOSTED_RUNTIME_ATTEMPT_ID_HEADER)).toBe(false);
+    expect(request.headers.has(HOSTED_RUNTIME_LEASE_GENERATION_HEADER)).toBe(false);
+    expect(request.headers.has(HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER)).toBe(false);
+    expect(request.headers.has(HOSTED_RUNNER_BOUND_USER_ID_HEADER)).toBe(false);
+  }
+}

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -7139,6 +7139,20 @@ describe("hostedRunnerIntercept", () => {
     },
     {
       body: {
+        address: "+15550000001",
+        from: "+15550000000",
+      },
+      method: "POST",
+      name: "iMessage capability check",
+      operation: "check_imessage_capability",
+      path: "/capability/check_imessage",
+      responseBody: JSON.stringify({
+        address: "+15550000001",
+        available: true,
+      }),
+    },
+    {
+      body: {
         message: { parts: [{ type: "text", value: "hello" }] },
       },
       method: "POST",

--- a/apps/cloudflare/test/runner-egress-linq-policy.test.ts
+++ b/apps/cloudflare/test/runner-egress-linq-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readAllowedHostedLinqOperation,
+} from "../src/runner-egress-linq-policy.ts";
+
+describe("hosted Linq egress policy", () => {
+  it("admits only the exact documented iMessage capability route", () => {
+    expect(
+      readAllowedHostedLinqOperation("POST", "/capability/check_imessage"),
+    ).toBe("check_imessage_capability");
+    expect(
+      readAllowedHostedLinqOperation("GET", "/capability/check_imessage"),
+    ).toBeNull();
+    expect(
+      readAllowedHostedLinqOperation(
+        "POST",
+        "/capability/check_imessage/extra",
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Murph’s existing Linq client already performs the documented `POST /capability/check_imessage` request before sending a native iMessage app card. The Cloudflare hosted-runner allowlist did not admit that route, so the Worker returned `403` before Linq saw it and the existing response-card path fell back to ordinary text.

The same boundary also protects Telegram. Its route matrix already named the hosted operations Murph uses, but the tests exercised hand-built requests rather than proving the real Telegram clients can traverse the production interceptor.

## User-visible outcome

- Supported private iMessage recipients can reach the existing native static app-card send instead of being forced into text by Murph’s own egress boundary.
- Telegram text, photo, voice, typing, cleanup, reaction, attachment lookup, and attachment-download paths retain their existing behavior with explicit cross-boundary proof.
- Telegram polling, webhook-administration, and web-control methods remain unavailable to hosted runner code.

## Implementation

### Linq

- Move the existing straight-line Worker-owned Linq allowlist into `apps/cloudflare/src/runner-egress-linq-policy.ts` so the trust-boundary policy can be tested directly without exporting an internal helper from the large interceptor.
- Admit exactly `POST /capability/check_imessage` as `check_imessage_capability`.
- Keep all eleven pre-existing Linq route grants unchanged.
- Extend the existing production-interceptor matrix with the capability body and Linq’s documented `{ address, available }` response shape.
- Add a real response-card client-through-interceptor regression that proves the capability request is followed by a one-part static `imessage_app` payload carrying the original idempotency key.

### Telegram

The new conformance suite invokes the real production clients for every Telegram route currently emitted by the hosted runtime:

- `POST sendMessage`
- `POST sendPhoto`
- `POST sendVoice`
- `POST sendChatAction`
- `POST deleteMessages`
- `POST deleteBusinessMessages`
- `POST setMessageReaction`
- `GET getFile`
- `GET /file/bot<token>/<file_path>`

For every request, the suite crosses `hostedRunnerIntercept`, validates the active write fence, proves the Worker-owned token replaces the sentinel, and proves runtime authority headers do not leave Cloudflare. It also verifies that `getMe`, `getUpdates`, `getWebhookInfo`, `deleteWebhook`, `getChat`, and `answerCallbackQuery` receive `403` before write-fence validation or upstream fetch because those methods are owned by Inboxd polling or web control rather than the hosted runner.

Telegram’s official Bot API currently supports both GET and POST for Bot API methods, so this PR does not invent a narrower HTTP-method policy. The regression still asserts the exact methods Murph’s current clients emit. File downloads remain on Telegram’s separate documented `/file/bot<token>/<file_path>` path and remain GET-only in the existing interceptor.

Official contracts checked:

- https://core.telegram.org/bots/api#making-requests
- https://core.telegram.org/bots/api#available-methods
- https://core.telegram.org/bots/api#getfile

## Architecture

The Cloudflare Worker remains the sole owner of hosted provider egress authority. Production authority is not generated from client declarations.

The existing Linq and Telegram clients, assistant outbox, persistence transitions, retry policy, delivery identities, and response rendering are unchanged. This intentionally adds no shared provider registry, generated firewall, client-side authority mirror, schema, queue, cache, feature flag, dependency, or second retry/delivery owner.

The new test is the integration seam: real clients on one side, the real production interceptor on the other.

## Verification

Current exact head: `11c224c4269be664da0838a55eb91bb0dbd19793`, one commit directly on current `main` `a2810215961fb1d31e81c5f6fb2358a72d74febc`.

Completed before push:

- direct TypeScript syntax/transpile checks for the new conformance source;
- complete source audit of hosted Telegram callers and the existing Worker allowlist;
- official Telegram Bot API contract review;
- `git` tree audit proving the temporary implementation workflow and trigger marker are absent from the final commit.

Pending exact-head repository gates:

- Cloudflare typecheck;
- focused Linq policy/interceptor/conformance tests;
- focused Telegram assistant-channel, operator-config runtime, and hosted-provider-effect tests;
- documentation drift/gardening and `git diff --check`;
- required GitHub Actions and final review.

The execution plan remains active until those gates complete. The PR remains draft.

## Change shape

| Area | Added | Deleted |
| --- | ---: | ---: |
| Worker source | 62 | 54 |
| Tests | 452 | 0 |
| Execution plan | 53 | 0 |
| Other production packages | 0 | 0 |
| **Total** | **567** | **54** |

## Deployment concerns

Deploy the Cloudflare Worker. Existing runner code already issues the Linq capability request and all tested Telegram requests, so no runner-bundle rollout, warm-container recycle, persisted-state migration, or feature-flag sequence is required.

Until the Worker is deployed, native iMessage cards continue to degrade to the existing text fallback. Telegram behavior is unchanged by deployment because its production route policy did not need modification.

After rollout, send a fresh response card to a supported production iPhone and verify that the native static card bubble renders. Interactive Messages-extension rendering remains outside this change.

ReviewGPT context sensitivity: sensitive — this changes the production Linq provider-egress allowlist and adds cross-boundary coverage for all hosted Telegram effects.
