### PR TITLE
Clarify Terra image detail changelog scope

### DIFF
--- a/.agents/friction-log/20260811115902-waited-reviewgpt-exits/friction.md
+++ b/.agents/friction-log/20260811115902-waited-reviewgpt-exits/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Waited ReviewGPT exits after an accepted long-running response detaches from capture'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A waited ReviewGPT run that successfully submits its prompt should remain attached until the configured response timeout, or automatically resume capture from the exact accepted thread.
+
+## Current Behavior
+
+A long-running review can continue in the managed ChatGPT thread while the local ReviewGPT command exits with a response-capture failure. Recovery then requires exporting the retained thread, confirming it is still composing, and starting a separate same-thread watcher without resending the audit.
+
+## Possible Solution
+
+When submission is confirmed, retain the selected browser endpoint and thread identifier as capture state, then fall through to the existing same-thread polling logic before reporting failure.
+
+## Minimal Reproducible Example
+
+1. Start an attached ReviewGPT audit with `--send --wait` and a response timeout longer than the expected review.
+2. Let the accepted review continue through a long reasoning phase.
+3. Observe the local command exit from response capture while the same managed thread remains busy.
+4. Export that exact thread and observe that it is still composing or has since completed.
+
+## Context
+
+This interrupted a required PR review gate after the expensive audit had already been accepted. The manual recovery had to preserve the original thread to avoid duplicate review work.

--- a/apps/web/changelog/editions/2026-08-10.json
+++ b/apps/web/changelog/editions/2026-08-10.json
@@ -1,5 +1,5 @@
 {
   "publishedOn": "2026-08-10",
   "title": "Training, group photos, Terra on OpenAI detail, health data, Starter, personality, reminders, cards, voices, and more",
-  "summary": "Training logs workouts; images become group photos; Terra on OpenAI gets more detail from one available photo; health settings and timing are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter; private reports preview their shape."
+  "summary": "Training logs workouts; images become group photos; Terra on OpenAI reviews one available photo in more detail; health settings and timing are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter; private reports preview their shape."
 }

--- a/apps/web/changelog/editions/2026-08-10.json
+++ b/apps/web/changelog/editions/2026-08-10.json
@@ -1,5 +1,5 @@
 {
   "publishedOn": "2026-08-10",
-  "title": "Training, group photos, Terra detail, health data, Starter, personality, reminders, cards, voices, and more",
-  "summary": "Training collects workouts; images can become group photos; Terra keeps lone first photos at original detail; health settings and timing are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter; private reports preview their shape."
+  "title": "Training, group photos, Terra on OpenAI detail, health data, Starter, personality, reminders, cards, voices, and more",
+  "summary": "Training logs workouts; images become group photos; Terra on OpenAI gets more detail from one available photo; health settings and timing are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter; private reports preview their shape."
 }

--- a/apps/web/changelog/entries/2026-08-10/sharper-single-photo-review.json
+++ b/apps/web/changelog/entries/2026-08-10/sharper-single-photo-review.json
@@ -5,8 +5,8 @@
     "id": "sharper-single-photo-review",
     "kind": "improvement",
     "priority": 3,
-    "title": "Terra on OpenAI keeps more detail for one first photo",
-    "summary": "When Murph uses Terra on OpenAI, one available initial photo is now prepared with more of its stored detail for closer visual review.",
+    "title": "Terra on OpenAI gets a closer look at one first photo",
+    "summary": "When Murph uses Terra on OpenAI, it now reviews one available initial photo with more detail.",
     "details": "Multiple available initial photos, follow-up photos added while Murph is working, Venice, other models, and custom inference stay at high detail to keep visual input cost and compatibility bounded.",
     "relevanceTags": ["assistant", "images", "messaging", "reliability"],
     "sourcePullRequests": [1616]

--- a/apps/web/changelog/entries/2026-08-10/sharper-single-photo-review.json
+++ b/apps/web/changelog/entries/2026-08-10/sharper-single-photo-review.json
@@ -5,9 +5,9 @@
     "id": "sharper-single-photo-review",
     "kind": "improvement",
     "priority": 3,
-    "title": "Terra keeps lone first photos at original detail",
-    "summary": "When Murph uses Terra, one initial photo is now sent at its original detail for closer visual review.",
-    "details": "Requests that start with multiple photos, use another model, add follow-up photos while Murph is working, or use custom inference stay at high detail to keep visual input cost and compatibility bounded.",
+    "title": "Terra on OpenAI keeps more detail for one first photo",
+    "summary": "When Murph uses Terra on OpenAI, one available initial photo is now prepared with more of its stored detail for closer visual review.",
+    "details": "Multiple available initial photos, follow-up photos added while Murph is working, Venice, other models, and custom inference stay at high detail to keep visual input cost and compatibility bounded.",
     "relevanceTags": ["assistant", "images", "messaging", "reliability"],
     "sourcePullRequests": [1616]
   }

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -68,7 +68,7 @@ describe("changelog registry", () => {
     expect(item?.details).toContain("one-time preview");
   });
 
-  it("keeps Terra's lone first-photo detail separate from other bounded image paths", () => {
+  it("keeps Terra on OpenAI's available first-photo detail separate from bounded image paths", () => {
     const item = listPublishedChangelogItems().find(
       (candidate) => candidate.id === "sharper-single-photo-review",
     );
@@ -76,11 +76,18 @@ describe("changelog registry", () => {
     expect(item).toMatchObject({
       editionId: "2026-08-10",
       sourcePullRequests: [1616],
-      summary: expect.stringContaining("Murph uses Terra"),
+      summary: expect.stringContaining("Terra on OpenAI"),
       details: expect.stringContaining("follow-up photos"),
     });
-    expect(item?.details).toContain("use another model");
+    expect(item?.summary).toContain("one available initial photo");
+    expect(item?.summary).toContain("stored detail");
+    expect(item?.details).toContain("Multiple available initial photos");
+    expect(item?.details).toContain("Venice");
+    expect(item?.details).toContain("other models");
     expect(item?.details).toContain("custom inference");
+    expect(`${item?.title} ${item?.summary} ${item?.details}`).not.toContain(
+      "original detail",
+    );
   });
 
   it("keeps the health-data Settings note bound to layout only", () => {

--- a/apps/web/test/changelog.test.ts
+++ b/apps/web/test/changelog.test.ts
@@ -80,7 +80,7 @@ describe("changelog registry", () => {
       details: expect.stringContaining("follow-up photos"),
     });
     expect(item?.summary).toContain("one available initial photo");
-    expect(item?.summary).toContain("stored detail");
+    expect(item?.summary).toContain("more detail");
     expect(item?.details).toContain("Multiple available initial photos");
     expect(item?.details).toContain("Venice");
     expect(item?.details).toContain("other models");


### PR DESCRIPTION
## Why this PR exists

PR #1616 shipped finer single-photo preparation, but its public changelog copy described the behavior as applying to Terra generally and as retaining original source detail. The runtime contract is narrower: one available initial photo uses the original-detail transport path only when Terra runs through a supported OpenAI route, and inbound photos have already passed through Murph's bounded storage normalization.

This follow-up makes the public release note match that shipped boundary.

## User goal and visible behavior

- The August 10 changelog now says Terra on OpenAI reviews one available initial photo with more detail.
- Multiple available initial photos, follow-up photos, Venice, other models, and custom inference remain explicitly on the bounded high-detail path.
- The entry no longer implies literal source-original resolution.

Members see a more accurate release note. Assistant behavior is unchanged.

## Invariants

- PR #1616 remains the sole behavior source for the changelog item.
- The edition date, stable item ID, permalink, archive order, feed, and share-card contracts are unchanged.
- No image bytes, runtime routing, provider policy, persisted state, or privacy boundary changes.
- The generic archive tests remain data-driven; this PR adds no hand-maintained page inventory.

## Architecture and reuse

- Existing systems reused: the dated changelog fragment, shared edition metadata, generated registry, and focused registry test remain the only owners.
- New logic: none. The existing item copy and semantic assertions now name the already-shipped OpenAI, available-image, and bounded high-detail boundaries.
- New abstractions: no new abstraction is needed because the existing fragment and generated registry already own the public copy and its validation.
- Complexity intentionally avoided: no component, schema, generator, dependency, compatibility path, inventory mirror, or new state owner.

## Non-obvious affected surfaces

The corrected fragment appears through the existing changelog archive, item permalink, feed, and share-card preparation. The source implementation and all assistant transports remain byte-for-byte unchanged from merged PR #1616.

## Preliminary specialist lenses

- Product experience: applicable; the release note must describe the shipped provider and availability boundary without overstating source resolution.
- Prompt: not applicable; no assistant instructions, tool descriptions, or provider-visible prompts changed.
- Frontend: not applicable; no component, layout, interaction, or visual state changed. Existing changelog rendering consumes the corrected data.
- Coverage: applicable; the registry assertions exercise the claim-critical provider, availability, and bounded-path wording, while the generic archive test remains data-driven.

ReviewGPT context sensitivity: routine

ReviewGPT first-reviewed head: c8a0a1dec4be8d94ba64d92ccd4c69dbcd66eca9

## Design proof

Not applicable. This is a content-only correction in the existing changelog component. It adds no component, layout, interaction, or visual state; the existing synthetic archive study and generic server-render test continue to cover the surface.

## Changelog

- Changelog: updated
- Items: 2026-08-10 · sharper-single-photo-review

## Change-shape breakdown

Classification rule: `apps/web/test/**` is tests/fixtures; structured changelog content and the public-safe Frog report are docs/content. No authored source, config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 10 | 3 |
| Docs/content | 32 | 5 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **42** | **8** |

## Verification

- Changelog registry and archive: 44 tests passed.
- Web typecheck: passed.
- Diff and public-data privacy checks: passed.
- Current-main merge-tree: clean before PR creation.
- Exact-head GitHub Actions: pending.

## Review results

- The recovered final audit for PR #1616 surfaced the copy mismatch on the merged head. Its response did not satisfy the required model-confirmation line, so it was not counted as a clean #1616 review round; the finding was independently traced through the runtime and accepted.
- Preliminary specialist ReviewGPT: pending on this exact follow-up head.

## Deployment concerns

This is a Web-only copy correction for behavior already merged in PR #1616. No tandem deployment or compatibility window is required. After Web deploys, verify the August 10 item names OpenAI and the available-photo boundary.
