### PR TITLE
Harden sponsorship creative consent and song execution

### DIFF
--- a/apps/web/src/lib/hosted-groups/group-sponsorship-contract.ts
+++ b/apps/web/src/lib/hosted-groups/group-sponsorship-contract.ts
@@ -33,23 +33,27 @@ export interface HostedGroupSponsorshipDraftInput {
 export function buildHostedGroupSponsorshipDraftInput(
   input: HostedGroupSponsorshipDraftInput,
 ): HostedGroupSponsorshipDraft {
+  const creativeRequest = input.creativeEnabled
+    ? {
+        format: input.creativeFormat,
+        prompt: normalizeOptionalDraftText(input.creativePrompt),
+        styleRequest:
+          input.creativeFormat === "song"
+            ? normalizeOptionalDraftText(input.creativeStyleRequest)
+            : null,
+      }
+    : null;
+  const runningBitRequest = input.runningBitAvailable
+    ? normalizeOptionalDraftText(input.runningBitRequest)
+    : null;
+
   return {
-    ...(input.creativeEnabled
-      ? {
-          creativeRequest: {
-            format: input.creativeFormat,
-            prompt: normalizeOptionalDraftText(input.creativePrompt),
-            styleRequest:
-              input.creativeFormat === "song"
-                ? normalizeOptionalDraftText(input.creativeStyleRequest)
-                : null,
-          },
-        }
-      : {}),
-    publicAlias: normalizeOptionalDraftText(input.publicAlias),
-    runningBitRequest: input.runningBitAvailable
-      ? normalizeOptionalDraftText(input.runningBitRequest)
-      : null,
+    ...(creativeRequest ? { creativeRequest } : {}),
+    publicAlias:
+      creativeRequest || runningBitRequest
+        ? normalizeOptionalDraftText(input.publicAlias)
+        : null,
+    runningBitRequest,
     sponsorMessage: null,
   };
 }

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -658,6 +658,97 @@ test("keeps a customizable sponsorship quiet by default", async () => {
   }
 });
 
+test("drops hidden sponsor details when their owning features are disabled", async () => {
+  const checkout = deferred<unknown>();
+  mocks.requestHostedOnboardingJson.mockReturnValueOnce(checkout.promise);
+  const { GroupSponsorshipDialog } = await import(
+    "@/src/components/hosted-groups/group-sponsorship-dialog"
+  );
+  const rendered = await renderClientComponent(
+    createElement(GroupSponsorshipDialog, {
+      checkoutUrl:
+        "/api/groups/fund/group_join_code_1234/usage-credit/checkout",
+      customizationAllowed: true,
+      initialOpen: true,
+      offers: groupSponsorshipOffers(),
+      payerMemberId: TEST_PAYER_MEMBER_ID,
+    }),
+    { requireButton: false },
+  );
+
+  try {
+    await clickRadio(rendered.container, rendered.window, "usage_20_usd");
+    await clickCheckboxByLabel(
+      rendered.container,
+      rendered.window,
+      "Send something to the group",
+    );
+    await setTextInput(
+      requireTextControlByLabel(
+        rendered.container,
+        rendered.window,
+        "Credit it as",
+      ),
+      rendered.window,
+      "The Group Historian",
+    );
+    await setTextInput(
+      requireTextControlByLabel(
+        rendered.container,
+        rendered.window,
+        "What should it be about?",
+      ),
+      rendered.window,
+      "Celebrate the room.",
+    );
+    await setTextInput(
+      requireTextControlByLabel(
+        rendered.container,
+        rendered.window,
+        "Temporary running bit",
+      ),
+      rendered.window,
+      "Treat me like Murph’s exhausted CFO.",
+    );
+
+    await clickCheckboxByLabel(
+      rendered.container,
+      rendered.window,
+      "Send something to the group",
+    );
+    await clickRadio(rendered.container, rendered.window, "usage_5_usd");
+
+    assert.equal(controlByLabel(rendered.container, "Credit it as"), null);
+    assert.equal(
+      controlByLabel(rendered.container, "Temporary running bit"),
+      null,
+    );
+    await clickButton(rendered.container, rendered.window, "Contribute $5");
+
+    expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledWith({
+      method: "POST",
+      payload: {
+        clientRequestKey: "00000000-0000-4000-8000-000000000001",
+        offerCode: "usage_5_usd",
+        sponsorship: {
+          publicAlias: null,
+          runningBitRequest: null,
+          sponsorMessage: null,
+        },
+        sponsorshipKind: "one_time",
+      },
+      signal: expect.any(AbortSignal),
+      url: "/api/groups/fund/group_join_code_1234/usage-credit/checkout",
+    });
+  } finally {
+    checkout.resolve({
+      purchaseId: "hucp_group_hidden_sponsorship_details",
+      status: "payment_pending",
+    });
+    await rendered.cleanup();
+  }
+});
+
 test("freezes an opted-in sponsorship creative request with the selected offer", async () => {
   const checkout = deferred<unknown>();
   mocks.requestHostedOnboardingJson.mockReturnValueOnce(checkout.promise);

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -139,6 +139,7 @@ import type {
   AssistantAcceptedMessageTargetAuthorizer,
 } from './assistant/message-target-selection.js'
 import type {
+  AssistantGenerateSongTurnPolicy,
   AssistantNoReplyDisposition,
   AssistantProviderDynamicTool,
   AssistantProviderFinishWithoutReplyAcceptedEvent,
@@ -475,6 +476,7 @@ export interface CodexAppServerTurnInput {
   baseInstructions?: string | null
   developerInstructions?: string | null
   dynamicTools: readonly AssistantProviderDynamicTool[]
+  generateSongPolicy?: AssistantGenerateSongTurnPolicy | null
   excludeResumeTurns?: boolean
   model?: string | null
   modelProvider?: string | null
@@ -3204,6 +3206,12 @@ async function runCodexAppServerTurnOnProcess(
   // Trusted turn-scoped murph.ask_grok provider-call ceiling: one counter per
   // assistant turn, owned here and threaded into the dynamic-tool executor.
   const askGrokTurnState = createAskGrokTurnState()
+  const generateSongTurnState = input.generateSongPolicy
+    ? {
+        attemptCount: 0,
+        policy: input.generateSongPolicy,
+      }
+    : null
   const subagentTokenUsageByTurn =
     new Map<string, CodexSubagentTurnTokenUsageSample>()
   const trackedSubagentUsageThreadIds = new Set<string>()
@@ -4464,6 +4472,7 @@ async function runCodexAppServerTurnOnProcess(
               ? input.askGrokRuntime ?? null
               : null,
           askGrokTurnState,
+          generateSongTurnState,
         })
         return result
       },

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -210,6 +210,7 @@ import {
   executeGenerateSongDynamicTool,
   MURPH_GENERATE_SONG_TOOL,
   parseGenerateSongArguments,
+  type GenerateSongTurnState,
 } from './dynamic-tools/generate-song.js'
 import {
   executeAskGrokDynamicTool,
@@ -1755,6 +1756,7 @@ export async function executeMurphDynamicToolRequest(input: {
   voiceMemoRuntime?: VoiceMemoToolRuntime | null
   askGrokRuntime?: AskGrokToolRuntime | null
   askGrokTurnState?: AskGrokTurnState | null
+  generateSongTurnState?: GenerateSongTurnState | null
 }): Promise<MurphDynamicToolExecutionResult> {
   if (
     isExecutableComputerDynamicToolRequest(input.request) &&
@@ -2714,6 +2716,7 @@ export async function executeMurphDynamicToolRequest(input: {
         abortSignal: input.abortSignal ?? null,
         args: input.request.args,
         currentResponseMedia: input.currentResponseMedia ?? [],
+        turnState: input.generateSongTurnState ?? null,
         voiceMemoRuntime: input.voiceMemoRuntime ?? null,
       })
     }

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-song.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/generate-song.ts
@@ -3,6 +3,9 @@ import * as z from '@murphai/contracts/zod-runtime'
 import type {
   AssistantResponseMedia,
 } from '@murphai/operator-config/assistant-cli-contracts'
+import type {
+  AssistantGenerateSongTurnPolicy,
+} from '../../assistant/providers/types.js'
 import type { SafeToolCallValidationDigest } from '../../assistant/tool-validation-digest.js'
 import {
   executeGenerateSongTool,
@@ -62,6 +65,11 @@ const generateSongArgumentsSchema = z
   })
   .strict()
 
+export interface GenerateSongTurnState {
+  attemptCount: number
+  policy: AssistantGenerateSongTurnPolicy
+}
+
 export function parseGenerateSongArguments(
   value: unknown,
 ):
@@ -78,12 +86,30 @@ export async function executeGenerateSongDynamicTool(input: {
   abortSignal?: AbortSignal | null
   args: GenerateSongToolArgs
   currentResponseMedia?: readonly AssistantResponseMedia[] | null
+  turnState?: GenerateSongTurnState | null
   voiceMemoRuntime?: VoiceMemoToolRuntime | null
 }): Promise<DynamicToolResult> {
+  const turnState = input.turnState ?? null
+  if (turnState) {
+    if (turnState.attemptCount >= turnState.policy.maxAttempts) {
+      return wrapVoiceMemoToolResult({
+        rpcSuccess: false,
+        rpcText:
+          'song generation attempt limit reached for this turn; no song ran',
+      })
+    }
+    turnState.attemptCount += 1
+  }
+
   return wrapVoiceMemoToolResult(
     await executeGenerateSongTool({
       abortSignal: input.abortSignal ?? null,
-      args: input.args,
+      args: turnState
+        ? {
+            ...input.args,
+            durationSeconds: turnState.policy.requiredDurationSeconds,
+          }
+        : input.args,
       currentResponseMedia: input.currentResponseMedia ?? [],
       runtime: input.voiceMemoRuntime ?? null,
     }),

--- a/packages/assistant-engine/src/assistant/codex-turn-runner.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn-runner.ts
@@ -26,6 +26,7 @@ import type {
   AssistantAcceptedMessageTargetAuthorizer,
 } from './message-target-selection.js'
 import type {
+  AssistantGenerateSongTurnPolicy,
   AssistantProviderServiceTier,
   AssistantProviderAttemptMetadata,
   AssistantProviderFinishWithoutReplyAcceptedEvent,
@@ -108,6 +109,10 @@ import {
 
 const ASSISTANT_PROVIDER_PLAN_TRACE_SCHEMA =
   'murph.assistant-provider-plan-diagnostics.v1'
+const ASSISTANT_CREATIVE_NOTIFICATION_SONG_POLICY = {
+  maxAttempts: 1,
+  requiredDurationSeconds: 15,
+} as const satisfies AssistantGenerateSongTurnPolicy
 const ASSISTANT_PROVIDER_PLAN_TRACE_TYPE = 'assistant.provider.plan'
 const ASSISTANT_PROVIDER_FLEX_TURN_DEADLINE_MS = 600_000
 const ASSISTANT_NATIVE_CAPABILITIES_RESTRICTED_THREAD_CONFIG = {
@@ -492,6 +497,9 @@ async function executeAssistantCodexAttempt(input: {
     const nativeCapabilitiesRestrictedTurn =
       outputOnlyTurn ||
       executionPlan.profile.promptProfile === 'creative-notification'
+    const creativeNotificationSongTurn =
+      executionPlan.profile.promptProfile === 'creative-notification' &&
+      executionPlan.profile.toolProfile === 'provider-turn'
     const systemNotificationTurn =
       executionPlan.profile.promptProfile === 'system-notification' ||
       executionPlan.profile.promptProfile === 'creative-notification'
@@ -568,6 +576,12 @@ async function executeAssistantCodexAttempt(input: {
           ? []
           : attemptPlan.routePlan.environments,
         env: attemptEnv,
+        ...(creativeNotificationSongTurn
+          ? {
+              generateSongPolicy:
+                ASSISTANT_CREATIVE_NOTIFICATION_SONG_POLICY,
+            }
+          : {}),
         groupConversation,
         groupRoomModelMaintenanceAuthorized: groupRoomModelMaintenanceTurn,
         hostedToolContext:

--- a/packages/assistant-engine/src/assistant/providers/codex-cli.ts
+++ b/packages/assistant-engine/src/assistant/providers/codex-cli.ts
@@ -243,6 +243,9 @@ export async function executeCodexAssistantTurnAttempt(
     environments: input.environments ?? undefined,
     ephemeral: input.providerThreadEphemeral ?? undefined,
     fetchImpl: input.providerFetch ?? undefined,
+    ...(input.generateSongPolicy
+      ? { generateSongPolicy: input.generateSongPolicy }
+      : {}),
     groupConversation: input.groupConversation === true,
     groupRoomModelMaintenanceAuthorized:
       input.groupRoomModelMaintenanceAuthorized === true,

--- a/packages/assistant-engine/src/assistant/providers/types.ts
+++ b/packages/assistant-engine/src/assistant/providers/types.ts
@@ -121,6 +121,15 @@ export interface AssistantProviderDynamicTool {
   readonly namespace: string
 }
 
+/**
+ * Trusted per-turn limits for generated songs. This is execution policy only:
+ * prompts and model-supplied tool arguments cannot relax it.
+ */
+export interface AssistantGenerateSongTurnPolicy {
+  readonly maxAttempts: number
+  readonly requiredDurationSeconds: number
+}
+
 export interface AssistantProviderTurn {
   activeTurnSteering?: AssistantActiveTurnLiveProviderSteering | null
   activeTurnId?: string | null
@@ -135,6 +144,7 @@ export interface AssistantProviderTurn {
   dynamicTools: readonly AssistantProviderDynamicTool[]
   environments?: readonly Readonly<Record<string, unknown>>[] | null
   env?: NodeJS.ProcessEnv
+  generateSongPolicy?: AssistantGenerateSongTurnPolicy | null
   groupConversation?: boolean | null
   groupRoomModelMaintenanceAuthorized?: boolean | null
   onFinishWithoutReplyAccepted?: ((

--- a/packages/assistant-engine/test/assistant-codex-dynamic-tool-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-dynamic-tool-runtime.test.ts
@@ -10,6 +10,7 @@ const codexMocks = vi.hoisted(() => ({
   dynamicToolCalls: [] as Array<{
     assistantStyleSettingsAvailable?: boolean
     deliveryContextOrdinal: number | null
+    generateSongTurnState?: unknown
     kind: string
     voiceMemoRuntime: unknown
   }>,
@@ -43,6 +44,12 @@ vi.mock('../src/assistant-codex/dynamic-tools.ts', async (importOriginal) => {
               }
             : {}),
           deliveryContextOrdinal: input.deliveryContextOrdinal ?? null,
+          ...(input.request.kind === 'generate-song'
+            ? {
+                generateSongTurnState:
+                  input.generateSongTurnState ?? null,
+              }
+            : {}),
           kind: input.request.kind,
           voiceMemoRuntime: input.voiceMemoRuntime ?? null,
         })
@@ -198,7 +205,7 @@ describe('Codex dynamic tool runtime routing', () => {
     ])
   })
 
-  it('passes voice memo and exact-turn style capabilities only to their tools', async () => {
+  it('passes voice memo, generated-song policy, and exact-turn style capabilities only to their tools', async () => {
     const workingDirectory = await createTempDir('assistant-codex-dynamic-runtime-work-')
     const codexHome = await createTempDir('assistant-codex-dynamic-runtime-home-')
     const voiceMemoRuntime: VoiceMemoToolRuntime = {
@@ -230,7 +237,11 @@ describe('Codex dynamic tool runtime routing', () => {
           CODEX_HOME: codexHome,
           PATH: '/usr/bin',
         },
-        prompt: 'Use three tools.',
+        generateSongPolicy: {
+          maxAttempts: 1,
+          requiredDurationSeconds: 15,
+        },
+        prompt: 'Use four tools.',
         sandbox: 'workspace-write',
         hostedToolContext: {
           beforeToolExecution,
@@ -268,21 +279,36 @@ describe('Codex dynamic tool runtime routing', () => {
         voiceMemoRuntime,
       },
       {
+        deliveryContextOrdinal: 0,
+        generateSongTurnState: {
+          attemptCount: 0,
+          policy: {
+            maxAttempts: 1,
+            requiredDurationSeconds: 15,
+          },
+        },
+        kind: 'generate-song',
+        voiceMemoRuntime,
+      },
+      {
         assistantStyleSettingsAvailable: true,
         deliveryContextOrdinal: 1,
         kind: 'assistant-style',
         voiceMemoRuntime: null,
       },
     ])
-    expect(beforeToolExecution).toHaveBeenCalledTimes(3)
+    expect(beforeToolExecution).toHaveBeenCalledTimes(4)
     expect(beforeToolExecution).toHaveBeenNthCalledWith(1, 0)
     expect(beforeToolExecution).toHaveBeenNthCalledWith(2, 0)
-    expect(beforeToolExecution).toHaveBeenNthCalledWith(3, 1)
+    expect(beforeToolExecution).toHaveBeenNthCalledWith(3, 0)
+    expect(beforeToolExecution).toHaveBeenNthCalledWith(4, 1)
     expect(codexMocks.executionOrder).toEqual([
       'checkpoint',
       'tool:send-progress-update',
       'checkpoint',
       'tool:generate-voice-memo',
+      'checkpoint',
+      'tool:generate-song',
       'checkpoint',
       'tool:assistant-style',
     ])
@@ -940,7 +966,7 @@ async function runScriptedDynamicToolTurn(
     params: {
       item: {
         id: 'user-dynamic-runtime-initial',
-        message: 'Use three tools.',
+        message: 'Use four tools.',
         type: 'user_message',
       },
     },
@@ -976,6 +1002,22 @@ async function runScriptedDynamicToolTurn(
   await child.waitForRpcId(2)
 
   child.stdout.write(jsonLine({
+    id: 3,
+    method: 'item/tool/call',
+    params: {
+      arguments: {
+        durationSeconds: 30,
+        instrumental: false,
+        prompt: 'An original group theme.',
+      },
+      namespace: 'murph',
+      tool: 'generate_song',
+      turnId: 'turn-dynamic-runtime',
+    },
+  }))
+  await child.waitForRpcId(3)
+
+  child.stdout.write(jsonLine({
     method: 'item/completed',
     params: {
       item: {
@@ -988,7 +1030,7 @@ async function runScriptedDynamicToolTurn(
   await new Promise((resolve) => setTimeout(resolve, 0))
 
   child.stdout.write(jsonLine({
-    id: 3,
+    id: 4,
     method: 'item/tool/call',
     params: {
       arguments: {
@@ -999,7 +1041,7 @@ async function runScriptedDynamicToolTurn(
       turnId: 'turn-dynamic-runtime',
     },
   }))
-  await child.waitForRpcId(3)
+  await child.waitForRpcId(4)
 
   child.stdout.write(jsonLine({
     method: 'item/completed',

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -930,6 +930,10 @@ describe('Codex model catalog', () => {
     expect(providerInput).toMatchObject({
       dynamicTools: [MURPH_GENERATE_SONG_TOOL],
       environments: [],
+      generateSongPolicy: {
+        maxAttempts: 1,
+        requiredDurationSeconds: 15,
+      },
       hostedToolContext: null,
       materializeWorkspaceArtifacts: null,
       progressDelivery: null,

--- a/packages/assistant-engine/test/assistant-codex-generate-voice-memo-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-generate-voice-memo-tool.test.ts
@@ -9,12 +9,18 @@ import {
 import {
   createVoiceMemoToolRuntimeFromEnv,
   executeGenerateVoiceMemoTool,
+  type VoiceMemoToolRuntime,
 } from '../src/assistant-codex/generate-voice-memo-tool.ts'
 import {
   MURPH_GENERATE_VOICE_MEMO_TOOL,
 } from '../src/assistant-codex/dynamic-tools/generate-voice-memo.ts'
 
 const mp3Bytes = new Uint8Array([0xff, 0xfb, 0x90, 0x64])
+
+type LinqVoiceMemoRuntime = Extract<
+  VoiceMemoToolRuntime,
+  { kind: 'linq' }
+>
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -907,6 +913,111 @@ describe('murph.generate_voice_memo dynamic tool execution', () => {
       op: 'append',
     })
     expect(result.usageDraft).toBeNull()
+  })
+})
+
+describe('murph.generate_song dynamic tool execution', () => {
+  it('forces the trusted turn duration before song generation', async () => {
+    const generateAndUpload = vi.fn<
+      LinqVoiceMemoRuntime['generateAndUpload']
+    >(async () => ({
+      attachmentId: 'attachment_song_policy',
+      filename: 'sponsor-song.mp3',
+    }))
+    const generateSongTurnState = {
+      attemptCount: 0,
+      policy: {
+        maxAttempts: 1,
+        requiredDurationSeconds: 15,
+      },
+    }
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: vi.fn<typeof fetch>(),
+      generateSongTurnState,
+      nextUsageOrdinal: vi.fn(() => 99),
+      progressDelivery: null,
+      request: {
+        args: {
+          durationSeconds: 30,
+          instrumental: false,
+          prompt: 'A bright, original group theme.',
+        },
+        kind: 'generate-song',
+      },
+      voiceMemoRuntime: {
+        elevenLabs: {
+          apiKeyAvailable: true,
+          modelId: null,
+          voiceId: null,
+        },
+        generateAndUpload,
+        kind: 'linq',
+      },
+    })
+
+    expect(generateAndUpload).toHaveBeenCalledTimes(1)
+    expect(generateAndUpload.mock.calls[0]?.[0]?.generation).toMatchObject({
+      durationMs: 15_000,
+      kind: 'elevenlabs_music',
+    })
+    expect(generateSongTurnState.attemptCount).toBe(1)
+    expect(result.rpcResult.success).toBe(true)
+  })
+
+  it('does not retry a failed creative song generation attempt', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const generateAndUpload = vi.fn<
+      LinqVoiceMemoRuntime['generateAndUpload']
+    >(async () => {
+      throw new Error('provider unavailable')
+    })
+    const generateSongTurnState = {
+      attemptCount: 0,
+      policy: {
+        maxAttempts: 1,
+        requiredDurationSeconds: 15,
+      },
+    }
+    const input = {
+      env: {},
+      fetchImpl: vi.fn<typeof fetch>(),
+      generateSongTurnState,
+      nextUsageOrdinal: vi.fn(() => 99),
+      progressDelivery: null,
+      request: {
+        args: {
+          durationSeconds: 15,
+          instrumental: false,
+          prompt: 'A bright, original group theme.',
+        },
+        kind: 'generate-song' as const,
+      },
+      voiceMemoRuntime: {
+        elevenLabs: {
+          apiKeyAvailable: true,
+          modelId: null,
+          voiceId: null,
+        },
+        generateAndUpload,
+        kind: 'linq' as const,
+      },
+    }
+
+    const first = await executeMurphDynamicToolRequest(input)
+    const second = await executeMurphDynamicToolRequest(input)
+
+    expect(first.rpcResult.success).toBe(false)
+    expect(second.rpcResult).toEqual({
+      success: false,
+      contentItems: [{
+        type: 'inputText',
+        text: 'song generation attempt limit reached for this turn; no song ran',
+      }],
+    })
+    expect(generateAndUpload).toHaveBeenCalledTimes(1)
+    expect(generateSongTurnState.attemptCount).toBe(1)
   })
 })
 

--- a/packages/assistant-engine/test/codex-thread-instructions.test.ts
+++ b/packages/assistant-engine/test/codex-thread-instructions.test.ts
@@ -137,6 +137,41 @@ describe('Codex thread instructions', () => {
     expect(appServerInput.prompt).not.toContain('Stable Murph instructions.')
   })
 
+  it('forwards trusted generated-song policy to the app-server turn', async () => {
+    codexAppServerMocks.executeCodexAppServerTurn.mockResolvedValue({
+      finalMessage: 'done',
+      precedingAgentMessageSegments: [],
+      responseDeliveryContextOrdinal: 0,
+      transcriptMessage: 'done',
+      jsonEvents: [],
+      providerActionCount: 0,
+      sessionId: 'thread-song-policy',
+      stderr: '',
+      stdout: '',
+      threadId: 'thread-song-policy',
+      turnId: 'turn-song-policy',
+    })
+    const generateSongPolicy = {
+      maxAttempts: 1,
+      requiredDurationSeconds: 15,
+    } as const
+
+    await executeCodexAssistantTurnAttemptUnchecked({
+      providerConfig: normalizeAssistantProviderConfig({
+        provider: 'codex-cli',
+      }),
+      dynamicTools: [],
+      env: {},
+      generateSongPolicy,
+      userPrompt: 'Create the bounded song.',
+      workingDirectory: '/tmp/provider-tests',
+    })
+
+    expect(codexAppServerMocks.executeCodexAppServerTurn).toHaveBeenCalledTimes(1)
+    expect(codexAppServerMocks.executeCodexAppServerTurn.mock.calls[0]?.[0])
+      .toMatchObject({ generateSongPolicy })
+  })
+
   it('keeps constrained profile inputs at the app-server seam', async () => {
     const scenarios = [
       {


### PR DESCRIPTION
## Summary

Follow-up to #1446.

- drops sponsor attribution and temporary running-bit text when the options that own them are disabled
- enforces sponsor-song duration and one-attempt bounds in the trusted runtime instead of relying only on prompt instructions
- adds browser and assistant-engine regression coverage for both behaviors

## Architecture

This reuses the existing sponsorship-draft contract and the existing turn-scoped dynamic-tool state. It does not add a service, queue, state machine, persistence owner, or alternate creative-delivery path.

The sponsor-song policy is carried through the existing provider-turn input and consumed only by `generate_song`. Ordinary song requests retain their existing behavior; the sponsorship continuation supplies a maximum of one attempt and a required 15-second duration.

## Verification

The published branch is one clean commit on `f7359e41ad63bdd430b3d67d34e77161323091b0`, with exactly the 12 intended files changed.

- assistant-engine typecheck
- hosted Web typecheck
- ESLint on the changed hosted Web boundary
- focused assistant song-policy and creative-notification tests
- focused sponsorship dialog, store, notification, funding, and checkout tests
- `git diff --check` and exact changed-file allowlist

Do not merge as part of this task.