### PR TITLE
fix(web): preserve referral claim origin proof

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-09-fix-referral-claim-origin.md
+++ b/agent-docs/exec-plans/active/2026-08-09-fix-referral-claim-origin.md
@@ -1,0 +1,79 @@
+# Fix referral claim origin policy
+
+Status: active
+Created: 2026-08-09
+Updated: 2026-08-09
+
+## Goal
+
+- A recipient who opens a valid reusable referral link can select **Join Murph**
+  and continue into ordinary signup without a JSON origin error, while the
+  stable referral token remains absent from downstream referrer headers.
+
+## Success criteria
+
+- The referral landing uses an origin-only referrer policy whose non-GET form
+  submission supplies the canonical origin required by the existing CSRF guard.
+- Cross-origin, missing-origin, and opaque-origin claim requests remain rejected.
+- Focused route/UX tests, the Web typecheck, and a production-shaped browser
+  form-submission proof pass.
+- Required specialist/final ReviewGPT gates and exact-head CI pass before merge.
+- Production deployment is verified with a fresh synthetic referral journey;
+  no private member token is reused as test evidence.
+
+## Scope
+
+- In scope: referral landing referrer policy, its durable product contract,
+  focused regression coverage, PR/deploy proof, and incident handoff.
+- Out of scope: changing the shared browser-mutation CSRF guard, weakening
+  cross-origin admission, referral reward accounting, or onboarding semantics.
+
+## Constraints
+
+- Technical constraints: preserve the signed-token privacy boundary and the
+  same-origin POST claim owner; prefer the existing global `strict-origin`
+  security posture over a new token or client-side submission layer.
+- Product/process constraints: keep confidential reported URLs and identifiers
+  out of repository artifacts and external coordination; use the isolated PR
+  lane and required exact-head review gates.
+
+## Risks and mitigations
+
+1. Risk: accepting origin-less requests would weaken CSRF protection.
+   Mitigation: change only the initiating page policy; keep the route guard and
+   its rejection behavior intact.
+2. Risk: a more permissive referrer policy could leak the stable token.
+   Mitigation: use `strict-origin`, which sends only the origin and never the
+   path token, including to cross-origin destinations.
+3. Risk: unit fixtures could pass while real browser headers still differ.
+   Mitigation: capture the submitted request headers through a real browser
+   against a synthetic local origin before handoff.
+
+## Tasks
+
+1. Add a focused regression that binds the referral page to an origin-only
+   policy compatible with the protected POST.
+2. Replace the conflicting `no-referrer` page metadata with `strict-origin` and
+   update the live referral product contract.
+3. Run focused route, UX, CSRF, config, and typecheck proof plus a real-browser
+   submission check.
+4. Inspect the diff for privacy and scope, then commit, push, and open the PR.
+5. Run preliminary specialists and final ReviewGPT with exact-head CI, resolve
+   findings, merge, deploy, and verify the production journey.
+
+## Decisions
+
+- Root cause: the landing's `no-referrer` policy makes a non-GET same-origin
+  form submission serialize an opaque `Origin`; the claim route then correctly
+  rejects it. This is a page-policy conflict, not a reason to weaken the guard.
+- Use `strict-origin`: the repository already applies it globally, it keeps the
+  token path out of referrer headers, and it preserves canonical-origin proof.
+
+## Verification
+
+- Commands to run: focused Vitest suites for referral UX/routes, hosted
+  onboarding CSRF, and Next security headers; `pnpm --dir apps/web typecheck`;
+  real-browser local form submission; exact-head GitHub Actions.
+- Expected outcomes: legitimate same-origin form POST carries the canonical
+  origin and redirects into signup; missing, opaque, and cross-origin requests
+  remain denied; all focused and remote checks pass.

--- a/agent-docs/product-specs/hosted-usage-referrals.md
+++ b/agent-docs/product-specs/hosted-usage-referrals.md
@@ -108,8 +108,10 @@ retryable.
 
 A public `GET /r/<token>` only validates the token and renders a small landing
 page. Link previews, crawlers, and scanners therefore cannot allocate onboarding
-state. The route is `noindex`, `nofollow`, and `no-referrer` so stable tokens do
-not enter search indexes or downstream referrer headers.
+state. The route is `noindex`, `nofollow`, and `strict-origin`: referrer headers
+carry only the first-party origin, never the stable-token path, while the native
+same-origin claim form retains the canonical `Origin` required by its mutation
+guard.
 
 The available landing has one action: `Join Murph`, above a single closing line
 stating that Murph credits whoever shared the link and that the referrer cannot

--- a/apps/web/app/r/[referralCode]/page.tsx
+++ b/apps/web/app/r/[referralCode]/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
     description: "Join Murph, your private health assistant.",
     title: "Join Murph",
   }),
-  referrer: "no-referrer",
+  referrer: "strict-origin",
   robots: {
     follow: false,
     index: false,

--- a/apps/web/test/hosted-onboarding-csrf.test.ts
+++ b/apps/web/test/hosted-onboarding-csrf.test.ts
@@ -108,6 +108,24 @@ describe("assertHostedOnboardingMutationOrigin", () => {
     }));
   });
 
+  it("rejects opaque browser origins", async () => {
+    const { assertHostedOnboardingMutationOrigin } = await import("@/src/lib/hosted-onboarding/csrf");
+
+    expect(() =>
+      assertHostedOnboardingMutationOrigin(
+        new Request("https://app.example.test/api/hosted-onboarding/invites", {
+          method: "POST",
+          headers: {
+            origin: "null",
+          },
+        }),
+      )
+    ).toThrowError(expect.objectContaining({
+      code: "HOSTED_ONBOARDING_ORIGIN_REQUIRED",
+      httpStatus: 403,
+    }));
+  });
+
   it("fails closed on non-loopback hosts when no canonical public origin is configured", async () => {
     mocks.getHostedOnboardingEnvironment.mockReturnValue(createHostedOnboardingEnvironment({
       publicBaseUrl: null,

--- a/apps/web/test/hosted-signup-referral-ux.test.tsx
+++ b/apps/web/test/hosted-signup-referral-ux.test.tsx
@@ -36,11 +36,11 @@ describe("hosted signup referral UX", () => {
     });
   });
 
-  it("keeps stable links out of indexes and referrer headers", async () => {
+  it("keeps stable links out of indexes while preserving same-origin claim proof", async () => {
     const page = await import("../app/r/[referralCode]/page");
 
     expect(page.metadata).toMatchObject({
-      referrer: "no-referrer",
+      referrer: "strict-origin",
       robots: {
         follow: false,
         index: false,


### PR DESCRIPTION
## Why this PR exists

A valid reusable referral landing set `no-referrer` while its native same-origin claim form required a canonical `Origin`. Browser non-GET fetch semantics therefore serialized an opaque origin, and selecting **Join Murph** returned `HOSTED_ONBOARDING_ORIGIN_REQUIRED` instead of starting setup.

## User goal / user-visible behavior

A recipient can open a valid referral link, select **Join Murph**, and continue into the ordinary signup flow. The stable referral token remains absent from downstream referrer headers.

## User experience

The existing one-action journey remains unchanged: the public landing is read-only, **Join Murph** submits the same native POST, and a successful claim redirects immediately to the existing `/join/<invite>` flow. Known unavailable links and retryable failures retain their existing human-readable recovery states. There is no new screen, choice, asynchronous owner, or wait.

## Invariants

- The reusable token path never enters a downstream `Referer`; `strict-origin` carries only the first-party origin.
- Missing, opaque, and foreign `Origin` values remain rejected by the existing mutation guard.
- `GET /r/<token>` remains read-only, `noindex`, and `nofollow`; only the explicit POST may allocate onboarding state.
- Claim rate limits, attribution, transactionality, and ordinary onboarding ownership are unchanged.

## Architecture and reuse

- **Existing systems reused:** the native referral form, Web-owned claim route, hosted-onboarding origin guard, global `strict-origin` security posture, and existing retryable landing.
- **New logic:** one referral-page metadata value now matches the existing origin-only policy.
- **New abstractions:** none; the existing page metadata and origin guard already own the complete boundary.
- **Complexity intentionally avoided:** no client-side fetch path, CSRF token store, exception in the shared guard, compatibility shim, or new state owner.

## Non-obvious affected surfaces

The page-level metadata previously overrode the app-wide `strict-origin` header. The fix changes only that override. The visible landing markup and design catalog component are unchanged, so no rendered design proof is applicable.

## Direct journey evidence

A real headless Chromium form submission against a synthetic local referral path sent the exact canonical `Origin`; its `Referer` contained only the bare origin and excluded the synthetic token path. The existing route/UX tests prove the same guarded claim and recovery owners.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-signup-referral-ux.test.tsx apps/web/test/hosted-signup-referral-route.test.ts apps/web/test/hosted-onboarding-csrf.test.ts apps/web/test/next-config.test.ts` — 63 passed
- `pnpm --dir apps/web typecheck` — passed
- Real Chromium form-header proof — passed
- Exact-head GitHub Actions — running

## Preliminary specialist lenses

- Product experience: **applicable** — restores the existing one-click referral-to-signup journey without changing its purpose or interaction count.
- Prompt: **not applicable** — no prompts, tools, or model input changed.
- Frontend: **not applicable** — no visible markup, presentation, accessibility state, or responsive behavior changed.
- Coverage: **applicable** — executable browser request behavior and its trust boundary changed; focused regression coverage is included.

Product purpose verdict: necessary and proportional. A legitimate first-party action becomes reachable again while privacy and cross-origin rejection remain intact.

ReviewGPT context sensitivity: sensitive

Classification reason: the patch changes the browser policy at a public mutation and signed-referral privacy boundary.

ReviewGPT first-reviewed head: 4a6fcac90ac78f358931119c75e7db6f0e5a81f7

## First-reviewed change shape

Classification: `apps/web/app/**` is source; `apps/web/test/**` is tests; `agent-docs/**` is docs. No config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests/fixtures | 20 | 2 |
| Docs | 83 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Total: 104 added, 5 deleted.

## Hot reply path impact

Not applicable. This is a Web-only public onboarding journey and does not touch messaging acceptance, provider start, or reply handoff.

## Murph initial provider input impact

Not applicable for individual or group Murph. No prompt, tool, schema, runtime, or model configuration changed.

## Deployment skew / compatibility

Web-only. A normal Vercel production deployment is sufficient; no Cloudflare deployment or database migration is required. Old instances continue returning the origin error while new instances accept the privacy-safe same-origin form POST. Post-deploy, verify a fresh referral landing redirects through the claim into ordinary signup and that a synthetic foreign-origin POST remains rejected.





## Design proof

- **Design page:** `/design?tab=sections#signup-referral-flow`
- **Desktop screenshot:** <img src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/717097d0-09bf-4865-02cb-5a4e34807e00/designproof" width="720" alt="Desktop reusable referral landing study">
- **Mobile screenshot:** <img src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/bdbe9ccd-e009-478c-b01d-96481ccc4600/designproof" width="390" alt="Mobile reusable referral landing study">



## Current-head review note

Current head `646008486956525a755ae794e9db3ca648b0aa08` adds only the existing referral design study contract marker and its catalog-render assertion, as required by the frontend design-proof check. Production referral markup and behavior are unchanged from the first-reviewed head.

The preliminary specialist pass returned `SPECIALIST_OUTCOME: PASS` with no findings and no patch artifact. Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no findings. Round 2 rechecks the design-only follow-up against the immutable first-reviewed baseline.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 1 |
| Tests/fixtures | 23 | 2 |
| Docs | 83 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Current total: 108 added, 5 deleted.
