### PR TITLE
fix(web): drop redundant caveat block from sensitive action approval screen

### DIFF
--- a/apps/web/app/design/action-approval-lifecycle-study.tsx
+++ b/apps/web/app/design/action-approval-lifecycle-study.tsx
@@ -1,7 +1,6 @@
 import { ShieldCheck } from "lucide-react";
 
 import {
-  ACTION_APPROVAL_PENDING_CAVEAT,
   ActionApprovalDecisionFallback,
   ActionApprovalScreen,
 } from "@/src/components/sensitive-actions/action-approval-screen";
@@ -17,7 +16,6 @@ export function ActionApprovalLifecycleStudy() {
         <ActionApprovalScreen
           badgeIcon={ShieldCheck}
           body={<p>Send generated report.zip to this conversation.</p>}
-          caveat={ACTION_APPROVAL_PENDING_CAVEAT}
           title="Send this file?"
         >
           <div className="mt-7 border-t border-[#c4a882]/25 pt-6">
@@ -49,7 +47,6 @@ function DecisionFallbackStudy({
     <ActionApprovalScreen
       badgeIcon={ShieldCheck}
       body={<p>Send generated report.zip to this conversation.</p>}
-      caveat={ACTION_APPROVAL_PENDING_CAVEAT}
       title="Send this file?"
     >
       <div className="mt-7 border-t border-[#c4a882]/25 pt-6">

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -175,7 +175,9 @@ export function SectionsContent() {
       <Separator />
 
       <StudySection title="Secure approval pending and recorded states">
-        <ActionApprovalLifecycleStudy />
+        <div id="action-approval-lifecycle">
+          <ActionApprovalLifecycleStudy />
+        </div>
       </StudySection>
 
       <Separator />

--- a/apps/web/src/components/sensitive-actions/action-approval-card.tsx
+++ b/apps/web/src/components/sensitive-actions/action-approval-card.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 import { requestHostedOnboardingJson } from "@/src/components/hosted-onboarding/client-api";
 import {
-  ACTION_APPROVAL_PENDING_CAVEAT,
   ActionApprovalDecisionFallback,
   ActionApprovalScreen,
 } from "@/src/components/sensitive-actions/action-approval-screen";
@@ -125,7 +124,6 @@ export function ActionApprovalCard({
     <ActionApprovalScreen
       badgeIcon={ShieldCheck}
       body={<p className="break-words">{approval.presentation.body}</p>}
-      caveat={ACTION_APPROVAL_PENDING_CAVEAT}
       title={approval.presentation.title}
     >
       {surfacedError ? (

--- a/apps/web/src/components/sensitive-actions/action-approval-screen.tsx
+++ b/apps/web/src/components/sensitive-actions/action-approval-screen.tsx
@@ -5,9 +5,6 @@ import { cn } from "@/src/lib/utils";
 
 type BadgeTone = "primary" | "muted";
 
-export const ACTION_APPROVAL_PENDING_CAVEAT =
-  "Approval applies only while Murph still has this request pending. It cannot undo a cancellation from the conversation. Murph must ask again if the file, destination, or any other detail changes.";
-
 export const ACTION_APPROVAL_RECORDED_DESCRIPTION =
   "Approval recorded. Murph will continue only if this request is still pending.";
 
@@ -36,7 +33,6 @@ interface ActionApprovalScreenProps {
   badgeIcon: LucideIcon;
   badgeTone?: BadgeTone;
   body: ReactNode;
-  caveat?: ReactNode;
   children?: ReactNode;
   title: string;
 }
@@ -45,7 +41,6 @@ export function ActionApprovalScreen({
   badgeIcon: BadgeIcon,
   badgeTone = "primary",
   body,
-  caveat,
   children,
   title,
 }: ActionApprovalScreenProps) {
@@ -82,17 +77,6 @@ export function ActionApprovalScreen({
           <div className="mt-5 text-[15px] leading-[1.6] text-muted-foreground text-pretty">
             {body}
           </div>
-
-          {caveat ? (
-            <div className="mt-6">
-              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#5a6e32]">
-                Only applies to this request
-              </p>
-              <p className="mt-1.5 text-[13px] leading-[1.55] text-muted-foreground">
-                {caveat}
-              </p>
-            </div>
-          ) : null}
 
           {children}
         </article>

--- a/apps/web/test/action-approval-card-accessibility.test.tsx
+++ b/apps/web/test/action-approval-card-accessibility.test.tsx
@@ -48,10 +48,10 @@ test("announces the disabled approval controls while approval is pending", async
 
   try {
     expect(rendered.container.textContent).toContain(
-      "Approval applies only while Murph still has this request pending.",
+      "Allow the requested action.",
     );
-    expect(rendered.container.textContent).toContain(
-      "It cannot undo a cancellation from the conversation.",
+    expect(rendered.container.textContent).not.toContain(
+      "Approval applies only while Murph still has this request pending.",
     );
     expect(rendered.container.querySelector("[role='status']")).toBeNull();
     expect(rendered.container.querySelector("[aria-busy='true']")).toBeNull();


### PR DESCRIPTION
## Why this PR exists

The secure approval page stacked a three-sentence "Only applies to this request" disclaimer under a body sentence that already states the approval covers only the named file and destination. Direct feedback on the rendered screen: too much copy for a single yes/no decision.

## User goal / user-visible behavior

A member sent to the approval page sees one short screen: what Murph will send and where, then Approve with passkey / Deny. The pending-state caveat block is gone. The decision-outcome truthfulness copy is untouched: after approving, the member still sees "Approval recorded. Murph will continue only if this request is still pending."

## User experience

Entry point is the approval link Murph issues in conversation for a sensitive action (e.g. a vault file send). The page renders instantly with the file, size, and destination; approving triggers the passkey challenge and then either redirects back to the Murph thread or shows the recorded/denied fallback copy; denying returns immediately; failures surface an inline error. None of those steps changed - this PR removes only the pending-state disclaimer, so the decision reads in one pass with the fewest necessary words. Rendered evidence: the "Secure approval pending and recorded states" study on `/design?tab=sections`, captured at desktop (all three states) and mobile (pending state) below.

## Invariants the PR must preserve

- Approval authorization is unchanged: the server-side action fingerprint still scopes an approval to the exact file, destination, and channel, and a cancelled request still does not run on approval. The removed text described that behavior; it never implemented it.
- The truthful decision-outcome contract from the recent cancellation-outcomes work stays: `ACTION_APPROVAL_RECORDED_DESCRIPTION` ("Murph will continue only if this request is still pending.") and the denied description still render via `ActionApprovalDecisionFallback`.
- The body still names the file, size, destination, and that the approval applies only to this file and destination.
- Approve still requires the passkey challenge; deny, error, aria-busy/status announcements, and redirect flows are untouched.

## Non-obvious affected surfaces

- `ActionApprovalScreen` loses its optional `caveat` prop and the exported `ACTION_APPROVAL_PENDING_CAVEAT` constant. Callers were the approval card and the design-catalog lifecycle study; both are updated in this diff. Regression proof: repo-wide grep finds no remaining references; web typecheck, lint, and both approval test files pass.
- `apps/web/test/action-approval-card-accessibility.test.tsx` pending-state test now asserts the body copy renders and the removed disclaimer does not, instead of asserting the disclaimer text.

## Architecture and reuse

- Existing systems reused: the production `ActionApprovalScreen`, `ActionApprovalCard`, and `ActionApprovalDecisionFallback`, plus the existing "Secure approval pending and recorded states" catalog study, which now renders the trimmed pending state.
- New logic: none; the diff deletes the caveat prop, render block, and constant, updates the two callers, and adds a deep-link `id` anchor around the catalog study registration.
- New abstractions: none; the existing `ActionApprovalScreen` props contract was sufficient once the unused prop was dropped.
- Complexity intentionally avoided: no per-action-kind configurable caveat and no server-driven caveat copy; deletion was the whole fix.

## Hot reply path impact

Not applicable - web-only presentational change on the approval page; no database, provider, or messaging call is added, moved, or removed on the Foreground Reply Critical Path.

## Murph initial provider input impact

Not applicable for both individual and group runtimes - no prompt builders, tool definitions or schemas, skills, Codex configuration, or provider request assembly changed; the diff is web UI only.

## Preliminary specialist lenses

- Product experience: applicable - removes a redundant pending-state disclaimer from the sensitive-action approval decision while keeping the truthful decision-outcome copy. Intended outcome: the member reads one scope statement and decides. Journey evidence: the rendered desktop and mobile catalog captures below.
- Prompt: not applicable - no prompt or assistant-engine changes.
- Frontend: applicable - evidence files `lifecycle-desktop.png` (1440 CSS px viewport at 2x, pending + recorded + denied states) and `lifecycle-mobile.png` (390 CSS px viewport at 2x, pending state), both captured on `/design?tab=sections`.
- Coverage: applicable - focused proof: `apps/web/test/action-approval-card-accessibility.test.tsx` and `apps/web/test/action-approval-client-auth.test.tsx` pass locally (7 tests), plus web typecheck and lint; exact-head CI: pending on this push.

## Change-shape breakdown

Classification rule: by file path; production components and design-catalog studies count as authored source, `apps/web/test/` counts as tests. No docs, config, generated, or binary files changed.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 3 | 22 |
| Tests/fixtures | 3 | 3 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 6 | 25 |

## Design proof

- Design page: [/design?tab=sections](https://www.withmurph.ai/design?tab=sections) - "Secure approval pending and recorded states" study (`#action-approval-lifecycle`)
- Desktop screenshot: ![Secure approval pending, recorded, and denied states, desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/13418256-08d9-498c-45a6-cf8860c49400/designproof)
- Mobile screenshot: ![Secure approval pending state, mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/523f084f-10cf-462d-50fe-26a94e90ce00/designproof)

## Deployment skew / compatibility

Not applicable - single web deploy surface with no server contract, schema, Worker, or runner change; old and new web builds render the same approval data, so there is no skew window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
