### PR TITLE
Seed Starter usage in hosted E2E members

### DIFF
--- a/apps/web/test/support/hosted-member-seeds.ts
+++ b/apps/web/test/support/hosted-member-seeds.ts
@@ -34,6 +34,10 @@ const hostedMemberBillingStoreModuleSpecifier = new URL(
   "../../src/lib/hosted-onboarding/hosted-member-billing-store.ts",
   import.meta.url,
 ).href;
+const hostedStarterUsageGrantModuleSpecifier = new URL(
+  "../../src/lib/hosted-onboarding/starter-usage-grant.ts",
+  import.meta.url,
+).href;
 const hostedLinqLineStoreModuleSpecifier = new URL(
   "../../src/lib/hosted-onboarding/linq-line-store.ts",
   import.meta.url,
@@ -442,12 +446,23 @@ interface HostedMemberSeedModules {
   upsertHostedMemberIdentity: HostedMemberIdentityStoreModule["upsertHostedMemberIdentity"];
   incrementHostedLinqInboundDailyState:
     HostedLinqDailyStateModule["incrementHostedLinqInboundDailyState"];
+  ensureHostedStarterUsageGrantTx:
+    HostedStarterUsageGrantModule["ensureHostedStarterUsageGrantTx"];
   projectHostedLinqLineForDeliveryReceiptTx:
     HostedLinqLineStoreModule["projectHostedLinqLineForDeliveryReceiptTx"];
   upsertHostedLinqLineForPhoneTx:
     HostedLinqLineStoreModule["upsertHostedLinqLineForPhoneTx"];
   writeHostedMemberStripeBillingRefTx:
     HostedMemberBillingStoreModule["writeHostedMemberStripeBillingRefTx"];
+}
+
+interface HostedStarterUsageGrantModule {
+  ensureHostedStarterUsageGrantTx(input: {
+    effectiveAt: Date;
+    memberId: string;
+    source: "web_onboarding";
+    tx: unknown;
+  }): Promise<unknown>;
 }
 
 interface HostedJunctionDeviceSyncReplaySeedModules {
@@ -490,7 +505,7 @@ export async function seedHostedActiveMember(
           tx,
           userId: input.memberId,
         });
-        await seedHostedMemberBillingRefTx({
+        await seedHostedMemberUsageCapacityTx({
           billingPlanCode: input.billingPlanCode,
           memberId: input.memberId,
           modules,
@@ -536,7 +551,7 @@ export async function seedHostedActiveLinqMember(
           tx,
           userId: input.memberId,
         });
-        await seedHostedMemberBillingRefTx({
+        await seedHostedMemberUsageCapacityTx({
           billingPlanCode: input.billingPlanCode,
           memberId: input.memberId,
           modules,
@@ -1266,6 +1281,7 @@ async function loadHostedMemberSeedModules(
     hostedMemberRoutingStoreModule,
     hostedMemberStoreModule,
     hostedMemberBillingStoreModule,
+    hostedStarterUsageGrantModule,
     hostedLinqDailyStateModule,
     hostedLinqLineStoreModule,
   ] = await Promise.all([
@@ -1276,6 +1292,7 @@ async function loadHostedMemberSeedModules(
     import(hostedMemberRoutingStoreModuleSpecifier),
     import(hostedMemberStoreModuleSpecifier),
     import(hostedMemberBillingStoreModuleSpecifier),
+    import(hostedStarterUsageGrantModuleSpecifier),
     import(hostedLinqDailyStateModuleSpecifier),
     import(hostedLinqLineStoreModuleSpecifier),
   ]);
@@ -1295,6 +1312,8 @@ async function loadHostedMemberSeedModules(
   const typedHostedMemberStoreModule = hostedMemberStoreModule as HostedMemberStoreModule;
   const typedHostedMemberBillingStoreModule =
     hostedMemberBillingStoreModule as HostedMemberBillingStoreModule;
+  const typedHostedStarterUsageGrantModule =
+    hostedStarterUsageGrantModule as HostedStarterUsageGrantModule;
   const typedHostedLinqDailyStateModule =
     hostedLinqDailyStateModule as HostedLinqDailyStateModule;
   const typedHostedLinqLineStoreModule =
@@ -1320,6 +1339,8 @@ async function loadHostedMemberSeedModules(
     upsertHostedMemberIdentity: typedHostedMemberIdentityStoreModule.upsertHostedMemberIdentity,
     incrementHostedLinqInboundDailyState:
       typedHostedLinqDailyStateModule.incrementHostedLinqInboundDailyState,
+    ensureHostedStarterUsageGrantTx:
+      typedHostedStarterUsageGrantModule.ensureHostedStarterUsageGrantTx,
     projectHostedLinqLineForDeliveryReceiptTx:
       typedHostedLinqLineStoreModule.projectHostedLinqLineForDeliveryReceiptTx,
     upsertHostedLinqLineForPhoneTx:
@@ -1380,7 +1401,7 @@ function readHostedJunctionReplayProviderAccountBlindIndexKey(
   return decodeHostedDeviceRoutingIndexKey(value);
 }
 
-async function seedHostedMemberBillingRefTx(input: {
+async function seedHostedMemberUsageCapacityTx(input: {
   billingPlanCode?: HostedMemberTestSeedBillingPlanCode;
   memberId: string;
   modules: HostedMemberSeedModules;
@@ -1389,6 +1410,12 @@ async function seedHostedMemberBillingRefTx(input: {
   tx: unknown;
 }): Promise<void> {
   if (!input.billingPlanCode) {
+    await input.modules.ensureHostedStarterUsageGrantTx({
+      effectiveAt: new Date(),
+      memberId: input.memberId,
+      source: "web_onboarding",
+      tx: input.tx,
+    });
     return;
   }
 


### PR DESCRIPTION
## Why this PR exists

The private PR's required paired hosted workflow began failing after the non-expiring Starter-usage change reached public `main`. Runtime evidence proved that hosted-local members were created with active access but neither paid-plan evidence nor the Starter grant that production onboarding creates, so the control plane correctly returned `ai_usage_denied` before the fixture could exercise the runtime behavior under test.

## User goal / user-visible behavior

Paired public/private hosted integration checks should create a production-valid Starter member and test the intended runtime path instead of stopping at an accidental zero-capacity fixture state.

## User experience

No user-facing effect. Production access, onboarding, billing, usage admission, messaging, and runtime behavior are unchanged; this repairs test-only member setup.

## Invariants

- Production usage admission must remain fail-closed when a member has no paid allowance or Starter credit.
- A hosted-local member without an explicit paid plan must receive capacity through the existing idempotent Starter-grant owner, matching production onboarding.
- A hosted-local member with an explicit paid plan must keep using the existing paid billing-ref fixture and must not also receive Starter credit.
- The member, crypto roots, and capacity setup remain in one database transaction.

## Changelog

- Changelog: not applicable
- Reason: This changes a test fixture only and has no member-visible behavior.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: The diff is test-only, but it controls the paired hosted runtime/deploy gate and models billing/usage admission.

ReviewGPT first-reviewed head: 17f90895dc73697e2c18ae37eba057a76075a45e

Current pushed head: 382bed3b950bf4d6e570361faa671c55184ab5d9. This is a clean base-only refresh of the exact reviewed change onto current `main`; its stable patch ID is unchanged, so repository policy requires fresh CI but no ReviewGPT rerun.

## Non-obvious affected surfaces

- The shared `seedHostedActiveMember` and `seedHostedActiveLinqMember` fixtures now model production Starter capacity when no paid plan is supplied. Direct paired local proof covers the Linq scheduled-reminder path that previously stalled at usage admission.
- Explicit paid-plan fixture calls are unchanged and still write only the paid billing reference.

## Architecture and reuse

- Existing systems reused: The production `ensureHostedStarterUsageGrantTx` ledger owner and the existing transactional hosted-member test seed.
- New logic: The test seed selects Starter capacity when no explicit paid billing plan is requested.
- New abstractions: None; the existing seed helper and production grant primitive are sufficient.
- Complexity intentionally avoided: No production bypass, test-only environment switch, duplicate credit insert, admission exception, fallback scheduler, or new state owner was added.

## Hot reply path impact

- Path status: Not applicable — only test support changed.
- Database calls: None in production; no production call path changed.
- Network/provider calls: None.
- Other awaited latency: None in production.
- Before/after proof: The exact paired local Linq scheduled-reminder scenario changed from deterministic `ai_usage_denied` timeout to 2/2 passing tests without altering production code.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no prompt or provider-input builder changed.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Preliminary specialist lenses

- Product experience: not applicable — no product journey or member-facing behavior changed.
- Prompt: not applicable — no prompt, tool description, schema, or request assembly changed.
- Frontend: not applicable — no presentation code changed.
- Coverage: applicable — this fixture is the shared admission setup for hosted full-stack scenarios; the exact previously failing paired scenario passes against the private Temporal worker candidate.
- Preliminary specialist result: timing-valid `SPECIALIST_OUTCOME: PASS` at exact head `17f90895dc73697e2c18ae37eba057a76075a45e`; no findings and no patch artifact.
- Final round 1 result: timing-valid `ROUND_OUTCOME: PASS` at the same exact head; no findings.

## Design proof

- Design page: Not applicable — no user-facing frontend UI changed.
- Coverage: Not applicable — no component or section changed.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: The only touched path is shared test support under `apps/web/test/**`; there are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 30 | 3 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **30** | **3** |

## Verification

- `pnpm --filter @murphai/hosted-web typecheck` — passed.
- `MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=<PRIVATE_TEMPORAL_PACKAGE> pnpm hosted-local e2e linq-scheduled-reminder` — passed, 1 file and 2 tests, against private worker head `a5044576391f3cfa0f2fead4aed6a09f437d95f0`.
- `git diff --check` — passed.
- `git merge-tree --write-tree <CURRENT_HEAD> origin/main` — clean against current public `main`; result tree `b8adf6ddb4fb0f207cd57a02479e455a68015b77`.
- Stable patch identity across the exact reviewed and base-refreshed commits — unchanged: `c04a8cd8a3d5dcce42d17b2ff9652f5e77306f6d`.
