### PR TITLE
Fix channel-specific tool advertisement proof

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -234,6 +234,7 @@ export function expectAdvertisedMurphDynamicTools(
   options: {
     connectedAppsAvailable?: boolean;
     computerToolsAvailable?: boolean;
+    exerciseRoutineResponseCardAvailable?: boolean;
     groupRoomModelAvailable?: boolean;
     imessageContactAvailable?: boolean;
     messageTargetingAvailable?: boolean;
@@ -306,6 +307,13 @@ export function expectAdvertisedMurphDynamicTools(
       if (
         options.responseCardAvailable !== true
         && name === "murph.attach_response_card"
+      ) {
+        return false;
+      }
+
+      if (
+        options.exerciseRoutineResponseCardAvailable !== true
+        && name === "murph.attach_exercise_routine_card"
       ) {
         return false;
       }

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -570,6 +570,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
       && name !== "murph.send_vault_file"
       && name !== "murph.ask_grok"
       && name !== "murph.attach_response_card"
+      && name !== "murph.attach_exercise_routine_card"
     );
     const baseToolNamesWithoutProgress = baseToolNames.filter((name) =>
       name !== "murph.send_progress_update"
@@ -585,6 +586,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     expect(allToolNames).toContain("murph.send_progress_update");
     expect(allToolNames).toContain("murph.ask_grok");
     expect(allToolNames).toContain("murph.attach_response_card");
+    expect(allToolNames).toContain("murph.attach_exercise_routine_card");
 
     expectAdvertisedMurphDynamicTools([
       buildResponsesRequest(baseToolNames),
@@ -626,6 +628,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
       {
         connectedAppsAvailable: true,
         computerToolsAvailable: true,
+        exerciseRoutineResponseCardAvailable: true,
         groupRoomModelAvailable: true,
         imessageContactAvailable: true,
         messageTargetingAvailable: true,

--- a/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
@@ -299,6 +299,7 @@ describe("hosted local Telegram auto-reply e2e", () => {
     expectAdvertisedMurphDynamicTools(requireScenario().assistantProviderRequests, {
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
+      exerciseRoutineResponseCardAvailable: true,
       imessageContactAvailable: true,
       messageTargetingAvailable: true,
       phoneCallsAvailable: true,


### PR DESCRIPTION
## Why this PR exists

The production Cloudflare deploy gate expected a Telegram-only routine-card tool in a Linq turn. That stale test expectation blocked deploys after PR #1657.

## User goal / user-visible behavior

Production deploys can validate the real channel-specific tool set and proceed when all runtime checks pass. This PR does not change member-visible behavior.

## User experience

No user-facing effect. The change only corrects deployment proof.

## Invariants

- Linq must not advertise the Telegram-only exercise routine card tool.
- Telegram must continue to advertise that tool when the channel supports it.
- The helper must fail when either channel advertises the wrong tool set.

## Non-obvious affected surfaces

- Cloudflare hosted-local deploy proof: the shared dynamic-tool assertion now models the existing channel gate explicitly. The focused helper test proves both disabled-by-default and enabled behavior.

## Architecture and reuse

- **Existing systems reused:** The existing hosted-local dynamic-tool assertion and channel-specific E2E scenarios remain the proof owners.
- **New logic:** One explicit test option controls whether the Telegram routine-card tool is expected.
- **New abstractions:** No new abstraction was added; the helper's existing option pattern is sufficient.
- **Complexity intentionally avoided:** The production tool catalog and channel planning remain unchanged because their behavior is correct.

## Changelog

- Changelog: not applicable
- Reason: This is a test-only correction with no member-visible behavior change.

## Hot reply path impact

Not applicable. The diff changes only tests and test helpers.

## Database collection fanout impact

Not applicable. The diff adds no database work.

## Murph initial provider input impact

- Individual Murph: Not applicable. Production tool availability and provider input are unchanged.
- Group Murph: Not applicable. Production tool availability and provider input are unchanged.

## Preliminary specialist lenses

- Product experience: not applicable; member behavior is unchanged.
- Prompt: not applicable; no prompt or production tool schema changes.
- Frontend: not applicable; no UI changes.
- Coverage: applicable; focused local proof passed 23/23 tests, and exact-head CI is pending.

ReviewGPT context sensitivity: routine

Reason: This is a narrow test-expectation fix with no production runtime change.

## Change-shape breakdown

Classification rule: authored files under `apps/cloudflare/test` are tests and direct-proof scaffolding. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 12 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **12** | **0** |

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/hosted-local-e2e-support.test.ts --no-coverage` — 23 passed.
- `git diff --check` — passed.

## Design proof

Not applicable. The PR has no user-facing frontend UI diff.
