### PR TITLE
copy(web): simplify inference choice heading

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -111,7 +111,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Homepage technical runtime">
+      <StudySection title="Homepage technical runtime · inference choice">
         <div
           id="homepage-technical-runtime"
           data-design-section="homepage-technical-runtime"

--- a/apps/web/src/components/homepage/technical-capabilities-section.tsx
+++ b/apps/web/src/components/homepage/technical-capabilities-section.tsx
@@ -168,7 +168,7 @@ export function TechnicalCapabilitiesSection({
                 Inference is a choice
               </p>
               <h3 className="mt-5 max-w-[22ch] text-balance font-serif text-[clamp(1.625rem,3vw,2.25rem)] font-semibold leading-[1.1] tracking-[-0.02em]">
-                The agent stays. The inference path is yours.
+                The inference path is yours.
               </h3>
             </div>
 

--- a/apps/web/test/homepage-technical-capabilities-section.test.tsx
+++ b/apps/web/test/homepage-technical-capabilities-section.test.tsx
@@ -31,6 +31,8 @@ test("TechnicalCapabilitiesSection renders the agent runtime and every enabled i
     markup,
     /You choose the model, the reasoning effort, and who supplies the inference\./,
   );
+  assert.match(markup, />The inference path is yours\.<\/h3>/);
+  assert.doesNotMatch(markup, /The agent stays\./);
   assert.doesNotMatch(markup, /changes model and reasoning effort/);
   assert.match(markup, /Codex CLI \+ App Server/);
   assert.match(markup, /be the most capable health agent in the world/);


### PR DESCRIPTION
## Why this PR exists

The homepage inference-choice heading included an unnecessary opening clause. This PR removes it so the section lands directly on the intended message.

## User goal / user-visible behavior

Visitors see “The inference path is yours.” as the complete inference-choice heading.

## User experience

The entry point remains the homepage technical-runtime section. The revised heading appears immediately with no action, wait, asynchronous continuation, failure state, or recovery path; visitors continue through the same provider choices and the rest of the page. Desktop and mobile catalog renders confirm the shorter wording remains legible and balanced.

## Invariants

- The removed clause does not appear in the production component.
- The retained sentence, inference options, provider-availability behavior, layout, and accessibility structure remain unchanged.
- The design catalog continues to render the real production component with synthetic provider flags.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: This is a narrow static-copy and design-study label change with no product-critical, stateful, runtime, trust-boundary, or external-system effect.

## Non-obvious affected surfaces

- The existing design-catalog study is relabeled to identify its inference-choice state; the catalog render and both viewport screenshots provide regression proof.

## Architecture and reuse

- Existing systems reused: The existing `TechnicalCapabilitiesSection` and its `/design?tab=sections` production-component study remain the single presentation source.
- New logic: No executable logic was added; the production heading is shortened and the existing catalog study is named more precisely.
- New abstractions: None; the shared component and current study boundary already cover production and review rendering.
- Complexity intentionally avoided: No duplicate markup, new component, state, branch, compatibility layer, or dependency was introduced.

## Hot reply path impact

- Path status: Not applicable — this changes static homepage and design-catalog copy only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable; the foreground reply path is untouched.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no prompt, tool, schema, skill, Codex configuration, adapter, or provider-request assembly surface changed.

## Preliminary specialist lenses

- Product experience: Applicable — the intended outcome is a more direct inference-choice message; the exact journey evidence is the existing production-component catalog study in the desktop and mobile captures below.
- Prompt: Not applicable — no assistant or provider prompt surface changed.
- Frontend: Applicable — `audit-packages/pr-1470-inference-choice-desktop.png` proves the inference-choice state at 1440 CSS px and 2x scale; `audit-packages/pr-1470-inference-choice-mobile.png` proves it at 390 CSS px and 2x scale. Both are redacted and contain no member data.
- Coverage: Applicable — the existing production-component render test now asserts the exact retained heading and rejects the removed clause; the focused component and page suites pass 11 tests. Exact-head CI is green on `3e6e3aa59643`.

Preliminary specialist result: one low-severity coverage finding was accepted. Its test-only patch was inspected, applied, and verified; no production remediation was required, so the specialist pass is not rerun.

## Design proof

- Design page: [/design?tab=sections#homepage-technical-runtime](https://www.withmurph.ai/design?tab=sections#homepage-technical-runtime)
- Coverage: Existing “Homepage technical runtime · inference choice” study rendering the real `TechnicalCapabilitiesSection` with all provider choices enabled.
- Desktop screenshot: ![Desktop inference-choice heading and provider options](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/417953d4-9d90-4705-2269-313622a12300/designproof)
- Mobile screenshot: ![Mobile inference-choice heading and provider options](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/bcb6f2ad-375f-44bd-8b1b-92f1a284b100/designproof)

## Change-shape breakdown

Classification rule: Authored files under `apps/web` are source; no binary, generated, test, documentation, or tooling files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 2 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **4** | **2** |

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/homepage-technical-capabilities-section.test.tsx apps/web/test/page.test.ts` — 11 tests passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm --dir apps/web exec eslint src/components/homepage/technical-capabilities-section.tsx` — passed.
- `pnpm --dir apps/web exec eslint app/design/sections-content.tsx` — passed.
- `pnpm --dir apps/web exec eslint test/homepage-technical-capabilities-section.test.tsx` — passed.
- Browser proof on `/design?tab=sections`: HTTP 200 at 1440×1000 and 390×844 CSS viewports; retained sentence present, removed clause absent, and both local and hosted PNGs inspected at native resolution.
- Claude UI double-check: attempted with Fable after rendered evidence was stable; unavailable because the account reported explicit usage-credit exhaustion, which the completion workflow treats as non-blocking.
- Exact-head GitHub Actions: 15 successful, 1 intentional skip, 0 failed, and 0 pending on `3e6e3aa59643`.
