### PR TITLE
fix: silence pg concurrent-query deprecation noise in web runtime

### DIFF
--- a/apps/web/src/lib/process-warnings.ts
+++ b/apps/web/src/lib/process-warnings.ts
@@ -3,17 +3,113 @@ import {
   isSqliteExperimentalWarning,
 } from "@murphai/runtime-state/node/sqlite-warning-filter";
 
+type ProcessEmitWarningRestArgs = Parameters<typeof process.emitWarning> extends [
+  string | Error,
+  ...infer Rest,
+]
+  ? Rest
+  : never;
+
+/**
+ * pg@8 emits this once per process through `util.deprecate` when
+ * `client.query()` is called while earlier queries are still pending on the
+ * same client (`_queryQueue.length > 0` in pg's `Client#query`). In this
+ * runtime that happens when app code awaits `Promise.all` over several
+ * queries on one Prisma interactive-transaction handle: `@prisma/adapter-pg`
+ * checks out a single pg client per transaction and forwards each query to
+ * it, and pg queues and serializes them, so the warning describes healthy,
+ * intended behavior today. It still prints to stderr once per lambda
+ * instance, which Vercel surfaces as an error-level log line on otherwise
+ * healthy requests.
+ *
+ * One process-level filter here covers every pg pool in the web runtime
+ * (prisma.ts, product-labels.ts, hosted-runtime-log), since Node deprecation
+ * warnings are process-global.
+ *
+ * Caveat: pg@9 removes the queueing this warning announces, so concurrent
+ * `client.query()` on one client becomes a hard error there. Before any pg@9
+ * upgrade, serialize transaction-handle queries (or prove the adapter does)
+ * and delete this filter.
+ */
+const PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE =
+  "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.";
+
+const PG_WARNING_FILTER_FLAG = Symbol.for(
+  "murph.pgConcurrentQueryDeprecationWarningFilterInstalled",
+);
+
+type ProcessWithWarningFilterFlag = NodeJS.Process & {
+  [key: symbol]: boolean | undefined;
+};
+
 export function installHostedWebWarningFilters(): void {
   installSqliteExperimentalWarningFilterWithOptions({
     matchMode: "includes",
   });
+  installPgConcurrentQueryDeprecationWarningFilter();
 }
 
 export function isHostedWebNoiseWarning(
   warning: string | Error,
   args: readonly unknown[],
 ): boolean {
-  return isSqliteExperimentalWarning(warning, args, {
-    matchMode: "includes",
-  });
+  return (
+    isSqliteExperimentalWarning(warning, args, {
+      matchMode: "includes",
+    }) || isPgConcurrentQueryDeprecationWarning(warning, args)
+  );
+}
+
+export function isPgConcurrentQueryDeprecationWarning(
+  warning: string | Error,
+  args: readonly unknown[],
+): boolean {
+  const message = typeof warning === "string" ? warning : warning.message;
+
+  return (
+    readWarningType(warning, args) === "DeprecationWarning" &&
+    message === PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE
+  );
+}
+
+function installPgConcurrentQueryDeprecationWarningFilter(): void {
+  const processWithFlag = process as ProcessWithWarningFilterFlag;
+
+  if (processWithFlag[PG_WARNING_FILTER_FLAG] === true) {
+    return;
+  }
+
+  processWithFlag[PG_WARNING_FILTER_FLAG] = true;
+  const originalEmitWarning = process.emitWarning.bind(process);
+
+  process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+    if (isPgConcurrentQueryDeprecationWarning(warning, args)) {
+      return;
+    }
+
+    return originalEmitWarning(
+      warning as Parameters<typeof process.emitWarning>[0],
+      ...(args as ProcessEmitWarningRestArgs),
+    );
+  }) as typeof process.emitWarning;
+}
+
+function readWarningType(
+  warning: string | Error,
+  args: readonly unknown[],
+): string {
+  if (typeof args[0] === "string") {
+    return args[0];
+  }
+
+  if (
+    typeof args[0] === "object" &&
+    args[0] !== null &&
+    "type" in args[0] &&
+    typeof args[0].type === "string"
+  ) {
+    return args[0].type;
+  }
+
+  return warning instanceof Error ? warning.name : "";
 }

--- a/apps/web/test/process-warnings.test.ts
+++ b/apps/web/test/process-warnings.test.ts
@@ -1,3 +1,5 @@
+import util from "node:util";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalEmitWarning = process.emitWarning;
@@ -98,6 +100,43 @@ describe("hosted web warning filters", () => {
       ["Some other deprecation", "DeprecationWarning"],
       [PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, "ExperimentalWarning"],
       ["Plain runtime warning", "Warning"],
+    ]);
+  });
+
+  it("suppresses util.deprecate wrappers created before the filter installs", async () => {
+    const forwardedWarnings: unknown[][] = [];
+
+    process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+      forwardedWarnings.push([warning, ...args]);
+    }) as typeof process.emitWarning;
+
+    // pg creates its deprecation wrappers at module evaluation, before
+    // prisma.ts reaches installHostedWebWarningFilters(), so wrapper creation
+    // must not bind the pre-filter emitter. util.deprecate resolves
+    // process.emitWarning at call time; this test fails if that ever changes
+    // (the pg message would reach the stub above, bypassing the filter).
+    const pgDeprecated = util.deprecate(
+      () => {},
+      PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE,
+    );
+    const otherDeprecated = util.deprecate(
+      () => {},
+      "Some other library deprecation.",
+    );
+
+    const { installHostedWebWarningFilters } = await import("@/src/lib/process-warnings");
+
+    installHostedWebWarningFilters();
+
+    pgDeprecated();
+    otherDeprecated();
+
+    expect(forwardedWarnings).toEqual([
+      [
+        "Some other library deprecation.",
+        "DeprecationWarning",
+        expect.any(Function),
+      ],
     ]);
   });
 

--- a/apps/web/test/process-warnings.test.ts
+++ b/apps/web/test/process-warnings.test.ts
@@ -5,23 +5,33 @@ const SQLITE_WARNING_FILTER_FLAG = Symbol.for("murph.sqliteExperimentalWarningFi
 const SQLITE_WARNING_FILTER_INCLUDES_FLAG = Symbol.for(
   "murph.sqliteExperimentalWarningFilterInstalled.includes",
 );
-type ProcessWithSqliteWarningFilterFlag = NodeJS.Process & {
+const PG_WARNING_FILTER_FLAG = Symbol.for(
+  "murph.pgConcurrentQueryDeprecationWarningFilterInstalled",
+);
+const PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE =
+  "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.";
+type ProcessWithWarningFilterFlags = NodeJS.Process & {
   [SQLITE_WARNING_FILTER_FLAG]?: boolean;
   [SQLITE_WARNING_FILTER_INCLUDES_FLAG]?: boolean;
+  [PG_WARNING_FILTER_FLAG]?: boolean;
 };
+
+function deleteWarningFilterFlags(): void {
+  delete (process as ProcessWithWarningFilterFlags)[SQLITE_WARNING_FILTER_FLAG];
+  delete (process as ProcessWithWarningFilterFlags)[SQLITE_WARNING_FILTER_INCLUDES_FLAG];
+  delete (process as ProcessWithWarningFilterFlags)[PG_WARNING_FILTER_FLAG];
+}
 
 describe("hosted web warning filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_FLAG];
-    delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_INCLUDES_FLAG];
+    deleteWarningFilterFlags();
   });
 
   afterEach(() => {
     process.emitWarning = originalEmitWarning;
-    delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_FLAG];
-    delete (process as ProcessWithSqliteWarningFilterFlag)[SQLITE_WARNING_FILTER_INCLUDES_FLAG];
+    deleteWarningFilterFlags();
   });
 
   it("suppresses the repeated SQLite experimental warning without hiding other warnings", async () => {
@@ -43,21 +53,86 @@ describe("hosted web warning filters", () => {
       "SQLite is an experimental feature and might change at any time (extra context)",
       "ExperimentalWarning",
     );
-    process.emitWarning(
-      "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.",
-      "DeprecationWarning",
-    );
     process.emitWarning("Different experimental warning", "ExperimentalWarning");
     process.emitWarning("Plain runtime warning", "Warning");
 
     expect(forwardedWarnings).toEqual([
-      [
-        "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.",
-        "DeprecationWarning",
-      ],
       ["Different experimental warning", "ExperimentalWarning"],
       ["Plain runtime warning", "Warning"],
     ]);
+  });
+
+  it("suppresses only the pg concurrent-query deprecation warning", async () => {
+    const forwardedWarnings: unknown[][] = [];
+
+    process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+      forwardedWarnings.push([warning, ...args]);
+    }) as typeof process.emitWarning;
+
+    const { installHostedWebWarningFilters } = await import("@/src/lib/process-warnings");
+
+    installHostedWebWarningFilters();
+
+    // util.deprecate emits (message, "DeprecationWarning", deprecatedFn); the
+    // trailing function must not defeat the match.
+    const deprecatedFn = () => {};
+    process.emitWarning(
+      PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE,
+      "DeprecationWarning",
+      deprecatedFn,
+    );
+    process.emitWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, "DeprecationWarning");
+    process.emitWarning(
+      "Client.queryQueue is deprecated and will be removed in pg@9.0.",
+      "DeprecationWarning",
+    );
+    process.emitWarning("Some other deprecation", "DeprecationWarning");
+    process.emitWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, "ExperimentalWarning");
+    process.emitWarning("Plain runtime warning", "Warning");
+
+    expect(forwardedWarnings).toEqual([
+      [
+        "Client.queryQueue is deprecated and will be removed in pg@9.0.",
+        "DeprecationWarning",
+      ],
+      ["Some other deprecation", "DeprecationWarning"],
+      [PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, "ExperimentalWarning"],
+      ["Plain runtime warning", "Warning"],
+    ]);
+  });
+
+  it("detects the pg deprecation across emitWarning argument shapes", async () => {
+    const { isPgConcurrentQueryDeprecationWarning } = await import(
+      "@/src/lib/process-warnings"
+    );
+
+    expect(
+      isPgConcurrentQueryDeprecationWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, [
+        "DeprecationWarning",
+      ]),
+    ).toBe(true);
+    expect(
+      isPgConcurrentQueryDeprecationWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, [
+        { type: "DeprecationWarning" },
+      ]),
+    ).toBe(true);
+    expect(
+      isPgConcurrentQueryDeprecationWarning(
+        Object.assign(new Error(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE), {
+          name: "DeprecationWarning",
+        }),
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      isPgConcurrentQueryDeprecationWarning(
+        `${PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE} (extra context)`,
+        ["DeprecationWarning"],
+      ),
+    ).toBe(false);
+    expect(
+      isPgConcurrentQueryDeprecationWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, []),
+    ).toBe(false);
   });
 
   it("is idempotent", async () => {


### PR DESCRIPTION
## Why this PR exists

In Vercel production logs, pg's once-per-process deprecation warning ("Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0...") prints to stderr once per lambda instance, which Vercel flags as an error-level log entry. Over Aug 1-7 it accounted for 560 of 1,314 error-level entries (43%), mostly attached to healthy 202 webhook requests, drowning real errors.

## User goal / user-visible behavior

No direct end-user behavior change. The operational goal: production error-level logs contain only real errors, so incidents are visible instead of buried under known-benign deprecation noise.

## User experience

Not applicable — this PR has no user-facing effect. It changes only which process warnings reach stderr in the hosted web runtime.

## Root cause and emission mechanism

- pg@8 (`pg/lib/client.js`) wraps this message in `nodeUtils.deprecate(() => {}, ...)` and invokes it in `Client#query` when `this._queryQueue.length > 0` (a third query arrives while one is active and another is queued on the same client).
- Node's `util.deprecate` emits once per process via `process.emitWarning(message, "DeprecationWarning", fn)`, and the default handler prints it to stderr. Intercepting `process.emitWarning` before the pool seam provably prevents the stderr print (verified with a direct scenario run).
- The concurrency that triggers it is **our own app code, not the adapter**: several call sites (e.g. `apps/web/src/lib/hosted-onboarding/family-plan.ts`) await `Promise.all([...])` over queries on a single Prisma interactive-transaction handle. `@prisma/adapter-pg` checks out one pg client per transaction and forwards each query to it; pg queues and serializes them, so behavior today is correct. The adapter's own calls are sequentially awaited; non-transaction queries go through `pool.query` (one client per query) and cannot trigger the warning.

## The fix

Extend the existing hosted-web warning-filter seam (`apps/web/src/lib/process-warnings.ts`, already installed by `src/lib/prisma.ts` at module scope before pool construction, mirroring the established SQLite ExperimentalWarning filter in `@murphai/runtime-state`) with a narrowly scoped `process.emitWarning` interceptor that drops only this exact DeprecationWarning message. Everything else — including other DeprecationWarnings — passes through untouched. No blanket `--no-deprecation` / `NODE_OPTIONS`. The filter is process-global, so the same install also covers the `product-labels.ts` and `hosted-runtime-log` pg pools in the same runtime.

## Invariants the PR must preserve

- Only the exact pg concurrent-query deprecation message (matched by full-string equality plus `DeprecationWarning` type) is dropped; every other warning, of every type, still reaches the default handler and stderr.
- The filter installs idempotently (process-flag symbol) and forwards with the original `emitWarning` binding; it never throws on unusual argument shapes.
- **pg@9 upgrade caveat (recorded in the module comment):** pg@9 removes the queueing this warning announces, making concurrent `client.query()` on one client a hard error. Because the concurrent pattern is ours (`Promise.all` over a `$transaction` handle, e.g. in `family-plan.ts`), any future pg@9 upgrade must first serialize transaction-handle queries or prove the new behavior safe, then delete this filter. Suppression is safe to ship now because pg@8 serializes correctly.

## Non-obvious affected surfaces

- `process.emitWarning` is patched process-wide in the hosted web runtime (wrapping the existing SQLite filter's patch). Necessary because Node prints deprecations from inside `util.deprecate` and there is no pg-level or per-warning opt-out; regression proof: `apps/web/test/process-warnings.test.ts` asserts exact-message-only filtering and pass-through of all other warnings/types, plus a direct `util.deprecate` scenario run showing the pg message silenced while another deprecation still prints.
- `isHostedWebNoiseWarning()` now also returns true for this pg warning (it previously covered only the SQLite warning). No current callers outside the module; the exported semantics stay truthful.
- The previous test expectation that this pg warning passes through was intentionally flipped — that assertion documented pre-fix behavior of the SQLite-only filter, not a product requirement.

## Architecture and reuse

- **Existing systems reused:** the `installHostedWebWarningFilters()` seam in `process-warnings.ts` (already invoked from `prisma.ts` before pool construction) and the interception pattern, idempotency-flag convention, and test harness shape of the `@murphai/runtime-state` SQLite warning filter.
- **New logic:** one exact-match predicate (`isPgConcurrentQueryDeprecationWarning`) and one idempotent `process.emitWarning` wrapper installing it.
- **New abstractions:** none — the existing per-warning filter contract was sufficient; the pg filter is a second concrete instance behind the same install function.
- **Complexity intentionally avoided:** no generic warning-filter registry, no `NODE_OPTIONS`/`--no-deprecation` blanket suppression, no `process.on("warning")` listener (which cannot prevent the default stderr print), and no attempt to rewrite the `Promise.all`-on-transaction call sites in this PR.

## Hot reply path impact

Not applicable. No database, network, or awaited operation is added or moved on the Foreground Reply Critical Path. The filter installs once at module load; per-warning cost is one string comparison inside `process.emitWarning`, which fires at most a handful of times per process lifetime.

## Murph initial provider input impact

Not applicable for both individual and group Murph runtimes. The diff touches no prompt text, prompt assembly, tool definitions/schemas/availability, skills, Codex configuration, model tool mode, or provider-request assembly — only Node process-warning handling and its tests.

## Preliminary specialist lenses

- **Product experience:** not applicable — no product-owned dimension changes; this is log-noise handling with no user-visible surface.
- **Prompt:** not applicable — no prompt or instruction content touched.
- **Frontend:** not applicable — no `apps/web` UI diff; no rendered evidence required.
- **Coverage:** applicable — runtime warning-handling behavior changed. Focused local proof: `pnpm --dir apps/web typecheck` (exit 0); `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/process-warnings.test.ts` (exit 0; 5 passed, including the pre-install ordering regression); earlier at the first head also `apps/web/test/prisma-database-retry-postgres.test.ts` (exit 0; DB-gated suite env-skipped) and `apps/web/test/account-settings-snapshot.test.ts` (imports `lib/prisma`, 12 passed, exit 0); direct `util.deprecate` scenario run proving the pg message is silenced while another deprecation still prints to stderr. Exact-head CI: pending.

## Preliminary specialist pass disposition

The `completion-specialists` pass at `0c5a1057e0` returned `SPECIALIST_OUTCOME: FINDINGS` with one accepted coverage finding: the tests only exercised `util.deprecate` wrappers created after the filter installed, while production creates pg's wrappers (static `pg` import in `prisma.ts`) before `installHostedWebWarningFilters()` runs; a creation-time capture of the pre-patch emitter would have kept tests green while production kept emitting. Disposition: accepted, verified honestly first — `util.deprecate` resolves `process.emitWarning` at call time, so the production ordering is safe and no mechanism change was needed. The discriminating ordering regression test (wrappers created before import/install; only the unrelated deprecation may reach the original emitter) landed in `85e89af9e8`. The returned `reviewgpt-coverage.patch` artifact was not applied; the correction was implemented directly per the finding's specification.

ReviewGPT context sensitivity: sensitive
Classification reason: patches a process-global runtime API (`process.emitWarning`) in the production web runtime, a cross-cutting surface even though the diff is small.

## Change-shape breakdown

Classification rule: `apps/web/src/**` counts as source; `apps/web/test/**` counts as tests/fixtures. No docs, config/tooling, generated, or binary files are touched.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 99 | 3 |
| Tests/fixtures | 123 | 9 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **222** | **12** |

## Design proof

Not applicable — no user-facing frontend UI diff; nothing renders differently in the design catalog.

## Deployment skew / compatibility

Not applicable — single-sided `apps/web` (Vercel) change with no shared assumption across the web/Worker/runner deploy boundary and no persisted state. During rollout, old lambdas keep printing the warning and new ones do not; fully reversible by revert. Post-deploy check: Vercel error-level log volume on webhook routes drops to real errors only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ReviewGPT first-reviewed head: 85e89af9e8d57a7ea40f6192947216cffebc1f49

