### PR TITLE
test(cloudflare): repair scheduled card E2E fixture

### DIFF
--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -519,7 +519,10 @@ describe("hosted local Linq scheduled reminder e2e", () => {
       buildAssistantProviderMurphToolCall("attach_response_card", {
         card: scheduledNutritionCard,
       }),
-      { text: "" },
+      buildHostedAssistantNotificationDecisionResponse({
+        privateSummary: "deliver scheduled nutrition card",
+        text: "Nutrition card attached.",
+      }),
     ], {
       matchInputContains: scheduledNutritionCardInstructions,
     });
@@ -551,7 +554,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
     });
     expect(requireLinqStub().readObservedMessageText(scheduledCardSend)).toBeNull();
     expect(requireLinqStub().readObservedMessageAppCard(scheduledCardSend)).toMatchObject({
-      fallback_text: "Ask Murph for this card in text",
+      fallback_text: "Your daily nutrition. Ask Murph for this card in text",
       interactive: true,
       layout: {
         caption: "Jul 28 · 3 meals",


### PR DESCRIPTION
## Why this PR exists

The private integration gate was red because the scheduled Linq response-card E2E scripted an invalid final notification response and asserted an obsolete native-card fallback label.

## User goal / user-visible behavior

Restore truthful CI coverage for scheduled native nutrition-card delivery so unrelated deploy work can pass required gates without weakening or bypassing them.

## User experience

No user-facing effect. This changes only the full-stack test fixture and its expectation; production rendering and delivery behavior are unchanged.

## Invariants

- Scheduled notification turns finish through the existing structured `send_message` decision contract.
- A successfully attached response card replaces authored text and sends as one native iMessage app card.
- The test asserts the current canonical nutrition fallback label.
- No production state, runtime behavior, data, or deployment configuration changes.

## Changelog

- Changelog: not applicable
- Reason: Test-only correction with no member-visible behavior change.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: Narrow test-only fixture and assertion correction with no production paths changed.

## Non-obvious affected surfaces

None. The private cross-repository integration shard consumes this public E2E, but the diff changes no production surface.

## Architecture and reuse

- Existing systems reused: Reuses the existing hosted notification decision builder and canonical response-card renderer contract already exercised by this scenario.
- New logic: None in production; the fixture now emits the valid structured decision required after attaching a scheduled response card.
- New abstractions: None; existing test helpers and renderer ownership are sufficient.
- Complexity intentionally avoided: No new helper, compatibility layer, retry override, service, state owner, or CI bypass.

## Hot reply path impact

- Path status: Not applicable — test-only diff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Production call paths are unchanged; the exact hosted-local scenario passes.

## Database collection fanout impact

Not applicable — no database-touching production path changed.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged; only a test stub response changed.
- Measurement method: Not run — no provider-input production surface changed.

## Preliminary specialist lenses

- Product experience: not applicable — no product-owned behavior changes.
- Prompt: not applicable — no production prompt or provider-input assembly changes.
- Frontend: not applicable — no `apps/web` presentation changes.
- Coverage: applicable — repairs the exact production-shaped Linq scheduled-card E2E; focused local scenario is green and exact-head CI is pending.

## Design proof

- Design page: Not applicable — no user-facing UI change.
- Coverage: Not applicable.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: TypeScript under `apps/cloudflare/test` is tests / fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 5 | 2 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **5** | **2** |

## Verification

- `pnpm hosted-local e2e linq-scheduled-reminder --no-bundle` with the unchanged private Temporal worker package: 2 tests passed.
- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/assistant-response-cards.test.ts test/http-linq-device-runtime.test.ts` from `packages/operator-config`: 79 tests passed.
- `pnpm --dir apps/cloudflare typecheck`: passed.
- `git diff --check`: passed.
