### PR TITLE
Resume asynchronous image completions on their origin session

### DIFF
--- a/packages/assistant-engine/src/assistant/automation/grouping.ts
+++ b/packages/assistant-engine/src/assistant/automation/grouping.ts
@@ -158,6 +158,8 @@ function isSameAuthenticatedGroupRoomBatch(
     first.source === candidate.source &&
     first.conversation.source === candidate.conversation.source &&
     first.conversation.accountId === candidate.conversation.accountId &&
+    (first.conversation.sessionId ?? null) ===
+      (candidate.conversation.sessionId ?? null) &&
     first.conversation.threadId === candidate.conversation.threadId &&
     first.conversation.threadIsDirect === false &&
     candidate.conversation.threadIsDirect === false &&

--- a/packages/assistant-engine/src/assistant/conversation-ref.ts
+++ b/packages/assistant-engine/src/assistant/conversation-ref.ts
@@ -196,7 +196,7 @@ export function conversationRefFromCapture(input: {
 export function conversationRefFromAssistantInputConversation(
   input: AssistantInputConversationRef,
 ): ConversationRef {
-  const conversation = normalizeConversationRef({
+  return normalizeConversationRef({
     sessionId: input.sessionId,
     channel: input.source,
     identityId:
@@ -207,12 +207,6 @@ export function conversationRefFromAssistantInputConversation(
     threadId: input.threadId,
     directness: conversationDirectnessFromThreadIsDirect(input.threadIsDirect),
   })
-  if (conversation.sessionId) {
-    // The exact durable session owns continuity. A runtime-authored input actor
-    // describes the input itself and must not rebind that session's participant.
-    delete conversation.participantId
-  }
-  return conversation
 }
 
 export function assistantInputConversationRefFromCapture(input: {

--- a/packages/assistant-engine/src/assistant/conversation-ref.ts
+++ b/packages/assistant-engine/src/assistant/conversation-ref.ts
@@ -57,6 +57,7 @@ export interface AssistantInputConversationRef {
   actorId: string | null
   actorIsSelf: boolean
   source: string | null
+  sessionId?: string | null
   threadId: string | null
   threadIsDirect: boolean | null
 }
@@ -195,7 +196,8 @@ export function conversationRefFromCapture(input: {
 export function conversationRefFromAssistantInputConversation(
   input: AssistantInputConversationRef,
 ): ConversationRef {
-  return normalizeConversationRef({
+  const conversation = normalizeConversationRef({
+    sessionId: input.sessionId,
     channel: input.source,
     identityId:
       input.source === 'email' || input.source === 'linq'
@@ -205,6 +207,12 @@ export function conversationRefFromAssistantInputConversation(
     threadId: input.threadId,
     directness: conversationDirectnessFromThreadIsDirect(input.threadIsDirect),
   })
+  if (conversation.sessionId) {
+    // The exact durable session owns continuity. A runtime-authored input actor
+    // describes the input itself and must not rebind that session's participant.
+    delete conversation.participantId
+  }
+  return conversation
 }
 
 export function assistantInputConversationRefFromCapture(input: {
@@ -239,6 +247,7 @@ export function isSameAssistantConversationRef(
     left.actorId === right.actorId &&
     left.actorIsSelf === right.actorIsSelf &&
     left.source === right.source &&
+    (left.sessionId ?? null) === (right.sessionId ?? null) &&
     left.threadId === right.threadId &&
     left.threadIsDirect === right.threadIsDirect
   )

--- a/packages/assistant-engine/src/assistant/execution-context.ts
+++ b/packages/assistant-engine/src/assistant/execution-context.ts
@@ -398,9 +398,15 @@ export type AssistantGeneratedImageCapturePersistence = <T>(
 
 export interface AssistantHostedImageGenerationLauncher {
   launch(input: {
+    // The durable assistant session that must receive the asynchronous
+    // completion. The host binds it; it is never derived from tool arguments
+    // and never doubles as the pending-image coordination scope.
+    continuationSessionId?: string | null
     operationId: string
     originAssistantInputId: string
     originAssistantInputIdExact: boolean
+    // Pending/queued duplicate prevention and cleanup scope. Unrelated to
+    // continuation identity.
     scopeId?: string | null
     run(
       signal: AbortSignal,

--- a/packages/assistant-engine/src/assistant/hosted-tool-context.ts
+++ b/packages/assistant-engine/src/assistant/hosted-tool-context.ts
@@ -296,21 +296,11 @@ export function createAssistantHostedToolContext(input: {
     imessageContactTool: executionContext?.imessageContactTool ?? null,
     labsTool: executionContext?.labsTool ?? null,
     imageGenerationLauncher: imageGenerationLauncher
-      ? {
-          launch(request) {
-            return imageGenerationLauncher.launch({
-              ...request,
-              scopeId: readDeliveryContext().session.sessionId,
-            })
-          },
-          ...(imageGenerationLauncher.readStatus
-            ? {
-                readStatus(scopeId: string) {
-                  return imageGenerationLauncher.readStatus?.(scopeId) ?? null
-                },
-              }
-            : {}),
-        }
+      ? bindAssistantHostedImageGenerationContinuation({
+          launcher: imageGenerationLauncher,
+          readContinuationSessionId: () =>
+            readDeliveryContext().session.sessionId,
+        })
       : null,
     persistGeneratedImageCapture:
       executionContext?.persistGeneratedImageCapture ?? null,
@@ -474,6 +464,24 @@ export function createAssistantHostedToolContext(input: {
       throw new Error('Vault-file sending is unavailable for this turn.')
     }),
     vaultFileSendAvailable: typeof input.sendVaultFile === 'function',
+  }
+}
+
+// The host, not the model or tool arguments, owns which durable session an
+// asynchronous image completion resumes. Binding it here keeps the caller's
+// `scopeId` (pending/queued coordination) and `readStatus` untouched.
+function bindAssistantHostedImageGenerationContinuation(input: {
+  launcher: AssistantHostedImageGenerationLauncher
+  readContinuationSessionId: () => string
+}): AssistantHostedImageGenerationLauncher {
+  return {
+    ...input.launcher,
+    launch(request) {
+      return input.launcher.launch({
+        ...request,
+        continuationSessionId: input.readContinuationSessionId(),
+      })
+    },
   }
 }
 

--- a/packages/assistant-engine/src/assistant/hosted-tool-context.ts
+++ b/packages/assistant-engine/src/assistant/hosted-tool-context.ts
@@ -199,6 +199,8 @@ export function createAssistantHostedToolContext(input: {
   const route = input.route ?? null
   const clinicalRecordsConnectLinkTool =
     executionContext?.clinicalRecordsConnectLinkTool ?? null
+  const imageGenerationLauncher =
+    executionContext?.imageGenerationLauncher ?? null
   const newsletterPort = input.messageInput.scheduledAutomationAuthority
     ? executionContext?.newsletterTool ?? null
     : null
@@ -293,7 +295,23 @@ export function createAssistantHostedToolContext(input: {
     groupTool: executionContext?.groupTool ?? null,
     imessageContactTool: executionContext?.imessageContactTool ?? null,
     labsTool: executionContext?.labsTool ?? null,
-    imageGenerationLauncher: executionContext?.imageGenerationLauncher ?? null,
+    imageGenerationLauncher: imageGenerationLauncher
+      ? {
+          launch(request) {
+            return imageGenerationLauncher.launch({
+              ...request,
+              scopeId: readDeliveryContext().session.sessionId,
+            })
+          },
+          ...(imageGenerationLauncher.readStatus
+            ? {
+                readStatus(scopeId: string) {
+                  return imageGenerationLauncher.readStatus?.(scopeId) ?? null
+                },
+              }
+            : {}),
+        }
+      : null,
     persistGeneratedImageCapture:
       executionContext?.persistGeneratedImageCapture ?? null,
     newsletterTool,

--- a/packages/assistant-engine/src/assistant/input-store.ts
+++ b/packages/assistant-engine/src/assistant/input-store.ts
@@ -164,6 +164,7 @@ const assistantInputConversationRefSchema = z
     actorId: safeNullableAssistantInputTokenSchema('actorId'),
     actorIsSelf: z.boolean(),
     source: safeNullableAssistantInputTokenSchema('source'),
+    sessionId: safeNullableAssistantInputTokenSchema('sessionId').optional(),
     threadId: safeNullableAssistantInputTokenSchema('threadId'),
     threadIsDirect: z.boolean().nullable().default(null),
   })

--- a/packages/assistant-engine/src/assistant/store.ts
+++ b/packages/assistant-engine/src/assistant/store.ts
@@ -140,7 +140,13 @@ export async function resolveAssistantSession(
     if (sessionId) {
       const resolved = await loadAndPersistResolvedSession({
         paths,
-        persistenceInput,
+        persistenceInput: {
+          ...persistenceInput,
+          bindingPatch:
+            persistenceInput.allowBindingRebind
+              ? bindingPatch
+              : bindingPatchWithoutIncomingSystemActor(bindingPatch),
+        },
         sessionId,
       })
       if (!resolved) {
@@ -309,6 +315,24 @@ export async function resolveAssistantSession(
       session: savedSession,
     }
   })
+}
+
+// A runtime-authored completion resumes an already-authorized thread and
+// carries no actor of its own (`actorId: null`), which would otherwise clear
+// the stored binding and fail closed on an isolation conflict. Only that
+// no-actor case is dropped: a differing non-null actor on an explicit session
+// still means the caller is retargeting the session at another participant, so
+// it keeps failing with a routing conflict unless the caller opts in through
+// `allowBindingRebind`. Channel, identity, thread, and directness always stay
+// in the patch so their isolation conflicts still fail closed.
+function bindingPatchWithoutIncomingSystemActor(
+  patch: AssistantBindingPatch,
+): AssistantBindingPatch {
+  if (patch.actorId !== null) {
+    return patch
+  }
+  const { actorId: _actorId, ...rest } = patch
+  return rest
 }
 
 function withAssistantSessionResolutionDiagnostics(

--- a/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
+++ b/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
@@ -1,10 +1,14 @@
+import { rm } from 'node:fs/promises'
+
 import {
+  createAssistantModelTarget,
   createDefaultLocalAssistantModelTarget,
+  type AssistantModelTarget,
 } from '@murphai/operator-config/assistant-backend'
 import type {
   AssistantSession,
 } from '@murphai/operator-config/assistant-cli-contracts'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type {
   AssistantHostedImageGenerationLauncher,
@@ -27,11 +31,30 @@ import {
 import type {
   AssistantAutomationInputSummary,
 } from '../src/assistant/automation/input-summary.js'
+import {
+  getAssistantSession,
+  resolveAssistantSession,
+} from '../src/assistant/store.js'
+import { createTempVaultContext } from './test-helpers.js'
 
 const ORIGIN_SESSION_ID = `asst_${'a'.repeat(32)}`
+const OTHER_SESSION_ID = `asst_${'b'.repeat(32)}`
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupPaths.splice(0).map((target) =>
+      rm(target, {
+        force: true,
+        recursive: true,
+      }),
+    ),
+  )
+})
 
 describe('exact asynchronous image session continuation', () => {
-  it('keeps a runtime-authored actor separate from the exact session binding', () => {
+  it('carries the exact session locator only on runtime-authored input', () => {
     const conversation = conversationRefFromAssistantInputConversation({
       accountId: 'identity_1',
       actorId: null,
@@ -46,10 +69,10 @@ describe('exact asynchronous image session continuation', () => {
       channel: 'linq',
       directness: 'direct',
       identityId: 'identity_1',
+      participantId: null,
       sessionId: ORIGIN_SESSION_ID,
       threadId: 'thread_1',
     })
-    expect(conversation).not.toHaveProperty('participantId')
 
     const ordinaryConversation = conversationRefFromAssistantInputConversation({
       accountId: 'identity_1',
@@ -59,7 +82,6 @@ describe('exact asynchronous image session continuation', () => {
       threadId: 'thread_1',
       threadIsDirect: true,
     })
-    expect(ordinaryConversation.participantId).toBe('actor_1')
     expect(ordinaryConversation.sessionId).toBeNull()
 
     const resolution = buildResolveAssistantSessionInput(
@@ -71,36 +93,169 @@ describe('exact asynchronous image session continuation', () => {
       createDefaultLocalAssistantModelTarget(),
     )
     expect(resolution).toMatchObject({
+      actorId: null,
       channel: 'linq',
       identityId: 'identity_1',
       sessionId: ORIGIN_SESSION_ID,
       threadId: 'thread_1',
       threadIsDirect: true,
     })
-    expect(resolution).not.toHaveProperty('actorId')
+  })
+
+  it('resumes the exact session without clearing or rebinding its participant', async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'assistant-image-continuation-session-',
+    )
+    cleanupPaths.push(parentRoot)
+
+    const created = await resolveAssistantSession({
+      actorId: 'linq-participant',
+      channel: 'linq',
+      identityId: 'linq-identity',
+      target: createCodexTarget(),
+      threadId: 'linq-thread',
+      threadIsDirect: true,
+      vault: vaultRoot,
+    })
+    expect(created.session.binding.actorId).toBe('linq-participant')
+
+    // The trusted completion is system-authored, so its conversation carries
+    // `actorId: null` next to the exact originating session id.
+    const completionConversation = conversationRefFromAssistantInputConversation({
+      accountId: 'linq-identity',
+      actorId: null,
+      actorIsSelf: false,
+      sessionId: created.session.sessionId,
+      source: 'linq',
+      threadId: 'linq-thread',
+      threadIsDirect: true,
+    })
+
+    const resumed = await resolveAssistantSession({
+      conversation: completionConversation,
+      createIfMissing: false,
+      vault: vaultRoot,
+    })
+    expect(resumed.created).toBe(false)
+    expect(resumed.session.sessionId).toBe(created.session.sessionId)
+    expect(resumed.resolutionDiagnostics).toMatchObject({
+      sessionResolutionLookupSource: 'session-id',
+    })
+    expect(resumed.session.binding.actorId).toBe('linq-participant')
+
+    // Only the system-authored no-actor case is exempt. A differing non-null
+    // actor on an explicit session is a retarget, so it still fails closed.
+    await expect(
+      resolveAssistantSession({
+        conversation: conversationRefFromAssistantInputConversation({
+          accountId: 'linq-identity',
+          actorId: 'linq-other-participant',
+          actorIsSelf: false,
+          sessionId: created.session.sessionId,
+          source: 'linq',
+          threadId: 'linq-thread',
+          threadIsDirect: true,
+        }),
+        createIfMissing: false,
+        vault: vaultRoot,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_ROUTING_CONFLICT',
+    })
+
+    const persisted = await getAssistantSession(
+      vaultRoot,
+      created.session.sessionId,
+    )
+    expect(persisted.binding.actorId).toBe('linq-participant')
+
+    // Channel, identity, thread, and directness isolation still fails closed.
+    await expect(
+      resolveAssistantSession({
+        conversation: conversationRefFromAssistantInputConversation({
+          accountId: 'linq-identity',
+          actorId: null,
+          actorIsSelf: false,
+          sessionId: created.session.sessionId,
+          source: 'linq',
+          threadId: 'other-thread',
+          threadIsDirect: true,
+        }),
+        createIfMissing: false,
+        vault: vaultRoot,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_SESSION_ROUTING_CONFLICT',
+    })
+
+    // An explicit opt-in retarget still rebinds the participant.
+    const rebound = await resolveAssistantSession({
+      actorId: 'linq-other-participant',
+      allowBindingRebind: true,
+      channel: 'linq',
+      createIfMissing: false,
+      identityId: 'linq-identity',
+      sessionId: created.session.sessionId,
+      threadId: 'linq-thread',
+      threadIsDirect: true,
+      vault: vaultRoot,
+    })
+    expect(rebound.session.binding.actorId).toBe('linq-other-participant')
   })
 
   it('does not coalesce completion inputs from different session owners', () => {
-    const first = createSummary(ORIGIN_SESSION_ID)
+    const first = createSummary({ sessionId: ORIGIN_SESSION_ID })
 
     expect(
-      shouldGroupAdjacentConversationInput(first, createSummary(null)),
+      shouldGroupAdjacentConversationInput(first, createSummary({ sessionId: null })),
     ).toBe(false)
     expect(
       shouldGroupAdjacentConversationInput(
         first,
-        createSummary(`asst_${'b'.repeat(32)}`),
+        createSummary({ sessionId: OTHER_SESSION_ID }),
       ),
     ).toBe(false)
     expect(
       shouldGroupAdjacentConversationInput(
         first,
-        createSummary(ORIGIN_SESSION_ID),
+        createSummary({ sessionId: ORIGIN_SESSION_ID }),
       ),
     ).toBe(true)
   })
 
-  it('binds image launches while preserving the launcher status API', () => {
+  it('does not coalesce different session owners in the authenticated group-room fast path', () => {
+    // The group-room fast path intentionally ignores the input actor, so exact
+    // session ownership is the only boundary left between a system-authored
+    // continuation and adjacent group messages.
+    const first = createGroupRoomSummary({ sessionId: ORIGIN_SESSION_ID })
+
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createGroupRoomSummary({ sessionId: null }),
+      ),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createGroupRoomSummary({ sessionId: OTHER_SESSION_ID }),
+      ),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createGroupRoomSummary({ sessionId: ORIGIN_SESSION_ID }),
+      ),
+    ).toBe(true)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        createGroupRoomSummary({ sessionId: null }),
+        createGroupRoomSummary({ sessionId: null }),
+      ),
+    ).toBe(true)
+  })
+
+  it('binds the continuation session without disturbing the launch scope', () => {
     const launch = vi.fn<AssistantHostedImageGenerationLauncher['launch']>(
       () => 'started',
     )
@@ -135,7 +290,8 @@ describe('exact asynchronous image session continuation', () => {
 
     expect(launch).toHaveBeenCalledOnce()
     expect(launch).toHaveBeenCalledWith(expect.objectContaining({
-      scopeId: ORIGIN_SESSION_ID,
+      continuationSessionId: ORIGIN_SESSION_ID,
+      scopeId: 'caller_selected_scope',
     }))
     expect(
       context.imageGenerationLauncher?.readStatus?.('caller_selected_scope'),
@@ -145,7 +301,9 @@ describe('exact asynchronous image session continuation', () => {
   })
 })
 
-function createSummary(sessionId: string | null): AssistantAutomationInputSummary {
+function createSummary(input: {
+  sessionId: string | null
+}): AssistantAutomationInputSummary {
   return {
     actorIsSelf: false,
     attachmentCount: 0,
@@ -153,7 +311,7 @@ function createSummary(sessionId: string | null): AssistantAutomationInputSummar
       accountId: 'identity_1',
       actorId: null,
       actorIsSelf: false,
-      ...(sessionId ? { sessionId } : {}),
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
       source: 'linq',
       threadId: 'thread_1',
       threadIsDirect: true,
@@ -169,4 +327,31 @@ function createSummary(sessionId: string | null): AssistantAutomationInputSummar
     source: 'hosted-mailbox',
     text: 'trusted image completion',
   }
+}
+
+function createGroupRoomSummary(input: {
+  sessionId: string | null
+}): AssistantAutomationInputSummary {
+  const summary = createSummary(input)
+  return {
+    ...summary,
+    conversation: {
+      ...summary.conversation,
+      threadIsDirect: false,
+    },
+    groupRoomBatchingEligible: true,
+    source: 'linq',
+  }
+}
+
+function createCodexTarget(): AssistantModelTarget {
+  const target = createAssistantModelTarget({
+    model: 'gpt-5-codex',
+    provider: 'codex-cli',
+  })
+  if (!target) {
+    throw new Error('Expected assistant model target.')
+  }
+
+  return target
 }

--- a/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
+++ b/packages/assistant-engine/test/assistant-image-continuation-session.test.ts
@@ -1,0 +1,172 @@
+import {
+  createDefaultLocalAssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import type {
+  AssistantSession,
+} from '@murphai/operator-config/assistant-cli-contracts'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  AssistantHostedImageGenerationLauncher,
+} from '../src/assistant/execution-context.js'
+import {
+  conversationRefFromAssistantInputConversation,
+} from '../src/assistant/conversation-ref.js'
+import {
+  createAssistantHostedToolContext,
+} from '../src/assistant/hosted-tool-context.js'
+import {
+  buildResolveAssistantSessionInput,
+} from '../src/assistant/session-resolution.js'
+import type {
+  AssistantMessageInput,
+} from '../src/assistant/service-contracts.js'
+import {
+  shouldGroupAdjacentConversationInput,
+} from '../src/assistant/automation/grouping.js'
+import type {
+  AssistantAutomationInputSummary,
+} from '../src/assistant/automation/input-summary.js'
+
+const ORIGIN_SESSION_ID = `asst_${'a'.repeat(32)}`
+
+describe('exact asynchronous image session continuation', () => {
+  it('keeps a runtime-authored actor separate from the exact session binding', () => {
+    const conversation = conversationRefFromAssistantInputConversation({
+      accountId: 'identity_1',
+      actorId: null,
+      actorIsSelf: false,
+      sessionId: ORIGIN_SESSION_ID,
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+
+    expect(conversation).toMatchObject({
+      channel: 'linq',
+      directness: 'direct',
+      identityId: 'identity_1',
+      sessionId: ORIGIN_SESSION_ID,
+      threadId: 'thread_1',
+    })
+    expect(conversation).not.toHaveProperty('participantId')
+
+    const ordinaryConversation = conversationRefFromAssistantInputConversation({
+      accountId: 'identity_1',
+      actorId: 'actor_1',
+      actorIsSelf: false,
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+    expect(ordinaryConversation.participantId).toBe('actor_1')
+    expect(ordinaryConversation.sessionId).toBeNull()
+
+    const resolution = buildResolveAssistantSessionInput(
+      {
+        conversation,
+        vault: '/unused',
+      },
+      null,
+      createDefaultLocalAssistantModelTarget(),
+    )
+    expect(resolution).toMatchObject({
+      channel: 'linq',
+      identityId: 'identity_1',
+      sessionId: ORIGIN_SESSION_ID,
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    })
+    expect(resolution).not.toHaveProperty('actorId')
+  })
+
+  it('does not coalesce completion inputs from different session owners', () => {
+    const first = createSummary(ORIGIN_SESSION_ID)
+
+    expect(
+      shouldGroupAdjacentConversationInput(first, createSummary(null)),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createSummary(`asst_${'b'.repeat(32)}`),
+      ),
+    ).toBe(false)
+    expect(
+      shouldGroupAdjacentConversationInput(
+        first,
+        createSummary(ORIGIN_SESSION_ID),
+      ),
+    ).toBe(true)
+  })
+
+  it('binds image launches while preserving the launcher status API', () => {
+    const launch = vi.fn<AssistantHostedImageGenerationLauncher['launch']>(
+      () => 'started',
+    )
+    const readStatus = vi.fn<
+      NonNullable<AssistantHostedImageGenerationLauncher['readStatus']>
+    >(() => 'pending')
+    const context = createAssistantHostedToolContext({
+      executionContext: {
+        imageGenerationLauncher: { launch, readStatus },
+        memberId: 'member_1',
+        userEnvKeys: [],
+      },
+      messageInput: {
+        vault: '/unused',
+      } as AssistantMessageInput,
+      session: {
+        sessionId: ORIGIN_SESSION_ID,
+      } as AssistantSession,
+    })
+
+    context.imageGenerationLauncher?.launch({
+      operationId: 'operation_1',
+      originAssistantInputId: `ain_${'1'.repeat(32)}`,
+      originAssistantInputIdExact: true,
+      scopeId: 'caller_selected_scope',
+      run: async () => ({
+        media: null,
+        runtimeIssue: null,
+        savedImageRef: null,
+      }),
+    })
+
+    expect(launch).toHaveBeenCalledOnce()
+    expect(launch).toHaveBeenCalledWith(expect.objectContaining({
+      scopeId: ORIGIN_SESSION_ID,
+    }))
+    expect(
+      context.imageGenerationLauncher?.readStatus?.('caller_selected_scope'),
+    ).toBe('pending')
+    expect(readStatus).toHaveBeenCalledOnce()
+    expect(readStatus).toHaveBeenCalledWith('caller_selected_scope')
+  })
+})
+
+function createSummary(sessionId: string | null): AssistantAutomationInputSummary {
+  return {
+    actorIsSelf: false,
+    attachmentCount: 0,
+    conversation: {
+      accountId: 'identity_1',
+      actorId: null,
+      actorIsSelf: false,
+      ...(sessionId ? { sessionId } : {}),
+      source: 'linq',
+      threadId: 'thread_1',
+      threadIsDirect: true,
+    },
+    deliveryTarget: 'thread_1',
+    groupRoomBatchingEligible: false,
+    inputId: `ain_${'2'.repeat(32)}`,
+    occurredAt: '2026-08-06T17:00:00.000Z',
+    optionalInboxCaptureId: null,
+    projectionReady: true,
+    receivedAt: '2026-08-06T17:00:00.000Z',
+    replyToMessageId: null,
+    source: 'hosted-mailbox',
+    text: 'trusted image completion',
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
@@ -357,6 +357,7 @@ async function stageImageGenerationCompletion(input: {
         ...origin.conversation,
         actorId: null,
         actorIsSelf: false,
+        sessionId: input.completion.scopeId,
       },
       occurredAt: input.completion.completedAt,
       receivedAt: input.completion.completedAt,

--- a/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/image-generation.ts
@@ -16,6 +16,7 @@ import {
 
 interface CompletedImageGeneration {
   completedAt: string;
+  continuationSessionId: string;
   operationId: string;
   originAssistantInputId: string;
   originAssistantInputIdExact: boolean;
@@ -70,6 +71,7 @@ export function createHostedImageGenerationController(input: {
   }>();
   const operations = new Set<string>();
   const activeOperations = new Map<string, {
+    continuationSessionId: string;
     operationId: string;
     originAssistantInputId: string;
     originAssistantInputIdExact: boolean;
@@ -113,6 +115,7 @@ export function createHostedImageGenerationController(input: {
     activeOperations.delete(operationId);
     completed.push({
       completedAt: new Date().toISOString(),
+      continuationSessionId: operation.continuationSessionId,
       operationId,
       originAssistantInputId: operation.originAssistantInputId,
       originAssistantInputIdExact: operation.originAssistantInputIdExact,
@@ -144,6 +147,16 @@ export function createHostedImageGenerationController(input: {
 
   const launcher: AssistantHostedImageGenerationLauncher = {
     launch(request) {
+      const continuationSessionId = request.continuationSessionId?.trim() || null;
+      if (!continuationSessionId) {
+        // The host binds continuation identity. Accepting a missing one would
+        // stage a completion without an exact session and silently reopen
+        // conversation-based resolution, so fail closed before any operation,
+        // pending scope, or start side effect is recorded.
+        throw new TypeError(
+          "Hosted image generation requires a continuation session id.",
+        );
+      }
       if (operations.has(request.operationId)) {
         return "already-started";
       }
@@ -153,6 +166,7 @@ export function createHostedImageGenerationController(input: {
       }
       operations.add(request.operationId);
       activeOperations.set(request.operationId, {
+        continuationSessionId,
         operationId: request.operationId,
         originAssistantInputId: request.originAssistantInputId,
         originAssistantInputIdExact: request.originAssistantInputIdExact,
@@ -357,7 +371,9 @@ async function stageImageGenerationCompletion(input: {
         ...origin.conversation,
         actorId: null,
         actorIsSelf: false,
-        sessionId: input.completion.scopeId,
+        // Continuation identity is host-bound and independent of the pending
+        // image coordination scope.
+        sessionId: input.completion.continuationSessionId,
       },
       occurredAt: input.completion.completedAt,
       receivedAt: input.completion.completedAt,

--- a/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
@@ -278,6 +278,7 @@ describe("hosted image generation", () => {
     assert.deepEqual(completion.conversation, {
       ...origin.conversation,
       actorId: null,
+      sessionId: "session_1",
     });
     assert.deepEqual(completion.replyTarget, origin.replyTarget);
     assert.equal(completion.sourceRef.kind, "hosted-mailbox");
@@ -356,6 +357,11 @@ describe("hosted image generation", () => {
       vault: vaultRoot,
     });
     assert.ok(failureCompletion);
+    assert.deepEqual(failureCompletion.conversation, {
+      ...origin.conversation,
+      actorId: null,
+      sessionId: "session_1",
+    });
     const failureText = failureCompletion.content.text ?? "";
     const failureDiagnosticLine = failureText.split("\n").find((line) =>
       line.startsWith(
@@ -426,6 +432,11 @@ describe("hosted image generation", () => {
       vault: vaultRoot,
     });
     assert.ok(completion);
+    assert.deepEqual(completion.conversation, {
+      ...origin.conversation,
+      actorId: null,
+      sessionId: "session_shutdown",
+    });
     assert.match(
       completion.content.text ?? "",
       /"originAssistantInputIdExact":true/u,

--- a/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-image-generation.test.ts
@@ -42,6 +42,7 @@ describe("hosted image generation", () => {
     }));
 
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_session_1",
       originAssistantInputId: "input_session_1",
       originAssistantInputIdExact: false,
@@ -49,6 +50,7 @@ describe("hosted image generation", () => {
       run,
     }), "started");
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_session_1_followup",
       originAssistantInputId: "input_session_1_followup",
       originAssistantInputIdExact: false,
@@ -56,6 +58,7 @@ describe("hosted image generation", () => {
       run,
     }), "already-pending");
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_2",
       operationId: "image_session_2",
       originAssistantInputId: "input_session_2",
       originAssistantInputIdExact: false,
@@ -67,6 +70,60 @@ describe("hosted image generation", () => {
     assert.equal(run.mock.calls.length, 2);
     assert.equal(controller.launcher.readStatus?.("session_1"), "pending");
     assert.equal(controller.launcher.readStatus?.("session_2"), "pending");
+    await controller.close();
+  });
+
+  test("rejects a launch without an exact continuation session", async () => {
+    const onStarted = vi.fn();
+    const notifyReady = vi.fn();
+    const controller = createHostedImageGenerationController({
+      notifyReady,
+      onStarted,
+      vaultRoot: "/unused",
+      withCanonicalWritePersistence: async (run) => await run(),
+    });
+    const run = vi.fn(async () => ({
+      media: null,
+      runtimeIssue: null,
+      savedImageRef: null,
+    }));
+
+    for (const continuationSessionId of [undefined, null, "   "]) {
+      assert.throws(
+        () =>
+          controller.launcher.launch({
+            continuationSessionId,
+            operationId: "image_unbound",
+            originAssistantInputId: "input_unbound",
+            originAssistantInputIdExact: false,
+            scopeId: "session_unbound",
+            run,
+          }),
+        /continuation session id/u,
+      );
+    }
+
+    // Nothing may be recorded for a rejected launch: no run, no start signal,
+    // no pending scope, and no operation id that would later suppress a
+    // correctly bound retry as "already-started".
+    assert.equal(run.mock.calls.length, 0);
+    assert.equal(onStarted.mock.calls.length, 0);
+    assert.equal(notifyReady.mock.calls.length, 0);
+    assert.equal(controller.launcher.readStatus?.("session_unbound"), null);
+    assert.equal(controller.hasWork(), false);
+    assert.equal(controller.hasCompleted(), false);
+    assert.equal(await controller.stageCompleted(), 0);
+
+    assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
+      operationId: "image_unbound",
+      originAssistantInputId: "input_unbound",
+      originAssistantInputIdExact: false,
+      scopeId: "session_unbound",
+      run,
+    }), "started");
+    assert.equal(onStarted.mock.calls.length, 1);
+    assert.equal(controller.launcher.readStatus?.("session_unbound"), "pending");
     await controller.close();
   });
 
@@ -166,6 +223,10 @@ describe("hosted image generation", () => {
     };
 
     assert.equal(controller.launcher.launch({
+      // The pending scope and the continuation session are separate concerns:
+      // `scopeId` coordinates duplicate prevention, `continuationSessionId`
+      // names the durable session the completion must resume.
+      continuationSessionId: "asst_origin_1",
       operationId: "image_operation_1",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -193,6 +254,7 @@ describe("hosted image generation", () => {
       savedImageRef: null,
     }));
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_operation_1",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -202,6 +264,7 @@ describe("hosted image generation", () => {
     assert.equal(duplicateRun.mock.calls.length, 0);
     assert.equal(onStarted.mock.calls.length, 1);
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_operation_2",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -235,6 +298,7 @@ describe("hosted image generation", () => {
     const completionInputId = await findCompletionInputId(vaultRoot);
     assert.equal(controller.launcher.readStatus?.("session_1"), "queued");
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_operation_2",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -278,7 +342,7 @@ describe("hosted image generation", () => {
     assert.deepEqual(completion.conversation, {
       ...origin.conversation,
       actorId: null,
-      sessionId: "session_1",
+      sessionId: "asst_origin_1",
     });
     assert.deepEqual(completion.replyTarget, origin.replyTarget);
     assert.equal(completion.sourceRef.kind, "hosted-mailbox");
@@ -314,6 +378,7 @@ describe("hosted image generation", () => {
     assert.equal(await controller.stageCompleted(), 0);
 
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_1",
       operationId: "image_operation_2",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -360,7 +425,7 @@ describe("hosted image generation", () => {
     assert.deepEqual(failureCompletion.conversation, {
       ...origin.conversation,
       actorId: null,
-      sessionId: "session_1",
+      sessionId: "asst_origin_1",
     });
     const failureText = failureCompletion.content.text ?? "";
     const failureDiagnosticLine = failureText.split("\n").find((line) =>
@@ -409,6 +474,7 @@ describe("hosted image generation", () => {
     });
 
     assert.equal(controller.launcher.launch({
+      continuationSessionId: "asst_origin_shutdown",
       operationId: "image_operation_shutdown",
       originAssistantInputId: origin.inputId,
       originAssistantInputIdExact: true,
@@ -435,7 +501,7 @@ describe("hosted image generation", () => {
     assert.deepEqual(completion.conversation, {
       ...origin.conversation,
       actorId: null,
-      sessionId: "session_shutdown",
+      sessionId: "asst_origin_shutdown",
     });
     assert.match(
       completion.content.text ?? "",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -18869,6 +18869,7 @@ describe("hosted workspace runtime entrypoint", () => {
                   phaseInput.imageGenerationLauncher ?? null;
                 assert.equal(
                   phaseInput.imageGenerationLauncher?.launch({
+                    continuationSessionId: "asst_image_evidence_retry",
                     operationId: "image_operation_evidence_retry_1",
                     originAssistantInputId: assistantInputId,
                     originAssistantInputIdExact: false,
@@ -18903,6 +18904,7 @@ describe("hosted workspace runtime entrypoint", () => {
                 );
                 assert.equal(
                   phaseInput.imageGenerationLauncher?.launch({
+                    continuationSessionId: "asst_image_evidence_retry",
                     operationId: "image_operation_evidence_retry_2",
                     originAssistantInputId: assistantInputId,
                     originAssistantInputIdExact: false,
@@ -18928,6 +18930,7 @@ describe("hosted workspace runtime entrypoint", () => {
                 );
                 assert.equal(
                   phaseInput.imageGenerationLauncher?.launch({
+                    continuationSessionId: "asst_image_evidence_retry",
                     operationId: "image_operation_evidence_retry_2",
                     originAssistantInputId: assistantInputId,
                     originAssistantInputIdExact: false,
@@ -25315,6 +25318,7 @@ describe("hosted workspace runtime entrypoint", () => {
                 });
               assert.equal(
                 phaseInput.imageGenerationLauncher?.launch({
+                  continuationSessionId: "asst_foreground_shutdown_handoff",
                   operationId: "image_operation_foreground_shutdown_handoff",
                   originAssistantInputId: assistantInputId,
                   originAssistantInputIdExact: true,
@@ -31439,6 +31443,7 @@ describe("hosted runtime shutdown signal", () => {
               retentionWakeAt: synchronousWakeAt,
             });
             assert.equal(input.imageGenerationLauncher?.launch({
+              continuationSessionId: "asst_retention_wake",
               operationId: "image_operation_retention_wake_later",
               originAssistantInputId: originInputId,
               originAssistantInputIdExact: true,
@@ -31451,6 +31456,7 @@ describe("hosted runtime shutdown signal", () => {
                 }),
             }), "started");
             assert.equal(input.imageGenerationLauncher?.launch({
+              continuationSessionId: "asst_retention_wake",
               operationId: "image_operation_retention_wake_earlier",
               originAssistantInputId: originInputId,
               originAssistantInputIdExact: true,
@@ -31605,6 +31611,7 @@ describe("hosted runtime shutdown signal", () => {
             });
             assert.equal(
               phaseInput.imageGenerationLauncher?.launch({
+                continuationSessionId: "asst_image_shutdown_handoff",
                 operationId: "image_operation_shutdown_handoff",
                 originAssistantInputId: originInputId,
                 originAssistantInputIdExact: true,


### PR DESCRIPTION
## Why this PR exists

Hosted image generation already returns through a trusted asynchronous input, but that input drops the assistant-session identity that launched the image and re-resolves continuity from conversation fields. The continuation should resume the exact durable session without adding product-specific instructions to generic image-completion prompts.

## User goal / user-visible behavior

After Murph starts an asynchronous image task, the finished image continues the same assistant session that started it. In the physical-note case, the existing session still knows the loaded skill and recipient-only mail flow, so Murph does not improvise a new return-address question.

## User experience

- Entry: Murph starts image generation through the existing `murph.generate_image` flow and gives the existing progress acknowledgement.
- Continuation: when generation finishes, the trusted completion wakes the exact originating assistant session through the ordinary auto-reply path.
- Intervening messages: a newer input may advance that same session, but cannot redirect the completion to another session or be coalesced with a differently owned continuation.
- Failure/recovery: existing trusted failure completion behavior is unchanged; there is no fallback to the latest or merely matching conversation session.

## Invariants

- The host, not the model or tool arguments, owns the continuation session id, and it is carried as its own `continuationSessionId` rather than overloaded onto the launch scope.
- A launch without an exact continuation session is a programmer error and is rejected before any operation, pending scope, or start side effect is recorded. The controller never normalizes a missing one to null, so a completion can never be staged without an exact session.
- `scopeId` keeps exactly its existing meaning: pending/queued duplicate prevention and cleanup. Nothing in this change reads, rewrites, or repurposes it.
- The completion remains system-authored (`actorId: null`) and does not clear the selected session's participant binding. A differing non-null actor on an explicit session still raises `ASSISTANT_SESSION_ROUTING_CONFLICT` unless the caller opts into `allowBindingRebind`.
- Ordinary inbound messages retain their existing participant attribution and have no exact session locator.
- Inputs owned by different assistant sessions are never batched into one provider turn.
- Saved-image reference, SHA-256, originating accepted input, idempotency, delivery routing, and pending-state cleanup remain unchanged.
- Hosted-image prompt text, physical-note policy, tool schemas, and mail transport remain unchanged.

## Design of the two identities

The launcher port now carries the two concerns separately, so neither can silently stand in for the other:

```ts
export interface AssistantHostedImageGenerationLauncher {
  launch(input: {
    // The durable assistant session that must receive the asynchronous
    // completion. The host binds it; it is never derived from tool arguments
    // and never doubles as the pending-image coordination scope.
    continuationSessionId?: string | null
    operationId: string
    // ...
    // Pending/queued duplicate prevention and cleanup scope. Unrelated to
    // continuation identity.
    scopeId?: string | null
  }): 'already-pending' | 'already-started' | 'started'
  readStatus?(scopeId: string): 'pending' | 'queued' | null
}
```

The controller treats a missing or blank continuation session as fail-closed rather than defaulting it, which is what keeps the exact-session invariant from silently degrading into conversation-based resolution:

```ts
launch(request) {
  const continuationSessionId = request.continuationSessionId?.trim() || null;
  if (!continuationSessionId) {
    throw new TypeError(
      "Hosted image generation requires a continuation session id.",
    );
  }
  // ...operation, pending scope, and onStarted side effects follow
}
```

The port field stays optional so the bound adapter and existing call sites keep their current types, while the controller's active and completed state hold a non-null `continuationSessionId` after validation.

The hosted tool context binds only the continuation identity, through a small adapter that leaves the caller's `scopeId` and `readStatus` (including its absence) untouched:

```ts
function bindAssistantHostedImageGenerationContinuation(input: {
  launcher: AssistantHostedImageGenerationLauncher
  readContinuationSessionId: () => string
}): AssistantHostedImageGenerationLauncher {
  return {
    ...input.launcher,
    launch(request) {
      return input.launcher.launch({
        ...request,
        continuationSessionId: input.readContinuationSessionId(),
      })
    },
  }
}
```

Participant protection lives with the session owner instead of in the shared conversation converter, and it is scoped to the one case that needs it. A runtime-authored completion carries no actor of its own, so only an explicitly null incoming actor is dropped when resuming an exact session without `allowBindingRebind`. A differing non-null actor is a genuine retarget and still fails closed, as do channel, identity, thread, and directness:

```ts
function bindingPatchWithoutIncomingSystemActor(
  patch: AssistantBindingPatch,
): AssistantBindingPatch {
  if (patch.actorId !== null) {
    return patch
  }
  const { actorId: _actorId, ...rest } = patch
  return rest
}
```

The `allowBindingRebind` carve-out is required: `cron/execution.ts` resumes an explicit session target and deliberately retargets its participant.

## Non-obvious affected surfaces

- Assistant input-event compatibility: `sessionId` is optional, so existing v1 records continue to parse; runtime tests cover new persisted completions. The schema object is `.strict()`, so a rollback to a build without this field cannot parse completions staged in the interim (same additive-optional shape as the existing `causalSeq` field).
- Session binding: the shared converter no longer deletes `participantId`, so every consumer of `ConversationRef` keeps a symmetric shape; the exact-session branch of `resolveAssistantSession` is the single owner of the null-actor rule, and no other explicit-session caller loses its existing routing-conflict protection.
- Adjacent input grouping: the existing conversation comparison now includes exact session ownership, including the authenticated group-room fast path, which is the only path that previously ignored the input actor.
- Hosted tool adaptation: the adapter binds continuation identity only, so turns without a user-action scope keep their previous `scopeId: null` launch behavior and take no new pending-scope lock.

## Architecture and reuse

- **Existing systems reused:** The existing assistant session resolver, `ConversationRef.sessionId`, trusted assistant-input store, hosted tool context, image-generation controller, and ordinary auto-reply path remain the only owners.
- **New logic:** One optional exact session locator on runtime-authored input, one optional `continuationSessionId` on the launcher port, and one null-actor binding-patch narrowing inside the exact-session resolve branch.
- **New abstractions:** One local bound adapter over the existing launcher port. No new owner, registry, or lifecycle.
- **Complexity intentionally avoided:** No image-specific session registry, bespoke continuation runner, prompt reconstruction, physical-note instruction, database table, scheduler, transcript replay, compatibility fork, or fallback-to-latest-session path was added.

## Intentional fail-closed decisions

- Exact continuation bypasses age and continuity-fingerprint rotation, because it resumes the already-authorized originating thread rather than selecting a session.
- A missing exact session does not fall back to a merely matching or latest conversation session.
- A completion may run as a separate provider turn in the same durable session rather than mutate an in-flight turn.

## Hot reply path impact

- **Path status:** Not applicable — the change affects asynchronous image launch/completion handling after provider start, not durable acceptance through initial provider start.
- **Database calls:** None added or moved.
- **Network/provider calls:** None added or moved.
- **Other awaited latency:** None; session binding and comparison are synchronous in-memory operations.
- **Before/after proof:** Focused tests cover launch binding, resolution, and batching; runtime tests cover the staged completion path.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- **Assembled instructions:** Unchanged.
- **Tool/schema/generated guidance:** Unchanged; the assistant input-event persistence schema is runtime state, not provider-visible tool schema.
- **Other provider-visible input:** The normalized trusted image completion content is unchanged; only host-side session routing metadata changes.
- **Measurement method:** Not run — no provider-visible prompt, tool, history, or generated-guidance surface changed.

## Design proof

- **Design page:** Not applicable.
- **Coverage:** No frontend or rendered UI changes.
- **Desktop screenshot:** Not applicable.
- **Mobile screenshot:** Not applicable.

## Review gates

- **Product-experience lens:** Applicable. The continuation ownership and no-extra-question journey are the product outcome; focused and runtime tests are the direct evidence.
- **Prompt lens:** Not applicable. No prompt, skill, instruction stack, or tool description changed.
- **Frontend lens:** Not applicable. No user-facing web UI changed.
- **Coverage lens:** Applicable. The patch changes executable runtime behavior and adds direct owner-boundary coverage.

## Change-shape breakdown

Classification rule: `src/**` is source; `test/**` is tests. No binary, generated, docs, configuration, or tooling files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 81 | 2 |
| Tests / fixtures | 441 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **522** | **2** |

## Verification

- Focused engine coverage: exact-session resolution preserving the stored participant against a null system actor, routing-conflict fail-closed on both a differing non-null actor and a thread mismatch, `allowBindingRebind` still rebinding, the exact session locator appearing only on runtime-authored input, host-bound continuation with the caller's scope preserved, and batching isolation in both the direct and authenticated group-room paths.
- Runtime coverage: successful, failed, and graceful-shutdown image completions stage the continuation session, asserted with a `continuationSessionId` deliberately distinct from `scopeId`; a focused regression proves that an unbound launch (`undefined`, `null`, and blank) throws and records no run, no `onStarted`, no `notifyReady`, no pending scope, and no operation id that would later suppress a correctly bound retry.
- Local run on the exact head: `assistant-engine` 11 focused session/binding/grouping files / 99 tests plus 11 broader session-resolution consumer files / 505 tests, `assistant-runtime` `hosted-runtime-image-generation.test.ts` (4 tests) and `hosted-runtime-workspace-entrypoint.test.ts` (270 tests) pass; `typecheck` clean on both owning packages.
- Required GitHub Actions own the broad suite on the exact head.
