### PR TITLE
refactor: single source for plan selling-point bullets

### DIFF
--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -4,7 +4,7 @@ import {
   HOSTED_ASSISTANT_OPENAI_PROVIDER,
 } from "@murphai/hosted-execution/assistant-model";
 import { useState } from "react";
-import { CheckCircle2, ContactRound, Monitor } from "lucide-react";
+import { CheckCircle2, CheckIcon, ContactRound, Monitor } from "lucide-react";
 import { SourceCard } from "@/app/(dashboard)/connect/connect-source-card";
 import type { ConnectSource } from "@/app/(dashboard)/connect/connect-page-types";
 import {
@@ -129,6 +129,19 @@ import type { ExperimentLibraryCard } from "@/src/lib/experiments/library-cards"
 import type { DeviceSyncCompletionDialogModel } from "@/src/lib/device-sync/connect-completion-types";
 import type { HostedConsentStatus } from "@/src/lib/legal/consent";
 import { buildWhoopAppleHealthSetupGuide } from "@/src/lib/device-sync/whoop-apple-health-setup-guide";
+import {
+  CHECKOUT_CORE_FEATURES,
+  CHECKOUT_PULSE_FEATURES,
+  EDGE_ONLY_FEATURES,
+  JOIN_EDGE_FEATURES,
+  JOIN_FAMILY_FEATURES,
+  JOIN_PULSE_FEATURES,
+  PULSE_TRIAL_FEATURES,
+  SETTINGS_CORE_FEATURES,
+  SETTINGS_EDGE_FEATURES,
+  SETTINGS_FAMILY_FEATURES,
+  SETTINGS_PULSE_FEATURES,
+} from "@/src/lib/hosted-onboarding/plan-features";
 import { MurphAssistantStylePicker } from "@/src/components/murph/murph-assistant-style-picker";
 import { HostedAiUsageActivity } from "@/src/components/settings/hosted-ai-usage-activity";
 import { HostedFamilyManager } from "@/src/components/settings/hosted-family-settings-actions";
@@ -201,6 +214,32 @@ function Section({
     <div id={id} className="flex flex-col gap-6">
       <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">{title}</h2>
       {children}
+    </div>
+  );
+}
+
+function PlanBulletListStudy({
+  features,
+  title,
+}: {
+  features: readonly string[];
+  title: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-border bg-card/80 p-4">
+      <p className="mb-2 text-sm font-medium text-foreground">{title}</p>
+      <ul className="flex flex-col gap-2 text-sm text-muted-foreground">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <CheckIcon
+              className="mt-0.5 size-3.5 shrink-0 text-primary"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            />
+            {feature}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -2361,6 +2400,39 @@ export function ComponentsContent() {
               <PlanVisual tier="edge" />
               <span className="text-xs text-muted-foreground">Edge</span>
             </div>
+          </div>
+        </Section>
+
+        <Separator />
+
+        <Section title="Plan selling points">
+          <p className="-mt-3 text-xs text-muted-foreground">
+            Canonical bullet lists from lib/hosted-onboarding/plan-features.ts. The join page,
+            billing settings, and the plan dialogs all render from these lists, so a wording
+            change here is the wording change everywhere. Only Edge may claim the most capable
+            AI models; the top model requires an active paid Edge plan.
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <PlanBulletListStudy title="Pulse trial · join page" features={PULSE_TRIAL_FEATURES} />
+            <PlanBulletListStudy title="Pulse · join page" features={JOIN_PULSE_FEATURES} />
+            <PlanBulletListStudy title="Edge · join page" features={JOIN_EDGE_FEATURES} />
+            <PlanBulletListStudy title="Family · join page" features={JOIN_FAMILY_FEATURES} />
+            <PlanBulletListStudy title="Core · settings" features={SETTINGS_CORE_FEATURES} />
+            <PlanBulletListStudy title="Pulse · settings" features={SETTINGS_PULSE_FEATURES} />
+            <PlanBulletListStudy title="Edge · settings" features={SETTINGS_EDGE_FEATURES} />
+            <PlanBulletListStudy title="Family · settings" features={SETTINGS_FAMILY_FEATURES} />
+            <PlanBulletListStudy
+              title="Pulse · start-paid dialog"
+              features={CHECKOUT_PULSE_FEATURES}
+            />
+            <PlanBulletListStudy
+              title="Core · start-paid dialog"
+              features={CHECKOUT_CORE_FEATURES}
+            />
+            <PlanBulletListStudy
+              title="Edge loses · downgrade dialog"
+              features={EDGE_ONLY_FEATURES}
+            />
           </div>
         </Section>
 

--- a/apps/web/src/components/hosted-onboarding/join-invite-stage-server.tsx
+++ b/apps/web/src/components/hosted-onboarding/join-invite-stage-server.tsx
@@ -23,6 +23,12 @@ import {
   isHostedAutoPulseTrialEnabled,
   isHostedPulseTrialCheckoutEnabled,
 } from "@/src/lib/hosted-onboarding/billing-plans";
+import {
+  JOIN_EDGE_FEATURES,
+  JOIN_FAMILY_FEATURES,
+  JOIN_PULSE_FEATURES,
+  PULSE_TRIAL_FEATURES,
+} from "@/src/lib/hosted-onboarding/plan-features";
 import type { HostedFamilyBillingRecoveryState } from "@/src/lib/hosted-onboarding/family-plan";
 import type { HostedInviteStatusPayload } from "@/src/lib/hosted-onboarding/types";
 import { buildHostedTelegramBotLink } from "@/src/lib/hosted-onboarding/telegram";
@@ -46,37 +52,6 @@ import {
 } from "./join-invite-islands";
 
 const MURPH_GITHUB_URL = "https://github.com/cobuildwithus/murph";
-
-const PULSE_TRIAL_FEATURES = [
-  `Full Pulse access for ${HOSTED_PULSE_TRIAL_DAYS} days`,
-  "Card required. Then $8/month unless canceled.",
-  "Cancel anytime",
-];
-
-const PULSE_FEATURES = [
-  "Private personal health assistant",
-  "Questions, decisions, plans, and follow-through",
-  "Sync your health data",
-  "Chat with Murph via iMessage, Telegram, or email",
-  "Experiments when you need a clear answer",
-];
-
-const EDGE_FEATURES = [
-  "Everything in Pulse and:",
-  "The most capable AI models",
-  "Higher monthly usage",
-  "Murph remembers more of your history",
-  "Deeper analysis across your context",
-  "Richer plans and protocol recommendations",
-  "Early access to new features",
-];
-
-const FAMILY_FEATURES = [
-  "2 to 6 people, one bill",
-  "Choose Pulse or Edge for each person",
-  "Each person keeps a private Murph",
-  "Family members' chats and health data stay private",
-];
 
 export function JoinInviteStageServer({ model }: { model: JoinInvitePageModel }) {
   const { status } = model;
@@ -361,7 +336,7 @@ export function JoinInviteCheckoutPanel({
           description="Your private personal health assistant."
           price={pulsePlan ? `$${Math.round(pulsePlan.recurringAmountUsdCents / 100)}` : "$8"}
           priceUnit="/ month"
-          features={PULSE_FEATURES}
+          features={JOIN_PULSE_FEATURES}
           cta={
             <JoinInviteCheckoutPlanButtonIsland
               billingReady={billingReady}
@@ -379,7 +354,7 @@ export function JoinInviteCheckoutPanel({
           description="More guidance and deeper research."
           price={edgePlan ? `$${Math.round(edgePlan.recurringAmountUsdCents / 100)}` : "$20"}
           priceUnit="/ month"
-          features={EDGE_FEATURES}
+          features={JOIN_EDGE_FEATURES}
           cta={
             <JoinInviteCheckoutPlanButtonIsland
               billingReady={billingReady}
@@ -401,7 +376,7 @@ export function JoinInviteCheckoutPanel({
               HOSTED_FAMILY_PLAN_DISPLAY.recurringAmountUsdCentsPerSeat / 100,
             )}`}
             priceUnit="/ person / month"
-            features={FAMILY_FEATURES}
+            features={JOIN_FAMILY_FEATURES}
             cta={
               <HostedFamilyStartButton
                 block

--- a/apps/web/src/components/settings/hosted-billing-settings.tsx
+++ b/apps/web/src/components/settings/hosted-billing-settings.tsx
@@ -16,6 +16,12 @@ import {
   parseHostedBillingPhase,
   parseHostedBillingPlanCode,
 } from "@/src/lib/hosted-onboarding/billing-plans";
+import {
+  SETTINGS_CORE_FEATURES,
+  SETTINGS_EDGE_FEATURES,
+  SETTINGS_FAMILY_FEATURES,
+  SETTINGS_PULSE_FEATURES,
+} from "@/src/lib/hosted-onboarding/plan-features";
 import type { MurphContactOption } from "@/src/lib/murph-contact-routing";
 import { cn } from "@/src/lib/utils";
 
@@ -32,36 +38,6 @@ import {
   type HostedUsageTopUpOffer,
   type HostedUsageTopUpReturn,
 } from "./hosted-usage-top-up-dialog";
-
-const GROUP_FEATURES = [
-  "Stay connected to Murph groups",
-  "Sync your health and activity data",
-  "Keep group scores current",
-  "Private Murph chat",
-  "Lighter included AI usage",
-];
-
-const PULSE_FEATURES = [
-  "Run experiments, see what changed",
-  "Sync your health data",
-  "Private before/after outcomes",
-  "Chat with Murph via iMessage, Telegram, or email",
-];
-
-const EDGE_FEATURES = [
-  "Everything in Pulse",
-  "The most capable AI models",
-  "Higher monthly usage",
-  "Murph remembers more of your history",
-  "Deeper research and analysis",
-];
-
-const FAMILY_FEATURES = [
-  "2 to 6 people, one bill",
-  "Choose Pulse or Edge for each person",
-  "Each person keeps a private Murph",
-  "You can't see members' chats or health data",
-];
 
 interface PlanCardModel {
   action: ReactNode;
@@ -210,7 +186,7 @@ export function HostedBillingSettings(props: {
                   : null,
             current: groupCurrent,
             currentLabel: "Current plan",
-            features: GROUP_FEATURES,
+            features: SETTINGS_CORE_FEATURES,
             key: "launch_group_monthly",
             name: HOSTED_GROUP_MEMBER_PLAN_DISPLAY_NAME,
             note: pendingGroupSwitchDate
@@ -256,7 +232,7 @@ export function HostedBillingSettings(props: {
             : <BillingPortalButton block variant="secondary" label="Choose Pulse" />,
       current: pulseCurrent,
       currentLabel: isPulseTrial ? "Free trial" : "Current plan",
-      features: PULSE_FEATURES,
+      features: SETTINGS_PULSE_FEATURES,
       key: "launch_monthly",
       name: "Pulse",
       note: familyOwner
@@ -298,7 +274,7 @@ export function HostedBillingSettings(props: {
           : <BillingPortalButton block variant="secondary" label="Choose Edge" />,
       current: edgeCurrent,
       currentLabel: "Current plan",
-      features: EDGE_FEATURES,
+      features: SETTINGS_EDGE_FEATURES,
       key: "launch_edge_monthly",
       name: "Edge",
       note: familyOwner
@@ -334,7 +310,7 @@ export function HostedBillingSettings(props: {
             : null,
       current: familyCurrent,
       currentLabel: familyState === "sponsored" ? "Sponsored" : "Current plan",
-      features: FAMILY_FEATURES,
+      features: SETTINGS_FAMILY_FEATURES,
       key: "family",
       name: "Family",
       note: familyState === "sponsored" ? "Paid by your family plan owner." : null,

--- a/apps/web/src/components/settings/hosted-plan-switch-to-pulse-button.tsx
+++ b/apps/web/src/components/settings/hosted-plan-switch-to-pulse-button.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { getHostedBillingPlanDefinition } from "@/src/lib/hosted-onboarding/billing-plans";
+import { EDGE_ONLY_FEATURES } from "@/src/lib/hosted-onboarding/plan-features";
 import { cn } from "@/src/lib/utils";
 
 import { toErrorMessage } from "./hosted-settings-sync-helpers";
@@ -95,13 +96,6 @@ export function SwitchToPulseButton(props: {
     </div>
   );
 }
-
-const EDGE_ONLY_FEATURES = [
-  "The most capable AI models",
-  "Higher monthly usage",
-  "Murph remembers more of your history",
-  "Deeper research and analysis",
-];
 
 function PulseSwitchConfirmationDialog(props: {
   currentPeriodEnd?: string | null;

--- a/apps/web/src/components/settings/hosted-start-paid-pulse-button.tsx
+++ b/apps/web/src/components/settings/hosted-start-paid-pulse-button.tsx
@@ -25,6 +25,10 @@ import {
   formatHostedBillingPrice,
   getHostedBillingPlanDefinition,
 } from "@/src/lib/hosted-onboarding/billing-plans";
+import {
+  CHECKOUT_CORE_FEATURES,
+  CHECKOUT_PULSE_FEATURES,
+} from "@/src/lib/hosted-onboarding/plan-features";
 import type { HostedPulseTrialContinuationAction } from "@/src/lib/hosted-onboarding/billing-pulse-trial-continuation-contract";
 import { cn } from "@/src/lib/utils";
 
@@ -53,19 +57,6 @@ const pulsePriceLabel = formatHostedBillingPrice(
   pulsePlan.recurringAmountUsdCents,
 );
 
-const PULSE_FEATURES = [
-  "Run experiments, see what changed",
-  "Sync your health data",
-  "Private before/after outcomes",
-  "Chat with Murph via iMessage, Telegram, or email",
-  "Guided experiment setup",
-];
-const GROUP_FEATURES = [
-  "Keep your wearable syncing",
-  "Keep group activity current",
-  "Private Murph conversations",
-  "Lighter included AI usage",
-];
 
 export function StartPaidPulseButton(props: {
   block?: boolean;
@@ -570,8 +561,8 @@ export function StartPaidPlanConfirmationContent(props: {
   );
   const targetFeatures =
     props.targetPlanCode === "launch_group_monthly"
-      ? GROUP_FEATURES
-      : PULSE_FEATURES;
+      ? CHECKOUT_CORE_FEATURES
+      : CHECKOUT_PULSE_FEATURES;
   const title = props.status === "scheduled"
     ? `${targetPlanName} is set`
     : props.timing === "at_trial_end"

--- a/apps/web/src/lib/hosted-onboarding/plan-features.ts
+++ b/apps/web/src/lib/hosted-onboarding/plan-features.ts
@@ -1,0 +1,88 @@
+import { HOSTED_PULSE_TRIAL_DAYS } from "./billing-plans";
+
+// Single source of truth for the member-facing selling points on every plan
+// card. Surfaces intentionally differ — the join page markets a plan to
+// someone deciding to sign up, while settings and the plan dialogs compare
+// plans a member can switch between — but every list lives here so a wording
+// change lands on all surfaces at once.
+//
+// Copy rule: only Edge may claim the most capable AI models. The top model
+// requires an active paid Edge plan (ASSISTANT_MODEL_SOL_REQUIRES_EDGE), so
+// that claim on Pulse or Core would promise something the product blocks.
+
+export const PULSE_TRIAL_FEATURES = [
+  `Full Pulse access for ${HOSTED_PULSE_TRIAL_DAYS} days`,
+  "Card required. Then $8/month unless canceled.",
+  "Cancel anytime",
+] as const;
+
+export const JOIN_PULSE_FEATURES = [
+  "Private personal health assistant",
+  "Questions, decisions, plans, and follow-through",
+  "Sync your health data",
+  "Chat with Murph via iMessage, Telegram, or email",
+  "Experiments when you need a clear answer",
+] as const;
+
+export const SETTINGS_PULSE_FEATURES = [
+  "Run experiments, see what changed",
+  "Sync your health data",
+  "Private before/after outcomes",
+  "Chat with Murph via iMessage, Telegram, or email",
+] as const;
+
+export const CHECKOUT_PULSE_FEATURES = [
+  ...SETTINGS_PULSE_FEATURES,
+  "Guided experiment setup",
+] as const;
+
+export const EDGE_ONLY_FEATURES = [
+  "The most capable AI models",
+  "Higher monthly usage",
+  "Murph remembers more of your history",
+  "Deeper research and analysis",
+] as const;
+
+export const SETTINGS_EDGE_FEATURES = [
+  "Everything in Pulse",
+  ...EDGE_ONLY_FEATURES,
+] as const;
+
+export const JOIN_EDGE_FEATURES = [
+  "Everything in Pulse and:",
+  "The most capable AI models",
+  "Higher monthly usage",
+  "Murph remembers more of your history",
+  "Deeper analysis across your context",
+  "Richer plans and protocol recommendations",
+  "Early access to new features",
+] as const;
+
+export const SETTINGS_CORE_FEATURES = [
+  "Stay connected to Murph groups",
+  "Sync your health and activity data",
+  "Keep group scores current",
+  "Private Murph chat",
+  "Lighter included AI usage",
+] as const;
+
+export const CHECKOUT_CORE_FEATURES = [
+  "Keep your wearable syncing",
+  "Keep group activity current",
+  "Private Murph conversations",
+  "Lighter included AI usage",
+] as const;
+
+export const JOIN_FAMILY_FEATURES = [
+  "2 to 6 people, one bill",
+  "Choose Pulse or Edge for each person",
+  "Each person keeps a private Murph",
+  "Family members' chats and health data stay private",
+] as const;
+
+export const SETTINGS_FAMILY_FEATURES = [
+  "2 to 6 people, one bill",
+  "Choose Pulse or Edge for each person",
+  "Each person keeps a private Murph",
+  "You can't see members' chats or health data",
+] as const;


### PR DESCRIPTION
## Why this PR exists

Plan selling-point bullets were duplicated across four components, and the copies drifted: the join page, billing settings, and the plan dialogs each carried slightly different wording for the same claims, and one drift shipped a claim the product blocks (Pulse advertising the most capable AI models while the top model is Edge-gated, fixed on main in 73b21ada6d). This PR makes that class of drift structurally impossible.

## User goal / user-visible behavior

No member-visible change. Every plan card and dialog renders exactly the bullets it rendered before this PR. The change is that all of those lists now come from one module, `apps/web/src/lib/hosted-onboarding/plan-features.ts`, so a future wording change lands on every surface at once.

## User experience

Member surfaces are byte-identical: the join page plan cards, billing settings plan cards, start-paid dialog, and Edge downgrade dialog all render the same strings as before, now imported instead of locally declared. The one new rendered surface is internal: a "Plan selling points" section on `/design?tab=components` showing all eleven canonical lists side by side, so plan copy can be reviewed in one place. Rendered evidence: hosted desktop and mobile captures of that section are embedded in the Design proof section below; the local capture run also asserted the Edge-only model bullet is visible before screenshotting.

## Invariants the PR must preserve

- Rendered bullet strings on every member surface are unchanged (join page, billing settings, start-paid dialog, downgrade dialog).
- Only Edge lists may claim "The most capable AI models"; Pulse and Core lists must not (the top model requires an active paid Edge plan, enforced by `ASSISTANT_MODEL_SOL_REQUIRES_EDGE`).
- `plan-features.ts` stays client-safe: string constants plus one import of `HOSTED_PULSE_TRIAL_DAYS`, no server-only dependencies, because two importers are client components.

## Non-obvious affected surfaces

None. The six touched files are the four components that owned the duplicated arrays, the new module, and the design catalog entry. No shared logic, state owner, or deploy surface changes; regression proof is the covering component tests plus the web typecheck (both green, details under lenses).

## Architecture and reuse

- Existing systems reused: the `@/src/lib/hosted-onboarding` module boundary all four components already import from (`billing-plans.ts` pattern), the existing `Section` scaffolding in the design catalog, and the plan cards' existing `readonly string[]` feature props.
- New logic: none — the module is string constants; two derived lists (`CHECKOUT_PULSE_FEATURES`, `SETTINGS_EDGE_FEATURES`) are spreads of their base lists so shared bullets cannot diverge.
- New abstractions: one module, `plan-features.ts`, holding eleven named per-plan, per-surface lists; plus a small catalog-only `PlanBulletListStudy` display helper.
- Complexity intentionally avoided: no forced unification of intentionally different per-surface wording (join page markets, settings compares — both variants kept, now adjacent and documented), no config/CMS layer, no i18n scaffolding.

## Hot reply path impact

Not applicable. This PR changes static web UI strings and their import locations only; it does not touch message acceptance, provider start, or reply handoff, and adds no database, network, or awaited calls anywhere.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. No prompt builders, tool definitions or schemas, skills, Codex configuration, model tool mode, or provider-request assembly changed; the diff is web plan-card strings and a design-catalog entry, none of which are provider-visible.

## Preliminary specialist lenses

- Product experience: applicable, narrowly — the intended outcome is unchanged member-facing copy with a single owner module; direct journey evidence is the byte-identical bullet strings (verified by string diff of the arrays against main) and the passing join/settings component tests.
- Prompt: not applicable — no prompt, tool, or provider-visible text changed.
- Frontend: applicable — hosted desktop (1440 CSS px viewport, 2x) and mobile (390 CSS px viewport, 3x) captures of the new `/design?tab=components` "Plan selling points" section are embedded below; they prove the one new rendered surface and show all eleven canonical lists (desktop) and the mobile single-column rendering (mobile crop, top of section within size limits).
- Coverage: focused local proof is `apps/web/test/hosted-billing-settings.test.tsx` and `apps/web/test/join-invite-page-view.test.ts` (76/76 passing in this worktree), plus the apps/web `tsc --noEmit` typecheck and eslint on all six files (clean). Exact-head CI status: pending (PR just opened).

## Change-shape breakdown

Classification rule: authored `.ts`/`.tsx` under `apps/web` counts as source (the design catalog page is authored source); no tests, docs, config, or generated files are touched. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 187 | 91 |
| Tests/fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **187** | **91** |

## Design proof

- Design page: [/design?tab=components](https://www.withmurph.ai/design?tab=components) — new "Plan selling points" section
- Desktop screenshot: ![Plan selling points, desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/96d82dd7-14e1-4fcc-1ec9-ae864fd34e00/designproof)
- Mobile screenshot: ![Plan selling points, mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/d432f321-c63d-4de0-d705-baae02dd3d00/designproof)

## Deployment skew / compatibility

Not applicable. Web-only change with no deploy boundary crossed: no Worker, runner, contract, environment, or persisted-state changes, and the rendered member-facing output is identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
