### PR TITLE
Show in-range and out-of-range bands on biomarker charts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,7 @@ A single-accent system. Sage green carries every affirmative signal; the rest of
 
 **The No Gray Rule.** All structural neutrals are tinted warm. Borders use `rgba(196, 168, 130, 0.25)`, not `#e0e0e0`. Cards sit on cream, not on gray. If a surface looks cold, it's wrong. Literal gray may appear inside a bounded identifying illustration, such as the Luna artwork, but does not become a page surface or general neutral token.
 
-**The Chalkboard Rule.** Data is presented on paper, as if written by hand. Stat numbers are serif (Fraunces), not the sans-serif dashboard default. Charts use dashed baseline + solid active lines, not filled areas.
+**The Chalkboard Rule.** Data is presented on paper, as if written by hand. Stat numbers are serif (Fraunces), not the sans-serif dashboard default. Charts use dashed reference rules and solid data lines. Restrained flat semantic range bands are allowed when they clarify a reference interval; decorative filled series areas and gradients are not.
 
 ## 3. Typography
 
@@ -285,22 +285,24 @@ qualitative, and incompatible-unit context stays explicit near the chart or in
 the ledger. When the latest comparable result has a normalized lab range, place
 one quiet `Latest lab range` legend above dashed boundary rules for its
 two-sided band or one-sided limit. Preserve exact `<`, `<=`, `>`, and `>=`
-source boundaries in the legend. Extend the data-focused scale just enough to
-keep a one-sided limit visible; keep two-sided overlays clipped rather than
-flattening the historical trend to fit a wide interval. Label source context as
-latest so it does not imply that older labs shared the same range. If the latest
-comparable result has no usable numeric source range, an exact-unit authored
-Health Commons range may appear instead as `Published adult comparator`; it
-never changes the source status and appears only when the result's normalized
-specimen kind is explicitly eligible. State in the legend that the published
-comparator is not the reporting lab's range. Missing, mismatched, and
-context-dependent specimens omit it. Keep the authored source label in the chart
-legend. Qualified source ranges remain ledger-only and block a comparator from
-superseding more specific source context. Do not add a visible chart title or
-single-result trend instruction above or below this graph. Simplifying the
-hierarchy must not imply that excluded values were plotted. The loading skeleton
-mirrors the same latest-result, chart, and ledger structure rather than
-substituting a generic card grid.
+source boundaries in the legend. Fit the vertical scale to the union of the
+comparable results and the available range bounds. Shade the source range with
+very light sage and the visible below/above regions with very light sienna; keep
+the legend and dashed rules as non-color cues. Label source context as latest so
+it does not imply that older labs shared the same range. If the latest comparable
+result has no usable numeric source range, an exact-unit authored Health Commons
+range may appear instead as `Published adult comparator`; it never changes the
+source status and appears only when the result's normalized specimen kind is
+explicitly eligible. State in the legend that the published comparator is not
+the reporting lab's range, and render it with neutral dashed boundaries only,
+without sage/sienna bands. Missing, mismatched, and context-dependent specimens
+omit it. Keep the authored source label in the chart legend. Qualified source
+ranges remain ledger-only and block a comparator from superseding more specific
+source context. Do not add a visible chart title or single-result trend
+instruction above or below this graph. Simplifying the hierarchy must not imply
+that excluded values were plotted. The loading skeleton mirrors the same
+latest-result, chart, and ledger structure rather than substituting a generic
+card grid.
 
 ### Home Experiment History Cards
 Completed experiment cards on `/home` are compact index entries, not miniature

--- a/agent-docs/product-specs/measured-biomarker-index.md
+++ b/agent-docs/product-specs/measured-biomarker-index.md
@@ -76,10 +76,12 @@ member-facing biomarker.
   adult comparator when the imported result has an explicitly eligible coarse
   specimen kind and the source covers the full adult population. Label it
   `Published adult comparator`, retain its exact source, and state that it is not
-  the reporting lab's range. Keep the imported source flag authoritative and
-  fail closed when the specimen is missing or when age, sex, pregnancy, fasting,
-  treatment, or risk context is required. A qualified source range stays exact
-  in the ledger and is not replaced by a comparator.
+  the reporting lab's range. Keep its boundary rules neutral and dashed-only;
+  do not reuse the sage/sienna lab-range bands or let it imply source status.
+  Keep the imported source flag authoritative and fail closed when the specimen
+  is missing or when age, sex, pregnancy, fasting, treatment, or risk context is
+  required. A qualified source range stays exact in the ledger and is not
+  replaced by a comparator.
 - The initial reviewed comparator catalog is intentionally sparse: named Mayo
   Clinic Laboratories adult serum intervals are authored for chloride, LDH,
   phosphate, and total protein only. They provide published context, never an
@@ -202,8 +204,9 @@ interchangeable assays, or shared reference guidance.
   status filters, flagged-first ordering, the one-row notebook shape,
   full-row links, the absence of `Other`, and the saved-but-unclassified empty
   state. Detail tests cover exact comparators, qualitative history, latest-range
-  band geometry and domain inclusion, missing or qualified range withholding,
-  responsive ledger structure, and Commons summary fallback.
+  band geometry and domain inclusion, neutral published-comparator context,
+  malformed-range omission, missing or qualified range withholding, responsive
+  ledger structure, and Commons summary fallback.
 - Health Commons coverage tests resolve every requested lab and device identity,
   enforce the deliberate aliases and non-equivalences, validate one-sentence
   summaries and source locators, and lock the guidance-classification counts.

--- a/agent-docs/product-specs/measured-biomarker-index.md
+++ b/agent-docs/product-specs/measured-biomarker-index.md
@@ -1,7 +1,7 @@
 # Measured Biomarker Index
 
 Status: Implemented
-Last verified: 2026-07-22
+Last verified: 2026-08-07
 
 ## Purpose
 
@@ -66,10 +66,11 @@ member-facing biomarker.
   and never become invented points.
 - When the latest result belongs to the normalized comparable series and has a
   numeric source range, show that range as quiet dashed boundary rules labeled
-  `Latest lab range`. Preserve exact one-sided source comparators. Clip the
-  two-sided rules to the data-focused vertical scale rather than compressing the
-  historical trend; extend that scale only enough to keep a one-sided limit
-  visible. Do not imply that older labs used the same range.
+  `Latest lab range`. Preserve exact one-sided source comparators. Fit the
+  vertical scale to the union of the comparable results and available range
+  bounds, then shade the in-range region with very light sage and the visible
+  below/above regions with very light sienna. Keep the label and dashed rules as
+  non-color cues, and do not imply that older labs used the same range.
 - When that latest comparable result has no usable numeric source range, an
   exact-unit authored Health Commons range may appear only as a named published
   adult comparator when the imported result has an explicitly eligible coarse
@@ -201,8 +202,8 @@ interchangeable assays, or shared reference guidance.
   status filters, flagged-first ordering, the one-row notebook shape,
   full-row links, the absence of `Other`, and the saved-but-unclassified empty
   state. Detail tests cover exact comparators, qualitative history, latest-range
-  band eligibility, missing or qualified range withholding, responsive ledger
-  structure, and Commons summary fallback.
+  band geometry and domain inclusion, missing or qualified range withholding,
+  responsive ledger structure, and Commons summary fallback.
 - Health Commons coverage tests resolve every requested lab and device identity,
   enforce the deliberate aliases and non-equivalences, validate one-sentence
   summaries and source locators, and lock the guidance-classification counts.

--- a/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/lab-biomarker-detail-client.tsx
+++ b/apps/web/app/(dashboard)/biomarkers/results/[metricKey]/lab-biomarker-detail-client.tsx
@@ -18,6 +18,7 @@ import {
   LabBiomarkerHistoryChart,
   type LabBiomarkerChartPoint,
   type LabBiomarkerChartRange,
+  type LabBiomarkerReferenceRangeTone,
 } from "@/src/components/biomarkers/lab-biomarker-history-chart";
 import { LabResultValue } from "@/src/components/biomarkers/lab-result-value";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
@@ -283,6 +284,7 @@ function BiomarkerDetailContent({
                   referenceRangeLabel={chartReference?.label}
                   referenceRangeSourceLabel={chartReference?.sourceLabel}
                   referenceRangeTitle={chartReference?.title}
+                  referenceRangeTone={chartReference?.tone}
                   unit={detail.comparableUnit}
                 />
               </div>
@@ -584,6 +586,7 @@ function resolveChartedReferenceContext(
   range: LabBiomarkerChartRange;
   sourceLabel: string | null;
   title: string;
+  tone: LabBiomarkerReferenceRangeTone;
 } | null {
   const latestPoint = detail.chartSeries.find((point) => point.rowId === detail.latest.id);
   if (
@@ -604,6 +607,7 @@ function resolveChartedReferenceContext(
       range: { high, low },
       sourceLabel: detail.latest.labName ?? detail.latest.sourceLabel,
       title: "Latest lab range",
+      tone: "lab",
     };
   }
 
@@ -636,6 +640,7 @@ function resolveChartedReferenceContext(
     },
     sourceLabel: `${fallback.label} · not the reporting lab's range`,
     title: "Published adult comparator",
+    tone: "context",
   };
 }
 

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -407,7 +407,9 @@ export function SectionsContent() {
       <Separator />
 
       <StudySection title="Biomarker result detail">
-        <BiomarkerDetailStudy />
+        <div id="biomarker-result-range-bands">
+          <BiomarkerDetailStudy />
+        </div>
       </StudySection>
 
       <Separator />

--- a/apps/web/src/components/biomarkers/biomarker-design-studies.tsx
+++ b/apps/web/src/components/biomarkers/biomarker-design-studies.tsx
@@ -505,6 +505,7 @@ export function BiomarkerReferenceContextStudy() {
             referenceRangeLabel="98 to 107 mmol/L"
             referenceRangeSourceLabel="Mayo Clinic Laboratories adult serum reference interval · not the reporting lab's range"
             referenceRangeTitle="Published adult comparator"
+            referenceRangeTone="context"
             unit="mmol/L"
           />
         </div>

--- a/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
+++ b/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
@@ -34,6 +34,8 @@ export interface LabBiomarkerChartRange {
   low: number | null;
 }
 
+const LATEST_LAB_RANGE_TITLE = "Latest lab range";
+
 const chartConfig = {
   value: {
     color: "var(--chart-1)",
@@ -41,10 +43,16 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const RANGE_LINE_STYLE = {
+const LAB_RANGE_LINE_STYLE = {
   stroke: "var(--color-value)",
   strokeDasharray: "4 4",
   strokeOpacity: 0.5,
+} as const;
+
+const CONTEXT_RANGE_LINE_STYLE = {
+  stroke: "var(--muted-foreground)",
+  strokeDasharray: "4 4",
+  strokeOpacity: 0.45,
 } as const;
 
 const IN_RANGE_AREA_STYLE = {
@@ -73,7 +81,7 @@ export function LabBiomarkerHistoryChart({
   referenceRange = null,
   referenceRangeLabel = null,
   referenceRangeSourceLabel = null,
-  referenceRangeTitle = "Latest lab range",
+  referenceRangeTitle = LATEST_LAB_RANGE_TITLE,
   unit,
 }: {
   ariaDescribedBy?: string;
@@ -108,7 +116,11 @@ export function LabBiomarkerHistoryChart({
   const rangeLabel = range ? referenceRangeLabel?.trim() || null : null;
   const rangeSourceLabel = rangeLabel ? referenceRangeSourceLabel?.trim() || null : null;
   const rangeIsBand = range !== null && range.low !== null && range.high !== null;
-  const inRangeArea = resolveInRangeArea(range);
+  const isLatestLabRange = referenceRangeTitle === LATEST_LAB_RANGE_TITLE;
+  const inRangeArea = isLatestLabRange ? resolveInRangeArea(range) : null;
+  const rangeLineStyle = isLatestLabRange
+    ? LAB_RANGE_LINE_STYLE
+    : CONTEXT_RANGE_LINE_STYLE;
   const yDomain = resolveYDomain(range);
 
   return (
@@ -118,8 +130,12 @@ export function LabBiomarkerHistoryChart({
           <span
             aria-hidden="true"
             className={rangeIsBand
-              ? "h-2 w-5 shrink-0 rounded-[2px] border-y border-dashed border-primary/50 bg-primary/10"
-              : "h-0 w-5 shrink-0 border-t border-dashed border-primary/50"}
+              ? isLatestLabRange
+                ? "h-2 w-5 shrink-0 rounded-[2px] border-y border-dashed border-primary/50 bg-primary/10"
+                : "h-2 w-5 shrink-0 border-y border-dashed border-muted-foreground/40"
+              : isLatestLabRange
+                ? "h-0 w-5 shrink-0 border-t border-dashed border-primary/50"
+                : "h-0 w-5 shrink-0 border-t border-dashed border-muted-foreground/40"}
           />
           <span>{referenceRangeTitle}</span>
           <span className="font-mono tabular-nums text-foreground">{rangeLabel}</span>
@@ -144,13 +160,13 @@ export function LabBiomarkerHistoryChart({
           data={data}
           margin={{ bottom: 0, left: 0, right: 12, top: 12 }}
         >
-          {range && range.low !== null ? (
+          {isLatestLabRange && range && range.low !== null ? (
             <ReferenceArea
               {...OUT_OF_RANGE_AREA_STYLE}
               y1={range.low}
             />
           ) : null}
-          {range && range.high !== null ? (
+          {isLatestLabRange && range && range.high !== null ? (
             <ReferenceArea
               {...OUT_OF_RANGE_AREA_STYLE}
               y2={range.high}
@@ -185,14 +201,14 @@ export function LabBiomarkerHistoryChart({
           />
           {range && range.low !== null ? (
             <ReferenceLine
-              {...RANGE_LINE_STYLE}
+              {...rangeLineStyle}
               ifOverflow="hidden"
               y={range.low}
             />
           ) : null}
           {range && range.high !== null ? (
             <ReferenceLine
-              {...RANGE_LINE_STYLE}
+              {...rangeLineStyle}
               ifOverflow="hidden"
               y={range.high}
             />
@@ -249,7 +265,7 @@ function normalizeRange(
   if (low === null && high === null) {
     return null;
   }
-  if (low !== null && high !== null && low > high) {
+  if (low !== null && high !== null && low >= high) {
     return null;
   }
 

--- a/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
+++ b/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
@@ -34,7 +34,7 @@ export interface LabBiomarkerChartRange {
   low: number | null;
 }
 
-const LATEST_LAB_RANGE_TITLE = "Latest lab range";
+export type LabBiomarkerReferenceRangeTone = "context" | "lab";
 
 const chartConfig = {
   value: {
@@ -81,7 +81,8 @@ export function LabBiomarkerHistoryChart({
   referenceRange = null,
   referenceRangeLabel = null,
   referenceRangeSourceLabel = null,
-  referenceRangeTitle = LATEST_LAB_RANGE_TITLE,
+  referenceRangeTitle = "Latest lab range",
+  referenceRangeTone = "lab",
   unit,
 }: {
   ariaDescribedBy?: string;
@@ -91,6 +92,7 @@ export function LabBiomarkerHistoryChart({
   referenceRangeLabel?: string | null;
   referenceRangeSourceLabel?: string | null;
   referenceRangeTitle?: string;
+  referenceRangeTone?: LabBiomarkerReferenceRangeTone;
   unit: string | null;
 }) {
   const data = useMemo(
@@ -116,27 +118,22 @@ export function LabBiomarkerHistoryChart({
   const rangeLabel = range ? referenceRangeLabel?.trim() || null : null;
   const rangeSourceLabel = rangeLabel ? referenceRangeSourceLabel?.trim() || null : null;
   const rangeIsBand = range !== null && range.low !== null && range.high !== null;
-  const isLatestLabRange = referenceRangeTitle === LATEST_LAB_RANGE_TITLE;
-  const inRangeArea = isLatestLabRange ? resolveInRangeArea(range) : null;
-  const rangeLineStyle = isLatestLabRange
+  const isLabRange = referenceRangeTone === "lab";
+  const inRangeArea = isLabRange ? resolveInRangeArea(range) : null;
+  const rangeLineStyle = isLabRange
     ? LAB_RANGE_LINE_STYLE
     : CONTEXT_RANGE_LINE_STYLE;
+  const rangeLegendClassName = resolveRangeLegendClassName(
+    rangeIsBand,
+    referenceRangeTone,
+  );
   const yDomain = resolveYDomain(range);
 
   return (
     <div className="min-w-0">
       {rangeLabel ? (
         <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-          <span
-            aria-hidden="true"
-            className={rangeIsBand
-              ? isLatestLabRange
-                ? "h-2 w-5 shrink-0 rounded-[2px] border-y border-dashed border-primary/50 bg-primary/10"
-                : "h-2 w-5 shrink-0 border-y border-dashed border-muted-foreground/40"
-              : isLatestLabRange
-                ? "h-0 w-5 shrink-0 border-t border-dashed border-primary/50"
-                : "h-0 w-5 shrink-0 border-t border-dashed border-muted-foreground/40"}
-          />
+          <span aria-hidden="true" className={rangeLegendClassName} />
           <span>{referenceRangeTitle}</span>
           <span className="font-mono tabular-nums text-foreground">{rangeLabel}</span>
           {rangeSourceLabel ? (
@@ -160,13 +157,13 @@ export function LabBiomarkerHistoryChart({
           data={data}
           margin={{ bottom: 0, left: 0, right: 12, top: 12 }}
         >
-          {isLatestLabRange && range && range.low !== null ? (
+          {isLabRange && range && range.low !== null ? (
             <ReferenceArea
               {...OUT_OF_RANGE_AREA_STYLE}
               y1={range.low}
             />
           ) : null}
-          {isLatestLabRange && range && range.high !== null ? (
+          {isLabRange && range && range.high !== null ? (
             <ReferenceArea
               {...OUT_OF_RANGE_AREA_STYLE}
               y2={range.high}
@@ -285,6 +282,21 @@ function resolveInRangeArea(
     return { y2: range.low };
   }
   return range.high !== null ? { y1: range.high } : null;
+}
+
+function resolveRangeLegendClassName(
+  rangeIsBand: boolean,
+  tone: LabBiomarkerReferenceRangeTone,
+): string {
+  if (tone === "lab") {
+    return rangeIsBand
+      ? "h-2 w-5 shrink-0 rounded-[2px] border-y border-dashed border-primary/50 bg-primary/10"
+      : "h-0 w-5 shrink-0 border-t border-dashed border-primary/50";
+  }
+
+  return rangeIsBand
+    ? "h-2 w-5 shrink-0 border-y border-dashed border-muted-foreground/40"
+    : "h-0 w-5 shrink-0 border-t border-dashed border-muted-foreground/40";
 }
 
 function resolveYDomain(

--- a/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
+++ b/apps/web/src/components/biomarkers/lab-biomarker-history-chart.tsx
@@ -5,6 +5,7 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceArea,
   ReferenceLine,
   XAxis,
   YAxis,
@@ -44,6 +45,20 @@ const RANGE_LINE_STYLE = {
   stroke: "var(--color-value)",
   strokeDasharray: "4 4",
   strokeOpacity: 0.5,
+} as const;
+
+const IN_RANGE_AREA_STYLE = {
+  fill: "var(--primary)",
+  fillOpacity: 0.1,
+  ifOverflow: "hidden",
+  stroke: "none",
+} as const;
+
+const OUT_OF_RANGE_AREA_STYLE = {
+  fill: "var(--destructive)",
+  fillOpacity: 0.07,
+  ifOverflow: "hidden",
+  stroke: "none",
 } as const;
 
 // Recharts needs a positive seed before ResizeObserver reports the container.
@@ -93,6 +108,7 @@ export function LabBiomarkerHistoryChart({
   const rangeLabel = range ? referenceRangeLabel?.trim() || null : null;
   const rangeSourceLabel = rangeLabel ? referenceRangeSourceLabel?.trim() || null : null;
   const rangeIsBand = range !== null && range.low !== null && range.high !== null;
+  const inRangeArea = resolveInRangeArea(range);
   const yDomain = resolveYDomain(range);
 
   return (
@@ -102,7 +118,7 @@ export function LabBiomarkerHistoryChart({
           <span
             aria-hidden="true"
             className={rangeIsBand
-              ? "h-2 w-5 shrink-0 border-y border-dashed border-primary/50"
+              ? "h-2 w-5 shrink-0 rounded-[2px] border-y border-dashed border-primary/50 bg-primary/10"
               : "h-0 w-5 shrink-0 border-t border-dashed border-primary/50"}
           />
           <span>{referenceRangeTitle}</span>
@@ -128,6 +144,24 @@ export function LabBiomarkerHistoryChart({
           data={data}
           margin={{ bottom: 0, left: 0, right: 12, top: 12 }}
         >
+          {range && range.low !== null ? (
+            <ReferenceArea
+              {...OUT_OF_RANGE_AREA_STYLE}
+              y1={range.low}
+            />
+          ) : null}
+          {range && range.high !== null ? (
+            <ReferenceArea
+              {...OUT_OF_RANGE_AREA_STYLE}
+              y2={range.high}
+            />
+          ) : null}
+          {inRangeArea ? (
+            <ReferenceArea
+              {...IN_RANGE_AREA_STYLE}
+              {...inRangeArea}
+            />
+          ) : null}
           <CartesianGrid vertical={false} strokeDasharray="3 5" />
           <XAxis
             axisLine={false}
@@ -215,8 +249,26 @@ function normalizeRange(
   if (low === null && high === null) {
     return null;
   }
+  if (low !== null && high !== null && low > high) {
+    return null;
+  }
 
   return { high, low };
+}
+
+function resolveInRangeArea(
+  range: LabBiomarkerChartRange | null,
+): { y1?: number; y2?: number } | null {
+  if (!range) {
+    return null;
+  }
+  if (range.low !== null && range.high !== null) {
+    return { y1: range.low, y2: range.high };
+  }
+  if (range.low !== null) {
+    return { y2: range.low };
+  }
+  return range.high !== null ? { y1: range.high } : null;
 }
 
 function resolveYDomain(
@@ -225,18 +277,20 @@ function resolveYDomain(
   (dataMinimum: number) => number,
   (dataMaximum: number) => number,
 ] {
-  if (!range || (range.low !== null && range.high !== null)) {
+  if (!range) {
     return ["auto", "auto"];
   }
 
-  const bound = range.low ?? range.high;
-  if (bound === null) {
-    return ["auto", "auto"];
-  }
+  const minimumBound = range.low ?? range.high;
+  const maximumBound = range.high ?? range.low;
 
   return [
-    (dataMinimum) => Math.min(dataMinimum, bound),
-    (dataMaximum) => Math.max(dataMaximum, bound),
+    (dataMinimum) => minimumBound === null
+      ? dataMinimum
+      : Math.min(dataMinimum, minimumBound),
+    (dataMaximum) => maximumBound === null
+      ? dataMaximum
+      : Math.max(dataMaximum, maximumBound),
   ];
 }
 

--- a/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
+++ b/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
@@ -8,6 +8,7 @@ const captured = vi.hoisted(() => ({
   chartInitialDimension: null as { height: number; width: number } | null,
   gridRendered: false,
   lineChartProps: null as Record<string, unknown> | null,
+  referenceAreas: [] as Record<string, unknown>[],
   referenceLines: [] as Record<string, unknown>[],
   tooltipFormatter: null as ((
     value: unknown,
@@ -34,6 +35,10 @@ vi.mock("recharts", async () => {
     LineChart(props: Record<string, unknown> & { children?: ReactNode }) {
       captured.lineChartProps = props;
       return passthrough(props);
+    },
+    ReferenceArea(props: Record<string, unknown>) {
+      captured.referenceAreas.push(props);
+      return null;
     },
     ReferenceLine(props: Record<string, unknown>) {
       captured.referenceLines.push(props);
@@ -96,6 +101,7 @@ beforeEach(() => {
   captured.chartInitialDimension = null;
   captured.gridRendered = false;
   captured.lineChartProps = null;
+  captured.referenceAreas = [];
   captured.referenceLines = [];
   captured.tooltipFormatter = null;
   captured.yAxisDomain = null;
@@ -121,13 +127,14 @@ test("lab chart keeps tiny values precise without adding a nested keyboard stop"
     value: { color: "var(--chart-1)" },
   });
   expect(captured.chartInitialDimension).toEqual({ height: 320, width: 1 });
+  expect(captured.referenceAreas).toHaveLength(0);
 
   const tooltip = captured.tooltipFormatter?.(0.0015);
   expect(tooltip).toBeTruthy();
   expect(renderToStaticMarkup(createElement("div", null, tooltip))).toContain("0.0015 mg/L");
 });
 
-test("the latest reference range renders quiet boundary context without flattening the trend", () => {
+test("the latest two-sided range expands the scale and separates in-range from review regions", () => {
   const markup = renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "HbA1c",
     points: [
@@ -143,18 +150,44 @@ test("the latest reference range renders quiet boundary context without flatteni
   expect(markup).toContain("Latest lab range");
   expect(markup).toContain("4 to 5.6%");
   expect(markup).toContain("Example Lab");
+  expect(markup).toContain("bg-primary/10");
   expect(captured.chartAriaLabel).toBe(
     "HbA1c results over time; latest lab range 4 to 5.6% from Example Lab",
   );
-  expect(markup).toContain("border-y");
-  expect(markup).toContain("border-dashed");
   expect(captured.referenceLines.map((line) => line.y)).toEqual([4, 5.6]);
+  expect(captured.referenceAreas).toHaveLength(3);
+  expect(captured.referenceAreas[0]).toMatchObject({
+    fill: "var(--destructive)",
+    fillOpacity: 0.07,
+    ifOverflow: "hidden",
+    stroke: "none",
+    y1: 4,
+  });
+  expect(captured.referenceAreas[1]).toMatchObject({
+    fill: "var(--destructive)",
+    fillOpacity: 0.07,
+    ifOverflow: "hidden",
+    stroke: "none",
+    y2: 5.6,
+  });
+  expect(captured.referenceAreas[2]).toMatchObject({
+    fill: "var(--primary)",
+    fillOpacity: 0.1,
+    ifOverflow: "hidden",
+    stroke: "none",
+    y1: 4,
+    y2: 5.6,
+  });
   expect(captured.gridRendered).toBe(true);
   expect(captured.yAxisPadding).toMatchObject({ bottom: 16, top: 16 });
 
-  // Keep the automatic, data-focused domain and clip a wider current lab
-  // range rather than compressing the historical trend into a flat line.
-  expect(captured.yAxisDomain).toEqual(["auto", "auto"]);
+  const [minimum, maximum] = captured.yAxisDomain as [
+    (value: number) => number,
+    (value: number) => number,
+  ];
+  expect(minimum(5.6)).toBe(4);
+  expect(maximum(5.8)).toBe(5.8);
+
   for (const line of captured.referenceLines) {
     expect(line).toMatchObject({ ifOverflow: "hidden" });
   }
@@ -163,7 +196,31 @@ test("the latest reference range renders quiet boundary context without flatteni
   expect(renderToStaticMarkup(createElement("div", null, tooltip))).toContain("5.8%");
 });
 
-test("a single reference bound renders one dashed line and no band", () => {
+test("a wide two-sided range stays fully visible around a single in-range result", () => {
+  renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
+    displayName: "Example marker",
+    points: [
+      { date: "2026-06-04", id: "p1", value: 15 },
+    ],
+    referenceRange: { high: 20, low: 6 },
+    referenceRangeLabel: "6 to 20 mg/dL",
+    unit: "mg/dL",
+  }));
+
+  const [minimum, maximum] = captured.yAxisDomain as [
+    (value: number) => number,
+    (value: number) => number,
+  ];
+  expect(minimum(15)).toBe(6);
+  expect(maximum(15)).toBe(20);
+  expect(captured.referenceAreas).toEqual(expect.arrayContaining([
+    expect.objectContaining({ fill: "var(--destructive)", y1: 6 }),
+    expect.objectContaining({ fill: "var(--destructive)", y2: 20 }),
+    expect.objectContaining({ fill: "var(--primary)", y1: 6, y2: 20 }),
+  ]));
+});
+
+test("an upper-only range shades the accepted side below its dashed limit", () => {
   const markup = renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "LDL cholesterol",
     points: [
@@ -179,6 +236,15 @@ test("a single reference bound renders one dashed line and no band", () => {
   expect(markup).toContain("Up to 99 mg/dL");
   expect(markup).toContain("border-dashed");
   expect(captured.referenceLines.map((line) => line.y)).toEqual([99]);
+  expect(captured.referenceAreas).toHaveLength(2);
+  expect(captured.referenceAreas[0]).toMatchObject({
+    fill: "var(--destructive)",
+    y2: 99,
+  });
+  expect(captured.referenceAreas[1]).toMatchObject({
+    fill: "var(--primary)",
+    y1: 99,
+  });
 });
 
 test("a fallback bound uses a distinct general-reference label", () => {
@@ -210,7 +276,7 @@ test("a fallback bound uses a distinct general-reference label", () => {
   expect(maximum(5)).toBe(5.7);
 });
 
-test("a lower-only reference keeps its bound visible below the data", () => {
+test("a lower-only range shades the accepted side above its dashed limit", () => {
   renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "eGFR",
     points: [
@@ -224,12 +290,37 @@ test("a lower-only reference keeps its bound visible below the data", () => {
   }));
 
   expect(captured.referenceLines.map((line) => line.y)).toEqual([60]);
+  expect(captured.referenceAreas).toHaveLength(2);
+  expect(captured.referenceAreas[0]).toMatchObject({
+    fill: "var(--destructive)",
+    y1: 60,
+  });
+  expect(captured.referenceAreas[1]).toMatchObject({
+    fill: "var(--primary)",
+    y2: 60,
+  });
   const [minimum, maximum] = captured.yAxisDomain as [
     (value: number) => number,
     (value: number) => number,
   ];
   expect(minimum(79)).toBe(60);
   expect(maximum(102)).toBe(102);
+});
+
+test("an inverted reference range is omitted instead of shading a misleading interval", () => {
+  renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
+    displayName: "Invalid range",
+    points: [
+      { date: "2026-06-14", id: "p1", value: 15 },
+    ],
+    referenceRange: { high: 6, low: 20 },
+    referenceRangeLabel: "20 to 6 mg/dL",
+    unit: "mg/dL",
+  }));
+
+  expect(captured.referenceAreas).toHaveLength(0);
+  expect(captured.referenceLines).toHaveLength(0);
+  expect(captured.yAxisDomain).toEqual(["auto", "auto"]);
 });
 
 test("a supplied display value preserves the lab's reported precision in the tooltip", () => {
@@ -259,6 +350,7 @@ test("no reference range keeps the grid and default domain", () => {
     unit: "mIU/L",
   }));
 
+  expect(captured.referenceAreas).toHaveLength(0);
   expect(captured.referenceLines).toHaveLength(0);
   expect(captured.gridRendered).toBe(true);
   expect(captured.yAxisDomain).toEqual(["auto", "auto"]);

--- a/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
+++ b/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
@@ -262,6 +262,7 @@ test("a published comparator stays neutral while keeping its bound visible", () 
     referenceRangeLabel: "<5.7%",
     referenceRangeSourceLabel: "Reviewed source · not the reporting lab's range",
     referenceRangeTitle: "Published adult comparator",
+    referenceRangeTone: "context",
     unit: "percent",
   }));
 

--- a/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
+++ b/apps/web/test/lab-biomarker-history-chart-contract.test.tsx
@@ -134,7 +134,7 @@ test("lab chart keeps tiny values precise without adding a nested keyboard stop"
   expect(renderToStaticMarkup(createElement("div", null, tooltip))).toContain("0.0015 mg/L");
 });
 
-test("the latest two-sided range expands the scale and separates in-range from review regions", () => {
+test("the latest two-sided lab range expands the scale and separates in-range from review regions", () => {
   const markup = renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "HbA1c",
     points: [
@@ -155,6 +155,14 @@ test("the latest two-sided range expands the scale and separates in-range from r
     "HbA1c results over time; latest lab range 4 to 5.6% from Example Lab",
   );
   expect(captured.referenceLines.map((line) => line.y)).toEqual([4, 5.6]);
+  for (const line of captured.referenceLines) {
+    expect(line).toMatchObject({
+      ifOverflow: "hidden",
+      stroke: "var(--color-value)",
+      strokeDasharray: "4 4",
+      strokeOpacity: 0.5,
+    });
+  }
   expect(captured.referenceAreas).toHaveLength(3);
   expect(captured.referenceAreas[0]).toMatchObject({
     fill: "var(--destructive)",
@@ -188,15 +196,11 @@ test("the latest two-sided range expands the scale and separates in-range from r
   expect(minimum(5.6)).toBe(4);
   expect(maximum(5.8)).toBe(5.8);
 
-  for (const line of captured.referenceLines) {
-    expect(line).toMatchObject({ ifOverflow: "hidden" });
-  }
-
   const tooltip = captured.tooltipFormatter?.(5.8);
   expect(renderToStaticMarkup(createElement("div", null, tooltip))).toContain("5.8%");
 });
 
-test("a wide two-sided range stays fully visible around a single in-range result", () => {
+test("a wide two-sided lab range stays fully visible around a single in-range result", () => {
   renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "Example marker",
     points: [
@@ -220,7 +224,7 @@ test("a wide two-sided range stays fully visible around a single in-range result
   ]));
 });
 
-test("an upper-only range shades the accepted side below its dashed limit", () => {
+test("an upper-only lab range shades the accepted side below its dashed limit", () => {
   const markup = renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "LDL cholesterol",
     points: [
@@ -234,7 +238,7 @@ test("an upper-only range shades the accepted side below its dashed limit", () =
 
   expect(markup).toContain("Latest lab range");
   expect(markup).toContain("Up to 99 mg/dL");
-  expect(markup).toContain("border-dashed");
+  expect(markup).toContain("border-primary/50");
   expect(captured.referenceLines.map((line) => line.y)).toEqual([99]);
   expect(captured.referenceAreas).toHaveLength(2);
   expect(captured.referenceAreas[0]).toMatchObject({
@@ -247,7 +251,7 @@ test("an upper-only range shades the accepted side below its dashed limit", () =
   });
 });
 
-test("a fallback bound uses a distinct general-reference label", () => {
+test("a published comparator stays neutral while keeping its bound visible", () => {
   const markup = renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "HbA1c",
     points: [
@@ -256,18 +260,28 @@ test("a fallback bound uses a distinct general-reference label", () => {
     ],
     referenceRange: { high: 5.7, low: null },
     referenceRangeLabel: "<5.7%",
-    referenceRangeSourceLabel: "Reviewed source",
-    referenceRangeTitle: "General reference",
+    referenceRangeSourceLabel: "Reviewed source · not the reporting lab's range",
+    referenceRangeTitle: "Published adult comparator",
     unit: "percent",
   }));
 
-  expect(markup).toContain("General reference");
+  expect(markup).toContain("Published adult comparator");
   expect(markup).toContain("Reviewed source");
   expect(markup).not.toContain("Latest lab range");
+  expect(markup).toContain("border-muted-foreground/40");
+  expect(markup).not.toContain("bg-primary/10");
   expect(captured.chartAriaLabel).toBe(
-    "HbA1c results over time; general reference <5.7% from Reviewed source",
+    "HbA1c results over time; published adult comparator <5.7% from Reviewed source · not the reporting lab's range",
   );
-  expect(captured.referenceLines.map((line) => line.y)).toEqual([5.7]);
+  expect(captured.referenceAreas).toHaveLength(0);
+  expect(captured.referenceLines).toHaveLength(1);
+  expect(captured.referenceLines[0]).toMatchObject({
+    ifOverflow: "hidden",
+    stroke: "var(--muted-foreground)",
+    strokeDasharray: "4 4",
+    strokeOpacity: 0.45,
+    y: 5.7,
+  });
   const [minimum, maximum] = captured.yAxisDomain as [
     (value: number) => number,
     (value: number) => number,
@@ -276,7 +290,7 @@ test("a fallback bound uses a distinct general-reference label", () => {
   expect(maximum(5)).toBe(5.7);
 });
 
-test("a lower-only range shades the accepted side above its dashed limit", () => {
+test("a lower-only lab range shades the accepted side above its dashed limit", () => {
   renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "eGFR",
     points: [
@@ -285,7 +299,6 @@ test("a lower-only range shades the accepted side above its dashed limit", () =>
     ],
     referenceRange: { high: null, low: 60 },
     referenceRangeLabel: ">=60 mL/min/1.73m^2",
-    referenceRangeTitle: "General reference",
     unit: "mL/min/1.73m^2",
   }));
 
@@ -307,14 +320,17 @@ test("a lower-only range shades the accepted side above its dashed limit", () =>
   expect(maximum(102)).toBe(102);
 });
 
-test("an inverted reference range is omitted instead of shading a misleading interval", () => {
+test.each([
+  { high: 6, label: "inverted", low: 20 },
+  { high: 10, label: "zero-width", low: 10 },
+])("a $label two-sided range is omitted instead of showing misleading bands", ({ high, low }) => {
   renderToStaticMarkup(createElement(LabBiomarkerHistoryChart, {
     displayName: "Invalid range",
     points: [
       { date: "2026-06-14", id: "p1", value: 15 },
     ],
-    referenceRange: { high: 6, low: 20 },
-    referenceRangeLabel: "20 to 6 mg/dL",
+    referenceRange: { high, low },
+    referenceRangeLabel: `${low} to ${high} mg/dL`,
     unit: "mg/dL",
   }));
 


### PR DESCRIPTION
## Why this PR exists

Biomarker detail charts currently draw dashed reference bounds but keep a data-only Y-axis for two-sided ranges. A wide source interval can therefore be clipped entirely, making an in-range result hard to place relative to the reporting lab's range.

## User-visible goal

On `/biomarkers/results/[metricKey]`, make the applicable reference context immediately legible without turning the chart into a warning dashboard:

- very light sage marks values inside the reporting lab's applicable range;
- very light sienna marks the visible regions below or above that range;
- the existing exact range label and dashed boundary rules remain as non-color cues.

The Y-axis fits the union of the comparable results and available range bounds. Two-sided, upper-only, and lower-only ranges are handled explicitly. Malformed inverted or zero-width intervals are omitted rather than rendered misleadingly.

## User experience

The existing biomarker result page and reading order stay unchanged. The member sees the same latest value, source status, collection date, chart, tooltip, and complete result ledger. The only changed interaction is visual comprehension inside the chart: the reporting lab's range remains visible and the plot is lightly partitioned so a point's position is understandable at a glance. No new control, explanation card, diagnosis, or required step is added.

Published Health Commons comparators remain materially different from the reporting lab's own range. They use neutral dashed boundaries only, remain labeled as not being the reporting lab's range, and never inherit the semantic sage/sienna bands.

## Invariants

- The reporting source's flag remains the status authority; shaded regions provide reference context only.
- Exact source comparator text and dashed boundaries remain visible, so color is never the sole cue.
- Missing, nonnumeric, inverted, or zero-width ranges render the ordinary chart without invented context.
- A published comparator never implies that the reporting lab marked a result in or out of range.
- The chart never infers that an unflagged result is normal or that an older lab used the latest source range.
- Tooltip precision, responsive initial sizing, single-result time-domain padding, and no-range behavior remain unchanged.

## Architecture and reuse

- **Existing systems reused:** `LabBiomarkerHistoryChart`, the existing normalized range contract, the existing chart-reference projection in `LabBiomarkerDetailClient`, Recharts `ReferenceArea` / `ReferenceLine`, and Murph's current semantic color tokens.
- **New logic:** quiet plot-edge areas derived from the already-owned range, a Y-domain correction so two-sided bounds remain visible, and one typed `lab | context` presentation field carried through the existing chart-reference object.
- **New abstractions:** none beyond that narrow union type. The chart remains the single presentation owner and the detail client remains the single source-vs-published-context resolver.
- **Complexity intentionally avoided:** no new state, data source, chart library, status inference, diagnosis logic, range registry, duplicate presentation component, or English-copy-based behavior switch.

## Non-obvious affected surfaces

- The previous durable product and design contracts explicitly required clipping two-sided ranges. Both owner documents now require the full applicable interval and restrained semantic shading.
- One-sided limits use the same plot-edge behavior: an upper limit shades the accepted side below it; a lower limit shades the accepted side above it.
- Published comparators expand the scale enough to show their neutral boundaries but render no semantic range fill.
- The existing real biomarker-result design study is directly addressable at `#biomarker-result-range-bands`; the reference-context study also shows the neutral published-comparator treatment.

## Final audit fixes

The final triple-check found and fixed three issues rather than leaving them as review notes:

1. **Published comparator semantics:** the first implementation would have given a general published comparator the same green/red status treatment as a reporting-lab range. It now uses neutral dashed-only context.
2. **Malformed intervals:** equal lower and upper bounds now fail closed alongside inverted intervals, avoiding a zero-height "range" with contradictory red regions.
3. **Maintainability:** semantic behavior is carried by a typed `referenceRangeTone` field rather than inferred from the English legend title. The root visual-design contract and the measured-biomarker product spec were updated in the same PR so future work cannot reintroduce the old clipping rule.

## Verification

Exact-head checks on `c759f12dba58d26745a6029e44a85f3c64d18ae3`:

- Repo Hygiene: passed.
- Web Viewport Overflow: passed.
- Complete Murph Host Support matrix: all eight jobs passed, including release build/typecheck, repository-tool checks, docs gardening, fixture coverage, all package-coverage shards, app verification, and both host matrices.
- Hosted billing hermetic proof and trust classification: passed. The unrelated live Stripe browser job was cancelled before executing any step, so the fail-closed aggregate remains red; this PR changes no billing, Stripe, browser-matrix, or workflow files.
- Frontend Design Proof: red only because the required hosted desktop and mobile design-catalog screenshots have not been captured yet. The architecture/reuse guard and design-catalog coverage guard both pass.
- Current `main` is `f3b7ae2a18cd8b7fcb64a92c179c0b50e6a8e1b8`. GitHub reports the PR mergeable, and the commits added to `main` since this branch split touch none of this PR's seven files.

Focused chart contract coverage includes:

- the reported example shape: one `15 mg/dL` result inside a `6–20 mg/dL` range;
- two-sided domain inclusion and three-region geometry;
- upper-only and lower-only limits;
- neutral published-comparator presentation;
- inverted- and zero-width-range omission;
- no-range behavior, tiny-value precision, and reported display precision.

## Preliminary specialist lenses

- Product experience: applicable — reference-position comprehension changes while source status authority remains unchanged.
- Prompt: not applicable.
- Frontend: applicable — chart presentation changes; hosted rendered evidence is pending.
- Coverage: applicable — executable range geometry, source/context semantics, and scale behavior changed with focused contract tests.

ReviewGPT context sensitivity: sensitive

## Change-shape breakdown

Classification rule: production components, the production caller, and design-catalog registration are source; `apps/web/test/**` is tests; `DESIGN.md` and the measured-biomarker product spec are docs. No binary, generated, or config/tooling files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 107 | 17 |
| Tests / fixtures | 128 | 19 |
| Docs | 34 | 28 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **269** | **64** |

## Design proof

- Design page: `/design?tab=sections#biomarker-result-range-bands` — real `BiomarkerDetailStudy` using the production chart component.
- Additional state: the existing Biomarker reference context study includes both an exact source limit and a neutral published comparator.
- Desktop screenshot: pending hosted capture.
- Mobile screenshot: pending hosted capture.

## Deployment concerns

None expected. This is a single Web presentation change with no schema, API, runtime, provider, persisted-state, or cross-deploy contract change. Old and new Web builds consume the same biomarker data and are safe during ordinary rollout.