### PR TITLE
Superseded: resume asynchronous image completions on origin session

### DIFF
--- a/packages/assistant-engine/src/assistant/automation/grouping.ts
+++ b/packages/assistant-engine/src/assistant/automation/grouping.ts
@@ -158,6 +158,8 @@ function isSameAuthenticatedGroupRoomBatch(
     first.source === candidate.source &&
     first.conversation.source === candidate.conversation.source &&
     first.conversation.accountId === candidate.conversation.accountId &&
+    (first.conversation.sessionId ?? null) ===
+      (candidate.conversation.sessionId ?? null) &&
     first.conversation.threadId === candidate.conversation.threadId &&
     first.conversation.threadIsDirect === false &&
     candidate.conversation.threadIsDirect === false &&

--- a/packages/assistant-engine/src/assistant/conversation-ref.ts
+++ b/packages/assistant-engine/src/assistant/conversation-ref.ts
@@ -57,6 +57,7 @@ export interface AssistantInputConversationRef {
   actorId: string | null
   actorIsSelf: boolean
   source: string | null
+  sessionId?: string | null
   threadId: string | null
   threadIsDirect: boolean | null
 }
@@ -195,7 +196,8 @@ export function conversationRefFromCapture(input: {
 export function conversationRefFromAssistantInputConversation(
   input: AssistantInputConversationRef,
 ): ConversationRef {
-  return normalizeConversationRef({
+  const conversation = normalizeConversationRef({
+    sessionId: input.sessionId,
     channel: input.source,
     identityId:
       input.source === 'email' || input.source === 'linq'
@@ -205,6 +207,12 @@ export function conversationRefFromAssistantInputConversation(
     threadId: input.threadId,
     directness: conversationDirectnessFromThreadIsDirect(input.threadIsDirect),
   })
+  if (conversation.sessionId) {
+    // The exact durable session owns continuity. A runtime-authored input actor
+    // describes the input itself and must not rebind that session's participant.
+    delete conversation.participantId
+  }
+  return conversation
 }
 
 export function assistantInputConversationRefFromCapture(input: {
@@ -239,6 +247,7 @@ export function isSameAssistantConversationRef(
     left.actorId === right.actorId &&
     left.actorIsSelf === right.actorIsSelf &&
     left.source === right.source &&
+    (left.sessionId ?? null) === (right.sessionId ?? null) &&
     left.threadId === right.threadId &&
     left.threadIsDirect === right.threadIsDirect
   )

--- a/packages/assistant-engine/src/assistant/hosted-tool-context.ts
+++ b/packages/assistant-engine/src/assistant/hosted-tool-context.ts
@@ -199,6 +199,8 @@ export function createAssistantHostedToolContext(input: {
   const route = input.route ?? null
   const clinicalRecordsConnectLinkTool =
     executionContext?.clinicalRecordsConnectLinkTool ?? null
+  const imageGenerationLauncher =
+    executionContext?.imageGenerationLauncher ?? null
   const newsletterPort = input.messageInput.scheduledAutomationAuthority
     ? executionContext?.newsletterTool ?? null
     : null
@@ -293,7 +295,23 @@ export function createAssistantHostedToolContext(input: {
     groupTool: executionContext?.groupTool ?? null,
     imessageContactTool: executionContext?.imessageContactTool ?? null,
     labsTool: executionContext?.labsTool ?? null,
-    imageGenerationLauncher: executionContext?.imageGenerationLauncher ?? null,
+    imageGenerationLauncher: imageGenerationLauncher
+      ? {
+          launch(request) {
+            return imageGenerationLauncher.launch({
+              ...request,
+              scopeId: readDeliveryContext().session.sessionId,
+            })
+          },
+          ...(imageGenerationLauncher.readStatus
+            ? {
+                readStatus(scopeId: string) {
+                  return imageGenerationLauncher.readStatus?.(scopeId) ?? null
+                },
+              }
+            : {}),
+        }
+      : null,
     persistGeneratedImageCapture:
       executionContext?.persistGeneratedImageCapture ?? null,
     newsletterTool,

--- a/packages/assistant-engine/src/assistant/input-store.ts
+++ b/packages/assistant-engine/src/assistant/input-store.ts
@@ -164,6 +164,7 @@ const assistantInputConversationRefSchema = z
     actorId: safeNullableAssistantInputTokenSchema('actorId'),
     actorIsSelf: z.boolean(),
     source: safeNullableAssistantInputTokenSchema('source'),
+    sessionId: safeNullableAssistantInputTokenSchema('sessionId').optional(),
     threadId: safeNullableAssistantInputTokenSchema('threadId'),
     threadIsDirect: z.boolean().nullable().default(null),
   })

--- a/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
+++ b/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
@@ -1,0 +1,170 @@
+import {
+  createDefaultLocalAssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import type {
+  AssistantSession,
+} from '@murphai/operator-config/assistant-cli-contracts'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  AssistantHostedImageGenerationLauncher,
+} from '../src/assistant/execution-context.js'
+import {
+  conversationRefFromAssistantInputConversation,
+} from '../src/assistant/conversation-ref.js'
+import {
+  createAssistantHostedToolContext,
+} from '../src/assistant/hosted-tool-context.js'
+import {
+  buildResolveAssistantSessionInput,
+} from '../src/assistant/session-resolution.js'
+import type {
+  AssistantMessageInput,
+} from '../src/assistant/service-contracts.js'
+import {
+  shouldGroupAdjacentConversationInput,
+} from '../src/assistant/automation/grouping.js'
+import type {
+  AssistantAutomationInputSummary,
+} from '../src/assistant/automation/input-summary.js'
+
+const ORIGIN_SESSION_ID = `asst_${'a'.repeat(32)}`
+
+describe('exact asynchronous image session continuation', () => {
+  it('keeps a runtime-authored actor separate from the exact session binding', () => {
+    const conversation = conversationRefFromAssistantInputConversation({
+      accountId: 'identity_1',
+      actorId: null,
+      actorIsSelf: false,
+      sessionId: ORIGIN_SESSION_ID,
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+
+    expect(conversation).toMatchObject({
+      channel: 'linq',
+      directness: 'direct',
+      identityId: 'identity_1',
+      sessionId: ORIGIN_SESSION_ID,
+      threadId: 'thread_1',
+    })
+    expect(conversation).not.toHaveProperty('participantId')
+
+    const ordinaryConversation = conversationRefFromAssistantInputConversation({
+      accountId: 'identity_1',
+      actorId: 'actor_1',
+      actorIsSelf: false,
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+    expect(ordinaryConversation.participantId).toBe('actor_1')
+
+    const resolution = buildResolveAssistantSessionInput(
+      {
+        conversation,
+        vault: '/unused',
+      },
+      null,
+      createDefaultLocalAssistantModelTarget(),
+    )
+    expect(resolution).toMatchObject({
+      channel: 'linq',
+      identityId: 'identity_1',
+      sessionId: ORIGIN_SESSION_ID,
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+    expect(resolution).not.toHaveProperty('actorId')
+  })
+
+  it('does not coalesce completion inputs from different session owners', () => {
+    const first = createSummary(ORIGIN_SESSION_ID)
+
+    expect(
+      shouldGroupAdjacentConversationInput(first, createSummary(null)),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createSummary(`asst_${'b'.repeat(32)}`),
+      ),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createSummary(ORIGIN_SESSION_ID),
+      ),
+    ).toBe(true)
+  })
+
+  it('binds image launches while preserving the launcher status API', () => {
+    const launch = vi.fn<AssistantHostedImageGenerationLauncher['launch']>(
+      () => 'started',
+    )
+    const readStatus = vi.fn<
+      NonNullable<AssistantHostedImageGenerationLauncher['readStatus']>
+    >(() => 'pending')
+    const context = createAssistantHostedToolContext({
+      executionContext: {
+        imageGenerationLauncher: { launch, readStatus },
+        memberId: 'member_1',
+        userEnvKeys: [],
+      },
+      messageInput: {
+        vault: '/unused',
+      } as AssistantMessageInput,
+      session: {
+        sessionId: ORIGIN_SESSION_ID,
+      } as AssistantSession,
+    })
+
+    context.imageGenerationLauncher?.launch({
+      operationId: 'operation_1',
+      originAssistantInputId: `ain_${'1'.repeat(32)}`,
+      originAssistantInputIdExact: true,
+      scopeId: 'caller_selected_scope',
+      run: async () => ({
+        media: null,
+        runtimeIssue: null,
+        savedImageRef: null,
+      }),
+    })
+
+    expect(launch).toHaveBeenCalledOnce()
+    expect(launch).toHaveBeenCalledWith(expect.objectContaining({
+      scopeId: ORIGIN_SESSION_ID,
+    }))
+    expect(
+      context.imageGenerationLauncher?.readStatus?.('caller_selected_scope'),
+    ).toBe('pending')
+    expect(readStatus).toHaveBeenCalledWith('caller_selected_scope')
+  })
+})
+
+function createSummary(sessionId: string | null): AssistantAutomationInputSummary {
+  return {
+    actorIsSelf: false,
+    attachmentCount: 0,
+    conversation: {
+      accountId: 'identity_1',
+      actorId: null,
+      actorIsSelf: false,
+      ...(sessionId ? { sessionId } : {}),
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    },
+    deliveryTarget: 'thread_1',
+    groupRoomBatchingEligible: false,
+    inputId: `ain_${'2'.repeat(32)}`,
+    occurredAt: '2026-08-06T17:00:00.000Z',
+    optionalInboxCaptureId: null,
+    projectionReady: true,
+    receivedAt: '2026-08-06T17:00:00.000Z',
+    replyToMessageId: null,
+    source: 'hosted-mailbox',
+    text: 'trusted image completion',
+  }
+}

--- a/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
+++ b/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
@@ -60,6 +60,7 @@ describe('exact asynchronous image session continuation', () => {
       threadIsDirect: true,
     })
     expect(ordinaryConversation.participantId).toBe('actor_1')
+    expect(ordinaryConversation.sessionId).toBeNull()
 
     const resolution = buildResolveAssistantSessionInput(
       {
@@ -139,6 +140,7 @@ describe('exact asynchronous image session continuation', () => {
     expect(
       context.imageGenerationLauncher?.readStatus?.('caller_selected_scope'),
     ).toBe('pending')
+    expect(readStatus).toHaveBeenCalledOnce()
     expect(readStatus).toHaveBeenCalledWith('caller_selected_scope')
   })
 })

--- a/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
@@ -357,6 +357,7 @@ async function stageImageGenerationCompletion(input: {
         ...origin.conversation,
         actorId: null,
         actorIsSelf: false,
+        sessionId: input.completion.scopeId,
       },
       occurredAt: input.completion.completedAt,
       receivedAt: input.completion.completedAt,

--- a/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
@@ -278,6 +278,7 @@ describe("hosted image generation", () => {
     assert.deepEqual(completion.conversation, {
       ...origin.conversation,
       actorId: null,
+      sessionId: "session_1",
     });
     assert.deepEqual(completion.replyTarget, origin.replyTarget);
     assert.equal(completion.sourceRef.kind, "hosted-mailbox");
@@ -356,6 +357,11 @@ describe("hosted image generation", () => {
       vault: vaultRoot,
     });
     assert.ok(failureCompletion);
+    assert.deepEqual(failureCompletion.conversation, {
+      ...origin.conversation,
+      actorId: null,
+      sessionId: "session_1",
+    });
     const failureText = failureCompletion.content.text ?? "";
     const failureDiagnosticLine = failureText.split("\n").find((line) =>
       line.startsWith(
@@ -426,6 +432,11 @@ describe("hosted image generation", () => {
       vault: vaultRoot,
     });
     assert.ok(completion);
+    assert.deepEqual(completion.conversation, {
+      ...origin.conversation,
+      actorId: null,
+      sessionId: "session_shutdown",
+    });
     assert.match(
       completion.content.text ?? "",
       /"originAssistantInputIdExact":true/u,


### PR DESCRIPTION
## Why

Hosted image generation already returns through a trusted asynchronous input, but that input currently drops the assistant-session identity that launched the image and re-resolves continuity from conversation fields. The completion is runtime-authored, so it must preserve system authorship while resuming the exact durable assistant session rather than reconstructing product policy in a generic completion prompt.

## What changed

- Bind every hosted image launch to the current host-owned durable assistant session.
- Carry that exact session locator on the runtime-authored completion input.
- Keep the completion's system actor separate from the session's participant binding.
- Prevent adjacent inputs with different session owners from being coalesced into one turn.
- Leave hosted-image prompt text, physical-note policy, tool schemas, and mail transport unchanged.

## Resulting flow

```text
assistant session starts image generation
  -> host binds the current session id
  -> provider work finishes asynchronously
  -> runtime stages trusted system input with the same session id
  -> ordinary session resolution resumes that exact durable session
```

## Architecture and reuse

- **Existing systems reused:** The existing assistant session resolver, `ConversationRef.sessionId`, trusted assistant-input store, hosted tool context, image-generation controller, and ordinary auto-reply path remain the only owners.
- **New logic:** One optional exact session locator is preserved on runtime-authored input; the input actor remains input metadata and is not used to rebind the selected session.
- **New abstractions:** None; the change extends the existing conversation locator used by ordinary assistant session resolution.
- **Complexity intentionally avoided:** No image-specific session registry, bespoke continuation runner, prompt reconstruction, physical-note instruction, database table, scheduler, transcript replay, or fallback-to-latest-session path was added.

## Hot reply path impact

Ordinary inbound messages still carry participant attribution and resolve exactly as before. Only runtime-authored inputs with an exact session locator use this path, and inputs owned by different sessions are not batched together.

## Design proof

Not applicable; no frontend or rendered UI changes.

## Verification

- Added focused engine coverage for exact-session resolution, participant-binding preservation, ordinary-input attribution, host-owned launch binding, and batching isolation.
- Extended runtime coverage for successful, failed, and shutdown image completions.
- Exact-head CI is pending on commit `7955a09cda312466dc21ad67ee3a6392347961e7`.
