### PR TITLE
fix(review-gpt): isolate the default browser lane

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1256,6 +1256,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptConfig).toContain(
       'review_gpt_all_browser_lanes=(eragon phlebas hercules mountain)',
     )
+    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
     expect(reviewGptConfig).toContain('REVIEW_GPT_THREAD_URL')
     expect(reviewGptConfig).toContain('REVIEW_GPT_FULL_REVIEW_REASON')
@@ -1942,7 +1943,7 @@ printf '%s|%s|%s|%s\n' \
         },
       })
       expect(localResult.status, localResult.stderr).toBe(0)
-      expect(localResult.stdout.trim()).toBe('main|1|/tmp/custom-brave|unthrottled')
+      expect(localResult.stdout.trim()).toBe('eragon|1|/tmp/custom-brave|unthrottled')
 
       rmSync(path.join(localConfigRoot, 'murph', 'review-gpt.conf'))
       const defaultResult = spawnSync('bash', ['-c', configHarness], {
@@ -1956,7 +1957,28 @@ printf '%s|%s|%s|%s\n' \
         },
       })
       expect(defaultResult.status, defaultResult.stderr).toBe(0)
-      expect(defaultResult.stdout.trim()).toBe(
+      const [defaultLane, defaultLaneCount, defaultBrowser, defaultBackgroundMode] =
+        defaultResult.stdout.trim().split('|')
+      expect(['eragon', 'phlebas', 'hercules', 'mountain']).toContain(defaultLane)
+      expect(defaultLaneCount).toBe('4')
+      expect(defaultBrowser).toBe(
+        '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+      )
+      expect(defaultBackgroundMode).toBe('balanced')
+
+      const mainResult = spawnSync('bash', ['-c', configHarness], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...withoutNodeV8Coverage(),
+          HOME: harnessRoot,
+          REPO_ROOT: repoRoot,
+          REVIEW_GPT_BROWSER_LANE: 'main',
+          XDG_CONFIG_HOME: localConfigRoot,
+        },
+      })
+      expect(mainResult.status, mainResult.stderr).toBe(0)
+      expect(mainResult.stdout.trim()).toBe(
         'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced',
       )
 

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1911,6 +1911,8 @@ printf '%s|%s|%s|%s|%s|%s\n' \
     const localConfigRoot = path.join(harnessRoot, 'config')
     const configHarness = `
 set -euo pipefail
+# Keep live local CDP ports out of the lock fixture.
+curl() { return 1; }
 review_gpt_register_dir_preset() { :; }
 review_gpt_register_preset_group() { :; }
 source "$REPO_ROOT/scripts/review-gpt.config.sh"
@@ -1920,6 +1922,17 @@ printf '%s|%s|%s|%s\n' \
   "$browser_binary_path" \
   "$managed_browser_background_mode"
 `
+    const cleanBrowserPreferenceEnv = () => {
+      const env = withoutNodeV8Coverage()
+      delete env.REVIEW_GPT_BROWSER_LANE
+      delete env.MURPH_REVIEW_GPT_BROWSER_LANE
+      delete env.MURPH_REVIEW_GPT_PROFILE_SLUG
+      delete env.REVIEW_GPT_BROWSER_LANE_COUNT
+      delete env.MURPH_REVIEW_GPT_BROWSER_LANE_COUNT
+      delete env.browser_binary_path
+      delete env.managed_browser_background_mode
+      return env
+    }
 
     try {
       writeHarnessFile(
@@ -1936,7 +1949,7 @@ printf '%s|%s|%s|%s\n' \
         cwd: repoRoot,
         encoding: 'utf8',
         env: {
-          ...withoutNodeV8Coverage(),
+          ...cleanBrowserPreferenceEnv(),
           HOME: harnessRoot,
           REPO_ROOT: repoRoot,
           XDG_CONFIG_HOME: localConfigRoot,
@@ -1946,11 +1959,18 @@ printf '%s|%s|%s|%s\n' \
       expect(localResult.stdout.trim()).toBe('eragon|1|/tmp/custom-brave|unthrottled')
 
       rmSync(path.join(localConfigRoot, 'murph', 'review-gpt.conf'))
+      for (const lane of ['Eragon', 'Phlebas', 'Hercules']) {
+        writeHarnessFile(
+          harnessRoot,
+          `Library/Application Support/MurphReviewGPT/${lane}/SingletonLock`,
+          'locked\n',
+        )
+      }
       const defaultResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,
         encoding: 'utf8',
         env: {
-          ...withoutNodeV8Coverage(),
+          ...cleanBrowserPreferenceEnv(),
           HOME: harnessRoot,
           REPO_ROOT: repoRoot,
           XDG_CONFIG_HOME: localConfigRoot,
@@ -1959,7 +1979,7 @@ printf '%s|%s|%s|%s\n' \
       expect(defaultResult.status, defaultResult.stderr).toBe(0)
       const [defaultLane, defaultLaneCount, defaultBrowser, defaultBackgroundMode] =
         defaultResult.stdout.trim().split('|')
-      expect(['eragon', 'phlebas', 'hercules', 'mountain']).toContain(defaultLane)
+      expect(defaultLane).toBe('mountain')
       expect(defaultLaneCount).toBe('4')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
@@ -1970,7 +1990,7 @@ printf '%s|%s|%s|%s\n' \
         cwd: repoRoot,
         encoding: 'utf8',
         env: {
-          ...withoutNodeV8Coverage(),
+          ...cleanBrowserPreferenceEnv(),
           HOME: harnessRoot,
           REPO_ROOT: repoRoot,
           REVIEW_GPT_BROWSER_LANE: 'main',

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -80,7 +80,7 @@ review_gpt_browser_lane_is_usable() {
   [[ ! -e "$review_gpt_lane_lock" && ! -L "$review_gpt_lane_lock" ]]
 }
 
-review_gpt_requested_browser_lane="${REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_PROFILE_SLUG:-main}}}"
+review_gpt_requested_browser_lane="${REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_PROFILE_SLUG:-auto}}}"
 review_gpt_requested_browser_lane="$(printf '%s' "$review_gpt_requested_browser_lane" | tr '[:upper:]' '[:lower:]')"
 review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
 


### PR DESCRIPTION
## Why this PR exists

Repo-wide ReviewGPT runs currently default to the ordinary `main` Brave lane. That lets review automation use the day-to-day browser profile unless every caller remembers a local override.

## User goal / behavior

An unset ReviewGPT browser preference now automatically selects an available isolated Eragon, Phlebas, Hercules, or Mountain lane. Operators can still explicitly select `main` when they intend to use it.

## Invariants

- Preserve explicit `REVIEW_GPT_BROWSER_LANE`, legacy environment, and local config overrides.
- Preserve lane-count limits, lock/CDP availability checks, browser binary freshness, profile isolation, ports, response capture, and all review presets.
- Keep this internal to developer tooling; production behavior is unchanged.

## Architecture and reuse

- Existing systems reused: the current automatic lane selector, isolated lane data directories, CDP ports, and local preference file.
- New logic: none; the existing selector becomes the fallback default.
- New abstractions: none are needed because the existing lane selector already owns availability filtering and lane selection.
- Complexity intentionally avoided: no new browser process owner, config file, dependency, or migration.

## Changelog

- Changelog: not applicable
- Reason: This changes internal ReviewGPT developer tooling only; no member-visible behavior changed.

## Specialist lenses

- Product experience: not applicable — internal developer tooling only.
- Prompt: not applicable — no prompt or instruction text changed.
- Frontend: not applicable — no user-facing UI changed.
- Coverage: applicable — regression assertions prove the isolated automatic default, locked-lane exclusion, ambient-variable isolation, and explicit `main` escape hatch.

## Verification

- `bash -n scripts/review-gpt.config.sh`
- Original full focused Vitest file: 43 passed, 1 skipped.
- Corrected-head changed test: 1 passed, 43 skipped by filter.
- Corrected-head full-file retry: the changed test and 40 other tests passed; two unrelated audit-ZIP packaging tests hit their existing 30s/120s timeouts under local contention.
- `pnpm --dir packages/cli typecheck`
- ReviewGPT dry run with one admitted lane selected Eragon, port 9448, and the isolated `MurphReviewGPT/Eragon` data directory without launching a browser.
- Exact-head required CI: green on both CLI host matrices and the hosted billing boundary.
- Current-base `git merge-tree --write-tree` proof: clean.

## Review results

- Preliminary ReviewGPT returned one low-severity coverage finding: the initial test inherited ambient lane variables and did not prove locked lanes were excluded.
- Accepted and fixed with a hermetic test environment, masked live CDP probes, three locked lanes, and an exact Mountain assertion.
- The returned test-only coverage patch was downloaded from the owned thread, fully inspected, path-checked, and applied with one unnecessary random seed omitted.
- Final cross-cutting ReviewGPT: not applicable; this is low-risk internal developer tooling with no production behavior change.

## Evidence

- Direct journey evidence: repo config dry run; browser launch intentionally skipped.
- Rendered evidence: not applicable.
- Design proof: not applicable.

## Change shape

Classification is by file purpose from `origin/main...HEAD`; no binary files.

- Source: +0 / -0
- Tests: +46 / -4
- Docs: +0 / -0
- Config/tooling: +1 / -1
- Generated/other: +0 / -0

ReviewGPT context sensitivity: routine
