### PR TITLE
feat(web): monthly revenue bar chart with source breakdown on ops growth

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -246,17 +246,18 @@ by its heading. Keep acquisition and revenue snapshots after the message charts.
 End the grid with **Monthly revenue**: restrained sage bars where each bar
 estimates one UTC month from the month's latest snapshot MRR plus fulfilled
 live-mode top-up and group-sponsorship cash. The card copy must say it is an
-estimate rather than summed invoices and that refunds are not subtracted. The
-bar carries only the total; the keyboard-reachable tooltip lists personal
-subscriptions, family subscriptions, group sponsorship, and usage top-ups with
-a summed total row, and labels the window-end month "month to date". Months
-whose snapshots predate the subscription split columns show one combined
-subscription line rather than an invented split; a recorded split is trusted
-only when it sums to the snapshot's MRR total. A month with no snapshot
-withholds its total ("Unavailable") and leaves a bar gap while still listing
-its known one-time cash. Months before the first revenue evidence are trimmed,
-and the card copy states that account deletion removes past top-ups from the
-bars.
+estimate rather than invoices, that refunds are not subtracted, and that
+account deletion can remove past purchase cash or leave an old one-time group
+gift counted as a regular top-up, and it must name hover, tap, and focus as the
+breakdown affordances. The bar carries only the total; the keyboard-reachable
+tooltip lists personal subscriptions, family subscriptions, group sponsorship,
+and usage top-ups with a summed total row, and labels the window-end month
+"month to date". Months whose snapshots predate the subscription split columns
+show one combined subscription line rather than an invented split; a recorded
+split is trusted only when it sums to the snapshot's MRR total. A month with no
+snapshot withholds its total ("Unavailable") and leaves a bar gap while still
+listing its known one-time cash. Months before the first revenue evidence are
+trimmed.
 
 Below the chart grid, show trial-start provenance in one flat bordered surface:
 30-day UTC totals for Direct iMessage, Website, Companion, and Unknown followed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -243,6 +243,15 @@ is reconciled; later known daily bars may still render. State that the daily
 message total combines inbound messages across supported channels with tracked
 Linq replies. Give each keyboard-enabled chart one visible focus surface named
 by its heading. Keep acquisition and revenue snapshots after the message charts.
+End the grid with **Monthly revenue**: restrained sage bars where each bar
+totals one UTC month from the month's latest snapshot MRR plus fulfilled
+live-mode top-up and group-sponsorship cash. The bar carries only the total;
+the keyboard-reachable tooltip lists personal subscriptions, family
+subscriptions, group sponsorship, and usage top-ups with a summed total row.
+Months whose snapshots predate the subscription split columns show one
+combined subscription line rather than an invented split, months before the
+first revenue evidence are trimmed, and the card copy states that account
+deletion removes past top-ups from the bars.
 
 Below the chart grid, show trial-start provenance in one flat bordered surface:
 30-day UTC totals for Direct iMessage, Website, Companion, and Unknown followed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -244,14 +244,19 @@ message total combines inbound messages across supported channels with tracked
 Linq replies. Give each keyboard-enabled chart one visible focus surface named
 by its heading. Keep acquisition and revenue snapshots after the message charts.
 End the grid with **Monthly revenue**: restrained sage bars where each bar
-totals one UTC month from the month's latest snapshot MRR plus fulfilled
-live-mode top-up and group-sponsorship cash. The bar carries only the total;
-the keyboard-reachable tooltip lists personal subscriptions, family
-subscriptions, group sponsorship, and usage top-ups with a summed total row.
-Months whose snapshots predate the subscription split columns show one
-combined subscription line rather than an invented split, months before the
-first revenue evidence are trimmed, and the card copy states that account
-deletion removes past top-ups from the bars.
+estimates one UTC month from the month's latest snapshot MRR plus fulfilled
+live-mode top-up and group-sponsorship cash. The card copy must say it is an
+estimate rather than summed invoices and that refunds are not subtracted. The
+bar carries only the total; the keyboard-reachable tooltip lists personal
+subscriptions, family subscriptions, group sponsorship, and usage top-ups with
+a summed total row, and labels the window-end month "month to date". Months
+whose snapshots predate the subscription split columns show one combined
+subscription line rather than an invented split; a recorded split is trusted
+only when it sums to the snapshot's MRR total. A month with no snapshot
+withholds its total ("Unavailable") and leaves a bar gap while still listing
+its known one-time cash. Months before the first revenue evidence are trimmed,
+and the card copy states that account deletion removes past top-ups from the
+bars.
 
 Below the chart grid, show trial-start provenance in one flat bordered surface:
 30-day UTC totals for Direct iMessage, Website, Companion, and Unknown followed

--- a/agent-docs/exec-plans/active/2026-08-07-growth-monthly-revenue-chart.md
+++ b/agent-docs/exec-plans/active/2026-08-07-growth-monthly-revenue-chart.md
@@ -1,0 +1,43 @@
+# Growth monthly revenue chart
+
+Status: active
+Created: 2026-08-07
+
+## Outcome
+
+- Let the operator see total revenue per calendar month on `/ops/growth` as a bar chart, with a tooltip that splits each month into personal subscriptions, family subscriptions, group sponsorship, and one-time usage top-ups.
+- Keep every existing growth chart, scorecard, and table behavior intact.
+
+## Ownership and evidence
+
+- There is no local subscription invoice ledger; `HostedGrowthDailySnapshot.mrrUsdCents` is the only durable subscription-revenue history, so monthly subscription revenue is the month's latest snapshot MRR.
+- The snapshot only stores the MRR total today, so the individual/family split must start being captured; two nullable columns written by the existing `captureHostedGrowthDailySnapshot` upsert close that gap from values `calculateHostedGrowthCurrentMetrics` already computes.
+- `HostedUsageCreditPurchase` is the exact cash ledger for top-ups and group sponsorship: fulfilled live-mode rows bucketed by `paidAt`, classified by the sponsorship authorization/moment markers.
+- Pre-split snapshot months (July 2026) cannot be split truthfully; they render one combined subscription value instead of an invented split.
+
+## Plan
+
+1. Add nullable `individual_mrr_usd_cents` and `family_mrr_usd_cents` snapshot columns (expand-only migration) and write them in the daily capture upsert.
+2. Add a pure `buildHostedGrowthMonthlyRevenueSeries` projection over month-latest snapshots and fulfilled live purchases, with leading no-evidence months trimmed.
+3. Read the bounded snapshot and purchase windows in `readHostedGrowthDashboard` and expose `monthlyRevenueSeries`.
+4. Render one restrained sage total bar per month in `GrowthCharts` with a custom breakdown tooltip, reusing the existing chart-token system.
+5. Extend the growth design study with synthetic monthly revenue data and update the growth charts e2e spec.
+6. Add focused projection, dashboard, and capture regressions; run scoped hosted-web checks and desktop/mobile browser proof.
+7. Commit, push a pull request, complete the required specialist and UI review gates, and require green exact-head CI.
+
+## Invariants
+
+- The migration stays expand-only: nullable columns, no backfill, no constraint changes.
+- Do not invent a personal/family split for months that predate the split columns; show them as combined subscriptions.
+- Only fulfilled, live-mode purchases count as revenue; deleted accounts remove their purchase history and the card copy says so.
+- Keep the series bounded, aggregate-only, and the operator page free of member or purchase identifiers.
+- Preserve responsive readability and the existing warm-paper chart vocabulary.
+
+## Verification
+
+- Focused hosted growth metric, capture, and series tests.
+- Hosted-web TypeScript and lint checks for touched files.
+- Frontend design-proof guard.
+- Desktop and mobile Playwright proof from `/design?tab=sections`.
+- Preliminary `completion-specialists` ReviewGPT pass with product-experience, frontend, and coverage lenses.
+- Exact-head required CI and parent final review.

--- a/agent-docs/exec-plans/completed/2026-08-07-growth-monthly-revenue-chart.md
+++ b/agent-docs/exec-plans/completed/2026-08-07-growth-monthly-revenue-chart.md
@@ -1,6 +1,6 @@
 # Growth monthly revenue chart
 
-Status: active
+Status: completed
 Created: 2026-08-07
 
 ## Outcome
@@ -41,3 +41,5 @@ Created: 2026-08-07
 - Desktop and mobile Playwright proof from `/design?tab=sections`.
 - Preliminary `completion-specialists` ReviewGPT pass with product-experience, frontend, and coverage lenses.
 - Exact-head required CI and parent final review.
+Updated: 2026-08-08
+Completed: 2026-08-08

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -22,6 +22,7 @@ import {
 import type {
   HostedGrowthDailyPoint,
   HostedGrowthMessagePoint,
+  HostedGrowthMonthlyRevenuePoint,
   HostedGrowthSnapshotPoint,
 } from "@/src/lib/hosted-ops/growth-metrics";
 
@@ -72,12 +73,20 @@ const revenueChartConfig = {
   },
 } satisfies ChartConfig;
 
+const monthlyRevenueChartConfig = {
+  totalRevenueUsd: {
+    color: "#7A8C6E",
+    label: "Monthly revenue",
+  },
+} satisfies ChartConfig;
+
 const interactiveChartClassName =
   "mt-4 h-64 w-full rounded-sm has-[:focus-visible]:outline has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-ring";
 
 interface GrowthChartsProps {
   dailySeries: HostedGrowthDailyPoint[];
   messageSeries: HostedGrowthMessagePoint[];
+  monthlyRevenueSeries: HostedGrowthMonthlyRevenuePoint[];
   snapshotSeries: HostedGrowthSnapshotPoint[];
 }
 
@@ -88,10 +97,15 @@ export function GrowthCharts(input: GrowthChartsProps) {
   const dailyMessagesTitleId = `${titleIdPrefix}-daily-messages`;
   const acquisitionTitleId = `${titleIdPrefix}-acquisition`;
   const revenueTitleId = `${titleIdPrefix}-revenue`;
+  const monthlyRevenueTitleId = `${titleIdPrefix}-monthly-revenue`;
   const revenueSeries = input.snapshotSeries.map((point) => ({
     date: point.date,
     mrrUsd: point.mrrUsdCents / 100,
     payingCustomers: point.payingCustomers,
+  }));
+  const monthlyRevenueSeries = input.monthlyRevenueSeries.map((point) => ({
+    ...point,
+    totalRevenueUsd: point.totalUsdCents / 100,
   }));
 
   return (
@@ -434,8 +448,153 @@ export function GrowthCharts(input: GrowthChartsProps) {
           </LineChart>
         </ChartContainer>
       </div>
+
+      <div className="min-w-0 rounded-xl border border-border/70 bg-card/90 p-5">
+        <div className="flex flex-col gap-1">
+          <h3
+            className="font-serif text-lg font-semibold tracking-tight text-foreground"
+            id={monthlyRevenueTitleId}
+          >
+            Monthly revenue
+          </h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Each bar totals one UTC month: subscriptions at the month&apos;s
+            latest daily snapshot plus fulfilled usage top-ups and group
+            sponsorships paid that month. Hover or focus a bar for the source
+            breakdown. Months before August 2026 show subscriptions without the
+            personal and family split, and account deletion removes past
+            top-ups from these bars.
+          </p>
+        </div>
+        <ChartContainer
+          className={interactiveChartClassName}
+          config={monthlyRevenueChartConfig}
+        >
+          <BarChart
+            accessibilityLayer
+            aria-labelledby={monthlyRevenueTitleId}
+            data={monthlyRevenueSeries}
+            margin={{ bottom: 0, left: 0, right: 8, top: 8 }}
+          >
+            <CartesianGrid
+              stroke="var(--color-border)"
+              strokeDasharray="3 3"
+              strokeOpacity={0.55}
+              vertical={false}
+            />
+            <XAxis
+              axisLine={false}
+              dataKey="month"
+              tickFormatter={formatMonthTick}
+              tickLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              axisLine={false}
+              tickFormatter={formatUsdAxisTick}
+              tickLine={false}
+              width={44}
+            />
+            <ChartTooltip
+              content={<MonthlyRevenueTooltip />}
+              cursor={{ fill: "var(--color-muted)", fillOpacity: 0.35 }}
+            />
+            <Bar
+              dataKey="totalRevenueUsd"
+              fill="var(--color-totalRevenueUsd)"
+              maxBarSize={64}
+              name="Monthly revenue"
+              radius={[3, 3, 0, 0]}
+            />
+          </BarChart>
+        </ChartContainer>
+      </div>
     </div>
   );
+}
+
+function MonthlyRevenueTooltip(props: {
+  active?: boolean;
+  payload?: readonly { payload?: unknown }[];
+}) {
+  const point = props.payload?.[0]?.payload;
+  if (props.active !== true || !isMonthlyRevenuePoint(point)) {
+    return null;
+  }
+
+  const subscriptionRows = point.individualSubscriptionsUsdCents === null
+    && point.familySubscriptionsUsdCents === null
+    && point.subscriptionsUnsplitUsdCents === null
+    ? [{ label: "Subscriptions", value: "No snapshot" }]
+    : [
+      ...(point.individualSubscriptionsUsdCents === null ? [] : [{
+        label: "Personal subscriptions",
+        value: formatUsdFromCents(point.individualSubscriptionsUsdCents),
+      }]),
+      ...(point.familySubscriptionsUsdCents === null ? [] : [{
+        label: "Family subscriptions",
+        value: formatUsdFromCents(point.familySubscriptionsUsdCents),
+      }]),
+      ...(point.subscriptionsUnsplitUsdCents === null ? [] : [{
+        label: "Subscriptions (personal + family)",
+        value: formatUsdFromCents(point.subscriptionsUnsplitUsdCents),
+      }]),
+    ];
+  const rows = [
+    ...subscriptionRows,
+    {
+      label: "Group sponsorship",
+      value: formatUsdFromCents(point.groupSponsorshipUsdCents),
+    },
+    {
+      label: "Usage top-ups",
+      value: formatUsdFromCents(point.usageTopUpsUsdCents),
+    },
+  ];
+
+  return (
+    <div className="grid min-w-52 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <div className="font-medium">{formatMonthLabel(point.month)}</div>
+      <div className="grid gap-1">
+        {rows.map((row) => (
+          <div className="flex w-full justify-between gap-4" key={row.label}>
+            <span className="text-muted-foreground">{row.label}</span>
+            <span className="font-mono font-medium tabular-nums text-foreground">
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex w-full justify-between gap-4 border-t border-border/50 pt-1 font-medium">
+        <span>Total</span>
+        <span className="font-mono tabular-nums">
+          {formatUsdFromCents(point.totalUsdCents)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function isMonthlyRevenuePoint(
+  value: unknown,
+): value is HostedGrowthMonthlyRevenuePoint {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate: Partial<Record<keyof HostedGrowthMonthlyRevenuePoint, unknown>> =
+    value;
+  return typeof candidate.month === "string"
+    && typeof candidate.totalUsdCents === "number"
+    && typeof candidate.groupSponsorshipUsdCents === "number"
+    && typeof candidate.usageTopUpsUsdCents === "number"
+    && isNullableNumber(candidate.individualSubscriptionsUsdCents)
+    && isNullableNumber(candidate.familySubscriptionsUsdCents)
+    && isNullableNumber(candidate.subscriptionsUnsplitUsdCents);
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return value === null || typeof value === "number";
 }
 
 function formatShortDate(value: string): string {
@@ -451,6 +610,34 @@ function formatCompactNumber(value: number): string {
     maximumFractionDigits: 1,
     notation: "compact",
   }).format(value);
+}
+
+function formatMonthTick(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(`${value}-01T00:00:00.000Z`));
+}
+
+function formatMonthLabel(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(`${value}-01T00:00:00.000Z`));
+}
+
+function formatUsdAxisTick(value: number): string {
+  return `$${formatCompactNumber(value)}`;
+}
+
+function formatUsdFromCents(valueUsdCents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    maximumFractionDigits: 2,
+    minimumFractionDigits: valueUsdCents % 100 === 0 ? 0 : 2,
+    style: "currency",
+  }).format(valueUsdCents / 100);
 }
 
 function formatTooltipDate(value: ReactNode): string {

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -103,9 +103,15 @@ export function GrowthCharts(input: GrowthChartsProps) {
     mrrUsd: point.mrrUsdCents / 100,
     payingCustomers: point.payingCustomers,
   }));
+  // A month with a withheld total renders no bar, and a bar-less month would
+  // also produce no tooltip payload. The zero-height anchor series keeps the
+  // breakdown tooltip reachable for those months without drawing anything.
   const monthlyRevenueSeries = input.monthlyRevenueSeries.map((point) => ({
     ...point,
-    totalRevenueUsd: point.totalUsdCents / 100,
+    tooltipAnchor: 0,
+    totalRevenueUsd: point.totalUsdCents === null
+      ? null
+      : point.totalUsdCents / 100,
   }));
 
   return (
@@ -458,12 +464,14 @@ export function GrowthCharts(input: GrowthChartsProps) {
             Monthly revenue
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
-            Each bar totals one UTC month: subscriptions at the month&apos;s
-            latest daily snapshot plus fulfilled usage top-ups and group
-            sponsorships paid that month. Hover or focus a bar for the source
-            breakdown. Months before August 2026 show subscriptions without the
-            personal and family split, and account deletion removes past
-            top-ups from these bars.
+            An estimate of each UTC month&apos;s revenue, not summed invoices:
+            the subscription rate at the month&apos;s latest daily snapshot
+            plus usage top-up and group sponsorship cash paid that month, with
+            refunds not subtracted. The newest bar covers only the month so
+            far. Hover or focus a bar for the source breakdown. Months recorded
+            before the subscription split show one combined subscriptions line,
+            a month with no snapshot withholds its total, and account deletion
+            removes that account&apos;s past top-ups from these bars.
           </p>
         </div>
         <ChartContainer
@@ -500,11 +508,20 @@ export function GrowthCharts(input: GrowthChartsProps) {
               cursor={{ fill: "var(--color-muted)", fillOpacity: 0.35 }}
             />
             <Bar
+              dataKey="tooltipAnchor"
+              fill="transparent"
+              isAnimationActive={false}
+              legendType="none"
+              maxBarSize={64}
+              stackId="revenue"
+            />
+            <Bar
               dataKey="totalRevenueUsd"
               fill="var(--color-totalRevenueUsd)"
               maxBarSize={64}
               name="Monthly revenue"
               radius={[3, 3, 0, 0]}
+              stackId="revenue"
             />
           </BarChart>
         </ChartContainer>
@@ -554,7 +571,10 @@ function MonthlyRevenueTooltip(props: {
 
   return (
     <div className="grid min-w-52 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
-      <div className="font-medium">{formatMonthLabel(point.month)}</div>
+      <div className="font-medium">
+        {formatMonthLabel(point.month)}
+        {point.monthToDate ? " · month to date" : ""}
+      </div>
       <div className="grid gap-1">
         {rows.map((row) => (
           <div className="flex w-full justify-between gap-4" key={row.label}>
@@ -568,7 +588,9 @@ function MonthlyRevenueTooltip(props: {
       <div className="flex w-full justify-between gap-4 border-t border-border/50 pt-1 font-medium">
         <span>Total</span>
         <span className="font-mono tabular-nums">
-          {formatUsdFromCents(point.totalUsdCents)}
+          {point.totalUsdCents === null
+            ? "Unavailable"
+            : formatUsdFromCents(point.totalUsdCents)}
         </span>
       </div>
     </div>
@@ -585,7 +607,8 @@ function isMonthlyRevenuePoint(
   const candidate: Partial<Record<keyof HostedGrowthMonthlyRevenuePoint, unknown>> =
     value;
   return typeof candidate.month === "string"
-    && typeof candidate.totalUsdCents === "number"
+    && typeof candidate.monthToDate === "boolean"
+    && isNullableNumber(candidate.totalUsdCents)
     && typeof candidate.groupSponsorshipUsdCents === "number"
     && typeof candidate.usageTopUpsUsdCents === "number"
     && isNullableNumber(candidate.individualSubscriptionsUsdCents)

--- a/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/growth-charts.tsx
@@ -464,14 +464,14 @@ export function GrowthCharts(input: GrowthChartsProps) {
             Monthly revenue
           </h3>
           <p className="text-sm leading-6 text-muted-foreground">
-            An estimate of each UTC month&apos;s revenue, not summed invoices:
-            the subscription rate at the month&apos;s latest daily snapshot
-            plus usage top-up and group sponsorship cash paid that month, with
-            refunds not subtracted. The newest bar covers only the month so
-            far. Hover or focus a bar for the source breakdown. Months recorded
-            before the subscription split show one combined subscriptions line,
-            a month with no snapshot withholds its total, and account deletion
-            removes that account&apos;s past top-ups from these bars.
+            An estimate, not invoices: the month&apos;s latest recorded
+            subscription rate plus top-up and group sponsorship cash paid that
+            UTC month. Refunds are not subtracted, and account deletion can
+            remove past purchase cash or leave an old group gift counted as a
+            regular top-up. The newest bar is month to date, a month with no
+            snapshot withholds its total, and months from before the
+            subscription split show subscriptions as one combined line. Hover,
+            tap, or focus a bar for the breakdown.
           </p>
         </div>
         <ChartContainer

--- a/apps/web/app/(dashboard)/ops/growth/page.tsx
+++ b/apps/web/app/(dashboard)/ops/growth/page.tsx
@@ -85,6 +85,7 @@ export default async function HostedOpsGrowthPage() {
       <GrowthCharts
         dailySeries={dashboard.dailySeries}
         messageSeries={dashboard.messageSeries}
+        monthlyRevenueSeries={dashboard.monthlyRevenueSeries}
         snapshotSeries={dashboard.snapshotSeries}
       />
 

--- a/apps/web/app/design/growth-scorecard-study.tsx
+++ b/apps/web/app/design/growth-scorecard-study.tsx
@@ -2,6 +2,9 @@ import {
   buildHostedGrowthMessageSeries,
   type HostedGrowthMessageSnapshot,
 } from "@/src/lib/hosted-ops/growth-message-series";
+import {
+  buildHostedGrowthMonthlyRevenueSeries,
+} from "@/src/lib/hosted-ops/growth-monthly-revenue-series";
 import type { HostedGrowthDashboard } from "@/src/lib/hosted-ops/growth-metrics";
 import type { HostedGrowthSponsorshipMetrics } from "@/src/lib/hosted-ops/growth-sponsorship-metrics";
 import {
@@ -75,6 +78,77 @@ const SNAPSHOT_SERIES = GROWTH_DATES.map((date, index) => ({
   payingCustomers: 54 + Math.floor(index * 0.8),
   trialingMembers: 16 + (index % 7),
 }));
+
+// April predates the subscription split columns, so it renders as one
+// unsplit subscription value; February and March have no data and are trimmed.
+const MONTHLY_REVENUE_SERIES = buildHostedGrowthMonthlyRevenueSeries({
+  monthCount: 6,
+  purchases: [
+    {
+      cashAmountMinor: 1_000,
+      isGroupSponsorship: false,
+      paidAt: new Date("2026-04-19T16:20:00.000Z"),
+    },
+    {
+      cashAmountMinor: 2_000,
+      isGroupSponsorship: false,
+      paidAt: new Date("2026-05-11T09:05:00.000Z"),
+    },
+    {
+      cashAmountMinor: 500,
+      isGroupSponsorship: true,
+      paidAt: new Date("2026-05-27T21:40:00.000Z"),
+    },
+    {
+      cashAmountMinor: 1_500,
+      isGroupSponsorship: true,
+      paidAt: new Date("2026-07-03T12:00:00.000Z"),
+    },
+    {
+      cashAmountMinor: 1_000,
+      isGroupSponsorship: false,
+      paidAt: new Date("2026-07-14T18:30:00.000Z"),
+    },
+    {
+      cashAmountMinor: 1_500,
+      isGroupSponsorship: false,
+      paidAt: new Date("2026-07-24T07:55:00.000Z"),
+    },
+  ],
+  snapshots: [
+    {
+      familyMrrUsdCents: null,
+      individualMrrUsdCents: null,
+      mrrUsdCents: 6_200,
+      snapshotDate: new Date("2026-04-28T00:00:00.000Z"),
+    },
+    {
+      familyMrrUsdCents: 2_100,
+      individualMrrUsdCents: 7_000,
+      mrrUsdCents: 9_100,
+      snapshotDate: new Date("2026-05-30T00:00:00.000Z"),
+    },
+    {
+      familyMrrUsdCents: 3_200,
+      individualMrrUsdCents: 9_600,
+      mrrUsdCents: 12_800,
+      snapshotDate: new Date("2026-06-29T00:00:00.000Z"),
+    },
+    {
+      familyMrrUsdCents: 3_300,
+      individualMrrUsdCents: 10_600,
+      mrrUsdCents: 13_900,
+      snapshotDate: new Date("2026-07-15T00:00:00.000Z"),
+    },
+    {
+      familyMrrUsdCents: 4_300,
+      individualMrrUsdCents: 11_800,
+      mrrUsdCents: 16_100,
+      snapshotDate: new Date("2026-07-30T00:00:00.000Z"),
+    },
+  ],
+  windowEnd: new Date("2026-07-31T12:00:00.000Z"),
+});
 
 const TRIAL_START_ATTRIBUTION = {
   counts: {
@@ -264,6 +338,7 @@ export function GrowthScorecardStudy() {
         <GrowthCharts
           dailySeries={DAILY_SERIES}
           messageSeries={MESSAGE_SERIES}
+          monthlyRevenueSeries={MONTHLY_REVENUE_SERIES}
           snapshotSeries={SNAPSHOT_SERIES}
         />
       </div>

--- a/apps/web/app/design/growth-scorecard-study.tsx
+++ b/apps/web/app/design/growth-scorecard-study.tsx
@@ -79,11 +79,18 @@ const SNAPSHOT_SERIES = GROWTH_DATES.map((date, index) => ({
   trialingMembers: 16 + (index % 7),
 }));
 
-// April predates the subscription split columns, so it renders as one
-// unsplit subscription value; February and March have no data and are trimmed.
+// March has purchase cash but no snapshot, so its total is withheld; April
+// predates the subscription split columns, so it renders as one unsplit
+// subscription value; February has no data and is trimmed; July is the
+// window-end month, so it renders as month to date.
 const MONTHLY_REVENUE_SERIES = buildHostedGrowthMonthlyRevenueSeries({
   monthCount: 6,
   purchases: [
+    {
+      cashAmountMinor: 800,
+      isGroupSponsorship: false,
+      paidAt: new Date("2026-03-12T15:00:00.000Z"),
+    },
     {
       cashAmountMinor: 1_000,
       isGroupSponsorship: false,

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -386,7 +386,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Ops weekly growth compass with sponsorship accounting, messaging-activity, and message-volume history">
+      <StudySection title="Ops weekly growth compass with sponsorship accounting, messaging-activity, message-volume, and monthly-revenue history">
         <div inert>
           <GrowthScorecardStudy />
         </div>

--- a/apps/web/e2e/ops-growth-message-charts.spec.ts
+++ b/apps/web/e2e/ops-growth-message-charts.spec.ts
@@ -147,11 +147,12 @@ for (const viewport of VIEWPORTS) {
       ".recharts-tooltip-wrapper",
     );
     await chartSurfaces.nth(5).focus();
-    for (let index = 0; index < 3; index += 1) {
+    for (let index = 0; index < 4; index += 1) {
       await page.keyboard.press("ArrowRight");
     }
     await expect(monthlyRevenueTooltip).toBeVisible();
     await expect(monthlyRevenueTooltip).toContainText("July 2026");
+    await expect(monthlyRevenueTooltip).toContainText("month to date");
     await expect(monthlyRevenueTooltip).toContainText("Personal subscriptions");
     await expect(monthlyRevenueTooltip).toContainText("$118");
     await expect(monthlyRevenueTooltip).toContainText("Family subscriptions");
@@ -171,6 +172,12 @@ for (const viewport of VIEWPORTS) {
     );
     await expect(monthlyRevenueTooltip).toContainText("$62");
     await expect(monthlyRevenueTooltip).toContainText("$72");
+    await page.keyboard.press("ArrowLeft");
+    await expect(monthlyRevenueTooltip).toContainText("March 2026");
+    await expect(monthlyRevenueTooltip).not.toContainText("month to date");
+    await expect(monthlyRevenueTooltip).toContainText("No snapshot");
+    await expect(monthlyRevenueTooltip).toContainText("$8");
+    await expect(monthlyRevenueTooltip).toContainText("Unavailable");
 
     await page.emulateMedia({ forcedColors: "active" });
     await expect(activityLines.nth(1)).toHaveAttribute("stroke-dasharray", "6 4");

--- a/apps/web/e2e/ops-growth-message-charts.spec.ts
+++ b/apps/web/e2e/ops-growth-message-charts.spec.ts
@@ -11,6 +11,7 @@ const CHART_NAMES = [
   "Messages sent per day",
   "Intake and activation",
   "Revenue snapshots",
+  "Monthly revenue",
 ] as const;
 
 function isLoopbackUrl(rawUrl: string): boolean {
@@ -71,8 +72,8 @@ for (const viewport of VIEWPORTS) {
     const chartSurfaces = chartCards.locator(
       '.recharts-surface[role="application"][tabindex="0"]',
     );
-    await expect(chartCards).toHaveCount(5);
-    await expect(chartSurfaces).toHaveCount(5);
+    await expect(chartCards).toHaveCount(6);
+    await expect(chartSurfaces).toHaveCount(6);
 
     for (const [index, name] of CHART_NAMES.entries()) {
       await expect(chartSurfaces.nth(index)).toHaveAccessibleName(name);
@@ -141,6 +142,35 @@ for (const viewport of VIEWPORTS) {
     await expect(dailyTooltip).toContainText("Jul 15");
     await expect(dailyTooltip).toContainText("Messages sent per day");
     await expect(dailyTooltip).toContainText("0");
+
+    const monthlyRevenueTooltip = chartCards.nth(5).locator(
+      ".recharts-tooltip-wrapper",
+    );
+    await chartSurfaces.nth(5).focus();
+    for (let index = 0; index < 3; index += 1) {
+      await page.keyboard.press("ArrowRight");
+    }
+    await expect(monthlyRevenueTooltip).toBeVisible();
+    await expect(monthlyRevenueTooltip).toContainText("July 2026");
+    await expect(monthlyRevenueTooltip).toContainText("Personal subscriptions");
+    await expect(monthlyRevenueTooltip).toContainText("$118");
+    await expect(monthlyRevenueTooltip).toContainText("Family subscriptions");
+    await expect(monthlyRevenueTooltip).toContainText("$43");
+    await expect(monthlyRevenueTooltip).toContainText("Group sponsorship");
+    await expect(monthlyRevenueTooltip).toContainText("$15");
+    await expect(monthlyRevenueTooltip).toContainText("Usage top-ups");
+    await expect(monthlyRevenueTooltip).toContainText("$25");
+    await expect(monthlyRevenueTooltip).toContainText("Total");
+    await expect(monthlyRevenueTooltip).toContainText("$201");
+    for (let index = 0; index < 3; index += 1) {
+      await page.keyboard.press("ArrowLeft");
+    }
+    await expect(monthlyRevenueTooltip).toContainText("April 2026");
+    await expect(monthlyRevenueTooltip).toContainText(
+      "Subscriptions (personal + family)",
+    );
+    await expect(monthlyRevenueTooltip).toContainText("$62");
+    await expect(monthlyRevenueTooltip).toContainText("$72");
 
     await page.emulateMedia({ forcedColors: "active" });
     await expect(activityLines.nth(1)).toHaveAttribute("stroke-dasharray", "6 4");

--- a/apps/web/prisma/migrations/20260807140000_hosted_growth_snapshot_mrr_breakdown/migration.sql
+++ b/apps/web/prisma/migrations/20260807140000_hosted_growth_snapshot_mrr_breakdown/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "hosted_growth_daily_snapshot"
+ADD COLUMN "individual_mrr_usd_cents" INTEGER,
+ADD COLUMN "family_mrr_usd_cents" INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1365,6 +1365,10 @@ model HostedGrowthDailySnapshot {
   // Null means the window is unknown or incomplete, never zero.
   activeUsersPriorDay      Int? @map("active_users_prior_day")
   activeUsersTrailing7Days Int? @map("active_users_trailing_7_days")
+  // MRR split behind mrr_usd_cents: individual plans versus family seats.
+  // Null means the row predates split capture, never zero.
+  individualMrrUsdCents Int? @map("individual_mrr_usd_cents")
+  familyMrrUsdCents     Int? @map("family_mrr_usd_cents")
 
   @@map("hosted_growth_daily_snapshot")
 }

--- a/apps/web/src/lib/hosted-ops/growth-metrics.ts
+++ b/apps/web/src/lib/hosted-ops/growth-metrics.ts
@@ -12,6 +12,7 @@ import {
 import { parseHostedExecutionWake } from "@murphai/hosted-execution/parsers";
 import {
   HostedBillingStatus,
+  HostedUsageCreditPurchaseStatus,
   type Prisma,
   type PrismaClient,
 } from "@prisma/client";
@@ -46,11 +47,19 @@ import {
   buildHostedGrowthMessageSeries,
   type HostedGrowthMessagePoint,
 } from "@/src/lib/hosted-ops/growth-message-series";
+import {
+  MONTHLY_REVENUE_MONTHS,
+  buildHostedGrowthMonthlyRevenueSeries,
+  startOfUtcMonthsAgo,
+  type HostedGrowthMonthlyRevenuePoint,
+} from "@/src/lib/hosted-ops/growth-monthly-revenue-series";
 import { HOSTED_MESSAGE_VOLUME_BASE } from "@/src/lib/message-volume";
 import { getPrisma } from "@/src/lib/prisma";
 
 export { buildHostedGrowthMessageSeries } from "@/src/lib/hosted-ops/growth-message-series";
 export type { HostedGrowthMessagePoint } from "@/src/lib/hosted-ops/growth-message-series";
+export { buildHostedGrowthMonthlyRevenueSeries } from "@/src/lib/hosted-ops/growth-monthly-revenue-series";
+export type { HostedGrowthMonthlyRevenuePoint } from "@/src/lib/hosted-ops/growth-monthly-revenue-series";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DAILY_SERIES_DAYS = 30;
@@ -180,7 +189,9 @@ export interface HostedGrowthSnapshotRow {
   activeUsersTrailing7Days: number | null;
   capturedAt: Date;
   coveredMembers: number;
+  familyMrrUsdCents: number | null;
   inboundMessagesPriorDay: number | null;
+  individualMrrUsdCents: number | null;
   mrrUsdCents: number;
   outboundMessagesPriorDay: number | null;
   payingCustomers: number;
@@ -275,6 +286,7 @@ export interface HostedGrowthDashboard {
   current: HostedGrowthCurrentMetrics;
   dailySeries: HostedGrowthDailyPoint[];
   messageSeries: HostedGrowthMessagePoint[];
+  monthlyRevenueSeries: HostedGrowthMonthlyRevenuePoint[];
   mrrWowPercent: number | null;
   newMembers: {
     today: number;
@@ -1176,6 +1188,10 @@ export async function readHostedGrowthDashboard(
   const activeUsersCurrentStart = addUtcDays(now, -7);
   const activeUsersPreviousStart = addUtcDays(now, -14);
   const activeUsersMonthlyStart = addUtcDays(now, -30);
+  const monthlyRevenueStart = startOfUtcMonthsAgo(
+    todayStart,
+    MONTHLY_REVENUE_MONTHS - 1,
+  );
 
   const [
     current,
@@ -1191,6 +1207,8 @@ export async function readHostedGrowthDashboard(
     activeUsersTrailing30DayDirectRows,
     activeUsersGroupRows,
     activeUsersTodayDirectRows,
+    monthlyRevenueSnapshots,
+    monthlyRevenuePurchases,
   ] = await Promise.all([
     readCurrentHostedGrowthMetrics(now, prisma),
     prisma.hostedMember.findMany({
@@ -1364,6 +1382,43 @@ export async function readHostedGrowthDashboard(
         },
       },
     }),
+    prisma.hostedGrowthDailySnapshot.findMany({
+      orderBy: {
+        snapshotDate: "asc",
+      },
+      select: {
+        familyMrrUsdCents: true,
+        individualMrrUsdCents: true,
+        mrrUsdCents: true,
+        snapshotDate: true,
+      },
+      where: {
+        snapshotDate: {
+          gte: monthlyRevenueStart,
+          lte: todayStart,
+        },
+      },
+    }),
+    prisma.hostedUsageCreditPurchase.findMany({
+      select: {
+        cashAmountMinor: true,
+        groupSponsorshipAuthorizationId: true,
+        groupSponsorshipMoment: {
+          select: {
+            purchaseId: true,
+          },
+        },
+        paidAt: true,
+      },
+      where: {
+        paidAt: {
+          gte: monthlyRevenueStart,
+          lte: now,
+        },
+        status: HostedUsageCreditPurchaseStatus.fulfilled,
+        stripeLiveMode: true,
+      },
+    }),
   ]);
   const activeUsers = await calculateHostedGrowthActiveUsers({
     currentDirectRows: activeUsersTrailing7DayDirectRows,
@@ -1476,6 +1531,20 @@ export async function readHostedGrowthDashboard(
       trackingEstablishedBeforeSeries:
         messagesBeforeSeries._count.inboundMessagesPriorDay > 0
         && messagesBeforeSeries._count.outboundMessagesPriorDay > 0,
+      windowEnd: now,
+    }),
+    monthlyRevenueSeries: buildHostedGrowthMonthlyRevenueSeries({
+      monthCount: MONTHLY_REVENUE_MONTHS,
+      purchases: monthlyRevenuePurchases.flatMap((purchase) =>
+        purchase.paidAt === null ? [] : [{
+          cashAmountMinor: purchase.cashAmountMinor,
+          isGroupSponsorship:
+            purchase.groupSponsorshipAuthorizationId !== null
+            || purchase.groupSponsorshipMoment !== null,
+          paidAt: purchase.paidAt,
+        }]
+      ),
+      snapshots: monthlyRevenueSnapshots,
       windowEnd: now,
     }),
     mrrWowPercent: comparableSnapshot === null
@@ -1654,7 +1723,10 @@ export async function captureHostedGrowthDailySnapshot(
       activeUsersTrailing7Days: activityCreateCounts.activeUsersTrailing7Days,
       capturedAt: now,
       coveredMembers: current.coveredMembers,
+      familyMrrUsdCents: current.familyMrrUsdCents,
       inboundMessagesPriorDay,
+      individualMrrUsdCents:
+        current.pulseMrrUsdCents + current.edgeMrrUsdCents,
       mrrUsdCents: current.mrrUsdCents,
       outboundMessagesPriorDay,
       payingCustomers: current.payingCustomers,
@@ -1675,7 +1747,10 @@ export async function captureHostedGrowthDailySnapshot(
         : {}),
       capturedAt: now,
       coveredMembers: current.coveredMembers,
+      familyMrrUsdCents: current.familyMrrUsdCents,
       inboundMessagesPriorDay,
+      individualMrrUsdCents:
+        current.pulseMrrUsdCents + current.edgeMrrUsdCents,
       mrrUsdCents: current.mrrUsdCents,
       outboundMessagesPriorDay,
       payingCustomers: current.payingCustomers,
@@ -1925,7 +2000,9 @@ const growthSnapshotSelect = {
   activeUsersTrailing7Days: true,
   capturedAt: true,
   coveredMembers: true,
+  familyMrrUsdCents: true,
   inboundMessagesPriorDay: true,
+  individualMrrUsdCents: true,
   mrrUsdCents: true,
   outboundMessagesPriorDay: true,
   payingCustomers: true,

--- a/apps/web/src/lib/hosted-ops/growth-metrics.ts
+++ b/apps/web/src/lib/hosted-ops/growth-metrics.ts
@@ -1207,7 +1207,6 @@ export async function readHostedGrowthDashboard(
     activeUsersTrailing30DayDirectRows,
     activeUsersGroupRows,
     activeUsersTodayDirectRows,
-    monthlyRevenueSnapshots,
     monthlyRevenuePurchases,
   ] = await Promise.all([
     readCurrentHostedGrowthMetrics(now, prisma),
@@ -1254,6 +1253,10 @@ export async function readHostedGrowthDashboard(
         },
       },
     }),
+    // One snapshot read serves both the 30-day chart series and the
+    // six-month revenue projection; the message-history aggregate below
+    // still ends at dailyStart, so widening this window double-counts
+    // nothing.
     prisma.hostedGrowthDailySnapshot.findMany({
       orderBy: {
         snapshotDate: "asc",
@@ -1261,7 +1264,7 @@ export async function readHostedGrowthDashboard(
       select: growthSnapshotSelect,
       where: {
         snapshotDate: {
-          gte: dailyStart,
+          gte: monthlyRevenueStart,
           lte: todayStart,
         },
       },
@@ -1379,23 +1382,6 @@ export async function readHostedGrowthDashboard(
         createdAt: {
           gte: todayStart,
           lt: now,
-        },
-      },
-    }),
-    prisma.hostedGrowthDailySnapshot.findMany({
-      orderBy: {
-        snapshotDate: "asc",
-      },
-      select: {
-        familyMrrUsdCents: true,
-        individualMrrUsdCents: true,
-        mrrUsdCents: true,
-        snapshotDate: true,
-      },
-      where: {
-        snapshotDate: {
-          gte: monthlyRevenueStart,
-          lte: todayStart,
         },
       },
     }),
@@ -1544,7 +1530,7 @@ export async function readHostedGrowthDashboard(
           paidAt: purchase.paidAt,
         }]
       ),
-      snapshots: monthlyRevenueSnapshots,
+      snapshots,
       windowEnd: now,
     }),
     mrrWowPercent: comparableSnapshot === null
@@ -1561,7 +1547,9 @@ export async function readHostedGrowthDashboard(
           current.payingCustomers,
           comparableSnapshot.payingCustomers,
         ),
-    snapshotSeries: snapshots.map(serializeSnapshotPoint),
+    snapshotSeries: snapshots
+      .filter((row) => row.snapshotDate.getTime() >= dailyStart.getTime())
+      .map(serializeSnapshotPoint),
     trialCohorts: buildTrialCohortRows({
       rowCount: WEEKLY_ROWS,
       trialStartRows,

--- a/apps/web/src/lib/hosted-ops/growth-monthly-revenue-series.ts
+++ b/apps/web/src/lib/hosted-ops/growth-monthly-revenue-series.ts
@@ -18,19 +18,24 @@ export interface HostedGrowthMonthlyRevenuePoint {
   groupSponsorshipUsdCents: number;
   individualSubscriptionsUsdCents: number | null;
   month: string;
+  monthToDate: boolean;
   subscriptionsUnsplitUsdCents: number | null;
-  totalUsdCents: number;
+  totalUsdCents: number | null;
   usageTopUpsUsdCents: number;
 }
 
 /**
- * Subscription revenue per month is the MRR recorded by that month's latest
- * daily snapshot; there is no local subscription invoice ledger to sum.
- * Snapshot rows written before the split columns existed only carry the MRR
- * total, so those months report one unsplit subscription value instead of the
- * individual/family split. Top-up and sponsorship revenue sums fulfilled
- * purchase cash by the UTC month of payment. Months before the first snapshot
- * or purchase are trimmed; the window-end month always renders.
+ * An operational estimate, not an invoice ledger: subscription revenue per
+ * month is the MRR recorded by that month's latest daily snapshot, and top-up
+ * and sponsorship revenue sums fulfilled purchase cash by the UTC month of
+ * payment. Snapshot rows written before the split columns existed only carry
+ * the MRR total, so those months report one unsplit subscription value. A
+ * recorded split is trusted only when it sums to the row's MRR total, so a
+ * stale or half-written split falls back to the honest unsplit value. A month
+ * with no snapshot has an unknown subscription component and therefore an
+ * unknown total, even when its purchase cash is known. Months before the
+ * first snapshot or purchase are trimmed; the window-end month always renders
+ * and is marked month-to-date.
  */
 export function buildHostedGrowthMonthlyRevenueSeries(input: {
   monthCount: number;
@@ -39,6 +44,7 @@ export function buildHostedGrowthMonthlyRevenueSeries(input: {
   windowEnd: Date;
 }): HostedGrowthMonthlyRevenuePoint[] {
   const endMonthStart = startOfUtcMonth(input.windowEnd);
+  const endMonth = formatUtcMonthKey(endMonthStart);
   const latestSnapshotByMonth = new Map<
     string,
     HostedGrowthRevenueSnapshotInput
@@ -91,18 +97,22 @@ export function buildHostedGrowthMonthlyRevenueSeries(input: {
     const purchases = purchaseTotalsByMonth.get(month);
     const groupSponsorshipUsdCents = purchases?.groupSponsorshipUsdCents ?? 0;
     const usageTopUpsUsdCents = purchases?.usageTopUpsUsdCents ?? 0;
+    const subscriptionsUsdCents = subscriptions.unsplitUsdCents
+      ?? (subscriptions.individualUsdCents === null
+        || subscriptions.familyUsdCents === null
+        ? null
+        : subscriptions.individualUsdCents + subscriptions.familyUsdCents);
 
     return {
       familySubscriptionsUsdCents: subscriptions.familyUsdCents,
       groupSponsorshipUsdCents,
       individualSubscriptionsUsdCents: subscriptions.individualUsdCents,
       month,
+      monthToDate: month === endMonth,
       subscriptionsUnsplitUsdCents: subscriptions.unsplitUsdCents,
-      totalUsdCents: (subscriptions.individualUsdCents ?? 0)
-        + (subscriptions.familyUsdCents ?? 0)
-        + (subscriptions.unsplitUsdCents ?? 0)
-        + groupSponsorshipUsdCents
-        + usageTopUpsUsdCents,
+      totalUsdCents: subscriptionsUsdCents === null
+        ? null
+        : subscriptionsUsdCents + groupSponsorshipUsdCents + usageTopUpsUsdCents,
       usageTopUpsUsdCents,
     };
   });
@@ -126,6 +136,8 @@ function readMonthSubscriptions(
   if (
     snapshot.individualMrrUsdCents !== null
     && snapshot.familyMrrUsdCents !== null
+    && snapshot.individualMrrUsdCents + snapshot.familyMrrUsdCents
+      === snapshot.mrrUsdCents
   ) {
     return {
       familyUsdCents: snapshot.familyMrrUsdCents,

--- a/apps/web/src/lib/hosted-ops/growth-monthly-revenue-series.ts
+++ b/apps/web/src/lib/hosted-ops/growth-monthly-revenue-series.ts
@@ -1,0 +1,162 @@
+export const MONTHLY_REVENUE_MONTHS = 6;
+
+export interface HostedGrowthRevenueSnapshotInput {
+  familyMrrUsdCents: number | null;
+  individualMrrUsdCents: number | null;
+  mrrUsdCents: number;
+  snapshotDate: Date;
+}
+
+export interface HostedGrowthRevenuePurchaseInput {
+  cashAmountMinor: number;
+  isGroupSponsorship: boolean;
+  paidAt: Date;
+}
+
+export interface HostedGrowthMonthlyRevenuePoint {
+  familySubscriptionsUsdCents: number | null;
+  groupSponsorshipUsdCents: number;
+  individualSubscriptionsUsdCents: number | null;
+  month: string;
+  subscriptionsUnsplitUsdCents: number | null;
+  totalUsdCents: number;
+  usageTopUpsUsdCents: number;
+}
+
+/**
+ * Subscription revenue per month is the MRR recorded by that month's latest
+ * daily snapshot; there is no local subscription invoice ledger to sum.
+ * Snapshot rows written before the split columns existed only carry the MRR
+ * total, so those months report one unsplit subscription value instead of the
+ * individual/family split. Top-up and sponsorship revenue sums fulfilled
+ * purchase cash by the UTC month of payment. Months before the first snapshot
+ * or purchase are trimmed; the window-end month always renders.
+ */
+export function buildHostedGrowthMonthlyRevenueSeries(input: {
+  monthCount: number;
+  purchases: HostedGrowthRevenuePurchaseInput[];
+  snapshots: HostedGrowthRevenueSnapshotInput[];
+  windowEnd: Date;
+}): HostedGrowthMonthlyRevenuePoint[] {
+  const endMonthStart = startOfUtcMonth(input.windowEnd);
+  const latestSnapshotByMonth = new Map<
+    string,
+    HostedGrowthRevenueSnapshotInput
+  >();
+  for (const snapshot of input.snapshots) {
+    const month = formatUtcMonthKey(snapshot.snapshotDate);
+    const existing = latestSnapshotByMonth.get(month);
+    if (existing === undefined || existing.snapshotDate < snapshot.snapshotDate) {
+      latestSnapshotByMonth.set(month, snapshot);
+    }
+  }
+
+  const purchaseTotalsByMonth = new Map<string, {
+    groupSponsorshipUsdCents: number;
+    usageTopUpsUsdCents: number;
+  }>();
+  for (const purchase of input.purchases) {
+    const month = formatUtcMonthKey(purchase.paidAt);
+    const totals = purchaseTotalsByMonth.get(month) ?? {
+      groupSponsorshipUsdCents: 0,
+      usageTopUpsUsdCents: 0,
+    };
+    if (purchase.isGroupSponsorship) {
+      totals.groupSponsorshipUsdCents += purchase.cashAmountMinor;
+    } else {
+      totals.usageTopUpsUsdCents += purchase.cashAmountMinor;
+    }
+    purchaseTotalsByMonth.set(month, totals);
+  }
+
+  const months = Array.from({ length: input.monthCount }, (_, index) => {
+    const month = formatUtcMonthKey(
+      addUtcMonths(endMonthStart, index - (input.monthCount - 1)),
+    );
+    return {
+      hasData: latestSnapshotByMonth.has(month)
+        || purchaseTotalsByMonth.has(month),
+      month,
+    };
+  });
+  const firstMonthWithData = months.findIndex((candidate) => candidate.hasData);
+  const renderedMonths = firstMonthWithData === -1
+    ? months.slice(-1)
+    : months.slice(firstMonthWithData);
+
+  return renderedMonths.map(({ month }) => {
+    const subscriptions = readMonthSubscriptions(
+      latestSnapshotByMonth.get(month),
+    );
+    const purchases = purchaseTotalsByMonth.get(month);
+    const groupSponsorshipUsdCents = purchases?.groupSponsorshipUsdCents ?? 0;
+    const usageTopUpsUsdCents = purchases?.usageTopUpsUsdCents ?? 0;
+
+    return {
+      familySubscriptionsUsdCents: subscriptions.familyUsdCents,
+      groupSponsorshipUsdCents,
+      individualSubscriptionsUsdCents: subscriptions.individualUsdCents,
+      month,
+      subscriptionsUnsplitUsdCents: subscriptions.unsplitUsdCents,
+      totalUsdCents: (subscriptions.individualUsdCents ?? 0)
+        + (subscriptions.familyUsdCents ?? 0)
+        + (subscriptions.unsplitUsdCents ?? 0)
+        + groupSponsorshipUsdCents
+        + usageTopUpsUsdCents,
+      usageTopUpsUsdCents,
+    };
+  });
+}
+
+function readMonthSubscriptions(
+  snapshot: HostedGrowthRevenueSnapshotInput | undefined,
+): {
+  familyUsdCents: number | null;
+  individualUsdCents: number | null;
+  unsplitUsdCents: number | null;
+} {
+  if (snapshot === undefined) {
+    return {
+      familyUsdCents: null,
+      individualUsdCents: null,
+      unsplitUsdCents: null,
+    };
+  }
+
+  if (
+    snapshot.individualMrrUsdCents !== null
+    && snapshot.familyMrrUsdCents !== null
+  ) {
+    return {
+      familyUsdCents: snapshot.familyMrrUsdCents,
+      individualUsdCents: snapshot.individualMrrUsdCents,
+      unsplitUsdCents: null,
+    };
+  }
+
+  return {
+    familyUsdCents: null,
+    individualUsdCents: null,
+    unsplitUsdCents: snapshot.mrrUsdCents,
+  };
+}
+
+function addUtcMonths(value: Date, months: number): Date {
+  return new Date(Date.UTC(
+    value.getUTCFullYear(),
+    value.getUTCMonth() + months,
+    1,
+  ));
+}
+
+function formatUtcMonthKey(value: Date): string {
+  return value.toISOString().slice(0, 7);
+}
+
+function startOfUtcMonth(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), 1));
+}
+
+export function startOfUtcMonthsAgo(value: Date, monthsAgo: number): Date {
+  return addUtcMonths(startOfUtcMonth(value), -monthsAgo);
+}

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -1083,6 +1083,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260806120000_hosted_growth_snapshot_active_users",
       "20260806170000_hosted_pulse_trial_start_source",
       "20260806180000_fix_hosted_usage_plan_transition_bridge",
+      "20260807140000_hosted_growth_snapshot_mrr_breakdown",
       "migration_lock.toml",
     ]);
     expect(hostedPendingGroupSetupMigrationSql).toContain(

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -2152,6 +2152,66 @@ describe("hosted ops growth metrics", () => {
     });
   });
 
+  it("moves a one-time group gift to usage top-ups when payer deletion removes its sponsorship moment", async () => {
+    // Payer-only account deletion retains the fulfilled cross-owner purchase
+    // but cascades away its HostedGroupSponsorshipMoment, so the same cash is
+    // classified as a plain top-up on the next read. The card copy discloses
+    // this; the total must not change.
+    const now = new Date("2026-08-07T12:00:00.000Z");
+    const giftRow = {
+      cashAmountMinor: 2_000,
+      groupSponsorshipAuthorizationId: null,
+      paidAt: new Date("2026-08-03T09:00:00.000Z"),
+    };
+    queueCurrentMetricMocks();
+    mocks.hostedMember.findMany.mockResolvedValueOnce([]);
+    mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce([
+      snapshotRow("2026-08-07", 2_900),
+    ]);
+    mocks.hostedUsageCreditPurchase.findMany.mockResolvedValueOnce([
+      {
+        ...giftRow,
+        groupSponsorshipMoment: { purchaseId: "purchase_group_gift" },
+      },
+    ]);
+    mocks.hostedMemberBillingRef.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+
+    const beforeDeletion = await readHostedGrowthDashboard(now);
+
+    queueCurrentMetricMocks();
+    mocks.hostedMember.findMany.mockResolvedValueOnce([]);
+    mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce([
+      snapshotRow("2026-08-07", 2_900),
+    ]);
+    mocks.hostedUsageCreditPurchase.findMany.mockResolvedValueOnce([
+      {
+        ...giftRow,
+        groupSponsorshipMoment: null,
+      },
+    ]);
+    mocks.hostedMemberBillingRef.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+
+    const afterDeletion = await readHostedGrowthDashboard(now);
+
+    const beforePoint = beforeDeletion.monthlyRevenueSeries.at(-1);
+    const afterPoint = afterDeletion.monthlyRevenueSeries.at(-1);
+    expect(beforePoint).toMatchObject({
+      groupSponsorshipUsdCents: 2_000,
+      usageTopUpsUsdCents: 0,
+    });
+    expect(afterPoint).toMatchObject({
+      groupSponsorshipUsdCents: 0,
+      usageTopUpsUsdCents: 2_000,
+    });
+    expect(afterPoint?.totalUsdCents).toEqual(beforePoint?.totalUsdCents);
+  });
+
   it("records the subscription split in the daily snapshot", async () => {
     const now = new Date("2026-08-07T12:00:00.000Z");
     mocks.hostedAccountGroup.findMany.mockResolvedValueOnce([

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -1929,6 +1929,7 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 1_500,
         individualSubscriptionsUsdCents: null,
         month: "2026-07",
+        monthToDate: false,
         subscriptionsUnsplitUsdCents: 17_100,
         totalUsdCents: 26_100,
         usageTopUpsUsdCents: 7_500,
@@ -1938,6 +1939,7 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 2_000,
         individualSubscriptionsUsdCents: 14_400,
         month: "2026-08",
+        monthToDate: true,
         subscriptionsUnsplitUsdCents: null,
         totalUsdCents: 25_500,
         usageTopUpsUsdCents: 3_000,
@@ -1945,7 +1947,36 @@ describe("hosted ops growth metrics", () => {
     ]);
   });
 
-  it("keeps purchase-only months after trimming months without revenue evidence", () => {
+  it("falls back to the unsplit subscription value when a recorded split does not sum to the MRR total", () => {
+    const series = buildHostedGrowthMonthlyRevenueSeries({
+      monthCount: 1,
+      purchases: [],
+      snapshots: [
+        {
+          familyMrrUsdCents: 6_100,
+          individualMrrUsdCents: 14_400,
+          mrrUsdCents: 21_700,
+          snapshotDate: new Date("2026-08-07T00:00:00.000Z"),
+        },
+      ],
+      windowEnd: new Date("2026-08-07T12:00:00.000Z"),
+    });
+
+    expect(series).toEqual([
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 0,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-08",
+        monthToDate: true,
+        subscriptionsUnsplitUsdCents: 21_700,
+        totalUsdCents: 21_700,
+        usageTopUpsUsdCents: 0,
+      },
+    ]);
+  });
+
+  it("withholds the total for months without a subscription snapshot", () => {
     const series = buildHostedGrowthMonthlyRevenueSeries({
       monthCount: 3,
       purchases: [
@@ -1965,8 +1996,9 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 0,
         individualSubscriptionsUsdCents: null,
         month: "2026-06",
+        monthToDate: false,
         subscriptionsUnsplitUsdCents: null,
-        totalUsdCents: 1_000,
+        totalUsdCents: null,
         usageTopUpsUsdCents: 1_000,
       },
       {
@@ -1974,8 +2006,9 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 0,
         individualSubscriptionsUsdCents: null,
         month: "2026-07",
+        monthToDate: false,
         subscriptionsUnsplitUsdCents: null,
-        totalUsdCents: 0,
+        totalUsdCents: null,
         usageTopUpsUsdCents: 0,
       },
       {
@@ -1983,8 +2016,9 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 0,
         individualSubscriptionsUsdCents: null,
         month: "2026-08",
+        monthToDate: true,
         subscriptionsUnsplitUsdCents: null,
-        totalUsdCents: 0,
+        totalUsdCents: null,
         usageTopUpsUsdCents: 0,
       },
     ]);
@@ -2004,8 +2038,9 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 0,
         individualSubscriptionsUsdCents: null,
         month: "2026-08",
+        monthToDate: true,
         subscriptionsUnsplitUsdCents: null,
-        totalUsdCents: 0,
+        totalUsdCents: null,
         usageTopUpsUsdCents: 0,
       },
     ]);
@@ -2016,22 +2051,14 @@ describe("hosted ops growth metrics", () => {
     queueCurrentMetricMocks();
     mocks.hostedMember.findMany.mockResolvedValueOnce([]);
     mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
-    mocks.hostedGrowthDailySnapshot.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          familyMrrUsdCents: null,
-          individualMrrUsdCents: null,
-          mrrUsdCents: 17_100,
-          snapshotDate: new Date("2026-07-31T00:00:00.000Z"),
-        },
-        {
-          familyMrrUsdCents: 6_100,
-          individualMrrUsdCents: 14_400,
-          mrrUsdCents: 20_500,
-          snapshotDate: new Date("2026-08-07T00:00:00.000Z"),
-        },
-      ]);
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValueOnce([
+      snapshotRow("2026-07-31", 17_100),
+      {
+        ...snapshotRow("2026-08-07", 20_500),
+        familyMrrUsdCents: 6_100,
+        individualMrrUsdCents: 14_400,
+      },
+    ]);
     mocks.hostedUsageCreditPurchase.findMany.mockResolvedValueOnce([
       {
         cashAmountMinor: 1_500,
@@ -2076,6 +2103,7 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 1_500,
         individualSubscriptionsUsdCents: null,
         month: "2026-07",
+        monthToDate: false,
         subscriptionsUnsplitUsdCents: 17_100,
         totalUsdCents: 26_100,
         usageTopUpsUsdCents: 7_500,
@@ -2085,6 +2113,7 @@ describe("hosted ops growth metrics", () => {
         groupSponsorshipUsdCents: 2_000,
         individualSubscriptionsUsdCents: 14_400,
         month: "2026-08",
+        monthToDate: true,
         subscriptionsUnsplitUsdCents: null,
         totalUsdCents: 25_500,
         usageTopUpsUsdCents: 3_000,
@@ -2110,8 +2139,9 @@ describe("hosted ops growth metrics", () => {
         stripeLiveMode: true,
       },
     });
+    expect(mocks.hostedGrowthDailySnapshot.findMany).toHaveBeenCalledTimes(1);
     expect(
-      mocks.hostedGrowthDailySnapshot.findMany.mock.calls[1]?.[0],
+      mocks.hostedGrowthDailySnapshot.findMany.mock.calls[0]?.[0],
     ).toMatchObject({
       where: {
         snapshotDate: {

--- a/apps/web/test/hosted-ops-growth.test.ts
+++ b/apps/web/test/hosted-ops-growth.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   addUtcDays,
   buildHostedGrowthMessageSeries,
+  buildHostedGrowthMonthlyRevenueSeries,
   buildHostedGrowthTrialStartAttribution,
   buildTrialCohortRows,
   calculateHostedGrowthCurrentMetrics,
@@ -78,6 +79,9 @@ const mocks = vi.hoisted(() => ({
   },
   hostedMemberBillingRef: {
     count: vi.fn(),
+    findMany: vi.fn(),
+  },
+  hostedUsageCreditPurchase: {
     findMany: vi.fn(),
   },
   requireActiveHostedAppSession: vi.fn(),
@@ -135,6 +139,7 @@ const prisma = {
   hostedMemberRouting: mocks.hostedMemberRouting,
   hostedMember: mocks.hostedMember,
   hostedMemberBillingRef: mocks.hostedMemberBillingRef,
+  hostedUsageCreditPurchase: mocks.hostedUsageCreditPurchase,
 };
 
 const zeroStatusCounts = {
@@ -175,6 +180,8 @@ describe("hosted ops growth metrics", () => {
     mocks.hostedGrowthAggregate.findUniqueOrThrow.mockResolvedValue({
       trackedFulfilledUsageTopUps: 0,
     });
+    mocks.hostedGrowthDailySnapshot.findMany.mockResolvedValue([]);
+    mocks.hostedUsageCreditPurchase.findMany.mockResolvedValue([]);
     mocks.hostedGrowthDailySnapshot.aggregate.mockResolvedValue({
       _count: {
         inboundMessagesPriorDay: 0,
@@ -1868,6 +1875,289 @@ describe("hosted ops growth metrics", () => {
     expect(selected?.mrrUsdCents).toBe(1_000);
   });
 
+  it("splits monthly subscriptions from the month's latest snapshot and buckets purchases by paid month", () => {
+    const series = buildHostedGrowthMonthlyRevenueSeries({
+      monthCount: 6,
+      purchases: [
+        {
+          cashAmountMinor: 1_500,
+          isGroupSponsorship: true,
+          paidAt: new Date("2026-07-31T23:59:59.999Z"),
+        },
+        {
+          cashAmountMinor: 7_500,
+          isGroupSponsorship: false,
+          paidAt: new Date("2026-07-04T10:00:00.000Z"),
+        },
+        {
+          cashAmountMinor: 2_000,
+          isGroupSponsorship: true,
+          paidAt: new Date("2026-08-01T00:00:00.000Z"),
+        },
+        {
+          cashAmountMinor: 3_000,
+          isGroupSponsorship: false,
+          paidAt: new Date("2026-08-05T15:00:00.000Z"),
+        },
+      ],
+      snapshots: [
+        {
+          familyMrrUsdCents: null,
+          individualMrrUsdCents: null,
+          mrrUsdCents: 17_100,
+          snapshotDate: new Date("2026-07-31T00:00:00.000Z"),
+        },
+        {
+          familyMrrUsdCents: 6_100,
+          individualMrrUsdCents: 14_400,
+          mrrUsdCents: 20_500,
+          snapshotDate: new Date("2026-08-07T00:00:00.000Z"),
+        },
+        {
+          familyMrrUsdCents: 5_000,
+          individualMrrUsdCents: 13_000,
+          mrrUsdCents: 18_000,
+          snapshotDate: new Date("2026-08-03T00:00:00.000Z"),
+        },
+      ],
+      windowEnd: new Date("2026-08-07T12:00:00.000Z"),
+    });
+
+    expect(series).toEqual([
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 1_500,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-07",
+        subscriptionsUnsplitUsdCents: 17_100,
+        totalUsdCents: 26_100,
+        usageTopUpsUsdCents: 7_500,
+      },
+      {
+        familySubscriptionsUsdCents: 6_100,
+        groupSponsorshipUsdCents: 2_000,
+        individualSubscriptionsUsdCents: 14_400,
+        month: "2026-08",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 25_500,
+        usageTopUpsUsdCents: 3_000,
+      },
+    ]);
+  });
+
+  it("keeps purchase-only months after trimming months without revenue evidence", () => {
+    const series = buildHostedGrowthMonthlyRevenueSeries({
+      monthCount: 3,
+      purchases: [
+        {
+          cashAmountMinor: 1_000,
+          isGroupSponsorship: false,
+          paidAt: new Date("2026-06-10T00:00:00.000Z"),
+        },
+      ],
+      snapshots: [],
+      windowEnd: new Date("2026-08-07T12:00:00.000Z"),
+    });
+
+    expect(series).toEqual([
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 0,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-06",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 1_000,
+        usageTopUpsUsdCents: 1_000,
+      },
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 0,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-07",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 0,
+        usageTopUpsUsdCents: 0,
+      },
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 0,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-08",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 0,
+        usageTopUpsUsdCents: 0,
+      },
+    ]);
+  });
+
+  it("renders only the window-end month when no revenue evidence exists", () => {
+    const series = buildHostedGrowthMonthlyRevenueSeries({
+      monthCount: 6,
+      purchases: [],
+      snapshots: [],
+      windowEnd: new Date("2026-08-07T12:00:00.000Z"),
+    });
+
+    expect(series).toEqual([
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 0,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-08",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 0,
+        usageTopUpsUsdCents: 0,
+      },
+    ]);
+  });
+
+  it("builds the dashboard monthly revenue series from fulfilled live purchases", async () => {
+    const now = new Date("2026-08-07T12:00:00.000Z");
+    queueCurrentMetricMocks();
+    mocks.hostedMember.findMany.mockResolvedValueOnce([]);
+    mocks.hostedMemberBillingRef.findMany.mockResolvedValueOnce([]);
+    mocks.hostedGrowthDailySnapshot.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          familyMrrUsdCents: null,
+          individualMrrUsdCents: null,
+          mrrUsdCents: 17_100,
+          snapshotDate: new Date("2026-07-31T00:00:00.000Z"),
+        },
+        {
+          familyMrrUsdCents: 6_100,
+          individualMrrUsdCents: 14_400,
+          mrrUsdCents: 20_500,
+          snapshotDate: new Date("2026-08-07T00:00:00.000Z"),
+        },
+      ]);
+    mocks.hostedUsageCreditPurchase.findMany.mockResolvedValueOnce([
+      {
+        cashAmountMinor: 1_500,
+        groupSponsorshipAuthorizationId: null,
+        groupSponsorshipMoment: { purchaseId: "purchase_group_gift" },
+        paidAt: new Date("2026-07-27T09:00:00.000Z"),
+      },
+      {
+        cashAmountMinor: 7_500,
+        groupSponsorshipAuthorizationId: null,
+        groupSponsorshipMoment: null,
+        paidAt: new Date("2026-07-04T10:00:00.000Z"),
+      },
+      {
+        cashAmountMinor: 2_000,
+        groupSponsorshipAuthorizationId: "auth_recurring",
+        groupSponsorshipMoment: null,
+        paidAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+      {
+        cashAmountMinor: 3_000,
+        groupSponsorshipAuthorizationId: null,
+        groupSponsorshipMoment: null,
+        paidAt: new Date("2026-08-05T15:00:00.000Z"),
+      },
+      {
+        cashAmountMinor: 9_900,
+        groupSponsorshipAuthorizationId: null,
+        groupSponsorshipMoment: null,
+        paidAt: null,
+      },
+    ]);
+    mocks.hostedMemberBillingRef.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+
+    const dashboard = await readHostedGrowthDashboard(now);
+
+    expect(dashboard.monthlyRevenueSeries).toEqual([
+      {
+        familySubscriptionsUsdCents: null,
+        groupSponsorshipUsdCents: 1_500,
+        individualSubscriptionsUsdCents: null,
+        month: "2026-07",
+        subscriptionsUnsplitUsdCents: 17_100,
+        totalUsdCents: 26_100,
+        usageTopUpsUsdCents: 7_500,
+      },
+      {
+        familySubscriptionsUsdCents: 6_100,
+        groupSponsorshipUsdCents: 2_000,
+        individualSubscriptionsUsdCents: 14_400,
+        month: "2026-08",
+        subscriptionsUnsplitUsdCents: null,
+        totalUsdCents: 25_500,
+        usageTopUpsUsdCents: 3_000,
+      },
+    ]);
+    expect(mocks.hostedUsageCreditPurchase.findMany.mock.calls[0]?.[0]).toEqual({
+      select: {
+        cashAmountMinor: true,
+        groupSponsorshipAuthorizationId: true,
+        groupSponsorshipMoment: {
+          select: {
+            purchaseId: true,
+          },
+        },
+        paidAt: true,
+      },
+      where: {
+        paidAt: {
+          gte: new Date("2026-03-01T00:00:00.000Z"),
+          lte: now,
+        },
+        status: "fulfilled",
+        stripeLiveMode: true,
+      },
+    });
+    expect(
+      mocks.hostedGrowthDailySnapshot.findMany.mock.calls[1]?.[0],
+    ).toMatchObject({
+      where: {
+        snapshotDate: {
+          gte: new Date("2026-03-01T00:00:00.000Z"),
+          lte: new Date("2026-08-07T00:00:00.000Z"),
+        },
+      },
+    });
+  });
+
+  it("records the subscription split in the daily snapshot", async () => {
+    const now = new Date("2026-08-07T12:00:00.000Z");
+    mocks.hostedAccountGroup.findMany.mockResolvedValueOnce([
+      {
+        billingRef: {
+          billedSeatCount: 2,
+          currentBillingPhase: "paid",
+        },
+        id: "group_family",
+        memberships: [
+          { memberId: "member_family_owner" },
+          { memberId: "member_family_seat" },
+        ],
+        planCapacities: [{ billedQuantity: 2, planCode: "pulse" }],
+      },
+    ]);
+    queueCurrentMetricMocks();
+    mocks.hostedGrowthDailySnapshot.upsert.mockResolvedValueOnce(
+      snapshotRow("2026-08-07", 4_200),
+    );
+
+    await captureHostedGrowthDailySnapshot(now);
+
+    const upsertArg = mocks.hostedGrowthDailySnapshot.upsert.mock.calls[0]?.[0];
+    expect(upsertArg?.create).toMatchObject({
+      familyMrrUsdCents: 1_400,
+      individualMrrUsdCents: 2_800,
+      mrrUsdCents: 4_200,
+    });
+    expect(upsertArg?.update).toMatchObject({
+      familyMrrUsdCents: 1_400,
+      individualMrrUsdCents: 2_800,
+      mrrUsdCents: 4_200,
+    });
+  });
+
   it("upserts one daily snapshot per UTC date", async () => {
     const now = new Date("2026-07-06T12:00:00.000Z");
     queueCurrentMetricMocks();
@@ -2628,7 +2918,9 @@ function snapshotRow(date: string, mrrUsdCents: number) {
     activeUsersTrailing7Days: null,
     capturedAt: new Date(`${date}T00:05:00.000Z`),
     coveredMembers: 3,
+    familyMrrUsdCents: null,
     inboundMessagesPriorDay: 0,
+    individualMrrUsdCents: null,
     mrrUsdCents,
     outboundMessagesPriorDay: 0,
     payingCustomers: 3,


### PR DESCRIPTION
## Why this PR exists

The ops growth page shows MRR snapshots and a current-state revenue mix table, but there is no way to see how much revenue each calendar month produced or where it came from. The operator asked for a monthly revenue bar chart whose tooltip splits each month into personal subscriptions, family subscriptions, group sponsorship, and one-time usage top-ups.

## User goal / user-visible behavior

On `/ops/growth`, a new **Monthly revenue** chart ends the chart grid: one restrained sage bar per UTC month. The bar is an explicitly labeled operational estimate, not summed invoices: the subscription rate at the month's latest daily snapshot plus fulfilled live-mode top-up and group-sponsorship cash paid that month. The card copy states the estimate basis, that refunds are not subtracted, and that account deletion can remove past purchase cash or leave an old group gift counted as a regular top-up. Hovering, tapping, or keyboard-focusing a bar opens a tooltip listing personal subscriptions, family subscriptions, group sponsorship, and usage top-ups with a summed total row. The window-end month is labeled "month to date". Months whose snapshots predate the new split columns show one combined "Subscriptions (personal + family)" line instead of an invented split, and a month with no snapshot withholds its total ("Unavailable") and renders a bar gap while still listing its known one-time cash.

## User experience

The irreducible purpose is answering "roughly how much did we make each month, and from what" in one glance plus one hover; a single-color total bar with a breakdown tooltip is the fewest-elements form of that (no legend, no extra controls). Entry point: the existing ops-allowlisted growth page; the chart renders synchronously with the rest of the server-rendered dashboard (same page load, no new timing class, no async continuation). There is no user input, so failure/recovery reduces to honest data gaps: a month with no snapshot shows "Subscriptions — No snapshot" and "Total — Unavailable" with a bar gap, pre-split months show the combined subscriptions line, the newest month is marked month to date, and months before the first revenue evidence are trimmed rather than drawn as zero. Rendered evidence: desktop and mobile catalog captures below — desktop shows the keyboard-opened month-to-date July tooltip with the four-way split; mobile shows the withheld-total no-snapshot month. The growth-charts Playwright spec passes on both viewports against this head and keyboard-asserts the split, unsplit, and withheld-total tooltips.

## Invariants the PR must preserve

- The migration is expand-only: two nullable columns, no backfill, no constraint or index changes.
- The chart never presents an exact-cash claim: the card copy defines the estimate basis, discloses non-subtracted refunds and both deletion consequences (removed purchase cash; reclassified one-time group gifts), and the window-end month is labeled month to date.
- Only fulfilled, live-mode purchases count as purchase revenue, bucketed by `paidAt` UTC month, classified as sponsorship by the sponsorship authorization/moment markers.
- No invented history: pre-split months never display a personal/family split; a recorded split is trusted only when it sums to the row's MRR total (otherwise it falls back to the combined value); a month with no snapshot withholds its total rather than coercing the unknown component to zero.
- The ops page stays aggregate-only (no member or purchase identifiers) behind the existing ops allowlist, which is checked before any Prisma read.
- All five existing growth charts, the scorecard, tables, and their keyboard/focus behavior are unchanged; the widened snapshot read is filtered back to the 30-day window for the existing snapshot series.

## Non-obvious affected surfaces

- `captureHostedGrowthDailySnapshot` (called by both the Vercel cron and every growth-page load) now writes `individualMrrUsdCents`/`familyMrrUsdCents` on create and update, so today's row gains the split on first capture after deploy. Proof: updated capture tests including "records the subscription split in the daily snapshot".
- `HostedGrowthSnapshotRow` and `growthSnapshotSelect` gained two fields, and the existing dashboard snapshot query widened from 30 days to six months so one read serves both the daily series and the monthly projection; `snapshotSeries` is filtered back to the 30-day window. Proof: full `hosted-ops-growth` test file green, including a single-call query-shape assertion.
- The chart's numbers deliberately inherit the purchase ledger's semantics rather than financial-reconciliation truth, and the card copy now discloses every consequence: refunds are not subtracted (refund/dispute reconciliation never reduces `cashAmountMinor`), and account deletion can remove past purchase cash (beneficiary deletion removes retained purchases, including sponsorship cash) or leave an old one-time group gift counted as a regular top-up (payer deletion cascades away the sponsorship moment while the fulfilled purchase survives). Regression proof for the operator-visible reclassification: the dashboard test "moves a one-time group gift to usage top-ups when payer deletion removes its sponsorship moment", which holds the total constant while the category flips. The deletion cascades themselves are the privacy subsystem's owned, already-specified behavior; this PR adds no behavior to them.
- `readHostedGrowthDashboard` adds one bounded purchase query (fulfilled live purchases by `paidAt` over six months). The filter is only partially covered by existing indexes; current table cardinality is tiny (tens of rows), so no new index is added.

## Architecture and reuse

- **Existing systems reused**: the daily snapshot capture/upsert seam and its select contract (one widened read, no second query); `calculateHostedGrowthCurrentMetrics` (already computes the pulse/edge/family MRR split); the `ChartContainer`/`ChartTooltip` primitives, chart tokens, and the growth design study + e2e spec.
- **New logic**: a pure `buildHostedGrowthMonthlyRevenueSeries` projection (month-latest snapshot selection, split-sum consistency guard, unsplit fallback, purchase classification/bucketing, withheld totals for snapshot-less months, month-to-date flag, leading-month trim) and a `MonthlyRevenueTooltip` renderer with a runtime type guard plus a zero-height tooltip-anchor series that keeps the tooltip reachable on bar-gap months.
- **New abstractions**: none beyond that pure function and presentational component; the existing dashboard read/build contract was sufficient.
- **Complexity intentionally avoided**: no invoice/payment ledger or financial-history owner, no Stripe API reads at page load, no backfill or estimation of July's split, no refund-netting reinterpretation of credit-adjustment entries, no stacked multi-series palette (the tooltip carries the split), and no new cron or persisted aggregate.

## Hot reply path impact

Not applicable. The diff touches only the ops growth dashboard, its data projection, the snapshot capture writes, and test/docs surfaces; nothing on the Foreground Reply Critical Path changes.

## Murph initial provider input impact

Not applicable for both runtimes. No prompts, tool definitions, schemas, skills, Codex configuration, or provider-request assembly change; the diff is web dashboard code, a snapshot schema addition, and tests/docs.

## Preliminary specialist lenses

- Product experience: applicable. Intended outcome: the operator reads month-level revenue estimates at a glance and the four-way source split on hover/focus, with honest gaps, withheld totals, and a month-to-date marker for unknowable or partial history. Direct journey evidence: the passing growth-charts Playwright spec (desktop + mobile keyboard traversal of the split, unsplit, and withheld-total tooltips) and the catalog captures below.
- Prompt: not applicable — no prompt surfaces change.
- Frontend: applicable. Redacted rendered evidence: `monthly-revenue-desktop.png` (1440px viewport, 2x, month-to-date July tooltip open via keyboard) and `monthly-revenue-mobile.png` (390px viewport, 3x, withheld-total no-snapshot March tooltip open via keyboard), both captured from `/design?tab=sections#ops-weekly-growth-compass`.
- Coverage: applicable. Focused local proof: `apps/web/test/hosted-ops-growth.test.ts` (48 tests, including series completeness, split-sum guard, deletion-reclassification, dashboard, and capture cases) plus the growth-charts e2e spec on both viewports; exact-head CI: pending on the current head.

ReviewGPT context sensitivity: sensitive
Classification reason: persisted-state schema addition on the billing-adjacent growth snapshot plus revenue reporting semantics.

## Change-shape breakdown

Classification rule: `apps/web/app` + `apps/web/src` authored code = source; `apps/web/test` + `apps/web/e2e` = tests/fixtures; `*.md` (DESIGN.md, exec plan) = docs; Prisma schema + migration SQL = config/tooling. No binary files. Counted from the merge-base-to-head diff.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 535 | 3 |
| Tests/fixtures | 422 | 2 |
| Docs | 58 | 0 |
| Config/tooling | 7 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1022** | **5** |

## Design proof

- Design page: [/design?tab=sections#ops-weekly-growth-compass](https://www.withmurph.ai/design?tab=sections#ops-weekly-growth-compass) — the Ops Weekly Growth Compass study renders the real `GrowthCharts` component with synthetic monthly revenue data covering split months, one pre-split unsplit month, one purchase-only no-snapshot month, a trimmed empty month, and the month-to-date marker.
- Desktop screenshot: ![Monthly revenue desktop, month-to-date tooltip open](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/b02945a8-f867-449e-b113-d9ae0a8e3900/designproof)
- Mobile screenshot: ![Monthly revenue mobile, withheld-total no-snapshot tooltip open](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/b2b66a97-436d-4fee-4a63-223b86c6b300/designproof)

## Deployment skew / compatibility

Web-only deploy (Vercel); no Cloudflare/runner boundary is touched. The migration is a plain nullable two-column `ADD COLUMN` that passes the predeploy destructive-migration guard. While old and new code disagree: old code writes snapshot rows without the split, which new code renders as the combined subscriptions line; old code's same-date upsert can also refresh `mrrUsdCents` on a row whose split was written earlier by new code, and the reader's split-sum consistency guard treats any split that no longer sums to the MRR total as unsplit, so the skew window degrades to the honest combined line and self-heals on the next new-code capture. Old code ignores the extra columns entirely. Either deploy order is safe, rollback is safe, and no backfill or convergence check is needed. Post-deploy check: load `/ops/growth` once and confirm the current month's tooltip shows the personal/family split and the month-to-date label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ReviewGPT first-reviewed head: c748f0f90d5c1ed119ed499359fab52c1622cd47
