### PR TITLE
chore: extend ReviewGPT timeout to 180 minutes

### DIFF
--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -100,13 +100,15 @@ or advance the final gate's baseline.
 
 Run the preliminary preset with exact-head packaging:
 
+The repo config defaults response capture to 180 minutes. The workflow commands
+inherit that timeout; use `--wait-timeout` only for an intentional per-run override.
+
 ```bash
 REVIEW_GPT_PR_URL=<pr-url-or-number> \
 REVIEW_GPT_REVIEW_PHASE=preliminary \
 REVIEW_GPT_RENDERED_EVIDENCE_PATHS=$'audit-packages/<desktop>.png\naudit-packages/<mobile>.png' \
   pnpm review:gpt completion-specialists \
     --wait \
-    --wait-timeout 120m \
     --response-marker SPECIALIST_REVIEW_COMPLETE \
     --response-file audit-packages/pr-<number>-specialists.md \
     --prompt "Preliminary specialist review target: <pr-url-or-number>. Checked commit: $(git rev-parse --short HEAD). Apply the product-experience, prompt, frontend, and coverage lenses declared in the PR body."
@@ -278,7 +280,6 @@ requires it or the current user explicitly asks for it.
    REVIEW_GPT_ROUND_NUMBER=1 \
      pnpm review:gpt pr-review \
        --wait \
-       --wait-timeout 120m \
        --response-marker REVIEW_COMPLETE \
        --response-file audit-packages/pr-<number>-round-<k>.md \
        --prompt "Review target: <pr-url-or-number>. Checked commit: $(git rev-parse --short HEAD). First-reviewed head: $(git rev-parse HEAD). Round 1 full-patch audit. Use the PR body as the intent contract and immutable first-review change-shape baseline."
@@ -294,7 +295,6 @@ requires it or the current user explicitly asks for it.
    REVIEW_GPT_THREAD_URL=<current-context-chatgpt-url> \
      pnpm review:gpt pr-review \
        --wait \
-       --wait-timeout 120m \
        --response-marker REVIEW_COMPLETE \
        --response-file audit-packages/pr-<number>-round-<k>.md \
        --prompt "Review target: <pr-url-or-number>. Checked commit: $(git rev-parse --short HEAD). First-reviewed head: <round-1-full-sha>. Substantive round <k>; follow review-round.json for full-audit versus correction scope. Prior findings, dispositions, landed fixes, and mechanisms: <compact-summary>. Retrospective status: <not-required-or-current-decision>."

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1683,6 +1683,68 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'research-init.mjs'))).toBe(false)
   })
 
+  it('applies ReviewGPT response timeout precedence from repo config to one run', () => {
+    const harnessRoot = mkdtempSync(path.join(os.tmpdir(), 'murph-review-gpt-timeout-'))
+    const localConfigRoot = path.join(harnessRoot, 'config')
+    const reviewGptBin = path.join(
+      repoRoot,
+      'node_modules',
+      '.bin',
+      'cobuild-review-gpt',
+    )
+    const runDry = (extraArgs: string[] = []) =>
+      spawnSync(
+        reviewGptBin,
+        [
+          '--config',
+          'scripts/review-gpt.config.sh',
+          '--wait',
+          '--dry-run',
+          '--no-zip',
+          '--prompt',
+          'Validate response timeout precedence.',
+          ...extraArgs,
+        ],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...withoutNodeV8Coverage(),
+            HOME: harnessRoot,
+            REVIEW_GPT_BROWSER_LANE_COUNT: '1',
+            XDG_CONFIG_HOME: localConfigRoot,
+          },
+        },
+      )
+
+    try {
+      const defaultResult = runDry()
+      expect(defaultResult.status, defaultResult.stderr).toBe(0)
+      expect(defaultResult.stdout).toContain(
+        'Response capture: enabled (10800000ms timeout)',
+      )
+
+      writeHarnessFile(
+        localConfigRoot,
+        'murph/review-gpt.conf',
+        'response_timeout_ms=7654321\n',
+      )
+      const localResult = runDry()
+      expect(localResult.status, localResult.stderr).toBe(0)
+      expect(localResult.stdout).toContain(
+        'Response capture: enabled (7654321ms timeout)',
+      )
+
+      const perRunResult = runDry(['--wait-timeout', '42m'])
+      expect(perRunResult.status, perRunResult.stderr).toBe(0)
+      expect(perRunResult.stdout).toContain(
+        'Response capture: enabled (2520000ms timeout)',
+      )
+    } finally {
+      rmSync(harnessRoot, { force: true, recursive: true })
+    }
+  })
+
   it('keeps ReviewGPT browser preferences local and reuses correction threads', () => {
     const harnessRoot = mkdtempSync(path.join(os.tmpdir(), 'murph-review-gpt-browser-'))
     const localConfigRoot = path.join(harnessRoot, 'config')

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1701,6 +1701,8 @@ describe('monorepo release flow coverage audit', () => {
           '--wait',
           '--dry-run',
           '--no-zip',
+          '--browser-path',
+          process.execPath,
           '--prompt',
           'Validate response timeout precedence.',
           ...extraArgs,

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -160,6 +160,7 @@ package_script="scripts/package-audit-context-full.sh"
 app_connector="current"
 model="gpt-5.6-sol"
 thinking="current"
+response_timeout_ms="${response_timeout_ms:-$((180 * 60 * 1000))}"
 
 review_gpt_review_phase="${REVIEW_GPT_REVIEW_PHASE:-final}"
 review_gpt_round_number="${REVIEW_GPT_ROUND_NUMBER:-}"


### PR DESCRIPTION
## Why

Long-running ReviewGPT responses can exceed the upstream 120-minute capture default. This change gives Murph review runs a 180-minute default while preserving intentional per-run and local-config overrides.

## Outcome and invariants

- ReviewGPT response capture defaults to 180 minutes for repository-managed runs.
- Explicit `--wait-timeout` values still override the default.
- A user-owned `response_timeout_ms` setting still overrides the repository default.
- No product runtime, deploy surface, or member-facing behavior changes.

## Architecture and reuse

- Existing systems reused: the ReviewGPT shell-config `response_timeout_ms` boundary and the current workflow commands.
- New logic: one defaulted duration expression in the existing config owner.
- New abstractions: none were introduced because the existing ReviewGPT config already owns response-capture timeout.
- Complexity intentionally avoided: removed three duplicated 120-minute command overrides so the examples inherit the single config-owned default.

## Preliminary specialist lenses

- Product experience: not applicable; this is internal review tooling.
- Prompt: not applicable; no provider or assistant instructions changed.
- Frontend: not applicable; no UI changed.
- Coverage: applicable; the configuration behavior and workflow examples changed.
- Focused proof: shell syntax/lint, ReviewGPT dry-run resolving `10800000ms`, and the repo-internal diff-aware verification lane.
- Specialist outcome: `FINDINGS`; the accepted timeout-precedence coverage gap is fixed on the current head.
- Exact-head CI status: green at `f4c11172eb5686cf1b7c38803dad7321cf828bc4`.

## Validation

- `bash -n scripts/review-gpt.config.sh`
- `shellcheck scripts/review-gpt.config.sh`
- `pnpm review:gpt --wait --dry-run --no-zip --prompt <validation prompt>` resolved `Response capture: enabled (10800000ms timeout)`.
- `pnpm test:diff scripts/review-gpt.config.sh agent-docs/operations/pr-reviewgpt-loop.md` passed: 33 files and 515 tests, plus syntax, architecture/privacy guards, repo-tools typecheck, and dependency policy.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts packages/cli/test/release-script-coverage-audit.test.ts --no-coverage -t <timeout precedence test>` passed.
- `pnpm --dir packages/cli typecheck` passed.
- `git diff --check`
- Exact-head GitHub Actions passed all required checks, including Linux CLI package coverage.
- Final ReviewGPT round 1: `PASS` with no findings on the validated full-patch bundle.

## Design proof

Not applicable.

## Change shape

Classification uses base-to-head line counts and assigns each touched path to exactly one category. Binary files: none.

- Source: +0 / -0
- Tests: +64 / -0
- Docs: +3 / -3
- Config/tooling: +1 / -0
- Generated/other: +0 / -0

ReviewGPT first-reviewed head: f4c11172eb5686cf1b7c38803dad7321cf828bc4

ReviewGPT context sensitivity: routine

Reason: narrow internal review-tooling default with no product, runtime, state, auth, billing, privacy, or deploy-boundary impact.