### PR TITLE
fix(web): register Family setup telemetry

### DIFF
--- a/apps/web/src/lib/observability/analytics-redaction.ts
+++ b/apps/web/src/lib/observability/analytics-redaction.ts
@@ -12,6 +12,7 @@ export const VERCEL_TELEMETRY_PATHNAMES = [
   "/environment",
   "/environment/print",
   "/experiments",
+  "/family/setup",
   "/groups/start",
   "/growth",
   "/history",


### PR DESCRIPTION
## Why this PR exists

PR #1527 added the static `/family/setup` page without registering it in the fail-closed Vercel telemetry pathname owner. The merged #1432 exact-head app verification caught the resulting deterministic `vercel-telemetry.test.tsx` failure.

## User goal / user-visible behavior

There is no visible UI change. Family setup continues to render as shipped; its telemetry now follows the same privacy-preserving route canonicalization as every other static Web page.

## Invariants

- Every static `app/**/page.tsx` route remains represented by the single `VERCEL_TELEMETRY_PATHNAMES` owner.
- Telemetry remains fail closed for unknown paths.
- Query strings, fragments, and private dynamic values remain excluded from telemetry URLs.
- No new telemetry owner, event, dependency, or runtime state is introduced.

## Non-obvious affected surfaces

- `apps/web/test/vercel-telemetry.test.tsx` discovers static pages from the filesystem and compares them with the canonical telemetry list, so the existing test directly covers this new entry without new fixtures.
- This restores the app-verification lane that failed after #1527 merged; it is unrelated to the provider-logo behavior in #1432.

## Architecture and reuse

- **Existing systems reused:** The existing `VERCEL_TELEMETRY_PATHNAMES` list, fail-closed suppression, URL redaction, and exhaustive static-page regression test remain the owners.
- **New logic:** One missing static route is registered in sorted order.
- **New abstractions:** None; the existing canonical pathname list already owns this exact static-route mapping.
- **Complexity intentionally avoided:** No new telemetry owner, route matcher, event, dependency, state, or test fixture is added.

## Hot reply path impact

Not applicable — this is hosted Web analytics routing only.

ReviewGPT context sensitivity: sensitive

Classification reason: the one-line fix changes the privacy-preserving telemetry route allowlist, so the final gate uses a sensitive full snapshot despite the tiny patch.

ReviewGPT first-reviewed head: cce78810d945e32d2cd677c8fdbe9cddc3f15832

## Preliminary specialist lenses

- Product experience: **not applicable** — no user-visible purpose, copy, interaction, timing, or state changes.
- Prompt: **not applicable** — no assistant or provider prompt surface changes.
- Frontend: **not applicable** — no rendered UI, layout, styling, accessibility, or responsive behavior changes.
- Coverage: **applicable** — the existing exhaustive static-route telemetry test directly failed before the fix and passes after it; no new test owner is needed.

## First-reviewed change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1** | **0** |

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts apps/web/test/vercel-telemetry.test.tsx --no-coverage --reporter=dot` — 10 passed.
- `pnpm --dir apps/web typecheck:prepared` — passed after repo-owned Prisma and Health Commons generation in the fresh worktree.
- Scoped ESLint — 0 errors; one pre-existing warning on an untouched constant.
- `git diff --check` — passed.
- GitHub Actions — all required exact-head checks passed, including app verification, package coverage, build/typecheck, design proof, billing, viewport, hygiene, host matrices, and Vercel.

## Design proof

Not applicable — no rendered UI, copy, layout, interaction, or visual state changes.
