### PR TITLE
chore: trigger isolated group-call verification

### DIFF
--- a/.github/group-call-cleanup-merge-trigger
+++ b/.github/group-call-cleanup-merge-trigger
@@ -1,0 +1,1 @@
+temporary scratch-branch trigger; removed by the verification workflow


### PR DESCRIPTION
Temporary scratch-to-scratch PR used only to create a GitHub-authored merge commit on `agent/remove-group-call-preview-clean`, which triggers the branch-scoped guarded cleanup workflow. It does not target `main` and must not be retained after verification.