### PR TITLE
Show referral rewards only in Murph days

### DIFF
--- a/agent-docs/product-specs/hosted-usage-referrals.md
+++ b/agent-docs/product-specs/hosted-usage-referrals.md
@@ -24,11 +24,11 @@ an individual member has enough rolling capacity for the next reward. Public
 signup-link copy therefore states that a completed signup can earn credit only
 after the later settlement eligibility and rolling-limit checks pass.
 On the compact homepage referral section, each enabled path leads with a
-typical-use estimate (about 10 days for the $2 rewards and about 14 days for the
-$3.50 reward) and keeps the exact dollar-denominated cost-weighted credit beside
-it. These day labels are presentation estimates, not accounting units; the
-homepage says that actual capacity varies, while `/refer` retains the full
-qualification and credit detail.
+plain typical-use day label (10 days for the $2 rewards and 14 days for the
+$3.50 reward) without repeating the underlying dollar-denominated credit. These
+day labels are presentation estimates, not accounting units; the homepage says
+that actual capacity varies, while `/refer` retains the full qualification and
+credit detail.
 
 The stable referral link remains available to an eligible signed-in member when
 either reward gate is disabled, but a disabled signup reward is not marketed or

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -260,7 +260,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Homepage referral program">
+      <StudySection title="Homepage referral program · days-only rewards">
         <div
           id="referral-program"
           data-design-section="homepage-referral-program"

--- a/apps/web/e2e/referral-page-responsive.spec.ts
+++ b/apps/web/e2e/referral-page-responsive.spec.ts
@@ -6,8 +6,8 @@ const OVERFLOW_TOLERANCE_PX = 1;
 const REFERRAL_STUDIES = [
   {
     dayLabels: [
-      { count: 2, label: "≈10 days of Murph" },
-      { count: 1, label: "≈14 days of Murph" },
+      { count: 2, label: "10 days of Murph" },
+      { count: 1, label: "14 days of Murph" },
     ],
     description: "Share your link or start a group with Murph.",
     rewardCount: 3,
@@ -21,8 +21,8 @@ const REFERRAL_STUDIES = [
   },
   {
     dayLabels: [
-      { count: 1, label: "≈10 days of Murph" },
-      { count: 1, label: "≈14 days of Murph" },
+      { count: 1, label: "10 days of Murph" },
+      { count: 1, label: "14 days of Murph" },
     ],
     description: "Start a fresh group with Murph.",
     rewardCount: 2,
@@ -32,7 +32,7 @@ const REFERRAL_STUDIES = [
     titles: ["Bring someone new to Murph", "Start an active group"],
   },
   {
-    dayLabels: [{ count: 1, label: "≈10 days of Murph" }],
+    dayLabels: [{ count: 1, label: "10 days of Murph" }],
     description: "Share your personal link with someone new.",
     rewardCount: 1,
     selector:
@@ -176,6 +176,7 @@ test.describe("homepage referral design proof", () => {
           ).toHaveCount(dayLabel.count);
         }
         await expect(study.getByText(/If eligible/)).toHaveCount(0);
+        await expect(study.getByText(/≈|\$[0-9]/)).toHaveCount(0);
 
         const overflowPx = await study.evaluate((element) =>
           element.scrollWidth - element.clientWidth

--- a/apps/web/src/components/homepage/referral-section.tsx
+++ b/apps/web/src/components/homepage/referral-section.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { ArrowRight, Link2, UsersRound } from "lucide-react";
 
 import {
-  formatHostedPublicReferralRewardAmount,
   formatHostedPublicReferralRewardDays,
   type HostedPublicReferralReward,
 } from "@/src/lib/hosted-growth/referral-program";
@@ -75,16 +74,11 @@ export function ReferralSection({
                       {reward.title}
                     </p>
                   </div>
-                  <div className="col-span-2 flex items-end justify-between gap-3 border-t border-white/10 pt-3 sm:col-span-1 sm:block sm:border-0 sm:pt-0 sm:text-right">
+                  <div className="col-span-2 border-t border-white/10 pt-3 sm:col-span-1 sm:border-0 sm:pt-0 sm:text-right">
                     <p className="text-base font-semibold text-[#f5f0e8]">
                       {formatHostedPublicReferralRewardDays(
                         reward.estimatedUsageDays,
                       )}
-                    </p>
-                    <p className="font-mono text-[9px] uppercase tracking-[0.1em] text-[#d4b87a] sm:mt-1">
-                      {formatHostedPublicReferralRewardAmount(
-                        reward.rewardUsdMicros,
-                      )} credit
                     </p>
                   </div>
                 </article>

--- a/apps/web/src/lib/hosted-growth/referral-program.ts
+++ b/apps/web/src/lib/hosted-growth/referral-program.ts
@@ -93,5 +93,5 @@ export function formatHostedPublicReferralRewardAmount(
 export function formatHostedPublicReferralRewardDays(
   estimatedUsageDays: number,
 ): string {
-  return `≈${estimatedUsageDays} days of Murph`;
+  return `${estimatedUsageDays} days of Murph`;
 }

--- a/apps/web/test/homepage-referral-section.test.tsx
+++ b/apps/web/test/homepage-referral-section.test.tsx
@@ -22,10 +22,9 @@ test("ReferralSection presents every available referral path on the homepage", (
   assert.match(markup, /Invite someone to Murph/);
   assert.match(markup, /Bring someone new to Murph/);
   assert.match(markup, /Start an active group/);
-  assert.match(markup, /≈10 days of Murph/);
-  assert.match(markup, /≈14 days of Murph/);
-  assert.match(markup, /\$2\.00 credit/);
-  assert.match(markup, /\$3\.50 credit/);
+  assert.match(markup, /10 days of Murph/);
+  assert.match(markup, /14 days of Murph/);
+  assert.doesNotMatch(markup, /≈|\$[0-9]/);
   assert.match(markup, /href="\/refer"/);
   assert.match(markup, /See ways to earn/);
   assert.match(markup, /Typical-use estimate\. Actual capacity varies\./);
@@ -58,8 +57,9 @@ test("ReferralSection keeps disabled referral paths out of its copy and rewards"
   assert.match(groupMarkup, /Start a fresh group with Murph\./);
   assert.match(groupMarkup, /Bring someone new to Murph/);
   assert.match(groupMarkup, /Start an active group/);
-  assert.match(groupMarkup, /≈10 days of Murph/);
-  assert.match(groupMarkup, /≈14 days of Murph/);
+  assert.match(groupMarkup, /10 days of Murph/);
+  assert.match(groupMarkup, /14 days of Murph/);
+  assert.doesNotMatch(groupMarkup, /≈|\$[0-9]/);
   assert.doesNotMatch(groupMarkup, /personal link/i);
   assert.doesNotMatch(groupMarkup, /Invite someone to Murph/);
 

--- a/apps/web/test/referral-program.test.ts
+++ b/apps/web/test/referral-program.test.ts
@@ -112,10 +112,10 @@ describe("public referral program projection", () => {
     )).toBe("$3.50");
     expect(formatHostedPublicReferralRewardDays(
       signup.estimatedUsageDays,
-    )).toBe("≈10 days of Murph");
+    )).toBe("10 days of Murph");
     expect(formatHostedPublicReferralRewardDays(
       activeGroup.estimatedUsageDays,
-    )).toBe("≈14 days of Murph");
+    )).toBe("14 days of Murph");
   });
 
   it("keeps the active-group public requirements exact", () => {


### PR DESCRIPTION
## Why this PR exists

The compact homepage referral cards still prefixed day values with an approximation symbol and repeated the underlying dollar credit. The requested presentation is the simpler practical value only.

## User goal / user-visible behavior

Visitors see one plain reward value per card: “10 days of Murph” or “14 days of Murph.” The approximation glyph and dollar-credit line no longer appear in the homepage section.

## User experience

The public homepage referral section still renders synchronously from its existing server-projected reward list. Each enabled path now pairs its title with one day value, followed by the existing shared note that usage is a typical-use estimate and actual capacity varies. The `/refer` destination retains full qualification and accounting details. There is no asynchronous continuation, wait state, or changed action. The real component was rendered in mixed, group-only, and signup-only catalog states at 390px and 1440px; all six captures are legible and overflow-free.

## Invariants

- Only gate-enabled rewards may be shown.
- Day counts remain presentation estimates; the shared capacity note stays visible.
- `/refer` retains exact dollar-denominated credit and qualification details.
- Referral settlement, limits, auth, and credit application are unchanged.

## Non-obvious affected surfaces

- The public day-label formatter now emits a plain day label. Focused projection tests prove the 10-day and 14-day values; the exact-dollar formatters used by `/refer` remain unchanged.
- The design catalog names the primary study as days-only and continues to render the real component in all three availability states. Playwright proves the labels, absence of approximation and dollar values, and responsive containment.

## Architecture and reuse

- **Existing systems reused:** The existing gate-derived public reward projection, `estimatedUsageDays` values, `ReferralSection`, `/refer` detail destination, and design-catalog studies remain the owners.
- **New logic:** No business logic was added; the existing day formatter now emits the plain label, and the card renders that single value without its former secondary amount.
- **New abstractions:** No abstraction was added because the existing public projection and formatter already own the presentation value.
- **Complexity intentionally avoided:** No alternate reward model, client state, accounting conversion, duplicated catalog, or conditional presentation layer was introduced.

## Hot reply path impact

Not applicable. This only changes public web referral presentation and tests; it does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool, skill, request assembly, or provider-visible input changed.
- Group Murph: Not applicable; no prompt, tool, skill, request assembly, or provider-visible input changed.

## Preliminary specialist lenses

- **Product experience — applicable:** The intended outcome is one uncluttered day value per reward card. Direct journey evidence is the mixed, group-only, and signup-only real-component catalog renders and browser assertions at both target viewports.
- **Prompt — not applicable:** No prompts, tool descriptions, or provider input assembly changed.
- **Frontend — applicable:** The packaged mixed, group-only, and signup-only desktop/mobile PNGs prove the days-only presentation at 1440 and 390 CSS px, all at device scale factor 2.
- **Coverage — applicable:** Focused Vitest, ESLint, typecheck, and the responsive Playwright file pass locally; exact-head GitHub CI is pending.

ReviewGPT context sensitivity: routine

This is a narrow public presentation refinement with no product-critical flow, state, authority, billing, health-safety, API, deploy, or cross-owner effect. The separate final ReviewGPT gate is exempt under the minor frontend/static-content rule; the preliminary combined specialist pass still applies.

## Change shape

Classification: authored production and catalog code is source; Vitest and Playwright files are tests/fixtures; product-spec text is docs; no binary or generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 9 |
| Tests / fixtures | 14 | 13 |
| Docs | 5 | 5 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **22** | **27** |

## Design proof

- Design page: [`/design?tab=sections`](https://murph.ai/design?tab=sections), studies “Homepage referral program · days-only rewards,” “Homepage referral program · group rewards,” and “Homepage referral program · signup reward.”
- Desktop screenshot: Mixed rewards, 1440 CSS px at 2×. ![Mixed referral rewards on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/993128e9-efb6-4419-1860-5311ae78c000/designproof)
- Mobile screenshot: Mixed rewards, 390 CSS px at 2×. ![Mixed referral rewards on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/fdc1f454-f8ff-4703-4393-d6c8474e5600/designproof)
- Group-only desktop screenshot: 1440 CSS px at 2×. ![Group-only referral rewards on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/b2a0c27d-0336-46c1-4e1a-a75ad215a400/designproof)
- Group-only mobile screenshot: 390 CSS px at 2×. ![Group-only referral rewards on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/28f86af8-d55c-4651-e043-18701ae03a00/designproof)
- Signup-only desktop screenshot: 1440 CSS px at 2×. ![Signup-only referral reward on desktop](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/1a9f9e29-2dbf-45a5-3c22-3190076b2600/designproof)
- Signup-only mobile screenshot: 390 CSS px at 2×. ![Signup-only referral reward on mobile](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/3f12b9ec-88ce-4245-107b-88431ea1b100/designproof)

## Deployment skew / compatibility

Not applicable. This is an `apps/web`-only presentation change with no cross-deploy contract.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/homepage-referral-section.test.tsx apps/web/test/referral-program.test.ts` — 8 tests passed.
- Targeted ESLint over all changed TypeScript/TSX files — passed.
- `pnpm --dir apps/web typecheck` — passed.
- Isolated Playwright run for `e2e/referral-page-responsive.spec.ts` — 2 tests passed, including five `/refer` breakpoints and all three homepage referral states at 390/1440.
- `git diff --check` — passed.
