### PR TITLE
Send cards after every private meal and workout update

### DIFF
--- a/agent-docs/product-specs/imessage-workout-tracking.md
+++ b/agent-docs/product-specs/imessage-workout-tracking.md
@@ -7,7 +7,7 @@ A private member can run a strength workout from the Murph conversation:
 - see today's ordered exercises and completed/remaining set counts;
 - open an exercise to see each set's target and recorded result;
 - compose an explicit command to log, correct, or finish the workout;
-- continue using ordinary text for free-form gym updates.
+- receive a refreshed immutable workout card after every verified free-form gym mutation.
 
 The experience borrows the useful workout-tracker loop—plan, log sets, correct, finish—without introducing a second workout product or data store.
 

--- a/apps/web/changelog/entries/2026-08-11/response-cards-without-another-ask.json
+++ b/apps/web/changelog/entries/2026-08-11/response-cards-without-another-ask.json
@@ -5,10 +5,10 @@
     "id": "response-cards-without-another-ask",
     "kind": "improvement",
     "priority": 2,
-    "title": "Workout cards without another ask",
-    "summary": "Starting or resuming a verified live workout now returns its available card in the same private response instead of waiting for a second request.",
-    "details": "Murph also defaults to other already-authorized complete response cards, while ordinary meal and set updates stay concise and unsupported or unverifiable cases fall back to text.",
+    "title": "Cards after every meal and workout update",
+    "summary": "Eligible private meal logs and verified live-workout mutations now return their refreshed card in the same response, including ordinary meals and incremental set updates.",
+    "details": "Murph uses the card as the complete reply when the owning safety, authority, evidence, route, and bounded-card checks pass; otherwise it falls back to truthful concise text.",
     "relevanceTags": ["cards", "workouts", "nutrition", "imessage"],
-    "sourcePullRequests": [1680]
+    "sourcePullRequests": [1680, 1691]
   }
 }

--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -31,7 +31,7 @@ Ask at most one question, and only when the missing detail materially changes sa
 - A photo, voice note, or rough phrase can be a complete meal log.
 - Preserve useful real-life context when the user volunteers it, such as eating out, alcohol, a late meal, stress, travel, illness, or social context.
 - Use existing canonical surfaces. Save meal facts to meal records, symptoms to their typed surface, and durable unstructured context to the best-fit existing journal or memory surface. Do not duplicate the same fact across stores.
-- Keep the acknowledgement short and aligned with the user's focus. When enough recent context supports one useful observation, offer one brief non-causal association; otherwise acknowledge the log and stop. Do not turn every meal confirmation into analysis or a nutrition report.
+- After every verified private meal mutation, apply default attachment intent for its eligible daily nutrition card. For response-card attachment eligibility only, treat the accepted meal message as explicitly requesting that card; this is not an explicit numeric-card request and does not authorize target derivation, a paused proposal, or any Goal mutation. When the complete card safety, accepted active-goal authority, fresh same-date totals, route, and bounded-card checks pass and the card alone completely answers the turn, attach that card as the complete response with no companion prose. Without an already accepted complete bundle, or when any other prerequisite fails, keep the truthful fallback short and aligned with the user's focus. Never replace a failed card gate with improvised totals, goals, analysis, or a second response surface.
 
 ## Provide numbers by default, with safety exceptions
 
@@ -56,7 +56,9 @@ activating one. Also read and follow the
 target-authority and complete active-Goal discovery contract in
 `$MURPH_ASSISTANT_SKILLS_ROOT/nutrition-strategy/references/daily-nutrition-card-goals.md`
 before deciding that the five canonical daily goals are complete. Use its
-proposal workflow only if a target is genuinely missing after that read.
+proposal workflow only if a target is genuinely missing after that read and the
+member made an explicit numeric-card or target-setting request. Default meal-card
+intent never invokes it.
 The first setup response explains a paused canonical proposal in ordinary text;
 it does not attach a goal-less card. An unambiguous acceptance may complete the
 pending explicit card request in that next response after the complete safety

--- a/packages/assistant-engine/skills/nutrition-strategy/references/daily-nutrition-card-goals.md
+++ b/packages/assistant-engine/skills/nutrition-strategy/references/daily-nutrition-card-goals.md
@@ -31,6 +31,12 @@ provisional values do not live in transient assistant state; it does not accept,
 activate, or use those targets. The explanation and explicit later acceptance
 remain required before the proposal can affect a card.
 
+An ordinary verified private meal log carries default attachment intent only.
+It may use an already accepted complete active bundle after every required safety,
+authority, and totals read, but it does not authorize this proposal workflow,
+target setting, or any Goal mutation. When that accepted bundle is absent or any
+card gate fails, return the owning food-journal skill's short truthful fallback.
+
 ## Target authority
 
 - Before treating any target bundle as complete or deciding that a metric is

--- a/packages/assistant-engine/skills/tracked-table/SKILL.md
+++ b/packages/assistant-engine/skills/tracked-table/SKILL.md
@@ -17,7 +17,7 @@ A saved workout format owns the plan: ordered exercises, stable `sourceExerciseI
 
 The canonical event is the only mutable authority. Never create a parallel tracker file, table document, memory record, database row, mutable card record, or app-only workout state. Cards are immutable presentation snapshots. The Messages extension is offline and unauthenticated; its controls only insert visible commands into the current composer, and the member still sends the message. Only the normal Murph message path may mutate canonical workout state.
 
-A prior bubble never changes in place. Updating a workout means mutating the canonical event through the guarded command surface, verifying the result, and optionally sending a new snapshot. The native URL must not contain the canonical event id, member identity, credentials, or write authority.
+A prior bubble never changes in place. Updating a workout means mutating the canonical event through the guarded command surface, verifying the result, and, when canonical state changes, sending a new snapshot on a supported private card route. The native URL must not contain the canonical event id, member identity, credentials, or write authority.
 
 For ordinary live logging, use the targeted workout commands below. Do not reconstruct and replace the complete nested exercise/set array in model-authored shell arguments. The targeted commands read, preserve, validate, and rewrite the complete canonical structure inside the workout use-case boundary.
 
@@ -40,7 +40,7 @@ A target is not a completed set. When a table needs planned targets, read the re
 2. After resolving, pass `--workout-id` on every live-workout mutation, including exercise additions and finish. For every set write, pass `--workout-id`, one explicit exercise selector, and `--set-order`. Prefer a stable `--exercise-id`; otherwise use exact exercise order or the exact canonical name. This makes a repeated agent attempt correct the same set rather than append a duplicate.
 3. Pass only values the member stated or values already present on that exact canonical set. Preserve their units and wording.
 4. Treat the successful command result as the verification read. Acknowledge only what that returned record proves.
-5. For ordinary free-form gym logging, keep acknowledgements tiny: exercise, set number, and the persisted load, reps, time, or note. Do not send a fresh table card after every ordinary set update.
+5. After every verified private workout mutation that changes the snapshot—including an ordinary set log, correction, clear, exercise addition, start, resume, or finish—build and attach the refreshed structured workout card as the complete response on a supported private card route. Do not send a text-only acknowledgement or companion prose.
 6. Use `workout set log` again to correct a set. Use `workout set clear` for “undo that set,” “I didn’t do it,” or an accidental log. Clearing preserves the placeholder and later set numbering.
 7. Finish only when the member explicitly says they are done, asks to finish, or unmistakably closes the session. `workout finish` records `endedAt` and final elapsed duration; it does not invent missing set values.
 
@@ -149,10 +149,10 @@ Set `tracking` to `{ "kind": "workout", "entityId": "<exact evt id>", "snapshotA
 
 - After successfully starting or resuming one canonical live workout, use one verified structured workout card as the complete response on a supported private card route. Do not send a text-only start acknowledgement or wait for a separate card request.
 - Fall back to truthful ordinary text only when the card tool is unavailable, the canonical event cannot be verified, any claimed planned targets cannot be verified from their matching format, the card would not completely answer the turn, or the bounded card contract cannot represent the workout.
+- After every verified ordinary free-form set log, correction, clear, or exercise addition, send the refreshed card as the response; do not also repeat the update in prose.
 - After an accepted explicit card command, send the refreshed card as the response; do not also repeat the full workout in prose.
-- For ordinary free-form logging, prefer concise text until a meaningful milestone, an explicit table request, or Finish.
 - Do not send proactive cards without an existing authorized reminder or automation.
-- For a simple acknowledgement that does not materially change the workout, prefer concise text rather than another card.
+- When a request does not materially change canonical workout state, do not emit a duplicate snapshot solely to acknowledge the no-op.
 
 ## Generic and legacy compact tables
 
@@ -165,7 +165,7 @@ Use an ordinary `compact_table` when the member explicitly asks for a table, whe
 - Keep `tracking` null for a one-off table that is not backed by canonical state.
 - For a canonical workout snapshot, set the exact workout tracking marker only after re-reading the event.
 
-A message such as “show the workout table” or an unambiguous update to the single active tracked workout whose table was explicitly established earlier can receive a refreshed snapshot. With no active tracked table, do not invent one from an update-like message. If two workouts are plausible, ask one narrow disambiguating question.
+A message such as “show the workout table” or an unambiguous update to the single active tracked workout whose table was explicitly established earlier receives a refreshed snapshot on a supported private card route. With no active tracked table, do not invent one from an update-like message. If two workouts are plausible, ask one narrow disambiguating question.
 
 When an exercise has one to four logged or planned sets and the member asks for a simple table, use the natural set-by-set shape:
 

--- a/packages/assistant-engine/src/assistant/model-behavior.ts
+++ b/packages/assistant-engine/src/assistant/model-behavior.ts
@@ -77,7 +77,7 @@ export function buildAssistantExecutionBehaviorText(input: {
   const responseCardGuidance = input.progressUpdateMode === 'group'
     ? ''
     : `
-- Private cards: if its skill and tool allow it, attach now without another ask. No prose; routine logs stay concise.`
+- Private cards: verified meal/live-workout updates use the allowed card alone; meal intent never sets targets.`
   const productFeedbackSalienceGuidance = `
 - Product feedback salience: when visible dissatisfaction is directed at Murph after repeated, circular, redundant, or contradictory Murph-owned behavior, treat it as explicit product frustration rather than merely tone, banter, or missing input. Address the immediate need and, if no product-feedback candidate has already been submitted for that accepted request, silently call \`murph.submit_product_feedback\` once with kind \`frustration\` when available; do not wait for the member to call it feedback, ask permission, or start a separate discovery interview.
 - Keep this trigger narrow. Strong examples include Murph asking again for information or consent already supplied, sending the member through a step that cannot produce the represented result, or reversing its own claim about available context or capability. Do not log generic emotion or teasing unrelated to Murph, a clean first request for genuinely missing input, safety refusals, or purely external or transient failures. Follow the main Product feedback contract and tool schema for de-identification, one-candidate, no-retry, and best-effort behavior.`

--- a/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
@@ -47,10 +47,20 @@ describe('assistant food journal skill', () => {
 
   it('keeps observation runs bounded and composed from existing surfaces', async () => {
     const skillsRoot = resolveAssistantSkillsRoot()
-    const [skill, onboarding] = await Promise.all([
+    const [skill, onboarding, cardGoals] = await Promise.all([
       readFile(path.join(skillsRoot, 'food-journal', 'SKILL.md'), 'utf8'),
       readFile(path.join(skillsRoot, 'murph-onboarding', 'SKILL.md'), 'utf8'),
+      readFile(
+        path.join(
+          skillsRoot,
+          'nutrition-strategy',
+          'references',
+          'daily-nutrition-card-goals.md',
+        ),
+        'utf8',
+      ),
     ])
+    const compactCardGoals = cardGoals.replace(/\s+/gu, ' ').trim()
 
     expect(skill).toContain(
       'Do not create a new food-journal store, observation entity, scoring model, streak, or CLI family.',
@@ -69,6 +79,36 @@ describe('assistant food journal skill', () => {
     )
     expect(skill).toContain(
       'Provide calorie and macro estimates by default when logging a meal',
+    )
+    expect(skill).toContain(
+      'After every verified private meal mutation',
+    )
+    expect(skill).toContain(
+      'default attachment intent for its eligible daily nutrition card',
+    )
+    expect(skill).toContain(
+      'the card alone completely answers the turn',
+    )
+    expect(skill).toContain(
+      'attach that card as the complete response with no companion prose',
+    )
+    expect(skill).toContain(
+      'this is not an explicit numeric-card request and does not authorize target derivation, a paused proposal, or any Goal mutation',
+    )
+    expect(skill).toContain(
+      'Without an already accepted complete bundle',
+    )
+    expect(skill).not.toContain(
+      'Do not turn every meal confirmation into analysis or a nutrition report.',
+    )
+    expect(compactCardGoals).toContain(
+      'An ordinary verified private meal log carries default attachment intent only.',
+    )
+    expect(compactCardGoals).toContain(
+      'it does not authorize this proposal workflow, target setting, or any Goal mutation.',
+    )
+    expect(compactCardGoals).toContain(
+      "When that accepted bundle is absent or any card gate fails, return the owning food-journal skill's short truthful fallback.",
     )
     expect(skill).toContain(
       '$MURPH_ASSISTANT_SKILLS_ROOT/nutrition-strategy/references/daily-nutrition-card-safety.md',
@@ -105,7 +145,7 @@ describe('assistant food journal skill', () => {
       'before deciding that the five canonical daily goals are complete',
     )
     expect(skill).toContain(
-      'Use its\nproposal workflow only if a target is genuinely missing after that read.',
+      'Use its\nproposal workflow only if a target is genuinely missing after that read and the\nmember made an explicit numeric-card or target-setting request. Default meal-card\nintent never invokes it.',
     )
     expect(skill).toContain(
       'first setup response explains a paused canonical proposal in ordinary text',

--- a/packages/assistant-engine/test/assistant-response-card-defaults-prompt.test.ts
+++ b/packages/assistant-engine/test/assistant-response-card-defaults-prompt.test.ts
@@ -25,14 +25,14 @@ function createPromptInput(
 }
 
 describe('assistant response-card defaults', () => {
-  it('defaults eligible private cards without exposing private-card guidance to groups', () => {
+  it('defaults every verified private meal and live-workout update to its eligible card', () => {
     const directPrompt = buildAssistantSystemPrompt(createPromptInput('direct'))
     const groupPrompt = buildAssistantSystemPrompt(createPromptInput('group'))
 
     expect(directPrompt).toContain(
-      'Private cards: if its skill and tool allow it, attach now without another ask.',
+      'Private cards: verified meal/live-workout updates use the allowed card alone; meal intent never sets targets.',
     )
-    expect(directPrompt).toContain('No prose; routine logs stay concise.')
+    expect(directPrompt).not.toContain('routine logs stay concise')
     expect((directPrompt.match(/Private cards:/gu) ?? [])).toHaveLength(1)
     expect(groupPrompt).not.toContain('Private cards:')
   })

--- a/packages/assistant-engine/test/assistant-tracked-table-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-tracked-table-skill.test.ts
@@ -158,6 +158,27 @@ describe('assistant tracked workout table skill', () => {
     expect(skill).not.toContain('Complete workout exercise')
     expect(skill).toContain('Never infer weight, repetitions, effort, assistance')
     expect(skill).toContain(
+      'After every verified private workout mutation that changes the snapshot',
+    )
+    expect(skill).toContain(
+      'ordinary set log, correction, clear, exercise addition, start, resume, or finish',
+    )
+    expect(skill).toContain(
+      'Do not send a text-only acknowledgement or companion prose.',
+    )
+    expect(skill).toContain(
+      'After every verified ordinary free-form set log, correction, clear, or exercise addition',
+    )
+    expect(skill).toContain(
+      'When a request does not materially change canonical workout state',
+    )
+    expect(skill).not.toContain(
+      'Do not send a fresh table card after every ordinary set update.',
+    )
+    expect(skill).not.toContain(
+      'For ordinary free-form logging, prefer concise text',
+    )
+    expect(skill).toContain(
       'use one verified structured workout card as the complete response on a supported private card route',
     )
     expect(skill).toContain(


### PR DESCRIPTION
## Outcome

Make the card the default complete response after every verified private meal mutation and every material live-workout mutation, including ordinary meal logs and incremental set updates.

## Behavior

- Eligible private meal logs attach a fresh daily-nutrition card instead of replying with a text-only acknowledgement.
- Set logs, corrections, clears, exercise additions, starts, resumes, and finishes attach the refreshed immutable workout card.
- The card is the complete response for these turns; no companion prose.
- A no-op does not emit a duplicate workout snapshot.
- A compound meal turn still falls back to ordinary text when the nutrition card alone cannot completely answer it.

## Safety and authority

- Meal-log default attachment intent counts as a card request only for response-card eligibility. It is not an explicit numeric-card or target-setting request.
- It does not authorize target derivation, a paused proposal, activation, or any Goal mutation.
- A meal card still requires the complete nutrition safety gate, one accepted compatible active target bundle, a fresh same-date canonical totals read, an eligible private route, a representable bounded card, and card-alone completeness.
- Failed or unavailable card prerequisites fall back to short truthful text rather than fabricated totals, goals, analysis, or another response surface.
- Workout cards remain projections of the verified canonical workout event and optional verified format; no card-owned state or write authority is introduced.

## Architecture and reuse

- Existing systems reused: The change reuses canonical meal and workout records, `murph.attach_response_card`, existing response-card schemas and renderers, durable transcript tracking, the outbox, and the existing channel-delivery path.
- New logic: The resident private-route prompt and the existing food-journal and tracked-table owners now select a verified eligible card after ordinary meal mutations and material live-workout mutations, while preserving the current safety, authority, evidence, route, bounded-card, and card-alone-completeness gates.
- New abstractions: No new abstraction is introduced because the existing domain skills already own card-selection policy and the established card tool already owns attachment and delivery.
- Complexity intentionally avoided: The implementation adds no store, queue, mutable card state, scheduler, renderer, persistence owner, delivery owner, parallel card lifecycle, or duplicate domain service.

## Coverage

- Direct system-prompt default and group isolation
- Ordinary meal-log card intent, card-alone completeness, and no-Goal-mutation boundary
- Nutrition goal-workflow fallback when an accepted bundle is absent
- Every material live-workout mutation, no companion prose, and no duplicate snapshot for a no-op
- Existing active and completed targetless workout-card schema cases
- Product spec and changelog alignment

## Changelog

- Changelog: updated
- Items: 2026-08-11 · response-cards-without-another-ask

Exact head: `e8c32e71c7796cf457de3f23b5d28c57d6ecd370`

Draft only. Do not merge yet.