### PR TITLE
Fix newsletter integration regressions

### DIFF
--- a/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
@@ -100,6 +100,26 @@ let scenario: HostedLocalFullStackScenario | null = null;
 let linqStub: HostedLocalLinqStub | null = null;
 let browserVaultSummary: JunctionWearableBrowserVaultReplicaSummary | null = null;
 
+describe("hosted system mailbox frontier proof", () => {
+  it.each([
+    null,
+    "not-a-sequence",
+    "-1",
+  ])("rejects a %s pre-trigger imported sequence", (value) => {
+    expect(() => requireNonNegativeDecimalSequence(
+      value,
+      "pre-trigger hosted system mailbox imported sequence",
+    )).toThrow("pre-trigger hosted system mailbox imported sequence");
+  });
+
+  it("accepts an explicit non-negative pre-trigger imported sequence", () => {
+    expect(requireNonNegativeDecimalSequence(
+      "42",
+      "pre-trigger hosted system mailbox imported sequence",
+    )).toBe("42");
+  });
+});
+
 describe("hosted local Junction wearable direct-resource replay e2e", () => {
   beforeAll(async () => {
     plan = await buildJunctionWearableHostedReplayPlan({ replaySize: "smoke" });
@@ -475,6 +495,7 @@ describe("hosted local Junction wearable direct-resource replay e2e", () => {
     }
 
     await assertHostedDeviceSyncReplayReceiptAccepted({
+      requireAdvancedDurableFrontier: true,
       scenario: activeScenario,
       systemImportedSeqBefore: systemImportedSeqBeforeDeviceSync,
       userId,
@@ -1232,6 +1253,7 @@ async function readBrowserVaultReplica(input: {
 }
 
 async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
+  requireAdvancedDurableFrontier?: boolean;
   scenario: HostedLocalFullStackScenario;
   systemImportedSeqBefore: string;
   userId: string;
@@ -1278,7 +1300,10 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
       lane.lane === "system" && lane.lag === "0"
     );
   const receiptObserved = durableSystemLaneAdvancedAndSettled
-    || recordedDeviceSyncLog !== undefined;
+    || (
+      input.requireAdvancedDurableFrontier !== true
+      && recordedDeviceSyncLog !== undefined
+    );
 
   if (
     !receiptObserved
@@ -1299,6 +1324,8 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
         systemHandledThroughSeq,
         systemImportedSeq,
         systemImportedSeqBefore: input.systemImportedSeqBefore,
+        requireAdvancedDurableFrontier:
+          input.requireAdvancedDurableFrontier === true,
       })}`,
       ...(safeErrors.length > 0
         ? [`system mailbox safe errors: ${JSON.stringify(safeErrors)}`]
@@ -1322,10 +1349,13 @@ async function readHostedSystemImportedSeq(input: {
       },
     ),
   );
-  return readStringAtPath(
-    status.workspace?.redactedStatus ?? null,
-    ["hostedMailboxSystemImportedSeq"],
-  ) ?? "0";
+  return requireNonNegativeDecimalSequence(
+    readStringAtPath(
+      status.workspace?.redactedStatus ?? null,
+      ["hostedMailboxSystemImportedSeq"],
+    ),
+    "pre-trigger hosted system mailbox imported sequence",
+  );
 }
 
 async function assertNoHostedDeviceSyncJobFailures(input: {
@@ -1728,6 +1758,16 @@ function hasDecimalSequenceAdvanced(before: string, after: string): boolean {
     return false;
   }
   return BigInt(after) > BigInt(before);
+}
+
+function requireNonNegativeDecimalSequence(
+  value: string | null,
+  label: string,
+): string {
+  if (value === null || !/^\d+$/u.test(value)) {
+    throw new Error(`${label} must be a non-negative decimal string.`);
+  }
+  return value;
 }
 
 function collectUnsafeHostedStatusFailureKeys(value: unknown): string[] {

--- a/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
@@ -330,6 +330,10 @@ describe("hosted local Junction wearable direct-resource replay e2e", () => {
     ], {
       matchInputContains: experimentActivityNudgeInstructions,
     });
+    const systemImportedSeqBeforeDeviceSync = await readHostedSystemImportedSeq({
+      scenario: activeScenario,
+      userId: experimentAdherenceUserId,
+    });
 
     await postSignedJunctionWebhook({
       dirtyResource: activityPlan.cycling,
@@ -357,6 +361,7 @@ describe("hosted local Junction wearable direct-resource replay e2e", () => {
     }
     await assertHostedDeviceSyncReplayReceiptAccepted({
       scenario: activeScenario,
+      systemImportedSeqBefore: systemImportedSeqBeforeDeviceSync,
       userId: experimentAdherenceUserId,
     });
     await assertNoHostedDeviceSyncJobFailures({
@@ -449,6 +454,10 @@ describe("hosted local Junction wearable direct-resource replay e2e", () => {
 
     expect(seed.dirtyResourceCount).toBe(replayPlan.dirtyResources.length);
     expect(seed.sourceCount).toBe(3);
+    const systemImportedSeqBeforeDeviceSync = await readHostedSystemImportedSeq({
+      scenario: activeScenario,
+      userId,
+    });
 
     await activeScenario.runWake(
       buildJunctionFixtureWake(seed.connectionId, seededAt),
@@ -467,6 +476,7 @@ describe("hosted local Junction wearable direct-resource replay e2e", () => {
 
     await assertHostedDeviceSyncReplayReceiptAccepted({
       scenario: activeScenario,
+      systemImportedSeqBefore: systemImportedSeqBeforeDeviceSync,
       userId,
     });
     await assertNoHostedDeviceSyncJobFailures({
@@ -812,6 +822,10 @@ async function runSignedJunctionHistoricalCoverageReplay(input: {
     sources: garminSources,
   });
   expect(seed.sourceCount).toBe(1);
+  const systemImportedSeqBeforeDeviceSync = await readHostedSystemImportedSeq({
+    scenario: input.scenario,
+    userId: input.userId,
+  });
 
   let retriedSleepCycleDelivery = false;
   for (const [index, dirtyResource] of input.dirtyResources.entries()) {
@@ -853,6 +867,7 @@ async function runSignedJunctionHistoricalCoverageReplay(input: {
   }
   await assertHostedDeviceSyncReplayReceiptAccepted({
     scenario: input.scenario,
+    systemImportedSeqBefore: systemImportedSeqBeforeDeviceSync,
     userId: input.userId,
   });
   await assertNoHostedDeviceSyncJobFailures({
@@ -1218,6 +1233,7 @@ async function readBrowserVaultReplica(input: {
 
 async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
   scenario: HostedLocalFullStackScenario;
+  systemImportedSeqBefore: string;
   userId: string;
 }): Promise<void> {
   const receiptStatus = parseHostedRunnerStatusResponse(
@@ -1255,16 +1271,14 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
     && (entry.status === "processed" || entry.status === "recorded")
     && (entry.recordFailed ?? 0) === 0
   );
-  const durableSystemLaneSettled = systemImportedSeq !== null
-    && systemImportedSeq !== "0"
+  const durableSystemLaneAdvancedAndSettled = systemImportedSeq !== null
+    && hasDecimalSequenceAdvanced(input.systemImportedSeqBefore, systemImportedSeq)
     && systemImportedSeq === systemHandledThroughSeq
     && receiptStatus.mailboxLag.some((lane) =>
       lane.lane === "system" && lane.lag === "0"
     );
-  const receiptObserved = durableSystemLaneSettled
-    || recordedDeviceSyncLog !== undefined
-    || recorded > 0
-    || prepared > 0;
+  const receiptObserved = durableSystemLaneAdvancedAndSettled
+    || recordedDeviceSyncLog !== undefined;
 
   if (
     !receiptObserved
@@ -1284,6 +1298,7 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
         retryableFailed,
         systemHandledThroughSeq,
         systemImportedSeq,
+        systemImportedSeqBefore: input.systemImportedSeqBefore,
       })}`,
       ...(safeErrors.length > 0
         ? [`system mailbox safe errors: ${JSON.stringify(safeErrors)}`]
@@ -1291,6 +1306,26 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
       `system mailbox logs: ${JSON.stringify(systemMailboxLogs)}`,
     ]));
   }
+}
+
+async function readHostedSystemImportedSeq(input: {
+  scenario: HostedLocalFullStackScenario;
+  userId: string;
+}): Promise<string> {
+  const status = parseHostedRunnerStatusResponse(
+    await input.scenario.harness.requestJson<unknown>(
+      buildCloudflareHostedControlUserStatusPath(input.userId),
+      {
+        headers: {
+          [HOSTED_EXECUTION_USER_ID_HEADER]: input.userId,
+        },
+      },
+    ),
+  );
+  return readStringAtPath(
+    status.workspace?.redactedStatus ?? null,
+    ["hostedMailboxSystemImportedSeq"],
+  ) ?? "0";
 }
 
 async function assertNoHostedDeviceSyncJobFailures(input: {
@@ -1686,6 +1721,13 @@ function readStringAtPath(value: unknown, keys: readonly string[]): string | nul
   }
 
   return typeof current === "string" ? current : null;
+}
+
+function hasDecimalSequenceAdvanced(before: string, after: string): boolean {
+  if (!/^\d+$/u.test(before) || !/^\d+$/u.test(after)) {
+    return false;
+  }
+  return BigInt(after) > BigInt(before);
 }
 
 function collectUnsafeHostedStatusFailureKeys(value: unknown): string[] {

--- a/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-device-sync-junction-wearable-direct-resource-replay-e2e.test.ts
@@ -1239,6 +1239,14 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
     readNumberAtPath(redactedStatus, ["hostedSystemMailboxRetryableFailed"]) ?? 0;
   const recordFailed =
     readNumberAtPath(redactedStatus, ["hostedSystemMailboxRecordFailed"]) ?? 0;
+  const systemImportedSeq = readStringAtPath(
+    redactedStatus,
+    ["hostedMailboxSystemImportedSeq"],
+  );
+  const systemHandledThroughSeq = readStringAtPath(
+    redactedStatus,
+    ["hostedMailboxSystemHandledThroughSeq"],
+  );
   const systemMailboxLogs = collectHostedSystemMailboxLogSummaries(receiptStatus);
   const retryableLog = systemMailboxLogs.find((entry) => entry.status === "retryable_failed");
   const recordedDeviceSyncLog = systemMailboxLogs.find((entry) =>
@@ -1247,7 +1255,14 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
     && (entry.status === "processed" || entry.status === "recorded")
     && (entry.recordFailed ?? 0) === 0
   );
-  const receiptObserved = recordedDeviceSyncLog !== undefined
+  const durableSystemLaneSettled = systemImportedSeq !== null
+    && systemImportedSeq !== "0"
+    && systemImportedSeq === systemHandledThroughSeq
+    && receiptStatus.mailboxLag.some((lane) =>
+      lane.lane === "system" && lane.lag === "0"
+    );
+  const receiptObserved = durableSystemLaneSettled
+    || recordedDeviceSyncLog !== undefined
     || recorded > 0
     || prepared > 0;
 
@@ -1267,6 +1282,8 @@ async function assertHostedDeviceSyncReplayReceiptAccepted(input: {
         recordFailed,
         recorded,
         retryableFailed,
+        systemHandledThroughSeq,
+        systemImportedSeq,
       })}`,
       ...(safeErrors.length > 0
         ? [`system mailbox safe errors: ${JSON.stringify(safeErrors)}`]
@@ -1657,6 +1674,18 @@ function readNumberAtPath(value: unknown, keys: readonly string[]): number | nul
   }
 
   return typeof current === "number" ? current : null;
+}
+
+function readStringAtPath(value: unknown, keys: readonly string[]): string | null {
+  let current = value;
+  for (const key of keys) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return null;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+
+  return typeof current === "string" ? current : null;
 }
 
 function collectUnsafeHostedStatusFailureKeys(value: unknown): string[] {

--- a/apps/cloudflare/test/hosted-local-linq-group-route-drift-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-group-route-drift-e2e.test.ts
@@ -237,8 +237,16 @@ describe("hosted local Linq group route drift e2e", () => {
       expectedMethod: "POST",
       expectedPath: "/capability/check_imessage",
     });
+    const route = await requireScenario().readHostedThreadRoute({
+      channel: "linq",
+      threadId: groupChatId,
+    });
+    expect(route).toMatchObject({ ownerMemberId });
+    if (!route) {
+      throw new Error("Expected the Linq group card fixture to retain its durable route.");
+    }
     const completionPromise = requireScenario().waitForHostedCompletion(
-      ownerMemberId,
+      route.containerMemberId,
       { timeoutMs: 600_000 },
     );
     const response = await postSignedLinqWebhook(buildHostedLinqInboundEvent(

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -4309,7 +4309,7 @@ async function runCodexAppServerTurnOnProcess(
       closeLiveTurn()
     }
 
-    let dynamicToolRequestSettled = false
+    let groupEmailTerminalEffectAccepted = false
     const runDynamicTool = () => withHostedCanonicalWritePort(
       hostedCanonicalWritePort,
       async () => {
@@ -4439,7 +4439,7 @@ async function runCodexAppServerTurnOnProcess(
         // an interrupt racing that continuation can leave the turn open.
         // TurnAborted resolves the pending server request structurally, so a
         // terminal external effect must not also write a tool response.
-        dynamicToolRequestSettled = true
+        groupEmailTerminalEffectAccepted = true
         await interruptLiveTurnForTerminalNoReply()
         return
       }
@@ -4542,19 +4542,15 @@ async function runCodexAppServerTurnOnProcess(
           dynamicToolDeliveryContextOrdinal ?? 0,
         )
       }
-      const writeFailure = tryWriteRpcMessage({
+      void tryWriteRpcMessage({
         id: requestId,
         result: result.rpcResult,
       })
-      if (writeFailure) {
-        return
-      }
-      dynamicToolRequestSettled = true
     }).catch((error: unknown) => {
       if (dynamicToolRequest.kind === 'send-progress-update') {
         releaseDynamicProgressPending?.()
       }
-      if (dynamicToolRequestSettled) {
+      if (groupEmailTerminalEffectAccepted) {
         rejectOnce(error)
         return
       }

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -4309,7 +4309,7 @@ async function runCodexAppServerTurnOnProcess(
       closeLiveTurn()
     }
 
-    let groupEmailTerminalEffectAccepted = false
+    let dynamicToolRequestSettled = false
     const runDynamicTool = () => withHostedCanonicalWritePort(
       hostedCanonicalWritePort,
       async () => {
@@ -4439,7 +4439,7 @@ async function runCodexAppServerTurnOnProcess(
         // an interrupt racing that continuation can leave the turn open.
         // TurnAborted resolves the pending server request structurally, so a
         // terminal external effect must not also write a tool response.
-        groupEmailTerminalEffectAccepted = true
+        dynamicToolRequestSettled = true
         await interruptLiveTurnForTerminalNoReply()
         return
       }
@@ -4542,15 +4542,19 @@ async function runCodexAppServerTurnOnProcess(
           dynamicToolDeliveryContextOrdinal ?? 0,
         )
       }
-      void tryWriteRpcMessage({
+      const writeFailure = tryWriteRpcMessage({
         id: requestId,
         result: result.rpcResult,
       })
+      if (writeFailure) {
+        return
+      }
+      dynamicToolRequestSettled = true
     }).catch((error: unknown) => {
       if (dynamicToolRequest.kind === 'send-progress-update') {
         releaseDynamicProgressPending?.()
       }
-      if (groupEmailTerminalEffectAccepted) {
+      if (dynamicToolRequestSettled) {
         rejectOnce(error)
         return
       }

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -2947,10 +2947,18 @@ function isHostedImageCompletionToolRequestAllowed(input: {
     return true
   }
   if (input.request.kind === 'attach-response-media') {
-    return matchesExactHostedImageCompletionMedia({
-      actual: input.request.media,
-      expected: input.scope.exactMedia,
-    })
+    const requested = input.request.media.length === 1
+      ? input.request.media[0]
+      : null
+    const expected = input.scope.exactMedia?.[0] ?? null
+    // The model relays a vault descriptor, but the vault remains authoritative
+    // for mutable capture metadata such as hash, size, filename and content
+    // type. Admit only the exact trusted ref here. The attachment path then
+    // rehydrates that ref from the vault and performs the full exact-media
+    // comparison before exposing a response patch.
+    return requested?.kind === 'vault_image' &&
+      expected !== null &&
+      requested.ref === expected.ref
   }
   // Physical-note generation already owns an exact-origin continuation: the
   // model must have launched generation with an authorized message_ref, and

--- a/packages/assistant-engine/test/assistant-hosted-image-completion-authority.test.ts
+++ b/packages/assistant-engine/test/assistant-hosted-image-completion-authority.test.ts
@@ -225,7 +225,41 @@ describe('hosted image completion effect authority', () => {
           tool: 'attach_response_media',
         },
       })
-      if (!exactRequest || !mismatchedRequest) {
+      const staleMetadataRequest = readTestMurphDynamicToolRequest({
+        method: 'item/tool/call',
+        params: {
+          arguments: {
+            media: [{
+              ...EXACT_MEDIA,
+              contentType: 'image/webp',
+              filename: 'stale.webp',
+              sha256: 'a'.repeat(64),
+              sizeBytes: EXACT_MEDIA.sizeBytes + 1,
+            }],
+          },
+          namespace: 'murph',
+          tool: 'attach_response_media',
+        },
+      })
+      const mismatchedAltRequest = readTestMurphDynamicToolRequest({
+        method: 'item/tool/call',
+        params: {
+          arguments: {
+            media: [{
+              ...EXACT_MEDIA,
+              alt: 'Different generated image',
+            }],
+          },
+          namespace: 'murph',
+          tool: 'attach_response_media',
+        },
+      })
+      if (
+        !exactRequest ||
+        !mismatchedRequest ||
+        !staleMetadataRequest ||
+        !mismatchedAltRequest
+      ) {
         throw new Error('Expected response-media requests.')
       }
 
@@ -247,6 +281,26 @@ describe('hosted image completion effect authority', () => {
         nextUsageOrdinal: () => 0,
         progressDelivery: null,
         request: mismatchedRequest,
+        vaultRoot,
+      })
+      const staleMetadata = await executeMurphDynamicToolRequest({
+        currentResponseMedia: [],
+        env: {},
+        fetchImpl: fetch,
+        hostedToolContext,
+        nextUsageOrdinal: () => 0,
+        progressDelivery: null,
+        request: staleMetadataRequest,
+        vaultRoot,
+      })
+      const mismatchedAlt = await executeMurphDynamicToolRequest({
+        currentResponseMedia: [],
+        env: {},
+        fetchImpl: fetch,
+        hostedToolContext,
+        nextUsageOrdinal: () => 0,
+        progressDelivery: null,
+        request: mismatchedAltRequest,
         vaultRoot,
       })
       await writeFile(
@@ -273,6 +327,19 @@ describe('hosted image completion effect authority', () => {
       expect(mismatched.rpcResult.contentItems[0]?.text).toContain(
         'carries no authority for that tool action',
       )
+      expect(staleMetadata.rpcResult.success).toBe(true)
+      expect(staleMetadata.responseMediaPatch).toEqual({
+        media: [EXACT_MEDIA],
+        op: 'replace',
+      })
+      expect(mismatchedAlt.rpcResult.success).toBe(false)
+      expect(mismatchedAlt.rpcResult.contentItems[0]?.text).toContain(
+        'no longer matches its saved media',
+      )
+      expect(mismatchedAlt.responseMediaPatch).toEqual({
+        media: [],
+        op: 'replace',
+      })
       expect(changed.rpcResult.success).toBe(false)
       expect(changed.rpcResult.contentItems[0]?.text).toContain(
         'no longer matches its saved media',


### PR DESCRIPTION
## Why this PR exists

The generic group-email cutover exposed two failures in the production-faithful public/private integration matrix. A generated-image completion could deliver its text without the requested attachment, and a Junction replay assertion could fail after later device-import logs rotated the earlier system-mailbox receipt out of the bounded status window.

## User goal / user-visible behavior

Generated-image completions keep their exact trusted response media even when model-relayed capture metadata is stale. Wearable replay verification continues to require a clean, durably settled system-mailbox lane without depending on an ephemeral diagnostic entry still being among the latest 50 logs.

## Root cause

- The trusted hosted-image completion gate compared the model-relayed vault descriptor before the runtime rehydrated its ref from the vault. A stale hash was rejected before the existing canonical read and full exact-media comparison, so the model continued with text alone.
- The device-sync scenario treated a recent per-invocation counter or log line as the only receipt evidence. New import timing logs can legitimately evict that line, but a merely settled system lane could also describe older work. The durable fallback therefore needs a pre-trigger frontier to prove the tested replay advanced the lane.

## Invariants

- A hosted image-completion turn may request only the exact trusted vault ref.
- The runtime rehydrates that ref and requires the complete trusted media descriptor to match before creating a response patch; a different ref, altered authored metadata, or changed bytes still fails closed.
- A device-sync receipt is accepted only when there is explicit receipt evidence or the system imported watermark advanced from the pre-trigger baseline, is handled through exactly, and has zero lag.
- Retryable or record failures still fail the wearable assertion.

## Architecture and reuse

- Existing systems reused: canonical vault-image rehydration, the existing full exact-media comparison, and the system mailbox's durable imported/handled-through watermarks.
- New logic: the early completion authority gate admits only the exact trusted ref and delegates mutable metadata proof to the canonical vault read; the wearable proof captures the system frontier before each trigger and requires the post-trigger frontier to advance and settle fully when bounded receipt logs have rotated.
- New abstractions: none are needed because both corrections stay within the existing assistant-engine and mailbox-test ownership boundaries.
- Complexity intentionally avoided: no new runtime owner, compatibility path, status retention, or diagnostic-log dependency.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: trusted private-image effect authority and durable mailbox settlement evidence are security/reliability boundaries even though the correction is small.

ReviewGPT first-reviewed head: 3bf3124ca84dbdbae13f17f144a6cd648279107b

ReviewGPT current candidate head: 575aaf34c71f252600ee14dfa1f52c27e819b853

- Final round 1 passed at `3bf3124ca84dbdbae13f17f144a6cd648279107b` with no findings.
- The independent completion-specialists pass found that a missing or malformed pre-trigger imported watermark was coerced to `"0"`, which could manufacture evidence of advancement. The accepted remediation now requires an explicit non-negative decimal baseline, proves the failure cases directly, and makes the high-volume replay require the durable frontier rather than a bounded log fallback.
- Final round 2 passed the exact remediation head with no findings; model verification confirmed GPT-5.6 Pro.
- Post-review integration triage proved that the route-authority test observed completion on the human owner even though the durable route binds work to its synthetic group container. The test now resolves the canonical route and waits on `containerMemberId`; this is the same narrow correction already reviewed independently in public PR #1597.
- The mandatory round-3 retrospective records an explicitly justified continuation: production shape is unchanged from round 1, both review-driven corrections are test-only proof required by this paired cutover gate, and no new production owner or lifecycle machinery is permitted.
- Final round 3 passed this exact head with no findings. It reverified generated-image authority, durable wearable-frontier proof, the canonical synthetic-container route observer, and the retrospective scope boundary; response-model evidence resolved to GPT-5.6 Pro.

## Review lenses

- Product experience: applicable — preserves generated-image attachment delivery.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: applicable — existing scripted runtime, media, group-email terminal, and combined hosted-local scenarios exercise the paths.

## Candidate shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 4 |
| Tests / fixtures | 191 | 5 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **203** | **9** |

## Changelog

- Changelog: not applicable
- Reason: This restores pre-cutover response-media delivery before the generic group-email rollout and introduces no new member-facing behavior.

## Verification

- Hosted image-completion authority and group-email terminal runtime: 10 tests passed.
- Full hosted-local Codex image-media delivery: 3 tests passed, including background completion and saved-image reuse.
- Runner bundle/package build passed as part of the hosted-local scenario.
- Cloudflare package typecheck passed.
- Focused hosted-system mailbox frontier proof: 4 tests passed, including missing, malformed, negative, and valid baselines.
- Full local Linq group-route drift E2E passed against the paired private Temporal worker: 2 tests passed in 51 seconds, including the corrected synthetic-container completion proof.
- Exact current-head public CI passed at `575aaf34c71f252600ee14dfa1f52c27e819b853`.
- Exact current-head public/private integration passed all 12 hosted-local scenario groups against public `575aaf34c71f252600ee14dfa1f52c27e819b853` and private `d4ff0dd77fd0ffdaece12f86b97bd6771451b185`, including group-email newsletter, route authority, generated-media/provider, trigger-bound wearable frontier, restart/retry, and checkpoint durability ([run](https://github.com/cobuildwithus/murph-cloud/actions/runs/31489870482)).
- `git diff --check`

The exact combined public/private hosted-local workflow is the production-faithful remote gate for both reported failures.
