### PR TITLE
fix(web): stop warning on latency traces the runtime never ingressed

### DIFF
--- a/apps/web/app/api/internal/hosted-runtime/latency/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/latency/route.ts
@@ -80,14 +80,22 @@ export const POST = withJsonError(async (request: Request) => {
           source: traceRequest.event.source,
         });
 
-  if (result.unmatchedCount > 0) {
+  // Assistant inputs the runtime created without an inbound messaging wake never
+  // get an ingress trace row, so reporting them is noise. Warn only when a row
+  // existed and the guarded write still declined it, which is the case an
+  // operator can act on.
+  const untracedCount = result.untracedCount ?? 0;
+  const rejectedCount = result.unmatchedCount - untracedCount;
+  if (rejectedCount > 0) {
     const eventType = traceRequest.event.type;
     const source = traceRequest.event.source;
-    console.warn("Hosted runtime latency trace callback had unmatched rows.", {
+    console.warn("Hosted runtime latency trace callback had rejected rows.", {
       eventType,
       matchedCount: result.matchedCount,
+      rejectedCount,
+      runtimeAttemptId,
       source,
-      unmatchedCount: result.unmatchedCount,
+      untracedCount,
     });
   }
 

--- a/apps/web/src/lib/hosted-runtime-latency/store.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/store.ts
@@ -92,6 +92,11 @@ export interface HostedIngressLatencyWriteResult {
   matchedCount: number;
   recorded: boolean;
   unmatchedCount: number;
+  // Subset of unmatchedCount whose assistant input has no ingress trace row at
+  // all. Traces exist only for inbound messaging wakes, so an assistant input
+  // the runtime created on its own (scheduled or follow-up turns) is untraced
+  // by construction rather than a write that lost its authority check.
+  untracedCount?: number;
 }
 
 export interface HostedIngressLatencyDeliveryLinkResult {
@@ -410,11 +415,11 @@ export async function recordHostedIngressProviderStarted(input: {
     .map((row) => row.assistantInputId)
     .filter((id): id is string => Boolean(id)));
 
-  return {
-    matchedCount: matchedIds.size,
-    recorded: matchedIds.size > 0,
-    unmatchedCount: assistantInputIds.filter((id) => !matchedIds.has(id)).length,
-  };
+  return buildHostedIngressLatencyWriteResult({
+    assistantInputIds,
+    matchedIds,
+    rows,
+  });
 }
 
 export async function recordHostedIngressAssistantMilestone(input: {
@@ -497,10 +502,29 @@ export async function recordHostedIngressAssistantMilestone(input: {
     .map((row) => row.assistantInputId)
     .filter((id): id is string => Boolean(id)));
 
+  return buildHostedIngressLatencyWriteResult({
+    assistantInputIds,
+    matchedIds,
+    rows,
+  });
+}
+
+function buildHostedIngressLatencyWriteResult(input: {
+  assistantInputIds: readonly string[];
+  matchedIds: ReadonlySet<string>;
+  rows: readonly { assistantInputId: string | null }[];
+}): HostedIngressLatencyWriteResult {
+  const tracedIds = new Set(input.rows
+    .map((row) => row.assistantInputId)
+    .filter((id): id is string => Boolean(id)));
+  const unmatchedIds = input.assistantInputIds.filter((id) => !input.matchedIds.has(id));
+  const untracedCount = unmatchedIds.filter((id) => !tracedIds.has(id)).length;
+
   return {
-    matchedCount: matchedIds.size,
-    recorded: matchedIds.size > 0,
-    unmatchedCount: assistantInputIds.filter((id) => !matchedIds.has(id)).length,
+    matchedCount: input.matchedIds.size,
+    recorded: input.matchedIds.size > 0,
+    unmatchedCount: unmatchedIds.length,
+    ...(untracedCount > 0 ? { untracedCount } : {}),
   };
 }
 

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -2834,6 +2834,79 @@ describe("hosted runtime internal web routes", () => {
     });
   });
 
+  it("warns only for latency rows a trace row rejected, never for untraced inputs", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      mocks.recordHostedIngressProviderStarted.mockResolvedValue({
+        matchedCount: 0,
+        recorded: false,
+        unmatchedCount: 1,
+        untracedCount: 1,
+      });
+      const untracedResponse = await runtimeLatencyRoute.POST(jsonRequest(
+        "/api/internal/hosted-runtime/latency",
+        {
+          event: {
+            assistantInputIds: ["input_untraced_1"],
+            at: FIXED_NOW,
+            providerRequestOrdinal: 0,
+            runtimeAttemptId: "attempt_routes_1",
+            source: "linq",
+            type: "provider_started",
+          },
+        },
+        runtimeWriteFenceHeaders(),
+      ));
+
+      expect(untracedResponse.status).toBe(200);
+      // The wire contract is unchanged so the runner's existing retry, which
+      // covers a staged callback still in flight, keeps working.
+      expect(parseHostedRuntimeLatencyTraceResponse(await untracedResponse.json())).toEqual({
+        matchedCount: 0,
+        recorded: false,
+        unmatchedCount: 1,
+      });
+      expect(warn).not.toHaveBeenCalled();
+
+      mocks.recordHostedIngressProviderStarted.mockResolvedValue({
+        matchedCount: 1,
+        recorded: true,
+        unmatchedCount: 2,
+        untracedCount: 1,
+      });
+      const rejectedResponse = await runtimeLatencyRoute.POST(jsonRequest(
+        "/api/internal/hosted-runtime/latency",
+        {
+          event: {
+            assistantInputIds: ["input_traced_1", "input_rejected_1", "input_untraced_1"],
+            at: FIXED_NOW,
+            providerRequestOrdinal: 0,
+            runtimeAttemptId: "attempt_routes_1",
+            source: "linq",
+            type: "provider_started",
+          },
+        },
+        runtimeWriteFenceHeaders(),
+      ));
+
+      expect(rejectedResponse.status).toBe(200);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        "Hosted runtime latency trace callback had rejected rows.",
+        {
+          eventType: "provider_started",
+          matchedCount: 1,
+          rejectedCount: 1,
+          runtimeAttemptId: "attempt_routes_1",
+          source: "linq",
+          untracedCount: 1,
+        },
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("signals a stateless runtime recheck after an accepted runtime attempt failure log", async () => {
     mocks.recordHostedRuntimeLogs.mockResolvedValue(1);
     mocks.claimHostedAcceptedAttemptFailureRecheck.mockResolvedValue(true);

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -2859,9 +2859,12 @@ describe("hosted runtime internal web routes", () => {
       ));
 
       expect(untracedResponse.status).toBe(200);
-      // The wire contract is unchanged so the runner's existing retry, which
-      // covers a staged callback still in flight, keeps working.
-      expect(parseHostedRuntimeLatencyTraceResponse(await untracedResponse.json())).toEqual({
+      // Assert the raw body, not the parsed projection: the parser drops
+      // unknown keys, so reparsing here would still pass if the route leaked
+      // untracedCount to the runner. The wire contract must stay exactly these
+      // three fields so the runner's existing retry, which covers a staged
+      // callback still in flight, keeps working.
+      expect(await untracedResponse.json()).toEqual({
         matchedCount: 0,
         recorded: false,
         unmatchedCount: 1,

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -1129,6 +1129,74 @@ describe("hosted runtime latency dashboard store", () => {
     expect(trace?.providerRequestOrdinal).toBeNull();
   });
 
+  it("separates untraced assistant inputs from rejected provider start rows", async () => {
+    const prisma = createLatencyWritePrisma({
+      mailboxAcceptedAtEpochMs: BigInt(Date.parse("2026-06-02T19:11:20.000Z")),
+    });
+
+    await expect(recordHostedIngressProviderStarted({
+      assistantInputIds: ["input_untraced_1"],
+      at: instant("2026-06-02T19:11:21.000Z"),
+      authenticatedUserId: "member_latency_1",
+      prisma,
+      providerRequestOrdinal: 0,
+      runtimeAttemptId: "attempt_untraced_1",
+      source: "linq",
+    })).resolves.toEqual({
+      matchedCount: 0,
+      recorded: false,
+      unmatchedCount: 1,
+      untracedCount: 1,
+    });
+
+    await recordHostedIngressAssistantInputStaged({
+      assistantInputId: "input_traced_1",
+      at: instant("2026-06-02T19:11:22.000Z"),
+      authenticatedUserId: "member_latency_1",
+      mailboxItemId: "mailbox_latency_1",
+      prisma,
+      runtimeAttemptId: "attempt_untraced_1",
+      source: "linq",
+    });
+
+    await expect(recordHostedIngressProviderStarted({
+      assistantInputIds: ["input_traced_1", "input_untraced_1"],
+      at: instant("2026-06-02T19:11:23.000Z"),
+      authenticatedUserId: "member_latency_1",
+      prisma,
+      providerRequestOrdinal: 0,
+      runtimeAttemptId: "attempt_untraced_1",
+      source: "linq",
+    })).resolves.toEqual({
+      matchedCount: 1,
+      recorded: true,
+      unmatchedCount: 1,
+      untracedCount: 1,
+    });
+  });
+
+  it("reports assistant milestones for untraced assistant inputs as untraced", async () => {
+    const prisma = createLatencyWritePrisma({
+      mailboxAcceptedAtEpochMs: BigInt(Date.parse("2026-06-02T19:11:40.000Z")),
+    });
+
+    await expect(recordHostedIngressAssistantMilestone({
+      assistantInputIds: ["input_untraced_2"],
+      at: instant("2026-06-02T19:11:41.000Z"),
+      authenticatedUserId: "member_latency_1",
+      milestone: "first_codex_output_observed",
+      prisma,
+      runtimeAttemptId: "attempt_untraced_2",
+      runtimeLeaseGeneration: "1",
+      source: "linq",
+    })).resolves.toEqual({
+      matchedCount: 0,
+      recorded: false,
+      unmatchedCount: 1,
+      untracedCount: 1,
+    });
+  });
+
   it("transfers terminal refresh ownership to the recovery attempt", async () => {
     const prisma = createLatencyWritePrisma({
       mailboxAcceptedAtEpochMs: BigInt(Date.parse("2026-06-02T19:12:20.000Z")),


### PR DESCRIPTION
## Why this PR exists

A production log sweep showed repeated `warn` rows from
`/api/internal/hosted-runtime/latency`:
`Hosted runtime latency trace callback had unmatched rows.` with
`matchedCount: 0, unmatchedCount: 1`, for `provider_started` and
`assistant_milestone` events on `source: 'linq'`.

The warning is a false alarm on ordinary turns. Ingress latency trace rows are
created only by the inbound messaging webhook wake path
(`apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts` →
`recordHostedIngressAcceptedFromMailboxItem`). An assistant input the runtime
raises without an inbound message — a scheduled or follow-up turn — therefore
has no trace row by construction. Every latency callback for that turn reports
its ids as unmatched, the runner retries each event twice more
(`HOSTED_ASSISTANT_MILESTONE_TRACE_RETRY_DELAYS_MS`), and each attempt logs
another warn. One such turn produces a burst of identical warnings that no
operator can act on.

Production evidence gathered while diagnosing (read-only): in each observed
burst there was no mailbox item and no trace row created in the window, and the
runtime attempt id on the neighbouring traces was unchanged across the burst —
so the callbacks were not rejected by the write fence, their ids simply had no
row. Over the trailing 7 days, `provider_request_ordinal` and the surrounding
trace rows are consistent with this: the ids in these callbacks never existed in
`hosted_ingress_latency_trace`.

## User goal / user-visible behavior

No user-visible behavior changes. This is operator-facing log hygiene: a warn
level reserved for conditions someone can act on, so a real latency-trace
authority failure is not buried under routine noise.

## User experience

Not applicable. No user-facing surface, copy, timing, or delivery path changes.
The wire response of the latency callback is byte-identical, so runtime turn
behavior and reply timing are untouched.

## Invariants the PR must preserve

- The latency callback response body keeps its exact shape and values
  (`matchedCount`, `recorded`, `unmatchedCount`). The runner's retry loop keys
  off `unmatchedCount`, and that retry is what covers the real race where an
  `assistant_input_staged` callback is still in flight when `provider_started`
  arrives. Narrowing the wire value would silently drop those traces.
- The write-fence authority check is unchanged: a callback whose runtime attempt
  does not match the trace row is still refused, still counted in
  `unmatchedCount`, and now still warns.
- No new database work: `untracedCount` is derived from rows already fetched by
  the existing `findMany`.

## Non-obvious affected surfaces

- **Runner retry contract (`packages/assistant-runtime`).** Not changed, but it
  is the reason the wire response is deliberately left alone. The route maps the
  store result through `parseHostedRuntimeLatencyTraceResponse`, which selects
  only the three existing fields, so `untracedCount` never reaches the runner and
  no deploy-skew window exists between the web and runner deploys.
- **Log message string.** `"…had unmatched rows."` becomes `"…had rejected
  rows."`. Grepped the repo for the old string: no alert rule, dashboard, doc, or
  test references it, so nothing keys off it.
- No schema, migration, or dashboard-query change. The latency dashboard's own
  data-quality counters (`missingProviderStartCount`,
  `stagedButMissingProviderCount`, `replyTraceQuality`) are untouched and remain
  the place where lost telemetry surfaces.

## Architecture and reuse

- **Existing systems reused:** The `rows` result already fetched by
  `recordHostedIngressProviderStarted` and
  `recordHostedIngressAssistantMilestone`; the existing
  `HostedIngressLatencyWriteResult` contract; the existing
  `parseHostedRuntimeLatencyTraceResponse` projection, which is what keeps the
  wire response unchanged without a second response type.
- **New logic:** Partition the ids that failed to write into "no trace row
  exists" (`untracedCount`) and "row existed, guarded write declined"
  (`unmatchedCount - untracedCount`), and warn only on the latter, with the
  runtime attempt id attached so a real occurrence is diagnosable.
- **New abstractions:** One private helper,
  `buildHostedIngressLatencyWriteResult`, replacing the duplicated result
  literal in the two multi-id record functions. No new module, port, or public
  type: the existing write-result interface was sufficient with one optional
  field.
- **Complexity intentionally avoided:** No new response field on the runner
  contract, no runner-side change, and no attempt to suppress the retries
  themselves. Suppressing retries would need the runtime to know which of its
  accepted inputs are traceable, which is a larger change on the hot path for a
  saving of at most two callbacks per untraced milestone.

## Hot reply path impact

Not applicable. The change touches only the diagnostic latency-trace callback
route, which runs off the `Foreground Reply Critical Path`. No database call,
network call, or awaited operation is added or moved; `untracedCount` is
computed from rows already in memory.

## Murph initial provider input impact

Not applicable for both individual and group Murph. No prompt builder, prompt
text, dynamic-tool description, schema, tool availability or deferral, skill,
Codex version or configuration, model tool mode, or provider-request assembly
is touched. The diff is confined to one internal API route, one web store
module, and their tests.

## Preliminary specialist lenses

- **Product experience:** not applicable. No semantic user-facing copy, action
  purpose, interaction step, UI state, screen, asynchronous continuation
  ownership, or journey timing/delivery/recovery changes. Intended outcome is
  operator log hygiene only.
- **Prompt:** not applicable. No prompt-bearing file is touched.
- **Frontend:** not applicable. No `apps/web` UI surface, component, or section
  changes; there is nothing to render.
- **Coverage:** applicable. Focused local proof —
  `apps/web/test/hosted-runtime-latency-store.test.ts` and
  `apps/web/test/hosted-runtime-internal-routes.test.ts` (98 tests, pass),
  `apps/web` typecheck clean, ESLint clean on the four touched files. Three new
  tests: untraced-only provider start, mixed traced/untraced provider start,
  untraced assistant milestone, plus a route test asserting no warn for
  untraced-only and exactly one warn — with the runtime attempt id — when a row
  is rejected. The pre-existing "rejects provider start from a different runtime
  attempt" test is the guard that the rejected path still reports as before.
  Preliminary round 1 (head c2f12b4c0f) returned one low coverage finding: the
  untraced-input assertion reparsed the response through
  `parseHostedRuntimeLatencyTraceResponse`, which ignores extra keys, so it
  could not prove the wire shape and would have passed if the route leaked
  `untracedCount`. Resolved in 47481737d8 by asserting the raw body, verified by
  temporarily returning the unprojected result and confirming the test fails on
  the leaked field. The confirming round on 47481737d8 returned
  `SPECIALIST_OUTCOME: PASS` with zero findings, having independently re-derived
  the untraced-versus-rejected classification for all four event types the route
  dispatches and their reachable early-return paths. Exact-head CI on
  47481737d8: green (the hosted Stripe browser lane skips by design on PRs).

ReviewGPT context sensitivity: routine

Narrow bug fix confined to diagnostic logging on one internal route. No auth,
privacy, billing, health-safety, persisted-state, public-API, ordering, retry,
or concurrency behavior changes; the wire contract and retry loop are unchanged
by construction.

## Change-shape breakdown

Classification rule: by path — `apps/web/test/**` is tests/fixtures, everything
else under `apps/web/src/**` and `apps/web/app/**` is source. No binary files, no
generated code.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 43 | 11 |
| Tests/fixtures | 144 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **187** | **11** |

## Design proof

Not applicable. No user-facing frontend UI surface changes, so there is no
`/design` catalog component or section to capture.

## Deployment skew

Safe in either order, web-only. The runner is not redeployed and never observes
`untracedCount`: the route serializes its response through
`parseHostedRuntimeLatencyTraceResponse`, which projects only `matchedCount`,
`recorded`, and `unmatchedCount`. An old runner against the new web sees the
identical response it sees today and retries identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
