### PR TITLE
Fix ReviewGPT PR context binding

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-10-reviewgpt-pr-context-guard.md
+++ b/agent-docs/exec-plans/completed/2026-08-10-reviewgpt-pr-context-guard.md
@@ -1,0 +1,92 @@
+# Fail closed when PR ReviewGPT context is missing
+
+Status: completed
+Created: 2026-08-10
+Updated: 2026-08-10
+
+## Goal
+
+- Make the canonical Murph ReviewGPT command fail closed before upload when a
+  PR-only preset is not bound to its exact pushed PR head and review phase.
+
+## Success criteria
+
+- `pnpm review:gpt completion-specialists ...` automatically packages the
+  current branch PR as a preliminary review without requiring callers to copy
+  two environment variables.
+- `pnpm review:gpt pr-review ...` automatically packages the current branch PR
+  as a final review.
+- Explicit mismatched phases, dirty worktrees, and non-matching pushed heads
+  fail before ReviewGPT can stage or send an attachment.
+- Generic ReviewGPT presets continue to invoke the package without PR lookup.
+- Focused tests, shell syntax validation, typecheck, and an exact-head dry run
+  prove the guarded entrypoint.
+
+## Scope
+
+- In scope: the existing ReviewGPT PR-head preflight, the root package command,
+  focused regression tests, and the live PR-review workflow documentation.
+- Out of scope: changing ReviewGPT prompts or their required evidence,
+  modifying the external package, and changing generic audit packaging.
+
+## Constraints
+
+- Technical constraints: keep the published `@cobuild/review-gpt` package as
+  the runner; preserve the existing one-argument preflight command; avoid a
+  second wrapper or duplicated packaging implementation.
+- Product/process constraints: required PR evidence remains fail-closed and
+  exact-head; the change must not weaken review validity to hide workflow
+  errors.
+
+## Risks and mitigations
+
+1. Risk: the guard could accidentally require GitHub context for exploratory
+   audits.
+   Mitigation: activate it only for the canonical PR preset names and aliases,
+   with a regression test for a generic preset.
+2. Risk: auto-detection could review the wrong branch or stale head.
+   Mitigation: resolve the current branch PR and retain the existing clean-tree
+   and exact-SHA checks before invoking the package.
+3. Risk: callers could supply a contradictory phase.
+   Mitigation: reject a mismatched explicit phase instead of overriding it.
+
+## Tasks
+
+1. Completed: extended the existing preflight with a package-run mode that
+   recognizes PR presets, resolves their PR context, and exports the required
+   phase.
+2. Completed: routed the root `review:gpt` command through that mode while
+   preserving the package as the implementation.
+3. Completed: added focused behavior tests and updated the PR ReviewGPT
+   workflow examples.
+4. Completed locally: ran scoped verification. Exact pushed-head proof follows
+   after this plan-closing commit opens its PR.
+
+## Decisions
+
+- Preserve the prompt's mandatory evidence contract. The invalid reviews were
+  caused by missing invocation context, not by an overly strict prompt.
+- Reuse `scripts/review-gpt-pr-head-preflight.sh` rather than add another
+  wrapper or patch the external dependency.
+
+## Verification
+
+- Commands to run: `bash -n scripts/review-gpt-pr-head-preflight.sh`, focused
+  Vitest for the guard and release-script contract, `pnpm --filter
+  @murphai/murph typecheck`, `git diff --check`, and an exact-head
+  `completion-specialists --dry-run` after the PR exists.
+- Expected outcomes: PR presets carry the correct derived PR URL and phase into
+  the package, invalid local state fails before package execution, and generic
+  presets pass through without GitHub lookup.
+- Passed: `bash -n scripts/review-gpt-pr-head-preflight.sh`.
+- Passed: focused guard Vitest, 6 tests.
+- Passed: focused root command contract Vitest, 1 test with 42 skipped.
+- Passed: `pnpm --filter @murphai/murph typecheck`.
+- Passed: `pnpm review:gpt simplify --dry-run --no-zip` through the guarded
+  package-backed entrypoint.
+- Passed: `git diff --check`.
+- The package-level `test:source -- <file>` wrapper ignored the file argument
+  and expanded into the broad CLI suite; it surfaced unrelated experiment
+  journal failures before the current session stopped that owned run. The
+  direct focused Vitest command above exercised this change and passed.
+Completed: 2026-08-10

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -86,9 +86,11 @@ Run one preliminary specialist pass when any of these lenses apply:
 - coverage: the diff changes executable behavior or changes the tests, fixtures,
   configuration, or direct-proof scaffolding that establishes its proof.
 
-The task must use a clean worktree/PR lane. Commit and push the review candidate,
-open or update the PR, and run
-`scripts/review-gpt-pr-head-preflight.sh <pr-url-or-number>`. The PR body must
+The task must use a clean worktree/PR lane. Commit and push the review candidate
+and open or update the PR. The canonical `pnpm review:gpt` command recognizes
+the PR-only preset, resolves the current branch PR, checks the clean local head
+against its pushed head, and exports the required PR ref and phase before the
+package can create an attachment. The PR body must
 declare each lens `applicable` or `not applicable`, name the product outcome and
 direct journey evidence or exact gap when applicable, name the focused local
 proof and current exact-head CI status, and list the redacted rendered-evidence
@@ -106,8 +108,6 @@ The repo config defaults response capture to 180 minutes. The workflow commands
 inherit that timeout; use `--wait-timeout` only for an intentional per-run override.
 
 ```bash
-REVIEW_GPT_PR_URL=<pr-url-or-number> \
-REVIEW_GPT_REVIEW_PHASE=preliminary \
 REVIEW_GPT_RENDERED_EVIDENCE_PATHS=$'audit-packages/<desktop>.png\naudit-packages/<mobile>.png' \
   pnpm review:gpt completion-specialists \
     --wait \
@@ -122,6 +122,11 @@ applicable. Evidence paths must be repo-relative PNG, JPEG, or WebP files under
 Redact direct identifiers and private content before packaging them. The
 packager rejects absolute paths, traversal, symlinks, missing files, unsupported
 types, and paths outside those two roots.
+
+Set `REVIEW_GPT_PR_URL` only when intentionally targeting a PR other than the
+one associated with the current branch. The guard still requires the local
+head to equal that PR's pushed head. An explicit `REVIEW_GPT_REVIEW_PHASE` must
+match the selected PR preset or the command fails before invoking ReviewGPT.
 
 The guarded ZIP contains:
 
@@ -252,16 +257,18 @@ the current user explicitly asks for it.
 
 ## One Round
 
-1. Verify the local checkout is the pushed PR head:
+1. The canonical command verifies that the local checkout is the pushed PR
+   head before invoking ReviewGPT. For a standalone preflight without starting
+   ReviewGPT, run:
 
    ```bash
    scripts/review-gpt-pr-head-preflight.sh <pr-url-or-number>
    ```
 
 2. Run ReviewGPT with the PR preset and the default randomized usable managed
-   browser lane. Set `REVIEW_GPT_REVIEW_PHASE=final` and pass the PR ref and
-   substantive round through `REVIEW_GPT_PR_URL` and
-   `REVIEW_GPT_ROUND_NUMBER`. Round 1 adds the full PR body, current patch,
+   browser lane. The command derives the final phase and current branch PR;
+   pass the substantive round through `REVIEW_GPT_ROUND_NUMBER`. Round 1 adds
+   the full PR body, current patch,
    exact round metadata, and guarded repository snapshot to `codebase.zip`:
 
    - `review-gpt-pr-context/pr-body.md`
@@ -281,8 +288,6 @@ the current user explicitly asks for it.
    reviewed head:
 
    ```bash
-   REVIEW_GPT_PR_URL=<pr-url-or-number> \
-   REVIEW_GPT_REVIEW_PHASE=final \
    REVIEW_GPT_ROUND_NUMBER=1 \
      pnpm review:gpt pr-review \
        --wait \
@@ -292,8 +297,6 @@ the current user explicitly asks for it.
    ```
 
    ```bash
-   REVIEW_GPT_PR_URL=<pr-url-or-number> \
-   REVIEW_GPT_REVIEW_PHASE=final \
    REVIEW_GPT_ROUND_NUMBER=<k> \
    REVIEW_GPT_FIRST_REVIEWED_HEAD=<round-1-full-sha> \
    REVIEW_GPT_PREVIOUS_REVIEWED_HEAD=<round-k-minus-1-full-sha> \

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "plan:open": "bash scripts/open-exec-plan.sh",
     "plan:close": "bash scripts/close-exec-plan.sh",
     "task:finish": "bash scripts/finish-task",
-    "review:gpt": "cobuild-review-gpt --config scripts/review-gpt.config.sh",
+    "review:gpt": "bash scripts/review-gpt-pr-head-preflight.sh --run",
     "benchmark:typescript": "node scripts/run-with-workspace-artifact-lock.mjs 'TypeScript benchmark' -- node scripts/run-with-host-verification-slot.mjs 'TypeScript benchmark' -- node scripts/benchmark-typescript.mjs",
     "onboard": "bash scripts/setup-host.sh",
     "chat": "pnpm exec tsx packages/cli/src/bin.ts assistant chat",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -929,7 +929,7 @@ describe('monorepo release flow coverage audit', () => {
     ]
 
     expect(rootPackageJson.scripts?.['review:gpt']).toBe(
-      'cobuild-review-gpt --config scripts/review-gpt.config.sh',
+      'bash scripts/review-gpt-pr-head-preflight.sh --run',
     )
     for (const scriptName of removedScripts) {
       expect(rootPackageJson.scripts?.[scriptName]).toBeUndefined()

--- a/packages/cli/test/review-gpt-pr-head-preflight.test.ts
+++ b/packages/cli/test/review-gpt-pr-head-preflight.test.ts
@@ -143,6 +143,17 @@ describe('ReviewGPT PR context guard', () => {
     expect(() => readFileSync(harness.capturePath, 'utf8')).toThrow()
   })
 
+  it('rejects mixed preliminary and final presets before invoking ReviewGPT', () => {
+    const harness = createHarness()
+    const result = runHarness(harness, ['completion-specialists,pr-review'])
+
+    expect(result.status).toBe(64)
+    expect(result.stderr).toContain(
+      'preliminary and final PR ReviewGPT presets cannot run together',
+    )
+    expect(() => readFileSync(harness.capturePath, 'utf8')).toThrow()
+  })
+
   it('rejects dirty or stale PR heads before invoking ReviewGPT', () => {
     const dirtyHarness = createHarness()
     writeFileSync(path.join(dirtyHarness.harnessRoot, 'untracked.txt'), 'dirty\n', 'utf8')

--- a/packages/cli/test/review-gpt-pr-head-preflight.test.ts
+++ b/packages/cli/test/review-gpt-pr-head-preflight.test.ts
@@ -1,0 +1,162 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = path.resolve(packageDir, '..', '..')
+const harnessRoots: string[] = []
+
+function writeExecutable(filePath: string, contents: string) {
+  writeFileSync(filePath, contents, 'utf8')
+  chmodSync(filePath, 0o755)
+}
+
+function createHarness() {
+  const harnessRoot = mkdtempSync(path.join(os.tmpdir(), 'murph-review-gpt-pr-guard-'))
+  const binDir = path.join(harnessRoot, 'bin')
+  const capturePath = path.join(harnessRoot, 'review-gpt-invocation.txt')
+  harnessRoots.push(harnessRoot)
+  mkdirSync(path.join(harnessRoot, 'scripts'), { recursive: true })
+  mkdirSync(binDir, { recursive: true })
+  cpSync(
+    path.join(repoRoot, 'scripts', 'review-gpt-pr-head-preflight.sh'),
+    path.join(harnessRoot, 'scripts', 'review-gpt-pr-head-preflight.sh'),
+  )
+  writeFileSync(path.join(harnessRoot, 'tracked.txt'), 'tracked\n', 'utf8')
+  writeExecutable(
+    path.join(binDir, 'gh'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == "pr view --json number --jq .number" ]]; then
+  printf '%s\\n' '42'
+elif [[ "$*" == "pr view 42 --json headRefOid --jq .headRefOid" ]]; then
+  printf '%s\\n' "\${STUB_PR_HEAD}"
+else
+  printf 'unexpected gh invocation: %s\\n' "$*" >&2
+  exit 2
+fi
+`,
+  )
+  writeExecutable(
+    path.join(binDir, 'pnpm'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'pr=%s\\n' "\${REVIEW_GPT_PR_URL:-}"
+  printf 'phase=%s\\n' "\${REVIEW_GPT_REVIEW_PHASE:-}"
+  printf 'args=%s\\n' "$*"
+} > "\${REVIEW_GPT_TEST_CAPTURE}"
+`,
+  )
+
+  execFileSync('git', ['init', '-q'], { cwd: harnessRoot })
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: harnessRoot })
+  execFileSync('git', ['config', 'user.email', 'test@users.noreply.github.com'], {
+    cwd: harnessRoot,
+  })
+  execFileSync('git', ['add', '.'], { cwd: harnessRoot })
+  execFileSync('git', ['commit', '-q', '-m', 'fixture'], { cwd: harnessRoot })
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: harnessRoot,
+    encoding: 'utf8',
+  }).trim()
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    REVIEW_GPT_PR_REF: '',
+    REVIEW_GPT_PR_URL: '',
+    REVIEW_GPT_REVIEW_PHASE: '',
+    REVIEW_GPT_TEST_CAPTURE: capturePath,
+    STUB_PR_HEAD: head,
+  }
+  return { capturePath, env, harnessRoot, head }
+}
+
+function runHarness(
+  harness: ReturnType<typeof createHarness>,
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+) {
+  return spawnSync('bash', ['scripts/review-gpt-pr-head-preflight.sh', '--run', ...args], {
+    cwd: harness.harnessRoot,
+    encoding: 'utf8',
+    env: { ...harness.env, ...envOverrides },
+  })
+}
+
+afterEach(() => {
+  for (const harnessRoot of harnessRoots.splice(0)) {
+    rmSync(harnessRoot, { force: true, recursive: true })
+  }
+})
+
+describe('ReviewGPT PR context guard', () => {
+  it.each([
+    ['completion-specialists', 'preliminary'],
+    ['pr-review', 'final'],
+    ['--preset=specialist-review', 'preliminary'],
+  ])('derives exact PR context for %s', (preset, expectedPhase) => {
+    const harness = createHarness()
+    const result = runHarness(harness, [preset, '--dry-run'])
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(readFileSync(harness.capturePath, 'utf8')).toBe(
+      `pr=42\nphase=${expectedPhase}\nargs=exec cobuild-review-gpt --config scripts/review-gpt.config.sh ${preset} --dry-run\n`,
+    )
+    expect(result.stdout).toContain(
+      `ReviewGPT PR attachment preflight passed for 42 at ${harness.head}.`,
+    )
+  })
+
+  it('leaves generic presets outside the PR workflow', () => {
+    const harness = createHarness()
+    const result = runHarness(harness, ['simplify', '--dry-run'])
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(readFileSync(harness.capturePath, 'utf8')).toBe(
+      'pr=\nphase=\nargs=exec cobuild-review-gpt --config scripts/review-gpt.config.sh simplify --dry-run\n',
+    )
+  })
+
+  it('rejects an explicit phase that conflicts with the selected preset', () => {
+    const harness = createHarness()
+    const result = runHarness(harness, ['completion-specialists'], {
+      REVIEW_GPT_REVIEW_PHASE: 'final',
+    })
+
+    expect(result.status).toBe(64)
+    expect(result.stderr).toContain(
+      'REVIEW_GPT_REVIEW_PHASE=final conflicts with the selected preliminary PR review preset',
+    )
+    expect(() => readFileSync(harness.capturePath, 'utf8')).toThrow()
+  })
+
+  it('rejects dirty or stale PR heads before invoking ReviewGPT', () => {
+    const dirtyHarness = createHarness()
+    writeFileSync(path.join(dirtyHarness.harnessRoot, 'untracked.txt'), 'dirty\n', 'utf8')
+    const dirtyResult = runHarness(dirtyHarness, ['completion-specialists'])
+    expect(dirtyResult.status).toBe(1)
+    expect(dirtyResult.stderr).toContain('requires a clean worktree')
+    expect(() => readFileSync(dirtyHarness.capturePath, 'utf8')).toThrow()
+
+    const staleHarness = createHarness()
+    const staleResult = runHarness(staleHarness, ['pr-review'], {
+      STUB_PR_HEAD: '0000000000000000000000000000000000000000',
+    })
+    expect(staleResult.status).toBe(1)
+    expect(staleResult.stderr).toContain('local HEAD does not match the pushed PR head')
+    expect(() => readFileSync(staleHarness.capturePath, 'utf8')).toThrow()
+  })
+})

--- a/scripts/review-gpt-pr-head-preflight.sh
+++ b/scripts/review-gpt-pr-head-preflight.sh
@@ -1,46 +1,153 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -ne 1 ]]; then
-  echo "Usage: scripts/review-gpt-pr-head-preflight.sh <pr-url-or-number>" >&2
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/review-gpt-pr-head-preflight.sh <pr-url-or-number>
+  scripts/review-gpt-pr-head-preflight.sh --run [review-gpt arguments...]
+EOF
   exit 64
-fi
+}
 
-pr_ref="$1"
+review_gpt_require_pr_head() {
+  local pr_ref="$1"
+  local dirty_status
+  local local_head
+  local pr_head
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "Error: gh is required to verify the pushed PR head before packaging ReviewGPT artifacts." >&2
-  exit 127
-fi
-
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  echo "Error: ReviewGPT PR preflight must run inside a git worktree." >&2
-  exit 1
-fi
-
-dirty_status="$(git status --porcelain --untracked-files=all)"
-if [[ -n "$dirty_status" ]]; then
-  echo "Error: ReviewGPT PR attachment preflight requires a clean worktree before packaging pushed-head artifacts." >&2
-  echo "$dirty_status" | sed -n '1,40p' >&2
-  if [[ "$(printf '%s\n' "$dirty_status" | wc -l | tr -d ' ')" -gt 40 ]]; then
-    echo "... additional dirty paths omitted" >&2
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh is required to verify the pushed PR head before packaging ReviewGPT artifacts." >&2
+    exit 127
   fi
-  exit 1
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: ReviewGPT PR preflight must run inside a git worktree." >&2
+    exit 1
+  fi
+
+  dirty_status="$(git status --porcelain --untracked-files=all)"
+  if [[ -n "$dirty_status" ]]; then
+    echo "Error: ReviewGPT PR attachment preflight requires a clean worktree before packaging pushed-head artifacts." >&2
+    echo "$dirty_status" | sed -n '1,40p' >&2
+    if [[ "$(printf '%s\n' "$dirty_status" | wc -l | tr -d ' ')" -gt 40 ]]; then
+      echo "... additional dirty paths omitted" >&2
+    fi
+    exit 1
+  fi
+
+  local_head="$(git rev-parse --verify HEAD)"
+  pr_head="$(gh pr view "$pr_ref" --json headRefOid --jq '.headRefOid')"
+
+  if [[ ! "$pr_head" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Error: could not resolve pushed PR head SHA for $pr_ref." >&2
+    exit 1
+  fi
+
+  if [[ "$local_head" != "$pr_head" ]]; then
+    echo "Error: local HEAD does not match the pushed PR head." >&2
+    echo "local HEAD: $local_head" >&2
+    echo "PR head:    $pr_head" >&2
+    exit 1
+  fi
+
+  echo "ReviewGPT PR attachment preflight passed for $pr_ref at $local_head."
+}
+
+review_gpt_phase_for_preset() {
+  case "$1" in
+    completion-specialists | completion-review | specialist-review | prompt-frontend-coverage)
+      printf 'preliminary\n'
+      ;;
+    pr-review | pr-deep-review | deep-pr-review | pr-bugs-and-architecture)
+      printf 'final\n'
+      ;;
+  esac
+}
+
+review_gpt_detect_pr_phase() {
+  local argument
+  local detected_phase=""
+  local phase
+  local positional_presets=1
+  local preset_token
+  local preset_value
+  local read_preset_value=0
+
+  for argument in "$@"; do
+    preset_value=""
+    if [[ "$read_preset_value" == "1" ]]; then
+      preset_value="$argument"
+      read_preset_value=0
+    elif [[ "$argument" == "--preset" ]]; then
+      read_preset_value=1
+      positional_presets=0
+      continue
+    elif [[ "$argument" == --preset=* ]]; then
+      preset_value="${argument#--preset=}"
+      positional_presets=0
+    elif [[ "$positional_presets" == "1" && "$argument" != -* ]]; then
+      preset_value="$argument"
+    elif [[ "$argument" == -* ]]; then
+      positional_presets=0
+    fi
+
+    [[ -z "$preset_value" ]] && continue
+    while IFS= read -r preset_token; do
+      [[ -z "$preset_token" ]] && continue
+      phase="$(review_gpt_phase_for_preset "$preset_token")"
+      [[ -z "$phase" ]] && continue
+      if [[ -n "$detected_phase" && "$detected_phase" != "$phase" ]]; then
+        echo "Error: preliminary and final PR ReviewGPT presets cannot run together." >&2
+        exit 64
+      fi
+      detected_phase="$phase"
+    done < <(printf '%s\n' "$preset_value" | tr ',' '\n')
+  done
+
+  printf '%s\n' "$detected_phase"
+}
+
+review_gpt_run() {
+  local detected_phase
+  local explicit_phase="${REVIEW_GPT_REVIEW_PHASE:-}"
+  local pr_ref="${REVIEW_GPT_PR_URL:-${REVIEW_GPT_PR_REF:-}}"
+
+  detected_phase="$(review_gpt_detect_pr_phase "$@")"
+  if [[ -n "$detected_phase" ]]; then
+    if [[ -n "$explicit_phase" && "$explicit_phase" != "$detected_phase" ]]; then
+      echo "Error: REVIEW_GPT_REVIEW_PHASE=$explicit_phase conflicts with the selected $detected_phase PR review preset." >&2
+      exit 64
+    fi
+    if [[ -z "$pr_ref" ]]; then
+      if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh is required to resolve the current branch PR for ReviewGPT." >&2
+        exit 127
+      fi
+      pr_ref="$(gh pr view --json number --jq '.number')"
+    fi
+    if [[ -z "$pr_ref" ]]; then
+      echo "Error: could not resolve a PR for the current branch." >&2
+      exit 1
+    fi
+    review_gpt_require_pr_head "$pr_ref"
+    export REVIEW_GPT_PR_URL="$pr_ref"
+    export REVIEW_GPT_REVIEW_PHASE="$detected_phase"
+  fi
+
+  exec pnpm exec cobuild-review-gpt --config scripts/review-gpt.config.sh "$@"
+}
+
+if [[ "${1:-}" == "--run" ]]; then
+  shift
+  review_gpt_run "$@"
 fi
 
-local_head="$(git rev-parse --verify HEAD)"
-pr_head="$(gh pr view "$pr_ref" --json headRefOid --jq '.headRefOid')"
-
-if [[ ! "$pr_head" =~ ^[0-9a-f]{40}$ ]]; then
-  echo "Error: could not resolve pushed PR head SHA for $pr_ref." >&2
-  exit 1
+if [[ "$#" -ne 1 ]]; then
+  usage
 fi
 
-if [[ "$local_head" != "$pr_head" ]]; then
-  echo "Error: local HEAD does not match the pushed PR head." >&2
-  echo "local HEAD: $local_head" >&2
-  echo "PR head:    $pr_head" >&2
-  exit 1
-fi
-
-echo "ReviewGPT PR attachment preflight passed for $pr_ref at $local_head."
+review_gpt_require_pr_head "$1"


### PR DESCRIPTION
## Why

The preliminary ReviewGPT lane could invoke the PR-only `completion-specialists` preset without `REVIEW_GPT_PR_URL` or `REVIEW_GPT_REVIEW_PHASE`. That produced a valid generic repository ZIP but omitted the mandatory PR-context artifacts, so the reviewer correctly returned `INVALID` only after the browser upload and model run had already consumed time.

## User-visible goal and applicable UX

This is an operator and agent workflow correction with no product UI. The canonical `pnpm review:gpt` command now makes PR-only presets work from a clean pushed PR branch without copied environment boilerplate, and it fails locally before browser staging when the branch is dirty, stale, or explicitly bound to the wrong phase.

## Invariants

- The mandatory PR body, patch, changed-file manifest, phase or round metadata, and rendered-evidence manifest remain required.
- The reviewed local commit must equal the pushed PR head before packaging.
- Preliminary and final presets cannot share a run or silently override an explicit conflicting phase.
- Generic ReviewGPT presets remain package-backed and do not require GitHub PR context.
- The installed `@cobuild/review-gpt` dependency remains the current `0.5.124` release.

## Architecture and reuse

The root command reuses the existing `scripts/review-gpt-pr-head-preflight.sh` owner instead of adding another wrapper or forking the ReviewGPT package. Its new run mode recognizes the configured PR preset names and aliases, resolves the current branch PR when no explicit target is supplied, reuses the existing clean-tree and exact-head checks, exports the derived PR ref and phase, then replaces itself with the installed package runner. The guarded ZIP packager and prompt evidence contract are unchanged.

- Existing systems reused: the PR-head preflight, guarded full-ZIP packager, GitHub CLI PR lookup, and installed `@cobuild/review-gpt` package runner.
- New logic: one run mode derives preliminary or final context from PR-only preset names, resolves the current branch PR, and rejects conflicting phases before package execution.
- New abstractions: none; the behavior stays in small functions inside the existing owner script.
- Complexity intentionally avoided: no second wrapper, dependency patch, new package, prompt relaxation, or duplicate ZIP implementation.

## Verification

- `bash -n scripts/review-gpt-pr-head-preflight.sh`
- `pnpm exec vitest run packages/cli/test/review-gpt-pr-head-preflight.test.ts --config packages/cli/vitest.workspace.ts --no-coverage` — 7 passed
- `pnpm exec vitest run packages/cli/test/release-script-coverage-audit.test.ts --config packages/cli/vitest.workspace.ts --no-coverage -t 'exposes only the package-backed review-gpt runner'` — 1 passed
- `pnpm --filter @murphai/murph typecheck`
- `pnpm review:gpt simplify --dry-run --no-zip`
- Exact pushed head: `pnpm review:gpt completion-specialists --dry-run` auto-resolved PR #1606, verified head `131fe623408261489a52aa6c6ba73d003d05e13c`, and packaged all five mandatory preliminary PR-context files without manual PR or phase variables.\n- The final base-only rebase onto current `main` preserved both patch IDs; focused checks were rerun on the pushed head. The already-valid preliminary ReviewGPT pass was not repeated for base-only movement, per workflow.
- `git diff --check`

The package-level `test:source -- <file>` wrapper expanded to unrelated CLI tests instead of honoring the file target; the direct focused Vitest invocation above exercises this change and passes. Exact-head CI is running against the final rebased head.

## Preliminary review lenses

- Product experience: not applicable — no member-facing journey changes.
- Prompt: not applicable — prompt content and evidence requirements are unchanged.
- Frontend: not applicable — no UI files or rendered states changed.
- Coverage: applicable — focused tests prove preliminary and final phase derivation, alias handling, generic pass-through, conflicting phase rejection, dirty-tree rejection, and stale-head rejection.
- Product outcome: PR ReviewGPT runs cannot send a generic ZIP through the canonical command when a PR-only preset is selected.
- Direct journey evidence: focused shell harnesses exercise the command through its package-exec boundary.
- Rendered evidence: none; frontend is not applicable.

## Change breakdown

- Source: +139 / -32 (`package.json` and the existing preflight script)
- Tests: +163 / -1
- Docs: +108 / -13
- Config/tooling: included in source above
- Generated/other: +0 / -0

## Design proof

Not applicable; no frontend surface changed.


## Changelog

- Changelog: not applicable
- Reason: This changes internal review tooling and has no member-visible behavior.

