### PR TITLE
Default eligible response cards in private conversations

### DIFF
--- a/apps/web/changelog/entries/2026-08-11/response-cards-without-another-ask.json
+++ b/apps/web/changelog/entries/2026-08-11/response-cards-without-another-ask.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-11",
+  "order": 100,
+  "item": {
+    "id": "response-cards-without-another-ask",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Workout cards without another ask",
+    "summary": "Starting or resuming a verified live workout now returns its available card in the same private response instead of waiting for a second request.",
+    "details": "Murph also defaults to other already-authorized complete response cards, while ordinary meal and set updates stay concise and unsupported or unverifiable cases fall back to text.",
+    "relevanceTags": ["cards", "workouts", "nutrition", "imessage"],
+    "sourcePullRequests": [1680]
+  }
+}

--- a/packages/assistant-engine/skills/tracked-table/SKILL.md
+++ b/packages/assistant-engine/skills/tracked-table/SKILL.md
@@ -48,7 +48,7 @@ The legacy `workout edit` full-structure replacement remains available only for 
 
 ## Starting a workout
 
-1. Resolve the requested saved format when the member named one. If there is no reusable plan, start a clearly requested empty session and add only the exercises and set counts the member actually specified.
+1. Resolve the requested saved format when the member named one. If there is no reusable plan, start a clearly requested empty session and preserve every distinct exercise the member named, including closely related variations; never collapse one variation into another or silently omit an item. Use exactly a stated set count. When an exercise has no stated count, create one unlogged targetless placeholder as the next log slot, not as a claimed plan or completed set.
 2. Ensure no second private live workout is plausible. Reuse the clearly active event or ask one narrow question rather than creating a duplicate.
 3. Run `vault-cli workout start`, passing `--routine` when using a saved format. The command must preserve plan ownership in the format and start every planned set as an unlogged placeholder containing only canonical event coordinates and actual-state fields.
 4. Treat the returned canonical event as the verified start result. Read the format separately before presenting planned targets.
@@ -85,23 +85,23 @@ An exact replay for the same exercise and set coordinate converges on that coord
 - “The next set was 8 reps” may target the clearly current exercise. If two exercises are plausible, ask one narrow disambiguating question.
 - Never infer weight, repetitions, effort, assistance, completion, rest, or failure from a plan, prior workout, elapsed time, or a reminder.
 - Treat member-defined shorthand as ambiguous until explained. Once defined as spotted repetitions, persist a plain set note such as `note=final rep spotted` or `note=final 2 reps spotted`; do not reinterpret it as assisted-load data.
-- Persist every qualitative annotation on that set's canonical `note`. Never leave meaningful notation only in conversation text, an exercise-level summary, or the card snapshot.
+- Persist every qualitative annotation on that exact set's canonical `note`. Never leave meaningful notation only in conversation text, an exercise-level summary, or the card snapshot.
 - If no active workout exists, do not treat an isolated “8 reps” message as authorization to invent one.
 
 ## Finishing
 
 Run `vault-cli workout finish --workout-id <evt_id>` only after an explicit finish. The returned event must contain the verified `endedAt` and final elapsed duration. Do not fabricate missing set values or copy targets into the event.
 
-For the completed presentation, every planned set without a corresponding actual result becomes `skipped` rather than disappearing. That is an explicit card status derived from the ended event plus the format; it is not invented actual performance.
+For the completed presentation, every planned set without a corresponding actual result becomes `skipped` rather than disappearing. A canonical targetless log slot that remains empty when the session ends also becomes `skipped` with `target=null`; that preserves the verified session structure without turning the slot into evidence of a plan or actual performance.
 
 ## Building a structured workout card
 
 Use `murph.attach_response_card` with `kind="compact_table"` and structured `workout` detail in a private direct conversation when a verified live or just-finished workout is the primary answer.
 
-Build it from two canonical sources:
+Build it from the verified canonical workout event and, when present, its verified workout format:
 
-- `target`: the matching planned set from the verified workout format;
-- `actual`: the matching completed set from the verified canonical workout event.
+- `target`: the matching planned set from the verified format, otherwise `null`;
+- `actual` and targetless log-slot coordinates: the verified canonical event.
 
 Do not add `rowHeader`, `columns`, or `rows` to a structured workout card. Text, provider-layout, and native-envelope consumers derive progress directly from `workout.exercises`. Map each planned set in `workout.exercises` to:
 
@@ -109,7 +109,7 @@ Do not add `rowHeader`, `columns`, or `rows` to a structured workout card. Text,
 - `completed`: a corresponding actual result exists;
 - `skipped`: no corresponding actual result and the workout has ended.
 
-If the event contains additional actual sets beyond the format, include them as completed sets with `target=null`. Preserve canonical exercise and set order. Keep the card within its exercise, set, text, and encoded URL limits; use a compact table or readable text when the full workout cannot fit.
+Also include every canonical event set with no matching format set. Use `target=null`; mark it `completed` when an actual result exists, `pending` while the workout is live and the slot is empty, or `skipped` after the workout ends and the slot remains empty. An empty targetless slot is a verified logging coordinate, not evidence of a planned set. Preserve canonical exercise and set order. Keep the card within its exercise, set, text, and encoded URL limits; use a compact table or readable text when the full workout cannot fit.
 
 The outer card remains `compact_table` V1. Set `workout` to:
 
@@ -147,7 +147,8 @@ Set `tracking` to `{ "kind": "workout", "entityId": "<exact evt id>", "snapshotA
 
 ## Card refresh behavior
 
-- Send one structured workout card when the workout starts and the planned session is useful.
+- After successfully starting or resuming one canonical live workout, use one verified structured workout card as the complete response on a supported private card route. Do not send a text-only start acknowledgement or wait for a separate card request.
+- Fall back to truthful ordinary text only when the card tool is unavailable, the canonical event cannot be verified, any claimed planned targets cannot be verified from their matching format, the card would not completely answer the turn, or the bounded card contract cannot represent the workout.
 - After an accepted explicit card command, send the refreshed card as the response; do not also repeat the full workout in prose.
 - For ordinary free-form logging, prefer concise text until a meaningful milestone, an explicit table request, or Finish.
 - Do not send proactive cards without an existing authorized reminder or automation.

--- a/packages/assistant-engine/src/assistant/model-behavior.ts
+++ b/packages/assistant-engine/src/assistant/model-behavior.ts
@@ -74,6 +74,10 @@ export function buildAssistantExecutionBehaviorText(input: {
   const messagingPresentationGuidance = `
 - Messaging: never send Markdown tables, even on request; overrides other table guidance. Use labeled lines.
 - Use \`murph.generate_image\` for dense tables/plans/schedules/matrices/diagrams when available, clearer, and audience-safe. Keep exact or safety-critical details (sets/reps, dates, dosages) in text. No decorative images or private health data in group images.`
+  const responseCardGuidance = input.progressUpdateMode === 'group'
+    ? ''
+    : `
+- Private cards: if its skill and tool allow it, attach now without another ask. No prose; routine logs stay concise.`
   const productFeedbackSalienceGuidance = `
 - Product feedback salience: when visible dissatisfaction is directed at Murph after repeated, circular, redundant, or contradictory Murph-owned behavior, treat it as explicit product frustration rather than merely tone, banter, or missing input. Address the immediate need and, if no product-feedback candidate has already been submitted for that accepted request, silently call \`murph.submit_product_feedback\` once with kind \`frustration\` when available; do not wait for the member to call it feedback, ask permission, or start a separate discovery interview.
 - Keep this trigger narrow. Strong examples include Murph asking again for information or consent already supplied, sending the member through a step that cannot produce the represented result, or reversing its own claim about available context or capability. Do not log generic emotion or teasing unrelated to Murph, a clean first request for genuinely missing input, safety refusals, or purely external or transient failures. Follow the main Product feedback contract and tool schema for de-identification, one-candidate, no-retry, and best-effort behavior.`
@@ -87,7 +91,7 @@ Group context and continuity:
 - Use context naturally without a memory preamble on every turn. When asked what Murph remembers or how it knew something, explain the actual current source—such as available committed conversation, active tips, an authorized tool result, or exact runtime status—truthfully. Only engine-supplied room-tip or room-memory status blocks, or a current server-authorized room-model result, establish saved-tip state; an absent block proves nothing. Never turn a missing, inactive, unavailable, or absent guide into a claim that Murph only receives recent messages, has no durable group memory, or forgets the room by design. Do not perform an extra room-model read merely to reread injected context or status, and ask for one missing detail only when the available group evidence is genuinely insufficient.`
     : ''
 
-  return `Murph progress-delivery, browser-action, and appointment-reminder rules:${progressUpdateGuidance}${browserActionGuidance}${appointmentReminderGuidance}${messagingPresentationGuidance}${productFeedbackSalienceGuidance}${groupContextGuidance}`
+  return `Murph progress-delivery, browser-action, and appointment-reminder rules:${progressUpdateGuidance}${browserActionGuidance}${appointmentReminderGuidance}${messagingPresentationGuidance}${responseCardGuidance}${productFeedbackSalienceGuidance}${groupContextGuidance}`
 }
 
 export function buildAssistantResearchScoutCapabilityText(input: {

--- a/packages/assistant-engine/test/assistant-response-card-defaults-prompt.test.ts
+++ b/packages/assistant-engine/test/assistant-response-card-defaults-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildAssistantSystemPrompt,
+  type AssistantSystemPromptInput,
+} from '../src/assistant/system-prompt.js'
+
+function createPromptInput(
+  conversationScope: 'direct' | 'group',
+): AssistantSystemPromptInput {
+  return {
+    assistantCliContract: null,
+    channel: 'linq',
+    cliAccess: {
+      rawCommand: 'vault-cli',
+      setupCommand: 'murph',
+    },
+    conversationScope,
+    currentLocalDate: '2026-08-11',
+    currentTimeZone: 'America/New_York',
+    hostedRuntime: true,
+    modelBehaviorProfile: 'gpt5-agentic',
+    onboardingGuidance: false,
+  }
+}
+
+describe('assistant response-card defaults', () => {
+  it('defaults eligible private cards without exposing private-card guidance to groups', () => {
+    const directPrompt = buildAssistantSystemPrompt(createPromptInput('direct'))
+    const groupPrompt = buildAssistantSystemPrompt(createPromptInput('group'))
+
+    expect(directPrompt).toContain(
+      'Private cards: if its skill and tool allow it, attach now without another ask.',
+    )
+    expect(directPrompt).toContain('No prose; routine logs stay concise.')
+    expect((directPrompt.match(/Private cards:/gu) ?? [])).toHaveLength(1)
+    expect(groupPrompt).not.toContain('Private cards:')
+  })
+})

--- a/packages/assistant-engine/test/assistant-tracked-table-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-tracked-table-skill.test.ts
@@ -38,6 +38,46 @@ const FOUR_SET_CARD = {
   },
 } satisfies AssistantResponseCard
 
+const AD_HOC_EXERCISE_NAMES = [
+  'Bench press',
+  'Incline bench press',
+  'Push-up',
+  'Dip',
+] as const
+
+const AD_HOC_TARGETLESS_WORKOUT_CARD = {
+  kind: 'compact_table',
+  version: 1,
+  title: 'Upper body workout',
+  subtitle: null,
+  footer: 'Reply with the exercise, set, and result.',
+  tracking: {
+    kind: 'workout',
+    entityId: 'evt_01K1ABCDEFGHJKMNPQRSTVWXYZ',
+    snapshotAt: '2026-08-11T18:14:00.000Z',
+  },
+  workout: {
+    version: 1,
+    state: 'active',
+    exercises: AD_HOC_EXERCISE_NAMES.map((name) => ({
+      name,
+      sets: [{ status: 'pending' as const, target: null, actual: null }],
+    })),
+  },
+} satisfies AssistantResponseCard
+
+const AD_HOC_COMPLETED_TARGETLESS_WORKOUT_CARD = {
+  ...AD_HOC_TARGETLESS_WORKOUT_CARD,
+  workout: {
+    version: 1,
+    state: 'completed',
+    exercises: AD_HOC_EXERCISE_NAMES.map((name) => ({
+      name,
+      sets: [{ status: 'skipped' as const, target: null, actual: null }],
+    })),
+  },
+} satisfies AssistantResponseCard
+
 describe('assistant tracked workout table skill', () => {
   it('registers direct table and live-workout language with the skill router', () => {
     const matches = ASSISTANT_SKILLS.filter(
@@ -88,6 +128,22 @@ describe('assistant tracked workout table skill', () => {
     expect(skill).toContain('one explicit exercise selector, and `--set-order`')
     expect(skill).toContain('correct the same set rather than append a duplicate')
     expect(skill).toContain('Saved target values remain in the workout format')
+    expect(skill).toContain('preserve every distinct exercise the member named')
+    expect(skill).toContain('including closely related variations')
+    expect(skill).toContain(
+      'one unlogged targetless placeholder as the next log slot',
+    )
+    expect(skill).toContain('not as a claimed plan or completed set')
+    expect(skill).toContain(
+      'every canonical event set with no matching format set',
+    )
+    expect(skill).toContain(
+      '`pending` while the workout is live and the slot is empty',
+    )
+    expect(skill).toContain(
+      '`skipped` after the workout ends and the slot remains empty',
+    )
+    expect(skill).toContain('not evidence of a planned set')
     expect(skill).toContain('vault-cli workout format show')
     expect(skill).toContain(
       'Never copy planned targets into actual set fields',
@@ -101,6 +157,19 @@ describe('assistant tracked workout table skill', () => {
     expect(skill).toContain('already-completed return is convergence')
     expect(skill).not.toContain('Complete workout exercise')
     expect(skill).toContain('Never infer weight, repetitions, effort, assistance')
+    expect(skill).toContain(
+      'use one verified structured workout card as the complete response on a supported private card route',
+    )
+    expect(skill).toContain(
+      'Do not send a text-only start acknowledgement or wait for a separate card request.',
+    )
+    expect(skill).toContain('the canonical event cannot be verified')
+    expect(skill).toContain(
+      'any claimed planned targets cannot be verified from their matching format',
+    )
+    expect(skill).toContain(
+      'the bounded card contract cannot represent the workout',
+    )
   })
 
   it('keeps set annotations canonical and preserves a fourth set', async () => {
@@ -112,7 +181,7 @@ describe('assistant tracked workout table skill', () => {
     expect(skill).toMatch(/^---\nname: tracked-table\n/)
     expect(skill).toContain('one to four compact value columns')
     expect(skill).toContain('Never emit Markdown-table syntax')
-    expect(skill).toContain("that set's canonical `note`")
+    expect(skill).toContain("that exact set's canonical `note`")
     expect(skill).toContain('note=final rep spotted')
     expect(skill).toContain('Do not collapse or discard the fourth set')
     expect(skill).toContain('do not silently truncate it')
@@ -133,5 +202,16 @@ describe('assistant tracked workout table skill', () => {
     expect(assistantResponseCardSchema.parse(FOUR_SET_CARD)).toEqual(
       FOUR_SET_CARD,
     )
+  })
+
+  it('accepts distinct ad-hoc exercises with targetless active and finished slots', () => {
+    expect(
+      assistantResponseCardSchema.parse(AD_HOC_TARGETLESS_WORKOUT_CARD),
+    ).toEqual(AD_HOC_TARGETLESS_WORKOUT_CARD)
+    expect(
+      assistantResponseCardSchema.parse(
+        AD_HOC_COMPLETED_TARGETLESS_WORKOUT_CARD,
+      ),
+    ).toEqual(AD_HOC_COMPLETED_TARGETLESS_WORKOUT_CARD)
   })
 })


### PR DESCRIPTION
## Why this PR exists

Murph already had the runtime, authorization, persistence, and delivery machinery for private nutrition and workout response cards, but the model could still send a text-only acknowledgement and wait for a second explicit “send the card” request. That added avoidable friction and made the structured experience feel hidden.

## User goal / user-visible behavior

When an existing owning skill and the response-card tool already authorize a card as the complete answer, Murph attaches it in that response by default. Starting or resuming a verified live workout now returns its structured workout card immediately on a supported private route. Existing managed nutrition closeouts continue to attach their card after their complete safety, goal, and fresh-total checks pass.

Ordinary meal logs and incremental workout-set updates remain concise rather than producing a new card after every message.

## User experience

- A member starts or resumes one canonical live workout in a private conversation.
- Murph preserves every distinct named exercise, including nearby variants such as bench press and incline bench press.
- An explicitly stated set count is used exactly. When no count was supplied, one empty targetless logging slot is created per named exercise; it is not presented as a prescribed or completed set.
- Murph verifies the canonical event and any planned targets it chooses to show.
- When the supported card can completely answer the turn, Murph returns the card in the same response instead of requiring another ask.
- Targetless event slots remain visible in the initial card as pending, and become skipped if still empty when the workout finishes. They retain `target=null`, so the presentation does not invent a plan.
- If the card tool or verified evidence is unavailable, the card cannot completely answer the turn, or the bounded contract cannot represent the workout, Murph falls back to truthful ordinary text.
- Groups receive no private-card instruction, and incremental logs do not become card spam.

## Invariants

- The canonical workout event remains the only mutable workout authority; cards remain immutable presentation snapshots.
- Existing response-card audience, completeness, no-companion-prose, no-response-media, and delivery constraints remain authoritative.
- Existing managed nutrition safety, goal, proposal, and fresh-total gates remain unchanged.
- Ad-hoc live workouts remain valid without a saved format. A format read is required only for planned targets Murph chooses to claim.
- A missing set count creates a targetless logging coordinate, not evidence of a planned set, completed set, or recommendation.
- Every canonical event set remains representable even when no matching format set exists: `target=null`, then completed, pending, or skipped from verified event state.
- Group conversations do not receive private response-card guidance.
- No new state, queue, database row, scheduler, retry owner, card registry, or delivery path is added.

## Final audit findings and dispositions

- **Explicit card refresh could be accidentally suppressed by broad incremental-log wording:** fixed. The global rule now keeps only ordinary incremental logs concise; the owning tracked-table skill still requires a refreshed card after an accepted explicit card command.
- **Closely related exercise names could collapse during ad-hoc setup:** fixed. The owner now requires every distinct named exercise and variation to remain separate.
- **Missing set counts had no explicit truthful initial-card representation:** fixed. They become one targetless next-log slot rather than an inferred plan.
- **The card-builder guidance covered format sets and completed extra sets but not empty targetless event slots:** fixed. Active and completed targetless card shapes are now explicit and covered by regressions.
- **Set notes were described less precisely than the surrounding exact-coordinate contract:** fixed with the same exact-set language already used by the card-command path.
- **A new runtime card-selection or persistence mechanism:** intentionally not added. The existing skill and `murph.attach_response_card` contract already own authorization, completeness, audience, validation, persistence, and delivery; another mechanism would duplicate authority and increase long-term complexity without closing a real gap.

## Non-obvious affected surfaces

- The direct stable execution-behavior layer gains one concise response-card default, while the group layer remains byte-identical for this change.
- The tracked-table skill makes the initial-card default, ad-hoc exercise preservation, targetless-slot projection, and evidence-based fallback conditions explicit.
- The existing `murph.attach_response_card` contract remains the authorization owner for initial live-workout cards, established workout updates, and eligible managed meal closeouts.
- The prompt contract changes the assistant thread fingerprint for eligible private sessions; normal existing contract-fingerprint rotation and transcript replay behavior applies.
- The branch is one clean commit on exact current `main`; no stale-base code or unrelated branch history remains.

## Architecture and reuse

- **Existing systems reused:** current skill router, tracked-table and nutrition owners, canonical workout event and format reads, targeted workout commands, `murph.attach_response_card`, response-card validation, immutable outbox effect, and existing channel delivery adapters.
- **New logic:** one direct-only default stating that an already-authorized complete card should be attached now, plus explicit tracked-workout initial-card, targetless-slot, and fallback wording.
- **New abstractions:** none are needed because the current skill owner and response-card attachment contract already compose the full authorization, validation, persistence, and delivery path.
- **Complexity intentionally avoided:** no runtime heuristic, second authorization layer, database state, queue, card lifecycle, renderer, retry path, compatibility layer, or duplicated nutrition/workout policy in the global prompt.

## Changelog

- Changelog: updated
- Items: 2026-08-11 · response-cards-without-another-ask

## Hot reply path impact

- Path status: provider-visible instruction behavior only.
- Database calls: none added or moved.
- Network/provider calls: no unconditional call added. Eligible turns may use the existing response-card tool in the same provider turn instead of waiting for another user turn.
- Other awaited latency: none added.

## Database collection fanout impact

Not applicable. No database collection, query, write, transaction, or fanout changes.

## Murph initial provider input impact

- Individual/direct Murph: the authored stable execution-behavior layer increases by 183 UTF-8 bytes.
- Authenticated group Murph: 0-byte authored delta from this response-card change.
- Tool schemas, dynamic-tool availability, generated guidance, and user input are unchanged.
- Complete absolute provider-request token and byte capture remains pending exact-head verification; this PR does not present a partial calculation as the full request total.

## Preliminary specialist lenses

- Product experience: applicable — removes a redundant second ask while preserving concise incremental logging and truthful fallback.
- Prompt: applicable — changes direct provider-visible guidance and one owning skill.
- Frontend: not applicable — no Web or native renderer/layout changes.
- Coverage: applicable — prompt scope, exercise preservation, targetless active/completed cards, and tracked-workout fallback behavior have focused regressions; exact-head CI is running.

ReviewGPT context sensitivity: routine

Classification reason: narrow prompt/skill behavior change that reuses existing card authority and delivery boundaries without changing authorization, privacy, safety, persistence, or runtime ownership.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source / skill guidance | 14 | 9 |
| Tests / fixtures | 122 | 1 |
| Docs / changelog | 14 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **150** | **10** |

## Verification

- Exact head: `81263718e739370d1c4ec0143966ced857f721bb`.
- Compared against exact base `b3672630fce628304480ac0965bdcba02033d831`: one commit ahead, zero behind, five intended files.
- TypeScript parse checks passed for the changed source and both focused test files with Node’s type-stripping parser.
- Direct/group prompt construction check passed: exactly one private-card rule in direct and none in group; the existing product-frustration policy remains present exactly once in each applicable prompt.
- The direct authored prompt delta is +183 UTF-8 bytes; group delta is zero.
- Added schema regressions for all four named exercises in both active targetless-pending and finished targetless-skipped cards.
- The tracked-workout fallback was checked against ad-hoc sessions: a saved format is required only for planned targets Murph chooses to claim, not for every valid live workout.
- Existing managed automatic-meal-closeout guidance and response-card tool admission were inspected and remain the sole nutrition authority rather than being duplicated globally.
- JSON parsing and trailing-whitespace checks passed for every changed file.
- `node --test scripts/check-pr-changelog.test.mjs` — 13 tests passed.
- Full package Vitest/typecheck, prompt-budget, and exact complete provider-input verification are owned by exact-head CI and are currently running.
