### PR TITLE
Build hosted-execution before the predeploy migrate step

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm release:production:migrate && MURPH_HOSTED_WEB_PRISMA_GENERATED_BY_MIGRATIONS=1 pnpm build",
+  "buildCommand": "pnpm --dir ../../packages/hosted-execution build && pnpm release:production:migrate && MURPH_HOSTED_WEB_PRISMA_GENERATED_BY_MIGRATIONS=1 pnpm build",
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
## Why this PR exists

Every production Vercel deploy off `main` has failed in ~25 seconds since 2026-08-08 ~04:20 UTC. PR #1419 (`4b333f4bc2`) added a group-funding-recovery preflight to `run-production-migrations.ts` that imports `src/lib/hosted-web/public-url.ts`, which imports `@murphai/hosted-execution/env`. The `release:production:migrate` step runs before `pnpm build`, so `packages/hosted-execution/dist` does not exist yet and the migrate step dies with `MODULE_NOT_FOUND` before doing anything. Nothing merged after ~04:20 UTC is reaching production (including PR #1438).

## User goal / user-visible behavior

No direct user-visible change; production deploys resume, which un-strands every change merged since the breakage.

## User experience

Not applicable — deploy pipeline configuration only.

## Invariants the PR must preserve

- Migrations still run before the Next build, in the same predeploy path with unchanged guards.
- The #1419 funding-recovery preflight keeps failing closed with its real shared implementation (no duplicated or stubbed logic).
- The dependency build is the package's own canonical `build` script (`tsc -b`), so the later `typecheck:prepared` builders reuse the same outputs — work is reordered, not added.

## Non-obvious affected surfaces

None — one-line reorder of the Vercel `buildCommand` in `apps/web/vercel.json`. Proof: local reproduction below.

## Architecture and reuse

- Existing systems reused: the package's own `build` script and the existing buildCommand chain; no new scripts.
- New logic: none — one prepended command.
- New abstractions: none; the existing package build contract was sufficient.
- Complexity intentionally avoided: no tsx tsconfig-paths plumbing, no duplicated env-normalization helpers in the migrate script, no lazy-import fallbacks that could fail open.

## Hot reply path impact

Not applicable — deploy pipeline only; no runtime code changes.

## Murph initial provider input impact

Not applicable for both runtimes — no prompt, tool, or provider-request surfaces changed.

## Preliminary specialist lenses

All four lenses not applicable (no product, prompt, frontend, or test-coverage surface changes). Process note: this is a production-deploy-outage fix taken on the incident fast path with direct local proof, matching the `e5cb1e4568` precedent; no ReviewGPT round was run.

## Change shape

Classification rule: config/tooling = `vercel.json`. No other files. No binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests | 0 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 1 | 1 |
| Generated/other | 0 | 0 |

## Design proof

Not applicable — no frontend UI paths changed.

## Deployment skew

None — the buildCommand takes effect per-deployment atomically. Direct proof, fresh worktree with no built dists: `pnpm --dir apps/web release:production:migrate` fails with `Cannot find module .../@murphai/hosted-execution/dist/env.js` (exact production error); after `pnpm --dir packages/hosted-execution build` (3.1s, builds the package plus its 8 referenced projects) the same command imports cleanly and exits with the normal "Skipping hosted web production migrations outside main-branch Vercel production deploys." guard message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
