### PR TITLE
fix(device-sync): bound webhook admission locks and map transaction expiry to retryable 503

### DIFF
--- a/apps/web/src/lib/device-sync/http.ts
+++ b/apps/web/src/lib/device-sync/http.ts
@@ -5,6 +5,7 @@ import {
 import {
   buildPublicDeviceSyncErrorPayload,
   DeviceSyncError,
+  deviceSyncError,
   isDeviceSyncError,
 } from "@murphai/device-syncd/errors";
 import { NextResponse } from "next/server";
@@ -101,11 +102,78 @@ function matchDeviceSyncError(error: unknown): JsonErrorMapping | null {
   };
 }
 
+// Prisma reports every transaction-API fault as P2028, covering both a
+// transaction that expired mid-flight and one that never started in time.
+const PRISMA_TRANSACTION_FAULT_CODE = "P2028";
+// Postgres raises 55P03 when a bounded `lock_timeout` wait gives up, which is
+// how the admission member-row lock fails fast under webhook fan-out bursts.
+const POSTGRES_LOCK_TIMEOUT_CODE = "55P03";
+const DATABASE_CONTENTION_CAUSE_CHAIN_LIMIT = 5;
+
+const DEVICE_SYNC_STORE_CONTENTION_ERROR_CODE = "STORE_CONTENTION";
+
+/**
+ * Providers retry this path on a retryable 503 (`WEBHOOK_ACCOUNT_NOT_READY`,
+ * `WEBHOOK_TRACE_IN_PROGRESS`, ...); an unmapped 500 breaks that redelivery
+ * contract. Nothing is committed when a transaction expires, because the
+ * ingress releases the webhook trace claim, so contention faults are safe to
+ * retry.
+ */
+function matchDatabaseContentionError(error: unknown): JsonErrorMapping | null {
+  if (!isDatabaseContentionError(error)) {
+    return null;
+  }
+
+  return {
+    error: buildPublicDeviceSyncErrorPayload(deviceSyncError({
+      code: DEVICE_SYNC_STORE_CONTENTION_ERROR_CODE,
+      message: "The device-sync store timed out under contention. Retry later.",
+      retryable: true,
+      httpStatus: 503,
+    })).error,
+    log: { level: "warn" },
+    status: 503,
+  };
+}
+
+function isDatabaseContentionError(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  for (
+    let depth = 0;
+    current !== null && typeof current === "object" && depth < DATABASE_CONTENTION_CAUSE_CHAIN_LIMIT;
+    depth += 1
+  ) {
+    if (seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+
+    const record = current as { cause?: unknown; code?: unknown; meta?: unknown };
+    if (record.code === PRISMA_TRANSACTION_FAULT_CODE || record.code === POSTGRES_LOCK_TIMEOUT_CODE) {
+      return true;
+    }
+    const meta = record.meta;
+    if (
+      meta !== null
+      && typeof meta === "object"
+      && (meta as { code?: unknown }).code === POSTGRES_LOCK_TIMEOUT_CODE
+    ) {
+      return true;
+    }
+
+    current = record.cause;
+  }
+
+  return false;
+}
+
 const deviceSyncJsonRouteHelpers = createJsonRouteHelpers({
   defaultHeaders: HOSTED_DEVICE_SYNC_DEFAULT_HEADERS,
   internalMessage: "Hosted device-sync route failed unexpectedly.",
   logMessage: "Hosted device-sync route failed.",
-  matchers: [matchDeviceSyncError],
+  matchers: [matchDeviceSyncError, matchDatabaseContentionError],
 });
 
 export const jsonOk = deviceSyncJsonRouteHelpers.jsonOk;

--- a/apps/web/src/lib/device-sync/http.ts
+++ b/apps/web/src/lib/device-sync/http.ts
@@ -105,8 +105,11 @@ function matchDeviceSyncError(error: unknown): JsonErrorMapping | null {
 // Prisma reports every transaction-API fault as P2028, covering both a
 // transaction that expired mid-flight and one that never started in time.
 const PRISMA_TRANSACTION_FAULT_CODE = "P2028";
+// Raw queries fail with P2010; @prisma/adapter-pg nests the original Postgres
+// code under meta.driverAdapterError.cause.
+const PRISMA_RAW_QUERY_FAULT_CODE = "P2010";
 // Postgres raises 55P03 when a bounded `lock_timeout` wait gives up, which is
-// how the admission member-row lock fails fast under webhook fan-out bursts.
+// how the webhook admission member-row lock fails fast under fan-out bursts.
 const POSTGRES_LOCK_TIMEOUT_CODE = "55P03";
 const DATABASE_CONTENTION_CAUSE_CHAIN_LIMIT = 5;
 
@@ -154,11 +157,9 @@ function isDatabaseContentionError(error: unknown): boolean {
     if (record.code === PRISMA_TRANSACTION_FAULT_CODE || record.code === POSTGRES_LOCK_TIMEOUT_CODE) {
       return true;
     }
-    const meta = record.meta;
     if (
-      meta !== null
-      && typeof meta === "object"
-      && (meta as { code?: unknown }).code === POSTGRES_LOCK_TIMEOUT_CODE
+      record.code === PRISMA_RAW_QUERY_FAULT_CODE
+      && isAdapterPgLockTimeoutMeta(record.meta)
     ) {
       return true;
     }
@@ -167,6 +168,28 @@ function isDatabaseContentionError(error: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * The production adapter-pg shape for a raw-query lock timeout: P2010 with the
+ * Postgres code at meta.driverAdapterError.cause.originalCode (or .code). The
+ * hosted member billing store decodes this exact shape for its own lock bound.
+ */
+function isAdapterPgLockTimeoutMeta(meta: unknown): boolean {
+  if (meta === null || typeof meta !== "object") {
+    return false;
+  }
+  const driverAdapterError = (meta as { driverAdapterError?: unknown }).driverAdapterError;
+  if (driverAdapterError === null || typeof driverAdapterError !== "object") {
+    return false;
+  }
+  const cause = (driverAdapterError as { cause?: unknown }).cause;
+  if (cause === null || typeof cause !== "object") {
+    return false;
+  }
+  const causeRecord = cause as { code?: unknown; originalCode?: unknown };
+  return causeRecord.originalCode === POSTGRES_LOCK_TIMEOUT_CODE
+    || causeRecord.code === POSTGRES_LOCK_TIMEOUT_CODE;
 }
 
 const deviceSyncJsonRouteHelpers = createJsonRouteHelpers({

--- a/apps/web/src/lib/device-sync/http.ts
+++ b/apps/web/src/lib/device-sync/http.ts
@@ -111,7 +111,6 @@ const PRISMA_RAW_QUERY_FAULT_CODE = "P2010";
 // Postgres raises 55P03 when a bounded `lock_timeout` wait gives up, which is
 // how the webhook admission member-row lock fails fast under fan-out bursts.
 const POSTGRES_LOCK_TIMEOUT_CODE = "55P03";
-const DATABASE_CONTENTION_CAUSE_CHAIN_LIMIT = 5;
 
 const DEVICE_SYNC_STORE_CONTENTION_ERROR_CODE = "STORE_CONTENTION";
 
@@ -139,35 +138,19 @@ function matchDatabaseContentionError(error: unknown): JsonErrorMapping | null {
   };
 }
 
+/**
+ * Both contention shapes arrive directly: the Prisma wrapper, the webhook
+ * trace-release catch, and the shared JSON route helper all rethrow the
+ * original error, so the classifier decodes exactly what the store emits.
+ */
 function isDatabaseContentionError(error: unknown): boolean {
-  let current: unknown = error;
-  const seen = new Set<unknown>();
-
-  for (
-    let depth = 0;
-    current !== null && typeof current === "object" && depth < DATABASE_CONTENTION_CAUSE_CHAIN_LIMIT;
-    depth += 1
-  ) {
-    if (seen.has(current)) {
-      return false;
-    }
-    seen.add(current);
-
-    const record = current as { cause?: unknown; code?: unknown; meta?: unknown };
-    if (record.code === PRISMA_TRANSACTION_FAULT_CODE || record.code === POSTGRES_LOCK_TIMEOUT_CODE) {
-      return true;
-    }
-    if (
-      record.code === PRISMA_RAW_QUERY_FAULT_CODE
-      && isAdapterPgLockTimeoutMeta(record.meta)
-    ) {
-      return true;
-    }
-
-    current = record.cause;
+  if (error === null || typeof error !== "object") {
+    return false;
   }
 
-  return false;
+  const record = error as { code?: unknown; meta?: unknown };
+  return record.code === PRISMA_TRANSACTION_FAULT_CODE
+    || (record.code === PRISMA_RAW_QUERY_FAULT_CODE && isAdapterPgLockTimeoutMeta(record.meta));
 }
 
 /**

--- a/apps/web/src/lib/device-sync/prisma-store.ts
+++ b/apps/web/src/lib/device-sync/prisma-store.ts
@@ -94,16 +94,6 @@ export type {
   UpsertHostedDeviceSyncDirtyConnectionResult,
 } from "./prisma-store/types";
 
-/**
- * Webhook fan-out bursts queue many admissions on one member row. Without a
- * lock bound, each queued transaction burns its whole 15s budget waiting and
- * then expires mid-callback; with one, waiters fail fast with a retryable
- * error the provider redelivers. The bound rides the transaction-local
- * `lock_timeout` set by `lockHostedMemberRow`, which also covers the
- * advisory-lock step in the same transaction.
- */
-const HEALTH_DATA_ADMISSION_LOCK_TIMEOUT_MS = 5_000;
-
 export class PrismaDeviceSyncControlPlaneStore
   implements DeviceSyncPublicIngressStore, HostedBrowserAssertionNonceStore
 {
@@ -499,13 +489,29 @@ export class PrismaDeviceSyncControlPlaneStore
     userId: string,
     connectionId: string,
     callback: (tx: HostedPrismaTransactionClient) => Promise<TResult>,
+    options: {
+      /**
+       * Bounds the member-row lock wait via a transaction-local
+       * `lock_timeout`, which also covers the advisory-lock step in the same
+       * transaction. Only callers whose failure is absorbed by an external
+       * redelivery loop (webhook acceptance) should pass this: a bounded
+       * waiter fails fast with a retryable error and the provider redelivers.
+       * Journeys without redelivery (connection establishment, companion
+       * ingestion, scheduled wakes) keep the full transaction budget.
+       */
+      memberRowLockTimeoutMs?: number;
+    } = {},
   ): Promise<TResult> {
     return this.prisma.$transaction(async (tx) => {
       // Member first is the repository-wide consent serialization order.
       // Connection state is locked only after withdrawal authority is current.
-      await lockHostedMemberRow(tx, userId, {
-        timeoutMs: HEALTH_DATA_ADMISSION_LOCK_TIMEOUT_MS,
-      });
+      await lockHostedMemberRow(
+        tx,
+        userId,
+        options.memberRowLockTimeoutMs !== undefined
+          ? { timeoutMs: options.memberRowLockTimeoutMs }
+          : {},
+      );
       if (await readHostedHealthDataConsentState({
         memberId: userId,
         prisma: tx,

--- a/apps/web/src/lib/device-sync/prisma-store.ts
+++ b/apps/web/src/lib/device-sync/prisma-store.ts
@@ -94,6 +94,16 @@ export type {
   UpsertHostedDeviceSyncDirtyConnectionResult,
 } from "./prisma-store/types";
 
+/**
+ * Webhook fan-out bursts queue many admissions on one member row. Without a
+ * lock bound, each queued transaction burns its whole 15s budget waiting and
+ * then expires mid-callback; with one, waiters fail fast with a retryable
+ * error the provider redelivers. The bound rides the transaction-local
+ * `lock_timeout` set by `lockHostedMemberRow`, which also covers the
+ * advisory-lock step in the same transaction.
+ */
+const HEALTH_DATA_ADMISSION_LOCK_TIMEOUT_MS = 5_000;
+
 export class PrismaDeviceSyncControlPlaneStore
   implements DeviceSyncPublicIngressStore, HostedBrowserAssertionNonceStore
 {
@@ -493,7 +503,9 @@ export class PrismaDeviceSyncControlPlaneStore
     return this.prisma.$transaction(async (tx) => {
       // Member first is the repository-wide consent serialization order.
       // Connection state is locked only after withdrawal authority is current.
-      await lockHostedMemberRow(tx, userId);
+      await lockHostedMemberRow(tx, userId, {
+        timeoutMs: HEALTH_DATA_ADMISSION_LOCK_TIMEOUT_MS,
+      });
       if (await readHostedHealthDataConsentState({
         memberId: userId,
         prisma: tx,

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -548,9 +548,13 @@ export class PrismaHostedConnectionStore {
       ...hostedConnectionRecordArgs,
     });
 
-    return await this.buildDurableConnectionRecord(record, {
-      externalAccountId: account.externalAccountId,
-    });
+    return await this.buildDurableConnectionRecord(
+      record,
+      {
+        externalAccountId: account.externalAccountId,
+      },
+      prisma,
+    );
   }
 
   async listConnectionsForUser(userId: string): Promise<PublicDeviceSyncAccount[]> {
@@ -564,7 +568,9 @@ export class PrismaHostedConnectionStore {
     tx?: HostedPrismaTransactionClient,
   ): Promise<PublicDeviceSyncAccount | null> {
     const record = await this.getConnectionRecordForUser(userId, connectionId, tx);
-    return record ? await this.buildDurableConnectionRecord(record) : null;
+    return record
+      ? await this.buildDurableConnectionRecord(record, {}, tx ?? this.prisma)
+      : null;
   }
 
   async getStoredConnectionAccountForUser(
@@ -981,9 +987,13 @@ export class PrismaHostedConnectionStore {
     fallback: {
       externalAccountId?: string | null;
     } = {},
+    // Callers already inside a transaction must pass their transaction client:
+    // the secure-box read otherwise checks out a second pooled connection while
+    // the transaction holds its own, which self-starves the pool under bursts.
+    prisma: HostedSecureBoxPrismaClient = this.prisma,
   ): Promise<PublicDeviceSyncAccount> {
     const mappedRecord = mapHostedConnectionRecord(record);
-    mappedRecord.externalAccountId = await readHostedStoredExternalAccountId(record, this.testCodec, this.prisma);
+    mappedRecord.externalAccountId = await readHostedStoredExternalAccountId(record, this.testCodec, prisma);
 
     return toRedactedPublicDeviceSyncAccount(
       buildHostedPublicDeviceSyncAccount({

--- a/apps/web/src/lib/device-sync/public-ingress-service.ts
+++ b/apps/web/src/lib/device-sync/public-ingress-service.ts
@@ -491,11 +491,13 @@ export class HostedDeviceSyncPublicIngressService {
 
   async handleWebhook(provider: string, rawBody?: Buffer): Promise<HandleWebhookResult> {
     const resolvedRawBody = rawBody ?? (await this.readWebhookRawBody());
-    // One webhook request opens several secure-box fields under the same
-    // domain root (account lookup, then admission work inside the transaction).
-    // Scope the unwrap memo to the request so the KMS round trip happens once,
-    // before the admission transaction opens, instead of per field while a
-    // pooled connection is held. Hosted-onboarding webhooks use the same seam.
+    // One webhook request opens and seals several secure-box fields under the
+    // member's device domain roots. Scope the unwrap memo to the request so
+    // each distinct root key costs at most one KMS round trip per request
+    // instead of one per field: the concrete root is unwrapped by the account
+    // lookup before the admission transaction, while the @active root used for
+    // sealing payloads is a separate cache key whose first unwrap still runs
+    // inside the transaction. Hosted-onboarding webhooks use the same seam.
     return runWithHostedDomainRootUnwrapCache(() =>
       this.ingress.handleWebhook(provider, this.context.request.headers, resolvedRawBody),
     );

--- a/apps/web/src/lib/device-sync/public-ingress-service.ts
+++ b/apps/web/src/lib/device-sync/public-ingress-service.ts
@@ -26,6 +26,7 @@ import {
 } from "@murphai/device-syncd/types";
 import type { CompanionHrvRmssdObservation } from "@murphai/contracts";
 
+import { runWithHostedDomainRootUnwrapCache } from "../hosted-crypto/domain-root-unwrap-cache";
 import { formatHostedExecutionSafeLogErrorDetails } from "../hosted-execution/logging";
 import { readHostedHealthDataConsentState } from "../legal/consent";
 import type { HostedDeviceSyncControlPlaneContext } from "./control-plane-context";
@@ -490,7 +491,14 @@ export class HostedDeviceSyncPublicIngressService {
 
   async handleWebhook(provider: string, rawBody?: Buffer): Promise<HandleWebhookResult> {
     const resolvedRawBody = rawBody ?? (await this.readWebhookRawBody());
-    return this.ingress.handleWebhook(provider, this.context.request.headers, resolvedRawBody);
+    // One webhook request opens several secure-box fields under the same
+    // domain root (account lookup, then admission work inside the transaction).
+    // Scope the unwrap memo to the request so the KMS round trip happens once,
+    // before the admission transaction opens, instead of per field while a
+    // pooled connection is held. Hosted-onboarding webhooks use the same seam.
+    return runWithHostedDomainRootUnwrapCache(() =>
+      this.ingress.handleWebhook(provider, this.context.request.headers, resolvedRawBody),
+    );
   }
 
   async resolveWebhookPreflight(

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -2169,6 +2169,15 @@ async function startHostedDeviceSyncWakeWorkflow(
   }
 }
 
+/**
+ * Webhook fan-out bursts queue many admissions on one member row. Without a
+ * lock bound, each queued transaction burns its whole 15s budget waiting and
+ * then expires mid-callback; with one, waiters fail fast with a retryable 503
+ * the provider absorbs by redelivering. Only webhook acceptance passes this
+ * bound: other admission callers have no redelivery loop.
+ */
+const WEBHOOK_ADMISSION_MEMBER_ROW_LOCK_TIMEOUT_MS = 5_000;
+
 async function persistHostedDeviceSyncWebhookAccepted(input: {
   acceptedAt: string;
   acceptanceMode: DeviceSyncWebhookAcceptanceMode;
@@ -2316,6 +2325,9 @@ async function persistHostedDeviceSyncWebhookAccepted(input: {
       return {
         wakeMailboxItemId,
       };
+      },
+      {
+        memberRowLockTimeoutMs: WEBHOOK_ADMISSION_MEMBER_ROW_LOCK_TIMEOUT_MS,
       },
     ));
 

--- a/apps/web/test/agent-route.test.ts
+++ b/apps/web/test/agent-route.test.ts
@@ -1,6 +1,7 @@
 import {
   deviceSyncError,
 } from "@murphai/device-syncd/errors";
+import { Prisma } from "@prisma/client";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createBearerRequest, createJsonPostRequest, createRouteContext } from "./route-test-helpers";
@@ -376,6 +377,55 @@ describe("hosted device-sync agent and webhook routes", () => {
       orphaned: true,
       provider: "junction",
     });
+  });
+
+  it("returns a retryable 503 when webhook admission loses its bounded member-row lock wait", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // The production adapter-pg shape raised when the webhook admission
+    // transaction's bounded lock_timeout gives up waiting on the member row.
+    mocks.handleWebhook.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError(
+        "Raw query failed. Code: `55P03`.",
+        {
+          clientVersion: "7.8.0",
+          code: "P2010",
+          meta: {
+            driverAdapterError: {
+              cause: {
+                kind: "postgres",
+                message: "canceling statement due to lock timeout",
+                originalCode: "55P03",
+                severity: "ERROR",
+              },
+              name: "DriverAdapterError",
+            },
+          },
+        },
+      ),
+    );
+
+    const response = await webhookRoute.POST(
+      new Request("https://example.test/api/device-sync/webhooks/junction", {
+        method: "POST",
+      }),
+      createRouteContext({ provider: "junction" }),
+    );
+
+    // A 500 would break the provider redelivery contract; the claimed webhook
+    // trace is released by the ingress on failure so the retry reprocesses.
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "STORE_CONTENTION",
+        message: "The device-sync store timed out under contention. Retry later.",
+        retryable: true,
+      },
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("short-circuits hosted webhook POSTs when provider preflight returns a response", async () => {

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1108,6 +1108,13 @@ describe("hosted device-sync wakes", () => {
       expect(mocks.signalHostedDeviceSyncMailboxRuntime).toHaveBeenCalledWith({
         mailboxItemId: "mailbox_123",
       });
+      // Generic wake persistence has no provider redelivery loop, so it must
+      // not opt into the webhook-only member-row lock bound.
+      expect(mocks.withHealthDataAdmissionLock).toHaveBeenCalledWith(
+        "user-123",
+        "dsc_123",
+        expect.any(Function),
+      );
       expect(warn).toHaveBeenCalledWith(
         "Hosted device-sync wake Temporal signal failed after mailbox append.",
         expect.objectContaining({
@@ -1406,6 +1413,8 @@ describe("hosted device-sync wakes", () => {
       connection.id,
       mocks.prismaTx,
     );
+    // Companion ingestion has no provider redelivery loop, so it must not opt
+    // into the webhook-only member-row lock bound (exact three-argument call).
     expect(mocks.withHealthDataAdmissionLock).toHaveBeenCalledWith(
       "user-123",
       connection.id,
@@ -3282,6 +3291,9 @@ describe("hosted device-sync wakes", () => {
 
     await controlPlane.handleOAuthCallback("oura", { expectedOwnerId: "user-123" });
 
+    // Connection establishment must keep the full transaction budget: a
+    // bounded member-row wait here would destroy a successful OAuth journey
+    // (exact three-argument call proves no lock-timeout option is passed).
     expect(mocks.withHealthDataAdmissionLock).toHaveBeenCalledWith(
       "user-123",
       "dsc_123",
@@ -3858,10 +3870,13 @@ describe("hosted device-sync wakes", () => {
       accepted: true,
     });
 
+    // Webhook acceptance is the only admission caller that bounds the
+    // member-row lock wait; its failures are absorbed by provider redelivery.
     expect(mocks.withHealthDataAdmissionLock).toHaveBeenCalledWith(
       "user-123",
       "dsc_123",
       expect.any(Function),
+      { memberRowLockTimeoutMs: 5_000 },
     );
     expect(mocks.getConnectionForUser).toHaveBeenCalledWith(
       "user-123",
@@ -5192,6 +5207,7 @@ describe("hosted device-sync wakes", () => {
       "user-123",
       "dsc_123",
       expect.any(Function),
+      { memberRowLockTimeoutMs: 5_000 },
     );
   });
 

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -408,6 +408,7 @@ import {
   HOSTED_SOURCE_DISCONNECT_IN_PROGRESS_ERROR_CODE,
 } from "@/src/lib/device-sync/connection-source-lifecycle";
 import { PrismaDeviceSyncControlPlaneStore } from "@/src/lib/device-sync/prisma-store";
+import { getHostedDomainRootUnwrapCache } from "@/src/lib/hosted-crypto/domain-root-unwrap-cache";
 import { getPrisma } from "@/src/lib/prisma";
 import {
   appendHostedDeviceSyncScheduledReconcileWake,
@@ -692,6 +693,39 @@ describe("hosted device-sync wakes", () => {
       scope: "read:sleep",
       state: "xyz",
     }));
+  });
+
+  it("opens a domain-root unwrap scope around webhook delivery and closes it on failure", async () => {
+    const observedCacheDuringDelegation: unknown[] = [];
+    const delegationFailure = new Error("webhook delegation sentinel");
+    const handleWebhook = vi.fn(async () => {
+      // The webhook owner must establish the scope before delegating: without
+      // it every secure-box field repeats its envelope read and KMS unwrap.
+      observedCacheDuringDelegation.push(getHostedDomainRootUnwrapCache());
+      throw delegationFailure;
+    });
+    mocks.createDeviceSyncPublicIngress.mockReturnValueOnce({
+      describeProviders: vi.fn(() => []),
+      handleWebhook,
+    });
+    const ingress = createHostedDeviceSyncPublicIngressService(
+      new Request("https://control.example.test/api/device-sync/webhooks/junction", {
+        body: JSON.stringify({ event_type: "daily.data.steps.created" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(getHostedDomainRootUnwrapCache()).toBeUndefined();
+
+    await expect(ingress.handleWebhook("junction")).rejects.toBe(delegationFailure);
+
+    expect(handleWebhook).toHaveBeenCalledOnce();
+    expect(observedCacheDuringDelegation).toHaveLength(1);
+    expect(observedCacheDuringDelegation[0]).toBeInstanceOf(Map);
+    // The scope is request-bounded: a rejection must not leak cached root keys
+    // past the request that unwrapped them.
+    expect(getHostedDomainRootUnwrapCache()).toBeUndefined();
   });
 
   it("uses explicit companion connect intent as the only lifecycle-changing SDK path", async () => {

--- a/apps/web/test/device-sync-http.test.ts
+++ b/apps/web/test/device-sync-http.test.ts
@@ -229,32 +229,6 @@ describe("device sync callback redirect helpers", () => {
     expect(warnSpy).toHaveBeenCalledOnce();
   });
 
-  it("maps transaction-start-timeout faults carried in a cause chain to the retryable 503", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrappedStartTimeout = new Error("Webhook admission failed.", {
-      cause: Object.assign(
-        new Error("Unable to start a transaction in the given time."),
-        {
-          code: "P2028",
-          name: "PrismaClientKnownRequestError",
-        },
-      ),
-    });
-
-    const response = httpModule.jsonError(wrappedStartTimeout);
-
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({
-      error: {
-        code: "STORE_CONTENTION",
-        message: "The device-sync store timed out under contention. Retry later.",
-        retryable: true,
-      },
-    });
-    expect(errorSpy).not.toHaveBeenCalled();
-  });
-
   it.each(["originalCode", "code"] as const)(
     "maps adapter-pg P2010 lock timeouts from the nested cause %s to the retryable 503",
     async (codeField) => {

--- a/apps/web/test/device-sync-http.test.ts
+++ b/apps/web/test/device-sync-http.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -87,6 +88,31 @@ vi.mock("next/server", () => {
 type HttpModule = typeof import("../src/lib/device-sync/http");
 
 let httpModule: HttpModule;
+
+// Mirrors the production @prisma/adapter-pg raw-query lock-timeout shape, as
+// encoded by the hosted member billing store fixtures.
+function createAdapterPgLockTimeout(
+  codeField: "code" | "originalCode",
+): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError(
+    "Raw query failed. Code: `55P03`.",
+    {
+      clientVersion: "7.8.0",
+      code: "P2010",
+      meta: {
+        driverAdapterError: {
+          cause: {
+            [codeField]: "55P03",
+            kind: "postgres",
+            message: "canceling statement due to lock timeout",
+            severity: "ERROR",
+          },
+          name: "DriverAdapterError",
+        },
+      },
+    },
+  );
+}
 
 describe("device sync callback redirect helpers", () => {
   beforeAll(async () => {
@@ -229,30 +255,26 @@ describe("device sync callback redirect helpers", () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it("maps bounded lock-timeout raw-query faults to the retryable 503", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const lockTimeoutError = Object.assign(
-      new Error("canceling statement due to lock timeout"),
-      {
-        code: "P2010",
-        meta: { code: "55P03" },
-        name: "PrismaClientKnownRequestError",
-      },
-    );
+  it.each(["originalCode", "code"] as const)(
+    "maps adapter-pg P2010 lock timeouts from the nested cause %s to the retryable 503",
+    async (codeField) => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const lockTimeoutError = createAdapterPgLockTimeout(codeField);
 
-    const response = httpModule.jsonError(lockTimeoutError);
+      const response = httpModule.jsonError(lockTimeoutError);
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({
-      error: {
-        code: "STORE_CONTENTION",
-        message: "The device-sync store timed out under contention. Retry later.",
-        retryable: true,
-      },
-    });
-    expect(errorSpy).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: {
+          code: "STORE_CONTENTION",
+          message: "The device-sync store timed out under contention. Retry later.",
+          retryable: true,
+        },
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps unrelated Prisma errors on the internal 500 path", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/apps/web/test/device-sync-http.test.ts
+++ b/apps/web/test/device-sync-http.test.ts
@@ -178,6 +178,105 @@ describe("device sync callback redirect helpers", () => {
     });
   });
 
+  it("maps expired Prisma transaction faults to a retryable 503", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const expiredTransactionError = Object.assign(
+      new Error("A query cannot be executed on an expired transaction."),
+      {
+        code: "P2028",
+        name: "PrismaClientKnownRequestError",
+      },
+    );
+
+    const response = httpModule.jsonError(expiredTransactionError);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "STORE_CONTENTION",
+        message: "The device-sync store timed out under contention. Retry later.",
+        retryable: true,
+      },
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it("maps transaction-start-timeout faults carried in a cause chain to the retryable 503", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrappedStartTimeout = new Error("Webhook admission failed.", {
+      cause: Object.assign(
+        new Error("Unable to start a transaction in the given time."),
+        {
+          code: "P2028",
+          name: "PrismaClientKnownRequestError",
+        },
+      ),
+    });
+
+    const response = httpModule.jsonError(wrappedStartTimeout);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "STORE_CONTENTION",
+        message: "The device-sync store timed out under contention. Retry later.",
+        retryable: true,
+      },
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps bounded lock-timeout raw-query faults to the retryable 503", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const lockTimeoutError = Object.assign(
+      new Error("canceling statement due to lock timeout"),
+      {
+        code: "P2010",
+        meta: { code: "55P03" },
+        name: "PrismaClientKnownRequestError",
+      },
+    );
+
+    const response = httpModule.jsonError(lockTimeoutError);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "STORE_CONTENTION",
+        message: "The device-sync store timed out under contention. Retry later.",
+        retryable: true,
+      },
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps unrelated Prisma errors on the internal 500 path", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const uniqueViolation = Object.assign(
+      new Error("Unique constraint failed."),
+      {
+        code: "P2002",
+        name: "PrismaClientKnownRequestError",
+      },
+    );
+
+    const response = httpModule.jsonError(uniqueViolation);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal error.",
+      },
+    });
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
   it("maps shared malformed request errors to the existing 400 JSON shapes", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const invalidJsonError = new SyntaxError(

--- a/apps/web/test/prisma-store-local-heartbeat.test.ts
+++ b/apps/web/test/prisma-store-local-heartbeat.test.ts
@@ -2,6 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DEVICE_SYNC_DISCONNECT_IN_PROGRESS_ERROR_CODE } from "@murphai/device-syncd/public-account";
 
+const { openHostedUserSecureBoxStringMock } = vi.hoisted(() => ({
+  openHostedUserSecureBoxStringMock: vi.fn(
+    async (_input: { prisma?: unknown; value?: unknown }) => "acct_456",
+  ),
+}));
+
+// Only the secure-box open seam is mocked so the Prisma client the store hands
+// to the decrypt path stays observable.
+vi.mock("@/src/lib/hosted-crypto/secure-box", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/src/lib/hosted-crypto/secure-box")>()),
+  openHostedUserSecureBoxString: openHostedUserSecureBoxStringMock,
+}));
+
 import { PrismaDeviceSyncControlPlaneStore } from "@/src/lib/device-sync/prisma-store";
 
 type StaticConnectionRecord = {
@@ -222,6 +235,74 @@ describe("PrismaDeviceSyncControlPlaneStore local heartbeat updates", () => {
         lastSyncCompletedAt: expect.any(Date),
       }),
     }));
+  });
+
+  it("decrypts heartbeat connection secrets through the mutation transaction client", async () => {
+    const record: StaticConnectionRecord = {
+      id: "dsc_123",
+      userId: "user-123",
+      provider: "oura",
+      providerAccountBlindIndex: "hbdi_test",
+      status: "active",
+      credentialKind: "oauth_tokens",
+      credentialMetadataJson: null,
+      providerConfigKey: null,
+      displayName: "Oura ring",
+      externalAccountIdEncrypted: "sealed:acct_456",
+      connectedAt: new Date("2026-03-25T00:00:00.000Z"),
+      lastWebhookAt: null,
+      lastSyncStartedAt: null,
+      lastSyncCompletedAt: null,
+      lastSyncErrorAt: null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      metadataJson: {},
+      nextReconcileAt: null,
+      scopesJson: ["daily"],
+      setupExpiresAt: null,
+      setupPhase: null,
+      createdAt: new Date("2026-03-25T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-25T00:00:00.000Z"),
+    };
+    // The heartbeat update runs inside an interactive transaction that already
+    // holds a pooled connection; a secret read that falls back to the root
+    // client would check out a second one.
+    const rootClientUse = vi.fn();
+    const failOnRootClientUse = async () => {
+      rootClientUse();
+      throw new Error("root Prisma client must not be used inside a transaction");
+    };
+    const tx = {
+      $executeRaw: vi.fn(async () => 0),
+      deviceConnection: {
+        findFirst: vi.fn(async () => ({ ...record })),
+        update: vi.fn(async () => ({ ...record })),
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      prisma: {
+        deviceConnection: {
+          findFirst: failOnRootClientUse,
+          update: failOnRootClientUse,
+        },
+        $transaction: async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx),
+      } as never,
+    });
+
+    await expect(store.updateConnectionFromLocalHeartbeat("user-123", "dsc_123", {
+      lastErrorMessage: "Heartbeat failure",
+    })).resolves.toMatchObject({
+      externalAccountId: "acct_456",
+      id: "dsc_123",
+    });
+
+    // Both the pre-update read and the post-update rebuild decrypt the stored
+    // external account id; each must use the transaction client.
+    expect(openHostedUserSecureBoxStringMock).toHaveBeenCalledTimes(2);
+    for (const [input] of openHostedUserSecureBoxStringMock.mock.calls) {
+      expect(input.prisma).toBe(tx);
+    }
+    expect(rootClientUse).not.toHaveBeenCalled();
   });
 
   it("only applies the provided error fields", async () => {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -3,11 +3,15 @@ import { DEVICE_SYNC_DISCONNECT_IN_PROGRESS_ERROR_CODE } from "@murphai/device-s
 
 const {
   lockHostedMemberRowMock,
+  openHostedUserSecureBoxStringMock,
   randomBytesMock,
   readHostedHealthDataConsentStateMock,
   supersedeDirtyStateMock,
 } = vi.hoisted(() => ({
   lockHostedMemberRowMock: vi.fn(async () => undefined),
+  openHostedUserSecureBoxStringMock: vi.fn(
+    async (_input: { prisma?: unknown; value?: unknown }) => "acct_456",
+  ),
   randomBytesMock: vi.fn((length: number) => Buffer.from(Array.from({ length }, (_, index) => index))),
   readHostedHealthDataConsentStateMock: vi.fn(
     async (): Promise<"granted" | "missing" | "revoked"> => "missing",
@@ -26,6 +30,14 @@ vi.mock("@/src/lib/hosted-onboarding/shared", async (importOriginal) => ({
 vi.mock("@/src/lib/legal/consent", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/src/lib/legal/consent")>()),
   readHostedHealthDataConsentState: readHostedHealthDataConsentStateMock,
+}));
+
+// Only the secure-box open seam is mocked so the Prisma client the store hands
+// to the decrypt path stays observable. Tests that pass a test codec never
+// reach this seam.
+vi.mock("@/src/lib/hosted-crypto/secure-box", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/src/lib/hosted-crypto/secure-box")>()),
+  openHostedUserSecureBoxString: openHostedUserSecureBoxStringMock,
 }));
 
 vi.mock("node:crypto", async () => {
@@ -1527,6 +1539,75 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       provider: "junction",
       status: "active",
     }));
+  });
+
+  it("decrypts the external account id through the caller's transaction client", async () => {
+    const connection = createConnection({
+      externalAccountIdEncrypted: "sealed:acct_456",
+      id: "dsc_123",
+      provider: "oura",
+      status: "active",
+      userId: "user-123",
+    });
+    // An interactive transaction already holds one pooled connection. A read
+    // that falls back to the root client checks out a second one and can
+    // self-starve the pool under webhook bursts, so touching it fails here.
+    const rootClientUse = vi.fn();
+    const rootPrisma = {
+      deviceConnection: {
+        findFirst: async () => {
+          rootClientUse();
+          throw new Error("root Prisma client must not be used inside a transaction");
+        },
+      },
+    };
+    const tx = {
+      deviceConnection: {
+        findFirst: async () => cloneConnection(connection),
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      prisma: rootPrisma as never,
+    });
+
+    await expect(
+      store.getConnectionForUser("user-123", "dsc_123", tx as never),
+    ).resolves.toMatchObject({
+      externalAccountId: "acct_456",
+      id: "dsc_123",
+    });
+
+    expect(openHostedUserSecureBoxStringMock).toHaveBeenCalledTimes(1);
+    expect(openHostedUserSecureBoxStringMock.mock.calls[0]?.[0]).toMatchObject({
+      value: "sealed:acct_456",
+    });
+    expect(openHostedUserSecureBoxStringMock.mock.calls[0]?.[0].prisma).toBe(tx);
+    expect(rootClientUse).not.toHaveBeenCalled();
+  });
+
+  it("keeps the root Prisma client as the default external-account reader", async () => {
+    const connection = createConnection({
+      externalAccountIdEncrypted: "sealed:acct_456",
+      id: "dsc_123",
+      provider: "oura",
+      status: "active",
+      userId: "user-123",
+    });
+    const rootPrisma = {
+      deviceConnection: {
+        findFirst: async () => cloneConnection(connection),
+      },
+    };
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      prisma: rootPrisma as never,
+    });
+
+    await expect(store.getConnectionForUser("user-123", "dsc_123")).resolves.toMatchObject({
+      externalAccountId: "acct_456",
+    });
+
+    expect(openHostedUserSecureBoxStringMock).toHaveBeenCalledTimes(1);
+    expect(openHostedUserSecureBoxStringMock.mock.calls[0]?.[0].prisma).toBe(rootPrisma);
   });
 
   it("keeps explicit operational connection reads on durable Prisma metadata", async () => {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -194,13 +194,45 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       httpStatus: 403,
     });
 
-    expect(lockHostedMemberRowMock).toHaveBeenCalledWith(tx, "user-123");
+    expect(lockHostedMemberRowMock).toHaveBeenCalledWith(tx, "user-123", {
+      timeoutMs: 5_000,
+    });
     expect(readHostedHealthDataConsentStateMock).toHaveBeenCalledWith({
       memberId: "user-123",
       prisma: tx,
     });
     expect(executeRaw).not.toHaveBeenCalled();
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("bounds the member-row lock wait before taking the admission advisory lock", async () => {
+    const executeRaw = vi.fn(async () => 0);
+    const tx = { $executeRaw: executeRaw };
+    const callback = vi.fn(async () => "admitted");
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      prisma: {
+        $transaction: async <TResult>(
+          transactionCallback: (transaction: typeof tx) => Promise<TResult>,
+        ) => transactionCallback(tx),
+      } as never,
+    });
+
+    await expect(store.withHealthDataAdmissionLock(
+      "user-123",
+      "dsc_123",
+      callback,
+    )).resolves.toBe("admitted");
+
+    // A queued webhook burst must fail fast with a retryable error instead of
+    // burning the transaction budget waiting on the member row. The
+    // transaction-local lock_timeout also bounds the advisory-lock step.
+    expect(lockHostedMemberRowMock).toHaveBeenCalledWith(tx, "user-123", {
+      timeoutMs: 5_000,
+    });
+    expect(executeRaw).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(tx);
+    expect(lockHostedMemberRowMock.mock.invocationCallOrder[0]!)
+      .toBeLessThan(executeRaw.mock.invocationCallOrder[0]!);
   });
 
   it("creates new hosted connections without creating a Prisma secret row", async () => {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -194,9 +194,9 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       httpStatus: 403,
     });
 
-    expect(lockHostedMemberRowMock).toHaveBeenCalledWith(tx, "user-123", {
-      timeoutMs: 5_000,
-    });
+    // Callers that pass no options keep the unbounded member-row wait; only
+    // webhook acceptance opts into a lock bound.
+    expect(lockHostedMemberRowMock).toHaveBeenCalledWith(tx, "user-123", {});
     expect(readHostedHealthDataConsentStateMock).toHaveBeenCalledWith({
       memberId: "user-123",
       prisma: tx,
@@ -205,7 +205,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it("bounds the member-row lock wait before taking the admission advisory lock", async () => {
+  it("bounds the member-row lock wait only for callers that request it", async () => {
     const executeRaw = vi.fn(async () => 0);
     const tx = { $executeRaw: executeRaw };
     const callback = vi.fn(async () => "admitted");
@@ -221,6 +221,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       "user-123",
       "dsc_123",
       callback,
+      { memberRowLockTimeoutMs: 5_000 },
     )).resolves.toBe("admitted");
 
     // A queued webhook burst must fail fast with a retryable error instead of
@@ -233,6 +234,35 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(callback).toHaveBeenCalledWith(tx);
     expect(lockHostedMemberRowMock.mock.invocationCallOrder[0]!)
       .toBeLessThan(executeRaw.mock.invocationCallOrder[0]!);
+  });
+
+  it("propagates bounded lock-wait faults without taking the advisory lock", async () => {
+    const executeRaw = vi.fn(async () => 0);
+    const tx = { $executeRaw: executeRaw };
+    const callback = vi.fn();
+    const lockTimeout = Object.assign(new Error("Raw query failed. Code: `55P03`."), {
+      code: "P2010",
+    });
+    lockHostedMemberRowMock.mockRejectedValueOnce(lockTimeout);
+    const store = new PrismaDeviceSyncControlPlaneStore({
+      prisma: {
+        $transaction: async <TResult>(
+          transactionCallback: (transaction: typeof tx) => Promise<TResult>,
+        ) => transactionCallback(tx),
+      } as never,
+    });
+
+    // The fault must reach the route unwrapped so the shared device-sync JSON
+    // helper can map it to a retryable 503 and the provider redelivers.
+    await expect(store.withHealthDataAdmissionLock(
+      "user-123",
+      "dsc_123",
+      callback,
+      { memberRowLockTimeoutMs: 5_000 },
+    )).rejects.toBe(lockTimeout);
+
+    expect(executeRaw).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it("creates new hosted connections without creating a Prisma secret row", async () => {


### PR DESCRIPTION
## Why this PR exists

POST `/api/device-sync/webhooks/junction` returned ~103 HTTP 500s across Aug 6-7 with Prisma P2028 ("expired transaction"). A provider webhook fan-out burst (tens of deliveries in one second for one member) queued admissions on the health-data member-row lock with no lock bound, each waiter burned the global 15s transaction budget, and a KMS decrypt inside the transaction checked out a second pooled connection, starving the pool. The resulting P2028 fell through the device-sync error mapper as an unmapped 500, which breaks the path's deliberate retryable-503 redelivery contract.

## User goal / user-visible behavior

Health data from connected wearables keeps flowing during provider webhook bursts. Instead of dropping deliveries into 500s (which providers treat as terminal-ish failures), the route now fails fast with a retryable 503 so the provider redelivers and the data lands on the next attempt.

## User experience

Not applicable beyond reliability: there is no UI change. The user-observable effect is that wearable data arrives reliably even when a provider sends many webhooks at once; previously a burst could delay or require manual reconciliation of health data. Connection establishment, companion ingestion, and scheduled wakes keep their prior lock-wait behavior, so a slower-than-usual but successful OAuth connection journey is unaffected.

## Invariants the PR must preserve

- Every rejection on the webhook path stays retryable 503 (matching `WEBHOOK_ACCOUNT_NOT_READY`, `WEBHOOK_SOURCE_NOT_READY`, `WEBHOOK_TRACE_IN_PROGRESS`); nothing is committed when an admission transaction fails, and the ingress releases the webhook trace claim so redelivery reprocesses (release-then-successful-redelivery is proven by the existing hook-failure tests in `packages/device-syncd/test/public-ingress.test.ts`).
- The member-row lock bound is caller-scoped policy: only webhook acceptance (`persistHostedDeviceSyncWebhookAccepted`) passes `memberRowLockTimeoutMs`, because only its failure is absorbed by a provider redelivery loop. Connection establishment, companion ingestion, and scheduled/generic wake persistence keep the full 15s transaction budget so a 5-15s member-row contention window cannot destroy a successful OAuth journey via the setup-failure cleanup path.
- Member-row-first consent serialization order in `withHealthDataAdmissionLock` is unchanged; when the bound applies it rides one transaction-local `lock_timeout`, which also bounds the subsequent advisory-lock step in the same transaction.
- No transaction ever checks out a second pooled connection mid-flight: reads inside a transaction go through the transaction client.
- Domain-root key hygiene: `runWithHostedDomainRootUnwrapCache` zeroizes cached root keys when the request scope closes; behavior outside a scope is unchanged.
- `DeviceSyncError` mappings keep priority over the new database-contention matcher, so domain errors are never re-labeled.

## Non-obvious affected surfaces

- The changed matcher lives in `apps/web/src/lib/device-sync/http.ts`, which is shared by 8 route modules (the webhook route, the agent/session/token routes, the device-sync root route, and the internal Junction workouts route), so P2028 and adapter-pg lock-timeout faults on any of those now return retryable 503 `STORE_CONTENTION` instead of 500. This is intentional: those faults are transient contention and safe to retry. Scope bound: 31 other device-sync route modules use the separate `apps/web/src/lib/device-sync/settings-http.ts` helper and are unaffected, and the OAuth callback route imports only `errorToCallbackRedirect` from the changed module while handling its own errors. Proof: matcher tests in `apps/web/test/device-sync-http.test.ts` (including a non-contention P2002 staying on the 500 path) plus a webhook route-level 503 test in `apps/web/test/agent-route.test.ts`.
- `withHealthDataAdmissionLock` gained an optional `memberRowLockTimeoutMs`; the shorter lock-acquisition policy applies only to webhook acceptance. Browser connection callbacks, companion submissions, and scheduled health-data wakes explicitly keep the previous unbounded wait. Proof: exact-argument assertions for each caller class in `apps/web/test/device-sync-hosted-wake.test.ts` and the default-path assertion in `apps/web/test/prisma-store-oauth-connection.test.ts`.
- `getConnectionForUser` and `syncDurableConnectionLocalHeartbeatState` now pass their transaction client into the secure-box external-account-id read; callers without a transaction are unchanged (`tx ?? this.prisma`). Proof: exact client-identity tests added in the specialist round (`prisma-store-oauth-connection.test.ts`, `prisma-store-local-heartbeat.test.ts`) that fail if either propagation is reverted, plus a retained non-transaction case pinning the root client as the default reader.
- `handleWebhook` for every provider (not only the affected one) now runs inside the KMS unwrap memo scope, matching how hosted-onboarding, ops, and phone-calls paths already wrap themselves. Precisely: the memo bounds repeated unwraps of the same cache key within one request; a payload-bearing webhook can still unwrap the same active device-domain root twice, because account lookup caches under the concrete rootKeyId key while sealing uses the distinct @active key and the alias back-fill does not overwrite an existing concrete entry. The concrete domain root is unwrapped by the account lookup before the admission transaction; a payload-bearing webhook still performs its first `@active`-root unwrap (used for sealing) inside the transaction, under a separate cache key. The fix removes per-field repetition; it does not move every KMS call out of the transaction.

## Architecture and reuse

- Existing systems reused: `lockHostedMemberRow`'s existing `timeoutMs` option (transaction-local `set_config('lock_timeout', ...)`), the existing `runWithHostedDomainRootUnwrapCache` seam used by hosted-onboarding webhooks, the existing `JsonErrorMatcher` chain in `createJsonRouteHelpers`, the existing `prisma`-parameter convention already present on `buildStoredConnectionAccount`, and the adapter-pg error shape already decoded by the hosted member billing store.
- New logic: one route-level matcher that classifies Prisma P2028 transaction faults and Postgres `55P03` lock timeouts (top-level, in a bounded cause chain, or nested in the adapter-pg `meta.driverAdapterError.cause` shape under P2010) as retryable 503 `STORE_CONTENTION`; one caller-selected lock-bound option on `withHealthDataAdmissionLock`.
- New abstractions: none; every change rides an existing parameter, option, or matcher seam. The existing contracts were sufficient.
- Complexity intentionally avoided: no restructuring of the admission transaction, no separate advisory-lock timeout mechanism (the transaction-local `lock_timeout` already covers it), no queueing/backoff machinery (the provider's redelivery is the retry loop), no generic error-traversal framework (the classifier is one direct guard over the two shapes the store actually emits), and no cross-transaction KMS cache (request-scoped memo only).

## Hot reply path impact

Not applicable. The device-sync webhook ingress is not part of the Foreground Reply Critical Path (durable acceptance of a conversation message through provider start and reply handoff); no call is added to or moved onto that path.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. The diff changes no prompts, tool definitions, schemas, provider-request assembly, or Codex configuration; it is webhook ingress transaction hygiene and HTTP error mapping only.

## Preliminary specialist lenses

- Product experience: not applicable. No product-owned dimension changes; the intended outcome is unchanged data delivery with provider-side retries absorbing transient contention, and unchanged behavior for connection journeys without a redelivery loop.
- Prompt: not applicable. No prompt or instruction text changes.
- Frontend: not applicable. No `apps/web` UI diff.
- Coverage: applicable. Focused local proof at head `dba1055c89`: `pnpm --dir apps/web typecheck` (exit 0), targeted vitest run over 57 device-sync/prisma-store/crypto suites (774 passed, 2 skipped, exit 0). Covers the P2028 and adapter-pg P2010/55P03 mappings (fixtures built from the real Prisma error class), a webhook route-level 503 test, caller-scoped lock-bound assertions for every admission caller class, transaction-client identity for the secure-box external-account decrypt on both the connection-read and heartbeat-update paths, and the webhook unwrap-cache scope. Exact-head CI: pending.

ReviewGPT context sensitivity: sensitive
Classification reason: external webhook ingress, retry/idempotency contract, and transaction/locking behavior around sensitive health-data admission.

## ReviewGPT round 1 record

Round 1 reviewed `d059c417cb` and returned FINDINGS. All three items accepted and fixed in commit `966bde6068`:

- Finding 1 (High, accepted): the 55P03 matcher missed the production @prisma/adapter-pg shape (P2010 with the Postgres code at `meta.driverAdapterError.cause.originalCode`/`.code`), so a bounded lock-wait loss would still have returned 500. Fixed by decoding that exact nested shape in `isDatabaseContentionError` (mirroring the hosted member billing store decoder), replacing the fabricated `meta.code` test with fixtures constructed from the real `Prisma.PrismaClientKnownRequestError` covering both nested code fields, and adding a webhook route-level test asserting 503 `STORE_CONTENTION` (trace release for redelivery on hook failure is owned and proven by `packages/device-syncd/test/public-ingress.test.ts`).
- Finding 2 (Material UX, accepted): the 5s bound was applied unconditionally to the shared admission lock, which could destroy a successful OAuth connection journey when establishment waited 5-15s on a busy member row (the setup-failure cleanup marks the account for reauthorization and revokes provider access). Fixed by making the bound an explicit `memberRowLockTimeoutMs` option passed only by `persistHostedDeviceSyncWebhookAccepted`; establishment, companion, and scheduled/generic wake callers keep prior behavior, with exact-argument tests for each caller class.
- Finding 3 (Body discrepancy, accepted): the earlier wording overclaimed that the KMS unwrap happens once before the admission transaction. Corrected in the code comment and this body: the concrete-root unwrap happens pre-transaction, while a payload-bearing webhook's first `@active`-root unwrap (sealing) still runs inside the transaction under a distinct cache key; the memo bounds unwraps per cache key per request, so the same active root can still be unwrapped once under its concrete `rootKeyId` key and once under `@active`.

Current-head note: the change-shape table below reflects the base-to-head diff at the current head `4c312aeba1`. Authored source shrank in round 3 (net -17 source lines and -26 test lines against `dba1055c89`); earlier growth came from round-1 remediation (adapter-pg decoding, caller-scoped option plumbing) and the specialist round's test-only additions.

## ReviewGPT round 2 and preliminary specialist record

Final gate round 2 reviewed `966bde6068` and returned PASS with both round-1 corrections confirmed effective.

The preliminary specialist pass at `966bde6068` returned FINDINGS with two coverage items (product-experience: no findings, purpose verdict affirmed; prompt and frontend lenses not applicable). Both accepted and fixed test-only in commit `dba1055c89`; no production behavior changed:

- Finding A (medium, accepted): the transaction-client fix for the secure-box external-account read was invisible to the suites (the store tests pass a test codec that bypasses `openHostedUserSecureBoxString`, the heartbeat fixture seeded no encrypted field, and the wake suite mocks the whole store), so the "no second pooled connection inside a transaction" invariant could regress silently. Fixed by adding focused store tests with distinct root and transaction clients, an encrypted external-account field, and only the secure-box open seam mocked: `getConnectionForUser(..., tx)` and the transactional heartbeat update must pass that exact `tx` as `prisma`, and the root client throws if either path touches it. A non-transaction case pins the root client as the default reader.
- Finding B (low, accepted): nothing proved the webhook owner establishes the unwrap-cache scope. Fixed by one public-ingress test whose mocked underlying `handleWebhook` observes `getHostedDomainRootUnwrapCache()` and rejects with a sentinel: a cache must exist during delegation, the sentinel must propagate, and no scope may remain after the rejection. No cryptographic fixtures duplicated.

Regression proof (the point of both findings): each new test was run against a temporarily reverted production line and observed to fail. Reverting `prisma` to `this.prisma` in `buildDurableConnectionRecord` fails both new secret-read tests while the other 47 in those files still pass; removing the `runWithHostedDomainRootUnwrapCache` wrapper fails the new scope test while the other 141 still pass. Production code was restored before commit. Neither test revealed a defect in the production behavior claimed by the earlier rounds.

Current-head note: authored source is unchanged from `966bde6068` (149 added / 8 deleted); this pass added 196 test-only lines, so the change-shape table below reflects the base-to-head diff at `dba1055c89`.

## ReviewGPT round 3 record

Round 3 reviewed `dba1055c89`, cleared the retrospective gate, re-verified all four prior corrections as still effective, and confirmed the specialist round's test-only delta introduced no production behavior or concealing mock. It returned one finding, accepted and fixed in commit `4c312aeba1`:

- Finding (Complexity Collapse, accepted): `isDatabaseContentionError` walked up to five arbitrary `cause` objects with a visited-node `Set` and additionally accepted a bare top-level `55P03`, none of which any production path emits. Verified independently before deleting: `runWithDatabaseRetry` (`apps/web/src/lib/prisma.ts`) rethrows the original error on every exit, `DeviceSyncPublicIngress.handleWebhook` (`packages/device-syncd/src/public-ingress.ts`) releases the trace claim and rethrows the same error, `retryHostedDirtyStateContention` (`wake-service.ts`) rethrows unchanged, and `withJsonError` (`apps/web/src/lib/http.ts`) hands that exact rejection to the matcher. The only `cause`-setting site on that module, `attachOAuthCallbackContext`, applies to device-sync domain errors on the OAuth callback path and returns any other error untouched. Both evidenced shapes therefore match at depth 0. Fixed by replacing the traversal with one direct object guard for P2028, or P2010 whose metadata satisfies the adapter-pg lock-timeout shape, deleting the depth constant, the visited set, the loop, the cycle branch, the cause descent, and the bare `55P03` branch, plus the synthetic cause-chain test whose wrapper existed only inside the test. Direct P2028 still covers both transaction start-timeout and expiry, since Prisma reports both under that code.

Retained proof after the deletion: direct P2028, both real adapter-pg nested code fields (`originalCode` and `code`), an unrelated P2002 still returning 500, `DeviceSyncError` matcher priority, and the webhook route-level retryable 503.

Regression proof re-run at `4c312aeba1`: reverting `prisma` to `this.prisma` in `buildDurableConnectionRecord` still fails both transaction-client tests (2 failed / 47 passed), and removing the `runWithHostedDomainRootUnwrapCache` wrapper still fails the scope test (1 failed / 114 passed). Production code was restored before commit.

## Change-shape breakdown

Classification rule: `apps/web/src/**` is source; `apps/web/test/**` is tests/fixtures. No docs, config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 132 | 8 |
| Tests/fixtures | 420 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Total: 552 added, 9 deleted.

## Design proof

Not applicable: backend-only change with no user-facing frontend UI diff.

## Deployment skew / compatibility

Not applicable as a cross-boundary skew: every change is inside `apps/web` (one Vercel deploy surface); `packages/device-syncd` and Cloudflare code are untouched. During a gradual rollout, old and new web instances answer webhooks independently and both shapes are valid to the provider (500 from old, retryable 503 from new); no persisted state, schema, or credential shape changes. Reversible by redeploying the previous build. Post-deploy check: webhook route error-rate logs should show `STORE_CONTENTION` 503 warns replacing P2028 500s under bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ReviewGPT first-reviewed head: d059c417cb52efc4e434dfc327b13b519a0fc058




## Round-3 change-shape retrospective

Round 3 at `dba1055c89` returned `ROUND_OUTCOME: RETROSPECTIVE_REQUIRED` with no
qualifying findings and confirmed every prior correction still effective. The
trigger was the round number itself, not a repeated defect mechanism and not
source churn (the patch is below the churn thresholds). This section completes
the required retrospective.

### First-reviewed direction vs. current direction

| Dimension | First-reviewed head `d059c417cb` | Current head `dba1055c89` |
| --- | --- | --- |
| Member-row lock bound | Applied unconditionally inside the shared `withHealthDataAdmissionLock` | Opt-in `memberRowLockTimeoutMs`; only webhook acceptance passes it, default preserves prior wait |
| Contention → HTTP status | Matched a fabricated `meta.code` shape the adapter never emits | Decodes the real adapter-pg `P2010` + nested `55P03`, plus `P2028` → retryable 503 |
| Secure-box read inside a transaction | Threaded the transaction client (unproven) | Same behavior, now bound by tests that fail if it regresses |
| KMS unwrap scope | Wrapped the webhook in the existing request cache (unproven) | Same behavior, now bound by a test that fails if the wrapper is removed |

Between the two heads, `apps/web/src` moved by 66 insertions and 23 deletions
across four existing files. Authored source has been unchanged since round 2;
all growth since is test-only.

### Concepts and owners added or removed

Added: one optional parameter on an existing function; one error-classification
branch inside an existing matcher chain; one call to the existing request-scoped
unwrap-cache primitive; and test coverage binding each of those seams.

Removed: the unconditional application of the lock bound to every caller of the
shared admission lock; the fabricated `meta.code` matcher branch; and the
fabricated-shape test that asserted a shape production never produces.

Not added: no queue, state machine, lease, scheduler, reconciliation owner,
durable schema, deployment path, or new lifecycle owner. Every change attaches to
an existing owner — the ingress trace claim, provider redelivery, the existing
interactive transaction and locks, the shared route error helper, and the
existing request cache. Rounds 2 and 3 both independently confirmed this.

### Disposition: explicitly justified continuation

Deletion or reversion is rejected: both would restore the production defect this
PR exists to fix — webhook bursts returning terminal-looking 500s that break the
provider's redelivery contract, and an interactive transaction checking out a
second pooled connection under the same burst.

Shrinking is rejected on inspection of each remaining part. The `P2028` mapping
is the original defect. The `55P03` mapping is required *because* of the lock
bound, which introduces that failure mode. The transaction-client threading is
the pool self-starvation fix. The unwrap-cache scope removes uncached KMS round
trips from the burst path. None is redundant with another.

Splitting is rejected as actively worse: shipping the lock bound without the
`55P03` mapping would convert one unmapped 500 into a different unmapped 500, so
a split would need a strict landing order with a live window in which webhook
bursts still violate the retryable-503 contract.

The single direction change across rounds — from an unconditional shared-lock
policy to a caller-scoped opt-in — narrowed authority rather than adding
machinery, which is the correct direction of travel for this gate.

Retrospective addendum: round 3 accepted a shrink that this retrospective's own shrinking analysis had missed. The retrospective treated the whole contention classifier as incident-required, but only its two direct shape checks are. Deleted at `4c312aeba1`: the five-deep cause-chain traversal, its depth constant, the cycle-detection `Set`, the arbitrary cause descent, the unevidenced bare top-level `55P03` branch, and the synthetic cause-chain test — 27 source lines and 26 test lines removed for 10 added, with no loss of incident coverage.



## Round-4 body corrections

Round 4 returned `ROUND_OUTCOME: PASS` with no qualifying findings and two body
discrepancies, corrected here: the contention matcher accepts a top-level Prisma P2028, or a top-level P2010 whose adapter-pg metadata carries PostgreSQL 55P03 at meta.driverAdapterError.cause.originalCode or .code — the only two representations the production path can deliver (the bounded-cause-chain and bare top-level
55P03 wording described the shape deleted in 4c312aeba1); and the change-shape table reflects 4c312aeba1, not dba1055c89.
