### PR TITLE
Refresh legacy Pattern replicas automatically

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-10-patterns-legacy-replica-refresh.md
+++ b/agent-docs/exec-plans/active/2026-08-10-patterns-legacy-replica-refresh.md
@@ -1,0 +1,66 @@
+# Refresh legacy Browser Vault replicas for Patterns
+
+Status: active
+Created: 2026-08-10
+Updated: 2026-08-10
+
+## Goal
+
+- Make Patterns available to existing members without requiring a health-data
+  change or a manual refresh action.
+
+## Success criteria
+
+- Browser Vault replicas created before the Patterns projection are classified
+  as stale.
+- Opening the signed-in app schedules the existing Browser Vault refresh path.
+- The current polling flow replaces the preparing state when the refreshed
+  replica is ready.
+- Focused generation, freshness, Web session, and Patterns page tests pass.
+- Exact-head CI and required ReviewGPT checks pass.
+
+## Scope
+
+- In scope:
+  - Advance the Browser Vault replica generation for the new Patterns
+    projection.
+  - Update focused generation expectations and legacy-refresh coverage.
+- Out of scope:
+  - New refresh routes, queues, cron jobs, or persisted state.
+  - Manual refresh controls.
+  - Changes to pattern detection or scoring.
+
+## Constraints
+
+- Reuse the existing generation-aware freshness check, mailbox control event,
+  Temporal wake, runtime materialization, and browser polling flow.
+- Keep prior-generation replicas readable while their replacement is prepared.
+- Preserve the current Browser Vault privacy and authority boundaries.
+
+## Tasks
+
+1. Advance the Browser Vault replica generation and update focused contracts.
+2. Prove prior-generation replicas schedule refresh and remain readable.
+3. Run focused tests and inspect the final diff.
+4. Commit, push, open a PR, and complete required ReviewGPT and CI gates.
+5. Perform the parent final review and close this plan.
+
+## Decisions
+
+- Use the existing replica generation seam. The Patterns projection changed the
+  derived replica shape, so a generation advance is the canonical invalidation
+  signal.
+- Do not add a feature-specific refresh request. The existing freshness owner
+  already schedules and deduplicates refresh work for an older generation.
+
+## Verification
+
+- Query and hosted-execution focused Vitest suite: 4 files, 58 tests passed.
+- Browser Vault Web session, dashboard, and polling suite: 3 files, 98 tests
+  passed after the standard Prisma client generation step.
+- Contracts, Query, Hosted Execution, and Web typechecks passed.
+- Direct contract proof: a generation-4 replica is readable but the Web session
+  classifies it as `generation_mismatch`, schedules the existing refresh
+  control event, and returns `refreshPending: true` for browser polling.
+- Pending: pushed-head ReviewGPT, exact-head CI, parent final review, and plan
+  closure.

--- a/agent-docs/exec-plans/active/2026-08-10-patterns-legacy-replica-refresh.md
+++ b/agent-docs/exec-plans/active/2026-08-10-patterns-legacy-replica-refresh.md
@@ -15,7 +15,7 @@ Updated: 2026-08-10
   as stale.
 - Opening the signed-in app schedules the existing Browser Vault refresh path.
 - The current polling flow replaces the preparing state when the refreshed
-  replica is ready.
+  replica is ready, including when publication takes more than 20 seconds.
 - Focused generation, freshness, Web session, and Patterns page tests pass.
 - Exact-head CI and required ReviewGPT checks pass.
 
@@ -24,6 +24,8 @@ Updated: 2026-08-10
 - In scope:
   - Advance the Browser Vault replica generation for the new Patterns
     projection.
+  - Continue the existing browser-owned polling at a slower interval after its
+    fast window until the pending refresh completes.
   - Update focused generation expectations and legacy-refresh coverage.
 - Out of scope:
   - New refresh routes, queues, cron jobs, or persisted state.
@@ -52,15 +54,25 @@ Updated: 2026-08-10
   signal.
 - Do not add a feature-specific refresh request. The existing freshness owner
   already schedules and deduplicates refresh work for an older generation.
+- Keep the existing 1.5-second fast polling window, then slow to 15-second
+  checks. This retains automatic completion without indefinite fast polling or
+  a new continuation owner.
 
 ## Verification
 
 - Query and hosted-execution focused Vitest suite: 4 files, 58 tests passed.
-- Browser Vault Web session, dashboard, and polling suite: 3 files, 98 tests
+- Browser Vault Web session, dashboard, and polling suite: 3 files, 99 tests
   passed after the standard Prisma client generation step.
 - Contracts, Query, Hosted Execution, and Web typechecks passed.
 - Direct contract proof: a generation-4 replica is readable but the Web session
   classifies it as `generation_mismatch`, schedules the existing refresh
   control event, and returns `refreshPending: true` for browser polling.
+- Preliminary ReviewGPT returned two accepted findings with one mechanism: the
+  fast browser polling owner stopped after 20 seconds, and no test proved the
+  terminal generation-4 to generation-5 journey. The browser now continues at
+  a 15-second slow interval while refresh remains pending. A fake-timer
+  BrowserVaultProvider test delays publication beyond the fast window and
+  proves the open page adopts a generation-5 replica with Personal Patterns
+  without focus, navigation, or a manual action.
 - Pending: pushed-head ReviewGPT, exact-head CI, parent final review, and plan
   closure.

--- a/agent-docs/exec-plans/completed/2026-08-10-patterns-legacy-replica-refresh.md
+++ b/agent-docs/exec-plans/completed/2026-08-10-patterns-legacy-replica-refresh.md
@@ -1,6 +1,6 @@
 # Refresh legacy Browser Vault replicas for Patterns
 
-Status: active
+Status: completed
 Created: 2026-08-10
 Updated: 2026-08-10
 
@@ -74,5 +74,14 @@ Updated: 2026-08-10
   BrowserVaultProvider test delays publication beyond the fast window and
   proves the open page adopts a generation-5 replica with Personal Patterns
   without focus, navigation, or a manual action.
-- Pending: pushed-head ReviewGPT, exact-head CI, parent final review, and plan
-  closure.
+- Preliminary ReviewGPT returned `SPECIALIST_OUTCOME: FINDINGS`; both accepted
+  findings shared the polling-continuation mechanism and are resolved above.
+- Final ReviewGPT full audit on corrected head `d96f3edf790d` returned
+  `ROUND_OUTCOME: PASS` with no findings.
+- Exact-head GitHub Actions passed: 15 successful checks, one expected skipped
+  hosted-local Stripe matrix, and no failures.
+- Parent final review confirmed the change uses the documented generation seam,
+  retains one BrowserVaultProvider timer chain, stops on completion or unmount,
+  and adds no durable state or new runtime owner.
+- Plan ready for closure after the final docs-only commit.
+Completed: 2026-08-10

--- a/agent-docs/product-specs/personal-patterns.md
+++ b/agent-docs/product-specs/personal-patterns.md
@@ -22,11 +22,18 @@ new collection window when the feature ships.
 - Existing members can receive a result from data that predates deployment.
 - Overview reads a derived report from the encrypted Browser Vault replica.
 - An older replica has no Personal Patterns field. The web keeps that state
-  separate from a calculated empty report and explains the bounded wait.
-- On the member's next runtime execution, the hosted runtime rebuilds a replica
-  after source data changes or after its normal 24-hour maximum age is exceeded.
-- A code deployment alone does not force every inactive member's replica to
-  rebuild immediately.
+  separate from a calculated empty report and shows preparation while an
+  automatic refresh remains pending.
+- The shared Browser Vault projection generation advances when a new projection
+  makes an otherwise current replica incomplete. The next authenticated
+  dashboard session marks the older generation stale and schedules the existing
+  low-priority refresh through the runtime mailbox and Temporal workflow.
+- The browser checks quickly for 20 seconds, then every 15 seconds while the
+  refresh remains pending. A delayed or initially failed refresh can therefore
+  complete on the open page without a health-data change or manual action.
+- A generation advance does not rebuild every inactive member at deploy time.
+  It refreshes each member when their next authenticated dashboard session uses
+  the existing Browser Vault path.
 - The Weekly health insight reads the query through `vault-cli` and does not
   depend on the browser replica.
 

--- a/apps/web/src/lib/browser-vault/context.tsx
+++ b/apps/web/src/lib/browser-vault/context.tsx
@@ -33,6 +33,7 @@ export type BrowserVaultStatus = "loading" | "ready" | "empty" | "error";
 
 const BROWSER_VAULT_STALE_POLL_INTERVAL_MS = 1_500;
 const BROWSER_VAULT_STALE_POLL_WINDOW_MS = 20_000;
+const BROWSER_VAULT_STALE_POLL_SLOW_INTERVAL_MS = 15_000;
 const EMPTY_BROWSER_VAULT_SESSION_METADATA: BrowserVaultSessionMetadata = {
   deviceSyncImportPending: false,
   freshness: "stale",
@@ -354,13 +355,16 @@ function ActiveBrowserVaultProvider({ children, initialMemberId }: {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const poll = () => {
-      if (cancelled || Date.now() - startedAt > BROWSER_VAULT_STALE_POLL_WINDOW_MS) {
+      if (cancelled) {
         return;
       }
 
       void pollStaleReplica().finally(() => {
-        if (!cancelled && Date.now() - startedAt <= BROWSER_VAULT_STALE_POLL_WINDOW_MS) {
-          timeoutId = setTimeout(poll, BROWSER_VAULT_STALE_POLL_INTERVAL_MS);
+        if (!cancelled) {
+          const interval = Date.now() - startedAt <= BROWSER_VAULT_STALE_POLL_WINDOW_MS
+            ? BROWSER_VAULT_STALE_POLL_INTERVAL_MS
+            : BROWSER_VAULT_STALE_POLL_SLOW_INTERVAL_MS;
+          timeoutId = setTimeout(poll, interval);
         }
       });
     };

--- a/apps/web/test/browser-vault-context.test.tsx
+++ b/apps/web/test/browser-vault-context.test.tsx
@@ -6,6 +6,7 @@ import {
   BROWSER_VAULT_REPLICA_SCHEMA,
   type BrowserVaultReplica,
 } from "@murphai/query/browser";
+import type { HostedBrowserVaultReplicaRef } from "@murphai/hosted-execution/browser-vault";
 import { act, useState } from "react";
 import { createElement } from "react";
 import type { ReactNode } from "react";
@@ -628,6 +629,100 @@ test("browser-vault provider polls pending refreshes without a global sync indic
   assert.equal(fetchMock.mock.calls.length > 1, true);
   assert.equal(rendered.container.textContent?.includes("Preparing dashboard..."), false);
   assert.equal(rendered.container.textContent?.includes("Syncing latest changes..."), false);
+
+  await rendered.cleanup();
+});
+
+test("browser-vault provider adopts a refreshed Patterns replica after the fast polling window", async () => {
+  vi.useFakeTimers();
+  const legacyRef = createReplicaRef({
+    generation: BROWSER_VAULT_REPLICA_CURRENT_GENERATION - 1,
+  });
+  const currentRef = createReplicaRef({
+    dataVersion: "e".repeat(64),
+    keyId: "browser-vault-replica:e",
+  });
+  let currentReplicaPublished = false;
+  const fetchMock = vi.fn(() => {
+    if (fetchMock.mock.calls.length === 1) {
+      return Promise.resolve(jsonResponse({
+        encryptedReplica: createReplicaEnvelope(),
+        freshness: "stale",
+        replicaAad: createReplicaAad(),
+        replicaKeyEnvelope: createReplicaKeyEnvelope(),
+        replicaRef: legacyRef,
+        refreshPending: true,
+        state: "ready",
+      }));
+    }
+
+    if (!currentReplicaPublished) {
+      return Promise.resolve(jsonResponse({
+        encryptedReplica: null,
+        freshness: "stale",
+        memberId: "member_123",
+        replicaAad: null,
+        replicaKeyEnvelope: null,
+        replicaRef: legacyRef,
+        refreshPending: true,
+        state: "not_modified",
+      }));
+    }
+
+    return Promise.resolve(jsonResponse({
+      encryptedReplica: createReplicaEnvelope("e"),
+      freshness: "fresh",
+      replicaAad: createReplicaAad("member_123", "e"),
+      replicaKeyEnvelope: createReplicaKeyEnvelope("member_123", "e"),
+      replicaRef: currentRef,
+      refreshPending: false,
+      state: "ready",
+    }));
+  });
+
+  installBrowserVaultCryptoMocks();
+  const legacyReplica = createReplica({
+    generation: BROWSER_VAULT_REPLICA_CURRENT_GENERATION - 1,
+  });
+  delete legacyReplica.personalPatterns;
+  mocks.decryptHostedStoragePayload
+    .mockResolvedValueOnce(new TextEncoder().encode(JSON.stringify(legacyReplica)))
+    .mockResolvedValueOnce(new TextEncoder().encode(JSON.stringify(createReplica({
+      personalPatterns: {
+        asOfDate: "2026-04-30",
+        cells: [],
+        factors: [],
+        lagDays: 1,
+        notes: [],
+        outcomes: [],
+        repeatableCellCount: 0,
+        testedCellCount: 0,
+        windowDays: 120,
+      },
+      source: {
+        dataVersion: currentRef.dataVersion,
+        sourceBundleHash: currentRef.sourceBundleHash,
+      },
+    }))));
+  vi.stubGlobal("fetch", fetchMock);
+
+  const rendered = await renderClientComponent(
+    createAuthenticatedBrowserVaultElement(createElement(BrowserVaultPatternsProbe)),
+    { requireButton: false },
+  );
+
+  await waitForText(rendered.container, "legacy:pending");
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(25_000);
+  });
+  assert.equal(rendered.container.textContent, "legacy:pending");
+
+  currentReplicaPublished = true;
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(15_000);
+  });
+  await waitForText(rendered.container, "patterns:ready");
+  assert.equal(fetchMock.mock.calls.length > 2, true);
 
   await rendered.cleanup();
 });
@@ -1970,6 +2065,17 @@ function PublicDashboardRouteProbe() {
   );
 }
 
+function BrowserVaultPatternsProbe() {
+  const vault = useBrowserVault();
+  const patternsAvailable = vault.client?.replica.personalPatterns !== undefined;
+
+  return createElement(
+    "div",
+    null,
+    `${patternsAvailable ? "patterns" : "legacy"}:${vault.refreshPending ? "pending" : "ready"}`,
+  );
+}
+
 function installBrowserVaultCryptoMocks(): void {
   mocks.generateHostedUserRecipientKeyPair.mockResolvedValue({
     privateKeyJwk: { kty: "EC" },
@@ -2021,7 +2127,16 @@ function createDeferred<T>() {
   return { promise, reject, resolve };
 }
 
-function createReplicaRef() {
+function createReplicaRef(
+  overrides: Partial<HostedBrowserVaultReplicaRef> = {},
+): HostedBrowserVaultReplicaRef {
+  return {
+    ...createReplicaRefBase(),
+    ...overrides,
+  };
+}
+
+function createReplicaRefBase(): HostedBrowserVaultReplicaRef {
   return {
     byteLength: 128,
     dataVersion: "d".repeat(64),
@@ -2036,9 +2151,9 @@ function createReplicaRef() {
   };
 }
 
-function createReplicaAad(memberId = "member_123") {
+function createReplicaAad(memberId = "member_123", version = "d") {
   return {
-    dataVersion: "d".repeat(64),
+    dataVersion: version.repeat(64),
     objectKey: "users/browser-vault-replicas/opaque/replica.json",
     purpose: "browser-vault-replica" as const,
     runtimeRootKeyId: "udrk:runtime:test-root",
@@ -2048,21 +2163,21 @@ function createReplicaAad(memberId = "member_123") {
   };
 }
 
-function createReplicaEnvelope() {
+function createReplicaEnvelope(version = "d") {
   return {
     algorithm: "AES-GCM" as const,
     ciphertext: "ciphertext",
     iv: "iv",
-    keyId: "browser-vault-replica:d",
+    keyId: `browser-vault-replica:${version}`,
     schema: "murph.hosted-cipher.v1",
     scope: "browser-vault-replica" as const,
   };
 }
 
-function createReplicaKeyEnvelope(memberId = "member_123") {
+function createReplicaKeyEnvelope(memberId = "member_123", version = "d") {
   return {
     createdAt: "2026-04-20T08:00:00.000Z",
-    keyId: "browser-vault-replica:d",
+    keyId: `browser-vault-replica:${version}`,
     purpose: "browser-vault-replica" as const,
     recipients: [
       {
@@ -2074,7 +2189,7 @@ function createReplicaKeyEnvelope(memberId = "member_123") {
           y: "ephemeral-y",
         },
         iv: "iv",
-        keyId: "browser-vault-replica:d",
+        keyId: `browser-vault-replica:${version}`,
         kind: "browser-session" as const,
       },
     ],

--- a/packages/contracts/src/browser-vault.ts
+++ b/packages/contracts/src/browser-vault.ts
@@ -4,4 +4,4 @@ export const BROWSER_VAULT_REPLICA_SCHEMA = "murph.browser-vault-replica" as con
  * Increment when a projection-shape or projection-interpretation change makes
  * an otherwise source-current browser replica incomplete for current readers.
  */
-export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 4 as const;
+export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 5 as const;

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -287,7 +287,7 @@ describe("hosted execution coverage gaps", () => {
   });
 
   it("centralizes browser-vault replica source hash and refresh decisions", () => {
-    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(4);
+    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(5);
     const base = {
       hash: "a".repeat(64),
       key: "cloudflare-workspace-snapshots/base.bundle",

--- a/packages/query/test/browser-vault-lab-results.test.ts
+++ b/packages/query/test/browser-vault-lab-results.test.ts
@@ -79,8 +79,8 @@ test("browser vault projects all live lab history without widening the wearable 
     sourceBundleHash: "f".repeat(64),
     vault,
   });
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 4);
-  assert.equal(replica.generation, 4);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 5);
+  assert.equal(replica.generation, 5);
   const client = createBrowserVaultQueryClient(parseBrowserVaultReplica(replica));
 
   assert.equal(replica.labResultRows.length, 7);
@@ -870,7 +870,7 @@ test("lab-only aliases preserve manual metric selection and goal authority", asy
     sourceBundleHash: "a".repeat(64),
     vault,
   });
-  assert.equal(replica.generation, 4);
+  assert.equal(replica.generation, 5);
   const client = createBrowserVaultQueryClient(parseBrowserVaultReplica(replica));
   const indexed = selectBrowserVaultMeasuredBiomarkers(client)
     .find((entry) => entry.metricKey === "total-testosterone");

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -8,6 +8,7 @@ import { test } from "vitest";
 
 import type { CanonicalEntity } from "../src/canonical-entities.ts";
 import {
+  BROWSER_VAULT_REPLICA_CURRENT_GENERATION,
   createBrowserVaultReplica,
   parseBrowserVaultReplica,
 } from "../src/browser.ts";
@@ -78,6 +79,7 @@ test("Browser Vault parsing preserves a missing legacy Personal Patterns project
       vaultRoot: "test://legacy-personal-patterns",
     }),
   });
+  replica.generation = BROWSER_VAULT_REPLICA_CURRENT_GENERATION - 1;
   delete replica.personalPatterns;
 
   const parsed = parseBrowserVaultReplica(replica);


### PR DESCRIPTION
## Why this PR exists

Patterns shipped as a new Browser Vault projection, but the shared replica generation did not advance. Existing members can therefore receive a source-current replica that is missing Patterns and wait up to 24 hours for age-based refresh.

## User goal / user-visible behavior

Existing members get Patterns from their existing private history without changing health data or pressing a refresh control.

## User experience

Opening the signed-in dashboard performs the existing Browser Vault session check. A generation-4 replica stays readable, is classified as stale, and schedules the existing low-priority refresh after the response. Patterns shows its preparing state while the browser polls every 1.5 seconds for 20 seconds, then every 15 seconds while refresh remains pending. The existing mailbox, Temporal workflow, runtime materializer, and Browser Vault publication replace the replica with generation 5. The open page adopts that result without focus, navigation, a health-data mutation, or a manual refresh action. Auth or session errors still use the existing error and retry state.

## Invariants

- Older replicas remain readable during deployment and refresh.
- Web retains freshness and scheduling ownership; the runtime retains source hashing and replica materialization ownership.
- Refresh remains low-priority, deduplicated mailbox work and cannot block foreground assistant replies.
- Browser Vault authority, encryption, and member binding do not change.
- Slow polling stops as soon as refreshPending clears or the provider unmounts.

## Non-obvious affected surfaces

- All Browser Vault sessions: generation 4 becomes stale because it is incomplete for the current projection shape. Covered by the hosted-execution freshness and Web session route tests.
- Query replica creation: every newly built replica and published ref carries generation 5. Covered by Query replica and Personal Patterns tests.
- Browser continuation: pending refreshes retain the existing fast checks, then move to a 15-second slow interval so a delayed publication completes on the open page. Covered by the delayed BrowserVaultProvider terminal-journey test.
- Web/Worker/container rollout: an old runner can temporarily publish generation 4 while Web expects generation 5. The readable stale replica remains available, and refresh retries converge after the runner bundle updates.

## Architecture and reuse

- **Existing systems reused:** The shared replica generation contract, Web freshness assessment, deduplicated browser-vault control mailbox event, Temporal wake, runtime replica builder, BrowserVaultProvider timer owner, and warm-store load path.
- **New logic:** Advance the canonical generation from 4 to 5 and slow existing pending-refresh polling from 1.5 seconds to 15 seconds after the first 20 seconds.
- **New abstractions:** None. The existing generation seam and provider-owned timer are sufficient.
- **Complexity intentionally avoided:** No feature-specific refresh flag, API route, queue, cron, migration table, manual control, repair job, or second state owner.

## Changelog

- Changelog: not applicable
- Reason: The same-day 2026-08-10 · personal-patterns item already announces Patterns for existing history. This PR only corrects the rollout invalidation and continuation needed to deliver that announced behavior.

## Hot reply path impact

Not applicable. The change only affects post-response Browser Vault refresh scheduling, client rechecks, and derived replica publication.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool, model, configuration, or provider-request assembly changed.
- Group Murph: Not applicable. No prompt, tool, model, configuration, or provider-request assembly changed.

## Preliminary specialist lenses

- Product experience: **applicable** — existing members should move from the preparing state to Patterns without a manual action. Direct journey proof now covers generation-4 readability, stale classification, refresh scheduling, delayed publication beyond 20 seconds, and automatic generation-5 adoption on the open page.
- Prompt: **not applicable** — no provider-visible instructions or tools changed.
- Frontend: **not applicable** — no component, copy, layout, or rendered state changed; the product-experience lens owns the existing context provider's continuation timing.
- Coverage: **applicable** — 4 package test files passed with 58 tests; 3 Web Browser Vault files passed with 99 tests; Contracts, Query, Hosted Execution, and Web typechecks passed. Exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: This changes a persisted replica-generation and Web/runtime deployment contract, while preserving backward-readable stale replicas.

ReviewGPT first-reviewed head: c5169273fdaff0ef0fec5f3d3cb9447a37a3565c

## First-reviewed change shape

Classification: runtime contract code is source; Vitest files are tests; the execution plan is docs. No config, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests / fixtures | 6 | 4 |
| Docs | 66 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **73** | **5** |

## Review finding resolution

The preliminary specialist pass found one continuation mechanism with two effects: polling stopped after 20 seconds, and coverage did not prove the terminal journey. The accepted correction keeps the existing fast window, continues at a 15-second slow interval while pending, and adds a generation-4 to generation-5 provider test with publication delayed beyond 20 seconds. No new owner or durable state was added.

## Current change shape

Current head: 391bbc4cd5248113319697f8b2352c11dce4e631

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 4 |
| Tests / fixtures | 129 | 12 |
| Docs | 99 | 5 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **239** | **21** |

## Design proof

Not applicable. Existing rendered states and components did not change. The production Personal Patterns component already has component and section studies; this PR changes only the BrowserVaultProvider continuation cadence.

## Deployment skew / compatibility

Deploy Cloudflare Worker and runner bundle before Web, with immediate container rollout for the generation bump. During temporary skew, Web can read generation-4 replicas but continues to classify them as stale; an old runner may republish generation 4 until it is replaced. The operation is reversible by reverting the shared generation. Current production member/event volume was not measured in this PR; exposure is limited to authenticated Browser Vault sessions during the short rollout window. After deploy, verify that a generation-4 session reports refresh pending, the runtime publishes generation 5, and the open Patterns page leaves the preparing state even when publication takes more than 20 seconds.


