### PR TITLE
perf(outbox): batch inventory reads

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-06-runner-outbox-inventory-concurrency.md
+++ b/agent-docs/exec-plans/active/2026-08-06-runner-outbox-inventory-concurrency.md
@@ -1,0 +1,77 @@
+# Bound concurrent outbox inventory reads
+
+Status: active
+Created: 2026-08-06
+Updated: 2026-08-06
+
+## Goal
+
+- Remove the sequential per-file I/O chain from the foreground assistant
+  outbox inventory scan.
+- Preserve exact parsing, quarantine, sorting, and delivery behavior.
+
+## Success criteria
+
+- Outbox JSON files are read with a small fixed concurrency bound.
+- Malformed files are still quarantined, missing-file races are still ignored,
+  and returned intents retain deterministic delivery order.
+- A delayed-I/O reproduction proves that the inventory no longer pays one
+  file-latency interval per entry.
+- Focused tests, typechecking, exact-head CI, and required reviews pass.
+
+## Evidence
+
+- The investigated cold start spent 1.026 seconds in the outbox scan, around
+  the 99th percentile.
+- `listAssistantOutboxIntentsLocal` currently awaits every file read and schema
+  parse inside a serial loop.
+- Terminal retention is bounded to 100 entries, but the inventory reader also
+  includes active entries and should not schedule an unbounded number of open
+  files.
+
+## Scope
+
+- In scope:
+  - Add fixed-width concurrent inventory reads in the existing store owner.
+  - Add direct delayed-read proof for the bound and semantic regression tests.
+- Out of scope:
+  - A second index, status-specific directory layout, migration, watcher, or
+    persisted cache.
+  - Outbox schema, delivery, retry, pruning, or retention changes.
+  - Runner JavaScript lazy-loading and snapshot composition.
+
+## Constraints
+
+- Keep `store.ts` as the sole file-inventory owner.
+- Do not add a dependency or long-lived cache/state owner.
+- Do not let one malformed file prevent other inventory reads from completing.
+
+## Tasks
+
+1. Capture a delayed-read baseline and choose the smallest useful bound.
+2. Implement fixed-width inventory batches in `store.ts`.
+3. Prove the concurrency ceiling plus existing order/quarantine behavior.
+4. Run focused package proof, commit, push, and open an isolated PR.
+5. Complete exact-head CI and the ReviewGPT completion gates, then close this
+   plan with `scripts/finish-task`.
+
+## Decisions
+
+- Use fixed batches in the existing loop rather than a general concurrency
+  helper. The outbox inventory is the only demonstrated need, and batching
+  keeps the failure and ordering semantics explicit.
+- Wait for every read in the active batch to settle before surfacing a hard
+  inventory error. This prevents quarantine or read work from escaping the
+  caller after a sibling file fails.
+
+## Verification
+
+- The direct delayed-read regression created 17 valid files, held their reads,
+  observed exactly 16 active operations, then proved the final read began only
+  after the first batch released.
+- Assistant Engine typecheck passed.
+- Focused outbox runtime, outbox threshold, and runtime threshold suites passed:
+  125 tests.
+- Workspace boundary and package-cycle checks passed.
+- Existing malformed-file ordering/quarantine and hard rename-error tests pass
+  through the same focused suites.

--- a/packages/assistant-engine/src/assistant/outbox/store.ts
+++ b/packages/assistant-engine/src/assistant/outbox/store.ts
@@ -29,6 +29,7 @@ import { readAssistantCronCanonicalRuntimeStore } from '../cron/runtime-state.js
 
 const ASSISTANT_TERMINAL_OUTBOX_RETENTION_LIMIT = 100
 const ASSISTANT_TERMINAL_OUTBOX_RETENTION_MS = 14 * 24 * 60 * 60 * 1000
+const ASSISTANT_OUTBOX_INVENTORY_READ_CONCURRENCY = 16
 
 export async function readAssistantOutboxIntent(
   vault: string,
@@ -70,18 +71,31 @@ export async function listAssistantOutboxIntentsLocal(
     withFileTypes: true,
   })
   const intents: AssistantOutboxIntent[] = []
+  const intentPaths = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(paths.outboxDirectory, entry.name))
 
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.json')) {
-      continue
-    }
-
-    const intent = await readAssistantOutboxIntentInventoryEntry(
-      vault,
-      path.join(paths.outboxDirectory, entry.name),
+  for (
+    let offset = 0;
+    offset < intentPaths.length;
+    offset += ASSISTANT_OUTBOX_INVENTORY_READ_CONCURRENCY
+  ) {
+    const batch = intentPaths.slice(
+      offset,
+      offset + ASSISTANT_OUTBOX_INVENTORY_READ_CONCURRENCY,
     )
-    if (intent) {
-      intents.push(intent)
+    const batchResults = await Promise.allSettled(
+      batch.map((intentPath) =>
+        readAssistantOutboxIntentInventoryEntry(vault, intentPath),
+      ),
+    )
+    for (const result of batchResults) {
+      if (result.status === 'rejected') {
+        throw result.reason
+      }
+      if (result.value) {
+        intents.push(result.value)
+      }
     }
   }
 

--- a/packages/assistant-engine/test/assistant-outbox-thresholds.test.ts
+++ b/packages/assistant-engine/test/assistant-outbox-thresholds.test.ts
@@ -1,4 +1,4 @@
-import { rm, writeFile } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -36,6 +36,64 @@ afterEach(async () => {
 })
 
 describe('assistant outbox thresholds', () => {
+  it('bounds concurrent outbox inventory reads without serializing every file', async () => {
+    const initial = await loadOutboxModule()
+    const { paths, vaultRoot } = await createAssistantVault(
+      'assistant-outbox-thresholds-inventory-concurrency-',
+    )
+    const intentCount = 17
+    const seeded = await createIntent(initial.outbox, vaultRoot, {
+      createdAt: '2026-04-08T10:00:00.000Z',
+      message: 'inventory message',
+      sessionId: 'session-inventory',
+      turnId: 'turn-inventory',
+    })
+    await Promise.all(
+      Array.from({ length: intentCount - 1 }, (_, index) =>
+        writeFile(
+          path.join(paths.outboxDirectory, `inventory-copy-${index}.json`),
+          JSON.stringify(seeded),
+          'utf8',
+        ),
+      ),
+    )
+
+    let activeReads = 0
+    let maximumActiveReads = 0
+    let releaseReads = (): void => undefined
+    const readsReleased = new Promise<void>((resolve) => {
+      releaseReads = resolve
+    })
+    const delayedReadFile = vi.fn(
+      async (filePath: string, encoding: BufferEncoding): Promise<string> => {
+        activeReads += 1
+        maximumActiveReads = Math.max(maximumActiveReads, activeReads)
+        await readsReleased
+        try {
+          return await readFile(filePath, encoding)
+        } finally {
+          activeReads -= 1
+        }
+      },
+    )
+    const { outbox } = await loadOutboxModule({
+      readFile: delayedReadFile,
+    })
+
+    const listing = outbox.listAssistantOutboxIntentsLocal(vaultRoot)
+    try {
+      await vi.waitFor(() => {
+        expect(maximumActiveReads).toBe(16)
+      })
+    } finally {
+      releaseReads()
+    }
+
+    await expect(listing).resolves.toHaveLength(intentCount)
+    expect(delayedReadFile).toHaveBeenCalledTimes(intentCount)
+    expect(maximumActiveReads).toBe(16)
+  })
+
   it('skips dispatch when a retryable intent is not due yet', async () => {
     const deliverAssistantMessageOverBinding = vi.fn()
     const { outbox } = await loadOutboxModule({
@@ -1012,6 +1070,7 @@ describe('assistant outbox thresholds', () => {
 
 async function loadOutboxModule(options: {
   deliverAssistantMessageOverBinding?: (...args: never[]) => Promise<unknown>
+  readFile?: (filePath: string, encoding: BufferEncoding) => Promise<string>
   rename?: (...args: never[]) => Promise<unknown>
   saveAssistantSession?: (...args: never[]) => Promise<unknown>
 } = {}) {
@@ -1021,14 +1080,15 @@ async function loadOutboxModule(options: {
       options.deliverAssistantMessageOverBinding ?? vi.fn(),
   }))
 
-  if (options.rename) {
+  if (options.readFile || options.rename) {
     vi.doMock('node:fs/promises', async () => {
       const actual = await vi.importActual<typeof import('node:fs/promises')>(
         'node:fs/promises',
       )
       return {
         ...actual,
-        rename: options.rename,
+        ...(options.readFile ? { readFile: options.readFile } : {}),
+        ...(options.rename ? { rename: options.rename } : {}),
       }
     })
   }


### PR DESCRIPTION
## Why

The investigated hosted cold start spent 1.026 seconds scanning the assistant outbox, around the 99th percentile. The inventory owner opened, read, parsed, and awaited every JSON file serially, so restored-filesystem latency accumulated once per retained intent.

## User-visible goal

Reduce foreground startup latency before an assistant reply without changing any delivery, retry, quarantine, ordering, or retention behavior. This change removes the serial I/O chain; it does not claim to eliminate the required durable inventory.

## Invariants

- Every outbox JSON file is still parsed through the same schema and malformed files are still quarantined.
- Missing-file races remain ignored and hard filesystem failures still fail closed.
- Returned intents retain the same deterministic timestamp and delivery-sequence order.
- Delivery, retry, dedupe, pruning, retention, and mailbox ownership remain unchanged.
- No concurrent read work escapes after a sibling read fails.

## Architecture and reuse

- Existing systems reused: `store.ts` remains the only outbox file-inventory owner, the existing read/quarantine function processes each path, and the existing sorter establishes delivery order.
- New logic: the existing inventory loop reads fixed batches of at most 16 files and waits for the complete batch to settle before continuing or surfacing a hard error.
- New abstractions: none; the concurrency bound and batch loop stay local to the demonstrated owner.
- Complexity intentionally avoided: no persisted index, status directories, migration, cache, watcher, dependency, queue, or new state owner was added.

## Evidence

The direct delayed-I/O regression creates 17 valid outbox files, holds all reads, observes exactly 16 active reads, releases them, and proves the 17th file is read in the next batch. The previous implementation could have only one active read.

For an inventory of 100 retained entries, this changes the I/O dependency depth from 100 serial read intervals to seven bounded waves. Actual hosted savings will depend on restored-filesystem latency and are not inferred from local disk speed.

## Hot reply path

The foreground inventory still reads the same files and returns the same result. Independent reads now overlap; no new network request, provider input, or additional phase is added.

## Murph initial provider input

Not changed. Prompts, tool descriptions, schemas, provider options, and context content are untouched.

## Non-obvious surfaces

- `Promise.allSettled` is intentional: it drains every started read/quarantine operation before returning a hard sibling failure.
- Normal malformed-file quarantine resolves to `null`, so other valid files in the batch remain available exactly as before.
- Fixed batches bound open-file pressure even when active intents temporarily exceed the terminal retention limit.

## Verification

- Assistant Engine typecheck
- Focused outbox runtime, outbox threshold, and runtime threshold suites: 125 tests passed
- Direct 17-file delayed-read concurrency regression
- Existing malformed-file quarantine, deterministic ordering, missing-file race, and hard rename-error coverage
- Workspace-boundary and package-cycle verification

Broad exact-head verification remains owned by required GitHub Actions.

## Review lenses

- Product experience: applicable only to reply latency; delivery behavior is unchanged.
- Prompt behavior: not applicable.
- Frontend: not applicable.
- Coverage: applicable; the concurrency ceiling and existing inventory failure semantics have direct proof.

ReviewGPT context sensitivity: sensitive

ReviewGPT first-reviewed head: a90a4767687d16b7c045f795445640c761265ce2

## Change shape

| Area | Added | Deleted |
| --- | ---: | ---: |
| Source | 24 | 10 |
| Tests | 63 | 3 |
| Docs | 77 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
