### PR TITLE
Add iOS app link to website footer

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -338,7 +338,7 @@ export function SectionsContent() {
 
       <Separator />
 
-      <StudySection title="Homepage footer with vitals and split link columns">
+      <StudySection title="Homepage footer with vitals, iOS app, and split link columns">
         <div
           data-design-section="homepage-footer"
           className="-mx-5 sm:-mx-8 lg:-mx-12"

--- a/apps/web/e2e/viewport-overflow.spec.ts
+++ b/apps/web/e2e/viewport-overflow.spec.ts
@@ -146,6 +146,71 @@ for (const route of ROUTES) {
   }
 }
 
+test("homepage footer link columns stay separate at the sm breakpoint", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 640, height: 900 });
+  await page.route("**/*", (route) => {
+    if (isLoopbackUrl(route.request().url())) {
+      route.continue();
+    } else {
+      route.abort();
+    }
+  });
+
+  const response = await page.goto("/", { waitUntil: "load" });
+  expect(response?.status(), "homepage should respond 200 at 640px").toBe(200);
+  await page.evaluate(async () => {
+    await document.fonts?.ready;
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+  });
+
+  const footer = page.locator("#site-footer");
+  await expect(footer).toBeVisible();
+  const overlaps = await footer.evaluate((element, tolerance) => {
+    const readLinks = (ariaLabel: string) =>
+      Array.from(
+        element.querySelectorAll<HTMLAnchorElement>(
+          `nav[aria-label="${ariaLabel}"] a`,
+        ),
+      ).map((link) => {
+        const rect = link.getBoundingClientRect();
+        return {
+          bottom: rect.bottom,
+          label: link.textContent?.trim() ?? "",
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+        };
+      });
+
+    const productLinks = readLinks("Product links");
+    const legalLinks = readLinks("Legal links");
+    if (productLinks.length === 0 || legalLinks.length === 0) {
+      throw new Error("Homepage footer link columns are missing.");
+    }
+
+    return productLinks.flatMap((productLink) =>
+      legalLinks
+        .filter(
+          (legalLink) =>
+            productLink.left < legalLink.right - tolerance
+            && productLink.right > legalLink.left + tolerance
+            && productLink.top < legalLink.bottom - tolerance
+            && productLink.bottom > legalLink.top + tolerance,
+        )
+        .map((legalLink) => `${productLink.label} / ${legalLink.label}`),
+    );
+  }, OVERFLOW_TOLERANCE_PX);
+
+  expect(
+    overlaps,
+    `footer product and legal links overlap at 640px: ${overlaps.join(", ")}`,
+  ).toEqual([]);
+});
+
 test("health-data consent actions stay inline and contained", async ({ page }) => {
   test.setTimeout(300_000);
   await page.setViewportSize({ width: 1440, height: 900 });

--- a/apps/web/src/components/homepage/site-footer.tsx
+++ b/apps/web/src/components/homepage/site-footer.tsx
@@ -41,6 +41,11 @@ const footerLinks = {
     { label: "Referrals", href: "/refer", external: false },
     { label: "Changelog", href: "/changelog", external: false },
     {
+      label: "iOS app",
+      href: "https://apps.apple.com/us/app/murph-ai/id6786145859",
+      external: true,
+    },
+    {
       label: "Status",
       href: "https://status.withmurph.ai",
       external: true,

--- a/apps/web/src/components/homepage/site-footer.tsx
+++ b/apps/web/src/components/homepage/site-footer.tsx
@@ -101,7 +101,7 @@ export function SiteFooter({
                 Murph
               </span>
               <nav
-                className="grid gap-2 sm:grid-flow-col sm:grid-rows-4 sm:gap-x-12"
+                className="grid gap-2 sm:grid-flow-col sm:grid-rows-5 sm:gap-x-12 md:grid-rows-4"
                 aria-label="Product links"
               >
                 {productLinks.map((link) => (

--- a/apps/web/test/consumer-health-data-privacy-policy.test.ts
+++ b/apps/web/test/consumer-health-data-privacy-policy.test.ts
@@ -131,6 +131,17 @@ test("SiteFooter exposes the public status page in the product nav column", () =
   assert.match(markup, /href="https:\/\/status\.withmurph\.ai" target="_blank" rel="noreferrer"/u);
 });
 
+test("SiteFooter links to the Murph iOS app in the product nav column", () => {
+  const markup = renderToStaticMarkup(createElement(SiteFooter));
+
+  assert.match(markup, /aria-label="Product links"/u);
+  assert.match(
+    markup,
+    /href="https:\/\/apps\.apple\.com\/us\/app\/murph-ai\/id6786145859" target="_blank" rel="noreferrer"/u,
+  );
+  assert.match(markup, />iOS app<\/a>/u);
+});
+
 test("SiteFooter exposes referrals only while a reward path is available", () => {
   const availableMarkup = renderToStaticMarkup(
     createElement(SiteFooter, { referralsAvailable: true }),


### PR DESCRIPTION
## Why this PR exists

The public website footer did not provide a direct route to Murph’s iOS app. This adds the canonical App Store listing alongside the existing product links.

## User goal / user-visible behavior

A visitor can select “iOS app” in the website footer and open the Murph App Store listing in a new browser tab.

## User experience

The entry point is the existing Product links column in the footer. One short link and one click open the App Store immediately through standard browser navigation; there is no in-product wait or asynchronous continuation. The final destination is Apple’s public App Store listing. If the browser cannot open the external destination, the current page remains available. Desktop and mobile renders of the real footer component in the design catalog show the link fitting the existing hierarchy without another screen or control.

## Invariants the PR must preserve

- Keep the existing footer link groups, legal content, status presentation, and responsive layout intact.
- Keep external-link behavior explicit with a new tab and safe opener isolation.
- Reuse the canonical App Store URL already owned elsewhere in the repository.
- Keep the design catalog rendering the real production footer component with synthetic data only.

## Non-obvious affected surfaces

None.

## Architecture and reuse

- **Existing systems reused:** The existing `SiteFooter` product-link data and shared external-link rendering path remain the single production owner.
- **New logic:** One static product-link entry points at the canonical Murph App Store listing, plus a breakpoint-only row adjustment that preserves separation from Legal links.
- **New abstractions:** No abstraction was added because the existing footer link and responsive grid contracts are sufficient.
- **Complexity intentionally avoided:** No new component, state, request, dependency, duplicate design-study markup, snapshot, or layout helper was introduced.

## Hot reply path impact

Not applicable — this changes only static public website footer presentation and does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable — no prompt, tool, provider-request, or runtime assembly surface changed.
- Group Murph: Not applicable — no prompt, tool, provider-request, or runtime assembly surface changed.

## Preliminary specialist lenses

- **Product experience: applicable.** Intended outcome: visitors can reach the iOS listing directly from the footer. Direct journey evidence is the rendered catalog footer at desktop and mobile sizes, the static-markup destination assertion, and corrected-head overlap measurements at responsive boundaries.
- **Prompt: not applicable.** No prompt or provider-visible input changed.
- **Frontend: applicable.** Packaged evidence: `audit-packages/pr-1530-rendered/footer-desktop-1440.png` at a 1440×900 CSS viewport and `audit-packages/pr-1530-rendered/footer-mobile.png` at a 390×844 CSS viewport, both at device scale factor 2, covering the default footer state.
- **Coverage: applicable.** Focused Vitest verifies the exact external destination and link semantics; a production-browser test verifies Product and Legal anchors do not overlap at the 640px breakpoint. Exact-head task-relevant and independent CI shards are green; the base-owned telemetry mismatch described below blocks the broad app-verification aggregate.

ReviewGPT context sensitivity: routine

Classification reason: this is a narrow static footer-link addition with no auth, persisted state, privacy, billing, health-safety, runtime, deploy-boundary, or public-API change.

## Preliminary specialist disposition

The substantive `completion-specialists` result was `SPECIALIST_OUTCOME: FINDINGS` on commit `5c8d9613032`.

- **Accepted frontend finding:** Nine Product links created a third column at the 640px `sm` breakpoint and overlapped the Legal column. The real catalog footer reproduced `GitHub / Terms of Use`; the Product grid now uses five rows through `sm` and returns to four rows at `md`.
- **Accepted coverage finding:** The existing overflow suite could not detect sibling-anchor intersection. The returned `reviewgpt-coverage.patch` was downloaded from the owned specialist thread, inspected in full, verified to touch only `apps/web/e2e/viewport-overflow.spec.ts`, applied deliberately, and retained as focused browser coverage.
- **Corrected-head proof:** Product and Legal anchor rectangles remain disjoint at 390, 640, 667, 768, and 1440 CSS pixels. The semantic one-click iOS journey is unchanged.
- **Patch artifact disposition:** accepted and applied; no production, prompt, config, schema, dependency, generated, or documentation hunk was present.
- **Rerun disposition:** the preliminary pass is intentionally not rerun after a substantive result; all accepted findings are resolved and parent final review covers the corrected patch.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/consumer-health-data-privacy-policy.test.ts apps/web/test/biomarker-design-studies.test.tsx` — 16 tests passed.
- `pnpm --dir apps/web typecheck:prepared` — passed.
- `pnpm --dir apps/web exec eslint src/components/homepage/site-footer.tsx app/design/sections-content.tsx test/consumer-health-data-privacy-policy.test.ts e2e/viewport-overflow.spec.ts` — passed.
- `pnpm test:frontend-design-proof` — 10 tests passed.
- `VIEWPORT_OVERFLOW_PORT=3330 pnpm --dir apps/web exec playwright test e2e/viewport-overflow.spec.ts --grep 'homepage footer link columns stay separate'` — 1 test passed.
- `git diff --check` — passed.
- Direct scenario: rendered the real `SiteFooter` study, reproduced the original 640px overlap, then confirmed zero Product/Legal intersections at 390, 640, 667, 768, and 1440 CSS pixels after correction.
- Claude Code UI double-check: Fable ended at explicit usage-credit exhaustion; no substitute review was added per workflow.

## Exact-head CI

Green: frontend design proof, marketing viewport overflow, release build/typecheck, assistant/CLI/platform package coverage, both CLI host matrices, fixture coverage, repository hygiene, and hosted Stripe billing checks.

Unrelated base blocker:

- `Release app verification (ubuntu)` fails only at `apps/web/test/vercel-telemetry.test.tsx:485`, and the dependent `Release checks (ubuntu)` aggregate therefore fails.
- The assertion expects the base-added `/family/setup` static page, but `VERCEL_TELEMETRY_PATHNAMES` on current `main` does not include it.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/vercel-telemetry.test.tsx` reproduces the same missing `/family/setup` mismatch locally.
- This PR changes none of the Family setup route, Vercel telemetry owner, or telemetry test; the base-only rebase was conflict-free and left the PR patch unchanged.

## Change-shape breakdown

Classification rule: authored runtime and design-catalog component code is source; executable assertions are tests/fixtures; no docs, config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 7 | 2 |
| Tests/fixtures | 76 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **83** | **2** |

Binary files: none.

## Design proof

- Design page: [`/design?tab=sections`](http://localhost:3000/design?tab=sections)
- Desktop screenshot: 1440×900 CSS viewport, device scale factor 2, cropped to the footer section.

  ![Desktop footer design proof](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/857523e2-b924-4633-5425-724524684800/designproof)
- Mobile screenshot: 390×844 CSS viewport, device scale factor 2, cropped to the footer section.

  ![Mobile footer design proof](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/68ce0d15-ed91-459b-3037-372b6a607f00/designproof)

## Audit path

Final ReviewGPT is not triggered because this remains a low-risk, single-component static presentation change. The substantive preliminary specialist findings were resolved; the base-only rebase was conflict-free and did not require a rerun.