### PR TITLE
test(web): skip manual design capture in default runs

### DIFF
--- a/apps/web/e2e/pr-1498-design-proof.spec.ts
+++ b/apps/web/e2e/pr-1498-design-proof.spec.ts
@@ -84,21 +84,24 @@ test("capture signed-in invite recovery design proof", async ({ browser }) => {
   );
   test.setTimeout(300_000);
   const outputDir = process.env.DESIGN_PROOF_OUTPUT_DIR;
-  expect(outputDir, "DESIGN_PROOF_OUTPUT_DIR is required").toBeTruthy();
-  await mkdir(outputDir!, { recursive: true });
+  if (!outputDir) {
+    test.skip(true, "DESIGN_PROOF_OUTPUT_DIR is required for manual capture");
+    return;
+  }
+  await mkdir(outputDir, { recursive: true });
 
   await captureStudy({
     browser,
     fileName: "desktop.png",
     height: 1000,
-    outputDir: outputDir!,
+    outputDir,
     width: 1440,
   });
   await captureStudy({
     browser,
     fileName: "mobile.png",
     height: 844,
-    outputDir: outputDir!,
+    outputDir,
     width: 390,
   });
 });


### PR DESCRIPTION
## Why this PR exists

The Web Viewport Overflow workflow runs every Playwright spec under `apps/web/e2e`. A manual design-proof capture spec added by #1498 currently fails that default run when its opt-in output directory is absent, even though all 82 actual overflow checks pass.

## User goal / user-visible behavior

Repository checks should stay green for ordinary changes while maintainers can still run the signed-in referral recovery screenshot capture explicitly.

## User experience

No user-facing effect. Production UI, referral behavior, and design-study rendering are unchanged. This only changes whether a manual screenshot helper runs during default automated Playwright discovery.

## Invariants

- The capture spec skips before navigation when `DESIGN_PROOF_OUTPUT_DIR` is absent.
- Supplying `DESIGN_PROOF_OUTPUT_DIR` still captures both desktop and mobile images.
- The Web Viewport Overflow workflow continues to run its ordinary browser coverage unchanged.
- No production runtime, authentication, member data, or deploy configuration changes.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: The diff is one test-scaffolding guard with no production behavior, public API, persisted state, trust boundary, or deploy effect.

## Non-obvious affected surfaces

- Web Viewport Overflow test discovery: its unfiltered `playwright test` command collects this manual capture spec. The missing-environment run is directly proven to report one intentional skip instead of a failure.

## Architecture and reuse

- Existing systems reused: The existing Playwright `test.skip` annotation and the capture spec's existing `DESIGN_PROOF_OUTPUT_DIR` opt-in remain the only control path.
- New logic: The capture test returns as skipped when its manual output directory is not supplied.
- New abstractions: No new abstraction is needed because the environment variable already owns capture admission inside this single spec.
- Complexity intentionally avoided: No workflow filter, second Playwright project, wrapper script, fixture owner, or production fallback was added.

## Hot reply path impact

- Path status: Not applicable — this test-only diff does not touch conversation acceptance, provider start, or reply handoff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable; no hot reply code changed.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no prompt or provider-input builder changed.
- Tool/schema/generated guidance: Unchanged; no tool or schema surface changed.
- Other provider-visible input: Unchanged; this is Playwright test scaffolding only.
- Measurement method: Not run — no provider-input surface changed.

## Preliminary specialist lenses

- Product experience: Not applicable — no production journey, copy, action, state, timing, permission, or recovery behavior changes.
- Prompt: Not applicable — no prompt, tool description, or provider-visible input changes.
- Frontend: Not applicable — no rendered component, styling, layout, interaction, or accessibility surface changes.
- Coverage: Applicable — the missing-environment run reports one skipped capture test, the explicit-output run passes and writes both images, and the prepared Web typecheck passes; exact-head CI is pending.

## Design proof

Not applicable. The diff changes only test admission and does not change rendered UI.

## Change-shape breakdown

Classification rule: The single Playwright spec is tests/fixtures. No binary, generated, source, docs, or configuration files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 7 | 4 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **7** | **4** |

## Verification

- Missing environment, no-server focused Playwright run — one test collected and skipped; exit 0.
- Explicit output directory, isolated smoke Web server and design route — one test passed and wrote desktop and mobile PNGs; exit 0.
- `pnpm --dir apps/web typecheck:prepared` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Privacy and one-file scope scan of the exact base-to-head diff — passed.
