### PR TITLE
Refresh pitch traction metrics

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -28,6 +28,7 @@ import { Separator } from "@/src/components/ui/separator";
 import {
   HOSTED_PUBLIC_REFERRAL_REWARDS,
 } from "@/src/lib/hosted-growth/referral-program";
+import { ValidationSlide } from "../pitch/_components/slides";
 import {
   projectHostedVaultShareProjectionDisplays,
   resolveHostedGroupAccessOfferProjectionScopes,
@@ -602,6 +603,19 @@ export function SectionsContent() {
 
       <StudySection title="Private structured-review result">
         <StructuredReviewResultsStudy />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Pitch deck progress slide">
+        <div
+          id="pitch-progress-slide"
+          data-design-section="pitch-progress-slide"
+          className="-mx-5 overflow-hidden sm:-mx-8 lg:-mx-12"
+          inert
+        >
+          <ValidationSlide />
+        </div>
       </StudySection>
 
       <Separator />

--- a/apps/web/app/pitch/_components/slides.tsx
+++ b/apps/web/app/pitch/_components/slides.tsx
@@ -1014,7 +1014,7 @@ export function ValidationSlide() {
       <SlideHeading>
         The product is live.
         <br />
-        MRR doubled in the last 30 days.
+        MRR grew 103% in the last 30 days.
       </SlideHeading>
       <p className="mt-5 max-w-[64ch] text-base leading-[1.7] text-[#635a48]">
         We shipped the personal experiment loop first. The wedge became
@@ -1025,16 +1025,16 @@ export function ValidationSlide() {
       <div className="mt-9 grid gap-3 sm:grid-cols-3">
         {[
           {
-            value: "18% w/w MRR growth",
-            note: "Five-week average, and up every single week. MRR doubled in the last 30 days.",
+            value: "+103% MRR growth",
+            note: "In 30 days, with revenue up every week.",
           },
           {
-            value: "+80% paying customers",
+            value: "+82% paying customers",
             note: "In 30 days, with zero paid acquisition.",
           },
           {
-            value: "8 msgs / day / active user",
-            note: "2,400 messages exchanged last week — engagement per user up 2.5x since June.",
+            value: "10 msgs / day / active user",
+            note: "3,003 messages exchanged last week — 73 per weekly active user.",
           },
         ].map((card) => (
           <div
@@ -1064,8 +1064,8 @@ export function ValidationSlide() {
         <PivotCard
           highlight
           items={[
-            "Six group chats live, up from one in June",
-            "The most active: an eight-person group text, 107 messages to Murph last week",
+            "12 group chats active last week, up from one in June",
+            "The most active group sent 255 messages to Murph last week",
             "Laughs, reactions, trash talk at the referee",
             "Voice memos back and forth with Murph",
           ]}

--- a/apps/web/app/pitch/_components/slides.tsx
+++ b/apps/web/app/pitch/_components/slides.tsx
@@ -1025,8 +1025,8 @@ export function ValidationSlide() {
       <div className="mt-9 grid gap-3 sm:grid-cols-3">
         {[
           {
-            value: "+103% MRR growth",
-            note: "In 30 days, with revenue up every week.",
+            value: "18% w/w MRR growth",
+            note: "Compounded over the last 30 days, with revenue up every week.",
           },
           {
             value: "+82% paying customers",

--- a/apps/web/test/pitch-and-biomarkers-pages.test.tsx
+++ b/apps/web/test/pitch-and-biomarkers-pages.test.tsx
@@ -98,6 +98,14 @@ test("PitchPage metadata and route entrypoint render the deck landmark", () => {
   assert.match(markup, /data-pitch-chrome="true"/);
   assert.match(markup, /aria-label="Slide 1: Title"/);
   assert.match(markup, /The social layer for health experiments\./);
+  assert.match(markup, /\+103% MRR growth/);
+  assert.match(markup, /\+82% paying customers/);
+  assert.match(markup, /10 msgs \/ day \/ active user/);
+  assert.match(markup, /3,003 messages exchanged last week/);
+  assert.match(markup, /12 group chats active last week/);
+  assert.match(markup, /255 messages to Murph last week/);
+  assert.doesNotMatch(markup, /2,400 messages exchanged last week/);
+  assert.doesNotMatch(markup, /107 messages to Murph last week/);
   assert.match(markup, /Scroll or use arrow keys/);
   assert.match(markup, /01 \/ 13/);
 });

--- a/apps/web/test/pitch-and-biomarkers-pages.test.tsx
+++ b/apps/web/test/pitch-and-biomarkers-pages.test.tsx
@@ -98,10 +98,12 @@ test("PitchPage metadata and route entrypoint render the deck landmark", () => {
   assert.match(markup, /data-pitch-chrome="true"/);
   assert.match(markup, /aria-label="Slide 1: Title"/);
   assert.match(markup, /The social layer for health experiments\./);
-  assert.match(markup, /\+103% MRR growth/);
+  assert.match(markup, /MRR grew 103% in the last 30 days/);
+  assert.match(markup, /18% w\/w MRR growth/);
   assert.match(markup, /\+82% paying customers/);
   assert.match(markup, /10 msgs \/ day \/ active user/);
   assert.match(markup, /3,003 messages exchanged last week/);
+  assert.match(markup, /73 per weekly active user/);
   assert.match(markup, /12 group chats active last week/);
   assert.match(markup, /255 messages to Murph last week/);
   assert.doesNotMatch(markup, /2,400 messages exchanged last week/);


### PR DESCRIPTION
## Why

Refresh the public pitch deck Progress slide from the latest aggregate production snapshot while preserving the existing investor-facing hierarchy: relative MRR growth, relative paying-customer growth, and engagement per active user.

## User-visible outcome

A visitor opens `/pitch`, reaches the Progress slide, and sees the current 30-day growth and completed seven-day messaging evidence. The slide remains static and immediately visible; there is no asynchronous continuation, permission boundary, or recovery state.

## Architecture and reuse

- Existing systems reused: The existing `ValidationSlide`, `PivotCard`, pitch-page layout, Sections catalog, and route-render test remain the only owners.
- New logic: No runtime logic was added; this patch changes static aggregate copy and focused assertions only.
- New abstractions: No abstraction was added because the existing slide and catalog primitives already render the complete surface.
- Complexity intentionally avoided: The figures remain static deck content; no production database read, dynamic metrics endpoint, dependency, state owner, or refresh mechanism was introduced.

## Invariants

- Keep metric priority relative and rate-led; do not foreground small absolute customer or revenue totals.
- Use completed UTC-day aggregates only.
- Keep private customer records and direct identifiers out of source and review artifacts.
- Preserve the existing responsive slide structure and deck navigation.

## Preliminary specialist lenses

- Product experience: applicable — semantic investor-facing traction claims changed. Direct journey evidence: rendered `/design?tab=sections` study at desktop and mobile widths.
- Prompt: not applicable — no prompt or instruction stack changed.
- Frontend: applicable — public `/pitch` copy changed and the real slide is present in the design catalog.
- Coverage: applicable — focused render assertions prove the new claims and reject stale figures.

## Specialist resolution

- Accepted the experience-collapse finding: the duplicate 103% card is now the distinct `18% w/w MRR growth` signal, preserving the requested rate-led hierarchy beneath the 103% 30-day headline.
- Accepted the coverage finding: the focused route test now asserts `73 per weekly active user`.
- The architecture/reuse, design-page, and hosted screenshot requirements are resolved with current desktop and mobile render evidence.
- Refreshed product purpose verdict: the heading and three cards now each carry a distinct investor signal — 30-day MRR growth, weekly MRR growth, paying-customer growth, and per-user engagement — with no repeated primary evidence. The static journey remains immediate and complete. No product-experience finding remains.

## Verification

- `pnpm --dir apps/web exec eslint app/pitch/_components/slides.tsx app/design/sections-content.tsx test/pitch-and-biomarkers-pages.test.tsx`
- `pnpm --dir apps/web typecheck:prepared`
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/pitch-and-biomarkers-pages.test.tsx` — 8 passed
- `git diff --check`
- Rendered evidence inspected at 1440x1000 and 390x844 after remediation.
- Claude Code UI double-check unavailable because the `claude` executable is not installed.

## Design proof

- Design page: [Sections study](https://www.withmurph.ai/design?tab=sections#pitch-progress-slide)
- Desktop screenshot: ![Pitch progress desktop](https://github.com/user-attachments/assets/d7dbd681-305c-4098-82b5-37050d3bce74)
- Mobile screenshot: ![Pitch progress mobile](https://github.com/user-attachments/assets/f9b46523-32ac-41d4-9ea5-92cb732b24b0)

## Changelog

- Changelog: not applicable
- Reason: This changes investor-facing pitch collateral, not member-visible product behavior.

## Change shape

Classification rule: production and catalog TSX are source; Vitest assertions are tests. No binary files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 7 |
| Tests | 10 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

ReviewGPT context sensitivity: routine

Static marketing copy and focused regression coverage only; no product workflow, persisted state, billing logic, health-safety behavior, trust boundary, or deploy contract changes.