### PR TITLE
Remove Cloudflare container SSH access

### DIFF
--- a/.agents/friction-log/20260811021050-sanctioned-worktree-briefly/friction.md
+++ b/.agents/friction-log/20260811021050-sanctioned-worktree-briefly/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Sanctioned worktree briefly reports every tracked file deleted'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+After scripts/create-worktree reports success, an immediate git status should show a clean task checkout.
+
+## Current Behavior
+
+The first status in a newly created sanctioned worktree reported every tracked file as deleted while the same paths appeared untracked. Subsequent index and blob inspection showed the checked-out files matched HEAD exactly, and a later status became clean without content changes.
+
+## Possible Solution
+
+Have the creator verify a clean status after checkout completion and retry the refresh or fail closed before reporting success.
+
+## Minimal Reproducible Example
+
+1. Create a branch worktree from origin/main with scripts/create-worktree.
+2. Immediately run git status --short --branch in the new checkout.
+3. Observe repository-wide deletions and matching untracked paths.
+4. Inspect exact index and worktree blobs, then rerun status and observe a clean checkout.
+
+## Context
+
+The transient state looked like a repository-wide destructive diff and blocked a security configuration change until the checkout could be proven safe.

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -928,6 +928,11 @@ Last verified: 2026-08-10
   Because a newly added workflow is not yet a protected trust root, its first
   credentialed proof occurs only after that exact workflow lands on `main`.
 - Cloudflare hosted deploys intentionally run the manual predeploy gates, hosted Codex auth guard, production build prep, Wrangler deploy, and deployed endpoint smoke on protected-main Blacksmith runners. Treat that as the only approved Blacksmith production-secret trust expansion: keep the workflow protected-main-only before environment attachment, scope production secrets to the validation, render, deploy, and smoke steps after checkout verification, and do not move any broader production secret access to Blacksmith without a fresh security review and durable docs update.
+- Cloudflare runner Containers must explicitly render Wrangler SSH disabled for
+  every class and must contain no authorized keys. Deploy automation must not
+  accept an environment-controlled SSH key or compatibility switch that can
+  restore an operator shell. Use structured logs, Durable Object status,
+  Container inventory, and managed deploy smoke as the diagnostic boundary.
 - The same protected-main Cloudflare workflow may attach the GitHub `Preview`
   Environment only for the explicit `preview` target. That environment must
   contain staging-only credentials and must not duplicate production database,

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -931,7 +931,9 @@ Last verified: 2026-08-10
 - Cloudflare runner Containers must explicitly render Wrangler SSH disabled for
   every class and must contain no authorized keys. Deploy automation must not
   accept an environment-controlled SSH key or compatibility switch that can
-  restore an operator shell. Use structured logs, Durable Object status,
+  restore an operator shell. Keep the independent Container PID-namespace
+  isolation flag enabled until the configured compatibility date provides the
+  same boundary by default. Use structured logs, Durable Object status,
   Container inventory, and managed deploy smoke as the diagnostic boundary.
 - The same protected-main Cloudflare workflow may attach the GitHub `Preview`
   Environment only for the explicit `preview` target. That environment must

--- a/agent-docs/exec-plans/active/2026-08-11-remove-container-ssh.md
+++ b/agent-docs/exec-plans/active/2026-08-11-remove-container-ssh.md
@@ -1,0 +1,60 @@
+# Remove Cloudflare Container SSH
+
+Status: active
+Created: 2026-08-11
+Updated: 2026-08-11
+
+## Goal
+
+- Remove Murph's Wrangler SSH access path from every Cloudflare Container and
+  make future deploy rendering fail closed with SSH explicitly disabled.
+
+## Success criteria
+
+- Checked-in and generated container configs set `ssh.enabled` to `false` for
+  both runner classes and contain no authorized keys.
+- Deploy automation no longer accepts, validates, exports, or documents
+  container SSH key inputs or the SSH-only compatibility flag.
+- Focused tests prove environment inputs cannot re-enable SSH and every
+  rendered container remains disabled.
+- The private deploy workflow stops forwarding the retired inputs so public and
+  private deploy contracts remain aligned.
+- Exact-head CI, preliminary coverage review, final ReviewGPT, and parent final
+  review have no unresolved accepted findings.
+
+## Scope
+
+- In scope: Cloudflare deploy environment parsing, Wrangler config rendering,
+  checked-in config, deploy docs, focused tests, and private workflow
+  pass-through cleanup.
+- Out of scope: rewriting Git history, exporting or rotating private keys,
+  deploying before review, or changing unrelated container lifecycle behavior.
+
+## Constraints
+
+- Remove the capability instead of retaining a dormant operator switch.
+- Preserve the existing runner and deploy-smoke topology.
+- Do not print, persist, or publish private key material or environment values.
+- Keep unrelated changes in the primary checkout and sibling worktrees intact.
+
+## Tasks
+
+1. Map every public and private SSH capability owner and confirm Cloudflare's
+   current default-enabled behavior.
+2. Delete the key/input path and render explicit SSH disablement for each
+   container, with focused regression coverage and durable-doc cleanup.
+3. Remove the private workflow pass-through and verify both diffs.
+4. Run focused tests, typecheck, config rendering/direct proof, and final diff
+   privacy inspection.
+5. Commit, push, open the PRs, run preliminary and final ReviewGPT with CI,
+   resolve accepted findings, and complete parent final review.
+
+## Verification
+
+- Focused Cloudflare deploy-automation tests.
+- Cloudflare app typecheck.
+- Generated-config assertion that every container has `ssh.enabled: false`, no
+  `authorized_keys`, and no SSH-only compatibility flag.
+- Exact-head GitHub Actions plus preliminary ReviewGPT coverage lens and final
+  ReviewGPT security/deploy gate.
+

--- a/agent-docs/exec-plans/active/2026-08-11-remove-container-ssh.md
+++ b/agent-docs/exec-plans/active/2026-08-11-remove-container-ssh.md
@@ -14,7 +14,8 @@ Updated: 2026-08-11
 - Checked-in and generated container configs set `ssh.enabled` to `false` for
   both runner classes and contain no authorized keys.
 - Deploy automation no longer accepts, validates, exports, or documents
-  container SSH key inputs or the SSH-only compatibility flag.
+  container SSH key inputs, while retaining independent PID-namespace
+  isolation.
 - Focused tests prove environment inputs cannot re-enable SSH and every
   rendered container remains disabled.
 - The private deploy workflow stops forwarding the retired inputs so public and
@@ -57,4 +58,3 @@ Updated: 2026-08-11
   `authorized_keys`, and no SSH-only compatibility flag.
 - Exact-head GitHub Actions plus preliminary ReviewGPT coverage lens and final
   ReviewGPT security/deploy gate.
-

--- a/agent-docs/exec-plans/completed/2026-08-11-remove-container-ssh.md
+++ b/agent-docs/exec-plans/completed/2026-08-11-remove-container-ssh.md
@@ -1,6 +1,6 @@
 # Remove Cloudflare Container SSH
 
-Status: active
+Status: completed
 Created: 2026-08-11
 Updated: 2026-08-11
 
@@ -58,3 +58,26 @@ Updated: 2026-08-11
   `authorized_keys`, and no SSH-only compatibility flag.
 - Exact-head GitHub Actions plus preliminary ReviewGPT coverage lens and final
   ReviewGPT security/deploy gate.
+
+## Completion evidence
+
+- Cloudflare config tests passed: 38 tests across deploy rendering, the
+  checked-in scaffold, and hosted-local fidelity; the post-specialist focused
+  rerun passed 35 tests.
+- Hosted-local environment tests passed: 94 tests. Both affected package
+  typechecks passed.
+- The private workflow test passed 10 tests and the full private `pnpm verify`
+  suite passed after the accepted coverage correction.
+- Public preliminary coverage review returned one accepted per-class scaffold
+  assertion gap, which is resolved. Final review round 1 returned two accepted
+  findings: preserve independent PID isolation and cover the hosted-local
+  config owner. Final round 2 returned `ROUND_OUTCOME: PASS` with no qualifying
+  findings.
+- Private preliminary review returned one accepted retired-mapping assertion
+  gap, which is resolved. Private final round 1 returned
+  `ROUND_OUTCOME: PASS` with no implementation findings.
+- Both PR heads merge cleanly with current `main`. Public exact-head CI is green
+  except for a current-main assistant prompt assertion mismatch outside this
+  diff. Private exact-head CI is green except for the same public-main wearable
+  replay scenario that failed before and after its test-only head update.
+Completed: 2026-08-11

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1480,6 +1480,11 @@ checked-in scaffold and generated deploy config must set `ssh.enabled` to
 re-enable the capability. This explicit setting is required because Cloudflare
 enables Wrangler SSH by default.
 
+Keep `containers_pid_namespace` enabled independently of SSH. Murph's current
+compatibility date predates Cloudflare's default for isolated Container PID
+namespaces, and removing the flag would change process topology and widen
+`/proc` visibility rather than merely remove operator access.
+
 Use bounded structured runtime logs, Durable Object status, Container
 application and instance inventory, and the managed deploy smoke for production
 diagnosis. Do not add an operator shell or per-deploy SSH key escape hatch.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -807,15 +807,6 @@ Core execution tuning:
 - `CF_COMPATIBILITY_DATE` defaults to `2026-03-27`
 - `CF_CONTAINER_INSTANCE_TYPE` defaults to `{"vcpu":2,"memory_mib":6144,"disk_mb":6000}`
 - `CF_CONTAINER_MAX_INSTANCES` defaults to `1000`
-- `CF_CONTAINER_SSH_PUBLIC_KEY` optionally adds one `ssh-ed25519` public key to
-  both runner Container `authorized_keys` entries for Wrangler SSH debugging.
-  The deploy renderer keeps only the key type and key body, so local key
-  comments are not copied into the generated Wrangler config. When this is set,
-  deploy automation also adds the `containers_pid_namespace` compatibility flag
-  so SSH debug sessions do not see unrelated VM processes.
-- `CF_CONTAINER_SSH_KEY_NAME` optionally sets the displayed key name for
-  `CF_CONTAINER_SSH_PUBLIC_KEY`; use a neutral lowercase slug. Defaults to
-  `local-debug`.
 - `CF_MAX_EVENT_ATTEMPTS` defaults to `3`
 - `CF_RETRY_DELAY_MS` defaults to `30000`
 - `CF_WEB_CONTROL_TIMEOUT_MS` defaults to `30000`
@@ -1231,6 +1222,13 @@ pnpm --dir apps/cloudflare deploy:preflight
 pnpm --dir apps/cloudflare deploy:artifacts
 ```
 
+To inspect the runner bundle and generated Wrangler config independently:
+
+```bash
+pnpm --dir apps/cloudflare runner:bundle
+pnpm --dir apps/cloudflare deploy:config:render
+```
+
 Local deploys and Docker smoke checks also prepare the stable native base image:
 
 ```bash
@@ -1474,39 +1472,14 @@ Optional smoke env:
 
 If neither managed-container smoke nor `HOSTED_EXECUTION_SMOKE_USER_ID` is configured, smoke stops after the public banner and health checks.
 
-## Wrangler SSH Debugging
+## Container Operator Access
 
-Wrangler SSH for Cloudflare Containers is an operator debug path only. It does
-not expose a public port, but it does let Cloudflare account writers connect to
-running Container instances when their local private key matches a public key in
-the rendered Container `authorized_keys`.
+Wrangler SSH is intentionally disabled for both runner Container classes. The
+checked-in scaffold and generated deploy config must set `ssh.enabled` to
+`false`, contain no `authorized_keys`, and expose no environment input that can
+re-enable the capability. This explicit setting is required because Cloudflare
+enables Wrangler SSH by default.
 
-Use a local `ssh-ed25519` key. If you create a dedicated key, use a neutral
-comment and keep the private key outside source control:
-
-```bash
-ssh-keygen -t ed25519 -C murph-cloudflare-containers -f <SSH_PRIVATE_KEY>
-ssh-add <SSH_PRIVATE_KEY>
-```
-
-Before rendering or deploying, export the public key without the local comment:
-
-```bash
-export CF_CONTAINER_SSH_PUBLIC_KEY="$(awk '{print $1 \" \" $2}' < <SSH_PUBLIC_KEY>)"
-export CF_CONTAINER_SSH_KEY_NAME=local-debug
-pnpm --dir apps/cloudflare runner:bundle
-pnpm --dir apps/cloudflare deploy:config:render
-```
-
-`pnpm --dir apps/cloudflare deploy:worker` also renders the config, so keep
-those env vars present for the deploy that should carry the debug key. After
-deploying, find a running instance and connect:
-
-```bash
-pnpm --dir apps/cloudflare exec wrangler containers instances <APPLICATION>
-pnpm --dir apps/cloudflare exec wrangler containers ssh <INSTANCE_ID>
-```
-
-SSH does not wake stopped Containers and does not keep an otherwise idle
-Container alive. Unset `CF_CONTAINER_SSH_PUBLIC_KEY` and redeploy when the debug
-window is over.
+Use bounded structured runtime logs, Durable Object status, Container
+application and instance inventory, and the managed deploy smoke for production
+diagnosis. Do not add an operator shell or per-deploy SSH key escape hatch.

--- a/apps/cloudflare/scripts/deploy-automation.ts
+++ b/apps/cloudflare/scripts/deploy-automation.ts
@@ -1,7 +1,6 @@
 export type {
   HostedContainerCustomInstanceType,
   HostedContainerInstanceType,
-  HostedContainerSshKey,
   HostedDeployAutomationEnvironment,
 } from "./deploy-automation/environment.ts";
 export { readHostedDeployAutomationEnvironment } from "./deploy-automation/environment.ts";

--- a/apps/cloudflare/scripts/deploy-automation/environment.ts
+++ b/apps/cloudflare/scripts/deploy-automation/environment.ts
@@ -1,5 +1,3 @@
-import { Buffer } from "node:buffer";
-
 import {
   isMurphAndroidAppEnabled,
   MURPH_ANDROID_APP_ENABLED_ENV,
@@ -44,22 +42,13 @@ export type HostedContainerInstanceType =
   | NamedContainerInstanceType
   | HostedContainerCustomInstanceType;
 
-export interface HostedContainerSshKey {
-  name: string;
-  public_key: string;
-}
-
 const DEFAULT_CONTAINER_INSTANCE_TYPE: HostedContainerInstanceType = {
   disk_mb: 6000,
   memory_mib: 6144,
   vcpu: 2,
 };
 const DEFAULT_CONTAINER_MAX_INSTANCES = 1000;
-const DEFAULT_CONTAINER_SSH_KEY_NAME = "local-debug";
 const RUNNER_COMMIT_RESPONSE_MARGIN_MS = 5_000;
-const CONTAINER_SSH_KEY_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/u;
-const SSH_ED25519_KEY_TYPE = "ssh-ed25519";
-const SSH_ED25519_PUBLIC_KEY_LENGTH = 32;
 
 export interface HostedDeployAutomationEnvironment {
   allowedRunnerSecretKeys: string | null;
@@ -68,7 +57,6 @@ export interface HostedDeployAutomationEnvironment {
   compatibilityDate: string;
   containerInstanceType: HostedContainerInstanceType;
   containerMaxInstances: number;
-  containerSshKey: HostedContainerSshKey | null;
   logHeadSamplingRate: number;
   maxEventAttempts: string;
   retryDelayMs: string;
@@ -143,10 +131,6 @@ export function readHostedDeployAutomationEnvironment(
       DEFAULT_CONTAINER_MAX_INSTANCES,
       "CF_CONTAINER_MAX_INSTANCES",
     ),
-    containerSshKey: normalizeContainerSshKey(
-      source.CF_CONTAINER_SSH_PUBLIC_KEY,
-      source.CF_CONTAINER_SSH_KEY_NAME,
-    ),
     logHeadSamplingRate: normalizeSamplingRate(
       source.CF_LOG_HEAD_SAMPLING_RATE,
       DEFAULT_LOG_HEAD_SAMPLING_RATE,
@@ -210,80 +194,6 @@ function readHostedWorkerVars(source: EnvSource): Record<string, string> {
       ? { [MURPH_ANDROID_APP_ENABLED_ENV]: "1" }
       : {}),
   };
-}
-
-function normalizeContainerSshKey(
-  publicKey: string | undefined,
-  name: string | undefined,
-): HostedContainerSshKey | null {
-  const normalizedPublicKey = normalizeOptionalString(publicKey);
-
-  if (!normalizedPublicKey) {
-    return null;
-  }
-
-  const parts = normalizedPublicKey.split(/\s+/u);
-  const [keyType, keyBody] = parts;
-
-  if (keyType !== SSH_ED25519_KEY_TYPE || !isValidOpenSshEd25519PublicKeyBody(keyBody)) {
-    throw new Error("CF_CONTAINER_SSH_PUBLIC_KEY must be an ssh-ed25519 public key.");
-  }
-
-  return {
-    name: normalizeContainerSshKeyName(name),
-    public_key: `${SSH_ED25519_KEY_TYPE} ${keyBody}`,
-  };
-}
-
-function isValidOpenSshEd25519PublicKeyBody(keyBody: string): boolean {
-  if (!/^[A-Za-z0-9+/]+={0,2}$/u.test(keyBody)) {
-    return false;
-  }
-
-  let decoded: Buffer;
-  try {
-    decoded = Buffer.from(keyBody, "base64");
-  } catch {
-    return false;
-  }
-
-  let offset = 0;
-  const readField = (): Buffer | null => {
-    if (offset + 4 > decoded.length) {
-      return null;
-    }
-
-    const fieldLength = decoded.readUInt32BE(offset);
-    offset += 4;
-    if (fieldLength > decoded.length - offset) {
-      return null;
-    }
-
-    const field = decoded.subarray(offset, offset + fieldLength);
-    offset += fieldLength;
-    return field;
-  };
-
-  const type = readField();
-  const publicKey = readField();
-
-  return Boolean(
-    type?.equals(Buffer.from(SSH_ED25519_KEY_TYPE))
-      && publicKey?.length === SSH_ED25519_PUBLIC_KEY_LENGTH
-      && offset === decoded.length,
-  );
-}
-
-function normalizeContainerSshKeyName(name: string | undefined): string {
-  const normalized = normalizeOptionalString(name) ?? DEFAULT_CONTAINER_SSH_KEY_NAME;
-
-  if (!CONTAINER_SSH_KEY_NAME_PATTERN.test(normalized)) {
-    throw new Error(
-      "CF_CONTAINER_SSH_KEY_NAME must be a neutral lowercase slug up to 32 characters.",
-    );
-  }
-
-  return normalized;
 }
 
 function normalizePositiveInteger(

--- a/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
+++ b/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
@@ -15,7 +15,6 @@ const DEFAULT_DEPLOY_ROOT = path.resolve(
 const RUNNER_CONTAINER_ROLLOUT_ACTIVE_GRACE_PERIOD_SECONDS = 300;
 const DEPLOY_SMOKE_CONTAINER_ROLLOUT_ACTIVE_GRACE_PERIOD_SECONDS = 0;
 const CONTAINER_ROLLOUT_STEP_PERCENTAGE = [10, 25, 50, 100] as const;
-const CONTAINER_SSH_COMPATIBILITY_FLAG = "containers_pid_namespace";
 
 function resolveContainerRolloutStepPercentage(maxInstances: number): number[] {
   if (maxInstances >= CONTAINER_ROLLOUT_STEP_PERCENTAGE.length) {
@@ -68,12 +67,8 @@ export function buildHostedWranglerDeployConfig(
       max_instances: input.maxInstances,
       rollout_active_grace_period: input.rolloutActiveGracePeriodSeconds,
       rollout_step_percentage: resolveContainerRolloutStepPercentage(input.maxInstances),
+      ssh: { enabled: false },
     };
-
-    if (environment.containerSshKey) {
-      container.ssh = { enabled: true };
-      container.authorized_keys = [environment.containerSshKey];
-    }
 
     return container;
   };
@@ -83,9 +78,7 @@ export function buildHostedWranglerDeployConfig(
     name: environment.workerName,
     main: "../src/index.ts",
     compatibility_date: environment.compatibilityDate,
-    compatibility_flags: environment.containerSshKey
-      ? ["nodejs_compat", CONTAINER_SSH_COMPATIBILITY_FLAG]
-      : ["nodejs_compat"],
+    compatibility_flags: ["nodejs_compat"],
     placement: {
       mode: "smart",
     },

--- a/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
+++ b/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
@@ -78,7 +78,7 @@ export function buildHostedWranglerDeployConfig(
     name: environment.workerName,
     main: "../src/index.ts",
     compatibility_date: environment.compatibilityDate,
-    compatibility_flags: ["nodejs_compat"],
+    compatibility_flags: ["nodejs_compat", "containers_pid_namespace"],
     placement: {
       mode: "smart",
     },

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -791,6 +791,9 @@ describe("hosted runner container image contract", () => {
 
     expect(wranglerConfig).toContain('"image": "../../Dockerfile.cloudflare-hosted-runner"');
     expect(wranglerConfig).toContain('"image_build_context": "."');
+    expect(wranglerConfig).toContain(
+      '"compatibility_flags": ["nodejs_compat", "containers_pid_namespace"]',
+    );
     expect(wranglerConfig).toContain('"ssh": { "enabled": false }');
     expect(wranglerConfig).not.toContain('"authorized_keys"');
     expect(container.ssh).toEqual({ enabled: false });

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -51,7 +51,6 @@ function createDeployEnvironment() {
       vcpu: 2,
     },
     containerMaxInstances: 1000,
-    containerSshKey: null,
     logHeadSamplingRate: 1,
     maxEventAttempts: "3",
     retryDelayMs: "30000",
@@ -792,6 +791,10 @@ describe("hosted runner container image contract", () => {
 
     expect(wranglerConfig).toContain('"image": "../../Dockerfile.cloudflare-hosted-runner"');
     expect(wranglerConfig).toContain('"image_build_context": "."');
+    expect(wranglerConfig).toContain('"ssh": { "enabled": false }');
+    expect(wranglerConfig).not.toContain('"authorized_keys"');
+    expect(container.ssh).toEqual({ enabled: false });
+    expect(container).not.toHaveProperty("authorized_keys");
     expect(packageJson.scripts?.["deploy:worker"]).toBe(
       "pnpm deploy:artifacts && pnpm runner:docker:base -- --force && pnpm deploy:worker:apply",
     );

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -504,6 +504,7 @@ describe("hosted deploy automation helpers", () => {
         max_instances: number;
         rollout_active_grace_period?: number;
         rollout_step_percentage?: number[];
+        ssh: { enabled: boolean };
       }>;
       durable_objects: {
         bindings: Array<{
@@ -547,6 +548,7 @@ describe("hosted deploy automation helpers", () => {
         max_instances: number;
         rollout_active_grace_period?: number;
         rollout_step_percentage?: number[];
+        ssh: { enabled: boolean };
       }>;
       durable_objects: {
         bindings: Array<{
@@ -589,12 +591,14 @@ describe("hosted deploy automation helpers", () => {
     ]);
     expect(checkedInConfig.containers).toHaveLength(generatedConfig.containers.length);
     for (const [index, generatedContainer] of generatedConfig.containers.entries()) {
+      expect(generatedContainer.ssh).toEqual({ enabled: false });
       expect(checkedInConfig.containers[index]).toMatchObject({
         class_name: generatedContainer.class_name,
         instance_type: generatedContainer.instance_type,
         max_instances: generatedContainer.max_instances,
         rollout_active_grace_period: generatedContainer.rollout_active_grace_period,
         rollout_step_percentage: generatedContainer.rollout_step_percentage,
+        ssh: generatedContainer.ssh,
       });
     }
     expect(checkedInConfig.durable_objects.bindings).toEqual(generatedConfig.durable_objects.bindings);

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -114,8 +114,6 @@ const REQUIRED_R2_PRESIGN_WORKER_SECRETS = {
 const REQUIRED_PRIVATE_IMAGE_WORKER_SECRET = {
   HOSTED_PRIVATE_MEDIA_CAPABILITY_SECRET: "images-signing-fixture",
 } as const;
-const VALID_TEST_SSH_ED25519_PUBLIC_KEY =
-  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB";
 
 function expectedRequiredHostedCryptoWorkerVars(): Record<string, string> {
   return Object.fromEntries(
@@ -242,6 +240,7 @@ describe("hosted deploy automation helpers", () => {
         max_instances: number;
         rollout_active_grace_period: number;
         rollout_step_percentage: number[];
+        ssh: { enabled: boolean };
       }>;
       durable_objects: {
         bindings: Array<{
@@ -308,6 +307,7 @@ describe("hosted deploy automation helpers", () => {
         max_instances: 250,
         rollout_active_grace_period: 300,
         rollout_step_percentage: [10, 25, 50, 100],
+        ssh: { enabled: false },
       },
       {
         class_name: "DeploySmokeRunnerContainer",
@@ -317,6 +317,7 @@ describe("hosted deploy automation helpers", () => {
         max_instances: 1,
         rollout_active_grace_period: 0,
         rollout_step_percentage: [100],
+        ssh: { enabled: false },
       },
     ]);
     expect(config.durable_objects.bindings).toEqual([
@@ -729,12 +730,12 @@ describe("hosted deploy automation helpers", () => {
     });
   });
 
-  it("renders an optional local container SSH public key without preserving comments", () => {
+  it("keeps container SSH disabled when retired SSH inputs are still present", () => {
     const environment = readHostedDeployAutomationEnvironment({
       CF_BUNDLES_BUCKET: "hosted-bundles",
       CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
       CF_CONTAINER_SSH_KEY_NAME: "debug-key",
-      CF_CONTAINER_SSH_PUBLIC_KEY: `${VALID_TEST_SSH_ED25519_PUBLIC_KEY} local-comment`,
+      CF_CONTAINER_SSH_PUBLIC_KEY: "ssh-ed25519 retired-key-material",
       CF_WORKER_NAME: "hosted-worker",
       ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
     });
@@ -742,58 +743,17 @@ describe("hosted deploy automation helpers", () => {
       compatibility_flags: string[];
       containers: Array<{
         authorized_keys?: Array<{ name: string; public_key: string }>;
-        ssh?: { enabled: boolean };
+        ssh: { enabled: boolean };
       }>;
     };
 
-    expect(config.compatibility_flags).toEqual(["nodejs_compat", "containers_pid_namespace"]);
+    expect(environment).not.toHaveProperty("containerSshKey");
+    expect(config.compatibility_flags).toEqual(["nodejs_compat"]);
     expect(config.containers).toHaveLength(2);
     for (const container of config.containers) {
-      expect(container.ssh).toEqual({ enabled: true });
-      expect(container.authorized_keys).toEqual([{
-        name: "debug-key",
-        public_key: VALID_TEST_SSH_ED25519_PUBLIC_KEY,
-      }]);
+      expect(container.ssh).toEqual({ enabled: false });
+      expect(container).not.toHaveProperty("authorized_keys");
     }
-  });
-
-  it("rejects non-Ed25519 container SSH public keys", () => {
-    expect(() =>
-      readHostedDeployAutomationEnvironment({
-        CF_BUNDLES_BUCKET: "hosted-bundles",
-        CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
-        CF_CONTAINER_SSH_PUBLIC_KEY:
-          "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCinvalid",
-        CF_WORKER_NAME: "hosted-worker",
-        ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
-      }),
-    ).toThrowError(/CF_CONTAINER_SSH_PUBLIC_KEY must be an ssh-ed25519 public key\./u);
-  });
-
-  it("rejects malformed Ed25519 container SSH public key bodies", () => {
-    expect(() =>
-      readHostedDeployAutomationEnvironment({
-        CF_BUNDLES_BUCKET: "hosted-bundles",
-        CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
-        CF_CONTAINER_SSH_PUBLIC_KEY:
-          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMurphContainerDebugKey000000000000000",
-        CF_WORKER_NAME: "hosted-worker",
-        ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
-      }),
-    ).toThrowError(/CF_CONTAINER_SSH_PUBLIC_KEY must be an ssh-ed25519 public key\./u);
-  });
-
-  it("rejects container SSH key names that are not neutral slugs", () => {
-    expect(() =>
-      readHostedDeployAutomationEnvironment({
-        CF_BUNDLES_BUCKET: "hosted-bundles",
-        CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
-        CF_CONTAINER_SSH_KEY_NAME: "Debug Key",
-        CF_CONTAINER_SSH_PUBLIC_KEY: VALID_TEST_SSH_ED25519_PUBLIC_KEY,
-        CF_WORKER_NAME: "hosted-worker",
-        ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
-      }),
-    ).toThrowError(/CF_CONTAINER_SSH_KEY_NAME must be a neutral lowercase slug/u);
   });
 
   it("rejects invalid custom container instance JSON", () => {

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -367,7 +367,10 @@ describe("hosted deploy automation helpers", () => {
         crons: ["*/5 * * * *"],
       },
     });
-    expect(config.compatibility_flags).toEqual(["nodejs_compat"]);
+    expect(config.compatibility_flags).toEqual([
+      "nodejs_compat",
+      "containers_pid_namespace",
+    ]);
     expect(config.placement).toEqual({ mode: "smart" });
     expect(config.r2_buckets).toEqual([
       {
@@ -748,7 +751,10 @@ describe("hosted deploy automation helpers", () => {
     };
 
     expect(environment).not.toHaveProperty("containerSshKey");
-    expect(config.compatibility_flags).toEqual(["nodejs_compat"]);
+    expect(config.compatibility_flags).toEqual([
+      "nodejs_compat",
+      "containers_pid_namespace",
+    ]);
     expect(config.containers).toHaveLength(2);
     for (const container of config.containers) {
       expect(container.ssh).toEqual({ enabled: false });

--- a/apps/cloudflare/test/hosted-local-dev-wrangler-fidelity.test.ts
+++ b/apps/cloudflare/test/hosted-local-dev-wrangler-fidelity.test.ts
@@ -54,11 +54,21 @@ describe("hosted-local dev wrangler config fidelity", () => {
     );
 
     // Container sizing, instance caps, and rollout staging are deploy-only
-    // concerns; the class names backing the durable object bindings must match.
-    const devContainers = dev.containers as Array<{ class_name: string }>;
-    const productionContainers = production.containers as Array<{ class_name: string }>;
-    expect(devContainers.map((container) => container.class_name)).toEqual(
-      productionContainers.map((container) => container.class_name),
+    // concerns; class identity and operator-access policy must match.
+    type ContainerRuntimeSurface = {
+      authorized_keys?: unknown;
+      class_name: string;
+      ssh?: unknown;
+    };
+    const devContainers = dev.containers as ContainerRuntimeSurface[];
+    const productionContainers = production.containers as ContainerRuntimeSurface[];
+    const runtimeSurface = (container: ContainerRuntimeSurface) => ({
+      authorized_keys: container.authorized_keys,
+      class_name: container.class_name,
+      ssh: container.ssh,
+    });
+    expect(devContainers.map(runtimeSurface)).toEqual(
+      productionContainers.map(runtimeSurface),
     );
   });
 

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "murph-hosted",
   "main": "src/index.ts",
   "compatibility_date": "2026-03-27",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "containers_pid_namespace"],
   "placement": {
     "mode": "smart"
   },

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -10,12 +10,6 @@
   "containers": [
     {
       "class_name": "RunnerContainer",
-      "authorized_keys": [
-        {
-          "name": "incident-debug",
-          "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDz0o0L6ibmTmmtmTdlxboJ1a+dd9oMBcSyiI8a+bnzd"
-        }
-      ],
       "image": "../../Dockerfile.cloudflare-hosted-runner",
       "image_build_context": ".",
       "instance_type": {
@@ -25,7 +19,8 @@
       },
       "max_instances": 1000,
       "rollout_active_grace_period": 300,
-      "rollout_step_percentage": [10, 25, 50, 100]
+      "rollout_step_percentage": [10, 25, 50, 100],
+      "ssh": { "enabled": false }
     },
     {
       "class_name": "DeploySmokeRunnerContainer",
@@ -38,7 +33,8 @@
       },
       "max_instances": 1,
       "rollout_active_grace_period": 0,
-      "rollout_step_percentage": [100]
+      "rollout_step_percentage": [100],
+      "ssh": { "enabled": false }
     }
   ],
   "durable_objects": {

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -1071,6 +1071,7 @@ export function buildWranglerLocalDevConfig(
     },
     instance_type: "standard-1",
     max_instances: input.maxInstances,
+    ssh: { enabled: false },
   });
 
   return {
@@ -1080,7 +1081,7 @@ export function buildWranglerLocalDevConfig(
       path.join(cloudflareAppDir, "src", resolveWranglerLocalDevWorkerEntrypoint(source)),
     ),
     compatibility_date: "2026-03-27",
-    compatibility_flags: ["nodejs_compat"],
+    compatibility_flags: ["nodejs_compat", "containers_pid_namespace"],
     containers: [
       buildRunnerContainerConfig({ className: "RunnerContainer", maxInstances: 50 }),
       buildRunnerContainerConfig({ className: "DeploySmokeRunnerContainer", maxInstances: 1 }),

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -1594,6 +1594,8 @@ describe("buildWranglerLocalDevConfig", () => {
       image_build_context: string;
       image_vars: Record<string, string>;
       max_instances: number;
+      authorized_keys?: unknown;
+      ssh: { enabled: boolean };
     }[];
     const container = containers[0]!;
     const smokeContainer = containers[1]!;
@@ -1605,6 +1607,14 @@ describe("buildWranglerLocalDevConfig", () => {
       "RunnerContainer",
       "DeploySmokeRunnerContainer",
     ]);
+    expect(config.compatibility_flags).toEqual([
+      "nodejs_compat",
+      "containers_pid_namespace",
+    ]);
+    for (const entry of containers) {
+      expect(entry.ssh).toEqual({ enabled: false });
+      expect(entry).not.toHaveProperty("authorized_keys");
+    }
     expect(config.durable_objects).toMatchObject({
       bindings: expect.arrayContaining([
         {


### PR DESCRIPTION
## Why this PR exists

Cloudflare Wrangler SSH is enabled by default, while Murph retained a key-configured operator shell path. This removes that capability and makes every checked-in and generated Container config fail closed with SSH explicitly disabled.

## User goal / user-visible behavior

Operators can no longer SSH into Murph runner or deploy-smoke containers. Hosted member behavior is unchanged.

## User experience

No member-facing effect. Container diagnosis continues through bounded runtime logs, Durable Object status, deployment inventory, and managed-container smoke.

## Invariants

- Both Container classes render `ssh.enabled: false` and no `authorized_keys` in production and hosted-local configs.
- Retired environment inputs cannot re-enable SSH.
- Independent `containers_pid_namespace` isolation remains enabled for the current compatibility date.
- Production container topology, runtime behavior, and diagnostic paths stay unchanged; hosted-local now matches production PID isolation.
- Public deploy rendering and the private deployment workflow remain aligned through the companion PR.

## Changelog

- Changelog: not applicable
- Reason: Internal security and deployment hardening with no member-visible behavior change.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: Security-sensitive runtime/deploy change spanning the public config owner, hosted-local fidelity owner, and private deployment workflow.

ReviewGPT first-reviewed head: f90da7767c8f9bf42fcd30de9bfdddff45e159b5

## Review lenses

- Product experience: Not applicable; no member journey or product semantics change.
- Prompt: Not applicable; no prompt or provider-input surface changes.
- Frontend: Not applicable; no UI changes.
- Coverage: Applicable; focused tests cover checked-in, generated production, and hosted-local configs, ignored retired inputs, PID isolation, and absence of authorized keys for every Container class.

## Non-obvious affected surfaces

- Generated production Wrangler config: focused tests assert both Container entries remain explicitly disabled even when retired SSH environment names are supplied.
- Checked-in Wrangler scaffold: parsed contract coverage asserts per-class explicit disablement, absence of authorized keys, and retained PID isolation.
- Hosted-local Wrangler renderer: the same per-Container operator-access policy and compatibility flags are enforced and compared against the checked-in production scaffold.
- Private deployment workflow: cobuildwithus/murph-cloud#25 removes the retired input forwarding after this fail-closed renderer lands.

## Architecture and reuse

- Existing systems reused: Existing environment parser, production Wrangler renderer, hosted-local renderer, fidelity contract, container contract tests, and structured runtime diagnostics.
- New logic: A fixed fail-closed `ssh.enabled: false` setting on every real Container config owner while the independent PID-namespace isolation flag remains unconditional.
- New abstractions: None; the SSH key type, parser, validator, conditional renderer, and environment switch were deleted.
- Complexity intentionally avoided: No dormant feature flag, alternate key path, or compatibility shim remains.

## Hot reply path impact

- Path status: Not applicable — deploy configuration only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Focused config rendering, hosted-local fidelity, and container contract tests.

## Murph initial provider input impact

| **Total** | **199** | **209** |

## Review remediation

- Current head: 5a5f41a836a3d2bdaaf55970ac21d5bfdc342dcc\n- Review-passed head: b5a44059d250c28c6a7cc1c141bde06de1559eea; the subsequent commit only archives the completed execution plan.
- Round 1 finding 1: accepted; `containers_pid_namespace` is an independent isolation control and is now retained unconditionally for the current pre-default compatibility date.
- Round 1 finding 2: accepted; the hosted-local Wrangler renderer now explicitly disables SSH for both Container classes, and the existing production/local fidelity test compares operator-access policy.
- Preliminary coverage finding: accepted; the parsed checked-in scaffold loop now proves `ssh.enabled: false` per Container class against the generated production config.
- Remediation movement beyond the first-reviewed head: +3/-2 source lines and +1/-1 config lines; remaining additions are focused tests and durable intent documentation.

## Verification

- `pnpm --dir apps/cloudflare typecheck`
- `pnpm --dir packages/hosted-local-harness typecheck`
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/deploy-automation.test.ts apps/cloudflare/test/container-image-contract.test.ts apps/cloudflare/test/hosted-local-dev-wrangler-fidelity.test.ts` — 38 passed
- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts --no-coverage test/dev-hosted-local/environment.test.ts` — 94 passed
- Post-specialist focused rerun: deploy automation and container contract tests — 35 passed
- `git diff --check`
- Private companion: focused workflow test 10 passed and `pnpm verify` passed after remediation.
- Exact-head public CI has an unrelated current-main failure in `packages/assistant-engine/test/model-behavior.test.ts`: current `origin/main` contains the new appointment-reminder heading while two base assertions still require the retired heading. This PR touches neither owner.

## Deployment concerns

Land this public fail-closed renderer before removing the private workflow mappings. After both PRs merge, deploy Cloudflare with an immediate container rollout and verify both Container classes report SSH disabled with no authorized keys and retain isolated PID namespaces.

Companion private workflow cleanup: cobuildwithus/murph-cloud#25
