### PR TITLE
fix(web): hide patterns from sidebar

### DIFF
--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -177,6 +177,7 @@ import { DataExportControlStudy } from "./data-export-study";
 import { HealthDataConsentControlStudy } from "./health-data-consent-study";
 import { SignupReferralComponentStudy } from "./signup-referral-study";
 import { PersonalPatternsComponentStudy } from "./personal-patterns-study";
+import { DashboardSidebarStudy } from "./dashboard-sidebar-study";
 import { LegacyTrialRetirementControl } from "@/src/components/hosted-ops/legacy-trial-retirement-control";
 
 const DESIGN_SIGNED_GROUP_FUNDING_ENDPOINT =
@@ -637,6 +638,15 @@ export function ComponentsContent() {
           <h1 className="font-serif text-4xl font-semibold tracking-tight text-foreground">Components</h1>
           <p className="mt-2 text-sm text-muted-foreground">Shadcn base UI + custom Murph components. Colors and typography live in the Brand tab.</p>
         </div>
+
+        <Separator />
+
+        <Section title="Dashboard primary navigation">
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Production dashboard destinations in their standard visual hierarchy.
+          </p>
+          <DashboardSidebarStudy />
+        </Section>
 
         <Separator />
 

--- a/apps/web/app/design/dashboard-sidebar-study.tsx
+++ b/apps/web/app/design/dashboard-sidebar-study.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { SidebarPrimaryNavigation } from "@/src/components/dashboard/sidebar";
+import { SidebarProvider } from "@/src/components/ui/sidebar";
+
+export function DashboardSidebarStudy() {
+  return (
+    <div
+      className="w-full max-w-72 overflow-hidden rounded-3xl bg-linear-to-br from-[#2d3436] via-[#3a2e24] to-[#2a1f16] p-4"
+      data-design-component="dashboard-primary-navigation"
+      id="dashboard-primary-navigation-component"
+      inert
+    >
+      <SidebarProvider
+        className="min-h-0 bg-transparent"
+        style={
+          {
+            "--sidebar": "transparent",
+            "--sidebar-foreground": "rgba(255, 255, 255, 0.85)",
+            "--sidebar-accent": "rgba(255, 255, 255, 0.1)",
+            "--sidebar-accent-foreground": "#ffffff",
+            "--sidebar-ring": "rgba(255, 255, 255, 0.3)",
+          } as React.CSSProperties
+        }
+      >
+        <SidebarPrimaryNavigation pathname="/home" />
+      </SidebarProvider>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -323,36 +323,48 @@ export function Sidebar({
       </SidebarHeader>
 
       <SidebarContent className="justify-center px-2">
-        <SidebarMenu className="mb-12 gap-3 md:gap-3">
-          {navItems.map((item) => {
-            const activePrefix = item.matchPrefix ?? item.href;
-            const isActive =
-              pathname === item.href || pathname.startsWith(activePrefix);
-            const Icon = item.icon;
-
-            return (
-              <SidebarMenuItem key={item.href}>
-                <SidebarMenuButton
-                  isActive={isActive}
-                  size="lg"
-                  className={SIDEBAR_NAV_ITEM_CLASS}
-                  render={
-                    <Link href={item.href}>
-                      {Icon ? <Icon className={SIDEBAR_NAV_ICON_CLASS} /> : null}
-                      {item.label}
-                    </Link>
-                  }
-                />
-              </SidebarMenuItem>
-            );
-          })}
-          {chatAction}
-        </SidebarMenu>
+        <SidebarPrimaryNavigation chatAction={chatAction} pathname={pathname} />
       </SidebarContent>
 
       <SidebarFooter className="pb-4">
         <AccountMenu initialAuth={initialAuth} />
       </SidebarFooter>
     </ShadcnSidebar>
+  );
+}
+
+export function SidebarPrimaryNavigation({
+  chatAction,
+  pathname,
+}: {
+  chatAction?: ReactElement;
+  pathname: string;
+}) {
+  return (
+    <SidebarMenu className="mb-12 gap-3 md:gap-3">
+      {navItems.map((item) => {
+        const activePrefix = item.matchPrefix ?? item.href;
+        const isActive =
+          pathname === item.href || pathname.startsWith(activePrefix);
+        const Icon = item.icon;
+
+        return (
+          <SidebarMenuItem key={item.href}>
+            <SidebarMenuButton
+              isActive={isActive}
+              size="lg"
+              className={SIDEBAR_NAV_ITEM_CLASS}
+              render={
+                <Link href={item.href}>
+                  {Icon ? <Icon className={SIDEBAR_NAV_ICON_CLASS} /> : null}
+                  {item.label}
+                </Link>
+              }
+            />
+          </SidebarMenuItem>
+        );
+      })}
+      {chatAction}
+    </SidebarMenu>
   );
 }

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
   Activity,
-  ChartScatter,
   ChevronsUpDown,
   FlaskConical,
   Home,
@@ -77,11 +76,6 @@ const navItems: {
     href: "/biomarkers",
     matchPrefix: "/biomarkers",
     icon: Activity,
-  },
-  {
-    label: "Patterns",
-    href: "/patterns",
-    icon: ChartScatter,
   },
   { label: "Experiments", href: "/experiments", icon: FlaskConical },
 ];

--- a/apps/web/test/dashboard-sidebar.test.ts
+++ b/apps/web/test/dashboard-sidebar.test.ts
@@ -188,27 +188,16 @@ beforeEach(() => {
   mocks.setOpenMobile.mockClear();
 });
 
-test("Sidebar renders Patterns instead of the internal Overview route", () => {
+test("Sidebar hides Patterns and the internal Overview route", () => {
   mocks.usePathname.mockReturnValue("/experiments");
 
   const markup = renderToStaticMarkup(createElement(Sidebar));
 
   assert.match(markup, /href="\/home"[^>]*>\s*<svg/);
-  assert.match(markup, /href="\/patterns"/);
-  assert.match(markup, />Patterns<\/a>/);
+  assert.doesNotMatch(markup, /href="\/patterns"/);
+  assert.doesNotMatch(markup, />Patterns<\/a>/);
   assert.doesNotMatch(markup, /href="\/overview"/);
   assert.doesNotMatch(markup, />Overview<\/a>/);
-});
-
-test("Sidebar marks Patterns as active on its page", () => {
-  mocks.usePathname.mockReturnValue("/patterns");
-
-  const markup = renderToStaticMarkup(createElement(Sidebar));
-
-  assert.match(
-    markup,
-    /data-active="true">\s*<a[^>]*href="\/patterns"[^>]*>[\s\S]*Patterns<\/a>/,
-  );
 });
 
 test("Sidebar renders Environment as an active primary destination", () => {


### PR DESCRIPTION
## Why this PR exists

Patterns is not ready to be advertised in the dashboard navigation. This temporarily removes its sidebar entry while preserving direct access to the route.

## User goal / user-visible behavior

Members see Home, Environment, Biomarkers, and Experiments in the dashboard sidebar, with no Patterns destination.

## User experience

The Patterns link is absent from both desktop and mobile dashboard navigation immediately on render. Existing navigation behavior is unchanged, and `/patterns` remains directly accessible. This adds no loading, failure, or recovery state.

## Invariants

- The `/patterns` route and direct access remain intact.
- Active states for Home, Environment, Biomarkers, and Experiments remain unchanged.
- Authentication, data access, persistence, and runtime behavior are untouched.
- No private data is included in the design proof.

## Changelog

- Changelog: not applicable
- Reason: This is temporary navigation release gating, not a feature or improvement announcement; the route and product capability remain available.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: This is a small client-only navigation and design-catalog change with no trust boundary, persistence, provider, or deploy impact.

## Non-obvious affected surfaces

- The component design catalog now renders the production dashboard navigation fragment so reviewers can verify the exact destinations at desktop and mobile sizes.
- The focused sidebar regression test asserts that no Patterns link is rendered.

## Architecture and reuse

- Existing systems reused: The existing dashboard navigation data, sidebar primitives, and component design catalog.
- New logic: None beyond omitting the Patterns navigation item and asserting its absence.
- New abstractions: One small production navigation fragment is extracted so the design catalog can render the real sidebar content instead of maintaining parallel markup.
- Complexity intentionally avoided: No feature flag, redirect, route deletion, compatibility layer, or new dependency.

## Hot reply path impact

- Path status: Not applicable - this is client-side dashboard navigation only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run - no provider-input surface changed.

## Preliminary specialist lenses

- Product experience: Applicable. The visible destination set changes; direct desktop and mobile proof confirms the remaining hierarchy and direct route preservation.
- Prompt: Not applicable. No prompts, tools, schemas, or provider assembly changed.
- Frontend: Applicable. The production navigation fragment is rendered at `/design?tab=components#dashboard-primary-navigation-component` with hosted desktop and mobile proof.
- Coverage: Applicable. The focused 21-test sidebar suite and web typecheck pass; exact-head CI is pending.

## Design proof

- Design page: [Dashboard primary navigation](https://www.withmurph.ai/design?tab=components#dashboard-primary-navigation-component)
- Coverage: Production dashboard primary navigation with Home active and the Patterns destination absent.
- Desktop screenshot: ![Dashboard navigation desktop](https://github.com/user-attachments/assets/b526e76c-3da3-4e5e-bb7f-4dacc34fe18d)
- Mobile screenshot: ![Dashboard navigation mobile](https://github.com/user-attachments/assets/a6977b46-a325-4918-99f3-70ca02557540)

## Change-shape breakdown

Classification rule: Production and design-catalog TSX are source; the focused Vitest file is tests. No docs, config, generated files, or binary files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 77 | 31 |
| Tests / fixtures | 3 | 14 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **80** | **45** |

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/dashboard-sidebar.test.ts` (21 tests passed)
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web exec eslint src/components/dashboard/sidebar.tsx app/design/components-content.tsx app/design/dashboard-sidebar-study.tsx test/dashboard-sidebar.test.ts`
- Desktop and mobile design-catalog captures at device scale factor 3; an automated browser assertion found no link named `Patterns`.
- Hosted screenshots were checked at native resolution and return `image/png`.
- Claude UI double-check not run: the `claude` executable is unavailable in this environment.
