### PR TITLE
Show every homepage referral reward in Murph days

### DIFF
--- a/agent-docs/product-specs/hosted-usage-referrals.md
+++ b/agent-docs/product-specs/hosted-usage-referrals.md
@@ -23,6 +23,12 @@ a share action. Gate-derived availability is program-level, not a promise that
 an individual member has enough rolling capacity for the next reward. Public
 signup-link copy therefore states that a completed signup can earn credit only
 after the later settlement eligibility and rolling-limit checks pass.
+On the compact homepage referral section, each enabled path leads with a
+typical-use estimate (about 10 days for the $2 rewards and about 14 days for the
+$3.50 reward) and keeps the exact dollar-denominated cost-weighted credit beside
+it. These day labels are presentation estimates, not accounting units; the
+homepage says that actual capacity varies, while `/refer` retains the full
+qualification and credit detail.
 
 The stable referral link remains available to an eligible signed-in member when
 either reward gate is disabled, but a disabled signup reward is not marketed or

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -289,6 +289,22 @@ export function SectionsContent() {
 
       <Separator />
 
+      <StudySection title="Homepage referral program · signup reward">
+        <div
+          data-design-section="homepage-referral-program-signup-only"
+          className="-mx-5 sm:-mx-8 lg:-mx-12"
+          inert
+        >
+          <ReferralSection
+            rewards={HOSTED_PUBLIC_REFERRAL_REWARDS.filter(
+              ({ id }) => id === "signup-link",
+            )}
+          />
+        </div>
+      </StudySection>
+
+      <Separator />
+
       <StudySection title="Referral rewards unavailable">
         <div
           data-design-section="referral-rewards-unavailable"

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -273,6 +273,22 @@ export function SectionsContent() {
 
       <Separator />
 
+      <StudySection title="Homepage referral program · group rewards">
+        <div
+          data-design-section="homepage-referral-program-group-only"
+          className="-mx-5 sm:-mx-8 lg:-mx-12"
+          inert
+        >
+          <ReferralSection
+            rewards={HOSTED_PUBLIC_REFERRAL_REWARDS.filter(
+              ({ id }) => id !== "signup-link",
+            )}
+          />
+        </div>
+      </StudySection>
+
+      <Separator />
+
       <StudySection title="Referral rewards unavailable">
         <div
           data-design-section="referral-rewards-unavailable"

--- a/apps/web/e2e/referral-page-responsive.spec.ts
+++ b/apps/web/e2e/referral-page-responsive.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 const WIDTHS = [320, 375, 390, 768, 1280] as const;
+const GROUP_STUDY_WIDTHS = [390, 1440] as const;
 const OVERFLOW_TOLERANCE_PX = 1;
 
 function isLoopbackUrl(rawUrl: string): boolean {
@@ -76,4 +77,77 @@ test("referral page stays contained and actionable at every marketing breakpoint
       page.getByText("$3.50 of cost-weighted usage credit", { exact: true }),
     ).toBeVisible();
   }
+});
+
+test.describe("group-only referral design proof", () => {
+  test.use({ deviceScaleFactor: 2 });
+
+  test("group-only homepage referral study shows both concise rewards", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    await page.route("**/*", (route) => {
+      if (isLoopbackUrl(route.request().url())) {
+        route.continue();
+      } else {
+        route.abort();
+      }
+    });
+    await page.addInitScript(() => {
+      const style = document.createElement("style");
+      style.textContent =
+        "*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}";
+      (document.head ?? document.documentElement).appendChild(style);
+    });
+
+    for (const width of GROUP_STUDY_WIDTHS) {
+      await page.setViewportSize({ width, height: 1000 });
+      const response = await page.goto("/design?tab=sections", {
+        waitUntil: "load",
+      });
+      expect(
+        response?.status(),
+        `/design should respond 200 at ${width}px`,
+      ).toBe(200);
+
+      const study = page.locator(
+        '[data-design-section="homepage-referral-program-group-only"]',
+      );
+      await expect(study).toBeVisible();
+      await expect(study.locator("article")).toHaveCount(2);
+      await expect(
+        study.getByText("Bring someone new to Murph", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        study.getByText("Start an active group", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        study.getByText("≈10 days of Murph", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        study.getByText("≈14 days of Murph", { exact: true }),
+      ).toBeVisible();
+      await expect(study.getByText(/If eligible/)).toHaveCount(0);
+
+      const overflowPx = await study.evaluate((element) =>
+        element.scrollWidth - element.clientWidth
+      );
+      expect(
+        overflowPx,
+        `group-only referral study should not overflow at ${width}px`,
+      ).toBeLessThanOrEqual(OVERFLOW_TOLERANCE_PX);
+
+      const screenshotPath = testInfo.outputPath(
+        `homepage-referral-group-${width}.png`,
+      );
+      await study.locator("section > div").first().screenshot({
+        path: screenshotPath,
+      });
+      await testInfo.attach(`homepage-referral-group-${width}`, {
+        contentType: "image/png",
+        path: screenshotPath,
+      });
+    }
+  });
 });

--- a/apps/web/e2e/referral-page-responsive.spec.ts
+++ b/apps/web/e2e/referral-page-responsive.spec.ts
@@ -1,8 +1,46 @@
 import { expect, test } from "@playwright/test";
 
 const WIDTHS = [320, 375, 390, 768, 1280] as const;
-const GROUP_STUDY_WIDTHS = [390, 1440] as const;
+const REFERRAL_STUDY_WIDTHS = [390, 1440] as const;
 const OVERFLOW_TOLERANCE_PX = 1;
+const REFERRAL_STUDIES = [
+  {
+    dayLabels: [
+      { count: 2, label: "≈10 days of Murph" },
+      { count: 1, label: "≈14 days of Murph" },
+    ],
+    description: "Share your link or start a group with Murph.",
+    rewardCount: 3,
+    selector: '[data-design-section="homepage-referral-program"]',
+    slug: "mixed",
+    titles: [
+      "Invite someone to Murph",
+      "Bring someone new to Murph",
+      "Start an active group",
+    ],
+  },
+  {
+    dayLabels: [
+      { count: 1, label: "≈10 days of Murph" },
+      { count: 1, label: "≈14 days of Murph" },
+    ],
+    description: "Start a fresh group with Murph.",
+    rewardCount: 2,
+    selector:
+      '[data-design-section="homepage-referral-program-group-only"]',
+    slug: "group-only",
+    titles: ["Bring someone new to Murph", "Start an active group"],
+  },
+  {
+    dayLabels: [{ count: 1, label: "≈10 days of Murph" }],
+    description: "Share your personal link with someone new.",
+    rewardCount: 1,
+    selector:
+      '[data-design-section="homepage-referral-program-signup-only"]',
+    slug: "signup-only",
+    titles: ["Invite someone to Murph"],
+  },
+] as const;
 
 function isLoopbackUrl(rawUrl: string): boolean {
   try {
@@ -79,13 +117,13 @@ test("referral page stays contained and actionable at every marketing breakpoint
   }
 });
 
-test.describe("group-only referral design proof", () => {
+test.describe("homepage referral design proof", () => {
   test.use({ deviceScaleFactor: 2 });
 
-  test("group-only homepage referral study shows both concise rewards", async ({
+  test("every homepage referral state stays concise and complete", async ({
     page,
   }, testInfo) => {
-    test.setTimeout(120_000);
+    test.setTimeout(180_000);
 
     await page.route("**/*", (route) => {
       if (isLoopbackUrl(route.request().url())) {
@@ -101,7 +139,7 @@ test.describe("group-only referral design proof", () => {
       (document.head ?? document.documentElement).appendChild(style);
     });
 
-    for (const width of GROUP_STUDY_WIDTHS) {
+    for (const width of REFERRAL_STUDY_WIDTHS) {
       await page.setViewportSize({ width, height: 1000 });
       const response = await page.goto("/design?tab=sections", {
         waitUntil: "load",
@@ -110,44 +148,57 @@ test.describe("group-only referral design proof", () => {
         response?.status(),
         `/design should respond 200 at ${width}px`,
       ).toBe(200);
-
-      const study = page.locator(
-        '[data-design-section="homepage-referral-program-group-only"]',
-      );
-      await expect(study).toBeVisible();
-      await expect(study.locator("article")).toHaveCount(2);
-      await expect(
-        study.getByText("Bring someone new to Murph", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        study.getByText("Start an active group", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        study.getByText("≈10 days of Murph", { exact: true }),
-      ).toBeVisible();
-      await expect(
-        study.getByText("≈14 days of Murph", { exact: true }),
-      ).toBeVisible();
-      await expect(study.getByText(/If eligible/)).toHaveCount(0);
-
-      const overflowPx = await study.evaluate((element) =>
-        element.scrollWidth - element.clientWidth
-      );
-      expect(
-        overflowPx,
-        `group-only referral study should not overflow at ${width}px`,
-      ).toBeLessThanOrEqual(OVERFLOW_TOLERANCE_PX);
-
-      const screenshotPath = testInfo.outputPath(
-        `homepage-referral-group-${width}.png`,
-      );
-      await study.locator("section > div").first().screenshot({
-        path: screenshotPath,
+      await page.evaluate(async () => {
+        await document.fonts?.ready;
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)),
+        );
       });
-      await testInfo.attach(`homepage-referral-group-${width}`, {
-        contentType: "image/png",
-        path: screenshotPath,
-      });
+
+      for (const expected of REFERRAL_STUDIES) {
+        const study = page.locator(expected.selector);
+        await expect(study).toBeVisible();
+        await expect(study.locator("article")).toHaveCount(
+          expected.rewardCount,
+        );
+        await expect(
+          study.getByText(expected.description, { exact: true }),
+        ).toBeVisible();
+        await expect(
+          study.getByRole("link", { name: "See ways to earn" }),
+        ).toBeVisible();
+        for (const title of expected.titles) {
+          await expect(study.getByText(title, { exact: true })).toBeVisible();
+        }
+        for (const dayLabel of expected.dayLabels) {
+          await expect(
+            study.getByText(dayLabel.label, { exact: true }),
+          ).toHaveCount(dayLabel.count);
+        }
+        await expect(study.getByText(/If eligible/)).toHaveCount(0);
+
+        const overflowPx = await study.evaluate((element) =>
+          element.scrollWidth - element.clientWidth
+        );
+        expect(
+          overflowPx,
+          `${expected.slug} referral study should not overflow at ${width}px`,
+        ).toBeLessThanOrEqual(OVERFLOW_TOLERANCE_PX);
+
+        const screenshotPath = testInfo.outputPath(
+          `homepage-referral-${expected.slug}-${width}.png`,
+        );
+        await study.locator("section > div").first().screenshot({
+          path: screenshotPath,
+        });
+        await testInfo.attach(
+          `homepage-referral-${expected.slug}-${width}`,
+          {
+            contentType: "image/png",
+            path: screenshotPath,
+          },
+        );
+      }
     }
   });
 });

--- a/apps/web/src/components/homepage/referral-section.tsx
+++ b/apps/web/src/components/homepage/referral-section.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import { ArrowRight, CheckCircle2, Link2, UsersRound } from "lucide-react";
+import { ArrowRight, Link2, UsersRound } from "lucide-react";
 
 import {
-  formatHostedPublicReferralRewardValue,
+  formatHostedPublicReferralRewardAmount,
+  formatHostedPublicReferralRewardDays,
   type HostedPublicReferralReward,
 } from "@/src/lib/hosted-growth/referral-program";
 
@@ -15,16 +16,13 @@ export function ReferralSection({
     return null;
   }
 
-  const featuredRewards = rewards.filter(
-    ({ id }) => id === "signup-link" || id === "active-group",
-  );
   const signupAvailable = rewards.some(({ id }) => id === "signup-link");
   const groupAvailable = rewards.some(({ id }) => id !== "signup-link");
   const description = signupAvailable && groupAvailable
-    ? "Explore your personal link or a group mission. Eligibility, rolling-limit, and completion checks determine whether Murph applies usage automatically."
+    ? "Share your link or start a group with Murph."
     : signupAvailable
-    ? "Share your personal link. A genuinely new completed signup can earn usage after Murph’s eligibility and rolling-limit checks pass."
-    : "Explore a group mission. Murph applies usage automatically after the mission is accepted and reaches its real-participation requirements.";
+    ? "Share your personal link with someone new."
+    : "Start a fresh group with Murph.";
 
   return (
     <section className="bg-[#f5f0e8] px-4 py-10 sm:px-8 sm:py-16 lg:px-16 lg:py-20">
@@ -38,7 +36,7 @@ export function ReferralSection({
           }}
         />
 
-        <div className="relative grid items-end gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)] lg:gap-14">
+        <div className="relative grid items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)] lg:gap-14">
           <div>
             <p className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-[#d4b87a]">
               Murph referrals
@@ -53,7 +51,7 @@ export function ReferralSection({
               className="group mt-7 inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[#f5f0e8] px-5 py-3.5 text-[0.9375rem] font-semibold text-[#2d3436] transition-colors hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d4b87a]"
               href="/refer"
             >
-              See the referral program
+              See ways to earn
               <ArrowRight
                 aria-hidden="true"
                 className="size-4 transition-transform group-hover:translate-x-0.5"
@@ -62,7 +60,7 @@ export function ReferralSection({
           </div>
 
           <div className="grid gap-3">
-            {featuredRewards.map((reward) => {
+            {rewards.map((reward) => {
               const Icon = reward.id === "signup-link" ? Link2 : UsersRound;
               return (
                 <article
@@ -76,34 +74,25 @@ export function ReferralSection({
                     <p className="text-sm font-semibold text-[#f5f0e8]">
                       {reward.title}
                     </p>
-                    <p className="mt-1 text-xs leading-[1.55] text-[#f5f0e8]/60">
-                      {reward.availabilityLabel}
-                    </p>
                   </div>
-                  <div className="col-span-2 flex items-baseline justify-between gap-3 border-t border-white/10 pt-3 sm:col-span-1 sm:block sm:border-0 sm:pt-0 sm:text-right">
-                    <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-[#d4b87a]">
-                      If eligible
-                    </p>
-                    <p className="text-sm font-semibold text-[#f5f0e8] sm:mt-1">
-                      {formatHostedPublicReferralRewardValue(
-                        reward.rewardUsdMicros,
+                  <div className="col-span-2 flex items-end justify-between gap-3 border-t border-white/10 pt-3 sm:col-span-1 sm:block sm:border-0 sm:pt-0 sm:text-right">
+                    <p className="text-base font-semibold text-[#f5f0e8]">
+                      {formatHostedPublicReferralRewardDays(
+                        reward.estimatedUsageDays,
                       )}
+                    </p>
+                    <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-[#d4b87a] sm:mt-1">
+                      {formatHostedPublicReferralRewardAmount(
+                        reward.rewardUsdMicros,
+                      )} credit
                     </p>
                   </div>
                 </article>
               );
             })}
-            <div className="flex items-start gap-2.5 px-1 pt-1 text-xs leading-[1.6] text-[#f5f0e8]/55">
-              <CheckCircle2
-                aria-hidden="true"
-                className="mt-0.5 size-4 shrink-0 text-[#d4b87a]"
-              />
-              <p>
-                Qualifying rewards are applied automatically to the Murph they
-                were earned for. Dollar labels state exact cost-weighted usage
-                credit; actual message capacity varies.
-              </p>
-            </div>
+            <p className="px-1 pt-1 text-xs leading-[1.5] text-[#f5f0e8]/55">
+              Typical-use estimate. Actual capacity varies.
+            </p>
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/hosted-growth/referral-program.ts
+++ b/apps/web/src/lib/hosted-growth/referral-program.ts
@@ -19,6 +19,7 @@ export type HostedPublicReferralRewardId =
 export interface HostedPublicReferralReward {
   availabilityLabel: string;
   description: string;
+  estimatedUsageDays: number;
   id: HostedPublicReferralRewardId;
   rewardUsdMicros: bigint;
   title: string;
@@ -34,6 +35,7 @@ export const HOSTED_PUBLIC_REFERRAL_REWARDS = [
     availabilityLabel: "Personal referral link",
     description:
       "Share your stable link. A genuinely new completed signup can earn the fixed usage credit after Murph’s eligibility and rolling-limit checks pass.",
+    estimatedUsageDays: 10,
     id: "signup-link",
     rewardUsdMicros: 2_000_000n,
     title: HOSTED_SIGNUP_REFERRAL_POLICY_DISPLAY.title,
@@ -42,6 +44,7 @@ export const HOSTED_PUBLIC_REFERRAL_REWARDS = [
     availabilityLabel: "Fresh iMessage group",
     description:
       "Tell Murph first, then make a fresh group with someone new. It completes after they set up their own Murph and join the conversation.",
+    estimatedUsageDays: 10,
     id: "new-person-group",
     rewardUsdMicros: 2_000_000n,
     title: "Bring someone new to Murph",
@@ -50,6 +53,7 @@ export const HOSTED_PUBLIC_REFERRAL_REWARDS = [
     availabilityLabel: "Supported group chats",
     description:
       "Tell Murph first, then make the fresh group genuinely active: 15 human messages, including 8 from at least 2 other people, across at least 10 minutes.",
+    estimatedUsageDays: 14,
     id: "active-group",
     rewardUsdMicros: 3_500_000n,
     title: "Start an active group",
@@ -72,9 +76,22 @@ export function getAvailableHostedPublicReferralRewards(
 export function formatHostedPublicReferralRewardValue(
   rewardUsdMicros: bigint,
 ): string {
+  return `${formatHostedPublicReferralRewardAmount(
+    rewardUsdMicros,
+  )} of cost-weighted usage credit`;
+}
+
+export function formatHostedPublicReferralRewardAmount(
+  rewardUsdMicros: bigint,
+): string {
   const cents = (rewardUsdMicros + 5_000n) / 10_000n;
-  const value = HOSTED_PUBLIC_REFERRAL_USD_FORMATTER.format(
+  return HOSTED_PUBLIC_REFERRAL_USD_FORMATTER.format(
     Number(cents) / 100,
   );
-  return `${value} of cost-weighted usage credit`;
+}
+
+export function formatHostedPublicReferralRewardDays(
+  estimatedUsageDays: number,
+): string {
+  return `≈${estimatedUsageDays} days of Murph`;
 }

--- a/apps/web/test/homepage-referral-section.test.tsx
+++ b/apps/web/test/homepage-referral-section.test.tsx
@@ -18,17 +18,19 @@ test("ReferralSection presents every available referral path on the homepage", (
 
   assert.match(markup, /Murph referrals/);
   assert.match(markup, /Bring your people\. Earn more Murph time\./);
-  assert.match(markup, /Explore your personal link or a group mission/);
-  assert.match(markup, /Eligibility, rolling-limit, and completion checks/);
+  assert.match(markup, /Share your link or start a group with Murph/);
   assert.match(markup, /Invite someone to Murph/);
+  assert.match(markup, /Bring someone new to Murph/);
   assert.match(markup, /Start an active group/);
-  assert.match(markup, /\$2\.00 of cost-weighted usage credit/);
-  assert.match(markup, /\$3\.50 of cost-weighted usage credit/);
+  assert.match(markup, /≈10 days of Murph/);
+  assert.match(markup, /≈14 days of Murph/);
+  assert.match(markup, /\$2\.00 credit/);
+  assert.match(markup, /\$3\.50 credit/);
   assert.match(markup, /href="\/refer"/);
-  assert.match(markup, /See the referral program/);
-  assert.match(markup, /Qualifying rewards are applied automatically to the Murph they/);
-  assert.match(markup, /Dollar labels state exact cost-weighted usage credit/);
-  assert.match(markup, /If eligible/);
+  assert.match(markup, /See ways to earn/);
+  assert.match(markup, /Typical-use estimate\. Actual capacity varies\./);
+  assert.doesNotMatch(markup, /If eligible/);
+  assert.doesNotMatch(markup, /Dollar labels state exact cost-weighted usage credit/);
   assert.doesNotMatch(markup, /applies earned usage automatically when/);
 });
 
@@ -40,11 +42,10 @@ test("ReferralSection keeps disabled referral paths out of its copy and rewards"
     createElement(ReferralSection, { rewards: signupReward }),
   );
 
-  assert.match(signupMarkup, /Share your personal link\./);
-  assert.match(signupMarkup, /eligibility and rolling-limit checks pass/);
-  assert.doesNotMatch(signupMarkup, /when setup completes|checks at completion/);
+  assert.match(signupMarkup, /Share your personal link with someone new\./);
   assert.match(signupMarkup, /Invite someone to Murph/);
   assert.doesNotMatch(signupMarkup, /group mission/i);
+  assert.doesNotMatch(signupMarkup, /Bring someone new to Murph/);
   assert.doesNotMatch(signupMarkup, /Start an active group/);
 
   const groupRewards = HOSTED_PUBLIC_REFERRAL_REWARDS.filter(
@@ -54,8 +55,11 @@ test("ReferralSection keeps disabled referral paths out of its copy and rewards"
     createElement(ReferralSection, { rewards: groupRewards }),
   );
 
-  assert.match(groupMarkup, /Explore a group mission\./);
+  assert.match(groupMarkup, /Start a fresh group with Murph\./);
+  assert.match(groupMarkup, /Bring someone new to Murph/);
   assert.match(groupMarkup, /Start an active group/);
+  assert.match(groupMarkup, /≈10 days of Murph/);
+  assert.match(groupMarkup, /≈14 days of Murph/);
   assert.doesNotMatch(groupMarkup, /personal link/i);
   assert.doesNotMatch(groupMarkup, /Invite someone to Murph/);
 

--- a/apps/web/test/referral-program.test.ts
+++ b/apps/web/test/referral-program.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatHostedPublicReferralRewardAmount,
+  formatHostedPublicReferralRewardDays,
   formatHostedPublicReferralRewardValue,
   getAvailableHostedPublicReferralRewards,
   HOSTED_PUBLIC_REFERRAL_REWARDS,
@@ -105,6 +107,15 @@ describe("public referral program projection", () => {
     )).toBe(
       "$2.00 of cost-weighted usage credit",
     );
+    expect(formatHostedPublicReferralRewardAmount(
+      HOSTED_USAGE_REFERRAL_GROUP_REWARD_USD_MICROS,
+    )).toBe("$3.50");
+    expect(formatHostedPublicReferralRewardDays(
+      signup.estimatedUsageDays,
+    )).toBe("≈10 days of Murph");
+    expect(formatHostedPublicReferralRewardDays(
+      activeGroup.estimatedUsageDays,
+    )).toBe("≈14 days of Murph");
   });
 
   it("keeps the active-group public requirements exact", () => {


### PR DESCRIPTION
## Why this PR exists

The homepage referral section hid the `new-person-group` reward, so a group-only configuration showed only “Start an active group.” It also made exact accounting language more prominent than the practical value a visitor wants to understand.

## User goal / user-visible behavior

Visitors can see every enabled referral path and understand its approximate value in Murph days at a glance. Group-only mode now shows both “Bring someone new to Murph” (≈10 days) and “Start an active group” (≈14 days), with exact dollar credit retained as secondary truth.

## User experience

The public homepage referral section renders synchronously with its existing server-projected reward list. It now uses one short availability sentence, compact reward cards, and a “See ways to earn” link to `/refer` for the full eligibility details. There is no asynchronous continuation or wait state; if no reward is enabled, the existing null state remains. The real component was rendered in mixed, group-only, and signup-only catalog states at 390px and 1440px; all six captures were legible and overflow-free.

## Invariants

- Only gate-enabled rewards may be shown.
- Exact dollar-denominated cost-weighted usage credit remains the accounting truth; day counts are explicitly typical-use estimates and actual capacity may vary.
- `/refer` keeps the full qualification and reward details.
- Referral settlement, limits, auth, and credit application are unchanged.

## Non-obvious affected surfaces

- The public referral projection now owns a small presentation estimate for each reward so homepage copy is data-driven. Focused projection tests prove the exact values and preserve the existing dollar formatter.
- The design catalog adds a synthetic group-only state for the real homepage component. A focused browser regression proves both cards, both estimates, and responsive containment.

## Architecture and reuse

- **Existing systems reused:** The existing gate-derived `HOSTED_PUBLIC_REFERRAL_REWARDS`, `ReferralSection`, `/refer` destination, and design-catalog study infrastructure remain the owners.
- **New logic:** Each public reward carries its typical-use day estimate, and two narrow formatters render the day estimate and exact dollar amount.
- **New abstractions:** No new service or state owner was added; the existing public reward projection was sufficient.
- **Complexity intentionally avoided:** No client state, reward recomputation, duplicated reward catalog, or accounting conversion was introduced.

## Hot reply path impact

Not applicable. This only changes public web referral presentation and tests; it does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool, skill, request assembly, or provider-visible input changed.
- Group Murph: Not applicable; no prompt, tool, skill, request assembly, or provider-visible input changed.

## Preliminary specialist lenses

- **Product experience — applicable:** The outcome is concise, complete referral value communication. Direct journey evidence is the mixed, group-only, and signup-only real-component catalog renders and browser assertions at both target viewports.
- **Prompt — not applicable:** No prompts, tool descriptions, or provider input assembly changed.
- **Frontend — applicable:** `.artifacts/review-gpt/referral-mixed-desktop.png`, `.artifacts/review-gpt/referral-mixed-mobile.png`, `.artifacts/review-gpt/referral-group-only-desktop.png`, `.artifacts/review-gpt/referral-group-only-mobile.png`, `.artifacts/review-gpt/referral-signup-only-desktop.png`, and `.artifacts/review-gpt/referral-signup-only-mobile.png` prove all three enabled-reward states at 1440 and 390 CSS px, all at device scale factor 2.
- **Coverage — applicable:** Focused Vitest coverage and the serial Playwright responsive/design proof pass locally; exact-head GitHub CI is pending.

ReviewGPT context sensitivity: routine

This is a narrow public presentation bug fix with no product-critical flow, state, authority, billing, health-safety, API, deploy, or cross-owner effect. The separate final ReviewGPT gate is exempt under the minor frontend/static-content rule; the preliminary combined specialist pass still applies.

## Change shape

Classification: authored production and catalog code is source; Vitest and Playwright files are tests/fixtures; product-spec text is docs; no binary or generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 71 | 33 |
| Tests / fixtures | 152 | 12 |
| Docs | 6 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **229** | **45** |

## Design proof

- Design page: [`/design?tab=sections`](https://murph.ai/design?tab=sections), study “Homepage referral program · group rewards” (`homepage-referral-program-group-only`).
- Desktop screenshot: Mixed rewards, 1440 CSS px at 2×. ![Mixed referral rewards on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e885bb51-dd32-4209-3eed-0b57ab4b7100/designproof)
- Mobile screenshot: Mixed rewards, 390 CSS px at 2×. ![Mixed referral rewards on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1d105ccc-1627-4c31-5a27-e37b3d05ec00/designproof)
- Group-only desktop screenshot: 1440 CSS px at 2×. ![Group-only referral rewards on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/73286036-70a0-47e8-bac0-fad14a34d800/designproof)
- Group-only mobile screenshot: 390 CSS px at 2×. ![Group-only referral rewards on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/db9c660a-7590-4a16-98ce-bfdf64b23500/designproof)
- Signup-only desktop screenshot: 1440 CSS px at 2×. ![Signup-only referral reward on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e74bac63-a51d-43e0-da55-64b00f127200/designproof)
- Signup-only mobile screenshot: 390 CSS px at 2×. ![Signup-only referral reward on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/2b144e79-e095-43fa-00d0-cd44bb7a0000/designproof)

## Deployment skew / compatibility

Not applicable. This is an `apps/web`-only presentation change with no cross-deploy contract.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/homepage-referral-section.test.tsx apps/web/test/referral-program.test.ts` — 8 tests passed.
- Targeted ESLint over all changed TypeScript/TSX files — passed.
- `pnpm --dir apps/web typecheck` — passed.
- Serial Playwright run for `e2e/referral-page-responsive.spec.ts` — 2 tests passed, including five `/refer` breakpoints and all three referral states at 390/1440; the focused rendered-state test also passed after font/CTA capture hardening.
- `git diff --check` — passed.
