### PR TITLE
fix(cloudflare): preserve partial database telemetry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1056,7 +1056,9 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   consecutive incomplete or failed collections. One bounded obligation in the
   existing incident row survives a busy pending slot, restart, and recovery
   until a telemetry-bearing page is acknowledged; complete collection then
-  rearms the next outage. Concrete unsafe conditions retain paced recurrence. First-incident
+  rearms the next outage. Its additive columns preserve the existing schema
+  version so the prior Worker remains rollback-compatible. Concrete unsafe
+  conditions retain paced recurrence. First-incident
   and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1053,8 +1053,10 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   family stays null and its canonical allowlisted name is retained, while
   available families continue to drive their own conditions. Missing data is
   never treated as zero. A telemetry-only incident pages once after two
-  consecutive incomplete or failed collections and rearms only after a complete
-  sample; concrete unsafe conditions retain paced recurrence. First-incident
+  consecutive incomplete or failed collections. One bounded obligation in the
+  existing incident row survives a busy pending slot, restart, and recovery
+  until a telemetry-bearing page is acknowledged; complete collection then
+  rearms the next outage. Concrete unsafe conditions retain paced recurrence. First-incident
   and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1058,15 +1058,20 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   until a telemetry-bearing page is acknowledged. Recovery and another metric
   gap before that acknowledgment coalesce into the same unresolved operator
   notification instead of creating a backlog; the first threshold's bounded
-  evidence and observation time remain authoritative. An owed telemetry page does not
-  occupy a closed provider fence: the next eligible sample includes any current
-  unsafe database evidence, with historical telemetry labeled by its own
-  observation time. A later complete collection rearms telemetry only after the
-  obligation is acknowledged. Its additive columns preserve the existing schema
+  evidence and observation time remain authoritative. An owed telemetry page
+  alone does not occupy a closed provider fence. A newly opened incident still
+  persists its current concrete evidence without the telemetry marker, so the
+  exact pressure event owns the next eligible attempt while telemetry remains
+  owed behind it. An acknowledged-incident recurrence waits for the eligible
+  sample, which includes any still-current unsafe evidence and labels historical
+  telemetry by its own observation time. A later complete collection rearms
+  telemetry only after the obligation is acknowledged. Its additive columns
+  preserve the existing schema
   version; current code also recognizes a telemetry pending body cleared by the
   prior Worker, preventing a duplicate after rollback and re-upgrade. Concrete
-  unsafe conditions retain paced recurrence, but acknowledged monitoring evidence
-  cannot enter their later pages without a currently owed obligation. First-incident
+  unsafe conditions retain paced recurrence, but acknowledged monitoring
+  evidence cannot enter their later pages without a currently owed obligation.
+  First-incident
   and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1060,8 +1060,9 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   notification instead of creating a backlog; the first threshold's bounded
   evidence and observation time remain authoritative. An owed telemetry page
   alone does not occupy a closed provider fence. Before an incident admits its
-  first page, concrete evidence that appears on the threshold or a later sample
-  persists in one combined immutable body, so the exact pressure and truthful
+  first page, concrete evidence—including a direct-error delta—that appears on
+  the threshold or a later sample persists in one combined immutable body, so
+  the exact pressure and truthful
   telemetry facts share the next eligible attempt and one acknowledgment cycle.
   An acknowledged-incident recurrence waits for the eligible sample, which
   includes any still-current unsafe evidence and labels

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1065,7 +1065,8 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   obligation is acknowledged. Its additive columns preserve the existing schema
   version; current code also recognizes a telemetry pending body cleared by the
   prior Worker, preventing a duplicate after rollback and re-upgrade. Concrete
-  unsafe conditions retain paced recurrence. First-incident
+  unsafe conditions retain paced recurrence, but acknowledged monitoring evidence
+  cannot enter their later pages without a currently owed obligation. First-incident
   and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1059,11 +1059,12 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   gap before that acknowledgment coalesce into the same unresolved operator
   notification instead of creating a backlog; the first threshold's bounded
   evidence and observation time remain authoritative. An owed telemetry page
-  alone does not occupy a closed provider fence. A newly opened incident with
-  concrete evidence persists one combined immutable body, so the exact pressure
-  and truthful telemetry facts share the next eligible attempt and one
-  acknowledgment cycle. An acknowledged-incident recurrence waits for the
-  eligible sample, which includes any still-current unsafe evidence and labels
+  alone does not occupy a closed provider fence. Before an incident admits its
+  first page, concrete evidence that appears on the threshold or a later sample
+  persists in one combined immutable body, so the exact pressure and truthful
+  telemetry facts share the next eligible attempt and one acknowledgment cycle.
+  An acknowledged-incident recurrence waits for the eligible sample, which
+  includes any still-current unsafe evidence and labels
   historical telemetry by its own observation time. A later complete collection rearms
   telemetry only after the obligation is acknowledged. Its additive columns
   preserve the existing schema

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1059,12 +1059,12 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   gap before that acknowledgment coalesce into the same unresolved operator
   notification instead of creating a backlog; the first threshold's bounded
   evidence and observation time remain authoritative. An owed telemetry page
-  alone does not occupy a closed provider fence. A newly opened incident still
-  persists its current concrete evidence without the telemetry marker, so the
-  exact pressure event owns the next eligible attempt while telemetry remains
-  owed behind it. An acknowledged-incident recurrence waits for the eligible
-  sample, which includes any still-current unsafe evidence and labels historical
-  telemetry by its own observation time. A later complete collection rearms
+  alone does not occupy a closed provider fence. A newly opened incident with
+  concrete evidence persists one combined immutable body, so the exact pressure
+  and truthful telemetry facts share the next eligible attempt and one
+  acknowledgment cycle. An acknowledged-incident recurrence waits for the
+  eligible sample, which includes any still-current unsafe evidence and labels
+  historical telemetry by its own observation time. A later complete collection rearms
   telemetry only after the obligation is acknowledged. Its additive columns
   preserve the existing schema
   version; current code also recognizes a telemetry pending body cleared by the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1052,13 +1052,20 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   admission state. Metric families normalize independently: an unavailable
   family stays null and its canonical allowlisted name is retained, while
   available families continue to drive their own conditions. Missing data is
-  never treated as zero. A telemetry-only incident pages once after two
+  never treated as zero. A telemetry-only notification opens after two
   consecutive incomplete or failed collections. One bounded obligation in the
   existing incident row survives a busy pending slot, restart, and recovery
-  until a telemetry-bearing page is acknowledged; complete collection then
-  rearms the next outage. Its additive columns preserve the existing schema
-  version so the prior Worker remains rollback-compatible. Concrete unsafe
-  conditions retain paced recurrence. First-incident
+  until a telemetry-bearing page is acknowledged. Recovery and another metric
+  gap before that acknowledgment coalesce into the same unresolved operator
+  notification instead of creating a backlog; the first threshold's bounded
+  evidence and observation time remain authoritative. An owed telemetry page does not
+  occupy a closed provider fence: the next eligible sample includes any current
+  unsafe database evidence, with historical telemetry labeled by its own
+  observation time. A later complete collection rearms telemetry only after the
+  obligation is acknowledged. Its additive columns preserve the existing schema
+  version; current code also recognizes a telemetry pending body cleared by the
+  prior Worker, preventing a duplicate after rollback and re-upgrade. Concrete
+  unsafe conditions retain paced recurrence. First-incident
   and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1049,7 +1049,13 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   branch-local PgBouncer and Postgres connection conditions, and page two
   preconfigured direct operator Linq chats. Its SQLite contains only counts,
   ratios, bounded state maps, error-counter baselines, failure codes, and alert
-  admission state. First-incident and non-replayable direct-error alert
+  admission state. Metric families normalize independently: an unavailable
+  family stays null and its canonical allowlisted name is retained, while
+  available families continue to drive their own conditions. Missing data is
+  never treated as zero. A telemetry-only incident pages once after two
+  consecutive incomplete or failed collections and rearms only after a complete
+  sample; concrete unsafe conditions retain paced recurrence. First-incident
+  and non-replayable direct-error alert
   admission shares one synchronous SQLite transaction with sample/baseline
   persistence; an inside-fence direct-error body excludes co-occurring
   replayable evidence, and acknowledged replayable recurrence is admitted only

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1053,12 +1053,16 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   family stays null and its canonical allowlisted name is retained, while
   available families continue to drive their own conditions. Missing data is
   never treated as zero. A telemetry-only notification opens after two
-  consecutive incomplete or failed collections. One bounded obligation in the
+  consecutive incomplete or failed collections. The first two-check threshold
+  window counts incomplete versus unavailable observations, unions only
+  canonical missing families observed on partial checks, and uses the threshold
+  time as the window end; one bounded evidence value on each existing sample
+  preserves that provenance across restart. One bounded obligation in the
   existing incident row survives a busy pending slot, restart, and recovery
   until a telemetry-bearing page is acknowledged. Recovery and another metric
   gap before that acknowledgment coalesce into the same unresolved operator
-  notification instead of creating a backlog; the first threshold's bounded
-  evidence and observation time remain authoritative. An owed telemetry page
+  notification instead of creating a backlog; the first threshold window remains
+  authoritative. An owed telemetry page
   alone does not occupy a closed provider fence. Before an incident admits its
   first page, concrete evidence—including a direct-error delta—that appears on
   the threshold or a later sample persists in one combined immutable body, so
@@ -1067,7 +1071,8 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   An acknowledged-incident recurrence waits for the eligible sample, which
   includes any still-current unsafe evidence and labels
   historical telemetry by its own observation time. A later complete collection rearms
-  telemetry only after the obligation is acknowledged. Its additive columns
+  telemetry only after the obligation is acknowledged. Its additive alert-state
+  and sample-evidence columns
   preserve the existing schema
   version; current code also recognizes a telemetry pending body cleared by the
   prior Worker, preventing a duplicate after rollback and re-upgrade. Concrete

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -189,7 +189,11 @@ Last verified: 2026-08-07
   its canonical allowlisted name is retained with the failed sample and warning,
   and every available signal is still evaluated. No unknown value becomes zero.
   Discovery, scrape, parse, or incomplete required metrics must recur on two
-  consecutive runs before paging the monitoring condition.
+  consecutive runs before paging the monitoring condition. Crossing that
+  threshold persists one bounded telemetry-page obligation in the existing
+  incident row. It survives an occupied pending-message slot, restart, recovery,
+  and direct-error-only prioritization; only acknowledgment of a pending body
+  that includes the monitoring condition clears it.
   A newly opened incident or one-shot direct migration admission failure admits
   its exact body and idempotency key in the same synchronous SQLite transaction
   that persists the sample and advances any direct-error counter baseline.
@@ -215,8 +219,9 @@ Last verified: 2026-08-07
   current gauge admits the recurrence. An acknowledged telemetry-only incident
   is one-shot while collection remains continuously incomplete or unavailable;
   its current samples remain queryable, but they do not admit repeated pages.
-  A complete healthy sample closes that incident and rearms a future telemetry
-  outage. An already pending page is
+  A complete healthy sample cannot discard an unacknowledged telemetry
+  obligation. Once any owed page is acknowledged, complete collection closes
+  that incident and rearms a future telemetry outage. An already pending page is
   processed or deferred before a later clean sample can close the incident,
   and only an acknowledged provider response clears it. Provider entry is
   globally fenced by the persisted last-attempt

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -216,10 +216,12 @@ Last verified: 2026-08-07
   closed attempt fence, that pending body contains the non-replayable direct
   error plus any durable telemetry obligation already available at admission;
   co-occurring replayable gauges remain in the persisted sample but cannot
-  become stale pending claims. The direct error keeps its original check time,
-  while historical telemetry carries its separate observation time. That exact
-  combined page owns the next eligible attempt and acknowledgment clears the
-  represented telemetry obligation, avoiding a second notification lifecycle.
+  become stale pending claims. Pure deferred evidence keeps its stored check
+  time; when a current direct-error delta joins the promoted count, the page uses
+  the latest included check. Historical telemetry carries its separate
+  observation time. That exact combined page owns the next eligible attempt and
+  acknowledgment clears the represented telemetry obligation, avoiding a
+  second notification lifecycle.
   A replayable condition still unsafe at that boundary remains eligible for the
   following paced recurrence. The same one-slot ordering applies in reverse: a
   later direct-error obligation waits behind an older page but cannot be consumed

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -225,8 +225,9 @@ Last verified: 2026-08-07
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does
   not occupy a closed provider fence. Until an incident admits its first page,
-  concrete evidence that appears on the threshold or a later sample persists in
-  one combined immutable body with exact identity, concrete check time, and
+  concrete evidence, including a direct-error delta, that appears on the
+  threshold or a later sample persists in one combined immutable body with
+  exact identity, concrete check time, and
   condition-local telemetry time; both facts share the first eligible attempt
   and one acknowledgment cycle. For an acknowledged-incident
   recurrence, the first eligible sample supplies any still-current concrete

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -229,8 +229,9 @@ Last verified: 2026-08-07
   historical telemetry evidence carries its own observation time. An
   acknowledged telemetry-only notification is one-shot while collection remains
   continuously incomplete or unavailable; its current samples remain queryable,
-  but they do not admit repeated pages. A complete healthy sample cannot discard
-  an unacknowledged telemetry obligation or rearm a separately recovered gap.
+  but they do not admit repeated pages or add monitoring copy to concrete-pressure
+  recurrences without a currently owed obligation. A complete healthy sample
+  cannot discard an unacknowledged telemetry obligation or rearm a separately recovered gap.
   Once any owed page is acknowledged, complete collection closes that incident
   and rearms telemetry. An already pending page is
   processed or deferred before a later clean sample can close the incident,

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -184,8 +184,12 @@ Last verified: 2026-08-07
   owner. A five-minute Cron Trigger records one normalized PlanetScale sample
   or classified failure in Durable Object SQLite and prunes history after 30
   days. A two-minute persisted run lease coalesces overlapping cron delivery.
-  Concrete unhealthy gauges page immediately; discovery, scrape, parse, or
-  required-metric absence must recur on two consecutive runs before paging.
+  Concrete unhealthy gauges page immediately. Metric families are normalized
+  independently: an absent or structurally unusable family remains unknown,
+  its canonical allowlisted name is retained with the failed sample and warning,
+  and every available signal is still evaluated. No unknown value becomes zero.
+  Discovery, scrape, parse, or incomplete required metrics must recur on two
+  consecutive runs before paging the monitoring condition.
   A newly opened incident or one-shot direct migration admission failure admits
   its exact body and idempotency key in the same synchronous SQLite transaction
   that persists the sample and advances any direct-error counter baseline.
@@ -206,10 +210,13 @@ Last verified: 2026-08-07
   behind an older page but cannot be consumed by the counter baseline. This
   explicit prioritization keeps admitted bodies immutable without another
   message queue or delivery lifecycle.
-  An acknowledged incident's replayable gauge or monitoring recurrence does
-  not admit stale evidence while the attempt fence is closed; once the fence
-  opens, a still-unsafe current sample admits the recurrence, while recovery
-  closes the incident without another page. An already pending page is
+  An acknowledged incident's replayable gauge does not admit stale evidence
+  while the attempt fence is closed; once the fence opens, a still-unsafe
+  current gauge admits the recurrence. An acknowledged telemetry-only incident
+  is one-shot while collection remains continuously incomplete or unavailable;
+  its current samples remain queryable, but they do not admit repeated pages.
+  A complete healthy sample closes that incident and rearms a future telemetry
+  outage. An already pending page is
   processed or deferred before a later clean sample can close the incident,
   and only an acknowledged provider response clears it. Provider entry is
   globally fenced by the persisted last-attempt
@@ -239,8 +246,10 @@ Last verified: 2026-08-07
   destination keys for the next eligible cycle; only acknowledged entry to both
   distinct recipients clears the pending alert. An idempotent replay of a
   destination that already succeeded cannot produce another recipient-visible
-  message. Acknowledged recurrences advance the alert
+  message. Acknowledged concrete-condition recurrences advance the alert
   sequence and choose another fixed opening from current metric evidence.
+  Telemetry-only copy instead states that monitoring is incomplete or
+  unavailable and cannot claim that the database itself is under pressure.
   Message variation must remain contextual and deterministic, never random
   padding. Database pages intentionally have no quiet hours.
 - Linq edit delivery is at-least-once and remains owned by the existing hosted

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -193,8 +193,14 @@ Last verified: 2026-08-07
   threshold persists one bounded telemetry-page obligation in the existing
   incident row. It survives an occupied pending-message slot, restart, recovery,
   and direct-error-only prioritization; only acknowledgment of a pending body
-  that includes the monitoring condition clears it. The additive columns retain
-  the existing schema version so a rollback Worker can safely ignore them.
+  that includes the monitoring condition clears it. Recovery and another
+  threshold before acknowledgment deliberately coalesce into that unresolved
+  notification, retaining the first threshold's bounded evidence and observation
+  time; this monitor does not maintain an outage backlog. The additive
+  columns retain the existing schema version so a rollback Worker can ignore
+  them. Current code recognizes the prior Worker's cleared pending key/body with
+  the telemetry marker still set as an acknowledgment and removes the stale
+  obligation before re-admission.
   A newly opened incident or one-shot direct migration admission failure admits
   its exact body and idempotency key in the same synchronous SQLite transaction
   that persists the sample and advances any direct-error counter baseline.
@@ -217,12 +223,16 @@ Last verified: 2026-08-07
   message queue or delivery lifecycle.
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
-  current gauge admits the recurrence. An acknowledged telemetry-only incident
-  is one-shot while collection remains continuously incomplete or unavailable;
-  its current samples remain queryable, but they do not admit repeated pages.
-  A complete healthy sample cannot discard an unacknowledged telemetry
-  obligation. Once any owed page is acknowledged, complete collection closes
-  that incident and rearms a future telemetry outage. An already pending page is
+  current gauge admits the recurrence. An unadmitted monitoring obligation does
+  not occupy a closed provider fence. At the first eligible sample, current
+  concrete database evidence shares the page and keeps its ordinary recurrence;
+  historical telemetry evidence carries its own observation time. An
+  acknowledged telemetry-only notification is one-shot while collection remains
+  continuously incomplete or unavailable; its current samples remain queryable,
+  but they do not admit repeated pages. A complete healthy sample cannot discard
+  an unacknowledged telemetry obligation or rearm a separately recovered gap.
+  Once any owed page is acknowledged, complete collection closes that incident
+  and rearms telemetry. An already pending page is
   processed or deferred before a later clean sample can close the incident,
   and only an acknowledged provider response clears it. Provider entry is
   globally fenced by the persisted last-attempt

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -224,9 +224,10 @@ Last verified: 2026-08-07
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does
-  not occupy a closed provider fence. A newly opened incident still persists its
-  current concrete evidence alone, with exact identity and check time, while the
-  telemetry obligation remains owed behind it. For an acknowledged-incident
+  not occupy a closed provider fence. A newly opened incident with concrete
+  evidence persists one combined immutable body with exact identity, concrete
+  check time, and condition-local telemetry time; both facts share the first
+  eligible attempt and one acknowledgment cycle. For an acknowledged-incident
   recurrence, the first eligible sample supplies any still-current concrete
   evidence and historical telemetry carries its own observation time. An
   acknowledged telemetry-only notification is one-shot while collection remains

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -209,18 +209,22 @@ Last verified: 2026-08-07
   direct-error count plus latest check time in the existing alert row instead
   of dropping it. An acknowledged older page cannot close the incident while
   that evidence remains. The next run with a free slot atomically promotes the
-  accumulated count into one direct-error page, which then follows the ordinary
-  attempt fence, health preflight, exact-body retry, and restart contract.
+  accumulated count into one non-replayable page, retaining any owed telemetry
+  condition in the same body, which then follows the ordinary attempt fence,
+  health preflight, exact-body retry, and restart contract.
   When a direct error forces admission inside an acknowledged incident's
-  closed attempt fence, that pending body contains only the non-replayable
-  direct-error evidence; co-occurring replayable gauges remain in the persisted
-  sample but cannot become stale pending claims. That exact direct-error page
-  owns the next eligible attempt. A replayable condition still unsafe at that
-  boundary remains eligible for the following paced recurrence. The same
-  one-slot ordering applies in reverse: a later direct-error obligation waits
-  behind an older page but cannot be consumed by the counter baseline. This
-  explicit prioritization keeps admitted bodies immutable without another
-  message queue or delivery lifecycle.
+  closed attempt fence, that pending body contains the non-replayable direct
+  error plus any durable telemetry obligation already available at admission;
+  co-occurring replayable gauges remain in the persisted sample but cannot
+  become stale pending claims. The direct error keeps its original check time,
+  while historical telemetry carries its separate observation time. That exact
+  combined page owns the next eligible attempt and acknowledgment clears the
+  represented telemetry obligation, avoiding a second notification lifecycle.
+  A replayable condition still unsafe at that boundary remains eligible for the
+  following paced recurrence. The same one-slot ordering applies in reverse: a
+  later direct-error obligation waits behind an older page but cannot be consumed
+  by the counter baseline. This explicit prioritization keeps admitted bodies
+  immutable without another message queue or delivery lifecycle.
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -193,7 +193,8 @@ Last verified: 2026-08-07
   threshold persists one bounded telemetry-page obligation in the existing
   incident row. It survives an occupied pending-message slot, restart, recovery,
   and direct-error-only prioritization; only acknowledgment of a pending body
-  that includes the monitoring condition clears it.
+  that includes the monitoring condition clears it. The additive columns retain
+  the existing schema version so a rollback Worker can safely ignore them.
   A newly opened incident or one-shot direct migration admission failure admits
   its exact body and idempotency key in the same synchronous SQLite transaction
   that persists the sample and advances any direct-error counter baseline.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -224,14 +224,17 @@ Last verified: 2026-08-07
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does
-  not occupy a closed provider fence. At the first eligible sample, current
-  concrete database evidence shares the page and keeps its ordinary recurrence;
-  historical telemetry evidence carries its own observation time. An
+  not occupy a closed provider fence. A newly opened incident still persists its
+  current concrete evidence alone, with exact identity and check time, while the
+  telemetry obligation remains owed behind it. For an acknowledged-incident
+  recurrence, the first eligible sample supplies any still-current concrete
+  evidence and historical telemetry carries its own observation time. An
   acknowledged telemetry-only notification is one-shot while collection remains
   continuously incomplete or unavailable; its current samples remain queryable,
   but they do not admit repeated pages or add monitoring copy to concrete-pressure
   recurrences without a currently owed obligation. A complete healthy sample
-  cannot discard an unacknowledged telemetry obligation or rearm a separately recovered gap.
+  cannot discard an unacknowledged telemetry obligation or rearm a separately
+  recovered gap.
   Once any owed page is acknowledged, complete collection closes that incident
   and rearms telemetry. An already pending page is
   processed or deferred before a later clean sample can close the incident,

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -224,10 +224,11 @@ Last verified: 2026-08-07
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does
-  not occupy a closed provider fence. A newly opened incident with concrete
-  evidence persists one combined immutable body with exact identity, concrete
-  check time, and condition-local telemetry time; both facts share the first
-  eligible attempt and one acknowledgment cycle. For an acknowledged-incident
+  not occupy a closed provider fence. Until an incident admits its first page,
+  concrete evidence that appears on the threshold or a later sample persists in
+  one combined immutable body with exact identity, concrete check time, and
+  condition-local telemetry time; both facts share the first eligible attempt
+  and one acknowledgment cycle. For an acknowledged-incident
   recurrence, the first eligible sample supplies any still-current concrete
   evidence and historical telemetry carries its own observation time. An
   acknowledged telemetry-only notification is one-shot while collection remains

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -191,16 +191,19 @@ Last verified: 2026-08-07
   Discovery, scrape, parse, or incomplete required metrics must recur on two
   consecutive runs before paging the monitoring condition. Crossing that
   threshold persists one bounded telemetry-page obligation in the existing
-  incident row. It survives an occupied pending-message slot, restart, recovery,
-  and direct-error-only prioritization; only acknowledgment of a pending body
-  that includes the monitoring condition clears it. Recovery and another
-  threshold before acknowledgment deliberately coalesce into that unresolved
-  notification, retaining the first threshold's bounded evidence and observation
-  time; this monitor does not maintain an outage backlog. The additive
-  columns retain the existing schema version so a rollback Worker can ignore
-  them. Current code recognizes the prior Worker's cleared pending key/body with
-  the telemetry marker still set as an acknowledgment and removes the stale
-  obligation before re-admission.
+  incident row. The represented first two-check window counts incomplete versus
+  unavailable observations, unions only canonical missing families observed on
+  partial checks, and uses the threshold time as its window end. One bounded
+  evidence value on each existing sample preserves that aggregate provenance
+  across restart. The obligation survives an occupied pending-message slot,
+  restart, recovery, and direct-error-only prioritization; only acknowledgment
+  of a pending body that includes the monitoring condition clears it. Recovery
+  and another threshold before acknowledgment deliberately coalesce into that
+  unresolved notification, retaining the first threshold window; this monitor
+  does not maintain an outage backlog. The additive columns retain the existing
+  schema version so a rollback Worker can ignore them. Current code recognizes
+  the prior Worker's cleared pending key/body with the telemetry marker still set
+  as an acknowledgment and removes the stale obligation before re-admission.
   A newly opened incident or one-shot direct migration admission failure admits
   its exact body and idempotency key in the same synchronous SQLite transaction
   that persists the sample and advances any direct-error counter baseline.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -128,4 +128,10 @@ Updated: 2026-08-09
   restart, clears the obligation after both recipients acknowledge it, and
   produces no second provider attempt. The focused close/reopen, mixed-threshold,
   recovery, restart, and both-recipient regression covers the correction. Final
-  ReviewGPT round 6 remains pending.
+  ReviewGPT round 6 found that `incidentOpen` still misclassified an unadmitted
+  telemetry incident as an acknowledged recurrence when pressure began on the
+  following sample. The accepted correction derives admission from the existing
+  zero alert sequence instead: pressure appearing before the first page creates
+  the same combined immutable body. A focused delayed-pressure, recovery,
+  restart, both-recipient, acknowledgment, and no-second-attempt regression
+  covers the path. Final ReviewGPT round 7 remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -1,0 +1,81 @@
+# Database health telemetry incident remediation
+
+Status: active
+Created: 2026-08-09
+Updated: 2026-08-09
+
+## Goal
+
+- Keep genuine production database-pressure conditions fail-closed and recurring.
+- Report PlanetScale telemetry loss as a monitoring outage, not as evidence that
+  the database itself is degraded.
+- Send one acknowledged operator page per uninterrupted telemetry outage while
+  retaining paced exact-body retries for failed or ambiguous delivery.
+- Preserve a bounded, allowlisted record of which required metric families were
+  absent so the next provider-side outage is diagnosable without raw payloads.
+
+## Evidence
+
+- The production control database remained within its configured connection
+  capacity and had no waiting or idle-in-transaction sessions during the live
+  investigation.
+- The supplied bounded sample export contained only
+  `required_metrics_missing` failures, followed by successful samples without a
+  database restart.
+- The operator messages repeated every 30 to 35 minutes and used generic
+  database-pressure openings even though the only condition was unavailable
+  monitoring telemetry.
+- Existing persisted samples and warnings identify the failure class but not
+  the missing required metric family, so provider-specific root-cause proof is
+  unavailable for the completed incident.
+
+## Success criteria
+
+- Two consecutive telemetry failures still open and page a monitoring incident.
+- After both destinations acknowledge that page, continued telemetry failures
+  do not admit recurrent pages until a successful sample closes the incident.
+- A failed or ambiguous first page remains pending and retries under the existing
+  30-minute provider-attempt fence with the same body and idempotency keys.
+- A later successful sample closes the telemetry incident, and a fresh sequence
+  of failures can page again.
+- Real gauge and direct-migration conditions retain their existing recurrence,
+  ordering, and retry behavior.
+- Telemetry-only copy is calm and explicit that the monitor is blind; it does
+  not claim the database is under pressure.
+- Missing metric diagnostics contain only canonical allowlisted PlanetScale
+  metric names and never raw response data, labels, targets, credentials, chat
+  identities, or provider prose.
+
+## Scope
+
+- Cloudflare database-health metric parsing, alert admission, and focused tests.
+- Current Cloudflare and reliability owner documentation.
+
+## Constraints
+
+- No metric is made optional and no missing value is treated as zero.
+- No new state owner, queue, dependency, external service, or schema migration.
+- Preserve the existing transactional sample/admission boundary, global attempt
+  fence, destination health checks, and exact-body retry contract.
+- Do not deploy from this repository; production deployment remains owned by the
+  private deployment workflow after merge.
+
+## Tasks
+
+1. [x] Add bounded missing-family evidence to parse failures and monitoring
+   conditions.
+2. [x] Admit telemetry-only pages once per uninterrupted incident and make their
+   copy truthful while leaving genuine unsafe recurrence unchanged.
+3. [x] Add focused parser, retry, recurrence, recovery, and copy regressions.
+4. [x] Update the durable operational contract and run focused verification.
+5. [ ] Push the exact candidate, open the PR, and complete ReviewGPT plus CI.
+
+## Verification log
+
+- Focused Node Vitest: 3 files and 59 tests passed.
+- Focused Workers-runtime Vitest: 1 file and 1 test passed.
+- Cloudflare package typecheck passed.
+- Raw health/model/vault log guard passed.
+- Agent docs drift guard initially required the material owner-doc updates to be
+  indexed; `agent-docs/index.md` was synchronized and the rerun passed.
+- `git diff --check` passed.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -78,7 +78,7 @@ Updated: 2026-08-09
 
 ## Verification log
 
-- Focused Node Vitest after review remediation: 4 files and 65 tests passed.
+- Focused Node Vitest after review remediation: 4 files and 66 tests passed.
 - Focused Workers-runtime Vitest: 1 file and 1 test passed.
 - Cloudflare package typecheck passed.
 - Raw health/model/vault log guard passed.
@@ -108,4 +108,13 @@ Updated: 2026-08-09
   historical telemetry with its own observation time, and normalizes a
   telemetry pending body acknowledged by the rollback Worker. Focused repeated-
   threshold, restart, both-recipient, current-pressure-ordering, exact-copy, and
-  legacy-ack tests cover that decision. Final ReviewGPT round 3 remains pending.
+  legacy-ack tests cover that decision.
+- Final ReviewGPT round 3 found that current post-ack monitoring conditions could
+  still enter a concrete-pressure pending body, whose later success could clear a
+  different rearmed obligation. The correction deletes that fallback: alert
+  admission includes monitoring only from the durable obligation and cannot
+  create an empty body. A focused two-window regression proves the first page to
+  both recipients, a pressure-only ambiguous recurrence, recovery, a distinct
+  rearmed missing-family obligation across restart, exact old-body retry without
+  clearing it, and delivery of the second page to both recipients. Final
+  ReviewGPT round 4 remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -156,4 +156,17 @@ Updated: 2026-08-09
   uses the stored time, while a mixed aggregate uses the latest included check
   and telemetry retains its separate observation time. Focused telemetry-bearing
   and direct-only regressions cover both timestamp branches. ReviewGPT round 10
-  remains pending.
+  found the same aggregate-provenance mechanism in the original telemetry
+  threshold and required a new retrospective before remediation: mixed partial
+  and unavailable checks were labeled using only the threshold observation.
+  The continuation decision applies one rule across aggregates: count, category,
+  time, and evidence presented as one fact must describe the same represented
+  observations. The telemetry page will summarize the entire first two-check
+  threshold window, count incomplete versus unavailable checks, union canonical
+  missing families actually observed on partial checks, label that union as
+  observed evidence, and identify the threshold time as the window end. One
+  bounded per-sample monitoring-evidence value in the existing sample table is
+  sufficient to compose the existing obligation across restart; no backlog,
+  second identity, queue, scheduler, or lifecycle owner is added. Required proof
+  covers both mixed orders and two partial checks with different families,
+  including exact both-recipient delivery, restart/retry, and acknowledgment.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -93,8 +93,8 @@ Updated: 2026-08-09
   passed `git apply --check`; its full-outage-copy and malformed-label scenarios
   were incorporated and executed.
 - Final ReviewGPT round 1 independently found the same owed-page loss. No
-  additional finding was reported. Round 2 remains pending on the corrected
-  pushed head.
+  additional finding was reported. Later rounds reviewed each correction on a
+  new exact pushed head.
 - Parent rollout review replaced the schema-version bump with idempotent
   additive columns at the existing version, preserving compatibility with the
   previously deployed Worker during overlap or rollback.
@@ -118,10 +118,14 @@ Updated: 2026-08-09
   rearmed missing-family obligation across restart, exact old-body retry without
   clearing it, and delivery of the second page to both recipients.
 - Final ReviewGPT round 4 found that the closed-fence hold also suppressed a newly
-  opened incident's current concrete pressure. The narrowed admission persists
-  that new-incident pressure alone with exact identity and check time, leaves the
-  telemetry obligation owed behind it, and keeps telemetry-only plus
-  acknowledged-incident recurrence on the fresh eligible-sample path. A focused
-  close/reopen, mixed-threshold, recovery, restart, both-recipient pressure, and
-  later telemetry regression covers the correction. Final ReviewGPT round 5
-  remains pending.
+  opened incident's current concrete pressure. The correction retained that
+  pressure in an exact pending body while keeping telemetry-only plus
+  acknowledged-incident recurrence on the fresh eligible-sample path. Final
+  ReviewGPT round 5 confirmed the pressure-loss fix but found that the
+  intermediate pressure-only body created a second avoidable page and 30-minute
+  telemetry delay. The accepted net-deletion correction now retains one combined
+  body with exact identity and truthful telemetry evidence across recovery and
+  restart, clears the obligation after both recipients acknowledge it, and
+  produces no second provider attempt. The focused close/reopen, mixed-threshold,
+  recovery, restart, and both-recipient regression covers the correction. Final
+  ReviewGPT round 6 remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -149,4 +149,11 @@ Updated: 2026-08-09
   from promoted deferred direct evidence even when telemetry is also present.
   Focused inside-fence and deferred-promotion regressions prove exact identity,
   restart, recovery, both recipients, condition-local times, obligation cleanup,
-  and no second telemetry page. ReviewGPT round 9 remains pending.
+  and no second telemetry page. Final ReviewGPT round 9 found that the broadened
+  deferred-time predicate could date an aggregate containing both old deferred
+  errors and a new current delta to only the older sample. The accepted local
+  correction restores the current-delta distinction: pure deferred promotion
+  uses the stored time, while a mixed aggregate uses the latest included check
+  and telemetry retains its separate observation time. Focused telemetry-bearing
+  and direct-only regressions cover both timestamp branches. ReviewGPT round 10
+  remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -141,4 +141,12 @@ Updated: 2026-08-09
   there while preserving direct-only promotion behind an older admitted page.
   A focused three-condition, recovery, restart, both-recipient,
   acknowledgment, and no-second-attempt regression covers the path. Final
-  ReviewGPT round 8 remains pending.
+  ReviewGPT round 8 found that the deliberately retained direct-only path could
+  split an already owed telemetry fact from a non-replayable direct-error page,
+  forcing a second provider fence and acknowledgment lifecycle. The accepted
+  correction retains both durable non-replayable conditions in one immutable
+  body while still excluding replayable gauges, and derives the page check time
+  from promoted deferred direct evidence even when telemetry is also present.
+  Focused inside-fence and deferred-promotion regressions prove exact identity,
+  restart, recovery, both recipients, condition-local times, obligation cleanup,
+  and no second telemetry page. ReviewGPT round 9 remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -54,7 +54,9 @@ Updated: 2026-08-09
 ## Constraints
 
 - No metric is made optional and no missing value is treated as zero.
-- No new state owner, queue, dependency, external service, or schema migration.
+- No new state owner, queue, dependency, external service, or table. One
+  additive metadata-row migration may retain a bounded owed-page obligation
+  inside the existing Durable Object owner.
 - Preserve the existing transactional sample/admission boundary, global attempt
   fence, destination health checks, and exact-body retry contract.
 - Do not deploy from this repository; production deployment remains owned by the
@@ -72,10 +74,20 @@ Updated: 2026-08-09
 
 ## Verification log
 
-- Focused Node Vitest: 3 files and 59 tests passed.
+- Focused Node Vitest after review remediation: 4 files and 63 tests passed.
 - Focused Workers-runtime Vitest: 1 file and 1 test passed.
 - Cloudflare package typecheck passed.
 - Raw health/model/vault log guard passed.
 - Agent docs drift guard initially required the material owner-doc updates to be
   indexed; `agent-docs/index.md` was synchronized and the rerun passed.
 - `git diff --check` passed.
+- Preliminary ReviewGPT returned one accepted high-severity owed-page finding
+  and one accepted coverage finding. The implementation now retains a bounded
+  telemetry obligation behind older pending and direct-only pages across
+  restart and recovery. The attached coverage patch was downloaded from the
+  owned review thread, read in full, limited to one focused test file, and
+  passed `git apply --check`; its full-outage-copy and malformed-label scenarios
+  were incorporated and executed.
+- Final ReviewGPT round 1 independently found the same owed-page loss. No
+  additional finding was reported. Round 2 remains pending on the corrected
+  pushed head.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -134,4 +134,11 @@ Updated: 2026-08-09
   zero alert sequence instead: pressure appearing before the first page creates
   the same combined immutable body. A focused delayed-pressure, recovery,
   restart, both-recipient, acknowledgment, and no-second-attempt regression
-  covers the path. Final ReviewGPT round 7 remains pending.
+  covers the path. Final ReviewGPT round 7 found the neighboring direct-error
+  priority branch still used `incidentOpen` and could strip pressure plus
+  telemetry from that first page when a direct-error delta appeared on the later
+  sample. The accepted correction applies the same zero-sequence admission fact
+  there while preserving direct-only promotion behind an older admitted page.
+  A focused three-condition, recovery, restart, both-recipient,
+  acknowledgment, and no-second-attempt regression covers the path. Final
+  ReviewGPT round 8 remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -78,7 +78,7 @@ Updated: 2026-08-09
 
 ## Verification log
 
-- Focused Node Vitest after review remediation: 4 files and 66 tests passed.
+- Focused Node Vitest after review remediation: 4 files and 67 tests passed.
 - Focused Workers-runtime Vitest: 1 file and 1 test passed.
 - Cloudflare package typecheck passed.
 - Raw health/model/vault log guard passed.
@@ -116,5 +116,12 @@ Updated: 2026-08-09
   create an empty body. A focused two-window regression proves the first page to
   both recipients, a pressure-only ambiguous recurrence, recovery, a distinct
   rearmed missing-family obligation across restart, exact old-body retry without
-  clearing it, and delivery of the second page to both recipients. Final
-  ReviewGPT round 4 remains pending.
+  clearing it, and delivery of the second page to both recipients.
+- Final ReviewGPT round 4 found that the closed-fence hold also suppressed a newly
+  opened incident's current concrete pressure. The narrowed admission persists
+  that new-incident pressure alone with exact identity and check time, leaves the
+  telemetry obligation owed behind it, and keeps telemetry-only plus
+  acknowledged-incident recurrence on the fresh eligible-sample path. A focused
+  close/reopen, mixed-threshold, recovery, restart, both-recipient pressure, and
+  later telemetry regression covers the correction. Final ReviewGPT round 5
+  remains pending.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -91,3 +91,6 @@ Updated: 2026-08-09
 - Final ReviewGPT round 1 independently found the same owed-page loss. No
   additional finding was reported. Round 2 remains pending on the corrected
   pushed head.
+- Parent rollout review replaced the schema-version bump with idempotent
+  additive columns at the existing version, preserving compatibility with the
+  previously deployed Worker during overlap or rollback.

--- a/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-09-database-health-telemetry.md
@@ -9,8 +9,10 @@ Updated: 2026-08-09
 - Keep genuine production database-pressure conditions fail-closed and recurring.
 - Report PlanetScale telemetry loss as a monitoring outage, not as evidence that
   the database itself is degraded.
-- Send one acknowledged operator page per uninterrupted telemetry outage while
-  retaining paced exact-body retries for failed or ambiguous delivery.
+- Send one acknowledged operator page per unresolved telemetry-notification
+  window while retaining paced exact-body retries for failed or ambiguous
+  delivery. Recovery before acknowledgment coalesces instead of creating a
+  notification backlog.
 - Preserve a bounded, allowlisted record of which required metric families were
   absent so the next provider-side outage is diagnosable without raw payloads.
 
@@ -36,8 +38,8 @@ Updated: 2026-08-09
   do not admit recurrent pages until a successful sample closes the incident.
 - A failed or ambiguous first page remains pending and retries under the existing
   30-minute provider-attempt fence with the same body and idempotency keys.
-- A later successful sample closes the telemetry incident, and a fresh sequence
-  of failures can page again.
+- A successful sample closes and rearms telemetry only after any unresolved page
+  is acknowledged; intervening recovered gaps remain part of that notification.
 - Real gauge and direct-migration conditions retain their existing recurrence,
   ordering, and retry behavior.
 - Telemetry-only copy is calm and explicit that the monitor is blind; it does
@@ -66,15 +68,17 @@ Updated: 2026-08-09
 
 1. [x] Add bounded missing-family evidence to parse failures and monitoring
    conditions.
-2. [x] Admit telemetry-only pages once per uninterrupted incident and make their
-   copy truthful while leaving genuine unsafe recurrence unchanged.
+2. [x] Admit telemetry-only pages once per unresolved notification window,
+   preserve current-pressure priority at the first eligible provider slot, and
+   make historical copy truthful while leaving genuine unsafe recurrence
+   unchanged.
 3. [x] Add focused parser, retry, recurrence, recovery, and copy regressions.
 4. [x] Update the durable operational contract and run focused verification.
 5. [ ] Push the exact candidate, open the PR, and complete ReviewGPT plus CI.
 
 ## Verification log
 
-- Focused Node Vitest after review remediation: 4 files and 63 tests passed.
+- Focused Node Vitest after review remediation: 4 files and 65 tests passed.
 - Focused Workers-runtime Vitest: 1 file and 1 test passed.
 - Cloudflare package typecheck passed.
 - Raw health/model/vault log guard passed.
@@ -94,3 +98,14 @@ Updated: 2026-08-09
 - Parent rollout review replaced the schema-version bump with idempotent
   additive columns at the existing version, preserving compatibility with the
   previously deployed Worker during overlap or rollback.
+- Final ReviewGPT round 2 required a second anomaly retrospective after proving
+  that two recovered threshold epochs cannot both fit one bounded obligation and
+  that early telemetry admission could overtake current pressure. The chosen
+  contract coalesces all thresholds before acknowledgment into one unresolved
+  notification with the first threshold's evidence, holds unadmitted telemetry
+  outside a closed provider fence,
+  includes current unsafe evidence at the first eligible sample, labels
+  historical telemetry with its own observation time, and normalizes a
+  telemetry pending body acknowledged by the rollback Worker. Focused repeated-
+  threshold, restart, both-recipient, current-pressure-ordering, exact-copy, and
+  legacy-ack tests cover that decision. Final ReviewGPT round 3 remains pending.

--- a/agent-docs/exec-plans/completed/2026-08-09-database-health-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-09-database-health-telemetry.md
@@ -1,6 +1,6 @@
 # Database health telemetry incident remediation
 
-Status: active
+Status: completed
 Created: 2026-08-09
 Updated: 2026-08-09
 
@@ -74,11 +74,11 @@ Updated: 2026-08-09
    unchanged.
 3. [x] Add focused parser, retry, recurrence, recovery, and copy regressions.
 4. [x] Update the durable operational contract and run focused verification.
-5. [ ] Push the exact candidate, open the PR, and complete ReviewGPT plus CI.
+5. [x] Push the exact candidate, open the PR, and complete ReviewGPT plus CI.
 
 ## Verification log
 
-- Focused Node Vitest after review remediation: 4 files and 67 tests passed.
+- Focused Node Vitest after review remediation: 4 files and 74 tests passed.
 - Focused Workers-runtime Vitest: 1 file and 1 test passed.
 - Cloudflare package typecheck passed.
 - Raw health/model/vault log guard passed.
@@ -170,3 +170,16 @@ Updated: 2026-08-09
   second identity, queue, scheduler, or lifecycle owner is added. Required proof
   covers both mixed orders and two partial checks with different families,
   including exact both-recipient delivery, restart/retry, and acknowledgment.
+- Final ReviewGPT round 11 reviewed the complete sensitive patch on the exact
+  pushed candidate and passed with no qualifying finding. Requested-model
+  verification confirmed the response model.
+- All required GitHub Actions checks passed on that exact candidate, including
+  release app verification, package coverage, build/typecheck, host matrices,
+  hosted billing proof, repo hygiene, and frontend proof.
+- The parent final review found no additional defect in the partial-observation
+  parser, bounded evidence migration, alert admission, immutable retry identity,
+  both-recipient acknowledgment, or obligation cleanup paths. The worktree was
+  clean at the reviewed commit.
+- After fetching the latest `main`, GitHub reported the candidate mergeable and
+  a local merge-tree proof completed without conflicts.
+Completed: 2026-08-09

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -16,7 +16,8 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
-priority including one combined pre-first-page incident, post-ack recurrence
+priority including direct errors in one combined pre-first-page incident,
+post-ack recurrence
 suppression, durable owed-page preservation, and rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -1,6 +1,6 @@
 # Murph Agent Docs Index
 
-Last verified: 2026-08-07
+Last verified: 2026-08-09
 
 ## Purpose
 
@@ -12,6 +12,12 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 `agent-docs/SECURITY.md`, `agent-docs/RELIABILITY.md`,
 `agent-docs/operations/verification-and-runtime.md`, and
 `agent-docs/references/testing-ci-map.md`.
+
+Independent partial PlanetScale metric normalization, explicit unknown-family
+evidence, continued evaluation of available database signals, and one-shot
+telemetry-only operator paging are jointly specified by `ARCHITECTURE.md`,
+`agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
+`apps/cloudflare/README.md`.
 
 Automatic meal-photo schema-v2 enrollment ordering, including the one-row
 per-installation revision fence, credential-free revocation tombstone,

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -16,8 +16,8 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
-priority, durable owed-page preservation, and rollback-compatible additive state
-are jointly specified by `ARCHITECTURE.md`,
+priority, post-ack recurrence suppression, durable owed-page preservation, and
+rollback-compatible additive state are jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.
 

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -15,7 +15,8 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
-telemetry-only operator paging are jointly specified by `ARCHITECTURE.md`,
+telemetry-only operator paging with durable owed-page preservation are jointly
+specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.
 

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -16,8 +16,8 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
-priority including exact new-incident retention, post-ack recurrence suppression,
-durable owed-page preservation, and rollback-compatible additive state are
+priority including one combined new-incident page, post-ack recurrence
+suppression, durable owed-page preservation, and rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -15,8 +15,8 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
-telemetry-only operator paging with durable owed-page preservation are jointly
-specified by `ARCHITECTURE.md`,
+telemetry-only operator paging with durable owed-page preservation and
+rollback-compatible additive state are jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.
 

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -18,7 +18,8 @@ evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
 priority including direct errors in one combined pre-first-page incident,
 post-ack recurrence suppression, durable owed-page preservation inside
-non-replayable direct-error admission, and rollback-compatible additive state are
+non-replayable direct-error admission with truthful aggregate timing, and
+rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -18,8 +18,8 @@ evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
 priority including direct errors in one combined pre-first-page incident,
 post-ack recurrence suppression, durable owed-page preservation inside
-non-replayable direct-error admission with truthful aggregate timing, and
-rollback-compatible additive state are
+non-replayable direct-error admission, truthful direct-error and mixed telemetry
+window provenance, and rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -15,8 +15,9 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
-telemetry-only operator paging with durable owed-page preservation and
-rollback-compatible additive state are jointly specified by `ARCHITECTURE.md`,
+telemetry-only operator paging with unresolved-window coalescing, current-pressure
+priority, durable owed-page preservation, and rollback-compatible additive state
+are jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.
 

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -17,8 +17,8 @@ Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
 priority including direct errors in one combined pre-first-page incident,
-post-ack recurrence
-suppression, durable owed-page preservation, and rollback-compatible additive state are
+post-ack recurrence suppression, durable owed-page preservation inside
+non-replayable direct-error admission, and rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -16,7 +16,7 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
-priority including one combined new-incident page, post-ack recurrence
+priority including one combined pre-first-page incident, post-ack recurrence
 suppression, durable owed-page preservation, and rollback-compatible additive state are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -16,8 +16,9 @@ verification scheduling are jointly specified by `ARCHITECTURE.md`,
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, and one-shot
 telemetry-only operator paging with unresolved-window coalescing, current-pressure
-priority, post-ack recurrence suppression, durable owed-page preservation, and
-rollback-compatible additive state are jointly specified by `ARCHITECTURE.md`,
+priority including exact new-incident retention, post-ack recurrence suppression,
+durable owed-page preservation, and rollback-compatible additive state are
+jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.
 

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -540,7 +540,8 @@ supported provider credential.
   pages across restart and recovery, current-pressure priority at the first
   eligible provider slot with historical observation time, rollback-compatible
   additive SQLite alert-state migration and legacy-ack normalization, recovery
-  reset and rearming,
+  reset and rearming, post-ack monitoring suppression inside concrete-pressure
+  recurrence, stale pressure retry isolation from a later rearmed obligation,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -529,10 +529,13 @@ supported provider credential.
   hours, while a fully stale trace is deleted.
 - `apps/cloudflare/test/database-health-{metrics,monitor,worker}.test.ts`
   covers the independent PlanetScale/Linq database-health plane. The tests
-  prove strict metric normalization and required-series failure, positive
-  direct-port counter deltas with reset/new-series suppression, SQLite sample
-  persistence and 30-day pruning, concrete connection thresholds, two-failure
-  collection hysteresis, failed-scrape incident preservation, recovery reset,
+  prove strict per-family metric normalization, explicit unknowns for missing
+  required series, continued evaluation of available signals, positive
+  direct-port counter deltas with reset/new-series suppression across complete
+  and partial samples, SQLite sample persistence and 30-day pruning, concrete
+  connection thresholds, two-failure collection hysteresis, one acknowledged
+  page per uninterrupted telemetry-only outage, failed-scrape incident
+  preservation, recovery reset and rearming,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -539,9 +539,11 @@ supported provider credential.
   telemetry obligation retention behind older pending and direct-error-only
   pages across restart and recovery, current-pressure priority at the first
   eligible provider slot with historical observation time, exact combined
-  new-incident pressure and telemetry retention across recovery and restart,
-  rollback-compatible additive SQLite alert-state migration and legacy-ack normalization, recovery
-  reset and rearming, post-ack monitoring suppression inside concrete-pressure
+  pressure and telemetry retention when pressure appears at or after the
+  unadmitted threshold across recovery and restart,
+  rollback-compatible additive SQLite alert-state migration and legacy-ack
+  normalization, recovery reset and rearming, post-ack monitoring suppression
+  inside concrete-pressure
   recurrence, stale pressure retry isolation from a later rearmed obligation,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -539,8 +539,8 @@ supported provider credential.
   telemetry obligation retention behind older pending and direct-error-only
   pages across restart and recovery, current-pressure priority at the first
   eligible provider slot with historical observation time, exact combined
-  pressure and telemetry retention when pressure appears at or after the
-  unadmitted threshold across recovery and restart,
+  pressure, telemetry, and direct-error retention when concrete evidence appears
+  at or after the unadmitted threshold across recovery and restart,
   rollback-compatible additive SQLite alert-state migration and legacy-ack
   normalization, recovery reset and rearming, post-ack monitoring suppression
   inside concrete-pressure

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -536,8 +536,8 @@ supported provider credential.
   connection thresholds, two-failure collection hysteresis, one acknowledged
   page per uninterrupted telemetry-only outage, failed-scrape incident
   preservation, telemetry obligation retention behind older pending and
-  direct-error-only pages across restart and recovery, version-one SQLite alert
-  state migration, recovery reset and rearming,
+  direct-error-only pages across restart and recovery, rollback-compatible
+  additive SQLite alert-state migration, recovery reset and rearming,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -534,10 +534,13 @@ supported provider credential.
   direct-port counter deltas with reset/new-series suppression across complete
   and partial samples, SQLite sample persistence and 30-day pruning, concrete
   connection thresholds, two-failure collection hysteresis, one acknowledged
-  page per uninterrupted telemetry-only outage, failed-scrape incident
-  preservation, telemetry obligation retention behind older pending and
-  direct-error-only pages across restart and recovery, rollback-compatible
-  additive SQLite alert-state migration, recovery reset and rearming,
+  page per unresolved telemetry-notification window, recovered threshold
+  coalescing before acknowledgment, failed-scrape incident preservation,
+  telemetry obligation retention behind older pending and direct-error-only
+  pages across restart and recovery, current-pressure priority at the first
+  eligible provider slot with historical observation time, rollback-compatible
+  additive SQLite alert-state migration and legacy-ack normalization, recovery
+  reset and rearming,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -538,7 +538,8 @@ supported provider credential.
   coalescing before acknowledgment, failed-scrape incident preservation,
   telemetry obligation retention behind older pending and direct-error-only
   pages across restart and recovery, current-pressure priority at the first
-  eligible provider slot with historical observation time, rollback-compatible
+  eligible provider slot with historical observation time, exact new-incident
+  pressure retention ahead of telemetry across recovery and restart, rollback-compatible
   additive SQLite alert-state migration and legacy-ack normalization, recovery
   reset and rearming, post-ack monitoring suppression inside concrete-pressure
   recurrence, stale pressure retry isolation from a later rearmed obligation,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -535,7 +535,9 @@ supported provider credential.
   and partial samples, SQLite sample persistence and 30-day pruning, concrete
   connection thresholds, two-failure collection hysteresis, one acknowledged
   page per unresolved telemetry-notification window, recovered threshold
-  coalescing before acknowledgment, failed-scrape incident preservation,
+  coalescing before acknowledgment, truthful partial-then-unavailable,
+  unavailable-then-partial, and different-family partial-window summaries with
+  bounded observed evidence, failed-scrape incident preservation,
   telemetry obligation retention behind older pending and direct-error-only
   pages across restart and recovery, current-pressure priority at the first
   eligible provider slot with historical observation time, exact combined

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -538,9 +538,9 @@ supported provider credential.
   coalescing before acknowledgment, failed-scrape incident preservation,
   telemetry obligation retention behind older pending and direct-error-only
   pages across restart and recovery, current-pressure priority at the first
-  eligible provider slot with historical observation time, exact new-incident
-  pressure retention ahead of telemetry across recovery and restart, rollback-compatible
-  additive SQLite alert-state migration and legacy-ack normalization, recovery
+  eligible provider slot with historical observation time, exact combined
+  new-incident pressure and telemetry retention across recovery and restart,
+  rollback-compatible additive SQLite alert-state migration and legacy-ack normalization, recovery
   reset and rearming, post-ack monitoring suppression inside concrete-pressure
   recurrence, stale pressure retry isolation from a later rearmed obligation,
   global 30-minute wall-time provider-attempt pacing across incident recovery,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -535,7 +535,9 @@ supported provider credential.
   and partial samples, SQLite sample persistence and 30-day pruning, concrete
   connection thresholds, two-failure collection hysteresis, one acknowledged
   page per uninterrupted telemetry-only outage, failed-scrape incident
-  preservation, recovery reset and rearming,
+  preservation, telemetry obligation retention behind older pending and
+  direct-error-only pages across restart and recovery, version-one SQLite alert
+  state migration, recovery reset and rearming,
   global 30-minute wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and rotated evidence-bearing recurrence copy,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -203,9 +203,12 @@ evaluates every available signal, and records the canonical missing metric names
 without retaining labels or raw scrape data. Unsafe available signals therefore
 still open an incident immediately. Two consecutive incomplete or failed
 collections open the fallback monitoring incident. An acknowledged
-telemetry-only page is one-shot for that uninterrupted outage; a complete sample
-closes it and allows a later outage to page again. Concrete unsafe conditions
-retain their 30-minute recurrence. The object writes Linq provider-attempt
+telemetry-only page is one-shot for that uninterrupted outage. Crossing the
+two-failure threshold records one bounded alert obligation in the existing
+incident row, so an older pending page or direct-error priority cannot lose it;
+only acknowledgment of a telemetry-bearing page clears it. A complete sample
+closes and rearms the incident after any owed page is delivered. Concrete unsafe
+conditions retain their 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
 send. The message reports actual collection time rather than the scheduled Cron

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -203,17 +203,24 @@ evaluates every available signal, and records the canonical missing metric names
 without retaining labels or raw scrape data. Unsafe available signals therefore
 still open an incident immediately. Two consecutive incomplete or failed
 collections open the fallback monitoring incident. An acknowledged
-telemetry-only page is one-shot for that uninterrupted outage. Crossing the
-two-failure threshold records one bounded alert obligation in the existing
-incident row, so an older pending page or direct-error priority cannot lose it;
-only acknowledgment of a telemetry-bearing page clears it. A complete sample
-closes and rearms the incident after any owed page is delivered. Concrete unsafe
-conditions retain their 30-minute recurrence. The object writes Linq provider-attempt
+telemetry-only page is one-shot for one unresolved operator-notification window.
+Crossing the two-failure threshold records one bounded alert obligation in the
+existing incident row, so an older pending page or direct-error priority cannot
+lose it; recovery and another gap before acknowledgment coalesce into that same
+notification while the first threshold's bounded evidence and observation time
+remain authoritative. The obligation does not occupy a closed provider fence. At the
+next eligible sample, current unsafe database evidence shares the page while
+historical telemetry keeps its own observation time. Only acknowledgment of a
+telemetry-bearing page clears the obligation; a later complete sample then
+closes and rearms the incident. Concrete unsafe conditions retain their
+30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
 send. The obligation columns are added idempotently without advancing the
 schema version, so the previously deployed Worker can ignore them during a
-rollback. The message reports actual collection time rather than the scheduled Cron
+rollback. If that Worker acknowledges a telemetry pending body, current code
+recognizes its cleared key/body plus retained marker and prevents duplicate
+re-admission after re-upgrade. The message reports actual collection time rather than the scheduled Cron
 slot and describes partial or unavailable telemetry without claiming database
 pressure.
 Before each message POST it requires the configured direct

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -209,9 +209,10 @@ existing incident row, so an older pending page or direct-error priority cannot
 lose it; recovery and another gap before acknowledgment coalesce into that same
 notification while the first threshold's bounded evidence and observation time
 remain authoritative. The obligation does not occupy a closed provider fence.
-At the same time, a newly opened incident with concrete evidence persists one
-combined immutable body, so the exact pressure and truthful telemetry facts
-share the next eligible attempt and one acknowledgment cycle. For
+At the same time, until an incident admits its first page, concrete evidence
+that appears on the threshold or a later sample persists in one combined
+immutable body. The exact pressure and truthful telemetry facts therefore share
+the next eligible attempt and one acknowledgment cycle. For
 acknowledged-incident recurrence, the next eligible sample
 supplies any still-current unsafe evidence while historical telemetry keeps its
 own observation time. Only acknowledgment of a

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -212,7 +212,9 @@ remain authoritative. The obligation does not occupy a closed provider fence. At
 next eligible sample, current unsafe database evidence shares the page while
 historical telemetry keeps its own observation time. Only acknowledgment of a
 telemetry-bearing page clears the obligation; a later complete sample then
-closes and rearms the incident. Concrete unsafe conditions retain their
+closes and rearms the incident. After acknowledgment, incomplete samples remain
+queryable but cannot repeat telemetry copy inside concrete-pressure pages unless
+a later rearmed threshold creates a new obligation. Concrete unsafe conditions retain their
 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -208,14 +208,17 @@ Crossing the two-failure threshold records one bounded alert obligation in the
 existing incident row, so an older pending page or direct-error priority cannot
 lose it; recovery and another gap before acknowledgment coalesce into that same
 notification while the first threshold's bounded evidence and observation time
-remain authoritative. The obligation does not occupy a closed provider fence. At the
-next eligible sample, current unsafe database evidence shares the page while
-historical telemetry keeps its own observation time. Only acknowledgment of a
+remain authoritative. The obligation does not occupy a closed provider fence.
+At the same time, a newly opened incident persists its current concrete evidence alone,
+so that exact pressure event owns the next eligible attempt and telemetry stays
+owed behind it. For acknowledged-incident recurrence, the next eligible sample
+supplies any still-current unsafe evidence while historical telemetry keeps its
+own observation time. Only acknowledgment of a
 telemetry-bearing page clears the obligation; a later complete sample then
 closes and rearms the incident. After acknowledgment, incomplete samples remain
 queryable but cannot repeat telemetry copy inside concrete-pressure pages unless
-a later rearmed threshold creates a new obligation. Concrete unsafe conditions retain their
-30-minute recurrence. The object writes Linq provider-attempt
+a later rearmed threshold creates a new obligation. Concrete unsafe conditions
+retain their 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
 send. The obligation columns are added idempotently without advancing the

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -209,9 +209,10 @@ existing incident row, so an older pending page or direct-error priority cannot
 lose it; recovery and another gap before acknowledgment coalesce into that same
 notification while the first threshold's bounded evidence and observation time
 remain authoritative. The obligation does not occupy a closed provider fence.
-At the same time, a newly opened incident persists its current concrete evidence alone,
-so that exact pressure event owns the next eligible attempt and telemetry stays
-owed behind it. For acknowledged-incident recurrence, the next eligible sample
+At the same time, a newly opened incident with concrete evidence persists one
+combined immutable body, so the exact pressure and truthful telemetry facts
+share the next eligible attempt and one acknowledgment cycle. For
+acknowledged-incident recurrence, the next eligible sample
 supplies any still-current unsafe evidence while historical telemetry keeps its
 own observation time. Only acknowledgment of a
 telemetry-bearing page clears the obligation; a later complete sample then

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -220,8 +220,12 @@ own observation time. Only acknowledgment of a
 telemetry-bearing page clears the obligation; a later complete sample then
 closes and rearms the incident. After acknowledgment, incomplete samples remain
 queryable but cannot repeat telemetry copy inside concrete-pressure pages unless
-a later rearmed threshold creates a new obligation. Concrete unsafe conditions
-retain their 30-minute recurrence. The object writes Linq provider-attempt
+a later rearmed threshold creates a new obligation. When a direct-error delta
+takes admission priority after an earlier page, any currently owed telemetry
+travels in that same immutable body while replayable gauges remain excluded;
+the direct error keeps its original check time and telemetry keeps its own
+condition-local observation time. Concrete unsafe conditions retain their
+30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
 send. The obligation columns are added idempotently without advancing the

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -210,8 +210,9 @@ lose it; recovery and another gap before acknowledgment coalesce into that same
 notification while the first threshold's bounded evidence and observation time
 remain authoritative. The obligation does not occupy a closed provider fence.
 At the same time, until an incident admits its first page, concrete evidence
-that appears on the threshold or a later sample persists in one combined
-immutable body. The exact pressure and truthful telemetry facts therefore share
+that appears on the threshold or a later sample, including a direct-error delta,
+persists in one combined immutable body. The exact pressure and truthful
+telemetry facts therefore share
 the next eligible attempt and one acknowledgment cycle. For
 acknowledged-incident recurrence, the next eligible sample
 supplies any still-current unsafe evidence while historical telemetry keeps its

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -223,7 +223,8 @@ queryable but cannot repeat telemetry copy inside concrete-pressure pages unless
 a later rearmed threshold creates a new obligation. When a direct-error delta
 takes admission priority after an earlier page, any currently owed telemetry
 travels in that same immutable body while replayable gauges remain excluded;
-the direct error keeps its original check time and telemetry keeps its own
+pure deferred evidence keeps its stored check time, an aggregate containing a
+new current delta uses the latest included check, and telemetry keeps its own
 condition-local observation time. Concrete unsafe conditions retain their
 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -205,10 +205,14 @@ still open an incident immediately. Two consecutive incomplete or failed
 collections open the fallback monitoring incident. An acknowledged
 telemetry-only page is one-shot for one unresolved operator-notification window.
 Crossing the two-failure threshold records one bounded alert obligation in the
-existing incident row, so an older pending page or direct-error priority cannot
-lose it; recovery and another gap before acknowledgment coalesce into that same
-notification while the first threshold's bounded evidence and observation time
-remain authoritative. The obligation does not occupy a closed provider fence.
+existing incident row. The first two-check window counts incomplete versus
+unavailable observations, unions only canonical missing families observed on
+partial checks, and identifies the threshold time as the window end. A bounded
+per-sample evidence value preserves that provenance across restart. An older
+pending page or direct-error priority cannot lose the obligation; recovery and
+another gap before acknowledgment coalesce into that same notification while
+the first threshold window remains authoritative. The obligation does not occupy
+a closed provider fence.
 At the same time, until an incident admits its first page, concrete evidence
 that appears on the threshold or a later sample, including a direct-error delta,
 persists in one combined immutable body. The exact pressure and truthful
@@ -229,7 +233,7 @@ condition-local observation time. Concrete unsafe conditions retain their
 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
-send. The obligation columns are added idempotently without advancing the
+send. The alert-state and sample-evidence columns are added idempotently without advancing the
 schema version, so the previously deployed Worker can ignore them during a
 rollback. If that Worker acknowledges a telemetry pending body, current code
 recognizes its cleared key/body plus retained marker and prevents duplicate

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -197,11 +197,20 @@ application traffic is required to use transaction-mode PgBouncer on 6432 and
 the direct endpoint is migration-only. Adding another direct production client
 requires splitting that signal first.
 
-Unsafe samples open one incident. Two consecutive collection failures open the
-fallback monitoring incident. The object writes Linq provider-attempt admission
-before egress, never attempts more than once per 30 minutes across all incidents,
-and reuses the exact body plus idempotency key after an ambiguous send. The
-message reports actual collection time rather than the scheduled Cron slot.
+Each metric family is normalized independently. When a documented family is
+absent, the sample keeps that family unknown instead of substituting zero, still
+evaluates every available signal, and records the canonical missing metric names
+without retaining labels or raw scrape data. Unsafe available signals therefore
+still open an incident immediately. Two consecutive incomplete or failed
+collections open the fallback monitoring incident. An acknowledged
+telemetry-only page is one-shot for that uninterrupted outage; a complete sample
+closes it and allows a later outage to page again. Concrete unsafe conditions
+retain their 30-minute recurrence. The object writes Linq provider-attempt
+admission before egress, never attempts more than once per 30 minutes across all
+incidents, and reuses the exact body plus idempotency key after an ambiguous
+send. The message reports actual collection time rather than the scheduled Cron
+slot and describes partial or unavailable telemetry without claiming database
+pressure.
 Before each message POST it requires the configured direct
 [Linq chat health](https://docs.linqapp.com/guides/chats/chat-health/) and its
 current [line reputation](https://docs.linqapp.com/guides/phone-numbers/phone-reputation/)

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -211,7 +211,9 @@ closes and rearms the incident after any owed page is delivered. Concrete unsafe
 conditions retain their 30-minute recurrence. The object writes Linq provider-attempt
 admission before egress, never attempts more than once per 30 minutes across all
 incidents, and reuses the exact body plus idempotency key after an ambiguous
-send. The message reports actual collection time rather than the scheduled Cron
+send. The obligation columns are added idempotently without advancing the
+schema version, so the previously deployed Worker can ignore them during a
+rollback. The message reports actual collection time rather than the scheduled Cron
 slot and describes partial or unavailable telemetry without claiming database
 pressure.
 Before each message POST it requires the configured direct

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -95,8 +95,10 @@ export type DatabaseHealthCondition =
     }
   | {
       failures: number;
+      incompleteChecks?: number;
       kind: "monitoring_unavailable";
       missingMetrics: readonly DatabaseHealthRequiredMetricName[];
+      unavailableChecks?: number;
     };
 
 interface PrometheusMetricPoint {

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -1,4 +1,4 @@
-const SELECTED_METRIC_NAMES = new Set([
+export const DATABASE_HEALTH_REQUIRED_METRIC_NAMES = [
   "planetscale_edge_postgres_connection_errors_total",
   "planetscale_pgbouncer_current_connections",
   "planetscale_pgbouncer_pools_client",
@@ -6,7 +6,14 @@ const SELECTED_METRIC_NAMES = new Set([
   "planetscale_pgbouncer_pools_server",
   "planetscale_postgres_connection_state",
   "planetscale_postgres_settings_max_connections",
-]);
+] as const;
+
+export type DatabaseHealthRequiredMetricName =
+  typeof DATABASE_HEALTH_REQUIRED_METRIC_NAMES[number];
+
+const SELECTED_METRIC_NAMES = new Set<string>(
+  DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
+);
 
 const BRANCH_LABEL = "planetscale_database_branch_id";
 const POD_LABEL = "planetscale_pod";
@@ -34,11 +41,29 @@ export interface DatabaseMetricSnapshot {
   serverPoolStates: Record<string, number>;
 }
 
+export interface DatabaseMetricObservationSnapshot {
+  clientWaitSeconds: number | null;
+  clientWaitingConnections: number | null;
+  directConnectionErrorCounters: Record<string, number> | null;
+  postgresConnections: number | null;
+  postgresConnectionStates: Record<string, number> | null;
+  postgresMaxConnections: number | null;
+  serverConnections: number | null;
+  serverPoolCapacity: number | null;
+  serverPoolSaturationRatio: number | null;
+  serverPoolStates: Record<string, number> | null;
+}
+
+export interface DatabaseMetricObservation {
+  missingMetrics: readonly DatabaseHealthRequiredMetricName[];
+  snapshot: DatabaseMetricObservationSnapshot;
+}
+
 export type DatabaseHealthCondition =
   | {
       kind: "client_wait";
       seconds: number;
-      waitingConnections: number;
+      waitingConnections: number | null;
     }
   | {
       connections: number;
@@ -71,6 +96,7 @@ export type DatabaseHealthCondition =
   | {
       failures: number;
       kind: "monitoring_unavailable";
+      missingMetrics: readonly DatabaseHealthRequiredMetricName[];
     };
 
 interface PrometheusMetricPoint {
@@ -81,11 +107,16 @@ interface PrometheusMetricPoint {
 
 export class DatabaseMetricsParseError extends Error {
   readonly code: "metrics_parse_failed" | "required_metrics_missing";
+  readonly missingMetrics: readonly DatabaseHealthRequiredMetricName[];
 
-  constructor(code: "metrics_parse_failed" | "required_metrics_missing") {
+  constructor(
+    code: "metrics_parse_failed" | "required_metrics_missing",
+    missingMetrics: readonly DatabaseHealthRequiredMetricName[] = [],
+  ) {
     super(code);
     this.name = "DatabaseMetricsParseError";
     this.code = code;
+    this.missingMetrics = [...missingMetrics];
   }
 }
 
@@ -93,6 +124,56 @@ export function parsePlanetScaleDatabaseMetrics(
   body: string,
   branchId: string,
 ): DatabaseMetricSnapshot {
+  const observation = parsePlanetScaleDatabaseMetricObservation(
+    body,
+    branchId,
+  );
+  return requireCompleteDatabaseMetricSnapshot(observation);
+}
+
+export function requireCompleteDatabaseMetricSnapshot(
+  observation: DatabaseMetricObservation,
+): DatabaseMetricSnapshot {
+  if (observation.missingMetrics.length > 0) {
+    throw new DatabaseMetricsParseError(
+      "required_metrics_missing",
+      observation.missingMetrics,
+    );
+  }
+  const snapshot = observation.snapshot;
+  if (
+    snapshot.clientWaitSeconds === null
+    || snapshot.clientWaitingConnections === null
+    || snapshot.directConnectionErrorCounters === null
+    || snapshot.postgresConnections === null
+    || snapshot.postgresConnectionStates === null
+    || snapshot.postgresMaxConnections === null
+    || snapshot.serverConnections === null
+    || snapshot.serverPoolCapacity === null
+    || snapshot.serverPoolSaturationRatio === null
+    || snapshot.serverPoolStates === null
+  ) {
+    throw new DatabaseMetricsParseError("required_metrics_missing");
+  }
+  return {
+    clientWaitSeconds: snapshot.clientWaitSeconds,
+    clientWaitingConnections: snapshot.clientWaitingConnections,
+    directConnectionErrorCounters:
+      snapshot.directConnectionErrorCounters,
+    postgresConnections: snapshot.postgresConnections,
+    postgresConnectionStates: snapshot.postgresConnectionStates,
+    postgresMaxConnections: snapshot.postgresMaxConnections,
+    serverConnections: snapshot.serverConnections,
+    serverPoolCapacity: snapshot.serverPoolCapacity,
+    serverPoolSaturationRatio: snapshot.serverPoolSaturationRatio,
+    serverPoolStates: snapshot.serverPoolStates,
+  };
+}
+
+export function parsePlanetScaleDatabaseMetricObservation(
+  body: string,
+  branchId: string,
+): DatabaseMetricObservation {
   const points = parsePrometheusText(body)
     .filter((point) => point.labels[BRANCH_LABEL] === branchId);
   const primaryPoints = points.filter(isPrimaryMetricPoint);
@@ -123,61 +204,130 @@ export function parsePlanetScaleDatabaseMetrics(
       && point.labels[PORT_LABEL] === "5432",
   );
 
+  const missingMetricSet = new Set<DatabaseHealthRequiredMetricName>();
+  if (directErrorPoints.length === 0) {
+    missingMetricSet.add(
+      "planetscale_edge_postgres_connection_errors_total",
+    );
+  }
+  if (currentConnectionPoints.length === 0) {
+    missingMetricSet.add("planetscale_pgbouncer_current_connections");
+  }
+  if (clientPoolPoints.length === 0) {
+    missingMetricSet.add("planetscale_pgbouncer_pools_client");
+  }
+  if (clientWaitPoints.length === 0) {
+    missingMetricSet.add(
+      "planetscale_pgbouncer_pools_client_maxwait_seconds",
+    );
+  }
+  if (serverPoolPoints.length === 0) {
+    missingMetricSet.add("planetscale_pgbouncer_pools_server");
+  }
+  if (postgresStatePoints.length === 0) {
+    missingMetricSet.add("planetscale_postgres_connection_state");
+  }
+  if (postgresMaxPoints.length === 0) {
+    missingMetricSet.add(
+      "planetscale_postgres_settings_max_connections",
+    );
+  }
+
+  const postgresConnectionStates = postgresStatePoints.length === 0
+    ? null
+    : sumByLabel(postgresStatePoints, CONNECTION_STATE_LABEL);
+  if (postgresConnectionStates === null) {
+    missingMetricSet.add("planetscale_postgres_connection_state");
+  }
+  const serverPoolStates = serverPoolPoints.length === 0
+    ? null
+    : sumByLabel(serverPoolPoints, PGBOUNCER_POOL_LABEL);
+  if (serverPoolStates === null) {
+    missingMetricSet.add("planetscale_pgbouncer_pools_server");
+  }
+  const clientWaitingConnections = clientPoolPoints.length === 0
+    || !clientPoolPoints.every(
+      (point) => Boolean(point.labels[PGBOUNCER_POOL_LABEL]),
+    )
+    ? null
+    : sumMetricValues(
+      clientPoolPoints.filter(
+        (point) =>
+          point.labels[PGBOUNCER_POOL_LABEL]?.toLowerCase() === "waiting",
+      ),
+    );
+  if (clientWaitingConnections === null) {
+    missingMetricSet.add("planetscale_pgbouncer_pools_client");
+  }
+  const connectionCapacityByPod = postgresMaxPoints.length === 0
+    ? null
+    : maximumByPod(postgresMaxPoints);
+  if (connectionCapacityByPod === null) {
+    missingMetricSet.add(
+      "planetscale_postgres_settings_max_connections",
+    );
+  }
+  const serverConnectionsByPod = currentConnectionPoints.length === 0
+    ? null
+    : sumByPod(currentConnectionPoints);
+  if (serverConnectionsByPod === null) {
+    missingMetricSet.add("planetscale_pgbouncer_current_connections");
+  }
+  const mostSaturatedServerPool =
+    connectionCapacityByPod && serverConnectionsByPod
+      ? resolveMostSaturatedServerPool({
+        connectionCapacityByPod,
+        serverConnectionsByPod,
+      })
+      : null;
   if (
-    clientWaitPoints.length === 0
-    || clientPoolPoints.length === 0
-    || currentConnectionPoints.length === 0
-    || serverPoolPoints.length === 0
-    || postgresStatePoints.length === 0
-    || postgresMaxPoints.length === 0
-    || directErrorPoints.length === 0
+    connectionCapacityByPod
+    && serverConnectionsByPod
+    && !mostSaturatedServerPool
   ) {
-    throw new DatabaseMetricsParseError("required_metrics_missing");
+    missingMetricSet.add("planetscale_pgbouncer_current_connections");
+    missingMetricSet.add(
+      "planetscale_postgres_settings_max_connections",
+    );
   }
-
-  const postgresConnectionStates = sumByLabel(
-    postgresStatePoints,
-    CONNECTION_STATE_LABEL,
-  );
-  const serverPoolStates = sumByLabel(serverPoolPoints, PGBOUNCER_POOL_LABEL);
-  const clientWaitingConnections = sumMetricValues(
-    clientPoolPoints.filter(
-      (point) => point.labels[PGBOUNCER_POOL_LABEL]?.toLowerCase() === "waiting",
-    ),
-  );
-  const connectionCapacityByPod = maximumByPod(postgresMaxPoints);
-  const serverConnectionsByPod = sumByPod(currentConnectionPoints);
-  const mostSaturatedServerPool = resolveMostSaturatedServerPool({
-    connectionCapacityByPod,
-    serverConnectionsByPod,
-  });
-  if (!mostSaturatedServerPool) {
-    throw new DatabaseMetricsParseError("required_metrics_missing");
+  const postgresMaxConnections = connectionCapacityByPod
+    ? sumMapValues(connectionCapacityByPod)
+    : null;
+  if (postgresMaxConnections !== null && postgresMaxConnections <= 0) {
+    missingMetricSet.add(
+      "planetscale_postgres_settings_max_connections",
+    );
   }
-
-  const postgresMaxConnections = sumMapValues(connectionCapacityByPod);
-  const postgresConnections = sumMapValues(
-    new Map(Object.entries(postgresConnectionStates)),
+  const missingMetrics = DATABASE_HEALTH_REQUIRED_METRIC_NAMES.filter(
+    (name) => missingMetricSet.has(name),
   );
-  if (postgresMaxConnections <= 0) {
-    throw new DatabaseMetricsParseError("required_metrics_missing");
-  }
-
   return {
-    clientWaitSeconds: maximumMetricValue(clientWaitPoints),
-    clientWaitingConnections,
-    directConnectionErrorCounters: sumByOptionalLabel(
-      directErrorPoints,
-      REGION_LABEL,
-      "unknown",
-    ),
-    postgresConnections,
-    postgresConnectionStates,
-    postgresMaxConnections,
-    serverConnections: mostSaturatedServerPool.connections,
-    serverPoolCapacity: mostSaturatedServerPool.limit,
-    serverPoolSaturationRatio: mostSaturatedServerPool.ratio,
-    serverPoolStates,
+    missingMetrics,
+    snapshot: {
+      clientWaitSeconds: clientWaitPoints.length === 0
+        ? null
+        : maximumMetricValue(clientWaitPoints),
+      clientWaitingConnections,
+      directConnectionErrorCounters: directErrorPoints.length === 0
+        ? null
+        : sumByOptionalLabel(
+          directErrorPoints,
+          REGION_LABEL,
+          "unknown",
+        ),
+      postgresConnections: postgresConnectionStates
+        ? sumMapValues(new Map(Object.entries(postgresConnectionStates)))
+        : null,
+      postgresConnectionStates,
+      postgresMaxConnections:
+        postgresMaxConnections !== null && postgresMaxConnections > 0
+          ? postgresMaxConnections
+          : null,
+      serverConnections: mostSaturatedServerPool?.connections ?? null,
+      serverPoolCapacity: mostSaturatedServerPool?.limit ?? null,
+      serverPoolSaturationRatio: mostSaturatedServerPool?.ratio ?? null,
+      serverPoolStates,
+    },
   };
 }
 
@@ -205,11 +355,14 @@ export function calculateDirectConnectionErrorDelta(
 }
 
 export function evaluateDatabaseMetricSnapshot(
-  snapshot: DatabaseMetricSnapshot,
-  directConnectionErrorDelta: number,
+  snapshot: DatabaseMetricObservationSnapshot,
+  directConnectionErrorDelta: number | null,
 ): DatabaseHealthCondition[] {
   const conditions: DatabaseHealthCondition[] = [];
-  if (snapshot.clientWaitSeconds >= DATABASE_CLIENT_WAIT_ALERT_SECONDS) {
+  if (
+    snapshot.clientWaitSeconds !== null
+    && snapshot.clientWaitSeconds >= DATABASE_CLIENT_WAIT_ALERT_SECONDS
+  ) {
     conditions.push({
       kind: "client_wait",
       seconds: snapshot.clientWaitSeconds,
@@ -217,8 +370,11 @@ export function evaluateDatabaseMetricSnapshot(
     });
   }
   if (
-    snapshot.serverPoolSaturationRatio
+    snapshot.serverPoolSaturationRatio !== null
+    && snapshot.serverPoolSaturationRatio
     >= DATABASE_SERVER_POOL_ALERT_RATIO
+    && snapshot.serverConnections !== null
+    && snapshot.serverPoolCapacity !== null
   ) {
     conditions.push({
       connections: snapshot.serverConnections,
@@ -229,10 +385,16 @@ export function evaluateDatabaseMetricSnapshot(
   }
 
   const postgresConnectionRatio =
-    snapshot.postgresConnections / snapshot.postgresMaxConnections;
+    snapshot.postgresConnections !== null
+    && snapshot.postgresMaxConnections !== null
+      ? snapshot.postgresConnections / snapshot.postgresMaxConnections
+      : null;
   if (
-    postgresConnectionRatio
+    postgresConnectionRatio !== null
+    && postgresConnectionRatio
     >= DATABASE_CONNECTION_UTILIZATION_ALERT_RATIO
+    && snapshot.postgresConnections !== null
+    && snapshot.postgresMaxConnections !== null
   ) {
     conditions.push({
       connections: snapshot.postgresConnections,
@@ -242,9 +404,9 @@ export function evaluateDatabaseMetricSnapshot(
     });
   }
 
-  const normalizedStates = normalizeStateCounts(
-    snapshot.postgresConnectionStates,
-  );
+  const normalizedStates = snapshot.postgresConnectionStates
+    ? normalizeStateCounts(snapshot.postgresConnectionStates)
+    : {};
   const abortedConnections =
     normalizedStates["idle in transaction (aborted)"] ?? 0;
   if (abortedConnections > 0) {
@@ -270,7 +432,10 @@ export function evaluateDatabaseMetricSnapshot(
       kind: "postgres_idle_in_transaction",
     });
   }
-  if (directConnectionErrorDelta > 0) {
+  if (
+    directConnectionErrorDelta !== null
+    && directConnectionErrorDelta > 0
+  ) {
     conditions.push({
       count: directConnectionErrorDelta,
       kind: "direct_migration_admission_failures",
@@ -398,12 +563,12 @@ function isPrimaryMetricPoint(point: PrometheusMetricPoint): boolean {
 function sumByLabel(
   points: readonly PrometheusMetricPoint[],
   label: string,
-): Record<string, number> {
+): Record<string, number> | null {
   const totals: Record<string, number> = {};
   for (const point of points) {
     const key = point.labels[label];
     if (!key) {
-      throw new DatabaseMetricsParseError("required_metrics_missing");
+      return null;
     }
     totals[key] = (totals[key] ?? 0) + point.value;
   }
@@ -425,12 +590,12 @@ function sumByOptionalLabel(
 
 function sumByPod(
   points: readonly PrometheusMetricPoint[],
-): ReadonlyMap<string, number> {
+): ReadonlyMap<string, number> | null {
   const totals = new Map<string, number>();
   for (const point of points) {
     const pod = point.labels[POD_LABEL];
     if (!pod) {
-      throw new DatabaseMetricsParseError("required_metrics_missing");
+      return null;
     }
     totals.set(pod, (totals.get(pod) ?? 0) + point.value);
   }
@@ -439,12 +604,12 @@ function sumByPod(
 
 function maximumByPod(
   points: readonly PrometheusMetricPoint[],
-): ReadonlyMap<string, number> {
+): ReadonlyMap<string, number> | null {
   const maximums = new Map<string, number>();
   for (const point of points) {
     const pod = point.labels[POD_LABEL];
     if (!pod) {
-      throw new DatabaseMetricsParseError("required_metrics_missing");
+      return null;
     }
     maximums.set(pod, Math.max(maximums.get(pod) ?? 0, point.value));
   }

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -1,6 +1,7 @@
 import type { DurableObjectSqlStorageLike } from "../user-runner/types.js";
 import {
   calculateDirectConnectionErrorDelta,
+  DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
   DatabaseMetricsParseError,
   evaluateDatabaseMetricSnapshot,
   parsePlanetScaleDatabaseMetricObservation,
@@ -13,6 +14,8 @@ import {
 import {
   DatabaseHealthStore,
   type DatabaseHealthAlertState,
+  type DatabaseHealthMonitoringAlertObligation,
+  type DatabaseHealthMonitoringEvidence,
   type DatabaseHealthStoredSample,
 } from "./store.js";
 
@@ -122,6 +125,7 @@ type DatabaseHealthCollectedSample =
     directConnectionErrorDelta: number | null;
     failureCode: DatabaseHealthFailureCode;
     failures: number;
+    monitoringEvidence: DatabaseHealthMonitoringEvidence;
     snapshot: DatabaseMetricObservationSnapshot | null;
     status: "failed";
   };
@@ -251,6 +255,10 @@ export class DatabaseHealthMonitor {
           directConnectionErrorDelta,
           failureCode: "required_metrics_missing",
           failures,
+          monitoringEvidence: {
+            availability: "incomplete",
+            missingMetrics: observation.missingMetrics,
+          },
           snapshot: observation.snapshot,
           status: "failed",
         };
@@ -293,6 +301,10 @@ export class DatabaseHealthMonitor {
         directConnectionErrorDelta: null,
         failureCode,
         failures,
+        monitoringEvidence: {
+          availability: "unavailable",
+          missingMetrics: [],
+        },
         snapshot: null,
         status: "failed",
       };
@@ -319,11 +331,23 @@ export class DatabaseHealthMonitor {
       && sample.failures === MONITORING_FAILURE_ALERT_COUNT
       && currentMonitoringCondition
     ) {
-      this.store.recordMonitoringAlertObligation({
+      const priorEvidence = this.store.readLatestMonitoringEvidence();
+      if (priorEvidence === null) {
+        throw new Error(
+          "Database monitoring threshold is missing prior evidence.",
+        );
+      }
+      const monitoringAlertObligation = buildMonitoringAlertObligation({
         checkedAtMs: input.checkedAtMs,
         failures: currentMonitoringCondition.failures,
-        missingMetrics: currentMonitoringCondition.missingMetrics,
+        observations: [priorEvidence, sample.monitoringEvidence],
       });
+      Object.assign(currentMonitoringCondition, {
+        incompleteChecks: monitoringAlertObligation.incompleteChecks,
+        missingMetrics: monitoringAlertObligation.missingMetrics,
+        unavailableChecks: monitoringAlertObligation.unavailableChecks,
+      });
+      this.store.recordMonitoringAlertObligation(monitoringAlertObligation);
     }
 
     let alertState = this.store.readAlertState();
@@ -365,8 +389,10 @@ export class DatabaseHealthMonitor {
       const monitoringConditionForAdmission = monitoringAlertObligation
         ? {
           failures: monitoringAlertObligation.failures,
+          incompleteChecks: monitoringAlertObligation.incompleteChecks,
           kind: "monitoring_unavailable" as const,
           missingMetrics: monitoringAlertObligation.missingMetrics,
+          unavailableChecks: monitoringAlertObligation.unavailableChecks,
         }
         : null;
       const currentReplayableConditions = sample.conditions.filter(
@@ -484,6 +510,7 @@ export class DatabaseHealthMonitor {
         conditions: sample.conditions,
         directConnectionErrorDelta: sample.directConnectionErrorDelta,
         failureCode: sample.failureCode,
+        monitoringEvidence: sample.monitoringEvidence,
         observedAtMs: input.observedAtMs,
         snapshot: sample.snapshot,
       });
@@ -973,7 +1000,7 @@ function buildDatabaseAlertMessage(input: {
         input.monitoringCheckedAtMs,
       ))
       .join("; ");
-    return `${evidence}. Checked ${checkedAt} UTC.`;
+    return `${evidence}. Window ended ${checkedAt} UTC.`;
   }
   const openingIndex =
     (
@@ -1127,30 +1154,67 @@ function formatMonitoringUnavailableCondition(
   >,
   observedAtMs: number | null,
 ): string {
+  const incompleteChecks = condition.incompleteChecks
+    ?? (condition.missingMetrics.length > 0 ? condition.failures : 0);
+  const unavailableChecks = condition.unavailableChecks
+    ?? (condition.missingMetrics.length > 0 ? 0 : condition.failures);
   const missingMetricLabels = condition.missingMetrics.map(
     (name) => DATABASE_METRIC_ALERT_LABELS[name],
   );
   const details = [
     observedAtMs === null
       ? null
-      : `observed ${
+      : `window ended ${
         new Date(observedAtMs).toISOString().slice(11, 16)
       } UTC`,
+    incompleteChecks > 0 && unavailableChecks > 0
+      ? `${formatCount(incompleteChecks)} incomplete, ${formatCount(
+        unavailableChecks,
+      )} unavailable`
+      : null,
     missingMetricLabels.length === 0
       ? null
       : `missing PlanetScale ${
-      missingMetricLabels.length === 1 ? "metric" : "metrics"
-      }: ${missingMetricLabels.join(", ")}`,
+        missingMetricLabels.length === 1 ? "metric" : "metrics"
+      } observed: ${missingMetricLabels.join(", ")}`,
   ].filter((detail): detail is string => detail !== null);
   const detailEvidence = details.length === 0
     ? ""
     : ` (${details.join("; ")})`;
-  const availability = missingMetricLabels.length === 0
-    ? "unavailable"
-    : "incomplete";
+  const availability = incompleteChecks > 0 && unavailableChecks > 0
+    ? "impaired"
+    : incompleteChecks > 0
+      ? "incomplete"
+      : "unavailable";
   return `Database monitor telemetry was ${availability} for ${formatCount(
     condition.failures,
   )} checks${detailEvidence}`;
+}
+
+function buildMonitoringAlertObligation(input: {
+  checkedAtMs: number;
+  failures: number;
+  observations: readonly DatabaseHealthMonitoringEvidence[];
+}): DatabaseHealthMonitoringAlertObligation {
+  if (input.observations.length !== input.failures) {
+    throw new Error("Database monitoring window evidence is incomplete.");
+  }
+  const incompleteChecks = input.observations.filter(
+    (observation) => observation.availability === "incomplete",
+  ).length;
+  const unavailableChecks = input.observations.length - incompleteChecks;
+  const observedMissingMetrics = new Set(
+    input.observations.flatMap((observation) => observation.missingMetrics),
+  );
+  return {
+    checkedAtMs: input.checkedAtMs,
+    failures: input.failures,
+    incompleteChecks,
+    missingMetrics: DATABASE_HEALTH_REQUIRED_METRIC_NAMES.filter(
+      (name) => observedMissingMetrics.has(name),
+    ),
+    unavailableChecks,
+  };
 }
 
 function buildDatabaseAlertIdempotencyKey(input: {

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -405,7 +405,8 @@ export class DatabaseHealthMonitor {
         )
           ? conditionsWithDeferredDirectErrors.filter(
             (condition) =>
-              condition.kind === "direct_migration_admission_failures",
+              condition.kind === "direct_migration_admission_failures"
+              || condition.kind === "monitoring_unavailable",
           )
           : conditionsWithDeferredDirectErrors;
       const shouldHoldMonitoringForFence =
@@ -417,10 +418,11 @@ export class DatabaseHealthMonitor {
           || currentReplayableConditions.length === 0
         );
       const admittedCheckedAtMs =
-        admittedConditions.length === 1
-        && admittedConditions[0]?.kind
-          === "direct_migration_admission_failures"
-        && currentDirectError === undefined
+        isPromotingDeferredDirectError
+        && admittedConditions.some(
+          (condition) =>
+            condition.kind === "direct_migration_admission_failures",
+        )
         && alertState.deferredDirectErrorCheckedAtMs !== null
           ? alertState.deferredDirectErrorCheckedAtMs
           : admittedConditions.length === 1

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -368,7 +368,7 @@ export class DatabaseHealthMonitor {
           kind: "monitoring_unavailable" as const,
           missingMetrics: monitoringAlertObligation.missingMetrics,
         }
-        : currentMonitoringCondition;
+        : null;
       const conditionsWithDeferredDirectErrors = [
         ...sample.conditions.filter(
           (condition) =>
@@ -387,11 +387,6 @@ export class DatabaseHealthMonitor {
       ];
       const hasDirectConnectionError =
         directErrorCountAvailableForAdmission > 0;
-      const isMonitoringOnly =
-        conditionsWithDeferredDirectErrors.length > 0
-        && conditionsWithDeferredDirectErrors.every(
-          (condition) => condition.kind === "monitoring_unavailable",
-        );
       const attemptFenceOpen =
         alertState.lastAlertAttemptedAtMs === null
         || (
@@ -433,15 +428,12 @@ export class DatabaseHealthMonitor {
           !alertState.pendingAlertIdempotencyKey
           || !alertState.pendingAlertMessage
         )
+        && admittedConditions.length > 0
         && !shouldHoldMonitoringForFence
         && (
           isNewIncident
           || hasDirectConnectionError
           || attemptFenceOpen
-          || monitoringAlertObligation !== null
-        )
-        && (
-          !isMonitoringOnly
           || monitoringAlertObligation !== null
         )
       ) {

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -413,7 +413,7 @@ export class DatabaseHealthMonitor {
         && !attemptFenceOpen
         && !hasDirectConnectionError
         && (
-          !isNewIncident
+          alertState.alertSequence > 0
           || currentReplayableConditions.length === 0
         );
       const admittedCheckedAtMs =

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -3,8 +3,11 @@ import {
   calculateDirectConnectionErrorDelta,
   DatabaseMetricsParseError,
   evaluateDatabaseMetricSnapshot,
-  parsePlanetScaleDatabaseMetrics,
+  parsePlanetScaleDatabaseMetricObservation,
+  requireCompleteDatabaseMetricSnapshot,
   type DatabaseHealthCondition,
+  type DatabaseHealthRequiredMetricName,
+  type DatabaseMetricObservationSnapshot,
   type DatabaseMetricSnapshot,
 } from "./metrics.js";
 import {
@@ -39,6 +42,22 @@ const DATABASE_ALERT_OPENINGS = [
   "Database connection health is degraded.",
   "The database is still reporting an unsafe condition.",
 ] as const;
+
+const DATABASE_METRIC_ALERT_LABELS: Readonly<
+  Record<DatabaseHealthRequiredMetricName, string>
+> = {
+  planetscale_edge_postgres_connection_errors_total:
+    "direct connection errors",
+  planetscale_pgbouncer_current_connections:
+    "PgBouncer current connections",
+  planetscale_pgbouncer_pools_client: "PgBouncer client pools",
+  planetscale_pgbouncer_pools_client_maxwait_seconds:
+    "PgBouncer client wait",
+  planetscale_pgbouncer_pools_server: "PgBouncer server pools",
+  planetscale_postgres_connection_state: "Postgres connection states",
+  planetscale_postgres_settings_max_connections:
+    "Postgres max connections",
+};
 
 export interface DatabaseHealthMonitorEnvironment {
   HOSTED_DATABASE_ALERT_LINQ_CHAT_ID?: string;
@@ -100,8 +119,10 @@ type DatabaseHealthCollectedSample =
   }
   | {
     conditions: DatabaseHealthCondition[];
+    directConnectionErrorDelta: number | null;
     failureCode: DatabaseHealthFailureCode;
     failures: number;
+    snapshot: DatabaseMetricObservationSnapshot | null;
     status: "failed";
   };
 
@@ -194,10 +215,47 @@ export class DatabaseHealthMonitor {
         config: this.config,
         fetchImplementation: this.fetchImplementation,
       });
-      const snapshot = parsePlanetScaleDatabaseMetrics(
+      const observation = parsePlanetScaleDatabaseMetricObservation(
         metricsBody,
         this.config.branchId,
       );
+      if (observation.missingMetrics.length > 0) {
+        const directConnectionErrorDelta =
+          observation.snapshot.directConnectionErrorCounters === null
+            ? null
+            : calculateDirectConnectionErrorDelta(
+              observation.snapshot.directConnectionErrorCounters,
+              this.store.readLatestDirectConnectionErrorCounters(),
+            );
+        const conditions = evaluateDatabaseMetricSnapshot(
+          observation.snapshot,
+          directConnectionErrorDelta,
+        );
+        const priorFailures =
+          this.store.readAlertState().consecutiveScrapeFailures;
+        const failures = priorFailures + 1;
+        if (failures >= MONITORING_FAILURE_ALERT_COUNT) {
+          conditions.push({
+            failures,
+            kind: "monitoring_unavailable",
+            missingMetrics: observation.missingMetrics,
+          });
+        }
+        console.warn("Database health metrics collection failed.", {
+          failureCode: "required_metrics_missing",
+          failures,
+          missingMetrics: observation.missingMetrics,
+        });
+        return {
+          conditions,
+          directConnectionErrorDelta,
+          failureCode: "required_metrics_missing",
+          failures,
+          snapshot: observation.snapshot,
+          status: "failed",
+        };
+      }
+      const snapshot = requireCompleteDatabaseMetricSnapshot(observation);
       const directConnectionErrorDelta =
         calculateDirectConnectionErrorDelta(
           snapshot.directConnectionErrorCounters,
@@ -215,21 +273,27 @@ export class DatabaseHealthMonitor {
       };
     } catch (error) {
       const failureCode = classifyDatabaseHealthFailure(error);
+      const missingMetrics = error instanceof DatabaseMetricsParseError
+        ? error.missingMetrics
+        : [];
       const priorFailures =
         this.store.readAlertState().consecutiveScrapeFailures;
       const failures = priorFailures + 1;
       const conditions: DatabaseHealthCondition[] =
         failures >= MONITORING_FAILURE_ALERT_COUNT
-          ? [{ failures, kind: "monitoring_unavailable" }]
+          ? [{ failures, kind: "monitoring_unavailable", missingMetrics }]
           : [];
       console.warn("Database health metrics collection failed.", {
         failureCode,
         failures,
+        missingMetrics,
       });
       return {
         conditions,
+        directConnectionErrorDelta: null,
         failureCode,
         failures,
+        snapshot: null,
         status: "failed",
       };
     }
@@ -295,6 +359,18 @@ export class DatabaseHealthMonitor {
           : sample.conditions;
       const hasDirectConnectionError =
         directErrorCountAvailableForAdmission > 0;
+      const isMonitoringOnly =
+        conditionsWithDeferredDirectErrors.length > 0
+        && conditionsWithDeferredDirectErrors.every(
+          (condition) => condition.kind === "monitoring_unavailable",
+        );
+      const isInitialMonitoringAlert =
+        isMonitoringOnly
+        && conditionsWithDeferredDirectErrors.some(
+          (condition) =>
+            condition.kind === "monitoring_unavailable"
+            && condition.failures === MONITORING_FAILURE_ALERT_COUNT,
+        );
       const attemptFenceOpen =
         alertState.lastAlertAttemptedAtMs === null
         || (
@@ -328,7 +404,17 @@ export class DatabaseHealthMonitor {
           !alertState.pendingAlertIdempotencyKey
           || !alertState.pendingAlertMessage
         )
-        && (isNewIncident || hasDirectConnectionError || attemptFenceOpen)
+        && (
+          isNewIncident
+          || hasDirectConnectionError
+          || attemptFenceOpen
+          || isInitialMonitoringAlert
+        )
+        && (
+          !isMonitoringOnly
+          || isNewIncident
+          || isInitialMonitoringAlert
+        )
       ) {
         const nextAlertSequence = alertState.alertSequence + 1;
         const pendingState = this.store.createPendingAlert({
@@ -362,8 +448,10 @@ export class DatabaseHealthMonitor {
     } else {
       this.store.recordFailedSample({
         conditions: sample.conditions,
+        directConnectionErrorDelta: sample.directConnectionErrorDelta,
         failureCode: sample.failureCode,
         observedAtMs: input.observedAtMs,
+        snapshot: sample.snapshot,
       });
     }
   }
@@ -834,6 +922,18 @@ function buildDatabaseAlertMessage(input: {
   conditions: readonly DatabaseHealthCondition[];
   incidentSequence: number;
 }): string {
+  const checkedAt = new Date(input.checkedAtMs).toISOString().slice(11, 16);
+  if (
+    input.conditions.length > 0
+    && input.conditions.every(
+      (condition) => condition.kind === "monitoring_unavailable",
+    )
+  ) {
+    const evidence = input.conditions
+      .map(formatDatabaseHealthCondition)
+      .join("; ");
+    return `${evidence}. Checked ${checkedAt} UTC.`;
+  }
   const openingIndex =
     (
       input.incidentSequence
@@ -844,7 +944,6 @@ function buildDatabaseAlertMessage(input: {
     DATABASE_ALERT_OPENINGS[openingIndex]
     ?? DATABASE_ALERT_OPENINGS[0];
   const evidence = input.conditions.map(formatDatabaseHealthCondition).join("; ");
-  const checkedAt = new Date(input.checkedAtMs).toISOString().slice(11, 16);
   return `${opening} ${evidence}. Checked ${checkedAt} UTC.`;
 }
 
@@ -962,10 +1061,30 @@ function formatDatabaseHealthCondition(
         condition.count === 1 ? "connection error" : "connection errors"
       }`;
     case "monitoring_unavailable":
-      return `PlanetScale metrics unavailable for ${formatCount(
-        condition.failures,
-      )} checks`;
+      return formatMonitoringUnavailableCondition(condition);
   }
+}
+
+function formatMonitoringUnavailableCondition(
+  condition: Extract<
+    DatabaseHealthCondition,
+    { kind: "monitoring_unavailable" }
+  >,
+): string {
+  const missingMetricLabels = condition.missingMetrics.map(
+    (name) => DATABASE_METRIC_ALERT_LABELS[name],
+  );
+  const missingMetricEvidence = missingMetricLabels.length === 0
+    ? ""
+    : ` (missing PlanetScale ${
+      missingMetricLabels.length === 1 ? "metric" : "metrics"
+    }: ${missingMetricLabels.join(", ")})`;
+  const availability = missingMetricLabels.length === 0
+    ? "unavailable"
+    : "incomplete";
+  return `Database monitor telemetry is ${availability} for ${formatCount(
+    condition.failures,
+  )} checks${missingMetricEvidence}`;
 }
 
 function buildDatabaseAlertIdempotencyKey(input: {

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -369,12 +369,13 @@ export class DatabaseHealthMonitor {
           missingMetrics: monitoringAlertObligation.missingMetrics,
         }
         : null;
+      const currentReplayableConditions = sample.conditions.filter(
+        (condition) =>
+          condition.kind !== "direct_migration_admission_failures"
+          && condition.kind !== "monitoring_unavailable",
+      );
       const conditionsWithDeferredDirectErrors = [
-        ...sample.conditions.filter(
-          (condition) =>
-            condition.kind !== "direct_migration_admission_failures"
-            && condition.kind !== "monitoring_unavailable",
-        ),
+        ...currentReplayableConditions,
         ...(monitoringConditionForAdmission
           ? [monitoringConditionForAdmission]
           : []),
@@ -393,6 +394,12 @@ export class DatabaseHealthMonitor {
           input.checkedAtMs - alertState.lastAlertAttemptedAtMs
           >= DATABASE_HEALTH_ALERT_INTERVAL_MS
         );
+      const isRetainingNewIncidentPressure =
+        isNewIncident
+        && monitoringAlertObligation !== null
+        && !attemptFenceOpen
+        && !hasDirectConnectionError
+        && currentReplayableConditions.length > 0;
       const admittedConditions =
         (
           isPromotingDeferredDirectError
@@ -406,11 +413,14 @@ export class DatabaseHealthMonitor {
             (condition) =>
               condition.kind === "direct_migration_admission_failures",
           )
-          : conditionsWithDeferredDirectErrors;
+          : isRetainingNewIncidentPressure
+            ? currentReplayableConditions
+            : conditionsWithDeferredDirectErrors;
       const shouldHoldMonitoringForFence =
         monitoringAlertObligation !== null
         && !attemptFenceOpen
-        && !hasDirectConnectionError;
+        && !hasDirectConnectionError
+        && !isRetainingNewIncidentPressure;
       const admittedCheckedAtMs =
         admittedConditions.length === 1
         && admittedConditions[0]?.kind

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -423,6 +423,7 @@ export class DatabaseHealthMonitor {
           (condition) =>
             condition.kind === "direct_migration_admission_failures",
         )
+        && currentDirectError === undefined
         && alertState.deferredDirectErrorCheckedAtMs !== null
           ? alertState.deferredDirectErrorCheckedAtMs
           : admittedConditions.length === 1

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -394,12 +394,6 @@ export class DatabaseHealthMonitor {
           input.checkedAtMs - alertState.lastAlertAttemptedAtMs
           >= DATABASE_HEALTH_ALERT_INTERVAL_MS
         );
-      const isRetainingNewIncidentPressure =
-        isNewIncident
-        && monitoringAlertObligation !== null
-        && !attemptFenceOpen
-        && !hasDirectConnectionError
-        && currentReplayableConditions.length > 0;
       const admittedConditions =
         (
           isPromotingDeferredDirectError
@@ -413,14 +407,15 @@ export class DatabaseHealthMonitor {
             (condition) =>
               condition.kind === "direct_migration_admission_failures",
           )
-          : isRetainingNewIncidentPressure
-            ? currentReplayableConditions
-            : conditionsWithDeferredDirectErrors;
+          : conditionsWithDeferredDirectErrors;
       const shouldHoldMonitoringForFence =
         monitoringAlertObligation !== null
         && !attemptFenceOpen
         && !hasDirectConnectionError
-        && !isRetainingNewIncidentPressure;
+        && (
+          !isNewIncident
+          || currentReplayableConditions.length === 0
+        );
       const admittedCheckedAtMs =
         admittedConditions.length === 1
         && admittedConditions[0]?.kind

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -398,7 +398,7 @@ export class DatabaseHealthMonitor {
         (
           isPromotingDeferredDirectError
           || (
-            !isNewIncident
+            alertState.alertSequence > 0
             && !attemptFenceOpen
             && hasDirectConnectionError
           )

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -411,15 +411,11 @@ export class DatabaseHealthMonitor {
             (condition) =>
               condition.kind === "direct_migration_admission_failures",
           )
-          : (
-            monitoringAlertObligation
-            && !isNewIncident
-            && !attemptFenceOpen
-          )
-            ? conditionsWithDeferredDirectErrors.filter(
-              (condition) => condition.kind === "monitoring_unavailable",
-            )
-            : conditionsWithDeferredDirectErrors;
+          : conditionsWithDeferredDirectErrors;
+      const shouldHoldMonitoringForFence =
+        monitoringAlertObligation !== null
+        && !attemptFenceOpen
+        && !hasDirectConnectionError;
       const admittedCheckedAtMs =
         admittedConditions.length === 1
         && admittedConditions[0]?.kind
@@ -437,6 +433,7 @@ export class DatabaseHealthMonitor {
           !alertState.pendingAlertIdempotencyKey
           || !alertState.pendingAlertMessage
         )
+        && !shouldHoldMonitoringForFence
         && (
           isNewIncident
           || hasDirectConnectionError
@@ -462,6 +459,8 @@ export class DatabaseHealthMonitor {
             checkedAtMs: admittedCheckedAtMs,
             conditions: admittedConditions,
             incidentSequence: alertState.incidentSequence,
+            monitoringCheckedAtMs:
+              monitoringAlertObligation?.checkedAtMs ?? null,
           }),
         });
         if (
@@ -958,6 +957,7 @@ function buildDatabaseAlertMessage(input: {
   checkedAtMs: number;
   conditions: readonly DatabaseHealthCondition[];
   incidentSequence: number;
+  monitoringCheckedAtMs: number | null;
 }): string {
   const checkedAt = new Date(input.checkedAtMs).toISOString().slice(11, 16);
   if (
@@ -967,7 +967,11 @@ function buildDatabaseAlertMessage(input: {
     )
   ) {
     const evidence = input.conditions
-      .map(formatDatabaseHealthCondition)
+      .map((condition) => formatDatabaseHealthCondition(
+        condition,
+        input.checkedAtMs,
+        input.monitoringCheckedAtMs,
+      ))
       .join("; ");
     return `${evidence}. Checked ${checkedAt} UTC.`;
   }
@@ -980,7 +984,13 @@ function buildDatabaseAlertMessage(input: {
   const opening =
     DATABASE_ALERT_OPENINGS[openingIndex]
     ?? DATABASE_ALERT_OPENINGS[0];
-  const evidence = input.conditions.map(formatDatabaseHealthCondition).join("; ");
+  const evidence = input.conditions.map((condition) =>
+    formatDatabaseHealthCondition(
+      condition,
+      input.checkedAtMs,
+      input.monitoringCheckedAtMs,
+    )
+  ).join("; ");
   return `${opening} ${evidence}. Checked ${checkedAt} UTC.`;
 }
 
@@ -1071,6 +1081,8 @@ function hasHealthyLinqSenderLine(input: {
 
 function formatDatabaseHealthCondition(
   condition: DatabaseHealthCondition,
+  checkedAtMs: number,
+  monitoringCheckedAtMs: number | null,
 ): string {
   switch (condition.kind) {
     case "client_wait":
@@ -1098,7 +1110,13 @@ function formatDatabaseHealthCondition(
         condition.count === 1 ? "connection error" : "connection errors"
       }`;
     case "monitoring_unavailable":
-      return formatMonitoringUnavailableCondition(condition);
+      return formatMonitoringUnavailableCondition(
+        condition,
+        monitoringCheckedAtMs !== null
+          && monitoringCheckedAtMs !== checkedAtMs
+          ? monitoringCheckedAtMs
+          : null,
+      );
   }
 }
 
@@ -1107,21 +1125,32 @@ function formatMonitoringUnavailableCondition(
     DatabaseHealthCondition,
     { kind: "monitoring_unavailable" }
   >,
+  observedAtMs: number | null,
 ): string {
   const missingMetricLabels = condition.missingMetrics.map(
     (name) => DATABASE_METRIC_ALERT_LABELS[name],
   );
-  const missingMetricEvidence = missingMetricLabels.length === 0
-    ? ""
-    : ` (missing PlanetScale ${
+  const details = [
+    observedAtMs === null
+      ? null
+      : `observed ${
+        new Date(observedAtMs).toISOString().slice(11, 16)
+      } UTC`,
+    missingMetricLabels.length === 0
+      ? null
+      : `missing PlanetScale ${
       missingMetricLabels.length === 1 ? "metric" : "metrics"
-    }: ${missingMetricLabels.join(", ")})`;
+      }: ${missingMetricLabels.join(", ")}`,
+  ].filter((detail): detail is string => detail !== null);
+  const detailEvidence = details.length === 0
+    ? ""
+    : ` (${details.join("; ")})`;
   const availability = missingMetricLabels.length === 0
     ? "unavailable"
     : "incomplete";
-  return `Database monitor telemetry is ${availability} for ${formatCount(
+  return `Database monitor telemetry was ${availability} for ${formatCount(
     condition.failures,
-  )} checks${missingMetricEvidence}`;
+  )} checks${detailEvidence}`;
 }
 
 function buildDatabaseAlertIdempotencyKey(input: {

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -311,6 +311,21 @@ export class DatabaseHealthMonitor {
       this.store.setConsecutiveScrapeFailures(sample.failures);
     }
 
+    const currentMonitoringCondition = sample.conditions.find(
+      (condition) => condition.kind === "monitoring_unavailable",
+    );
+    if (
+      sample.status === "failed"
+      && sample.failures === MONITORING_FAILURE_ALERT_COUNT
+      && currentMonitoringCondition
+    ) {
+      this.store.recordMonitoringAlertObligation({
+        checkedAtMs: input.checkedAtMs,
+        failures: currentMonitoringCondition.failures,
+        missingMetrics: currentMonitoringCondition.missingMetrics,
+      });
+    }
+
     let alertState = this.store.readAlertState();
     const currentDirectError = sample.conditions.find(
       (condition) =>
@@ -339,37 +354,43 @@ export class DatabaseHealthMonitor {
     if (
       sample.conditions.length > 0
       || directErrorCountAvailableForAdmission > 0
+      || alertState.monitoringAlertObligation !== null
     ) {
       const isNewIncident = !alertState.incidentOpen;
       if (isNewIncident) {
         alertState = this.store.openIncident();
       }
-      const conditionsWithDeferredDirectErrors =
-        directErrorCountAvailableForAdmission > 0
-          ? [
-            ...sample.conditions.filter(
-              (condition) =>
-                condition.kind !== "direct_migration_admission_failures",
-            ),
-            {
-              count: directErrorCountAvailableForAdmission,
-              kind: "direct_migration_admission_failures" as const,
-            },
-          ]
-          : sample.conditions;
+      const monitoringAlertObligation =
+        alertState.monitoringAlertObligation;
+      const monitoringConditionForAdmission = monitoringAlertObligation
+        ? {
+          failures: monitoringAlertObligation.failures,
+          kind: "monitoring_unavailable" as const,
+          missingMetrics: monitoringAlertObligation.missingMetrics,
+        }
+        : currentMonitoringCondition;
+      const conditionsWithDeferredDirectErrors = [
+        ...sample.conditions.filter(
+          (condition) =>
+            condition.kind !== "direct_migration_admission_failures"
+            && condition.kind !== "monitoring_unavailable",
+        ),
+        ...(monitoringConditionForAdmission
+          ? [monitoringConditionForAdmission]
+          : []),
+        ...(directErrorCountAvailableForAdmission > 0
+          ? [{
+            count: directErrorCountAvailableForAdmission,
+            kind: "direct_migration_admission_failures" as const,
+          }]
+          : []),
+      ];
       const hasDirectConnectionError =
         directErrorCountAvailableForAdmission > 0;
       const isMonitoringOnly =
         conditionsWithDeferredDirectErrors.length > 0
         && conditionsWithDeferredDirectErrors.every(
           (condition) => condition.kind === "monitoring_unavailable",
-        );
-      const isInitialMonitoringAlert =
-        isMonitoringOnly
-        && conditionsWithDeferredDirectErrors.some(
-          (condition) =>
-            condition.kind === "monitoring_unavailable"
-            && condition.failures === MONITORING_FAILURE_ALERT_COUNT,
         );
       const attemptFenceOpen =
         alertState.lastAlertAttemptedAtMs === null
@@ -390,7 +411,15 @@ export class DatabaseHealthMonitor {
             (condition) =>
               condition.kind === "direct_migration_admission_failures",
           )
-          : conditionsWithDeferredDirectErrors;
+          : (
+            monitoringAlertObligation
+            && !isNewIncident
+            && !attemptFenceOpen
+          )
+            ? conditionsWithDeferredDirectErrors.filter(
+              (condition) => condition.kind === "monitoring_unavailable",
+            )
+            : conditionsWithDeferredDirectErrors;
       const admittedCheckedAtMs =
         admittedConditions.length === 1
         && admittedConditions[0]?.kind
@@ -398,7 +427,11 @@ export class DatabaseHealthMonitor {
         && currentDirectError === undefined
         && alertState.deferredDirectErrorCheckedAtMs !== null
           ? alertState.deferredDirectErrorCheckedAtMs
-          : input.checkedAtMs;
+          : admittedConditions.length === 1
+            && admittedConditions[0]?.kind === "monitoring_unavailable"
+            && monitoringAlertObligation
+              ? monitoringAlertObligation.checkedAtMs
+              : input.checkedAtMs;
       if (
         (
           !alertState.pendingAlertIdempotencyKey
@@ -408,12 +441,11 @@ export class DatabaseHealthMonitor {
           isNewIncident
           || hasDirectConnectionError
           || attemptFenceOpen
-          || isInitialMonitoringAlert
+          || monitoringAlertObligation !== null
         )
         && (
           !isMonitoringOnly
-          || isNewIncident
-          || isInitialMonitoringAlert
+          || monitoringAlertObligation !== null
         )
       ) {
         const nextAlertSequence = alertState.alertSequence + 1;
@@ -422,6 +454,9 @@ export class DatabaseHealthMonitor {
             alertSequence: nextAlertSequence,
             incidentSequence: alertState.incidentSequence,
           }),
+          includesMonitoring: admittedConditions.some(
+            (condition) => condition.kind === "monitoring_unavailable",
+          ),
           message: buildDatabaseAlertMessage({
             alertSequence: nextAlertSequence,
             checkedAtMs: admittedCheckedAtMs,
@@ -469,6 +504,7 @@ export class DatabaseHealthMonitor {
       input.conditions.length === 0
       && !hasPendingAlert
       && alertState.deferredDirectErrorCount === 0
+      && alertState.monitoringAlertObligation === null
     ) {
       if (
         input.sampleStatus === "ok"
@@ -597,6 +633,7 @@ export class DatabaseHealthMonitor {
         input.sampleStatus === "ok"
         && input.conditions.length === 0
         && stateAfterSuccess.deferredDirectErrorCount === 0
+        && stateAfterSuccess.monitoringAlertObligation === null
       ) {
         this.store.closeIncident();
       }

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -10,7 +10,7 @@ import {
   type DatabaseMetricSnapshot,
 } from "./metrics.js";
 
-const DATABASE_HEALTH_SCHEMA_VERSION = 2;
+const DATABASE_HEALTH_SCHEMA_VERSION = 1;
 
 export interface DatabaseHealthMonitoringAlertObligation {
   checkedAtMs: number;
@@ -509,20 +509,18 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       "Database health Durable Object schema is newer than this Worker.",
     );
   }
-  if (version < 2) {
-    ensureDatabaseHealthTableColumn(
-      sql,
-      "database_health_meta",
-      "monitoring_alert_owed_json",
-      "TEXT",
-    );
-    ensureDatabaseHealthTableColumn(
-      sql,
-      "database_health_meta",
-      "pending_alert_includes_monitoring",
-      "INTEGER NOT NULL DEFAULT 0 CHECK (pending_alert_includes_monitoring IN (0, 1))",
-    );
-  }
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_meta",
+    "monitoring_alert_owed_json",
+    "TEXT",
+  );
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_meta",
+    "pending_alert_includes_monitoring",
+    "INTEGER NOT NULL DEFAULT 0 CHECK (pending_alert_includes_monitoring IN (0, 1))",
+  );
   sql.exec(
     `INSERT INTO database_health_schema_meta (key, value)
      VALUES ('schema_version', ?)

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -15,6 +15,13 @@ const DATABASE_HEALTH_SCHEMA_VERSION = 1;
 export interface DatabaseHealthMonitoringAlertObligation {
   checkedAtMs: number;
   failures: number;
+  incompleteChecks: number;
+  missingMetrics: readonly DatabaseHealthRequiredMetricName[];
+  unavailableChecks: number;
+}
+
+export interface DatabaseHealthMonitoringEvidence {
+  availability: "incomplete" | "unavailable";
   missingMetrics: readonly DatabaseHealthRequiredMetricName[];
 }
 
@@ -70,6 +77,7 @@ interface DatabaseHealthSampleRow extends Record<string, DurableObjectSqlValue> 
   conditions_json: string;
   direct_connection_error_delta: number | null;
   failure_code: string | null;
+  monitoring_evidence_json: string | null;
   observed_at_ms: number;
   postgres_connections: number | null;
   postgres_max_connections: number | null;
@@ -276,8 +284,9 @@ export class DatabaseHealthStore {
          postgres_connection_states_json,
          direct_connection_error_delta,
          direct_connection_error_counters_json,
+         monitoring_evidence_json,
          conditions_json
-       ) VALUES (?, 'ok', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ) VALUES (?, 'ok', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
        ON CONFLICT(observed_at_ms) DO UPDATE SET
          scrape_status = excluded.scrape_status,
          failure_code = excluded.failure_code,
@@ -293,6 +302,7 @@ export class DatabaseHealthStore {
          direct_connection_error_delta = excluded.direct_connection_error_delta,
          direct_connection_error_counters_json =
            excluded.direct_connection_error_counters_json,
+         monitoring_evidence_json = excluded.monitoring_evidence_json,
          conditions_json = excluded.conditions_json`,
       input.observedAtMs,
       input.snapshot.clientWaitSeconds,
@@ -314,6 +324,7 @@ export class DatabaseHealthStore {
     conditions: readonly DatabaseHealthCondition[];
     directConnectionErrorDelta: number | null;
     failureCode: string;
+    monitoringEvidence: DatabaseHealthMonitoringEvidence;
     observedAtMs: number;
     snapshot: DatabaseMetricObservationSnapshot | null;
   }): void {
@@ -334,8 +345,9 @@ export class DatabaseHealthStore {
          postgres_connection_states_json,
          direct_connection_error_delta,
          direct_connection_error_counters_json,
+         monitoring_evidence_json,
          conditions_json
-       ) VALUES (?, 'failed', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ) VALUES (?, 'failed', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(observed_at_ms) DO UPDATE SET
          scrape_status = excluded.scrape_status,
          failure_code = excluded.failure_code,
@@ -353,6 +365,7 @@ export class DatabaseHealthStore {
            excluded.direct_connection_error_delta,
          direct_connection_error_counters_json =
            excluded.direct_connection_error_counters_json,
+         monitoring_evidence_json = excluded.monitoring_evidence_json,
          conditions_json = excluded.conditions_json`,
       input.observedAtMs,
       input.failureCode,
@@ -367,8 +380,34 @@ export class DatabaseHealthStore {
       JSON.stringify(snapshot?.postgresConnectionStates ?? {}),
       input.directConnectionErrorDelta,
       JSON.stringify(snapshot?.directConnectionErrorCounters ?? {}),
+      JSON.stringify(input.monitoringEvidence),
       JSON.stringify(input.conditions),
     );
+  }
+
+  readLatestMonitoringEvidence(): DatabaseHealthMonitoringEvidence | null {
+    const row = this.sql.exec<{
+      failure_code: string;
+      monitoring_evidence_json: string | null;
+    }>(
+      `SELECT failure_code, monitoring_evidence_json
+       FROM database_health_samples
+       WHERE scrape_status = 'failed'
+       ORDER BY observed_at_ms DESC
+       LIMIT 1`,
+    ).toArray()[0];
+    if (!row) {
+      return null;
+    }
+    if (row.monitoring_evidence_json !== null) {
+      return parseMonitoringEvidence(row.monitoring_evidence_json);
+    }
+    return {
+      availability: row.failure_code === "required_metrics_missing"
+        ? "incomplete"
+        : "unavailable",
+      missingMetrics: [],
+    };
   }
 
   pruneSamples(beforeMs: number): void {
@@ -497,6 +536,7 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       postgres_connection_states_json TEXT NOT NULL,
       direct_connection_error_delta INTEGER,
       direct_connection_error_counters_json TEXT NOT NULL,
+      monitoring_evidence_json TEXT,
       conditions_json TEXT NOT NULL,
       CHECK (
         (scrape_status = 'ok' AND failure_code IS NULL)
@@ -532,6 +572,12 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
     sql,
     "database_health_meta",
     "monitoring_alert_owed_json",
+    "TEXT",
+  );
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_samples",
+    "monitoring_evidence_json",
     "TEXT",
   );
   ensureDatabaseHealthTableColumn(
@@ -580,7 +626,9 @@ function parseMonitoringAlertObligation(
   }
   const checkedAtMs = parsed.checkedAtMs;
   const failures = parsed.failures;
+  const incompleteChecks = parsed.incompleteChecks;
   const missingMetrics = parsed.missingMetrics;
+  const unavailableChecks = parsed.unavailableChecks;
   const allowedMetrics = new Set<string>(
     DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
   );
@@ -599,7 +647,61 @@ function parseMonitoringAlertObligation(
   ) {
     throw new Error("Stored database monitoring alert obligation is invalid.");
   }
-  return { checkedAtMs, failures, missingMetrics };
+  const normalizedIncompleteChecks = incompleteChecks === undefined
+    ? (missingMetrics.length > 0 ? failures : 0)
+    : incompleteChecks;
+  const normalizedUnavailableChecks = unavailableChecks === undefined
+    ? (missingMetrics.length > 0 ? 0 : failures)
+    : unavailableChecks;
+  if (
+    typeof normalizedIncompleteChecks !== "number"
+    || !Number.isSafeInteger(normalizedIncompleteChecks)
+    || normalizedIncompleteChecks < 0
+    || typeof normalizedUnavailableChecks !== "number"
+    || !Number.isSafeInteger(normalizedUnavailableChecks)
+    || normalizedUnavailableChecks < 0
+    || normalizedIncompleteChecks + normalizedUnavailableChecks !== failures
+  ) {
+    throw new Error("Stored database monitoring alert obligation is invalid.");
+  }
+  return {
+    checkedAtMs,
+    failures,
+    incompleteChecks: normalizedIncompleteChecks,
+    missingMetrics,
+    unavailableChecks: normalizedUnavailableChecks,
+  };
+}
+
+function parseMonitoringEvidence(
+  value: string,
+): DatabaseHealthMonitoringEvidence {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("Stored database monitoring evidence is invalid.");
+  }
+  if (!isObjectRecord(parsed)) {
+    throw new Error("Stored database monitoring evidence is invalid.");
+  }
+  const availability = parsed.availability;
+  const missingMetrics = parsed.missingMetrics;
+  const allowedMetrics = new Set<string>(
+    DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
+  );
+  if (
+    (availability !== "incomplete" && availability !== "unavailable")
+    || !Array.isArray(missingMetrics)
+    || !missingMetrics.every(
+      (metric): metric is DatabaseHealthRequiredMetricName =>
+        typeof metric === "string" && allowedMetrics.has(metric),
+    )
+    || (availability === "unavailable" && missingMetrics.length > 0)
+  ) {
+    throw new Error("Stored database monitoring evidence is invalid.");
+  }
+  return { availability, missingMetrics };
 }
 
 function parseNumberRecord(value: string): Record<string, number> {

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -4,6 +4,7 @@ import type {
 } from "../user-runner/types.js";
 import type {
   DatabaseHealthCondition,
+  DatabaseMetricObservationSnapshot,
   DatabaseMetricSnapshot,
 } from "./metrics.js";
 
@@ -203,7 +204,7 @@ export class DatabaseHealthStore {
     const row = this.sql.exec<DatabaseHealthCounterRow>(
       `SELECT direct_connection_error_counters_json
        FROM database_health_samples
-       WHERE scrape_status = 'ok'
+       WHERE direct_connection_error_counters_json <> '{}'
        ORDER BY observed_at_ms DESC
        LIMIT 1`,
     ).toArray()[0];
@@ -270,38 +271,61 @@ export class DatabaseHealthStore {
 
   recordFailedSample(input: {
     conditions: readonly DatabaseHealthCondition[];
+    directConnectionErrorDelta: number | null;
     failureCode: string;
     observedAtMs: number;
+    snapshot: DatabaseMetricObservationSnapshot | null;
   }): void {
+    const snapshot = input.snapshot;
     this.sql.exec(
       `INSERT INTO database_health_samples (
          observed_at_ms,
          scrape_status,
          failure_code,
+         client_wait_seconds,
+         client_waiting_connections,
+         server_connections,
+         server_pool_capacity,
+         server_pool_saturation_ratio,
          server_pool_states_json,
+         postgres_connections,
+         postgres_max_connections,
          postgres_connection_states_json,
+         direct_connection_error_delta,
          direct_connection_error_counters_json,
          conditions_json
-       ) VALUES (?, 'failed', ?, '{}', '{}', '{}', ?)
+       ) VALUES (?, 'failed', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(observed_at_ms) DO UPDATE SET
          scrape_status = excluded.scrape_status,
          failure_code = excluded.failure_code,
-         client_wait_seconds = NULL,
-         client_waiting_connections = NULL,
-         server_connections = NULL,
-         server_pool_capacity = NULL,
-         server_pool_saturation_ratio = NULL,
+         client_wait_seconds = excluded.client_wait_seconds,
+         client_waiting_connections = excluded.client_waiting_connections,
+         server_connections = excluded.server_connections,
+         server_pool_capacity = excluded.server_pool_capacity,
+         server_pool_saturation_ratio = excluded.server_pool_saturation_ratio,
          server_pool_states_json = excluded.server_pool_states_json,
-         postgres_connections = NULL,
-         postgres_max_connections = NULL,
+         postgres_connections = excluded.postgres_connections,
+         postgres_max_connections = excluded.postgres_max_connections,
          postgres_connection_states_json =
            excluded.postgres_connection_states_json,
-         direct_connection_error_delta = NULL,
+         direct_connection_error_delta =
+           excluded.direct_connection_error_delta,
          direct_connection_error_counters_json =
            excluded.direct_connection_error_counters_json,
          conditions_json = excluded.conditions_json`,
       input.observedAtMs,
       input.failureCode,
+      snapshot?.clientWaitSeconds ?? null,
+      snapshot?.clientWaitingConnections ?? null,
+      snapshot?.serverConnections ?? null,
+      snapshot?.serverPoolCapacity ?? null,
+      snapshot?.serverPoolSaturationRatio ?? null,
+      JSON.stringify(snapshot?.serverPoolStates ?? {}),
+      snapshot?.postgresConnections ?? null,
+      snapshot?.postgresMaxConnections ?? null,
+      JSON.stringify(snapshot?.postgresConnectionStates ?? {}),
+      input.directConnectionErrorDelta,
+      JSON.stringify(snapshot?.directConnectionErrorCounters ?? {}),
       JSON.stringify(input.conditions),
     );
   }

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -413,7 +413,7 @@ export class DatabaseHealthStore {
   }
 
   private readMetaRow(): DatabaseHealthMetaRow {
-    return this.sql.exec<DatabaseHealthMetaRow>(
+    const row = this.sql.exec<DatabaseHealthMetaRow>(
       `SELECT
          run_lease_until_ms,
          consecutive_scrape_failures,
@@ -430,6 +430,25 @@ export class DatabaseHealthStore {
        FROM database_health_meta
        WHERE singleton = 1`,
     ).one();
+    if (
+      row.pending_alert_includes_monitoring === 1
+      && row.pending_alert_idempotency_key === null
+      && row.pending_alert_message === null
+    ) {
+      this.sql.exec(
+        `UPDATE database_health_meta
+         SET
+           monitoring_alert_owed_json = NULL,
+           pending_alert_includes_monitoring = 0
+         WHERE singleton = 1`,
+      );
+      return {
+        ...row,
+        monitoring_alert_owed_json: null,
+        pending_alert_includes_monitoring: 0,
+      };
+    }
+    return row;
   }
 }
 

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -2,13 +2,21 @@ import type {
   DurableObjectSqlStorageLike,
   DurableObjectSqlValue,
 } from "../user-runner/types.js";
-import type {
-  DatabaseHealthCondition,
-  DatabaseMetricObservationSnapshot,
-  DatabaseMetricSnapshot,
+import {
+  DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
+  type DatabaseHealthRequiredMetricName,
+  type DatabaseHealthCondition,
+  type DatabaseMetricObservationSnapshot,
+  type DatabaseMetricSnapshot,
 } from "./metrics.js";
 
-const DATABASE_HEALTH_SCHEMA_VERSION = 1;
+const DATABASE_HEALTH_SCHEMA_VERSION = 2;
+
+export interface DatabaseHealthMonitoringAlertObligation {
+  checkedAtMs: number;
+  failures: number;
+  missingMetrics: readonly DatabaseHealthRequiredMetricName[];
+}
 
 export interface DatabaseHealthAlertState {
   alertSequence: number;
@@ -18,6 +26,8 @@ export interface DatabaseHealthAlertState {
   incidentOpen: boolean;
   incidentSequence: number;
   lastAlertAttemptedAtMs: number | null;
+  monitoringAlertObligation: DatabaseHealthMonitoringAlertObligation | null;
+  pendingAlertIncludesMonitoring: boolean;
   pendingAlertIdempotencyKey: string | null;
   pendingAlertMessage: string | null;
 }
@@ -44,6 +54,8 @@ interface DatabaseHealthMetaRow extends Record<string, DurableObjectSqlValue> {
   incident_open: number;
   incident_sequence: number;
   last_alert_attempted_at_ms: number | null;
+  monitoring_alert_owed_json: string | null;
+  pending_alert_includes_monitoring: number;
   pending_alert_idempotency_key: string | null;
   pending_alert_message: string | null;
   run_lease_until_ms: number;
@@ -105,6 +117,11 @@ export class DatabaseHealthStore {
       incidentOpen: row.incident_open === 1,
       incidentSequence: row.incident_sequence,
       lastAlertAttemptedAtMs: row.last_alert_attempted_at_ms,
+      monitoringAlertObligation: parseMonitoringAlertObligation(
+        row.monitoring_alert_owed_json,
+      ),
+      pendingAlertIncludesMonitoring:
+        row.pending_alert_includes_monitoring === 1,
       pendingAlertIdempotencyKey: row.pending_alert_idempotency_key,
       pendingAlertMessage: row.pending_alert_message,
     };
@@ -126,6 +143,7 @@ export class DatabaseHealthStore {
          incident_open = 1,
          incident_sequence = incident_sequence + 1,
          alert_sequence = 0,
+         pending_alert_includes_monitoring = 0,
          pending_alert_idempotency_key = NULL,
          pending_alert_message = NULL
        WHERE singleton = 1`,
@@ -139,6 +157,8 @@ export class DatabaseHealthStore {
        SET
          incident_open = 0,
          alert_sequence = 0,
+         monitoring_alert_owed_json = NULL,
+         pending_alert_includes_monitoring = 0,
          pending_alert_idempotency_key = NULL,
          pending_alert_message = NULL
        WHERE singleton = 1`,
@@ -147,19 +167,35 @@ export class DatabaseHealthStore {
 
   createPendingAlert(input: {
     idempotencyKey: string;
+    includesMonitoring: boolean;
     message: string;
   }): DatabaseHealthAlertState {
     this.sql.exec(
       `UPDATE database_health_meta
        SET
          alert_sequence = alert_sequence + 1,
+         pending_alert_includes_monitoring = ?,
          pending_alert_idempotency_key = ?,
          pending_alert_message = ?,
          deferred_direct_error_count = 0,
          deferred_direct_error_checked_at_ms = NULL
        WHERE singleton = 1`,
+      input.includesMonitoring ? 1 : 0,
       input.idempotencyKey,
       input.message,
+    );
+    return this.readAlertState();
+  }
+
+  recordMonitoringAlertObligation(
+    obligation: DatabaseHealthMonitoringAlertObligation,
+  ): DatabaseHealthAlertState {
+    this.sql.exec(
+      `UPDATE database_health_meta
+       SET monitoring_alert_owed_json = ?
+       WHERE singleton = 1
+         AND monitoring_alert_owed_json IS NULL`,
+      JSON.stringify(obligation),
     );
     return this.readAlertState();
   }
@@ -194,6 +230,11 @@ export class DatabaseHealthStore {
     this.sql.exec(
       `UPDATE database_health_meta
        SET
+         monitoring_alert_owed_json = CASE
+           WHEN pending_alert_includes_monitoring = 1 THEN NULL
+           ELSE monitoring_alert_owed_json
+         END,
+         pending_alert_includes_monitoring = 0,
          pending_alert_idempotency_key = NULL,
          pending_alert_message = NULL
        WHERE singleton = 1`,
@@ -382,6 +423,8 @@ export class DatabaseHealthStore {
          deferred_direct_error_count,
          deferred_direct_error_checked_at_ms,
          last_alert_attempted_at_ms,
+         monitoring_alert_owed_json,
+         pending_alert_includes_monitoring,
          pending_alert_idempotency_key,
          pending_alert_message
        FROM database_health_meta
@@ -408,6 +451,9 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       deferred_direct_error_count INTEGER NOT NULL DEFAULT 0,
       deferred_direct_error_checked_at_ms INTEGER,
       last_alert_attempted_at_ms INTEGER,
+      monitoring_alert_owed_json TEXT,
+      pending_alert_includes_monitoring INTEGER NOT NULL DEFAULT 0
+        CHECK (pending_alert_includes_monitoring IN (0, 1)),
       pending_alert_idempotency_key TEXT,
       pending_alert_message TEXT,
       CHECK (
@@ -463,12 +509,80 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       "Database health Durable Object schema is newer than this Worker.",
     );
   }
+  if (version < 2) {
+    ensureDatabaseHealthTableColumn(
+      sql,
+      "database_health_meta",
+      "monitoring_alert_owed_json",
+      "TEXT",
+    );
+    ensureDatabaseHealthTableColumn(
+      sql,
+      "database_health_meta",
+      "pending_alert_includes_monitoring",
+      "INTEGER NOT NULL DEFAULT 0 CHECK (pending_alert_includes_monitoring IN (0, 1))",
+    );
+  }
   sql.exec(
     `INSERT INTO database_health_schema_meta (key, value)
      VALUES ('schema_version', ?)
      ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
     DATABASE_HEALTH_SCHEMA_VERSION,
   );
+}
+
+function ensureDatabaseHealthTableColumn(
+  sql: DurableObjectSqlStorageLike,
+  tableName: string,
+  columnName: string,
+  definition: string,
+): void {
+  const columns = sql.exec<{ name: DurableObjectSqlValue }>(
+    `PRAGMA table_info(${tableName})`,
+  ).toArray().map((row) => row.name);
+  if (columns.includes(columnName)) {
+    return;
+  }
+  sql.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+}
+
+function parseMonitoringAlertObligation(
+  value: string | null,
+): DatabaseHealthMonitoringAlertObligation | null {
+  if (value === null) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("Stored database monitoring alert obligation is invalid.");
+  }
+  if (!isObjectRecord(parsed)) {
+    throw new Error("Stored database monitoring alert obligation is invalid.");
+  }
+  const checkedAtMs = parsed.checkedAtMs;
+  const failures = parsed.failures;
+  const missingMetrics = parsed.missingMetrics;
+  const allowedMetrics = new Set<string>(
+    DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
+  );
+  if (
+    typeof checkedAtMs !== "number"
+    || !Number.isSafeInteger(checkedAtMs)
+    || checkedAtMs <= 0
+    || typeof failures !== "number"
+    || !Number.isSafeInteger(failures)
+    || failures < 2
+    || !Array.isArray(missingMetrics)
+    || !missingMetrics.every(
+      (metric): metric is DatabaseHealthRequiredMetricName =>
+        typeof metric === "string" && allowedMetrics.has(metric),
+    )
+  ) {
+    throw new Error("Stored database monitoring alert obligation is invalid.");
+  }
+  return { checkedAtMs, failures, missingMetrics };
 }
 
 function parseNumberRecord(value: string): Record<string, number> {

--- a/apps/cloudflare/test/database-health-metrics.test.ts
+++ b/apps/cloudflare/test/database-health-metrics.test.ts
@@ -153,16 +153,32 @@ describe("PlanetScale database health metrics", () => {
     )).toBe(0);
   });
 
-  it("fails closed when a required metric or selected label set is malformed", () => {
+  it("identifies the canonical required metric families that are missing", () => {
     const missingMaxConnections = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
       /^planetscale_postgres_settings_max_connections.*$/mu,
       "",
     );
-    expect(() =>
-      parsePlanetScaleDatabaseMetrics(missingMaxConnections, BRANCH_ID)
-    ).toThrowError(DatabaseMetricsParseError);
+
+    try {
+      parsePlanetScaleDatabaseMetrics(missingMaxConnections, BRANCH_ID);
+      throw new Error("Expected required metrics parsing to fail.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DatabaseMetricsParseError);
+      if (!(error instanceof DatabaseMetricsParseError)) {
+        throw error;
+      }
+      expect(error).toMatchObject({
+        code: "required_metrics_missing",
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+      });
+    }
+  });
+
+  it("fails closed when a selected label set is malformed", () => {
 
     const malformedLabels = buildMetricsBody({
       branchId: BRANCH_ID,

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1419,6 +1419,122 @@ describe("database health monitor", () => {
     expect(harness.allLinqRequests).toHaveLength(4);
   });
 
+  it("retains pressure that begins after an unadmitted telemetry threshold", async () => {
+    let clientWaitSeconds = 8;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    clientWaitSeconds = 0;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 4)).resolves
+      .toMatchObject({
+        conditions: [{ failures: 2, kind: "monitoring_unavailable" }],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      alertSequence: 0,
+      incidentOpen: true,
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 4,
+        failures: 2,
+      },
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+
+    clientWaitSeconds = 8;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 5)).resolves
+      .toMatchObject({
+        conditions: [
+          { kind: "client_wait", seconds: 8 },
+          { failures: 3, kind: "monitoring_unavailable" },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    const mixedPending = harness.monitor.readAlertState();
+    expect(mixedPending).toMatchObject({
+      alertSequence: 1,
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 4,
+        failures: 2,
+      },
+      pendingAlertIncludesMonitoring: true,
+    });
+    expect(mixedPending.pendingAlertMessage).toBe(
+      "Database health is outside the safe range. PgBouncer wait 8s; "
+      + "Database monitor telemetry was incomplete for 2 checks "
+      + "(observed 00:20 UTC; missing PlanetScale metric: "
+      + "Postgres max connections). Checked 00:25 UTC.",
+    );
+    expect(mixedPending.pendingAlertIdempotencyKey).not.toBeNull();
+
+    clientWaitSeconds = 0;
+    omitMaxConnections = false;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 6)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey: mixedPending.pendingAlertIdempotencyKey,
+      pendingAlertMessage: mixedPending.pendingAlertMessage,
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      incidentOpen: false,
+      monitoringAlertObligation: null,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+
+    const allBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    const mixedAttempts = allBodies.filter(
+      (body) =>
+        body.message.parts[0]?.value === mixedPending.pendingAlertMessage,
+    );
+    expect(mixedAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
+    ]);
+    expect(mixedAttempts.map(
+      (body) => body.message.idempotency_key,
+    ).sort()).toEqual([
+      mixedPending.pendingAlertIdempotencyKey,
+      `${mixedPending.pendingAlertIdempotencyKey}-recipient-2`,
+    ]);
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    expect(harness.allLinqRequests).toHaveLength(4);
+  });
+
   it("keeps a stale pressure retry from clearing rearmed telemetry", async () => {
     let clientWaitSeconds = 0;
     let missingFamily: "max_connections" | "server_pools" | null =

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -939,6 +939,85 @@ describe("database health monitor", () => {
       .not.toBe(firstAlert.message.idempotency_key);
   });
 
+  it("pages a fully unavailable telemetry outage with explicit unavailable copy", async () => {
+    const harness = createMonitorHarness({
+      serviceDiscoveryResponses: [
+        () => new Response(null, { status: 503 }),
+        () => new Response(null, { status: 503 }),
+      ],
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        {
+          failures: 2,
+          kind: "monitoring_unavailable",
+          missingMetrics: [],
+        },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
+    expect(alert.message.parts[0]?.value).toBe(
+      "Database monitor telemetry is unavailable for 2 checks. "
+      + "Checked 00:10 UTC.",
+    );
+    expect(alert.message.parts[0]?.value).not.toContain(
+      "database is under pressure",
+    );
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      failureCode: "service_discovery_failed",
+      scrapeStatus: "failed",
+    });
+  });
+
+  it("keeps an available unsafe signal when a present family lacks its required pod label", async () => {
+    const completeMaxConnectionsLine =
+      "planetscale_postgres_settings_max_connections{"
+      + `planetscale_database_branch_id="${BRANCH_ID}",`
+      + 'planetscale_pod="pod-primary",planetscale_role="primary"} 50';
+    const structurallyIncompleteMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+    }).replace(
+      completeMaxConnectionsLine,
+      "planetscale_postgres_settings_max_connections{"
+      + `planetscale_database_branch_id="${BRANCH_ID}",`
+      + 'planetscale_role="primary"} 50',
+    );
+    const harness = createMonitorHarness({
+      metricsBody: structurallyIncompleteMetricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({
+        conditions: [
+          {
+            kind: "client_wait",
+            seconds: 8,
+            waitingConnections: 3,
+          },
+        ],
+        outcome: "alert_sent",
+        sampleStatus: "failed",
+      });
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      clientWaitSeconds: 8,
+      failureCode: "required_metrics_missing",
+      postgresMaxConnections: null,
+      scrapeStatus: "failed",
+    });
+  });
+
   it("still pages an available unsafe signal when another metric is missing", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
@@ -973,48 +1052,147 @@ describe("database health monitor", () => {
     });
   });
 
-  it("retains the first telemetry page behind an existing incident fence", async () => {
-    const unsafeMetricsBody = buildMetricsBody({
-      branchId: BRANCH_ID,
-      clientWaitSeconds: 8,
-    });
-    const partialHealthyMetricsBody = buildMetricsBody({
-      branchId: BRANCH_ID,
-    }).replace(
-      /^planetscale_postgres_settings_max_connections.*$/mu,
-      "",
-    );
-    let metricsBody = unsafeMetricsBody;
+  it("retains a mixed telemetry obligation behind an older pending page", async () => {
+    let clientWaitSeconds = 8;
+    let omitMaxConnections = false;
     const harness = createMonitorHarness({
-      readMetricsBody: () => metricsBody,
+      linqResponses: [
+        () => {
+          throw new Error("ambiguous send");
+        },
+      ],
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
     });
 
     await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
-      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
-    metricsBody = partialHealthyMetricsBody;
-    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
-      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
-    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
-      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "failed" });
-
-    const pendingAlert = harness.monitor.readAlertState();
-    expect(pendingAlert.pendingAlertMessage).toContain(
-      "Database monitor telemetry is incomplete for 2 checks",
+      .toMatchObject({ outcome: "alert_failed", sampleStatus: "ok" });
+    const olderPendingAlert = harness.monitor.readAlertState();
+    expect(olderPendingAlert.pendingAlertMessage).toContain(
+      "PgBouncer wait 8s",
     );
+
+    omitMaxConnections = true;
+    clientWaitSeconds = 0;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "failed" });
+    clientWaitSeconds = 8;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({
+        conditions: [
+          {
+            kind: "client_wait",
+            seconds: 8,
+          },
+          {
+            failures: 2,
+            kind: "monitoring_unavailable",
+          },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 3,
+        failures: 2,
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+      },
+      pendingAlertIdempotencyKey:
+        olderPendingAlert.pendingAlertIdempotencyKey,
+      pendingAlertMessage: olderPendingAlert.pendingAlertMessage,
+    });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey:
+        olderPendingAlert.pendingAlertIdempotencyKey,
+    });
+
+    clientWaitSeconds = 0;
+    omitMaxConnections = false;
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({
       outcome: "alert_sent",
-      sampleStatus: "failed",
+      sampleStatus: "ok",
     });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_deferred",
+      sampleStatus: "ok",
+    });
+    const telemetryPendingAlert = harness.monitor.readAlertState();
+    expect(telemetryPendingAlert.pendingAlertMessage).toBe(
+      "Database monitor telemetry is incomplete for 2 checks "
+      + "(missing PlanetScale metric: Postgres max connections). "
+      + "Checked 00:15 UTC.",
+    );
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
     ).resolves.toMatchObject({
-      outcome: "alert_deferred",
-      sampleStatus: "failed",
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      incidentOpen: false,
+      monitoringAlertObligation: null,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
     });
 
-    expect(harness.primaryLinqRequests).toHaveLength(2);
+    expect(harness.primaryLinqRequests).toHaveLength(3);
+    const firstAttempt = await readLinqRequestBody(
+      harness.primaryLinqRequests[0],
+    );
+    const olderRetry = await readLinqRequestBody(
+      harness.primaryLinqRequests[1],
+    );
+    const telemetryAttempt = await readLinqRequestBody(
+      harness.primaryLinqRequests[2],
+    );
+    expect(olderRetry).toEqual(firstAttempt);
+    expect(telemetryAttempt.message.idempotency_key)
+      .toBe(telemetryPendingAlert.pendingAlertIdempotencyKey);
+    expect(telemetryAttempt.message.parts[0]?.value)
+      .toBe(telemetryPendingAlert.pendingAlertMessage);
+    const telemetryAttempts = (
+      await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
+    ).filter(
+      (body) =>
+        body.message.parts[0]?.value
+        === telemetryPendingAlert.pendingAlertMessage,
+    );
+    expect(telemetryAttempts).toHaveLength(2);
+    expect(telemetryAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
+    ]);
+    expect(telemetryAttempts.map(
+      (body) => body.message.idempotency_key,
+    ).sort()).toEqual([
+      telemetryPendingAlert.pendingAlertIdempotencyKey,
+      `${telemetryPendingAlert.pendingAlertIdempotencyKey}-recipient-2`,
+    ]);
   });
 
   it("advances an available direct-error baseline across partial samples", async () => {
@@ -1065,6 +1243,81 @@ describe("database health monitor", () => {
     expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
       directConnectionErrorDelta: 0,
       failureCode: "required_metrics_missing",
+    });
+  });
+
+  it("retains telemetry owed behind direct-only inside-fence admission", async () => {
+    let clientWaitSeconds = 8;
+    let directErrors = 5;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+          directErrors,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    clientWaitSeconds = 0;
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    clientWaitSeconds = 9;
+    directErrors = 7;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({
+        conditions: [
+          { kind: "client_wait", seconds: 9 },
+          { count: 2, kind: "direct_migration_admission_failures" },
+          { failures: 2, kind: "monitoring_unavailable" },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+
+    const directPendingAlert = harness.monitor.readAlertState();
+    expect(directPendingAlert).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIncludesMonitoring: false,
+    });
+    expect(directPendingAlert.pendingAlertMessage).toContain(
+      "2 direct migration connection errors",
+    );
+    expect(directPendingAlert.pendingAlertMessage).not.toContain(
+      "telemetry",
+    );
+
+    clientWaitSeconds = 0;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    const telemetryPendingAlert = harness.monitor.readAlertState();
+    expect(telemetryPendingAlert).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIncludesMonitoring: true,
+    });
+    expect(telemetryPendingAlert.pendingAlertMessage).toContain(
+      "Database monitor telemetry is incomplete for 2 checks",
+    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertIdempotencyKey: null,
     });
   });
 

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -874,8 +874,8 @@ describe("database health monitor", () => {
     );
     expect(firstAlert.message.parts[0]?.value).toBe(
       "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric: Postgres max connections). "
-      + "Checked 00:10 UTC.",
+      + "(missing PlanetScale metric observed: Postgres max connections). "
+      + "Window ended 00:10 UTC.",
     );
     expect(firstAlert.message.parts[0]?.value).not.toContain(
       "database is under pressure",
@@ -897,10 +897,12 @@ describe("database health monitor", () => {
     expect(failedSample?.conditions).toEqual([
       {
         failures: 2,
+        incompleteChecks: 2,
         kind: "monitoring_unavailable",
         missingMetrics: [
           "planetscale_postgres_settings_max_connections",
         ],
+        unavailableChecks: 0,
       },
     ]);
 
@@ -969,7 +971,7 @@ describe("database health monitor", () => {
     const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
     expect(alert.message.parts[0]?.value).toBe(
       "Database monitor telemetry was unavailable for 2 checks. "
-      + "Checked 00:10 UTC.",
+      + "Window ended 00:10 UTC.",
     );
     expect(alert.message.parts[0]?.value).not.toContain(
       "database is under pressure",
@@ -977,6 +979,171 @@ describe("database health monitor", () => {
     expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
       failureCode: "service_discovery_failed",
       scrapeStatus: "failed",
+    });
+  });
+
+  it("summarizes a partial-then-unavailable telemetry window across retry", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({
+      linqResponses: [
+        () => {
+          throw new Error("ambiguous send");
+        },
+      ],
+      metricsBody: partialMetricsBody,
+      serviceDiscoveryResponses: [
+        createServiceDiscoveryResponse,
+        () => new Response(null, { status: 503 }),
+      ],
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_failed", sampleStatus: "failed" });
+
+    const expectedMessage =
+      "Database monitor telemetry was impaired for 2 checks "
+      + "(1 incomplete, 1 unavailable; missing PlanetScale metric observed: "
+      + "Postgres max connections). Window ended 00:10 UTC.";
+    const pendingAlert = harness.monitor.readAlertState();
+    const idempotencyKey = pendingAlert.pendingAlertIdempotencyKey;
+    if (!idempotencyKey || !pendingAlert.pendingAlertMessage) {
+      throw new Error("Expected a persisted mixed telemetry alert.");
+    }
+    expect(pendingAlert).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 2,
+        failures: 2,
+        incompleteChecks: 1,
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+        unavailableChecks: 1,
+      },
+      pendingAlertMessage: expectedMessage,
+    });
+    const firstBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    expect(firstBodies.map((body) => body.message.parts[0]?.value))
+      .toEqual([expectedMessage, expectedMessage]);
+
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      pendingAlertIdempotencyKey: idempotencyKey,
+      pendingAlertMessage: expectedMessage,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+
+    const allBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    expect(allBodies.map((body) => body.message.parts[0]?.value))
+      .toEqual([
+        expectedMessage,
+        expectedMessage,
+        expectedMessage,
+        expectedMessage,
+      ]);
+    expect(allBodies.map((body) => body.message.idempotency_key).sort())
+      .toEqual([
+        idempotencyKey,
+        idempotencyKey,
+        `${idempotencyKey}-recipient-2`,
+        `${idempotencyKey}-recipient-2`,
+      ].sort());
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertMessage: null,
+    });
+  });
+
+  it("summarizes an unavailable-then-partial telemetry window", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({
+      metricsBody: partialMetricsBody,
+      serviceDiscoveryResponses: [
+        () => new Response(null, { status: 503 }),
+        createServiceDiscoveryResponse,
+      ],
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "failed" });
+
+    const expectedMessage =
+      "Database monitor telemetry was impaired for 2 checks "
+      + "(1 incomplete, 1 unavailable; missing PlanetScale metric observed: "
+      + "Postgres max connections). Window ended 00:10 UTC.";
+    const bodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    expect(bodies).toHaveLength(2);
+    expect(bodies.map((body) => body.message.parts[0]?.value))
+      .toEqual([expectedMessage, expectedMessage]);
+    expect(bodies[1]?.message.idempotency_key)
+      .toBe(`${bodies[0]?.message.idempotency_key}-recipient-2`);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertMessage: null,
+    });
+  });
+
+  it("unions observed missing families across a partial telemetry window", async () => {
+    const healthyMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
+    let metricsBody = healthyMetricsBody.replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    metricsBody = healthyMetricsBody.replace(
+      /^planetscale_pgbouncer_pools_server.*$/gmu,
+      "",
+    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "failed" });
+
+    const expectedMessage =
+      "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metrics observed: PgBouncer server pools, "
+      + "Postgres max connections). Window ended 00:10 UTC.";
+    const bodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    expect(bodies).toHaveLength(2);
+    expect(bodies.map((body) => body.message.parts[0]?.value))
+      .toEqual([expectedMessage, expectedMessage]);
+    expect(bodies[1]?.message.idempotency_key)
+      .toBe(`${bodies[0]?.message.idempotency_key}-recipient-2`);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertMessage: null,
     });
   });
 
@@ -1215,8 +1382,8 @@ describe("database health monitor", () => {
     expect(olderRetry).toEqual(firstAttempt);
     expect(telemetryAttempt.message.parts[0]?.value).toBe(
       "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric: Postgres max connections). "
-      + "Checked 00:15 UTC.",
+      + "(missing PlanetScale metric observed: Postgres max connections). "
+      + "Window ended 00:15 UTC.",
     );
     const telemetryAttempts = (
       await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
@@ -1296,7 +1463,7 @@ describe("database health monitor", () => {
     expect(combinedAlert.message.parts[0]?.value).toBe(
       "Database health is outside the safe range. PgBouncer wait 9s; "
       + "Database monitor telemetry was incomplete for 2 checks "
-      + "(observed 00:15 UTC; missing PlanetScale metric: "
+      + "(window ended 00:15 UTC; missing PlanetScale metric observed: "
       + "Postgres max connections). Checked 00:35 UTC.",
     );
     const combinedAttempts = (
@@ -1361,7 +1528,7 @@ describe("database health monitor", () => {
     expect(pressurePending.pendingAlertMessage).toBe(
       "Database health is outside the safe range. PgBouncer wait 8s; "
       + "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric: Postgres max connections). "
+      + "(missing PlanetScale metric observed: Postgres max connections). "
       + "Checked 00:20 UTC.",
     );
     expect(pressurePending.pendingAlertIdempotencyKey).not.toBeNull();
@@ -1485,7 +1652,7 @@ describe("database health monitor", () => {
     expect(mixedPending.pendingAlertMessage).toBe(
       "Database health is outside the safe range. PgBouncer wait 8s; "
       + "Database monitor telemetry was incomplete for 2 checks "
-      + "(observed 00:20 UTC; missing PlanetScale metric: "
+      + "(window ended 00:20 UTC; missing PlanetScale metric observed: "
       + "Postgres max connections). Checked 00:25 UTC.",
     );
     expect(mixedPending.pendingAlertIdempotencyKey).not.toBeNull();
@@ -1601,7 +1768,7 @@ describe("database health monitor", () => {
     expect(mixedPending.pendingAlertMessage).toBe(
       "Database health is outside the safe range. PgBouncer wait 8s; "
       + "Database monitor telemetry was incomplete for 2 checks "
-      + "(observed 00:20 UTC; missing PlanetScale metric: "
+      + "(window ended 00:20 UTC; missing PlanetScale metric observed: "
       + "Postgres max connections); 2 direct migration connection errors. "
       + "Checked 00:25 UTC.",
     );
@@ -1693,8 +1860,8 @@ describe("database health monitor", () => {
     );
     expect(firstTelemetryAlert.message.parts[0]?.value).toBe(
       "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric: Postgres max connections). "
-      + "Checked 00:10 UTC.",
+      + "(missing PlanetScale metric observed: Postgres max connections). "
+      + "Window ended 00:10 UTC.",
     );
 
     clientWaitSeconds = 8;
@@ -1776,8 +1943,8 @@ describe("database health monitor", () => {
     );
     expect(secondTelemetryAlert.message.parts[0]?.value).toBe(
       "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric: PgBouncer server pools). "
-      + "Checked 00:55 UTC.",
+      + "(missing PlanetScale metric observed: PgBouncer server pools). "
+      + "Window ended 00:55 UTC.",
     );
     const telemetryAttempts = (
       await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
@@ -2515,7 +2682,7 @@ describe("database health monitor", () => {
     expect(harness.monitor.readAlertState().pendingAlertMessage)
       .toContain(
         "Database monitor telemetry was incomplete for 2 checks "
-        + "(observed 00:25 UTC; missing PlanetScale metric: "
+        + "(window ended 00:25 UTC; missing PlanetScale metric observed: "
         + "Postgres max connections)",
       );
     expect(harness.monitor.readAlertState().pendingAlertMessage)
@@ -2544,7 +2711,7 @@ describe("database health monitor", () => {
     expect(directErrorPage.message.parts[0]?.value)
       .toContain(
         "Database monitor telemetry was incomplete for 2 checks "
-        + "(observed 00:25 UTC; missing PlanetScale metric: "
+        + "(window ended 00:25 UTC; missing PlanetScale metric observed: "
         + "Postgres max connections)",
       );
     expect(directErrorPage.message.parts[0]?.value)

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1312,6 +1312,119 @@ describe("database health monitor", () => {
     ]);
   });
 
+  it("retains new-incident pressure ahead of owed telemetry", async () => {
+    let clientWaitSeconds = 8;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    clientWaitSeconds = 0;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    expect(harness.monitor.readAlertState().incidentOpen).toBe(false);
+
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    clientWaitSeconds = 8;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 4)).resolves
+      .toMatchObject({
+        conditions: [
+          { kind: "client_wait", seconds: 8 },
+          { failures: 2, kind: "monitoring_unavailable" },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    const pressurePending = harness.monitor.readAlertState();
+    expect(pressurePending).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 4,
+        failures: 2,
+      },
+      pendingAlertIncludesMonitoring: false,
+    });
+    expect(pressurePending.pendingAlertMessage).toBe(
+      "Database health is outside the safe range. PgBouncer wait 8s. "
+      + "Checked 00:20 UTC.",
+    );
+    expect(pressurePending.pendingAlertIdempotencyKey).not.toBeNull();
+
+    clientWaitSeconds = 0;
+    omitMaxConnections = false;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 5)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey:
+        pressurePending.pendingAlertIdempotencyKey,
+      pendingAlertMessage: pressurePending.pendingAlertMessage,
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      incidentOpen: false,
+      monitoringAlertObligation: null,
+    });
+
+    const allBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    const pressureAttempts = allBodies.filter(
+      (body) =>
+        body.message.parts[0]?.value === pressurePending.pendingAlertMessage,
+    );
+    expect(pressureAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
+    ]);
+    expect(pressureAttempts.map(
+      (body) => body.message.idempotency_key,
+    ).sort()).toEqual([
+      pressurePending.pendingAlertIdempotencyKey,
+      `${pressurePending.pendingAlertIdempotencyKey}-recipient-2`,
+    ]);
+    const telemetryAttempts = allBodies.filter(
+      (body) =>
+        body.message.parts[0]?.value
+        === "Database monitor telemetry was incomplete for 2 checks "
+          + "(missing PlanetScale metric: Postgres max connections). "
+          + "Checked 00:20 UTC.",
+    );
+    expect(telemetryAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
+    ]);
+  });
+
   it("keeps a stale pressure retry from clearing rearmed telemetry", async () => {
     let clientWaitSeconds = 0;
     let missingFamily: "max_connections" | "server_pools" | null =

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -2317,6 +2317,8 @@ describe("database health monitor", () => {
     expect(directErrorPage.message.parts[0]?.value)
       .toContain("2 direct migration connection errors");
     expect(directErrorPage.message.parts[0]?.value)
+      .toContain("Checked 00:20 UTC");
+    expect(directErrorPage.message.parts[0]?.value)
       .not.toContain("PgBouncer wait");
     expect(
       harness.monitor.readRecentSamples(10)
@@ -2325,6 +2327,83 @@ describe("database health monitor", () => {
     expect(harness.monitor.readAlertState()).toMatchObject({
       deferredDirectErrorCount: 0,
       incidentOpen: false,
+      pendingAlertMessage: null,
+    });
+  });
+
+  it("dates mixed current and deferred direct evidence to the current check", async () => {
+    let metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+      directErrors: 5,
+    });
+    const harness = createMonitorHarness({
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent" });
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 5,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "healthy" });
+
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 9,
+      directErrors: 5,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 9,
+      directErrors: 7,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 4),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      deferredDirectErrorCheckedAtMs: FIVE_MINUTES_MS * 4,
+      deferredDirectErrorCount: 2,
+    });
+
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 7,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 7),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 9,
+    });
+    harness.restartMonitor();
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 14),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+
+    expect(harness.primaryLinqRequests).toHaveLength(3);
+    const aggregatePage = await readLinqRequestBody(
+      harness.primaryLinqRequests[2],
+    );
+    expect(aggregatePage.message.parts[0]?.value)
+      .toContain("4 direct migration connection errors");
+    expect(aggregatePage.message.parts[0]?.value)
+      .toContain("Checked 01:10 UTC");
+    expect(aggregatePage.message.parts[0]?.value)
+      .not.toContain("Checked 00:20 UTC");
+    expect(aggregatePage.message.parts[0]?.value)
+      .not.toContain("PgBouncer wait");
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      deferredDirectErrorCheckedAtMs: null,
+      deferredDirectErrorCount: 0,
       pendingAlertMessage: null,
     });
   });
@@ -2413,7 +2492,7 @@ describe("database health monitor", () => {
     metricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
       clientWaitSeconds: 12,
-      directErrors: 7,
+      directErrors: 9,
     });
     harness.restartMonitor();
     await expect(
@@ -2426,11 +2505,13 @@ describe("database health monitor", () => {
       monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
       pendingAlertIncludesMonitoring: true,
       pendingAlertMessage: expect.stringContaining(
-        "2 direct migration connection errors",
+        "4 direct migration connection errors",
       ),
     });
     expect(harness.monitor.readAlertState().pendingAlertMessage)
-      .toContain("Checked 00:30 UTC");
+      .toContain("Checked 01:10 UTC");
+    expect(harness.monitor.readAlertState().pendingAlertMessage)
+      .not.toContain("Checked 00:30 UTC");
     expect(harness.monitor.readAlertState().pendingAlertMessage)
       .toContain(
         "Database monitor telemetry was incomplete for 2 checks "
@@ -2442,7 +2523,7 @@ describe("database health monitor", () => {
 
     metricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
-      directErrors: 7,
+      directErrors: 9,
     });
     harness.restartMonitor();
     await expect(
@@ -2455,9 +2536,11 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toHaveLength(3);
     const directErrorPage = await readLinqRequestBody(harness.primaryLinqRequests[2]);
     expect(directErrorPage.message.parts[0]?.value)
-      .toContain("2 direct migration connection errors");
+      .toContain("4 direct migration connection errors");
     expect(directErrorPage.message.parts[0]?.value)
-      .toContain("Checked 00:30 UTC");
+      .toContain("Checked 01:10 UTC");
+    expect(directErrorPage.message.parts[0]?.value)
+      .not.toContain("Checked 00:30 UTC");
     expect(directErrorPage.message.parts[0]?.value)
       .toContain(
         "Database monitor telemetry was incomplete for 2 checks "
@@ -2477,7 +2560,7 @@ describe("database health monitor", () => {
     expect(
       harness.monitor.readRecentSamples(20)
         .filter((sample) => sample.directConnectionErrorDelta === 2),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     expect(harness.monitor.readAlertState()).toMatchObject({
       deferredDirectErrorCheckedAtMs: null,
       deferredDirectErrorCount: 0,

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1848,7 +1848,7 @@ describe("database health monitor", () => {
     });
   });
 
-  it("retains telemetry owed behind direct-only inside-fence admission", async () => {
+  it("combines owed telemetry with direct-only inside-fence admission", async () => {
     let clientWaitSeconds = 8;
     let directErrors = 5;
     let omitMaxConnections = false;
@@ -1887,44 +1887,64 @@ describe("database health monitor", () => {
         sampleStatus: "failed",
       });
 
-    const directPendingAlert = harness.monitor.readAlertState();
-    expect(directPendingAlert).toMatchObject({
+    const combinedPendingAlert = harness.monitor.readAlertState();
+    const combinedIdempotencyKey =
+      combinedPendingAlert.pendingAlertIdempotencyKey;
+    const combinedMessage = combinedPendingAlert.pendingAlertMessage;
+    if (!combinedIdempotencyKey || !combinedMessage) {
+      throw new Error("Expected a persisted combined alert.");
+    }
+    expect(combinedPendingAlert).toMatchObject({
       monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
-      pendingAlertIncludesMonitoring: false,
+      pendingAlertIncludesMonitoring: true,
     });
-    expect(directPendingAlert.pendingAlertMessage).toContain(
+    expect(combinedPendingAlert.pendingAlertMessage).toContain(
       "2 direct migration connection errors",
     );
-    expect(directPendingAlert.pendingAlertMessage).not.toContain(
-      "telemetry",
+    expect(combinedPendingAlert.pendingAlertMessage).toContain(
+      "Database monitor telemetry was incomplete for 2 checks",
+    );
+    expect(combinedPendingAlert.pendingAlertMessage).not.toContain(
+      "PgBouncer wait",
     );
 
     clientWaitSeconds = 0;
+    omitMaxConnections = false;
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      pendingAlertIdempotencyKey:
+        combinedIdempotencyKey,
+      pendingAlertIncludesMonitoring: true,
+      pendingAlertMessage: combinedMessage,
+    });
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({ outcome: "alert_sent" });
-    await expect(
-      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
-    ).resolves.toMatchObject({ outcome: "alert_deferred" });
     expect(harness.monitor.readAlertState()).toMatchObject({
-      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      monitoringAlertObligation: null,
       pendingAlertIncludesMonitoring: false,
       pendingAlertIdempotencyKey: null,
       pendingAlertMessage: null,
     });
+    expect(harness.allLinqRequests).toHaveLength(4);
+    const combinedBodies = await Promise.all(
+      harness.allLinqRequests.slice(2).map(readLinqRequestBody),
+    );
+    expect(combinedBodies.map((body) => body.message.parts[0]?.value))
+      .toEqual([
+        combinedMessage,
+        combinedMessage,
+      ]);
+    expect(combinedBodies.map((body) => body.message.idempotency_key).sort())
+      .toEqual([
+        combinedIdempotencyKey,
+        `${combinedIdempotencyKey}-recipient-2`,
+      ].sort());
+
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
-    ).resolves.toMatchObject({ outcome: "alert_sent" });
-    expect(harness.monitor.readAlertState()).toMatchObject({
-      monitoringAlertObligation: null,
-      pendingAlertIdempotencyKey: null,
-    });
-    expect(harness.primaryLinqRequests).toHaveLength(3);
-    expect((
-      await readLinqRequestBody(harness.primaryLinqRequests[2])
-    ).message.parts[0]?.value).toContain(
-      "Database monitor telemetry was incomplete for 2 checks",
-    );
+    ).resolves.toMatchObject({ outcome: "healthy" });
+    expect(harness.allLinqRequests).toHaveLength(4);
   });
 
   it("retries an unacknowledged telemetry page with its exact identity", async () => {
@@ -2309,7 +2329,7 @@ describe("database health monitor", () => {
     });
   });
 
-  it("promotes deferred direct evidence alone after the attempt fence reopens", async () => {
+  it("promotes deferred direct evidence with owed telemetry after the fence reopens", async () => {
     let metricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
       clientWaitSeconds: 8,
@@ -2350,21 +2370,43 @@ describe("database health monitor", () => {
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
     ).resolves.toMatchObject({ outcome: "alert_deferred" });
+
+    metricsBody = metricsBody.replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 4),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 5),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 5,
+        failures: 2,
+      },
+    });
     metricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
       clientWaitSeconds: 9,
       directErrors: 7,
     });
     await expect(
-      harness.runScheduledCheck(FIVE_MINUTES_MS * 4),
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 6),
     ).resolves.toMatchObject({ outcome: "alert_deferred" });
 
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 7,
+    });
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS * 7),
     ).resolves.toMatchObject({ outcome: "alert_sent" });
     expect(harness.monitor.readAlertState()).toMatchObject({
-      deferredDirectErrorCheckedAtMs: FIVE_MINUTES_MS * 4,
+      deferredDirectErrorCheckedAtMs: FIVE_MINUTES_MS * 6,
       deferredDirectErrorCount: 2,
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
       pendingAlertMessage: null,
     });
 
@@ -2381,12 +2423,20 @@ describe("database health monitor", () => {
     expect(harness.monitor.readAlertState()).toMatchObject({
       deferredDirectErrorCheckedAtMs: null,
       deferredDirectErrorCount: 0,
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIncludesMonitoring: true,
       pendingAlertMessage: expect.stringContaining(
         "2 direct migration connection errors",
       ),
     });
     expect(harness.monitor.readAlertState().pendingAlertMessage)
-      .toContain("Checked 00:20 UTC");
+      .toContain("Checked 00:30 UTC");
+    expect(harness.monitor.readAlertState().pendingAlertMessage)
+      .toContain(
+        "Database monitor telemetry was incomplete for 2 checks "
+        + "(observed 00:25 UTC; missing PlanetScale metric: "
+        + "Postgres max connections)",
+      );
     expect(harness.monitor.readAlertState().pendingAlertMessage)
       .not.toContain("PgBouncer wait");
 
@@ -2407,9 +2457,23 @@ describe("database health monitor", () => {
     expect(directErrorPage.message.parts[0]?.value)
       .toContain("2 direct migration connection errors");
     expect(directErrorPage.message.parts[0]?.value)
-      .toContain("Checked 00:20 UTC");
+      .toContain("Checked 00:30 UTC");
+    expect(directErrorPage.message.parts[0]?.value)
+      .toContain(
+        "Database monitor telemetry was incomplete for 2 checks "
+        + "(observed 00:25 UTC; missing PlanetScale metric: "
+        + "Postgres max connections)",
+      );
     expect(directErrorPage.message.parts[0]?.value)
       .not.toContain("PgBouncer wait");
+    const combinedBodies = await Promise.all(
+      harness.allLinqRequests.slice(4).map(readLinqRequestBody),
+    );
+    expect(combinedBodies).toHaveLength(2);
+    expect(combinedBodies[1]?.message.parts)
+      .toEqual(combinedBodies[0]?.message.parts);
+    expect(combinedBodies[1]?.message.idempotency_key)
+      .toBe(`${combinedBodies[0]?.message.idempotency_key}-recipient-2`);
     expect(
       harness.monitor.readRecentSamples(20)
         .filter((sample) => sample.directConnectionErrorDelta === 2),
@@ -2418,8 +2482,13 @@ describe("database health monitor", () => {
       deferredDirectErrorCheckedAtMs: null,
       deferredDirectErrorCount: 0,
       incidentOpen: false,
+      monitoringAlertObligation: null,
       pendingAlertMessage: null,
     });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 26),
+    ).resolves.toMatchObject({ outcome: "healthy" });
+    expect(harness.allLinqRequests).toHaveLength(6);
   });
 
   it("retains a direct-error page suppressed by Linq health after recovery", async () => {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1535,6 +1535,123 @@ describe("database health monitor", () => {
     expect(harness.allLinqRequests).toHaveLength(4);
   });
 
+  it("keeps a delayed direct error in an unadmitted mixed incident", async () => {
+    let clientWaitSeconds = 8;
+    let directErrors = 5;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+          directErrors,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    clientWaitSeconds = 0;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 4)).resolves
+      .toMatchObject({
+        conditions: [{ failures: 2, kind: "monitoring_unavailable" }],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      alertSequence: 0,
+      incidentOpen: true,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+
+    clientWaitSeconds = 8;
+    directErrors = 7;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 5)).resolves
+      .toMatchObject({
+        conditions: [
+          { kind: "client_wait", seconds: 8 },
+          { count: 2, kind: "direct_migration_admission_failures" },
+          { failures: 3, kind: "monitoring_unavailable" },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    const mixedPending = harness.monitor.readAlertState();
+    expect(mixedPending).toMatchObject({
+      alertSequence: 1,
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 4,
+        failures: 2,
+      },
+      pendingAlertIncludesMonitoring: true,
+    });
+    expect(mixedPending.pendingAlertMessage).toBe(
+      "Database health is outside the safe range. PgBouncer wait 8s; "
+      + "Database monitor telemetry was incomplete for 2 checks "
+      + "(observed 00:20 UTC; missing PlanetScale metric: "
+      + "Postgres max connections); 2 direct migration connection errors. "
+      + "Checked 00:25 UTC.",
+    );
+    expect(mixedPending.pendingAlertIdempotencyKey).not.toBeNull();
+
+    clientWaitSeconds = 0;
+    omitMaxConnections = false;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 6)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      pendingAlertIdempotencyKey: mixedPending.pendingAlertIdempotencyKey,
+      pendingAlertMessage: mixedPending.pendingAlertMessage,
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      incidentOpen: false,
+      monitoringAlertObligation: null,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+
+    const allBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    const mixedAttempts = allBodies.filter(
+      (body) =>
+        body.message.parts[0]?.value === mixedPending.pendingAlertMessage,
+    );
+    expect(mixedAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
+    ]);
+    expect(mixedAttempts.map(
+      (body) => body.message.idempotency_key,
+    ).sort()).toEqual([
+      mixedPending.pendingAlertIdempotencyKey,
+      `${mixedPending.pendingAlertIdempotencyKey}-recipient-2`,
+    ]);
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    expect(harness.allLinqRequests).toHaveLength(4);
+  });
+
   it("keeps a stale pressure retry from clearing rearmed telemetry", async () => {
     let clientWaitSeconds = 0;
     let missingFamily: "max_connections" | "server_pools" | null =

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1312,6 +1312,151 @@ describe("database health monitor", () => {
     ]);
   });
 
+  it("keeps a stale pressure retry from clearing rearmed telemetry", async () => {
+    let clientWaitSeconds = 0;
+    let missingFamily: "max_connections" | "server_pools" | null =
+      "max_connections";
+    const harness = createMonitorHarness({
+      linqResponses: [
+        () => new Response(null, { status: 202 }),
+        () => {
+          throw new Error("ambiguous pressure send");
+        },
+      ],
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+        });
+        if (missingFamily === "max_connections") {
+          return body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          );
+        }
+        if (missingFamily === "server_pools") {
+          return body.replace(
+            /^planetscale_pgbouncer_pools_server.*$/gmu,
+            "",
+          );
+        }
+        return body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "failed" });
+    const firstTelemetryAlert = await readLinqRequestBody(
+      harness.primaryLinqRequests[0],
+    );
+    expect(firstTelemetryAlert.message.parts[0]?.value).toBe(
+      "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metric: Postgres max connections). "
+      + "Checked 00:10 UTC.",
+    );
+
+    clientWaitSeconds = 8;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_failed",
+      sampleStatus: "failed",
+    });
+    const pressurePending = harness.monitor.readAlertState();
+    expect(pressurePending).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertIncludesMonitoring: false,
+    });
+    expect(pressurePending.pendingAlertMessage).toContain(
+      "PgBouncer wait 8s",
+    );
+    expect(pressurePending.pendingAlertMessage).not.toContain("telemetry");
+
+    clientWaitSeconds = 0;
+    missingFamily = null;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    missingFamily = "server_pools";
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 4 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 5 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      conditions: [
+        { failures: 2, kind: "monitoring_unavailable" },
+      ],
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 5 + THIRTY_MINUTES_MS,
+        failures: 2,
+        missingMetrics: ["planetscale_pgbouncer_pools_server"],
+      },
+      pendingAlertIdempotencyKey:
+        pressurePending.pendingAlertIdempotencyKey,
+      pendingAlertIncludesMonitoring: false,
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 5 + THIRTY_MINUTES_MS,
+        failures: 2,
+      },
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    expect(await readLinqRequestBody(harness.primaryLinqRequests[2])).toEqual(
+      await readLinqRequestBody(harness.primaryLinqRequests[1]),
+    );
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3 + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS * 3),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+    const secondTelemetryAlert = await readLinqRequestBody(
+      harness.primaryLinqRequests[3],
+    );
+    expect(secondTelemetryAlert.message.parts[0]?.value).toBe(
+      "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metric: PgBouncer server pools). "
+      + "Checked 00:55 UTC.",
+    );
+    const telemetryAttempts = (
+      await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
+    ).filter((body) =>
+      body.message.parts[0]?.value
+      === firstTelemetryAlert.message.parts[0]?.value
+      || body.message.parts[0]?.value
+      === secondTelemetryAlert.message.parts[0]?.value
+    );
+    expect(telemetryAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550123",
+      "+12025550124",
+      "+12025550124",
+    ]);
+    expect(secondTelemetryAlert.message.idempotency_key)
+      .not.toBe(firstTelemetryAlert.message.idempotency_key);
+  });
+
   it("advances an available direct-error baseline across partial samples", async () => {
     let directErrors = 5;
     let omitMaxConnections = false;

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1312,7 +1312,7 @@ describe("database health monitor", () => {
     ]);
   });
 
-  it("retains new-incident pressure ahead of owed telemetry", async () => {
+  it("retains one mixed new-incident page across the fence and recovery", async () => {
     let clientWaitSeconds = 8;
     let omitMaxConnections = false;
     const harness = createMonitorHarness({
@@ -1356,10 +1356,12 @@ describe("database health monitor", () => {
         checkedAtMs: FIVE_MINUTES_MS * 4,
         failures: 2,
       },
-      pendingAlertIncludesMonitoring: false,
+      pendingAlertIncludesMonitoring: true,
     });
     expect(pressurePending.pendingAlertMessage).toBe(
-      "Database health is outside the safe range. PgBouncer wait 8s. "
+      "Database health is outside the safe range. PgBouncer wait 8s; "
+      + "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metric: Postgres max connections). "
       + "Checked 00:20 UTC.",
     );
     expect(pressurePending.pendingAlertIdempotencyKey).not.toBeNull();
@@ -1380,16 +1382,17 @@ describe("database health monitor", () => {
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
     expect(harness.monitor.readAlertState()).toMatchObject({
-      monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
+      incidentOpen: false,
+      monitoringAlertObligation: null,
       pendingAlertIdempotencyKey: null,
       pendingAlertMessage: null,
     });
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
-    ).resolves.toMatchObject({ outcome: "alert_deferred", sampleStatus: "ok" });
+    ).resolves.toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
-    ).resolves.toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    ).resolves.toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
     expect(harness.monitor.readAlertState()).toMatchObject({
       incidentOpen: false,
       monitoringAlertObligation: null,
@@ -1412,17 +1415,8 @@ describe("database health monitor", () => {
       pressurePending.pendingAlertIdempotencyKey,
       `${pressurePending.pendingAlertIdempotencyKey}-recipient-2`,
     ]);
-    const telemetryAttempts = allBodies.filter(
-      (body) =>
-        body.message.parts[0]?.value
-        === "Database monitor telemetry was incomplete for 2 checks "
-          + "(missing PlanetScale metric: Postgres max connections). "
-          + "Checked 00:20 UTC.",
-    );
-    expect(telemetryAttempts.map((body) => body.to[0]).sort()).toEqual([
-      "+12025550123",
-      "+12025550124",
-    ]);
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    expect(harness.allLinqRequests).toHaveLength(4);
   });
 
   it("keeps a stale pressure retry from clearing rearmed telemetry", async () => {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -873,7 +873,7 @@ describe("database health monitor", () => {
       harness.primaryLinqRequests[0],
     );
     expect(firstAlert.message.parts[0]?.value).toBe(
-      "Database monitor telemetry is incomplete for 2 checks "
+      "Database monitor telemetry was incomplete for 2 checks "
       + "(missing PlanetScale metric: Postgres max connections). "
       + "Checked 00:10 UTC.",
     );
@@ -968,7 +968,7 @@ describe("database health monitor", () => {
 
     const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
     expect(alert.message.parts[0]?.value).toBe(
-      "Database monitor telemetry is unavailable for 2 checks. "
+      "Database monitor telemetry was unavailable for 2 checks. "
       + "Checked 00:10 UTC.",
     );
     expect(alert.message.parts[0]?.value).not.toContain(
@@ -1052,9 +1052,10 @@ describe("database health monitor", () => {
     });
   });
 
-  it("retains a mixed telemetry obligation behind an older pending page", async () => {
+  it("coalesces recovered telemetry thresholds behind an older pending page", async () => {
     let clientWaitSeconds = 8;
     let omitMaxConnections = false;
+    let omitServerPools = false;
     const harness = createMonitorHarness({
       linqResponses: [
         () => {
@@ -1066,12 +1067,18 @@ describe("database health monitor", () => {
           branchId: BRANCH_ID,
           clientWaitSeconds,
         });
-        return omitMaxConnections
+        const withMaxConnections = omitMaxConnections
           ? body.replace(
             /^planetscale_postgres_settings_max_connections.*$/mu,
             "",
           )
           : body;
+        return omitServerPools
+          ? withMaxConnections.replace(
+            /^planetscale_pgbouncer_pools_server.*$/gmu,
+            "",
+          )
+          : withMaxConnections;
       },
     });
 
@@ -1135,30 +1142,65 @@ describe("database health monitor", () => {
       pendingAlertIdempotencyKey: null,
       pendingAlertMessage: null,
     });
+
+    omitServerPools = true;
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({
       outcome: "alert_deferred",
-      sampleStatus: "ok",
+      sampleStatus: "failed",
     });
-    const telemetryPendingAlert = harness.monitor.readAlertState();
-    expect(telemetryPendingAlert.pendingAlertMessage).toBe(
-      "Database monitor telemetry is incomplete for 2 checks "
-      + "(missing PlanetScale metric: Postgres max connections). "
-      + "Checked 00:15 UTC.",
-    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      conditions: [
+        {
+          failures: 2,
+          kind: "monitoring_unavailable",
+        },
+      ],
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 3,
+        failures: 2,
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+      },
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
     ).resolves.toMatchObject({
       outcome: "alert_sent",
-      sampleStatus: "ok",
+      sampleStatus: "failed",
     });
     expect(harness.monitor.readAlertState()).toMatchObject({
-      incidentOpen: false,
+      incidentOpen: true,
       monitoringAlertObligation: null,
       pendingAlertIdempotencyKey: null,
       pendingAlertMessage: null,
     });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+    omitServerPools = false;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3 + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+    expect(harness.monitor.readAlertState().incidentOpen).toBe(false);
 
     expect(harness.primaryLinqRequests).toHaveLength(3);
     const firstAttempt = await readLinqRequestBody(
@@ -1171,16 +1213,17 @@ describe("database health monitor", () => {
       harness.primaryLinqRequests[2],
     );
     expect(olderRetry).toEqual(firstAttempt);
-    expect(telemetryAttempt.message.idempotency_key)
-      .toBe(telemetryPendingAlert.pendingAlertIdempotencyKey);
-    expect(telemetryAttempt.message.parts[0]?.value)
-      .toBe(telemetryPendingAlert.pendingAlertMessage);
+    expect(telemetryAttempt.message.parts[0]?.value).toBe(
+      "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metric: Postgres max connections). "
+      + "Checked 00:15 UTC.",
+    );
     const telemetryAttempts = (
       await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
     ).filter(
       (body) =>
         body.message.parts[0]?.value
-        === telemetryPendingAlert.pendingAlertMessage,
+        === telemetryAttempt.message.parts[0]?.value,
     );
     expect(telemetryAttempts).toHaveLength(2);
     expect(telemetryAttempts.map((body) => body.to[0]).sort()).toEqual([
@@ -1190,8 +1233,82 @@ describe("database health monitor", () => {
     expect(telemetryAttempts.map(
       (body) => body.message.idempotency_key,
     ).sort()).toEqual([
-      telemetryPendingAlert.pendingAlertIdempotencyKey,
-      `${telemetryPendingAlert.pendingAlertIdempotencyKey}-recipient-2`,
+      telemetryAttempt.message.idempotency_key,
+      `${telemetryAttempt.message.idempotency_key}-recipient-2`,
+    ]);
+  });
+
+  it("gives the first eligible slot to current pressure with owed telemetry", async () => {
+    let clientWaitSeconds = 8;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          clientWaitSeconds,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    clientWaitSeconds = 0;
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    clientWaitSeconds = 9;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({
+        conditions: [
+          { kind: "client_wait", seconds: 9 },
+          { failures: 2, kind: "monitoring_unavailable" },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      monitoringAlertObligation: {
+        checkedAtMs: FIVE_MINUTES_MS * 3,
+        failures: 2,
+      },
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+
+    harness.restartMonitor();
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    const combinedAlert = await readLinqRequestBody(
+      harness.primaryLinqRequests[1],
+    );
+    expect(combinedAlert.message.parts[0]?.value).toBe(
+      "Database health is outside the safe range. PgBouncer wait 9s; "
+      + "Database monitor telemetry was incomplete for 2 checks "
+      + "(observed 00:15 UTC; missing PlanetScale metric: "
+      + "Postgres max connections). Checked 00:35 UTC.",
+    );
+    const combinedAttempts = (
+      await Promise.all(harness.allLinqRequests.map(readLinqRequestBody))
+    ).filter(
+      (body) =>
+        body.message.parts[0]?.value
+        === combinedAlert.message.parts[0]?.value,
+    );
+    expect(combinedAttempts.map((body) => body.to[0]).sort()).toEqual([
+      "+12025550123",
+      "+12025550124",
     ]);
   });
 
@@ -1304,14 +1421,12 @@ describe("database health monitor", () => {
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({ outcome: "alert_deferred" });
-    const telemetryPendingAlert = harness.monitor.readAlertState();
-    expect(telemetryPendingAlert).toMatchObject({
+    expect(harness.monitor.readAlertState()).toMatchObject({
       monitoringAlertObligation: expect.objectContaining({ failures: 2 }),
-      pendingAlertIncludesMonitoring: true,
+      pendingAlertIncludesMonitoring: false,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
     });
-    expect(telemetryPendingAlert.pendingAlertMessage).toContain(
-      "Database monitor telemetry is incomplete for 2 checks",
-    );
     await expect(
       harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
     ).resolves.toMatchObject({ outcome: "alert_sent" });
@@ -1319,6 +1434,12 @@ describe("database health monitor", () => {
       monitoringAlertObligation: null,
       pendingAlertIdempotencyKey: null,
     });
+    expect(harness.primaryLinqRequests).toHaveLength(3);
+    expect((
+      await readLinqRequestBody(harness.primaryLinqRequests[2])
+    ).message.parts[0]?.value).toContain(
+      "Database monitor telemetry was incomplete for 2 checks",
+    );
   });
 
   it("retries an unacknowledged telemetry page with its exact identity", async () => {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -829,12 +829,16 @@ describe("database health monitor", () => {
       .toBe(pendingAlert.pendingAlertMessage);
   });
 
-  it("pages only after two consecutive scrape failures and clears after recovery", async () => {
+  it("pages once per uninterrupted telemetry outage and identifies missing metrics", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const healthyMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
+    const missingMetricsBody = healthyMetricsBody.replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    let metricsBody = missingMetricsBody;
     const harness = createMonitorHarness({
-      serviceDiscoveryResponses: [
-        () => new Response(null, { status: 503 }),
-        () => new Response(null, { status: 503 }),
-      ],
+      readMetricsBody: () => metricsBody,
     });
 
     await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
@@ -849,13 +853,60 @@ describe("database health monitor", () => {
         {
           failures: 2,
           kind: "monitoring_unavailable",
+          missingMetrics: [
+            "planetscale_postgres_settings_max_connections",
+          ],
         },
       ],
       outcome: "alert_sent",
       sampleStatus: "failed",
     });
     await expect(
-      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+
+    const firstAlert = await readLinqRequestBody(
+      harness.primaryLinqRequests[0],
+    );
+    expect(firstAlert.message.parts[0]?.value).toBe(
+      "Database monitor telemetry is incomplete for 2 checks "
+      + "(missing PlanetScale metric: Postgres max connections). "
+      + "Checked 00:10 UTC.",
+    );
+    expect(firstAlert.message.parts[0]?.value).not.toContain(
+      "database is under pressure",
+    );
+    expect(warning).toHaveBeenCalledWith(
+      "Database health metrics collection failed.",
+      {
+        failureCode: "required_metrics_missing",
+        failures: 1,
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+      },
+    );
+
+    const failedSample = harness.monitor.readRecentSamples().find(
+      (sample) => sample.observedAtMs === FIVE_MINUTES_MS * 2,
+    );
+    expect(failedSample?.conditions).toEqual([
+      {
+        failures: 2,
+        kind: "monitoring_unavailable",
+        missingMetrics: [
+          "planetscale_postgres_settings_max_connections",
+        ],
+      },
+    ]);
+
+    metricsBody = healthyMetricsBody;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3 + THIRTY_MINUTES_MS),
     ).resolves.toMatchObject({
       outcome: "healthy",
       sampleStatus: "ok",
@@ -865,7 +916,200 @@ describe("database health monitor", () => {
       consecutiveScrapeFailures: 0,
       incidentOpen: false,
     });
+
+    metricsBody = missingMetricsBody;
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 4 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 5 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    const secondAlert = await readLinqRequestBody(
+      harness.primaryLinqRequests[1],
+    );
+    expect(secondAlert.message.idempotency_key)
+      .not.toBe(firstAlert.message.idempotency_key);
+  });
+
+  it("still pages an available unsafe signal when another metric is missing", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({ metricsBody: partialMetricsBody });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({
+        conditions: [
+          {
+            kind: "client_wait",
+            seconds: 8,
+            waitingConnections: 3,
+          },
+        ],
+        outcome: "alert_sent",
+        sampleStatus: "failed",
+      });
+
     expect(harness.primaryLinqRequests).toHaveLength(1);
+    const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
+    expect(alert.message.parts[0]?.value).toContain("PgBouncer wait 8s");
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      clientWaitSeconds: 8,
+      failureCode: "required_metrics_missing",
+      postgresMaxConnections: null,
+      scrapeStatus: "failed",
+    });
+  });
+
+  it("retains the first telemetry page behind an existing incident fence", async () => {
+    const unsafeMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+    });
+    const partialHealthyMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    let metricsBody = unsafeMetricsBody;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_sent", sampleStatus: "ok" });
+    metricsBody = partialHealthyMetricsBody;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "failed" });
+
+    const pendingAlert = harness.monitor.readAlertState();
+    expect(pendingAlert.pendingAlertMessage).toContain(
+      "Database monitor telemetry is incomplete for 2 checks",
+    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + THIRTY_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      outcome: "alert_deferred",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+  });
+
+  it("advances an available direct-error baseline across partial samples", async () => {
+    let directErrors = 5;
+    let omitMaxConnections = false;
+    const harness = createMonitorHarness({
+      readMetricsBody: () => {
+        const body = buildMetricsBody({
+          branchId: BRANCH_ID,
+          directErrors,
+        });
+        return omitMaxConnections
+          ? body.replace(
+            /^planetscale_postgres_settings_max_connections.*$/mu,
+            "",
+          )
+          : body;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    directErrors = 7;
+    omitMaxConnections = true;
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({
+        conditions: [
+          {
+            count: 2,
+            kind: "direct_migration_admission_failures",
+          },
+        ],
+        outcome: "alert_sent",
+        sampleStatus: "failed",
+      });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({
+        conditions: [
+          {
+            failures: 2,
+            kind: "monitoring_unavailable",
+          },
+        ],
+        outcome: "alert_deferred",
+        sampleStatus: "failed",
+      });
+
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      directConnectionErrorDelta: 0,
+      failureCode: "required_metrics_missing",
+    });
+  });
+
+  it("retries an unacknowledged telemetry page with its exact identity", async () => {
+    const missingMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({
+      linqResponses: [
+        () => {
+          throw new Error("ambiguous send");
+        },
+      ],
+      metricsBody: missingMetricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "failed" });
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 2)).resolves
+      .toMatchObject({ outcome: "alert_failed", sampleStatus: "failed" });
+    const pendingAlert = harness.monitor.readAlertState();
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS * 3)).resolves
+      .toMatchObject({ outcome: "alert_deferred", sampleStatus: "failed" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + THIRTY_MINUTES_MS),
+    ).resolves.toMatchObject({
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.primaryLinqRequests).toHaveLength(2);
+    const firstAttempt = await readLinqRequestBody(
+      harness.primaryLinqRequests[0],
+    );
+    const retryAttempt = await readLinqRequestBody(
+      harness.primaryLinqRequests[1],
+    );
+    expect(retryAttempt).toEqual(firstAttempt);
+    expect(retryAttempt.message.idempotency_key)
+      .toBe(pendingAlert.pendingAlertIdempotencyKey);
+    expect(retryAttempt.message.parts[0]?.value)
+      .toBe(pendingAlert.pendingAlertMessage);
   });
 
   it("retains an admitted page across failed and healthy samples until delivery", async () => {

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -61,6 +61,6 @@ describe("database health store", () => {
       `SELECT value
        FROM database_health_schema_meta
        WHERE key = 'schema_version'`,
-    ).one().value).toBe(2);
+    ).one().value).toBe(1);
   });
 });

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -64,6 +64,66 @@ describe("database health store", () => {
     ).one().value).toBe(1);
   });
 
+  it("adds bounded monitoring evidence to version-one sample history", () => {
+    const sql = createTestSqlStorage();
+    sql.exec(`
+      CREATE TABLE database_health_schema_meta (
+        key TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+      )
+    `);
+    sql.exec(`
+      INSERT INTO database_health_schema_meta (key, value)
+      VALUES ('schema_version', 1)
+    `);
+    sql.exec(`
+      CREATE TABLE database_health_samples (
+        observed_at_ms INTEGER PRIMARY KEY,
+        scrape_status TEXT NOT NULL CHECK (scrape_status IN ('ok', 'failed')),
+        failure_code TEXT,
+        client_wait_seconds REAL,
+        client_waiting_connections INTEGER,
+        server_connections INTEGER,
+        server_pool_capacity INTEGER,
+        server_pool_saturation_ratio REAL,
+        server_pool_states_json TEXT NOT NULL,
+        postgres_connections INTEGER,
+        postgres_max_connections INTEGER,
+        postgres_connection_states_json TEXT NOT NULL,
+        direct_connection_error_delta INTEGER,
+        direct_connection_error_counters_json TEXT NOT NULL,
+        conditions_json TEXT NOT NULL
+      )
+    `);
+    sql.exec(`
+      INSERT INTO database_health_samples (
+        observed_at_ms,
+        scrape_status,
+        failure_code,
+        server_pool_states_json,
+        postgres_connection_states_json,
+        direct_connection_error_counters_json,
+        conditions_json
+      ) VALUES (300000, 'failed', 'required_metrics_missing', '{}', '{}', '{}', '[]')
+    `);
+
+    const store = new DatabaseHealthStore(sql);
+
+    expect(store.readLatestMonitoringEvidence()).toEqual({
+      availability: "incomplete",
+      missingMetrics: [],
+    });
+    expect(sql.exec<{ name: string }>(
+      "PRAGMA table_info(database_health_samples)",
+    ).toArray().map((column) => column.name))
+      .toContain("monitoring_evidence_json");
+    expect(sql.exec<{ value: number }>(
+      `SELECT value
+       FROM database_health_schema_meta
+       WHERE key = 'schema_version'`,
+    ).one().value).toBe(1);
+  });
+
   it("recognizes a telemetry pending body acknowledged by a rollback Worker", () => {
     const sql = createTestSqlStorage();
     const store = new DatabaseHealthStore(sql);
@@ -71,9 +131,11 @@ describe("database health store", () => {
     store.recordMonitoringAlertObligation({
       checkedAtMs: 600_000,
       failures: 2,
+      incompleteChecks: 2,
       missingMetrics: [
         "planetscale_postgres_settings_max_connections",
       ],
+      unavailableChecks: 0,
     });
     store.createPendingAlert({
       idempotencyKey: "murph-db-1-1",

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { DatabaseHealthStore } from "../src/database-health/store.ts";
+import { createTestSqlStorage } from "./sql-storage.ts";
+
+describe("database health store", () => {
+  it("adds monitoring obligations without disturbing version-one alert state", () => {
+    const sql = createTestSqlStorage();
+    sql.exec(`
+      CREATE TABLE database_health_schema_meta (
+        key TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+      )
+    `);
+    sql.exec(`
+      INSERT INTO database_health_schema_meta (key, value)
+      VALUES ('schema_version', 1)
+    `);
+    sql.exec(`
+      CREATE TABLE database_health_meta (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        run_lease_until_ms INTEGER NOT NULL DEFAULT 0,
+        consecutive_scrape_failures INTEGER NOT NULL DEFAULT 0,
+        incident_open INTEGER NOT NULL DEFAULT 0 CHECK (incident_open IN (0, 1)),
+        incident_sequence INTEGER NOT NULL DEFAULT 0,
+        alert_sequence INTEGER NOT NULL DEFAULT 0,
+        deferred_direct_error_count INTEGER NOT NULL DEFAULT 0,
+        deferred_direct_error_checked_at_ms INTEGER,
+        last_alert_attempted_at_ms INTEGER,
+        pending_alert_idempotency_key TEXT,
+        pending_alert_message TEXT,
+        CHECK (
+          (pending_alert_idempotency_key IS NULL) =
+          (pending_alert_message IS NULL)
+        )
+      )
+    `);
+    sql.exec(`
+      INSERT INTO database_health_meta (
+        singleton,
+        incident_open,
+        incident_sequence,
+        alert_sequence,
+        pending_alert_idempotency_key,
+        pending_alert_message
+      ) VALUES (1, 1, 7, 1, 'murph-db-7-1', 'existing alert')
+    `);
+
+    const store = new DatabaseHealthStore(sql);
+
+    expect(store.readAlertState()).toMatchObject({
+      alertSequence: 1,
+      incidentOpen: true,
+      incidentSequence: 7,
+      monitoringAlertObligation: null,
+      pendingAlertIdempotencyKey: "murph-db-7-1",
+      pendingAlertIncludesMonitoring: false,
+      pendingAlertMessage: "existing alert",
+    });
+    expect(sql.exec<{ value: number }>(
+      `SELECT value
+       FROM database_health_schema_meta
+       WHERE key = 'schema_version'`,
+    ).one().value).toBe(2);
+  });
+});

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -63,4 +63,37 @@ describe("database health store", () => {
        WHERE key = 'schema_version'`,
     ).one().value).toBe(1);
   });
+
+  it("recognizes a telemetry pending body acknowledged by a rollback Worker", () => {
+    const sql = createTestSqlStorage();
+    const store = new DatabaseHealthStore(sql);
+    store.openIncident();
+    store.recordMonitoringAlertObligation({
+      checkedAtMs: 600_000,
+      failures: 2,
+      missingMetrics: [
+        "planetscale_postgres_settings_max_connections",
+      ],
+    });
+    store.createPendingAlert({
+      idempotencyKey: "murph-db-1-1",
+      includesMonitoring: true,
+      message: "telemetry alert",
+    });
+
+    sql.exec(
+      `UPDATE database_health_meta
+       SET
+         pending_alert_idempotency_key = NULL,
+         pending_alert_message = NULL
+       WHERE singleton = 1`,
+    );
+
+    expect(store.readAlertState()).toMatchObject({
+      monitoringAlertObligation: null,
+      pendingAlertIncludesMonitoring: false,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+  });
 });


### PR DESCRIPTION
## Why this PR exists

The production database monitor treated a missing PlanetScale metric family as
a total scrape failure, discarded still-usable signals, and described a
telemetry-only outage as database pressure. This PR evaluates partial scrapes
without inventing zeroes and makes telemetry paging truthful, durable, and
bounded.

## User goal / user-visible behavior

Operators continue receiving immediate, recurring pages for concrete database
pressure. When PlanetScale telemetry alone is incomplete or unavailable, they
receive one explicit historical monitoring page per unresolved notification
window, with bounded canonical missing-family evidence when available. Once
that page is acknowledged by both destinations, continued blindness does not
produce repeated 30-minute noise until a complete sample rearms the incident.

## User experience

The five-minute singleton evaluates every usable signal. Concrete unsafe
conditions page immediately and recur every 30 minutes while unsafe. A
telemetry-only condition becomes owed after two consecutive impaired checks.
Its first page summarizes that complete two-check window: incomplete versus
unavailable observations, canonical missing families actually observed on
partial checks, and the window end.

If a pending page, the global provider fence, restart, recovery, or ambiguous
delivery blocks completion, one durable obligation preserves the same window
and immutable body until both operator destinations acknowledge it. Recovery
and another gap before acknowledgment deliberately coalesce into that one
unresolved notification; this monitor is a pager, not an outage ledger.

Concrete pressure that appears before an incident admits its first page joins
the owed telemetry in one exact body. Later direct-error priority retains owed
telemetry in that same non-replayable body while excluding transient gauges.
Pure deferred direct evidence keeps its stored check time; an aggregate with a
new current delta uses the latest included check, while telemetry retains its
separate window end.

## Invariants preserved

- Missing values remain unknown and are never treated as zero.
- Every available signal remains eligible during a partial scrape.
- Direct-error counter baselines advance without recounting partial-sample
  deltas.
- Concrete database conditions retain immediate admission, 30-minute
  recurrence, destination-health checks, and exact-body retries.
- Diagnostics retain only canonical allowlisted metric names, never raw scrape
  payloads, labels, credentials, targets, or recipient data.
- Linq provider entry remains globally fenced to one attempt per 30 minutes.
- One unresolved telemetry notification survives pending-slot contention,
  restart, recovery, and ambiguous delivery, and clears only after both
  destinations acknowledge its telemetry-bearing body.
- A telemetry summary's count, availability categories, window end, and
  missing-family evidence describe the same represented observations.
- Post-ack pressure recurrence stays pressure-only until a later telemetry
  obligation rearms.

## Non-obvious affected surfaces

- Failed samples retain available numeric fields plus bounded monitoring
  evidence. Direct-error baselines may therefore advance on partial checks.
- The existing incident metadata row gains two additive fields for the bounded
  obligation and pending-body classification. The existing sample row gains one
  bounded evidence field. Version-one migration and rollback acknowledgment are
  covered without a schema-version bump.
- Linq admission combines non-replayable direct errors with owed telemetry,
  preserves exact body/idempotency identity, and requires both configured
  destinations before acknowledgment.
- Operator copy distinguishes incomplete, unavailable, and mixed telemetry
  windows from concrete database pressure. Historical telemetry gets its own
  condition-local window end.

## Architecture and reuse

- **Existing systems reused:** the singleton Durable Object, synchronous SQLite
  transaction owner, existing sample table and incident row, global attempt
  fence, and two-destination Linq delivery path remain authoritative.
- **New logic:** metric families normalize independently into nullable fields.
  Each failed sample stores bounded availability and canonical missing-family
  evidence. Crossing the two-check threshold composes that exact window into
  one obligation. Pending admission records whether its immutable body includes
  the obligation, so acknowledgment clears only what was actually delivered.
- **New abstractions:** a partial-observation snapshot represents unknown family
  values while preserving the strict complete-snapshot contract. Small evidence
  and obligation values retain only counts, window end, and canonical names.
- **Complexity intentionally avoided:** no new table, queue, backlog, service,
  dependency, provider call, scheduler, replay loop, state owner, or fallback
  lifecycle. Three additive fields on existing rows are sufficient.

## Hot reply path impact

Not applicable. This changes the independent Cloudflare database-health cron
singleton, not the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: not applicable; no prompt, tool schema, model configuration,
  or provider-request assembly changed.
- Group Murph: not applicable; no prompt, tool schema, model configuration, or
  provider-request assembly changed.

## Preliminary specialist lenses

- **Product experience: applicable.** Focused state-transition and request-body
  tests cover unavailable, partial, unsafe, retry, restart, recovery,
  coalescing, rearming, first-page and recurrence ordering, and both-recipient
  journeys.
- **Prompt: not applicable.** No model prompt or instruction surface changed.
- **Frontend: not applicable.** No `apps/web` presentation changed.
- **Coverage: applicable.** Focused proof is 74 Node tests across four
  database-health files, one Workers-runtime test, Cloudflare typecheck, log
  guard, docs drift guard, and diff check. Required CI passed on both the
  reviewed runtime candidate and the closure-only plan archival head.

ReviewGPT context sensitivity: sensitive

Reason: this changes an operational runtime, persisted state, external paging,
and retry/idempotency admission behavior.

ReviewGPT first-reviewed head: 272f78c5b63f3e678cda1d63410c82351f500af6

## Review findings and remediation

- Preliminary specialist review and final round 1 found exact-threshold
  telemetry loss behind an older pending message or direct-only priority. One
  bounded obligation now survives restart and recovery until acknowledged.
- Rollout review found a schema-version bump would break rollback. Columns are
  now discovered idempotently at the existing version.
- Rounds 2-3 covered repeated pre-ack thresholds, current-pressure ordering,
  legacy acknowledgment, and post-ack obligation isolation. Monitoring
  admission now derives only from the durable obligation, and recovered gaps
  coalesce before acknowledgment.
- Rounds 4-8 covered pressure appearing inside a closed fence, first-page
  admission, delayed direct errors, and preventing pressure plus telemetry from
  splitting into multiple provider cycles. The existing zero alert sequence is
  the first-page fact; non-replayable conditions share one immutable body.
- Round 9 corrected timestamp provenance for a promoted direct-error aggregate
  containing both deferred and current evidence.
- Round 10 required a continuation retrospective because a mixed two-check
  telemetry window was classified from only its threshold observation. Each
  failed sample now stores bounded evidence so the threshold transaction can
  compose the whole represented window.
- Round 11 reviewed the complete sensitive patch and passed with no qualifying
  finding. Requested-model verification confirmed the response model.

## Anomaly retrospective

The first-reviewed source shape was 395 additions and 87 deletions; the reviewed
runtime candidate was 785 additions and 112 deletions. Review work added 390
source lines, 25 source deletions, 1,362 test lines, and 203 documentation lines.
Most growth is focused regression coverage for durable alert-state interactions.

The structural decision is intentionally smaller than retaining every outage
epoch. Strict retention would require a backlog and new outage identity. This
pager instead owns one bounded unresolved obligation: recovered thresholds
before acknowledgment coalesce, the first threshold's complete two-check
evidence remains immutable, and the global provider fence stays the only
delivery scheduler. One Durable Object, the existing sample table, and one
incident row remain the sole owners.

The general aggregate-provenance rule is now explicit: count, category,
timestamp, and evidence presented as one fact must describe the same represented
observations. The telemetry threshold therefore counts incomplete and
unavailable checks across the complete window, unions only canonical families
observed on partial checks, and identifies the threshold check as the window
end. Direct aggregates follow the corresponding timing rule.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; Vitest files are
tests/fixtures; Markdown owner contracts and the execution plan are docs; no
binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 785 | 112 |
| Tests/fixtures | 1632 | 33 |
| Docs | 348 | 29 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2765** | **174** |

## Deployment skew / compatibility

This is a Cloudflare Worker-only change; web and runner containers have no
tandem dependency. New code adds two nullable/defaulted metadata fields and one
nullable sample-evidence field idempotently without advancing the stored schema
version, so an older Worker can overlap or be restored without rejecting the
object. Old rows fall back to their classified failure code when evidence is
absent. Current code also normalizes a telemetry pending body acknowledged by
the older Worker before re-admission.

No immediate container rollout or backfill is required. After deploy, verify
the next scheduled sample, truthful mixed-window copy, canonical observed-family
diagnostics, and absence of repeated acknowledged telemetry-only pages.

## Design proof

Not applicable; no user-facing frontend UI changed.

## Verification

- Focused Node Vitest: 74 tests passed across four database-health files.
- Focused Workers-runtime Vitest: 1 test passed.
- Cloudflare package typecheck: passed.
- Raw health/model/vault log guard: passed.
- Agent docs drift guard: passed.
- `git diff --check`: passed.
- Reviewed-candidate required GitHub Actions: passed.
- Final ReviewGPT round 11: PASS with no qualifying finding; requested-model
  verification passed.
- Closure-only plan archival head: required CI passed.
