### PR TITLE
chore: trigger isolated macOS group-call verifier

### DIFF
--- a/.github/group-call-cleanup-macos-v2-trigger
+++ b/.github/group-call-cleanup-macos-v2-trigger
@@ -1,0 +1,1 @@
+temporary trigger; removed by the verified cleanup commit


### PR DESCRIPTION
Temporary scratch-to-scratch PR used only to trigger the fresh-concurrency macOS verifier for #1386. It never targets `main`; the trigger and workflow are deleted by the verified cleanup commit.