### PR TITLE
fix(web): slim homepage phone on mobile

### DIFF
--- a/.agents/friction-log/20260811025721-design-catalog-otp/friction.md
+++ b/.agents/friction-log/20260811025721-design-catalog-otp/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Design catalog OTP study adds a hydration warning overlay to unrelated frontend proof'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Opening the Sections tab in local development should render synthetic catalog studies without a Next.js issue overlay, so a section can be captured directly for frontend design proof.
+
+## Current Behavior
+
+The synthetic homepage authentication warm-runtime study renders an OTP input whose server and client inline style attributes differ. React reports a hydration mismatch and Next.js adds a one-issue overlay, even when the section under review is unrelated.
+
+## Possible Solution
+
+Make the OTP study's server and client style serialization deterministic, or defer that synthetic input until after hydration without changing the production component contract.
+
+## Minimal Reproducible Example
+
+1. Start the hosted Web app in local development.
+2. Open `/design?tab=sections` at a mobile viewport.
+3. Wait for hydration.
+4. Observe the Next.js issue overlay reporting an inline-style mismatch in the synthetic OTP input.
+
+## Context
+
+The overlay contaminates otherwise valid desktop and mobile catalog screenshots and forces proof tooling to remove unrelated development chrome before capture.

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -111,7 +111,7 @@ export function SectionsContent() {
         <div
           id="homepage-solo-first-hero"
           data-design-section="homepage-solo-first-hero"
-          data-design-state="soft-topic-labels"
+          data-design-state="soft-topic-labels-mobile-narrow-phone"
           className="-mx-5 sm:-mx-8 lg:-mx-12"
           inert
         >

--- a/apps/web/changelog/entries/2026-08-11/homepage-mobile-phone-proportions.json
+++ b/apps/web/changelog/entries/2026-08-11/homepage-mobile-phone-proportions.json
@@ -1,0 +1,18 @@
+{
+  "publishedOn": "2026-08-11",
+  "order": 100,
+  "item": {
+    "id": "homepage-mobile-phone-proportions",
+    "kind": "improvement",
+    "priority": 1,
+    "title": "The homepage phone fits mobile screens better",
+    "summary": "On phone-size screens, the public homepage now gives its iPhone conversation preview a narrower, more natural shape while keeping the message and signup action easy to read.",
+    "details": "Tablet and desktop proportions, conversation behavior, and the signup path are unchanged.",
+    "relevanceTags": ["homepage", "mobile", "design"],
+    "sourcePullRequests": [1643],
+    "tryIt": {
+      "href": "/",
+      "label": "Visit the homepage"
+    }
+  }
+}

--- a/apps/web/src/components/homepage/hero-clocks-in.tsx
+++ b/apps/web/src/components/homepage/hero-clocks-in.tsx
@@ -1297,7 +1297,7 @@ export function HeroClocksIn({
         </div>
 
         <div className="pointer-events-auto relative z-10 lg:col-span-5">
-          <div className="relative mx-auto w-full max-w-[320px] lg:aspect-[3/4] lg:max-w-[520px]">
+          <div className="relative mx-auto w-full max-w-[280px] sm:max-w-[320px] lg:aspect-[3/4] lg:max-w-[520px]">
             <div className="lg:absolute lg:left-1/2 lg:top-1/2 lg:w-[340px] lg:-translate-x-1/2 lg:-translate-y-1/2">
               <PhoneShell>
                 <StatusBar />

--- a/apps/web/test/hero-clocks-in.test.tsx
+++ b/apps/web/test/hero-clocks-in.test.tsx
@@ -92,6 +92,11 @@ test("HeroClocksIn renders the solo exchange without animation for reduced motio
   assert.ok(topic.classList.contains("text-[#756c5a]"));
   assert.ok(topic.classList.contains("focus-visible:ring-2"));
   assert.ok(member.classList.contains("text-[#736a58]"));
+  const phoneFrame = [...view.container.querySelectorAll("div")].find(
+    (element) => element.classList.contains("max-w-[280px]"),
+  );
+  assert.ok(phoneFrame);
+  assert.ok(phoneFrame.classList.contains("sm:max-w-[320px]"));
   const controls = [...view.container.querySelectorAll("input, button")];
   assert.ok(controls.indexOf(composer) < controls.indexOf(topic));
   assert.ok(


### PR DESCRIPTION
## Why this PR exists

The homepage phone mockup occupies too much of a narrow viewport and reads wider than an iPhone. This PR gives the existing hero phone a slimmer mobile silhouette without changing the tablet or desktop composition.

## User goal / user-visible behavior

Visitors on phone-width screens see a narrower, more convincing iPhone mockup with the conversation and CTA still fully legible.

## User experience

The entry point remains the public homepage hero. Below the `sm` breakpoint, the phone frame renders at a 280px maximum width instead of 320px; the change is immediate, has no asynchronous continuation or failure state, and leaves the existing conversation, CTA, navigation, and destinations unchanged. The real production hero rendered cleanly in the design catalog at 390px and 1440px.

## Invariants

- The existing 320px tablet width and desktop layout remain unchanged.
- Conversation content, animation, interaction, accessibility, and CTA behavior remain unchanged.
- The design catalog continues to render the real production hero with synthetic props.
- No member data, runtime state, database path, or provider boundary changes.

## Changelog

- Changelog: updated
- Items: 2026-08-11 · homepage-mobile-phone-proportions

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: This is a narrow responsive styling change with no product-critical, persisted-state, auth, billing, health-safety, runtime, or cross-owner behavior.

## Non-obvious affected surfaces

- The Sections design-catalog state marker now names the narrow mobile phone presentation; the existing production-component study and hosted screenshots prove it.
- The HeroClocksIn component test asserts both the new phone-width maximum and the existing `sm` breakpoint restoration.
- The sharded public changelog contains one isolated entry for the visible mobile improvement.
- A public-safe Frog entry records an unrelated synthetic OTP hydration overlay encountered during catalog capture.

## Architecture and reuse

- Existing systems reused: The existing `HeroClocksIn` production component, Tailwind responsive breakpoint, `/design?tab=sections` study, and sharded changelog loader remain the only owners.
- New logic: One responsive maximum-width override applies below `sm`; the established 320px and desktop rules continue above it.
- New abstractions: None; the existing responsive class contract is sufficient for a single visual proportion change.
- Complexity intentionally avoided: No new component, hook, viewport listener, CSS variable, JavaScript measurement, duplicate catalog markup, or central changelog registry edit was added.

## Hot reply path impact

- Path status: Not applicable; this PR changes only public homepage presentation.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The focused component test and rendered catalog proof exercise the changed surface without touching the reply path.

## Database collection fanout impact

Not applicable; the diff adds no database access or collection work.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run; no prompt, tool, schema, model configuration, or provider-request surface changed.

## Preliminary specialist lenses

- Product experience: applicable; the intended outcome is a slimmer mobile homepage phone, directly proven by the 390px catalog capture while the 1440px capture proves desktop stability.
- Prompt: not applicable; no prompt or provider-input surface changed.
- Frontend: applicable; the hosted desktop and mobile screenshots below show the exact production hero study and responsive states.
- Coverage: applicable; the focused HeroClocksIn test asserts the new mobile maximum and existing breakpoint restoration. Exact-head web checks are green; one unrelated assistant-engine package check failed on a stale base assertion that is already corrected on current `main`.

## Rendered-evidence manifest

- `audit-packages/pr-1643-homepage-desktop.png` — redacted production hero study at a 1440px desktop viewport and 2x device scale.
- `audit-packages/pr-1643-homepage-mobile.png` — redacted production hero study at a 390px mobile viewport and 2x device scale.

## Design proof

- Design page: [Homepage solo-first hero](https://www.withmurph.ai/design?tab=sections#homepage-solo-first-hero)
- Coverage: Existing production `HeroClocksIn` section at 1440px desktop and 390px mobile, both at 2x device scale.
- Desktop screenshot: ![Homepage hero desktop design proof](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/3b2cfdc5-1168-4f12-3f9e-9c6440b0b500/designproof)
- Mobile screenshot: ![Homepage hero mobile design proof](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/59e8a5a8-3258-421c-addf-7b2f8f1cec00/designproof)

## Audit results

- Preliminary `completion-specialists` ReviewGPT: `SPECIALIST_OUTCOME: PASS` on exact head `2aed059fe79f0df4da26910c85d87958ddcb194d`; product, frontend, and coverage findings: none; patch artifact: none.
- Product purpose verdict: the single mobile width change completely delivers the narrower phone silhouette while preserving the conversation, CTA, and desktop composition.
- Final cross-cutting ReviewGPT: not applicable under the routine frontend-only exemption.
- Claude UI double-check: attempted with Fable; explicit usage-credit exhaustion ended the check under repository policy, with no fallback model request permitted.

## Change-shape breakdown

Classification rule: Runtime TSX, catalog TSX, and the sharded product changelog entry are source; Vitest assertions are tests; and the Frog report is docs. No binary or generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 20 | 2 |
| Tests / fixtures | 5 | 0 |
| Docs | 27 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **52** | **2** |

## Verification

- `pnpm exec vitest run apps/web/test/changelog-fragments.test.ts apps/web/test/changelog.test.ts apps/web/test/changelog-page.test.tsx apps/web/test/hero-clocks-in.test.tsx --config apps/web/vitest.config.ts --no-coverage` — 59 tests passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm test:frontend-design-proof` — 10 tests passed.
- `pnpm --dir apps/web exec eslint src/components/homepage/hero-clocks-in.tsx app/design/sections-content.tsx test/hero-clocks-in.test.tsx` — passed.
- `git diff --check` — passed.
- Playwright catalog proof — the production hero was inspected at 390px and 1440px; the mobile phone is narrower with a clear CTA and the desktop composition is unchanged.
- Playwright changelog proof — the latest archive and its catalog study were inspected at desktop and mobile widths with no horizontal overflow; the new entry renders on the public archive.
- Hosted design proof — both `/designproof` PNGs returned HTTP 200 and matched the inspected local captures.
- Exact-head GitHub web checks — Frontend design proof, viewport overflow, release build/typecheck, repo hygiene, and Vercel passed.
- `Release package coverage (assistant)` — failed in two pre-existing prompt-header assertions outside this PR's diff; current `main` contains the focused correction in `3778113822`.
- `git merge-tree --write-tree HEAD origin/main` — clean against current `main` at `85b1f59297`.
