### PR TITLE
fix(web): skip the capture-only design proof when no capture was asked for

### DIFF
--- a/apps/web/e2e/pr-1498-design-proof.spec.ts
+++ b/apps/web/e2e/pr-1498-design-proof.spec.ts
@@ -79,7 +79,12 @@ async function captureStudy({
 
 test("capture signed-in invite recovery design proof", async ({ browser }) => {
   test.setTimeout(300_000);
+  // Capture-only: Playwright's testDir picks this up in every e2e job, but a
+  // job that did not ask for a capture has nowhere to put one. Skipping there
+  // keeps this runnable on demand without failing the suites it shares a
+  // directory with.
   const outputDir = process.env.DESIGN_PROOF_OUTPUT_DIR;
+  test.skip(!outputDir, "DESIGN_PROOF_OUTPUT_DIR is not set for this run.");
   expect(outputDir, "DESIGN_PROOF_OUTPUT_DIR is required").toBeTruthy();
   await mkdir(outputDir!, { recursive: true });
 


### PR DESCRIPTION
## Why this PR exists

`apps/web/e2e/pr-1498-design-proof.spec.ts` (added by #1498) asserts that `DESIGN_PROOF_OUTPUT_DIR` is set. Playwright's `testDir` is `./e2e`, so that spec also runs in the **No horizontal overflow on marketing pages** job, which never asks for a capture and sets no output directory. The job has failed on `main` from the commit that added the spec (`cca3c15b99`) onward, and because PR CI tests the merge with `main`, it fails on every open PR as well.

## User goal / user-visible behavior

None. This is CI-only; no product behavior changes.

## User experience

Not applicable — no user-facing surface, copy, timing, or delivery path changed.

## Invariants the PR must preserve

- The design-proof job still gets a real capture: the assertion is unchanged for runs that set `DESIGN_PROOF_OUTPUT_DIR`.
- No other e2e spec's behavior changes.

## Non-obvious affected surfaces

- **Every Playwright job in `apps/web/e2e`.** They share one `testDir`, so a spec that hard-fails on a missing environment variable fails jobs that were never meant to run it. The skip is conditioned on that variable rather than on a job name, so it stays correct if the capture moves to a different workflow.

## Architecture and reuse

- Existing systems reused: Playwright's own `test.skip(condition, reason)`.
- New logic: one conditional skip.
- New abstractions: none, because the condition already exists — the spec reads `DESIGN_PROOF_OUTPUT_DIR` to decide where to write, so the same value decides whether it should run at all. Introducing a name for "is this a capture run" would add a concept where a single environment read already answers it.
- Complexity intentionally avoided: no `testIgnore` list, no per-job spec filter, and no deletion of the capture spec — any of those would have to be maintained as specs come and go.

## Hot reply path impact

Not applicable. No runtime code changed.

## Murph initial provider input impact

No change. No prompt, tool description, or schema touched.

## Preliminary specialist lenses

- Product experience: **not applicable.** No product-owned dimension changed.
- Prompt: **not applicable.** No prompt surface changed.
- Frontend: **not applicable.** No `apps/web/app/**`, `apps/web/src/components/**`, or asset path changed.
- Coverage: **applicable.** The change is to test scaffolding; verification is below.

ReviewGPT context sensitivity: routine

Reason: a one-line conditional skip in a capture-only e2e spec, with no runtime, schema, authority, or delivery surface involved.

## Change-shape breakdown

Classification rule: `**/src/**` and other non-test production files are source; `**/test/**` and `**/e2e/**` are tests/fixtures; `agent-docs/**` is docs; build/CI/lockfiles are config/tooling. Counts are `git diff --numstat origin/main...HEAD`.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests/fixtures | 5 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **5** | **0** |

## Design proof

Not applicable. No user-facing `apps/web` UI path changed; this PR only changes when an existing capture spec runs.

## Verification

- The failing job is reproducible from CI history: **No horizontal overflow on marketing pages** is red on `main` at `cca3c15b99`, `93c359eacb`, and `b855d04518`, and green at `7816f428d4` immediately before the spec landed.
- The exact failure is `Error: DESIGN_PROOF_OUTPUT_DIR is required` from `e2e/pr-1498-design-proof.spec.ts`, on both the initial attempt and the retry.
- Exact-head CI on this PR is the proof that the job goes green again.

## Deployment concerns

None. CI-only change; nothing ships to Web, the runner, or any provider.
