### PR TITLE
Preserve changelog edition boundaries

### DIFF
--- a/apps/web/changelog/editions/2026-08-10.json
+++ b/apps/web/changelog/editions/2026-08-10.json
@@ -1,5 +1,5 @@
 {
   "publishedOn": "2026-08-10",
   "title": "Training, group photos, Terra on OpenAI detail, health data, Starter, personality, reminders, cards, voices, and more",
-  "summary": "Training logs workouts; images become group photos; Terra on OpenAI reviews one available photo in more detail; health settings and timing are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter; private reports preview their shape."
+  "summary": "Training shows saved workouts; generated images can become group photos on request; Terra on OpenAI reviews one available first photo more closely; health settings are clearer; Starter waits until used; patterns link actions to sleep; personality stays editable; referrals stay in their chat; reminders keep local time; cards and voices stay clear; search is current; pages start lighter."
 }

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -81,6 +81,23 @@ describe("ChangelogPage", () => {
       expect(markup).not.toContain(`id="edition-${edition.id}"`);
     }
 
+    const correctedEdition = firstPage.editions.find(
+      (edition) => edition.id === "2026-08-10",
+    );
+    expect(correctedEdition).toBeDefined();
+    if (!correctedEdition) {
+      throw new TypeError(
+        "The current archive must include the corrected edition.",
+      );
+    }
+    expect(markup).toContain(
+      renderToStaticMarkup(<>{correctedEdition.summary}</>),
+    );
+    expect(correctedEdition.summary).toContain("Training shows saved workouts");
+    expect(correctedEdition.summary).toContain("group photos on request");
+    expect(correctedEdition.summary).toContain("one available first photo");
+    expect(correctedEdition.summary).not.toContain("original detail");
+
     expect(markup).toContain('aria-label="Changelog pages"');
     expect(markup).toContain(`href="${buildChangelogPagePath(2)}"`);
     expect(markup).toContain('aria-label="Changelog pages"');


### PR DESCRIPTION
## Why this PR exists

PR #1669 corrected the Terra item copy and auto-merged when its GitHub checks passed. Its preliminary specialist review completed afterward and found that the compressed August 10 edition summary had broadened three separate claims: Training sounded writable, group-photo conversion sounded automatic, and the Terra improvement no longer said the photo must be initial.

This follow-up applies those accepted findings and their rendered-boundary proof.

## User goal and visible behavior

A member scanning the August 10 edition summary now sees the same important limits as the item cards beneath it:

- Training shows workouts already saved with Murph.
- Generated images can become group photos only on request.
- Terra on OpenAI reviews one available first photo more closely.

The summary no longer implies a write path, an automatic group change, a follow-up-photo capability, or literal source-original resolution.

## Invariants

- Assistant runtime behavior remains unchanged from merged PR #1616.
- The edition date, stable item IDs, archive order, permalinks, feed, and share-card contracts are unchanged.
- The summary stays within its 400-character schema limit at 388 characters.
- The archive test asserts semantic boundaries without restoring a hand-maintained item-title inventory or full-sentence snapshot.

## Architecture and reuse

- Existing systems reused: the dated edition metadata, generated changelog registry, production archive renderer, and existing current-window server-render test remain the only owners.
- New logic: none. The test reads the real edition summary already rendered by the production archive and checks only the three claim-critical boundaries.
- New abstractions: no new abstraction is needed because the existing edition registry and archive test already expose the corrected summary at its rendered boundary.
- Complexity intentionally avoided: no component, schema, generator, dependency, snapshot, title inventory, compatibility path, or new state owner.

## Non-obvious affected surfaces

The edition summary is visible above its item cards in the public changelog archive. Item content, assistant routing, provider policy, feeds, permalinks, and share-card mechanics are unchanged.

## Preliminary specialist lenses

- Product experience: applicable; the completed #1669 specialist pass found the three broadened summary claims, and this PR is their parent-owned remediation.
- Prompt: not applicable; no assistant instructions, tool descriptions, or provider-visible prompts changed.
- Frontend: not applicable; no component, layout, interaction, styling, or visual state changed.
- Coverage: applicable; the existing production archive render test now verifies the corrected edition summary and its semantic limits.

The preliminary pass is not rerun after substantive findings. Parent product-experience revalidation on this corrected head finds the smallest complete experience: one 388-character summary that preserves read-only Training ownership, request-bound group-photo changes, and the available-first-photo OpenAI boundary, with no additional action or explanation.

ReviewGPT context sensitivity: routine

## Design proof

Not applicable. This is a static-copy correction in the existing changelog component. It adds no component, layout, interaction, or visual state; the server-render test exercises the real production archive summary.

## Changelog

- Changelog: updated
- Items: 2026-08-10 · sharper-single-photo-review

## Change-shape breakdown

Classification rule: `apps/web/test/**` is tests/fixtures and structured edition metadata is docs/content. No authored source, config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 17 | 0 |
| Docs/content | 1 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **18** | **1** |

## Verification

- Changelog registry and production archive: 44 tests passed.
- Web typecheck: passed.
- Edition summary length: 388 of 400 characters.
- Diff and public-data privacy checks: passed.
- Current-main merge-tree: clean before PR creation.
- Exact-head GitHub Actions: pending.

## Review results

- The substantive preliminary specialist pass on PR #1669 accepted two findings: restore Training/group-photo/first-photo semantics in the edition summary, and prove those semantics at the rendered archive boundary.
- Both findings are resolved in this exact diff. No patch artifact was returned or applied.
- Parent product-experience revalidation: no remaining findings or material evidence gaps. The archive has no asynchronous handoff, new action, permission, loading, failure, or recovery state.
- Final cross-cutting ReviewGPT gate: not applicable for this tiny static-copy/test remediation with no runtime, trust-boundary, prompt, component, or architecture change.

## Deployment concerns

This is a Web-only copy correction for behavior already deployed from PR #1616. No tandem deployment or compatibility window is required. After Web deploys, verify the August 10 edition summary preserves the saved-workout, on-request group-photo, and available-first-photo boundaries.
