### PR TITLE
Teach Murph unsupported-provider export handoffs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,7 @@
     "typecheck:watch": "pnpm health-commons:generate && pnpm prisma:generate && pnpm --dir ../.. exec tsx scripts/ensure-next-route-type-stubs.ts apps/web && node ../../scripts/run-typescript.mjs watch -p tsconfig.json --pretty false --watch --tsBuildInfoFile typecheck.watch.tsbuildinfo",
     "test": "pnpm health-commons:generate && pnpm test:prepared",
     "test:prepared": "pnpm --dir ../.. exec vitest run --config apps/web/vitest.workspace.ts --no-coverage",
-    "test:viewport-overflow": "playwright test",
+    "test:viewport-overflow": "playwright test e2e/viewport-overflow.spec.ts",
     "prisma:generate": "prisma generate && pnpm --dir ../.. exec tsx apps/web/scripts/ensure-prisma-client-link.ts",
     "prisma:generate:build": "pnpm --dir ../.. exec tsx apps/web/scripts/prepare-prisma-client-for-build.ts",
     "prisma:migrate:deploy": "pnpm --dir ../.. exec tsx apps/web/scripts/run-prisma-migrate-deploy.ts",

--- a/packages/assistant-engine/skills/connected-apps/SKILL.md
+++ b/packages/assistant-engine/skills/connected-apps/SKILL.md
@@ -48,9 +48,10 @@ Management, Strong, and Hevy. Do not use `murph.connected_apps_search` to hunt
 for an arbitrary health integration, and do not claim support because a provider
 appears in the reference.
 
-Give the provider's official export link and the smallest useful steps, ask for
-the original downloaded file, and describe the result as a manual export or
-one-time import rather than a live sync. The member performs the export by
+Give the provider's verified action link—an account or export page when one is
+documented, otherwise the official instructions—plus the smallest useful steps.
+Ask for the original downloaded file and describe the result as a manual export
+or one-time import rather than a live sync. The member performs the export by
 default. Use `computer-use` only when they explicitly ask Murph to operate the
 portal and that skill permits the action. Once a file arrives, the global
 health-record ingestion invariant owns preservation and canonical extraction.

--- a/packages/assistant-engine/skills/connected-apps/SKILL.md
+++ b/packages/assistant-engine/skills/connected-apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: connected-apps
-description: Use when Murph needs a connected email, calendar, document, storage, note, or task account; an approved accountless service such as weather, places, provider registry, product search, or Instacart; account connection or removal; or connected-app context for another action. Covers account selection, narrow discovery and reads, approved email and calendar writes, privacy, and untrusted provider content.
+description: Use when Murph needs a connected email, calendar, document, storage, note, or task account; an approved accountless service such as weather, places, provider registry, product search, or Instacart; account connection or removal; connected-app context for another action; or a verified manual export fallback for an unsupported health or fitness data source. Covers account selection, narrow discovery and reads, approved email and calendar writes, privacy, untrusted provider content, and official provider export handoffs.
 ---
 
 # Connected Apps
@@ -32,6 +32,29 @@ Before asking the user to repeat a task-relevant fact these surfaces are likely
 to contain, perform the narrow read when the account and task are clear. Ask one
 narrow question when multiple accounts, providers, visit types, files, or
 locations remain materially plausible.
+
+## Unsupported health and fitness sources
+
+A request to connect, sync, or import a health or fitness service does not make
+that service a connected-app provider. First use the trusted live provider list
+in the current prompt to determine whether Murph has a real direct connection.
+If a direct route is proven, use its device or app connection owner and do not
+substitute a manual export.
+
+When no direct connection is proven and the member wants existing data from the
+service, read `references/provider-data-exports.md`. That reference owns the
+verified fallback routes for Function Health, Teladoc Health/Livongo, Strong,
+and Hevy. Do not use `murph.connected_apps_search` to hunt for an arbitrary
+health integration, and do not claim support because a provider appears in the
+reference.
+
+Give the provider's official export link and the smallest useful steps, ask for
+the original downloaded file, and describe the result as a manual export or
+one-time import rather than a live sync. The member performs the export by
+default. Use `computer-use` only when they explicitly ask Murph to operate the
+portal and that skill permits the action. Once a file arrives, the global
+health-record ingestion invariant owns preservation and canonical extraction.
+In a group, ask the member to continue privately before sharing account data.
 
 ## Prefer connected email over webmail
 

--- a/packages/assistant-engine/skills/connected-apps/SKILL.md
+++ b/packages/assistant-engine/skills/connected-apps/SKILL.md
@@ -43,10 +43,10 @@ substitute a manual export.
 
 When no direct connection is proven and the member wants existing data from the
 service, read `references/provider-data-exports.md`. That reference owns the
-verified fallback routes for Function Health, Teladoc Health/Livongo, Strong,
-and Hevy. Do not use `murph.connected_apps_search` to hunt for an arbitrary
-health integration, and do not claim support because a provider appears in the
-reference.
+verified fallback routes for Function Health, Livongo/Teladoc Condition
+Management, Strong, and Hevy. Do not use `murph.connected_apps_search` to hunt
+for an arbitrary health integration, and do not claim support because a provider
+appears in the reference.
 
 Give the provider's official export link and the smallest useful steps, ask for
 the original downloaded file, and describe the result as a manual export or

--- a/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
+++ b/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
@@ -78,6 +78,12 @@ The official legacy export instructions are:
 4. Choose the relevant report and click `Export`.
 5. Send the downloaded original file to Murph without changing it.
 
+For the normal legacy handoff, use the Livongo sign-in page as the user-facing
+action link and put it alone on the final line. Do not make the member open the
+help article first when the documented account flow is available.
+
+https://my.livongo.com
+
 Teladoc's article says the download contains all of the member's data but does
 not state the file format, schema, timestamp semantics, or how migrated accounts
 are represented. Never call it a CSV or promise reading-level fields before
@@ -87,9 +93,9 @@ Some members now see existing Livongo information in the Teladoc Health app or
 website under `Programs` → `Condition Management`. Teladoc's public migration
 FAQ documents that viewing path but does not document an equivalent export menu
 for the newer experience. If the legacy `Reports and Data` path is unavailable,
-do not invent another menu. Give the official export article and tell the
-member to use any first-party export their account shows or contact Teladoc
-support.
+do not invent another menu. Give the official export article below as the
+fallback action link and tell the member to use any first-party export their
+account shows or contact Teladoc support.
 
 This is a one-time snapshot, not continuous Teladoc sync. The member must export
 again to refresh later readings. When the file arrives, inspect its real format

--- a/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
+++ b/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
@@ -84,25 +84,34 @@ help article first when the documented account flow is available.
 
 https://my.livongo.com
 
-Teladoc's article says the download contains all of the member's data but does
-not state the file format, schema, timestamp semantics, or how migrated accounts
-are represented. Never call it a CSV or promise reading-level fields before
-inspecting the actual export.
+The official legacy export article says the download contains all of the
+member's data but does not state the file format, schema, timestamp semantics,
+or how migrated accounts are represented. Never call it a CSV or promise
+reading-level fields before inspecting the actual export. Use this article when
+the member asks for the official instructions or source; it is not the normal
+sign-in action link.
 
-Some members now see existing Livongo information in the Teladoc Health app or
-website under `Programs` → `Condition Management`. Teladoc's public migration
-FAQ documents that viewing path but does not document an equivalent export menu
-for the newer experience. If the legacy `Reports and Data` path is unavailable,
-do not invent another menu. Give the official export article below as the
-fallback action link and tell the member to use any first-party export their
-account shows or contact Teladoc support.
+https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website
+
+Some members now access existing Livongo programs through the Teladoc Health app
+or website. The official migration FAQ tells members to sign in, choose
+`Condition Management`, then choose `Go to programs`; it does not document an
+equivalent export control for the newer experience. If the legacy `Reports and
+Data` path is unavailable, do not invent another menu. Explain that no verified
+new export path is documented, give the migration FAQ below as the fallback
+action link, and tell the member to use any first-party export their account
+shows or contact Livongo Member Support at `membersupport@livongo.com` or
+`800-945-4355`.
+
+Send exactly one action link: the Livongo sign-in page for the normal legacy
+flow, or the migration FAQ only when the legacy path is unavailable.
+
+https://www.teladochealth.com/start/new-experience-faq
 
 This is a one-time snapshot, not continuous Teladoc sync. The member must export
 again to refresh later readings. When the file arrives, inspect its real format
 and use the narrowest existing measurement or health-record ingestion path; do
 not infer blood pressure, weight, or glucose rows from an unsupported summary.
-
-https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website
 
 ## Strong
 

--- a/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
+++ b/packages/assistant-engine/skills/connected-apps/references/provider-data-exports.md
@@ -1,0 +1,106 @@
+# Manual provider data exports
+
+Read the top-level `../SKILL.md` first. This reference owns the fallback when a
+member wants data from a health or fitness service that has no proven direct
+Murph connection.
+
+The routes below were checked against official provider documentation on
+2026-08-09. Provider menus and migrations can change, so use the exact official
+link in the matching entry and do not invent a replacement path from memory.
+
+## Decision order
+
+1. Prefer a real, currently advertised Murph connection. The trusted live
+   provider list in the current prompt is authoritative. Do not call a provider
+   supported or connected because it appears in this file.
+2. If no direct connection is proven, use the matching official export route
+   below.
+3. If the provider is not listed here, do not guess a menu path or present a
+   third-party article as authority. Say Murph does not have a verified direct
+   route for it yet and offer to look for the provider's official export
+   instructions.
+
+## Handoff contract
+
+- Give only the instructions for the provider the member named. Keep the reply
+  short and put the official action URL on its own final line.
+- The member performs the export in their own account. Never ask them to send a
+  password, one-time code, recovery code, or portal cookie.
+- Ask for the original downloaded file as-is. Prefer it over screenshots,
+  copied tables, or a reformatted spreadsheet because the original preserves
+  more provenance and structure.
+- Call this a manual export or one-time import, not a live sync. New readings or
+  workouts require another export until Murph has a real direct connection.
+- Do not promise a file type that the provider does not document. Murph can
+  inspect the actual file after the member sends it.
+- Once the file arrives, follow the global health-record ingestion invariant:
+  preserve the source and save recoverable facts to their canonical owners
+  rather than ending with only a chat summary.
+- In a group conversation, do not ask someone to upload private account data to
+  the room. Ask them to continue in their private Murph conversation.
+
+## Function Health
+
+Function Health is a lab-testing service. Members can download completed lab
+results as PDFs and send the PDFs to Murph.
+
+Tell the member to open the Function documents page, download every relevant
+`Lab Results of Record` PDF, and send the original PDFs to Murph. Naming
+Function without supplying a file is not an import.
+
+https://my.functionhealth.com/documents
+
+## Teladoc Health / Livongo
+
+Teladoc Health is the broader virtual-care company. Livongo was the connected
+chronic-condition program for areas such as diabetes, hypertension, and weight
+management; Livongo became part of Teladoc Health in 2020. The same member may
+therefore see Livongo branding, Teladoc Health branding, or a Teladoc
+`Condition Management` entry. Treat `Teladoc`, `Teladoc Health`, and `Livongo`
+as aliases for this export path, not as separate device integrations.
+
+The official export article currently directs the member to:
+
+1. Sign in at `https://my.livongo.com`.
+2. Click their name in the upper-right corner.
+3. Choose `Reports and Data`.
+4. Choose the report and click `Export`.
+5. Send the downloaded file to Murph without changing it.
+
+Some accounts are being migrated into the Teladoc Health app and website. If
+the legacy sign-in does not work, explain the branding transition and send the
+official article below; do not invent a different Teladoc menu path. The
+article says the export downloads a file containing the member's data but does
+not state the file format, so never call it a CSV before seeing it.
+
+https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website
+
+## Strong
+
+Strong is a workout-tracking app. Its official export is a
+spreadsheet-friendly CSV containing workout data.
+
+- iPhone/iPad: open Strong, go to `Settings`, then choose
+  `Export Strong Data`.
+- Android: open Strong, go to `Settings`, then choose `Export Data`.
+- Ask the member to send the exported CSV to Murph. Strong says the CSV cannot
+  be imported back into Strong; do not imply that Murph changes their Strong
+  account.
+
+https://help.strongapp.io/article/235-export-workout-data
+
+## Hevy
+
+The product name is `Hevy`; members may type or dictate `Heavy`. Hevy can export
+workout history and body-measurement history separately.
+
+Tell the member to open Hevy and go to:
+
+`Profile` → `Settings` → `Export & Import Data` → `Export Data`
+
+Then choose `Export Workouts` and, only when body measurements are relevant,
+`Export Measurements`. Ask them to send the original exported file or files to
+Murph. Do not make them export measurements when they only want workout
+history.
+
+https://help.hevyapp.com/hc/en-us/articles/38001424401943-How-to-Import-Strong-App-CSV-Files-and-Export-Your-Data-in-Hevy

--- a/packages/assistant-engine/src/assistant-skill-assets.ts
+++ b/packages/assistant-engine/src/assistant-skill-assets.ts
@@ -203,7 +203,7 @@ export const ASSISTANT_SKILLS = [
     slug: 'connected-apps',
     name: 'connected-apps',
     triggerHint:
-      'Use when Murph needs connected email, calendar, documents, storage, notes, or tasks; an approved accountless service such as weather, places, provider registry, product search, or Instacart; account connection or removal; or connected-app context for another action. Owns account selection, narrow discovery and reads, limited calendar writes, privacy, and untrusted provider content.',
+      'Use when Murph needs connected email, calendar, documents, storage, notes, or tasks; an approved accountless service such as weather, places, provider registry, product search, or Instacart; account connection or removal; connected-app context for another action; or a verified manual export or one-time import fallback for a health or fitness source without a proven direct Murph connection. Owns account selection, narrow discovery and reads, limited calendar writes, verified provider export handoffs, privacy, and untrusted provider content.',
   },
   {
     slug: 'computer-use',

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -7,6 +7,7 @@ import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
 import { buildAssistantSystemPrompt } from '../src/assistant/system-prompt.js'
 
 const FUNCTION_DOCUMENTS_URL = 'https://my.functionhealth.com/documents'
+const LIVONGO_SIGN_IN_URL = 'https://my.livongo.com'
 const TELADOC_EXPORT_URL =
   'https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website'
 const STRONG_EXPORT_URL =
@@ -86,6 +87,7 @@ describe('assistant manual provider export guidance', () => {
     const normalizedReference = reference.replace(/\s+/gu, ' ')
 
     expect(reference).toContain(FUNCTION_DOCUMENTS_URL)
+    expect(reference).toContain(LIVONGO_SIGN_IN_URL)
     expect(reference).toContain(TELADOC_EXPORT_URL)
     expect(reference).toContain(STRONG_EXPORT_URL)
     expect(reference).toContain(HEVY_EXPORT_URL)
@@ -99,10 +101,16 @@ describe('assistant manual provider export guidance', () => {
     )
     expect(reference).toContain('`Reports and Data`')
     expect(normalizedReference).toContain(
+      'For the normal legacy handoff, use the Livongo sign-in page as the user-facing action link',
+    )
+    expect(normalizedReference).toContain(
       "download contains all of the member's data but does not state the file format",
     )
     expect(normalizedReference).toContain(
       'does not document an equivalent export menu',
+    )
+    expect(normalizedReference).toContain(
+      'Give the official export article below as the fallback action link',
     )
     expect(normalizedReference).toContain(
       'one-time snapshot, not continuous Teladoc sync',

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -1,0 +1,92 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveAssistantSkillsRoot,
+} from '../src/assistant-skill-assets.js'
+
+const FUNCTION_DOCUMENTS_URL = 'https://my.functionhealth.com/documents'
+const TELADOC_EXPORT_URL =
+  'https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website'
+const STRONG_EXPORT_URL =
+  'https://help.strongapp.io/article/235-export-workout-data'
+const HEVY_EXPORT_URL =
+  'https://help.hevyapp.com/hc/en-us/articles/38001424401943-How-to-Import-Strong-App-CSV-Files-and-Export-Your-Data-in-Hevy'
+
+function connectedAppsPath(...segments: readonly string[]): string {
+  return path.join(resolveAssistantSkillsRoot(), 'connected-apps', ...segments)
+}
+
+describe('assistant manual provider export guidance', () => {
+  it('routes unsupported health and fitness sources through verified export handoffs', async () => {
+    const [skill, reference] = await Promise.all([
+      readFile(connectedAppsPath('SKILL.md'), 'utf8'),
+      readFile(
+        connectedAppsPath('references', 'provider-data-exports.md'),
+        'utf8',
+      ),
+    ])
+
+    expect(skill).toContain('references/provider-data-exports.md')
+    expect(skill).toContain(
+      'manual export or one-time import rather than a live sync',
+    )
+    expect(skill).toContain(
+      'does not make that service a connected-app provider',
+    )
+    expect(reference).toContain(
+      'manual export or one-time import, not a live sync',
+    )
+    expect(reference).toContain(
+      'The trusted live provider list in the current prompt is authoritative',
+    )
+    expect(reference).toContain(
+      'Ask for the original downloaded file as-is',
+    )
+  })
+
+  it('keeps each provider route grounded in its official export instructions', async () => {
+    const reference = await readFile(
+      connectedAppsPath('references', 'provider-data-exports.md'),
+      'utf8',
+    )
+
+    expect(reference).toContain(FUNCTION_DOCUMENTS_URL)
+    expect(reference).toContain(TELADOC_EXPORT_URL)
+    expect(reference).toContain(STRONG_EXPORT_URL)
+    expect(reference).toContain(HEVY_EXPORT_URL)
+    expect(reference).toContain('`Reports and Data`')
+    expect(reference).toContain('does not state the file format')
+    expect(reference).toContain('`Export Strong Data`')
+    expect(reference).toContain('`Export Workouts`')
+    expect(reference).toContain('`Export Measurements`')
+    expect(reference).toContain(
+      'Treat `Teladoc`, `Teladoc Health`, and `Livongo` as aliases',
+    )
+  })
+
+  it('keeps the Function Health onboarding shortcut aligned with the shared catalog', async () => {
+    const [onboarding, reference] = await Promise.all([
+      readFile(
+        path.join(
+          resolveAssistantSkillsRoot(),
+          'murph-onboarding',
+          'references',
+          'aspiration-foundation-delegation.md',
+        ),
+        'utf8',
+      ),
+      readFile(
+        connectedAppsPath('references', 'provider-data-exports.md'),
+        'utf8',
+      ),
+    ])
+
+    expect(onboarding).toContain(FUNCTION_DOCUMENTS_URL)
+    expect(reference).toContain(FUNCTION_DOCUMENTS_URL)
+    expect(onboarding).toContain('Lab Results of Record')
+    expect(reference).toContain('Lab Results of Record')
+  })
+})

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -10,6 +10,8 @@ const FUNCTION_DOCUMENTS_URL = 'https://my.functionhealth.com/documents'
 const LIVONGO_SIGN_IN_URL = 'https://my.livongo.com'
 const TELADOC_EXPORT_URL =
   'https://library.teladochealth.com/hc/en-us/articles/360044659034-How-to-Export-Your-Personal-Data-from-the-Secure-Livongo-Website'
+const TELADOC_MIGRATION_URL =
+  'https://www.teladochealth.com/start/new-experience-faq'
 const STRONG_EXPORT_URL =
   'https://help.strongapp.io/article/235-export-workout-data'
 const HEVY_EXPORT_URL =
@@ -89,6 +91,7 @@ describe('assistant manual provider export guidance', () => {
     expect(reference).toContain(FUNCTION_DOCUMENTS_URL)
     expect(reference).toContain(LIVONGO_SIGN_IN_URL)
     expect(reference).toContain(TELADOC_EXPORT_URL)
+    expect(reference).toContain(TELADOC_MIGRATION_URL)
     expect(reference).toContain(STRONG_EXPORT_URL)
     expect(reference).toContain(HEVY_EXPORT_URL)
 
@@ -107,10 +110,21 @@ describe('assistant manual provider export guidance', () => {
       "download contains all of the member's data but does not state the file format",
     )
     expect(normalizedReference).toContain(
-      'does not document an equivalent export menu',
+      'choose `Condition Management`, then choose `Go to programs`',
+    )
+    expect(normalizedReference).not.toContain(
+      'under `Programs` → `Condition Management`',
     )
     expect(normalizedReference).toContain(
-      'Give the official export article below as the fallback action link',
+      'does not document an equivalent export control',
+    )
+    expect(normalizedReference).toContain(
+      'give the migration FAQ below as the fallback action link',
+    )
+    expect(normalizedReference).toContain('membersupport@livongo.com')
+    expect(normalizedReference).toContain('800-945-4355')
+    expect(normalizedReference).toContain(
+      'Send exactly one action link',
     )
     expect(normalizedReference).toContain(
       'one-time snapshot, not continuous Teladoc sync',

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -3,7 +3,10 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+import {
+  ASSISTANT_SKILLS,
+  resolveAssistantSkillsRoot,
+} from '../src/assistant-skill-assets.js'
 import { buildAssistantSystemPrompt } from '../src/assistant/system-prompt.js'
 
 const FUNCTION_DOCUMENTS_URL = 'https://my.functionhealth.com/documents'
@@ -47,7 +50,17 @@ describe('assistant manual provider export guidance', () => {
         'utf8',
       ),
     ])
+    const connectedAppsSkill = ASSISTANT_SKILLS.find(
+      (candidate) => candidate.slug === 'connected-apps',
+    )
 
+    expect(connectedAppsSkill).toBeTruthy()
+    expect(connectedAppsSkill?.triggerHint).toContain(
+      'verified manual export or one-time import fallback',
+    )
+    expect(connectedAppsSkill?.triggerHint).toContain(
+      'without a proven direct Murph connection',
+    )
     expect(buildDirectPrompt()).toContain(
       'Read `$MURPH_ASSISTANT_SKILLS_ROOT/connected-apps/SKILL.md`.',
     )

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -55,8 +55,14 @@ describe('assistant manual provider export guidance', () => {
     expect(skill).toContain(
       'does not make that service a connected-app provider',
     )
+
+    const normalizedSkill = skill.replace(/\s+/gu, ' ')
     const normalizedReference = reference.replace(/\s+/gu, ' ')
 
+    expect(normalizedSkill).toContain(
+      'verified fallback routes for Function Health, Livongo/Teladoc Condition Management, Strong, and Hevy',
+    )
+    expect(normalizedSkill).not.toContain('Teladoc Health/Livongo')
     expect(normalizedReference).toContain(
       'manual export or one-time import, not a live sync',
     )

--- a/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
+++ b/packages/assistant-engine/test/assistant-connected-app-provider-exports.test.ts
@@ -65,6 +65,15 @@ describe('assistant manual provider export guidance', () => {
     expect(normalizedSkill).toContain(
       'verified fallback routes for Function Health, Livongo/Teladoc Condition Management, Strong, and Hevy',
     )
+    expect(normalizedSkill).toContain(
+      "Give the provider's verified action link",
+    )
+    expect(normalizedSkill).toContain(
+      'an account or export page when one is documented, otherwise the official instructions',
+    )
+    expect(normalizedSkill).not.toContain(
+      "Give the provider's official export link",
+    )
     expect(normalizedSkill).not.toContain('Teladoc Health/Livongo')
     expect(normalizedReference).toContain(
       'manual export or one-time import, not a live sync',


### PR DESCRIPTION
## Why this PR exists

Members can have useful longitudinal health or workout history in services Murph cannot directly connect to. Murph needs a truthful, low-friction fallback that points to official provider exports, preserves the original artifact, and never misrepresents a file upload as continuous sync.

The original draft had two correctness gaps: it treated generic Teladoc requests too much like Livongo/Condition Management data, and it stopped at “send me the file” even though Murph already has structured Strong/Hevy workout importers.

The final review also exposed an existing CI scoping bug: the viewport-overflow script ran every Playwright spec, including an unrelated design-proof test that requires `DESIGN_PROOF_OUTPUT_DIR`. This PR narrows that script to its one intended overflow spec.

## User goal / user-visible behavior

When a member asks to bring data into Murph from an unsupported provider:

1. Murph checks the trusted live provider list first and uses a real connection when one exists.
2. Otherwise Murph gives the shortest verified first-party export steps and puts the official action link last.
3. Murph calls the result a manual export or one-time import, not live sync.
4. The member sends the original artifact back in their private Murph conversation.
5. Strong/Hevy workout CSVs are inspected and imported through the existing structured workout importer; other artifacts use the narrowest canonical health-record path their actual format supports.

For Livongo/Teladoc, the recipe applies only to Condition Management data such as blood pressure, weight, and glucose. Generic Teladoc visit notes, billing records, and encounter records are explicitly outside that route. Migrated members are told where Teladoc documents viewing their data, but Murph does not invent an undocumented export menu.

## User experience

- **Entry point:** a private member asks to connect, sync, export, import, migrate, or backfill data from Function Health, Livongo/Teladoc Condition Management, Strong, Hevy, or another unsupported source.
- **Immediate feedback:** Murph says whether it has a proven live connection or is offering a manual fallback, then gives only the relevant provider steps.
- **Success:** the member uploads the original export; Murph preserves provenance and imports structured facts through an existing canonical owner.
- **Failure / unavailable path:** Murph says the exact route is not verified, avoids guessing a menu or file type, and points to official provider documentation or support.
- **Group behavior:** Murph moves private account-data handoff to the member’s private conversation rather than asking for an upload in the room.
- **Timing:** export guidance is immediate; ingestion occurs after the member supplies the artifact.

## Invariants

- A provider is supported only when the trusted current provider list proves it.
- A file export is a snapshot, never proof of a live or continuously updating connection.
- Private health exports are not requested in group chat.
- Passwords, one-time codes, cookies, API keys, and recovery secrets are never requested in chat.
- Function Health remains user-operated because the existing computer-use policy forbids portal automation.
- Original artifacts and provenance are preserved; a chat summary or freeform memory is not a substitute for canonical ingestion.
- Teladoc/Livongo aliasing is scoped to Condition Management data, not all Teladoc records.
- Strong/Hevy workout writes occur only after the existing inspect command says the file is importable.
- The viewport-overflow CI command runs only the viewport-overflow spec.

## Non-obvious affected surfaces

- The direct assistant prompt already requires reading `connected-apps/SKILL.md`, so no new top-level skill or router entry is needed.
- Function Health onboarding retains its proactive Lab Results of Record shortcut; focused coverage keeps its URL and label aligned with the shared export catalog.
- Existing `vault-cli workout import inspect` and `vault-cli workout import csv` commands are reused for Strong and Hevy workout exports.
- The existing health-record ingestion invariant remains the owner after any file arrives.
- `.github/workflows/web-viewport-overflow.yml` invokes the package script; scoping the script prevents unrelated Playwright specs from entering that workflow without changing production behavior.

## Architecture and reuse

- **Existing systems reused:** connected-apps skill ownership, trusted live provider context, computer-use provider restrictions, health-record ingestion, Function Health onboarding, Strong/Hevy workout import commands, and the existing viewport-overflow Playwright spec.
- **New logic:** one provider-export reference catalog plus narrow provider-specific guardrails and importer instructions; one script-argument correction for the existing CI workflow.
- **New abstractions:** none beyond the reference file under the existing skill owner.
- **Complexity intentionally avoided:** no new top-level skill, skill registry entry, system-prompt route, database model, generic import framework, browser automation, unofficial provider API, second persistence path, or new CI workflow.

## Hot reply path impact

No new server calls, awaits, tool schemas, or runtime branches. The existing direct route already reads `connected-apps/SKILL.md`; this PR adds a small routing section there. The larger provider catalog is read only for a matching unsupported-source request. The package-script change affects test execution only.

## Murph initial provider input impact

Not applicable. This PR does not change the system/developer prompt builder, provider request assembly, admitted tool schemas, or initial model input. It changes on-disk skill content read after routing; the provider catalog is loaded only for matching requests.

## Preliminary specialist lenses

- **Product-experience lens: applicable.** Reviewed the complete unsupported-source journey from request through private export handoff, upload, structured import, and failure fallback.
- **Prompt lens: applicable.** Kept instructions under the existing owner, stated each invariant once, and avoided a second skill/router surface.
- **Frontend lens: not applicable.** No UI or visual surface changed.
- **Coverage lens: applicable.** Added focused regression coverage for direct-route reachability, native-support precedence, private handoff, narrow Teladoc scope, migrated-account honesty, exact official links, Strong/Hevy importer commands, Function onboarding alignment, and exact viewport-spec execution through CI.

ReviewGPT context sensitivity: sensitive

## Change-shape classification

| Category | Files | Additions | Deletions |
| --- | ---: | ---: | ---: |
| Source / runtime skill content | 2 | 181 | 1 |
| Tests | 1 | 156 | 0 |
| CI / package script | 1 | 1 | 1 |
| Generated artifacts | 0 | 0 | 0 |
| Config / docs / migrations | 0 | 0 | 0 |
| Total | 4 | 338 | 2 |

## Design proof

Not applicable; no frontend surface changed.

## Deployment skew

No persisted schema, API contract, or runtime state changed. Mixed deployments can differ only in assistant guidance text; the package-script correction is CI-only, so rollout ordering is safe.

## Validation

- Rechecked the complete final diff after merging the latest `main` into the branch.
- Re-verified the Teladoc/Livongo export article and migration FAQ, Strong export article, Hevy export article, and Function documents route against official sources on 2026-08-09.
- Verified the production workout CLI exposes `workout import inspect` and `workout import csv` with Strong/Hevy source hints.
- Ran a strict synthetic TypeScript compile of the focused test with TypeScript 5.8.3.
- Ran local provider-catalog contract assertions covering required and forbidden wording.
- Confirmed the viewport workflow failure came from an unchanged base-branch design-proof spec being unintentionally selected by the broad `playwright test` script, then narrowed the script to `e2e/viewport-overflow.spec.ts`.
- Confirmed the PR remains draft, open, unmerged, and up to date with `main`.

## Not run

- The full monorepo test suite was not run locally because this environment does not expose a repository checkout, `pnpm`, or the repository-required Node 24 runtime. Exact-head GitHub checks remain the authoritative full-suite signal.
- Managed-browser ReviewGPT was unavailable in this connector-only environment; the final cross-cutting review was performed manually against the full exact-head diff, repository architecture guidance, official provider documentation, and existing importer contracts.