### PR TITLE
fix(web): let a thread container assert its own durable Linq thread

### DIFF
--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -196,21 +196,12 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     threadId: input.target,
   });
   if (targetThreadRoute) {
+    // The route's container member is the canonical owner of this durable
+    // thread, and thread containers are synthetic members that no personal
+    // runtime can ever authenticate as. Exact ownership is therefore the whole
+    // authority: a personal proactive send still cannot reach a group thread,
+    // and the owning container is not held to a home route it cannot have.
     if (targetThreadRoute.containerMemberId !== input.memberId) {
-      throwHostedLinqRouteAuthorityMismatch();
-    }
-    // A current-home-only assertion keeps a member's proactive direct send out
-    // of a durable group thread by pinning it to that member's home Linq route.
-    // A thread container owns no member Linq route, so the container thread it
-    // is asserting against is the only route it can ever reach; holding it to a
-    // home route it cannot have would reject every proactive send it makes.
-    if (
-      isHostedLinqCurrentHomeOnlyAssertion(input)
-      && await hasHostedMemberLinqHomeRoute({
-        memberId: input.memberId,
-        prisma: input.prisma,
-      })
-    ) {
       throwHostedLinqRouteAuthorityMismatch();
     }
 
@@ -243,41 +234,6 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     homeRouteFallbackAllowed:
       input.homeRouteFallbackAllowed === true && input.authorityCheckOnly === true,
   });
-}
-
-async function hasHostedMemberLinqHomeRoute(input: {
-  memberId: string;
-  prisma: HostedLinqEngagementClient;
-}): Promise<boolean> {
-  const routing = await input.prisma.hostedMemberRouting.findUnique({
-    where: { memberId: input.memberId },
-    select: {
-      linqChatIdEncrypted: true,
-      linqChatLookupKey: true,
-      pendingLinqChatIdEncrypted: true,
-      pendingLinqChatLookupKey: true,
-    },
-  });
-  if (!routing) {
-    return false;
-  }
-
-  return Boolean(
-    routing.linqChatIdEncrypted
-    ?? routing.linqChatLookupKey
-    ?? routing.pendingLinqChatIdEncrypted
-    ?? routing.pendingLinqChatLookupKey,
-  );
-}
-
-function isHostedLinqCurrentHomeOnlyAssertion(input: {
-  answeredMailboxItemIds?: readonly string[] | null;
-  homeRouteFallbackAllowed?: boolean | null;
-  replyToMessageId?: string | null;
-}): boolean {
-  return input.homeRouteFallbackAllowed === true
-    && normalizeNullable(input.replyToMessageId) === null
-    && (input.answeredMailboxItemIds?.length ?? 0) === 0;
 }
 
 async function matchesPersistedHostedLinqDirectInbound(input: {

--- a/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-egress-engagement.ts
@@ -196,9 +196,20 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     threadId: input.target,
   });
   if (targetThreadRoute) {
+    if (targetThreadRoute.containerMemberId !== input.memberId) {
+      throwHostedLinqRouteAuthorityMismatch();
+    }
+    // A current-home-only assertion keeps a member's proactive direct send out
+    // of a durable group thread by pinning it to that member's home Linq route.
+    // A thread container owns no member Linq route, so the container thread it
+    // is asserting against is the only route it can ever reach; holding it to a
+    // home route it cannot have would reject every proactive send it makes.
     if (
       isHostedLinqCurrentHomeOnlyAssertion(input)
-      || targetThreadRoute.containerMemberId !== input.memberId
+      && await hasHostedMemberLinqHomeRoute({
+        memberId: input.memberId,
+        prisma: input.prisma,
+      })
     ) {
       throwHostedLinqRouteAuthorityMismatch();
     }
@@ -232,6 +243,31 @@ export async function assertHostedLinqRecentInboundEngagementForRuntime(input: {
     homeRouteFallbackAllowed:
       input.homeRouteFallbackAllowed === true && input.authorityCheckOnly === true,
   });
+}
+
+async function hasHostedMemberLinqHomeRoute(input: {
+  memberId: string;
+  prisma: HostedLinqEngagementClient;
+}): Promise<boolean> {
+  const routing = await input.prisma.hostedMemberRouting.findUnique({
+    where: { memberId: input.memberId },
+    select: {
+      linqChatIdEncrypted: true,
+      linqChatLookupKey: true,
+      pendingLinqChatIdEncrypted: true,
+      pendingLinqChatLookupKey: true,
+    },
+  });
+  if (!routing) {
+    return false;
+  }
+
+  return Boolean(
+    routing.linqChatIdEncrypted
+    ?? routing.linqChatLookupKey
+    ?? routing.pendingLinqChatIdEncrypted
+    ?? routing.pendingLinqChatLookupKey,
+  );
 }
 
 function isHostedLinqCurrentHomeOnlyAssertion(input: {

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -216,15 +216,14 @@ describe("hosted Linq egress authority", () => {
     });
   });
 
-  it("uses a same-member durable route for replies but not current-home sends", async () => {
+  it("uses a container's durable route for replies and current-home-fallback preflights", async () => {
     const prisma = createPrismaStub({
-      homeChatId: "chat-home",
-      threadRouteContainerMemberId: "member-1",
+      threadRouteContainerMemberId: "container-1",
     });
 
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: false,
-      memberId: "member-1",
+      memberId: "container-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-authorized",
       targetKind: "thread",
@@ -234,20 +233,22 @@ describe("hosted Linq egress authority", () => {
     expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
     expect(prisma.hostedMember.findUnique).toHaveBeenCalled();
 
+    // A scheduled occurrence whose route never recorded threadIsDirect asks for
+    // the home-route fallback. The container owns no home route, so its own
+    // durable thread stays the answer instead of a mismatch.
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: true,
       homeRouteFallbackAllowed: true,
-      memberId: "member-1",
+      memberId: "container-1",
       prisma: asRuntimeEngagementPrisma(prisma),
       target: "chat-authorized",
       targetKind: "thread",
-    })).rejects.toMatchObject({
-      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
-      httpStatus: 403,
-    });
+    })).resolves.toEqual({ targetOverride: null, threadIsDirect: false });
+
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
 
     const foreignRoutePrisma = createPrismaStub({
-      threadRouteContainerMemberId: "member-2",
+      threadRouteContainerMemberId: "container-2",
     });
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: false,
@@ -260,51 +261,23 @@ describe("hosted Linq egress authority", () => {
       httpStatus: 403,
     });
     expect(foreignRoutePrisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
-  });
 
-  it("authorizes a container runtime's current-home-only send to its own durable thread", async () => {
-    const prisma = createPrismaStub({
-      memberRoutingMissing: true,
-      threadRouteContainerMemberId: "container-1",
+    const memberHomeRoutePrisma = createPrismaStub({
+      homeChatId: "chat-home",
+      threadRouteContainerMemberId: "container-2",
     });
-
-    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
-      authorityCheckOnly: true,
-      homeRouteFallbackAllowed: true,
-      memberId: "container-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
-      target: "chat-authorized",
-      targetKind: "thread",
-    })).resolves.toMatchObject({ targetOverride: null, threadIsDirect: false });
-
-    expect(prisma.hostedMemberRouting.findUnique).toHaveBeenCalledWith({
-      select: {
-        linqChatIdEncrypted: true,
-        linqChatLookupKey: true,
-        pendingLinqChatIdEncrypted: true,
-        pendingLinqChatLookupKey: true,
-      },
-      where: { memberId: "container-1" },
-    });
-  });
-
-  it("rejects a current-home-only send to a durable thread when the runtime holds a pending home route", async () => {
-    const prisma = createPrismaStub({
-      pendingChatId: "chat-pending",
-      threadRouteContainerMemberId: "member-1",
-    });
-
     await expect(assertHostedLinqRecentInboundEngagementForRuntime({
       authorityCheckOnly: true,
       homeRouteFallbackAllowed: true,
       memberId: "member-1",
-      prisma: asRuntimeEngagementPrisma(prisma),
+      prisma: asRuntimeEngagementPrisma(memberHomeRoutePrisma),
       target: "chat-authorized",
       targetKind: "thread",
     })).rejects.toMatchObject({
       code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
       httpStatus: 403,
     });
+    expect(memberHomeRoutePrisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
   });
 
   it("rejects non-participant sends before route resolution when member access is inactive", async () => {
@@ -1626,9 +1599,6 @@ function createPrismaStub(input: {
   homeParticipantContactKind?: "email" | "phone" | null;
   homeParticipantContactLookupKey?: string | null;
   identityPhone?: string;
-  // Thread containers own a durable group thread and never carry member
-  // routing, so their runtime reads no routing row at all.
-  memberRoutingMissing?: boolean;
   pendingChatId?: string;
   threadRouteContainerMemberId?: string;
 }) {
@@ -1650,7 +1620,7 @@ function createPrismaStub(input: {
       }),
     },
     hostedMemberRouting: {
-      findUnique: vi.fn().mockResolvedValue(input.memberRoutingMissing ? null : {
+      findUnique: vi.fn().mockResolvedValue({
         linqChatIdEncrypted: input.homeChatId ? "encrypted-home-chat" : null,
         linqChatLookupKey: createRequiredLinqChatLookupKey(input.homeChatId),
         linqParticipantContactKind:

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -218,6 +218,7 @@ describe("hosted Linq egress authority", () => {
 
   it("uses a same-member durable route for replies but not current-home sends", async () => {
     const prisma = createPrismaStub({
+      homeChatId: "chat-home",
       threadRouteContainerMemberId: "member-1",
     });
 
@@ -259,6 +260,51 @@ describe("hosted Linq egress authority", () => {
       httpStatus: 403,
     });
     expect(foreignRoutePrisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("authorizes a container runtime's current-home-only send to its own durable thread", async () => {
+    const prisma = createPrismaStub({
+      memberRoutingMissing: true,
+      threadRouteContainerMemberId: "container-1",
+    });
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: true,
+      homeRouteFallbackAllowed: true,
+      memberId: "container-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      target: "chat-authorized",
+      targetKind: "thread",
+    })).resolves.toMatchObject({ targetOverride: null, threadIsDirect: false });
+
+    expect(prisma.hostedMemberRouting.findUnique).toHaveBeenCalledWith({
+      select: {
+        linqChatIdEncrypted: true,
+        linqChatLookupKey: true,
+        pendingLinqChatIdEncrypted: true,
+        pendingLinqChatLookupKey: true,
+      },
+      where: { memberId: "container-1" },
+    });
+  });
+
+  it("rejects a current-home-only send to a durable thread when the runtime holds a pending home route", async () => {
+    const prisma = createPrismaStub({
+      pendingChatId: "chat-pending",
+      threadRouteContainerMemberId: "member-1",
+    });
+
+    await expect(assertHostedLinqRecentInboundEngagementForRuntime({
+      authorityCheckOnly: true,
+      homeRouteFallbackAllowed: true,
+      memberId: "member-1",
+      prisma: asRuntimeEngagementPrisma(prisma),
+      target: "chat-authorized",
+      targetKind: "thread",
+    })).rejects.toMatchObject({
+      code: "HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH",
+      httpStatus: 403,
+    });
   });
 
   it("rejects non-participant sends before route resolution when member access is inactive", async () => {
@@ -1580,6 +1626,9 @@ function createPrismaStub(input: {
   homeParticipantContactKind?: "email" | "phone" | null;
   homeParticipantContactLookupKey?: string | null;
   identityPhone?: string;
+  // Thread containers own a durable group thread and never carry member
+  // routing, so their runtime reads no routing row at all.
+  memberRoutingMissing?: boolean;
   pendingChatId?: string;
   threadRouteContainerMemberId?: string;
 }) {
@@ -1601,7 +1650,7 @@ function createPrismaStub(input: {
       }),
     },
     hostedMemberRouting: {
-      findUnique: vi.fn().mockResolvedValue({
+      findUnique: vi.fn().mockResolvedValue(input.memberRoutingMissing ? null : {
         linqChatIdEncrypted: input.homeChatId ? "encrypted-home-chat" : null,
         linqChatLookupKey: createRequiredLinqChatLookupKey(input.homeChatId),
         linqParticipantContactKind:


### PR DESCRIPTION
## Why this PR exists

A scheduled Linq send from a thread-container runtime has been failing
`HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH` (403) on every hourly wake, for
multiple containers, continuously. Production logs for 2026-08-08 show 60 such
403s across a 12-hour window in five fixed hourly slots — the same container
runtimes retrying the same rejected assertion, never delivering and never
converging.

The rejection comes from the current-home-only branch of
`assertHostedLinqRecentInboundEngagementForRuntime`. That guard pins a proactive
direct send to the runtime's member Linq home route so it cannot land in a
durable group thread. Thread containers hold no `HostedMemberRouting` row at
all — verified in production: every `hosted_thread_container` row has zero
matching `hosted_member_routing` rows — so a container runtime can never satisfy
a home-route requirement. Its only reachable route *is* the container thread the
assertion is being made against, so the guard rejected every proactive send it
could ever make.

## User goal / user-visible behavior

A scheduled automation bound to a group thread delivers into that group thread
again. Before this PR the send was rejected before provider dispatch, so the
group silently received nothing on every occurrence.

## User experience

Entry point is a scheduled automation occurrence inside a group thread; there is
no interactive surface. The runtime resolves egress authority, dispatches to the
provider, and the message appears in the group thread on its normal scheduled
cadence. Timing class is unchanged — this is the same pre-provider authority
call the reply-anchored group path already makes successfully today. Failure
behavior is unchanged for every other caller: a member runtime that tries to
aim a proactive direct send at a durable group thread still receives the same
403. There is no `apps/web` presentation change and no rendered evidence to
capture.

## Invariants the PR must preserve

- Cross-container and personal-to-container egress is still refused: the
  `containerMemberId !== memberId` comparison is the sole gate on this branch
  and is unchanged.
- A personal runtime still cannot aim a proactive direct send at a durable
  group thread. That is now enforced structurally rather than by a second
  check: thread containers are synthetic members created with a fresh id
  (`ensureHostedThreadContainerRouteTx` -> `createHostedMember`, an ordinary
  `create`), so a personal member id can never own a thread route.
- A known group route never falls back to a personal home destination; the
  route-present branch returns the canonical group classification and no
  override.
- Route-absent sends still flow through the existing durable current/pending
  home resolver, so the stale-home redirect for personal automations is
  untouched.
- Container access is still asserted before route resolution
  (`assertActiveHostedThreadRouteContainerAccess`), so suspended or inactive
  containers stay blocked.
- Reply-anchored behavior, health policy, provider-boundary revalidation,
  dispatch fencing, and idempotency are unchanged.

## Non-obvious affected surfaces

- **Scheduled cron route resolution** (`resolveAssistantCronAuthorizedNotification-
  DeliveryRoute` in `packages/assistant-engine`). It sends
  `homeRouteFallbackAllowed: route.threadIsDirect !== false`, so an automation
  whose target never recorded `threadIsDirect` requests current-home-only
  semantics even when it is bound to a group thread. That caller is unchanged
  here; it now receives `threadIsDirect: false` from the authority response
  instead of a 403, which is what the declared-group path already returns.
  Downstream, a member-scope managed automation that resolves to a group thread
  still ends as an owner mismatch and is skipped — the correct outcome, now
  reached without an exception. Proof: existing assistant-engine cron authority
  tests, unchanged and green in CI.
- **No added database work.** The final shape adds no query on any path; it
  deletes one branch from the route-present path. The regression asserts
  `hostedMemberRouting.findUnique` is not reached for reply, current-home
  fallback, or foreign-route outcomes.

## Architecture and reuse

- **Existing systems reused:** `HostedThreadRoute.containerMemberId` is already
  the canonical owner record for an external thread, and the branch already
  compared it against the callback-authenticated runtime id. That comparison
  now carries the whole decision.
- **New logic:** None in the final shape. The diff removes the current-home-only
  disqualifier from the route-present branch so exact container ownership is
  the only gate, and deletes the predicate that supported it.
- **New abstractions:** None. No new state, no new contract, no new error code,
  no new query, and no change to the response shape.
- **Complexity intentionally avoided:** An earlier revision of this PR added a
  `HostedMemberRouting` lookup so the relaxation only applied to runtimes with
  no home route. Round-1 review showed that guards an unreachable state — a
  personal member can never become a container member — so it was a second
  authority owner for a route the container model already owns. It was deleted
  rather than kept as defence in depth. Also avoided: changing how
  `homeRouteFallbackAllowed` is computed in the cron caller, adding an
  is-container flag to the request contract, and any repair or backfill for
  automation targets that never recorded `threadIsDirect`.

## Hot reply path impact

Not applicable. The changed branch is only reached by proactive
(`homeRouteFallbackAllowed`, no reply anchor, no answered mailbox items) egress
assertions. Foreground conversation replies carry a reply anchor or answered
mailbox items, so they do not enter the current-home-only predicate and gain no
database call.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. No prompt file, tool
definition, tool schema, deferral metadata, Codex configuration, or provider
request assembly changed; the diff is one web authority predicate and its tests.

## Preliminary specialist lenses

- **Product experience: applicable.** Intended outcome is that a scheduled
  group automation reaches its group thread instead of failing closed forever.
  Direct journey evidence is the production log/database trace described above
  (403 recurrence in fixed hourly slots, container runtimes with no routing
  row, and a sibling container succeeding on the reply-anchored path in the same
  window). No end-user interactive surface changed. Preliminary pass returned
  `SPECIALIST_OUTCOME: PASS` with no findings at head 02ab69f795.
- **Prompt: not applicable.** No prompt text or builder changed.
- **Frontend: not applicable.** No `apps/web` presentation change.
- **Coverage: applicable.** Focused local proof:
  `vitest run --config apps/web/vitest.workspace.ts apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts apps/web/test/hosted-onboarding-linq-transport.test.ts`
  (120 passed), plus `pnpm test:diff` and `pnpm typecheck` green at the first
  head. The container regression was confirmed to fail against the unmodified
  source both before and after the round-1 simplification. Exact-head CI: all
  15 required checks passed at 02ab69f795; rerunning for the current head.

ReviewGPT first-reviewed head: 02ab69f795bbe8ff0f77554b16c96454a834a0c3

ReviewGPT context sensitivity: sensitive

Trust-boundary change: it relaxes an egress authority guard on a hosted runtime
callback.

## Change-shape breakdown

Classification rule: path-based. `apps/web/src/**` is source; `apps/web/test/**`
is tests/fixtures. No binary files, no generated files, no docs or config in
this diff. Counts are base-to-current-head; the round-1 remediation deleted more
than it added, so they are below the first-reviewed baseline.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 6 | 14 |
| Tests/fixtures | 28 | 9 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **34** | **23** |

## Design proof for user-facing frontend UI

Not applicable. No user-facing frontend UI diff.

## Deployment skew / compatibility

Web-only change behind an existing runtime callback whose request and response
shapes are untouched, so warm runner containers on the previous bundle need no
coordination and either deploy order is safe. Deploying web alone is sufficient
and is the recommended order. During rollout, requests served by the old web
build keep returning the current 403 — the behavior in production today — so
skew degrades to the status quo rather than to a new failure. Reversibility is a
plain revert with no persisted state to unwind. Current exposure is small:
production holds 31 thread containers and 30 Linq thread routes, and the
observed failure rate was 60 rejected assertions in 12 hours. Post-deploy check:
watch `/api/internal/hosted-runtime/linq-egress/engagement` for
`HOSTED_LINQ_EGRESS_ROUTE_AUTHORITY_MISMATCH` and confirm the fixed hourly
403 slots stop.
