### PR TITLE
Bound group-email authorization graph reads

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
+++ b/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
@@ -61,3 +61,20 @@ share authorization semantics.
 - Exact-head required GitHub Actions, preliminary specialist PASS or resolved
   findings, final ReviewGPT PASS with zero accepted findings, and a clean
   current-base merge-tree proof.
+
+## Progress
+
+- The implementation-first ReviewGPT patch was applied exactly, reconciled to
+  current main, and proved with the focused suite, hosted Web typecheck,
+  scoped lint, documentation drift, diff integrity, and privacy checks.
+- The preliminary specialist found that a corrupt second email-kind grant
+  could consume the overflow-sentinel slot because the database uniqueness key
+  constrains scope rather than projection kind. The reader now requires every
+  email-kind grant to use the canonical scope key and rejects more than one
+  before constructing participants or proofs; preparation, recipient, and
+  singleton-noncanonical regressions cover the correction.
+- The specialist's request for a new live PostgreSQL and KMS maximum-graph
+  harness was not accepted. This diff adds only bounded metadata relation reads;
+  the exact Prisma order/take shape and composed reader call counts are covered
+  here, while the unchanged verified-email owner already proves one email batch,
+  one envelope batch, and concurrency-capped KMS unwraps in its own suite.

--- a/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
+++ b/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
@@ -13,7 +13,9 @@ share authorization semantics.
 ## Success criteria
 
 - The preliminary group-membership read and canonical RepeatableRead snapshot
-  select at most the admitted participant maximum plus one overflow sentinel.
+  select at most the composed shared-read raw-member maximum plus one overflow
+  sentinel, while the result independently enforces the lower eligible email-
+  participant maximum.
 - Each canonical member share relation selects the email authorization grant,
   the full admitted authorized-share maximum, and only one overflow sentinel.
 - Oversized membership or share snapshots fail closed before access/email
@@ -34,7 +36,8 @@ share authorization semantics.
 
 ## Constraints
 
-- Reuse the existing hosted runtime participant and authorized-share limits.
+- Reuse the existing hosted runtime raw shared-read member, eligible email-
+  participant, and authorized-share limits.
 - Preserve the final RepeatableRead authority snapshot and stable proof
   derivation.
 - Keep queries and ordering deterministic, including stable row tie-breakers.
@@ -78,3 +81,10 @@ share authorization semantics.
   the exact Prisma order/take shape and composed reader call counts are covered
   here, while the unchanged verified-email owner already proves one email batch,
   one envelope batch, and concurrency-capped KMS unwraps in its own suite.
+- Final ReviewGPT found that the first candidate had applied the 100 eligible
+  email-participant limit to raw group memberships. The corrected reader reuses
+  the composed shared-read owner's 200-member raw bound for both membership
+  queries and separately rejects the 101st active, canonically authorized email
+  participant. Focused proof covers 101 raw members with 100 eligible through
+  preparation and final recipients, 101 eligible participants, both raw
+  201-member overflow stages, and the exact 201-row query sentinels.

--- a/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
+++ b/agent-docs/exec-plans/active/2026-08-11-bound-group-email-graph-reads.md
@@ -1,0 +1,63 @@
+# Bound group-email graph reads
+
+Status: active
+Created: 2026-08-11
+Updated: 2026-08-11
+
+## Goal
+
+Keep generic group-email preparation and final recipient revalidation bounded
+at database query time without weakening membership, access, email-identity, or
+share authorization semantics.
+
+## Success criteria
+
+- The preliminary group-membership read and canonical RepeatableRead snapshot
+  select at most the admitted participant maximum plus one overflow sentinel.
+- Each canonical member share relation selects the email authorization grant,
+  the full admitted authorized-share maximum, and only one overflow sentinel.
+- Oversized membership or share snapshots fail closed before access/email
+  expansion or authorization-proof and recipient construction.
+- Exact participant and authorized-share maxima preserve current preparation,
+  recipient, and proof-change behavior.
+- Focused tests assert the Prisma query bounds and both exact-boundary and
+  one-over-bound outcomes.
+
+## Scope
+
+- In scope: the hosted Web group-email authorization reader, its focused unit
+  tests, and only the durable documentation needed if the runtime contract
+  materially changes.
+- Out of scope: schema changes, new persisted state, group membership policy,
+  share semantics, email delivery or retry ownership, and unrelated hosted
+  group readers.
+
+## Constraints
+
+- Reuse the existing hosted runtime participant and authorized-share limits.
+- Preserve the final RepeatableRead authority snapshot and stable proof
+  derivation.
+- Keep queries and ordering deterministic, including stable row tie-breakers.
+- Prefer one bounded query-shape correction over new state, caching, or a new
+  abstraction.
+
+## Tasks
+
+1. Inspect and integrate the ReviewGPT implementation patch against the exact
+   supplied base, then reconcile current `origin/main` before candidate proof.
+2. Verify member and share sentinel arithmetic and ensure overflow exits before
+   downstream expansion or construction.
+3. Run the focused hosted Web test, app-local typecheck, diff/docs/privacy
+   checks, and the parent candidate review.
+4. Commit and push the exact candidate, open the PR, run the preliminary
+   coverage specialist and sensitive final ReviewGPT gate with CI, resolve all
+   accepted findings, perform the parent final review, and close this plan.
+
+## Verification
+
+- Focused `apps/web/test/hosted-group-email.test.ts` Vitest suite.
+- Hosted Web typecheck and scoped lint when selected by the final diff.
+- `git diff --check`, documentation-drift checks, and identifier/privacy scan.
+- Exact-head required GitHub Actions, preliminary specialist PASS or resolved
+  findings, final ReviewGPT PASS with zero accepted findings, and a clean
+  current-base merge-tree proof.

--- a/agent-docs/exec-plans/completed/2026-08-11-bound-group-email-graph-reads.md
+++ b/agent-docs/exec-plans/completed/2026-08-11-bound-group-email-graph-reads.md
@@ -1,6 +1,6 @@
 # Bound group-email graph reads
 
-Status: active
+Status: completed
 Created: 2026-08-11
 Updated: 2026-08-11
 
@@ -88,3 +88,10 @@ share authorization semantics.
   participant. Focused proof covers 101 raw members with 100 eligible through
   preparation and final recipients, 101 eligible participants, both raw
   201-member overflow stages, and the exact 201-row query sentinels.
+- The mandated round-three anomaly retrospective attributed all review growth,
+  confirmed one unchanged graph/transaction owner and no concept growth, and
+  selected justified continuation. The same-head full-snapshot retry returned
+  PASS on `bde164cf6a9394198dbfb987b87753f1ce684d34`; both accepted findings are
+  resolved, parent corrective review has no finding, and exact-head required CI
+  is green before this archive-only closure.
+Completed: 2026-08-11

--- a/apps/web/src/lib/hosted-groups/group-email.ts
+++ b/apps/web/src/lib/hosted-groups/group-email.ts
@@ -5,6 +5,7 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
   HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+  HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS,
 } from "@murphai/hosted-execution/runtime-control";
 import { normalizeHostedEmailAddress } from "@murphai/runtime-state";
 
@@ -67,7 +68,7 @@ export type HostedGroupEmailPreparationResult =
 type ReadClient = PrismaClient;
 
 const HOSTED_GROUP_EMAIL_MEMBER_QUERY_TAKE =
-  HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1;
+  HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS + 1;
 const HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY = "group-email.v0";
 // The selected relation also carries the exact group-email.v0 authorization
 // grant, so retain that row plus the first over-limit authorized-share row.
@@ -256,7 +257,7 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
   if (!group) {
     return { status: "unavailable", unavailableReason: "group_not_found" };
   }
-  if (group.members.length > HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX) {
+  if (group.members.length > HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS) {
     return {
       status: "unavailable",
       unavailableReason: "authorization_snapshot_too_large",
@@ -369,7 +370,7 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
   }
   if (
     canonicalGroup.members.length
-    > HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX
+    > HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS
   ) {
     return {
       status: "unavailable",
@@ -445,6 +446,12 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
             }),
           }
         : null;
+    if (participants.length >= HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX) {
+      return {
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_too_large",
+      };
+    }
     participants.push({
       address: emailUnchanged?.address ?? null,
       authorizedShares: member.vaultSharesGranted

--- a/apps/web/src/lib/hosted-groups/group-email.ts
+++ b/apps/web/src/lib/hosted-groups/group-email.ts
@@ -68,8 +68,11 @@ type ReadClient = PrismaClient;
 
 const HOSTED_GROUP_EMAIL_MEMBER_QUERY_TAKE =
   HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1;
+const HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY = "group-email.v0";
 // The selected relation also carries the exact group-email.v0 authorization
 // grant, so retain that row plus the first over-limit authorized-share row.
+// The snapshot validation below rejects a second or noncanonical email-kind
+// row, which keeps these two non-data slots sufficient for corrupt graphs too.
 const HOSTED_GROUP_EMAIL_SHARE_QUERY_TAKE =
   HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX + 2;
 
@@ -381,9 +384,23 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
     if (!hasHostedGroupEmailMemberActiveAccess(member)) {
       continue;
     }
+    const emailAuthorizationGrants = member.vaultSharesGranted.filter((grant) =>
+      grant.projectionKind === HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
+    );
+    if (
+      emailAuthorizationGrants.length > 1
+      || emailAuthorizationGrants.some((grant) =>
+        grant.projectionScopeKey !== HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
+      )
+    ) {
+      return {
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_invalid",
+      };
+    }
     if (
       member.vaultSharesGranted.filter((grant) =>
-        grant.projectionKind !== "group-email.v0"
+        grant.projectionKind !== HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
       ).length
       > HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX
     ) {
@@ -405,7 +422,8 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
       continue;
     }
     if (!member.vaultSharesGranted.some((grant) =>
-      grant.projectionKind === "group-email.v0"
+      grant.projectionKind === HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
+      && grant.projectionScopeKey === HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
     )) {
       continue;
     }
@@ -430,7 +448,9 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
     participants.push({
       address: emailUnchanged?.address ?? null,
       authorizedShares: member.vaultSharesGranted
-        .filter((grant) => grant.projectionKind !== "group-email.v0")
+        .filter((grant) =>
+          grant.projectionKind !== HOSTED_GROUP_EMAIL_AUTHORIZATION_KEY
+        )
         .map((grant) => ({
           projectionScopeKey: grant.projectionScopeKey,
           shareId: grant.id,

--- a/apps/web/src/lib/hosted-groups/group-email.ts
+++ b/apps/web/src/lib/hosted-groups/group-email.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
+  HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
 } from "@murphai/hosted-execution/runtime-control";
 import { normalizeHostedEmailAddress } from "@murphai/runtime-state";
 
@@ -65,6 +66,13 @@ export type HostedGroupEmailPreparationResult =
 
 type ReadClient = PrismaClient;
 
+const HOSTED_GROUP_EMAIL_MEMBER_QUERY_TAKE =
+  HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1;
+// The selected relation also carries the exact group-email.v0 authorization
+// grant, so retain that row plus the first over-limit authorized-share row.
+const HOSTED_GROUP_EMAIL_SHARE_QUERY_TAKE =
+  HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX + 2;
+
 function buildHostedGroupEmailMemberAccessSelect(now: Date) {
   return Prisma.validator<Prisma.HostedMemberSelect>()({
     ...hostedMemberAccessSelect,
@@ -123,17 +131,6 @@ export async function prepareHostedGroupEmail(input: {
   const resolved = await readHostedGroupEmailParticipantEmailFacts(input);
   if (resolved.status !== "ok") {
     return resolved;
-  }
-  if (
-    resolved.participants.some((participant) =>
-      participant.authorizedShares.length
-      > HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX
-    )
-  ) {
-    return {
-      status: "unavailable",
-      unavailableReason: "authorization_snapshot_too_large",
-    };
   }
   const authorizationParticipants = resolved.participants.map((participant) => ({
     authorizedShares: participant.authorizedShares,
@@ -247,13 +244,20 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
     select: {
       id: true,
       members: {
-        orderBy: { createdAt: "asc" },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
         select: { memberId: true },
+        take: HOSTED_GROUP_EMAIL_MEMBER_QUERY_TAKE,
       },
     },
   });
   if (!group) {
     return { status: "unavailable", unavailableReason: "group_not_found" };
+  }
+  if (group.members.length > HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX) {
+    return {
+      status: "unavailable",
+      unavailableReason: "authorization_snapshot_too_large",
+    };
   }
 
   const memberIds = group.members.map((member) => member.memberId);
@@ -300,7 +304,8 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
 
   // This is the final awaited authority read. Its late repeatable-read snapshot
   // keeps group binding, membership, active access, verified-email identity,
-  // and every grant coherent even if Prisma splits nested relation loading.
+  // and the admitted grant snapshot coherent even if Prisma splits nested
+  // relation loading.
   const canonicalGroup = await prisma.$transaction(async (tx) =>
     await tx.hostedGroup.findFirst({
       where: {
@@ -310,7 +315,7 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
       select: {
         id: true,
         members: {
-          orderBy: { createdAt: "asc" },
+          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
           select: {
             member: {
               select: {
@@ -322,7 +327,10 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
                   },
                 },
                 vaultSharesGranted: {
-                  orderBy: { projectionScopeKey: "asc" },
+                  orderBy: [
+                    { projectionScopeKey: "asc" },
+                    { id: "asc" },
+                  ],
                   where: {
                     destinationMemberId: input.runtimeMemberId,
                     status: "granted",
@@ -332,10 +340,12 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
                     projectionKind: true,
                     projectionScopeKey: true,
                   },
+                  take: HOSTED_GROUP_EMAIL_SHARE_QUERY_TAKE,
                 },
               },
             },
           },
+          take: HOSTED_GROUP_EMAIL_MEMBER_QUERY_TAKE,
         },
         runtimeMember: {
           select: memberAccessSelect,
@@ -353,6 +363,35 @@ async function readHostedGroupEmailParticipantEmailFacts(input: {
     || !hasHostedGroupEmailMemberActiveAccess(canonicalGroup.runtimeMember)
   ) {
     return { status: "unavailable", unavailableReason: "runtime_inactive" };
+  }
+  if (
+    canonicalGroup.members.length
+    > HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX
+  ) {
+    return {
+      status: "unavailable",
+      unavailableReason: "authorization_snapshot_too_large",
+    };
+  }
+
+  // Check the bounded share snapshot before testing email authorization. When
+  // the snapshot is over budget, a later group-email.v0 row may be outside the
+  // cap, so skipping first would turn an unknown authorization into success.
+  for (const { member } of canonicalGroup.members) {
+    if (!hasHostedGroupEmailMemberActiveAccess(member)) {
+      continue;
+    }
+    if (
+      member.vaultSharesGranted.filter((grant) =>
+        grant.projectionKind !== "group-email.v0"
+      ).length
+      > HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX
+    ) {
+      return {
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_too_large",
+      };
+    }
   }
 
   const participants: Array<{

--- a/apps/web/test/hosted-group-email.test.ts
+++ b/apps/web/test/hosted-group-email.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
+  HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+} from "@murphai/hosted-execution/runtime-control";
 
 const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
@@ -48,6 +52,173 @@ describe("hosted group email authorization", () => {
         })),
     );
   });
+
+  it("bounds preliminary and canonical member/share reads with stable ordering", async () => {
+    const prisma = createPrismaMock();
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    })).resolves.toEqual(expect.objectContaining({ status: "ok" }));
+
+    const memberQueries = prisma.hostedGroup.findFirst.mock.calls
+      .map(([args]) => args)
+      .filter((args) => args?.select?.members);
+    expect(memberQueries).toHaveLength(2);
+
+    const preliminaryMembers = memberQueries[0]?.select?.members;
+    expect(preliminaryMembers).toEqual(expect.objectContaining({
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      select: { memberId: true },
+      take: HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+    }));
+
+    const canonicalMembers = memberQueries[1]?.select?.members;
+    expect(canonicalMembers).toEqual(expect.objectContaining({
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+    }));
+    expect(
+      canonicalMembers?.select?.member?.select?.vaultSharesGranted,
+    ).toEqual(expect.objectContaining({
+      orderBy: [{ projectionScopeKey: "asc" }, { id: "asc" }],
+      take:
+        HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX + 2,
+    }));
+  });
+
+  it("admits exactly the hosted group email participant maximum", async () => {
+    const memberIds = buildGroupEmailMemberIds(
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+    );
+    const prisma = createPrismaMock({ groupEmailMemberIds: memberIds });
+    prisma.hostedVaultShare.findMany.mockResolvedValue(
+      memberIds.map(buildGroupEmailGrant),
+    );
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    const result = await prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    });
+
+    if (result.status !== "ok") {
+      throw new Error("Expected the exact participant maximum to remain valid.");
+    }
+    expect(result.participants).toHaveLength(
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+    );
+    expect(result.missingEmailParticipants).toEqual([]);
+  });
+
+  it("admits exactly the authorized-share maximum plus the email grant", async () => {
+    const memberId = "member_share_boundary";
+    const shares = buildGroupEmailShareSnapshot(
+      memberId,
+      HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
+    );
+    const prisma = createPrismaMock({ groupEmailMemberIds: [memberId] });
+    prisma.hostedVaultShare.findMany.mockResolvedValue(shares);
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    const prepared = await prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    });
+    if (prepared.status !== "ok") {
+      throw new Error("Expected the exact authorized-share maximum to remain valid.");
+    }
+    expect(prepared.participants).toHaveLength(1);
+    expect(prepared.participants[0]?.authorizedShares).toHaveLength(
+      HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
+    );
+
+    const recipientPrisma = createPrismaMock({ groupEmailMemberIds: [memberId] });
+    recipientPrisma.hostedVaultShare.findMany.mockResolvedValue(shares);
+    mocks.getPrisma.mockReturnValue(recipientPrisma);
+    await expect(readHostedGroupEmailRecipients({
+      expectedGroupEmailAuthorizationProof: prepared.authorizationProof,
+      groupId: "hgrp_123",
+      runtimeMemberId: "group_runtime_member",
+    })).resolves.toEqual({
+      recipients: [{
+        address: `${memberId}@example.com`,
+        memberId,
+      }],
+      status: "ok",
+    });
+  });
+
+  it("fails before access and email expansion when preliminary membership is one over", async () => {
+    const prisma = createPrismaMock({
+      groupEmailMemberIds: buildGroupEmailMemberIds(
+        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+      ),
+    });
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    })).resolves.toEqual({
+      status: "unavailable",
+      unavailableReason: "authorization_snapshot_too_large",
+    });
+    expect(prisma.hostedMember.findMany).not.toHaveBeenCalled();
+    expect(mocks.readHostedMemberVerifiedEmailSnapshots).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("fails canonical one-over membership before proof or recipient construction", async () => {
+    const prisma = createPrismaMock({
+      groupEmailCanonicalMemberIds: buildGroupEmailMemberIds(
+        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+      ),
+      groupEmailPreliminaryMemberIds: buildGroupEmailMemberIds(
+        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+      ),
+    });
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(readHostedGroupEmailRecipients({
+      expectedGroupEmailAuthorizationProof: "stale-proof",
+      groupId: "hgrp_123",
+      runtimeMemberId: "group_runtime_member",
+    })).resolves.toEqual({
+      status: "unavailable",
+      unavailableReason: "authorization_snapshot_too_large",
+    });
+    expect(prisma.hostedMember.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.readHostedMemberVerifiedEmailSnapshots).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["prepare", "recipients"] as const)(
+    "fails a one-over authorized-share snapshot during %s without truncated success",
+    async (operation) => {
+      const memberId = "member_share_overflow";
+      const prisma = createPrismaMock({ groupEmailMemberIds: [memberId] });
+      prisma.hostedVaultShare.findMany.mockResolvedValue(
+        buildGroupEmailShareSnapshot(
+          memberId,
+          HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX + 1,
+        ),
+      );
+      mocks.getPrisma.mockReturnValue(prisma);
+
+      const result = operation === "prepare"
+        ? await prepareHostedGroupEmail({
+            runtimeMemberId: "group_runtime_member",
+          })
+        : await readHostedGroupEmailRecipients({
+            expectedGroupEmailAuthorizationProof: "stale-proof",
+            groupId: "hgrp_123",
+            runtimeMemberId: "group_runtime_member",
+          });
+
+      expect(result).toEqual({
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_too_large",
+      });
+    },
+  );
 
   it("excludes inactive granted members from group email preparation and email recipients", async () => {
     const prisma = createPrismaMock();
@@ -460,6 +631,81 @@ describe("hosted group email authorization", () => {
 
 });
 
+interface MockHostedVaultShare {
+  grantorMemberId: string;
+  id: string;
+  projectionKind: string;
+  projectionScopeKey: string;
+}
+
+interface MockHostedVaultShareRelationArgs {
+  orderBy?: unknown;
+  take?: number;
+}
+
+interface MockHostedGroupMemberRelationArgs {
+  orderBy?: unknown;
+  select?: {
+    member?: {
+      select?: {
+        vaultSharesGranted?: MockHostedVaultShareRelationArgs;
+      };
+    };
+    memberId?: boolean;
+  };
+  take?: number;
+}
+
+interface MockHostedGroupFindFirstArgs {
+  select?: {
+    members?: MockHostedGroupMemberRelationArgs;
+    runtimeMember?: unknown;
+    runtimeMemberId?: boolean;
+  };
+}
+
+interface MockHostedMemberFindManyArgs {
+  where?: {
+    id?: {
+      in?: readonly string[];
+    };
+  };
+}
+
+function buildGroupEmailMemberIds(count: number): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `member_${String(index).padStart(3, "0")}`,
+  );
+}
+
+function buildGroupEmailGrant(memberId: string): MockHostedVaultShare {
+  return {
+    grantorMemberId: memberId,
+    id: `share_email_${memberId}`,
+    projectionKind: "group-email.v0",
+    projectionScopeKey: "group-email.v0",
+  };
+}
+
+function buildGroupEmailShareSnapshot(
+  memberId: string,
+  authorizedShareCount: number,
+): MockHostedVaultShare[] {
+  return [
+    buildGroupEmailGrant(memberId),
+    ...Array.from({ length: authorizedShareCount }, (_, index) => {
+      const suffix = String(index).padStart(3, "0");
+      return {
+        grantorMemberId: memberId,
+        id: `share_authorized_${suffix}`,
+        projectionKind: "steps-days.v0",
+        projectionScopeKey: `authorized-share-${suffix}`,
+      };
+    }),
+  ];
+}
+
 function verifiedEmailFact(address: string, input?: {
   lookupKey?: string;
   verifiedAt?: Date;
@@ -513,21 +759,33 @@ function createPrismaMock(input?: {
   groupRuntimeMemberId?: string | null;
   groupEmailLookupKeyByMember?: Readonly<Record<string, string | null>>;
   groupEmailActiveOwnerMemberIds?: readonly string[];
+  groupEmailCanonicalMemberIds?: readonly string[];
+  groupEmailMemberIds?: readonly string[];
   groupEmailMissingEmailMemberIds?: readonly string[];
   groupEmailParticipantBackedMemberIds?: readonly string[];
   groupEmailParticipantUnavailableMemberIds?: readonly string[];
+  groupEmailPreliminaryMemberIds?: readonly string[];
   groupEmailSuspendedMemberIds?: readonly string[];
   groupEmailWithdrawnMemberIds?: readonly string[];
   groupEmailWithdrawnOwnerMemberIds?: readonly string[];
 }) {
+  const defaultMemberIds = [
+    "member_active_with_email",
+    "member_suspended",
+    "member_active_missing_email",
+  ];
+  const preliminaryMemberIds = input?.groupEmailPreliminaryMemberIds
+    ?? input?.groupEmailMemberIds
+    ?? defaultMemberIds;
+  const canonicalMemberIds = input?.groupEmailCanonicalMemberIds
+    ?? input?.groupEmailMemberIds
+    ?? defaultMemberIds;
   const prisma = {
     $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
       callback(prisma)
     ),
     hostedGroup: {
-      findFirst: vi.fn(async (args?: {
-        select?: { runtimeMember?: unknown; runtimeMemberId?: boolean };
-      }) => {
+      findFirst: vi.fn(async (args?: MockHostedGroupFindFirstArgs) => {
         if (args?.select?.runtimeMemberId) {
           return {
             displayName: "Sunday group",
@@ -560,15 +818,14 @@ function createPrismaMock(input?: {
           const withdrawnOwnerMemberIds = new Set(
             input?.groupEmailWithdrawnOwnerMemberIds ?? [],
           );
-          const memberIds = [
-            "member_active_with_email",
-            "member_suspended",
-            "member_active_missing_email",
-          ];
+          const memberTake = args.select.members?.take
+            ?? canonicalMemberIds.length;
+          const shareTake =
+            args.select.members?.select?.member?.select?.vaultSharesGranted?.take;
           return {
             displayName: "Sunday group",
             id: "hgrp_123",
-            members: memberIds.map((memberId) => ({
+            members: canonicalMemberIds.slice(0, memberTake).map((memberId) => ({
               member: {
                 ...groupEmailMemberAccessState({
                   activeOwner: activeOwnerMemberIds.has(memberId),
@@ -588,9 +845,13 @@ function createPrismaMock(input?: {
                       verifiedEmailVerifiedAt:
                         verifiedEmailFact(`${memberId}@example.com`).verifiedAt,
                     },
-                vaultSharesGranted: grants.filter((grant) =>
-                  grant.grantorMemberId === memberId
-                ),
+                vaultSharesGranted: grants
+                  .filter((grant) => grant.grantorMemberId === memberId)
+                  .sort((left, right) =>
+                    left.projectionScopeKey.localeCompare(right.projectionScopeKey)
+                    || left.id.localeCompare(right.id)
+                  )
+                  .slice(0, shareTake),
               },
             })),
             runtimeMember: groupEmailMemberAccessState({
@@ -603,16 +864,14 @@ function createPrismaMock(input?: {
         return {
           displayName: "Sunday group",
           id: "hgrp_123",
-          members: [
-            { memberId: "member_active_with_email" },
-            { memberId: "member_suspended" },
-            { memberId: "member_active_missing_email" },
-          ],
+          members: preliminaryMemberIds
+            .slice(0, args?.select?.members?.take)
+            .map((memberId) => ({ memberId })),
         };
       }),
     },
     hostedMember: {
-      findMany: vi.fn(async () => {
+      findMany: vi.fn(async (args?: MockHostedMemberFindManyArgs) => {
         const suspendedMemberIds = new Set(
           input?.groupEmailSuspendedMemberIds ?? ["member_suspended"],
         );
@@ -631,23 +890,21 @@ function createPrismaMock(input?: {
         const withdrawnOwnerMemberIds = new Set(
           input?.groupEmailWithdrawnOwnerMemberIds ?? [],
         );
-        return [
-          "member_active_with_email",
-          "member_suspended",
-          "member_active_missing_email",
-        ].map((memberId) => groupEmailMemberAccessState({
-          activeOwner: activeOwnerMemberIds.has(memberId),
-          memberId,
-          participantBacked: participantBackedMemberIds.has(memberId),
-          participantEligible: !participantUnavailableMemberIds.has(memberId),
-          suspended: suspendedMemberIds.has(memberId),
-          withdrawn: withdrawnMemberIds.has(memberId),
-          withdrawnOwner: withdrawnOwnerMemberIds.has(memberId),
-        }));
+        return (args?.where?.id?.in ?? preliminaryMemberIds).map((memberId) =>
+          groupEmailMemberAccessState({
+            activeOwner: activeOwnerMemberIds.has(memberId),
+            memberId,
+            participantBacked: participantBackedMemberIds.has(memberId),
+            participantEligible: !participantUnavailableMemberIds.has(memberId),
+            suspended: suspendedMemberIds.has(memberId),
+            withdrawn: withdrawnMemberIds.has(memberId),
+            withdrawnOwner: withdrawnOwnerMemberIds.has(memberId),
+          })
+        );
       }),
     },
     hostedVaultShare: {
-      findMany: vi.fn(async () => [
+      findMany: vi.fn(async (): Promise<MockHostedVaultShare[]> => [
         {
           grantorMemberId: "member_active_with_email",
           id: "share_email_ready",

--- a/apps/web/test/hosted-group-email.test.ts
+++ b/apps/web/test/hosted-group-email.test.ts
@@ -220,6 +220,74 @@ describe("hosted group email authorization", () => {
     },
   );
 
+  it.each(["prepare", "recipients"] as const)(
+    "fails a duplicate noncanonical email grant during %s before truncated success",
+    async (operation) => {
+      const memberId = "member_corrupt_email_grant";
+      const prisma = createPrismaMock({ groupEmailMemberIds: [memberId] });
+      prisma.hostedVaultShare.findMany.mockResolvedValue([
+        buildGroupEmailGrant(memberId),
+        {
+          grantorMemberId: memberId,
+          id: "share_email_duplicate",
+          projectionKind: "group-email.v0",
+          projectionScopeKey: "group-email-corrupt.v0",
+        },
+        ...Array.from(
+          {
+            length:
+              HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX
+              + 1,
+          },
+          (_, index) => {
+            const suffix = String(index).padStart(3, "0");
+            return {
+              grantorMemberId: memberId,
+              id: `share_corrupt_authorized_${suffix}`,
+              projectionKind: "steps-days.v0",
+              projectionScopeKey: `z-authorized-share-${suffix}`,
+            };
+          },
+        ),
+      ]);
+      mocks.getPrisma.mockReturnValue(prisma);
+
+      const result = operation === "prepare"
+        ? await prepareHostedGroupEmail({
+            runtimeMemberId: "group_runtime_member",
+          })
+        : await readHostedGroupEmailRecipients({
+            expectedGroupEmailAuthorizationProof: "stale-proof",
+            groupId: "hgrp_123",
+            runtimeMemberId: "group_runtime_member",
+          });
+
+      expect(result).toEqual({
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_invalid",
+      });
+    },
+  );
+
+  it("fails a noncanonical singleton email authorization grant", async () => {
+    const memberId = "member_noncanonical_email_grant";
+    const prisma = createPrismaMock({ groupEmailMemberIds: [memberId] });
+    prisma.hostedVaultShare.findMany.mockResolvedValue([{
+      grantorMemberId: memberId,
+      id: "share_email_noncanonical",
+      projectionKind: "group-email.v0",
+      projectionScopeKey: "group-email-legacy.v0",
+    }]);
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    await expect(prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    })).resolves.toEqual({
+      status: "unavailable",
+      unavailableReason: "authorization_snapshot_invalid",
+    });
+  });
+
   it("excludes inactive granted members from group email preparation and email recipients", async () => {
     const prisma = createPrismaMock();
     mocks.getPrisma.mockReturnValue(prisma);

--- a/apps/web/test/hosted-group-email.test.ts
+++ b/apps/web/test/hosted-group-email.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOSTED_RUNTIME_GROUP_EMAIL_AUTHORIZED_SHARES_PER_PARTICIPANT_MAX,
   HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+  HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS,
 } from "@murphai/hosted-execution/runtime-control";
 
 const mocks = vi.hoisted(() => ({
@@ -70,13 +71,13 @@ describe("hosted group email authorization", () => {
     expect(preliminaryMembers).toEqual(expect.objectContaining({
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: { memberId: true },
-      take: HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+      take: HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS + 1,
     }));
 
     const canonicalMembers = memberQueries[1]?.select?.members;
     expect(canonicalMembers).toEqual(expect.objectContaining({
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-      take: HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+      take: HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS + 1,
     }));
     expect(
       canonicalMembers?.select?.member?.select?.vaultSharesGranted,
@@ -109,6 +110,73 @@ describe("hosted group email authorization", () => {
     );
     expect(result.missingEmailParticipants).toEqual([]);
   });
+
+  it("admits 101 raw members when exactly 100 have canonical email authorization", async () => {
+    const memberIds = buildGroupEmailMemberIds(
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+    );
+    const eligibleMemberIds = memberIds.slice(
+      0,
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+    );
+    const prisma = createPrismaMock({ groupEmailMemberIds: memberIds });
+    prisma.hostedVaultShare.findMany.mockResolvedValue(
+      eligibleMemberIds.map(buildGroupEmailGrant),
+    );
+    mocks.getPrisma.mockReturnValue(prisma);
+
+    const prepared = await prepareHostedGroupEmail({
+      runtimeMemberId: "group_runtime_member",
+    });
+    if (prepared.status !== "ok") {
+      throw new Error("Expected 100 eligible participants to remain valid.");
+    }
+    expect(prepared.participants).toHaveLength(
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+    );
+
+    const recipients = await readHostedGroupEmailRecipients({
+      expectedGroupEmailAuthorizationProof: prepared.authorizationProof,
+      groupId: prepared.groupId,
+      runtimeMemberId: "group_runtime_member",
+    });
+    expect(recipients.status).toBe("ok");
+    if (recipients.status !== "ok") {
+      throw new Error("Expected final recipient resolution to remain valid.");
+    }
+    expect(recipients.recipients).toHaveLength(
+      HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+    );
+  });
+
+  it.each(["prepare", "recipients"] as const)(
+    "fails 101 eligible email participants during %s",
+    async (operation) => {
+      const memberIds = buildGroupEmailMemberIds(
+        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+      );
+      const prisma = createPrismaMock({ groupEmailMemberIds: memberIds });
+      prisma.hostedVaultShare.findMany.mockResolvedValue(
+        memberIds.map(buildGroupEmailGrant),
+      );
+      mocks.getPrisma.mockReturnValue(prisma);
+
+      const result = operation === "prepare"
+        ? await prepareHostedGroupEmail({
+            runtimeMemberId: "group_runtime_member",
+          })
+        : await readHostedGroupEmailRecipients({
+            expectedGroupEmailAuthorizationProof: "stale-proof",
+            groupId: "hgrp_123",
+            runtimeMemberId: "group_runtime_member",
+          });
+
+      expect(result).toEqual({
+        status: "unavailable",
+        unavailableReason: "authorization_snapshot_too_large",
+      });
+    },
+  );
 
   it("admits exactly the authorized-share maximum plus the email grant", async () => {
     const memberId = "member_share_boundary";
@@ -147,10 +215,10 @@ describe("hosted group email authorization", () => {
     });
   });
 
-  it("fails before access and email expansion when preliminary membership is one over", async () => {
+  it("fails before access and email expansion when raw membership is one over", async () => {
     const prisma = createPrismaMock({
       groupEmailMemberIds: buildGroupEmailMemberIds(
-        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+        HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS + 1,
       ),
     });
     mocks.getPrisma.mockReturnValue(prisma);
@@ -166,13 +234,13 @@ describe("hosted group email authorization", () => {
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it("fails canonical one-over membership before proof or recipient construction", async () => {
+  it("fails canonical one-over raw membership before proof or recipient construction", async () => {
     const prisma = createPrismaMock({
       groupEmailCanonicalMemberIds: buildGroupEmailMemberIds(
-        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX + 1,
+        HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS + 1,
       ),
       groupEmailPreliminaryMemberIds: buildGroupEmailMemberIds(
-        HOSTED_RUNTIME_GROUP_EMAIL_PARTICIPANTS_MAX,
+        HOSTED_RUNTIME_GROUP_SHARED_READ_MAX_MEMBERS,
       ),
     });
     mocks.getPrisma.mockReturnValue(prisma);


### PR DESCRIPTION
## Why this PR exists

The generic hosted group-email authorization reader bounded its serialized output but still allowed Prisma to materialize arbitrarily large membership and per-member share relations first. A large or corrupt authorization graph could therefore consume unbounded database/application memory before the existing fail-closed checks ran.

## User goal / user-visible behavior

Keep generic group email available and semantically unchanged for admitted groups while making oversized authorization graphs fail closed before recipient or authorization-proof construction.

## User experience

There is no new UI or intended new workflow. Groups within the existing limits behave as before. A group whose raw membership exceeds the existing 200-member composed shared-read bound, whose eligible email participants exceed 100, or whose active-member share snapshot exceeds its existing limit now receives the stable `authorization_snapshot_too_large` unavailable outcome before any email can be delivered.

## Invariants

- The existing maximum of 200 raw group members in the composed shared-read path remains authoritative.
- The existing maximum of 100 eligible group-email participants remains authoritative.
- The existing maximum of 100 authorized data shares per participant remains authoritative.
- The required `group-email.v0` authorization grant is not counted as a data share.
- An active participant has at most one email-kind grant, and that grant must use the canonical `group-email.v0` scope key.
- Exact-limit snapshots remain accepted; a single row over any enforced limit is detected deterministically.
- The final RepeatableRead remains the authoritative snapshot for live group binding, membership, member access, verified-email identity, and share grants.
- Oversized snapshots fail closed before proof or recipient construction.

## Non-obvious affected surfaces

- Generic group-email preparation and final recipient revalidation share this graph reader, so both paths receive the same database-time bounds.
- The per-member share relation takes 102 rows: one required email grant, 100 admitted data-share grants, and one overflow sentinel.
- A second or noncanonical email-kind row is itself rejected, so corrupt email grants cannot consume the sentinel and hide a data-share overflow.
- Deterministic `createdAt`/`id` and scope-key/`id` ordering makes the sentinel read stable.

## Architecture and reuse

- **Existing systems reused:** hosted-runtime raw-member, eligible-participant, and per-participant share constants; the shared group-email graph reader; existing access and verified-email readers; and the final RepeatableRead authority transaction.
- **New logic:** deterministic `take` bounds and stable overflow checks on preliminary raw members, canonical raw members, eligible email participants, and active-member share relations.
- **New abstractions:** none, because the existing shared reader and runtime limit constants already own this authorization graph and its admitted bounds.
- **Complexity intentionally avoided:** no schema, cache, persisted snapshot, concurrency, delivery, or new retry mechanism; existing unavailable outcomes continue through the existing retry path.

## Changelog

- Changelog: not applicable
- Reason: this is internal query-bound protection, not a new member-visible feature. Admitted responses remain unchanged; oversized internal snapshots now return the existing stable unavailable outcome.

## Hot reply path impact

Not applicable. This changes generic group-email authorization reads only; it does not change hot-reply delivery, retry, or idempotency ownership.

## Database collection fanout impact

API-owner query shape is unchanged: one active-access gate, one preliminary group read, one set-based member-access read, one verified-email snapshot batch, and one final RepeatableRead containing the canonical group graph read. Prisma may continue to split nested relation loading internally.

The preliminary and canonical raw-membership relations change from unbounded to 201 rows (the existing 200-member composed shared-read maximum plus one overflow sentinel). Eligible email participants remain independently capped at 100 after live access and canonical email-grant filtering. Each selected member share relation changes from unbounded to 102 rows (the required email grant, 100 admitted data shares, plus one overflow sentinel), for at most 20,400 selected nested share rows across 200 admitted raw members.

Peak pooled connections remain one. Concurrent transactions remain one RepeatableRead. This diff adds no external or cryptographic work and no new concurrency; existing verified-email snapshot work remains before the final transaction. Live runtime, group, membership, member-access, email-authorization, and grant checks remain owned by the same readers and final authority snapshot.

## Murph initial provider input

Not applicable. No individual/group initial prompt, tool schema, or request assembly changes.

## Preliminary specialist lenses

- **Product experience:** not applicable; this is internal query bounding with no new journey. Direct evidence is the 25-test exact-boundary/overflow suite.
- **Prompt:** not applicable; no prompt or provider-input changes.
- **Frontend:** not applicable; no UI code or user interaction changes.
- **Coverage:** applicable. Focused hosted group-email Vitest, hosted Web typecheck, scoped ESLint, documentation drift, diff/privacy checks, and exact-head CI cover the changed behavior.

## Preliminary specialist outcome

The preliminary pass returned findings on the immutable baseline head. Its malformed email-grant finding was accepted: the corrected head requires a singleton canonical email grant and adds preparation, recipient, and singleton-noncanonical regressions. Its proposed new live PostgreSQL/KMS maximum-graph harness was not accepted because this diff adds only bounded metadata relation reads; exact relation order/take and composed reader call counts are covered here, while the unchanged verified-email owner already proves one email batch, one envelope batch, and concurrency-capped KMS unwraps in its own focused suite.

## Final ReviewGPT outcome

The first final full-snapshot correction audit found that the initial 101-row membership sentinel had applied the 100 eligible-participant limit to raw group membership. The corrected reader reuses the existing 200-member raw bound from the composed shared-read owner, independently rejects the 101st eligible email participant, and proves both thresholds across preparation and final recipient resolution. After the mandatory round-three retrospective, the same-head full-snapshot retry returned `PASS` with both accepted findings resolved and no remaining qualifying finding.

## Round 3 anomaly retrospective

Decision: justified continuation of the current localized PR.

- **Original requirement:** bound the preliminary and final group-membership relations and every selected member's granted-share relation at query time without changing the existing cardinality or authority policies.
- **Authoritative policies reaffirmed:** at most 200 raw group members from the composed shared-read owner, at most 100 active participants with one singleton canonical `group-email.v0` grant, and at most 100 authorized data shares per eligible participant. The final RepeatableRead remains the authority owner.
- **First-reviewed versus current shape:** the immutable baseline was 406 additions and 47 deletions (source 54/15, tests 289/32, docs 63/0). The corrected head is 598 additions and 49 deletions (source 83/17, tests 425/32, docs 90/0). Authored-source churn grew from 69 to 100 lines; it remains one small owner-local correction.
- **Review-growth attribution:** the direct first-to-current delta is 205 additions and 15 deletions. The malformed-grant correction accounts for docs 17/0, source 23/3, and tests 68/0. The raw-versus-eligible threshold correction accounts for docs 12/2, source 10/3, and tests 75/7. The growth is therefore predominantly adversarial boundary coverage and the required durable review ledger, not production concept growth.
- **Concept and owner inventory:** no schema, dependency, durable state, queue, retry owner, lifecycle, transaction layer, public API, or reusable abstraction was added or removed. The existing `readHostedGroupEmailParticipantEmailFacts` owner still serves preparation and final recipients. The change reuses the existing raw-member, eligible-participant, and share constants; adds one local canonical authorization-key constant; and adds the stable `authorization_snapshot_invalid` unavailable reason for malformed email grants. Verified-email database/KMS ownership remains unchanged.
- **Alternatives considered:** deletion or reversion would restore unbounded relation materialization or reopen a reproduced authorization truncation/policy regression. A migration or redesign would add an unnecessary owner and still would not separate raw from eligible cardinality. Shrinking the focused cases would remove distinct preparation, recipient, exact-boundary, corrupt-row, or race-stage proof; no redundant production branch or test case was found. Splitting the two corrections would leave an intermediate graph reader whose query sentinel, malformed-grant validation, and raw/eligible thresholds could not be reviewed atomically and would weaken maintainability rather than improve it.
- **Continuation boundary:** retain the current three-file direction with no further concept growth. Only a new production-faithful defect may justify more behavior changes; otherwise the remaining work is ReviewGPT confirmation, plan archival, CI, and mergeability proof.

ReviewGPT context sensitivity: sensitive

Reason: the change is fail-closed authorization logic inside a repeatable-read database snapshot and affects collection bounds.

ReviewGPT first-reviewed head: 72c8d9f08e4cdbde17a45c5547ee3cadc3f145f3

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 83 | 17 |
| Tests/fixtures | 425 | 32 |
| Docs | 97 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **605** | **49** |

Classification rule: files are classified by primary purpose; test files count as tests, the execution plan counts as docs, and the hosted group-email implementation counts as source. No binary or generated artifacts are included.

## Design proof

Not applicable. No UI or visual behavior changes.

## Deployment skew

No schema, protocol, persisted-state, or cross-service contract changes. This is compatible with an ordinary Web deployment and mixed-version rollout.

## Verification completed before review

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-group-email.test.ts` — 25 tests passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm --dir apps/web exec eslint src/lib/hosted-groups/group-email.ts test/hosted-group-email.test.ts` — passed.
- `pnpm docs:drift` — passed.
- `git diff --check` — passed.
- Scoped direct-identifier scan — passed.
- Parent corrective review — no findings.
