### PR TITLE
fix(web): allow retention crypto reads for paused members

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
+++ b/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
@@ -6,9 +6,10 @@ Updated: 2026-08-09
 
 ## Goal
 
-- Let signed hosted retention runs obtain the workspace crypto they need for
-  paused members while keeping ordinary inactive-member assistant work blocked
-  by the existing mode-aware reconciliation and Temporal admission owner.
+- Let signed workspace-bound callers obtain the crypto they are independently
+  authorized to use, including paused-member retention and Settings vault
+  export, while keeping ordinary inactive-member assistant work blocked by its
+  existing admission owners.
 
 ## Success criteria
 
@@ -16,11 +17,13 @@ Updated: 2026-08-09
   member entitlement checks after signed callback authentication.
 - Both callbacks still require the callback-bound user, a provisioned hosted
   workspace, and the existing signed/encrypted crypto-envelope authority.
-- Focused route tests prove paused members with workspaces succeed, missing
-  workspaces remain forbidden, and requests cannot reach crypto reads before
-  callback authentication succeeds.
+- Focused route tests prove signed workspace-bound reads succeed without
+  duplicate caller admission, missing workspaces remain forbidden, and requests
+  cannot reach crypto reads before callback authentication succeeds.
 - Existing inactive-member orchestration proof continues to confine execution
   to `inbox_media_retention`, never default processing.
+- A full-stack regression covers the paused-member Temporal-to-Cloudflare
+  retention handoff and asserts that it emits no assistant-provider request.
 - Focused tests, typecheck, preliminary coverage review, final ReviewGPT,
   exact-head CI, mergeability proof, and parent final review complete without
   unresolved accepted findings.
@@ -28,8 +31,8 @@ Updated: 2026-08-09
 ## Scope
 
 - In scope: the two hosted runtime crypto-context routes, their focused Web
-  tests, and any minimal durable contract clarification required by the trust
-  boundary.
+  tests, one existing full-stack Temporal regression, its narrow test support,
+  and the durable contract clarification required by the trust boundary.
 - Out of scope: changing runtime admission, Temporal scheduling, billing state,
   crypto formats, keys, envelopes, workspace provisioning, or Cloudflare code.
 
@@ -45,11 +48,11 @@ Updated: 2026-08-09
 
 ## Risks and mitigations
 
-1. Risk: removing the route-local entitlement gate could appear to authorize
-   ordinary paused-member execution.
-   Mitigation: retain callback/workspace/crypto authority at the routes and
-   directly re-run the existing orchestration test proving inactive members
-   receive retention-only processing.
+1. Risk: removing the route-local entitlement gate could be mistaken for
+   operation admission.
+   Mitigation: retain callback/workspace/crypto resource authority at the
+   routes, document each caller's independent admission owner, and prove
+   inactive runtime work receives retention-only processing.
 2. Risk: the historical-root route remains blocked and fails only when older
    ciphertext is encountered.
    Mitigation: make and test the same owner-bound correction on both crypto
@@ -61,27 +64,28 @@ Updated: 2026-08-09
 ## Tasks
 
 1. Remove the redundant active-member query from both signed crypto callbacks.
-2. Replace entitlement-specific fixtures with paused-member, workspace, and
-   auth-boundary route regressions.
-3. Run focused Web tests, the existing inactive-retention orchestration proof,
-   hosted Web typecheck, diff hygiene, and parent diff review.
+2. Replace entitlement-specific fixtures with workspace and auth-boundary route
+   regressions; add a paused-member full-stack Temporal regression.
+3. Run focused Web tests, inactive-retention owner proof, Web and Cloudflare
+   typechecks, diff hygiene, and parent diff review.
 4. Commit and push the exact candidate, open the PR, run the preliminary
    coverage pass plus final ReviewGPT with CI, resolve accepted findings, and
    close this plan through the repository finish path.
 
 ## Decisions
 
-- Use deletion at the two incorrect ownership points. Do not add a retention
-  flag to the crypto request or a new authorization mechanism because the
-  mode-aware runtime owner already authorizes the only work inactive members
-  may execute.
+- Use deletion at the two incorrect ownership points. Do not add a purpose flag
+  or a new authorization mechanism because runtime mode, Settings
+  session/MFA/consent, and ordinary active-access owners already admit their
+  respective operations.
 - Preserve the provisioned-workspace check as the route-local resource boundary.
 
 ## Verification
 
 - Focused route tests for current and historical crypto context.
 - Existing inactive workspace retention reconciliation/orchestration test.
-- Hosted Web typecheck and `git diff --check`.
+- Full-stack paused-member Temporal-to-Cloudflare retention scenario.
+- Hosted Web and Cloudflare typechecks and `git diff --check`.
 - Exact-head CI plus preliminary coverage and final ReviewGPT trust-boundary
   review.
 
@@ -92,3 +96,19 @@ Updated: 2026-08-09
   runtime signaling.
 - Hosted Web typecheck passed.
 - Agent-doc drift, diff whitespace, and direct-identifier guards passed.
+- ReviewGPT round 1 identified the shared Settings-export resource boundary;
+  the durable contract and route-test language now state caller-owned admission.
+- Preliminary coverage review requested a real paused-member owner-handoff
+  regression; the existing hosted-local Temporal scenario now seeds an active
+  workspace, pauses the member, makes retention due, and asserts successful
+  completion without an assistant-provider request.
+- Hosted Web and Cloudflare typechecks passed after that regression.
+- Private Temporal owner suite passed 16 files and 122 tests, including due
+  retention for an inactive member. Signed Cloudflare crypto transport passed
+  two tests, and focused assistant-runtime retention-only processing passed two
+  tests.
+- The full-stack scenario could not start locally: the first setup exhausted
+  its existing hook timeout; after producing missing build artifacts through
+  supported scripts, runner-bundle validation failed on the unrelated existing
+  entrypoint byte budget (9,934,039 bytes versus 9,920,209). No scenario test
+  executed, and this change does not alter the runner bundle.

--- a/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
+++ b/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
@@ -112,3 +112,9 @@ Updated: 2026-08-09
   supported scripts, runner-bundle validation failed on the unrelated existing
   entrypoint byte budget (9,934,039 bytes versus 9,920,209). No scenario test
   executed, and this change does not alter the runner bundle.
+- Final ReviewGPT round 2 passed the production correction and authorization
+  contract. Its non-qualifying body check exposed two E2E proof errors, which
+  were corrected: the scenario now uses the retention-specific signal that
+  bypasses active-member admission and waits only for an execution timestamp at
+  or after that signal. The production signal-owner suite passed all 30 tests,
+  and Cloudflare typecheck passed again.

--- a/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
+++ b/agent-docs/exec-plans/active/2026-08-09-paused-retention-crypto.md
@@ -1,0 +1,94 @@
+# Paused-member retention crypto access
+
+Status: active
+Created: 2026-08-09
+Updated: 2026-08-09
+
+## Goal
+
+- Let signed hosted retention runs obtain the workspace crypto they need for
+  paused members while keeping ordinary inactive-member assistant work blocked
+  by the existing mode-aware reconciliation and Temporal admission owner.
+
+## Success criteria
+
+- The current and historical-root crypto callbacks no longer duplicate active
+  member entitlement checks after signed callback authentication.
+- Both callbacks still require the callback-bound user, a provisioned hosted
+  workspace, and the existing signed/encrypted crypto-envelope authority.
+- Focused route tests prove paused members with workspaces succeed, missing
+  workspaces remain forbidden, and requests cannot reach crypto reads before
+  callback authentication succeeds.
+- Existing inactive-member orchestration proof continues to confine execution
+  to `inbox_media_retention`, never default processing.
+- Focused tests, typecheck, preliminary coverage review, final ReviewGPT,
+  exact-head CI, mergeability proof, and parent final review complete without
+  unresolved accepted findings.
+
+## Scope
+
+- In scope: the two hosted runtime crypto-context routes, their focused Web
+  tests, and any minimal durable contract clarification required by the trust
+  boundary.
+- Out of scope: changing runtime admission, Temporal scheduling, billing state,
+  crypto formats, keys, envelopes, workspace provisioning, or Cloudflare code.
+
+## Constraints
+
+- Technical: preserve signed callback auth, replay defense, user binding,
+  workspace existence, envelope signature/recipient checks, and historical-key
+  lookup semantics.
+- Architecture: Web/Temporal remain the mode-aware admission owners; crypto
+  retrieval is not a second billing-entitlement owner.
+- Product/process: privacy retention must not be disabled or weakened, and the
+  unrelated primary-checkout changes stay untouched.
+
+## Risks and mitigations
+
+1. Risk: removing the route-local entitlement gate could appear to authorize
+   ordinary paused-member execution.
+   Mitigation: retain callback/workspace/crypto authority at the routes and
+   directly re-run the existing orchestration test proving inactive members
+   receive retention-only processing.
+2. Risk: the historical-root route remains blocked and fails only when older
+   ciphertext is encountered.
+   Mitigation: make and test the same owner-bound correction on both crypto
+   routes.
+3. Risk: a malformed or unsigned request reaches sensitive reads.
+   Mitigation: keep auth as the first awaited operation and add focused proof
+   that an auth failure prevents workspace and crypto access.
+
+## Tasks
+
+1. Remove the redundant active-member query from both signed crypto callbacks.
+2. Replace entitlement-specific fixtures with paused-member, workspace, and
+   auth-boundary route regressions.
+3. Run focused Web tests, the existing inactive-retention orchestration proof,
+   hosted Web typecheck, diff hygiene, and parent diff review.
+4. Commit and push the exact candidate, open the PR, run the preliminary
+   coverage pass plus final ReviewGPT with CI, resolve accepted findings, and
+   close this plan through the repository finish path.
+
+## Decisions
+
+- Use deletion at the two incorrect ownership points. Do not add a retention
+  flag to the crypto request or a new authorization mechanism because the
+  mode-aware runtime owner already authorizes the only work inactive members
+  may execute.
+- Preserve the provisioned-workspace check as the route-local resource boundary.
+
+## Verification
+
+- Focused route tests for current and historical crypto context.
+- Existing inactive workspace retention reconciliation/orchestration test.
+- Hosted Web typecheck and `git diff --check`.
+- Exact-head CI plus preliminary coverage and final ReviewGPT trust-boundary
+  review.
+
+## Verification log
+
+- Focused Web Vitest run passed: five files and 90 tests covering both crypto
+  callbacks plus inactive-workspace retention facts, cleanup signaling, and
+  runtime signaling.
+- Hosted Web typecheck passed.
+- Agent-doc drift, diff whitespace, and direct-identifier guards passed.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -90,9 +90,10 @@ uses only the canonical ENAM binding. The contract is jointly specified by
 `ARCHITECTURE.md`, `agent-docs/SECURITY.md`, `agent-docs/RELIABILITY.md`, and
 `apps/cloudflare/README.md`.
 
-Signed hosted runtime crypto callbacks require callback-bound user authority
-and a provisioned workspace without duplicating active-member entitlement;
-mode-aware orchestration confines inactive members to retention-only work. The
+Signed hosted runtime crypto callbacks are user-bound, workspace-scoped
+resource authority without duplicate operation admission. Temporal/UserRunner,
+Settings vault export, and ordinary active-member runtime surfaces retain their
+own mode, session/MFA/consent, and active-access admission respectively. The
 contract is specified by `agent-docs/references/hosted-runtime-protocol.md` and
 `agent-docs/references/hosted-temporal-orchestration.md`.
 

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -90,6 +90,12 @@ uses only the canonical ENAM binding. The contract is jointly specified by
 `ARCHITECTURE.md`, `agent-docs/SECURITY.md`, `agent-docs/RELIABILITY.md`, and
 `apps/cloudflare/README.md`.
 
+Signed hosted runtime crypto callbacks require callback-bound user authority
+and a provisioned workspace without duplicating active-member entitlement;
+mode-aware orchestration confines inactive members to retention-only work. The
+contract is specified by `agent-docs/references/hosted-runtime-protocol.md` and
+`agent-docs/references/hosted-temporal-orchestration.md`.
+
 Metadata-only Stripe failure email ownership for terminal checkout and
 subscription actions, current-attempt/provider-effect
 identity, paid Family capacity/member-transition identity, safe request

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -56,6 +56,11 @@ The live ownership split is:
   signature, and unwraps only its `cloudflare-automation-secret` recipient. The
   signed full envelopes are disclosed to preserve signature verification over
   the web-authored body; Cloudflare still has no GCP KMS decrypt authority.
+  Current and historical root callbacks require that signed, user-bound
+  authority plus a provisioned workspace; they do not repeat active-member
+  entitlement checks because the mode-aware runtime owner already confines an
+  inactive member to `inbox_media_retention`, and cleanup still needs those
+  workspace roots.
   During active mailbox import, the runner container calls a Worker-owned
   mailbox-payload decode route over the invocation outbound proxy. That route
   requires the runtime write fence, decrypts the mailbox payload with the

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -56,11 +56,15 @@ The live ownership split is:
   signature, and unwraps only its `cloudflare-automation-secret` recipient. The
   signed full envelopes are disclosed to preserve signature verification over
   the web-authored body; Cloudflare still has no GCP KMS decrypt authority.
-  Current and historical root callbacks require that signed, user-bound
-  authority plus a provisioned workspace; they do not repeat active-member
-  entitlement checks because the mode-aware runtime owner already confines an
-  inactive member to `inbox_media_retention`, and cleanup still needs those
-  workspace roots.
+  Current and historical root callbacks are signed, user-bound,
+  workspace-scoped resource authority. They do not repeat operation admission:
+  Temporal and UserRunner own mode-aware runtime admission (including
+  `inbox_media_retention` for an inactive member), Settings vault export owns
+  app-session, MFA, and consent admission, and ordinary browser-vault, media
+  staging, and ingress owners keep their existing active-access gates. This
+  separation lets paused-member retention and an explicitly authorized
+  Settings export restore encrypted workspace state without reopening ordinary
+  assistant or model work.
   During active mailbox import, the runner container calls a Worker-owned
   mailbox-payload decode route over the invocation outbound proxy. That route
   requires the runtime write fence, decrypts the mailbox payload with the

--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -15,7 +15,7 @@ import {
   seedHostedWorkspaceInboxMediaRetentionWakeForTest,
   signalHostedMailboxAppendRuntimeForTest,
   signalHostedManualRunRuntimeForTest,
-  signalHostedRuntimeRecheckRuntimeForTest,
+  signalHostedRetentionRuntimeRecheckForTest,
   updateHostedMemberBillingStatusForTest,
 } from "#hosted-web-testing";
 
@@ -145,12 +145,14 @@ describe("hosted local Temporal orchestration e2e", () => {
       wakeAt: new Date(Date.now() - 60_000),
     });
 
-    const signal = await signalHostedRuntimeRecheckRuntimeForTest({
+    const retentionSignalStartedAt = new Date();
+    const signal = await signalHostedRetentionRuntimeRecheckForTest({
       environment: activeScenario.runtimeEnv,
       userId: pausedRetentionUserId,
     });
     const workflowState = await waitForWorkflowExecutionState({
       env: activeScenario.runtimeEnv,
+      executionNotBefore: retentionSignalStartedAt,
       workflowId: signal.workflowId,
     });
     expect(workflowState.lastExecutionErrorCode).toBeNull();
@@ -170,6 +172,7 @@ describe("hosted local Temporal orchestration e2e", () => {
 
 async function waitForWorkflowExecutionState(input: {
   env: NodeJS.ProcessEnv;
+  executionNotBefore?: Date;
   workflowId: string;
 }): Promise<ObservedHostedRuntimeWorkflowState> {
   const deadline = Date.now() + 180_000;
@@ -185,7 +188,10 @@ async function waitForWorkflowExecutionState(input: {
           workflowId: input.workflowId,
         }),
       );
-      if (latestState.lastExecutionKind !== null) {
+      if (
+        latestState.lastExecutionKind !== null
+        && isExecutionAtOrAfter(latestState.lastExecutionAt, input.executionNotBefore)
+      ) {
         return latestState;
       }
     } catch (error) {
@@ -204,6 +210,22 @@ async function waitForWorkflowExecutionState(input: {
       .filter((line): line is string => Boolean(line))
       .join("\n"),
   );
+}
+
+function isExecutionAtOrAfter(
+  lastExecutionAt: string | null,
+  executionNotBefore: Date | undefined,
+): boolean {
+  if (!executionNotBefore) {
+    return true;
+  }
+  if (!lastExecutionAt) {
+    return false;
+  }
+
+  const executionAtMs = Date.parse(lastExecutionAt);
+  return Number.isFinite(executionAtMs)
+    && executionAtMs >= executionNotBefore.getTime();
 }
 
 interface ObservedHostedRuntimeWorkflowState {

--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -12,8 +12,11 @@ import {
 } from "./helpers/hosted-local-full-stack-scenario.js";
 import {
   queryHostedRuntimeWorkflowForTest,
+  seedHostedWorkspaceInboxMediaRetentionWakeForTest,
   signalHostedMailboxAppendRuntimeForTest,
   signalHostedManualRunRuntimeForTest,
+  signalHostedRuntimeRecheckRuntimeForTest,
+  updateHostedMemberBillingStatusForTest,
 } from "#hosted-web-testing";
 
 vi.mock("server-only", () => ({}));
@@ -21,6 +24,8 @@ vi.mock("server-only", () => ({}));
 const runUserId = `member_local_temporal_orchestration_${Date.now()}`;
 const mailboxWorkspaceUserId =
   `member_local_temporal_mailbox_workspace_${Date.now()}`;
+const pausedRetentionUserId =
+  `member_local_temporal_paused_retention_${Date.now()}`;
 
 const streamDevLogs = process.env.MURPH_E2E_STREAM_DEV_LOGS === "1";
 const workerPersistDirOverride = process.env.MURPH_E2E_CF_PERSIST_DIR?.trim() || null;
@@ -115,6 +120,52 @@ describe("hosted local Temporal orchestration e2e", () => {
     expect(finalStatus.workspace).not.toBeNull();
     expect(finalStatus.lastErrorCode ?? null).toBeNull();
   }, 300_000);
+
+  it("runs due retention for a paused member without assistant provider work", async () => {
+    const activeScenario = requireScenario();
+
+    await activeScenario.seedActiveHostedMember({
+      memberId: pausedRetentionUserId,
+    });
+    await activeScenario.runWake(
+      buildActivationWake(pausedRetentionUserId, "paused-retention"),
+      pausedRetentionUserId,
+    );
+    await activeScenario.waitForHostedCompletion(pausedRetentionUserId);
+    const providerRequestBaseline = activeScenario.assistantProviderRequests.length;
+
+    await updateHostedMemberBillingStatusForTest({
+      billingStatus: "paused",
+      environment: activeScenario.runtimeEnv,
+      memberId: pausedRetentionUserId,
+    });
+    await seedHostedWorkspaceInboxMediaRetentionWakeForTest({
+      environment: activeScenario.runtimeEnv,
+      userId: pausedRetentionUserId,
+      wakeAt: new Date(Date.now() - 60_000),
+    });
+
+    const signal = await signalHostedRuntimeRecheckRuntimeForTest({
+      environment: activeScenario.runtimeEnv,
+      userId: pausedRetentionUserId,
+    });
+    const workflowState = await waitForWorkflowExecutionState({
+      env: activeScenario.runtimeEnv,
+      workflowId: signal.workflowId,
+    });
+    expect(workflowState.lastExecutionErrorCode).toBeNull();
+    expect(workflowState.lastExecutionKind).toMatch(/runtime_/u);
+    expect(workflowState.lastReconciliationBlockedReason).toBe("user_not_active");
+
+    const finalStatus = await activeScenario.waitForHostedCompletion(
+      pausedRetentionUserId,
+    );
+    expect(finalStatus.lastErrorCode ?? null).toBeNull();
+    expect(finalStatus.workspace?.inboxMediaRetentionWakeAt ?? null).toBeNull();
+    expect(activeScenario.assistantProviderRequests).toHaveLength(
+      providerRequestBaseline,
+    );
+  }, 300_000);
 });
 
 async function waitForWorkflowExecutionState(input: {
@@ -159,6 +210,7 @@ interface ObservedHostedRuntimeWorkflowState {
   lastExecutionAt: string | null;
   lastExecutionErrorCode: string | null;
   lastExecutionKind: string | null;
+  lastReconciliationBlockedReason: string | null;
   userId: string;
 }
 
@@ -174,6 +226,9 @@ function readObservedHostedRuntimeWorkflowState(
     record.lastExecutionErrorCode,
   );
   const lastExecutionKind = readNullableString(record.lastExecutionKind);
+  const lastReconciliationBlockedReason = readNullableString(
+    record.lastReconciliationBlockedReason,
+  );
   if (typeof record.userId !== "string" || record.userId.length === 0) {
     throw new TypeError("Hosted runtime Workflow query returned an invalid userId.");
   }
@@ -182,6 +237,7 @@ function readObservedHostedRuntimeWorkflowState(
     lastExecutionAt,
     lastExecutionErrorCode,
     lastExecutionKind,
+    lastReconciliationBlockedReason,
     userId: record.userId,
   };
 }

--- a/apps/web/app/api/internal/hosted-runtime/crypto-context/root/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/crypto-context/root/route.ts
@@ -4,7 +4,6 @@ import {
   readHostedDomainRootEnvelopeByRootKeyIdOrThrow,
 } from "@/src/lib/hosted-crypto/domain-root-store";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
-import { readActiveHostedMemberAccess } from "@/src/lib/hosted-onboarding/member-access";
 import { jsonError, jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
 import { getPrisma } from "@/src/lib/prisma";
 
@@ -17,9 +16,6 @@ export const POST = withJsonError(async (request: Request) => {
   });
   const body = parseHostedRuntimeCryptoRootRequest(await request.json());
   const prisma = getPrisma();
-  if (!await readActiveHostedMemberAccess({ memberId: userId, prisma })) {
-    return Response.json({ error: "hosted_member_not_active" }, { status: 403 });
-  }
   const workspace = await prisma.hostedWorkspace.findUnique({
     select: { userId: true },
     where: { userId },

--- a/apps/web/app/api/internal/hosted-runtime/crypto-context/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/crypto-context/route.ts
@@ -1,6 +1,5 @@
 import { requireHostedCloudflareCallbackRequest } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
 import { readHostedRuntimeCryptoContextForWorker } from "@/src/lib/hosted-crypto/domain-root-store";
-import { readActiveHostedMemberAccess } from "@/src/lib/hosted-onboarding/member-access";
 import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
 import { getPrisma } from "@/src/lib/prisma";
 
@@ -11,9 +10,6 @@ export const POST = withJsonError(async (request: Request) => {
     maxBodyBytes: HOSTED_RUNTIME_CRYPTO_CONTEXT_CALLBACK_BODY_LIMIT_BYTES,
   });
   const prisma = getPrisma();
-  if (!await readActiveHostedMemberAccess({ memberId: userId, prisma })) {
-    return Response.json({ error: "hosted_member_not_active" }, { status: 403 });
-  }
   const workspace = await prisma.hostedWorkspace.findUnique({
     select: { userId: true },
     where: { userId },

--- a/apps/web/test/hosted-runtime-crypto-context-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-context-route.test.ts
@@ -39,7 +39,7 @@ describe("hosted runtime crypto-context route", () => {
     });
   });
 
-  it("returns signed runtime crypto context for paused-member retention with a provisioned workspace", async () => {
+  it("returns signed workspace-bound crypto context without repeating caller admission", async () => {
     const prisma = createPrisma({
       workspace: { userId: "member_crypto_1" },
     });

--- a/apps/web/test/hosted-runtime-crypto-context-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-context-route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+
 const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   readHostedRuntimeCryptoContextForWorker: vi.fn(),
@@ -18,16 +20,9 @@ vi.mock("@/src/lib/hosted-crypto/domain-root-store", () => ({
   readHostedRuntimeCryptoContextForWorker: mocks.readHostedRuntimeCryptoContextForWorker,
 }));
 
-import { hostedMemberAccessSelect } from "@/src/lib/hosted-onboarding/member-access";
-
 type RouteModule = typeof import("../app/api/internal/hosted-runtime/crypto-context/route");
 
 let route: RouteModule;
-
-const ACTIVE_SPONSORSHIP = {
-  group: { billingStatus: "active", suspendedAt: null },
-  status: "active",
-};
 
 describe("hosted runtime crypto-context route", () => {
   beforeEach(async () => {
@@ -44,14 +39,8 @@ describe("hosted runtime crypto-context route", () => {
     });
   });
 
-  it("returns signed runtime crypto context for an active member with a provisioned workspace", async () => {
+  it("returns signed runtime crypto context for paused-member retention with a provisioned workspace", async () => {
     const prisma = createPrisma({
-      member: {
-        accountGroupMemberships: [],
-        billingStatus: "active",
-        suspendedAt: null,
-        threadContainer: null,
-      },
       workspace: { userId: "member_crypto_1" },
     });
     mocks.getPrisma.mockReturnValue(prisma);
@@ -62,10 +51,6 @@ describe("hosted runtime crypto-context route", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(prisma.hostedMember.findUnique).toHaveBeenCalledWith({
-      select: hostedMemberAccessSelect,
-      where: { id: "member_crypto_1" },
-    });
     expect(prisma.hostedWorkspace.findUnique).toHaveBeenCalledWith({
       select: { userId: true },
       where: { userId: "member_crypto_1" },
@@ -81,111 +66,8 @@ describe("hosted runtime crypto-context route", () => {
     expect(payload.fetchedAt).toEqual(expect.any(String));
   });
 
-  it("allows family-sponsored members whose direct billing is not started", async () => {
+  it("rejects callbacks that do not have a provisioned hosted workspace", async () => {
     const prisma = createPrisma({
-      member: {
-        accountGroupMemberships: [ACTIVE_SPONSORSHIP],
-        billingStatus: "not_started",
-        suspendedAt: null,
-        threadContainer: null,
-      },
-      workspace: { userId: "member_crypto_1" },
-    });
-    mocks.getPrisma.mockReturnValue(prisma);
-
-    const response = await route.POST(new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context", {
-      method: "POST",
-    }));
-
-    expect(response.status).toBe(200);
-    expect(mocks.readHostedRuntimeCryptoContextForWorker).toHaveBeenCalledWith({
-      prisma,
-      userId: "member_crypto_1",
-    });
-  });
-
-  it("allows thread-container runtime context when an active participant keeps an inactive-owner group alive", async () => {
-    const prisma = createPrisma({
-      member: {
-        accountGroupMemberships: [],
-        billingStatus: "not_started",
-        suspendedAt: null,
-        threadContainer: {
-          owner: {
-            accountGroupMemberships: [],
-            billingStatus: "paused",
-            suspendedAt: null,
-          },
-        },
-      },
-      participantActive: true,
-      workspace: { userId: "member_crypto_1" },
-    });
-    mocks.getPrisma.mockReturnValue(prisma);
-
-    const response = await route.POST(new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context", {
-      method: "POST",
-    }));
-
-    expect(response.status).toBe(200);
-    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
-      select: {
-        participantMemberId: true,
-      },
-      where: expect.objectContaining({
-        containerMemberId: "member_crypto_1",
-        removedAt: null,
-      }),
-    });
-    expect(mocks.readHostedRuntimeCryptoContextForWorker).toHaveBeenCalledWith({
-      prisma,
-      userId: "member_crypto_1",
-    });
-  });
-
-
-  it("rejects missing, inactive, or suspended hosted members before reading crypto roots", async () => {
-    for (const member of [
-      null,
-      {
-        accountGroupMemberships: [],
-        billingStatus: "not_started",
-        suspendedAt: null,
-        threadContainer: null,
-      },
-      {
-        accountGroupMemberships: [ACTIVE_SPONSORSHIP],
-        billingStatus: "active",
-        suspendedAt: new Date("2026-05-01T00:00:00.000Z"),
-        threadContainer: null,
-      },
-    ]) {
-      const prisma = createPrisma({
-        member,
-        workspace: { userId: "member_crypto_1" },
-      });
-      mocks.getPrisma.mockReturnValue(prisma);
-      mocks.readHostedRuntimeCryptoContextForWorker.mockClear();
-
-      const response = await route.POST(new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context", {
-        method: "POST",
-      }));
-
-      expect(response.status).toBe(403);
-      await expect(response.json()).resolves.toEqual({ error: "hosted_member_not_active" });
-      expect(prisma.hostedWorkspace.findUnique).not.toHaveBeenCalled();
-      expect(mocks.readHostedRuntimeCryptoContextForWorker).not.toHaveBeenCalled();
-    }
-  });
-
-  it("rejects active members that do not have a provisioned hosted workspace", async () => {
-    const prisma = createPrisma({
-      member: {
-        accountGroupMemberships: [],
-        billingStatus: "active",
-        suspendedAt: null,
-        threadContainer: null,
-      },
       workspace: null,
     });
     mocks.getPrisma.mockReturnValue(prisma);
@@ -198,32 +80,28 @@ describe("hosted runtime crypto-context route", () => {
     await expect(response.json()).resolves.toEqual({ error: "hosted_workspace_not_provisioned" });
     expect(mocks.readHostedRuntimeCryptoContextForWorker).not.toHaveBeenCalled();
   });
+
+  it("rejects unauthenticated callbacks before reading workspace or crypto state", async () => {
+    mocks.requireHostedCloudflareCallbackRequest.mockRejectedValueOnce(hostedOnboardingError({
+      code: "HOSTED_CLOUDFLARE_CALLBACK_UNAUTHORIZED",
+      httpStatus: 401,
+      message: "Unauthorized hosted Cloudflare callback request.",
+      retryable: false,
+    }));
+
+    const response = await route.POST(new Request(
+      "https://join.example.test/api/internal/hosted-runtime/crypto-context",
+      { method: "POST" },
+    ));
+
+    expect(response.status).toBe(401);
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+    expect(mocks.readHostedRuntimeCryptoContextForWorker).not.toHaveBeenCalled();
+  });
 });
 
-type HostedMemberAccessFixture = {
-  accountGroupMemberships: Array<{
-    group: { billingStatus: string; suspendedAt: Date | null };
-    status: string;
-  }>;
-  billingStatus: string;
-  suspendedAt: Date | null;
-  threadContainer: null | { owner: unknown };
-};
-
-function createPrisma(input: {
-  member: HostedMemberAccessFixture | null;
-  participantActive?: boolean;
-  workspace: { userId: string } | null;
-}) {
+function createPrisma(input: { workspace: { userId: string } | null }) {
   return {
-    hostedMember: {
-      findUnique: vi.fn().mockResolvedValue(input.member),
-    },
-    hostedThreadContainerParticipant: {
-      findFirst: vi.fn(async () => input.participantActive
-        ? { participantMemberId: "member_active_participant" }
-        : null),
-    },
     hostedWorkspace: {
       findUnique: vi.fn().mockResolvedValue(input.workspace),
     },

--- a/apps/web/test/hosted-runtime-crypto-root-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-root-route.test.ts
@@ -88,7 +88,7 @@ describe("hosted runtime crypto root route", () => {
     });
   });
 
-  it("returns historical crypto roots for paused-member retention", async () => {
+  it("returns historical workspace roots without repeating caller admission", async () => {
     const prisma = createPrisma({
       workspace: {
         userId: "member_123",

--- a/apps/web/test/hosted-runtime-crypto-root-route.test.ts
+++ b/apps/web/test/hosted-runtime-crypto-root-route.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+
 const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   readHostedDomainRootEnvelopeByRootKeyIdOrThrow: vi.fn(),
@@ -42,12 +44,6 @@ describe("hosted runtime crypto root route", () => {
     vi.clearAllMocks();
     mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member_123");
     mocks.getPrisma.mockReturnValue(createPrisma({
-      member: {
-        accountGroupMemberships: [],
-        billingStatus: "active",
-        suspendedAt: null,
-        threadContainer: null,
-      },
       workspace: {
         userId: "member_123",
       },
@@ -92,21 +88,8 @@ describe("hosted runtime crypto root route", () => {
     });
   });
 
-  it("allows crypto root reads when an active participant keeps an inactive-owner group alive", async () => {
+  it("returns historical crypto roots for paused-member retention", async () => {
     const prisma = createPrisma({
-      member: {
-        accountGroupMemberships: [],
-        billingStatus: "not_started",
-        suspendedAt: null,
-        threadContainer: {
-          owner: {
-            accountGroupMemberships: [],
-            billingStatus: "paused",
-            suspendedAt: null,
-          },
-        },
-      },
-      participantActive: true,
       workspace: {
         userId: "member_123",
       },
@@ -124,14 +107,9 @@ describe("hosted runtime crypto root route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(prisma.hostedThreadContainerParticipant.findFirst).toHaveBeenCalledWith({
-      select: {
-        participantMemberId: true,
-      },
-      where: expect.objectContaining({
-        containerMemberId: "member_123",
-        removedAt: null,
-      }),
+    expect(prisma.hostedWorkspace.findUnique).toHaveBeenCalledWith({
+      select: { userId: true },
+      where: { userId: "member_123" },
     });
     expect(mocks.readHostedDomainRootEnvelopeByRootKeyIdOrThrow).toHaveBeenCalledWith({
       domain: "runtime",
@@ -140,27 +118,55 @@ describe("hosted runtime crypto root route", () => {
       userId: "member_123",
     });
   });
+
+  it("rejects callbacks that do not have a provisioned hosted workspace", async () => {
+    mocks.getPrisma.mockReturnValue(createPrisma({ workspace: null }));
+
+    const response = await hostedRuntimeCryptoRootRoute.POST(
+      new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context/root", {
+        body: JSON.stringify({
+          domain: "runtime",
+          rootKeyId: "udrk:runtime:test-root",
+        }),
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "hosted_workspace_not_provisioned",
+    });
+    expect(mocks.readHostedDomainRootEnvelopeByRootKeyIdOrThrow).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated callbacks before reading workspace or crypto state", async () => {
+    mocks.requireHostedCloudflareCallbackRequest.mockRejectedValueOnce(hostedOnboardingError({
+      code: "HOSTED_CLOUDFLARE_CALLBACK_UNAUTHORIZED",
+      httpStatus: 401,
+      message: "Unauthorized hosted Cloudflare callback request.",
+      retryable: false,
+    }));
+
+    const response = await hostedRuntimeCryptoRootRoute.POST(
+      new Request("https://join.example.test/api/internal/hosted-runtime/crypto-context/root", {
+        body: JSON.stringify({
+          domain: "runtime",
+          rootKeyId: "udrk:runtime:test-root",
+        }),
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+    expect(mocks.readHostedDomainRootEnvelopeByRootKeyIdOrThrow).not.toHaveBeenCalled();
+  });
 });
 
 function createPrisma(input: {
-  member: {
-    accountGroupMemberships: unknown[];
-    billingStatus: string;
-    suspendedAt: Date | null;
-    threadContainer: null | { owner: unknown };
-  } | null;
-  participantActive?: boolean;
   workspace: { userId: string } | null;
 }) {
   return {
-    hostedMember: {
-      findUnique: vi.fn().mockResolvedValue(input.member),
-    },
-    hostedThreadContainerParticipant: {
-      findFirst: vi.fn(async () => input.participantActive
-        ? { participantMemberId: "member_active_participant" }
-        : null),
-    },
     hostedWorkspace: {
       findUnique: vi.fn().mockResolvedValue(input.workspace),
     },

--- a/apps/web/test/support/hosted-web-testkit.ts
+++ b/apps/web/test/support/hosted-web-testkit.ts
@@ -586,6 +586,15 @@ interface HostedRuntimeSignalModule {
     signalAccepted: true;
     workflowId: string;
   }>;
+  signalHostedRetentionRuntimeRecheck(input: {
+    client?: HostedRuntimeTemporalSignalClient | null;
+    environment?: NodeJS.ProcessEnv;
+    prisma?: HostedTestPrismaClient;
+    userId: string;
+  }): Promise<{
+    signalAccepted: true;
+    workflowId: string;
+  }>;
   signalHostedRuntimeWakeRuntime(input: {
     client?: HostedRuntimeTemporalSignalClient | null;
     environment?: NodeJS.ProcessEnv;
@@ -1790,6 +1799,24 @@ export async function signalHostedRuntimeRecheckRuntimeForTest(input: {
   return withHostedWebSignalTestkitDeps(input.environment, async (deps) => {
     const signalModule = await loadHostedRuntimeSignalModule();
     return await signalModule.signalHostedRuntimeRecheckRuntime({
+      client: deps.temporalSignalClient,
+      environment: deps.environment,
+      prisma: deps.prisma,
+      userId: input.userId,
+    });
+  });
+}
+
+export async function signalHostedRetentionRuntimeRecheckForTest(input: {
+  environment?: NodeJS.ProcessEnv;
+  userId: string;
+}): Promise<{
+  signalAccepted: true;
+  workflowId: string;
+}> {
+  return withHostedWebSignalTestkitDeps(input.environment, async (deps) => {
+    const signalModule = await loadHostedRuntimeSignalModule();
+    return await signalModule.signalHostedRetentionRuntimeRecheck({
       client: deps.temporalSignalClient,
       environment: deps.environment,
       prisma: deps.prisma,

--- a/apps/web/test/support/hosted-web-testkit.ts
+++ b/apps/web/test/support/hosted-web-testkit.ts
@@ -79,6 +79,7 @@ import { Client } from "pg";
 import { hostedRuntimeLogSubjectKey } from "@/src/lib/hosted-runtime-log/subject-key";
 import { createHostedWebSmokeEnvironment } from "../../next-artifacts";
 import type { HostedRuntimeTemporalSignalClient } from "../../src/lib/hosted-orchestration/temporal-client";
+import type { HostedBillingStatusForTest } from "./hosted-billing-live-testkit";
 
 const hostedRuntimeLogTestMigrationTable = "_murph_e2e_runtime_log_migration";
 const hostedRuntimeLogTestMigrationsRoot = new URL(
@@ -183,6 +184,7 @@ interface HostedTestPrismaFactoryClient {
   };
   hostedMember: {
     create(args: unknown): Promise<{ id: string }>;
+    update(args: unknown): Promise<{ id: string }>;
   };
 }
 
@@ -1187,6 +1189,23 @@ export async function seedHostedWorkspaceInboxMediaRetentionWakeForTest(input: {
         "Hosted-local retention wake seed requires exactly one existing workspace.",
       );
     }
+  });
+}
+
+export async function updateHostedMemberBillingStatusForTest(input: {
+  billingStatus: HostedBillingStatusForTest;
+  environment?: NodeJS.ProcessEnv;
+  memberId: string;
+}): Promise<void> {
+  return withHostedWebTestkitDeps(input.environment, async (deps) => {
+    await deps.prisma.hostedMember.update({
+      data: {
+        billingStatus: input.billingStatus,
+      },
+      where: {
+        id: input.memberId,
+      },
+    });
   });
 }
 


### PR DESCRIPTION
## Why

Paused members with due inbox-media retention work reached the signed runtime crypto callbacks, but both callbacks repeated the active-member entitlement check and returned 403 before Cloudflare could restore the workspace. That prevented the already-authorized retention-only runtime from deleting expired inbox media.

Review established the more precise ownership rule: these callbacks are signed, user-bound, workspace-scoped crypto resource authority. Each caller independently owns operation admission; the crypto routes must not duplicate it.

## User-visible goal and flow

A paused member remains blocked from ordinary assistant and model work. When the existing mode-aware runtime owner selects `inbox_media_retention`, Cloudflare can fetch the current or historical workspace crypto root, restore the workspace, complete privacy cleanup, and checkpoint through the existing path.

- Entry point: an existing due inbox-media retention wake.
- Timing and continuation owner: Temporal selects retention-only processing; Cloudflare runs the existing workspace invocation and retry path.
- Immediate feedback: no new UI or message is introduced.
- Terminal delivery/recovery: the existing retention checkpoint and wake projection remain authoritative; transport failures retain their existing retry behavior.
- Permission boundary: the callbacks still require signed, nonce-protected, user-bound Cloudflare authority and a provisioned workspace. Runtime mode, Settings session/MFA/consent, and ordinary active-access owners admit their own operations.

## Invariants

- Inactive members never gain default assistant/model processing.
- Signed callback verification, timestamp and nonce replay defense, and callback-bound user identity remain first.
- Missing hosted workspaces still fail closed with 403.
- Crypto envelopes remain signed, workspace/user scoped, and unwrap only for the configured Cloudflare automation recipient.
- Historical-root lookup retains its exact root-key and domain binding.
- Settings vault export retains app-session, MFA, and consent/retained-replica admission.
- Ordinary browser-vault, media-staging, and ingress paths retain their existing active-access gates.
- Privacy retention is not disabled or silently dropped.

## Architecture and reuse

- Existing systems reused: callback auth, workspace provisioning, hosted domain-root storage, mode-aware reconciliation, Temporal retention dispatch, Settings export admission, ordinary active-access gates, and Cloudflare crypto verification.
- New logic: none. The production change deletes the two duplicate entitlement gates; test-only support adds one direct billing-status transition for the existing full-stack scenario.
- New abstractions: This change introduces no new abstraction because the existing caller admission owners and signed workspace resource boundary already cover the complete flow.
- Complexity intentionally avoided: no purpose flag on crypto requests, second authorization policy, queue, compatibility shim, or new state owner.

## Non-obvious affected surfaces

- The historical-root callback needs the same correction because retention restore or Settings export may encounter ciphertext written under an older root.
- Paused-member Settings vault export intentionally uses the same crypto resource path after its own app-session, MFA, and consent checks.
- A runtime admitted while active can be narrowed to model-free `system_mailbox` if platform usage becomes unavailable before invocation; the existing provider-egress fence still denies model work.
- Ordinary browser-vault, media-staging, and ingress owners keep their active-member admission checks; this PR does not alter them.

## Preliminary specialist lenses

- Product experience: applicable — restores the intended asynchronous privacy-retention and explicitly authorized export contracts without changing their owners.
- Prompt: not applicable — no prompt or instruction-stack behavior changes.
- Frontend: not applicable — no rendered UI changes.
- Coverage: applicable — executable route authority changes and focused regression coverage changed.

Product outcome evidence: focused Web tests exercise both crypto callbacks, signed-auth denial before database access, and missing-workspace denial. The added full-stack scenario seeds a workspace while active, pauses the member, makes retention due, signals the real Temporal workflow, requires `user_not_active` reconciliation plus successful wake clearance, and asserts zero assistant-provider requests. The private Temporal owner, Cloudflare signed current/historical-root transport, and assistant-runtime retention-only seams pass focused executable tests.

Rendered evidence: not applicable.

## Review remediation

- Final ReviewGPT round 1 finding accepted: corrected retention-only wording to the shared caller-admission/resource-authority contract and disclosed Settings export plus the narrow model-free mailbox race.
- Preliminary coverage finding accepted: added the paused-member Temporal-to-Cloudflare full-stack regression at the existing scenario seam.
- Final ReviewGPT round 2 passed the production correction and shared authorization contract at `0eacb4ad6f`. Its non-qualifying E2E discrepancies were then corrected on the test-only follow-up head: the scenario uses the retention-specific signal that bypasses active admission and waits only for an execution timestamp at or after that signal.
- The local full-stack command could not execute any scenario test because setup first exhausted its existing hook timeout, then supported runner-bundle preparation hit an unrelated existing runner entrypoint byte-budget failure (9,934,039 bytes versus 9,920,209). This PR does not change the runner bundle. The regression is typechecked and remains available to the canonical E2E lane once that independent bundle gate is green.

## Verification

- Focused Web Vitest: 5 files, 90 tests passed on the production candidate; final route rerun: 2 files, 7 tests passed.
- Hosted Web and Cloudflare typechecks passed.
- Private Temporal owner suite: 16 files, 122 tests passed, including inactive-member due-retention dispatch.
- Cloudflare signed crypto transport: 1 file, 2 tests passed, including historical-root resolution.
- Production signal owner: 1 file, 30 tests passed, including retention rechecks that bypass inactive-member admission.
- Assistant-runtime retention-only processing: 1 file, 2 focused tests passed.
- Agent-doc drift guard passed.
- `git diff --check` and direct-identifier scan passed.
- Merge-tree against current `origin/main` is clean.
- Exact-head GitHub Actions: running on the remediation head.

## Design proof

Not applicable; this PR has no user-facing frontend UI diff.

## Change shape

Classification rule: production route code is source; Vitest files and test support are tests; durable protocol/index and the execution plan are docs; no config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 8 |
| Tests | 195 | 187 |
| Docs | 136 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT context sensitivity: sensitive

Reason: the patch changes a hosted execution crypto trust-boundary route, even though the production implementation is a narrow deletion.

ReviewGPT first-reviewed head: 0fcb8576be80bd4468faa662db96a92c258304f6

ReviewGPT final round-2 reviewed head: 0eacb4ad6fc02647439ed690b0b89f7405ae11cb

ReviewGPT current test-only follow-up head: 6d3d81839dbb1feca36d940bb973c03a03d1fee4

## Deployment skew / compatibility

This is a Web-only, backward-compatible route correction. Cloudflare, Temporal, crypto envelope formats, and persisted state do not change, so there is no tandem deploy, warm-container convergence requirement, or compatibility window. Until the Web deploy reaches production, old instances may continue returning the observed 403 and the existing retention retry remains pending. Rollback reintroduces that backlog but does not corrupt state. After deploy, verify the aggregate crypto-context 403 rate falls, overdue paused-member retention wakes drain, and inactive members remain absent from default/model processing.

