### PR TITLE
chore: update ReviewGPT CPU fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.122",
+    "@cobuild/review-gpt": "^0.5.124",
     "@murphai/hosted-local-harness": "workspace:*",
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -943,13 +943,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.122')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.124')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.122'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.124'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       '@cobuild/review-gpt':
-        specifier: ^0.5.122
-        version: 0.5.122(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.124
+        version: 0.5.124(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@murphai/health-metrics':
         specifier: workspace:*
         version: link:packages/health-metrics
@@ -1407,8 +1407,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.122':
-    resolution: {integrity: sha512-+STlVUmDLiLvVK6W0tBpSznVHIMspov7VXZrCfUpsN+jj7RBAfJ3QtTB4HU2Gqea2E5dwFZa6ORo3AMHh1XLMA==}
+  '@cobuild/review-gpt@0.5.124':
+    resolution: {integrity: sha512-nNMbdXfPn6GQH2L1y6tvHOMB8KQEX9fDtDoHctWxqefzjIfjSKcAxFAz8zmkTZk0GQmkbOEQV8NaI0/9qzA4uw==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10519,7 +10519,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)': {}
 
-  '@cobuild/review-gpt@0.5.122(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.124(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.122'
+  - '@cobuild/review-gpt@0.5.124'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why this PR exists

Murph is pinned to ReviewGPT 0.5.122, whose active-response capture loop inspects the ChatGPT DOM every second and launches managed Chromium with background timer throttling disabled. ReviewGPT 0.5.124 is already published with the CPU fixes, so Murph should consume that patch release.

## User goal / user-visible behavior

Developers can run Murph ReviewGPT lanes without one-second active-response scans, disabled background throttling, or harvested review tabs accumulating after completed waits.

## User experience

No Murph product flow changes. The developer entry point remains `pnpm review:gpt`; long-running response capture now uses ReviewGPT's one-minute active scan cadence, balanced Chromium background behavior, and owned-tab cleanup. Existing timeout and recovery behavior are unchanged.

## Invariants the PR must preserve

- Review packaging, model selection, wait timeouts, and completion-marker validation remain unchanged.
- Only ReviewGPT-owned harvested tabs may be closed.
- The dependency remains registry-sourced, represented in both the manifest and lockfile, and admitted through the existing minimum-release-age exception.
- No Murph production runtime, product state, or deploy surface changes.

## Non-obvious affected surfaces

- Root dependency policy: the exact ReviewGPT release-age exception moves with the dependency so pnpm's supply-chain gate remains explicit. Proof: `pnpm deps:guard` and frozen-lockfile installation.
- Managed ReviewGPT browser behavior: supplied by the published dependency, not new Murph logic. Proof: installed 0.5.124 source inspection and focused upstream tests.
- CLI release-contract coverage: the existing package-backed assertions move with the manifest and release-age exception. Proof: focused `cli-release-smoke` test.

## Architecture and reuse

- **Existing systems reused:** Murph's existing `pnpm review:gpt` wrapper, managed browser lanes, pnpm lockfile, dependency policy, and release-contract test remain the sole owners.
- **New logic:** No Murph logic is added; the manifest selects ReviewGPT 0.5.124's published CPU fixes and the existing test expects that release.
- **New abstractions:** No abstractions are added because the existing package boundary and CLI contract are sufficient.
- **Complexity intentionally avoided:** No duplicate polling, browser-freezing layer, local package patch, or redundant ReviewGPT release is introduced.

## Hot reply path impact

Not applicable: this developer-tool dependency does not touch the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, skill, model mode, provider adapter, or request assembly changed.
- Group Murph: Not applicable; no prompt, tool schema, skill, model mode, provider adapter, or request assembly changed.

## Preliminary specialist lenses

- **Product experience:** not applicable — no Murph product-owned journey or user-facing product behavior changes.
- **Prompt:** not applicable — no prompt, instruction stack, tool description, or prompt assembly changes.
- **Frontend:** not applicable — no `apps/web` UI changes or rendered states.
- **Coverage:** applicable — this configuration change establishes the ReviewGPT proof/runtime version. Focused local proof: frozen-lockfile install, installed CLI version, installed-source CPU invariant inspection, dependency policy checks, focused upstream polling/background/tab-cleanup tests, and the exact CLI release-contract test. Current exact-head CI status: all required checks green.

## Preliminary specialist result

`SPECIALIST_OUTCOME: FINDINGS` at the first pushed head. One medium coverage finding was accepted: the existing CLI release-contract test still expected 0.5.122. The assistant-owned `reviewgpt-coverage.patch` was downloaded from the exact specialist thread, inspected in full, confirmed to touch only the existing test, checked with `git apply --check`, applied, and verified. No other finding was reported; the preliminary pass is not rerun after substantive findings by repository policy.

## Verification

Passed:

- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm install --filter . --frozen-lockfile`
- `pnpm exec cobuild-review-gpt --version` → `0.5.124`
- Installed-source proof: active-response sleep is `60_000` ms; balanced browser args leave background throttling enabled; harvested-tab cleanup is present.
- `pnpm deps:guard`
- `pnpm deps:ignored-builds` — no new lifecycle-script approval introduced.
- Upstream focused tests for one-minute active polling, balanced browser throttling, and finalized harvested-tab closure: 3 passed.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --project cli-release-smoke packages/cli/test/release-script-coverage-audit.test.ts --no-coverage --maxWorkers=1 --maxConcurrency=1 --testNamePattern "exposes only the package-backed review-gpt runner"`: 1 passed.
- `git diff --check`

`pnpm deps:audit` reports the same pre-existing baseline on both the PR head and `main`: 77 advisories (1 critical, 32 high, 38 moderate, 6 low). This dependency bump adds no advisory count; remediation is outside this CPU-only patch.

The pre-commit CLI config-schema generator could not complete with the root-only local install; exact-head Release build/typecheck passed and cleared that local proof gap.

## Change-shape breakdown

Classification: the dependency manifests and lockfile are config/tooling; the version-contract assertions are tests. No authored source, docs, generated files, binaries, or moves changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 2 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 7 | 7 |
| Generated/other | 0 | 0 |
| **Total** | **9** | **9** |

## Design proof

Not applicable: there is no user-facing frontend UI diff.
