### PR TITLE
Honor end-to-end runtime request deadlines

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-06-runtime-request-deadline.md
+++ b/agent-docs/exec-plans/completed/2026-08-06-runtime-request-deadline.md
@@ -1,0 +1,96 @@
+# Propagate Temporal request deadline into hosted runtime command budget
+
+Status: completed
+Created: 2026-08-06
+Updated: 2026-08-06
+
+## Goal
+
+- Ensure a slow hosted-runtime wake returns a typed `retry_later` response before
+  the Temporal activity request deadline instead of leaking into an outer
+  transport timeout that delays the member reply.
+
+## Success criteria
+
+- The existing Temporal request-start timestamp shortens the Cloudflare command
+  budget across route and Durable Object dispatch time.
+- Missing request timing preserves the current local-budget behavior.
+- Future request timing cannot extend Cloudflare's locally configured cap.
+- An already exhausted request returns `retry_later` before runner state or
+  container work begins.
+- Existing per-user write-fence coordination remains the sole concurrency owner.
+- Focused Cloudflare tests and typecheck pass; required PR review and CI are
+  clean on the exact pushed head.
+
+## Scope
+
+- In scope:
+  - Reuse the request timing already carried in runtime orchestration metadata.
+  - Clamp that timing at the UserRunner command-budget boundary.
+  - Add focused regression coverage for elapsed, exhausted, future, fallback,
+    and existing concurrent-wake behavior.
+- Out of scope:
+  - Changing the direct web wake path.
+  - Adding queues, coalescers, state owners, or retry services.
+  - Changing Temporal workflow history or activity retry policy.
+
+## Constraints
+
+- Technical constraints:
+  - Caller metadata may shorten but never extend the Cloudflare deadline.
+  - Preserve the existing one-second response margin and per-step timeout caps.
+  - Preserve behavior for callers that omit Temporal timing metadata.
+- Product/process constraints:
+  - Keep the correction state-free and within existing ownership boundaries.
+  - Do not encode incident-specific member or message details in repository
+    artifacts.
+
+## Risks and mitigations
+
+1. Risk: A future or malformed caller timestamp accidentally extends work.
+   Mitigation: The route already rejects malformed timing; the budget clamps a
+   valid timestamp to the local UserRunner start so it can only shorten work.
+2. Risk: The shorter budget interrupts an accepted runtime start.
+   Mitigation: Apply the deadline only to the existing pre-accept command path;
+   invocation ownership and write-fence cleanup remain unchanged.
+3. Risk: Worker and web deployments become coupled.
+   Mitigation: The change consumes an existing optional field and retains the
+   current fallback, so it is backward compatible and Worker-only.
+
+## Tasks
+
+1. Trace request timing and command-budget ownership end to end.
+2. Propagate the existing request start into the command budget with a local
+   upper clamp and an early exhausted-budget response.
+3. Add focused deadline and concurrency regression coverage.
+4. Run focused tests and Cloudflare typecheck.
+5. Commit, push, open the PR, and run ReviewGPT with CI on the exact head.
+
+## Decisions
+
+- Keep the direct web ensure unchanged because the existing Durable Object
+  write fence already serializes simultaneous wakes and no evidence identifies
+  direct wake contention as the failure.
+- Reuse `temporalActivityRequestStartedAtEpochMs`; do not add protocol fields or
+  persisted state.
+- Keep deadline derivation in `createRuntimeProcessingCommandBudget`, the
+  existing owner of timeout clamping and response margin.
+
+## Verification
+
+- Commands to run:
+  - Focused `apps/cloudflare` Vitest files covering UserRunner budgeting and the
+    signed runtime-control route.
+  - `pnpm --filter @murphai/cloudflare-runner typecheck`.
+  - Required GitHub Actions and ReviewGPT gates on the exact PR head.
+- Expected outcomes:
+  - Elapsed request time reduces every command step's remaining timeout.
+  - Exhausted requests return typed `retry_later` without starting runtime
+    work.
+  - Future timing is clamped and missing timing retains current behavior.
+  - Concurrent fresh ensures still produce a single invocation owner.
+- Results:
+  - Focused Cloudflare tests: 217 passed across the UserRunner and signed route
+    suites.
+  - Cloudflare typecheck: passed.
+Completed: 2026-08-06

--- a/apps/cloudflare/src/user-runner/runtime-command-budget.ts
+++ b/apps/cloudflare/src/user-runner/runtime-command-budget.ts
@@ -12,16 +12,20 @@ export interface RuntimeProcessingCommandBudget {
 
 export function createRuntimeProcessingCommandBudget(input: {
   commandTimeoutMs: number | null;
+  requestStartedAtMs?: number | null;
   startedAtMs: number;
   webControlTimeoutMs: number;
 }): RuntimeProcessingCommandBudget {
-  const effectiveTimeoutMs = Math.min(
-    input.webControlTimeoutMs,
-    input.commandTimeoutMs ?? DEFAULT_HOSTED_RUNTIME_PROCESSING_TIMEOUT_MS,
+  const requestStartedAtMs = Math.min(
+    input.requestStartedAtMs ?? input.startedAtMs,
+    input.startedAtMs,
   );
+  const requestDeadlineAtMs = requestStartedAtMs
+    + (input.commandTimeoutMs ?? DEFAULT_HOSTED_RUNTIME_PROCESSING_TIMEOUT_MS);
+  const localDeadlineAtMs = input.startedAtMs + input.webControlTimeoutMs;
   return {
-    deadlineAtMs:
-      input.startedAtMs + effectiveTimeoutMs - HOSTED_RUNTIME_PROCESSING_COMMAND_RESPONSE_MARGIN_MS,
+    deadlineAtMs: Math.min(requestDeadlineAtMs, localDeadlineAtMs)
+      - HOSTED_RUNTIME_PROCESSING_COMMAND_RESPONSE_MARGIN_MS,
   };
 }
 

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -162,9 +162,17 @@ export class RuntimeProcessingController {
     });
     const commandBudget = createRuntimeProcessingCommandBudget({
       commandTimeoutMs: processingInput.commandTimeoutMs ?? null,
+      requestStartedAtMs:
+        processingInput.orchestration?.temporalActivityRequestStartedAtEpochMs ?? null,
       startedAtMs: runtimeWakeStartedAt,
       webControlTimeoutMs: this.input.env.webControlTimeoutMs,
     });
+    if (!this.hasRuntimeProcessingCommandBudgetRemaining(commandBudget)) {
+      return createRuntimeProcessingRetryLater({
+        reason: "command_budget_exhausted",
+        userId: processingInput.userId,
+      });
+    }
     await this.input.stateStore.bindUser(processingInput.userId);
     const record = await this.input.stateStore.readState();
     if (record.writeFence) {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1419,6 +1419,114 @@ describe("HostedUserRunner execution coordination", () => {
     await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
   });
 
+  it("includes elapsed Temporal request time in the caller command budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const workspaceReadTimeouts: number[] = [];
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => ({ kind: "ready" }));
+    const { invoke, runner } = createRunnerHarness({
+      ensureReadyForProcessing,
+      onWorkspaceRead: (input) => {
+        workspaceReadTimeouts.push(input.timeoutMs);
+      },
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 10_000,
+      orchestration: {
+        temporalActivityRequestStartedAtEpochMs: Date.now() - 7_000,
+      },
+      orchestrationAttemptId: "test-orchestration-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+
+    expect(workspaceReadTimeouts).toEqual([2_000]);
+    expect(mocks.fetchHostedExecutionWebControlPlaneResponse.mock.calls.filter(
+      ([input]) => input.path === HOSTED_RUNTIME_CRYPTO_CONTEXT_PATH,
+    )).toEqual([
+      [expect.objectContaining({ timeoutMs: 2_000 })],
+    ]);
+    expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      timeoutMs: 2_000,
+      userId: TEST_USER_ID,
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+  });
+
+  it("returns retry_later when the Temporal request command budget is already exhausted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const onWorkspaceRead = vi.fn();
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => ({ kind: "ready" }));
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureReadyForProcessing,
+      onWorkspaceRead,
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 10_000,
+      orchestration: {
+        temporalActivityRequestStartedAtEpochMs: Date.now() - 9_000,
+      },
+      orchestrationAttemptId: "test-orchestration-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:10.000Z",
+    });
+
+    expect(onWorkspaceRead).not.toHaveBeenCalled();
+    expect(ensureReadyForProcessing).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
+  });
+
+  it("does not let future Temporal request timing extend the local command budget", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const workspaceReadTimeouts: number[] = [];
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => ({ kind: "ready" }));
+    const { runner } = createRunnerHarness({
+      ensureReadyForProcessing,
+      onWorkspaceRead: (input) => {
+        workspaceReadTimeouts.push(input.timeoutMs);
+      },
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      commandTimeoutMs: 5_000,
+      orchestration: {
+        temporalActivityRequestStartedAtEpochMs: Date.now() + 60_000,
+      },
+      orchestrationAttemptId: "test-orchestration-attempt",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+
+    expect(workspaceReadTimeouts).toEqual([4_000]);
+    expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      timeoutMs: 4_000,
+      userId: TEST_USER_ID,
+    });
+  });
+
   it("does not let caller timeout metadata increase Cloudflare's configured cap", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -1437,6 +1545,9 @@ describe("HostedUserRunner execution coordination", () => {
 
     await expect(runner.ensureRuntimeProcessingForUser({
       commandTimeoutMs: 120_000,
+      orchestration: {
+        temporalActivityRequestStartedAtEpochMs: Date.now() - 7_000,
+      },
       orchestrationAttemptId: "test-orchestration-attempt",
       userId: TEST_USER_ID,
     })).resolves.toMatchObject({
@@ -4316,7 +4427,7 @@ describe("HostedUserRunner execution coordination", () => {
     );
   });
 
-  it("serializes simultaneous fresh ensure calls behind one write fence", async () => {
+  it("serializes simultaneous direct and Temporal ensures behind one write fence", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     const invocationResult = createDeferred<HostedWorkspaceInvocationResult>();
@@ -4335,10 +4446,15 @@ describe("HostedUserRunner execution coordination", () => {
 
     const results = await Promise.all([
       runner.ensureRuntimeProcessingForUser({
+        orchestration: { triggeredByWebDirect: true },
         orchestrationAttemptId: "test-orchestration-attempt-first",
         userId: TEST_USER_ID,
       }),
       runner.ensureRuntimeProcessingForUser({
+        commandTimeoutMs: 10_000,
+        orchestration: {
+          temporalActivityRequestStartedAtEpochMs: Date.now(),
+        },
         orchestrationAttemptId: "test-orchestration-attempt-second",
         userId: TEST_USER_ID,
       }),


### PR DESCRIPTION
## Why this PR exists

A hosted runtime wake could restart its timeout clock after route and Durable
Object dispatch time had already consumed most of Temporal's HTTP deadline.
That turned a recoverable cold-start delay into an outer transport timeout and
slowed the eventual conversation reply.

## User goal / user-visible behavior

When a runtime needs longer than the current wake request allows, the existing
Temporal owner should receive `retry_later` in time to schedule the next attempt.
The conversation can then continue without requiring another inbound message.

## User experience

The entry point remains a durably accepted inbound conversation message. There
is no new UI or acknowledgement. Web may still send its existing best-effort
direct wake, while Temporal remains the canonical retry owner. Cold-start
confirmation keeps its existing eight-second cap; if the remaining request
budget is shorter, Cloudflare returns `retry_later`, Temporal waits until the
returned retry time, and processing resumes without unrelated user action. The
final destination and audience remain the reply in the same conversation.

## Invariants the PR must preserve

- Health-data consent remains fail-closed before runtime processing is admitted.
- The per-user write fence remains the only runtime invocation owner and still
  prevents duplicate starts.
- Request metadata may shorten Cloudflare work but can never extend the local
  timeout cap.
- The existing one-second response margin and per-step timeout caps remain in
  force.
- Missing Temporal timing metadata preserves existing direct-call behavior.

## Non-obvious affected surfaces

- Signed Temporal runtime-control requests: the existing request-start header
  now contributes to the UserRunner deadline. The route and UserRunner suites
  prove parsing, elapsed-budget behavior, and typed exhaustion.
- Direct web wakes: no production path changes; focused simultaneous direct and
  Temporal coverage proves the existing write fence still yields one invocation
  owner.
- Private Temporal workflow behavior: no private code changes; its existing
  activity sends both timing headers and its workflow already schedules
  `retry_later` responses.

## Architecture and reuse

- **Existing systems reused:** The existing signed timing headers,
  `RuntimeProcessingCommandBudget`, typed `retry_later` response, Temporal retry
  loop, and per-user write fence remain the complete flow.
- **New logic:** Derive the command deadline as the earlier of the outer request
  deadline and Cloudflare's local deadline, clamp future request starts to the
  local start, and return early when no response budget remains.
- **New abstractions:** None. The existing command-budget helper was sufficient
  to own deadline arithmetic and response margin.
- **Complexity intentionally avoided:** No new queue, coalescer, persisted state,
  compatibility layer, retry service, or change to the direct wake path.

## Hot reply path impact

Applicable because runtime acceptance precedes provider start. No database,
network, provider, or other awaited calls were added or moved onto the path;
before and after call counts are unchanged. The only production additions are
deadline arithmetic and an early typed response before existing runner state or
container work. Focused tests prove exact remaining step timeouts, exhausted
budget behavior with zero invocation starts, and unchanged single-owner
concurrency.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, model mode, or
  provider-request assembly surface changed.
- Group Murph: Not applicable for the same reason.

## Preliminary specialist lenses

- **Product experience: applicable.** Intended outcome: a delayed cold wake
  retries without requiring a new message. Direct evidence is the signed route
  parsing coverage plus UserRunner elapsed/exhausted-budget and concurrency
  coverage; an end-to-end live-message replay was not run.
- **Prompt: not applicable.** No prompt or instruction surface changed.
- **Frontend: not applicable.** No `apps/web` UI or rendered state changed.
- **Coverage: applicable.** Focused proof: 217 Cloudflare tests passed across
  the signed route and UserRunner suites, and Cloudflare typecheck passed.
  Exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: this changes a product-critical hosted runtime boundary and its timeout,
retry, and concurrency behavior.

ReviewGPT first-reviewed head: f10f540a05ea0a7c5cde8307205a755aa3e3b140

## Change-shape breakdown

Classification uses repository path and authored role; the completed execution
plan is docs, executable runtime files are source, and the Vitest file is tests.
There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 17 | 5 |
| Tests/fixtures | 117 | 1 |
| Docs | 96 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **230** | **6** |

## Design proof

Not applicable; no user-facing frontend UI changed.

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/index.test.ts --no-coverage`
- `pnpm --filter @murphai/cloudflare-runner typecheck`
