### PR TITLE
Shorten health consent copy

### DIFF
--- a/apps/web/src/components/legal/hosted-legal-consent-card.tsx
+++ b/apps/web/src/components/legal/hosted-legal-consent-card.tsx
@@ -689,7 +689,7 @@ function resolveLaunchConsentCopy(variant: HostedLaunchConsentVariant): {
       actionLabel: "Consent",
       assurances: LAUNCH_CONSENT_ASSURANCES,
       description:
-        "Murph uses health data you share to personalize answers and insights. AI providers process relevant data on Murph’s behalf to generate results.",
+        "Murph uses health data you share to personalize answers and insights. AI providers process relevant data on Murph’s behalf.",
       title: "Use your health data",
     };
   }
@@ -698,7 +698,7 @@ function resolveLaunchConsentCopy(variant: HostedLaunchConsentVariant): {
     actionLabel: "Consent",
     assurances: LAUNCH_CONSENT_ASSURANCES,
     description:
-      "Murph uses health data you share to personalize answers and insights. AI providers process relevant data on Murph’s behalf to generate results. You’ll also agree to Murph’s Terms.",
+      "Murph uses health data you share to personalize answers and insights. AI providers process relevant data on Murph’s behalf. You’ll also agree to Murph’s Terms.",
     title: "Use your health data",
   };
 }

--- a/apps/web/test/hosted-legal-consent-card.test.ts
+++ b/apps/web/test/hosted-legal-consent-card.test.ts
@@ -163,7 +163,7 @@ test("launch consent renders one explicit decision without checkboxes", async ()
       "Murph uses health data you share to personalize answers and insights.",
     );
     expect(container.textContent).toContain(
-      "AI providers process relevant data on Murph’s behalf to generate results.",
+      "AI providers process relevant data on Murph’s behalf.",
     );
   });
 


### PR DESCRIPTION
## What changed

- Shortens the hosted launch consent disclosure by removing the redundant “to generate results” phrase.
- Applies the same wording to both launch-consent variants.
- Updates the existing focused UI assertion to match.

## Why

The prompt keeps the material disclosure that relevant data is processed by AI providers on Murph’s behalf, while reducing signup copy.

## Architecture and reuse

- **Existing systems reused:** The existing `resolveLaunchConsentCopy` variants and hosted legal-consent component test remain the single owners of this UI and its coverage.
- **New logic:** No behavior or consent logic changes; only the two existing user-facing strings and their matching assertion change.
- **New abstractions:** No abstraction was added because a dedicated copy layer would add indirection for a three-line edit.
- **Complexity intentionally avoided:** No new component, configuration, state, or consent path was introduced.

## Validation

- Audited the final PR diff: one commit, two modified files, three additions, and three deletions.
- Confirmed both launch-consent variants use the shortened sentence and the old wording is absent from the final diff.
- Updated the focused component assertion.
- Vercel deployment status: passed.
- GitHub Actions did not create runs for this connector-authored draft head; no broader test-suite result is claimed.