### PR TITLE
Fix Personal Patterns for normalized wearable data

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-11-fix-personal-patterns-provider-data.md
+++ b/agent-docs/exec-plans/active/2026-08-11-fix-personal-patterns-provider-data.md
@@ -1,0 +1,58 @@
+# Fix Personal Patterns provider data analysis
+
+Status: active
+Created: 2026-08-11
+Updated: 2026-08-11
+
+## Goal
+
+- Make Personal Patterns analyze repeated Oura and WHOOP activity against the
+  next day's normalized sleep and recovery data when enough evidence exists.
+
+## Success criteria
+
+- A provider-shaped regression fixture produces tested pattern cells.
+- Patterns reuses the canonical activity-kind resolver instead of a narrower
+  second interpretation.
+- Focused query tests and type checks pass.
+- Required PR review and exact-head CI pass before merge.
+
+## Scope
+
+- In scope: Personal Patterns factor collection and focused query coverage.
+- Out of scope: pattern thresholds, UI design, provider import schemas, and
+  persisted data changes.
+
+## Constraints
+
+- Technical constraints: keep one canonical activity-kind interpretation and
+  preserve the current matching and evidence thresholds.
+- Product/process constraints: do not add private exported health data to the
+  repository. Use synthetic provider-shaped fixtures only.
+
+## Risks and mitigations
+
+1. Risk: A broader resolver could turn generic workouts into misleading factors.
+   Mitigation: reuse the existing resolver, which already rejects generic kinds.
+2. Risk: The observed export mismatch could also involve outcome projection.
+   Mitigation: add direct proof for provider-shaped activity plus normalized
+   next-day outcomes before choosing the final correction.
+
+## Tasks
+
+1. Add a focused failing provider-shaped regression test.
+2. Fix the smallest shared ownership mismatch.
+3. Run focused tests and inspect the exact diff.
+4. Commit, push, open the PR, complete required reviews and CI, then merge.
+
+## Decisions
+
+- Keep the current statistical thresholds unchanged.
+- Treat the exported member data only as local diagnostic evidence.
+
+## Verification
+
+- Commands to run: focused Personal Patterns Vitest suite and the owning query
+  package type check.
+- Expected outcomes: provider-shaped activity reaches tested cells and all
+  existing Personal Patterns behavior remains green.

--- a/agent-docs/exec-plans/active/2026-08-11-fix-personal-patterns-provider-data.md
+++ b/agent-docs/exec-plans/active/2026-08-11-fix-personal-patterns-provider-data.md
@@ -8,6 +8,8 @@ Updated: 2026-08-11
 
 - Make Personal Patterns analyze repeated Oura and WHOOP activity against the
   next day's normalized sleep and recovery data when enough evidence exists.
+- Keep Browser Vault and the assistant runtime on the same canonical metric
+  selection path.
 
 ## Success criteria
 
@@ -19,7 +21,8 @@ Updated: 2026-08-11
 
 ## Scope
 
-- In scope: Personal Patterns factor collection and focused query coverage.
+- In scope: Personal Patterns factor collection, normalized metric fallback,
+  Browser Vault refresh generation, and focused query coverage.
 - Out of scope: pattern thresholds, UI design, provider import schemas, and
   persisted data changes.
 
@@ -49,10 +52,13 @@ Updated: 2026-08-11
 
 - Keep the current statistical thresholds unchanged.
 - Treat the exported member data only as local diagnostic evidence.
+- Use canonical metric points and their existing selection policy. Do not use
+  Browser Vault display rows as a second calculation source.
+- Advance the Browser Vault generation so existing empty reports refresh.
 
 ## Verification
 
-- Commands to run: focused Personal Patterns Vitest suite and the owning query
-  package type check.
+- Commands run: focused Personal Patterns, Browser Vault, and hosted-execution
+  Vitest suites, plus the owning query package type check.
 - Expected outcomes: provider-shaped activity reaches tested cells and all
   existing Personal Patterns behavior remains green.

--- a/agent-docs/exec-plans/completed/2026-08-11-fix-personal-patterns-provider-data.md
+++ b/agent-docs/exec-plans/completed/2026-08-11-fix-personal-patterns-provider-data.md
@@ -1,6 +1,6 @@
 # Fix Personal Patterns provider data analysis
 
-Status: active
+Status: completed
 Created: 2026-08-11
 Updated: 2026-08-11
 
@@ -62,3 +62,9 @@ Updated: 2026-08-11
   Vitest suites, plus the owning query package type check.
 - Expected outcomes: provider-shaped activity reaches tested cells and all
   existing Personal Patterns behavior remains green.
+- Result: Personal Patterns 16/16, Browser Vault 41/41, hosted execution 9/9,
+  query typecheck, and `git diff --check` passed.
+- Review: the local final-gate fallback found one duplicate canonical readiness
+  outcome. The fix gained regression coverage. Its final exact-head review
+  returned no findings.
+Completed: 2026-08-11

--- a/agent-docs/product-specs/personal-patterns.md
+++ b/agent-docs/product-specs/personal-patterns.md
@@ -1,6 +1,6 @@
 # Personal Patterns
 
-Last verified: 2026-08-10
+Last verified: 2026-08-11
 
 ## Product boundary
 
@@ -48,6 +48,10 @@ date. This keeps retroactively logged sessions on their intended day.
 
 Sleep outcomes use the sleep-analysis date and eligibility policy. Explicit
 naps do not count as next-day sleep outcomes.
+
+Recovery outcomes first use the canonical wearable summary. When a provider's
+normalized recovery values exist only as metric samples, the query uses the
+same canonical metric-selection policy in Browser Vault and `vault-cli`.
 
 Names that describe an outcome rather than an action are not eligible factors.
 This includes sleep, sleep score, sleep efficiency, HRV, resting heart rate,
@@ -112,10 +116,10 @@ stored state or member configuration.
 
 ## Ownership
 
-`@murphai/query` owns the calculation. Browser Vault stores only the derived
-report. Overview presents that report. `vault-cli` exposes the same query to
-the assistant runtime. The existing Weekly health insight owns message timing
-and deduplication.
+`@murphai/query` owns the calculation and canonical metric selection. Browser
+Vault stores only the derived report. Overview presents that report. `vault-cli`
+exposes the same query to the assistant runtime. The existing Weekly health
+insight owns message timing and deduplication.
 
 Do not add a database table, API, cron, dependency, statistical service, or
 second calculation in React or an assistant prompt for this feature.

--- a/apps/web/changelog/entries/2026-08-11/personal-patterns-wearable-recovery.json
+++ b/apps/web/changelog/entries/2026-08-11/personal-patterns-wearable-recovery.json
@@ -1,0 +1,18 @@
+{
+  "publishedOn": "2026-08-11",
+  "order": 300,
+  "item": {
+    "id": "personal-patterns-wearable-recovery",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Patterns can use normalized recovery data",
+    "summary": "Personal Patterns can now compare repeated wearable activity with selected next-day recovery metrics when enough evidence exists.",
+    "details": "The existing matching thresholds stay unchanged, and unclear or insufficient evidence still remains labeled as such.",
+    "relevanceTags": ["patterns", "wearables", "recovery"],
+    "sourcePullRequests": [1668],
+    "tryIt": {
+      "href": "/patterns",
+      "label": "View your patterns"
+    }
+  }
+}

--- a/apps/web/test/browser-vault-session-route.test.ts
+++ b/apps/web/test/browser-vault-session-route.test.ts
@@ -1314,12 +1314,12 @@ describe("browser vault session route", () => {
     });
   });
 
-  it("serves a fresh pre-Training generation-5 replica as stale and schedules refresh", async () => {
+  it("serves a fresh previous-generation replica as stale and schedules refresh", async () => {
     const browser = await generateHostedUserRecipientKeyPair();
     const replicaRef = createReplicaRef({
       generation: BROWSER_VAULT_REPLICA_CURRENT_GENERATION - 1,
     });
-    expect(replicaRef.generation).toBe(5);
+    expect(replicaRef.generation).toBe(BROWSER_VAULT_REPLICA_CURRENT_GENERATION - 1);
     const createBrowserVaultSession = vi.fn().mockResolvedValue({
       encryptedReplica: createReplicaEnvelope(),
       replicaAad: createReplicaAad(),

--- a/packages/contracts/src/browser-vault.ts
+++ b/packages/contracts/src/browser-vault.ts
@@ -6,4 +6,4 @@ export const BROWSER_VAULT_TRAINING_SESSION_SCHEMA =
  * Increment when a projection-shape or projection-interpretation change makes
  * an otherwise source-current browser replica incomplete for current readers.
  */
-export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 6 as const;
+export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 7 as const;

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -289,7 +289,7 @@ describe("hosted execution coverage gaps", () => {
   });
 
   it("centralizes browser-vault replica source hash and refresh decisions", () => {
-    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(6);
+    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(7);
     const base = {
       hash: "a".repeat(64),
       key: "cloudflare-workspace-snapshots/base.bundle",

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -1,7 +1,7 @@
 import type { CanonicalEntity } from "../canonical-entities.ts";
 import { experimentOutcomeSchema } from "@murphai/contracts";
 import { metricPointRecordIds } from "../metrics/index.ts";
-import { buildPersonalPatternReportFromWearableBundleAndMetricRows } from "../personal-patterns.ts";
+import { buildPersonalPatternReportFromWearableBundleAndMetricPoints } from "../personal-patterns.ts";
 import { isDefaultProjectedQueryEntity } from "../query-visibility.ts";
 import type { OverviewWeeklySampleSummary } from "../overview.ts";
 import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts";
@@ -111,10 +111,10 @@ export async function createBrowserVaultReplica(
     metricGoalProgressRows: buildMetricGoalProgressRows(defaultProjectedVault.entities, allMetricPoints, generatedAt),
     metricRows,
     metricSelectionRows,
-    personalPatterns: buildPersonalPatternReportFromWearableBundleAndMetricRows(
+    personalPatterns: buildPersonalPatternReportFromWearableBundleAndMetricPoints(
       input.vault,
       wearableSummaryBundle,
-      metricRows,
+      allMetricPoints,
       { asOf: generatedAt },
     ),
     policy,

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -1,7 +1,7 @@
 import type { CanonicalEntity } from "../canonical-entities.ts";
 import { experimentOutcomeSchema } from "@murphai/contracts";
 import { metricPointRecordIds } from "../metrics/index.ts";
-import { buildPersonalPatternReport } from "../personal-patterns.ts";
+import { buildPersonalPatternReportFromWearableBundleAndMetricRows } from "../personal-patterns.ts";
 import { isDefaultProjectedQueryEntity } from "../query-visibility.ts";
 import type { OverviewWeeklySampleSummary } from "../overview.ts";
 import { summarizeDailySamples, type DailySampleSummary } from "../summaries.ts";
@@ -10,6 +10,7 @@ import { createVaultReadModel, type VaultReadModel } from "../read-model.ts";
 import { resolveAdherenceObservationActivityKind } from "../experiment-adherence.ts";
 import {
   buildWearableAssistantSummary,
+  buildWearableSummaryBundle,
   summarizeWearableSourceHealth,
   type WearableAssistantSummary,
   type WearableSourceHealthSummary,
@@ -97,6 +98,7 @@ export async function createBrowserVaultReplica(
   });
   const sourceHealthRows = summarizeWearableSourceHealth(defaultProjectedVault, { limit: SOURCE_HEALTH_LIMIT })
     .map(projectSourceHealthRow);
+  const wearableSummaryBundle = buildWearableSummaryBundle(input.vault);
   const replicaWithoutVersion: BrowserVaultReplica = {
     assistantSummary: projectWearableAssistantSummary(buildWearableAssistantSummary(defaultProjectedVault)),
     entities,
@@ -109,7 +111,12 @@ export async function createBrowserVaultReplica(
     metricGoalProgressRows: buildMetricGoalProgressRows(defaultProjectedVault.entities, allMetricPoints, generatedAt),
     metricRows,
     metricSelectionRows,
-    personalPatterns: buildPersonalPatternReport(input.vault, { asOf: generatedAt }),
+    personalPatterns: buildPersonalPatternReportFromWearableBundleAndMetricRows(
+      input.vault,
+      wearableSummaryBundle,
+      metricRows,
+      { asOf: generatedAt },
+    ),
     policy,
     schema: BROWSER_VAULT_REPLICA_SCHEMA,
     searchRows: entities.map(projectSearchRow),

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -9,6 +9,10 @@ import {
   resolveActivityEvidenceLocalDate,
   resolveInterventionSessionLocalDate,
 } from "./experiment-adherence.ts";
+import {
+  selectMetricSeries,
+  type MetricPoint,
+} from "./metrics/index.ts";
 import type { VaultReadModel } from "./read-model.ts";
 import { buildWearableSummaryBundle } from "./wearables.ts";
 import type {
@@ -112,13 +116,6 @@ interface PatternWindow {
   outcomeToDate: string;
 }
 
-export interface PersonalPatternMetricRow {
-  confidence: string | null;
-  date: string;
-  metricKey: string;
-  value: number | null;
-}
-
 export function buildPersonalPatternReport(
   vault: VaultReadModel,
   options: { asOf?: Date | string; windowDays?: number } = {},
@@ -146,10 +143,10 @@ export function buildPersonalPatternReportFromWearableBundle(
   );
 }
 
-export function buildPersonalPatternReportFromWearableBundleAndMetricRows(
+export function buildPersonalPatternReportFromWearableBundleAndMetricPoints(
   vault: VaultReadModel,
   wearableBundle: Pick<WearableSummaryBundle, "recoveryDays" | "sleepNights">,
-  metricRows: readonly PersonalPatternMetricRow[],
+  metricPoints: readonly MetricPoint[],
   options: { asOf?: Date | string; windowDays?: number } = {},
 ): PersonalPatternReport {
   const window = resolveWindow(options);
@@ -159,7 +156,7 @@ export function buildPersonalPatternReportFromWearableBundleAndMetricRows(
     readVaultTimeZone(vault),
   );
   const wearableOutcomeIds = new Set(wearableOutcomes.map((outcome) => outcome.id));
-  const fallbackOutcomes = collectMetricRowRecoveryOutcomeSeries(metricRows, window)
+  const fallbackOutcomes = collectMetricPointRecoveryOutcomeSeries(metricPoints, window)
     .filter((outcome) => !wearableOutcomeIds.has(outcome.id));
 
   return buildPersonalPatternReportFromOutcomeSeries(
@@ -339,33 +336,34 @@ function collectOutcomeSeries(
   ].filter((series) => series.values.size >= MIN_MATCHED_DAYS * 2);
 }
 
-function collectMetricRowRecoveryOutcomeSeries(
-  metricRows: readonly PersonalPatternMetricRow[],
+function collectMetricPointRecoveryOutcomeSeries(
+  metricPoints: readonly MetricPoint[],
   window: PatternWindow,
 ): OutcomeSeries[] {
-  const rows = metricRows.filter((row) =>
-    row.confidence !== "none" &&
-    row.date >= window.fromDate &&
-    row.date <= window.outcomeToDate
-  );
-
   return [
-    metricRowOutcome("recovery-score", "Recovery score", "score", 3, 0.03, "recovery-score", rows),
-    metricRowOutcome("readiness-score", "Readiness score", "score", 3, 0.03, "readiness-score", rows),
-    metricRowOutcome("hrv", "HRV", "ms", 2, 0.05, "hrv-rmssd", rows),
-    metricRowOutcome("resting-heart-rate", "Resting heart rate", "bpm", 2, 0.03, "resting-heart-rate", rows),
+    metricPointOutcome("recovery-score", "Recovery score", "score", 3, 0.03, "recovery-score", metricPoints, window),
+    metricPointOutcome("readiness-score", "Readiness score", "score", 3, 0.03, "readiness-score", metricPoints, window),
+    metricPointOutcome("hrv", "HRV", "ms", 2, 0.05, "hrv-rmssd", metricPoints, window),
+    metricPointOutcome("resting-heart-rate", "Resting heart rate", "bpm", 2, 0.03, "resting-heart-rate", metricPoints, window),
   ].filter((series) => series.values.size >= MIN_MATCHED_DAYS * 2);
 }
 
-function metricRowOutcome(
+function metricPointOutcome(
   id: string,
   label: string,
   unit: string,
   meaningfulAbsoluteDelta: number,
   meaningfulRelativeDelta: number,
   metricKey: string,
-  rows: readonly PersonalPatternMetricRow[],
+  metricPoints: readonly MetricPoint[],
+  window: PatternWindow,
 ): OutcomeSeries {
+  const rows = selectMetricSeries({
+    from: window.fromDate,
+    metricKey,
+    points: metricPoints,
+    to: window.outcomeToDate,
+  }).rows;
   return {
     id,
     label,
@@ -373,11 +371,11 @@ function metricRowOutcome(
     meaningfulRelativeDelta,
     unit,
     values: new Map(
-      rows
-        .filter((row): row is PersonalPatternMetricRow & { value: number } =>
-          row.metricKey === metricKey && row.value !== null
-        )
-        .map((row) => [row.date, row.value] as const),
+      rows.flatMap((row) =>
+        row.confidence !== "none" && row.value !== null
+          ? [[row.date, row.value] as const]
+          : []
+      ),
     ),
   };
 }

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -341,7 +341,6 @@ function collectMetricPointRecoveryOutcomeSeries(
   window: PatternWindow,
 ): OutcomeSeries[] {
   return [
-    metricPointOutcome("recovery-score", "Recovery score", "score", 3, 0.03, "recovery-score", metricPoints, window),
     metricPointOutcome("readiness-score", "Readiness score", "score", 3, 0.03, "readiness-score", metricPoints, window),
     metricPointOutcome("hrv", "HRV", "ms", 2, 0.05, "hrv-rmssd", metricPoints, window),
     metricPointOutcome("resting-heart-rate", "Resting heart rate", "bpm", 2, 0.03, "resting-heart-rate", metricPoints, window),

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -5,6 +5,7 @@ import {
 
 import type { CanonicalEntity } from "./canonical-entities.ts";
 import {
+  resolveAdherenceObservationActivityKind,
   resolveActivityEvidenceLocalDate,
   resolveInterventionSessionLocalDate,
 } from "./experiment-adherence.ts";
@@ -106,6 +107,18 @@ interface MatchedPair {
   exposedValue: number;
 }
 
+interface PatternWindow {
+  fromDate: string;
+  outcomeToDate: string;
+}
+
+export interface PersonalPatternMetricRow {
+  confidence: string | null;
+  date: string;
+  metricKey: string;
+  value: number | null;
+}
+
 export function buildPersonalPatternReport(
   vault: VaultReadModel,
   options: { asOf?: Date | string; windowDays?: number } = {},
@@ -122,6 +135,45 @@ export function buildPersonalPatternReportFromWearableBundle(
   wearableBundle: Pick<WearableSummaryBundle, "recoveryDays" | "sleepNights">,
   options: { asOf?: Date | string; windowDays?: number } = {},
 ): PersonalPatternReport {
+  return buildPersonalPatternReportFromOutcomeSeries(
+    vault,
+    collectOutcomeSeries(
+      wearableBundle,
+      resolveWindow(options),
+      readVaultTimeZone(vault),
+    ),
+    options,
+  );
+}
+
+export function buildPersonalPatternReportFromWearableBundleAndMetricRows(
+  vault: VaultReadModel,
+  wearableBundle: Pick<WearableSummaryBundle, "recoveryDays" | "sleepNights">,
+  metricRows: readonly PersonalPatternMetricRow[],
+  options: { asOf?: Date | string; windowDays?: number } = {},
+): PersonalPatternReport {
+  const window = resolveWindow(options);
+  const wearableOutcomes = collectOutcomeSeries(
+    wearableBundle,
+    window,
+    readVaultTimeZone(vault),
+  );
+  const wearableOutcomeIds = new Set(wearableOutcomes.map((outcome) => outcome.id));
+  const fallbackOutcomes = collectMetricRowRecoveryOutcomeSeries(metricRows, window)
+    .filter((outcome) => !wearableOutcomeIds.has(outcome.id));
+
+  return buildPersonalPatternReportFromOutcomeSeries(
+    vault,
+    [...wearableOutcomes, ...fallbackOutcomes],
+    options,
+  );
+}
+
+function buildPersonalPatternReportFromOutcomeSeries(
+  vault: VaultReadModel,
+  outcomes: readonly OutcomeSeries[],
+  options: { asOf?: Date | string; windowDays?: number },
+): PersonalPatternReport {
   const asOfDate = resolveAsOfDate(options.asOf);
   const windowDays = normalizeWindowDays(options.windowDays);
   const fromDate = addDays(asOfDate, -(windowDays - 1));
@@ -130,12 +182,6 @@ export function buildPersonalPatternReportFromWearableBundle(
     .filter((factor) => factor.observedDays >= MIN_MATCHED_DAYS);
   const factorDatesById = new Map(
     [...factorAccumulators.values()].map((factor) => [factor.token, factor.dates] as const),
-  );
-  const outcomes = collectOutcomeSeries(
-    wearableBundle,
-    fromDate,
-    addDays(asOfDate, 1),
-    readVaultTimeZone(vault),
   );
   const candidateCells = candidateFactors.flatMap((factor) =>
     outcomes.map((outcome) => buildPatternCell(
@@ -246,9 +292,9 @@ function readFactorCandidate(
   event: CanonicalEntity,
 ): { kind: "activity" | "intervention"; token: string } | null {
   if (event.kind === "activity_session") {
-    const token = canonicalFactorToken(normalizeActivityKindToken(
-      readString(event.attributes.activityType) ?? readString(event.attributes.activityKind),
-    ));
+    const token = canonicalFactorToken(resolveAdherenceObservationActivityKind({
+      attributes: event.attributes,
+    }));
     return token && !OUTCOME_LIKE_FACTOR_TOKENS.has(token)
       ? { kind: "activity", token }
       : null;
@@ -270,10 +316,10 @@ function readFactorCandidate(
 
 function collectOutcomeSeries(
   wearableBundle: Pick<WearableSummaryBundle, "recoveryDays" | "sleepNights">,
-  fromDate: string,
-  toDate: string,
+  window: PatternWindow,
   fallbackTimeZone: string | null,
 ): OutcomeSeries[] {
+  const { fromDate, outcomeToDate: toDate } = window;
   const sleep = wearableBundle.sleepNights
     .filter(isWearableSleepPatternEligibleNight)
     .filter((day) => {
@@ -291,6 +337,49 @@ function collectOutcomeSeries(
     outcome("hrv", "HRV", "ms", 2, 0.05, recovery, (day) => day.hrv),
     outcome("resting-heart-rate", "Resting heart rate", "bpm", 2, 0.03, recovery, (day) => day.restingHeartRate),
   ].filter((series) => series.values.size >= MIN_MATCHED_DAYS * 2);
+}
+
+function collectMetricRowRecoveryOutcomeSeries(
+  metricRows: readonly PersonalPatternMetricRow[],
+  window: PatternWindow,
+): OutcomeSeries[] {
+  const rows = metricRows.filter((row) =>
+    row.confidence !== "none" &&
+    row.date >= window.fromDate &&
+    row.date <= window.outcomeToDate
+  );
+
+  return [
+    metricRowOutcome("recovery-score", "Recovery score", "score", 3, 0.03, "recovery-score", rows),
+    metricRowOutcome("readiness-score", "Readiness score", "score", 3, 0.03, "readiness-score", rows),
+    metricRowOutcome("hrv", "HRV", "ms", 2, 0.05, "hrv-rmssd", rows),
+    metricRowOutcome("resting-heart-rate", "Resting heart rate", "bpm", 2, 0.03, "resting-heart-rate", rows),
+  ].filter((series) => series.values.size >= MIN_MATCHED_DAYS * 2);
+}
+
+function metricRowOutcome(
+  id: string,
+  label: string,
+  unit: string,
+  meaningfulAbsoluteDelta: number,
+  meaningfulRelativeDelta: number,
+  metricKey: string,
+  rows: readonly PersonalPatternMetricRow[],
+): OutcomeSeries {
+  return {
+    id,
+    label,
+    meaningfulAbsoluteDelta,
+    meaningfulRelativeDelta,
+    unit,
+    values: new Map(
+      rows
+        .filter((row): row is PersonalPatternMetricRow & { value: number } =>
+          row.metricKey === metricKey && row.value !== null
+        )
+        .map((row) => [row.date, row.value] as const),
+    ),
+  };
 }
 
 function outcome<T extends { date: string }>(
@@ -430,6 +519,17 @@ function hasRepeatedDirection(pairs: readonly MatchedPair[], fullDelta: number):
   const firstDelta = mean(first.map((pair) => pair.exposedValue - pair.comparisonValue));
   const secondDelta = mean(second.map((pair) => pair.exposedValue - pair.comparisonValue));
   return Math.sign(firstDelta) === Math.sign(fullDelta) && Math.sign(secondDelta) === Math.sign(fullDelta);
+}
+
+function resolveWindow(
+  options: { asOf?: Date | string; windowDays?: number },
+): PatternWindow {
+  const asOfDate = resolveAsOfDate(options.asOf);
+  const windowDays = normalizeWindowDays(options.windowDays);
+  return {
+    fromDate: addDays(asOfDate, -(windowDays - 1)),
+    outcomeToDate: addDays(asOfDate, 1),
+  };
 }
 
 function resolveAsOfDate(value: Date | string | undefined): string {

--- a/packages/query/src/query-projection.ts
+++ b/packages/query/src/query-projection.ts
@@ -90,7 +90,7 @@ import {
 import { resolveWearableSleepPatternReadFilters } from "./wearables/sleep-pattern.ts";
 import { createVaultReadModel } from "./read-model.ts";
 import {
-  buildPersonalPatternReportFromWearableBundle,
+  buildPersonalPatternReportFromWearableBundleAndMetricPoints,
   type PersonalPatternReport,
 } from "./personal-patterns.ts";
 
@@ -292,7 +292,16 @@ export async function buildPersonalPatternReportRuntime(
     vaultRoot,
   });
   const wearableBundle = readStoredPublicWearableSummaryBundle(location, {});
-  return buildPersonalPatternReportFromWearableBundle(vault, wearableBundle, options);
+  const metricPoints = listStoredMetricPoints(
+    location,
+    normalizeMetricPointFilters({ limit: null }),
+  );
+  return buildPersonalPatternReportFromWearableBundleAndMetricPoints(
+    vault,
+    wearableBundle,
+    metricPoints,
+    options,
+  );
 }
 
 export async function summarizeWearableActivityRuntime(

--- a/packages/query/test/browser-vault-lab-results.test.ts
+++ b/packages/query/test/browser-vault-lab-results.test.ts
@@ -79,8 +79,8 @@ test("browser vault projects all live lab history without widening the wearable 
     sourceBundleHash: "f".repeat(64),
     vault,
   });
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 6);
-  assert.equal(replica.generation, 6);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 7);
+  assert.equal(replica.generation, BROWSER_VAULT_REPLICA_CURRENT_GENERATION);
   const client = createBrowserVaultQueryClient(parseBrowserVaultReplica(replica));
 
   assert.equal(replica.labResultRows.length, 7);
@@ -870,7 +870,7 @@ test("lab-only aliases preserve manual metric selection and goal authority", asy
     sourceBundleHash: "a".repeat(64),
     vault,
   });
-  assert.equal(replica.generation, 6);
+  assert.equal(replica.generation, BROWSER_VAULT_REPLICA_CURRENT_GENERATION);
   const client = createBrowserVaultQueryClient(parseBrowserVaultReplica(replica));
   const indexed = selectBrowserVaultMeasuredBiomarkers(client)
     .find((entry) => entry.metricKey === "total-testosterone");

--- a/packages/query/test/browser-vault-training-projection.test.ts
+++ b/packages/query/test/browser-vault-training-projection.test.ts
@@ -308,7 +308,7 @@ test("browser vault replicas expose a bounded sanitized training projection with
   assert.equal(liveTraining.state, "in_progress");
   assert.equal("sourceApp" in liveTraining, false);
   assert.deepEqual(liveTraining.exercises, []);
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 6);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 7);
 });
 
 test("browser training projection preserves completed next-local-day sessions before UTC midnight", async () => {

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -170,6 +170,39 @@ test("Browser Vault Personal Patterns falls back to its selected metric rows", a
   assert.deepEqual(parseBrowserVaultReplica(reversedReplica).personalPatterns, report);
 });
 
+test("Personal Patterns does not duplicate the canonical readiness metric as recovery", async () => {
+  const start = "2026-01-05";
+  const runningDates = Array.from({ length: 8 }, (_, index) => addDays(start, index * 14));
+  const vault = createVaultReadModel({
+    entities: runningDates.map((date, index) => event(`readiness_run_${index}`, date, "activity_session", {
+      activityType: "running",
+    })),
+    vaultRoot: "test://personal-pattern-readiness-alias",
+  });
+  const metricPoints = Array.from({ length: 112 }, (_, index) => {
+    const date = addDays(start, index);
+    return metricPoint(
+      `metric_readiness_${index}`,
+      date,
+      "readiness-score",
+      runningDates.includes(addDays(date, -1)) ? 90 : 70,
+      "score",
+    );
+  });
+
+  const replica = await createBrowserVaultReplica({
+    generatedAt: "2026-04-27T12:00:00.000Z",
+    metricPoints,
+    sourceBundleHash: "q".repeat(64),
+    vault,
+  });
+  const report = parseBrowserVaultReplica(replica).personalPatterns;
+
+  assert.deepEqual(report?.outcomes.map((outcome) => outcome.id), ["readiness-score"]);
+  assert.deepEqual(report?.cells.map((cell) => cell.outcomeId), ["readiness-score"]);
+  assert.equal(report?.cells[0]?.stage, "seen_again");
+});
+
 test("Personal Patterns qualifies factors before applying the six-row display cap", () => {
   const start = "2026-01-05";
   const runningDates = Array.from({ length: 8 }, (_, index) => addDays(start, index * 14));

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/browser.ts";
 import { buildPersonalPatternReport } from "../src/personal-patterns.ts";
 import { createVaultReadModel } from "../src/read-model.ts";
+import type { MetricPoint } from "../src/metrics/index.ts";
 import {
   buildPersonalPatternReportRuntime,
   rebuildQueryProjection,
@@ -85,6 +86,71 @@ test("Browser Vault parsing preserves a missing legacy Personal Patterns project
   const parsed = parseBrowserVaultReplica(replica);
 
   assert.equal(parsed.personalPatterns, undefined);
+});
+
+test("Personal Patterns reuses the canonical provider activity-kind resolver", () => {
+  const start = "2026-01-05";
+  const runningDates = Array.from({ length: 8 }, (_, index) => addDays(start, index * 14));
+  const report = buildPersonalPatternReport(createVaultReadModel({
+    entities: [
+      ...runningDates.map((date, index) => event(`provider_run_${index}`, date, "activity_session", {
+        workout: { sportName: "Run" },
+      })),
+      ...Array.from({ length: 112 }, (_, index) => {
+        const date = addDays(start, index);
+        return observation(
+          `provider_hrv_${index}`,
+          date,
+          "hrv",
+          runningDates.includes(addDays(date, -1)) ? 70 : 50,
+          "ms",
+        );
+      }),
+    ],
+    vaultRoot: "test://personal-pattern-provider-activity",
+  }), {
+    asOf: "2026-04-27T12:00:00.000Z",
+  });
+
+  assert.equal(report.factors[0]?.id, "running");
+  assert.equal(report.cells.find((cell) => cell.outcomeId === "hrv")?.stage, "seen_again");
+});
+
+test("Browser Vault Personal Patterns falls back to its selected metric rows", async () => {
+  const start = "2026-01-05";
+  const runningDates = Array.from({ length: 8 }, (_, index) => addDays(start, index * 14));
+  const vault = createVaultReadModel({
+    entities: runningDates.map((date, index) => event(`metric_run_${index}`, date, "activity_session", {
+      activityType: "running",
+    })),
+    vaultRoot: "test://personal-pattern-metric-rows",
+  });
+  const metricPoints = Array.from({ length: 112 }, (_, index) => {
+    const date = addDays(start, index);
+    return metricPoint(
+      `metric_hrv_${index}`,
+      date,
+      "hrv-rmssd",
+      runningDates.includes(addDays(date, -1)) ? 70 : 50,
+      "ms",
+    );
+  });
+
+  assert.deepEqual(buildPersonalPatternReport(vault, {
+    asOf: "2026-04-27T12:00:00.000Z",
+  }).factors, []);
+
+  const replica = await createBrowserVaultReplica({
+    generatedAt: "2026-04-27T12:00:00.000Z",
+    metricPoints,
+    sourceBundleHash: "m".repeat(64),
+    vault,
+  });
+  const report = parseBrowserVaultReplica(replica).personalPatterns;
+
+  assert.equal(report?.factors[0]?.id, "running");
+  assert.equal(report?.cells.find((cell) => cell.outcomeId === "hrv")?.stage, "seen_again");
+  assert.equal(report?.testedCellCount, 1);
 });
 
 test("Personal Patterns qualifies factors before applying the six-row display cap", () => {
@@ -622,6 +688,50 @@ function observation(
     unit,
     value,
   });
+}
+
+function metricPoint(
+  id: string,
+  date: string,
+  metricKey: string,
+  value: number,
+  unit: string,
+): MetricPoint {
+  return {
+    biomarkerKey: null,
+    canonicalUnit: unit,
+    canonicalValue: value,
+    comparator: null,
+    confidence: "high",
+    context: {},
+    effectiveDate: date,
+    grain: "day",
+    id,
+    metricKey,
+    observedAt: `${date}T00:00:00.000Z`,
+    provenance: {
+      dataOrigin: null,
+      externalRef: null,
+      labName: null,
+      provider: "whoop",
+      rawRefs: [],
+      sourceLabel: "Wearable summary",
+    },
+    recordedAt: null,
+    reportedAt: null,
+    schemaVersion: "murph.metric-point.v1",
+    source: {
+      family: "derived",
+      kind: "wearable-summary",
+      path: "",
+      recordId: `record:${id}`,
+      resultIndex: null,
+    },
+    statistic: "value",
+    textValue: null,
+    unit,
+    value,
+  };
 }
 
 function entity(

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -17,6 +17,8 @@ import { createVaultReadModel } from "../src/read-model.ts";
 import type { MetricPoint } from "../src/metrics/index.ts";
 import {
   buildPersonalPatternReportRuntime,
+  listMetricPointsRuntime,
+  loadProjectedVaultSource,
   rebuildQueryProjection,
 } from "../src/query-projection.ts";
 
@@ -135,6 +137,12 @@ test("Browser Vault Personal Patterns falls back to its selected metric rows", a
       "ms",
     );
   });
+  const duplicate = {
+    ...metricPoints[1]!,
+    confidence: "low" as const,
+    id: "metric_hrv_duplicate",
+    value: 999,
+  };
 
   assert.deepEqual(buildPersonalPatternReport(vault, {
     asOf: "2026-04-27T12:00:00.000Z",
@@ -142,7 +150,7 @@ test("Browser Vault Personal Patterns falls back to its selected metric rows", a
 
   const replica = await createBrowserVaultReplica({
     generatedAt: "2026-04-27T12:00:00.000Z",
-    metricPoints,
+    metricPoints: [duplicate, ...metricPoints],
     sourceBundleHash: "m".repeat(64),
     vault,
   });
@@ -151,6 +159,15 @@ test("Browser Vault Personal Patterns falls back to its selected metric rows", a
   assert.equal(report?.factors[0]?.id, "running");
   assert.equal(report?.cells.find((cell) => cell.outcomeId === "hrv")?.stage, "seen_again");
   assert.equal(report?.testedCellCount, 1);
+  assert.equal(report?.cells.find((cell) => cell.outcomeId === "hrv")?.exposedMean, 70);
+
+  const reversedReplica = await createBrowserVaultReplica({
+    generatedAt: "2026-04-27T12:00:00.000Z",
+    metricPoints: [...metricPoints, duplicate],
+    sourceBundleHash: "n".repeat(64),
+    vault,
+  });
+  assert.deepEqual(parseBrowserVaultReplica(reversedReplica).personalPatterns, report);
 });
 
 test("Personal Patterns qualifies factors before applying the six-row display cap", () => {
@@ -564,47 +581,38 @@ test("Personal Patterns suppresses outcome-like activity and intervention factor
   assert.equal(report.testedCellCount, 0);
 });
 
-test("Personal Patterns runtime reuses projected wearable summaries without exposing raw observations", async () => {
+test("Personal Patterns runtime and Browser Vault reuse the same projected metric samples", async () => {
   const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-personal-pattern-runtime-"));
   const start = "2026-01-05";
   const runningDates = Array.from({ length: 8 }, (_, index) => addDays(start, index * 14));
-  const events = [
-    ...runningDates.map((date, index) => ({
-      activityType: "running",
+  const events = runningDates.map((date, index) => ({
+    activityType: "running",
+    dayKey: date,
+    id: `evt_runtime_run_${index}`,
+    kind: "activity_session",
+    occurredAt: `${date}T12:00:00.000Z`,
+    schemaVersion: "murph.event.v1",
+    source: "manual",
+    title: "Running",
+  }));
+  const metricSamples = Array.from({ length: 112 }, (_, index) => {
+    const date = addDays(start, index);
+    return {
       dayKey: date,
-      id: `evt_runtime_run_${index}`,
-      kind: "activity_session",
-      occurredAt: `${date}T12:00:00.000Z`,
-      schemaVersion: "murph.event.v1",
-      source: "manual",
-      title: "Running",
-    })),
-    ...Array.from({ length: 112 }, (_, index) => {
-      const date = addDays(start, index);
-      return {
-        dayKey: date,
-        externalRef: {
-          resourceId: `runtime-hrv-${date}`,
-          resourceType: "daily-summary",
-          system: "whoop",
-        },
-        id: `evt_runtime_hrv_${index}`,
-        kind: "observation",
-        metric: "hrv",
-        observationGrain: "summary",
-        occurredAt: `${date}T07:00:00.000Z`,
-        recordedAt: `${date}T07:05:00.000Z`,
-        schemaVersion: "murph.event.v1",
-        source: "device",
-        title: "Daily HRV",
-        unit: "ms",
-        value: runningDates.includes(addDays(date, -1)) ? 70 : 50,
-      };
-    }),
-  ];
+      id: `smp_runtime_hrv_${index}`,
+      metric: "hrv-rmssd",
+      quality: "derived",
+      recordedAt: `${date}T07:00:00.000Z`,
+      schemaVersion: "murph.metric-sample.v1",
+      source: "device",
+      unit: "ms",
+      value: runningDates.includes(addDays(date, -1)) ? 70 : 50,
+    };
+  });
 
   try {
     await mkdir(path.join(vaultRoot, "ledger/events/2026"), { recursive: true });
+    await mkdir(path.join(vaultRoot, "ledger/metric-samples/hrv-rmssd/2026"), { recursive: true });
     await writeFile(path.join(vaultRoot, "vault.json"), `${JSON.stringify({
       createdAt: "2026-01-01T00:00:00.000Z",
       formatVersion: CURRENT_VAULT_FORMAT_VERSION,
@@ -617,14 +625,38 @@ test("Personal Patterns runtime reuses projected wearable summaries without expo
       `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
       "utf8",
     );
+    for (const month of ["01", "02", "03", "04"]) {
+      const monthSamples = metricSamples.filter((sample) => sample.dayKey.startsWith(`2026-${month}`));
+      await writeFile(
+        path.join(vaultRoot, `ledger/metric-samples/hrv-rmssd/2026/2026-${month}.jsonl`),
+        `${monthSamples.map((sample) => JSON.stringify(sample)).join("\n")}\n`,
+        "utf8",
+      );
+    }
 
     await rebuildQueryProjection(vaultRoot);
-    const report = await buildPersonalPatternReportRuntime(vaultRoot, {
+    const runtimeReport = await buildPersonalPatternReportRuntime(vaultRoot, {
       asOf: "2026-04-27",
     });
+    const snapshot = await loadProjectedVaultSource(vaultRoot);
+    const metricPoints = await listMetricPointsRuntime(vaultRoot, { limit: null });
+    assert.equal(metricPoints.length, 112);
+    assert.ok(metricPoints.every((point) => point.metricKey === "hrv-rmssd"));
+    const replica = await createBrowserVaultReplica({
+      generatedAt: "2026-04-27T12:00:00.000Z",
+      metricPoints,
+      sourceBundleHash: "r".repeat(64),
+      vault: createVaultReadModel({
+        entities: snapshot.entities,
+        metadata: snapshot.metadata,
+        vaultRoot,
+      }),
+    });
+    const browserReport = parseBrowserVaultReplica(replica).personalPatterns;
 
-    assert.equal(report.factors[0]?.id, "running");
-    assert.equal(report.cells.find((cell) => cell.outcomeId === "hrv")?.stage, "seen_again");
+    assert.equal(runtimeReport.factors[0]?.id, "running");
+    assert.equal(runtimeReport.cells.find((cell) => cell.outcomeId === "hrv")?.stage, "seen_again");
+    assert.deepEqual(browserReport, runtimeReport);
   } finally {
     await rm(vaultRoot, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Why this PR exists

Personal Patterns can show no tested comparisons even when normalized wearable activity and recovery metrics meet its evidence thresholds. The report reads narrower raw fields than the shared query projection.

## User goal / user-visible behavior

Members with repeated Oura, WHOOP, or other normalized wearable activity can see tested Personal Patterns comparisons when enough next-day recovery evidence exists.

## User experience

The existing Patterns page and thresholds stay unchanged. The next dashboard session marks the old Browser Vault replica stale and schedules its existing refresh. Eligible data can then populate the current comparison view. Empty and unclear-result states remain when evidence is insufficient or flat.

## Invariants

- Keep the current five-pair, 21-day, same-weekday, and next-day matching rules.
- Reject generic activity labels through the existing canonical resolver.
- Prefer wearable summary outcomes when they are available.
- Use canonically selected metric points only as a fallback for missing recovery outcomes.
- Keep Browser Vault and vault-cli results equal.
- Do not persist new state or include private member data in fixtures.

## Non-obvious affected surfaces

- Browser Vault generation advances from 6 to 7. Existing source-current replicas refresh because their stored report can be incomplete.
- Browser Vault and the assistant runtime now pass the same projected metric points into Personal Patterns.
- Canonical selection resolves duplicate daily metric points independent of input order.
- Canonical activity extraction reuses the existing adherence activity-kind resolver.

## Architecture and reuse

- **Existing systems reused:** the canonical activity-kind resolver, wearable summary selection, metric-point selection policy, projection store, and current pattern matcher.
- **New logic:** one shared report entrypoint uses normalized metric points when the wearable summary lacks a recovery series.
- **New abstractions:** none. The earlier browser-row input shape was deleted.
- **Complexity intentionally avoided:** no new provider mapping, persistence, migration, statistical threshold, queue, or UI state.

## Changelog

- Changelog: updated
- Items: `2026-08-11 · personal-patterns-wearable-recovery`

## Hot reply path impact

Not applicable. This reuses the existing query projection read in the assistant runtime.

## Database collection fanout impact

Not applicable. The change reads the existing local metric projection and adds no database call.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool, skill, or provider-request assembly changed.
- Group Murph: Not applicable. No prompt, tool, skill, or provider-request assembly changed.

## Preliminary specialist lenses

- Product experience: applicable. Eligible repeated activity can reach the existing comparison view after the automatic replica refresh.
- Prompt: not applicable. No provider-visible instructions or tools changed.
- Frontend: not applicable. No `apps/web` presentation changed.
- Coverage: applicable. Synthetic provider data covers canonical activity resolution, metric-sample projection, duplicate selection, Browser Vault, and runtime equality.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 30936c92df3d7a2749c9b0f14e2dadfc94e170c9

Reason: this changes shared health-analysis behavior and the Browser Vault projection.

## Change shape

Classification rule: production TypeScript is source, Vitest files are tests, plan/spec/changelog files are docs, and no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 129 | 16 |
| Tests/fixtures | 217 | 42 |
| Docs | 97 | 5 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **443** | **63** |

## Design proof

Not applicable. This PR does not change user-facing frontend UI.

## Verification

- `pnpm --filter @murphai/query typecheck`
- Personal Patterns Vitest suite — 16 tests passed
- Browser Vault focused Vitest suites — 25 tests passed
- Hosted execution Vitest suite — 9 tests passed
- Full query package suite on the first reviewed head — 64 files and 653 tests passed


