### PR TITLE
chore: trigger macOS group-call verification

### DIFF
--- a/.github/group-call-cleanup-macos-trigger
+++ b/.github/group-call-cleanup-macos-trigger
@@ -1,0 +1,1 @@
+temporary trigger; removed by the macOS verification workflow


### PR DESCRIPTION
Temporary scratch-to-scratch PR used only to register and trigger the macOS verifier for #1386. It never targets `main` and the trigger/workflow are removed by the verified cleanup commit.