### PR TITLE
Align hosted E2E with Starter cutover

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -584,6 +584,14 @@ function readHostedLocalAssistantProviderResponsePayload(
     : scriptedResponse;
 }
 
+function isHostedLocalAssistantProviderHeldTextResponse(
+  scriptedResponse: HostedLocalAssistantProviderScriptedResponsePayload,
+): scriptedResponse is HostedLocalAssistantProviderHeldTextResponse {
+  return typeof scriptedResponse === "object"
+    && scriptedResponse !== null
+    && "text" in scriptedResponse;
+}
+
 function normalizeHostedLocalAssistantProviderResponsePayload(
   scriptedResponse: HostedLocalAssistantProviderScriptedResponsePayload,
 ): HostedLocalAssistantProviderScriptedResponsePayload {
@@ -736,13 +744,15 @@ async function prepareAssistantProviderScriptedResponse(
   return scriptedResponse.text;
 }
 
-function writeAssistantProviderResponsesApiStubStream(input: {
+async function writeAssistantProviderResponsesApiStubStream(input: {
+  beforeContent?: (() => Promise<void> | void) | null;
   modelId: string;
+  onStarted?: (() => void) | null;
   response: ServerResponse;
   responseId: string;
   responseText: string;
   usage: HostedLocalAssistantProviderUsage;
-}): void {
+}): Promise<void> {
   const messageId = `msg_${input.responseId}`;
   const content = {
     annotations: [],
@@ -778,6 +788,8 @@ function writeAssistantProviderResponsesApiStubStream(input: {
     },
     type: "response.created",
   });
+  input.onStarted?.();
+  await input.beforeContent?.();
   writeAssistantProviderSseEvent(input.response, "response.output_item.added", {
     item: {
       ...outputItem,
@@ -1093,6 +1105,28 @@ export async function startAssistantProviderStubServer(input: {
         return;
       }
 
+      if (
+        bodyJson.stream === true
+        && isHostedLocalAssistantProviderHeldTextResponse(scriptedResponse)
+      ) {
+        const responseText = scriptedResponse.text;
+        const usage = buildAssistantProviderStubUsage({
+          body,
+          responseText,
+          usageMode: input.usageMode ?? "fixed",
+        });
+        await writeAssistantProviderResponsesApiStubStream({
+          beforeContent: scriptedResponse.beforeResponse,
+          modelId,
+          onStarted: scriptedResponse.onResponseStarted,
+          response,
+          responseId,
+          responseText,
+          usage,
+        });
+        return;
+      }
+
       const preparedScriptedResponse =
         await prepareAssistantProviderScriptedResponse(scriptedResponse, {
           requestBody: body,
@@ -1143,7 +1177,7 @@ export async function startAssistantProviderStubServer(input: {
       });
 
       if (bodyJson.stream === true) {
-        writeAssistantProviderResponsesApiStubStream({
+        await writeAssistantProviderResponsesApiStubStream({
           modelId,
           response,
           responseId,

--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -197,7 +197,10 @@ function buildAssistantProviderMurphCodeModeInput(
   tool: string,
   toolArguments: Record<string, unknown>,
 ): string {
+  // Scripted provider responses cannot inspect a yielded cell and call `wait`.
+  // Keep the nested tool in the initial exec window on loaded CI runners.
   return [
+    '// @exec: {"yield_time_ms": 30000}',
     `const result = await tools.murph__${tool}(${JSON.stringify(toolArguments)});`,
     "text(result);",
   ].join("\n");

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => ({
     phase: "completed",
     redactedJson: null,
   }]),
+  reserveLocalTcpPort: vi.fn(async () => 4300),
+  reserveLocalTemporalTcpPort: vi.fn(async () => 7233),
   startHostedLocalDevHarness: vi.fn(),
   startHostedLocalOidcFixture: vi.fn(async () => ({
     jwksUrl: "http://127.0.0.1:4100/.well-known/jwks.json",
@@ -49,8 +51,8 @@ vi.mock("./hosted-local-e2e-support.js", () => ({
   buildHostLoopbackStubBaseUrl: vi.fn(() => "http://127.0.0.1:4200"),
   buildHostedLocalDeviceSyncProviderEnvClearances: vi.fn(() => ({})),
   mergeRequiredEnvProfile: vi.fn((_current, required) => required),
-  reserveLocalTemporalTcpPort: vi.fn(async () => 7233),
-  reserveLocalTcpPort: vi.fn(async () => 4300),
+  reserveLocalTemporalTcpPort: mocks.reserveLocalTemporalTcpPort,
+  reserveLocalTcpPort: mocks.reserveLocalTcpPort,
   resolveHostedAssistantLocalDevEnv: vi.fn(() => ({})),
   resolveHostedAssistantProviderMode: vi.fn(() => "live"),
   resolveHostedLocalSmokeWebEnv: vi.fn(() => ({})),
@@ -292,6 +294,32 @@ it("keeps Wrangler inspector traffic out of streamed hosted E2E logs", async () 
   } finally {
     await scenario.stop();
   }
+});
+
+it("retries startup with fresh port reservations after an address-in-use race", async () => {
+  const harness = createScenarioHarness();
+  mocks.startHostedLocalDevHarness
+    .mockRejectedValueOnce(new Error("Address already in use (0.0.0.0:4300)."))
+    .mockResolvedValueOnce(harness);
+
+  const scenario = await startScenario();
+  try {
+    expect(mocks.startHostedLocalDevHarness).toHaveBeenCalledTimes(2);
+    expect(mocks.reserveLocalTcpPort).toHaveBeenCalledTimes(4);
+    expect(mocks.reserveLocalTemporalTcpPort).toHaveBeenCalledTimes(2);
+    expect(mocks.startHostedLocalOidcFixture).toHaveBeenCalledTimes(2);
+  } finally {
+    await scenario.stop();
+  }
+});
+
+it("does not retry non-port startup failures", async () => {
+  mocks.startHostedLocalDevHarness.mockRejectedValueOnce(
+    new Error("Hosted local database migration failed."),
+  );
+
+  await expect(startScenario()).rejects.toThrow("Hosted local database migration failed.");
+  expect(mocks.startHostedLocalDevHarness).toHaveBeenCalledOnce();
 });
 
 it("forwards explicitly supplied provider credentials to the worker harness", async () => {

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
@@ -84,6 +84,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const reuseExplicitDatabaseUrlEnv = "MURPH_HOSTED_LOCAL_E2E_REUSE_DATABASE_URL";
+const maxHostedLocalFullStackStartupAttempts = 3;
 const preparedRunnerBundleCacheKeys = new Set<string>();
 
 interface HostedActiveMemberSeedArgs {
@@ -200,7 +201,7 @@ export interface HostedLocalFullStackScenario {
   ): Promise<HostedJunctionDeviceSyncReplaySeedResult>;
 }
 
-export async function startHostedLocalFullStackScenario(input: {
+interface HostedLocalFullStackScenarioInput {
   additionalEnv?: NodeJS.ProcessEnv;
   assistantProviderMode?: HostedLocalAssistantProviderMode;
   assistantProviderMaxResponsesApiRequestBodies?: number;
@@ -226,7 +227,30 @@ export async function startHostedLocalFullStackScenario(input: {
   streamLogs?: boolean;
   testControls?: boolean;
   webProcessEnvOverrides?: NodeJS.ProcessEnv;
-}): Promise<HostedLocalFullStackScenario> {
+}
+
+export async function startHostedLocalFullStackScenario(
+  input: HostedLocalFullStackScenarioInput,
+): Promise<HostedLocalFullStackScenario> {
+  for (let attempt = 1; attempt <= maxHostedLocalFullStackStartupAttempts; attempt += 1) {
+    try {
+      return await startHostedLocalFullStackScenarioAttempt(input);
+    } catch (error) {
+      if (
+        attempt === maxHostedLocalFullStackStartupAttempts
+        || !isHostedLocalPortBindCollision(error)
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error("Hosted local full-stack startup exhausted its bounded attempts.");
+}
+
+async function startHostedLocalFullStackScenarioAttempt(
+  input: HostedLocalFullStackScenarioInput,
+): Promise<HostedLocalFullStackScenario> {
   const assistantProviderRequests: HostedLocalAssistantProviderStubRequest[] = [];
   const providerRequestBodyFingerprintSecret = randomUUID();
   const assistantProviderStubState: HostedLocalAssistantProviderStubState = {
@@ -605,6 +629,20 @@ export async function startHostedLocalFullStackScenario(input: {
     await localDatabase.cleanup().catch(() => {});
     throw error;
   }
+}
+
+function isHostedLocalPortBindCollision(error: unknown): boolean {
+  if (error instanceof AggregateError) {
+    return error.errors.some(isHostedLocalPortBindCollision);
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return ("code" in error && error.code === "EADDRINUSE")
+    || /\baddress already in use\b/ui.test(error.message)
+    || /\bport \d+ is already in use\b/ui.test(error.message);
 }
 
 export function buildHostedLocalFullStackWebProcessEnvOverrides(

--- a/apps/cloudflare/test/hosted-local-device-connect-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-device-connect-e2e.test.ts
@@ -270,7 +270,7 @@ describe("hosted local device connect e2e", () => {
   );
 
   it(
-    "binds rejected subscription actions to one real mailbox input across signed Web control",
+    "binds idempotent subscription actions to one real mailbox input across signed Web control",
     async () => {
       await requireScenario().seedActiveHostedMember({
         billingPlanCode: "launch_monthly",
@@ -308,15 +308,15 @@ describe("hosted local device connect e2e", () => {
         assistantInputId,
       };
 
-      await expect(subscriptionPort.request(request)).rejects.toMatchObject({
-        code: "HOSTED_PULSE_TRIAL_START_PAID_UNSUPPORTED",
-        status: 409,
-        statusCode: 409,
+      await expect(subscriptionPort.request(request)).resolves.toMatchObject({
+        action: "continue_pulse",
+        plan: { code: "launch_monthly" },
+        status: "no_action_required",
       });
-      await expect(subscriptionPort.request(request)).rejects.toMatchObject({
-        code: "HOSTED_PULSE_TRIAL_START_PAID_UNSUPPORTED",
-        status: 409,
-        statusCode: 409,
+      await expect(subscriptionPort.request(request)).resolves.toMatchObject({
+        action: "continue_pulse",
+        plan: { code: "launch_monthly" },
+        status: "no_action_required",
       });
       await expect(subscriptionPort.request({
         action: "upgrade_edge",

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -114,6 +114,55 @@ describe("startAssistantProviderStubServer", () => {
     }
   });
 
+  it("starts held Responses API streams before releasing their content", async () => {
+    let release = (): void => {};
+    let markStarted = (): void => {};
+    const releasePromise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const server = await startAssistantProviderStubServer({
+      responseState: {
+        queuedResponses: [{
+          beforeResponse: () => releasePromise,
+          onResponseStarted: markStarted,
+          text: "held streamed reply",
+        }],
+      },
+    });
+
+    try {
+      const responsePromise = fetch(
+        `${buildHostLoopbackStubBaseUrl(server, "assistant provider test")}/v1/responses`,
+        {
+          body: JSON.stringify({
+            input: [],
+            model: "gpt-5.6-terra",
+            stream: true,
+          }),
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          method: "POST",
+        },
+      );
+
+      await started;
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      release();
+      const body = await response.text();
+      expect(body).toContain("response.created");
+      expect(body).toContain("response.completed");
+      expect(body).toContain("held streamed reply");
+    } finally {
+      release();
+      await stopHttpStubServer(server);
+    }
+  });
+
   it("streams a scripted function_call item for tool-call turns", async () => {
     const server = await startAssistantProviderStubServer({
       responseState: {

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -200,6 +200,8 @@ describe("startAssistantProviderStubServer", () => {
       expect(body).toContain("response.completed");
       expect(body).toContain('"type":"custom_tool_call"');
       expect(body).toContain('"name":"exec"');
+      expect(body).toContain("yield_time_ms");
+      expect(body).toContain("30000");
       expect(body).toContain("tools.murph__automation");
       expect(body).toContain("Morning reminder");
     } finally {

--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -423,7 +423,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       );
       expect(overlapForegroundWebhookResponse.status).toBe(202);
       await waitForAssistantProviderResponsesApiRequestCount(
-        overlapProviderBaselineCount + 2,
+        overlapProviderBaselineCount + 3,
         userId,
       );
       const foregroundOverlapProviderRequest =
@@ -434,11 +434,6 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         request: foregroundOverlapProviderRequest,
         userId,
       });
-      heldOverlapReminderResponse.release();
-      await waitForAssistantProviderResponsesApiRequestCount(
-        overlapProviderBaselineCount + 3,
-        userId,
-      );
 
       const overlapForegroundSend = await requireLinqStub().waitForAdditionalSend({
         baselineCount: overlapForegroundCardBaselineCount,
@@ -470,6 +465,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         scenario: requireScenario(),
         userId,
       });
+      heldOverlapReminderResponse.release();
       const overlapReminderSend = await requireLinqStub().waitForAdditionalSend({
         baselineCount: overlapReminderSendBaselineCount,
         expectedPath: reminderPath,

--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -41,27 +41,8 @@ const scheduledReminderImageAlt = "Sleep reminder illustration";
 const scheduledReminderDeliveredText =
   `${reminderText}\n\n${scheduledReminderImageAlt}`;
 const overlapReminderText = "Time to sleep. This is the overlap reminder.";
-const overlapForegroundInboundText = "Show the daily nutrition summary as a card.";
-const overlapForegroundNutritionCard = {
-  kind: "daily_nutrition",
-  version: 2,
-  localDate: "2026-07-28",
-  mealCount: 3,
-  totals: {
-    calories: { mealCount: 3, total: 1_490.25 },
-    carbsGrams: { mealCount: 3, total: 193.125 },
-    fatGrams: { mealCount: 3, total: 34.75 },
-    fiberGrams: { mealCount: 3, total: 26.5 },
-    proteinGrams: { mealCount: 3, total: 94.5 },
-  },
-  goals: {
-    calories: { status: "under_target", target: 2_100 },
-    carbsGrams: { status: "on_target", target: 220 },
-    fatGrams: { status: "on_target", target: 40 },
-    fiberGrams: { status: "under_target", target: 30 },
-    proteinGrams: { status: "on_target", target: 100 },
-  },
-} as const;
+const overlapForegroundInboundText = "Still there while the bedtime reminder is due?";
+const overlapForegroundReplyText = "Yep, I am here.";
 const wakePreservationWindowRequestText =
   "Confirm the hosted-local wake-preservation checkpoint window.";
 const wakePreservationWindowReplyText =
@@ -370,37 +351,30 @@ describe("hosted local Linq scheduled reminder e2e", () => {
     );
     requireScenario().queueAssistantResponses([
       heldOverlapReminderResponse.response,
+      buildHostedAssistantNotificationDecisionResponse({
+        privateSummary: "deliver overlap sleep reminder after foreground reply",
+        text: overlapReminderText,
+      }),
     ], {
       matchInputContains: scheduledReminderInstructions,
     });
     requireScenario().queueAssistantResponses([
-      buildAssistantProviderMurphToolCall("attach_response_card", {
-        card: overlapForegroundNutritionCard,
-      }),
-      { text: "" },
+      overlapForegroundReplyText,
     ], {
       matchInputContains: overlapForegroundInboundText,
     });
     const overlapProviderBaselineCount = countAssistantProviderResponsesApiRequests();
-    const overlapForegroundCardMatcher = createObservedLinqIMessageAppCardMatcher();
+    const overlapForegroundReplyMatcher =
+      createObservedLinqMessageTextMatcher(overlapForegroundReplyText);
     const overlapReminderMatcher =
       createObservedLinqMessageTextMatcher(overlapReminderText);
     const overlapForegroundSendBaselineCount = requireLinqStub().countObservedSends(reminderPath);
-    const overlapForegroundCardBaselineCount =
-      requireLinqStub().countObservedSends(reminderPath, overlapForegroundCardMatcher);
     const overlapCreateChatBaselineCount = requireLinqStub().countObservedRequests({
       expectedMethod: "POST",
       expectedPath: requireLinqStub().createChatPath,
     });
-    const capabilityPath = "/capability/check_imessage";
-    const capabilityMatcher = requireLinqStub().createIMessageCapabilityRequestMatcher({
-      address: memberPhone,
-    });
-    const overlapCapabilityBaselineCount = requireLinqStub().countObservedRequests({
-      expectedMethod: "POST",
-      expectedPath: capabilityPath,
-      matchRequest: capabilityMatcher,
-    });
+    const overlapForegroundReplyBaselineCount =
+      requireLinqStub().countObservedSends(reminderPath, overlapForegroundReplyMatcher);
     const overlapReminderSendBaselineCount =
       requireLinqStub().countObservedSends(reminderPath, overlapReminderMatcher);
     try {
@@ -423,7 +397,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       );
       expect(overlapForegroundWebhookResponse.status).toBe(202);
       await waitForAssistantProviderResponsesApiRequestCount(
-        overlapProviderBaselineCount + 3,
+        overlapProviderBaselineCount + 2,
         userId,
       );
       const foregroundOverlapProviderRequest =
@@ -436,35 +410,16 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       });
 
       const overlapForegroundSend = await requireLinqStub().waitForAdditionalSend({
-        baselineCount: overlapForegroundCardBaselineCount,
+        baselineCount: overlapForegroundReplyBaselineCount,
         expectedPath: reminderPath,
-        matchRequest: overlapForegroundCardMatcher,
+        matchRequest: overlapForegroundReplyMatcher,
         scenario: requireScenario(),
         userId,
       });
-      expect(requireLinqStub().readObservedMessageText(overlapForegroundSend)).toBeNull();
-      expect(requireLinqStub().readObservedMessageAppCard(overlapForegroundSend)).toMatchObject({
-        fallback_text: "Ask Murph for this card in text",
-        interactive: true,
-        layout: {
-          caption: "Jul 28 · 3 meals",
-          image_url: expect.stringMatching(
-            /^https:\/\/www\.withmurph\.ai\/imessage\/card\/v1\/[A-Za-z0-9_-]+\.png$/u,
-          ),
-        },
-        type: "imessage_app",
-        url: expect.stringMatching(/^https:\/\/www\.withmurph\.ai\/#murph-card=/u),
-      });
+      expect(requireLinqStub().readObservedMessageText(overlapForegroundSend))
+        .toBe(overlapForegroundReplyText);
       expect(requireLinqStub().countObservedSends(reminderPath))
         .toBe(overlapForegroundSendBaselineCount + 1);
-      await requireLinqStub().waitForMatchingRequestCount({
-        expectedCount: overlapCapabilityBaselineCount + 1,
-        expectedMethod: "POST",
-        expectedPath: capabilityPath,
-        matchRequest: capabilityMatcher,
-        scenario: requireScenario(),
-        userId,
-      });
       heldOverlapReminderResponse.release();
       const overlapReminderSend = await requireLinqStub().waitForAdditionalSend({
         baselineCount: overlapReminderSendBaselineCount,
@@ -481,13 +436,8 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         timeoutMs: scheduledReminderCompletionWaitMs,
       });
       expect(overlapFinalStatus.lastErrorCode ?? null).toBeNull();
-      expect(requireLinqStub().countObservedSends(reminderPath, overlapForegroundCardMatcher))
-        .toBe(overlapForegroundCardBaselineCount + 1);
-      expect(requireLinqStub().countObservedRequests({
-        expectedMethod: "POST",
-        expectedPath: capabilityPath,
-        matchRequest: capabilityMatcher,
-      })).toBe(overlapCapabilityBaselineCount + 1);
+      expect(requireLinqStub().countObservedSends(reminderPath, overlapForegroundReplyMatcher))
+        .toBe(overlapForegroundReplyBaselineCount + 1);
       expect(requireLinqStub().countObservedSends(reminderPath, overlapReminderMatcher))
         .toBe(overlapReminderSendBaselineCount + 1);
       expect(requireLinqStub().countObservedSends(reminderPath))
@@ -1037,10 +987,6 @@ function createObservedLinqMessageTextMatcher(
   expectedText: string,
 ): ObservedLinqRequestMatcher {
   return (request) => requireLinqStub().readObservedMessageText(request) === expectedText;
-}
-
-function createObservedLinqIMessageAppCardMatcher(): ObservedLinqRequestMatcher {
-  return (request) => requireLinqStub().readObservedMessageAppCard(request) !== null;
 }
 
 function resolveScheduledReminderTimes(

--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -423,7 +423,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       );
       expect(overlapForegroundWebhookResponse.status).toBe(202);
       await waitForAssistantProviderResponsesApiRequestCount(
-        overlapProviderBaselineCount + 3,
+        overlapProviderBaselineCount + 2,
         userId,
       );
       const foregroundOverlapProviderRequest =
@@ -434,6 +434,11 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         request: foregroundOverlapProviderRequest,
         userId,
       });
+      heldOverlapReminderResponse.release();
+      await waitForAssistantProviderResponsesApiRequestCount(
+        overlapProviderBaselineCount + 3,
+        userId,
+      );
 
       const overlapForegroundSend = await requireLinqStub().waitForAdditionalSend({
         baselineCount: overlapForegroundCardBaselineCount,
@@ -465,15 +470,6 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         scenario: requireScenario(),
         userId,
       });
-      requireScenario().queueAssistantResponses([
-        buildHostedAssistantNotificationDecisionResponse({
-          privateSummary: "deliver overlap sleep reminder after foreground reply",
-          text: overlapReminderText,
-        }),
-      ], {
-        matchInputContains: scheduledReminderInstructions,
-      });
-      heldOverlapReminderResponse.release();
       const overlapReminderSend = await requireLinqStub().waitForAdditionalSend({
         baselineCount: overlapReminderSendBaselineCount,
         expectedPath: reminderPath,
@@ -483,6 +479,8 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       });
       expect(requireLinqStub().readObservedMessageText(overlapReminderSend))
         .toBe(overlapReminderText);
+      expect(requireObservedRequestTimestamp(overlapForegroundSend))
+        .toBeLessThanOrEqual(requireObservedRequestTimestamp(overlapReminderSend));
       const overlapFinalStatus = await requireScenario().waitForHostedCompletion(userId, {
         timeoutMs: scheduledReminderCompletionWaitMs,
       });
@@ -1020,6 +1018,14 @@ function summarizeObservedLinqRequests(): Array<{ method: string; url: string }>
     method: request.method,
     url: request.url,
   }));
+}
+
+function requireObservedRequestTimestamp(request: ObservedLinqRequest): number {
+  const observedAtEpochMs = request.observedAtEpochMs;
+  if (typeof observedAtEpochMs !== "number" || !Number.isSafeInteger(observedAtEpochMs)) {
+    throw new Error("Expected a Linq request observation timestamp.");
+  }
+  return observedAtEpochMs;
 }
 
 function readObservedLinqMessageParts(request: ObservedLinqRequest): unknown[] {

--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -1181,12 +1181,9 @@ describe.skipIf(!runPostgresProof)(
 
       workflowBoundary.start.mockClear();
       runtimeRecheckBoundary.signal.mockReset();
-      runtimeRecheckBoundary.signal
-        .mockRejectedValueOnce(new Error("Temporal fixture unavailable"))
-        .mockResolvedValue({
-          signalAccepted: true,
-          workflowId: `hosted-user-runtime:${memberId}`,
-        });
+      runtimeRecheckBoundary.signal.mockRejectedValue(
+        new Error("Temporal fixture unavailable"),
+      );
       configureHostedStripeFixtureEnvironment({
         edgePriceId,
         pulsePriceId,
@@ -1280,6 +1277,10 @@ describe.skipIf(!runPostgresProof)(
           expect.objectContaining({ userId: memberId }),
         );
 
+        runtimeRecheckBoundary.signal.mockResolvedValue({
+          signalAccepted: true,
+          workflowId: `hosted-user-runtime:${memberId}`,
+        });
         await makeStripeReceiptImmediatelyRetryable({
           eventId: stripeEventId,
           prisma,
@@ -1360,12 +1361,9 @@ describe.skipIf(!runPostgresProof)(
 
       workflowBoundary.start.mockClear();
       runtimeRecheckBoundary.signal.mockReset();
-      runtimeRecheckBoundary.signal
-        .mockRejectedValueOnce(new Error("Temporal fixture unavailable"))
-        .mockResolvedValue({
-          signalAccepted: true,
-          workflowId: `hosted-user-runtime:${memberId}`,
-        });
+      runtimeRecheckBoundary.signal.mockRejectedValue(
+        new Error("Temporal fixture unavailable"),
+      );
       configureHostedStripeFixtureEnvironment({
         edgePriceId,
         familyEdgePriceId,
@@ -1499,6 +1497,10 @@ describe.skipIf(!runPostgresProof)(
           expect.objectContaining({ userId: memberId }),
         );
 
+        runtimeRecheckBoundary.signal.mockResolvedValue({
+          signalAccepted: true,
+          workflowId: `hosted-user-runtime:${memberId}`,
+        });
         await makeStripeReceiptImmediatelyRetryable({
           eventId: stripeEventId,
           prisma,
@@ -1596,12 +1598,9 @@ describe.skipIf(!runPostgresProof)(
 
       workflowBoundary.start.mockClear();
       runtimeRecheckBoundary.signal.mockReset();
-      runtimeRecheckBoundary.signal
-        .mockRejectedValueOnce(new Error("Temporal fixture unavailable"))
-        .mockResolvedValue({
-          signalAccepted: true,
-          workflowId: `hosted-user-runtime:${ownerMemberId}`,
-        });
+      runtimeRecheckBoundary.signal.mockRejectedValue(
+        new Error("Temporal fixture unavailable"),
+      );
       configureHostedStripeFixtureEnvironment({
         edgePriceId,
         familyEdgePriceId,
@@ -1767,6 +1766,10 @@ describe.skipIf(!runPostgresProof)(
         });
         expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(1);
 
+        runtimeRecheckBoundary.signal.mockResolvedValue({
+          signalAccepted: true,
+          workflowId: `hosted-user-runtime:${ownerMemberId}`,
+        });
         await makeStripeReceiptImmediatelyRetryable({
           eventId: stripeEventId,
           prisma,

--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -1255,7 +1255,7 @@ describe.skipIf(!runPostgresProof)(
           billingPlanCode: "launch_monthly",
           blockedAt: null,
           highestBillingPlanCode: "launch_monthly",
-          planResetAt: null,
+          planResetAt: eventCreatedAt,
           spentUsdMicros: 0n,
         });
         await expect(readPendingMailboxProof({
@@ -1300,7 +1300,7 @@ describe.skipIf(!runPostgresProof)(
           billingPlanCode: "launch_monthly",
           blockedAt: null,
           highestBillingPlanCode: "launch_monthly",
-          planResetAt: null,
+          planResetAt: eventCreatedAt,
           spentUsdMicros: 0n,
         });
         await expect(readStripeReceiptProof({

--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -1171,6 +1171,7 @@ describe.skipIf(!runPostgresProof)(
         customerId: stripeCustomerId,
         eventId: stripeEventId,
         invoiceId: stripeInvoiceId,
+        priceId: pulsePriceId,
         subscriptionId: stripeSubscriptionId,
       });
       const stripeFixture = await startHostedStripeHttpFixture({
@@ -1974,6 +1975,7 @@ function buildInvoicePaidEvent(input: {
   customerId: string;
   eventId: string;
   invoiceId: string;
+  priceId: string;
   subscriptionId: string;
 }): Stripe.Event {
   const invoiceFields = {
@@ -1982,6 +1984,18 @@ function buildInvoicePaidEvent(input: {
     charge: `ch_${input.invoiceId}`,
     customer: input.customerId,
     id: input.invoiceId,
+    lines: {
+      data: [{
+        pricing: {
+          price_details: {
+            price: input.priceId,
+            product: "prod_hosted_trial_conversion",
+          },
+          type: "price_details",
+          unit_amount_decimal: "800",
+        },
+      }],
+    },
     object: "invoice",
     payment_intent: `pi_${input.invoiceId}`,
     payments: {

--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -1022,12 +1022,9 @@ describe.skipIf(!runPostgresProof)(
 
       workflowBoundary.start.mockClear();
       runtimeRecheckBoundary.signal.mockReset();
-      runtimeRecheckBoundary.signal
-        .mockRejectedValueOnce(new Error("Temporal fixture unavailable"))
-        .mockResolvedValue({
-          signalAccepted: true,
-          workflowId: `hosted-user-runtime:${memberId}`,
-        });
+      runtimeRecheckBoundary.signal.mockRejectedValue(
+        new Error("Temporal fixture unavailable"),
+      );
       configureHostedStripeFixtureEnvironment({
         edgePriceId,
         pulsePriceId,
@@ -1103,6 +1100,10 @@ describe.skipIf(!runPostgresProof)(
           expect.objectContaining({ userId: memberId }),
         );
 
+        runtimeRecheckBoundary.signal.mockResolvedValue({
+          signalAccepted: true,
+          workflowId: `hosted-user-runtime:${memberId}`,
+        });
         await makeStripeReceiptImmediatelyRetryable({
           eventId: stripeEventId,
           prisma,

--- a/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
@@ -4815,10 +4815,16 @@ describe.skipIf(!runPostgresConcurrencyProof)(
             ),
           },
         });
+        expect(persistedPayload).toMatchObject({
+          notification: {
+            externalThreadRouteAuthority: {
+              channel: "linq",
+              containerMemberId: memberId,
+              threadId: sourceThreadId,
+            },
+          },
+        });
         const serializedPayload = JSON.stringify(persistedPayload);
-        expect(serializedPayload).not.toContain(
-          '"externalThreadRouteAuthority"',
-        );
         expect(serializedPayload).not.toContain('"conversationHistory"');
         expect(serializedPayload).not.toContain('"messages"');
         expect(serializedPayload).not.toContain('"referrer"');


### PR DESCRIPTION
## Why

The exact Murph Cloud integration runs for the landed Starter seed repair exposed seven stale or timing-sensitive test assumptions around #1464:

1. The hosted device-connect E2E still expected the removed Pulse-trial 409 even though the retained rolling-deploy action now deliberately returns an idempotent `no_action_required` response for an active Pulse member.
2. The paid-conversion replay test used a one-shot rejected mock inside a retrying processor, so its intermediate failed receipt depended on scheduler timing.
3. Scripted Code mode tool calls inherited the 10-second default yield. On a loaded runner the canned provider could advance to final text while the dynamic tool was still running, cancelling a valid Telegram reaction.
4. The scheduled-reminder overlap fixture held provider work while also requiring a two-turn nutrition-card response. Foreground takeover cancels the held background attempt by design, so the card side effect could be cancelled and the scheduled response consumed before retry.
5. Full-stack scenarios released OS-assigned ephemeral ports before several seconds of setup. A local socket could claim a released port before Wrangler bound it, producing an unrelated address-in-use failure.
6. The reminder fixture did not provide a deterministic response for the expected post-preemption retry.
7. Current `main` intentionally persists validated direct Linq audience authority, while one PostgreSQL referral test still asserted that authority was absent.

## User-visible goal and applicable UX

No product behavior changes. The Murph Cloud suite should assert the already-shipped Starter, paid-plan, Telegram reaction, scheduled-reminder, and foreground-priority contracts deterministically instead of failing on removed behavior, unrelated card composition, or runner speed.

## Invariants

- An active Pulse member receives the same idempotent `no_action_required` result for repeated legacy `continue_pulse` requests bound to one mailbox input.
- Reusing that mailbox input for a different subscription action still fails closed with the existing action-conflict error.
- The Stripe replay test holds the runtime wake boundary unavailable for the whole first processing call, inspects the failed receipt and preserved pending work, then explicitly restores the boundary before proving replay.
- Scripted Murph dynamic tools remain real Code mode calls through the production app-server path; the fixture only gives their initial exec a bounded 30-second yield window.
- A deliberately held Responses API fixture emits `response.created` immediately, holds only its content, and completes through the existing stream writer after release.
- The overlap test proves the one-turn foreground reply sends exactly once before the cancelled scheduled attempt retries and sends the reminder exactly once.
- Native nutrition-card behavior remains covered at its owning tool, response retention, outbox, Linq capability, and hosted callback boundaries instead of being coupled to reminder preemption.
- Only startup errors proven to be local port-bind collisions receive a bounded fresh full-stack attempt; database and application failures still fail immediately.
- Every startup retry rebuilds the scenario with fresh port reservations and runs the existing failed-attempt cleanup first.
- Direct Linq referral celebrations retain their validated external thread authority, matching the current durable product contract.
- Production subscription, Stripe, assistant, delivery, and retry code is unchanged.

## Architecture and reuse

- Existing systems reused: the hosted full-stack subscription tool port, mailbox action claim, Stripe fixture, runtime recheck mock, recorded webhook retry helper, Code mode exec pragma, Responses API SSE writer, scoped scripted-response queues, and full-stack scenario cleanup.
- New production logic: none.
- New logic: held SSE responses start before awaiting the gate; the reminder retry gets its own scoped response; and the full-stack entrypoint retries a fresh scenario only for a recognized port-bind race.
- New abstractions: one narrow held-response type guard and one private startup-attempt function in test support.
- Complexity intentionally avoided: no production compatibility branch, retry delay, outer timeout increase, CI-only skip, heartbeat loop, fixed port pool, or new runtime state owner.

## Verification

- `pnpm --filter @murphai/hosted-web typecheck`
- `pnpm --filter @murphai/cloudflare-runner typecheck`
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts apps/cloudflare/test/hosted-local-e2e-support.test.ts` — 39 passed on the exact rebased head
- `pnpm test:diff` — Cloudflare node suite 2,393 passed / 2 skipped; worker suite 10 passed
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree HEAD origin/main`
- Earlier base-only rebases preserved all nine branch patch IDs.
- Private run 31450208749 proved all eleven other jobs green, including Telegram and both original #1464 shards, then reproduced the reminder first-byte retry.
- Private run 31451688258 proved the held-stream correction across the completed shards and exposed the independent port reservation-to-bind race.
- Private run 31452506404 proved the port-race retry across the previously failing shard and isolated the unrelated two-turn card composition in the reminder overlap.
- Private run 31456102899 proved all hosted scenario shards green, including the reminder and port-race corrections; its only real failure was the stale current-main PostgreSQL authority assertion.
- Private run 31456752635 failed before checkout because the workflow input used an abbreviated commit id; no repository step ran.
- Final PR-patch private run 31456871246 passed its public bundle build, all eleven scenario shards, and the aggregate Temporal gate against head `61253168b35417a423b2044e338f892e68113559`.
- The final rebase onto current `main` reconciled PR #1608 by retaining the already-reviewed one-turn reminder-preemption fixture while preserving its new response-card fast-gate coverage. The final reminder E2E file is byte-for-byte identical to the privately green head. Current head `e3ac1aee82729e790ae829e76fc93a61145bbe4e` passes both affected typechecks and the 39 focused support tests; public CI is rerunning, and the unchanged private scenario matrix is not.
- The shared local test database is stale and read-restricted, including a missing current schema column. It failed before the changed PostgreSQL test body; this PR does not mutate that shared database.

## Preliminary review lenses

- Product experience: not applicable — production behavior and member-facing journeys are unchanged.
- Prompt: not applicable — no prompts or agent instructions changed.
- Frontend: not applicable — no UI files or rendered states changed.
- Coverage: applicable — these are direct hosted full-stack, PostgreSQL, provider-harness, and startup-race regression corrections.
- Product outcome: the hosted integration suite deterministically validates current Starter-era subscription, paid-conversion replay, reaction delivery, foreground-priority, scheduled retry, and full-stack startup behavior.
- Direct journey evidence: exact private integration against this pushed head.
- Rendered evidence: none; frontend is not applicable.

## Change breakdown

- Source: +0 / -0
- Tests: +251 / -116
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Design proof

Not applicable; no frontend surface changed.

## Changelog

- Changelog: not applicable
- Reason: This changes test contracts only and has no member-visible behavior.

## Preliminary ReviewGPT resolution

- Reviewed head: 06131438bb6dc37cb66e9ca3dc0fc274cc467659
- Model attestation: gpt-5-6-pro
- Outcome: one accepted medium coverage finding
- Resolution: the paid-conversion invoice carries the matching line-item price required by the hardened #1464 acceptance contract, the failed wake boundary remains unavailable until explicit replay, both usage snapshots assert the paid-transition reset timestamp, and the same phase isolation covers the sibling retry fixtures.
- Patch artifact: not applied; the finding text was inspected and the parent implemented the correction directly.
- Preliminary pass not rerun after substantive remediation, per workflow.
- Final cross-cutting gate: not applicable because the diff changes test proof only and does not alter runtime state, ordering, retry, billing, or trust-boundary behavior.






