### PR TITLE
perf(web): bound Linq diagnostic compaction scans

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-11-linq-diagnostic-compaction-index.md
+++ b/agent-docs/exec-plans/active/2026-08-11-linq-diagnostic-compaction-index.md
@@ -1,0 +1,57 @@
+# Bound Linq diagnostic compaction scans
+
+Status: active
+Created: 2026-08-11
+Updated: 2026-08-11
+
+## Goal
+
+- Keep the hourly Linq provider-event diagnostic compactor proportional to the
+  rows that still retain diagnostic JSON as the durable duplicate-gate table
+  grows.
+
+## Success criteria
+
+- A backward-compatible predeploy migration adds one concurrent partial index
+  matching the compactor's predicate and `(received_at, event_id)` ordering.
+- The existing full Prisma-managed retention index remains available for other
+  ordered provider-event scans.
+- Focused migration/source proof, Prisma validation, exact-head CI, preliminary
+  specialist review, final ReviewGPT review, and current-base mergeability all
+  pass for the pull request head.
+
+## Scope
+
+- The additive hosted Web Prisma migration and its focused source guards.
+- The hosted migration inventory expectation required by the current schema
+  proof suite.
+
+## Constraints
+
+- Do not deploy the migration or query production.
+- Use `CREATE INDEX CONCURRENTLY` outside an explicit transaction.
+- Keep PostgreSQL partial-index ownership migration-only because the current
+  Prisma schema cannot express the predicate.
+- Do not drop or replace the existing full index in this change.
+
+## Tasks
+
+1. Inspect and hash-match the ReviewGPT implementation artifact.
+2. Apply the additive migration and focused regression proof, then reconcile
+   the exact migration inventory guard.
+3. Run focused migration, retention, production-guard, Prisma, and TypeScript
+   validation and inspect the final diff.
+4. Commit, push, open the pull request, and run the exact-head specialist and
+   final ReviewGPT gates concurrently with CI.
+5. Resolve accepted findings, close this plan through `scripts/finish-task`,
+   and prove current-base mergeability without merging the pull request.
+
+## Evidence
+
+- The compaction query selects only rows with at least one of three diagnostic
+  JSON fields populated, ordered by `received_at` then `event_id`.
+- The existing index covers that order for every row, so already-compacted
+  durable duplicate-gate rows remain in the scanned index indefinitely.
+- Existing hosted Web migrations use concurrent, migration-only partial indexes
+  with exact predicates and no transaction wrapper.
+

--- a/agent-docs/exec-plans/active/2026-08-11-linq-diagnostic-compaction-index.md
+++ b/agent-docs/exec-plans/active/2026-08-11-linq-diagnostic-compaction-index.md
@@ -54,4 +54,3 @@ Updated: 2026-08-11
   durable duplicate-gate rows remain in the scanned index indefinitely.
 - Existing hosted Web migrations use concurrent, migration-only partial indexes
   with exact predicates and no transaction wrapper.
-

--- a/agent-docs/exec-plans/completed/2026-08-11-linq-diagnostic-compaction-index.md
+++ b/agent-docs/exec-plans/completed/2026-08-11-linq-diagnostic-compaction-index.md
@@ -1,6 +1,6 @@
 # Bound Linq diagnostic compaction scans
 
-Status: active
+Status: completed
 Created: 2026-08-11
 Updated: 2026-08-11
 
@@ -54,3 +54,4 @@ Updated: 2026-08-11
   durable duplicate-gate rows remain in the scanned index indefinitely.
 - Existing hosted Web migrations use concurrent, migration-only partial indexes
   with exact predicates and no transaction wrapper.
+Completed: 2026-08-11

--- a/apps/web/prisma/migrations/20260811190000_hosted_linq_provider_event_diagnostics_retention_index/migration.sql
+++ b/apps/web/prisma/migrations/20260811190000_hosted_linq_provider_event_diagnostics_retention_index/migration.sql
@@ -1,0 +1,5 @@
+CREATE INDEX CONCURRENTLY "hosted_linq_provider_event_diagnostics_retention_idx"
+  ON "hosted_linq_provider_event"("received_at", "event_id")
+  WHERE "extraction_json" IS NOT NULL
+    OR "payload_sanitized_json" IS NOT NULL
+    OR "payload_shape_json" IS NOT NULL;

--- a/apps/web/test/hosted-linq-provider-event-diagnostics-retention-index-migration.test.ts
+++ b/apps/web/test/hosted-linq-provider-event-diagnostics-retention-index-migration.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260811190000_hosted_linq_provider_event_diagnostics_retention_index/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const cleanupSource = readFileSync(
+  new URL("../src/lib/hosted-retention/cleanup.ts", import.meta.url),
+  "utf8",
+);
+const prismaSchema = readFileSync(
+  new URL("../prisma/schema.prisma", import.meta.url),
+  "utf8",
+);
+
+describe("Hosted Linq provider-event diagnostics retention index migration", () => {
+  it("adds only the concurrent partial index for the ordered compaction scan", () => {
+    expect(migrationSql.trim()).toBe([
+      'CREATE INDEX CONCURRENTLY "hosted_linq_provider_event_diagnostics_retention_idx"',
+      '  ON "hosted_linq_provider_event"("received_at", "event_id")',
+      '  WHERE "extraction_json" IS NOT NULL',
+      '    OR "payload_sanitized_json" IS NOT NULL',
+      '    OR "payload_shape_json" IS NOT NULL;',
+    ].join("\n"));
+    expect(cleanupSource).toContain([
+      '      WHERE "received_at" < ${cutoff}',
+      "        AND (",
+      '          "extraction_json" IS NOT NULL',
+      '          OR "payload_sanitized_json" IS NOT NULL',
+      '          OR "payload_shape_json" IS NOT NULL',
+      "        )",
+      '      ORDER BY "received_at" ASC, "event_id" ASC',
+    ].join("\n"));
+    expect(prismaSchema).toContain("@@index([receivedAt, eventId])");
+  });
+});

--- a/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
+++ b/apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts
@@ -1093,6 +1093,7 @@ describe("hosted Prisma baseline migration", () => {
       "20260810050000_relax_detached_automatic_refill_failure",
       "20260810150000_hosted_usage_credit_grant_slot_release",
       "20260811160000_add_group_sponsorship_funding_alias_publication",
+      "20260811190000_hosted_linq_provider_event_diagnostics_retention_index",
       "migration_lock.toml",
     ]);
     expect(hostedPendingGroupSetupMigrationSql).toContain(


### PR DESCRIPTION
## Why this PR exists

The durable Linq provider-event duplicate-gate table grows indefinitely, while the hourly diagnostic compactor needs to visit only rows that still retain diagnostic JSON. The existing full `(received_at, event_id)` index leaves already-compacted rows in the scan path, so this PR adds the narrow access path the maintenance query actually needs.

## User goal / user-visible behavior

Members should keep receiving reliable service as provider-event history grows; hourly internal retention work should not create avoidable database pressure. This PR changes no member-facing feature, copy, or interaction.

## User experience

No direct user-facing effect. The existing retention schedule, diagnostic lifetime, duplicate protection, and failure behavior remain unchanged; only PostgreSQL's access path for the existing bounded compaction query improves.

## Invariants the PR must preserve

- Provider-event rows remain durable webhook duplicate gates; only optional diagnostic JSON is compacted.
- The partial predicate exactly matches the three nullable diagnostic fields cleared by the existing compactor.
- The index order remains `(received_at, event_id)` so the existing oldest-first bounded batch is supported.
- Production writes are not blocked by index construction: the migration uses `CREATE INDEX CONCURRENTLY` with no transaction wrapper.
- The existing full Prisma-managed `(receivedAt, eventId)` index remains available for other provider-event scans.
- Partial-index ownership remains migration-only because the current Prisma schema cannot represent the predicate.

## Non-obvious affected surfaces

- Vercel predeploy schema migration: the additive migration is eligible for the normal backward-compatible predeploy lane. `production-migration-guard.test.ts` proves it does not require a destructive-migration exception.
- Hosted Prisma migration inventory: the exact sorted inventory expectation includes the new migration so fresh-schema proof cannot silently omit it.

## Architecture and reuse

- **Existing systems reused:** The existing hourly retention owner, bounded compaction SQL, normal hosted Web Prisma migration lane, and established concurrent partial-index convention.
- **New logic:** One PostgreSQL partial B-tree index whose columns and predicate mirror the existing query exactly.
- **New abstractions:** None; the current migration and source-guard patterns are sufficient.
- **Complexity intentionally avoided:** No query rewrite, new cursor, retention state, duplicate counter, scheduler, schema-model approximation, production backfill, or removal of the broader index.

## Changelog

- Changelog: not applicable
- Reason: This is internal database-maintenance indexing with no member-visible behavior change.

## Hot reply path impact

Not applicable. No request, provider, transaction, or reply-handoff code changes; the new index is installed only through the predeploy migration lane.

## Database collection fanout impact

Not applicable. No database-touching collection path changes: query count, pooled connections, concurrent transactions, and external/crypto work remain unchanged. The existing single bounded compaction statement can use a smaller partial index.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool, schema, provider adapter, or request-assembly surface changed.
- Group Murph: Not applicable; no prompt, tool, schema, provider adapter, or request-assembly surface changed.

## Preliminary specialist lenses

- Product experience: not applicable — the retention schedule and every member-visible flow remain unchanged; direct proof is the migration-only production diff.
- Prompt: not applicable — no prompt, instruction, tool description, or provider-visible input changed.
- Frontend: not applicable — no user-facing UI or rendered state changed.
- Coverage: applicable — focused migration/source guard, exact migration inventory, retention cleanup, and production migration guard tests pass locally; exact substantive-head specialist and final ReviewGPT gates passed. All exact archive-head CI checks passed.

ReviewGPT context sensitivity: sensitive

Reason: This PR changes a production database index and migration surface.

ReviewGPT first-reviewed head: 411c1645699dff654f0b0aeea62c3476e3d973bb

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-linq-provider-event-diagnostics-retention-index-migration.test.ts apps/web/test/hosted-onboarding-privacy-foundation-migration.test.ts apps/web/test/hosted-retention-cleanup.test.ts apps/web/test/production-migration-guard.test.ts` — 4 files, 73 tests passed.
- `pnpm --dir apps/web exec prisma validate --schema prisma/schema.prisma` — passed.
- `pnpm typecheck` — passed.
- `pnpm --dir apps/web lint` — passed with 0 errors and 39 existing warnings outside this diff.
- Direct SQL/source checks — one statement; 52-byte index name; no `BEGIN`, `COMMIT`, DML, destructive DDL, local identifier, or path leakage.
- ReviewGPT implementation artifact SHA-256 matched the returned digest before application: `b0519b19a3d5bdecbfe35856774df8fb1fac34e41d293acfe5d508a3c6053608`.
- Exact-head preliminary specialist ReviewGPT — PASS with no findings or patch: https://chatgpt.com/c/6a7b8e80-f294-83ea-bf46-940b168ca470
- Exact-head final full-snapshot ReviewGPT — PASS with no findings: https://chatgpt.com/c/6a7b90e0-1978-83ea-a748-2e3c04ab0ad6
- Exact archive-head GitHub CI — all required checks passed on run 31538254497; earlier assistant failures were reproduced on the exact old base and later recovered without PR scope changes.

## Change shape

Classification: production migration SQL is source; Vitest and migration-inventory guards are tests/fixtures; the execution plan is docs; no binary files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 0 |
| Tests/fixtures | 42 | 0 |
| Docs | 57 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **104** | **0** |

## Design proof

Not applicable; this PR has no user-facing frontend UI diff.


