### PR TITLE
Teach unfamiliar exercises with full-motion image sequences

### DIFF
--- a/packages/assistant-engine/skills/shared/exercise-catalog-runtime.md
+++ b/packages/assistant-engine/skills/shared/exercise-catalog-runtime.md
@@ -37,9 +37,19 @@ programmatically appropriate.
    supports response media:
    - If any movement being taught is likely unfamiliar or uncommon, attach at
      least one useful returned catalog image and normally two in the same
-     response. Prioritize the least familiar or most technique-sensitive
-     movements and the setup or endpoint frames that best explain them; attach
-     more only when different movements still need visual explanation.
+     response. Count useful frames per unfamiliar movement, not only across the
+     whole response. Prioritize the least familiar or most technique-sensitive
+     movements, and attach the available frames in exercise order so each
+     illustrated movement shows its setup, important transitions or side
+     changes, and endpoint across the full range of motion. Use at least two
+     frames for a simple start/end motion and three or more when an intermediate
+     phase is needed to make the path clear.
+   - Do not satisfy this rule with one static frame for each of several
+     unfamiliar movements. If teaching every movement completely would create a
+     long media dump, teach fewer movements at a time rather than sacrificing
+     sequence clarity. If only one useful catalog frame exists for a movement,
+     say the catalog does not yet show the full motion and keep the written cue
+     simple rather than presenting that frame as a complete walkthrough.
    - If the user clearly demonstrates relevant training fluency and every
      movement being taught is common or already familiar, omit exercise images
      unless the user asks for them.

--- a/packages/assistant-engine/test/exercise-catalog-runtime-guidance.test.ts
+++ b/packages/assistant-engine/test/exercise-catalog-runtime-guidance.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { resolveAssistantSkillsRoot } from '../src/assistant-skill-assets.js'
+
+describe('exercise catalog runtime guidance', () => {
+  it('uses ordered multi-frame media for unfamiliar movements', async () => {
+    const raw = await readFile(
+      path.join(
+        resolveAssistantSkillsRoot(),
+        'shared',
+        'exercise-catalog-runtime.md',
+      ),
+      'utf8',
+    )
+    const compact = raw.replace(/\s+/gu, ' ')
+
+    expect(compact).toContain(
+      'Count useful frames per unfamiliar movement, not only across the whole response.',
+    )
+    expect(compact).toContain(
+      'attach the available frames in exercise order so each illustrated movement shows its setup, important transitions or side changes, and endpoint across the full range of motion.',
+    )
+    expect(compact).toContain(
+      'Use at least two frames for a simple start/end motion and three or more when an intermediate phase is needed to make the path clear.',
+    )
+    expect(compact).toContain(
+      'Do not satisfy this rule with one static frame for each of several unfamiliar movements.',
+    )
+    expect(compact).toContain(
+      'teach fewer movements at a time rather than sacrificing sequence clarity.',
+    )
+    expect(compact).toContain(
+      'If only one useful catalog frame exists for a movement, say the catalog does not yet show the full motion',
+    )
+  })
+})


### PR DESCRIPTION
## Why

The exercise-media guidance currently counts images across the whole response. That allows Murph to attach one static frame for each of several unfamiliar movements while technically satisfying the instruction to include images, even though the member still cannot see how any one movement travels from setup through its endpoint.

The owning surface is the shared exercise-catalog presentation guidance loaded by mobility, physical-therapy, and strength-training skills, so this PR fixes that narrow prompt owner rather than expanding the resident top-level system prompt.

## User-visible goal and UX

When Murph is actively teaching an unfamiliar or uncommon exercise:

- count useful frames per movement, not only per response;
- send the available frames in exercise order so the member can see setup, important transitions or side changes, and the endpoint across the full range of motion;
- use at least two frames for a simple start/end movement and three or more when an intermediate phase is necessary;
- teach fewer movements at once when complete sequences would otherwise become a large media dump;
- when the catalog has only one useful frame, state that it does not show the full motion and keep the written cue simple instead of presenting the frame as a complete walkthrough.

Common or already-familiar exercises keep the existing concise behavior.

## Invariants

- Exercise choice, dose, progression, and safety remain owned by the domain skill.
- Media still comes only from reviewed catalog `images[]`; this adds no generated-image path or invented exercise asset.
- Exercise images remain limited to turns that are actually teaching or cueing a movement.
- The existing familiar/common-movement omission rule remains unchanged.
- No persisted state, tool schema, delivery owner, provider integration, or runtime branch changes.

## Architecture and reuse

- Existing owner reused: `packages/assistant-engine/skills/shared/exercise-catalog-runtime.md`.
- New behavior: one explicit per-movement sequence rule, one progressive-disclosure fallback for large media sets, and one truthful single-frame limitation.
- New abstractions: none.
- Complexity avoided: no new prompt layer, classifier, image generator, catalog field, or delivery mechanism.

## Direct proof

- Added a focused Vitest regression that pins per-movement frame counting, ordered setup/transition/endpoint coverage, the two-versus-three-frame threshold, the no-one-static-frame shortcut, progressive disclosure, and the single-frame fallback.
- The pre-existing assistant skill-asset regression continues to pin the existing unfamiliar/common-media behavior.
- Exact-head GitHub Actions: pending.

## Murph initial provider input impact

This does not change the resident top-level system prompt. It changes a lazy shared exercise-catalog reference loaded only when a relevant domain skill presents a named drill or routine. No tool schema or generated provider guidance changes.

## Preliminary specialist lenses

- Product experience: applicable — changes how an unfamiliar movement is taught and how many movements are presented at once.
- Prompt: applicable — changes model-facing exercise-media guidance.
- Frontend: not applicable — no UI or renderer changes.
- Coverage: applicable — focused guidance regression added.

ReviewGPT context sensitivity: routine

## Changelog

- Changelog: not applicable.
- Reason: this is a narrow instruction-quality correction to an existing exercise-media capability, not a new member-facing feature or release announcement.

## Change shape

Classification: the runtime skill Markdown is production prompt source; the Vitest file is tests/fixtures.

- Source/prompt: 13 added, 3 deleted.
- Tests/fixtures: 38 added, 0 deleted.
- Docs: 0 added, 0 deleted.
- Config/tooling: 0 added, 0 deleted.
- Generated/other: 0 added, 0 deleted.
