### PR TITLE
fix(cloudflare): ratchet runner bundle budget

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -166,10 +166,13 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 //
 // Adding the personalized generated contact card puts its request contract,
 // exact-shape parser, direct route resolution, and acknowledgement handling in
-// the runner's lazy output. Exact ubuntu assembly measured a 9,887,441B total
-// on 2026-08-09; startup entry and static closure are unchanged, so ratchet
-// only the total ceiling and keep both startup baselines and all tolerances.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_887_441 + 32_768;
+// the runner's lazy output. The subsequent reviewed biomarker ranges, hosted
+// runtime-control compaction, and named-diet guidance moved exact ubuntu total
+// output from 9,908,973B to 9,933,847B by 2026-08-10. Entry and static closure
+// remain within their existing ceilings and no forbidden subsystem enters the
+// boot graph, so ratchet only the total ceiling and keep both startup baselines
+// and all tolerances.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 9_933_847 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_641_254;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_885_509;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -609,7 +609,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_641_254 + 48_000,
       staticClosureBytes: 7_885_509 + 96_000,
-      totalBytes: 9_887_441 + 32_768,
+      totalBytes: 9_933_847 + 32_768,
     });
   });
 


### PR DESCRIPTION
## Why this PR exists

The main-push Hosted Stripe Billing workflow has failed for five consecutive commits before reaching its live billing scenarios because intended runner output crossed the reviewed total-byte ceiling. Current Ubuntu assembly is 9,933,847 bytes; the entry chunk, static boot closure, and forbidden-input guard remain within their existing limits.

## User goal / user-visible behavior

Restore the production-shaped hosted-local Stripe matrix on main so billing regressions are exercised after every merge. This changes no product behavior.

## Invariants the PR must preserve

- The runner entry and static-closure baselines and tolerances remain unchanged.
- Forbidden boot inputs remain rejected.
- Total-output growth remains bounded by the existing 32 KiB allowance above an exact reviewed measurement.
- The live Stripe matrix remains main-push-only and continues using its existing scenarios and credentials.

## Non-obvious affected surfaces

The PR billing workflow continues to skip the live matrix by policy; the repaired path is exercised only by the required main-push workflow after merge.

## Architecture and reuse

- **Existing systems reused:** The existing runner bundle-budget guard and its explicit unit-test mirror.
- **New logic:** The total ceiling is ratcheted to the exact current Ubuntu measurement.
- **New abstractions:** No abstraction is added; the existing byte-budget owner remains authoritative.
- **Complexity intentionally avoided:** No dependency, compatibility path, alternate measurement owner, or runtime behavior is added.

## Preliminary specialist lenses

- Product experience: not applicable; there is no product behavior or UI change.
- Prompt: not applicable; no model input changes.
- Frontend: not applicable; no rendered surface changes.
- Coverage: applicable; the budget-policy contract is updated and the focused runner/deploy contract suite passes.

ReviewGPT context sensitivity: sensitive

Reason: this changes a production runner deployment guard that gates the live Stripe billing workflow.

ReviewGPT first-reviewed head: e254b381fe78eb8dfe10ebdfcf897247d2b31c87

## Change-shape breakdown

Classification: the budget constant is config/tooling policy and the mirrored Vitest assertion is tests/fixtures.

First-reviewed baseline:

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 7 | 4 |
| Generated/other | 0 | 0 |
| **Total** | **8** | **5** |

## Verification

- Focused runner/deploy contracts: 53 passed.
- Cloudflare runner typecheck: passed.
- Production-shaped hosted-local assembly: reproduced current main measurements; on macOS the existing platform variance exceeds the Ubuntu-oriented ceiling, while a same-platform before/after comparison showed the named-diet change contributed only 77 bytes and did not introduce a new eager subsystem.
- Exact main-push workflow after merge: pending.
- Final sensitive-runtime ReviewGPT: passed with no qualifying findings.

## Design proof

Not applicable; there is no user-facing frontend diff.

## Deployment skew / compatibility

There is no schema, API, environment, persisted-shape, or runtime change. The only effect is allowing the reviewed current runner output through its existing deployment guard.