### PR TITLE
feat: start Family setup safely from group chat

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -423,7 +423,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Settings sign-in required">
+      <StudySection title="Settings and Family sign-in handoffs">
         <SettingsAuthRequiredStudy />
       </StudySection>
 

--- a/apps/web/app/design/settings-auth-required-study.tsx
+++ b/apps/web/app/design/settings-auth-required-study.tsx
@@ -1,19 +1,34 @@
+import { FamilySetupAuthRequiredView } from "@/src/components/family/family-setup-auth-required";
 import { SettingsAuthRequiredView } from "../(dashboard)/settings/settings-auth-required";
 
 export function SettingsAuthRequiredStudy() {
   return (
-    <div
-      className="overflow-hidden rounded-2xl border border-border bg-background"
-      data-design-section="settings-auth-required-payment-return"
-      id="settings-auth-required-payment-return-section"
-      // Renders the presentational view, not the live screen, whose effect
-      // would open the app-wide auth dialog over the catalog itself.
-      inert
-    >
-      <p className="border-b border-border px-5 py-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-        Returning from Stripe without a session
-      </p>
-      <SettingsAuthRequiredView />
+    <div className="grid gap-6 lg:grid-cols-2">
+      <div
+        className="overflow-hidden rounded-2xl border border-border bg-background"
+        data-design-section="settings-auth-required-payment-return"
+        id="settings-auth-required-payment-return-section"
+        // Renders the presentational view, not the live screen, whose effect
+        // would open the app-wide auth dialog over the catalog itself.
+        inert
+      >
+        <p className="border-b border-border px-5 py-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Returning from Stripe without a session
+        </p>
+        <SettingsAuthRequiredView />
+      </div>
+
+      <div
+        className="overflow-hidden rounded-2xl border border-border bg-background"
+        data-design-section="family-setup-auth-required"
+        id="family-setup-auth-required-section"
+        inert
+      >
+        <p className="border-b border-border px-5 py-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Opening Family setup without a session
+        </p>
+        <FamilySetupAuthRequiredView />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/family/setup/page.tsx
+++ b/apps/web/app/family/setup/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { FamilySetupAuthRequired } from "@/src/components/family/family-setup-auth-required";
+import { getHostedPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+import { createMurphPageMetadata } from "@/src/lib/site-metadata";
+
+export const metadata: Metadata = {
+  ...createMurphPageMetadata({
+    title: "Set up Family · Murph",
+    description: "Open your private Murph Family settings.",
+  }),
+  robots: { follow: false, index: false },
+};
+
+export default async function FamilySetupPage() {
+  const auth = await getHostedPageAuthSnapshot();
+
+  if (auth.authenticated) {
+    redirect("/settings#family");
+  }
+
+  return <FamilySetupAuthRequired />;
+}

--- a/apps/web/src/components/family/family-setup-auth-required.tsx
+++ b/apps/web/src/components/family/family-setup-auth-required.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { UsersRound } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { AuthDialog } from "@/src/components/hosted-onboarding/auth-dialog";
+import { HostedAuthRequiredScreenView } from "@/src/components/hosted-onboarding/hosted-auth-required-screen";
+import {
+  navigateHostedAuthRedirect,
+  reloadCurrentHostedAuthDocument,
+} from "@/src/components/hosted-onboarding/hosted-auth-navigation";
+import { isHostedOnboardingAccessibleStage } from "@/src/lib/hosted-onboarding/stage";
+import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
+
+const FAMILY_SETUP_AUTH_COPY = {
+  description:
+    "Sign in or create your Murph account to open your private Family settings.",
+  eyebrow: "Murph Family",
+  eyebrowIcon: UsersRound,
+  footer:
+    "Family billing, membership, and invitations stay private to your account.",
+  title: "Set up Family",
+} as const;
+
+export function FamilySetupAuthRequired() {
+  const [open, setOpen] = useState(true);
+  const handleAuthCompleted = useCallback(
+    (payload: HostedPrivyCompletionPayload) => {
+      if (isHostedOnboardingAccessibleStage(payload.stage)) {
+        reloadCurrentHostedAuthDocument();
+        return;
+      }
+
+      navigateHostedAuthRedirect(payload.joinUrl);
+    },
+    [],
+  );
+
+  return (
+    <>
+      <HostedAuthRequiredScreenView
+        {...FAMILY_SETUP_AUTH_COPY}
+        onLogin={() => setOpen(true)}
+      />
+      <AuthDialog
+        description="Sign in to continue to your private Family settings."
+        onCompleted={handleAuthCompleted}
+        onOpenChange={setOpen}
+        open={open}
+        requireLaunchConsentOnCompletion
+        title="Set up Murph Family"
+      />
+    </>
+  );
+}
+
+export function FamilySetupAuthRequiredView() {
+  return <HostedAuthRequiredScreenView {...FAMILY_SETUP_AUTH_COPY} />;
+}

--- a/apps/web/test/family-setup-auth-required.test.tsx
+++ b/apps/web/test/family-setup-auth-required.test.tsx
@@ -1,0 +1,84 @@
+import { act, createElement } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+const mocks = vi.hoisted(() => ({
+  authDialogProps: null as {
+    onCompleted?: (payload: {
+      activationPending: boolean;
+      inviteCode: string;
+      joinUrl: string;
+      stage: "active" | "activating" | "blocked" | "checkout" | "expired" | "invalid" | "verify";
+    }) => Promise<void> | void;
+    open?: boolean;
+  } | null,
+}));
+
+vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
+  AuthDialog(props: {
+    onCompleted?: (payload: {
+      activationPending: boolean;
+      inviteCode: string;
+      joinUrl: string;
+      stage: "active" | "activating" | "blocked" | "checkout" | "expired" | "invalid" | "verify";
+    }) => Promise<void> | void;
+    open?: boolean;
+  }) {
+    mocks.authDialogProps = props;
+    return props.open
+      ? createElement(
+          "button",
+          {
+            type: "button",
+            onClick: () =>
+              void props.onCompleted?.({
+                activationPending: false,
+                inviteCode: "invite-code",
+                joinUrl: "/join/invite-code",
+                stage: "active",
+              }),
+          },
+          "Complete Family auth",
+        )
+      : null;
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.authDialogProps = null;
+});
+
+test("Family setup reloads the handoff after an accessible sign-in", async () => {
+  const { FamilySetupAuthRequired } = await import(
+    "@/src/components/family/family-setup-auth-required"
+  );
+  const rendered = await renderClientComponent(
+    createElement(FamilySetupAuthRequired),
+    {
+      location: {
+        hash: "",
+        href: "https://join.example.test/family/setup",
+        origin: "https://join.example.test",
+        pathname: "/family/setup",
+        search: "",
+      },
+    },
+  );
+  const completeButton = Array.from(
+    rendered.container.querySelectorAll("button"),
+  ).find((button) => button.textContent === "Complete Family auth");
+
+  expect(completeButton).toBeTruthy();
+  await act(async () => {
+    completeButton?.dispatchEvent(new rendered.window.Event("click", {
+      bubbles: true,
+    }));
+  });
+
+  expect(rendered.reload).toHaveBeenCalledTimes(1);
+  expect(rendered.assign).not.toHaveBeenCalled();
+
+  await rendered.cleanup();
+});

--- a/apps/web/test/family-setup-auth-required.test.tsx
+++ b/apps/web/test/family-setup-auth-required.test.tsx
@@ -1,24 +1,23 @@
 import { act, createElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
 
-import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
-
 import { renderClientComponent } from "./render-client-component";
+
+type AuthCompletion = {
+  joinUrl: string;
+  stage: "active" | "activating" | "blocked" | "checkout";
+};
 
 const mocks = vi.hoisted(() => ({
   authDialogProps: null as {
-    onCompleted?: (
-      payload: HostedPrivyCompletionPayload,
-    ) => Promise<void> | void;
+    onCompleted?: (payload: AuthCompletion) => Promise<void> | void;
     open?: boolean;
   } | null,
 }));
 
 vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
   AuthDialog(props: {
-    onCompleted?: (
-      payload: HostedPrivyCompletionPayload,
-    ) => Promise<void> | void;
+    onCompleted?: (payload: AuthCompletion) => Promise<void> | void;
     open?: boolean;
   }) {
     mocks.authDialogProps = props;
@@ -29,8 +28,6 @@ vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
             type: "button",
             onClick: () =>
               void props.onCompleted?.({
-                activationPending: false,
-                inviteCode: "invite-code",
                 joinUrl: "/join/invite-code",
                 stage: "active",
               }),

--- a/apps/web/test/family-setup-auth-required.test.tsx
+++ b/apps/web/test/family-setup-auth-required.test.tsx
@@ -1,28 +1,24 @@
 import { act, createElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
 
+import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/types";
+
 import { renderClientComponent } from "./render-client-component";
 
 const mocks = vi.hoisted(() => ({
   authDialogProps: null as {
-    onCompleted?: (payload: {
-      activationPending: boolean;
-      inviteCode: string;
-      joinUrl: string;
-      stage: "active" | "activating" | "blocked" | "checkout" | "expired" | "invalid" | "verify";
-    }) => Promise<void> | void;
+    onCompleted?: (
+      payload: HostedPrivyCompletionPayload,
+    ) => Promise<void> | void;
     open?: boolean;
   } | null,
 }));
 
 vi.mock("@/src/components/hosted-onboarding/auth-dialog", () => ({
   AuthDialog(props: {
-    onCompleted?: (payload: {
-      activationPending: boolean;
-      inviteCode: string;
-      joinUrl: string;
-      stage: "active" | "activating" | "blocked" | "checkout" | "expired" | "invalid" | "verify";
-    }) => Promise<void> | void;
+    onCompleted?: (
+      payload: HostedPrivyCompletionPayload,
+    ) => Promise<void> | void;
     open?: boolean;
   }) {
     mocks.authDialogProps = props;

--- a/packages/assistant-engine/skills/murph-family/SKILL.md
+++ b/packages/assistant-engine/skills/murph-family/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: murph-family
-description: Use only for Murph Family product questions or account actions involving Family plans, sponsored seats, owner status, checkout, member invites, member usage handoffs, billing, or access. Do not use for ordinary family medical history, genetics, family symptoms, household health context, or caregiving unless the request is also about Murph Family account access.
+description: Use only for Murph Family product questions or account actions involving Family plans, sponsored seats, owner status, checkout, member invites, member usage handoffs, billing, or access. In a hosted group, requests to set up a plan for the requester's family, add family members, or manage Family stay here and are not group sponsorship, room funding, or room usage top-ups. Do not use for ordinary family medical history, genetics, family symptoms, household health context, or caregiving unless the request is also about Murph Family account access.
 ---
 
 # Murph Family
@@ -84,18 +84,31 @@ A hosted group cannot own a Family plan, begin checkout, inspect account status,
 or create invites. Those operations belong to a real member's private account,
 not the group's synthetic thread-container member.
 
-When someone explicitly asks in a group to start, convert, or manage their own
-Family plan, send `https://www.withmurph.ai/family/setup` immediately. This is a
-stable navigation-only handoff: it authenticates the person when needed and
-opens that person's Family Settings once their Murph account is accessible. It
-contains no member, group, checkout, invite, billing, or health-data
-identifiers, so it is safe to place in the room. Do not require an extra
-confirmation merely to send it.
+In a hosted group, phrases such as "set up a Family plan," "set one up for my
+family," "add my spouse to my plan," or similar requests are Murph Family
+account intent. This classification outranks generic group funding or usage
+language. Do not call `murph.group` usage or referral actions, and do not present
+room sponsorship, group funding, or room usage top-up options, unless the same
+request explicitly asks about funding or usage for the current room.
+
+For an explicit request to start or convert to Family, reply briefly with this
+choice:
+
+```text
+You can message me privately to set one up for your family, or click this link to do it:
+https://www.withmurph.ai/family/setup
+```
+
+Keep the raw URL on the final line. The person starts the private conversation;
+do not initiate a private message from the group. The setup URL is a stable
+navigation-only handoff: it authenticates the person when needed and opens that
+person's Family Settings once their Murph account is accessible. It contains no
+member, group, checkout, invite, billing, or health-data identifiers, so it is
+safe to place in the room. Do not require an extra confirmation merely to send
+it.
 
 Do not call `murph.family_plan`, claim account state, choose an owner, or create
-a checkout or invite from the group runtime. If the requester wants Murph to
-complete checkout or create an invite conversationally, ask them to continue in
-their private Murph after opening the handoff. Never return a generated Family
+a checkout or invite from the group runtime. Never return a generated Family
 checkout, top-up, or invite URL to a group.
 
 Never treat ordinary family medical history, symptoms, genetics, household

--- a/packages/assistant-engine/skills/murph-family/SKILL.md
+++ b/packages/assistant-engine/skills/murph-family/SKILL.md
@@ -86,10 +86,11 @@ not the group's synthetic thread-container member.
 
 When someone explicitly asks in a group to start, convert, or manage their own
 Family plan, send `https://www.withmurph.ai/family/setup` immediately. This is a
-stable navigation-only handoff: it signs the person in when needed, then opens
-that person's authenticated Family Settings. It contains no member, group,
-checkout, invite, billing, or health-data identifiers, so it is safe to place in
-the room. Do not require an extra confirmation merely to send it.
+stable navigation-only handoff: it authenticates the person when needed and
+opens that person's Family Settings once their Murph account is accessible. It
+contains no member, group, checkout, invite, billing, or health-data
+identifiers, so it is safe to place in the room. Do not require an extra
+confirmation merely to send it.
 
 Do not call `murph.family_plan`, claim account state, choose an owner, or create
 a checkout or invite from the group runtime. If the requester wants Murph to

--- a/packages/assistant-engine/skills/murph-family/SKILL.md
+++ b/packages/assistant-engine/skills/murph-family/SKILL.md
@@ -81,9 +81,21 @@ claim that payment or usage was added.
 ## Group and privacy boundary
 
 A hosted group cannot own a Family plan, begin checkout, inspect account status,
-or create invites. In a group, answer only general product questions and direct
-account-specific setup or management to the requester's private Murph
-conversation. Never return a Family checkout, top-up, or invite URL to a group.
+or create invites. Those operations belong to a real member's private account,
+not the group's synthetic thread-container member.
+
+When someone explicitly asks in a group to start, convert, or manage their own
+Family plan, send `https://www.withmurph.ai/family/setup` immediately. This is a
+stable navigation-only handoff: it signs the person in when needed, then opens
+that person's authenticated Family Settings. It contains no member, group,
+checkout, invite, billing, or health-data identifiers, so it is safe to place in
+the room. Do not require an extra confirmation merely to send it.
+
+Do not call `murph.family_plan`, claim account state, choose an owner, or create
+a checkout or invite from the group runtime. If the requester wants Murph to
+complete checkout or create an invite conversationally, ask them to continue in
+their private Murph after opening the handoff. Never return a generated Family
+checkout, top-up, or invite URL to a group.
 
 Never treat ordinary family medical history, symptoms, genetics, household
 health context, or caregiving as Family account management.

--- a/packages/assistant-engine/src/assistant-skill-assets.ts
+++ b/packages/assistant-engine/src/assistant-skill-assets.ts
@@ -23,7 +23,7 @@ export const ASSISTANT_SKILLS = [
     slug: 'hosted-low-usage',
     name: 'hosted-low-usage',
     triggerHint:
-      'Use when trusted hosted turn context says Murph usage is running low; when a user asks about hosted plan, AI usage, billing, group funding, or the available ways to add or earn more usage; or when they ask how to keep a direct trial, paid plan, Family-sponsored Murph, or hosted group conversation going.',
+      'Use when trusted hosted turn context says Murph usage is running low; when a user asks about hosted plan, AI usage, billing, group funding, or the available ways to add or earn more usage; or when they ask how to keep a direct trial, paid plan, Family-sponsored Murph, or hosted group conversation going. In a hosted group, a request to start or manage a Murph Family plan, seats, or invites is not room funding or a room usage top-up; use murph-family unless the same request explicitly asks about funding or usage for the current room.',
   },
   {
     slug: 'signup-link',
@@ -221,7 +221,7 @@ export const ASSISTANT_SKILLS = [
     slug: 'murph-family',
     name: 'murph-family',
     triggerHint:
-      'Use only for Murph Family product questions or account actions involving plans, sponsored seats, owner status, checkout, member invites, member usage handoffs, billing, or access. Do not use for ordinary family medical history, genetics, family symptoms, household health context, or caregiving unless Murph Family account access is also in scope.',
+      'Use only for Murph Family product questions or account actions involving plans, sponsored seats, owner status, checkout, member invites, member usage handoffs, billing, or access. In a hosted group, requests to set up a plan for the requester\'s family, add family members, or manage Family stay here and are not group sponsorship, room funding, or room usage top-ups. Do not use for ordinary family medical history, genetics, family symptoms, household health context, or caregiving unless Murph Family account access is also in scope.',
   },
   {
     slug: 'pdf',

--- a/packages/assistant-engine/test/assistant-family-group-handoff-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-family-group-handoff-skill.test.ts
@@ -2,10 +2,33 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+import {
+  ASSISTANT_SKILLS,
+  resolveAssistantSkillsRoot,
+} from '../src/assistant-skill-assets.js'
 
 describe('Murph Family group setup handoff', () => {
-  it('starts setup from the room without granting the room billing authority', async () => {
+  it('routes Family setup away from room funding at the skill index', () => {
+    const family = ASSISTANT_SKILLS.find(
+      (candidate) => candidate.slug === 'murph-family',
+    )
+    const lowUsage = ASSISTANT_SKILLS.find(
+      (candidate) => candidate.slug === 'hosted-low-usage',
+    )
+
+    expect(family?.triggerHint).toContain(
+      'are not group sponsorship, room funding, or room usage top-ups',
+    )
+    expect(lowUsage?.triggerHint).toContain(
+      'is not room funding or a room usage top-up',
+    )
+    expect(lowUsage?.triggerHint).toContain('use murph-family')
+    expect(lowUsage?.triggerHint).toContain(
+      'unless the same request explicitly asks about funding or usage for the current room',
+    )
+  })
+
+  it('offers a private conversation or stable link without room billing authority', async () => {
     const skill = await readFile(
       path.join(resolveAssistantSkillsRoot(), 'murph-family', 'SKILL.md'),
       'utf8',
@@ -16,7 +39,23 @@ describe('Murph Family group setup handoff', () => {
       'not the group\'s synthetic thread-container member',
     )
     expect(normalized).toContain(
-      'send `https://www.withmurph.ai/family/setup` immediately',
+      'This classification outranks generic group funding or usage language.',
+    )
+    expect(normalized).toContain(
+      'Do not call `murph.group` usage or referral actions',
+    )
+    expect(normalized).toContain(
+      'unless the same request explicitly asks about funding or usage for the current room.',
+    )
+    expect(normalized).toContain(
+      'You can message me privately to set one up for your family, or click this link to do it:',
+    )
+    expect(normalized).toContain(
+      'https://www.withmurph.ai/family/setup',
+    )
+    expect(normalized).toContain('Keep the raw URL on the final line.')
+    expect(normalized).toContain(
+      'The person starts the private conversation; do not initiate a private message from the group.',
     )
     expect(normalized).toContain(
       'It contains no member, group, checkout, invite, billing, or health-data identifiers',

--- a/packages/assistant-engine/test/assistant-family-group-handoff-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-family-group-handoff-skill.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+
+describe('Murph Family group setup handoff', () => {
+  it('starts setup from the room without granting the room billing authority', async () => {
+    const skill = await readFile(
+      path.join(resolveAssistantSkillsRoot(), 'murph-family', 'SKILL.md'),
+      'utf8',
+    )
+    const normalized = skill.replace(/\s+/gu, ' ').trim()
+
+    expect(normalized).toContain(
+      'not the group\'s synthetic thread-container member',
+    )
+    expect(normalized).toContain(
+      'send `https://www.withmurph.ai/family/setup` immediately',
+    )
+    expect(normalized).toContain(
+      'It contains no member, group, checkout, invite, billing, or health-data identifiers',
+    )
+    expect(normalized).toContain(
+      'Do not require an extra confirmation merely to send it.',
+    )
+    expect(normalized).toContain(
+      'Do not call `murph.family_plan`, claim account state, choose an owner, or create a checkout or invite from the group runtime.',
+    )
+    expect(normalized).toContain(
+      'Never return a generated Family checkout, top-up, or invite URL to a group.',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add a stable `https://www.withmurph.ai/family/setup` handoff that signs an existing member in when needed and then opens that authenticated member's `#family` Settings section
- teach group Murph to answer Family setup requests with one simple choice: message Murph privately or open the setup link
- disambiguate Murph Family from group sponsorship, room funding, referral missions, and room usage top-ups at both the skill-index and Family-policy boundaries
- keep all Family status reads, Stripe checkout creation, invite creation, and generated billing URLs out of the group runtime
- add regression coverage for the auth continuation, exact group copy, routing distinction, and assistant authority boundary

## Route trace

The existing conversational route is private-only by design:

1. turn planning exposes `murph.family_plan` only for a direct audience
2. Cloudflare binds the Family tool call to the runtime member id
3. a hosted group runtime is bound to its synthetic thread-container member
4. the web Family handler rejects that synthetic member with `HOSTED_FAMILY_PERSONAL_MEMBER_REQUIRED`
5. private calls can then read the real owner's Family snapshot and start Stripe checkout or create invites

Removing either guard would let a synthetic room identity approach account ownership and billing, so this PR does not make the Family tool group-capable.

Instead, the room gets one account-neutral navigation URL. The URL carries no member, room, checkout, invite, billing, or health identifiers. The browser authenticates the person who clicked it, and only then redirects into that person's existing Family Settings surface. Generated checkout and invite URLs remain private.

## UX after this change

For an explicit Family setup request in a hosted group, Murph answers briefly:

```text
You can message me privately to set one up for your family, or click this link to do it:
https://www.withmurph.ai/family/setup
```

The raw URL stays on the final line. Murph does not proactively DM the requester; the person starts the private conversation.

- **Signed in:** group request → `/family/setup` → private `Settings#family`
- **Signed out with an accessible Murph account:** group request → `/family/setup` → normal Murph auth dialog → same handoff reloads → private `Settings#family`
- **Brand-new or onboarding-incomplete account:** the existing join/activation flow remains authoritative; after the account becomes accessible, the person can reopen the stable Family handoff. This PR does not let a room create billing before a real personal member exists.
- **Conversational checkout or invite creation:** the requester messages their private Murph, where the existing `murph.family_plan` route remains authoritative

A request to start or manage a **Murph Family plan**, add Family seats, or invite family members is not interpreted as sponsorship or added usage for the current chat room. Group funding and top-up tooling remains available only when the same request explicitly concerns funding, sponsorship, usage, or Murph time for the current room.

A true one-turn group request that silently creates checkout and sends it privately would require a new sender-bound, action-capable handoff. The current sender continuation work in #1481 is intentionally read-only, so reusing it for billing would weaken its authority contract rather than simplify this flow.

## Architecture and reuse

- Existing systems reused: hosted page-auth snapshots, the shared Murph authentication dialog and auth-required presentation, the authenticated `Settings#family` owner surface, the existing skill registry, and the existing private Family/Stripe services.
- New logic: one stable `/family/setup` continuation route, one exact group-response contract, and one narrow Family-vs-room-funding classifier shared between the two relevant skill-index entries.
- New abstractions: one narrow public navigation page and one inert design-catalog state; neither owns Family, billing, invitations, or member identity.
- Complexity intentionally avoided: no group billing identity, sender impersonation, room-scoped Family state, schema or queue, new checkout service, generated private URL in the room, parallel intent router, or weakening of the private-only Family tool boundary.

## Tests

- `apps/web/test/family-setup-auth-required.test.tsx`
- `packages/assistant-engine/test/assistant-family-group-handoff-skill.test.ts`

The assistant test pins both sides of the route boundary: the Family skill claims Family setup, while the low-usage skill explicitly refuses to reinterpret it as room funding unless the user also asks about the current room.

## Design proof

- Design page: [`/design?tab=sections#family-setup-auth-required-section`](https://www.withmurph.ai/design?tab=sections#family-setup-auth-required-section), section “Settings and Family sign-in handoffs”.

- Desktop screenshot: existing hosted capture of the exact shared `HostedAuthRequiredScreenView` production primitive reused by the Family card; the branch catalog state changes only its Family-specific copy and eyebrow icon.

  <img src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/885e21d9-806f-41f5-02e7-2d792db51800/public" width="420">

- Mobile screenshot: existing hosted 390×844 capture of the same shared auth-required primitive. The Family-specific state is also rendered inertly in the catalog at the design link above.

  <img src="https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/ddb2b531-1dba-4d99-fdc5-5785b3060900/public" width="220">

The deployment preview is intentionally ignored for this branch, so these hosted captures document the reused production primitive rather than claiming to be a live branch preview. All catalog props are synthetic and contain no member data.
