### PR TITLE
fix(cloudflare): use a Workers-supported redirect mode in database-health fetches

### DIFF
--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -550,7 +550,6 @@ async function fetchPlanetScaleMetrics(input: {
         accept: "application/json",
       },
       method: "GET",
-      redirect: "error",
     },
   ).catch(() => {
     throw new DatabaseHealthFetchError("service_discovery_failed");
@@ -582,7 +581,6 @@ async function fetchPlanetScaleMetrics(input: {
         accept: "text/plain",
       },
       method: "GET",
-      redirect: "error",
     },
   ).catch(() => {
     throw new DatabaseHealthFetchError("metrics_scrape_failed");
@@ -738,7 +736,6 @@ async function resolveDatabaseHealthLinqDestination(input: {
         {
           headers: { authorization },
           method: "GET",
-          redirect: "error",
         },
       ),
       fetchWithTimeout(
@@ -747,7 +744,6 @@ async function resolveDatabaseHealthLinqDestination(input: {
         {
           headers: { authorization },
           method: "GET",
-          redirect: "error",
         },
       ),
     ]);
@@ -821,7 +817,6 @@ async function sendDatabaseHealthLinqAlert(input: {
         "idempotency-key": input.idempotencyKey,
       },
       method: "POST",
-      redirect: "error",
     },
   );
   if (!response.ok) {
@@ -1066,6 +1061,10 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   return await fetchImplementation(input, {
     ...init,
+    // Workers fetch rejects redirect: "error" outright (TypeError before any
+    // network I/O); "manual" keeps the fail-closed intent because a 3xx
+    // response is !ok for every caller.
+    redirect: "manual",
     signal: AbortSignal.timeout(DATABASE_HEALTH_FETCH_TIMEOUT_MS),
   });
 }

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1447,7 +1447,7 @@ describe("database health monitor", () => {
       expect(request).toBeDefined();
       expect(request.url).not.toContain("service-token-id");
       expect(request.url).not.toContain("service-token");
-      expect(request.redirect).toBe("error");
+      expect(request.redirect).toBe("manual");
     }
   });
 


### PR DESCRIPTION
## Why this PR exists

The production database-health monitor (Cloudflare Worker cron, `DatabaseHealthDurableObject`) has never completed a single successful run since it first deployed on Jul 29: ~2,680 consecutive `service_discovery_failed` collection failures and a `linq_health_unavailable` failure on every 30-minute pager attempt. During the Aug 7 connection-slot exhaustion incident it therefore neither detected the saturation nor paged. Live probing from a disposable Worker on the same account proved the mechanism: Workers `fetch` rejects `redirect: "error"` with `TypeError: Invalid redirect value, must be one of "follow" or "manual"` before any network I/O, and every fetch in `monitor.ts` passed `redirect: "error"`. The identical authenticated request with `redirect: "manual"` returns HTTP 200 from inside a Worker.

## User goal / user-visible behavior

No end-user-visible behavior. Operators get a working database saturation monitor: scheduled scrapes actually collect PlanetScale metrics, and alert conditions can actually deliver Linq pages.

## User experience

Not applicable — operational monitoring only; no product surface changes.

## Invariants the PR must preserve

- Fail-closed semantics on redirects: with `redirect: "manual"` a 3xx response is returned (not followed), stays `!response.ok`, and every caller already treats `!ok` as the corresponding failure (`service_discovery_failed`, `metrics_scrape_failed`, `linq_health_unavailable`, delivery failure). No redirect is ever silently followed to an unexpected host.
- Service-token credentials appear only on the discovery request; the signed scrape URL and Linq requests keep their existing header shapes (existing tests assert this and still pass).
- The 10s `AbortSignal.timeout` continues to apply to every fetch (unchanged in the same init object).

## Non-obvious affected surfaces

All five external fetches of the database-health module change redirect mode at once (PlanetScale discovery, metrics scrape, Linq chat health, Linq phone-number health, Linq message send) because the mode is now centralized in `fetchWithTimeout`. That centralization is the point: no future call site can reintroduce the Workers-unsupported value. Regression proof: all 54 tests across `database-health-{monitor,worker,metrics}.test.ts` pass, including the request-shape test now asserting `redirect: "manual"`.

## Architecture and reuse

- **Existing systems reused**: the single `fetchWithTimeout` wrapper every database-health fetch already flows through; the existing `!response.ok` failure classification at each call site.
- **New logic**: one `redirect: "manual"` line in `fetchWithTimeout` (with a comment stating the Workers constraint), replacing five per-call `redirect: "error"` entries.
- **New abstractions**: none — the net diff is −1 line of code.
- **Complexity intentionally avoided**: no per-call redirect configuration, no response-status special-casing for 3xx (the existing `!ok` handling already covers it), no fetch wrapper replacement.

## Hot reply path impact

Not applicable. The database-health monitor runs on a cron-triggered Durable Object and shares no code path with the Foreground Reply Critical Path; no operation is added or moved anywhere on that path.

## Murph initial provider input impact

Not applicable for both individual and group runtimes — no prompt, tool, schema, or provider-request assembly surface is touched.

## Preliminary specialist lenses

- Product experience: not applicable — no product surface.
- Prompt: not applicable — no prompt surfaces.
- Frontend: not applicable — no UI.
- Coverage: applicable — focused proof: `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage` on the three database-health test files → 54 passed, plus `pnpm run typecheck` clean in `apps/cloudflare`. The pre-existing request-shape test asserted the broken value (`redirect: "error"`) and now asserts the supported one. Exact-head CI: pending.

ReviewGPT context sensitivity: sensitive

Classification reason: this is production alerting/deploy-runtime infrastructure; the change alters the egress behavior of every external call the monitor makes.

## Change-shape breakdown

Classification rule: by path — `apps/cloudflare/src/**` = source, `apps/cloudflare/test/**` = tests/fixtures. No binary files, no generated code.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 4 | 5 |
| Tests/fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **5** | **6** |

## Design proof

Not applicable — no user-facing frontend UI change.

## Deployment concerns

The fix only takes effect in production after the murph-cloud `deploy-cloudflare-hosted` workflow redeploys the Worker (the worker's PlanetScale service-token secrets were already rotated to a verified-working token earlier today). No web/Worker or Worker/container skew risk: the module is self-contained monitoring; old and new versions differ only in whether their outbound fetches execute. Post-deploy check: `wrangler tail murph-hosted` over one 5-minute cron tick — success is the absence of the `Database health metrics collection failed.` warn (the consecutive-failure counter, ~2,680+, resets on first success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ReviewGPT first-reviewed head: 22284f6e9b99bd28fad39bb9630aba2a987aa830
