### PR TITLE
chore: trigger corrected group-call verification

### DIFF
--- a/.github/group-call-cleanup-verifier-v2-trigger
+++ b/.github/group-call-cleanup-verifier-v2-trigger
@@ -1,0 +1,1 @@
+temporary scratch-branch trigger; removed by the verified cleanup commit


### PR DESCRIPTION
Temporary scratch-to-scratch PR used only to create a GitHub-authored push on `agent/remove-group-call-preview-clean`. That push runs the corrected guarded verifier, which applies the product changes, runs focused tests and typecheck, restores the original workflow, and deletes all temporary files. This never targets `main` or PR #1386 directly.