### PR TITLE
chore: trigger stale group-preview runtime test verification

### DIFF
--- a/.github/stale-group-preview-runtime-test-trigger
+++ b/.github/stale-group-preview-runtime-test-trigger
@@ -1,0 +1,1 @@
+temporary scratch-branch trigger; removed by the verified cleanup commit


### PR DESCRIPTION
Temporary scratch-to-scratch PR used only to trigger the isolated verifier on `agent/remove-stale-group-preview-runtime-test`. The verifier removes one obsolete five-case preview acceptance block, runs workspace typecheck and full assistant-runtime coverage, deletes all scaffolding, and commits only if both failing lanes pass. This never targets `main` or PR #1386.