### PR TITLE
feat(web): show today's repeated experiment cadence

### DIFF
--- a/apps/web/app/design/design-page.tsx
+++ b/apps/web/app/design/design-page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { BrandContent } from "./brand-content";
 import { ComponentsContent } from "./components-content";
 import { ConsentContent } from "./consent-content";
+import { ExperimentCadenceStudy } from "./experiment-cadence-study";
 import { SectionsContent } from "./sections-content";
 
 const TABS = [
@@ -54,7 +55,10 @@ export function DesignPage({ activeTab = "brand" }: { activeTab?: string }) {
       ) : selectedTab === "consent" ? (
         <ConsentContent />
       ) : (
-        <ComponentsContent />
+        <>
+          <ExperimentCadenceStudy />
+          <ComponentsContent />
+        </>
       )}
     </main>
   );

--- a/apps/web/app/design/experiment-cadence-study.tsx
+++ b/apps/web/app/design/experiment-cadence-study.tsx
@@ -1,0 +1,57 @@
+import { HomeExperimentCard } from "@/src/components/home/home-experiment-card";
+import type { ExperimentLibraryCard } from "@/src/lib/experiments/library-cards";
+
+const DESIGN_REPEATED_CADENCE_CARD: ExperimentLibraryCard = {
+  category: "Movement",
+  description: "Synthetic repeated-cadence run for component review.",
+  hasPrivateData: true,
+  href: "/design?tab=components#experiment-daily-cadence-card",
+  id: "design-repeated-cadence",
+  image: "/design-assets/hero-03.png",
+  privateBadgeLabel: "Private data",
+  runStatus: "active",
+  runSummary: {
+    completionPercent: 36,
+    dailyCadence: {
+      cadence: "6x Daily",
+      completed: 3,
+      expected: 6,
+      label: "Movement practice",
+    },
+    day: 5,
+    metrics: [],
+  },
+  searchText: "synthetic repeated daily movement cadence",
+  startedOn: "2026-08-03",
+  statusLabel: "Active",
+  statusVariant: "default",
+  title: "Movement practice",
+};
+
+export function ExperimentCadenceStudy() {
+  return (
+    <section
+      className="mx-auto w-full max-w-5xl px-6 pb-4 pt-12 sm:px-10 lg:px-16"
+      id="experiment-daily-cadence-card"
+    >
+      <div className="border-b border-[#e5e1d8] pb-12">
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+          Experiment cadence
+        </p>
+        <h1 className="mt-2 max-w-2xl font-serif text-3xl font-semibold tracking-tight text-foreground">
+          Repeated daily targets
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Active runs with multiple actions per day lead with today&apos;s completed count instead of elapsed-time progress.
+        </p>
+
+        <div
+          className="mt-7 max-w-xl"
+          data-design-experiment-daily-cadence-card
+        >
+          <HomeExperimentCard card={DESIGN_REPEATED_CADENCE_CARD} variant="default" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/home/home-experiment-card.tsx
+++ b/apps/web/src/components/home/home-experiment-card.tsx
@@ -15,6 +15,8 @@ interface HomeExperimentCardProps {
   variant: "default" | "history";
 }
 
+const MAX_EXACT_CADENCE_SEGMENTS = 12;
+
 export function HomeExperimentCard({ card, variant }: HomeExperimentCardProps) {
   const dateLabel = resolveDateLabel(card);
   const content = (
@@ -112,6 +114,10 @@ function ExperimentDataVisual({ card, variant }: HomeExperimentCardProps) {
   const summary = card.runSummary;
   const inProgress = card.runStatus === "active" || card.runStatus === "paused";
   const comparableMetrics = summary?.metrics ?? [];
+
+  if (inProgress && summary?.dailyCadence) {
+    return <ExperimentDailyCadence summary={summary} />;
+  }
 
   if (inProgress && typeof summary?.completionPercent === "number") {
     return <ExperimentProgress summary={summary} />;
@@ -242,6 +248,103 @@ function ResultValue({ label, value }: { label: string; value: string }) {
       <p className="mt-1 truncate font-serif text-lg font-semibold tabular-nums text-foreground">
         {value}
       </p>
+    </div>
+  );
+}
+
+function ExperimentDailyCadence({ summary }: { summary: ExperimentRunCardSummary }) {
+  const cadence = summary.dailyCadence;
+  if (!cadence) {
+    return null;
+  }
+
+  const expected = Math.max(1, Math.trunc(cadence.expected));
+  const completed = Math.min(expected, Math.max(0, Math.trunc(cadence.completed)));
+  const progress = Math.round((completed / expected) * 100);
+  const context = [cadence.label, cadence.cadence]
+    .filter((value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+    )
+    .join(" · ");
+  const ariaLabel = cadence.label
+    ? `${cadence.label} today`
+    : "Today's cadence";
+  const ariaValueText = `${completed} of ${expected} completed today`;
+  const showExactSegments = expected <= MAX_EXACT_CADENCE_SEGMENTS;
+
+  return (
+    <div className="w-full" data-home-experiment-daily-cadence>
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+            Today
+          </p>
+          <p
+            aria-hidden="true"
+            className="mt-2 font-serif text-4xl font-semibold leading-none tabular-nums text-foreground"
+          >
+            {completed}
+            <span className="mx-1.5 text-foreground/30">/</span>
+            <span className="text-foreground/55">{expected}</span>
+          </p>
+          <p className="sr-only">{ariaValueText}</p>
+        </div>
+        {typeof summary.day === "number" ? (
+          <p className="pb-1 text-sm tabular-nums text-muted-foreground">
+            Day {summary.day}
+          </p>
+        ) : null}
+      </div>
+
+      {context ? (
+        <p className="mt-2 text-sm text-muted-foreground">
+          {context}
+        </p>
+      ) : null}
+
+      {showExactSegments ? (
+        <div
+          role="progressbar"
+          aria-label={ariaLabel}
+          aria-valuemin={0}
+          aria-valuemax={expected}
+          aria-valuenow={completed}
+          aria-valuetext={ariaValueText}
+          className="mt-5 grid gap-1.5"
+          style={{ gridTemplateColumns: `repeat(${expected}, minmax(0, 1fr))` }}
+        >
+          {Array.from({ length: expected }, (_, index) => {
+            const complete = index < completed;
+            return (
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "h-2 rounded-full",
+                  complete ? "bg-primary" : "bg-secondary/35",
+                )}
+                data-complete={complete ? "true" : "false"}
+                data-home-experiment-cadence-segment
+                key={index}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div
+          role="progressbar"
+          aria-label={ariaLabel}
+          aria-valuemin={0}
+          aria-valuemax={expected}
+          aria-valuenow={completed}
+          aria-valuetext={ariaValueText}
+          className="mt-5 h-2 overflow-hidden rounded-full bg-secondary/35"
+        >
+          <div
+            className="h-full rounded-full bg-primary"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/experiments/library-cards.ts
+++ b/apps/web/src/lib/experiments/library-cards.ts
@@ -9,6 +9,7 @@ import {
   resolveBrowserVaultExperimentRun,
   resolveBrowserVaultExperimentRunById,
 } from "@/src/lib/browser-vault/experiment-run";
+import { resolveExperimentRunCardDailyCadence } from "@/src/lib/experiments/run-card-daily-cadence";
 import {
   buildExperimentRunCardSummary,
   type ExperimentRunCardSummary,
@@ -88,7 +89,7 @@ export function buildExperimentLibraryCards({
 }): ExperimentLibraryCard[] {
   const protocolCards = protocols.map((protocol) => {
     const privateRun = resolveBrowserVaultExperimentRun({ client, protocol });
-    return protocolToCard(protocol, privateRun);
+    return protocolToCard(client, protocol, privateRun);
   });
   const matchedTrackedExperimentIds = new Set(
     protocolCards.flatMap((card) => card.trackedExperimentId ? [card.trackedExperimentId] : []),
@@ -96,6 +97,7 @@ export function buildExperimentLibraryCards({
   const trackedOnlyCards = trackedExperiments
     .filter((entry) => !matchedTrackedExperimentIds.has(entry.id))
     .map((entry) => trackedExperimentToCard(
+      client,
       entry,
       resolveBrowserVaultExperimentRunById({ client, experimentId: entry.id }),
     ));
@@ -104,6 +106,7 @@ export function buildExperimentLibraryCards({
 }
 
 function protocolToCard(
+  client: BrowserVaultQueryClient | null,
   protocol: ExperimentProtocol,
   privateRun: ExperimentRunProjection | null,
 ): ExperimentLibraryCard {
@@ -132,7 +135,7 @@ function protocolToCard(
     description,
     hasPrivateData: privateRun !== null,
     runStatus: privateRun?.status,
-    runSummary: privateRun ? buildExperimentRunCardSummary(privateRun) : undefined,
+    runSummary: buildPrivateRunCardSummary(client, privateRun),
     startedOn,
     trackedExperimentId: privateRun?.id,
     searchText: [
@@ -154,6 +157,7 @@ function formatProtocolDays(protocol: ExperimentProtocol): number {
 }
 
 function trackedExperimentToCard(
+  client: BrowserVaultQueryClient | null,
   entry: OverviewExperiment,
   privateRun: ExperimentRunProjection | null,
 ): ExperimentLibraryCard {
@@ -183,7 +187,7 @@ function trackedExperimentToCard(
       ?? "This experiment has private data saved on this device, but it doesn't match a public protocol page right now.",
     hasPrivateData: true,
     runStatus,
-    runSummary: privateRun ? buildExperimentRunCardSummary(privateRun) : undefined,
+    runSummary: buildPrivateRunCardSummary(client, privateRun),
     startedOn,
     trackedExperimentId: entry.id,
     searchText: [
@@ -199,6 +203,30 @@ function trackedExperimentToCard(
       .filter((value): value is string => typeof value === "string")
       .join(" "),
   };
+}
+
+function buildPrivateRunCardSummary(
+  client: BrowserVaultQueryClient | null,
+  privateRun: ExperimentRunProjection | null,
+): ExperimentRunCardSummary | undefined {
+  if (!privateRun) {
+    return undefined;
+  }
+
+  const summary = buildExperimentRunCardSummary(privateRun);
+  if (privateRun.status !== "active" && privateRun.status !== "paused") {
+    return summary;
+  }
+
+  const dailyCadence = resolveExperimentRunCardDailyCadence({
+    cadence: privateRun.schedule?.cadence,
+    client,
+    experimentId: privateRun.id,
+  });
+
+  return dailyCadence
+    ? { ...summary, dailyCadence }
+    : summary;
 }
 
 function compareExperimentCards(left: ExperimentLibraryCard, right: ExperimentLibraryCard): number {

--- a/apps/web/src/lib/experiments/run-card-daily-cadence.ts
+++ b/apps/web/src/lib/experiments/run-card-daily-cadence.ts
@@ -1,0 +1,130 @@
+import {
+  resolveExperimentAdherenceRollupTarget,
+  selectBrowserVaultExperimentResults,
+  type BrowserVaultExperimentResultsView,
+  type BrowserVaultQueryClient,
+} from "@murphai/query/browser-experiments";
+
+import type { ExperimentRunCardDailyCadence } from "@/src/lib/experiments/run-card-summary";
+
+interface ResolveExperimentRunCardDailyCadenceInput {
+  cadence?: string;
+  client: BrowserVaultQueryClient | null;
+  experimentId: string;
+}
+
+type BrowserVaultAdherenceCell = NonNullable<
+  BrowserVaultExperimentResultsView["adherence"]
+>["cells"][number];
+
+export function resolveExperimentRunCardDailyCadence({
+  cadence,
+  client,
+  experimentId,
+}: ResolveExperimentRunCardDailyCadenceInput): ExperimentRunCardDailyCadence | undefined {
+  const normalizedCadence = cadence?.trim();
+  if (!client || !normalizedCadence) {
+    return undefined;
+  }
+
+  const results = selectBrowserVaultExperimentResults(
+    client,
+    { experimentId },
+    { asOf: client.replica.generatedAt },
+  );
+  const adherence = results?.adherence;
+  if (!results || !adherence) {
+    return undefined;
+  }
+
+  const target = resolveExperimentAdherenceRollupTarget(
+    results.experiment.runPlan.adherenceTargets,
+  );
+  if (!target?.calendar) {
+    return undefined;
+  }
+
+  const todayLocalDate = formatIsoDateInTimeZone(results.asOf, adherence.timeZone);
+  const todayCells = adherence.cells.filter((cell) =>
+    cell.targetId === target.targetId && cell.localDate === todayLocalDate
+  );
+  const expected = todayCells.reduce(
+    (total, cell) => total + normalizeCount(cell.expectedCount),
+    0,
+  );
+
+  // A one-per-day target is already served well by the standard experiment
+  // progress treatment. This view is specifically for repeated daily actions.
+  if (expected <= 1) {
+    return undefined;
+  }
+
+  const completed = Math.min(
+    expected,
+    todayCells.reduce(
+      (total, cell) => total + resolveCompletedCount(cell),
+      0,
+    ),
+  );
+
+  return {
+    cadence: normalizedCadence,
+    completed,
+    expected,
+    label: target.label,
+  };
+}
+
+function resolveCompletedCount(cell: BrowserVaultAdherenceCell): number {
+  const expected = normalizeCount(cell.expectedCount);
+  const observed = normalizeOptionalCount(cell.observedCount);
+
+  if (observed !== null) {
+    return Math.min(expected, observed);
+  }
+
+  return cell.status === "satisfied" || cell.status === "assumed"
+    ? expected
+    : 0;
+}
+
+function normalizeCount(value: number | null | undefined): number {
+  return normalizeOptionalCount(value) ?? 0;
+}
+
+function normalizeOptionalCount(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.max(0, Math.trunc(value));
+}
+
+function formatIsoDateInTimeZone(value: string, timeZone: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    return value;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      day: "2-digit",
+      month: "2-digit",
+      timeZone,
+      year: "numeric",
+    }).formatToParts(date);
+    const year = parts.find((part) => part.type === "year")?.value;
+    const month = parts.find((part) => part.type === "month")?.value;
+    const day = parts.find((part) => part.type === "day")?.value;
+
+    return year && month && day
+      ? `${year}-${month}-${day}`
+      : date.toISOString().slice(0, 10);
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}

--- a/apps/web/src/lib/experiments/run-card-summary.ts
+++ b/apps/web/src/lib/experiments/run-card-summary.ts
@@ -13,8 +13,16 @@ export interface ExperimentRunCardMetric {
   sentiment?: ExperimentSignal["sentiment"];
 }
 
+export interface ExperimentRunCardDailyCadence {
+  cadence: string;
+  completed: number;
+  expected: number;
+  label?: string;
+}
+
 export interface ExperimentRunCardSummary {
   completionPercent?: number;
+  dailyCadence?: ExperimentRunCardDailyCadence;
   dateRange?: string;
   day?: number;
   metric?: ExperimentRunCardMetric;

--- a/apps/web/test/repeated-cadence-home-card.test.tsx
+++ b/apps/web/test/repeated-cadence-home-card.test.tsx
@@ -1,0 +1,179 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  createBrowserVaultQueryClient,
+  createBrowserVaultReplica,
+  createVaultReadModel,
+  selectBrowserVaultTrackedExperiments,
+  type BrowserVaultQueryClient,
+} from "@murphai/query/browser";
+import { expect, test, vi } from "vitest";
+
+import { HomeExperimentCard } from "@/src/components/home/home-experiment-card";
+import { buildExperimentLibraryCards } from "@/src/lib/experiments/library-cards";
+
+vi.mock("next/link", () => ({
+  default(props: {
+    children?: ReactNode;
+    className?: string;
+    href: string;
+  }) {
+    return createElement(
+      "a",
+      {
+        className: props.className,
+        href: props.href,
+      },
+      props.children,
+    );
+  },
+}));
+
+type BrowserVaultEntity = Parameters<typeof createVaultReadModel>[0]["entities"][number];
+
+const EXPERIMENT_ID = "exp_repeated_cadence";
+const EXPERIMENT_SLUG = "movement-practice";
+const GENERATED_AT = "2026-04-09T02:00:00.000Z";
+
+test("repeated daily experiments lead with today's completed target count", async () => {
+  const client = await createClient();
+  const [card] = buildExperimentLibraryCards({
+    client,
+    protocols: [],
+    trackedExperiments: selectBrowserVaultTrackedExperiments(client),
+  });
+
+  expect(card?.runSummary?.dailyCadence).toEqual({
+    cadence: "6x Daily",
+    completed: 3,
+    expected: 6,
+    label: "Movement practice",
+  });
+
+  const markup = renderToStaticMarkup(createElement(HomeExperimentCard, {
+    card: card!,
+    variant: "default",
+  }));
+
+  expect(markup).toContain("data-home-experiment-daily-cadence");
+  expect(markup).toContain('aria-valuemax="6"');
+  expect(markup).toContain('aria-valuenow="3"');
+  expect(markup).toContain('aria-valuetext="3 of 6 completed today"');
+  expect(markup).toContain("Movement practice · 6x Daily");
+  expect(markup.match(/data-home-experiment-cadence-segment/gu)).toHaveLength(6);
+  expect(markup.match(/data-complete="true"/gu)).toHaveLength(3);
+  expect(markup).not.toContain("Experiment progress");
+  expect(markup).not.toContain("14%");
+});
+
+async function createClient(): Promise<BrowserVaultQueryClient> {
+  const replica = await createBrowserVaultReplica({
+    generatedAt: GENERATED_AT,
+    metricPoints: [],
+    sourceBundleHash: "b".repeat(64),
+    vault: createVaultReadModel({
+      entities: [
+        createExperimentEntity(),
+        createSessionEntity(1, "2026-04-08T12:00:00.000Z"),
+        createSessionEntity(2, "2026-04-08T14:00:00.000Z"),
+        createSessionEntity(3, "2026-04-08T16:00:00.000Z"),
+      ],
+      metadata: null,
+      vaultRoot: "browser://vault",
+    }),
+  });
+
+  return createBrowserVaultQueryClient({
+    ...replica,
+    experimentOutcomes: [],
+    metricRows: replica.metricRows,
+  });
+}
+
+function createExperimentEntity(): BrowserVaultEntity {
+  return {
+    attributes: {},
+    body: "A synthetic repeated daily movement experiment.",
+    date: "2026-04-08",
+    entityId: EXPERIMENT_ID,
+    experimentSlug: EXPERIMENT_SLUG,
+    family: "experiment",
+    frontmatter: {
+      docType: "experiment",
+      experimentId: EXPERIMENT_ID,
+      hypothesis: "Frequent low-fatigue practice improves movement quality.",
+      runPlan: {
+        adherenceTargets: [{
+          calendar: {
+            kind: "daily",
+            targetCountPerDay: 6,
+            timeZone: "America/New_York",
+          },
+          evidence: {
+            eventKind: "intervention_session",
+            kind: "linkedEventCount",
+            missing: "missed_after_grace",
+          },
+          grace: { hours: 2 },
+          label: "Movement practice",
+          phase: "intervention",
+          rollup: {
+            minimumUsefulCompletions: 28,
+            targetCompletions: 42,
+          },
+          targetId: "movement-practice",
+        }],
+        interventionEnd: "2026-04-14",
+        interventionStart: "2026-04-08",
+      },
+      schemaVersion: "murph.frontmatter.experiment.v1",
+      slug: EXPERIMENT_SLUG,
+      startedOn: "2026-04-08",
+      status: "active",
+      title: "Movement practice",
+    },
+    kind: "experiment_entry",
+    links: [],
+    lookupIds: [EXPERIMENT_ID, EXPERIMENT_SLUG],
+    occurredAt: "2026-04-08T08:00:00.000Z",
+    path: `bank/experiments/${EXPERIMENT_ID}.md`,
+    primaryLookupId: EXPERIMENT_ID,
+    recordClass: "bank",
+    relatedIds: [],
+    status: "active",
+    stream: null,
+    tags: ["movement"],
+    title: "Movement practice",
+  };
+}
+
+function createSessionEntity(index: number, occurredAt: string): BrowserVaultEntity {
+  const entityId = `evt_repeated_cadence_${index}`;
+
+  return {
+    attributes: {
+      experimentId: EXPERIMENT_ID,
+      experimentSlug: EXPERIMENT_SLUG,
+      sessionStatus: "completed",
+    },
+    body: null,
+    date: "2026-04-08",
+    entityId,
+    experimentSlug: EXPERIMENT_SLUG,
+    family: "event",
+    frontmatter: null,
+    kind: "intervention_session",
+    links: [{ targetId: EXPERIMENT_ID, type: "related_to" }],
+    lookupIds: [entityId],
+    occurredAt,
+    path: `history/events/${entityId}.md`,
+    primaryLookupId: entityId,
+    recordClass: "ledger",
+    relatedIds: [],
+    status: "completed",
+    stream: null,
+    tags: [],
+    title: "Movement practice session",
+  };
+}


### PR DESCRIPTION
## Why

Active experiments with several actions per day currently lead with elapsed-time progress, so a member can be on day 9 and still see an unhelpful percentage instead of the thing they need to do today.

## User goal

When an experiment has a repeated daily target, show today's truthful completed count at a glance (for example, `3 / 6`) without introducing a one-off protocol type or streak/gamification machinery.

## UX trace

1. The home page builds a member's private experiment cards.
2. For active or paused runs only, the card projection checks the canonical browser-vault adherence result for the selected rollup target.
3. When today's expected count is greater than one, the card leads with today's completed/expected count and a segmented target strip.
4. Targets of 12 or fewer render exact segments; larger counts use a continuous progress bar so the UI remains bounded.
5. Once-daily targets and experiments without count-backed cadence keep the existing elapsed-time/metric treatment.
6. The experiment-time-zone local date is used, including across UTC date boundaries.

## Invariants

- No new persisted experiment schema or one-off “grease the groove” type.
- No streak, failure, shame, or reward language.
- Counts come from canonical adherence cells; the UI does not parse message text or infer completed actions from elapsed time.
- The existing home-card fallback remains intact when count evidence is missing or the target is once daily.
- Read-only browser-vault behavior only; no permission, consent, billing, or health-data write changes.

## Non-obvious surfaces checked

- Private protocol-backed and private-only home cards share the same projection helper.
- Paused runs preserve the actionable today view when canonical counts exist.
- Completed/stopped history cards are unchanged.
- More than 12 daily actions use a bounded continuous bar rather than creating an unbounded row of segments.
- The design catalog renders the production `HomeExperimentCard`, not a lookalike.

## Architecture / reuse

- Adds one generic `ExperimentRunCardDailyCadence` presentation primitive.
- Resolves data only for active/paused cards and only from the existing browser-vault experiment selector.
- Keeps the rendering decision at the home-card projection boundary instead of changing protocol definitions or duplicating experiment types.
- Adds a focused end-to-end projection/render regression from vault entities through the home card.

## Hot reply path impact

None.

## Provider input impact

None.

## Preliminary lenses

- Architecture/reuse: self-reviewed; generic cadence primitive, no protocol-specific branch.
- Product/UX: self-reviewed against actionable-state-first and non-gamified language requirements.
- Test/coverage: added a focused browser-vault-to-card regression, including an experiment-local date that differs from UTC.
- ReviewGPT sensitivity: **sensitive** because this is a health-experiment data projection, although it is read-only and does not alter access control.
- Repository-local ReviewGPT, Claude UI audit, and browser walkthrough were not runnable from the GitHub connector environment used for this change.

## Change shape

| Surface | Change | Risk control |
| --- | --- | --- |
| Home experiment card | Repeated-daily `Today` count and segmented progress | Exact canonical counts; generic fallback retained |
| Card projection | Active/paused cadence resolver | Requires a single selected rollup target and expected count > 1 |
| Design catalog | Production component study on `/design?tab=components` | Synthetic data only |
| Tests | Vault → projection → SSR card regression | Covers timezone boundary and prevents percentage fallback |

## Design proof

- Catalog route added: `/design?tab=components#experiment-daily-cadence-card`
- Hosted desktop/mobile screenshots are not attached yet because this connector session has no repository runtime or browser/preview access. The PR remains draft until CI and required visual proof can be completed.

## Verification

- Local commands were not available in this connector-only environment.
- GitHub Actions results will be treated as the source of truth and any failures will be fixed on this branch.
