### PR TITLE
fix(web): stop signed-out dashboard visitors from starting a browser-vault load

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -26,14 +26,20 @@ export default async function DashboardLayout({
     );
   }
 
-  const consentStatus = auth.pageAuth.authenticatedMember
-    ? await readDashboardConsentReminderStatus(auth.pageAuth.authenticatedMember.id)
+  const authenticatedMember = auth.pageAuth.authenticatedMember;
+  const consentStatus = authenticatedMember
+    ? await readDashboardConsentReminderStatus(authenticatedMember.id)
     : null;
-  const browserVaultLoadEnabled = consentStatus?.launchGranted ?? true;
+  // A signed-out visitor has no vault to load. Without this the provider would
+  // post a session request that can only be rejected, and the dashboard would
+  // tell someone who never signed in that their session expired.
+  const browserVaultLoadEnabled = authenticatedMember
+    ? consentStatus?.launchGranted ?? true
+    : false;
 
   return (
     <BrowserVaultProvider
-      initialMemberId={auth.pageAuth.authenticatedMember?.id ?? null}
+      initialMemberId={authenticatedMember?.id ?? null}
       loadEnabled={browserVaultLoadEnabled}
     >
       <DashboardShell sidebarAuth={auth.sidebarAuth}>

--- a/apps/web/app/design/home-load-state-study.tsx
+++ b/apps/web/app/design/home-load-state-study.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { DashboardCriticalLoadError } from "@/src/components/dashboard/dashboard-critical-load-error";
+import { BrowserVaultUnavailableAlert } from "@/src/components/home/browser-vault-unavailable-alert";
 import { HomeDataLoadAlert } from "@/src/components/home/home-data-load-alert";
 import { PageHeader } from "@/src/components/ui/page-header";
 
@@ -38,6 +41,22 @@ export function HomeLoadStateStudy() {
         id="home-critical-load-section"
       >
         <DashboardCriticalLoadError />
+      </div>
+      {/*
+        Only a signed-in member whose vault load failed sees this. A signed-out
+        visitor gets the onboarding steps above instead, because the dashboard
+        layout never starts a vault load without a member to load.
+      */}
+      <div
+        className="rounded-2xl border border-border bg-background p-5 sm:p-8"
+        data-design-section="home-browser-vault-unavailable"
+        id="home-browser-vault-unavailable-section"
+        inert
+      >
+        <BrowserVaultUnavailableAlert
+          message="Your dashboard data is not available right now."
+          onRetry={() => {}}
+        />
       </div>
     </div>
   );

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -332,7 +332,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Home partial-load recovery">
+      <StudySection title="Home partial-load and vault-unavailable recovery">
         <HomeLoadStateStudy />
       </StudySection>
 

--- a/apps/web/src/components/home/browser-vault-onboarding-steps.tsx
+++ b/apps/web/src/components/home/browser-vault-onboarding-steps.tsx
@@ -6,14 +6,13 @@ import {
   type BrowserVaultQueryClient,
 } from "@murphai/query/browser-overview";
 
+import { BrowserVaultUnavailableAlert } from "./browser-vault-unavailable-alert";
 import { HomeExperiments } from "./home-experiments";
 import {
   OnboardingSteps,
   type OnboardingStepsProps,
 } from "./onboarding-steps";
 
-import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
-import { Button } from "@/src/components/ui/button";
 import { useBrowserVault } from "@/src/lib/browser-vault/context";
 import {
   buildExperimentLibraryCards,
@@ -49,17 +48,10 @@ export function BrowserVaultOnboardingStepsContent({
   if (vaultUnavailable) {
     return (
       <>
-        <Alert variant="destructive">
-          <AlertTitle>Could not load your dashboard</AlertTitle>
-          <AlertDescription>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <span>{error ?? "Your dashboard data is not available right now."}</span>
-              <Button size="sm" variant="outline" onClick={() => void refresh()}>
-                Retry
-              </Button>
-            </div>
-          </AlertDescription>
-        </Alert>
+        <BrowserVaultUnavailableAlert
+          message={error}
+          onRetry={() => void refresh()}
+        />
         <OnboardingSteps
           {...props}
           hideExperimentStep

--- a/apps/web/src/components/home/browser-vault-unavailable-alert.tsx
+++ b/apps/web/src/components/home/browser-vault-unavailable-alert.tsx
@@ -1,0 +1,33 @@
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { Button } from "@/src/components/ui/button";
+
+export const BROWSER_VAULT_UNAVAILABLE_FALLBACK_MESSAGE =
+  "Your dashboard data is not available right now.";
+
+/**
+ * Shown when a signed-in member's browser vault could not be loaded. Retry is
+ * the only useful action, so this stays presentational and the caller owns what
+ * retrying does. A signed-out visitor must never reach this state; the
+ * dashboard layout leaves their vault load disabled instead.
+ */
+export function BrowserVaultUnavailableAlert({
+  message,
+  onRetry,
+}: {
+  message?: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Could not load your dashboard</AlertTitle>
+      <AlertDescription>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <span>{message ?? BROWSER_VAULT_UNAVAILABLE_FALLBACK_MESSAGE}</span>
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/test/browser-vault-provider-ownership.test.ts
+++ b/apps/web/test/browser-vault-provider-ownership.test.ts
@@ -24,11 +24,11 @@ test("the persistent dashboard layout fences fresh vault authority to its server
   assert.match(layoutSource, /!consentStatus\.launchGranted/u);
   assert.match(
     layoutSource,
-    /initialMemberId=\{auth\.pageAuth\.authenticatedMember\?\.id \?\? null\}/u,
+    /initialMemberId=\{authenticatedMember\?\.id \?\? null\}/u,
   );
   assert.match(
     layoutSource,
-    /browserVaultLoadEnabled = consentStatus\?\.launchGranted \?\? true/u,
+    /browserVaultLoadEnabled = authenticatedMember\s*\?\s*consentStatus\?\.launchGranted \?\? true\s*:\s*false/u,
   );
   assert.match(layoutSource, /loadEnabled=\{browserVaultLoadEnabled\}/u);
   assert.match(contextSource, /expectedMemberId: initialMemberId/u);

--- a/apps/web/test/dashboard-layout-browser-vault-load.test.tsx
+++ b/apps/web/test/dashboard-layout-browser-vault-load.test.tsx
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+
+import { isValidElement, type ReactNode } from "react";
+import { beforeEach, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getHostedDashboardLayoutAuthSnapshot: vi.fn(),
+  readHostedConsentStatus: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/src/lib/hosted-onboarding/page-auth", () => ({
+  getHostedDashboardLayoutAuthSnapshot: mocks.getHostedDashboardLayoutAuthSnapshot,
+}));
+
+vi.mock("@/src/lib/legal/consent", () => ({
+  hasHostedHistoricalLaunchConsent: () => false,
+  readHostedConsentStatus: mocks.readHostedConsentStatus,
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: () => ({}),
+}));
+
+vi.mock("@/src/components/dashboard/dashboard-shell", () => ({
+  DashboardShell: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/src/components/dashboard/dashboard-critical-load-error", () => ({
+  DashboardCriticalLoadError: () => null,
+}));
+
+vi.mock("@/src/components/legal/dashboard-legal-consent-gate", () => ({
+  DashboardLegalConsentGate: () => null,
+}));
+
+vi.mock("@/src/lib/browser-vault/context", () => ({
+  BrowserVaultProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+async function renderLayoutProviderProps(): Promise<{
+  initialMemberId: string | null;
+  loadEnabled: boolean;
+}> {
+  const { default: DashboardLayout } = await import("../app/(dashboard)/layout");
+  const element = await DashboardLayout({ children: null });
+
+  assert.ok(isValidElement(element), "the dashboard layout should render an element");
+
+  const props = element.props as {
+    initialMemberId?: unknown;
+    loadEnabled?: unknown;
+  };
+
+  assert.equal(typeof props.loadEnabled, "boolean");
+  assert.ok(props.initialMemberId === null || typeof props.initialMemberId === "string");
+
+  return {
+    initialMemberId: props.initialMemberId as string | null,
+    loadEnabled: props.loadEnabled as boolean,
+  };
+}
+
+function readyAuthSnapshot(member: { id: string } | null) {
+  return {
+    pageAuth: {
+      authenticated: member !== null,
+      authenticatedMember: member,
+      session: member === null ? null : { member },
+    },
+    sidebarAuth: { authenticated: member !== null, label: null },
+    status: "ready" as const,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockReset();
+  mocks.readHostedConsentStatus.mockReset();
+});
+
+// A signed-out visitor reaches the dashboard route group without a redirect, so
+// the layout is the only place that can stop the provider from posting a vault
+// session request that has no member to load. Without this gate the rejected
+// request surfaces "Your dashboard session expired" to someone who never
+// signed in.
+test("a signed-out dashboard visitor never starts a browser vault load", async () => {
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockResolvedValue(readyAuthSnapshot(null));
+
+  const props = await renderLayoutProviderProps();
+
+  assert.equal(props.loadEnabled, false);
+  assert.equal(props.initialMemberId, null);
+  assert.equal(mocks.readHostedConsentStatus.mock.calls.length, 0);
+});
+
+test("an authenticated member with launch consent still starts a browser vault load", async () => {
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockResolvedValue(
+    readyAuthSnapshot({ id: "usr_dashboard_member" }),
+  );
+  mocks.readHostedConsentStatus.mockResolvedValue({ launchGranted: true });
+
+  const props = await renderLayoutProviderProps();
+
+  assert.equal(props.loadEnabled, true);
+  assert.equal(props.initialMemberId, "usr_dashboard_member");
+});
+
+test("an authenticated member missing launch consent still blocks the browser vault load", async () => {
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockResolvedValue(
+    readyAuthSnapshot({ id: "usr_dashboard_member" }),
+  );
+  mocks.readHostedConsentStatus.mockResolvedValue({ launchGranted: false });
+
+  const props = await renderLayoutProviderProps();
+
+  assert.equal(props.loadEnabled, false);
+  assert.equal(props.initialMemberId, "usr_dashboard_member");
+});
+
+// An unreadable consent record must not lock an authenticated member out of
+// their own dashboard data; that fallback predates this change and stays.
+test("an authenticated member keeps the vault load when consent is unreadable", async () => {
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockResolvedValue(
+    readyAuthSnapshot({ id: "usr_dashboard_member" }),
+  );
+  mocks.readHostedConsentStatus.mockRejectedValue(new Error("consent store unavailable"));
+
+  const props = await renderLayoutProviderProps();
+
+  assert.equal(props.loadEnabled, true);
+  assert.equal(props.initialMemberId, "usr_dashboard_member");
+});


### PR DESCRIPTION
## Why this PR exists

Production emitted repeated `403 HOSTED_ONBOARDING_ORIGIN_REQUIRED` warnings on `POST /api/browser-vault/session`. Tracing them showed the CSRF guard was doing its job — the caller was an AI crawler that omits `Origin` — but it also showed why that caller reached a mutation route at all: the dashboard route-group layout starts a browser-vault load for visitors who are not signed in.

`app/(dashboard)/layout.tsx` derived `browserVaultLoadEnabled` from the consent status alone:

```ts
const consentStatus = auth.pageAuth.authenticatedMember ? await read(...) : null;
const browserVaultLoadEnabled = consentStatus?.launchGranted ?? true;
```

A signed-out visitor has no member, so no consent record is read, so `consentStatus` is `null` and the `?? true` fallback mounts an **active** `BrowserVaultProvider` with `initialMemberId: null`. Every dashboard route serves 200 HTML anonymously (no redirect), so each anonymous page view generates an X25519 keypair and posts a session request that has no member to load and can only be rejected.

## User goal and user experience

Someone who is not signed in lands on a dashboard URL — from a shared link, a bookmark, or search — and should see the signed-out welcome and onboarding steps.

Today the doomed request runs and its rejection decides what renders:

- `401` (the common signed-out case, no session cookie) lands on the empty state, so the page looks right but paid for a wasted round trip and a loading flash.
- Any **non-401** rejection sets `status: "error"`, and `BrowserVaultOnboardingStepsContent` renders a destructive "Could not load your dashboard" alert and collapses the three onboarding steps to one. `403` reaches this branch, which is exactly what a browser that sends no usable `Origin` (sandboxed iframe, privacy tooling, the crawler above) receives.

After this change a signed-out visitor never starts the load, so neither outcome is reachable and the full onboarding renders immediately.

Captured in the Playwright smoke harness on the real page, signed out:

| | `/home`, signed out |
| --- | --- |
| Before | <img width="700" src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/d731c1db-4685-4803-a0af-460b16be8400/designproof" /> |
| After | <img width="700" src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/41263483-929a-4f98-c531-9d6334f68700/designproof" /> |

Instrumented request counts from the same runs: **before** `[{status:500},{status:500}]`, **after** `[]`. (The harness uses a placeholder database, so its rejection is a 500 rather than production's 401/403; the request firing at all is the part under test.)

## Invariants

- A browser-vault load requires an authenticated member. The layout is the only place that can enforce this, because the route group has no anonymous redirect.
- The consent gate is unchanged for members who have one: `launchGranted: false` still disables the load, and an unreadable consent record still falls back to enabled so a real member is never locked out of their own data.
- No change to the CSRF guard, the session route's auth, or `assertBrowserVaultMemberAuthority`. This removes a caller; it does not loosen a check.
- `DisabledBrowserVaultProvider` clears warm state on mount, so a signed-out render cannot publish a decrypted snapshot left by a prior identity.

## Non-obvious affected surfaces

- **Post-login**: `use-hosted-auth-completion` finishes with `navigateHostedAuthRedirect`, a full document navigation, so the layout re-runs server-side with the session cookie set. There is no window where a just-signed-in member is stuck with the load disabled.
- **Landing warm path**: `LandingBrowserVaultWarm` was already gated on `authenticated` and is untouched.
- **Alert extraction**: `BrowserVaultUnavailableAlert` is new but renders byte-identical markup to the inline block it replaces. It exists so the design catalog can show the state without mounting a provider that would issue a live request, per the studies-use-synthetic-props rule.

## Preliminary specialist lenses

- *Product experience*: the signed-out dashboard is a real entry point; the change replaces a failure-shaped render with the intended onboarding.
- *Frontend*: no new state owner, no new lifecycle machinery — one boolean gains its missing precondition and reuses the existing `loadEnabled` seam and `DisabledBrowserVaultProvider`.
- *Security*: strictly fewer unauthenticated calls to a mutation route. No guard was relaxed.
- *Coverage*: the new layout test fails on `main` and passes here (verified by reverting only the layout hunk).

## Change shape

| Source | Added | Deleted |
| --- | --- | --- |
| Source | 68 | 18 |
| Tests | 136 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

## Architecture and reuse

- Existing systems reused: the layout's existing `loadEnabled` prop and `BrowserVaultProvider`'s existing `DisabledBrowserVaultProvider` branch, both already built and shipped for the legal-consent gate. The signed-out case routes through the same disabled path rather than a parallel one. `getHostedDashboardLayoutAuthSnapshot` already returned the authenticated member; the layout simply had not consulted it for this decision.
- New logic: one added precondition — `browserVaultLoadEnabled` now requires an authenticated member before consulting consent. The `?? true` fallback is preserved for the case it was written for (an authenticated member whose consent record is unreadable) and is now unreachable for the case it never covered (no member at all).
- New abstractions: none. `BrowserVaultUnavailableAlert` is an extraction, not an addition — the alert markup moves out of `browser-vault-onboarding-steps.tsx` unchanged so production and the `/design` study render one component instead of duplicating copy. The catalog rule requires studies to use synthetic props with no live requests, and a study of `BrowserVaultOnboardingStepsContent` could not satisfy that: it reads `useBrowserVault()`, so rendering it in the catalog would need a provider issuing the very request this PR removes.
- Complexity intentionally avoided: no anonymous redirect or middleware guard on the dashboard route group (the signed-out shell is intended and already renders), no new provider state or "anonymous" mode, no client-side auth check duplicating the server snapshot, no loosening of the CSRF guard or the session route's auth to accommodate callers that should not be calling.

## ReviewGPT round metadata

ReviewGPT first-reviewed head: 6b018228f201348abeb1dffc8b8943212417a135

ReviewGPT context sensitivity: sensitive

Reason: the changed decision reads the server-authenticated member and gates a member-only data path, so it sits on an auth-adjacent boundary even though no guard is relaxed and no schema, contract, migration, or deploy boundary moves. Round 1 packaged a full snapshot, which matches this declaration.

First-reviewed change shape (immutable baseline):

| Source | Added | Deleted |
| --- | --- | --- |
| Source | 68 | 18 |
| Tests | 136 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |


Round 1 flagged two body inaccuracies, both corrected above with no code change and no head movement: the source change-shape counts were mis-added (35/17 → the correct 68/18 across the five authored `.tsx` source files), and the sensitivity declaration was malformed so the packager read it as `undeclared`. `undeclared` defaults to the full snapshot, which is what round 1 actually reviewed, so the corrected `sensitive` declaration describes the packaging that already happened.

## Design proof

- Design page: [/design?tab=sections](https://www.withmurph.ai/design?tab=sections) — "Home partial-load and vault-unavailable recovery"
- Desktop screenshot: <img width="900" src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/fcfc7577-6e38-4978-885f-a2fd0e26a000/designproof" />
- Mobile screenshot: <img width="360" src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/9cebfaa5-28c2-46a4-bb52-a332719f2e00/designproof" />

## Deployment skew

Not applicable. `apps/web` only, no schema, contract, or runtime boundary change; the web deploy is independently safe in either order with `apps/cloudflare`.

## Follow-up found while tracing (not in this PR)

The same 7-day window holds 22 `403 HOSTED_ACCESS_REQUIRED` responses on this route. Those are *authenticated* members whose access is not active (`assertActiveHostedMemberAccessAllowed`), so this change does not affect them — their load stays enabled and the 403 still routes to `status: "error"`. They see "Could not load your dashboard / Your dashboard session expired. Refresh and try again." for what is actually a billing/access state, with a Retry that cannot succeed. Worth its own fix.
