### PR TITLE
Add Murph for health creators landing page

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-11-creator-programs-page.md
+++ b/agent-docs/exec-plans/active/2026-08-11-creator-programs-page.md
@@ -1,0 +1,93 @@
+# Creator programs recruiting page
+
+Status: active
+Created: 2026-08-11
+Updated: 2026-08-11
+
+## Goal
+
+Ship a focused `/creators` page that helps a serious health educator, creator,
+coach, clinician, researcher, or community leader imagine turning an existing
+body of work into personalized health guidance and a community program, then
+opens one white-glove conversation with the Murph team.
+
+## Success criteria
+
+- The hero leads with one concrete health-specific promise: give every member a
+  personal health guide grounded in the partner's work.
+- The page makes source fidelity, personal adaptation, aggregate community
+  participation, creator control, privacy, and optional creator economics
+  tangible without implying that a creator platform already ships.
+- The copy serves research-led educators, clinicians, coaches, membership and
+  community operators, and creator-led health brands rather than a generic
+  social-media creator.
+- The sole continuation is a prefilled email to Murph's existing support inbox.
+- The production component appears in `/design?tab=sections` with synthetic,
+  inert examples.
+- Metadata, telemetry admission, focused rendering tests, responsive browser
+  proof, exact-head CI, and required frontend review gates pass before merge.
+
+## Scope
+
+- In scope: `/creators`, metadata, static presentation, deterministic creator
+  mailto, creator-program product spec, design-catalog study, focused tests, and
+  telemetry allowlist alignment.
+- Out of scope: creator accounts, database state, application forms, self-serve
+  building, program installation, runtime prompts or skills, creator analytics,
+  attribution, payouts, paid programs, galleries, or remixing.
+
+## Constraints
+
+- Keep the underlying strategy practical in the public interface. Do not expose
+  academic language about body futurism, protocolism, or social forms.
+- Make health expertise, reviewed guidance, member outcomes, and community
+  implementation explicit; do not rely on generic creator-platform language.
+- Use Murph's existing warm research-library design system with a more cinematic,
+  restrained marketing composition rather than copying another brand's visual
+  language.
+- Use only synthetic creator concepts and aggregate values; imply no third-party
+  partnership, testimonial, or production scale.
+- Treat earnings as a secondary founding-partner possibility with no guaranteed
+  amount, automatic settlement, or revenue-share promise.
+- Keep participant-level health and conversation data private from creators.
+
+## Risks and mitigations
+
+1. Risk: the page sounds like an already-shipped creator marketplace.
+   Mitigation: describe the founding program as white-glove, label examples
+   illustrative, and state that no self-serve publishing system is implied.
+2. Risk: generic creator language fails to explain the health-specific value.
+   Mitigation: lead with a personal health guide grounded in the partner's work,
+   then show source review, private adaptation, tracking, and shared health
+   programs.
+3. Risk: money-first copy attracts low-quality affiliate demand.
+   Mitigation: lead with impact, personal support, community, and creator
+   control; place economics late in the page.
+4. Risk: creator authority weakens member agency or privacy.
+   Mitigation: document aggregate-only creator reporting and keep Murph's safety,
+   consent, evidence, and privacy boundaries superior.
+5. Risk: a dense page loses the requested confidence and restraint.
+   Mitigation: use large editorial typography, one concrete hero artifact,
+   hairline-separated rows, and one primary CTA.
+
+## Tasks
+
+1. Add the durable creator-program recruiting contract.
+2. Build the static `/creators` production page and deterministic contact handoff.
+3. Register the real composed page in the design catalog.
+4. Add focused rendering, metadata, mailto, telemetry, and responsive proof.
+5. Audit the message against a broad synthetic set of health-creator buying
+   motives and remove generic creator-platform copy.
+6. Push a draft candidate and run exact-head CI, desktop/mobile design capture,
+   the preliminary specialist review, Claude UI double-check when available,
+   and the parent final review.
+7. Resolve findings, archive this plan, and finish the scoped PR.
+
+## Current verification state
+
+- Connector-only implementation environment: repository dependencies and a
+  runnable browser are unavailable locally.
+- Static TypeScript/TSX parsing and direct mailto assertions are required before
+  the draft candidate is pushed.
+- Exact-head GitHub Actions, browser captures, and required review gates remain
+  open completion requirements on the draft PR.

--- a/agent-docs/product-specs/creator-programs.md
+++ b/agent-docs/product-specs/creator-programs.md
@@ -1,0 +1,170 @@
+# Creator Programs
+
+Last verified: 2026-08-11
+Status: Specified for the creator-recruiting surface; no creator-program runtime ships yet
+
+## Product decision
+
+Murph may work directly with selected health educators, creators, coaches,
+clinicians, researchers, trainers, and community leaders to turn an existing
+body of work into a personalized, community-oriented health experience.
+
+The public recruiting route is `/creators`. It uses ordinary language such as
+**program**, **experience**, and **guidance** rather than introducing a permanent
+Murph category name before creator demand is understood. Its central promise is:
+
+> Give every member a personal health guide grounded in your work.
+
+The page recruits founding partners. It is not a public program marketplace,
+self-serve builder, install gallery, creator dashboard, payout ledger, or
+runtime publication system.
+
+## Intended creator
+
+The best early partner has:
+
+- a coherent body of health knowledge or a signature method;
+- a repeatable action, routine, challenge, protocol, or bounded program;
+- a community that asks how to apply the work;
+- enough source material for Murph and the creator to review together; and
+- willingness to pilot the experience with a small participant group.
+
+Audience size alone is not qualification. A focused coach with a trusted,
+repeatable system may be a better partner than a broad lifestyle influencer.
+
+## Audience buying motives
+
+The recruiting copy should work across five broad motive clusters rather than
+speaking to a generic social-media creator:
+
+1. **Research-led educators** care about source fidelity, nuance, approved
+   claims, and helping an audience implement a large archive of work.
+2. **Clinicians and professional educators** care about scope, participant
+   privacy, reviewed guidance, and not implying individualized clinical care.
+3. **Coaches and performance experts** care about adaptation, progression,
+   tracking, accountability, and scaling beyond one-to-one support.
+4. **Membership and community operators** care about participation, retention,
+   shared launches, cohorts, milestones, and a stronger member experience.
+5. **Creator-led health brands** care about intellectual-property control,
+   brand fidelity, a new product or revenue line, and aggregate evidence that
+   the experience is being used.
+
+The page therefore leads with health expertise, personal guidance, and community
+implementation. Creator economics remains visible but secondary.
+
+## Founding-partner experience
+
+The v0 route has one terminal action: a prefilled email to Murph's existing
+support inbox with the partner's name, role or health brand, work link, trusted
+health topic or outcome, source material to bring to life, intended participant
+result, possible community goal, and approximate audience or member size. It
+requires no account, application record, sign-in, or detached workflow.
+
+After contact, the Murph team may manually:
+
+1. review the partner's existing work;
+2. define one participant journey, approved source set, adaptation boundary,
+   community rhythm, and completion state;
+3. build the first experience from existing Murph primitives;
+4. run a small pilot;
+5. revise it with the partner; and
+6. agree separately on any wider launch.
+
+The recruiting page does not promise response time, acceptance, publication, or
+a launch date.
+
+## Public value proposition
+
+The creator-facing story has five ordered parts:
+
+1. Turn an existing body of health work into guidance people can follow.
+2. Give each member private support adapted to their life and authorized data.
+3. Bring the community together around one reviewed health program and
+   aggregate progress.
+4. Keep content ownership, source review, scientific standards, brand control,
+   and adaptation boundaries explicit.
+5. Offer creator economics only after the product and trust proposition are clear.
+
+The public page may use clearly labeled synthetic concepts to make the product
+tangible. It must not imply that a named third-party creator is affiliated, that
+illustrative participation numbers are real, or that a program already ships.
+
+## Creator economics
+
+Two reward concepts remain distinct:
+
+- **Referral reward** recognizes the person who introduced a new participant to
+  Murph through an existing referral path.
+- **Creator reward** may recognize the person who created a health experience
+  that produces qualified, retained participation.
+
+For the founding program, any creator reward, qualification milestone, cap,
+payment amount, or paid launch partnership is manually agreed before launch.
+The public page may state that selected founding creators can earn based on
+qualified retained use and may receive separate paid launch support. It must not
+promise a payout amount, automatic settlement, revenue share, or typical income.
+
+No creator reward gives the creator ownership of a member, a Murph account, a
+subscription, or participant data.
+
+## Ownership and versioning
+
+A creator retains ownership of their original writing, recordings, media,
+brand, and program intellectual property. Any production agreement must define
+the license Murph receives to operate the approved experience.
+
+The creator reviews the participant-facing health guidance, approved sources,
+permitted adaptations, prohibited claims, and public presentation before
+launch. A material change should create an explicit reviewed version rather
+than silently changing the experience people joined. This document does not
+create a runtime version store or publication mechanism.
+
+## Member privacy and safety
+
+A creator may receive only aggregate program information such as starts,
+qualified participation, retention, and completion when the eventual product
+supports those projections. They do not receive private messages, wearable
+records, labs, meals, symptoms, schedules, individual outcomes, or other
+member-level health information merely because a member joins their experience.
+
+Creator-authored material never overrides Murph's safety, privacy, consent,
+evidence, authorization, or health-data-sharing rules. V0 does not accept
+arbitrary creator prompts, skills, tools, code, or unreviewed health programs.
+Murph should preserve participant agency: no shame-based adherence, public body
+ranking, creator surveillance, or claim that silence proves failure.
+
+## Architecture and reuse
+
+The recruiting page reuses the existing public marketing shell, metadata helper,
+StickyNav, SiteFooter, design catalog, Vercel telemetry allowlist, and responsive
+browser checks. Its only action is a deterministic mailto helper.
+
+No database table, API route, form service, scheduler, queue, payout service,
+creator account, program registry, assistant skill, prompt assembly, or health
+runtime changes in the v0 page.
+
+## Deferred work
+
+Defer until manual pilots establish repeated demand and a stable common shape:
+
+- a public builder or authoring schema;
+- program discovery or installation;
+- creator authentication and dashboards;
+- automated attribution or payouts;
+- paid participant access;
+- remixing, forks, or contributor rewards;
+- creator-facing member-level analytics; and
+- any generic runtime object named Recipe, Practice, Program, or similar.
+
+## Evidence to collect
+
+The creator page should be evaluated by qualified creator conversations rather
+than raw pageviews. Manual pilots should measure:
+
+- creator outreach to qualified conversation;
+- accepted concept to pilot launch;
+- participant start to first useful result;
+- retained participation at the agreed milestone;
+- creator willingness to launch another experience;
+- participant trust and opt-out signals; and
+- Murph usage cost plus any creator payment per retained member.

--- a/agent-docs/product-specs/index.md
+++ b/agent-docs/product-specs/index.md
@@ -1,6 +1,6 @@
 # Product Specs Index
 
-Last verified: 2026-08-10
+Last verified: 2026-08-11
 
 | Path | Purpose | Status |
 | --- | --- | --- |
@@ -21,6 +21,7 @@ Last verified: 2026-08-10
 | `agent-docs/product-specs/hosted-support-escalation.md` | Direct support address plus explicit, member-linked, de-identified product-team escalation with a three-email-per-UTC-day server limit and stable provider idempotency. | Implemented |
 | `agent-docs/product-specs/hosted-family-plan.md` | Hosted Family plan for 2-6 sponsored people with mixed Pulse/Edge seats, exact owner-funded member usage top-ups, private member accounts, chat-first invites, and privacy boundaries. | Active |
 | `agent-docs/product-specs/health-commons.md` | Health Commons page graph, catalog, versioning, future aggregate outcome summaries, and artifact-storage product boundary. | Active |
+| `agent-docs/product-specs/creator-programs.md` | Curated, white-glove creator partnerships that turn an approved body of health knowledge into a personalized community experience, with aggregate-only creator reporting and no self-serve runtime yet. | Specified |
 | `agent-docs/product-specs/murph-safe-public-product-search.md` | Public supplement and branded-food evidence search, normalized API contract, exact product-test semantics, privacy, and abuse bounds. | Active |
 | `agent-docs/product-specs/protocol-summary-copy.md` | Source-of-truth copy rules for Health Commons protocol `summary:` fields shown on `/experiments` cards. | Active |
 | `agent-docs/product-specs/murph-onboarding.md` | Aspiration-anchored onboarding through a compact progressive-disclosure skill: private relationship, observable bounded-history resume rules, brief aspiration-thread capture, explicit park, progressive health foundation, contextual return, collaborative first step, finite completion, and one code-owned first personal read. | Active |

--- a/apps/web/app/creators/page.tsx
+++ b/apps/web/app/creators/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+import { CreatorsPageContent } from "@/src/components/creators/creators-page-content";
+import { SiteFooter } from "@/src/components/homepage/site-footer";
+import { getMurphGithubStarCount } from "@/src/lib/github-stars";
+import { getHostedPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
+import { createMurphPageMetadata } from "@/src/lib/site-metadata";
+
+import { StickyNav } from "../sticky-nav";
+
+const CREATORS_METADATA_DESCRIPTION =
+  "Turn podcasts, protocols, courses, and coaching into reviewed, personalized health guidance your community can follow together.";
+
+export const metadata: Metadata = createMurphPageMetadata({
+  title: "Murph for Health Creators · Put your expertise into practice",
+  description: CREATORS_METADATA_DESCRIPTION,
+  alternates: {
+    canonical: "/creators",
+  },
+  openGraph: {
+    type: "website",
+  },
+});
+
+export default async function CreatorsPage() {
+  const [{ authenticated }, githubStarCount] = await Promise.all([
+    getHostedPageAuthSnapshot(),
+    getMurphGithubStarCount(),
+  ]);
+
+  return (
+    <>
+      <StickyNav
+        authenticated={authenticated}
+        darkTop
+        githubStarCount={githubStarCount}
+      />
+      <CreatorsPageContent />
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/web/app/design/creators-page-study.tsx
+++ b/apps/web/app/design/creators-page-study.tsx
@@ -1,0 +1,29 @@
+import { CreatorsPageContent } from "@/src/components/creators/creators-page-content";
+import { buildCreatorProgramMailto } from "@/src/lib/creator-program-contact";
+
+export function CreatorsPageStudy() {
+  return (
+    <section
+      className="mx-auto flex max-w-7xl flex-col gap-6 px-5 pt-12 sm:px-8 lg:px-12"
+      data-design-section="creators-marketing-page-study"
+      id="creators-marketing-page-study"
+    >
+      <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        Health creators page · expertise into personal guidance
+      </h2>
+      <div
+        className="-mx-5 overflow-hidden sm:-mx-8 lg:-mx-12"
+        data-design-state="founding-creator-partnership"
+        data-design-study="creators-marketing-page"
+        inert
+      >
+        <CreatorsPageContent
+          creatorMailto={buildCreatorProgramMailto({
+            body: "Design study only",
+            subject: "Design study only",
+          })}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -43,6 +43,7 @@ import { ActionApprovalLifecycleStudy } from "./action-approval-lifecycle-study"
 import { ChangelogArchiveStudy } from "./changelog-archive-study";
 import { ClinicalRecordsConnectLauncherStudy } from "./clinical-records-connect-launcher-study";
 import { ClubsPageStudy } from "./clubs-page-study";
+import { CreatorsPageStudy } from "./creators-page-study";
 import { ConnectedAppAuthorizationStudy } from "./connected-app-authorization-study";
 import {
   AppleHealthRelaySetupStudy,
@@ -525,6 +526,12 @@ export function SectionsContent() {
 
       <StudySection title="Clubs profiles, iMessage, and wearables">
         <ClubsPageStudy />
+      </StudySection>
+
+      <Separator />
+
+      <StudySection title="Health creators · expertise into personal guidance">
+        <CreatorsPageStudy />
       </StudySection>
 
       <Separator />

--- a/apps/web/e2e/creators-page-responsive.spec.ts
+++ b/apps/web/e2e/creators-page-responsive.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+const WIDTHS = [320, 390, 768, 1280] as const;
+const OVERFLOW_TOLERANCE_PX = 1;
+
+function isLoopbackUrl(rawUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rawUrl);
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+for (const width of WIDTHS) {
+  test(`creators page stays contained at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.route("**/*", (route) => {
+      if (isLoopbackUrl(route.request().url())) {
+        route.continue();
+      } else {
+        route.abort();
+      }
+    });
+
+    const response = await page.goto("/creators", { waitUntil: "load" });
+    expect(response?.status(), "/creators should respond 200").toBe(200);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Give every member a personal health guide grounded in your work.",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Explore a partnership" }).first(),
+    ).toBeVisible();
+
+    await page.evaluate(async () => {
+      await document.fonts?.ready;
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      );
+    });
+
+    const layout = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      width: document.documentElement.scrollWidth,
+    }));
+    expect(layout.width - layout.viewport).toBeLessThanOrEqual(
+      OVERFLOW_TOLERANCE_PX,
+    );
+  });
+}

--- a/apps/web/src/components/creators/creators-page-content.tsx
+++ b/apps/web/src/components/creators/creators-page-content.tsx
@@ -1,0 +1,733 @@
+import {
+  ArrowRight,
+  Check,
+  CircleDollarSign,
+  LockKeyhole,
+  UsersRound,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { buildCreatorProgramMailto } from "@/src/lib/creator-program-contact";
+
+const KNOWLEDGE_INPUTS = [
+  "Podcast and newsletter archive",
+  "Protocols and toolkits",
+  "Course or coaching method",
+  "Research and citations",
+] as const;
+
+const PROGRAM_STEPS = [
+  {
+    label: "Your body of work",
+    detail: "The health guidance, sources, claims, and boundaries you approve.",
+  },
+  {
+    label: "Personal guidance",
+    detail:
+      "Murph helps each person apply it to their schedule, goals, and health context.",
+  },
+  {
+    label: "A community program",
+    detail: "Shared starts, milestones, creator updates, and aggregate progress.",
+  },
+] as const;
+
+const ADAPTATIONS = [
+  {
+    context: "Before school",
+    time: "7:10 AM",
+    action: "Ten minutes outside after waking",
+  },
+  {
+    context: "After a night shift",
+    time: "11:40 AM",
+    action: "Outdoor light after the main sleep period",
+  },
+  {
+    context: "Travel day",
+    time: "Minimum version",
+    action: "Five minutes outdoors before the first long indoor block",
+  },
+] as const;
+
+const CREATOR_VALUE = [
+  {
+    number: "01",
+    title: "Activate your archive",
+    body:
+      "Turn years of episodes, books, newsletters, courses, and protocols into a guided health experience.",
+  },
+  {
+    number: "02",
+    title: "Personalize at scale",
+    body:
+      "Give each member answers and adaptations grounded in your approved work without coaching every person yourself.",
+  },
+  {
+    number: "03",
+    title: "Strengthen your membership",
+    body:
+      "Run cohorts, launches, challenges, and shared milestones that give people a reason to participate.",
+  },
+  {
+    number: "04",
+    title: "Learn what people use",
+    body:
+      "See aggregate starts, retention, and completion without seeing anyone’s private health information.",
+  },
+  {
+    number: "05",
+    title: "Open a new revenue line",
+    body:
+      "Founding partners can earn from qualified participation, separately from existing referral rewards.",
+  },
+] as const;
+
+const EXAMPLE_PROGRAMS = [
+  {
+    type: "Science educator",
+    title: "Fourteen-Day Sleep Toolkit",
+    body:
+      "Turn a research-backed toolkit into personal timing guidance, private check-ins, and one shared cohort.",
+  },
+  {
+    type: "Performance coach",
+    title: "Foundational Fitness Cycle",
+    body:
+      "Turn a training framework into progressive sessions, workout support, and community milestones.",
+  },
+  {
+    type: "Women’s health educator",
+    title: "Stronger Through Midlife",
+    body:
+      "Turn women-specific training and recovery education into a reviewed, stage-aware member experience.",
+  },
+  {
+    type: "Nutrition educator",
+    title: "Thirty Days of Protein",
+    body:
+      "Turn a nutrition method into meal support, simple tracking, and an aggregate consistency goal without public body rankings.",
+  },
+] as const;
+
+const PRIMARY_ACTION_CLASS =
+  "inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-[#f5f0e8] px-6 py-3.5 text-[0.9375rem] font-semibold text-[#1a1f16] transition-colors hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#d4b87a]";
+
+export function CreatorsPageContent({
+  creatorMailto = buildCreatorProgramMailto(),
+}: {
+  creatorMailto?: string;
+}) {
+  return (
+    <main
+      className="isolate min-h-dvh overflow-hidden bg-[#f5f0e8] antialiased"
+      data-design-section="creators-marketing-page"
+      id="creators-marketing-page"
+    >
+      <HeroSection creatorMailto={creatorMailto} />
+      <KnowledgeToPracticeSection />
+      <PersonalAdaptationSection />
+      <CommunitySection />
+      <CreatorValueSection />
+      <CreatorControlSection />
+      <EarningsSection />
+      <ExamplesSection />
+      <FoundingPartnerSection creatorMailto={creatorMailto} />
+    </main>
+  );
+}
+
+function HeroSection({ creatorMailto }: { creatorMailto: string }) {
+  return (
+    <section
+      aria-labelledby="creators-hero-title"
+      className="relative min-h-[94svh] overflow-hidden bg-[#1a1f16] px-5 pb-20 pt-32 sm:px-10 sm:pb-24 sm:pt-36 lg:px-16 lg:pb-28 lg:pt-40"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-[18rem] top-[10%] size-[42rem] rounded-full border border-[#c4a882]/10 bg-[#5a6e32]/10"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-24 bottom-0 h-px w-[44%] bg-[#c4a882]/25"
+      />
+
+      <div className="relative mx-auto grid max-w-[1180px] items-center gap-16 lg:grid-cols-[minmax(0,1.02fr)_minmax(360px,0.98fr)] lg:gap-20">
+        <div>
+          <SectionEyebrow dark>Murph for health experts & creators</SectionEyebrow>
+          <h1
+            className="mt-7 max-w-[13ch] text-balance font-serif text-[clamp(3.1rem,7vw,6.5rem)] font-semibold leading-[0.92] tracking-[-0.055em] text-[#f5f0e8]"
+            id="creators-hero-title"
+          >
+            Give every member a personal health guide grounded in your work.
+          </h1>
+          <p className="mt-8 max-w-[60ch] text-pretty text-[1rem] leading-[1.75] text-[#f5f0e8]/68 sm:text-[1.125rem]">
+            Murph turns your podcasts, protocols, courses, and coaching into a
+            reviewed health experience—helping each person apply your guidance
+            privately while the whole community moves through it together.
+          </p>
+          <div className="mt-9 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
+            <a className={PRIMARY_ACTION_CLASS} href={creatorMailto}>
+              Explore a partnership
+              <ArrowRight aria-hidden="true" className="size-4" />
+            </a>
+            <a
+              className="inline-flex min-h-11 items-center text-sm font-semibold text-[#f5f0e8]/68 underline decoration-[#c4a882]/50 underline-offset-4 transition-colors hover:text-[#f5f0e8]"
+              href="#creator-experience"
+            >
+              See how Murph works
+            </a>
+          </div>
+          <p className="mt-8 font-mono text-[9px] font-medium uppercase tracking-[0.15em] text-[#f5f0e8]/48 sm:text-[10px]">
+            Built with the Murph team · No code · Your content stays yours
+          </p>
+        </div>
+
+        <LivingProgramPreview />
+      </div>
+    </section>
+  );
+}
+
+function LivingProgramPreview() {
+  return (
+    <div
+      aria-label="Illustrative health program showing approved creator knowledge, a private member adaptation, and aggregate community participation"
+      className="relative mx-auto w-full max-w-[520px]"
+      role="img"
+    >
+      <div className="border-y border-[#c4a882]/20 py-5">
+        <div className="flex items-center justify-between gap-4 font-mono text-[9px] uppercase tracking-[0.14em] text-[#d4b87a]">
+          <span>Illustrative health program</span>
+          <span>Version 1.0</span>
+        </div>
+        <div className="mt-5 flex flex-wrap gap-2">
+          {KNOWLEDGE_INPUTS.map((input) => (
+            <span
+              className="rounded-full border border-[#c4a882]/15 px-3 py-2 text-[0.75rem] text-[#f5f0e8]/58"
+              key={input}
+            >
+              {input}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 bg-[#fffcf6] p-6 sm:p-8">
+        <div className="flex items-start justify-between gap-6 border-b border-[#c4a882]/20 pb-5">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+              Morning Light Month
+            </p>
+            <h2 className="mt-2 font-serif text-[2rem] font-semibold leading-none tracking-[-0.04em] text-[#2d3436]">
+              Day 8 of 30
+            </h2>
+          </div>
+          <div className="text-right">
+            <p className="font-serif text-[1.8rem] font-semibold leading-none tracking-[-0.04em] text-[#2d3436]">
+              12,840
+            </p>
+            <p className="mt-2 text-[0.72rem] text-[#736a58]">participating</p>
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          <div className="ml-auto max-w-[82%] rounded-2xl rounded-br-[5px] bg-[#5a6e32] px-4 py-3 text-[0.875rem] leading-[1.55] text-white">
+            I work nights. When should I get outside?
+          </div>
+          <div className="max-w-[91%] rounded-2xl rounded-bl-[5px] bg-[#ede5d8] px-4 py-3 text-[0.875rem] leading-[1.55] text-[#2d3436]">
+            Your waking schedule shifts the timing. Start after your main sleep
+            period rather than forcing a morning clock time. When do you usually
+            wake on workdays?
+          </div>
+        </div>
+
+        <div className="mt-7 grid grid-cols-3 gap-4 border-t border-[#c4a882]/20 pt-5">
+          <ProgramStat label="Active this week" value="8,910" />
+          <ProgramStat label="Practiced today" value="68%" />
+          <ProgramStat label="Approved sources" value="14" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgramStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="font-serif text-[1.35rem] font-semibold leading-none tracking-[-0.03em] text-[#2d3436]">
+        {value}
+      </p>
+      <p className="mt-2 text-[0.68rem] leading-[1.4] text-[#736a58]">{label}</p>
+    </div>
+  );
+}
+
+function KnowledgeToPracticeSection() {
+  return (
+    <section
+      aria-labelledby="knowledge-practice-title"
+      className="bg-[#f5f0e8] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+      id="creator-experience"
+    >
+      <div className="mx-auto max-w-[1120px]">
+        <div className="max-w-[850px]">
+          <SectionEyebrow>From health content to health action</SectionEyebrow>
+          <h2
+            className="mt-6 text-balance font-serif text-[clamp(2.5rem,5.5vw,5rem)] font-semibold leading-[0.96] tracking-[-0.05em] text-[#2d3436]"
+            id="knowledge-practice-title"
+          >
+            Turn years of health knowledge into guidance people can actually follow.
+          </h2>
+          <p className="mt-7 max-w-[64ch] text-[1rem] leading-[1.75] text-[#5a5045]">
+            Your audience already asks what to do first, how to adapt it, and
+            how to stay consistent. Murph answers from the sources and
+            boundaries you approve, then supports the follow-through after the
+            episode, post, or course ends.
+          </p>
+        </div>
+
+        <div className="mt-16 border-y border-[#c4a882]/30 lg:grid lg:grid-cols-3 lg:divide-x lg:divide-[#c4a882]/30">
+          {PROGRAM_STEPS.map((step, index) => (
+            <article className="py-8 lg:px-8 lg:py-10 first:lg:pl-0 last:lg:pr-0" key={step.label}>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+                0{index + 1}
+              </p>
+              <h3 className="mt-5 font-serif text-[1.75rem] font-semibold leading-[1.05] tracking-[-0.035em] text-[#2d3436]">
+                {step.label}
+              </h3>
+              <p className="mt-4 max-w-[36ch] text-[0.9375rem] leading-[1.7] text-[#635a48]">
+                {step.detail}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PersonalAdaptationSection() {
+  return (
+    <section
+      aria-labelledby="personal-adaptation-title"
+      className="bg-[#ebdfc6] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+    >
+      <div className="mx-auto max-w-[1120px]">
+        <div className="grid gap-10 lg:grid-cols-[0.88fr_1.12fr] lg:items-end lg:gap-20">
+          <div>
+            <SectionEyebrow>Personal without 1:1 coaching</SectionEyebrow>
+            <h2
+              className="mt-6 text-balance font-serif text-[clamp(2.3rem,5vw,4.5rem)] font-semibold leading-[0.98] tracking-[-0.05em] text-[#2d3436]"
+              id="personal-adaptation-title"
+            >
+              The same health program, adapted to each person’s life.
+            </h2>
+          </div>
+          <p className="max-w-[54ch] text-[1rem] leading-[1.75] text-[#4d4533] lg:pb-1">
+            Murph uses each member’s schedule, goals, prior actions, questions,
+            and authorized health data while staying inside the principles and
+            adaptation boundaries you approve.
+          </p>
+        </div>
+
+        <div className="mt-14 grid gap-px overflow-hidden border border-[#c4a882]/35 bg-[#c4a882]/35 lg:grid-cols-3">
+          {ADAPTATIONS.map((adaptation) => (
+            <article className="bg-[#fffcf6] p-7 sm:p-9" key={adaptation.context}>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+                {adaptation.context}
+              </p>
+              <p className="mt-7 font-serif text-[2.3rem] font-semibold leading-none tracking-[-0.05em] text-[#2d3436]">
+                {adaptation.time}
+              </p>
+              <p className="mt-5 text-[0.9375rem] leading-[1.7] text-[#635a48]">
+                {adaptation.action}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CommunitySection() {
+  return (
+    <section
+      aria-labelledby="community-practice-title"
+      className="bg-[#1d271b] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+    >
+      <div className="mx-auto grid max-w-[1120px] items-center gap-16 lg:grid-cols-[minmax(0,0.92fr)_minmax(360px,1.08fr)] lg:gap-24">
+        <div>
+          <SectionEyebrow dark>Your community in action</SectionEyebrow>
+          <h2
+            className="mt-6 text-balance font-serif text-[clamp(2.4rem,5vw,4.8rem)] font-semibold leading-[0.97] tracking-[-0.05em] text-[#f5f0e8]"
+            id="community-practice-title"
+          >
+            Bring your community together around a shared health program.
+          </h2>
+          <p className="mt-7 max-w-[54ch] text-[1rem] leading-[1.75] text-[#f5f0e8]/64">
+            Run one launch, cohort, challenge, or seasonal reset. Each member
+            gets private support while the community sees only the shared
+            milestones and aggregate progress you choose to make visible.
+          </p>
+          <div className="mt-9 grid gap-6 border-t border-[#c4a882]/20 pt-8 sm:grid-cols-2">
+            <BoundaryNote
+              title="Private member support"
+              body="Questions, schedule, health data, progress, and personal adaptation."
+            />
+            <BoundaryNote
+              title="Community-wide progress"
+              body="Shared starts, milestones, creator updates, and aggregate participation."
+            />
+          </div>
+        </div>
+
+        <CommunityPulse />
+      </div>
+    </section>
+  );
+}
+
+function CommunityPulse() {
+  const dots = Array.from({ length: 48 }, (_, index) => index);
+
+  return (
+    <div
+      aria-label="Illustrative aggregate community progress for Morning Light Month"
+      className="relative mx-auto flex aspect-square w-full max-w-[520px] items-center justify-center rounded-full border border-[#c4a882]/15"
+      role="img"
+    >
+      <div className="absolute inset-[11%] rounded-full border border-dashed border-[#c4a882]/20" />
+      <div className="absolute inset-[22%] rounded-full border border-[#c4a882]/15" />
+      <div className="absolute inset-0 grid grid-cols-8 place-items-center gap-2 p-[8%] sm:gap-3">
+        {dots.map((dot) => (
+          <span
+            aria-hidden="true"
+            className={`size-2 rounded-full sm:size-2.5 ${
+              dot % 5 === 0 || dot % 7 === 0
+                ? "bg-[#d4b87a]"
+                : dot % 3 === 0
+                ? "bg-[#7a8c6e]"
+                : "bg-[#f5f0e8]/20"
+            }`}
+            key={dot}
+          />
+        ))}
+      </div>
+      <div className="relative z-10 w-[58%] bg-[#1d271b] px-4 py-8 text-center">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#d4b87a]">
+          Week two
+        </p>
+        <p className="mt-4 font-serif text-[clamp(2.5rem,7vw,4.8rem)] font-semibold leading-none tracking-[-0.06em] text-[#f5f0e8]">
+          84,216
+        </p>
+        <p className="mt-3 text-[0.8rem] leading-[1.5] text-[#f5f0e8]/58">
+          aggregate minutes outdoors
+        </p>
+        <p className="mt-6 border-t border-[#c4a882]/20 pt-5 font-mono text-[8px] uppercase tracking-[0.14em] text-[#f5f0e8]/44">
+          Next milestone · 100,000
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function BoundaryNote({ body, title }: { body: string; title: string }) {
+  return (
+    <div>
+      <h3 className="font-serif text-[1.35rem] font-semibold leading-[1.1] tracking-[-0.03em] text-[#f5f0e8]">
+        {title}
+      </h3>
+      <p className="mt-3 text-[0.875rem] leading-[1.65] text-[#f5f0e8]/56">
+        {body}
+      </p>
+    </div>
+  );
+}
+
+function CreatorValueSection() {
+  return (
+    <section
+      aria-labelledby="creator-value-title"
+      className="bg-[#f5f0e8] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+    >
+      <div className="mx-auto max-w-[1120px]">
+        <div className="max-w-[790px]">
+          <SectionEyebrow>Why health leaders build with Murph</SectionEyebrow>
+          <h2
+            className="mt-6 text-balance font-serif text-[clamp(2.4rem,5vw,4.7rem)] font-semibold leading-[0.98] tracking-[-0.05em] text-[#2d3436]"
+            id="creator-value-title"
+          >
+            Scale the work without watering it down.
+          </h2>
+        </div>
+
+        <div className="mt-14 border-y border-[#c4a882]/30">
+          {CREATOR_VALUE.map((value) => (
+            <article
+              className="grid gap-4 border-t border-[#c4a882]/25 py-8 first:border-t-0 md:grid-cols-[70px_minmax(0,0.8fr)_minmax(0,1.2fr)] md:items-baseline md:gap-8 lg:py-10"
+              key={value.number}
+            >
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+                {value.number}
+              </p>
+              <h3 className="font-serif text-[1.7rem] font-semibold leading-[1.08] tracking-[-0.035em] text-[#2d3436]">
+                {value.title}
+              </h3>
+              <p className="max-w-[52ch] text-[0.9375rem] leading-[1.72] text-[#635a48]">
+                {value.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CreatorControlSection() {
+  const reviewRows = [
+    ["Approved sources", "14"],
+    ["Core guidance", "6"],
+    ["Permitted adaptations", "4"],
+    ["Excluded claims", "3"],
+    ["Current version", "1.0"],
+  ] as const;
+
+  return (
+    <section
+      aria-labelledby="creator-control-title"
+      className="bg-[#ede5d8] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+    >
+      <div className="mx-auto grid max-w-[1080px] items-start gap-14 lg:grid-cols-[minmax(0,0.9fr)_minmax(380px,1.1fr)] lg:gap-24">
+        <div>
+          <SectionEyebrow>Scientific and brand control</SectionEyebrow>
+          <h2
+            className="mt-6 text-balance font-serif text-[clamp(2.35rem,5vw,4.5rem)] font-semibold leading-[0.98] tracking-[-0.05em] text-[#2d3436]"
+            id="creator-control-title"
+          >
+            Your sources, standards, and name stay intact.
+          </h2>
+          <p className="mt-7 max-w-[54ch] text-[1rem] leading-[1.75] text-[#5a5045]">
+            You approve the health guidance, sources, permitted adaptations,
+            excluded claims, public presentation, and member journey before
+            launch. Material changes create a reviewed new version rather than
+            silently rewriting what people joined.
+          </p>
+          <ul className="mt-8 space-y-4">
+            <ControlPromise>You retain ownership of your original content.</ControlPromise>
+            <ControlPromise>You approve the member-facing health guidance before launch.</ControlPromise>
+            <ControlPromise>Creators receive aggregate program reporting only.</ControlPromise>
+            <ControlPromise>Private messages and personal health data stay private.</ControlPromise>
+            <ControlPromise>Murph’s safety, consent, and evidence rules remain in force.</ControlPromise>
+          </ul>
+        </div>
+
+        <div className="border border-[#c4a882]/35 bg-[#fffcf6] p-7 sm:p-9">
+          <div className="flex items-center justify-between gap-5 border-b border-[#c4a882]/25 pb-6">
+            <div>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+                Health program review
+              </p>
+              <p className="mt-2 font-serif text-[1.7rem] font-semibold tracking-[-0.035em] text-[#2d3436]">
+                Morning Light Month
+              </p>
+            </div>
+            <LockKeyhole aria-hidden="true" className="size-6 text-[#5a6e32]" strokeWidth={1.6} />
+          </div>
+          <dl className="divide-y divide-[#c4a882]/20">
+            {reviewRows.map(([label, value]) => (
+              <div className="flex items-center justify-between gap-6 py-5" key={label}>
+                <dt className="text-[0.875rem] text-[#635a48]">{label}</dt>
+                <dd className="font-serif text-[1.25rem] font-semibold text-[#2d3436]">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <p className="border-t border-[#c4a882]/25 pt-5 text-[0.75rem] leading-[1.6] text-[#736a58]">
+            Illustrative review brief. Founding programs are built and reviewed
+            directly with the Murph team; no self-serve publishing system is
+            implied.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ControlPromise({ children }: { children: ReactNode }) {
+  return (
+    <li className="flex items-start gap-3 text-[0.9375rem] leading-[1.65] text-[#4d4533]">
+      <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[#5a6e32]/10 text-[#5a6e32]">
+        <Check aria-hidden="true" className="size-3" strokeWidth={2.4} />
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function EarningsSection() {
+  return (
+    <section
+      aria-labelledby="creator-earnings-title"
+      className="bg-[#dfe7d3] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-28"
+    >
+      <div className="mx-auto max-w-[1060px]">
+        <div className="grid gap-10 lg:grid-cols-[0.78fr_1.22fr] lg:items-end lg:gap-20">
+          <div>
+            <SectionEyebrow>Creator economics</SectionEyebrow>
+            <h2
+              className="mt-6 text-balance font-serif text-[clamp(2.3rem,4.8vw,4.3rem)] font-semibold leading-[0.98] tracking-[-0.05em] text-[#2d3436]"
+              id="creator-earnings-title"
+            >
+              Earn when your health program creates real participation.
+            </h2>
+          </div>
+          <p className="max-w-[54ch] text-[1rem] leading-[1.75] text-[#4d4533]">
+            Founding creator rewards are tied to qualified, retained
+            participation—not impressions, clicks, or empty signups. Exact
+            qualifications, caps, and payment terms are agreed before launch.
+          </p>
+        </div>
+
+        <div className="mt-14 grid gap-px overflow-hidden border border-[#5a6e32]/15 bg-[#5a6e32]/15 md:grid-cols-2">
+          <EarningDefinition
+            icon={<UsersRound aria-hidden="true" className="size-5" strokeWidth={1.8} />}
+            title="Referral reward"
+          >
+            Recognizes the person who introduced a new participant to Murph.
+          </EarningDefinition>
+          <EarningDefinition
+            icon={<CircleDollarSign aria-hidden="true" className="size-5" strokeWidth={1.8} />}
+            title="Creator reward"
+          >
+            Recognizes the person who created the health experience that
+            produced qualified, retained participation.
+          </EarningDefinition>
+        </div>
+        <p className="mt-7 max-w-[72ch] text-[0.8125rem] leading-[1.65] text-[#5a5045]">
+          Selected founding creators may also receive a separate paid launch
+          partnership. Creator rewards do not provide access to participant
+          accounts or private health information, and no amount of income is
+          guaranteed.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function EarningDefinition({
+  children,
+  icon,
+  title,
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  title: string;
+}) {
+  return (
+    <article className="bg-[#fffcf6] p-7 sm:p-9">
+      <span className="flex size-10 items-center justify-center rounded-full bg-[#5a6e32]/10 text-[#5a6e32]">
+        {icon}
+      </span>
+      <h3 className="mt-6 font-serif text-[1.75rem] font-semibold leading-[1.05] tracking-[-0.035em] text-[#2d3436]">
+        {title}
+      </h3>
+      <p className="mt-4 max-w-[42ch] text-[0.9375rem] leading-[1.7] text-[#635a48]">
+        {children}
+      </p>
+    </article>
+  );
+}
+
+function ExamplesSection() {
+  return (
+    <section
+      aria-labelledby="creator-examples-title"
+      className="bg-[#f5f0e8] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32"
+    >
+      <div className="mx-auto max-w-[1120px]">
+        <div className="max-w-[820px]">
+          <SectionEyebrow>What could your health expertise become?</SectionEyebrow>
+          <h2
+            className="mt-6 text-balance font-serif text-[clamp(2.35rem,5vw,4.6rem)] font-semibold leading-[0.98] tracking-[-0.05em] text-[#2d3436]"
+            id="creator-examples-title"
+          >
+            Start with the health outcome your audience already trusts you to help with.
+          </h2>
+        </div>
+
+        <div className="mt-14 grid gap-px overflow-hidden border border-[#c4a882]/30 bg-[#c4a882]/30 md:grid-cols-2">
+          {EXAMPLE_PROGRAMS.map((program) => (
+            <article className="min-h-64 bg-[#fffcf6] p-7 sm:p-9" key={program.title}>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-[#5a6e32]">
+                Illustrative · {program.type}
+              </p>
+              <h3 className="mt-8 max-w-[14ch] font-serif text-[2rem] font-semibold leading-[1.02] tracking-[-0.04em] text-[#2d3436]">
+                {program.title}
+              </h3>
+              <p className="mt-5 max-w-[42ch] text-[0.9375rem] leading-[1.72] text-[#635a48]">
+                {program.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FoundingPartnerSection({ creatorMailto }: { creatorMailto: string }) {
+  return (
+    <section className="relative overflow-hidden bg-[#2a2520] px-5 py-20 sm:px-10 sm:py-24 lg:px-16 lg:py-32">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-56 right-[8%] size-[34rem] rounded-full border border-[#c4a882]/10 bg-[#5a6e32]/10"
+      />
+      <div className="relative mx-auto grid max-w-[1080px] items-end gap-12 lg:grid-cols-[1fr_auto] lg:gap-20">
+        <div>
+          <SectionEyebrow dark>Founding health partnerships</SectionEyebrow>
+          <h2 className="mt-6 max-w-[16ch] text-balance font-serif text-[clamp(2.6rem,5.5vw,5rem)] font-semibold leading-[0.95] tracking-[-0.055em] text-[#f5f0e8]">
+            Bring us the health work your audience already trusts.
+          </h2>
+          <p className="mt-7 max-w-[62ch] text-[1rem] leading-[1.75] text-[#f5f0e8]/65">
+            We’ll choose one valuable part of your podcast, course, protocol,
+            book, or coaching system, turn it into a guided member experience,
+            pilot it with a small cohort, and help you launch it to the wider
+            community.
+          </p>
+        </div>
+        <a className={PRIMARY_ACTION_CLASS} href={creatorMailto}>
+          Explore a partnership
+          <ArrowRight aria-hidden="true" className="size-4" />
+        </a>
+      </div>
+      <div className="relative mx-auto mt-12 flex max-w-[1080px] flex-wrap gap-x-7 gap-y-3 border-t border-[#c4a882]/20 pt-7 font-mono text-[8px] uppercase tracking-[0.14em] text-[#f5f0e8]/45 sm:text-[9px]">
+        <span>Creator-owned content</span>
+        <span>Reviewed health guidance</span>
+        <span>Private member data</span>
+        <span>Aggregate program insight</span>
+      </div>
+    </section>
+  );
+}
+
+function SectionEyebrow({
+  children,
+  dark = false,
+}: {
+  children: ReactNode;
+  dark?: boolean;
+}) {
+  return (
+    <p
+      className={`font-mono text-[9px] font-semibold uppercase tracking-[0.16em] sm:text-[10px] ${
+        dark ? "text-[#d4b87a]" : "text-[#5a6e32]"
+      }`}
+    >
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/lib/creator-program-contact.ts
+++ b/apps/web/src/lib/creator-program-contact.ts
@@ -1,0 +1,24 @@
+export const MURPH_CREATOR_CONTACT_EMAIL = "support@withmurph.ai";
+
+const DEFAULT_CREATOR_PROGRAM_SUBJECT = "Explore a Murph health partnership";
+const DEFAULT_CREATOR_PROGRAM_BODY = [
+  "Name, role, or health brand:",
+  "Link to your work:",
+  "What health topic or outcome does your audience trust you for?",
+  "Which podcast, protocol, course, book, or coaching method should Murph bring to life?",
+  "What should each participant be able to do or understand?",
+  "What could the community work toward together?",
+  "Approximate audience or member size:",
+].join("\n");
+
+export function buildCreatorProgramMailto({
+  body = DEFAULT_CREATOR_PROGRAM_BODY,
+  subject = DEFAULT_CREATOR_PROGRAM_SUBJECT,
+}: {
+  body?: string;
+  subject?: string;
+} = {}): string {
+  const query = new URLSearchParams({ body, subject });
+
+  return `mailto:${MURPH_CREATOR_CONTACT_EMAIL}?${query.toString()}`;
+}

--- a/apps/web/src/lib/observability/analytics-redaction.ts
+++ b/apps/web/src/lib/observability/analytics-redaction.ts
@@ -7,6 +7,7 @@ export const VERCEL_TELEMETRY_PATHNAMES = [
   "/clubs",
   "/connect",
   "/consumer-health-data-privacy-policy",
+  "/creators",
   "/design",
   "/device-sync/connect/complete",
   "/environment",

--- a/apps/web/test/creators-page.test.tsx
+++ b/apps/web/test/creators-page.test.tsx
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getHostedPageAuthSnapshot: vi.fn(),
+  getMurphGithubStarCount: vi.fn(),
+  LandingAuthActions: vi.fn(
+    (props: { authenticated: boolean; authLabel: string; context: string }) =>
+      createElement(
+        "div",
+        {
+          "data-creators-authenticated": String(props.authenticated),
+          "data-creators-auth-label": props.authLabel,
+          "data-creators-auth-context": props.context,
+        },
+        "Landing auth actions",
+      ),
+  ),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/src/lib/hosted-onboarding/page-auth", () => ({
+  getHostedPageAuthSnapshot: mocks.getHostedPageAuthSnapshot,
+}));
+
+vi.mock("@/src/lib/github-stars", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/src/lib/github-stars")>(
+      "@/src/lib/github-stars",
+    );
+  return {
+    ...actual,
+    getMurphGithubStarCount: mocks.getMurphGithubStarCount,
+  };
+});
+
+vi.mock("../app/auth-controls", () => ({
+  LandingAuthActions: mocks.LandingAuthActions,
+  LandingAuthDialog: () => null,
+}));
+
+import { metadata } from "../app/creators/page";
+import { CreatorsPageStudy } from "../app/design/creators-page-study";
+import {
+  buildCreatorProgramMailto,
+  MURPH_CREATOR_CONTACT_EMAIL,
+} from "@/src/lib/creator-program-contact";
+
+test("creator contact handoff asks for the minimum useful health partnership context", () => {
+  const mailto = buildCreatorProgramMailto();
+  const url = new URL(mailto);
+
+  assert.equal(url.protocol, "mailto:");
+  assert.equal(url.pathname, MURPH_CREATOR_CONTACT_EMAIL);
+  assert.equal(
+    url.searchParams.get("subject"),
+    "Explore a Murph health partnership",
+  );
+  assert.equal(
+    url.searchParams.get("body"),
+    [
+      "Name, role, or health brand:",
+      "Link to your work:",
+      "What health topic or outcome does your audience trust you for?",
+      "Which podcast, protocol, course, book, or coaching method should Murph bring to life?",
+      "What should each participant be able to do or understand?",
+      "What could the community work toward together?",
+      "Approximate audience or member size:",
+    ].join("\n"),
+  );
+});
+
+test("Creators page metadata names the health outcome and canonical route", () => {
+  assert.equal(
+    metadata.title,
+    "Murph for Health Creators · Put your expertise into practice",
+  );
+  assert.equal(
+    metadata.description,
+    "Turn podcasts, protocols, courses, and coaching into reviewed, personalized health guidance your community can follow together.",
+  );
+  assert.equal(metadata.alternates?.canonical, "/creators");
+});
+
+test("the sections catalog renders the real creator page as an inert synthetic study", () => {
+  const registrySource = readFileSync(
+    new URL("../app/design/sections-content.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    registrySource,
+    /import \{ CreatorsPageStudy \} from "\.\/creators-page-study";/u,
+  );
+  assert.match(registrySource, /<CreatorsPageStudy \/>/u);
+
+  const markup = renderToStaticMarkup(createElement(CreatorsPageStudy));
+  assert.match(markup, /data-design-study="creators-marketing-page"/u);
+  assert.match(markup, /data-design-state="founding-creator-partnership"/u);
+  assert.match(markup, /Illustrative health program/u);
+  assert.match(markup, /inert=""/u);
+});
+
+test("CreatorsPage sells a health-specific founding partnership without inventing a marketplace", async () => {
+  vi.clearAllMocks();
+  mocks.getHostedPageAuthSnapshot.mockResolvedValue({ authenticated: false });
+  mocks.getMurphGithubStarCount.mockResolvedValue(null);
+
+  const { default: CreatorsPage } = await import("../app/creators/page");
+  const markup = renderToStaticMarkup(await CreatorsPage());
+
+  expect(mocks.getHostedPageAuthSnapshot).toHaveBeenCalledTimes(1);
+  expect(mocks.getMurphGithubStarCount).toHaveBeenCalledTimes(1);
+  assert.equal((markup.match(/<h1\b/gu) ?? []).length, 1);
+  assert.match(
+    markup,
+    /Give every member a personal health guide grounded in your work\./u,
+  );
+  assert.match(markup, /Explore a partnership/u);
+  assert.match(markup, /No code/u);
+  assert.match(markup, /Your content stays yours/u);
+  assert.match(markup, /href="mailto:support@withmurph\.ai\?/u);
+  assert.match(markup, /Illustrative health program/u);
+  assert.match(
+    markup,
+    /Turn years of health knowledge into guidance people can actually follow\./u,
+  );
+  assert.match(
+    markup,
+    /The same health program, adapted to each person’s life\./u,
+  );
+  assert.match(
+    markup,
+    /Bring your community together around a shared health program\./u,
+  );
+  assert.match(markup, /Private member support/u);
+  assert.match(markup, /Community-wide progress/u);
+  assert.match(markup, /Scale the work without watering it down\./u);
+  assert.match(markup, /Your sources, standards, and name stay intact\./u);
+  assert.match(
+    markup,
+    /You approve the member-facing health guidance before launch\./u,
+  );
+  assert.match(markup, /aggregate program reporting only/u);
+  assert.match(markup, /Referral reward/u);
+  assert.match(markup, /Creator reward/u);
+  assert.match(
+    markup,
+    /Earn when your health program creates real participation\./u,
+  );
+  assert.match(markup, /qualified, retained participation/u);
+  assert.match(markup, /no amount of income is guaranteed/u);
+  assert.match(markup, /Founding health partnerships/u);
+  assert.match(
+    markup,
+    /Bring us the health work your audience already trusts\./u,
+  );
+  assert.match(markup, /data-design-section="creators-marketing-page"/u);
+  assert.doesNotMatch(markup, /Turn what you teach/iu);
+  assert.doesNotMatch(markup, /personalized AI experience/iu);
+  assert.doesNotMatch(markup, /Huberman/u);
+  assert.doesNotMatch(markup, /marketplace/iu);
+  assert.doesNotMatch(markup, /anyone can publish/iu);
+  assert.doesNotMatch(markup, /recipe/iu);
+});


### PR DESCRIPTION
## Why this PR exists

Murph needs a credible destination for founder-led outreach to serious health educators, creators, coaches, clinicians, researchers, trainers, and community leaders before a creator builder, marketplace, or payout system exists.

The page should help a prospective partner imagine turning an existing body of health work into source-grounded personal guidance and a shared community program, while keeping the v0 offer truthful and white-glove.

## User goal / user-visible behavior

A prospective health partner can open `/creators`, understand the product in one pass, and select **Explore a partnership** to start a prefilled email conversation with the Murph team.

The page leads with health expertise, participant value, source fidelity, and community implementation rather than generic creator-platform language or affiliate economics. It shows one clearly illustrative health program, private member adaptation, aggregate community progress, creator ownership and review boundaries, the distinction between referral and creator rewards, and four synthetic health-program concepts. It makes no claim that self-serve authoring, publishing, analytics, installation, or automated payouts already ship.

## Copy audit

The message was re-audited through a synthetic 50-perspective set spanning:

- research-led health educators and podcasters;
- clinicians and professional educators;
- strength, endurance, nutrition, sleep, recovery, and women’s-health coaches;
- athlete-led and creator-led health brands;
- membership communities, gyms, clubs, and cohort operators; and
- authors, course businesses, newsletters, and protocol-focused communities.

This was a perspective and official-positioning audit, not 50 interviews. The recurring buying motives were source and brand fidelity, implementation beyond content, personalization without one-to-one coaching, stronger membership participation, aggregate evidence of use, participant privacy, and a credible new business line. The page now speaks directly to those motives.

## User experience

- Entry: a direct founder-outreach link to `/creators`.
- Immediate feedback: a restrained dark hero with one health-specific promise — **Give every member a personal health guide grounded in your work.**
- Product understanding: the page moves from a body of health work to personal guidance, a shared health program, source and brand control, privacy, aggregate learning, and optional economics.
- Continuation: both primary CTAs open one deterministic prefilled email to Murph's existing support inbox. There is no sign-in, application record, detached workflow, or wait state owned by this PR.
- Evidence: every creator program, participant count, and community metric on the page is labeled illustrative or synthetic.
- Recovery: ordinary mail-client behavior owns send or cancellation; the page itself performs no mutation.

## Invariants

- Do not imply a third-party creator partnership, testimonial, production program, or real participation count.
- Do not promise acceptance, publication, launch timing, automatic payout, revenue share, or a typical income amount.
- Keep referral rewards and creator rewards conceptually separate.
- Creators retain ownership of their original content; any operating license remains agreement-owned rather than inferred by the page.
- Creator reporting is aggregate only. Private messages and member-level health information remain private.
- Creator material never overrides Murph's safety, privacy, consent, evidence, or authorization rules.
- The v0 route adds no creator account, database table, API, builder, program registry, runtime skill, prompt input, attribution owner, or payout state.

## Changelog

- Changelog: not applicable
- Reason: this is a creator-recruiting marketing surface and durable product specification; it adds no member-facing Murph capability or changed member workflow to announce.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: the patch is a static public marketing page, deterministic mailto handoff, design-catalog registration, tests, telemetry pathname admission, and product documentation. It changes no persisted state, authenticated action, health-data flow, runtime prompt, billing execution, provider boundary, or deployment contract.

ReviewGPT first-reviewed head: pending

Current candidate head: `6df5958446eac05e40e24d0223d91d2e94f36b04`

## Non-obvious affected surfaces

- Vercel telemetry: `/creators` joins the existing exact static-path allowlist, so query and fragment state continue to be stripped before delivery.
- Design catalog: `/design?tab=sections#creators-marketing-page-study` renders the real production component with an inert synthetic contact action.
- Responsive coverage: a focused Playwright spec covers 320, 390, 768, and 1280px plus the exact health-specific hero and CTA.
- Product docs: the creator-program contract records five health-partner buying-motive clusters and explicitly separates the current recruiting page from deferred runtime, marketplace, analytics, attribution, and payout work.

## Architecture and reuse

- Existing systems reused: App Router metadata, `StickyNav`, `SiteFooter`, the Murph typography and warm research-library palette, the existing Sections design catalog, static telemetry admission, and the current support inbox.
- New logic: one deterministic health-partnership mailto helper and static presentation components.
- New abstractions: one creator-program contact helper; no state or service owner.
- Complexity intentionally avoided: no form backend, application table, creator auth, builder schema, prompt injection, gallery, program installation path, analytics dashboard, attribution mechanism, payment system, or compatibility layer.

## Hot reply path impact

Not applicable. This patch does not touch conversation acceptance, provider start, model work, or durable reply handoff.

## Murph initial provider input impact

- Individual Murph: not applicable; no prompt, tool, skill, schema, model configuration, or request assembly changed.
- Group Murph: not applicable for the same reason.

## Design proof

- Design page: `/design?tab=sections#creators-marketing-page-study`
- Coverage: complete production `/creators` page with the founding health-partnership state and synthetic program data.
- Desktop screenshot: pending exact-head hosted capture.
- Mobile screenshot: pending exact-head hosted capture.

## Change-shape breakdown

Classification rule: production route/component/helper, design-catalog source, and telemetry code are source; Vitest and Playwright files are tests; the product spec, product-spec index, and active execution plan are docs. No binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 836 | 0 |
| Tests / fixtures | 223 | 0 |
| Docs | 265 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1,324** | **1** |

## Verification

- The branch is one commit at `6df5958446eac05e40e24d0223d91d2e94f36b04` and is cleanly ahead of PR base `303d67ef8d6cc8fd2637edec956a63df7017f592`.
- GitHub compare confirms the intended 11-file patch, 1,324 additions, and 1 deletion.
- Vercel, Repo Hygiene, and Hosted Stripe Billing are green on the exact head; remaining workflows continue independently.
- The design-proof guard recognizes the real Sections-catalog study. Its only reported blockers are the still-pending hosted desktop and mobile screenshots.
- The copy contract explicitly rejects generic creator-platform framing, named creator affiliation, marketplace claims, arbitrary publishing, Recipe naming, public body ranking, private creator health-data access, and guaranteed-income language.
- The contact handoff and focused tests require a health topic or outcome, source material, participant result, community goal, and audience or member size.
- Repository dependencies and a runnable Murph checkout are unavailable in this connector-only implementation environment. Focused Vitest, Web typecheck/lint, exact production rendering, hosted desktop/mobile captures, preliminary specialist review, and the rest of exact-head GitHub Actions remain explicit draft gates rather than claimed proof.

## Deployment skew / compatibility

Web-only and backward compatible. There is no schema, environment, Worker, runner, provider, mailbox, or persisted-contract change. A normal Web deployment is sufficient after the draft completion gates pass.
