### PR TITLE
perf(hosted): bound receipt scans and trace automation lane

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-09-receipt-scan-preprovider-timing.md
+++ b/agent-docs/exec-plans/active/2026-08-09-receipt-scan-preprovider-timing.md
@@ -1,0 +1,108 @@
+# Hosted receipt scan and pre-provider timing
+
+Status: active
+Updated: 2026-08-09
+
+## Goal
+
+Reduce the measured hosted receipt-history tail without weakening proactive
+message reply continuity, and partition the currently opaque automation-lane
+work before assistant service entry.
+
+Success means:
+
+- exact native replies and already-cheap history cases remain lazy;
+- the unanchored cross-session fallback still consumes each eligible proactive
+  delivery at most once and never replays an older delivery;
+- receipt inventory reads use bounded concurrency while parsing, quarantine,
+  ordering, locking, and metrics remain deterministic;
+- the provider-start trace carries adjacent metadata-only automation-lane
+  subdivisions whose sum equals the canonical lane duration;
+- no message content, route, identifier, path, prompt, transcript, or new
+  synchronous telemetry request is introduced; and
+- focused tests, owner typechecks, required audits, PR CI, and ReviewGPT pass.
+
+## Evidence
+
+- The production outlier spent 859 ms reading 232 receipt files totaling about
+  469 KB; lock wait was only 4 ms. The measured cost is serial local file reads
+  plus parsing and validation, not lock contention or remote object requests.
+- The full receipt check is needed only when an unanchored inbound message has
+  an eligible sent delivery from another assistant session. It prevents a
+  consumed proactive message, or an older one, from resurfacing as context.
+- Existing code already skips receipts for exact provider-native replies, no
+  matching delivery, same-session-only history, and future-stamped history.
+- The remaining inventory is read serially under the assistant runtime write
+  lock even though the outbox owner already uses fixed concurrency four.
+- Current monotonic telemetry jumps directly from automation-lane entry to
+  assistant-service entry across readiness, input selection, state, candidate,
+  operation-scope, evidence, session, history, prompt, and handoff work.
+
+## Implementation
+
+1. Refactor receipt inventory reads to read at most four files concurrently,
+   then parse, quarantine, and fold each batch serially in directory order.
+2. Preserve the existing full-history consumption truth and all cross-session
+   selection semantics. Do not add a persisted index, source-intent consumed
+   flag, session timestamp heuristic, cache, migration, or second state owner.
+3. Add adjacent monotonic timing boundaries for readiness, input selection,
+   pass setup, candidate scan, group/operation scope, terminal evidence,
+   session preflight, cross-session context, prompt preparation, and service
+   handoff. Drop the optional subdivision if any boundary is missing or
+   unordered while retaining the canonical trace.
+4. Attach only numeric nested diagnostics to the existing fire-and-forget
+   `provider_started` phase breakdown and update its strict shared parser.
+5. Add focused receipt concurrency/order/corruption/metrics tests plus timing
+   adjacency, propagation, sum, and parser tests. Update the live hosted runtime
+   protocol for the additive diagnostic contract.
+
+## Invariants
+
+- Current inbound replies remain foreground priority and cannot become silent.
+- Provider message ids outrank unanchored time-based context selection.
+- Only completed or deferred receipt evidence consumes cross-session context;
+  failed or running turns do not.
+- Assistant receipt/outbox/runtime mutations remain serialized under the
+  existing runtime write lock.
+- Corrupt receipt quarantine and runtime-event writes remain serialized.
+- Observability stays content-free, best-effort, and off the reply path.
+- Canonical provider-start additive fields do not change meaning; the new
+  leaves are nested diagnostics only.
+
+## Verification
+
+- Run focused Assistant Engine receipt, automation, and provider critical-path
+  tests.
+- Run focused Assistant Runtime maintenance and workspace operation-scope
+  tests.
+- Run focused Hosted Execution latency contract/parser tests.
+- Run typechecks for every touched owner and the narrow reverse dependents
+  identified by the verification map.
+- Inspect the final diff, run privacy/secret/path checks, complete the required
+  preliminary specialist ReviewGPT pass and final ReviewGPT gate concurrently
+  with exact-head CI, and resolve every accepted finding.
+
+Current local evidence:
+
+- the receipt inventory suite passes all six cases, including bounded read
+  concurrency, deterministic ordering/filtering/metrics, disappearing files,
+  and serialized corrupt-file quarantine;
+- Assistant Engine, Assistant Runtime, and Hosted Execution typechecks pass;
+- the Hosted Execution parser/emitter suite passes all 32 cases, including
+  incomplete and non-additive subdivision rejection; and
+- independent static reviews found no remaining receipt or timing blocker.
+
+The receipt change is a measured constant-factor correction, not an O(1)
+lookup. A first-use unconsumed candidate still requires a complete inventory
+proof because receipt filenames do not encode source intent. Do not introduce a
+recent-N cap; consider an existing-owner, crash-safe derived backpointer or a
+bounded lifecycle only if post-rollout cohort data shows material residual cost.
+
+## Deployment
+
+Deploy the Web parser before the hosted Cloudflare runner bundle because the
+older strict parser drops a phase breakdown containing unknown optional leaves.
+Old and new runners are behavior-compatible; no tandem correctness cutover or
+persisted workspace migration is required. After rollout, compare receipt scan
+latency for 200+ file cohorts and inspect the new automation subdivision before
+choosing any further deletion or state-layout change.

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1047,6 +1047,24 @@ stream EOF. Body consumption overlaps streamed hash/decrypt work and its
 backpressure, so it is not pure network-transfer latency. These two bounded
 numbers are appended to the existing in-memory staged phase breakdown; they do
 not add a request, awaited reporting step, per-chunk timer, or separate log.
+The same existing `provider_started` phase breakdown may subdivide
+`automationLaneToAssistantServiceMs` into ten adjacent monotonic durations:
+readiness, input selection, pass setup, candidate scan, group/operation scope,
+terminal evidence, session preflight, cross-session context, prompt preparation,
+and service handoff. When present, those ten values sum exactly to their parent;
+outbox and receipt-scan timings remain nested within cross-session context, and
+the subdivision adds no I/O or awaited reporting work. The emitter omits a
+partial or non-additive subdivision, and Web's best-effort parser drops the
+malformed phase breakdown without losing the core provider-start milestone.
+The complete subdivision is emitted only when the provider-producing group is
+the first group processed in that automation pass. If an earlier group finishes
+without reaching the provider, later provider starts retain the canonical path
+but omit the subdivision so earlier group work and pass-shared history scans are
+not misattributed; the scan-nesting statement applies only to an emitted complete
+subdivision.
+Because Web strictly parses phase-breakdown leaves, roll this telemetry out
+Web-first so its reader accepts the additive fields before a runner emits them;
+during rollback, remove the runner/Cloudflare emitter before rolling Web back.
 The web-owned `provider_started` field
 means the runtime observed a local Codex `turn/start`; it is not evidence of an
 upstream OpenAI request or first token. The runtime may also emit metadata-only

--- a/packages/assistant-engine/src/assistant/automation/operation-scope.ts
+++ b/packages/assistant-engine/src/assistant/automation/operation-scope.ts
@@ -1,4 +1,5 @@
 import type { AssistantExecutionContext } from '../execution-context.js'
+import type { AssistantProviderStartCriticalPathContext } from '../provider-start-critical-path.js'
 import type { AssistantTurnEnvironment } from '../service-contracts.js'
 
 export interface AssistantAutomationOperationScope {
@@ -8,7 +9,9 @@ export interface AssistantAutomationOperationScope {
     operation(
       executionContext: AssistantExecutionContext,
       turnEnvironment: AssistantTurnEnvironment | null,
+      providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null,
     ): Promise<T>
+    providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null
     turnEnvironment: AssistantTurnEnvironment | null
   }): Promise<T>
 }

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -26,8 +26,9 @@ import {
   isAssistantProviderStalledError,
 } from '../provider-failure-diagnostics.js'
 import type { AssistantProviderRequestStartTiming } from '../providers/types.js'
-import type {
-  AssistantProviderStartCriticalPathContext,
+import {
+  stampAssistantProviderStartCriticalPath,
+  type AssistantProviderStartCriticalPathContext,
 } from '../provider-start-critical-path.js'
 import type { AssistantProviderTraceEvent } from '../provider-traces.js'
 import type { AssistantProviderProgressEvent } from '../provider-progress.js'
@@ -195,6 +196,7 @@ interface AssistantAutoReplyReplyDecision {
   operatorAuthority: AssistantOperatorAuthority
   primaryInput: AssistantAutoReplyPrimaryInput
   prompt: string
+  providerStartCriticalPath: AssistantProviderStartCriticalPathContext | null
   turnContext: string | null
   userMessageContent: AssistantUserMessageContentPart[] | null
 }
@@ -567,6 +569,9 @@ async function resolveAssistantAutoReplyGroupOutcome(input: {
     group: context,
     onEvent: input.onEvent,
     historyReader: input.historyReader,
+    ...(input.providerStartCriticalPath
+      ? { providerStartCriticalPath: input.providerStartCriticalPath }
+      : {}),
     receiptFallbackEnabled: shouldUseAssistantAutoReplyReceiptFallback({
       deliveryDispatchMode: input.deliveryDispatchMode,
       executionContext: input.executionContext,
@@ -692,8 +697,8 @@ async function resolveAssistantAutoReplyGroupOutcome(input: {
     ...(input.beforeProviderAcceptedInputs
       ? { beforeProviderAcceptedInputs: input.beforeProviderAcceptedInputs }
       : {}),
-    ...(input.providerStartCriticalPath
-      ? { providerStartCriticalPath: input.providerStartCriticalPath }
+    ...(decision.providerStartCriticalPath
+      ? { providerStartCriticalPath: decision.providerStartCriticalPath }
       : {}),
     captureIds: context.optionalInboxCaptureIds,
     inputIds: context.inputIds,
@@ -1270,12 +1275,14 @@ async function evaluateAssistantAutoReplyGroup(input: {
   historyReader: AssistantAutoReplyHistoryReader
   group: AssistantAutoReplyGroupContext
   onEvent?: (event: AssistantRunEvent) => void
+  providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null
   receiptFallbackEnabled: boolean
   requestId: string | null
   sessionMaxAgeMs: number | null
   signal?: AbortSignal
   vault: string
 }): Promise<AssistantAutoReplyDecision> {
+  let providerStartCriticalPath = input.providerStartCriticalPath ?? null
   if (!input.enabledChannels.includes(input.group.firstItem.summary.source)) {
     return createAdvancingSkipDecision(
       'channel not enabled for assistant auto-reply',
@@ -1370,6 +1377,10 @@ async function evaluateAssistantAutoReplyGroup(input: {
       'assistant reply terminal evidence is incomplete; will retry this input after evidence is rebuilt.',
     )
   }
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    'automationTerminalEvidenceDoneAtMonotonicMs',
+  )
 
   let promptInputs = await loadAssistantAutoReplyPromptInputs({
     group: input.group,
@@ -1424,6 +1435,10 @@ async function evaluateAssistantAutoReplyGroup(input: {
     maxSessionAgeMs: input.sessionMaxAgeMs,
     vault: input.vault,
   })
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    'automationSessionPreflightDoneAtMonotonicMs',
+  )
   const bindingDeliveryTarget = readAutoReplyBindingDeliveryTarget(input.group)
   const conversationDeliveryTarget =
     bindingDeliveryTarget ?? readAutoReplyConversationDeliveryTarget(input.group)
@@ -1470,6 +1485,10 @@ async function evaluateAssistantAutoReplyGroup(input: {
           : readPromptInputsCrossSessionReplyToMessageId(promptInputs),
         session: existingSession,
       })
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    'automationCrossSessionContextDoneAtMonotonicMs',
+  )
   const affirmativeReaction =
     primaryReplyInput.sourceMetadata?.kind === 'linq' &&
     primaryReplyInput.sourceMetadata.affirmativeReaction === true
@@ -1506,6 +1525,10 @@ async function evaluateAssistantAutoReplyGroup(input: {
   if (preparedInput.kind === 'skip') {
     return createAdvancingSkipDecision(preparedInput.reason)
   }
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    'automationPromptPreparationDoneAtMonotonicMs',
+  )
 
   return {
     bindingDeliveryTarget,
@@ -1526,6 +1549,7 @@ async function evaluateAssistantAutoReplyGroup(input: {
     operatorAuthority: 'direct-operator',
     primaryInput: primaryReplyInput,
     prompt: preparedInput.prompt,
+    providerStartCriticalPath,
     turnContext: buildAssistantAutoReplyTurnContext({
       baseContext: affirmativeReaction
       ? buildAssistantAutoReplyReactionTurnContext(

--- a/packages/assistant-engine/src/assistant/automation/run-loop.ts
+++ b/packages/assistant-engine/src/assistant/automation/run-loop.ts
@@ -72,8 +72,9 @@ import { acquireAssistantAutomationRunLock } from './runtime-lock.js'
 import type { AssistantAutoReplyProviderRequestStartHook } from './reply.js'
 import type { AssistantBeforeProviderAcceptedInputsHook } from '../service-contracts.js'
 import type { AssistantAutomationOperationScope } from './operation-scope.js'
-import type {
-  AssistantProviderStartCriticalPathContext,
+import {
+  stampAssistantProviderStartCriticalPath,
+  type AssistantProviderStartCriticalPathContext,
 } from '../provider-start-critical-path.js'
 
 type AssistantAutomationLoopStateSnapshot = Pick<
@@ -927,6 +928,10 @@ export async function runAssistantAutomationPass(
     }
   }
   let state = await readAssistantAutomationState(input.vault)
+  const providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    input.providerStartCriticalPath,
+    'automationPassSetupDoneAtMonotonicMs',
+  )
   const stateBeforeScan = snapshotAssistantAutomationLoopState(state)
 
   const scanStartedAt = Date.now()
@@ -936,8 +941,8 @@ export async function runAssistantAutomationPass(
     ...(input.beforeProviderAcceptedInputs
       ? { beforeProviderAcceptedInputs: input.beforeProviderAcceptedInputs }
       : {}),
-    ...(input.providerStartCriticalPath
-      ? { providerStartCriticalPath: input.providerStartCriticalPath }
+    ...(providerStartCriticalPath
+      ? { providerStartCriticalPath }
       : {}),
     deliveryDispatchMode: input.deliveryDispatchMode,
     executionContext,

--- a/packages/assistant-engine/src/assistant/automation/scanner.ts
+++ b/packages/assistant-engine/src/assistant/automation/scanner.ts
@@ -10,8 +10,9 @@ import type {
   AssistantBeforeProviderAcceptedInputsHook,
   AssistantTurnEnvironment,
 } from '../service-contracts.js'
-import type {
-  AssistantProviderStartCriticalPathContext,
+import {
+  stampAssistantProviderStartCriticalPath,
+  type AssistantProviderStartCriticalPathContext,
 } from '../provider-start-critical-path.js'
 import {
   type AssistantInputCandidate,
@@ -89,6 +90,7 @@ export async function scanAssistantAutomationOnce(input: {
   const scanState = cloneAutomationScanState(input.state)
   let persistedState = cloneAutomationScanState(scanState)
   let providerStartCriticalPath = input.providerStartCriticalPath ?? null
+  let automationLaneSubdivisionEligible = true
   const onProviderRequestStarted: AssistantAutoReplyProviderRequestStartHook = (
     event,
   ) => {
@@ -126,6 +128,10 @@ export async function scanAssistantAutomationOnce(input: {
     signal: input.signal,
     vault: input.vault,
   })
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    'automationCandidateScanDoneAtMonotonicMs',
+  )
   if (candidates.length === 0) {
     return {
       currentTurnDeliveryIntentIds,
@@ -183,50 +189,80 @@ export async function scanAssistantAutomationOnce(input: {
     }
 
     replies.considered += context.inputCount
+    const groupProviderStartCriticalPath =
+      providerStartCriticalPath && !automationLaneSubdivisionEligible
+        ? {
+            ...providerStartCriticalPath,
+            automationLaneSubdivisionEligible: false as const,
+          }
+        : providerStartCriticalPath
     const processGroup = async (
       executionContext: AssistantExecutionContext | null | undefined,
       turnEnvironment: AssistantTurnEnvironment | null,
-    ) => await processAssistantAutoReplyGroup({
-      allowSelfAuthored: input.allowSelfAuthored ?? false,
-      ...(input.beforeProviderAcceptedInputs
-        ? { beforeProviderAcceptedInputs: input.beforeProviderAcceptedInputs }
-        : {}),
-      ...(providerStartCriticalPath
-        ? { providerStartCriticalPath }
-        : {}),
-      context,
-      deliveryDispatchMode: input.deliveryDispatchMode,
-      enabledChannels: replyChannels,
-      executionContext,
-      inboxServices: input.inboxServices,
-      onEvent: input.onEvent,
-      onProviderEvent: input.onProviderEvent ?? null,
-      onProviderRequestStarted:
-        providerStartCriticalPath || input.onProviderRequestStarted
-          ? onProviderRequestStarted
-          : null,
-      onTerminalNonReplyCommitted: input.onTerminalNonReplyCommitted ?? null,
-      onTraceEvent: input.onTraceEvent,
-      providerHeartbeatMs: input.providerHeartbeatMs,
-      providerLongRunningCommandStallTimeoutMs:
-        input.providerLongRunningCommandStallTimeoutMs,
-      providerStallTimeoutMs: input.providerStallTimeoutMs,
-      historyReader,
-      requestId: input.requestId ?? null,
-      signal: input.signal,
-      sessionMaxAgeMs: input.sessionMaxAgeMs ?? null,
-      turnEnvironment,
-      inputSource: input.inputSource,
-      vault: input.vault,
-    })
+      scopedProviderStartCriticalPath?:
+        AssistantProviderStartCriticalPathContext | null,
+    ) => {
+      const providerStartAtGroupAndOperationScopeDone =
+        scopedProviderStartCriticalPath === undefined
+          ? stampAssistantProviderStartCriticalPath(
+              groupProviderStartCriticalPath,
+              'automationGroupAndOperationScopeDoneAtMonotonicMs',
+            )
+          : scopedProviderStartCriticalPath
+      return await processAssistantAutoReplyGroup({
+        allowSelfAuthored: input.allowSelfAuthored ?? false,
+        ...(input.beforeProviderAcceptedInputs
+          ? { beforeProviderAcceptedInputs: input.beforeProviderAcceptedInputs }
+          : {}),
+        ...(providerStartAtGroupAndOperationScopeDone
+          ? {
+              providerStartCriticalPath:
+                providerStartAtGroupAndOperationScopeDone,
+            }
+          : {}),
+        context,
+        deliveryDispatchMode: input.deliveryDispatchMode,
+        enabledChannels: replyChannels,
+        executionContext,
+        inboxServices: input.inboxServices,
+        onEvent: input.onEvent,
+        onProviderEvent: input.onProviderEvent ?? null,
+        onProviderRequestStarted:
+          providerStartCriticalPath || input.onProviderRequestStarted
+            ? onProviderRequestStarted
+            : null,
+        onTerminalNonReplyCommitted: input.onTerminalNonReplyCommitted ?? null,
+        onTraceEvent: input.onTraceEvent,
+        providerHeartbeatMs: input.providerHeartbeatMs,
+        providerLongRunningCommandStallTimeoutMs:
+          input.providerLongRunningCommandStallTimeoutMs,
+        providerStallTimeoutMs: input.providerStallTimeoutMs,
+        historyReader,
+        requestId: input.requestId ?? null,
+        signal: input.signal,
+        sessionMaxAgeMs: input.sessionMaxAgeMs ?? null,
+        turnEnvironment,
+        inputSource: input.inputSource,
+        vault: input.vault,
+      })
+    }
     const replyResult = input.operationScope && input.executionContext
       ? await input.operationScope.runAutoReplyGroup({
           executionContext: input.executionContext,
           inputIds: context.inputIds,
           operation: processGroup,
+          providerStartCriticalPath: groupProviderStartCriticalPath,
           turnEnvironment: input.turnEnvironment ?? null,
         })
-      : await processGroup(input.executionContext, input.turnEnvironment ?? null)
+      : await processGroup(
+          input.executionContext,
+          input.turnEnvironment ?? null,
+          stampAssistantProviderStartCriticalPath(
+            groupProviderStartCriticalPath,
+            'automationGroupAndOperationScopeDoneAtMonotonicMs',
+          ),
+        )
+    automationLaneSubdivisionEligible = false
     const stopReplyScan = applyAssistantAutoReplyProcessResult({
       context,
       result: replyResult,

--- a/packages/assistant-engine/src/assistant/provider-start-critical-path.ts
+++ b/packages/assistant-engine/src/assistant/provider-start-critical-path.ts
@@ -5,7 +5,17 @@ export interface AssistantProviderStartCriticalPathContext {
   readonly assistantServiceStartedAtMonotonicMs?: number
   readonly assistantTurnLockAcquiredAtMonotonicMs?: number
   readonly assistantTurnLockWaitStartedAtMonotonicMs?: number
+  readonly automationLaneSubdivisionEligible?: false
+  readonly automationCandidateScanDoneAtMonotonicMs?: number
+  readonly automationCrossSessionContextDoneAtMonotonicMs?: number
+  readonly automationGroupAndOperationScopeDoneAtMonotonicMs?: number
+  readonly automationInputSelectionDoneAtMonotonicMs?: number
   readonly automationLaneStartedAtMonotonicMs?: number
+  readonly automationPassSetupDoneAtMonotonicMs?: number
+  readonly automationPromptPreparationDoneAtMonotonicMs?: number
+  readonly automationReadinessDoneAtMonotonicMs?: number
+  readonly automationSessionPreflightDoneAtMonotonicMs?: number
+  readonly automationTerminalEvidenceDoneAtMonotonicMs?: number
   readonly codexAppServerProcessTurnStartedAtMonotonicMs?: number
   readonly codexAppServerTurnStartedAtMonotonicMs?: number
   readonly mailboxImportDoneAtMonotonicMs: number
@@ -17,14 +27,33 @@ export type AssistantProviderStartCriticalPathBoundary =
   | 'assistantServiceStartedAtMonotonicMs'
   | 'assistantTurnLockAcquiredAtMonotonicMs'
   | 'assistantTurnLockWaitStartedAtMonotonicMs'
+  | 'automationCandidateScanDoneAtMonotonicMs'
+  | 'automationCrossSessionContextDoneAtMonotonicMs'
+  | 'automationGroupAndOperationScopeDoneAtMonotonicMs'
+  | 'automationInputSelectionDoneAtMonotonicMs'
   | 'automationLaneStartedAtMonotonicMs'
+  | 'automationPassSetupDoneAtMonotonicMs'
+  | 'automationPromptPreparationDoneAtMonotonicMs'
+  | 'automationReadinessDoneAtMonotonicMs'
+  | 'automationSessionPreflightDoneAtMonotonicMs'
+  | 'automationTerminalEvidenceDoneAtMonotonicMs'
   | 'codexAppServerProcessTurnStartedAtMonotonicMs'
   | 'codexAppServerTurnStartedAtMonotonicMs'
   | 'preProviderSetupDoneAtMonotonicMs'
 
 export interface AssistantProviderStartCriticalPathTiming {
   assistantServicePreLockMs: number
+  automationCandidateScanMs?: number
+  automationCrossSessionContextMs?: number
+  automationGroupAndOperationScopeMs?: number
+  automationInputSelectionMs?: number
   automationLaneToAssistantServiceMs: number
+  automationPassSetupMs?: number
+  automationPromptPreparationMs?: number
+  automationReadinessMs?: number
+  automationServiceHandoffMs?: number
+  automationSessionPreflightMs?: number
+  automationTerminalEvidenceMs?: number
   codexAppServerPreProviderMs: number
   codexProcessPreparationMs: number
   mailboxImportDoneToAssistantPhaseMs: number
@@ -107,6 +136,8 @@ export function completeAssistantProviderStartCriticalPath(
     providerStarted,
   ] = boundaries as [number, number, number, number, number, number, number, number, number, number]
 
+  const automationLaneTiming = completeAssistantAutomationLaneTiming(context)
+
   return {
     mailboxImportDoneToAssistantPhaseMs:
       assistantPhaseStarted - mailboxImportDone,
@@ -114,6 +145,7 @@ export function completeAssistantProviderStartCriticalPath(
       automationLaneStarted - assistantPhaseStarted,
     automationLaneToAssistantServiceMs:
       assistantServiceStarted - automationLaneStarted,
+    ...(automationLaneTiming ?? {}),
     assistantServicePreLockMs:
       turnLockWaitStarted - assistantServiceStarted,
     turnLockWaitMs: turnLockAcquired - turnLockWaitStarted,
@@ -124,5 +156,99 @@ export function completeAssistantProviderStartCriticalPath(
       codexAppServerProcessTurnStarted - codexAppServerTurnStarted,
     codexAppServerPreProviderMs:
       providerStarted - codexAppServerProcessTurnStarted,
+  }
+}
+
+function completeAssistantAutomationLaneTiming(
+  context: AssistantProviderStartCriticalPathContext,
+): Pick<
+  AssistantProviderStartCriticalPathTiming,
+  | 'automationCandidateScanMs'
+  | 'automationCrossSessionContextMs'
+  | 'automationGroupAndOperationScopeMs'
+  | 'automationInputSelectionMs'
+  | 'automationPassSetupMs'
+  | 'automationPromptPreparationMs'
+  | 'automationReadinessMs'
+  | 'automationServiceHandoffMs'
+  | 'automationSessionPreflightMs'
+  | 'automationTerminalEvidenceMs'
+> | null {
+  if (context.automationLaneSubdivisionEligible === false) {
+    return null
+  }
+  const boundaries = [
+    context.automationLaneStartedAtMonotonicMs,
+    context.automationReadinessDoneAtMonotonicMs,
+    context.automationInputSelectionDoneAtMonotonicMs,
+    context.automationPassSetupDoneAtMonotonicMs,
+    context.automationCandidateScanDoneAtMonotonicMs,
+    context.automationGroupAndOperationScopeDoneAtMonotonicMs,
+    context.automationTerminalEvidenceDoneAtMonotonicMs,
+    context.automationSessionPreflightDoneAtMonotonicMs,
+    context.automationCrossSessionContextDoneAtMonotonicMs,
+    context.automationPromptPreparationDoneAtMonotonicMs,
+    context.assistantServiceStartedAtMonotonicMs,
+  ]
+  let previousBoundary: number | null = null
+  for (const boundary of boundaries) {
+    if (
+      typeof boundary !== 'number'
+      || !Number.isSafeInteger(boundary)
+      || boundary < 0
+      || (previousBoundary !== null && boundary < previousBoundary)
+    ) {
+      return null
+    }
+    previousBoundary = boundary
+  }
+
+  const [
+    automationLaneStarted,
+    automationReadinessDone,
+    automationInputSelectionDone,
+    automationPassSetupDone,
+    automationCandidateScanDone,
+    automationGroupAndOperationScopeDone,
+    automationTerminalEvidenceDone,
+    automationSessionPreflightDone,
+    automationCrossSessionContextDone,
+    automationPromptPreparationDone,
+    assistantServiceStarted,
+  ] = boundaries as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ]
+
+  return {
+    automationReadinessMs:
+      automationReadinessDone - automationLaneStarted,
+    automationInputSelectionMs:
+      automationInputSelectionDone - automationReadinessDone,
+    automationPassSetupMs:
+      automationPassSetupDone - automationInputSelectionDone,
+    automationCandidateScanMs:
+      automationCandidateScanDone - automationPassSetupDone,
+    automationGroupAndOperationScopeMs:
+      automationGroupAndOperationScopeDone - automationCandidateScanDone,
+    automationTerminalEvidenceMs:
+      automationTerminalEvidenceDone - automationGroupAndOperationScopeDone,
+    automationSessionPreflightMs:
+      automationSessionPreflightDone - automationTerminalEvidenceDone,
+    automationCrossSessionContextMs:
+      automationCrossSessionContextDone - automationSessionPreflightDone,
+    automationPromptPreparationMs:
+      automationPromptPreparationDone - automationCrossSessionContextDone,
+    automationServiceHandoffMs:
+      assistantServiceStarted - automationPromptPreparationDone,
   }
 }

--- a/packages/assistant-engine/src/assistant/turns.ts
+++ b/packages/assistant-engine/src/assistant/turns.ts
@@ -32,6 +32,7 @@ import {
 } from './redaction.js'
 
 const ASSISTANT_TURN_RECEIPT_SCHEMA = 'murph.assistant-turn-receipt.v1'
+const ASSISTANT_TURN_RECEIPT_READ_CONCURRENCY = 4
 const PROVIDER_MODEL_PREVIEW_LIMIT = 240
 const TURN_TEXT_PREVIEW_HASH_LENGTH = 12
 
@@ -300,24 +301,43 @@ async function listRecentAssistantTurnReceiptsInternal(
     let filesRead = 0
     const receipts: AssistantTurnReceipt[] = []
 
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.json')) {
-        continue
-      }
-
-      const receipt = await readAssistantTurnReceiptAtPath(
-        paths,
-        path.join(paths.turnsDirectory, entry.name),
-        (bytes) => {
-          filesRead += 1
-          bytesRead += bytes
-        },
+    const receiptEntries = entries.filter(
+      (entry) => entry.isFile() && entry.name.endsWith('.json'),
+    )
+    for (
+      let index = 0;
+      index < receiptEntries.length;
+      index += ASSISTANT_TURN_RECEIPT_READ_CONCURRENCY
+    ) {
+      const batch = receiptEntries.slice(
+        index,
+        index + ASSISTANT_TURN_RECEIPT_READ_CONCURRENCY,
       )
-      if (!receipt || (sessionFilter && receipt.sessionId !== sessionFilter)) {
-        continue
-      }
+      const rawReceipts = await Promise.all(
+        batch.map((entry) =>
+          readAssistantTurnReceiptRawAtPath(
+            path.join(paths.turnsDirectory, entry.name),
+          ),
+        ),
+      )
 
-      insertRecentAssistantTurnReceipt(receipts, receipt, normalizedLimit)
+      // Parse and quarantine in directory order so parallel reads do not turn
+      // quarantine writes or timestamp ties into concurrent side effects.
+      for (const rawReceipt of rawReceipts) {
+        const receipt = await parseAssistantTurnReceiptRawAtPath(
+          paths,
+          rawReceipt,
+          (bytes) => {
+            filesRead += 1
+            bytesRead += bytes
+          },
+        )
+        if (!receipt || (sessionFilter && receipt.sessionId !== sessionFilter)) {
+          continue
+        }
+
+        insertRecentAssistantTurnReceipt(receipts, receipt, normalizedLimit)
+      }
     }
 
     return {
@@ -375,25 +395,86 @@ async function readAssistantTurnReceiptAtPath(
   receiptPath: string,
   onBytesRead?: (bytes: number) => void,
 ): Promise<AssistantTurnReceipt | null> {
-  let raw: string | null = null
-  try {
-    raw = await readFile(receiptPath, 'utf8')
-    onBytesRead?.(Buffer.byteLength(raw, 'utf8'))
-    return assistantTurnReceiptSchema.parse(JSON.parse(raw))
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return null
+  return await parseAssistantTurnReceiptRawAtPath(
+    paths,
+    await readAssistantTurnReceiptRawAtPath(receiptPath),
+    onBytesRead,
+  )
+}
+
+type AssistantTurnReceiptRawRead =
+  | {
+      kind: 'error'
+      error: unknown
+      receiptPath: string
+    }
+  | {
+      kind: 'missing'
+      receiptPath: string
+    }
+  | {
+      kind: 'read'
+      raw: string
+      receiptPath: string
     }
 
-    await quarantineAssistantStateFile({
-      artifactKind: 'turn-receipt',
+async function readAssistantTurnReceiptRawAtPath(
+  receiptPath: string,
+): Promise<AssistantTurnReceiptRawRead> {
+  try {
+    return {
+      kind: 'read',
+      raw: await readFile(receiptPath, 'utf8'),
+      receiptPath,
+    }
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return {
+        kind: 'missing',
+        receiptPath,
+      }
+    }
+
+    return {
       error,
-      ...(raw === null ? {} : { expectedContent: raw }),
-      filePath: receiptPath,
-      paths,
-    }).catch(() => undefined)
+      kind: 'error',
+      receiptPath,
+    }
+  }
+}
+
+async function parseAssistantTurnReceiptRawAtPath(
+  paths: AssistantStatePaths,
+  input: AssistantTurnReceiptRawRead,
+  onBytesRead?: (bytes: number) => void,
+): Promise<AssistantTurnReceipt | null> {
+  if (input.kind === 'missing') {
     return null
   }
+
+  if (input.kind === 'read') {
+    try {
+      onBytesRead?.(Buffer.byteLength(input.raw, 'utf8'))
+      return assistantTurnReceiptSchema.parse(JSON.parse(input.raw))
+    } catch (error) {
+      await quarantineAssistantStateFile({
+        artifactKind: 'turn-receipt',
+        error,
+        expectedContent: input.raw,
+        filePath: input.receiptPath,
+        paths,
+      }).catch(() => undefined)
+      return null
+    }
+  }
+
+  await quarantineAssistantStateFile({
+    artifactKind: 'turn-receipt',
+    error: input.error,
+    filePath: input.receiptPath,
+    paths,
+  }).catch(() => undefined)
+  return null
 }
 
 async function writeAssistantTurnReceiptAtPath(

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -1642,7 +1642,7 @@ describe('assistant automation scanner', () => {
     }
   })
 
-  it('consumes provider-start timing only when the first group reaches the provider', async () => {
+  it('preserves canonical provider-start timing but suppresses mixed-work subdivision after an earlier group', async () => {
     const captures = [
       createCaptureSummary({
         captureId: 'capture-timing-no-provider',
@@ -1698,11 +1698,73 @@ describe('assistant automation scanner', () => {
     })
 
     expect(receivedCriticalPaths).toEqual([
-      providerStartCriticalPath,
-      providerStartCriticalPath,
+      expect.objectContaining({
+        ...providerStartCriticalPath,
+        automationCandidateScanDoneAtMonotonicMs: expect.any(Number),
+        automationGroupAndOperationScopeDoneAtMonotonicMs: expect.any(Number),
+      }),
+      expect.objectContaining({
+        ...providerStartCriticalPath,
+        automationCandidateScanDoneAtMonotonicMs: expect.any(Number),
+        automationGroupAndOperationScopeDoneAtMonotonicMs: expect.any(Number),
+        automationLaneSubdivisionEligible: false,
+      }),
       undefined,
     ])
+    expect(receivedCriticalPaths[0]).not.toHaveProperty(
+      'automationLaneSubdivisionEligible',
+    )
     expect(onProviderRequestStarted).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates the automation timing context through scanning and reply preparation', async () => {
+    const capture = createCaptureSummary({
+      captureId: 'capture-timing-propagation',
+      occurredAt: '2026-04-08T00:01:00.000Z',
+    })
+    const reply = await vi.importActual<
+      typeof import('../src/assistant/automation/reply.ts')
+    >('../src/assistant/automation/reply.ts')
+    scannerReplyMocks.processAssistantAutoReplyGroup.mockImplementationOnce(
+      async (groupInput) => await reply.processAssistantAutoReplyGroup(groupInput),
+    )
+    const scanner = await vi.importActual<
+      typeof import('../src/assistant/automation/scanner.ts')
+    >('../src/assistant/automation/scanner.ts')
+
+    await scanner.scanAssistantAutomationOnce({
+      inboxServices: createInboxServices(),
+      inputSource: createAssistantInputSourceForCaptures([capture]),
+      providerStartCriticalPath: {
+        automationInputSelectionDoneAtMonotonicMs: 0,
+        automationLaneStartedAtMonotonicMs: 0,
+        automationPassSetupDoneAtMonotonicMs: 0,
+        automationReadinessDoneAtMonotonicMs: 0,
+        mailboxImportDoneAtMonotonicMs: 0,
+      },
+      state: createAutomationState({
+        autoReplyChannels: ['telegram'],
+      }),
+      vault: '/tmp/assistant-automation-vault',
+    })
+
+    expect(replyMocks.sendAssistantMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerStartCriticalPath: expect.objectContaining({
+          automationCandidateScanDoneAtMonotonicMs: expect.any(Number),
+          automationCrossSessionContextDoneAtMonotonicMs: expect.any(Number),
+          automationGroupAndOperationScopeDoneAtMonotonicMs: expect.any(Number),
+          automationInputSelectionDoneAtMonotonicMs: 0,
+          automationLaneStartedAtMonotonicMs: 0,
+          automationPassSetupDoneAtMonotonicMs: 0,
+          automationPromptPreparationDoneAtMonotonicMs: expect.any(Number),
+          automationReadinessDoneAtMonotonicMs: 0,
+          automationSessionPreflightDoneAtMonotonicMs: expect.any(Number),
+          automationTerminalEvidenceDoneAtMonotonicMs: expect.any(Number),
+          mailboxImportDoneAtMonotonicMs: 0,
+        }),
+      }),
+    )
   })
 
   it('advances the auto-reply channel cursor with the processed assistant input cursor', async () => {
@@ -6736,6 +6798,12 @@ describe('assistant auto-reply runtime', () => {
       beforeProviderAcceptedInputs,
       executionContext,
       onProviderEvent,
+      providerStartCriticalPath: {
+        automationInputSelectionDoneAtMonotonicMs: 0,
+        automationLaneStartedAtMonotonicMs: 0,
+        automationReadinessDoneAtMonotonicMs: 0,
+        mailboxImportDoneAtMonotonicMs: 0,
+      },
       requestId: 'request-hosted',
       vault: '/tmp/assistant-automation-vault',
     })
@@ -6748,6 +6816,13 @@ describe('assistant auto-reply runtime', () => {
         beforeProviderAcceptedInputs,
         executionContext,
         onProviderEvent,
+        providerStartCriticalPath: expect.objectContaining({
+          automationInputSelectionDoneAtMonotonicMs: 0,
+          automationLaneStartedAtMonotonicMs: 0,
+          automationPassSetupDoneAtMonotonicMs: expect.any(Number),
+          automationReadinessDoneAtMonotonicMs: 0,
+          mailboxImportDoneAtMonotonicMs: 0,
+        }),
         inputSource: expect.objectContaining({
           listInputCandidates: expect.any(Function),
           listNewConversationInputs: expect.any(Function),

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -41,6 +41,9 @@ import { resolveAssistantConversationKey } from '../src/assistant/bindings.ts'
 import {
   ASSISTANT_IMAGE_RESPONSE_TRANSCRIPT_MARKER,
 } from '../src/assistant/response-media.ts'
+import type {
+  AssistantProviderStartCriticalPathContext,
+} from '../src/assistant/provider-start-critical-path.ts'
 import { readAssistantTranscriptEntries } from '../src/assistant/store/persistence.ts'
 import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
 import { createTempVaultContext } from './test-helpers.ts'
@@ -2374,12 +2377,7 @@ test('sendAssistantMessageLocal reports thrown preceding delivery when no final 
 test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProviderRequestStarted', async () => {
   const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule()
   let providerStartCriticalPath:
-    | {
-        assistantServiceStartedAtMonotonicMs?: number
-        assistantTurnLockAcquiredAtMonotonicMs?: number
-        assistantTurnLockWaitStartedAtMonotonicMs?: number
-        preProviderSetupDoneAtMonotonicMs?: number
-      }
+    | AssistantProviderStartCriticalPathContext
     | null
     | undefined
 
@@ -2413,7 +2411,16 @@ test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProvi
     onProviderRequestStarted: providerRequestStarted,
     providerStartCriticalPath: {
       assistantPhaseStartedAtMonotonicMs: 0,
+      automationCandidateScanDoneAtMonotonicMs: 0,
+      automationCrossSessionContextDoneAtMonotonicMs: 0,
+      automationGroupAndOperationScopeDoneAtMonotonicMs: 0,
+      automationInputSelectionDoneAtMonotonicMs: 0,
       automationLaneStartedAtMonotonicMs: 0,
+      automationPassSetupDoneAtMonotonicMs: 0,
+      automationPromptPreparationDoneAtMonotonicMs: 0,
+      automationReadinessDoneAtMonotonicMs: 0,
+      automationSessionPreflightDoneAtMonotonicMs: 0,
+      automationTerminalEvidenceDoneAtMonotonicMs: 0,
       mailboxImportDoneAtMonotonicMs: 0,
     },
     prompt: 'Measure setup split',
@@ -2425,6 +2432,16 @@ test('sendAssistantMessageLocal surfaces the provider setup sub-split on onProvi
     assistantServiceStartedAtMonotonicMs: expect.any(Number),
     assistantTurnLockAcquiredAtMonotonicMs: expect.any(Number),
     assistantTurnLockWaitStartedAtMonotonicMs: expect.any(Number),
+    automationCandidateScanDoneAtMonotonicMs: 0,
+    automationCrossSessionContextDoneAtMonotonicMs: 0,
+    automationGroupAndOperationScopeDoneAtMonotonicMs: 0,
+    automationInputSelectionDoneAtMonotonicMs: 0,
+    automationLaneStartedAtMonotonicMs: 0,
+    automationPassSetupDoneAtMonotonicMs: 0,
+    automationPromptPreparationDoneAtMonotonicMs: 0,
+    automationReadinessDoneAtMonotonicMs: 0,
+    automationSessionPreflightDoneAtMonotonicMs: 0,
+    automationTerminalEvidenceDoneAtMonotonicMs: 0,
     preProviderSetupDoneAtMonotonicMs: expect.any(Number),
   }))
   expect(

--- a/packages/assistant-engine/test/assistant-provider-start-critical-path.test.ts
+++ b/packages/assistant-engine/test/assistant-provider-start-critical-path.test.ts
@@ -21,6 +21,51 @@ describe('assistant provider-start critical path', () => {
     )!
     context = stampAssistantProviderStartCriticalPath(
       context,
+      'automationReadinessDoneAtMonotonicMs',
+      132,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationInputSelectionDoneAtMonotonicMs',
+      135,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationPassSetupDoneAtMonotonicMs',
+      139,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationCandidateScanDoneAtMonotonicMs',
+      142,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationGroupAndOperationScopeDoneAtMonotonicMs',
+      145,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationTerminalEvidenceDoneAtMonotonicMs',
+      148,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationSessionPreflightDoneAtMonotonicMs',
+      152,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationCrossSessionContextDoneAtMonotonicMs',
+      155,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
+      'automationPromptPreparationDoneAtMonotonicMs',
+      158,
+    )!
+    context = stampAssistantProviderStartCriticalPath(
+      context,
       'assistantServiceStartedAtMonotonicMs',
       160,
     )!
@@ -53,7 +98,17 @@ describe('assistant provider-start critical path', () => {
     const timing = completeAssistantProviderStartCriticalPath(context, 270)
     expect(timing).toEqual({
       assistantServicePreLockMs: 5,
+      automationCandidateScanMs: 3,
+      automationCrossSessionContextMs: 3,
+      automationGroupAndOperationScopeMs: 3,
+      automationInputSelectionMs: 3,
       automationLaneToAssistantServiceMs: 30,
+      automationPassSetupMs: 4,
+      automationPromptPreparationMs: 3,
+      automationReadinessMs: 2,
+      automationServiceHandoffMs: 2,
+      automationSessionPreflightMs: 4,
+      automationTerminalEvidenceMs: 3,
       codexAppServerPreProviderMs: 30,
       codexProcessPreparationMs: 10,
       mailboxImportDoneToAssistantPhaseMs: 10,
@@ -62,8 +117,88 @@ describe('assistant provider-start critical path', () => {
       turnLockWaitMs: 7,
       workspaceAssistantPreAutomationMs: 20,
     })
-    expect(Object.values(timing ?? {}).reduce((sum, value) => sum + value, 0))
+    const canonicalTiming = timing && [
+      timing.mailboxImportDoneToAssistantPhaseMs,
+      timing.workspaceAssistantPreAutomationMs,
+      timing.automationLaneToAssistantServiceMs,
+      timing.assistantServicePreLockMs,
+      timing.turnLockWaitMs,
+      timing.preProviderSetupMs,
+      timing.providerPlanAndGateMs,
+      timing.codexProcessPreparationMs,
+      timing.codexAppServerPreProviderMs,
+    ]
+    expect(canonicalTiming?.reduce((sum, value) => sum + value, 0))
       .toBe(170)
+    const automationLaneTiming = timing && [
+      timing.automationReadinessMs,
+      timing.automationInputSelectionMs,
+      timing.automationPassSetupMs,
+      timing.automationCandidateScanMs,
+      timing.automationGroupAndOperationScopeMs,
+      timing.automationTerminalEvidenceMs,
+      timing.automationSessionPreflightMs,
+      timing.automationCrossSessionContextMs,
+      timing.automationPromptPreparationMs,
+      timing.automationServiceHandoffMs,
+    ]
+    expect(automationLaneTiming?.reduce<number>(
+      (sum, value) => sum + (value ?? 0),
+      0,
+    )).toBe(timing?.automationLaneToAssistantServiceMs)
+  })
+
+  test('drops an incomplete or invalid nested automation partition without losing the canonical path', () => {
+    const timing = completeAssistantProviderStartCriticalPath({
+      assistantPhaseStartedAtMonotonicMs: 110,
+      assistantServiceStartedAtMonotonicMs: 160,
+      assistantTurnLockAcquiredAtMonotonicMs: 172,
+      assistantTurnLockWaitStartedAtMonotonicMs: 165,
+      automationLaneStartedAtMonotonicMs: 130,
+      automationReadinessDoneAtMonotonicMs: 129,
+      codexAppServerProcessTurnStartedAtMonotonicMs: 240,
+      codexAppServerTurnStartedAtMonotonicMs: 230,
+      mailboxImportDoneAtMonotonicMs: 100,
+      preProviderSetupDoneAtMonotonicMs: 190,
+    }, 270)
+
+    expect(timing).toMatchObject({
+      automationLaneToAssistantServiceMs: 30,
+      mailboxImportDoneToAssistantPhaseMs: 10,
+    })
+    expect(timing).not.toHaveProperty('automationReadinessMs')
+    expect(timing).not.toHaveProperty('automationServiceHandoffMs')
+  })
+
+  test('keeps the canonical path but omits mixed-work automation subdivision timing', () => {
+    const timing = completeAssistantProviderStartCriticalPath({
+      assistantPhaseStartedAtMonotonicMs: 110,
+      assistantServiceStartedAtMonotonicMs: 160,
+      assistantTurnLockAcquiredAtMonotonicMs: 172,
+      assistantTurnLockWaitStartedAtMonotonicMs: 170,
+      automationCandidateScanDoneAtMonotonicMs: 142,
+      automationCrossSessionContextDoneAtMonotonicMs: 155,
+      automationGroupAndOperationScopeDoneAtMonotonicMs: 145,
+      automationInputSelectionDoneAtMonotonicMs: 135,
+      automationLaneStartedAtMonotonicMs: 130,
+      automationLaneSubdivisionEligible: false,
+      automationPassSetupDoneAtMonotonicMs: 139,
+      automationPromptPreparationDoneAtMonotonicMs: 158,
+      automationReadinessDoneAtMonotonicMs: 132,
+      automationSessionPreflightDoneAtMonotonicMs: 152,
+      automationTerminalEvidenceDoneAtMonotonicMs: 148,
+      codexAppServerProcessTurnStartedAtMonotonicMs: 202,
+      codexAppServerTurnStartedAtMonotonicMs: 190,
+      mailboxImportDoneAtMonotonicMs: 100,
+      preProviderSetupDoneAtMonotonicMs: 177,
+    }, 220)
+
+    expect(timing).toEqual(expect.objectContaining({
+      automationLaneToAssistantServiceMs: 30,
+      mailboxImportDoneToAssistantPhaseMs: 10,
+    }))
+    expect(timing).not.toHaveProperty('automationReadinessMs')
+    expect(timing).not.toHaveProperty('automationServiceHandoffMs')
   })
 
   test('fails open when a boundary is absent, unsafe, or out of order', () => {

--- a/packages/assistant-engine/test/assistant-turns.test.ts
+++ b/packages/assistant-engine/test/assistant-turns.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { listAssistantQuarantineEntriesAtPaths } from '../src/assistant/quarantine.ts'
 import { listAssistantRuntimeEventsAtPath } from '../src/assistant/runtime-events.ts'
@@ -25,6 +25,9 @@ import { createTempVaultContext } from './test-helpers.ts'
 const tempRoots: string[] = []
 
 afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  vi.doUnmock('node:fs/promises')
   await Promise.all(
     tempRoots.splice(0).map((rootPath) =>
       rm(rootPath, {
@@ -345,6 +348,219 @@ describe('assistant turns', () => {
     expect(oneRecent.map((receipt) => receipt.turnId)).toEqual(['turn-a'])
   })
 
+  it('reads receipt inventory with fixed bounded concurrency while preserving order, filters, and metrics', async () => {
+    const { paths, vaultRoot } = await createAssistantPaths(
+      'assistant-turns-list-concurrency-',
+    )
+    await ensureAssistantState(paths)
+
+    const turnIds = Array.from(
+      { length: 10 },
+      (_, index) => `turn-concurrency-${String(index).padStart(2, '0')}`,
+    )
+    for (const [index, turnId] of turnIds.entries()) {
+      await createAssistantTurnReceipt({
+        deliveryRequested: false,
+        prompt: `concurrency prompt ${index}`,
+        provider: 'codex-cli',
+        providerModel: null,
+        sessionId: index % 2 === 0 ? 'session-even' : 'session-odd',
+        startedAt: `2026-04-08T04:00:${String(index).padStart(2, '0')}.000Z`,
+        turnId,
+        vault: vaultRoot,
+      })
+    }
+
+    const receiptPaths = new Set(
+      turnIds.map((turnId) =>
+        path.resolve(resolveAssistantTurnReceiptPath(paths, turnId)),
+      ),
+    )
+    const expectedBytesRead = (
+      await Promise.all([...receiptPaths].map(async (receiptPath) =>
+        await readFile(receiptPath, 'utf8')
+      ))
+    ).reduce((total, raw) => total + Buffer.byteLength(raw, 'utf8'), 0)
+    let activeReads = 0
+    let maxActiveReads = 0
+    const delayedReadFile = async (
+      filePath: string,
+      encoding: 'utf8',
+    ): Promise<string> => {
+      if (!receiptPaths.has(path.resolve(filePath))) {
+        return await readFile(filePath, encoding)
+      }
+
+      activeReads += 1
+      maxActiveReads = Math.max(maxActiveReads, activeReads)
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        return await readFile(filePath, encoding)
+      } finally {
+        activeReads -= 1
+      }
+    }
+    const turns = await loadTurnsModule({ readFile: delayedReadFile })
+    const scanMetrics: AssistantTurnReceiptScanMetrics[] = []
+
+    const recent = await turns.listRecentAssistantTurnReceipts(
+      vaultRoot,
+      4,
+      (metrics) => {
+        scanMetrics.push(metrics)
+      },
+    )
+
+    expect(maxActiveReads).toBe(4)
+    expect(recent.map((receipt) => receipt.turnId)).toEqual([
+      'turn-concurrency-09',
+      'turn-concurrency-08',
+      'turn-concurrency-07',
+      'turn-concurrency-06',
+    ])
+    expect(scanMetrics).toEqual([{
+      bytesRead: expectedBytesRead,
+      filesRead: 10,
+      lockWaitMs: expect.any(Number),
+      scanElapsedMs: expect.any(Number),
+    }])
+
+    const sessionFiltered = await turns.listRecentAssistantTurnReceiptsForSession(
+      vaultRoot,
+      ' session-even ',
+      3,
+    )
+    expect(sessionFiltered.map((receipt) => receipt.turnId)).toEqual([
+      'turn-concurrency-08',
+      'turn-concurrency-06',
+      'turn-concurrency-04',
+    ])
+  })
+
+  it('serializes quarantine writes while skipping multiple corrupt and missing inventory entries', async () => {
+    const { paths, vaultRoot } = await createAssistantPaths(
+      'assistant-turns-list-invalid-batch-',
+    )
+    await ensureAssistantState(paths)
+    const records = [
+      { turnId: 'turn-valid-batch', startedAt: '2026-04-08T05:00:00.000Z' },
+      { turnId: 'turn-corrupt-batch-a', startedAt: '2026-04-08T05:00:01.000Z' },
+      { turnId: 'turn-corrupt-batch-b', startedAt: '2026-04-08T05:00:02.000Z' },
+      { turnId: 'turn-missing-batch', startedAt: '2026-04-08T05:00:03.000Z' },
+    ]
+    for (const record of records) {
+      await createAssistantTurnReceipt({
+        deliveryRequested: false,
+        prompt: 'inventory validation prompt',
+        provider: 'codex-cli',
+        providerModel: null,
+        sessionId: 'session-invalid-batch',
+        startedAt: record.startedAt,
+        turnId: record.turnId,
+        vault: vaultRoot,
+      })
+    }
+
+    const validPath = resolveAssistantTurnReceiptPath(paths, 'turn-valid-batch')
+    const corruptPathA = resolveAssistantTurnReceiptPath(
+      paths,
+      'turn-corrupt-batch-a',
+    )
+    const corruptPathB = resolveAssistantTurnReceiptPath(
+      paths,
+      'turn-corrupt-batch-b',
+    )
+    const missingPath = resolveAssistantTurnReceiptPath(
+      paths,
+      'turn-missing-batch',
+    )
+    const corruptRawA = '{bad-json-a'
+    const corruptRawB = '{bad-json-b'
+    await writeFile(corruptPathA, corruptRawA, 'utf8')
+    await writeFile(corruptPathB, corruptRawB, 'utf8')
+    const validRaw = await readFile(validPath, 'utf8')
+    const corruptPaths = new Set([
+      path.resolve(corruptPathA),
+      path.resolve(corruptPathB),
+    ])
+    let activeQuarantineRenames = 0
+    let maxActiveQuarantineRenames = 0
+    const mockedReadFile = async (
+      filePath: string,
+      encoding: 'utf8',
+    ): Promise<string> => {
+      if (path.resolve(filePath) === path.resolve(missingPath)) {
+        throw Object.assign(new Error('receipt disappeared'), {
+          code: 'ENOENT',
+        })
+      }
+      return await readFile(filePath, encoding)
+    }
+    const delayedRename = async (
+      oldPath: string,
+      newPath: string,
+    ): Promise<void> => {
+      const tracksQuarantine = corruptPaths.has(path.resolve(oldPath))
+      if (tracksQuarantine) {
+        activeQuarantineRenames += 1
+        maxActiveQuarantineRenames = Math.max(
+          maxActiveQuarantineRenames,
+          activeQuarantineRenames,
+        )
+      }
+      try {
+        if (tracksQuarantine) {
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        }
+        await renameFile(oldPath, newPath)
+      } finally {
+        if (tracksQuarantine) {
+          activeQuarantineRenames -= 1
+        }
+      }
+    }
+    const turns = await loadTurnsModule({
+      readFile: mockedReadFile,
+      rename: delayedRename,
+    })
+    const scanMetrics: AssistantTurnReceiptScanMetrics[] = []
+
+    const recent = await turns.listRecentAssistantTurnReceipts(
+      vaultRoot,
+      10,
+      (metrics) => {
+        scanMetrics.push(metrics)
+      },
+    )
+
+    expect(recent.map((receipt) => receipt.turnId)).toEqual(['turn-valid-batch'])
+    expect(maxActiveQuarantineRenames).toBe(1)
+    expect(scanMetrics).toEqual([{
+      bytesRead:
+        Buffer.byteLength(validRaw, 'utf8') +
+        Buffer.byteLength(corruptRawA, 'utf8') +
+        Buffer.byteLength(corruptRawB, 'utf8'),
+      filesRead: 3,
+      lockWaitMs: expect.any(Number),
+      scanElapsedMs: expect.any(Number),
+    }])
+
+    const quarantines = await listAssistantQuarantineEntriesAtPaths(paths, {
+      artifactKind: 'turn-receipt',
+      limit: 10,
+    })
+    expect(quarantines).toHaveLength(2)
+    expect(quarantines.map((entry) => entry.originalPath)).toEqual(
+      expect.arrayContaining([corruptPathA, corruptPathB]),
+    )
+    expect(quarantines.map((entry) => entry.originalPath)).not.toContain(missingPath)
+
+    const runtimeEvents = await listAssistantRuntimeEventsAtPath(paths.runtimeEventsPath)
+    expect(
+      runtimeEvents.filter((event) => event.kind === 'turn.receipt.quarantined'),
+    ).toHaveLength(2)
+  })
+
   it('quarantines corrupted turn receipts and skips them from reads and listings', async () => {
     const { paths, vaultRoot } = await createAssistantPaths('assistant-turns-corrupt-')
 
@@ -407,6 +623,31 @@ function normalizePreview(value: string, limit: number): string {
     return trimmed
   }
   return `${trimmed.slice(0, limit - 1).trimEnd()}…`
+}
+
+async function loadTurnsModule(options: {
+  readFile?: (filePath: string, encoding: 'utf8') => Promise<string>
+  rename?: (oldPath: string, newPath: string) => Promise<void>
+} = {}) {
+  vi.resetModules()
+  vi.doMock('node:fs/promises', async () => {
+    const actual = await vi.importActual<typeof import('node:fs/promises')>(
+      'node:fs/promises',
+    )
+    return {
+      ...actual,
+      ...(options.readFile ? { readFile: options.readFile } : {}),
+      ...(options.rename ? { rename: options.rename } : {}),
+    }
+  })
+  return await import('../src/assistant/turns.ts')
+}
+
+async function renameFile(oldPath: string, newPath: string): Promise<void> {
+  const { rename } = await vi.importActual<typeof import('node:fs/promises')>(
+    'node:fs/promises',
+  )
+  await rename(oldPath, newPath)
 }
 
 function buildExpectedRedactedPreview(value: string): string {

--- a/packages/assistant-engine/test/assistant-turns.test.ts
+++ b/packages/assistant-engine/test/assistant-turns.test.ts
@@ -437,7 +437,7 @@ describe('assistant turns', () => {
     ])
   })
 
-  it('serializes quarantine writes while skipping multiple corrupt and missing inventory entries', async () => {
+  it('serializes quarantine writes while skipping corrupt, unreadable, and missing inventory entries', async () => {
     const { paths, vaultRoot } = await createAssistantPaths(
       'assistant-turns-list-invalid-batch-',
     )
@@ -447,6 +447,7 @@ describe('assistant turns', () => {
       { turnId: 'turn-corrupt-batch-a', startedAt: '2026-04-08T05:00:01.000Z' },
       { turnId: 'turn-corrupt-batch-b', startedAt: '2026-04-08T05:00:02.000Z' },
       { turnId: 'turn-missing-batch', startedAt: '2026-04-08T05:00:03.000Z' },
+      { turnId: 'turn-unreadable-batch', startedAt: '2026-04-08T05:00:04.000Z' },
     ]
     for (const record of records) {
       await createAssistantTurnReceipt({
@@ -474,14 +475,19 @@ describe('assistant turns', () => {
       paths,
       'turn-missing-batch',
     )
+    const unreadablePath = resolveAssistantTurnReceiptPath(
+      paths,
+      'turn-unreadable-batch',
+    )
     const corruptRawA = '{bad-json-a'
     const corruptRawB = '{bad-json-b'
     await writeFile(corruptPathA, corruptRawA, 'utf8')
     await writeFile(corruptPathB, corruptRawB, 'utf8')
     const validRaw = await readFile(validPath, 'utf8')
-    const corruptPaths = new Set([
+    const quarantinedPaths = new Set([
       path.resolve(corruptPathA),
       path.resolve(corruptPathB),
+      path.resolve(unreadablePath),
     ])
     let activeQuarantineRenames = 0
     let maxActiveQuarantineRenames = 0
@@ -489,9 +495,15 @@ describe('assistant turns', () => {
       filePath: string,
       encoding: 'utf8',
     ): Promise<string> => {
-      if (path.resolve(filePath) === path.resolve(missingPath)) {
+      const resolvedPath = path.resolve(filePath)
+      if (resolvedPath === path.resolve(missingPath)) {
         throw Object.assign(new Error('receipt disappeared'), {
           code: 'ENOENT',
+        })
+      }
+      if (resolvedPath === path.resolve(unreadablePath)) {
+        throw Object.assign(new Error('receipt read failed'), {
+          code: 'EACCES',
         })
       }
       return await readFile(filePath, encoding)
@@ -500,7 +512,7 @@ describe('assistant turns', () => {
       oldPath: string,
       newPath: string,
     ): Promise<void> => {
-      const tracksQuarantine = corruptPaths.has(path.resolve(oldPath))
+      const tracksQuarantine = quarantinedPaths.has(path.resolve(oldPath))
       if (tracksQuarantine) {
         activeQuarantineRenames += 1
         maxActiveQuarantineRenames = Math.max(
@@ -549,16 +561,22 @@ describe('assistant turns', () => {
       artifactKind: 'turn-receipt',
       limit: 10,
     })
-    expect(quarantines).toHaveLength(2)
+    expect(quarantines).toHaveLength(3)
     expect(quarantines.map((entry) => entry.originalPath)).toEqual(
-      expect.arrayContaining([corruptPathA, corruptPathB]),
+      expect.arrayContaining([corruptPathA, corruptPathB, unreadablePath]),
     )
+    expect(quarantines).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        errorCode: 'EACCES',
+        originalPath: unreadablePath,
+      }),
+    ]))
     expect(quarantines.map((entry) => entry.originalPath)).not.toContain(missingPath)
 
     const runtimeEvents = await listAssistantRuntimeEventsAtPath(paths.runtimeEventsPath)
     expect(
       runtimeEvents.filter((event) => event.kind === 'turn.receipt.quarantined'),
-    ).toHaveLength(2)
+    ).toHaveLength(3)
   })
 
   it('quarantines corrupted turn receipts and skips them from reads and listings', async () => {

--- a/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/maintenance.ts
@@ -35,6 +35,8 @@ import type {
   HostedRuntimeLatencyPhaseBreakdown,
 } from "@murphai/hosted-execution/runtime-control";
 import {
+  HOSTED_RUNTIME_AUTOMATION_LANE_TIMING_SUBDIVISION_KEYS,
+  inspectHostedRuntimeAutomationLaneTimingSubdivision,
   readHostedIngressLatencySource,
 } from "@murphai/hosted-execution/runtime-control";
 import {
@@ -163,7 +165,7 @@ export async function runHostedAssistantAutomationLane(input: {
   skipAssistantAutomation?: boolean;
   vaultRoot: string;
 }): Promise<HostedAssistantAutomationLaneMetrics> {
-  const providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+  let providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
     input.providerStartCriticalPath,
     "automationLaneStartedAtMonotonicMs",
   );
@@ -185,6 +187,10 @@ export async function runHostedAssistantAutomationLane(input: {
     readiness: assistantAutomation,
     readinessElapsedMs,
   } = await resolveReadiness();
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    "automationReadinessDoneAtMonotonicMs",
+  );
   const redactedLogEntries: HostedExecutionRedactedLogEntry[] = [];
 
   if (!assistantAutomation.configured) {
@@ -333,6 +339,7 @@ export async function runHostedAssistantAutomation(
   let activeProviderMilestoneTraceContext: HostedAssistantMilestoneTraceContext | null = null;
   const recordedProviderMilestones = new Set<string>();
   const freshAssistantInputIdCount = new Set(freshAssistantInputIds).size;
+  let providerStartCriticalPath = options?.providerStartCriticalPath ?? null;
   const selectedInputIds = await selectHostedAssistantInputIds(
     freshAssistantInputIdCount > 0
       ? {
@@ -345,6 +352,10 @@ export async function runHostedAssistantAutomation(
           mode: "background",
           vaultRoot,
         },
+  );
+  providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+    providerStartCriticalPath,
+    "automationInputSelectionDoneAtMonotonicMs",
   );
   const baseInputSource = createHostedAssistantInputSource({
     initialPendingInputIds: selectedInputIds.pendingInputIds,
@@ -449,10 +460,9 @@ export async function runHostedAssistantAutomation(
       ...(options?.beforeProviderAcceptedInputs
         ? { beforeProviderAcceptedInputs: options.beforeProviderAcceptedInputs }
         : {}),
-      ...(options?.providerStartCriticalPath
+      ...(providerStartCriticalPath
         ? {
-            providerStartCriticalPath:
-              options.providerStartCriticalPath,
+            providerStartCriticalPath,
           }
         : {}),
       executionContext,
@@ -793,6 +803,11 @@ function recordHostedAssistantProviderStartLatencyTraceBestEffort(input: {
 
   // In-memory pre-provider and provider diagnostics ride the EXISTING
   // provider_started POST. No new request, await, or I/O is added.
+  const automationLaneSubdivision = input.providerStartCriticalPath
+    ? inspectHostedRuntimeAutomationLaneTimingSubdivision(
+        input.providerStartCriticalPath,
+      )
+    : { kind: "absent" } as const;
   const preProvider: NonNullable<
     HostedRuntimeLatencyPhaseBreakdown["preProvider"]
   > = {
@@ -802,6 +817,9 @@ function recordHostedAssistantProviderStartLatencyTraceBestEffort(input: {
       ? {
           automationLaneToAssistantServiceMs:
             input.providerStartCriticalPath.automationLaneToAssistantServiceMs,
+          ...(automationLaneSubdivision.kind === "complete"
+            ? automationLaneSubdivision.subdivision
+            : {}),
           mailboxImportDoneToAssistantPhaseMs:
             input.providerStartCriticalPath.mailboxImportDoneToAssistantPhaseMs,
           workspaceAssistantPreAutomationMs:
@@ -809,6 +827,14 @@ function recordHostedAssistantProviderStartLatencyTraceBestEffort(input: {
         }
       : {}),
   };
+  if (
+    inspectHostedRuntimeAutomationLaneTimingSubdivision(preProvider).kind
+      === "invalid"
+  ) {
+    for (const key of HOSTED_RUNTIME_AUTOMATION_LANE_TIMING_SUBDIVISION_KEYS) {
+      delete preProvider[key];
+    }
+  }
   const provider: NonNullable<
     HostedRuntimeLatencyPhaseBreakdown["provider"]
   > = {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -939,7 +939,10 @@ function createHostedAssistantAutomationOperationScope(
       operation(
         executionContext: AssistantExecutionContext,
         turnEnvironment: AssistantTurnEnvironment | null,
+        providerStartCriticalPath?:
+          AssistantProviderStartCriticalPathContext | null,
       ): Promise<T>;
+      providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null;
       turnEnvironment: AssistantTurnEnvironment | null;
     }): Promise<T> {
       const durableContext = await resolveHostedAssistantInputIdsOperationContext({
@@ -968,9 +971,14 @@ function createHostedAssistantAutomationOperationScope(
         route,
         vaultRoot: input.restored.vaultRoot,
       });
+      const providerStartCriticalPath = stampAssistantProviderStartCriticalPath(
+        scopeInput.providerStartCriticalPath,
+        "automationGroupAndOperationScopeDoneAtMonotonicMs",
+      );
       return await scopeInput.operation(
         scopedExecutionContext,
         scopeInput.turnEnvironment,
+        providerStartCriticalPath,
       );
     },
   };

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -3650,6 +3650,9 @@ describe("runHostedAssistantAutomationLane", () => {
       preProviderPhase: {
         workspaceAssistantPreAutomationMs: 11,
       },
+      providerStartCriticalPath: {
+        mailboxImportDoneAtMonotonicMs: 0,
+      },
       vaultRoot: "/tmp/vault-root",
     });
 
@@ -3695,6 +3698,12 @@ describe("runHostedAssistantAutomationLane", () => {
       onProviderRequestStarted: expect.any(Function),
       onTerminalNonReplyCommitted: expect.any(Function),
       onTraceEvent: expect.any(Function),
+      providerStartCriticalPath: {
+        automationInputSelectionDoneAtMonotonicMs: 0,
+        automationLaneStartedAtMonotonicMs: 0,
+        automationReadinessDoneAtMonotonicMs: 0,
+        mailboxImportDoneAtMonotonicMs: 0,
+      },
       requestId: "req_123",
       shouldDeferCron: expect.any(Function),
       shouldYieldBackgroundMaintenance: null,
@@ -3731,7 +3740,17 @@ describe("runHostedAssistantAutomationLane", () => {
       codexAppServerWarmReuseMs: 0,
       providerStartCriticalPath: {
         assistantServicePreLockMs: 5,
+        automationCandidateScanMs: 1,
+        automationCrossSessionContextMs: 0,
+        automationGroupAndOperationScopeMs: 1,
+        automationInputSelectionMs: 1,
         automationLaneToAssistantServiceMs: 7,
+        automationPassSetupMs: 1,
+        automationPromptPreparationMs: 0,
+        automationReadinessMs: 1,
+        automationServiceHandoffMs: 0,
+        automationSessionPreflightMs: 1,
+        automationTerminalEvidenceMs: 1,
         codexAppServerPreProviderMs: 19,
         codexProcessPreparationMs: 3,
         mailboxImportDoneToAssistantPhaseMs: 29,
@@ -3751,6 +3770,10 @@ describe("runHostedAssistantAutomationLane", () => {
         at: "2026-04-08T00:00:01.000Z",
         phaseBreakdown: {
           preProvider: {
+            automationCandidateScanMs: 1,
+            automationCrossSessionContextMs: 0,
+            automationGroupAndOperationScopeMs: 1,
+            automationInputSelectionMs: 1,
             outboxScanBytesRead: 8_192,
             outboxScanElapsedMs: 23,
             outboxScanFilesRead: 10,
@@ -3761,6 +3784,12 @@ describe("runHostedAssistantAutomationLane", () => {
             receiptScanLockWaitMs: 3,
             receiptScanPerformed: true,
             automationLaneToAssistantServiceMs: 7,
+            automationPassSetupMs: 1,
+            automationPromptPreparationMs: 0,
+            automationReadinessMs: 1,
+            automationServiceHandoffMs: 0,
+            automationSessionPreflightMs: 1,
+            automationTerminalEvidenceMs: 1,
             mailboxImportDoneToAssistantPhaseMs: 29,
             workspaceAssistantPreAutomationMs: 17,
           },
@@ -3848,6 +3877,72 @@ describe("runHostedAssistantAutomationLane", () => {
         source: "telegram",
         type: "provider_started",
       },
+    });
+    const canonicalCriticalPath = {
+      assistantServicePreLockMs: 5,
+      automationLaneToAssistantServiceMs: 7,
+      codexAppServerPreProviderMs: 19,
+      codexProcessPreparationMs: 3,
+      mailboxImportDoneToAssistantPhaseMs: 29,
+      preProviderSetupMs: 11,
+      providerPlanAndGateMs: 13,
+      turnLockWaitMs: 2,
+      workspaceAssistantPreAutomationMs: 17,
+    };
+    automationPassInput.onProviderRequestStarted?.({
+      assistantInputIds: ["input_partial_subdivision"],
+      providerRequestOrdinal: 1,
+      providerStartCriticalPath: {
+        ...canonicalCriticalPath,
+        automationReadinessMs: 7,
+      },
+      source: "linq",
+      startedAt: "2026-04-08T00:00:03.000Z",
+    });
+    await Promise.resolve();
+    expect(latencyTraceRecord).toHaveBeenCalledTimes(5);
+    expect(latencyTraceRecord).toHaveBeenLastCalledWith({
+      event: expect.objectContaining({
+        phaseBreakdown: expect.objectContaining({
+          preProvider: {
+            automationLaneToAssistantServiceMs: 7,
+            mailboxImportDoneToAssistantPhaseMs: 29,
+            workspaceAssistantPreAutomationMs: 17,
+          },
+        }),
+      }),
+    });
+    automationPassInput.onProviderRequestStarted?.({
+      assistantInputIds: ["input_mismatched_subdivision"],
+      providerRequestOrdinal: 2,
+      providerStartCriticalPath: {
+        ...canonicalCriticalPath,
+        automationCandidateScanMs: 1,
+        automationCrossSessionContextMs: 0,
+        automationGroupAndOperationScopeMs: 1,
+        automationInputSelectionMs: 1,
+        automationPassSetupMs: 1,
+        automationPromptPreparationMs: 0,
+        automationReadinessMs: 2,
+        automationServiceHandoffMs: 0,
+        automationSessionPreflightMs: 1,
+        automationTerminalEvidenceMs: 1,
+      },
+      source: "linq",
+      startedAt: "2026-04-08T00:00:04.000Z",
+    });
+    await Promise.resolve();
+    expect(latencyTraceRecord).toHaveBeenCalledTimes(6);
+    expect(latencyTraceRecord).toHaveBeenLastCalledWith({
+      event: expect.objectContaining({
+        phaseBreakdown: expect.objectContaining({
+          preProvider: {
+            automationLaneToAssistantServiceMs: 7,
+            mailboxImportDoneToAssistantPhaseMs: 29,
+            workspaceAssistantPreAutomationMs: 17,
+          },
+        }),
+      }),
     });
     expect(mocks.createHostedRuntimeDeviceSyncService).not.toHaveBeenCalled();
   });

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -4216,9 +4216,20 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         "ain_00000000000000000000000000000001",
         "ain_00000000000000000000000000000002",
       ],
-      operation: async (executionContext) => {
+      operation: async (
+        executionContext,
+        _turnEnvironment,
+        providerStartCriticalPath,
+      ) => {
         expect(executionContext.hosted?.automationTool).toBeUndefined();
         expect(executionContext.hosted?.groupSharedReader).toBeUndefined();
+        expect(providerStartCriticalPath).toEqual(expect.objectContaining({
+          automationGroupAndOperationScopeDoneAtMonotonicMs: expect.any(Number),
+          mailboxImportDoneAtMonotonicMs: 0,
+        }));
+      },
+      providerStartCriticalPath: {
+        mailboxImportDoneAtMonotonicMs: 0,
       },
       turnEnvironment: null,
     });

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -51,6 +51,7 @@ import {
   HOSTED_RUNTIME_LATENCY_TRACE_ASSISTANT_INPUT_MAX_IDS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_KEYS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS,
+  inspectHostedRuntimeAutomationLaneTimingSubdivision,
   isHostedRuntimeDirectEnsureOrchestrationAttemptId,
   HOSTED_RUNTIME_LATENCY_TRACE_MILESTONES,
   HOSTED_MAILBOX_FETCH_CURSOR_MODES,
@@ -5901,10 +5902,20 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
       HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEY_SETS.preProvider,
       preProviderLabel,
     );
-    breakdown.preProvider = {
+    const parsedPreProvider = {
       ...requireOptionalNonNegativeInteger(preProvider, "mailboxImportDoneToAssistantPhaseMs", preProviderLabel),
       ...requireOptionalNonNegativeInteger(preProvider, "workspaceAssistantPreAutomationMs", preProviderLabel),
       ...requireOptionalNonNegativeInteger(preProvider, "automationLaneToAssistantServiceMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationReadinessMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationInputSelectionMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationPassSetupMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationCandidateScanMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationGroupAndOperationScopeMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationTerminalEvidenceMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationSessionPreflightMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationCrossSessionContextMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationPromptPreparationMs", preProviderLabel),
+      ...requireOptionalNonNegativeInteger(preProvider, "automationServiceHandoffMs", preProviderLabel),
       ...requireOptionalNonNegativeInteger(preProvider, "executionTargetHydrateMs", preProviderLabel),
       ...requireOptionalNonNegativeInteger(preProvider, "systemMailboxMaintenanceMs", preProviderLabel),
       ...requireOptionalNonNegativeInteger(preProvider, "memberPreferencesPrePlanningMs", preProviderLabel),
@@ -5919,6 +5930,15 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
       ...requireOptionalNonNegativeInteger(preProvider, "receiptScanLockWaitMs", preProviderLabel),
       ...requireOptionalBoolean(preProvider, "receiptScanPerformed", preProviderLabel),
     };
+    if (
+      inspectHostedRuntimeAutomationLaneTimingSubdivision(parsedPreProvider).kind
+        === "invalid"
+    ) {
+      throw new TypeError(
+        `${preProviderLabel} automation lane timing subdivision must be absent or contain all ten leaves summing to automationLaneToAssistantServiceMs`,
+      );
+    }
+    breakdown.preProvider = parsedPreProvider;
   }
 
   if (record.assistant !== undefined) {

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -2186,6 +2186,18 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
     mailboxImportDoneToAssistantPhaseMs?: number;
     workspaceAssistantPreAutomationMs?: number;
     automationLaneToAssistantServiceMs?: number;
+    // These adjacent nested leaves exactly partition
+    // automationLaneToAssistantServiceMs when all are present.
+    automationReadinessMs?: number;
+    automationInputSelectionMs?: number;
+    automationPassSetupMs?: number;
+    automationCandidateScanMs?: number;
+    automationGroupAndOperationScopeMs?: number;
+    automationTerminalEvidenceMs?: number;
+    automationSessionPreflightMs?: number;
+    automationCrossSessionContextMs?: number;
+    automationPromptPreparationMs?: number;
+    automationServiceHandoffMs?: number;
     executionTargetHydrateMs?: number;
     systemMailboxMaintenanceMs?: number;
     memberPreferencesPrePlanningMs?: number;
@@ -2232,6 +2244,106 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
     preProviderSetupMs?: number;
     providerPlanAndGateMs?: number;
     linqEgressGuardMs?: number;
+  };
+}
+
+export const HOSTED_RUNTIME_AUTOMATION_LANE_TIMING_SUBDIVISION_KEYS = [
+  "automationReadinessMs",
+  "automationInputSelectionMs",
+  "automationPassSetupMs",
+  "automationCandidateScanMs",
+  "automationGroupAndOperationScopeMs",
+  "automationTerminalEvidenceMs",
+  "automationSessionPreflightMs",
+  "automationCrossSessionContextMs",
+  "automationPromptPreparationMs",
+  "automationServiceHandoffMs",
+] as const;
+
+type HostedRuntimeAutomationLaneTimingSubdivision = Required<Pick<
+  NonNullable<HostedRuntimeLatencyPhaseBreakdown["preProvider"]>,
+  (typeof HOSTED_RUNTIME_AUTOMATION_LANE_TIMING_SUBDIVISION_KEYS)[number]
+>>;
+
+export type HostedRuntimeAutomationLaneTimingSubdivisionInspection =
+  | { kind: "absent" }
+  | { kind: "invalid" }
+  | {
+      kind: "complete";
+      subdivision: HostedRuntimeAutomationLaneTimingSubdivision;
+    };
+
+export function inspectHostedRuntimeAutomationLaneTimingSubdivision(
+  preProvider: NonNullable<HostedRuntimeLatencyPhaseBreakdown["preProvider"]>,
+): HostedRuntimeAutomationLaneTimingSubdivisionInspection {
+  const {
+    automationCandidateScanMs,
+    automationCrossSessionContextMs,
+    automationGroupAndOperationScopeMs,
+    automationInputSelectionMs,
+    automationPassSetupMs,
+    automationPromptPreparationMs,
+    automationReadinessMs,
+    automationServiceHandoffMs,
+    automationSessionPreflightMs,
+    automationTerminalEvidenceMs,
+  } = preProvider;
+  if (
+    automationCandidateScanMs === undefined
+    && automationCrossSessionContextMs === undefined
+    && automationGroupAndOperationScopeMs === undefined
+    && automationInputSelectionMs === undefined
+    && automationPassSetupMs === undefined
+    && automationPromptPreparationMs === undefined
+    && automationReadinessMs === undefined
+    && automationServiceHandoffMs === undefined
+    && automationSessionPreflightMs === undefined
+    && automationTerminalEvidenceMs === undefined
+  ) {
+    return { kind: "absent" };
+  }
+  if (
+    automationCandidateScanMs === undefined
+    || automationCrossSessionContextMs === undefined
+    || automationGroupAndOperationScopeMs === undefined
+    || automationInputSelectionMs === undefined
+    || automationPassSetupMs === undefined
+    || automationPromptPreparationMs === undefined
+    || automationReadinessMs === undefined
+    || automationServiceHandoffMs === undefined
+    || automationSessionPreflightMs === undefined
+    || automationTerminalEvidenceMs === undefined
+  ) {
+    return { kind: "invalid" };
+  }
+
+  const subdivision = {
+    automationReadinessMs,
+    automationInputSelectionMs,
+    automationPassSetupMs,
+    automationCandidateScanMs,
+    automationGroupAndOperationScopeMs,
+    automationTerminalEvidenceMs,
+    automationSessionPreflightMs,
+    automationCrossSessionContextMs,
+    automationPromptPreparationMs,
+    automationServiceHandoffMs,
+  };
+  const values = Object.values(subdivision);
+  if (values.some((value) => !Number.isSafeInteger(value) || value < 0)) {
+    return { kind: "invalid" };
+  }
+  const sum = values.reduce<number>((total, value) => total + value, 0);
+  if (
+    !Number.isSafeInteger(sum)
+    || !Number.isSafeInteger(preProvider.automationLaneToAssistantServiceMs)
+    || preProvider.automationLaneToAssistantServiceMs !== sum
+  ) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "complete",
+    subdivision,
   };
 }
 
@@ -2343,6 +2455,16 @@ export const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS: Record<
     "mailboxImportDoneToAssistantPhaseMs",
     "workspaceAssistantPreAutomationMs",
     "automationLaneToAssistantServiceMs",
+    "automationReadinessMs",
+    "automationInputSelectionMs",
+    "automationPassSetupMs",
+    "automationCandidateScanMs",
+    "automationGroupAndOperationScopeMs",
+    "automationTerminalEvidenceMs",
+    "automationSessionPreflightMs",
+    "automationCrossSessionContextMs",
+    "automationPromptPreparationMs",
+    "automationServiceHandoffMs",
     "executionTargetHydrateMs",
     "systemMailboxMaintenanceMs",
     "memberPreferencesPrePlanningMs",

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -1611,6 +1611,16 @@ describe("hosted runtime control contracts", () => {
         mailboxImportDoneToAssistantPhaseMs: 29,
         workspaceAssistantPreAutomationMs: 11,
         automationLaneToAssistantServiceMs: 7,
+        automationReadinessMs: 1,
+        automationInputSelectionMs: 1,
+        automationPassSetupMs: 1,
+        automationCandidateScanMs: 1,
+        automationGroupAndOperationScopeMs: 1,
+        automationTerminalEvidenceMs: 1,
+        automationSessionPreflightMs: 1,
+        automationCrossSessionContextMs: 0,
+        automationPromptPreparationMs: 0,
+        automationServiceHandoffMs: 0,
         executionTargetHydrateMs: 2,
         systemMailboxMaintenanceMs: 3,
         memberPreferencesPrePlanningMs: 4,
@@ -1719,6 +1729,24 @@ describe("hosted runtime control contracts", () => {
       { outboxScanBytesRead: -1 }, // counts must be non-negative
       { receiptScanBytesRead: -1 }, // counts must be non-negative
       { outboxScanElapsedMs: "23" }, // durations must stay numeric
+      { automationSessionPreflightMs: "2" }, // nested durations must stay numeric
+      {
+        automationLaneToAssistantServiceMs: 7,
+        automationReadinessMs: 7,
+      }, // a partial subdivision is ambiguous and must be dropped
+      {
+        automationLaneToAssistantServiceMs: 7,
+        automationReadinessMs: 2,
+        automationInputSelectionMs: 1,
+        automationPassSetupMs: 1,
+        automationCandidateScanMs: 1,
+        automationGroupAndOperationScopeMs: 1,
+        automationTerminalEvidenceMs: 1,
+        automationSessionPreflightMs: 1,
+        automationCrossSessionContextMs: 0,
+        automationPromptPreparationMs: 0,
+        automationServiceHandoffMs: 0,
+      }, // all leaves are required to sum exactly to their parent
       { mailboxImportDoneToAssistantPhaseMs: -1 }, // durations must be non-negative
       { receiptScanFilesRead: 12, receiptScanPath: 1 }, // arbitrary metadata is forbidden
     ]) {


### PR DESCRIPTION
## Why

A production latency outlier spent 859 ms scanning 232 local turn receipts and left roughly 1.84 seconds of the automation lane unattributed. The receipt scan protects plain replies to proactive or scheduled messages, so deleting it would replay stale context or break reply continuity.

## User-visible goal and flow

Keep proactive-message reply continuity unchanged while reducing avoidable local file-read latency and making the complete pre-provider automation path diagnosable.

- Exact provider-native replies and history-free cases continue to skip receipt inventory.
- The unanchored cross-session fallback still consults completed/deferred receipt evidence so one proactive delivery is consumed at most once.
- Receipt reads are issued in bounded batches of four; parse, schema validation, quarantine, ordering, metrics, and the runtime lock remain deterministic and serialized.
- A provider-producing first group emits ten adjacent timing spans from automation readiness through assistant-service handoff. Later groups retain the canonical total but omit the detailed subdivision rather than misattribute earlier work.
- There is no new user-facing state or copy. The current inbound remains foreground-owned, and the existing reply/provider path owns completion and recovery.

## Invariants

- Provider-native reply IDs outrank the unanchored time fallback.
- Only completed or deferred receipts consume cross-session context; failed/running turns do not.
- Current inbound replies cannot become silent or be deferred behind maintenance.
- Receipt/runtime mutations and corrupt-file quarantine remain under the existing runtime write lock.
- The ten optional timing leaves are all-or-none, non-negative safe integers, and sum exactly to the canonical automation-lane duration.
- Observability remains content-free and rides the existing best-effort provider-start event without a new request or awaited reporting step.

## Architecture and reuse

- Existing systems reused: the outbox fixed-concurrency pattern, monotonic provider-start path, existing fire-and-forget phase breakdown, strict parser, and Web-owned persistence.
- New logic: bounded parallel receipt reads with serial parse/quarantine, ten adjacent timing stamps, all-or-none exact-sum validation, and later-group subdivision omission.
- New abstractions: one shared Hosted Execution subdivision inspector and one internal false-only eligibility marker.
- Complexity intentionally avoided: no receipt index, cache, migration, dependency, remote call, recent-N cap, new state owner, or prompt change; the remaining O(receipt inventory) debt is explicit.

## Runtime call impact

- Receipt inventory file-read count is unchanged and still equals the eligible local inventory. Before: serial reads. After: at most four reads in parallel, matching the existing outbox I/O budget.
- Parsing and quarantine side effects remain serial. Missing files are skipped; non-missing corrupt/error entries follow the existing quarantine path. No retry or timeout policy changed.
- No provider, Web, Cloudflare, database, or object-store call was added. The ten numeric leaves use the existing provider-start POST.

## Verification

Exact rebased candidate:

- Assistant Engine, Assistant Runtime, and Hosted Execution package typechecks: pass.
- Assistant Engine focused proof: 3 files, 13 passed, 175 skipped.
- Assistant Runtime focused proof: 2 files, 2 passed, 354 skipped.
- Hosted Execution parser/contract proof: 1 file, 32 passed.
- Cold local-service propagation diagnostic: 1/1 passed; the local host required a diagnostic 180-second CLI timeout because dynamic module transform/import consumed most of the default timeout. No timeout change is committed.
- Independent receipt, timing, and final scope reviews: pass after exact-sum and later-group attribution remediation.
- Diff check and privacy/path/identifier scan: pass.
- Exact-head GitHub Actions: pending.

## Murph initial provider input impact

Not applicable for individual or group Murph. No prompt, instruction, tool definition/schema, model/tool mode, Codex configuration, or provider-request assembly changed; the new data is transport-only latency metadata recorded after the existing provider-start boundary.

## Preliminary specialist lenses

- Product experience: **applicable** — intended outcome is faster replies without losing scheduled/proactive-message continuation. Direct evidence is the cross-session continuity/regression coverage plus the bounded receipt inventory tests.
- Prompt: **not applicable** — no prompt-visible content or assembly changed.
- Frontend: **not applicable** — no Web UI changed; design proof is not applicable.
- Coverage: **applicable** — focused concurrency, recovery, timing propagation, arithmetic, malformed-contract, emitter, parser, and multi-group tests pass locally; exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: this changes hosted runtime concurrency, latency telemetry across the Web/runner deploy boundary, and cross-owner parser contracts.

ReviewGPT first-reviewed head: 5752a25a4bc32c80bc57bbcde0006eabb5c6b8e5

## Change shape

Classification rule: executable files under package src/ are source; package test/ files are tests; the active execution plan and live protocol are docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 527 | 76 |
| Tests / fixtures | 632 | 12 |
| Docs | 126 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1285** | **88** |

## Non-obvious affected surfaces

- Assistant Engine automation grouping, cross-session context selection, and local-service provider handoff.
- Assistant Runtime hosted readiness/input selection and hosted operation-scope route reconstruction.
- Hosted Execution strict phase-breakdown parsing.
- Web-owned phase-breakdown storage through the shared parser contract.
- Cloudflare runner bundles that package Assistant Runtime.

## Deployment skew and rollback

Deploy Web first so the strict reader accepts the additive leaves, then deploy the Cloudflare runner bundle. Old runners with new Web remain fully compatible and simply omit the leaves. A new runner against old Web preserves the core provider-start event but loses that event's best-effort phase breakdown.

The current production runner idle TTL is 20 minutes; gradual rollout may therefore leave warm old bundles during that window. This telemetry-only change does not require container_rollout=immediate for correctness, although the current production deploy default is immediate. The recent comparable cohort was only low tens of provider starts per day, so a gradual window would expose at most a small number of events to missing—not incorrect—subdivision data.

Post-deploy, require managed-container smoke to report the expected runner fingerprint, then compare receipt-scan latency for 200+ file cohorts and verify complete subdivisions sum to their canonical parent. Roll back the runner/Cloudflare emitter before Web. No data migration or repair is required.




