### PR TITLE
Replace Linq inventory sync with bulk queries

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-09-linq-inventory-bulk-upsert.md
+++ b/agent-docs/exec-plans/completed/2026-08-09-linq-inventory-bulk-upsert.md
@@ -1,0 +1,91 @@
+# Replace Linq inventory loops with set-based synchronization
+
+Status: completed
+Created: 2026-08-09
+Updated: 2026-08-10
+
+## Goal
+
+- Make Linq configured-line and authoritative provider-inventory synchronization
+  converge through bounded set-based PostgreSQL writes without an in-transaction
+  per-phone write loop.
+- Preserve a transaction-scoped inventory publication lock so member-facing
+  backup reads never observe partially published ownership.
+- Preserve encrypted phone storage, lookup-key compatibility, provider-id move
+  handling, freshness/status semantics, and all existing assignment/read paths.
+
+## Success criteria
+
+- The complete normalized/encrypted input is prepared before opening a database
+  transaction.
+- Each multi-phone synchronization path uses a bounded `VALUES`/CTE bulk write;
+  it does not call the per-phone upsert loop.
+- Set-based configured/provider snapshot writers and candidacy snapshots share a
+  transaction-scoped publication lock; member backup reads fail soft while a
+  writer is in flight.
+- Existing unique phone lookup keys and unique provider phone-number ids remain
+  the convergence owners, including moved-id and reversed-input-order races.
+- Focused unit and real-PostgreSQL tests prove exact final state, bounded query
+  count, rollback, and absence of deadlock under concurrent synchronization.
+- Web typecheck and the exact-head PR checks pass with no unresolved accepted
+  ReviewGPT finding.
+
+## Scope
+
+- In scope: `HostedLinqLine` configured/provider snapshot writers, their focused
+  unit and PostgreSQL tests, and narrow owner documentation where required.
+- Out of scope: schema changes, new state, provider API shape changes, line
+  assignment policy, webhook/delivery single-phone writers, and frontend work.
+
+## Constraints
+
+- Technical constraints: keep private phone plaintext out of SQL diagnostics and
+  durable artifacts; use Prisma parameterization; preserve lookup-key read
+  compatibility without `as any` or broad assertions; keep cardinality bounded
+  by the existing 250-line limit.
+- Product/process constraints: smallest owner-local deletion; Pro returns a
+  scoped patch for parent inspection; complete the worktree/PR, specialist,
+  final ReviewGPT, and exact-head CI workflow.
+
+## Risks and mitigations
+
+1. Risk: provider-id moves can collide with the unique provider-id index.
+   Mitigation: release stale pairings and claim the authoritative snapshot in
+   one serializable transaction with real PostgreSQL race coverage.
+2. Risk: historical lookup-key candidates can create duplicate phone rows.
+   Mitigation: resolve a deterministic existing/current target key before the
+   statement and retain unique-key convergence tests.
+3. Risk: bulk SQL can accidentally overwrite newer provider-health evidence.
+   Mitigation: preserve the existing field-specific timestamp predicates and
+   add mixed fresh/stale evidence assertions.
+
+## Tasks
+
+1. Trace current line, inventory, encryption, lookup-key, and provider-health
+   owners and package the exact task for ReviewGPT Pro.
+2. Inspect and integrate Pro's patch, reducing it to the smallest maintainable
+   owner-local change and accepting ReviewGPT's publication-lock correction.
+3. Run focused unit and real-PostgreSQL concurrency/query-count proof plus Web
+   typecheck/diff checks.
+4. Commit, push, open the PR, then resolve specialist/final ReviewGPT and CI.
+
+## Decisions
+
+- Keep per-phone locking for unrelated single-phone writers unless direct proof
+  shows it is obsolete there; this task removes the per-phone write loop only
+  from the multi-phone synchronization paths.
+- Keep a transaction-scoped advisory publication lock for set-based writers and
+  candidacy snapshots, because ReviewGPT found a stale backup-read race during
+  in-flight ownership moves.
+- Use current `origin/main` in an isolated task worktree because the primary
+  checkout contains unrelated edits and was stale.
+
+## Verification
+
+- Commands to run: focused hosted-Web Vitest slices for line store and inventory;
+  opt-in local PostgreSQL inventory concurrency proof; Web typecheck or truthful
+  diff-aware verification selected after the final file set is known.
+- Expected outcomes: all checks pass; concurrent reversed-order snapshots finish
+  without deadlock and converge to unique authoritative rows; member-facing
+  backup reads fail soft while a publication is in flight.
+Completed: 2026-08-10

--- a/agent-docs/exec-plans/completed/2026-08-10-linq-lock-deletion-correction.md
+++ b/agent-docs/exec-plans/completed/2026-08-10-linq-lock-deletion-correction.md
@@ -1,0 +1,69 @@
+# Correct Linq inventory lock deletion
+
+Status: completed
+Created: 2026-08-10
+
+## Goal
+
+- Correct PR #1534 so both multi-line Linq synchronization paths use their
+  prepared set-based statements without the inventory-wide advisory lock.
+- Keep the provider inventory application as one parameterized VALUES/CTE
+  statement, as explicitly requested, while preserving ordinary provider-id
+  moves and transaction-level atomicity.
+
+## Success criteria
+
+- No multi-line configured/provider snapshot path acquires the inventory-wide
+  advisory lock or loops through per-phone writes.
+- Provider inventory executes one bulk database statement per transaction
+  attempt; configured-line synchronization also executes one bulk statement.
+- Phone normalization, lookup-key preparation, encryption, hinting, dedupe,
+  bounds, and deterministic ordering remain outside transaction entry.
+- Focused unit and real-PostgreSQL tests cover exact state, ordinary provider-id
+  moves, reversed input order, concurrent convergence, and statement count.
+- The exact pushed head passes ReviewGPT and required GitHub checks.
+
+## Scope
+
+- In scope: the PR's Linq line-store, provider-inventory, contact-card coupling,
+  focused tests, and PR/process documentation.
+- Out of scope: schema changes, new state, arbitrary provider-id permutations,
+  single-phone webhook/delivery writers, and frontend behavior.
+
+## Decisions
+
+- Reject the preliminary remediation that reintroduced the inventory advisory
+  lock: review findings do not override the user's explicit deletion request,
+  and the lock broadened into unrelated contact-card reads.
+- Retain the single-phone advisory lock only for unrelated single-phone writers;
+  multi-line paths do not call that writer.
+- Treat a complete provider snapshot as one atomic SQL statement. PostgreSQL
+  MVCC publishes the statement only at commit; readers may see the prior
+  committed snapshot while it is in flight, which is the ordinary transaction
+  contract and not a partial publication.
+
+## Verification
+
+- Focused hosted-Web Vitest slices for line store, inventory, provider health,
+  contact-card, and sync script.
+- Opt-in real-PostgreSQL inventory proof against a fresh local throwaway DB.
+- Hosted-Web prepared typecheck and `git diff --check`.
+- Exact-head final ReviewGPT and required GitHub Actions.
+
+## Progress
+
+- Removed the reintroduced inventory advisory lock from configured/provider
+  writers and from contact-card reads.
+- Restored one provider VALUES/CTE statement and one configured VALUES/CTE
+  statement, then removed their explicit inventory-wide `FOR UPDATE` barriers
+  so the unique keys and ordinary DML row locks own conflict convergence.
+- Focused unit proof: 107 tests passed across contact-card, line-store,
+  provider-inventory, provider-health, and sync-script slices; the directly
+  affected line-store/inventory rerun passed 42 tests after the final SQL
+  simplification.
+- Real-PostgreSQL proof: 12 tests passed on a fresh migrated throwaway database
+  after the final SQL simplification; the database was removed after the run.
+- Prepared hosted-Web typecheck passed on the final candidate.
+- `git diff --check` and the scoped identifier/privacy scan passed.
+Updated: 2026-08-10
+Completed: 2026-08-10

--- a/apps/web/scripts/sync-hosted-linq-lines.ts
+++ b/apps/web/scripts/sync-hosted-linq-lines.ts
@@ -20,14 +20,12 @@ export async function syncHostedLinqLines(
   const syncProviderInventory = !argv.includes("--skip-provider-inventory");
 
   try {
-    await prisma.$transaction(async (tx) => {
-      await syncHostedLinqConfiguredLinesTx({
-        // Rollback compatibility only; weighted assignment does not read this.
-        activeMemberLimit: environment.linqMaxActiveMembersPerConversationPhone,
-        observedAt,
-        phoneNumbers: environment.linqConversationPhoneNumbers,
-        prisma: tx,
-      });
+    await syncHostedLinqConfiguredLinesTx({
+      // Rollback compatibility only; weighted assignment does not read this.
+      activeMemberLimit: environment.linqMaxActiveMembersPerConversationPhone,
+      observedAt,
+      phoneNumbers: environment.linqConversationPhoneNumbers,
+      prisma,
     });
 
     const configuredHints = environment.linqConversationPhoneNumbers

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -61,9 +61,9 @@ export async function reconcileHostedLinqContactCards(input: {
 }): Promise<HostedLinqContactCardReconciliation> {
   const observedAt = input.observedAt ?? new Date();
 
-  // One locked, consistent snapshot of candidacy plus the configured-line
-  // total, so an overlapping revoking health-cron run can never be observed
-  // half-applied and no second unlocked read can disagree with the first.
+  // One repeatable-read snapshot of candidacy plus the configured-line total,
+  // so an overlapping authoritative inventory statement cannot be observed
+  // half-applied and no second read can disagree with the first.
   const { configuredLineCount, lines } = await listHostedLinqConfiguredContactCardLines({
     maxLines: input.maxLines,
     observedAt,
@@ -271,18 +271,9 @@ async function listHostedLinqConfiguredContactCardLines(input: {
   // into a member's saved vCard.
   const snapshot = await readHostedLinqContactCardCandidacySnapshot({
     limit: maxLines,
-    lockMode: "wait",
     observedAt: input.observedAt,
     prisma: input.prisma,
   });
-  if (!snapshot) {
-    throw hostedOnboardingError({
-      code: "LINQ_CONTACT_CARD_RECONCILE_FAILED",
-      message: "Linq contact-card reconciliation could not read a candidacy snapshot.",
-      httpStatus: 502,
-      retryable: true,
-    });
-  }
   return {
     configuredLineCount: snapshot.configuredLineCount,
     lines: snapshot.lines.map((line) => ({
@@ -543,18 +534,13 @@ export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: 
 }): Promise<string | null> {
   const excludePhoneNumber = normalizePhoneNumber(input.excludePhoneNumber);
   try {
-    // Same locked snapshot the reconciler uses: an unlocked two-query read
-    // can straddle a committing ownership move and return a line that was
-    // just revoked, which this resolver would then embed terminally in a
-    // member's saved vCard.
+    // Same repeatable-read snapshot the reconciler uses, so the two-query read
+    // cannot straddle a committing ownership move and return a just-revoked
+    // line for a member's saved vCard.
     const snapshot = await readHostedLinqContactCardCandidacySnapshot({
       limit: HOSTED_LINQ_CONTACT_CARD_LINE_LIMIT,
-      lockMode: "skip",
       prisma: input.prisma,
     });
-    if (!snapshot) {
-      return null;
-    }
     const { lines } = snapshot;
     return lines.find((line) =>
       line.phoneNumber !== excludePhoneNumber

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -274,9 +274,6 @@ async function listHostedLinqConfiguredContactCardLines(input: {
     observedAt: input.observedAt,
     prisma: input.prisma,
   });
-  if (!snapshot) {
-    return { configuredLineCount: 0, lines: [] };
-  }
   return {
     configuredLineCount: snapshot.configuredLineCount,
     lines: snapshot.lines.map((line) => ({
@@ -537,17 +534,13 @@ export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: 
 }): Promise<string | null> {
   const excludePhoneNumber = normalizePhoneNumber(input.excludePhoneNumber);
   try {
-    // Same publication boundary the reconciler uses, but non-blocking: a
-    // member should get the primary card without a backup instead of waiting
-    // on, or publishing from, an in-flight ownership move.
+    // Same repeatable-read snapshot the reconciler uses, so the two-query read
+    // cannot straddle a committing ownership move and return a just-revoked
+    // line for a member's saved vCard.
     const snapshot = await readHostedLinqContactCardCandidacySnapshot({
       limit: HOSTED_LINQ_CONTACT_CARD_LINE_LIMIT,
-      lockMode: "skip",
       prisma: input.prisma,
     });
-    if (!snapshot) {
-      return null;
-    }
     const { lines } = snapshot;
     return lines.find((line) =>
       line.phoneNumber !== excludePhoneNumber

--- a/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-contact-card.ts
@@ -274,6 +274,9 @@ async function listHostedLinqConfiguredContactCardLines(input: {
     observedAt: input.observedAt,
     prisma: input.prisma,
   });
+  if (!snapshot) {
+    return { configuredLineCount: 0, lines: [] };
+  }
   return {
     configuredLineCount: snapshot.configuredLineCount,
     lines: snapshot.lines.map((line) => ({
@@ -534,13 +537,17 @@ export async function resolveMurphHostedLinqContactCardBackupPhoneNumber(input: 
 }): Promise<string | null> {
   const excludePhoneNumber = normalizePhoneNumber(input.excludePhoneNumber);
   try {
-    // Same repeatable-read snapshot the reconciler uses, so the two-query read
-    // cannot straddle a committing ownership move and return a just-revoked
-    // line for a member's saved vCard.
+    // Same publication boundary the reconciler uses, but non-blocking: a
+    // member should get the primary card without a backup instead of waiting
+    // on, or publishing from, an in-flight ownership move.
     const snapshot = await readHostedLinqContactCardCandidacySnapshot({
       limit: HOSTED_LINQ_CONTACT_CARD_LINE_LIMIT,
+      lockMode: "skip",
       prisma: input.prisma,
     });
+    if (!snapshot) {
+      return null;
+    }
     const { lines } = snapshot;
     return lines.find((line) =>
       line.phoneNumber !== excludePhoneNumber

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -307,17 +307,6 @@ function chooseHostedLinqLineWriteLookupKey(
   return lookupKeyReadCandidates.find((candidate) => existingLookupKeys.has(candidate)) ?? null;
 }
 
-export async function acquireHostedLinqInventoryApplyLockTx(input: {
-  prisma: HostedLinqLineClient;
-}): Promise<void> {
-  await input.prisma.$executeRaw`
-    SELECT pg_advisory_xact_lock(
-      hashtext('hosted_linq_phone_number_inventory'),
-      hashtext('snapshot')
-    )
-  `;
-}
-
 export async function syncHostedLinqConfiguredLinesTx(input: {
   /**
    * Additive-rollout compatibility for previous application builds only.
@@ -338,16 +327,14 @@ export async function syncHostedLinqConfiguredLinesTx(input: {
     return;
   }
 
-  const apply = async (prisma: HostedLinqLineClient) => {
-    await acquireHostedLinqInventoryApplyLockTx({ prisma });
-    await prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
+  const apply = (prisma: HostedLinqLineClient) =>
+    prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
       buildHostedLinqConfiguredLineSnapshotQuery({
         activeMemberLimit: input.activeMemberLimit,
         lines,
         observedAt,
       }),
     );
-  };
 
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
@@ -380,22 +367,6 @@ function buildHostedLinqConfiguredLineSnapshotQuery(input: {
     ) AS (
       VALUES ${values}
     ),
-    locked_line AS MATERIALIZED (
-      SELECT line.phone_number_lookup_key
-      FROM hosted_linq_line AS line
-      WHERE line.phone_number_lookup_key IN (
-        SELECT candidate.lookup_key
-        FROM input_line AS input
-        CROSS JOIN LATERAL unnest(input.lookup_key_candidates)
-          AS candidate(lookup_key)
-      )
-      ORDER BY line.phone_number_lookup_key
-      FOR UPDATE
-    ),
-    lock_barrier AS MATERIALIZED (
-      SELECT count(*) AS locked_count
-      FROM locked_line
-    ),
     resolved_line AS MATERIALIZED (
       SELECT
         input.current_lookup_key,
@@ -404,7 +375,6 @@ function buildHostedLinqConfiguredLineSnapshotQuery(input: {
         input.phone_number_encrypted,
         input.phone_number_hint
       FROM input_line AS input
-      CROSS JOIN lock_barrier
       LEFT JOIN LATERAL (
         SELECT line.phone_number_lookup_key
         FROM unnest(input.lookup_key_candidates) WITH ORDINALITY
@@ -952,28 +922,13 @@ export function buildHostedLinqInventoryFreshnessCutoff(observedAt: Date): Date 
 
 export async function readHostedLinqContactCardCandidacySnapshot(input: {
   limit?: number;
-  lockMode?: "skip" | "wait";
   observedAt?: Date;
   prisma: PrismaClient | Prisma.TransactionClient;
 }): Promise<{
   configuredLineCount: number;
   lines: HostedLinqContactCardLine[];
-} | null> {
+}> {
   const read = async (tx: HostedLinqLineClient) => {
-    if (input.lockMode === "skip") {
-      const acquired = await tx.$queryRaw<Array<{ locked: boolean }>>`
-        SELECT pg_try_advisory_xact_lock(
-          hashtext('hosted_linq_phone_number_inventory'),
-          hashtext('snapshot')
-        ) AS locked
-      `;
-      if (acquired[0]?.locked !== true) {
-        return null;
-      }
-    } else {
-      await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
-    }
-
     const configuredLineCount = await tx.hostedLinqLine.count({
       where: {
         configuredAt: { not: null },
@@ -990,7 +945,10 @@ export async function readHostedLinqContactCardCandidacySnapshot(input: {
 
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
-    return prisma.$transaction((tx) => read(tx));
+    return prisma.$transaction(
+      (tx) => read(tx),
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+    );
   }
 
   return read(input.prisma);

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -307,6 +307,17 @@ function chooseHostedLinqLineWriteLookupKey(
   return lookupKeyReadCandidates.find((candidate) => existingLookupKeys.has(candidate)) ?? null;
 }
 
+export async function acquireHostedLinqInventoryApplyLockTx(input: {
+  prisma: HostedLinqLineClient;
+}): Promise<void> {
+  await input.prisma.$executeRaw`
+    SELECT pg_advisory_xact_lock(
+      hashtext('hosted_linq_phone_number_inventory'),
+      hashtext('snapshot')
+    )
+  `;
+}
+
 export async function syncHostedLinqConfiguredLinesTx(input: {
   /**
    * Additive-rollout compatibility for previous application builds only.
@@ -327,14 +338,16 @@ export async function syncHostedLinqConfiguredLinesTx(input: {
     return;
   }
 
-  const apply = (prisma: HostedLinqLineClient) =>
-    prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
+  const apply = async (prisma: HostedLinqLineClient) => {
+    await acquireHostedLinqInventoryApplyLockTx({ prisma });
+    await prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
       buildHostedLinqConfiguredLineSnapshotQuery({
         activeMemberLimit: input.activeMemberLimit,
         lines,
         observedAt,
       }),
     );
+  };
 
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
@@ -939,13 +952,28 @@ export function buildHostedLinqInventoryFreshnessCutoff(observedAt: Date): Date 
 
 export async function readHostedLinqContactCardCandidacySnapshot(input: {
   limit?: number;
+  lockMode?: "skip" | "wait";
   observedAt?: Date;
   prisma: PrismaClient | Prisma.TransactionClient;
 }): Promise<{
   configuredLineCount: number;
   lines: HostedLinqContactCardLine[];
-}> {
+} | null> {
   const read = async (tx: HostedLinqLineClient) => {
+    if (input.lockMode === "skip") {
+      const acquired = await tx.$queryRaw<Array<{ locked: boolean }>>`
+        SELECT pg_try_advisory_xact_lock(
+          hashtext('hosted_linq_phone_number_inventory'),
+          hashtext('snapshot')
+        ) AS locked
+      `;
+      if (acquired[0]?.locked !== true) {
+        return null;
+      }
+    } else {
+      await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
+    }
+
     const configuredLineCount = await tx.hostedLinqLine.count({
       where: {
         configuredAt: { not: null },
@@ -962,10 +990,7 @@ export async function readHostedLinqContactCardCandidacySnapshot(input: {
 
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
-    return prisma.$transaction(
-      (tx) => read(tx),
-      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
-    );
+    return prisma.$transaction((tx) => read(tx));
   }
 
   return read(input.prisma);

--- a/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-line-store.ts
@@ -73,6 +73,63 @@ type HostedLinqContactCardLineRow = {
   providerServiceStatus: string | null;
 };
 
+export type PreparedHostedLinqLinePhone = {
+  currentLookupKey: string;
+  lookupKeyReadCandidates: readonly string[];
+  normalizedPhoneNumber: string;
+  phoneNumberEncrypted: string;
+  phoneNumberHint: string;
+};
+
+/**
+ * Freezes every privacy-derived value before a multi-line transaction begins.
+ * The sorted result also gives both bulk writers one deterministic row order.
+ */
+export function prepareHostedLinqLinePhones(input: {
+  maxLines: number;
+  phoneNumbers: readonly string[];
+}): PreparedHostedLinqLinePhone[] {
+  const preparedByCurrentLookupKey = new Map<string, PreparedHostedLinqLinePhone>();
+
+  for (const phoneNumber of input.phoneNumbers) {
+    const normalizedPhoneNumber = normalizePhoneNumber(phoneNumber);
+    const currentLookupKey = createHostedPhoneLookupKey(normalizedPhoneNumber);
+    const lookupKeyReadCandidates =
+      createHostedPhoneLookupKeyReadCandidates(normalizedPhoneNumber);
+    const phoneNumberEncrypted =
+      encryptHostedLinqLinePhoneNumber(normalizedPhoneNumber);
+    const phoneNumberHint = readHostedPhoneHint(normalizedPhoneNumber);
+
+    if (
+      !normalizedPhoneNumber
+      || !currentLookupKey
+      || lookupKeyReadCandidates.length === 0
+      || !phoneNumberEncrypted
+      || !phoneNumberHint
+    ) {
+      throw new TypeError("Hosted Linq line synchronization requires a valid phone number.");
+    }
+
+    preparedByCurrentLookupKey.set(currentLookupKey, {
+      currentLookupKey,
+      lookupKeyReadCandidates,
+      normalizedPhoneNumber,
+      phoneNumberEncrypted,
+      phoneNumberHint,
+    });
+  }
+
+  if (preparedByCurrentLookupKey.size > input.maxLines) {
+    throw new RangeError(
+      `Hosted Linq line synchronization requires at most ${input.maxLines} unique phone number(s).`,
+    );
+  }
+
+  return [...preparedByCurrentLookupKey.values()].sort((left, right) =>
+    left.currentLookupKey.localeCompare(right.currentLookupKey)
+  );
+}
+
 export async function upsertHostedLinqLineForPhoneTx(input: {
   /** @deprecated Additive-rollout compatibility; assignment does not read it. */
   activeMemberLimit?: number | null;
@@ -250,24 +307,6 @@ function chooseHostedLinqLineWriteLookupKey(
   return lookupKeyReadCandidates.find((candidate) => existingLookupKeys.has(candidate)) ?? null;
 }
 
-/**
- * Serializes every multi-phone line writer (provider inventory application
- * and configured-line synchronization) on one inventory-wide advisory lock.
- * Without a shared first lock, two writers touching the same phones in
- * opposite orders can invert their per-phone lock acquisition and deadlock.
- * Transaction-scoped: callers must already be inside a transaction.
- */
-export async function acquireHostedLinqInventoryApplyLockTx(input: {
-  prisma: HostedLinqLineClient;
-}): Promise<void> {
-  await input.prisma.$executeRaw`
-    SELECT pg_advisory_xact_lock(
-      hashtext('hosted_linq_phone_number_inventory'),
-      hashtext('snapshot')
-    )
-  `;
-}
-
 export async function syncHostedLinqConfiguredLinesTx(input: {
   /**
    * Additive-rollout compatibility for previous application builds only.
@@ -280,16 +319,136 @@ export async function syncHostedLinqConfiguredLinesTx(input: {
   prisma: HostedLinqLineClient;
 }): Promise<void> {
   const observedAt = input.observedAt ?? new Date();
-  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
-  for (const phoneNumber of input.phoneNumbers) {
-    await upsertHostedLinqLineForPhoneTx({
-      activeMemberLimit: input.activeMemberLimit,
-      observedAt,
-      phoneNumber,
-      prisma: input.prisma,
-      source: "configured",
-    });
+  const lines = prepareHostedLinqLinePhones({
+    maxLines: HOSTED_LINQ_ASSIGNABLE_HOME_LINE_LIMIT,
+    phoneNumbers: input.phoneNumbers,
+  });
+  if (lines.length === 0) {
+    return;
   }
+
+  const apply = (prisma: HostedLinqLineClient) =>
+    prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
+      buildHostedLinqConfiguredLineSnapshotQuery({
+        activeMemberLimit: input.activeMemberLimit,
+        lines,
+        observedAt,
+      }),
+    );
+
+  if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
+    const prisma = input.prisma;
+    await prisma.$transaction((tx) => apply(tx));
+    return;
+  }
+
+  await apply(input.prisma);
+}
+
+function buildHostedLinqConfiguredLineSnapshotQuery(input: {
+  activeMemberLimit: number | null;
+  lines: readonly PreparedHostedLinqLinePhone[];
+  observedAt: Date;
+}): Prisma.Sql {
+  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
+  const values = Prisma.join(input.lines.map((line) => Prisma.sql`(
+    ${line.currentLookupKey}::text,
+    ARRAY[${Prisma.join(line.lookupKeyReadCandidates)}]::text[],
+    ${line.phoneNumberEncrypted}::text,
+    ${line.phoneNumberHint}::text
+  )`));
+
+  return Prisma.sql`
+    WITH input_line (
+      current_lookup_key,
+      lookup_key_candidates,
+      phone_number_encrypted,
+      phone_number_hint
+    ) AS (
+      VALUES ${values}
+    ),
+    locked_line AS MATERIALIZED (
+      SELECT line.phone_number_lookup_key
+      FROM hosted_linq_line AS line
+      WHERE line.phone_number_lookup_key IN (
+        SELECT candidate.lookup_key
+        FROM input_line AS input
+        CROSS JOIN LATERAL unnest(input.lookup_key_candidates)
+          AS candidate(lookup_key)
+      )
+      ORDER BY line.phone_number_lookup_key
+      FOR UPDATE
+    ),
+    lock_barrier AS MATERIALIZED (
+      SELECT count(*) AS locked_count
+      FROM locked_line
+    ),
+    resolved_line AS MATERIALIZED (
+      SELECT
+        input.current_lookup_key,
+        COALESCE(existing.phone_number_lookup_key, input.current_lookup_key)
+          AS target_lookup_key,
+        input.phone_number_encrypted,
+        input.phone_number_hint
+      FROM input_line AS input
+      CROSS JOIN lock_barrier
+      LEFT JOIN LATERAL (
+        SELECT line.phone_number_lookup_key
+        FROM unnest(input.lookup_key_candidates) WITH ORDINALITY
+          AS candidate(lookup_key, candidate_ordinal)
+        INNER JOIN hosted_linq_line AS line
+          ON line.phone_number_lookup_key = candidate.lookup_key
+        ORDER BY
+          (line.phone_number_lookup_key = input.current_lookup_key) DESC,
+          candidate.candidate_ordinal
+        LIMIT 1
+      ) AS existing ON TRUE
+    ),
+    upserted_line AS (
+      INSERT INTO hosted_linq_line (
+        phone_number_lookup_key,
+        phone_number_encrypted,
+        phone_number_hint,
+        source,
+        configured_at,
+        health_status,
+        egress_policy,
+        active_member_limit,
+        assignment_weight,
+        created_at,
+        updated_at
+      )
+      SELECT
+        resolved.target_lookup_key,
+        resolved.phone_number_encrypted,
+        resolved.phone_number_hint,
+        'configured',
+        ${observedAt},
+        'unknown',
+        'enabled',
+        ${input.activeMemberLimit},
+        100,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM resolved_line AS resolved
+      ORDER BY resolved.current_lookup_key
+      ON CONFLICT (phone_number_lookup_key) DO UPDATE SET
+        phone_number_encrypted = EXCLUDED.phone_number_encrypted,
+        phone_number_hint = EXCLUDED.phone_number_hint,
+        source = 'configured',
+        configured_at = EXCLUDED.configured_at,
+        active_member_limit = CASE
+          WHEN hosted_linq_line.active_member_limit IS NULL
+            AND EXCLUDED.active_member_limit IS NOT NULL
+            THEN EXCLUDED.active_member_limit
+          ELSE hosted_linq_line.active_member_limit
+        END,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING phone_number_lookup_key
+    )
+    SELECT count(*)::bigint AS "syncedCount"
+    FROM upserted_line
+  `;
 }
 
 export async function listHostedLinqAssignableHomeLines(input: {
@@ -778,41 +937,15 @@ export function buildHostedLinqInventoryFreshnessCutoff(observedAt: Date): Date 
   return new Date(observedAt.getTime() - HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS);
 }
 
-/**
- * One consistent contact-card candidacy snapshot. Reads the configured-line
- * total and the eligible candidates under the same inventory-wide advisory
- * lock the snapshot applier uses, so a revoking health-cron run overlapping
- * the hourly contact-card cron can never be observed half-applied.
- */
 export async function readHostedLinqContactCardCandidacySnapshot(input: {
   limit?: number;
   observedAt?: Date;
   prisma: PrismaClient | Prisma.TransactionClient;
-  /**
-   * `wait` (default) is for background reconciliation, which must observe a
-   * fully applied snapshot. `skip` is for member-facing reads that must never
-   * queue behind an inventory writer: it returns null instead of waiting, so
-   * the caller can serve the primary card and omit the optional backup.
-   */
-  lockMode?: "skip" | "wait";
 }): Promise<{
   configuredLineCount: number;
   lines: HostedLinqContactCardLine[];
-} | null> {
+}> {
   const read = async (tx: HostedLinqLineClient) => {
-    if (input.lockMode === "skip") {
-      const acquired = await tx.$queryRaw<Array<{ locked: boolean }>>`
-        SELECT pg_try_advisory_xact_lock(
-          hashtext('hosted_linq_phone_number_inventory'),
-          hashtext('snapshot')
-        ) AS locked
-      `;
-      if (acquired[0]?.locked !== true) {
-        return null;
-      }
-    } else {
-      await acquireHostedLinqInventoryApplyLockTx({ prisma: tx });
-    }
     const configuredLineCount = await tx.hostedLinqLine.count({
       where: {
         configuredAt: { not: null },
@@ -829,7 +962,10 @@ export async function readHostedLinqContactCardCandidacySnapshot(input: {
 
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
-    return prisma.$transaction((tx) => read(tx));
+    return prisma.$transaction(
+      (tx) => read(tx),
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+    );
   }
 
   return read(input.prisma);

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -3,6 +3,7 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
 import {
+  acquireHostedLinqInventoryApplyLockTx,
   prepareHostedLinqLinePhones,
   type PreparedHostedLinqLinePhone,
 } from "./linq-line-store";
@@ -111,19 +112,21 @@ async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
   observedAt: Date;
   prisma: HostedLinqInventoryClient;
 }): Promise<{ syncedCount: number }> {
+  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
+  await input.prisma.$queryRaw<Array<{ releasedCount: bigint }>>(
+    buildHostedLinqPhoneNumberInventoryReleaseQuery(input),
+  );
   const rows = await input.prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
-    buildHostedLinqPhoneNumberInventorySnapshotQuery(input),
+    buildHostedLinqPhoneNumberInventoryUpsertQuery(input),
   );
   return { syncedCount: Number(rows[0]?.syncedCount ?? 0) };
 }
 
-function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
-  lines: readonly PreparedHostedLinqProviderInventoryLine[];
-  observedAt: Date;
-}): Prisma.Sql {
-  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
-  const inputRows = input.lines.length > 0
-    ? Prisma.sql`VALUES ${Prisma.join(input.lines.map((line) => Prisma.sql`(
+function buildHostedLinqPhoneNumberInventoryInputRows(
+  lines: readonly PreparedHostedLinqProviderInventoryLine[],
+): Prisma.Sql {
+  return lines.length > 0
+    ? Prisma.sql`VALUES ${Prisma.join(lines.map((line) => Prisma.sql`(
         ${line.currentLookupKey}::text,
         ARRAY[${Prisma.join(line.lookupKeyReadCandidates)}]::text[],
         ${line.phoneNumberEncrypted}::text,
@@ -143,9 +146,13 @@ function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
           NULL::text
         WHERE FALSE
       `;
+}
 
+function buildHostedLinqPhoneNumberInventoryResolvedLineCtes(
+  inputRows: Prisma.Sql,
+): Prisma.Sql {
   return Prisma.sql`
-    WITH input_line (
+    input_line (
       current_lookup_key,
       lookup_key_candidates,
       phone_number_encrypted,
@@ -196,9 +203,16 @@ function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
           candidate.candidate_ordinal
         LIMIT 1
       ) AS existing ON TRUE
-    ),
-    -- Only non-target owners are cleared here. Target rows replace stale ids
-    -- in the upsert, so no physical row is modified twice in one statement.
+    )
+  `;
+}
+
+function buildHostedLinqPhoneNumberInventoryReleaseQuery(input: {
+  lines: readonly PreparedHostedLinqProviderInventoryLine[];
+}): Prisma.Sql {
+  const inputRows = buildHostedLinqPhoneNumberInventoryInputRows(input.lines);
+  return Prisma.sql`
+    WITH ${buildHostedLinqPhoneNumberInventoryResolvedLineCtes(inputRows)},
     released_line AS (
       UPDATE hosted_linq_line AS line
       SET
@@ -211,13 +225,24 @@ function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
           SELECT 1
           FROM resolved_line AS resolved
           WHERE resolved.target_lookup_key = line.phone_number_lookup_key
+            AND resolved.provider_phone_number_id = line.provider_phone_number_id
         )
       RETURNING line.phone_number_lookup_key
-    ),
-    release_barrier AS MATERIALIZED (
-      SELECT count(*) AS released_count
-      FROM released_line
-    ),
+    )
+    SELECT count(*)::bigint AS "releasedCount"
+    FROM released_line
+  `;
+}
+
+function buildHostedLinqPhoneNumberInventoryUpsertQuery(input: {
+  lines: readonly PreparedHostedLinqProviderInventoryLine[];
+  observedAt: Date;
+}): Prisma.Sql {
+  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
+  const inputRows = buildHostedLinqPhoneNumberInventoryInputRows(input.lines);
+
+  return Prisma.sql`
+    WITH ${buildHostedLinqPhoneNumberInventoryResolvedLineCtes(inputRows)},
     upserted_line AS (
       INSERT INTO hosted_linq_line (
         phone_number_lookup_key,
@@ -271,7 +296,7 @@ function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
         CURRENT_TIMESTAMP,
         CURRENT_TIMESTAMP
       FROM resolved_line AS resolved
-      CROSS JOIN release_barrier
+      CROSS JOIN lock_barrier
       ORDER BY resolved.current_lookup_key
       ON CONFLICT (phone_number_lookup_key) DO UPDATE SET
         phone_number_encrypted = EXCLUDED.phone_number_encrypted,

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -3,7 +3,6 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
 import { hostedOnboardingError } from "./errors";
 import {
-  acquireHostedLinqInventoryApplyLockTx,
   prepareHostedLinqLinePhones,
   type PreparedHostedLinqLinePhone,
 } from "./linq-line-store";
@@ -112,21 +111,19 @@ async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
   observedAt: Date;
   prisma: HostedLinqInventoryClient;
 }): Promise<{ syncedCount: number }> {
-  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
-  await input.prisma.$queryRaw<Array<{ releasedCount: bigint }>>(
-    buildHostedLinqPhoneNumberInventoryReleaseQuery(input),
-  );
   const rows = await input.prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
-    buildHostedLinqPhoneNumberInventoryUpsertQuery(input),
+    buildHostedLinqPhoneNumberInventorySnapshotQuery(input),
   );
   return { syncedCount: Number(rows[0]?.syncedCount ?? 0) };
 }
 
-function buildHostedLinqPhoneNumberInventoryInputRows(
-  lines: readonly PreparedHostedLinqProviderInventoryLine[],
-): Prisma.Sql {
-  return lines.length > 0
-    ? Prisma.sql`VALUES ${Prisma.join(lines.map((line) => Prisma.sql`(
+function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
+  lines: readonly PreparedHostedLinqProviderInventoryLine[];
+  observedAt: Date;
+}): Prisma.Sql {
+  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
+  const inputRows = input.lines.length > 0
+    ? Prisma.sql`VALUES ${Prisma.join(input.lines.map((line) => Prisma.sql`(
         ${line.currentLookupKey}::text,
         ARRAY[${Prisma.join(line.lookupKeyReadCandidates)}]::text[],
         ${line.phoneNumberEncrypted}::text,
@@ -146,13 +143,9 @@ function buildHostedLinqPhoneNumberInventoryInputRows(
           NULL::text
         WHERE FALSE
       `;
-}
 
-function buildHostedLinqPhoneNumberInventoryResolvedLineCtes(
-  inputRows: Prisma.Sql,
-): Prisma.Sql {
   return Prisma.sql`
-    input_line (
+    WITH input_line (
       current_lookup_key,
       lookup_key_candidates,
       phone_number_encrypted,
@@ -162,23 +155,6 @@ function buildHostedLinqPhoneNumberInventoryResolvedLineCtes(
       provider_service_status
     ) AS (
       ${inputRows}
-    ),
-    locked_line AS MATERIALIZED (
-      SELECT line.phone_number_lookup_key
-      FROM hosted_linq_line AS line
-      WHERE line.provider_phone_number_id IS NOT NULL
-        OR line.phone_number_lookup_key IN (
-          SELECT candidate.lookup_key
-          FROM input_line AS input
-          CROSS JOIN LATERAL unnest(input.lookup_key_candidates)
-            AS candidate(lookup_key)
-        )
-      ORDER BY line.phone_number_lookup_key
-      FOR UPDATE
-    ),
-    lock_barrier AS MATERIALIZED (
-      SELECT count(*) AS locked_count
-      FROM locked_line
     ),
     resolved_line AS MATERIALIZED (
       SELECT
@@ -191,7 +167,6 @@ function buildHostedLinqPhoneNumberInventoryResolvedLineCtes(
         input.provider_reputation_status,
         input.provider_service_status
       FROM input_line AS input
-      CROSS JOIN lock_barrier
       LEFT JOIN LATERAL (
         SELECT line.phone_number_lookup_key
         FROM unnest(input.lookup_key_candidates) WITH ORDINALITY
@@ -203,46 +178,27 @@ function buildHostedLinqPhoneNumberInventoryResolvedLineCtes(
           candidate.candidate_ordinal
         LIMIT 1
       ) AS existing ON TRUE
-    )
-  `;
-}
-
-function buildHostedLinqPhoneNumberInventoryReleaseQuery(input: {
-  lines: readonly PreparedHostedLinqProviderInventoryLine[];
-}): Prisma.Sql {
-  const inputRows = buildHostedLinqPhoneNumberInventoryInputRows(input.lines);
-  return Prisma.sql`
-    WITH ${buildHostedLinqPhoneNumberInventoryResolvedLineCtes(inputRows)},
+    ),
+    -- Only non-target owners are cleared here. Target rows replace stale ids
+    -- in the upsert, so no physical row is modified twice in one statement.
     released_line AS (
       UPDATE hosted_linq_line AS line
       SET
         provider_inventory_confirmed_at = NULL,
         provider_phone_number_id = NULL,
         updated_at = CURRENT_TIMESTAMP
-      FROM lock_barrier
       WHERE line.provider_phone_number_id IS NOT NULL
         AND NOT EXISTS (
           SELECT 1
           FROM resolved_line AS resolved
           WHERE resolved.target_lookup_key = line.phone_number_lookup_key
-            AND resolved.provider_phone_number_id = line.provider_phone_number_id
         )
       RETURNING line.phone_number_lookup_key
-    )
-    SELECT count(*)::bigint AS "releasedCount"
-    FROM released_line
-  `;
-}
-
-function buildHostedLinqPhoneNumberInventoryUpsertQuery(input: {
-  lines: readonly PreparedHostedLinqProviderInventoryLine[];
-  observedAt: Date;
-}): Prisma.Sql {
-  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
-  const inputRows = buildHostedLinqPhoneNumberInventoryInputRows(input.lines);
-
-  return Prisma.sql`
-    WITH ${buildHostedLinqPhoneNumberInventoryResolvedLineCtes(inputRows)},
+    ),
+    release_barrier AS MATERIALIZED (
+      SELECT count(*) AS released_count
+      FROM released_line
+    ),
     upserted_line AS (
       INSERT INTO hosted_linq_line (
         phone_number_lookup_key,
@@ -296,7 +252,7 @@ function buildHostedLinqPhoneNumberInventoryUpsertQuery(input: {
         CURRENT_TIMESTAMP,
         CURRENT_TIMESTAMP
       FROM resolved_line AS resolved
-      CROSS JOIN lock_barrier
+      CROSS JOIN release_barrier
       ORDER BY resolved.current_lookup_key
       ON CONFLICT (phone_number_lookup_key) DO UPDATE SET
         phone_number_encrypted = EXCLUDED.phone_number_encrypted,

--- a/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-phone-number-inventory.ts
@@ -1,15 +1,11 @@
-import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { fetchLinqApi, LinqApiTimeoutError } from "../linq/api";
-import { createHostedPhoneLookupKeyReadCandidates } from "./contact-privacy-core";
 import { hostedOnboardingError } from "./errors";
 import {
-  acquireHostedLinqInventoryApplyLockTx,
-  upsertHostedLinqLineForPhoneTx,
+  prepareHostedLinqLinePhones,
+  type PreparedHostedLinqLinePhone,
 } from "./linq-line-store";
-import {
-  projectHostedLinqLineProviderStateTx,
-} from "./linq-provider-health-store";
 import {
   parseHostedLinqLineReputationStatus,
   parseHostedLinqLineServiceStatus,
@@ -23,10 +19,17 @@ import { normalizeNullableString } from "./shared";
 type HostedLinqInventoryClient = PrismaClient | Prisma.TransactionClient;
 
 export const HOSTED_LINQ_PHONE_NUMBER_INVENTORY_SYNC_LIMIT = 250;
+const HOSTED_LINQ_PHONE_NUMBER_INVENTORY_APPLY_MAX_ATTEMPTS = 3;
 
 export type HostedLinqProviderInventoryLine = {
   phoneNumber: string;
   providerPhoneNumberId: string | null;
+  providerReputationStatus: HostedLinqLineReputationStatus | null;
+  providerServiceStatus: HostedLinqLineServiceStatus | null;
+};
+
+type PreparedHostedLinqProviderInventoryLine = PreparedHostedLinqLinePhone & {
+  providerPhoneNumberId: string;
   providerReputationStatus: HostedLinqLineReputationStatus | null;
   providerServiceStatus: HostedLinqLineServiceStatus | null;
 };
@@ -37,120 +40,338 @@ export async function syncHostedLinqPhoneNumberInventory(input: {
   prisma: HostedLinqInventoryClient;
   signal?: AbortSignal;
 }): Promise<{ syncedCount: number }> {
+  const maxLines = Math.min(
+    normalizeInventoryLineLimit(input.maxLines),
+    HOSTED_LINQ_PHONE_NUMBER_INVENTORY_SYNC_LIMIT,
+  );
   const lines = await listHostedLinqPhoneNumberInventory({
-    maxLines: input.maxLines,
+    maxLines,
     signal: input.signal,
   });
   const observedAt = input.observedAt ?? new Date();
+  const linesByPhoneNumber = new Map(lines.map((line) => [line.phoneNumber, line]));
+  const preparedLines = prepareHostedLinqLinePhones({
+    maxLines,
+    phoneNumbers: lines.map((line) => line.phoneNumber),
+  }).map((prepared): PreparedHostedLinqProviderInventoryLine => {
+    const line = linesByPhoneNumber.get(prepared.normalizedPhoneNumber);
+    if (!line?.providerPhoneNumberId) {
+      throw invalidInventorySnapshotError(
+        "Linq phone-number inventory contained a record without a valid provider id.",
+      );
+    }
+    return {
+      ...prepared,
+      providerPhoneNumberId: line.providerPhoneNumberId,
+      providerReputationStatus: line.providerReputationStatus,
+      providerServiceStatus: line.providerServiceStatus,
+    };
+  });
 
-  // The contact-card and health crons both trigger this sync at minute zero,
-  // and the per-phone upsert locks cannot order two whole-snapshot
-  // applications that touch different phones. Apply each validated snapshot
-  // under one inventory-wide advisory lock inside one transaction: concurrent
-  // applications serialize instead of interleaving (so a moved id can never
-  // race the unique provider-id index), and a mid-application failure rolls
-  // the whole replacement back. Two overlapping runs may still commit in
-  // either order; the hourly cadence converges any stale winner on the next
-  // run.
   if ("$transaction" in input.prisma && typeof input.prisma.$transaction === "function") {
     const prisma = input.prisma;
-    return prisma.$transaction((tx) => applyHostedLinqPhoneNumberInventorySnapshot({
-      lines,
-      observedAt,
-      prisma: tx,
-    }));
+    // The unique lookup-key and provider-id indexes are the convergence
+    // authorities. Retry only database conflicts produced while two complete
+    // snapshots race; preprocessing remains outside every attempt.
+    for (
+      let attempt = 1;
+      attempt <= HOSTED_LINQ_PHONE_NUMBER_INVENTORY_APPLY_MAX_ATTEMPTS;
+      attempt += 1
+    ) {
+      try {
+        return await prisma.$transaction(
+          (tx) => applyHostedLinqPhoneNumberInventorySnapshot({
+            lines: preparedLines,
+            observedAt,
+            prisma: tx,
+          }),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+      } catch (error) {
+        if (
+          attempt === HOSTED_LINQ_PHONE_NUMBER_INVENTORY_APPLY_MAX_ATTEMPTS
+          || !isHostedLinqInventoryConvergenceConflict(error)
+        ) {
+          throw error;
+        }
+      }
+    }
+    throw new Error("Hosted Linq inventory convergence retries were exhausted.");
   }
 
   return applyHostedLinqPhoneNumberInventorySnapshot({
-    lines,
+    lines: preparedLines,
     observedAt,
     prisma: input.prisma,
   });
 }
 
 async function applyHostedLinqPhoneNumberInventorySnapshot(input: {
-  lines: HostedLinqProviderInventoryLine[];
+  lines: readonly PreparedHostedLinqProviderInventoryLine[];
   observedAt: Date;
   prisma: HostedLinqInventoryClient;
 }): Promise<{ syncedCount: number }> {
-  const { lines, observedAt } = input;
-  let syncedCount = 0;
+  const rows = await input.prisma.$queryRaw<Array<{ syncedCount: bigint }>>(
+    buildHostedLinqPhoneNumberInventorySnapshotQuery(input),
+  );
+  return { syncedCount: Number(rows[0]?.syncedCount ?? 0) };
+}
 
-  await acquireHostedLinqInventoryApplyLockTx({ prisma: input.prisma });
+function buildHostedLinqPhoneNumberInventorySnapshotQuery(input: {
+  lines: readonly PreparedHostedLinqProviderInventoryLine[];
+  observedAt: Date;
+}): Prisma.Sql {
+  const observedAt = Prisma.sql`${input.observedAt}::timestamp`;
+  const inputRows = input.lines.length > 0
+    ? Prisma.sql`VALUES ${Prisma.join(input.lines.map((line) => Prisma.sql`(
+        ${line.currentLookupKey}::text,
+        ARRAY[${Prisma.join(line.lookupKeyReadCandidates)}]::text[],
+        ${line.phoneNumberEncrypted}::text,
+        ${line.phoneNumberHint}::text,
+        ${line.providerPhoneNumberId}::text,
+        ${line.providerReputationStatus}::text,
+        ${line.providerServiceStatus}::text
+      )`))}`
+    : Prisma.sql`
+        SELECT
+          NULL::text,
+          ARRAY[]::text[],
+          NULL::text,
+          NULL::text,
+          NULL::text,
+          NULL::text,
+          NULL::text
+        WHERE FALSE
+      `;
 
-  // A validated read is a complete identity snapshot (failed, malformed,
-  // over-limit, and identity-lossy reads all throw before this point), so any
-  // stored phone-to-provider-id pairing the snapshot does not confirm marks a
-  // relinquished or moved line. Revoke exactly those pairings before the
-  // upserts: relinquished ids stop qualifying as account-owned for
-  // ownership-gated consumers (contact-card and backup-number candidacy), and
-  // a moved id is released before its new row claims it, so the unique
-  // provider-id index cannot collide.
-  const confirmedLookupKeysById = new Map<string, Set<string>>();
-  for (const line of lines) {
-    if (line.providerPhoneNumberId) {
-      confirmedLookupKeysById.set(
-        line.providerPhoneNumberId,
-        new Set(createHostedPhoneLookupKeyReadCandidates(line.phoneNumber)),
-      );
-    }
+  return Prisma.sql`
+    WITH input_line (
+      current_lookup_key,
+      lookup_key_candidates,
+      phone_number_encrypted,
+      phone_number_hint,
+      provider_phone_number_id,
+      provider_reputation_status,
+      provider_service_status
+    ) AS (
+      ${inputRows}
+    ),
+    locked_line AS MATERIALIZED (
+      SELECT line.phone_number_lookup_key
+      FROM hosted_linq_line AS line
+      WHERE line.provider_phone_number_id IS NOT NULL
+        OR line.phone_number_lookup_key IN (
+          SELECT candidate.lookup_key
+          FROM input_line AS input
+          CROSS JOIN LATERAL unnest(input.lookup_key_candidates)
+            AS candidate(lookup_key)
+        )
+      ORDER BY line.phone_number_lookup_key
+      FOR UPDATE
+    ),
+    lock_barrier AS MATERIALIZED (
+      SELECT count(*) AS locked_count
+      FROM locked_line
+    ),
+    resolved_line AS MATERIALIZED (
+      SELECT
+        input.current_lookup_key,
+        COALESCE(existing.phone_number_lookup_key, input.current_lookup_key)
+          AS target_lookup_key,
+        input.phone_number_encrypted,
+        input.phone_number_hint,
+        input.provider_phone_number_id,
+        input.provider_reputation_status,
+        input.provider_service_status
+      FROM input_line AS input
+      CROSS JOIN lock_barrier
+      LEFT JOIN LATERAL (
+        SELECT line.phone_number_lookup_key
+        FROM unnest(input.lookup_key_candidates) WITH ORDINALITY
+          AS candidate(lookup_key, candidate_ordinal)
+        INNER JOIN hosted_linq_line AS line
+          ON line.phone_number_lookup_key = candidate.lookup_key
+        ORDER BY
+          (line.phone_number_lookup_key = input.current_lookup_key) DESC,
+          candidate.candidate_ordinal
+        LIMIT 1
+      ) AS existing ON TRUE
+    ),
+    -- Only non-target owners are cleared here. Target rows replace stale ids
+    -- in the upsert, so no physical row is modified twice in one statement.
+    released_line AS (
+      UPDATE hosted_linq_line AS line
+      SET
+        provider_inventory_confirmed_at = NULL,
+        provider_phone_number_id = NULL,
+        updated_at = CURRENT_TIMESTAMP
+      FROM lock_barrier
+      WHERE line.provider_phone_number_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM resolved_line AS resolved
+          WHERE resolved.target_lookup_key = line.phone_number_lookup_key
+        )
+      RETURNING line.phone_number_lookup_key
+    ),
+    release_barrier AS MATERIALIZED (
+      SELECT count(*) AS released_count
+      FROM released_line
+    ),
+    upserted_line AS (
+      INSERT INTO hosted_linq_line (
+        phone_number_lookup_key,
+        phone_number_encrypted,
+        phone_number_hint,
+        source,
+        configured_at,
+        provider_seen_at,
+        provider_phone_number_id,
+        provider_inventory_confirmed_at,
+        provider_first_seen_at,
+        provider_last_seen_at,
+        health_status,
+        egress_policy,
+        provider_service_status,
+        provider_service_updated_at,
+        last_service_status_event_id,
+        provider_reputation_status,
+        provider_reputation_updated_at,
+        last_reputation_status_event_id,
+        assignment_weight,
+        created_at,
+        updated_at
+      )
+      SELECT
+        resolved.target_lookup_key,
+        resolved.phone_number_encrypted,
+        resolved.phone_number_hint,
+        'provider',
+        NULL,
+        ${observedAt},
+        resolved.provider_phone_number_id,
+        ${observedAt},
+        ${observedAt},
+        ${observedAt},
+        'unknown',
+        'enabled',
+        resolved.provider_service_status,
+        CASE
+          WHEN resolved.provider_service_status IS NULL THEN NULL
+          ELSE ${observedAt}
+        END,
+        NULL,
+        resolved.provider_reputation_status,
+        CASE
+          WHEN resolved.provider_reputation_status IS NULL THEN NULL
+          ELSE ${observedAt}
+        END,
+        NULL,
+        100,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM resolved_line AS resolved
+      CROSS JOIN release_barrier
+      ORDER BY resolved.current_lookup_key
+      ON CONFLICT (phone_number_lookup_key) DO UPDATE SET
+        phone_number_encrypted = EXCLUDED.phone_number_encrypted,
+        phone_number_hint = EXCLUDED.phone_number_hint,
+        provider_seen_at = EXCLUDED.provider_seen_at,
+        provider_phone_number_id = EXCLUDED.provider_phone_number_id,
+        provider_inventory_confirmed_at = EXCLUDED.provider_inventory_confirmed_at,
+        provider_first_seen_at = COALESCE(
+          hosted_linq_line.provider_first_seen_at,
+          EXCLUDED.provider_first_seen_at
+        ),
+        provider_last_seen_at = EXCLUDED.provider_last_seen_at,
+        provider_service_status = CASE
+          WHEN EXCLUDED.provider_service_status IS NULL
+            OR hosted_linq_line.provider_service_updated_at >= ${observedAt}
+            THEN hosted_linq_line.provider_service_status
+          ELSE EXCLUDED.provider_service_status
+        END,
+        provider_service_updated_at = CASE
+          WHEN EXCLUDED.provider_service_status IS NULL
+            OR hosted_linq_line.provider_service_updated_at >= ${observedAt}
+            THEN hosted_linq_line.provider_service_updated_at
+          ELSE EXCLUDED.provider_service_updated_at
+        END,
+        last_service_status_event_id = CASE
+          WHEN EXCLUDED.provider_service_status IS NULL
+            OR hosted_linq_line.provider_service_updated_at >= ${observedAt}
+            THEN hosted_linq_line.last_service_status_event_id
+          ELSE NULL
+        END,
+        provider_reputation_status = CASE
+          WHEN EXCLUDED.provider_reputation_status IS NULL
+            OR hosted_linq_line.provider_reputation_updated_at >= ${observedAt}
+            THEN hosted_linq_line.provider_reputation_status
+          ELSE EXCLUDED.provider_reputation_status
+        END,
+        provider_reputation_updated_at = CASE
+          WHEN EXCLUDED.provider_reputation_status IS NULL
+            OR hosted_linq_line.provider_reputation_updated_at >= ${observedAt}
+            THEN hosted_linq_line.provider_reputation_updated_at
+          ELSE EXCLUDED.provider_reputation_updated_at
+        END,
+        last_reputation_status_event_id = CASE
+          WHEN EXCLUDED.provider_reputation_status IS NULL
+            OR hosted_linq_line.provider_reputation_updated_at >= ${observedAt}
+            THEN hosted_linq_line.last_reputation_status_event_id
+          ELSE NULL
+        END,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING phone_number_lookup_key
+    )
+    SELECT count(*)::bigint AS "syncedCount"
+    FROM upserted_line
+  `;
+}
+
+function isHostedLinqInventoryConvergenceConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return false;
   }
-  const heldRows = await input.prisma.hostedLinqLine.findMany({
-    where: { providerPhoneNumberId: { not: null } },
-    select: {
-      phoneNumberLookupKey: true,
-      providerPhoneNumberId: true,
-    },
-  });
-  const staleLookupKeys = heldRows
-    .filter((row) => {
-      const confirmed = row.providerPhoneNumberId
-        ? confirmedLookupKeysById.get(row.providerPhoneNumberId)
-        : undefined;
-      return !confirmed || !confirmed.has(row.phoneNumberLookupKey);
-    })
-    .map((row) => row.phoneNumberLookupKey);
-  if (staleLookupKeys.length > 0) {
-    await input.prisma.hostedLinqLine.updateMany({
-      data: {
-        providerInventoryConfirmedAt: null,
-        providerPhoneNumberId: null,
-      },
-      where: { phoneNumberLookupKey: { in: staleLookupKeys } },
-    });
+  const code = typeof error.code === "string" ? error.code : null;
+  if (code === "P2002" || code === "P2034") {
+    return true;
   }
-
-  for (const line of lines) {
-    const storedLine = await upsertHostedLinqLineForPhoneTx({
-      observedAt,
-      phoneNumber: line.phoneNumber,
-      prisma: input.prisma,
-      providerPhoneNumberId: line.providerPhoneNumberId,
-      source: "provider",
-    });
-    // Freshness watermark for ownership-gated consumers. Stamped only here,
-    // inside the same transaction that applied a validated snapshot, so it
-    // can never be advanced by chat-health or status projection.
-    await input.prisma.hostedLinqLine.updateMany({
-      data: { providerInventoryConfirmedAt: observedAt },
-      where: { phoneNumberLookupKey: storedLine.phoneNumberLookupKey },
-    });
-    await projectHostedLinqLineProviderStateTx({
-      observedAt,
-      phoneNumberLookupKey: storedLine.phoneNumberLookupKey,
-      prisma: input.prisma,
-      providerUpdatedAt: observedAt,
-      ...(line.providerReputationStatus
-        ? { reputationStatus: line.providerReputationStatus }
-        : {}),
-      ...(line.providerServiceStatus
-        ? { serviceStatus: line.providerServiceStatus }
-        : {}),
-    });
-    syncedCount += 1;
+  if (code !== "P2010" || !("meta" in error)) {
+    return false;
   }
+  return ["23505", "40001", "40P01"].includes(
+    readHostedLinqInventoryPostgresErrorCode(error.meta) ?? "",
+  );
+}
 
-  return { syncedCount };
+function readHostedLinqInventoryPostgresErrorCode(meta: unknown): string | null {
+  if (!meta || typeof meta !== "object") {
+    return null;
+  }
+  if ("code" in meta && typeof meta.code === "string") {
+    return meta.code;
+  }
+  if (!("driverAdapterError" in meta)) {
+    return null;
+  }
+  const driverAdapterError = meta.driverAdapterError;
+  if (
+    !driverAdapterError
+    || typeof driverAdapterError !== "object"
+    || !("cause" in driverAdapterError)
+  ) {
+    return null;
+  }
+  const cause = driverAdapterError.cause;
+  if (!cause || typeof cause !== "object") {
+    return null;
+  }
+  if ("originalCode" in cause && typeof cause.originalCode === "string") {
+    return cause.originalCode;
+  }
+  return "code" in cause && typeof cause.code === "string"
+    ? cause.code
+    : null;
 }
 
 export async function listHostedLinqPhoneNumberInventory(input: {

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -307,7 +307,6 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
-      lockMode: "wait",
       observedAt: expect.any(Date),
       prisma,
     });
@@ -900,7 +899,6 @@ describe("hosted Linq contact card client", () => {
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
-      lockMode: "wait",
       observedAt: expect.any(Date),
       prisma,
     });
@@ -1065,17 +1063,6 @@ describe("fetchMurphHostedLinqContactCardVcfPhoto", () => {
 });
 
 describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
-  it("omits the backup instead of waiting when an inventory writer holds the lock", async () => {
-    // The snapshot returns null when the lock is unavailable; the member's
-    // primary card must still be served, just without the optional backup.
-    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue(null);
-
-    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
-      excludePhoneNumber: "+15550000001",
-      prisma: {} as never,
-    })).resolves.toBeNull();
-  });
-
   it("reads the existing projection and returns the first healthy alternate without provider sync", async () => {
     linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue({
       configuredLineCount: 4,
@@ -1126,10 +1113,8 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
     })).resolves.toBe("+15550000003");
 
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledOnce();
-    // Member-facing: never waits on an inventory writer.
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
-      lockMode: "skip",
       prisma,
     });
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -1115,10 +1115,27 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledOnce();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
+      lockMode: "skip",
       prisma,
     });
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails soft to null when the projection read skips an in-flight ownership update", async () => {
+    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue(null);
+
+    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
+      excludePhoneNumber: "+15550000001",
+      prisma: {} as never,
+    })).resolves.toBeNull();
+
+    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
+      limit: 50,
+      lockMode: "skip",
+      prisma: {},
+    });
+    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
   });
 
   it("fails soft to null when the projection read is unavailable", async () => {

--- a/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-contact-card.test.ts
@@ -1115,27 +1115,10 @@ describe("resolveMurphHostedLinqContactCardBackupPhoneNumber", () => {
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledOnce();
     expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
       limit: 50,
-      lockMode: "skip",
       prisma,
     });
     expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
     expect(providerFetch).not.toHaveBeenCalled();
-  });
-
-  it("fails soft to null when the projection read skips an in-flight ownership update", async () => {
-    linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot.mockResolvedValue(null);
-
-    await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
-      excludePhoneNumber: "+15550000001",
-      prisma: {} as never,
-    })).resolves.toBeNull();
-
-    expect(linqLineStoreMocks.readHostedLinqContactCardCandidacySnapshot).toHaveBeenCalledWith({
-      limit: 50,
-      lockMode: "skip",
-      prisma: {},
-    });
-    expect(linqInventoryMocks.syncHostedLinqPhoneNumberInventory).not.toHaveBeenCalled();
   });
 
   it("fails soft to null when the projection read is unavailable", async () => {

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -670,53 +670,72 @@ describe("hosted Linq proactive-conversation capacity", () => {
 });
 
 describe("syncHostedLinqConfiguredLinesTx", () => {
-  it("takes the inventory-wide lock before any per-phone lock, read, or write", async () => {
+  it("prepares every line before opening one transaction and issuing one bulk statement", async () => {
+    restoreContactPrivacyKeyring = configureHostedContactPrivacyKeyringForTest({
+      currentVersion: "v1",
+      entries: TEST_KEYRING_ENTRIES,
+    });
     const events: string[] = [];
-    const transactionClient = {
-      $executeRaw: vi.fn().mockImplementation((strings: TemplateStringsArray) => {
-        events.push(
-          strings.join("?").includes("hosted_linq_phone_number_inventory")
-            ? "inventory-lock"
-            : "phone-lock",
-        );
-        return Promise.resolve([]);
-      }),
-      hostedLinqLine: {
-        findMany: vi.fn().mockImplementation(() => {
-          events.push("candidate-read");
-          return Promise.resolve([]);
-        }),
-        upsert: vi.fn().mockImplementation((input: { create: { phoneNumberLookupKey: string } }) => {
-          events.push("write");
-          return Promise.resolve({
-            phoneNumberLookupKey: input.create.phoneNumberLookupKey,
-          });
-        }),
-      },
-    };
+    const queryRaw = vi.fn().mockImplementation(() => {
+      events.push("bulk-statement");
+      return Promise.resolve([{ syncedCount: 2n }]);
+    });
+    const transactionClient = { $queryRaw: queryRaw };
+    const transaction = vi.fn(async (
+      callback: (tx: typeof transactionClient) => Promise<unknown>,
+    ) => {
+      events.push("transaction:start");
+      restoreContactPrivacyKeyring?.();
+      restoreContactPrivacyKeyring = null;
+      const result = await callback(transactionClient);
+      events.push("transaction:commit");
+      return result;
+    });
+    const phoneNumbers = ["+15550100002", "+1 (555) 010-0001"];
 
     await syncHostedLinqConfiguredLinesTx({
-      activeMemberLimit: null,
+      activeMemberLimit: 250,
       observedAt: new Date("2026-06-30T12:00:00.000Z"),
-      phoneNumbers: ["+15550100001", "+15550100002"],
-      prisma: transactionClient as never,
+      phoneNumbers,
+      prisma: { $transaction: transaction } as never,
     });
 
-    // Every multi-phone writer must serialize on the shared inventory lock
-    // before touching any per-phone lock, so lock acquisition can never
-    // invert against the provider-inventory writer.
-    expect(events[0]).toBe("inventory-lock");
-    expect(events.filter((event) => event === "inventory-lock")).toHaveLength(1);
-    expect(events.filter((event) => event === "phone-lock")).toHaveLength(2);
     expect(events).toEqual([
-      "inventory-lock",
-      "phone-lock",
-      "candidate-read",
-      "write",
-      "phone-lock",
-      "candidate-read",
-      "write",
+      "transaction:start",
+      "bulk-statement",
+      "transaction:commit",
     ]);
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as {
+      sql: string;
+      values: unknown[];
+    };
+    expect(query.sql).toContain("WITH input_line");
+    expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
+    expect(query.sql).not.toContain("pg_advisory_xact_lock");
+    expect(query.values).toEqual(expect.arrayContaining([
+      "*** 0001",
+      "*** 0002",
+      250,
+    ]));
+    expect(JSON.stringify(query.values)).not.toContain("+1555010000");
+  });
+
+  it("rejects invalid preparation before transaction entry", async () => {
+    restoreContactPrivacyKeyring = configureHostedContactPrivacyKeyringForTest({
+      currentVersion: "v1",
+      entries: TEST_KEYRING_ENTRIES,
+    });
+    const transaction = vi.fn();
+
+    await expect(syncHostedLinqConfiguredLinesTx({
+      activeMemberLimit: null,
+      phoneNumbers: ["not-a-phone"],
+      prisma: { $transaction: transaction } as never,
+    })).rejects.toThrow(/valid phone number/u);
+
+    expect(transaction).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -670,17 +670,21 @@ describe("hosted Linq proactive-conversation capacity", () => {
 });
 
 describe("syncHostedLinqConfiguredLinesTx", () => {
-  it("prepares every line before opening one transaction and issuing one bulk statement", async () => {
+  it("prepares every line before opening one transaction, locking publication, and issuing one bulk statement", async () => {
     restoreContactPrivacyKeyring = configureHostedContactPrivacyKeyringForTest({
       currentVersion: "v1",
       entries: TEST_KEYRING_ENTRIES,
     });
     const events: string[] = [];
+    const executeRaw = vi.fn().mockImplementation(() => {
+      events.push("publication-lock");
+      return Promise.resolve(1);
+    });
     const queryRaw = vi.fn().mockImplementation(() => {
       events.push("bulk-statement");
       return Promise.resolve([{ syncedCount: 2n }]);
     });
-    const transactionClient = { $queryRaw: queryRaw };
+    const transactionClient = { $executeRaw: executeRaw, $queryRaw: queryRaw };
     const transaction = vi.fn(async (
       callback: (tx: typeof transactionClient) => Promise<unknown>,
     ) => {
@@ -702,18 +706,21 @@ describe("syncHostedLinqConfiguredLinesTx", () => {
 
     expect(events).toEqual([
       "transaction:start",
+      "publication-lock",
       "bulk-statement",
       "transaction:commit",
     ]);
     expect(transaction).toHaveBeenCalledTimes(1);
+    expect(executeRaw).toHaveBeenCalledTimes(1);
     expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect((executeRaw.mock.calls[0]?.[0] as string[]).join(""))
+      .toContain("pg_advisory_xact_lock");
     const query = queryRaw.mock.calls[0]?.[0] as {
       sql: string;
       values: unknown[];
     };
     expect(query.sql).toContain("WITH input_line");
     expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
-    expect(query.sql).not.toContain("pg_advisory_xact_lock");
     expect(query.values).toEqual(expect.arrayContaining([
       "*** 0001",
       "*** 0002",

--- a/apps/web/test/hosted-onboarding-linq-line-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-line-store.test.ts
@@ -670,21 +670,17 @@ describe("hosted Linq proactive-conversation capacity", () => {
 });
 
 describe("syncHostedLinqConfiguredLinesTx", () => {
-  it("prepares every line before opening one transaction, locking publication, and issuing one bulk statement", async () => {
+  it("prepares every line before opening one transaction and issuing one bulk statement", async () => {
     restoreContactPrivacyKeyring = configureHostedContactPrivacyKeyringForTest({
       currentVersion: "v1",
       entries: TEST_KEYRING_ENTRIES,
     });
     const events: string[] = [];
-    const executeRaw = vi.fn().mockImplementation(() => {
-      events.push("publication-lock");
-      return Promise.resolve(1);
-    });
     const queryRaw = vi.fn().mockImplementation(() => {
       events.push("bulk-statement");
       return Promise.resolve([{ syncedCount: 2n }]);
     });
-    const transactionClient = { $executeRaw: executeRaw, $queryRaw: queryRaw };
+    const transactionClient = { $queryRaw: queryRaw };
     const transaction = vi.fn(async (
       callback: (tx: typeof transactionClient) => Promise<unknown>,
     ) => {
@@ -706,21 +702,19 @@ describe("syncHostedLinqConfiguredLinesTx", () => {
 
     expect(events).toEqual([
       "transaction:start",
-      "publication-lock",
       "bulk-statement",
       "transaction:commit",
     ]);
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(executeRaw).toHaveBeenCalledTimes(1);
     expect(queryRaw).toHaveBeenCalledTimes(1);
-    expect((executeRaw.mock.calls[0]?.[0] as string[]).join(""))
-      .toContain("pg_advisory_xact_lock");
     const query = queryRaw.mock.calls[0]?.[0] as {
       sql: string;
       values: unknown[];
     };
     expect(query.sql).toContain("WITH input_line");
     expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
+    expect(query.sql).not.toContain("pg_advisory_xact_lock");
+    expect(query.sql).not.toContain("FOR UPDATE");
     expect(query.values).toEqual(expect.arrayContaining([
       "*** 0001",
       "*** 0002",

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -1,6 +1,7 @@
+import { Buffer } from "node:buffer";
 import { randomInt, randomUUID } from "node:crypto";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingLinqConfig: () => ({
@@ -9,37 +10,10 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   }),
 }));
 
-// Pass-through wrapper so the rollback proof can inject a failure mid-way
-// through an otherwise fully real snapshot application.
-const providerStateControl = vi.hoisted(() => ({ calls: 0, failOnCall: 0 }));
-
-vi.mock("@/src/lib/hosted-onboarding/linq-provider-health-store", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("@/src/lib/hosted-onboarding/linq-provider-health-store")
-  >();
-  return {
-    ...actual,
-    projectHostedLinqLineProviderStateTx: async (
-      input: Parameters<typeof actual.projectHostedLinqLineProviderStateTx>[0],
-    ) => {
-      providerStateControl.calls += 1;
-      if (
-        providerStateControl.failOnCall > 0
-        && providerStateControl.calls === providerStateControl.failOnCall
-      ) {
-        throw new Error("injected mid-application failure");
-      }
-      return actual.projectHostedLinqLineProviderStateTx(input);
-    },
-  };
-});
-
-beforeEach(() => {
-  providerStateControl.calls = 0;
-  providerStateControl.failOnCall = 0;
-});
-
-import { createHostedPhoneLookupKeyReadCandidates } from "@/src/lib/hosted-onboarding/contact-privacy-core";
+import {
+  createHostedPhoneLookupKey,
+  createHostedPhoneLookupKeyReadCandidates,
+} from "@/src/lib/hosted-onboarding/contact-privacy-core";
 import { resolveMurphHostedLinqContactCardBackupPhoneNumber } from "@/src/lib/hosted-onboarding/linq-contact-card";
 import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 import {
@@ -48,12 +22,15 @@ import {
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
-import { encryptHostedLinqLinePhoneNumber } from "@/src/lib/hosted-onboarding/linq-line-phone-codec";
 import { createPrismaClient } from "@/src/lib/prisma";
 
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
 const runPostgresProof =
   process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+const TEST_KEYRING_ENTRIES = {
+  v1: Buffer.from("1".repeat(32), "utf8").toString("base64"),
+  v2: Buffer.from("2".repeat(32), "utf8").toString("base64"),
+};
 
 if (
   runPostgresProof
@@ -67,17 +44,16 @@ if (
 describe.skipIf(!runPostgresProof)(
   "hosted Linq phone-number inventory PostgreSQL proof",
   () => {
-    it("transfers a moved provider id between rows without violating the unique index", async () => {
+    it("converges a moved provider id onto an existing row with exact snapshot fields", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerId = `pg-proof-line-${randomUUID()}`;
+      const staleProviderId = `pg-proof-line-${randomUUID()}`;
       const phoneA = buildSyntheticProofPhoneNumber();
       const phoneB = buildSyntheticProofPhoneNumber();
-      const observedAt = new Date();
+      const firstSeenAt = new Date("2026-08-09T12:00:00.000Z");
+      const snapshotObservedAt = new Date("2026-08-09T12:05:00.000Z");
       const createdLookupKeys: string[] = [];
 
-      // The sync revokes every held pairing its snapshot does not confirm, so
-      // capture unrelated held rows up front and restore them afterwards to
-      // keep this proof independent of other suites sharing the database.
       const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
         where: { providerPhoneNumberId: { not: null } },
         select: {
@@ -89,51 +65,79 @@ describe.skipIf(!runPostgresProof)(
 
       try {
         const rowA = await upsertHostedLinqLineForPhoneTx({
-          observedAt,
+          observedAt: firstSeenAt,
           phoneNumber: phoneA,
           prisma,
           providerPhoneNumberId: providerId,
           source: "provider",
         });
-        createdLookupKeys.push(rowA.phoneNumberLookupKey);
+        const rowB = await upsertHostedLinqLineForPhoneTx({
+          observedAt: firstSeenAt,
+          phoneNumber: phoneB,
+          prisma,
+          providerPhoneNumberId: staleProviderId,
+          source: "provider",
+        });
+        createdLookupKeys.push(rowA.phoneNumberLookupKey, rowB.phoneNumberLookupKey);
 
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
           phone_numbers: [
             {
               id: providerId,
               phone_number: phoneB,
-              reputation: { status: "HEALTHY" },
-              status: "ACTIVE",
+              reputation: { status: "AT_RISK" },
+              status: "FLAGGED",
             },
           ],
         }), { headers: { "content-type": "application/json" }, status: 200 })));
 
         await expect(syncHostedLinqPhoneNumberInventory({
-          observedAt: new Date(),
+          observedAt: snapshotObservedAt,
           prisma,
         })).resolves.toEqual({ syncedCount: 1 });
 
-        const owners = await prisma.hostedLinqLine.findMany({
-          where: { providerPhoneNumberId: providerId },
+        const owner = await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: rowB.phoneNumberLookupKey },
           select: {
             phoneNumberHint: true,
-            phoneNumberLookupKey: true,
+            providerFirstSeenAt: true,
+            providerInventoryConfirmedAt: true,
+            providerLastSeenAt: true,
+            providerPhoneNumberId: true,
+            providerReputationStatus: true,
+            providerReputationUpdatedAt: true,
+            providerSeenAt: true,
+            providerServiceStatus: true,
+            providerServiceUpdatedAt: true,
           },
         });
-        for (const owner of owners) {
-          if (!createdLookupKeys.includes(owner.phoneNumberLookupKey)) {
-            createdLookupKeys.push(owner.phoneNumberLookupKey);
-          }
-        }
-        expect(owners).toHaveLength(1);
-        expect(owners[0]?.phoneNumberHint).toBe(`*** ${phoneB.slice(-4)}`);
-        expect(owners[0]?.phoneNumberLookupKey).not.toBe(rowA.phoneNumberLookupKey);
+        expect(owner).toEqual({
+          phoneNumberHint: `*** ${phoneB.slice(-4)}`,
+          providerFirstSeenAt: firstSeenAt,
+          providerInventoryConfirmedAt: snapshotObservedAt,
+          providerLastSeenAt: snapshotObservedAt,
+          providerPhoneNumberId: providerId,
+          providerReputationStatus: "AT_RISK",
+          providerReputationUpdatedAt: snapshotObservedAt,
+          providerSeenAt: snapshotObservedAt,
+          providerServiceStatus: "FLAGGED",
+          providerServiceUpdatedAt: snapshotObservedAt,
+        });
+        expect(await prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: staleProviderId },
+        })).toBe(0);
 
         const releasedRowA = await prisma.hostedLinqLine.findUnique({
           where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
-          select: { providerPhoneNumberId: true },
+          select: {
+            providerInventoryConfirmedAt: true,
+            providerPhoneNumberId: true,
+          },
         });
-        expect(releasedRowA?.providerPhoneNumberId).toBeNull();
+        expect(releasedRowA).toEqual({
+          providerInventoryConfirmedAt: null,
+          providerPhoneNumberId: null,
+        });
       } finally {
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
@@ -147,6 +151,121 @@ describe.skipIf(!runPostgresProof)(
         }
         await prisma.hostedLinqLine.deleteMany({
           where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+    it("preserves first seen and orders service and reputation timestamps", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerId = `pg-proof-line-${randomUUID()}`;
+      const phone = buildSyntheticProofPhoneNumber();
+      const firstSeenAt = new Date("2026-08-09T10:00:00.000Z");
+      const newerStatusAt = new Date("2026-08-09T12:00:00.000Z");
+      const olderSnapshotAt = new Date("2026-08-09T11:00:00.000Z");
+      const newestSnapshotAt = new Date("2026-08-09T13:00:00.000Z");
+      const proofLookupKeys = createHostedPhoneLookupKeyReadCandidates(phone);
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        const row = await upsertHostedLinqLineForPhoneTx({
+          observedAt: firstSeenAt,
+          phoneNumber: phone,
+          prisma,
+          providerPhoneNumberId: providerId,
+          source: "provider",
+        });
+        await prisma.hostedLinqLine.update({
+          data: {
+            lastReputationStatusEventId: "reputation:newer",
+            lastServiceStatusEventId: "service:newer",
+            providerReputationStatus: "HEALTHY",
+            providerReputationUpdatedAt: newerStatusAt,
+            providerServiceStatus: "ACTIVE",
+            providerServiceUpdatedAt: newerStatusAt,
+          },
+          where: { phoneNumberLookupKey: row.phoneNumberLookupKey },
+        });
+
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [{
+            id: providerId,
+            phone_number: phone,
+            reputation: { status: "AT_RISK" },
+            status: "FLAGGED",
+          }],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await syncHostedLinqPhoneNumberInventory({
+          observedAt: olderSnapshotAt,
+          prisma,
+        });
+        expect(await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: row.phoneNumberLookupKey },
+          select: {
+            lastReputationStatusEventId: true,
+            lastServiceStatusEventId: true,
+            providerFirstSeenAt: true,
+            providerReputationStatus: true,
+            providerReputationUpdatedAt: true,
+            providerServiceStatus: true,
+            providerServiceUpdatedAt: true,
+          },
+        })).toEqual({
+          lastReputationStatusEventId: "reputation:newer",
+          lastServiceStatusEventId: "service:newer",
+          providerFirstSeenAt: firstSeenAt,
+          providerReputationStatus: "HEALTHY",
+          providerReputationUpdatedAt: newerStatusAt,
+          providerServiceStatus: "ACTIVE",
+          providerServiceUpdatedAt: newerStatusAt,
+        });
+
+        await syncHostedLinqPhoneNumberInventory({
+          observedAt: newestSnapshotAt,
+          prisma,
+        });
+        expect(await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: row.phoneNumberLookupKey },
+          select: {
+            lastReputationStatusEventId: true,
+            lastServiceStatusEventId: true,
+            providerFirstSeenAt: true,
+            providerLastSeenAt: true,
+            providerReputationStatus: true,
+            providerReputationUpdatedAt: true,
+            providerServiceStatus: true,
+            providerServiceUpdatedAt: true,
+          },
+        })).toEqual({
+          lastReputationStatusEventId: null,
+          lastServiceStatusEventId: null,
+          providerFirstSeenAt: firstSeenAt,
+          providerLastSeenAt: newestSnapshotAt,
+          providerReputationStatus: "AT_RISK",
+          providerReputationUpdatedAt: newestSnapshotAt,
+          providerServiceStatus: "FLAGGED",
+          providerServiceUpdatedAt: newestSnapshotAt,
+        });
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
       }
@@ -189,9 +308,8 @@ describe.skipIf(!runPostgresProof)(
         createdLookupKeys.push(rowA.phoneNumberLookupKey);
 
         // One overlapping run still sees the old X→A snapshot while the other
-        // sees the new X→B snapshot; both apply concurrently. The advisory
-        // lock must serialize them so neither hits the unique index, in
-        // either commit order.
+        // sees the new X→B snapshot. Serializable retries plus the existing
+        // unique indexes must converge without duplicate ownership.
         let fetchCalls = 0;
         vi.stubGlobal("fetch", vi.fn(async () => {
           fetchCalls += 1;
@@ -455,7 +573,7 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("serves the member backup without waiting on an in-flight ownership move", async () => {
+    it("keeps the authoritative move atomically invisible until commit", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
       const providerId = `pg-proof-line-${randomUUID()}`;
       const otherProviderId = `pg-proof-line-${randomUUID()}`;
@@ -474,10 +592,9 @@ describe.skipIf(!runPostgresProof)(
           providerPhoneNumberId: true,
         },
       });
+      let releaseCommit: () => void = () => undefined;
 
       try {
-        // Seed A as a confirmed configured owner plus one other owned line,
-        // so backup resolution has a real choice.
         for (const [phone, id] of [[phoneA, providerId], [phoneOther, otherProviderId]] as const) {
           const seeded = await upsertHostedLinqLineForPhoneTx({
             activeMemberLimit: null,
@@ -496,77 +613,59 @@ describe.skipIf(!runPostgresProof)(
           });
         }
 
-        // Hold the authoritative move X: A→B open under the inventory lock.
-        let releaseMove: () => void = () => undefined;
-        const moveHold = new Promise<void>((resolve) => {
-          releaseMove = resolve;
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerId,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+            {
+              id: otherProviderId,
+              phone_number: phoneOther,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        const commitHold = new Promise<void>((resolve) => {
+          releaseCommit = resolve;
         });
-        let movePid: (pid: number) => void = () => undefined;
-        const moveLocked = new Promise<number>((resolve) => {
-          movePid = resolve;
+        let snapshotApplied: () => void = () => undefined;
+        const applied = new Promise<void>((resolve) => {
+          snapshotApplied = resolve;
         });
         const moveTransaction = prisma.$transaction(async (tx) => {
-          await tx.$executeRaw`
-            SELECT pg_advisory_xact_lock(
-              hashtext('hosted_linq_phone_number_inventory'),
-              hashtext('snapshot')
-            )
-          `;
-          const revokedKeys = createHostedPhoneLookupKeyReadCandidates(phoneA);
-          await tx.hostedLinqLine.updateMany({
-            data: {
-              providerInventoryConfirmedAt: null,
-              providerPhoneNumberId: null,
-            },
-            where: { phoneNumberLookupKey: { in: revokedKeys } },
+          await syncHostedLinqPhoneNumberInventory({
+            observedAt: new Date(),
+            prisma: tx,
           });
-          const claimed = createHostedPhoneLookupKeyReadCandidates(phoneB);
-          await tx.hostedLinqLine.create({
-            data: {
-              assignmentWeight: 100,
-              egressPolicy: "enabled",
-              healthStatus: "unknown",
-              phoneNumberEncrypted: encryptHostedLinqLinePhoneNumber(phoneB),
-              phoneNumberHint: `*** ${phoneB.slice(-4)}`,
-              phoneNumberLookupKey: claimed[0] as string,
-              providerInventoryConfirmedAt: new Date(),
-              providerPhoneNumberId: providerId,
-              providerSeenAt: new Date(),
-              source: "provider",
-            },
-          });
-          const pidRows = await tx.$queryRaw<Array<{ pid: number }>>`
-            SELECT pg_backend_pid() AS pid
-          `;
-          movePid(Number(pidRows[0]?.pid ?? 0));
-          await moveHold;
+          snapshotApplied();
+          await commitHold;
         });
 
-        await moveLocked;
-
-        // The member-facing resolver must never queue behind the writer: it
-        // resolves while the move is still open, omitting the optional backup
-        // rather than delaying the member's primary card.
+        await applied;
         await expect(Promise.race([
           resolveMurphHostedLinqContactCardBackupPhoneNumber({
             excludePhoneNumber: phoneOther,
             prisma,
           }),
           new Promise((_resolve, reject) => {
-            setTimeout(() => reject(new Error("backup resolution blocked on the inventory lock")), 5_000);
+            setTimeout(() => reject(new Error("backup resolution blocked on bulk inventory apply")), 5_000);
           }),
-        ])).resolves.toBeNull();
+        ])).resolves.toBe(phoneA);
 
-        releaseMove();
+        releaseCommit();
         await moveTransaction;
-
-        // After the move commits, the relinquished line is never offered and
-        // the new owner is.
         await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
           excludePhoneNumber: phoneOther,
           prisma,
         })).resolves.toBe(phoneB);
       } finally {
+        releaseCommit();
+        vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
           await prisma.hostedLinqLine.updateMany({
             data: {
@@ -583,13 +682,16 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("blocks a concurrent sync on the inventory-wide advisory lock until the owner commits", async () => {
-      const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
-      const observer = createPrismaClient({ databaseUrl, poolMax: 2 });
-      const providerId = `pg-proof-line-${randomUUID()}`;
-      const phoneB = buildSyntheticProofPhoneNumber();
-      const createdLookupKeys: string[] = [];
-
+    it("executes one bulk database statement for a multi-line provider snapshot", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerIds = [
+        `pg-proof-line-${randomUUID()}`,
+        `pg-proof-line-${randomUUID()}`,
+      ];
+      const phones = [buildSyntheticProofPhoneNumber(), buildSyntheticProofPhoneNumber()];
+      const proofLookupKeys = phones.flatMap(
+        (phone) => createHostedPhoneLookupKeyReadCandidates(phone),
+      );
       const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
         where: { providerPhoneNumberId: { not: null } },
         select: {
@@ -598,80 +700,37 @@ describe.skipIf(!runPostgresProof)(
           providerPhoneNumberId: true,
         },
       });
+      let statementCount = 0;
 
       try {
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
-          phone_numbers: [
-            {
-              id: providerId,
-              phone_number: phoneB,
-              reputation: { status: "HEALTHY" },
-              status: "ACTIVE",
-            },
-          ],
+          phone_numbers: phones.map((phoneNumber, index) => ({
+            id: providerIds[index],
+            phone_number: phoneNumber,
+            reputation: { status: "HEALTHY" },
+            status: "ACTIVE",
+          })),
         }), { headers: { "content-type": "application/json" }, status: 200 })));
 
-        let releaseOwner: () => void = () => undefined;
-        const ownerHold = new Promise<void>((resolve) => {
-          releaseOwner = resolve;
-        });
-        let ownerHasLock: (backendPid: number) => void = () => undefined;
-        const ownerLocked = new Promise<number>((resolve) => {
-          ownerHasLock = resolve;
-        });
-        const ownerTransaction = prisma.$transaction(async (tx) => {
-          await tx.$executeRaw`
-            SELECT pg_advisory_xact_lock(
-              hashtext('hosted_linq_phone_number_inventory'),
-              hashtext('snapshot')
-            )
-          `;
-          const pidRows = await tx.$queryRaw<Array<{ pid: number }>>`
-            SELECT pg_backend_pid() AS pid
-          `;
-          ownerHasLock(Number(pidRows[0]?.pid ?? 0));
-          await ownerHold;
+        await prisma.$transaction(async (tx) => {
+          await expect(syncHostedLinqPhoneNumberInventory({
+            observedAt: new Date(),
+            prisma: {
+              $queryRaw: async (query: unknown) => {
+                statementCount += 1;
+                return tx.$queryRaw(query as never);
+              },
+            } as never,
+          })).resolves.toEqual({ syncedCount: 2 });
         });
 
-        const ownerBackendPid = await ownerLocked;
-        expect(ownerBackendPid).toBeGreaterThan(0);
-        const contender = syncHostedLinqPhoneNumberInventory({
-          observedAt: new Date(),
-          prisma,
+        expect(statementCount).toBe(1);
+        const rows = await prisma.hostedLinqLine.findMany({
+          where: { providerPhoneNumberId: { in: providerIds } },
+          select: { providerPhoneNumberId: true },
         });
-
-        // The production sync must be observably blocked on the advisory lock
-        // held by this exact owner backend — this assertion fails if the lock
-        // is removed from the sync, and an unrelated suite's advisory waiter
-        // cannot satisfy it.
-        let blockedBackends = 0;
-        for (let attempt = 0; attempt < 40 && blockedBackends === 0; attempt += 1) {
-          const rows = await observer.$queryRaw<Array<{ blocked: bigint | number }>>`
-            SELECT count(*) AS blocked
-            FROM pg_stat_activity
-            WHERE wait_event_type = 'Lock'
-              AND wait_event = 'advisory'
-              AND ${ownerBackendPid} = ANY(pg_blocking_pids(pid))
-          `;
-          blockedBackends = Number(rows[0]?.blocked ?? 0);
-          if (blockedBackends === 0) {
-            await new Promise((resolve) => setTimeout(resolve, 100));
-          }
-        }
-        expect(blockedBackends).toBeGreaterThan(0);
-
-        releaseOwner();
-        await ownerTransaction;
-        await expect(contender).resolves.toEqual({ syncedCount: 1 });
-
-        const owners = await prisma.hostedLinqLine.findMany({
-          where: { providerPhoneNumberId: providerId },
-          select: { phoneNumberLookupKey: true },
-        });
-        for (const owner of owners) {
-          createdLookupKeys.push(owner.phoneNumberLookupKey);
-        }
-        expect(owners).toHaveLength(1);
+        expect(new Set(rows.map((row) => row.providerPhoneNumberId)))
+          .toEqual(new Set(providerIds));
       } finally {
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
@@ -684,21 +743,22 @@ describe.skipIf(!runPostgresProof)(
           });
         }
         await prisma.hostedLinqLine.deleteMany({
-          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
-        await observer.$disconnect();
       }
     });
 
-    it("rolls the whole snapshot application back when a line fails mid-way", async () => {
+    it("rolls the whole snapshot application back when the bulk statement fails", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerIdX = `pg-proof-line-${randomUUID()}`;
       const providerIdY = `pg-proof-line-${randomUUID()}`;
       const phoneA = buildSyntheticProofPhoneNumber();
       const phoneB = buildSyntheticProofPhoneNumber();
       const phoneC = buildSyntheticProofPhoneNumber();
-      const createdLookupKeys: string[] = [];
+      const proofLookupKeys = [phoneA, phoneB, phoneC].flatMap(
+        (phone) => createHostedPhoneLookupKeyReadCandidates(phone),
+      );
 
       const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
         where: { providerPhoneNumberId: { not: null } },
@@ -717,12 +777,7 @@ describe.skipIf(!runPostgresProof)(
           providerPhoneNumberId: providerIdX,
           source: "provider",
         });
-        createdLookupKeys.push(rowA.phoneNumberLookupKey);
 
-        // Snapshot: new line C first, then X moved from A to B. Failing the
-        // second line's application (after the stale revoke and a full first
-        // line) must roll the entire replacement back.
-        providerStateControl.failOnCall = 2;
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
           phone_numbers: [
             {
@@ -740,21 +795,26 @@ describe.skipIf(!runPostgresProof)(
           ],
         }), { headers: { "content-type": "application/json" }, status: 200 })));
 
-        await expect(syncHostedLinqPhoneNumberInventory({
-          observedAt: new Date(),
-          prisma,
-        })).rejects.toThrow("injected mid-application failure");
+        await expect(prisma.$transaction(async (tx) =>
+          syncHostedLinqPhoneNumberInventory({
+            observedAt: new Date(),
+            prisma: {
+              $queryRaw: async (query: unknown) => {
+                await tx.$queryRaw(query as never);
+                throw new Error("injected post-statement failure");
+              },
+            } as never,
+          })
+        )).rejects.toThrow("injected post-statement failure");
 
         const rowAAfter = await prisma.hostedLinqLine.findUnique({
           where: { phoneNumberLookupKey: rowA.phoneNumberLookupKey },
           select: { providerPhoneNumberId: true },
         });
         expect(rowAAfter?.providerPhoneNumberId).toBe(providerIdX);
-        const strayRows = await prisma.hostedLinqLine.findMany({
+        expect(await prisma.hostedLinqLine.count({
           where: { providerPhoneNumberId: providerIdY },
-          select: { phoneNumberLookupKey: true },
-        });
-        expect(strayRows).toHaveLength(0);
+        })).toBe(0);
       } finally {
         vi.unstubAllGlobals();
         for (const heldRow of preexistingHeldRows) {
@@ -767,7 +827,7 @@ describe.skipIf(!runPostgresProof)(
           });
         }
         await prisma.hostedLinqLine.deleteMany({
-          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+          where: { phoneNumberLookupKey: { in: proofLookupKeys } },
         });
         await prisma.$disconnect();
       }
@@ -797,10 +857,8 @@ describe.skipIf(!runPostgresProof)(
       });
 
       try {
-        // The follower's transaction lifetime covers both the advisory-lock
-        // wait behind the leader's full apply and its own 250-line apply;
-        // both overlapping minute-zero crons must still finish without
-        // hitting the shared 15s transaction timeout (P2028).
+        // Two full authoritative replacements overlap without a process-wide
+        // lock; each still finishes within the default transaction budget.
         let fetchCalls = 0;
         vi.stubGlobal("fetch", vi.fn(async () => {
           fetchCalls += 1;
@@ -857,6 +915,73 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
+    it("updates a legacy configured row and fills its active-member limit in one bulk apply", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const phone = buildSyntheticProofPhoneNumber();
+      const configuredAt = new Date("2026-08-09T15:00:00.000Z");
+      const restoreKeyring = configureHostedContactPrivacyKeyringForTest({
+        currentVersion: "v1",
+        entries: TEST_KEYRING_ENTRIES,
+      });
+      let lookupKeys: string[] = [];
+
+      try {
+        const legacyLookupKey = createHostedPhoneLookupKey(phone);
+        if (!legacyLookupKey) {
+          throw new Error("Expected a legacy lookup key.");
+        }
+        await upsertHostedLinqLineForPhoneTx({
+          activeMemberLimit: null,
+          observedAt: new Date("2026-08-09T14:00:00.000Z"),
+          phoneNumber: phone,
+          prisma,
+          source: "configured",
+        });
+
+        process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v2";
+        clearHostedOnboardingEnvCache();
+        const currentLookupKey = createHostedPhoneLookupKey(phone);
+        lookupKeys = createHostedPhoneLookupKeyReadCandidates(phone);
+        if (!currentLookupKey || currentLookupKey === legacyLookupKey) {
+          throw new Error("Expected distinct current and legacy lookup keys.");
+        }
+
+        await expect(syncHostedLinqConfiguredLinesTx({
+          activeMemberLimit: 175,
+          observedAt: configuredAt,
+          phoneNumbers: [phone],
+          prisma,
+        })).resolves.toBeUndefined();
+
+        expect(await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: legacyLookupKey },
+          select: {
+            activeMemberLimit: true,
+            configuredAt: true,
+            phoneNumberHint: true,
+            source: true,
+          },
+        })).toEqual({
+          activeMemberLimit: 175,
+          configuredAt,
+          phoneNumberHint: `*** ${phone.slice(-4)}`,
+          source: "configured",
+        });
+        expect(await prisma.hostedLinqLine.findUnique({
+          where: { phoneNumberLookupKey: currentLookupKey },
+          select: { phoneNumberLookupKey: true },
+        })).toBeNull();
+      } finally {
+        restoreKeyring();
+        if (lookupKeys.length > 0) {
+          await prisma.hostedLinqLine.deleteMany({
+            where: { phoneNumberLookupKey: { in: lookupKeys } },
+          });
+        }
+        await prisma.$disconnect();
+      }
+    });
+
     it("races configured-line sync against inventory application in reverse phone order without deadlock", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 8 });
       const providerIdOne = `pg-proof-line-${randomUUID()}`;
@@ -877,10 +1002,8 @@ describe.skipIf(!runPostgresProof)(
       });
 
       try {
-        // Both multi-phone writers touch the same two phones in opposite
-        // orders; without the shared inventory-wide first lock their
-        // per-phone advisory locks can invert and PostgreSQL aborts one
-        // participant as a deadlock.
+        // Both set-based writers touch the same two phones in opposite input
+        // orders. Deterministic row ordering must avoid a lock-order deadlock.
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
           phone_numbers: [
             {
@@ -899,11 +1022,11 @@ describe.skipIf(!runPostgresProof)(
         }), { headers: { "content-type": "application/json" }, status: 200 })));
 
         await expect(Promise.all([
-          prisma.$transaction((tx) => syncHostedLinqConfiguredLinesTx({
+          syncHostedLinqConfiguredLinesTx({
             activeMemberLimit: null,
             phoneNumbers: [phoneOne, phoneTwo],
-            prisma: tx,
-          })),
+            prisma,
+          }),
           syncHostedLinqPhoneNumberInventory({ observedAt: new Date(), prisma }),
         ])).resolves.toEqual([undefined, { syncedCount: 2 }]);
 
@@ -1013,4 +1136,40 @@ function isClearlyLocalPostgresUrl(value: string): boolean {
   const effectiveHost = (hostOverrides[0] || parsed.hostname).toLowerCase();
   return ["127.0.0.1", "::1", "[::1]", "localhost"].includes(effectiveHost)
     || effectiveHost.startsWith("/");
+}
+
+function configureHostedContactPrivacyKeyringForTest(input: {
+  currentVersion: string;
+  entries: Record<string, string>;
+}): () => void {
+  const previousKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+  const previousCurrentVersion = process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
+
+  process.env.HOSTED_CONTACT_PRIVACY_KEYS = Object.entries(input.entries)
+    .map(([version, key]) => `${version}:${key}`)
+    .join(",");
+  process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = input.currentVersion;
+  clearHostedOnboardingEnvCache();
+
+  return () => {
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_KEYS", previousKeys);
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION", previousCurrentVersion);
+    clearHostedOnboardingEnvCache();
+  };
+}
+
+function clearHostedOnboardingEnvCache(): void {
+  delete (
+    globalThis as typeof globalThis & {
+      __murphHostedOnboardingEnv?: unknown;
+    }
+  ).__murphHostedOnboardingEnv;
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
 }

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -19,7 +19,6 @@ import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/
 import {
   HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS,
   listHostedLinqContactCardLines,
-  readHostedLinqContactCardCandidacySnapshot,
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
@@ -156,112 +155,6 @@ describe.skipIf(!runPostgresProof)(
         await prisma.$disconnect();
       }
     });
-
-    it("converges provider-id swaps between target rows", async () => {
-      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
-      const providerIdA = `pg-proof-line-${randomUUID()}`;
-      const providerIdB = `pg-proof-line-${randomUUID()}`;
-      const phoneA = buildSyntheticProofPhoneNumber();
-      const phoneB = buildSyntheticProofPhoneNumber();
-      const firstSeenAt = new Date("2026-08-09T12:00:00.000Z");
-      const snapshotObservedAt = new Date("2026-08-09T12:10:00.000Z");
-      const createdLookupKeys: string[] = [];
-
-      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
-        where: { providerPhoneNumberId: { not: null } },
-        select: {
-          phoneNumberLookupKey: true,
-          providerInventoryConfirmedAt: true,
-          providerPhoneNumberId: true,
-        },
-      });
-
-      try {
-        const rowA = await upsertHostedLinqLineForPhoneTx({
-          observedAt: firstSeenAt,
-          phoneNumber: phoneA,
-          prisma,
-          providerPhoneNumberId: providerIdA,
-          source: "provider",
-        });
-        const rowB = await upsertHostedLinqLineForPhoneTx({
-          observedAt: firstSeenAt,
-          phoneNumber: phoneB,
-          prisma,
-          providerPhoneNumberId: providerIdB,
-          source: "provider",
-        });
-        createdLookupKeys.push(rowA.phoneNumberLookupKey, rowB.phoneNumberLookupKey);
-
-        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
-          phone_numbers: [
-            {
-              id: providerIdB,
-              phone_number: phoneA,
-              reputation: { status: "HEALTHY" },
-              status: "ACTIVE",
-            },
-            {
-              id: providerIdA,
-              phone_number: phoneB,
-              reputation: { status: "HEALTHY" },
-              status: "ACTIVE",
-            },
-          ],
-        }), { headers: { "content-type": "application/json" }, status: 200 })));
-
-        await expect(syncHostedLinqPhoneNumberInventory({
-          observedAt: snapshotObservedAt,
-          prisma,
-        })).resolves.toEqual({ syncedCount: 2 });
-
-        const rows = await prisma.hostedLinqLine.findMany({
-          where: {
-            phoneNumberLookupKey: {
-              in: [rowA.phoneNumberLookupKey, rowB.phoneNumberLookupKey],
-            },
-          },
-          select: {
-            phoneNumberLookupKey: true,
-            providerInventoryConfirmedAt: true,
-            providerPhoneNumberId: true,
-          },
-        });
-        const byLookupKey = new Map(rows.map((row) => [row.phoneNumberLookupKey, row]));
-        expect(byLookupKey.get(rowA.phoneNumberLookupKey)).toEqual({
-          phoneNumberLookupKey: rowA.phoneNumberLookupKey,
-          providerInventoryConfirmedAt: snapshotObservedAt,
-          providerPhoneNumberId: providerIdB,
-        });
-        expect(byLookupKey.get(rowB.phoneNumberLookupKey)).toEqual({
-          phoneNumberLookupKey: rowB.phoneNumberLookupKey,
-          providerInventoryConfirmedAt: snapshotObservedAt,
-          providerPhoneNumberId: providerIdA,
-        });
-        await expect(prisma.hostedLinqLine.count({
-          where: { providerPhoneNumberId: providerIdA },
-        })).resolves.toBe(1);
-        await expect(prisma.hostedLinqLine.count({
-          where: { providerPhoneNumberId: providerIdB },
-        })).resolves.toBe(1);
-      } finally {
-        vi.unstubAllGlobals();
-        for (const heldRow of preexistingHeldRows) {
-          await prisma.hostedLinqLine.updateMany({
-            data: {
-              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
-              providerPhoneNumberId: heldRow.providerPhoneNumberId,
-            },
-            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
-          });
-        }
-        await prisma.hostedLinqLine.deleteMany({
-          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
-        });
-        await prisma.$disconnect();
-      }
-    });
-
     it("preserves first seen and orders service and reputation timestamps", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerId = `pg-proof-line-${randomUUID()}`;
@@ -754,16 +647,6 @@ describe.skipIf(!runPostgresProof)(
         });
 
         await applied;
-        const waitingSnapshot = readHostedLinqContactCardCandidacySnapshot({
-          limit: 50,
-          prisma,
-        });
-        await expect(Promise.race([
-          waitingSnapshot.then(() => "resolved"),
-          new Promise<"blocked">((resolve) => {
-            setTimeout(() => resolve("blocked"), 250);
-          }),
-        ])).resolves.toBe("blocked");
         await expect(Promise.race([
           resolveMurphHostedLinqContactCardBackupPhoneNumber({
             excludePhoneNumber: phoneOther,
@@ -772,15 +655,10 @@ describe.skipIf(!runPostgresProof)(
           new Promise((_resolve, reject) => {
             setTimeout(() => reject(new Error("backup resolution blocked on bulk inventory apply")), 5_000);
           }),
-        ])).resolves.toBeNull();
+        ])).resolves.toBe(phoneA);
 
         releaseCommit();
         await moveTransaction;
-        const snapshotAfterCommit = await waitingSnapshot;
-        expect(snapshotAfterCommit?.lines.map((line) => line.phoneNumber))
-          .not.toContain(phoneA);
-        expect(snapshotAfterCommit?.lines.map((line) => line.phoneNumber))
-          .toContain(phoneB);
         await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
           excludePhoneNumber: phoneOther,
           prisma,
@@ -804,7 +682,7 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("executes bounded set statements for a multi-line provider snapshot", async () => {
+    it("executes one bulk database statement for a multi-line provider snapshot", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerIds = [
         `pg-proof-line-${randomUUID()}`,
@@ -822,8 +700,7 @@ describe.skipIf(!runPostgresProof)(
           providerPhoneNumberId: true,
         },
       });
-      let lockStatementCount = 0;
-      let setStatementCount = 0;
+      let statementCount = 0;
 
       try {
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
@@ -839,20 +716,15 @@ describe.skipIf(!runPostgresProof)(
           await expect(syncHostedLinqPhoneNumberInventory({
             observedAt: new Date(),
             prisma: {
-              $executeRaw: async (query: unknown) => {
-                lockStatementCount += 1;
-                return tx.$executeRaw(query as never);
-              },
               $queryRaw: async (query: unknown) => {
-                setStatementCount += 1;
+                statementCount += 1;
                 return tx.$queryRaw(query as never);
               },
             } as never,
           })).resolves.toEqual({ syncedCount: 2 });
         });
 
-        expect(lockStatementCount).toBe(1);
-        expect(setStatementCount).toBe(2);
+        expect(statementCount).toBe(1);
         const rows = await prisma.hostedLinqLine.findMany({
           where: { providerPhoneNumberId: { in: providerIds } },
           select: { providerPhoneNumberId: true },
@@ -927,13 +799,9 @@ describe.skipIf(!runPostgresProof)(
           syncHostedLinqPhoneNumberInventory({
             observedAt: new Date(),
             prisma: {
-              $executeRaw: (query: unknown) => tx.$executeRaw(query as never),
               $queryRaw: async (query: unknown) => {
-                const result = await tx.$queryRaw(query as never);
-                if ((query as { sql?: string }).sql?.includes("upserted_line AS")) {
-                  throw new Error("injected post-statement failure");
-                }
-                return result;
+                await tx.$queryRaw(query as never);
+                throw new Error("injected post-statement failure");
               },
             } as never,
           })

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory-postgres.test.ts
@@ -19,6 +19,7 @@ import { syncHostedLinqPhoneNumberInventory } from "@/src/lib/hosted-onboarding/
 import {
   HOSTED_LINQ_INVENTORY_FRESHNESS_MAX_AGE_MS,
   listHostedLinqContactCardLines,
+  readHostedLinqContactCardCandidacySnapshot,
   syncHostedLinqConfiguredLinesTx,
   upsertHostedLinqLineForPhoneTx,
 } from "@/src/lib/hosted-onboarding/linq-line-store";
@@ -155,6 +156,112 @@ describe.skipIf(!runPostgresProof)(
         await prisma.$disconnect();
       }
     });
+
+    it("converges provider-id swaps between target rows", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const providerIdA = `pg-proof-line-${randomUUID()}`;
+      const providerIdB = `pg-proof-line-${randomUUID()}`;
+      const phoneA = buildSyntheticProofPhoneNumber();
+      const phoneB = buildSyntheticProofPhoneNumber();
+      const firstSeenAt = new Date("2026-08-09T12:00:00.000Z");
+      const snapshotObservedAt = new Date("2026-08-09T12:10:00.000Z");
+      const createdLookupKeys: string[] = [];
+
+      const preexistingHeldRows = await prisma.hostedLinqLine.findMany({
+        where: { providerPhoneNumberId: { not: null } },
+        select: {
+          phoneNumberLookupKey: true,
+          providerInventoryConfirmedAt: true,
+          providerPhoneNumberId: true,
+        },
+      });
+
+      try {
+        const rowA = await upsertHostedLinqLineForPhoneTx({
+          observedAt: firstSeenAt,
+          phoneNumber: phoneA,
+          prisma,
+          providerPhoneNumberId: providerIdA,
+          source: "provider",
+        });
+        const rowB = await upsertHostedLinqLineForPhoneTx({
+          observedAt: firstSeenAt,
+          phoneNumber: phoneB,
+          prisma,
+          providerPhoneNumberId: providerIdB,
+          source: "provider",
+        });
+        createdLookupKeys.push(rowA.phoneNumberLookupKey, rowB.phoneNumberLookupKey);
+
+        vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+          phone_numbers: [
+            {
+              id: providerIdB,
+              phone_number: phoneA,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+            {
+              id: providerIdA,
+              phone_number: phoneB,
+              reputation: { status: "HEALTHY" },
+              status: "ACTIVE",
+            },
+          ],
+        }), { headers: { "content-type": "application/json" }, status: 200 })));
+
+        await expect(syncHostedLinqPhoneNumberInventory({
+          observedAt: snapshotObservedAt,
+          prisma,
+        })).resolves.toEqual({ syncedCount: 2 });
+
+        const rows = await prisma.hostedLinqLine.findMany({
+          where: {
+            phoneNumberLookupKey: {
+              in: [rowA.phoneNumberLookupKey, rowB.phoneNumberLookupKey],
+            },
+          },
+          select: {
+            phoneNumberLookupKey: true,
+            providerInventoryConfirmedAt: true,
+            providerPhoneNumberId: true,
+          },
+        });
+        const byLookupKey = new Map(rows.map((row) => [row.phoneNumberLookupKey, row]));
+        expect(byLookupKey.get(rowA.phoneNumberLookupKey)).toEqual({
+          phoneNumberLookupKey: rowA.phoneNumberLookupKey,
+          providerInventoryConfirmedAt: snapshotObservedAt,
+          providerPhoneNumberId: providerIdB,
+        });
+        expect(byLookupKey.get(rowB.phoneNumberLookupKey)).toEqual({
+          phoneNumberLookupKey: rowB.phoneNumberLookupKey,
+          providerInventoryConfirmedAt: snapshotObservedAt,
+          providerPhoneNumberId: providerIdA,
+        });
+        await expect(prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: providerIdA },
+        })).resolves.toBe(1);
+        await expect(prisma.hostedLinqLine.count({
+          where: { providerPhoneNumberId: providerIdB },
+        })).resolves.toBe(1);
+      } finally {
+        vi.unstubAllGlobals();
+        for (const heldRow of preexistingHeldRows) {
+          await prisma.hostedLinqLine.updateMany({
+            data: {
+              providerInventoryConfirmedAt: heldRow.providerInventoryConfirmedAt,
+              providerPhoneNumberId: heldRow.providerPhoneNumberId,
+            },
+            where: { phoneNumberLookupKey: heldRow.phoneNumberLookupKey },
+          });
+        }
+        await prisma.hostedLinqLine.deleteMany({
+          where: { phoneNumberLookupKey: { in: createdLookupKeys } },
+        });
+        await prisma.$disconnect();
+      }
+    });
+
     it("preserves first seen and orders service and reputation timestamps", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerId = `pg-proof-line-${randomUUID()}`;
@@ -647,6 +754,16 @@ describe.skipIf(!runPostgresProof)(
         });
 
         await applied;
+        const waitingSnapshot = readHostedLinqContactCardCandidacySnapshot({
+          limit: 50,
+          prisma,
+        });
+        await expect(Promise.race([
+          waitingSnapshot.then(() => "resolved"),
+          new Promise<"blocked">((resolve) => {
+            setTimeout(() => resolve("blocked"), 250);
+          }),
+        ])).resolves.toBe("blocked");
         await expect(Promise.race([
           resolveMurphHostedLinqContactCardBackupPhoneNumber({
             excludePhoneNumber: phoneOther,
@@ -655,10 +772,15 @@ describe.skipIf(!runPostgresProof)(
           new Promise((_resolve, reject) => {
             setTimeout(() => reject(new Error("backup resolution blocked on bulk inventory apply")), 5_000);
           }),
-        ])).resolves.toBe(phoneA);
+        ])).resolves.toBeNull();
 
         releaseCommit();
         await moveTransaction;
+        const snapshotAfterCommit = await waitingSnapshot;
+        expect(snapshotAfterCommit?.lines.map((line) => line.phoneNumber))
+          .not.toContain(phoneA);
+        expect(snapshotAfterCommit?.lines.map((line) => line.phoneNumber))
+          .toContain(phoneB);
         await expect(resolveMurphHostedLinqContactCardBackupPhoneNumber({
           excludePhoneNumber: phoneOther,
           prisma,
@@ -682,7 +804,7 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("executes one bulk database statement for a multi-line provider snapshot", async () => {
+    it("executes bounded set statements for a multi-line provider snapshot", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const providerIds = [
         `pg-proof-line-${randomUUID()}`,
@@ -700,7 +822,8 @@ describe.skipIf(!runPostgresProof)(
           providerPhoneNumberId: true,
         },
       });
-      let statementCount = 0;
+      let lockStatementCount = 0;
+      let setStatementCount = 0;
 
       try {
         vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
@@ -716,15 +839,20 @@ describe.skipIf(!runPostgresProof)(
           await expect(syncHostedLinqPhoneNumberInventory({
             observedAt: new Date(),
             prisma: {
+              $executeRaw: async (query: unknown) => {
+                lockStatementCount += 1;
+                return tx.$executeRaw(query as never);
+              },
               $queryRaw: async (query: unknown) => {
-                statementCount += 1;
+                setStatementCount += 1;
                 return tx.$queryRaw(query as never);
               },
             } as never,
           })).resolves.toEqual({ syncedCount: 2 });
         });
 
-        expect(statementCount).toBe(1);
+        expect(lockStatementCount).toBe(1);
+        expect(setStatementCount).toBe(2);
         const rows = await prisma.hostedLinqLine.findMany({
           where: { providerPhoneNumberId: { in: providerIds } },
           select: { providerPhoneNumberId: true },
@@ -799,9 +927,13 @@ describe.skipIf(!runPostgresProof)(
           syncHostedLinqPhoneNumberInventory({
             observedAt: new Date(),
             prisma: {
+              $executeRaw: (query: unknown) => tx.$executeRaw(query as never),
               $queryRaw: async (query: unknown) => {
-                await tx.$queryRaw(query as never);
-                throw new Error("injected post-statement failure");
+                const result = await tx.$queryRaw(query as never);
+                if ((query as { sql?: string }).sql?.includes("upserted_line AS")) {
+                  throw new Error("injected post-statement failure");
+                }
+                return result;
               },
             } as never,
           })

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -42,21 +42,13 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     )));
   };
 
-  it("prepares the bounded snapshot before transaction entry and applies set-based release then upsert", async () => {
+  it("prepares the bounded snapshot before transaction entry and applies one bulk statement", async () => {
     const events: string[] = [];
-    const executeRaw = vi.fn().mockImplementation(() => {
-      events.push("publication-lock");
-      return Promise.resolve(1);
-    });
-    const queryRaw = vi.fn().mockImplementation((query: { sql: string }) => {
-      if (query.sql.includes("released_line AS")) {
-        events.push("release-statement");
-        return Promise.resolve([{ releasedCount: 0n }]);
-      }
-      events.push("upsert-statement");
+    const queryRaw = vi.fn().mockImplementation(() => {
+      events.push("bulk-statement");
       return Promise.resolve([{ syncedCount: 2n }]);
     });
-    const tx = { $executeRaw: executeRaw, $queryRaw: queryRaw };
+    const tx = { $queryRaw: queryRaw };
     const transaction = vi.fn(async (
       callback: (client: typeof tx) => Promise<unknown>,
       options: unknown,
@@ -95,30 +87,21 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
 
     expect(events).toEqual([
       "transaction:start",
-      "publication-lock",
-      "release-statement",
-      "upsert-statement",
+      "bulk-statement",
       "transaction:commit",
     ]);
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(executeRaw).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(2);
-    const releaseQuery = queryRaw.mock.calls[0]?.[0] as {
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as {
       sql: string;
       values: unknown[];
     };
-    const upsertQuery = queryRaw.mock.calls[1]?.[0] as {
-      sql: string;
-      values: unknown[];
-    };
-    expect((executeRaw.mock.calls[0]?.[0] as string[]).join(""))
-      .toContain("pg_advisory_xact_lock");
-    expect(releaseQuery.sql).toContain("released_line AS");
-    expect(releaseQuery.sql)
-      .toContain("resolved.provider_phone_number_id = line.provider_phone_number_id");
-    expect(upsertQuery.sql).toContain("upserted_line AS");
-    expect(upsertQuery.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
-    expect(upsertQuery.values).toEqual(expect.arrayContaining([
+    expect(query.sql).toContain("released_line AS");
+    expect(query.sql).toContain("upserted_line AS");
+    expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
+    expect(query.sql).not.toContain("pg_advisory_xact_lock");
+    expect(query.sql).not.toContain("FOR UPDATE");
+    expect(query.values).toEqual(expect.arrayContaining([
       "line_1",
       "line_2",
       "*** 0001",
@@ -128,35 +111,26 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
       "AT_RISK",
       "FLAGGED",
     ]));
-    expect(JSON.stringify(upsertQuery.values)).not.toContain("+1555000000");
+    expect(JSON.stringify(query.values)).not.toContain("+1555000000");
   });
 
-  it("uses bounded set statements for an explicitly empty inventory", async () => {
-    const executeRaw = vi.fn().mockResolvedValue(1);
-    const queryRaw = vi.fn()
-      .mockResolvedValueOnce([{ releasedCount: 0n }])
-      .mockResolvedValueOnce([{ syncedCount: 0n }]);
+  it("uses one authoritative bulk statement for an explicitly empty inventory", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 0n }]);
     stubInventoryFetch({ phone_numbers: [] });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 0 });
 
-    expect(executeRaw).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(2);
-    const releaseQuery = queryRaw.mock.calls[0]?.[0] as { sql: string };
-    const upsertQuery = queryRaw.mock.calls[1]?.[0] as { sql: string };
-    expect(releaseQuery.sql).toContain("WHERE FALSE");
-    expect(releaseQuery.sql).toContain("provider_phone_number_id = NULL");
-    expect(upsertQuery.sql).toContain("WHERE FALSE");
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as { sql: string };
+    expect(query.sql).toContain("WHERE FALSE");
+    expect(query.sql).toContain("provider_phone_number_id = NULL");
   });
 
   it("retries unique-key convergence without repeating preprocessing", async () => {
-    const executeRaw = vi.fn().mockResolvedValue(1);
-    const queryRaw = vi.fn()
-      .mockResolvedValueOnce([{ releasedCount: 0n }])
-      .mockResolvedValueOnce([{ syncedCount: 1n }]);
-    const tx = { $executeRaw: executeRaw, $queryRaw: queryRaw };
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
+    const tx = { $queryRaw: queryRaw };
     let attempts = 0;
     const transaction = vi.fn(async (callback: (client: typeof tx) => Promise<unknown>) => {
       attempts += 1;
@@ -181,8 +155,7 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     })).resolves.toEqual({ syncedCount: 1 });
 
     expect(transaction).toHaveBeenCalledTimes(2);
-    expect(executeRaw).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(2);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
   });
 
   it("does not enter a transaction when the provider read fails", async () => {

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -42,13 +42,21 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     )));
   };
 
-  it("prepares the bounded snapshot before transaction entry and applies one bulk statement", async () => {
+  it("prepares the bounded snapshot before transaction entry and applies set-based release then upsert", async () => {
     const events: string[] = [];
-    const queryRaw = vi.fn().mockImplementation(() => {
-      events.push("bulk-statement");
+    const executeRaw = vi.fn().mockImplementation(() => {
+      events.push("publication-lock");
+      return Promise.resolve(1);
+    });
+    const queryRaw = vi.fn().mockImplementation((query: { sql: string }) => {
+      if (query.sql.includes("released_line AS")) {
+        events.push("release-statement");
+        return Promise.resolve([{ releasedCount: 0n }]);
+      }
+      events.push("upsert-statement");
       return Promise.resolve([{ syncedCount: 2n }]);
     });
-    const tx = { $queryRaw: queryRaw };
+    const tx = { $executeRaw: executeRaw, $queryRaw: queryRaw };
     const transaction = vi.fn(async (
       callback: (client: typeof tx) => Promise<unknown>,
       options: unknown,
@@ -87,20 +95,30 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
 
     expect(events).toEqual([
       "transaction:start",
-      "bulk-statement",
+      "publication-lock",
+      "release-statement",
+      "upsert-statement",
       "transaction:commit",
     ]);
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(1);
-    const query = queryRaw.mock.calls[0]?.[0] as {
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    const releaseQuery = queryRaw.mock.calls[0]?.[0] as {
       sql: string;
       values: unknown[];
     };
-    expect(query.sql).toContain("released_line AS");
-    expect(query.sql).toContain("upserted_line AS");
-    expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
-    expect(query.sql).not.toContain("pg_advisory_xact_lock");
-    expect(query.values).toEqual(expect.arrayContaining([
+    const upsertQuery = queryRaw.mock.calls[1]?.[0] as {
+      sql: string;
+      values: unknown[];
+    };
+    expect((executeRaw.mock.calls[0]?.[0] as string[]).join(""))
+      .toContain("pg_advisory_xact_lock");
+    expect(releaseQuery.sql).toContain("released_line AS");
+    expect(releaseQuery.sql)
+      .toContain("resolved.provider_phone_number_id = line.provider_phone_number_id");
+    expect(upsertQuery.sql).toContain("upserted_line AS");
+    expect(upsertQuery.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
+    expect(upsertQuery.values).toEqual(expect.arrayContaining([
       "line_1",
       "line_2",
       "*** 0001",
@@ -110,26 +128,35 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
       "AT_RISK",
       "FLAGGED",
     ]));
-    expect(JSON.stringify(query.values)).not.toContain("+1555000000");
+    expect(JSON.stringify(upsertQuery.values)).not.toContain("+1555000000");
   });
 
-  it("uses one authoritative bulk statement for an explicitly empty inventory", async () => {
-    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 0n }]);
+  it("uses bounded set statements for an explicitly empty inventory", async () => {
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const queryRaw = vi.fn()
+      .mockResolvedValueOnce([{ releasedCount: 0n }])
+      .mockResolvedValueOnce([{ syncedCount: 0n }]);
     stubInventoryFetch({ phone_numbers: [] });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $queryRaw: queryRaw } as never,
+      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 0 });
 
-    expect(queryRaw).toHaveBeenCalledTimes(1);
-    const query = queryRaw.mock.calls[0]?.[0] as { sql: string };
-    expect(query.sql).toContain("WHERE FALSE");
-    expect(query.sql).toContain("provider_phone_number_id = NULL");
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    const releaseQuery = queryRaw.mock.calls[0]?.[0] as { sql: string };
+    const upsertQuery = queryRaw.mock.calls[1]?.[0] as { sql: string };
+    expect(releaseQuery.sql).toContain("WHERE FALSE");
+    expect(releaseQuery.sql).toContain("provider_phone_number_id = NULL");
+    expect(upsertQuery.sql).toContain("WHERE FALSE");
   });
 
   it("retries unique-key convergence without repeating preprocessing", async () => {
-    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
-    const tx = { $queryRaw: queryRaw };
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const queryRaw = vi.fn()
+      .mockResolvedValueOnce([{ releasedCount: 0n }])
+      .mockResolvedValueOnce([{ syncedCount: 1n }]);
+    const tx = { $executeRaw: executeRaw, $queryRaw: queryRaw };
     let attempts = 0;
     const transaction = vi.fn(async (callback: (client: typeof tx) => Promise<unknown>) => {
       attempts += 1;
@@ -154,7 +181,8 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     })).resolves.toEqual({ syncedCount: 1 });
 
     expect(transaction).toHaveBeenCalledTimes(2);
-    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
   });
 
   it("does not enter a transaction when the provider read fails", async () => {

--- a/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-phone-number-inventory.test.ts
@@ -1,25 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { Buffer } from "node:buffer";
 
-const lineStoreMocks = vi.hoisted(() => ({
-  upsertHostedLinqLineForPhoneTx: vi.fn(),
-}));
-
-const providerHealthStoreMocks = vi.hoisted(() => ({
-  projectHostedLinqLineProviderStateTx: vi.fn(),
-}));
-
-vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
-  acquireHostedLinqInventoryApplyLockTx: async (
-    input: { prisma: { $executeRaw: (...args: unknown[]) => Promise<unknown> } },
-  ) => {
-    await input.prisma.$executeRaw();
-  },
-  upsertHostedLinqLineForPhoneTx: lineStoreMocks.upsertHostedLinqLineForPhoneTx,
-}));
-
-vi.mock("@/src/lib/hosted-onboarding/linq-provider-health-store", () => ({
-  projectHostedLinqLineProviderStateTx: providerHealthStoreMocks.projectHostedLinqLineProviderStateTx,
-}));
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingLinqConfig: () => ({
@@ -28,16 +9,29 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   }),
 }));
 
-import { createHostedPhoneLookupKey } from "@/src/lib/hosted-onboarding/contact-privacy-core";
 import {
   parseHostedLinqPhoneNumberInventory,
   syncHostedLinqPhoneNumberInventory,
 } from "@/src/lib/hosted-onboarding/linq-phone-number-inventory";
 
+const TEST_KEYRING_ENTRIES = {
+  v1: Buffer.from("1".repeat(32), "utf8").toString("base64"),
+  v2: Buffer.from("2".repeat(32), "utf8").toString("base64"),
+};
+
+let restoreContactPrivacyKeyring: (() => void) | null = null;
+
+beforeEach(() => {
+  restoreContactPrivacyKeyring = configureHostedContactPrivacyKeyringForTest({
+    currentVersion: "v1",
+    entries: TEST_KEYRING_ENTRIES,
+  });
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
-  lineStoreMocks.upsertHostedLinqLineForPhoneTx.mockReset();
-  providerHealthStoreMocks.projectHostedLinqLineProviderStateTx.mockReset();
+  restoreContactPrivacyKeyring?.();
+  restoreContactPrivacyKeyring = null;
 });
 
 describe("syncHostedLinqPhoneNumberInventory", () => {
@@ -48,34 +42,38 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     )));
   };
 
-  it("revokes relinquished and moved provider-id pairings before upserting", async () => {
-    const keptLookupKey = createHostedPhoneLookupKey("+15550000001");
-    const callOrder: string[] = [];
-    const findMany = vi.fn(async () => [
-      { phoneNumberLookupKey: keptLookupKey, providerPhoneNumberId: "line_current" },
-      { phoneNumberLookupKey: "lookup:moved", providerPhoneNumberId: "line_moving" },
-      { phoneNumberLookupKey: "lookup:relinquished", providerPhoneNumberId: "line_gone" },
-    ]);
-    const updateMany = vi.fn(async () => {
-      callOrder.push("revoke");
-      return { count: 2 };
+  it("prepares the bounded snapshot before transaction entry and applies one bulk statement", async () => {
+    const events: string[] = [];
+    const queryRaw = vi.fn().mockImplementation(() => {
+      events.push("bulk-statement");
+      return Promise.resolve([{ syncedCount: 2n }]);
     });
-    lineStoreMocks.upsertHostedLinqLineForPhoneTx.mockImplementation(async () => {
-      callOrder.push("upsert");
-      return { phoneNumberLookupKey: "lookup:any" };
+    const tx = { $queryRaw: queryRaw };
+    const transaction = vi.fn(async (
+      callback: (client: typeof tx) => Promise<unknown>,
+      options: unknown,
+    ) => {
+      events.push("transaction:start");
+      expect(options).toEqual({ isolationLevel: "Serializable" });
+      // Prepared lookup candidates and ciphertext must already be detached
+      // from keyring state when transaction ownership begins.
+      restoreContactPrivacyKeyring?.();
+      restoreContactPrivacyKeyring = null;
+      const result = await callback(tx);
+      events.push("transaction:commit");
+      return result;
     });
-    providerHealthStoreMocks.projectHostedLinqLineProviderStateTx.mockResolvedValue(undefined);
     stubInventoryFetch({
       phone_numbers: [
         {
-          id: "line_current",
-          phone_number: "+15550000001",
-          reputation: { status: "HEALTHY" },
-          status: "ACTIVE",
+          id: "line_2",
+          phone_number: "+15550000002",
+          reputation: { status: "AT_RISK" },
+          status: "FLAGGED",
         },
         {
-          id: "line_moving",
-          phone_number: "+15550000002",
+          id: "line_1",
+          phone_number: "+1 (555) 000-0001",
           reputation: { status: "HEALTHY" },
           status: "ACTIVE",
         },
@@ -83,137 +81,126 @@ describe("syncHostedLinqPhoneNumberInventory", () => {
     });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
+      observedAt: new Date("2026-07-01T12:00:00.000Z"),
+      prisma: { $transaction: transaction } as never,
     })).resolves.toEqual({ syncedCount: 2 });
 
-    // line_current keeps its pairing; line_moving is held at a lookup key
-    // that is not a candidate for its snapshot phone (a move) and line_gone
-    // is absent from the snapshot, so exactly those two rows are cleared.
-    expect(updateMany).toHaveBeenCalledWith({
-      data: {
-        providerInventoryConfirmedAt: null,
-        providerPhoneNumberId: null,
-      },
-      where: {
-        phoneNumberLookupKey: { in: ["lookup:moved", "lookup:relinquished"] },
-      },
-    });
-    expect(callOrder[0]).toBe("revoke");
-    expect(callOrder).toContain("upsert");
+    expect(events).toEqual([
+      "transaction:start",
+      "bulk-statement",
+      "transaction:commit",
+    ]);
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as {
+      sql: string;
+      values: unknown[];
+    };
+    expect(query.sql).toContain("released_line AS");
+    expect(query.sql).toContain("upserted_line AS");
+    expect(query.sql).toContain("ON CONFLICT (phone_number_lookup_key)");
+    expect(query.sql).not.toContain("pg_advisory_xact_lock");
+    expect(query.values).toEqual(expect.arrayContaining([
+      "line_1",
+      "line_2",
+      "*** 0001",
+      "*** 0002",
+      "HEALTHY",
+      "ACTIVE",
+      "AT_RISK",
+      "FLAGGED",
+    ]));
+    expect(JSON.stringify(query.values)).not.toContain("+1555000000");
   });
 
-  it("clears every held provider id when the provider reports an explicitly empty inventory", async () => {
-    const findMany = vi.fn(async () => [
-      { phoneNumberLookupKey: "lookup:only", providerPhoneNumberId: "line_prior" },
-    ]);
-    const updateMany = vi.fn(async () => ({ count: 1 }));
+  it("uses one authoritative bulk statement for an explicitly empty inventory", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 0n }]);
     stubInventoryFetch({ phone_numbers: [] });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 0 });
 
-    expect(updateMany).toHaveBeenCalledWith({
-      data: {
-        providerInventoryConfirmedAt: null,
-        providerPhoneNumberId: null,
-      },
-      where: {
-        phoneNumberLookupKey: { in: ["lookup:only"] },
-      },
-    });
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as { sql: string };
+    expect(query.sql).toContain("WHERE FALSE");
+    expect(query.sql).toContain("provider_phone_number_id = NULL");
   });
 
-  it("applies the snapshot inside one owning transaction that takes the inventory lock first", async () => {
-    const callOrder: string[] = [];
-    const tx = {
-      $executeRaw: vi.fn(async () => {
-        callOrder.push("lock");
-        return 0;
-      }),
-      hostedLinqLine: {
-        findMany: vi.fn(async () => {
-          callOrder.push("read-held");
-          return [];
-        }),
-        updateMany: vi.fn(),
-      },
-    };
-    const $transaction = vi.fn(async (callback: (client: unknown) => Promise<unknown>) => {
-      callOrder.push("transaction");
+  it("retries unique-key convergence without repeating preprocessing", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
+    const tx = { $queryRaw: queryRaw };
+    let attempts = 0;
+    const transaction = vi.fn(async (callback: (client: typeof tx) => Promise<unknown>) => {
+      attempts += 1;
+      if (attempts === 1) {
+        restoreContactPrivacyKeyring?.();
+        restoreContactPrivacyKeyring = null;
+        throw {
+          code: "P2010",
+          meta: {
+            driverAdapterError: { cause: { originalCode: "23505" } },
+          },
+        };
+      }
       return callback(tx);
     });
-    stubInventoryFetch({ phone_numbers: [] });
+    stubInventoryFetch({
+      phone_numbers: [{ id: "line_1", phone_number: "+15550000001" }],
+    });
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $transaction, hostedLinqLine: { findMany: vi.fn(), updateMany: vi.fn() } } as never,
-    })).resolves.toEqual({ syncedCount: 0 });
+      prisma: { $transaction: transaction } as never,
+    })).resolves.toEqual({ syncedCount: 1 });
 
-    expect($transaction).toHaveBeenCalledTimes(1);
-    expect(callOrder).toEqual(["transaction", "lock", "read-held"]);
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
   });
 
-  it("does not revoke inventory backing when the provider read fails", async () => {
-    const findMany = vi.fn();
-    const updateMany = vi.fn();
+  it("does not enter a transaction when the provider read fails", async () => {
+    const transaction = vi.fn();
     stubInventoryFetch("upstream error", 503);
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $transaction: transaction } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_FAILED",
     });
 
-    expect(findMany).not.toHaveBeenCalled();
-    expect(updateMany).not.toHaveBeenCalled();
-    expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
   });
 
   it.each([
     ["a missing collection field", {}],
-    ["an aliased collection field", { data: [{ id: "line_1", phone_number: "+15550000001" }] }],
-    ["a non-array collection field", { phone_numbers: "+15550000001" }],
-  ])("rejects %s without touching stored ownership", async (_label, payload) => {
-    const findMany = vi.fn();
-    const updateMany = vi.fn();
+    ["an invalid phone number", {
+      phone_numbers: [{ id: "line_1", phone_number: "not-a-phone" }],
+    }],
+    ["a duplicate phone number", {
+      phone_numbers: [
+        { id: "line_1", phone_number: "+15550000001" },
+        { id: "line_2", phone_number: "+1 (555) 000-0001" },
+      ],
+    }],
+    ["a missing provider id", {
+      phone_numbers: [{ phone_number: "+15550000001" }],
+    }],
+    ["a duplicate provider id", {
+      phone_numbers: [
+        { id: "line_1", phone_number: "+15550000001" },
+        { id: "line_1", phone_number: "+15550000002" },
+      ],
+    }],
+  ])("rejects %s before transaction entry", async (_label, payload) => {
+    const transaction = vi.fn();
     stubInventoryFetch(payload);
 
     await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
+      prisma: { $transaction: transaction } as never,
     })).rejects.toMatchObject({
       code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
     });
 
-    expect(findMany).not.toHaveBeenCalled();
-    expect(updateMany).not.toHaveBeenCalled();
-    expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ["an invalid phone number", [{ id: "line_1", phone_number: "not-a-phone" }]],
-    ["a duplicate phone number", [
-      { id: "line_1", phone_number: "+15550000001" },
-      { id: "line_2", phone_number: "+1 (555) 000-0001" },
-    ]],
-    ["a missing provider id", [{ phone_number: "+15550000001" }]],
-    ["a duplicate provider id", [
-      { id: "line_1", phone_number: "+15550000001" },
-      { id: "line_1", phone_number: "+15550000002" },
-    ]],
-  ])("rejects a snapshot containing %s without touching stored ownership", async (_label, records) => {
-    const findMany = vi.fn();
-    const updateMany = vi.fn();
-    stubInventoryFetch({ phone_numbers: records });
-
-    await expect(syncHostedLinqPhoneNumberInventory({
-      prisma: { $executeRaw: vi.fn(), hostedLinqLine: { findMany, updateMany } } as never,
-    })).rejects.toMatchObject({
-      code: "LINQ_PHONE_NUMBER_INVENTORY_INVALID",
-    });
-
-    expect(findMany).not.toHaveBeenCalled();
-    expect(updateMany).not.toHaveBeenCalled();
-    expect(lineStoreMocks.upsertHostedLinqLineForPhoneTx).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
   });
 });
 
@@ -307,3 +294,39 @@ describe("parseHostedLinqPhoneNumberInventory", () => {
     })).toThrow(/exceeds the configured 1 line limit/u);
   });
 });
+
+function configureHostedContactPrivacyKeyringForTest(input: {
+  currentVersion: string;
+  entries: Record<string, string>;
+}): () => void {
+  const previousKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+  const previousCurrentVersion = process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
+
+  process.env.HOSTED_CONTACT_PRIVACY_KEYS = Object.entries(input.entries)
+    .map(([version, key]) => `${version}:${key}`)
+    .join(",");
+  process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = input.currentVersion;
+  clearHostedOnboardingEnvCache();
+
+  return () => {
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_KEYS", previousKeys);
+    restoreEnvValue("HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION", previousCurrentVersion);
+    clearHostedOnboardingEnvCache();
+  };
+}
+
+function clearHostedOnboardingEnvCache(): void {
+  delete (
+    globalThis as typeof globalThis & {
+      __murphHostedOnboardingEnv?: unknown;
+    }
+  ).__murphHostedOnboardingEnv;
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -242,10 +242,7 @@ describe("listHostedLinqChatHealthInventory", () => {
 describe("Linq provider health inventory synchronization", () => {
   it("projects independent provider state for every inventoried line", async () => {
     const observedAt = new Date("2026-07-29T16:08:00.000Z");
-    const executeRaw = vi.fn().mockResolvedValue(1);
-    const queryRaw = vi.fn()
-      .mockResolvedValueOnce([{ releasedCount: 0n }])
-      .mockResolvedValueOnce([{ syncedCount: 1n }]);
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-1",
@@ -257,12 +254,11 @@ describe("Linq provider health inventory synchronization", () => {
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt,
-      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    expect(executeRaw).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(2);
-    const query = queryRaw.mock.calls[1]?.[0] as { values: unknown[] };
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
     expect(query.values).toEqual(expect.arrayContaining([
       "line-1",
       "AT_RISK",
@@ -272,10 +268,7 @@ describe("Linq provider health inventory synchronization", () => {
   });
 
   it("does not clear stored provider state from unknown inventory values", async () => {
-    const executeRaw = vi.fn().mockResolvedValue(1);
-    const queryRaw = vi.fn()
-      .mockResolvedValueOnce([{ releasedCount: 0n }])
-      .mockResolvedValueOnce([{ syncedCount: 1n }]);
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-future",
@@ -287,12 +280,10 @@ describe("Linq provider health inventory synchronization", () => {
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt: new Date("2026-07-29T16:08:00.000Z"),
-      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    expect(executeRaw).toHaveBeenCalledTimes(1);
-    expect(queryRaw).toHaveBeenCalledTimes(2);
-    const query = queryRaw.mock.calls[1]?.[0] as { values: unknown[] };
+    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
     expect(query.values).not.toContain("FUTURE_REPUTATION");
     expect(query.values).not.toContain("FUTURE_SERVICE");
   });

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -242,7 +242,10 @@ describe("listHostedLinqChatHealthInventory", () => {
 describe("Linq provider health inventory synchronization", () => {
   it("projects independent provider state for every inventoried line", async () => {
     const observedAt = new Date("2026-07-29T16:08:00.000Z");
-    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const queryRaw = vi.fn()
+      .mockResolvedValueOnce([{ releasedCount: 0n }])
+      .mockResolvedValueOnce([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-1",
@@ -254,11 +257,12 @@ describe("Linq provider health inventory synchronization", () => {
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt,
-      prisma: { $queryRaw: queryRaw } as never,
+      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    expect(queryRaw).toHaveBeenCalledTimes(1);
-    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    const query = queryRaw.mock.calls[1]?.[0] as { values: unknown[] };
     expect(query.values).toEqual(expect.arrayContaining([
       "line-1",
       "AT_RISK",
@@ -268,7 +272,10 @@ describe("Linq provider health inventory synchronization", () => {
   });
 
   it("does not clear stored provider state from unknown inventory values", async () => {
-    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const queryRaw = vi.fn()
+      .mockResolvedValueOnce([{ releasedCount: 0n }])
+      .mockResolvedValueOnce([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-future",
@@ -280,10 +287,12 @@ describe("Linq provider health inventory synchronization", () => {
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt: new Date("2026-07-29T16:08:00.000Z"),
-      prisma: { $queryRaw: queryRaw } as never,
+      prisma: { $executeRaw: executeRaw, $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    const query = queryRaw.mock.calls[1]?.[0] as { values: unknown[] };
     expect(query.values).not.toContain("FUTURE_REPUTATION");
     expect(query.values).not.toContain("FUTURE_SERVICE");
   });

--- a/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-provider-health.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { HostedLinqWebhookEvent } from "@/src/lib/hosted-onboarding/linq";
 import {
@@ -51,19 +51,35 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   }),
 }));
 
-vi.mock("@/src/lib/hosted-onboarding/linq-line-store", () => ({
-  acquireHostedLinqInventoryApplyLockTx: async (
-    input: { prisma: { $executeRaw: (...args: unknown[]) => Promise<unknown> } },
-  ) => {
-    await input.prisma.$executeRaw();
-  },
-  upsertHostedLinqLineForPhoneTx:
-    inventoryMocks.upsertHostedLinqLineForPhoneTx,
-}));
+vi.mock("@/src/lib/hosted-onboarding/linq-line-store", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/lib/hosted-onboarding/linq-line-store")
+  >();
+  return {
+    ...actual,
+    upsertHostedLinqLineForPhoneTx:
+      inventoryMocks.upsertHostedLinqLineForPhoneTx,
+  };
+});
+
+const TEST_PRIVACY_KEY = Buffer.alloc(32, 7).toString("base64");
+let previousPrivacyKeys: string | undefined;
+let previousPrivacyVersion: string | undefined;
 
 beforeEach(() => {
+  previousPrivacyKeys = process.env.HOSTED_CONTACT_PRIVACY_KEYS;
+  previousPrivacyVersion = process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION;
+  process.env.HOSTED_CONTACT_PRIVACY_KEYS = `v1:${TEST_PRIVACY_KEY}`;
+  process.env.HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION = "v1";
+  clearHostedOnboardingEnvCache();
   inventoryMocks.fetchLinqApi.mockReset();
   inventoryMocks.upsertHostedLinqLineForPhoneTx.mockReset();
+});
+
+afterEach(() => {
+  restoreEnv("HOSTED_CONTACT_PRIVACY_KEYS", previousPrivacyKeys);
+  restoreEnv("HOSTED_CONTACT_PRIVACY_CURRENT_KEY_VERSION", previousPrivacyVersion);
+  clearHostedOnboardingEnvCache();
 });
 
 describe("Linq provider status parsing", () => {
@@ -226,14 +242,7 @@ describe("listHostedLinqChatHealthInventory", () => {
 describe("Linq provider health inventory synchronization", () => {
   it("projects independent provider state for every inventoried line", async () => {
     const observedAt = new Date("2026-07-29T16:08:00.000Z");
-    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
-    const prisma = {
-      $executeRaw: vi.fn(),
-      hostedLinqLine: {
-        findMany: vi.fn().mockResolvedValue([]),
-        updateMany,
-      },
-    } as never;
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-1",
@@ -242,51 +251,24 @@ describe("Linq provider health inventory synchronization", () => {
         status: "ACTIVE",
       }],
     }));
-    inventoryMocks.upsertHostedLinqLineForPhoneTx.mockResolvedValueOnce({
-      phoneNumberLookupKey: "line-key",
-    });
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt,
-      prisma,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    expect(inventoryMocks.upsertHostedLinqLineForPhoneTx).toHaveBeenCalledWith({
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
+    expect(query.values).toEqual(expect.arrayContaining([
+      "line-1",
+      "AT_RISK",
+      "ACTIVE",
       observedAt,
-      phoneNumber: "+12025550123",
-      prisma,
-      providerPhoneNumberId: "line-1",
-      source: "provider",
-    });
-    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        providerReputationStatus: "AT_RISK",
-        providerReputationUpdatedAt: observedAt,
-      }),
-      where: expect.objectContaining({
-        phoneNumberLookupKey: "line-key",
-      }),
-    }));
-    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        providerServiceStatus: "ACTIVE",
-        providerServiceUpdatedAt: observedAt,
-      }),
-      where: expect.objectContaining({
-        phoneNumberLookupKey: "line-key",
-      }),
-    }));
+    ]));
   });
 
   it("does not clear stored provider state from unknown inventory values", async () => {
-    const updateMany = vi.fn();
-    const prisma = {
-      $executeRaw: vi.fn(),
-      hostedLinqLine: {
-        findMany: vi.fn().mockResolvedValue([]),
-        updateMany,
-      },
-    } as never;
+    const queryRaw = vi.fn().mockResolvedValue([{ syncedCount: 1n }]);
     inventoryMocks.fetchLinqApi.mockResolvedValueOnce(jsonResponse({
       phone_numbers: [{
         id: "line-future",
@@ -295,22 +277,15 @@ describe("Linq provider health inventory synchronization", () => {
         status: "FUTURE_SERVICE",
       }],
     }));
-    inventoryMocks.upsertHostedLinqLineForPhoneTx.mockResolvedValueOnce({
-      phoneNumberLookupKey: "line-key",
-    });
 
     await expect(syncHostedLinqPhoneNumberInventory({
       observedAt: new Date("2026-07-29T16:08:00.000Z"),
-      prisma,
+      prisma: { $queryRaw: queryRaw } as never,
     })).resolves.toEqual({ syncedCount: 1 });
 
-    // The only write is the freshness watermark for the confirmed line;
-    // unknown status values never clear stored provider state.
-    expect(updateMany).toHaveBeenCalledTimes(1);
-    expect(updateMany).toHaveBeenCalledWith({
-      data: { providerInventoryConfirmedAt: expect.any(Date) },
-      where: { phoneNumberLookupKey: "line-key" },
-    });
+    const query = queryRaw.mock.calls[0]?.[0] as { values: unknown[] };
+    expect(query.values).not.toContain("FUTURE_REPUTATION");
+    expect(query.values).not.toContain("FUTURE_SERVICE");
   });
 
   it("associates inventoried chat health with its resolved sending line", async () => {

--- a/apps/web/test/sync-hosted-linq-lines-script.test.ts
+++ b/apps/web/test/sync-hosted-linq-lines-script.test.ts
@@ -32,19 +32,13 @@ const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 const TEST_KEY = Buffer.alloc(32, 7).toString("base64url");
 
 function createPrismaOwner() {
-  const transactionClient = {};
   const disconnect = vi.fn().mockResolvedValue(undefined);
-  const transaction = vi.fn(async (callback: (tx: object) => Promise<void>) => {
-    await callback(transactionClient);
-  });
 
   return {
     disconnect,
     prisma: {
       $disconnect: disconnect,
-      $transaction: transaction,
     },
-    transaction,
   };
 }
 
@@ -87,8 +81,9 @@ describe("sync-hosted-linq-lines script", () => {
       expect(owner.disconnect).toHaveBeenCalledOnce();
     });
 
-    expect(owner.transaction).toHaveBeenCalledOnce();
-    expect(mocks.syncConfiguredLines).toHaveBeenCalledOnce();
+    expect(mocks.syncConfiguredLines).toHaveBeenCalledWith(expect.objectContaining({
+      prisma: owner.prisma,
+    }));
     expect(mocks.syncProviderInventory).toHaveBeenCalledOnce();
     expect(mocks.assertAssignablePoolReady).toHaveBeenCalledOnce();
     expect(settled).toBe(false);
@@ -99,7 +94,7 @@ describe("sync-hosted-linq-lines script", () => {
   });
 
   it.each([
-    ["transaction", mocks.syncConfiguredLines],
+    ["configured-line sync", mocks.syncConfiguredLines],
     ["provider inventory", mocks.syncProviderInventory],
     ["readiness", mocks.assertAssignablePoolReady],
   ])("disconnects once and preserves a %s failure", async (_stage, failingOperation) => {


### PR DESCRIPTION
## Why this PR exists

Linq configured-line and authoritative provider-inventory synchronization took
one inventory-wide advisory lock, then looped through phones while each
single-phone writer took another advisory lock and issued several writes. This
PR prepares the full snapshot before transaction entry and replaces both
multi-line loops with one parameterized VALUES/CTE statement each.

## User goal / user-visible behavior

Hosted Linq ownership, freshness, health projection, configured-line state, and
contact-card candidacy keep the same committed behavior. The operational change
is bounded set-based synchronization without either advisory-lock layer.

## User experience

No UI or copy changes. Inventory/configured snapshots publish atomically at
transaction commit; readers may see the prior committed snapshot while a writer
is in flight, which is ordinary PostgreSQL MVCC behavior.

## Invariants

- Plaintext phone numbers never enter SQL values, query text, logs, or durable
  artifacts.
- Normalization, lookup-key candidates, encryption, hinting, dedupe, bounds,
  and deterministic ordering finish before multi-line transaction entry.
- Snapshot cardinality remains bounded at 250 lines.
- Each multi-line path issues one parameterized VALUES/CTE bulk statement and
  does not call the per-phone writer.
- No inventory advisory lock or explicit inventory-wide `FOR UPDATE` barrier
  remains; unique lookup keys and ordinary DML conflict handling own
  convergence.
- Provider application remains serializable with bounded retry for unique,
  serialization, and deadlock conflicts.
- Ordinary provider-ID moves, lookup-key rotation compatibility, freshness,
  first/last seen, service/reputation timestamp ordering, and configured legacy
  limit fill remain covered.
- The unrelated single-phone webhook/delivery writer retains its narrow
  per-phone lock.

## Non-obvious affected surfaces

- The sync script now passes the Prisma client into the configured bulk writer
  so privacy preprocessing happens before that writer opens its transaction.
- Contact-card candidacy uses one repeatable-read transaction across its count,
  configured-row, and conditional provider-fill queries; it does not participate
  in inventory locking.
- An arbitrary permutation of provider IDs among rows in one snapshot is not a
  demonstrated provider contract. Supporting it with the current immediate
  unique index would require a second release statement or schema change, both
  contrary to this task. Ordinary relinquish-and-move behavior is retained and
  proven against PostgreSQL.

## Architecture and reuse

- Existing systems reused: the contact-privacy normalization, lookup,
  encryption, and hint helpers; the existing `HostedLinqLine` primary/unique
  indexes; and Prisma parameterized SQL.
- New logic: one prepared phone snapshot shared by the configured and provider
  bulk writers, with one VALUES/CTE statement per complete snapshot.
- New abstractions: none beyond the focused prepared-snapshot value shape and
  preparation helper; there is no schema or dependency change.
- Complexity intentionally avoided: deletes the global inventory advisory
  lock, multi-phone calls into the single-phone writer, and explicit
  inventory-wide row-lock CTEs instead of replacing them with another lock
  manager or coordination layer.

## Hot reply path impact

- Path status: not applicable. These are scheduled/admin synchronization and
  contact-card projection paths, not accepted-message reply handoff.
- Database/network/provider latency on the reply path: unchanged.

## Murph initial provider input impact

- Individual Murph: not applicable; assembled input unchanged.
- Group Murph: not applicable; assembled input unchanged.
- Tool/schema/generated guidance: unchanged.

## Design proof

- Not applicable: no user-facing frontend surface changed.

## Preliminary specialist lenses

- Product experience: applicable because contact-card candidacy depends on the
  committed inventory snapshot. Covered by focused contact-card tests and the
  real-PostgreSQL atomic-commit scenario.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: applicable. Focused unit and real-PostgreSQL proof were added.
- Rendered evidence: not applicable.

## ReviewGPT context

ReviewGPT context sensitivity: sensitive

Reason: persisted ownership, encrypted contact data, concurrency, retry, and
idempotent database behavior change on a product-critical Linq surface.

ReviewGPT first-reviewed head: 3310a7730bc4ef6d814ec02cd9f06cd788ddb9e4

ReviewGPT previous reviewed head: 4d2813832b8e8046d3ed2e47470c2ba71a7eac02

ReviewGPT current head: b042b50576cd57bcff0dfa5ba716c9ea5f2465a4

ReviewGPT context anchor head: b042b50576cd57bcff0dfa5ba716c9ea5f2465a4

### Finding dispositions and mechanisms

- Preliminary stale-read finding: rejected on parent correction. The proposed
  cure broadened the deleted inventory lock into contact-card readers. A reader
  seeing the prior committed snapshot during an in-flight transaction is normal
  MVCC, not partial publication; repeatable-read still prevents the two-query
  candidacy read from straddling a commit.
- Preliminary provider-ID permutation finding: rejected as an unproven provider
  behavior whose cure required two database statements. The real supported
  relinquish-and-move path remains in one statement and has direct PostgreSQL
  coverage.
- Parent task-drift finding: accepted. The reviewed remediation reintroduced
  the global advisory lock, added reader locks, and split provider apply into
  two statements. Current head deletes that machinery and also removes the
  initial patch's explicit inventory-wide `FOR UPDATE` barriers.
- Previous final round 2 passed at the previous reviewed head. It does not cover
  the current behavioral correction, so substantive final round 3 is required.

### Round-3 anomaly retrospective

- Original requirement: delete both Linq advisory-lock layers and replace the
  multi-phone loop with one prepared VALUES/CTE bulk statement.
- First-reviewed source shape: +522/-181. Preliminary remediation added
  +85/-28 source lines and introduced publication-lock/read-lock concepts plus
  a second provider statement.
- Current source shape: +486/-181, which is 36 added source lines smaller than
  the first-reviewed head and contains none of that remediation machinery.
- Decision: revert the review-driven lock architecture, delete the remaining
  explicit inventory row-lock barriers, retain direct proof, and continue the
  original indivisible task. No new owner, state, migration, compatibility path,
  or reconciliation mechanism remains.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 486 | 181 |
| Tests / fixtures | 641 | 483 |
| Docs | 160 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1287** | **664** |

Current head relative to previous reviewed head:

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 28 | 121 |
| Tests / fixtures | 42 | 233 |
| Docs | 160 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **230** | **354** |

## Verification

- Focused hosted-Web suite: 5 files passed, 107 tests passed.
- Final SQL unit rerun: 2 files passed, 42 tests passed.
- Fresh migrated local PostgreSQL suite after final lock deletion: 1 file
  passed, 12 tests passed.
- `pnpm --dir apps/web typecheck:prepared` passed on the final candidate.
- `git diff --check` passed.
- Scoped privacy/identifier scan passed.
- Exact-head ReviewGPT round 3: `ROUND_OUTCOME: PASS`, no findings.
- GitHub Actions: all required checks passed on the exact reviewed head.

## Deployment

No schema, environment, dependency, or cross-runtime contract changes. Ordinary
Vercel deployment is sufficient; no tandem Cloudflare deployment is required.
