### PR TITLE
chore: add Frog developer friction logging

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -14,7 +14,9 @@ scripts/frog log
 Run `list` before working around a papercut. Humans may use interactive `log`;
 repository agents use `.agents/skills/frog/SKILL.md` for the noninteractive
 entry format. The wrapper forces the repository file store and permits no local
-publishing; the GitHub workflow is the sole issue and reconciliation owner.
+publishing. It enters the repository root itself and rejects caller-supplied
+`--cwd` and `--mcp` modes; the GitHub workflow is the sole issue and
+reconciliation owner.
 
 ## Public-data boundary
 

--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -16,7 +16,8 @@ repository agents use `.agents/skills/frog/SKILL.md` for the noninteractive
 entry format. The wrapper forces the repository file store and permits no local
 publishing. It enters the repository root itself and rejects caller-supplied
 `--cwd` and `--mcp` modes; the GitHub workflow is the sole issue and
-reconciliation owner.
+reconciliation owner. Both paths use the exact Frog `1.1.0` dependency from
+Murph's reviewed manifest and committed lockfile.
 
 ## Public-data boundary
 

--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -1,0 +1,42 @@
+# Friction log
+
+This directory contains unresolved developer friction encountered while working
+in this repository. Frog publishes each pending entry as a GitHub issue and
+keeps the active repository copy until that issue is resolved.
+
+## Use
+
+```sh
+scripts/frog list
+scripts/frog log
+```
+
+Run `list` before working around a papercut. Humans may use interactive `log`;
+repository agents use `.agents/skills/frog/SKILL.md` for the noninteractive
+entry format. The wrapper forces the repository file store and permits no local
+publishing; the GitHub workflow is the sole issue and reconciliation owner.
+
+## Public-data boundary
+
+Everything committed here and every issue Frog files is public repository
+content. Use minimal synthetic reproduction steps. Never include user or
+provider data, conversation or model transcripts, health information, member
+identifiers, credentials, raw logs or command output, local usernames,
+home-directory paths, or other private evidence.
+
+Resolution is workflow cleanup, not data deletion. The public issue and Git
+history remain, and Action-only reconciliation may retain an issue/path recovery
+binding in `.agents/friction-log/.sync.json` so a reopened issue can restore its
+entry. That journal does not store the report body in the pinned Frog version.
+
+Murph's product-feedback, support-escalation, and runtime-issue pipelines remain
+canonical for those signals. Frog is not for machine-specific, global, or
+internal-model friction, and this repository does not accept inbound or
+cross-repository Frog reports.
+
+## Lifecycle
+
+A friction-log change on `main` publishes pending entries. Frog-authored issue
+closures and reopenings reconcile immediately, and a daily recovery sweep runs
+at 00:17 UTC. Cleanup is written only to the reviewable `frog/sync` pull request,
+never directly to `main`.

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://unpkg.com/frog@1.1.0/schema.json",
+  "labels": [
+    "enhancement"
+  ],
+  "maxPerRun": 5,
+  "inbound": {
+    "enabled": false
+  },
+  "outbound": {
+    "enabled": false
+  }
+}

--- a/.agents/skills/frog/SKILL.md
+++ b/.agents/skills/frog/SKILL.md
@@ -63,8 +63,9 @@ known. Read back the returned `friction.md` before committing it.
 
 The wrapper permits only file-backed `list` and `log`; it rejects direct
 publishing, enters the repository root itself, and rejects caller-supplied
-`--cwd` and `--mcp` modes. The Action-only workflow is the sole issue and
-reconciliation owner.
+`--cwd` and `--mcp` modes. Local and Action execution use the exact Frog
+`1.1.0` dependency from Murph's reviewed manifest and committed lockfile. The
+Action-only workflow is the sole issue and reconciliation owner.
 
 ## Public-data boundary
 

--- a/.agents/skills/frog/SKILL.md
+++ b/.agents/skills/frog/SKILL.md
@@ -62,7 +62,9 @@ solutions optional; record the problem even when the correct fix is not yet
 known. Read back the returned `friction.md` before committing it.
 
 The wrapper permits only file-backed `list` and `log`; it rejects direct
-publishing. The Action-only workflow is the sole issue and reconciliation owner.
+publishing, enters the repository root itself, and rejects caller-supplied
+`--cwd` and `--mcp` modes. The Action-only workflow is the sole issue and
+reconciliation owner.
 
 ## Public-data boundary
 

--- a/.agents/skills/frog/SKILL.md
+++ b/.agents/skills/frog/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: frog
+description: Record repository-actionable developer friction with Frog. Use when tooling, documentation, APIs, tests, builds, or repository conventions force a workaround, waste time, or repeatedly confuse an agent; inspect unresolved entries before improvising around the problem.
+---
+
+# Frog
+
+Capture developer friction while the evidence is fresh without mixing it with
+Murph's product-feedback or runtime-issue systems.
+
+## Authority
+
+Use this skill only when the current request authorizes repository edits. During
+review-only, planning, or other no-edit work, do not create an entry; mention the
+friction in the handoff instead. Logging must not delay or replace the requested
+outcome.
+
+## Before a workaround
+
+Run:
+
+```sh
+scripts/frog list
+```
+
+Use an existing entry or linked issue when it already covers the problem. Do
+not create a title variant for the same friction.
+
+## Log new friction
+
+When the friction is new, reproducible, and actionable in this repository, pipe
+a specific title, a blank line, and a completed body into Frog:
+
+```sh
+cat <<'FROG' | scripts/frog log
+Specific searchable title
+
+## Expected Behavior
+
+Describe what should happen.
+
+## Current Behavior
+
+Describe what happens instead.
+
+## Possible Solution
+
+Optional.
+
+## Minimal Reproducible Example
+
+Use synthetic steps or code.
+
+## Context
+
+Describe the impact and task.
+FROG
+```
+
+Replace the example text with the actual public-safe report. Keep possible
+solutions optional; record the problem even when the correct fix is not yet
+known. Read back the returned `friction.md` before committing it.
+
+The wrapper permits only file-backed `list` and `log`; it rejects direct
+publishing. The Action-only workflow is the sole issue and reconciliation owner.
+
+## Public-data boundary
+
+Treat every entry, artifact, and Frog-filed issue as public repository content.
+Use synthetic reproduction data only. Never include user or provider data,
+conversation or model transcripts, health information, member identifiers,
+credentials, raw logs or command output, local usernames, home-directory
+paths, or other private evidence. Closing an issue is not data deletion: its
+public issue, Git history, and issue/path recovery binding can remain.
+
+Do not use Frog for product feedback, support escalation, observed production
+runtime failures, machine-specific setup, global tooling complaints, or
+internal-model friction. Murph's existing owners remain canonical for those
+signals. Inbound and cross-repository Frog reporting are disabled.

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -40,10 +40,22 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install reviewed dependency graph
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Report and reconcile frictions
         uses: wevm/frog/action@7b71c098683d49a573c279a2031a24205ea76841 # v1.1.0
         with:
           branch: frog/sync
+          command: node_modules/.bin/frog
           issue-author: github-actions[bot]
           push: pull-request
-          version: "1.1.0"

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,49 @@
+name: Friction Log
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".agents/friction-log/**"
+  issues:
+    types:
+      - closed
+      - reopened
+  workflow_dispatch:
+  schedule:
+    - cron: "17 0 * * *"
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  friction-log:
+    name: Friction Log
+    if: >-
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      (github.event_name != 'issues' ||
+      github.event.issue.user.login == 'github-actions[bot]')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Report and reconcile frictions
+        uses: wevm/frog/action@7b71c098683d49a573c279a2031a24205ea76841 # v1.1.0
+        with:
+          branch: frog/sync
+          issue-author: github-actions[bot]
+          push: pull-request
+          version: "1.1.0"

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,12 @@ apps/web/next-env.d.ts
 !/.agents/skills/write-changelog/SKILL.md
 !/.agents/skills/write-changelog/agents/
 !/.agents/skills/write-changelog/agents/openai.yaml
+!/.agents/skills/frog/
+!/.agents/skills/frog/SKILL.md
 !/.agents/skills/crabbox/
 !/.agents/skills/crabbox/SKILL.md
+!/.agents/friction-log/
+!/.agents/friction-log/**
 !/.agents/skills/health-commons-research/
 !/.agents/skills/health-commons-research/SKILL.md
 !/.agents/skills/work-with-pro/

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@murphai/health-metrics": "workspace:*",
     "@types/node": "^25.6.2",
     "@vitest/coverage-v8": "^4.1.6",
+    "frog": "1.1.0",
     "tsx": "^4.20.6",
     "typescript": "^7.0.2",
     "vite": "^8.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
+      frog:
+        specifier: 1.1.0
+        version: 1.1.0
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -1344,8 +1347,16 @@ packages:
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/containers@0.3.6':
     resolution: {integrity: sha512-8RrbK/Et165gjvXccui3pgkUuySVWysTC6bJRXfgqmbCA2vAmh8pm7cAKDh2nZFR/GSjW4BgxeKpffCTD8SJEg==}
@@ -2303,6 +2314,10 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/server@2.0.0-alpha.4':
+    resolution: {integrity: sha512-/KEo3ZJ50HlagHp0lz2vPgfBZFtXHu6zTBXT9XqPc+4O9i4+IbBVWKq/a9yAfv/ifp0u3+mRo8SUk5kMKzhN8A==}
+    engines: {node: '>=20'}
+
   '@msgpack/msgpack@3.1.2':
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
@@ -2604,6 +2619,64 @@ packages:
   '@oclif/plugin-help@6.2.37':
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.13':
+    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@onkernel/sdk@0.76.0':
     resolution: {integrity: sha512-jswopogv6wJEyvhPgZu+XJZgN87Heuo8nO+gpxsdvJtWFhUbAZME/oLjpIdtS57CRqHQLEf+p0+bavXCMYi72w==}
@@ -3255,6 +3328,10 @@ packages:
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@scalar/openapi-types@0.8.0':
+    resolution: {integrity: sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==}
+    engines: {node: '>=22'}
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -5176,6 +5253,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-result@2.9.1:
     resolution: {integrity: sha512-tPWnUPD8oLESRXMykkuTvi9tJVwaFSVfdhp1/WRd1q04SqengKdYt27avogObRC/BgH+zDqSo713dUEKkXbG5w==}
 
@@ -5511,6 +5591,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
@@ -6429,6 +6513,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  frog@1.1.0:
+    resolution: {integrity: sha512-dOUldqOw6uDybLcvDwUtp1e0JS/TD0DO3VdvBbh2wUdKHEU+xB4U55d+t0dfzDkvQ+eJyZDTb8dwNcmO9D1RRA==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -6732,6 +6821,11 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  incur@0.4.25:
+    resolution: {integrity: sha512-UHMc8OAafcalvhtfPs8rIPAUksRQ7gbR59zq8CWYFUaX1kVssfFQ6aYEb3mWglP4NMfh5HO+IfvzqhwPuCyMmg==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   incur@0.4.5:
     resolution: {integrity: sha512-4WFlqm5e+IKNoX+lDIjjpebO8ResPx3vPUBChxNfnNo3oGp0ooo6piiiTspOMub2dq2mcG/AmlUq0ejuGfKobg==}
@@ -7126,6 +7220,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -8165,6 +8262,10 @@ packages:
 
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
+
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
   powershell-utils@0.1.0:
@@ -9307,6 +9408,9 @@ packages:
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -10469,10 +10573,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
   '@clack/prompts@0.11.0':
     dependencies:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
   '@cloudflare/containers@0.3.6': {}
@@ -11463,6 +11579,10 @@ snapshots:
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
 
+  '@modelcontextprotocol/server@2.0.0-alpha.4':
+    dependencies:
+      zod: 4.4.3
+
   '@msgpack/msgpack@3.1.2': {}
 
   '@mswjs/interceptors@0.41.8':
@@ -11722,6 +11842,75 @@ snapshots:
   '@oclif/plugin-help@6.2.37':
     dependencies:
       '@oclif/core': 4.8.1
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.13
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.13':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@onkernel/sdk@0.76.0': {}
 
@@ -12852,6 +13041,8 @@ snapshots:
       - zod
 
   '@safe-global/safe-gateway-typescript-sdk@3.23.1': {}
+
+  '@scalar/openapi-types@0.8.0': {}
 
   '@scure/base@1.1.9': {}
 
@@ -15913,6 +16104,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
+  before-after-hook@4.0.0: {}
+
   better-result@2.9.1: {}
 
   better-sqlite3@12.6.2:
@@ -16265,6 +16458,8 @@ snapshots:
   content-disposition@2.0.1: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-hrtime@5.0.0: {}
 
@@ -17391,6 +17586,14 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  frog@1.1.0:
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@octokit/rest': 22.0.1
+      incur: 0.4.25
+      postgres: 3.4.9
+      yaml: 2.9.0
+
   fs-constants@1.0.0:
     optional: true
 
@@ -17701,6 +17904,16 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  incur@0.4.25:
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@modelcontextprotocol/server': 2.0.0-alpha.4
+      '@scalar/openapi-types': 0.8.0
+      '@toon-format/toon': 2.2.0
+      tokenx: 1.3.0
+      yaml: 2.9.0
+      zod: 4.4.3
 
   incur@0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e):
     dependencies:
@@ -18052,6 +18265,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-with-bigint@3.5.10: {}
 
   json5@1.0.2:
     dependencies:
@@ -19140,6 +19355,8 @@ snapshots:
       xtend: 4.0.2
 
   postgres@3.4.7: {}
+
+  postgres@3.4.9: {}
 
   powershell-utils@0.1.0: {}
 
@@ -20541,6 +20758,8 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   unicorn-magic@0.4.0: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 

--- a/scripts/frog
+++ b/scripts/frog
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
 case "${1:-}" in
   list|log) ;;
   *)
@@ -11,6 +13,10 @@ esac
 
 for argument in "$@"; do
   case "$argument" in
+    --cwd|--cwd=*|--mcp|--mcp=*)
+      echo "scripts/frog owns the repository root; --cwd and --mcp are not allowed." >&2
+      exit 2
+      ;;
     --publish|--publish=*)
       echo "Publishing is owned by .github/workflows/friction-log.yml." >&2
       exit 2
@@ -19,4 +25,5 @@ for argument in "$@"; do
 done
 
 unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA
+cd "$repo_root"
 exec pnpm dlx frog@1.1.0 "$@"

--- a/scripts/frog
+++ b/scripts/frog
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  list|log) ;;
+  *)
+    echo "Usage: scripts/frog {list|log} [options]" >&2
+    exit 2
+    ;;
+esac
+
+for argument in "$@"; do
+  case "$argument" in
+    --publish|--publish=*)
+      echo "Publishing is owned by .github/workflows/friction-log.yml." >&2
+      exit 2
+      ;;
+  esac
+done
+
+unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA
+exec pnpm dlx frog@1.1.0 "$@"

--- a/scripts/frog
+++ b/scripts/frog
@@ -26,4 +26,9 @@ done
 
 unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA
 cd "$repo_root"
-exec pnpm dlx frog@1.1.0 "$@"
+frog_bin="$repo_root/node_modules/.bin/frog"
+if [[ ! -x "$frog_bin" ]]; then
+  echo "Frog is not installed; run pnpm install --frozen-lockfile." >&2
+  exit 2
+fi
+exec "$frog_bin" "$@"

--- a/scripts/frog-workflow-guards.test.ts
+++ b/scripts/frog-workflow-guards.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -37,7 +38,11 @@ describe("Frog workflow guards", () => {
       "unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA",
     );
     expect(frogScript).toContain('cd "$repo_root"');
-    expect(frogScript).toContain('exec pnpm dlx frog@1.1.0 "$@"');
+    expect(frogScript).toContain(
+      'frog_bin="$repo_root/node_modules/.bin/frog"',
+    );
+    expect(frogScript).toContain('exec "$frog_bin" "$@"');
+    expect(frogScript).not.toContain("pnpm dlx");
 
     const publish = spawnSync(frogScriptPath, ["publish"], {
       encoding: "utf8",
@@ -69,11 +74,16 @@ describe("Frog workflow guards", () => {
 
   it("enters the repository root and clears ambient database settings", () => {
     const testRoot = mkdtempSync(path.join(tmpdir(), "frog-wrapper-"));
-    const fakeBin = path.join(testRoot, "bin");
+    const testRepo = path.join(testRoot, "repo");
+    const testScriptDir = path.join(testRepo, "scripts");
+    const testScript = path.join(testScriptDir, "frog");
+    const fakeBin = path.join(testRepo, "node_modules", ".bin");
     const capturePath = path.join(testRoot, "capture.txt");
-    mkdirSync(fakeBin);
+    mkdirSync(testScriptDir, { recursive: true });
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(testScript, readRepoFile("scripts", "frog"), { mode: 0o755 });
     writeFileSync(
-      path.join(fakeBin, "pnpm"),
+      path.join(fakeBin, "frog"),
       `#!/usr/bin/env bash
 set -euo pipefail
 
@@ -98,7 +108,7 @@ fi
     );
 
     try {
-      const result = spawnSync(frogScriptPath, ["list"], {
+      const result = spawnSync(testScript, ["list"], {
         cwd: testRoot,
         encoding: "utf8",
         env: {
@@ -107,14 +117,13 @@ fi
           FROG_NAMESPACE: "ambient",
           FROG_SCHEMA: "ambient",
           FROG_TEST_CAPTURE: capturePath,
-          FROG_TEST_EXPECTED_CWD: repoRoot,
-          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+          FROG_TEST_EXPECTED_CWD: realpathSync(testRepo),
         },
       });
 
       expect(result.status).toBe(0);
       expect(readFileSync(capturePath, "utf8")).toBe(
-        "cwd=repo\narg=dlx\narg=frog@1.1.0\narg=list\n",
+        "cwd=repo\narg=list\n",
       );
     } finally {
       rmSync(testRoot, { force: true, recursive: true });
@@ -144,6 +153,9 @@ fi
       maxPerRun: 5,
       outbound: { enabled: false },
     });
+    expect(JSON.parse(readRepoFile("package.json")).devDependencies.frog).toBe(
+      "1.1.0",
+    );
 
     const issueTemplateDir = path.join(repoRoot, ".github", "ISSUE_TEMPLATE");
     const issueForms = existsSync(issueTemplateDir)
@@ -234,18 +246,26 @@ fi
     expect(workflow).toContain("timeout-minutes: 10");
     expect(workflow).toContain("persist-credentials: false");
     expect(workflow).toContain("ref: ${{ github.sha }}");
+    expect(workflow).toContain(
+      "run: pnpm install --frozen-lockfile --ignore-scripts",
+    );
+    expect(workflow).not.toContain("pnpm dlx");
+    expect(workflow).not.toMatch(/\bnpm install\b/u);
     expect(workflow).not.toMatch(/^\s+max:/mu);
     expect(actionRefs(workflow)).toEqual([
       "de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+      "fc06bc1257f339d1d5d8b3a19a8cae5388b55320",
+      "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
       "7b71c098683d49a573c279a2031a24205ea76841",
     ]);
     for (const input of [
       "branch: frog/sync",
+      "command: node_modules/.bin/frog",
       "issue-author: github-actions[bot]",
       "push: pull-request",
-      'version: "1.1.0"',
     ]) {
       expect(workflow).toContain(input);
     }
+    expect(workflow).not.toMatch(/^\s+version:/mu);
   });
 });

--- a/scripts/frog-workflow-guards.test.ts
+++ b/scripts/frog-workflow-guards.test.ts
@@ -1,10 +1,15 @@
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
+  rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,6 +36,7 @@ describe("Frog workflow guards", () => {
     expect(frogScript).toContain(
       "unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA",
     );
+    expect(frogScript).toContain('cd "$repo_root"');
     expect(frogScript).toContain('exec pnpm dlx frog@1.1.0 "$@"');
 
     const publish = spawnSync(frogScriptPath, ["publish"], {
@@ -46,9 +52,89 @@ describe("Frog workflow guards", () => {
     expect(immediate.stderr).toContain(
       "Publishing is owned by .github/workflows/friction-log.yml.",
     );
+
+    for (const args of [
+      ["list", "--cwd", "."],
+      ["list", "--cwd=.."],
+      ["list", "--mcp"],
+      ["list", "--mcp=true"],
+    ]) {
+      const escaped = spawnSync(frogScriptPath, args, { encoding: "utf8" });
+      expect(escaped.status).toBe(2);
+      expect(escaped.stderr).toContain(
+        "scripts/frog owns the repository root; --cwd and --mcp are not allowed.",
+      );
+    }
+  });
+
+  it("enters the repository root and clears ambient database settings", () => {
+    const testRoot = mkdtempSync(path.join(tmpdir(), "frog-wrapper-"));
+    const fakeBin = path.join(testRoot, "bin");
+    const capturePath = path.join(testRoot, "capture.txt");
+    mkdirSync(fakeBin);
+    writeFileSync(
+      path.join(fakeBin, "pnpm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "\${FROG_DATABASE_URL+x}" || -n "\${FROG_NAMESPACE+x}" || -n "\${FROG_SCHEMA+x}" ]]; then
+  printf 'ambient-variable-present\n' > "$FROG_TEST_CAPTURE"
+  exit 91
+fi
+
+if [[ "$PWD" != "$FROG_TEST_EXPECTED_CWD" ]]; then
+  printf 'cwd=unexpected\n' > "$FROG_TEST_CAPTURE"
+  exit 92
+fi
+
+{
+  printf 'cwd=repo\n'
+  for argument in "$@"; do
+    printf 'arg=%s\n' "$argument"
+  done
+} > "$FROG_TEST_CAPTURE"
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync(frogScriptPath, ["list"], {
+        cwd: testRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FROG_DATABASE_URL: "postgresql://example.invalid/frog",
+          FROG_NAMESPACE: "ambient",
+          FROG_SCHEMA: "ambient",
+          FROG_TEST_CAPTURE: capturePath,
+          FROG_TEST_EXPECTED_CWD: repoRoot,
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(capturePath, "utf8")).toBe(
+        "cwd=repo\narg=dlx\narg=frog@1.1.0\narg=list\n",
+      );
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
   });
 
   it("keeps reporting local, bounded, and public-safe", () => {
+    for (const repoRelativePath of [
+      ".agents/friction-log/example/friction.md",
+      ".agents/skills/frog/SKILL.md",
+    ]) {
+      expect(
+        spawnSync(
+          "git",
+          ["check-ignore", "--no-index", "--quiet", repoRelativePath],
+          { cwd: repoRoot },
+        ).status,
+      ).toBe(1);
+    }
+
     expect(
       JSON.parse(readRepoFile(".agents", "friction-log", "config.json")),
     ).toEqual({
@@ -86,6 +172,8 @@ describe("Frog workflow guards", () => {
     expect(skill).toContain("current request authorizes repository edits");
     expect(skill).toContain("review-only");
     expect(skill).toContain("scripts/frog list");
+    expect(skill).toContain("repository root");
+    expect(skill).toContain("`--cwd` and `--mcp`");
     expect(skill).toContain("cat <<'FROG' | scripts/frog log");
     expect(skill).toContain("Use synthetic reproduction data only.");
     expect(skill).toContain("raw logs or command output");

--- a/scripts/frog-workflow-guards.test.ts
+++ b/scripts/frog-workflow-guards.test.ts
@@ -1,0 +1,163 @@
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const frogScriptPath = path.join(repoRoot, "scripts", "frog");
+const readRepoFile = (...parts: string[]) =>
+  readFileSync(path.join(repoRoot, ...parts), "utf8");
+
+function actionRefs(workflow: string): string[] {
+  return workflow.split("\n").flatMap((line) => {
+    const match = /^\s*-?\s*uses:\s+[^@\s]+@([^\s#]+)/u.exec(line);
+    return match?.[1] ? [match[1]] : [];
+  });
+}
+
+describe("Frog workflow guards", () => {
+  it("keeps local commands file-backed and workflow-owned", () => {
+    expect(statSync(frogScriptPath).mode & 0o111).not.toBe(0);
+    expect(spawnSync("bash", ["-n", frogScriptPath]).status).toBe(0);
+
+    const frogScript = readRepoFile("scripts", "frog");
+    expect(frogScript).toContain(
+      "unset FROG_DATABASE_URL FROG_NAMESPACE FROG_SCHEMA",
+    );
+    expect(frogScript).toContain('exec pnpm dlx frog@1.1.0 "$@"');
+
+    const publish = spawnSync(frogScriptPath, ["publish"], {
+      encoding: "utf8",
+    });
+    expect(publish.status).toBe(2);
+    expect(publish.stderr).toContain("Usage: scripts/frog {list|log}");
+
+    const immediate = spawnSync(frogScriptPath, ["log", "--publish"], {
+      encoding: "utf8",
+    });
+    expect(immediate.status).toBe(2);
+    expect(immediate.stderr).toContain(
+      "Publishing is owned by .github/workflows/friction-log.yml.",
+    );
+  });
+
+  it("keeps reporting local, bounded, and public-safe", () => {
+    expect(
+      JSON.parse(readRepoFile(".agents", "friction-log", "config.json")),
+    ).toEqual({
+      $schema: "https://unpkg.com/frog@1.1.0/schema.json",
+      inbound: { enabled: false },
+      labels: ["enhancement"],
+      maxPerRun: 5,
+      outbound: { enabled: false },
+    });
+
+    const issueTemplateDir = path.join(repoRoot, ".github", "ISSUE_TEMPLATE");
+    const issueForms = existsSync(issueTemplateDir)
+      ? readdirSync(issueTemplateDir, { withFileTypes: true })
+          .filter(
+            (entry) =>
+              entry.isFile()
+              && entry.name !== "config.yml"
+              && /\.ya?ml$/u.test(entry.name),
+          )
+          .map((entry) => entry.name)
+      : [];
+    const selectedIssueForm = issueForms.find((file) => file === "friction.yml")
+      ?? (issueForms.length === 1
+        ? issueForms[0]
+        : issueForms.find((file) => file.includes("bug")));
+    // Frog validates supplied bodies against the form it auto-selects.
+    expect(selectedIssueForm).toBeUndefined();
+
+    const readme = readRepoFile(".agents", "friction-log", "README.md");
+    expect(readme).toContain("scripts/frog list");
+    expect(readme).toContain("workflow cleanup, not data deletion");
+    expect(readme).toContain(".agents/friction-log/.sync.json");
+
+    const skill = readRepoFile(".agents", "skills", "frog", "SKILL.md");
+    expect(skill).toContain("current request authorizes repository edits");
+    expect(skill).toContain("review-only");
+    expect(skill).toContain("scripts/frog list");
+    expect(skill).toContain("cat <<'FROG' | scripts/frog log");
+    expect(skill).toContain("Use synthetic reproduction data only.");
+    expect(skill).toContain("raw logs or command output");
+    expect(skill).toContain("Closing an issue is not data deletion");
+    for (const heading of [
+      "## Expected Behavior",
+      "## Current Behavior",
+      "## Possible Solution",
+      "## Minimal Reproducible Example",
+      "## Context",
+    ]) {
+      expect(skill).toContain(heading);
+    }
+  });
+
+  it("keeps the Action on trusted default-branch events with narrow authority", () => {
+    const workflow = readRepoFile(
+      ".github",
+      "workflows",
+      "friction-log.yml",
+    );
+
+    expect(workflow).toContain(`push:
+    branches:
+      - main
+    paths:
+      - ".agents/friction-log/**"`);
+    expect(workflow).toContain(`issues:
+    types:
+      - closed
+      - reopened`);
+    expect(workflow).toContain("  workflow_dispatch:");
+    expect(workflow).toContain('cron: "17 0 * * *"');
+    expect(workflow).toContain("group: friction-log");
+    expect(workflow).toContain("cancel-in-progress: false");
+    expect(workflow).toContain(
+      "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)",
+    );
+    expect(workflow).toContain(
+      "github.event.issue.user.login == 'github-actions[bot]'",
+    );
+    expect(workflow).not.toMatch(/^\s+pull_request(?:_target)?:/mu);
+
+    const topLevelPermissions = workflow.indexOf("permissions: {}");
+    const jobs = workflow.indexOf("jobs:");
+    expect(topLevelPermissions).toBeGreaterThanOrEqual(0);
+    expect(jobs).toBeGreaterThan(topLevelPermissions);
+    expect(
+      (workflow.match(/^\s+[a-z-]+: write$/gmu) ?? []).map((line) =>
+        line.trim()
+      ),
+    ).toEqual([
+      "contents: write",
+      "issues: write",
+      "pull-requests: write",
+    ]);
+    expect(workflow).not.toContain("id-token: write");
+    expect(workflow).toContain("timeout-minutes: 10");
+    expect(workflow).toContain("persist-credentials: false");
+    expect(workflow).toContain("ref: ${{ github.sha }}");
+    expect(workflow).not.toMatch(/^\s+max:/mu);
+    expect(actionRefs(workflow)).toEqual([
+      "de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+      "7b71c098683d49a573c279a2031a24205ea76841",
+    ]);
+    for (const input of [
+      "branch: frog/sync",
+      "issue-author: github-actions[bot]",
+      "push: pull-request",
+      'version: "1.1.0"',
+    ]) {
+      expect(workflow).toContain(input);
+    }
+  });
+});


### PR DESCRIPTION
## Why this PR exists

Murph's coding agents encounter tooling, documentation, API, test, build, and convention papercuts that are easy to work around without recording. This adds Frog as a narrow developer-friction owner while leaving Murph's product-feedback, support-escalation, and runtime-issue pipelines unchanged.

## User goal / user-visible behavior

Developers and coding agents can inspect unresolved friction with `scripts/frog list` and record one new public-safe, repository-actionable item with `scripts/frog log`. A discoverable Murph skill supplies the noninteractive entry format.

There is no Murph member-facing behavior change.

## User experience

For edit-authorized tasks, the developer flow is: load the `frog` skill when repository friction appears, inspect unresolved entries, record one specific report when the problem is new, and commit the resulting entry with the work that exposed it. Review-only, planning, and other no-edit tasks report friction in the handoff without mutating the repository. A friction-log change on `main` publishes pending entries; Frog-authored issue closures and reopenings reconcile immediately; a recovery sweep runs daily at 00:17 UTC.

The repository entry remains the retryable pending record when publication fails. The local wrapper permits only file-backed `list` and `log`, enters the Murph repository root itself, rejects caller-supplied `--cwd`, `--mcp`, and direct publishing, and clears ambient Frog database-store variables. The Action-only workflow remains the sole issue-author and reconciliation owner. Cleanup is reviewed through `frog/sync`, never written directly to `main`.

## Invariants the PR must preserve

- Frog is for repository-actionable developer friction only; entries, artifacts, and filed issues are public content and use synthetic evidence.
- The current request must authorize repository edits before an agent creates an entry; review-only and no-edit tasks remain mutation-free.
- Local commands always enter this repository and use its file store; ambient database variables and caller-supplied `--cwd` or `--mcp` cannot redirect execution.
- Local direct publication is rejected. The Action-only workflow is the sole publisher, and issue-event reconciliation trusts only `github-actions[bot]` reports.
- User/provider data, conversation or model transcripts, health information, member identifiers, credentials, raw logs or command output, local usernames, home-directory paths, and other private evidence never enter the log or its issues.
- Issue closure is lifecycle cleanup, not data deletion. The public issue and Git history remain, and Action-only reconciliation may retain an issue/path recovery binding in `.sync.json`.
- Murph's product-feedback, support-escalation, and runtime-issue owners remain canonical.
- Inbound and cross-repository reporting remain explicitly disabled; each run publishes at most five entries.
- Every workflow event resolves to the repository's full current default-branch ref; dispatches against another branch or a same-named tag are skipped.
- Cleanup is written only through `frog/sync`.
- All four Action uses remain commit-SHA pinned and the installed Frog package remains exact at `1.1.0`.
- Adding an auto-selected GitHub issue form requires updating Frog's documented stdin headings and guard proof.
- The Frog skill and complete friction-log tree remain visible to ordinary Git and scoped commit tooling, including newly created nested entries and `.sync.json`.

## Non-obvious affected surfaces

- GitHub Actions gains a path-filtered, event-driven, and daily recovery workflow with scoped `contents`, `issues`, and `pull-requests` write permissions and a ten-minute timeout.
- Action-only reconciliation can add `.agents/friction-log/.sync.json`. In pinned Frog `1.1.0`, this journal retains issue/path recovery bindings, not report bodies, so reopened issues can be rebuilt from their already-public issue content.
- `.gitignore` explicitly exposes the Frog skill and full friction-log subtree so ordinary scoped commits can include new entries and workflow reconciliation state without `git add -f`.
- Frog `1.1.0` and its transitive graph are now reviewed in Murph's existing root manifest and committed lockfile. The workflow performs a frozen install with lifecycle scripts disabled, then passes the explicit repo-local binary to the exact-SHA Frog Action so the write-authorized step performs no package resolution.
- Repository activation requires **Allow GitHub Actions to create and approve pull requests** under Settings → Actions → General before the first run that needs `frog/sync`; this PR does not change that setting.
- Pull-request checks created or synchronized through the repository `GITHUB_TOKEN` enter GitHub's approval-required state. A maintainer approves the `frog/sync` checks rather than adding a PAT or third-party App solely to bypass that review step.

## Architecture and reuse

- **Existing systems reused:** Murph's `.agents/skills` discovery path, GitHub Issues and pull requests, the existing `enhancement` label, pinned `actions/checkout`, Frog's file-store/stdin/Action-only lifecycle, and Murph's repo-tools Vitest lane.
- **New logic:** One bounded Frog config, one agent skill, one short human README, one small fail-closed command wrapper, one pinned publication workflow, one focused workflow/agent guard test, narrow `.gitignore` exposure for their owned files, and exact Frog ownership in the existing root manifest and lockfile.
- **New abstractions:** No Murph runtime abstraction was added. `scripts/frog` is a narrow command boundary that fixes repository selection and the file store while denying local publication and MCP mode; Frog retains its existing file/issue ownership.
- **Complexity intentionally avoided:** No Frog GitHub App, inbound reports, upstream targets, duplicate public issue form, dedicated Frog workspace, secondary lockfile, database, MCP server, or replacement feedback pipeline.

## Changelog

- Changelog: not applicable
- Reason: this is internal developer tooling and changes no member-visible Murph behavior.

## Hot reply path impact

Not applicable. No production runtime, message acceptance, provider start, or reply handoff code changes.

## Murph initial provider input impact

- **Individual Murph:** Not applicable. No runtime prompt, tool/schema, model configuration, or provider-request assembly changes.
- **Group Murph:** Not applicable. No runtime prompt, tool/schema, model configuration, or provider-request assembly changes.

## Preliminary specialist lenses

- **Product experience: not applicable.** Internal repository tooling; no member-facing journey.
- **Prompt: applicable.** `.agents/skills/frog/SKILL.md` governs edit authority, timing, evidence, privacy, retention, and the noninteractive logging contract. The exact-head specialist review returned no prompt findings.
- **Frontend: not applicable.** No web UI or rendered product surface changes.
- **Coverage: applicable.** `scripts/frog-workflow-guards.test.ts` executes wrapper rejection and repository-root behavior, proves ambient database variables are removed at the process boundary, keeps the Frog-owned paths Git-visible, and locks workflow/config/privacy/version invariants. The focused test and full typecheck pass locally. The specialist returned two coverage findings: the missing real `log` round trip was accepted and resolved with the disposable direct proof below; the requested disposable-GitHub publication lifecycle was rejected because it would add an external write-bearing test harness for behavior already covered by the exact pinned vendor action tests, while Murph-specific trigger, ref, author, permission, pin, and write-path policy is covered locally. The acknowledged first-activation canary remains explicit below.

ReviewGPT context sensitivity: sensitive

Reason: the PR introduces a scheduled third-party GitHub Action with repository issue and pull-request write authority, although the package, targets, refs, local command boundary, and write path are bounded.

ReviewGPT first-reviewed head: b223bee2cadb3859d77400b6d26aea533f91b309

Round 1 on that head returned one accepted high-severity finding: local `pnpm dlx` and the Action's internal npm install left Frog transitive dependencies mutable outside Murph's reviewed supply-chain graph. Remediation head `0185570db9cf224c94442553ce157e7adf417591` adds exact Frog `1.1.0` to the existing root manifest and committed lockfile, uses only the explicit repo-local binary, installs the frozen graph with scripts disabled before the write-authorized step, and passes that binary through the pinned Action's `command` input. Round 2 passed on this corrected full snapshot with no qualifying findings. Branch protection then required a base-only rebase to current `main`; candidate `dd8b345837c45dedfe7df9f86abff18e6fc64988` preserves the reviewed diff byte-for-byte (`5abd2286fb846a6002a8489ca9ba6b86db7962894bdaf8cc956f5101b5d70ce9`).

## Verification

Completed on the exact candidate before ReviewGPT:

- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/frog-workflow-guards.test.ts` — 1 file and 4 tests passed.
- `pnpm typecheck` — passed again after dependency remediation across the full shell, dependency, boundary, architecture/privacy guard, repo-tools, contracts, package, and app typecheck surface.
- `pnpm deps:guard` — passed for all 30 manifests.
- `pnpm deps:ignored-builds` — Frog introduces no ignored install script and no approval exception.
- `pnpm deps:audit` — the repository's existing advisory backlog still makes the global command nonzero; structured audit inspection found no advisory path containing Frog.
- `pnpm install --frozen-lockfile --ignore-scripts` — skipped resolution with the corrected lockfile.
- The focused Frog guards pass 4/4 after remediation and explicitly reject `pnpm dlx`, dynamic `npm install`, Action `version` installation, and any non-lock-backed command path.
- From outside the checkout, `scripts/frog list` through the real pinned `frog@1.1.0` invocation returned an empty repository file store successfully.
- Also from outside the checkout, piped a synthetic report through the real pinned `scripts/frog log` with hostile `FROG_DATABASE_URL`, `FROG_NAMESPACE`, and `FROG_SCHEMA` values; it created the expected repository-local `friction.md`, and a second real `scripts/frog list` read it back as one pending entry. Repeated this proof through the corrected explicit lock-backed binary, then inspected and removed only the disposable entries, leaving the worktree clean.
- Verified the wrapper rejects split and inline `--cwd`, plus `--mcp` forms, before invoking Frog.
- Verified the wrapper enters the repository root and clears `FROG_DATABASE_URL`, `FROG_NAMESPACE`, and `FROG_SCHEMA` at the process boundary.
- Verified the Frog skill and nested friction-log entries are not ignored by Git.
- Verified Frog `main` still publishes `1.1.0`; the only upstream delta after the pinned Action commit is formatting/changelog-only.
- Inspected Frog's exact CLI selection, `log`, stdin, issue-form selection, file/Postgres store, publish, sync, mirror, provenance, and Action contracts.
- Verified existing already-filed reports consume no publish ceiling slot, so entries beyond the five-mutation cap continue progressing even while `frog/sync` is unmerged.
- Read current official GitHub workflow and `GITHUB_TOKEN` behavior and current OpenAI prompt guidance before the final workflow/prompt review.
- Verified the explicit pinned `actions/setup-node` step selects the repository Node version, satisfying Frog.s `node >=22` engine.
- Replaced the ineffective nested `AGENTS.md` with a repository-discoverable skill and Frog's real noninteractive stdin path.
- Added an explicit edit-authority fence so review-only, planning, and no-edit tasks cannot create entries.
- Added `scripts/frog` to force file storage, reject repository/MCP/publication escape hatches, and centralize exact Frog `1.1.0` invocation.
- Removed the duplicate public issue form; the guard mirrors Frog's actual selection rule, allowing multiple unrelated non-bug forms while rejecting a selected form that would invalidate the documented headings.
- Documented that closure is not privacy deletion and that the Action-only recovery journal stores linkage, not report bodies.
- Restricted ordinary pushes to friction-log changes, fenced every event to the full default-branch ref, offset the daily sweep from GitHub's high-load top-of-hour window, and added a ten-minute timeout.
- Explicitly disabled inbound and cross-repository reporting.
- Verified the `enhancement` label exists, no bot-authored enhancement issue can collide with deduplication, and `frog/sync` is unused.
- Parsed the final JSON/YAML, syntax-checked the wrapper and TypeScript test, confirmed full Action SHA pins and non-persisted checkout credentials, and read back all changed files.

Direct scenario gap: the workflow cannot execute as the repository's active Frog owner until it exists on `main`. The merge-triggered no-entry run is the first canary; it should create neither an issue nor `frog/sync`. Use `workflow_dispatch` on `main` only as a retry. Verify the Actions-created-PR setting before the first real entry needs cleanup. At the exact pinned vendor commit, upstream Action tests preserve queued changes on deferred publish/sync, preserve them when a later command fails, reset only `frog/sync` after a complete run, accept the configured bot author, and ignore issue events from another author; the vendor suite also covers CLI log, list, publish, sync, file-store, GitHub, and reconciliation behavior. A separate disposable public repository would duplicate those mechanics while introducing external write cleanup and credential risk, so it is not added to this scoped Murph integration.

## Review boundaries

- `.agents/friction-log/README.md`
- `.agents/friction-log/config.json`
- `.agents/skills/frog/SKILL.md`
- `.github/workflows/friction-log.yml`
- `.gitignore`
- `package.json`
- `pnpm-lock.yaml`
- `scripts/frog`
- `scripts/frog-workflow-guards.test.ts`

No existing Murph feedback, support, runtime, product, or application file changed.

## Change-shape breakdown

Classification rule: Markdown is docs/instructions; the Vitest file is tests/fixtures; JSON, workflow YAML, `.gitignore`, the root dependency manifest and lockfile, and the shell wrapper are config/tooling. No application source, generated code, move, or binary is present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 271 | 0 |
| Docs | 127 | 0 |
| Config/tooling | 332 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **730** | **0** |

## Design proof

Not applicable. This PR has no user-facing frontend UI diff.