### PR TITLE
Route automations by model cost

### DIFF
--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/automation.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/automation.ts
@@ -1,7 +1,6 @@
 import * as z from '@murphai/contracts/zod-runtime'
 
 import {
-  automationAssistantTargetOverrideSchema,
   automationActiveUntilSchema,
   automationContinuityPolicyValues,
   automationScheduleCronSchema,
@@ -9,6 +8,10 @@ import {
   automationStatusValues,
   automationSupportKindValues,
 } from '@murphai/contracts'
+import {
+  HOSTED_ASSISTANT_PRODUCT_MODELS,
+  HOSTED_ASSISTANT_REASONING_EFFORTS,
+} from '@murphai/hosted-execution/assistant-model'
 import type {
   AssistantHostedAutomationTool,
   AssistantHostedAutomationToolRequest,
@@ -61,10 +64,41 @@ const automationTagsSchema = z
     }
   })
 
+const hostedAutomationAssistantTargetOverrideSchema = z
+  .object({
+    model: z
+      .enum(HOSTED_ASSISTANT_PRODUCT_MODELS)
+      .optional()
+      .describe(
+        'Optional model for this automation turn only. Use Luna for self-contained cues and reminders with no reads or tools, Terra for bounded contextual judgment or a few targeted reads, and inherit the conversation model for broad context, research, complex or sensitive reasoning, or whenever that selected model materially matters.',
+      ),
+    reasoningEffort: z
+      .enum(HOSTED_ASSISTANT_REASONING_EFFORTS)
+      .optional()
+      .describe(
+        'Optional reasoning effort for this automation turn only. When omitted with an explicit model, Murph uses high for Luna and low for Terra or Sol at execution. A reasoning-only override keeps the conversation model.',
+      ),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.model === undefined && value.reasoningEffort === undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Target override must select a model, reasoning effort, or both.',
+        path: [],
+      })
+    }
+  })
+  .describe(
+    'Turn-scoped automation model and reasoning selection. It never changes the conversation default; later replies return to the saved conversation model with this automation message retained in shared history.',
+  )
+
 const saveAutomationArgumentsSchema = z.object({
   action: z.literal('save'),
   activeUntil: automationActiveUntilSchema.nullable().optional(),
-  assistantTargetOverride: automationAssistantTargetOverrideSchema.nullable().optional(),
+  assistantTargetOverride: hostedAutomationAssistantTargetOverrideSchema
+    .nullable()
+    .optional(),
   automationId: automationIdentifierSchema.optional(),
   continuityPolicy: z.enum(automationContinuityPolicyValues).optional(),
   instructions: automationInstructionsSchema,
@@ -85,7 +119,9 @@ const saveOnboardingFirstPersonalReadArgumentsSchema = z.object({
 const patchAutomationArgumentsSchema = z.object({
   action: z.literal('patch'),
   activeUntil: automationActiveUntilSchema.nullable().optional(),
-  assistantTargetOverride: automationAssistantTargetOverrideSchema.nullable().optional(),
+  assistantTargetOverride: hostedAutomationAssistantTargetOverrideSchema
+    .nullable()
+    .optional(),
   continuityPolicy: z.enum(automationContinuityPolicyValues).optional(),
   instructions: automationInstructionsSchema.optional(),
   lookup: automationIdentifierSchema,
@@ -199,7 +235,7 @@ export const MURPH_AUTOMATION_TOOL = {
   name: 'automation',
   deferLoading: true,
   description:
-    'Create, update, or reconcile durable Murph automations for the current authenticated conversation. save_onboarding_first_personal_read creates the fixed code-owned private first-read one-shot for the answered-onboarding completion turn; it accepts no prompt, timing, model, route, or other fields. Generic save cannot replace it, the fixed slug is reserved, and generic patch may only archive the existing record when the member cancels. save_newsletter creates or replaces this group\'s one health newsletter from structured name, cron schedule, delivery, tone, and health scopes; use it for both current-chat and group-email delivery instead of authoring newsletter instructions. save binds an ordinary automation to this conversation and accepts no route fields. patch preserves the stored route unless retargetToCurrentConversation=true is explicit. reconcile archives members of one supportSeriesId that are absent from desiredAutomationIds. Use patch status to pause, reactivate, or archive. Never pass credentials, delivery targets, filesystem paths, reserved system tags, or generic commands.',
+    'Create, update, or reconcile durable Murph automations for the current authenticated conversation. For ordinary save or patch, choose assistantTargetOverride deliberately: use Luna for self-contained cues and reminders with all needed context in the instructions and no reads or tools; use Terra for bounded contextual judgment or a few targeted reads; inherit the conversation-selected model for broad conversation history, research, complex or sensitive reasoning, or whenever that model materially matters. On save, omit assistantTargetOverride to inherit. On patch, assistantTargetOverride replaces the whole stored override: omit the field only to preserve it, use null to return to conversation inheritance, or send the complete replacement. Explicit model selections use high reasoning for Luna and low for Terra or Sol at execution unless reasoningEffort is supplied. The override applies only to the automation turn; a later reply returns to the saved conversation model with the automation message retained through compatible provider-thread continuity or committed history replay. save_onboarding_first_personal_read creates the fixed code-owned private first-read one-shot for the answered-onboarding completion turn; it accepts no prompt, timing, model, route, or other fields. Generic save cannot replace it, the fixed slug is reserved, and generic patch may only archive the existing record when the member cancels. save_newsletter creates or replaces this group\'s one health newsletter from structured name, cron schedule, delivery, tone, and health scopes; use it for both current-chat and group-email delivery instead of authoring newsletter instructions. save binds an ordinary automation to this conversation and accepts no route fields. patch preserves the stored route unless retargetToCurrentConversation=true is explicit. reconcile archives members of one supportSeriesId that are absent from desiredAutomationIds. Use patch status to pause, reactivate, or archive. Never pass credentials, delivery targets, filesystem paths, reserved system tags, model-provider ids, or generic commands.',
   inputSchema: z.toJSONSchema(automationArgumentsSchema, { io: 'input' }),
 } as const
 

--- a/packages/assistant-engine/src/assistant/automation/target-override.ts
+++ b/packages/assistant-engine/src/assistant/automation/target-override.ts
@@ -2,11 +2,37 @@ import {
   automationAssistantTargetOverrideSchema,
   type AutomationAssistantTargetOverride,
 } from '@murphai/contracts'
-import type {
-  AssistantProviderConfigInput,
+import {
+  HOSTED_ASSISTANT_LUNA_MODEL,
+  HOSTED_ASSISTANT_SOL_MODEL,
+  HOSTED_ASSISTANT_TERRA_MODEL,
+  isHostedAssistantProductModel,
+  type HostedAssistantProductModel,
+  type HostedAssistantReasoningEffort,
+} from '@murphai/hosted-execution/assistant-model'
+import {
+  assistantBackendTargetToProviderConfigInput,
+  type AssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import {
+  compactAssistantProviderConfigInput,
+  type AssistantProviderConfigInput,
 } from '@murphai/operator-config/assistant/provider-config'
+import {
+  assistantCodexModelProviderRequiresModelThreadCompatibility,
+  resolveAssistantRuntimeTarget,
+} from '@murphai/operator-config/assistant/target-runtime'
 
 import { normalizeNullableString } from '../shared.js'
+
+const AUTOMATION_DEFAULT_REASONING_BY_HOSTED_PRODUCT_MODEL = {
+  [HOSTED_ASSISTANT_LUNA_MODEL]: 'high',
+  [HOSTED_ASSISTANT_TERRA_MODEL]: 'low',
+  [HOSTED_ASSISTANT_SOL_MODEL]: 'low',
+} as const satisfies Record<
+  HostedAssistantProductModel,
+  HostedAssistantReasoningEffort
+>
 
 export function compactAutomationAssistantTargetOverride(
   input: AutomationAssistantTargetOverride | null | undefined,
@@ -29,10 +55,29 @@ export function compactAutomationAssistantTargetOverride(
     : null
 }
 
+function resolveAutomationAssistantTargetOverrideDefaults(
+  input: AutomationAssistantTargetOverride | null | undefined,
+): AutomationAssistantTargetOverride | null {
+  const target = compactAutomationAssistantTargetOverride(input)
+  if (
+    !target?.model ||
+    target.reasoningEffort ||
+    !isHostedAssistantProductModel(target.model)
+  ) {
+    return target
+  }
+
+  return {
+    ...target,
+    reasoningEffort:
+      AUTOMATION_DEFAULT_REASONING_BY_HOSTED_PRODUCT_MODEL[target.model],
+  }
+}
+
 export function automationAssistantTargetOverrideToProviderConfigInput(
   input: AutomationAssistantTargetOverride | null | undefined,
 ): AssistantProviderConfigInput | null {
-  const target = compactAutomationAssistantTargetOverride(input)
+  const target = resolveAutomationAssistantTargetOverrideDefaults(input)
   if (!target) {
     return null
   }
@@ -42,4 +87,62 @@ export function automationAssistantTargetOverrideToProviderConfigInput(
     ...(target.modelProvider ? { modelProvider: target.modelProvider } : {}),
     ...(target.reasoningEffort ? { reasoningEffort: target.reasoningEffort } : {}),
   }
+}
+
+/**
+ * Resolve a persisted turn override against the model provider that will
+ * actually execute it. Hosted product model names are managed-inference
+ * preferences, not portable model ids for endpoints whose thread identity
+ * depends on the exact model. Explicit provider transitions and arbitrary
+ * custom model ids remain available to canonical CLI/internal authors.
+ */
+export function resolveAutomationAssistantTargetOverrideForTarget(
+  input: AutomationAssistantTargetOverride | null | undefined,
+  baseTarget: AssistantModelTarget | null | undefined,
+): AssistantProviderConfigInput | null {
+  const override = automationAssistantTargetOverrideToProviderConfigInput(input)
+  if (!override) {
+    return null
+  }
+
+  const baseConfig = baseTarget
+    ? assistantBackendTargetToProviderConfigInput(baseTarget)
+    : null
+  const explicitModelProvider = normalizeNullableString(override.modelProvider)
+  const effectiveModelProvider =
+    explicitModelProvider ?? normalizeNullableString(baseConfig?.modelProvider)
+  if (!effectiveModelProvider) {
+    return override
+  }
+
+  const runtimeTarget = resolveAssistantRuntimeTarget({
+    modelProvider: effectiveModelProvider,
+    provider: 'codex-cli',
+  })
+  const inheritedModelSpecificProvider =
+    explicitModelProvider === null &&
+    assistantCodexModelProviderRequiresModelThreadCompatibility(
+      effectiveModelProvider,
+    )
+  if (
+    !inheritedModelSpecificProvider &&
+    runtimeTarget.supportsReasoningEffort
+  ) {
+    return override
+  }
+
+  const suppressProductModel =
+    inheritedModelSpecificProvider &&
+    Boolean(override.model) &&
+    isHostedAssistantProductModel(override.model)
+  const model = suppressProductModel ? null : override.model ?? null
+  const reasoningEffort = runtimeTarget.supportsReasoningEffort
+    ? override.reasoningEffort ?? null
+    : null
+
+  return compactAssistantProviderConfigInput({
+    ...(model ? { model } : {}),
+    ...(explicitModelProvider ? { modelProvider: explicitModelProvider } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  })
 }

--- a/packages/assistant-engine/src/assistant/service-turn-routes.ts
+++ b/packages/assistant-engine/src/assistant/service-turn-routes.ts
@@ -1,5 +1,5 @@
-import {
-  type AssistantModelTarget,
+import type {
+  AssistantModelTarget,
 } from '@murphai/operator-config/assistant-backend'
 import type { AssistantOperatorDefaults } from '@murphai/operator-config/operator-config'
 import type { CodexThreadIdentity } from './codex-thread-route.js'
@@ -20,7 +20,7 @@ import {
 } from './store.js'
 import { resolveAssistantExecutionPlan } from './execution-plan.js'
 import {
-  automationAssistantTargetOverrideToProviderConfigInput,
+  resolveAutomationAssistantTargetOverrideForTarget,
 } from './automation/target-override.js'
 
 export function resolveAssistantTurnRoute(
@@ -30,7 +30,10 @@ export function resolveAssistantTurnRoute(
 ): CodexThreadIdentity {
   return resolveAssistantExecutionPlan({
     defaults,
-    override: resolveAssistantTurnRouteOverride(input),
+    override: resolveAssistantTurnRouteOverride(
+      input,
+      resolved.session.target,
+    ),
     sessionTarget: resolved.session.target,
   }).codexRoute
 }
@@ -58,24 +61,48 @@ export async function resolveAssistantTurnRouteForMessage(
     }
 
     return resolveAssistantExecutionPlan({
-      boundaryDefaultTarget,
-      defaults,
-      override: resolveAssistantTurnRouteOverride(input),
+      defaults: null,
+      override: resolveAutomationAssistantTargetOverrideForTarget(
+        input.assistantTargetOverride,
+        sessionInput.target,
+      ),
+      sessionTarget: sessionInput.target,
     }).codexRoute
   }
 }
 
 function resolveAssistantTurnRouteOverride(
   input: AssistantMessageInput,
+  baseTarget: AssistantModelTarget | null,
 ): AssistantProviderConfigInput | null {
   const messageOverride = compactAssistantProviderConfigInput(input)
+  const automationBaseTarget = applyAssistantProviderConfigOverrideToTarget(
+    baseTarget,
+    messageOverride,
+  )
   const automationOverride =
-    automationAssistantTargetOverrideToProviderConfigInput(
+    resolveAutomationAssistantTargetOverrideForTarget(
       input.assistantTargetOverride,
+      automationBaseTarget,
     )
 
   return compactAssistantProviderConfigInput({
     ...(messageOverride ?? {}),
     ...(automationOverride ?? {}),
   })
+}
+
+function applyAssistantProviderConfigOverrideToTarget(
+  baseTarget: AssistantModelTarget | null,
+  override: AssistantProviderConfigInput | null,
+): AssistantModelTarget | null {
+  if (!override) {
+    return baseTarget
+  }
+
+  return resolveAssistantExecutionPlan({
+    defaults: null,
+    override,
+    sessionTarget: baseTarget,
+  }).primaryTarget
 }

--- a/packages/assistant-engine/src/assistant/turn-finalizer.ts
+++ b/packages/assistant-engine/src/assistant/turn-finalizer.ts
@@ -13,8 +13,12 @@ import {
 import { buildCodexResumeState } from '@murphai/operator-config/assistant/codex-resume-state'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import {
+  doesAssistantResumeBindingMatchRoute,
+} from './codex-resume-binding.js'
+import {
   readAssistantCodexResume,
 } from './conversation-persistence.js'
+import { resolveAssistantExecutionPlan } from './execution-plan.js'
 import { createAssistantRuntimeStateService } from './runtime-state-service.js'
 import {
   buildAssistantProviderTranscriptAuditEntries,
@@ -342,6 +346,10 @@ export async function persistAssistantTurnAndSession(input: {
     turnId: input.turnId,
     vault: input.input.vault,
   })
+  const turnCommittedConversationHistory =
+    persistUserPromptToTranscript ||
+    assistantTranscriptEntries.length > 0 ||
+    noReplyMarkerDeliveryContextOrdinals.length > 0
 
   const updatedAt = new Date().toISOString()
   const hasTurnScopedTargetOverride =
@@ -368,19 +376,23 @@ export async function persistAssistantTurnAndSession(input: {
         assistantBackendTargetToProviderConfigInput(nextTarget),
       )
     : input.session.providerOptions
-  const nextResumeState =
-    hasTurnScopedTargetOverride
-      ? null
-      : resolveAssistantNextResumeState({
-          action: input.providerResumeStateAction,
-          assistantContractFingerprint: input.providerResult.assistantContractFingerprint,
-          codexRolloutRelativePath: input.providerResult.codexRolloutRelativePath,
-          codexThreadId: input.providerResult.codexThreadId,
-          routeFingerprint: readCodexThreadRouteFingerprint(input.providerResult.route),
-          threadCompatibilityFingerprint:
-            readCodexThreadCompatibilityFingerprint(input.providerResult.route),
-          sessionResumeState: readAssistantCodexResume(input.session),
-        })
+  const resumeStateInput: AssistantNextResumeStateInput = {
+    action: input.providerResumeStateAction,
+    assistantContractFingerprint: input.providerResult.assistantContractFingerprint,
+    codexRolloutRelativePath: input.providerResult.codexRolloutRelativePath,
+    codexThreadId: input.providerResult.codexThreadId,
+    routeFingerprint: readCodexThreadRouteFingerprint(input.providerResult.route),
+    threadCompatibilityFingerprint:
+      readCodexThreadCompatibilityFingerprint(input.providerResult.route),
+    sessionResumeState: readAssistantCodexResume(input.session),
+  }
+  const nextResumeState = hasTurnScopedTargetOverride
+    ? resolveAssistantTurnScopedOverrideResumeState({
+        ...resumeStateInput,
+        durableTarget: nextTarget,
+        turnCommittedConversationHistory,
+      })
+    : resolveAssistantNextResumeState(resumeStateInput)
 
   const savedSession = await state.sessions.save({
     ...input.session,
@@ -398,7 +410,7 @@ export async function persistAssistantTurnAndSession(input: {
   return savedSession
 }
 
-function resolveAssistantNextResumeState(input: {
+type AssistantNextResumeStateInput = {
   action: AssistantProviderResumeStateAction
   assistantContractFingerprint?: string | null
   codexRolloutRelativePath?: string | null
@@ -406,7 +418,41 @@ function resolveAssistantNextResumeState(input: {
   routeFingerprint: string
   threadCompatibilityFingerprint?: string | null
   sessionResumeState: AssistantSession['resumeState']
-}): AssistantSession['resumeState'] {
+}
+
+function resolveAssistantTurnScopedOverrideResumeState(
+  input: AssistantNextResumeStateInput & {
+    durableTarget: AssistantSession['target']
+    turnCommittedConversationHistory: boolean
+  },
+): AssistantSession['resumeState'] {
+  if (!input.turnCommittedConversationHistory) {
+    return input.sessionResumeState
+  }
+  if (input.action !== 'persist-from-provider-turn') {
+    return null
+  }
+
+  const candidate = resolveAssistantNextResumeState(input)
+  if (!candidate) {
+    return null
+  }
+
+  const durableRoute = resolveAssistantExecutionPlan({
+    defaults: null,
+    sessionTarget: input.durableTarget,
+  }).codexRoute
+  return doesAssistantResumeBindingMatchRoute({
+    resumeState: candidate,
+    route: durableRoute,
+  })
+    ? candidate
+    : null
+}
+
+function resolveAssistantNextResumeState(
+  input: AssistantNextResumeStateInput,
+): AssistantSession['resumeState'] {
   switch (input.action) {
     case 'clear':
       return null

--- a/packages/assistant-engine/test/assistant-automation-fresh-session-routing.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-fresh-session-routing.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createAssistantModelTarget,
+  type AssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import type {
+  AssistantOperatorDefaults,
+} from '@murphai/operator-config/operator-config'
+import {
+  HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+  VENICE_CODEX_MODEL_PROVIDER_ID,
+} from '@murphai/operator-config/assistant/target-runtime'
+
+const assistantStore = vi.hoisted(() => ({
+  resolveAssistantSession: vi.fn(),
+}))
+
+vi.mock('../src/assistant/store.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../src/assistant/store.js')
+  >()
+  return {
+    ...actual,
+    resolveAssistantSession: assistantStore.resolveAssistantSession,
+  }
+})
+
+import {
+  resolveAutomationAssistantTargetOverrideForTarget,
+} from '../src/assistant/automation/target-override.ts'
+import {
+  resolveAssistantTurnRouteForMessage,
+} from '../src/assistant/service-turn-routes.ts'
+
+type AssistantRouteInput = Parameters<
+  typeof resolveAssistantTurnRouteForMessage
+>[0]
+
+beforeEach(() => {
+  assistantStore.resolveAssistantSession.mockReset()
+})
+
+describe('fresh automation model routing', () => {
+  it('filters a model-only preference against a custom-inference boundary target', async () => {
+    assistantStore.resolveAssistantSession.mockRejectedValueOnce({
+      code: 'ASSISTANT_SESSION_NOT_FOUND',
+    })
+
+    const route = await resolveAssistantTurnRouteForMessage(
+      createAutomationInput({ model: 'gpt-5.6-luna' }),
+      null,
+      requireTarget(
+        'glm-5.2',
+        'low',
+        HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+      ),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'glm-5.2',
+      modelProvider: HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+      reasoningEffort: 'low',
+    })
+  })
+
+  it('evaluates the preference after a fresh provider transition', async () => {
+    assistantStore.resolveAssistantSession.mockRejectedValueOnce({
+      code: 'ASSISTANT_SESSION_NOT_FOUND',
+    })
+
+    const route = await resolveAssistantTurnRouteForMessage(
+      {
+        ...createAutomationInput({ model: 'gpt-5.6-luna' }),
+        model: 'gpt-5.6-sol',
+        modelProvider: 'vercel-ai-gateway',
+        reasoningEffort: 'low',
+      },
+      null,
+      requireTarget(
+        'glm-5.2',
+        'low',
+        HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+      ),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'gpt-5.6-luna',
+      modelProvider: 'vercel-ai-gateway',
+      reasoningEffort: 'high',
+    })
+  })
+
+  it('keeps the resolved execution policy when no session exists', async () => {
+    assistantStore.resolveAssistantSession.mockRejectedValueOnce({
+      code: 'ASSISTANT_SESSION_NOT_FOUND',
+    })
+    const backend = createAssistantModelTarget({
+      approvalPolicy: 'never',
+      codexCommand: '/opt/murph-codex',
+      model: 'gpt-5.6-sol',
+      modelProvider: 'vercel-ai-gateway',
+      profile: 'scheduled-policy',
+      provider: 'codex-cli',
+      reasoningEffort: 'low',
+      sandbox: 'read-only',
+    })
+    if (!backend) {
+      throw new TypeError('Expected operator defaults target.')
+    }
+
+    const route = await resolveAssistantTurnRouteForMessage(
+      createAutomationInput({ model: 'gpt-5.6-luna' }),
+      {
+        backend,
+        identityId: null,
+        selfDeliveryTargets: null,
+      } as AssistantOperatorDefaults,
+    )
+
+    expect(route.codexCommand).toBe('/opt/murph-codex')
+    expect(route.providerOptions).toMatchObject({
+      approvalPolicy: 'never',
+      model: 'gpt-5.6-luna',
+      modelProvider: 'vercel-ai-gateway',
+      profile: 'scheduled-policy',
+      reasoningEffort: 'high',
+      sandbox: 'read-only',
+    })
+  })
+})
+
+describe('automation provider routing', () => {
+  it('keeps canonical product models for Venice egress translation', () => {
+    expect(
+      resolveAutomationAssistantTargetOverrideForTarget(
+        { model: 'gpt-5.6-luna' },
+        requireTarget(
+          'gpt-5.6-terra',
+          'low',
+          VENICE_CODEX_MODEL_PROVIDER_ID,
+        ),
+      ),
+    ).toEqual({
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'high',
+    })
+  })
+})
+
+function createAutomationInput(
+  assistantTargetOverride: NonNullable<
+    AssistantRouteInput['assistantTargetOverride']
+  >,
+): AssistantRouteInput {
+  return {
+    assistantTargetOverride,
+    prompt: 'Send the scheduled reminder.',
+    turnTrigger: 'automation-cron',
+    vault: '/vault',
+  }
+}
+
+function requireTarget(
+  model: string,
+  reasoningEffort: string,
+  modelProvider = 'vercel-ai-gateway',
+): AssistantModelTarget {
+  const target = createAssistantModelTarget({
+    model,
+    modelProvider,
+    provider: 'codex-cli',
+    reasoningEffort,
+  })
+  if (!target) {
+    throw new TypeError(`Expected a target for ${model}.`)
+  }
+  return target
+}

--- a/packages/assistant-engine/test/assistant-automation-model-continuity.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-model-continuity.test.ts
@@ -1,0 +1,461 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createAssistantModelTarget,
+  type AssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import {
+  parseAssistantSessionRecord,
+  type AssistantSession,
+} from '@murphai/operator-config/assistant-cli-contracts'
+import {
+  buildCodexResumeState,
+} from '@murphai/operator-config/assistant/codex-resume-state'
+import {
+  HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+} from '@murphai/operator-config/assistant/target-runtime'
+import type {
+  AssistantTurnSharedPlan,
+  ExecutedAssistantProviderTurnResult,
+} from '../src/assistant/service-contracts.ts'
+
+const runtimeState = vi.hoisted(() => ({
+  sessionsSave: vi.fn(async (session: AssistantSession) => session),
+  transcriptsAppend: vi.fn(async () => undefined),
+  transcriptsList: vi.fn(async () => []),
+  turnsAppendEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('../src/assistant/runtime-state-service.js', () => ({
+  createAssistantRuntimeStateService: () => ({
+    sessions: {
+      save: runtimeState.sessionsSave,
+    },
+    transcripts: {
+      append: runtimeState.transcriptsAppend,
+      list: runtimeState.transcriptsList,
+    },
+    turns: {
+      appendEvent: runtimeState.turnsAppendEvent,
+    },
+  }),
+}))
+
+import { createAssistantBinding } from '../src/assistant/bindings.ts'
+import {
+  resolveAssistantRouteResumeBinding,
+} from '../src/assistant/codex-resume-binding.ts'
+import {
+  readCodexThreadCompatibilityFingerprint,
+  readCodexThreadRouteFingerprint,
+  type CodexThreadIdentity,
+} from '../src/assistant/codex-thread-route.ts'
+import { resolveAssistantExecutionPlan } from '../src/assistant/execution-plan.ts'
+import { resolveAssistantTurnRoute } from '../src/assistant/service-turn-routes.ts'
+import {
+  persistAssistantTurnAndSession,
+  type AssistantProviderResumeStateAction,
+} from '../src/assistant/turn-finalizer.ts'
+
+beforeEach(() => {
+  runtimeState.sessionsSave.mockClear()
+  runtimeState.transcriptsAppend.mockClear()
+  runtimeState.transcriptsList.mockClear()
+  runtimeState.turnsAppendEvent.mockClear()
+})
+
+describe('automation model continuity', () => {
+  it.each([
+    ['gpt-5.6-luna', 'high'],
+    ['gpt-5.6-terra', 'low'],
+    ['gpt-5.6-sol', 'low'],
+  ] as const)(
+    'applies the canonical %s reasoning default to model-only stored overrides',
+    (model, reasoningEffort) => {
+      const selectedTarget = requireTarget('gpt-5.6-sol', 'xhigh')
+      const session = createGroupSession(selectedTarget, null)
+
+      const route = resolveAssistantTurnRoute(
+        createAutomationInput({ model }),
+        null,
+        resolvedSession(session),
+      )
+
+      expect(route.providerOptions).toMatchObject({
+        model,
+        reasoningEffort,
+      })
+    },
+  )
+
+  it('returns a Luna reminder reply to Sol on the same compatible provider thread', async () => {
+    const solTarget = requireTarget('gpt-5.6-sol', 'low')
+    const providerThreadId = 'provider-managed-thread'
+    const session = createGroupSession(
+      solTarget,
+      createResumeState(solTarget, providerThreadId),
+    )
+    const turnInput = createAutomationInput({
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'high',
+    })
+    const lunaRoute = resolveAssistantTurnRoute(
+      turnInput,
+      null,
+      resolvedSession(session),
+    )
+    const reminderText = 'Burpee time. Twenty clean reps, then continue your day.'
+
+    expect(lunaRoute.providerOptions).toMatchObject({
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'high',
+    })
+
+    const saved = await persistAutomationTurn({
+      route: lunaRoute,
+      session,
+      text: reminderText,
+      threadId: providerThreadId,
+      turnInput,
+    })
+
+    expect(runtimeState.transcriptsAppend).toHaveBeenCalledWith(
+      session.sessionId,
+      [
+        {
+          kind: 'assistant',
+          text: reminderText,
+        },
+      ],
+    )
+    expect(saved.target).toEqual(solTarget)
+    expect(saved.providerOptions).toMatchObject({
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'low',
+    })
+    expect(saved.resumeState?.threadId).toBe(providerThreadId)
+    expect(saved.codexResume?.threadId).toBe(providerThreadId)
+
+    const replyRoute = resolveAssistantTurnRoute(
+      {
+        prompt: 'Done. That was brutal.',
+        vault: '/vault',
+      },
+      null,
+      resolvedSession(saved),
+    )
+
+    expect(replyRoute.providerOptions).toMatchObject({
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'low',
+    })
+    expect(
+      resolveAssistantRouteResumeBinding({
+        route: replyRoute,
+        sessionResumeState: saved.resumeState,
+      })?.threadId,
+    ).toBe(providerThreadId)
+  })
+
+  it('clears the old selected-model thread after an isolated lower-tier turn', async () => {
+    const solTarget = requireTarget('gpt-5.6-sol', 'low')
+    const session = createGroupSession(
+      solTarget,
+      createResumeState(solTarget, 'provider-sol-thread'),
+    )
+    const turnInput = createAutomationInput({
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'high',
+    })
+    const lunaRoute = resolveAssistantTurnRoute(
+      turnInput,
+      null,
+      resolvedSession(session),
+    )
+
+    const saved = await persistAutomationTurn({
+      providerResumeStateAction: 'preserve-existing',
+      route: lunaRoute,
+      session,
+      text: 'Isolated Luna reminder.',
+      threadId: 'provider-isolated-luna-thread',
+      turnInput,
+    })
+
+    expect(saved.target).toEqual(solTarget)
+    expect(saved.resumeState).toBeNull()
+    expect(saved.codexResume).toBeNull()
+  })
+
+  it('inherits member custom inference and preserves its compatible resume state', async () => {
+    const customTarget = requireTarget(
+      'glm-5.2',
+      'low',
+      HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+    )
+    const providerThreadId = 'provider-custom-thread'
+    const session = createGroupSession(
+      customTarget,
+      createResumeState(customTarget, providerThreadId),
+    )
+    const turnInput = createAutomationInput({
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'high',
+    })
+    const route = resolveAssistantTurnRoute(
+      turnInput,
+      null,
+      resolvedSession(session),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'glm-5.2',
+      modelProvider: HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+      reasoningEffort: 'low',
+    })
+
+    const saved = await persistAutomationTurn({
+      route,
+      session,
+      text: 'Custom inference reminder.',
+      threadId: providerThreadId,
+      turnInput,
+    })
+
+    expect(saved.target).toEqual(customTarget)
+    expect(saved.resumeState?.threadId).toBe(providerThreadId)
+    expect(
+      resolveAssistantRouteResumeBinding({
+        route,
+        sessionResumeState: saved.resumeState,
+      })?.threadId,
+    ).toBe(providerThreadId)
+  })
+
+  it('keeps arbitrary custom model overrides turn-scoped and falls back through history', async () => {
+    const customTarget = requireTarget(
+      'glm-5.2',
+      'low',
+      HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+    )
+    const session = createGroupSession(
+      customTarget,
+      createResumeState(customTarget, 'provider-custom-52-thread'),
+    )
+    const turnInput = createAutomationInput({
+      model: 'glm-5.3',
+      reasoningEffort: 'high',
+    })
+    const route = resolveAssistantTurnRoute(
+      turnInput,
+      null,
+      resolvedSession(session),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'glm-5.3',
+      modelProvider: HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+      reasoningEffort: 'low',
+    })
+
+    const saved = await persistAutomationTurn({
+      route,
+      session,
+      text: 'Custom model reminder.',
+      threadId: 'provider-custom-53-thread',
+      turnInput,
+    })
+
+    expect(saved.target).toEqual(customTarget)
+    expect(saved.resumeState).toBeNull()
+    expect(saved.codexResume).toBeNull()
+  })
+
+  it('evaluates the automation preference after a current-turn provider transition', () => {
+    const customTarget = requireTarget(
+      'glm-5.2',
+      'low',
+      HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+    )
+    const session = createGroupSession(customTarget, null)
+
+    const route = resolveAssistantTurnRoute(
+      {
+        ...createAutomationInput({ model: 'gpt-5.6-luna' }),
+        model: 'gpt-5.6-sol',
+        modelProvider: 'vercel-ai-gateway',
+        reasoningEffort: 'low',
+      },
+      null,
+      resolvedSession(session),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'gpt-5.6-luna',
+      modelProvider: 'vercel-ai-gateway',
+      reasoningEffort: 'high',
+    })
+  })
+
+  it('preserves an explicit provider transition authored through the canonical contract', () => {
+    const customTarget = requireTarget(
+      'glm-5.2',
+      'low',
+      HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+    )
+    const session = createGroupSession(customTarget, null)
+
+    const route = resolveAssistantTurnRoute(
+      createAutomationInput({
+        model: 'gpt-5.6-luna',
+        modelProvider: 'vercel-ai-gateway',
+        reasoningEffort: 'high',
+      }),
+      null,
+      resolvedSession(session),
+    )
+
+    expect(route.providerOptions).toMatchObject({
+      model: 'gpt-5.6-luna',
+      modelProvider: 'vercel-ai-gateway',
+      reasoningEffort: 'high',
+    })
+  })
+})
+
+function createAutomationInput(
+  assistantTargetOverride: NonNullable<
+    Parameters<typeof resolveAssistantTurnRoute>[0]['assistantTargetOverride']
+  >,
+): Parameters<typeof resolveAssistantTurnRoute>[0] {
+  return {
+    assistantTargetOverride,
+    prompt: 'Send the scheduled reminder.',
+    turnTrigger: 'automation-cron',
+    vault: '/vault',
+  }
+}
+
+function createGroupSession(
+  target: AssistantModelTarget,
+  resumeState: AssistantSession['resumeState'],
+): AssistantSession {
+  return parseAssistantSessionRecord({
+    schema: 'murph.assistant-conversation.v2',
+    alias: null,
+    binding: createAssistantBinding({
+      actorId: 'group-member',
+      channel: 'linq',
+      deliveryKind: 'thread',
+      deliveryTarget: 'group-thread',
+      identityId: 'linq-line',
+      threadId: 'group-thread',
+      threadIsDirect: false,
+    }),
+    codexResume: resumeState,
+    codexTarget: target,
+    conversationId: 'conversation-group',
+    createdAt: '2026-08-07T00:00:00.000Z',
+    lastTurnAt: '2026-08-07T00:30:00.000Z',
+    turnCount: 3,
+    updatedAt: '2026-08-07T00:30:00.000Z',
+  })
+}
+
+function createResumeState(
+  target: AssistantModelTarget,
+  threadId: string,
+): AssistantSession['resumeState'] {
+  const route = resolveAssistantExecutionPlan({
+    defaults: null,
+    sessionTarget: target,
+  }).codexRoute
+  return buildCodexResumeState({
+    assistantContractFingerprint: 'a'.repeat(64),
+    rolloutRelativePath: null,
+    routeFingerprint: readCodexThreadRouteFingerprint(route),
+    threadCompatibilityFingerprint:
+      readCodexThreadCompatibilityFingerprint(route),
+    threadId,
+  })
+}
+
+function createProviderResult(input: {
+  route: CodexThreadIdentity
+  session: AssistantSession
+  text: string
+  threadId: string
+}): ExecutedAssistantProviderTurnResult {
+  return {
+    acceptedNoReplyDeliveryContextOrdinals: [],
+    additionalUsages: [],
+    assistantContractFingerprint: 'b'.repeat(64),
+    attemptCount: 1,
+    codexContinuation: {
+      kind: 'provider-state-optimization',
+    },
+    codexRolloutRelativePath: null,
+    codexThreadId: input.threadId,
+    provider: 'codex-cli',
+    providerOptions: input.route.providerOptions,
+    rawEvents: [],
+    response: input.text,
+    responseCard: null,
+    responseDeliveryContextOrdinal: 0,
+    responseMedia: [],
+    route: input.route,
+    session: input.session,
+    stderr: '',
+    stdout: '',
+    transcriptResponse: input.text,
+    usage: null,
+    workingDirectory: '/vault',
+  }
+}
+
+async function persistAutomationTurn(input: {
+  providerResumeStateAction?: AssistantProviderResumeStateAction
+  route: CodexThreadIdentity
+  session: AssistantSession
+  text: string
+  threadId: string
+  turnInput: Parameters<typeof resolveAssistantTurnRoute>[0]
+}): Promise<AssistantSession> {
+  return await persistAssistantTurnAndSession({
+    assistantTranscriptText: input.text,
+    input: input.turnInput,
+    persistUserPromptToTranscript: false,
+    plan: {
+      persistUserPromptOnFailure: false,
+    } as AssistantTurnSharedPlan,
+    providerResult: createProviderResult(input),
+    providerResumeStateAction:
+      input.providerResumeStateAction ?? 'persist-from-provider-turn',
+    session: input.session,
+    turnCreatedAt: '2026-08-07T01:00:00.000Z',
+    turnId: 'turn-automation-reminder',
+  })
+}
+
+function resolvedSession(session: AssistantSession): Parameters<
+  typeof resolveAssistantTurnRoute
+>[2] {
+  return { session } as Parameters<typeof resolveAssistantTurnRoute>[2]
+}
+
+function requireTarget(
+  model: string,
+  reasoningEffort: string,
+  modelProvider = 'vercel-ai-gateway',
+): AssistantModelTarget {
+  const target = createAssistantModelTarget({
+    model,
+    modelProvider,
+    provider: 'codex-cli',
+    reasoningEffort,
+  })
+  if (!target) {
+    throw new TypeError(`Expected a target for ${model}.`)
+  }
+  return target
+}

--- a/packages/assistant-engine/test/assistant-automation-model-selection.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-model-selection.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+} from '@murphai/operator-config/assistant/target-runtime'
+import {
+  readAutomationDynamicToolRequest,
+} from '../src/assistant-codex/dynamic-tools/automation.ts'
+import {
+  resolveAutomationAssistantTargetOverrideForTarget,
+} from '../src/assistant/automation/target-override.ts'
+
+const AUTOMATION_SCHEDULE = {
+  kind: 'at',
+  at: '2026-08-08T14:00:00.000Z',
+} as const
+
+function readSaveRequest(assistantTargetOverride?: unknown) {
+  return readAutomationDynamicToolRequest({
+    arguments: {
+      action: 'save',
+      ...(assistantTargetOverride === undefined
+        ? {}
+        : { assistantTargetOverride }),
+      instructions: 'Send one concise burpee reminder.',
+      schedule: AUTOMATION_SCHEDULE,
+      title: 'Burpee reminder',
+    },
+    tool: 'automation',
+  })
+}
+
+function readPatchRequest(assistantTargetOverride?: unknown) {
+  return readAutomationDynamicToolRequest({
+    arguments: {
+      action: 'patch',
+      ...(assistantTargetOverride === undefined
+        ? { title: 'Updated burpee reminder' }
+        : { assistantTargetOverride }),
+      lookup: 'burpee-reminder',
+    },
+    tool: 'automation',
+  })
+}
+
+describe('hosted automation model selection', () => {
+  it.each([
+    'gpt-5.6-luna',
+    'gpt-5.6-terra',
+    'gpt-5.6-sol',
+  ] as const)(
+    'persists the declarative %s preference without freezing derived reasoning',
+    (model) => {
+      const parsed = readSaveRequest({ model })
+      expect(parsed).toMatchObject({
+        kind: 'automation',
+        request: {
+          action: 'save',
+          assistantTargetOverride: {
+            model,
+          },
+        },
+      })
+      if (
+        parsed?.kind !== 'automation' ||
+        parsed.request.action !== 'save'
+      ) {
+        throw new TypeError('Expected a valid automation save request.')
+      }
+      expect(parsed.request.assistantTargetOverride).not.toHaveProperty(
+        'reasoningEffort',
+      )
+    },
+  )
+
+  it('preserves explicit reasoning and supports reasoning-only overrides', () => {
+    expect(
+      readSaveRequest({
+        model: 'gpt-5.6-luna',
+        reasoningEffort: 'medium',
+      }),
+    ).toMatchObject({
+      kind: 'automation',
+      request: {
+        assistantTargetOverride: {
+          model: 'gpt-5.6-luna',
+          reasoningEffort: 'medium',
+        },
+      },
+    })
+
+    expect(
+      readSaveRequest({
+        reasoningEffort: 'high',
+      }),
+    ).toMatchObject({
+      kind: 'automation',
+      request: {
+        assistantTargetOverride: {
+          reasoningEffort: 'high',
+        },
+      },
+    })
+  })
+
+  it('inherits the conversation target when no override is supplied', () => {
+    const parsed = readSaveRequest()
+    expect(parsed).toMatchObject({
+      kind: 'automation',
+      request: {
+        action: 'save',
+      },
+    })
+    if (
+      parsed?.kind !== 'automation' ||
+      parsed.request.action !== 'save'
+    ) {
+      throw new TypeError('Expected a valid automation save request.')
+    }
+    expect(parsed.request).not.toHaveProperty('assistantTargetOverride')
+  })
+
+  it('preserves an omitted patch override and accepts a complete replacement', () => {
+    const preserved = readPatchRequest()
+    expect(preserved).toMatchObject({
+      kind: 'automation',
+      request: {
+        action: 'patch',
+        lookup: 'burpee-reminder',
+        title: 'Updated burpee reminder',
+      },
+    })
+    if (
+      preserved?.kind !== 'automation' ||
+      preserved.request.action !== 'patch'
+    ) {
+      throw new TypeError('Expected a valid automation patch request.')
+    }
+    expect(preserved.request).not.toHaveProperty('assistantTargetOverride')
+
+    const replaced = readPatchRequest({
+      model: 'gpt-5.6-terra',
+    })
+    expect(replaced).toMatchObject({
+      kind: 'automation',
+      request: {
+        action: 'patch',
+        assistantTargetOverride: {
+          model: 'gpt-5.6-terra',
+        },
+        lookup: 'burpee-reminder',
+      },
+    })
+    if (
+      replaced?.kind !== 'automation' ||
+      replaced.request.action !== 'patch'
+    ) {
+      throw new TypeError('Expected a valid automation patch request.')
+    }
+    expect(replaced.request.assistantTargetOverride).not.toHaveProperty(
+      'reasoningEffort',
+    )
+  })
+
+  it('allows a patch to clear the stored turn override', () => {
+    expect(readPatchRequest(null)).toMatchObject({
+      kind: 'automation',
+      request: {
+        action: 'patch',
+        assistantTargetOverride: null,
+        lookup: 'burpee-reminder',
+      },
+    })
+  })
+
+  it('filters unsupported explicit-provider policy without a base target', () => {
+    expect(
+      resolveAutomationAssistantTargetOverrideForTarget(
+        {
+          model: 'glm-5.3',
+          modelProvider: HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+          reasoningEffort: 'high',
+        },
+        null,
+      ),
+    ).toEqual({
+      model: 'glm-5.3',
+      modelProvider: HOSTED_CUSTOM_INFERENCE_CODEX_MODEL_PROVIDER_ID,
+    })
+  })
+
+  it.each([
+    { model: 'gpt-5.6-luna', modelProvider: 'venice' },
+    { model: 'not-a-product-model' },
+    { model: 'gpt-5.6-luna', reasoningEffort: 'ultra' },
+    {},
+  ])('rejects unsupported hosted target override %j', (assistantTargetOverride) => {
+    expect(readSaveRequest(assistantTargetOverride)).toMatchObject({
+      kind: 'invalid-automation-arguments',
+    })
+  })
+})

--- a/packages/assistant-engine/test/assistant-automation-skipped-turn-continuity.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-skipped-turn-continuity.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createAssistantModelTarget,
+  type AssistantModelTarget,
+} from '@murphai/operator-config/assistant-backend'
+import {
+  parseAssistantSessionRecord,
+  type AssistantSession,
+} from '@murphai/operator-config/assistant-cli-contracts'
+import {
+  buildCodexResumeState,
+} from '@murphai/operator-config/assistant/codex-resume-state'
+import type {
+  AssistantTurnSharedPlan,
+  ExecutedAssistantProviderTurnResult,
+} from '../src/assistant/service-contracts.ts'
+
+const runtimeState = vi.hoisted(() => ({
+  sessionsSave: vi.fn(async (session: AssistantSession) => session),
+  transcriptsAppend: vi.fn(async () => undefined),
+  transcriptsList: vi.fn(async () => []),
+  turnsAppendEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('../src/assistant/runtime-state-service.js', () => ({
+  createAssistantRuntimeStateService: () => ({
+    sessions: {
+      save: runtimeState.sessionsSave,
+    },
+    transcripts: {
+      append: runtimeState.transcriptsAppend,
+      list: runtimeState.transcriptsList,
+    },
+    turns: {
+      appendEvent: runtimeState.turnsAppendEvent,
+    },
+  }),
+}))
+
+import { createAssistantBinding } from '../src/assistant/bindings.ts'
+import {
+  readCodexThreadCompatibilityFingerprint,
+  readCodexThreadRouteFingerprint,
+  type CodexThreadIdentity,
+} from '../src/assistant/codex-thread-route.ts'
+import { resolveAssistantExecutionPlan } from '../src/assistant/execution-plan.ts'
+import {
+  persistAssistantTurnAndSession,
+} from '../src/assistant/turn-finalizer.ts'
+
+beforeEach(() => {
+  runtimeState.sessionsSave.mockClear()
+  runtimeState.transcriptsAppend.mockClear()
+  runtimeState.transcriptsList.mockClear()
+  runtimeState.turnsAppendEvent.mockClear()
+})
+
+describe('skipped automation continuity', () => {
+  it('preserves the attended thread when a turn-scoped automation commits no history', async () => {
+    const solTarget = requireTarget('gpt-5.6-sol', 'low')
+    const attendedThreadId = 'provider-attended-sol-thread'
+    const session = createGroupSession(
+      solTarget,
+      createResumeState(solTarget, attendedThreadId),
+    )
+    const lunaRoute = resolveAssistantExecutionPlan({
+      defaults: null,
+      override: {
+        model: 'gpt-5.6-luna',
+        reasoningEffort: 'high',
+      },
+      sessionTarget: solTarget,
+    }).codexRoute
+
+    const saved = await persistAssistantTurnAndSession({
+      assistantTranscriptText: null,
+      input: {
+        assistantTargetOverride: {
+          model: 'gpt-5.6-luna',
+        },
+        prompt: 'Decide whether the scheduled reminder is still useful.',
+        turnTrigger: 'automation-cron',
+        vault: '/vault',
+      },
+      persistUserPromptToTranscript: false,
+      plan: {
+        persistUserPromptOnFailure: false,
+      } as AssistantTurnSharedPlan,
+      providerResult: createProviderResult({
+        route: lunaRoute,
+        session,
+        text: JSON.stringify({
+          kind: 'skip',
+          privateSummary: 'The reminder is no longer useful.',
+        }),
+        threadId: 'provider-isolated-luna-thread',
+      }),
+      providerResumeStateAction: 'preserve-existing',
+      session,
+      turnCreatedAt: '2026-08-07T01:00:00.000Z',
+      turnId: 'turn-skipped-automation',
+    })
+
+    expect(runtimeState.transcriptsAppend).not.toHaveBeenCalled()
+    expect(saved.target).toEqual(solTarget)
+    expect(saved.resumeState?.threadId).toBe(attendedThreadId)
+    expect(saved.codexResume?.threadId).toBe(attendedThreadId)
+  })
+})
+
+function createGroupSession(
+  target: AssistantModelTarget,
+  resumeState: AssistantSession['resumeState'],
+): AssistantSession {
+  return parseAssistantSessionRecord({
+    schema: 'murph.assistant-conversation.v2',
+    alias: null,
+    binding: createAssistantBinding({
+      actorId: 'group-member',
+      channel: 'linq',
+      deliveryKind: 'thread',
+      deliveryTarget: 'group-thread',
+      identityId: 'linq-line',
+      threadId: 'group-thread',
+      threadIsDirect: false,
+    }),
+    codexResume: resumeState,
+    codexTarget: target,
+    conversationId: 'conversation-group',
+    createdAt: '2026-08-07T00:00:00.000Z',
+    lastTurnAt: '2026-08-07T00:30:00.000Z',
+    turnCount: 3,
+    updatedAt: '2026-08-07T00:30:00.000Z',
+  })
+}
+
+function createResumeState(
+  target: AssistantModelTarget,
+  threadId: string,
+): AssistantSession['resumeState'] {
+  const route = resolveAssistantExecutionPlan({
+    defaults: null,
+    sessionTarget: target,
+  }).codexRoute
+  return buildCodexResumeState({
+    assistantContractFingerprint: 'a'.repeat(64),
+    rolloutRelativePath: null,
+    routeFingerprint: readCodexThreadRouteFingerprint(route),
+    threadCompatibilityFingerprint:
+      readCodexThreadCompatibilityFingerprint(route),
+    threadId,
+  })
+}
+
+function createProviderResult(input: {
+  route: CodexThreadIdentity
+  session: AssistantSession
+  text: string
+  threadId: string
+}): ExecutedAssistantProviderTurnResult {
+  return {
+    acceptedNoReplyDeliveryContextOrdinals: [],
+    additionalUsages: [],
+    assistantContractFingerprint: 'b'.repeat(64),
+    attemptCount: 1,
+    codexContinuation: {
+      kind: 'provider-state-optimization',
+    },
+    codexRolloutRelativePath: null,
+    codexThreadId: input.threadId,
+    provider: 'codex-cli',
+    providerOptions: input.route.providerOptions,
+    rawEvents: [],
+    response: input.text,
+    responseCard: null,
+    responseDeliveryContextOrdinal: 0,
+    responseMedia: [],
+    route: input.route,
+    session: input.session,
+    stderr: '',
+    stdout: '',
+    transcriptResponse: input.text,
+    usage: null,
+    workingDirectory: '/vault',
+  }
+}
+
+function requireTarget(
+  model: string,
+  reasoningEffort: string,
+  modelProvider = 'vercel-ai-gateway',
+): AssistantModelTarget {
+  const target = createAssistantModelTarget({
+    model,
+    modelProvider,
+    provider: 'codex-cli',
+    reasoningEffort,
+  })
+  if (!target) {
+    throw new TypeError(`Expected a target for ${model}.`)
+  }
+  return target
+}


### PR DESCRIPTION
## What changed

- Give `murph.automation` a hosted, turn-scoped model and reasoning contract using the canonical Luna, Terra, and Sol product models.
- Keep saved automation choices declarative. A model-only record stores only the selected model; the execution boundary derives Luna → `high` and Terra/Sol → `low`. Explicit reasoning still wins, and reasoning-only overrides remain supported.
- Teach Murph to use Luna for self-contained reminders and cues, Terra for bounded contextual work, and conversation inheritance for broad context, research, complex or sensitive reasoning, or work that materially depends on the selected model.
- Make patch semantics explicit: omit `assistantTargetOverride` to preserve it, send `null` to clear it, or send a complete replacement.
- Resolve product-model preferences against the provider that will execute the turn. Exact-model custom inference keeps its configured model, unsupported reasoning is stripped, arbitrary custom model IDs remain usable for canonical internal authors, explicit provider transitions are preserved, and Venice keeps canonical product names for its existing egress translation.
- Use the canonical resolved session target for fresh-session automation routing, preserving the resolved sandbox, approval, profile, command, provider, and other execution policy while applying only the turn-scoped model preference.
- Preserve the conversation's durable selected target across scheduled turns.
- Preserve an attended provider thread when a turn-scoped automation skips without committing user, assistant, or no-reply history. Once the turn commits model-visible conversation history, retain native resume only when the provider thread is compatible with the durable conversation route; otherwise clear it and let the next attended turn replay committed history.
- Preserve current `main`'s dynamic-tool startup boundary: the provider-visible automation definition uses the bounded contracts Zod runtime and does not import route-resolution or provider-runtime machinery.
- Preserve the code-owned onboarding first-personal-read action, reserved definition, and trusted completion-transition authority; the narrower model schema applies only to ordinary save and patch.

## Why

Automations already persisted a generic `assistantTargetOverride`, but the hosted tool exposed no product routing policy or reasoning defaults. Simple reminders therefore tended to inherit an unnecessarily expensive conversation model.

The policy must be applied at execution rather than frozen into newly authored records. That gives existing and new model-only automations identical behavior, keeps future policy changes centralized, and avoids coupling the eager provider-visible tool catalog to turn routing.

The existing finalizer also treated every turn-scoped override as a reason to discard provider continuity. That was too broad in both directions: a compatible provider thread can safely continue after a delivered automation, while an isolated automation that commits history must not leave a stale attended thread that never saw it. Conversely, a pure skip that commits no model-visible history should not destroy an otherwise valid attended thread.

## User-visible behavior

A room whose selected model is Sol can receive a simple Luna/high reminder without changing its durable model. A reply returns to Sol. When Codex can safely keep one provider thread, Sol sees the Luna message natively; when the provider, exact model, contract, or turn profile is incompatible, Murph falls back to the same durable transcript instead of resuming stale state. A scheduled check that decides to send nothing and commits no conversation history leaves the existing conversation thread untouched.

There is no new setup step or UI. Existing automations without an override continue to inherit the conversation model. Existing and newly created model-only Luna/Terra/Sol records receive the same reasoning defaults at execution.

## Patch semantics

`assistantTargetOverride` is a complete replacement field on patch, not a nested merge:

- omit it to preserve the stored override;
- use `null` to return to conversation inheritance;
- include the model again when changing reasoning while preserving an explicit model;
- use a reasoning-only object only when intentionally inheriting the conversation model.

## Invariants

- Automation target overrides are turn-scoped and never mutate the conversation-selected target.
- Delivered automation messages and accepted no-reply outcomes remain in the same conversation history.
- A turn-scoped automation that commits no user, assistant, or no-reply history preserves the existing attended resume state.
- Once model-visible history is committed, native resume is kept only when the provider-thread compatibility contract proves it safe.
- An isolated or incompatible automation turn that commits history clears stale attended resume because that thread did not observe the new history.
- Fresh-session routing starts from the canonical resolved target and does not discard its non-model execution policy.
- The hosted tool does not expose provider IDs or arbitrary model IDs.
- Canonical CLI/internal authors retain explicit provider transitions and arbitrary custom-model overrides.
- Derived reasoning defaults have one owner at execution and are not duplicated in persisted automation state.
- The onboarding first-personal-read action remains fieldless and code-owned; generic save cannot replace it and generic patch can only archive it.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: This changes persisted automation execution routing and session resume behavior while deliberately reusing the existing target, thread-compatibility, transcript, and finalization owners.

## Non-obvious affected surfaces

- Hosted automation save/patch parsing and replacement semantics.
- Existing and new model-only stored overrides.
- Fresh sessions resolved from operator or hosted boundary targets.
- Same-thread Luna/Terra/Sol model changes through Codex App Server.
- Custom-inference endpoints whose thread identity includes the exact model.
- Venice product-model translation at the egress boundary.
- Isolated scheduled profiles such as onboarding and creative-notification turns.
- Scheduled skip decisions that commit no transcript or no-reply marker.
- The next attended reply after a scheduled message.
- The eager dynamic-tool catalog introduced on current `main`.
- The code-owned onboarding first-read action, reserved slug, and completion-transition authority.

## Architecture and reuse

- Existing systems reused: canonical `assistantTargetOverride`, session target resolution, provider runtime capabilities, Codex thread compatibility fingerprints, execution-plan merging, notification turn envelopes, durable session targets, transcript/no-reply persistence, and session finalization.
- New logic: one pure defaults/provider-compatibility helper at the existing automation target boundary, plus history-aware compatibility retention in the existing finalizer.
- New abstractions: no new stateful abstraction or ownership layer; the PR adds one pure target-normalization helper and composes the existing route, compatibility, transcript, and finalizer primitives.
- New state owners: none.
- Complexity intentionally avoided: no classifier service, migration, database field, queue, provider mapping table, reminder-specific runtime, conversation-model mutation, or bespoke reply handoff state.

## Hot reply and startup impact

- No database or network calls were added.
- Ordinary replies keep their existing route; automation-specific normalization runs only when an automation override exists.
- The route resolver performs synchronous target normalization and capability checks using already-loaded configuration.
- The finalizer performs one history-presence check and, when needed, one compatibility comparison only when a persisted automation override was present.
- The automation tool retains current `main`'s `@murphai/contracts/zod-runtime` import and does not reach into the route-resolution layer from the eager tool definition.

## Murph initial provider input impact

`murph.automation` remains provider-deferred. The ordinary eager prompt and unrelated tool schemas are unchanged. The hosted automation schema is narrower than the generic persisted contract because it exposes only product model and reasoning choices, not provider IDs.

## Design proof

- Design page: not applicable; no UI files changed.
- Desktop/mobile screenshots: not applicable.

## Verification

Focused coverage proves:

- model-only records stay declarative while Luna/high and Terra/Sol/low are derived at execution;
- explicit reasoning and reasoning-only overrides;
- save inheritance plus patch preserve/replace/clear semantics;
- Sol → Luna reminder → Sol reply on one compatible provider thread;
- isolated lower-tier turns that commit history clear stale selected-model resume state;
- pure skipped automation turns preserve the attended thread when they commit no model-visible history;
- product preferences inherit exact-model custom inference safely;
- arbitrary custom-model one-turn overrides fall back through durable history;
- explicit provider transitions and fresh-session provider capability filtering;
- fresh-session routing preserves sandbox, approval, profile, and command policy from the canonical resolved target;
- Venice keeps canonical product names for egress translation;
- the code-owned onboarding first-read action, cancellation boundary, and trusted transition remain intact.

The branch is one commit and eight files rebased onto current `main`. Exact-head GitHub checks passed: assistant/platform/CLI/fixture coverage, release app verification, clean build/typecheck, package boundaries, repository verification tools, artifact hygiene, doc gardening, both host matrices, runner permission confinement, frontend architecture metadata, and viewport smoke. The Hosted Stripe Billing workflow was concurrency-cancelled; this PR changes no billing files. The PR remains draft and must not be merged.