### PR TITLE
Fix response card schema compaction in Codex

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-09-response-card-schema-compaction.md
+++ b/agent-docs/exec-plans/active/2026-08-09-response-card-schema-compaction.md
@@ -70,6 +70,9 @@ Updated: 2026-08-09
 - Keep the model schema inline. The deployed App Server drops local definitions
   during large-schema compaction, so reference reuse cannot preserve nested
   authoring shapes.
+- Retain one deterministic pinned-App-Server regression in the existing
+  scripted-runtime suite. It proves the provider-visible nested shapes and both
+  runtime tool calls without introducing another harness.
 
 ## Verification
 
@@ -79,3 +82,18 @@ Updated: 2026-08-09
 - Expected outcomes: all checks pass; both probes produce canonical arguments
   without a tool-schema rejection; the complete tool input remains below 5,000
   Codex-normalized bytes.
+- Completed outcomes: the focused card suites pass (16 tests), the expanded
+  pinned-App-Server and card-tool suites pass (40 tests), both affected package
+  typechecks pass, and the live Sol probes accepted nutrition V2 and compact
+  table cards.
+
+## Review dispositions
+
+- Accepted the preliminary coverage finding. The temporary live proof is now
+  backed by a committed test at the existing real App Server/local Responses
+  boundary; no coverage patch artifact was supplied.
+- Accepted the final Purpose Drift disclosure finding. A changed tool contract
+  intentionally rotates eligible native threads once so thread-start can adopt
+  the new schema; the PR contract documents bounded transcript continuity,
+  conditional hot-path work, rollback behavior, and the two-turn deployment
+  smoke. No compatibility mechanism is warranted.

--- a/agent-docs/exec-plans/active/2026-08-09-response-card-schema-compaction.md
+++ b/agent-docs/exec-plans/active/2026-08-09-response-card-schema-compaction.md
@@ -1,0 +1,81 @@
+# Preserve response-card schema through Codex
+
+Status: active
+Created: 2026-08-09
+Updated: 2026-08-09
+
+## Goal
+
+- Restore reliable `daily_nutrition` and `compact_table` response-card
+  attachment by keeping the model-facing tool schema below Codex's schema
+  compaction threshold without changing the canonical runtime card contract.
+
+## Success criteria
+
+- The response-card tool exposes only the current nutrition V2 and compact-table
+  V1 authoring contracts, with their nested field shapes intact.
+- The runtime parser still accepts retained nutrition V1 cards as well as the
+  current card formats.
+- A regression test fails before the full tool input schema reaches the pinned
+  Codex App Server's 5,000-byte compaction boundary.
+- Focused tests, package typechecks, and a real App Server probe pass for both
+  card kinds.
+
+## Scope
+
+- In scope: response-card JSON Schema generation, focused schema and tool tests,
+  and direct App Server verification.
+- Out of scope: card persistence, rendering, delivery, prompts, unrelated tool
+  schemas, and removal of nutrition V1 runtime compatibility.
+
+## Constraints
+
+- Technical constraints: retain one attachment tool and one canonical runtime
+  parser; derive the model schema from the existing Zod contracts; do not add a
+  second state or delivery owner.
+- Product/process constraints: preserve already-stored V1 cards, avoid exposing
+  private production evidence, and use the hosted-runtime PR verification lane.
+
+## Risks and mitigations
+
+1. Risk: removing V1 from model authoring could accidentally remove V1 runtime
+   support.
+   Mitigation: leave `assistantResponseCardSchema` unchanged and retain explicit
+   V1 parser coverage.
+2. Risk: later schema growth could trigger silent Codex compaction again.
+   Mitigation: guard the Codex-normalized full tool input below 5,000 bytes, not
+   only the nested card schema.
+3. Risk: hand-maintained JSON Schema could drift from the canonical contracts.
+   Mitigation: continue generating it directly from the current Zod schemas;
+   keep the small Codex normalization projection test-only and pinned to the
+   deployed App Server boundary.
+
+## Tasks
+
+1. Separate the current model-authoring union from the compatibility-preserving
+   runtime union.
+2. Generate a current-only inline schema and add normalized-size boundary
+   regression coverage.
+3. Run focused tests, package typechecks, and real App Server probes for both
+   response-card kinds.
+4. Review the exact diff, commit, open the PR, and complete CI and ReviewGPT
+   gates.
+
+## Decisions
+
+- Keep a single `attach_response_card` tool. Splitting tools would introduce a
+  second model-facing capability and duplicate authorization guidance.
+- Keep nutrition V1 only in the runtime union. New tool calls author V2, while
+  retained and replayed V1 cards remain valid.
+- Keep the model schema inline. The deployed App Server drops local definitions
+  during large-schema compaction, so reference reuse cannot preserve nested
+  authoring shapes.
+
+## Verification
+
+- Commands to run: focused operator-config and assistant-engine Vitest files;
+  both package typechecks; `git diff --check`; privacy scan; real App Server
+  probes for current nutrition and compact-table cards.
+- Expected outcomes: all checks pass; both probes produce canonical arguments
+  without a tool-schema rejection; the complete tool input remains below 5,000
+  Codex-normalized bytes.

--- a/agent-docs/exec-plans/completed/2026-08-09-response-card-schema-compaction.md
+++ b/agent-docs/exec-plans/completed/2026-08-09-response-card-schema-compaction.md
@@ -1,6 +1,6 @@
 # Preserve response-card schema through Codex
 
-Status: active
+Status: completed
 Created: 2026-08-09
 Updated: 2026-08-09
 
@@ -85,7 +85,8 @@ Updated: 2026-08-09
 - Completed outcomes: the focused card suites pass (16 tests), the expanded
   pinned-App-Server and card-tool suites pass (40 tests), both affected package
   typechecks pass, and the live Sol probes accepted nutrition V2 and compact
-  table cards.
+  table cards. Required exact-head CI is green, preliminary specialist findings
+  are resolved, and final ReviewGPT round 2 passed with no qualifying findings.
 
 ## Review dispositions
 
@@ -97,3 +98,4 @@ Updated: 2026-08-09
   the new schema; the PR contract documents bounded transcript continuity,
   conditional hot-path work, rollback behavior, and the two-turn deployment
   smoke. No compatibility mechanism is warranted.
+Completed: 2026-08-09

--- a/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
@@ -35,6 +35,9 @@ import {
   MURPH_GROUP_SHARED_READ_TOOL,
   MURPH_GROUP_TOOL,
 } from '../src/assistant-codex/dynamic-tools.ts'
+import {
+  MURPH_ATTACH_RESPONSE_CARD_TOOL,
+} from '../src/assistant-codex/dynamic-tool-catalog.ts'
 import type {
   VoiceMemoToolRuntime,
 } from '../src/assistant-codex/generate-voice-memo-tool.ts'
@@ -133,6 +136,8 @@ interface ScriptedProviderRequestSummary {
     includesAutomation: boolean
     includesGroup: boolean
     includesReadShared: boolean
+    includesResponseCardCompactTableShape: boolean
+    includesResponseCardNutritionV2Shape: boolean
     includesSaveNewsletter: boolean
     includesToolSearch: boolean
   }
@@ -1494,6 +1499,79 @@ if (!tool) {
       (directSummary?.providerRequestDiagnostics?.bytes ?? 0)
         - deferredRequestBytes,
     ).toBeGreaterThan(4_000)
+  })
+
+  it('preserves both response-card shapes through the real App Server boundary', {
+    timeout: TURN_TIMEOUT_MS,
+  }, async () => {
+    const cards = [
+      {
+        kind: 'compact_table',
+        version: 1,
+        title: 'Training sets',
+        subtitle: null,
+        rowHeader: 'Order',
+        columns: ['Set', 'Reps'],
+        rows: [
+          { label: 'First', values: ['1', '8'] },
+          { label: 'Second', values: ['2', '6'] },
+        ],
+        footer: null,
+        tracking: null,
+      },
+      {
+        kind: 'daily_nutrition',
+        version: 2,
+        localDate: '2026-08-08',
+        mealCount: 2,
+        totals: {
+          calories: { total: 900, mealCount: 2 },
+          proteinGrams: { total: 70, mealCount: 2 },
+          carbsGrams: { total: 80, mealCount: 2 },
+          fatGrams: { total: 30, mealCount: 2 },
+          fiberGrams: { total: 15, mealCount: 2 },
+        },
+        goals: {
+          calories: null,
+          proteinGrams: null,
+          carbsGrams: null,
+          fatGrams: null,
+          fiberGrams: null,
+        },
+      },
+    ] as const
+
+    for (const card of cards) {
+      const scenario = await prepareScriptedTurnScenario()
+      scenario.stub.captureProviderRequestDiagnostics()
+      scenario.stub.queue(
+        {
+          functionCall: {
+            arguments: { card },
+            name: 'attach_response_card',
+            namespace: 'murph',
+          },
+        },
+        { text: 'CARD_ATTACHED' },
+      )
+
+      const result = await executeCodexAppServerTurn({
+        ...scenario.turnInput,
+        dynamicTools: [MURPH_ATTACH_RESPONSE_CARD_TOOL],
+        groupConversation: false,
+        prompt: 'Attach the requested synthetic response card.',
+      })
+
+      expect(
+        scenario.stub.requestSummariesSinceBaseline()[0]
+          ?.providerRequestDiagnostics,
+      ).toMatchObject({
+        includesResponseCardCompactTableShape: true,
+        includesResponseCardNutritionV2Shape: true,
+      })
+      expect(result.runtimeIssueInputs).toEqual([])
+      expect(result.responseCard).toEqual(card)
+    }
   })
 
   it('discovers deferred Murph schemas through native Codex tool_search', {
@@ -3158,6 +3236,23 @@ function readScriptedProviderRequestSummary(
             includesAutomation: requestBody.includes('"name":"automation"'),
             includesGroup: requestBody.includes('"name":"group"'),
             includesReadShared: requestBody.includes('read_shared'),
+            includesResponseCardCompactTableShape: [
+              'compact_table',
+              'columns',
+              'rowHeader',
+              'rows',
+              'values',
+              'tracking',
+              'snapshotAt',
+            ].every((field) => requestBody.includes(field)),
+            includesResponseCardNutritionV2Shape: [
+              'daily_nutrition',
+              'fiberGrams',
+              'goals',
+              'status',
+              'target',
+              'totals',
+            ].every((field) => requestBody.includes(field)),
             includesSaveNewsletter: requestBody.includes('save_newsletter'),
             includesToolSearch: tools.some((tool) => tool?.type === 'tool_search'),
           },

--- a/packages/assistant-engine/test/assistant-response-card-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-response-card-tool.test.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'node:buffer'
+
 import { describe, expect, it } from 'vitest'
 
 import type { AssistantResponseMedia } from '@murphai/operator-config/assistant-cli-contracts'
@@ -83,7 +85,71 @@ function readCardToolRequest(argumentsValue: unknown) {
   })
 }
 
+function isSchemaObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeCodexSchemaForSize(value: unknown): unknown {
+  if (!isSchemaObject(value)) {
+    return value
+  }
+  if ('$ref' in value || '$defs' in value || 'definitions' in value) {
+    throw new TypeError('The response-card tool schema must remain inline.')
+  }
+
+  const normalized: Record<string, unknown> = {}
+  for (const key of ['type', 'description', 'encrypted'] as const) {
+    if (key in value) {
+      normalized[key] = value[key]
+    }
+  }
+  if ('const' in value) {
+    normalized.enum = [value.const]
+  } else if ('enum' in value) {
+    normalized.enum = value.enum
+  }
+  if ('items' in value) {
+    normalized.items = normalizeCodexSchemaForSize(value.items)
+  }
+  if (isSchemaObject(value.properties)) {
+    normalized.properties = Object.fromEntries(
+      Object.entries(value.properties).map(([key, schema]) => [
+        key,
+        normalizeCodexSchemaForSize(schema),
+      ]),
+    )
+  }
+  if ('required' in value) {
+    normalized.required = value.required
+  }
+  if ('additionalProperties' in value) {
+    normalized.additionalProperties = isSchemaObject(value.additionalProperties)
+      ? normalizeCodexSchemaForSize(value.additionalProperties)
+      : value.additionalProperties
+  }
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const variants = value[key]
+    if (Array.isArray(variants)) {
+      normalized[key] = variants.map(normalizeCodexSchemaForSize)
+    }
+  }
+  return normalized
+}
+
 describe('murph.attach_response_card', () => {
+  it('keeps the complete input schema below the Codex compaction boundary', () => {
+    const serializedBytes = Buffer.byteLength(
+      JSON.stringify(normalizeCodexSchemaForSize(
+        MURPH_ATTACH_RESPONSE_CARD_TOOL.inputSchema,
+      )),
+      'utf8',
+    )
+
+    // Mirrors the supported-key projection used for the pinned App Server's
+    // 5,000-byte compaction decision; compaction erases nested card shapes.
+    expect(serializedBytes).toBeLessThan(5_000)
+  })
+
   it('describes the private on-demand canonical-read contract', () => {
     expect(MURPH_ATTACH_RESPONSE_CARD_TOOL.description).toContain(
       'saved instructions for the exact scheduled automation occurrence explicitly request it',

--- a/packages/operator-config/src/assistant-response-cards.ts
+++ b/packages/operator-config/src/assistant-response-cards.ts
@@ -2,6 +2,8 @@ import { Buffer } from 'node:buffer'
 
 import {
   assistantResponseCardSchema,
+  compactTableResponseCardV1Schema,
+  dailyNutritionResponseCardV2Schema,
   type AssistantResponseCard,
   type CompactTableResponseCardV1,
   type DailyNutritionResponseCard,
@@ -378,13 +380,19 @@ function isDailyNutritionResponseCardV2(
 }
 
 function createAssistantResponseCardJsonSchema() {
+  // Retained nutrition V1 cards remain valid at the runtime boundary. New tool
+  // calls author only the current nutrition version or a compact table.
+  const authoringSchema = z.union([
+    dailyNutritionResponseCardV2Schema,
+    compactTableResponseCardV1Schema,
+  ])
   const {
     $schema: _dialect,
     ...portableSchema
-  } = z.toJSONSchema(assistantResponseCardSchema)
+  } = z.toJSONSchema(authoringSchema)
   return {
     ...portableSchema,
     description:
-      'One closed Murph response card: daily_nutrition for a canonical daily meal summary, or compact_table for a bounded one-off table or a refreshed snapshot backed by one canonical workout event.',
+      'Current card authoring contract: daily_nutrition V2 or compact_table V1.',
   }
 }

--- a/packages/operator-config/test/assistant-response-cards.test.ts
+++ b/packages/operator-config/test/assistant-response-cards.test.ts
@@ -53,95 +53,67 @@ function decodeAppCardUrl(url: string): unknown {
 }
 
 describe('assistant response cards', () => {
-  it('derives the model-facing JSON schema from the runtime contract', () => {
+  it('authors only current cards while the runtime still accepts nutrition V1', () => {
     expect(assistantResponseCardJsonSchema).not.toHaveProperty('$schema')
     expect(assistantResponseCardJsonSchema).toMatchObject({
-      description: expect.stringContaining('compact_table'),
+      description: expect.stringContaining('daily_nutrition V2'),
       anyOf: [
         {
-          anyOf: [
-            {
-              additionalProperties: false,
+          additionalProperties: false,
+          properties: {
+            goals: {
               properties: {
-                goals: {
-                  properties: {
-                    calories: {
-                      anyOf: [
-                        {
-                          properties: {
-                            status: {
-                              enum: [
-                                'far_under_target',
-                                'under_target',
-                                'on_target',
-                                'over_target',
-                                'far_over_target',
-                                'unavailable',
-                              ],
-                            },
-                            target: { type: 'number' },
-                          },
+                calories: {
+                  anyOf: [
+                    {
+                      properties: {
+                        status: {
+                          enum: [
+                            'far_under_target',
+                            'under_target',
+                            'on_target',
+                            'over_target',
+                            'far_over_target',
+                            'unavailable',
+                          ],
                         },
-                        { type: 'null' },
-                      ],
+                        target: { type: 'number' },
+                      },
                     },
-                  },
+                    { type: 'null' },
+                  ],
                 },
-                kind: { const: 'daily_nutrition' },
-                totals: {
-                  properties: {
-                    fiberGrams: {
-                      anyOf: [
-                        {
-                          properties: {
-                            total: { type: 'number' },
-                          },
-                        },
-                        {
-                          properties: {
-                            mealCount: { const: 0 },
-                            total: { type: 'null' },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                version: { const: 2 },
               },
             },
-            {
-              additionalProperties: false,
+            kind: { const: 'daily_nutrition' },
+            totals: {
               properties: {
-                kind: { const: 'daily_nutrition' },
-                totals: {
-                  properties: {
-                    calories: {
+                fiberGrams: {
+                  anyOf: [
+                    {
                       properties: {
                         total: { type: 'number' },
                       },
                     },
-                    proteinGrams: {
-                      anyOf: [
-                        {
-                          additionalProperties: false,
-                          properties: {
-                            total: { type: 'number' },
-                          },
-                        },
-                        {
-                          additionalProperties: false,
-                          properties: {
-                            mealCount: { const: 0 },
-                            total: { type: 'null' },
-                          },
-                        },
-                      ],
+                    {
+                      properties: {
+                        mealCount: { const: 0 },
+                        total: { type: 'null' },
+                      },
                     },
-                  },
+                  ],
                 },
               },
             },
+            version: { const: 2 },
+          },
+          required: [
+            'kind',
+            'version',
+            'localDate',
+            'mealCount',
+            'totals',
+            'goals',
           ],
         },
         {
@@ -171,9 +143,22 @@ describe('assistant response cards', () => {
             },
             version: { const: 1 },
           },
+          required: [
+            'kind',
+            'version',
+            'title',
+            'subtitle',
+            'rowHeader',
+            'columns',
+            'rows',
+            'footer',
+            'tracking',
+          ],
         },
       ],
     })
+    expect(assistantResponseCardJsonSchema).not.toHaveProperty('$defs')
+    expect(assistantResponseCardSchema.parse(COMPLETE_CARD)).toEqual(COMPLETE_CARD)
   })
 
   it('rejects malformed, unknown, and implausible daily nutrition values', () => {


### PR DESCRIPTION
## Why this PR exists

Codex App Server compacts the response-card tool schema after it crosses its 5,000-byte normalized budget, erasing the nested card shapes and causing valid-looking model calls to fail runtime validation.

## User goal / user-visible behavior

A member who explicitly requests a private daily-nutrition or compact-table card receives the requested response card instead of losing it to a tool-input rejection.

## User experience

The entry point remains the existing private-direct request. Murph uses the same provider turn, attachment tool, and ordinary typing feedback; no new action, choice, screen, or asynchronous continuation is introduced. The card remains the complete final reply in the current conversation. Existing validation failure and ordinary-text recovery behavior is unchanged. Direct pinned-App-Server probes produced and accepted both card kinds.

## Invariants the PR must preserve

- One `murph.attach_response_card` capability remains the only model-facing card attachment owner.
- Runtime parsing continues to accept retained nutrition V1 cards while new nutrition authoring uses V2.
- Compact tables retain their canonical bounded rows, string columns, nullable presentation fields, and optional tracking contract.
- Cards remain private-direct, mutually exclusive with response media, and delivered by the existing outbox/rendering path.

## Non-obvious affected surfaces

- Codex provider input: the current inline authoring schema stays below App Server compaction and is guarded by normalized-size coverage plus a real pinned-App-Server provider-seam regression.
- Retained card compatibility: the runtime union is intentionally unchanged and explicit V1 parser coverage remains.
- Native thread continuity: the dynamic-tool schema participates in `buildAssistantCodexContractFingerprint`. On the first ordinary eligible private-direct turn after rollout, a stored old fingerprint intentionally prevents `thread/resume`; Murph reads committed transcript history through its existing local state owner, starts a fresh thread with bounded retained history, and persists the replacement thread/fingerprint. The following turn resumes normally. This rollover is necessary because dynamic tools are supplied at `thread/start` and cannot change on `thread/resume`.
- Hosted runner bundle: warm containers on the old bundle retain the rejected schema until replaced; the deployment note below defines convergence proof. A rollback can cause the same one-time thread rollover in the opposite direction.

Existing regressions cover the thread lifecycle: `assistant-codex-runtime.test.ts` proves instructions and dynamic tools are present on thread start but resume and turn input remain scoped; `assistant-codex-turn-planning.test.ts` proves a dynamic-tool contract change starts a fresh thread; committed-transcript replay tests prove retained history is bounded.

## Architecture and reuse

- **Existing systems reused:** the canonical Zod V2 nutrition schema, compact-table V1 schema, runtime compatibility union, one attachment tool, existing App Server harness, and existing delivery/state owners.
- **New logic:** one current-authoring union used only for JSON Schema generation plus a test-local projection of the pinned Codex size calculation.
- **New abstractions:** no production abstraction or test harness was added; existing contract boundaries are sufficient.
- **Complexity intentionally avoided:** no second tool, compatibility shim, state owner, delivery branch, manual JSON Schema, queue, migration, invalidator, or reconciliation path.

## Hot reply path impact

Steady-state reply behavior is unchanged. The foreground provider request carries the corrected tool schema with no new database, network/provider, or other awaited operation. Only the first eligible private-direct session with the prior contract fingerprint conditionally awaits the existing committed-transcript-history owner, which reads local runtime state and fails open to empty retained history, before the existing fresh-thread bootstrap. The replacement fingerprint is persisted and subsequent turns resume normally. Timeout, retry, and provider-call behavior are otherwise unchanged.

## Murph initial provider input impact

Deterministic base/head capture used pinned Codex App Server 0.145.0, `gpt-5.6-sol` at low reasoning in its actual direct-tool mode, `gpt-tokenizer` 3.4.0 `o200k_harmony`, the production system-prompt builder, and identical synthetic Linq direct/group fixtures. Measurements include complete provider-visible `include`, `input`, `parallel_tool_calls`, `reasoning`, `text`, and `tool_choice` fields; identical model, streaming, storage, cache, transport, client, and account metadata are excluded. The response-card tool is available only in the direct fixture, matching production scope.

| Runtime | Base | Behavior head | Delta |
| --- | ---: | ---: | ---: |
| Individual tokens | 23,656 | 24,107 | +451 (+1.9065%) |
| Individual UTF-8 bytes | 107,964 | 109,452 | +1,488 (+1.3782%) |
| Group tokens | 19,921 | 19,921 | 0 (0.0000%) |
| Group UTF-8 bytes | 91,420 | 91,420 | 0 (0.0000%) |

Base is `origin/main`; behavior head is `f5f22dd3d7382ec74376f6dc67cd194d4616cc95`. Current PR head `71431a8f4e84015b730ed047e0659c9004c4d366` differs only by tests and plan evidence, so production provider input is identical to the measured behavior head. The entire direct delta is attributable to the `attach_response_card` argument schema and generated guidance; assembled instructions and other provider-visible fields are unchanged. Group input is identical because response cards are unavailable there. The temporary capture harness was removed.

## Preliminary specialist lenses

- **Product experience — applicable:** restores the intended private card outcome; direct evidence is the two-card real App Server probe.
- **Prompt — applicable:** the model-facing schema contract and its description change; focused schema assertions and the real App Server provider-seam regression exercise it.
- **Frontend — not applicable:** no `apps/web` UI or rendered surface changed.
- **Coverage — applicable:** the existing pinned App Server harness captures the provider-visible schema, proves both nested shapes survive, and accepts one valid compact-table and one valid nutrition V2 call. The expanded focused lane passes 40 tests; operator schema tests pass 8 tests; both affected package typechecks pass.

ReviewGPT context sensitivity: sensitive

Reason: this is a hosted runtime/provider boundary change affecting product-visible delivery and runner rollout behavior.

ReviewGPT first-reviewed head: f5f22dd3d7382ec74376f6dc67cd194d4616cc95

Final ReviewGPT round 2 passed the full snapshot at `a0803054daab1362ff50a81eea196e958adcfc6b`; the only later change archives the completed execution plan.

## Change-shape breakdown

Classification uses `git diff --numstat origin/main...HEAD`; production package code is source, Vitest files are tests/fixtures, the completed execution plan is docs, and no binary files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 2 |
| Tests/fixtures | 216 | 70 |
| Docs | 101 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **327** | **72** |

The remediation after first review changes tests/docs only; source shape remains 10 added / 2 deleted.

## Design proof

Not applicable; no user-facing frontend UI changed.

## Deployment skew / compatibility

This is runner-only and backward compatible with Web, Worker control code, persisted cards, and outbox delivery; no tandem Web/Worker deploy or data migration is needed. Existing warm runner processes keep the old compacted schema until replaced, so use `container_rollout=immediate`. Natural warm-container replacement is not bounded by this PR. The retained aggregate was roughly six schema rejections per day, so an immediate deployment-cycle window should expose at most one additional ordinary request at current volume; the failure is reversible by retry after convergence and requires no replay machinery.

After deployment:

1. Use a pre-existing eligible private-direct session for a non-card turn; confirm it starts a fresh native thread while retaining bounded committed continuity.
2. Send a second turn in that session; confirm it resumes the replacement thread.
3. Run one private nutrition-card and one compact-table smoke; confirm both attach and reach delivery.
4. Confirm the old validation fingerprint stops appearing in runtime logs. A rollback may rotate an affected session once again.
