### PR TITLE
fix(cloudflare): confirm missing database counters

### DIFF
--- a/.agents/friction-log/20260812104259-sanctioned-worktree-install/friction.md
+++ b/.agents/friction-log/20260812104259-sanctioned-worktree-install/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Sanctioned worktree install fails on transient storage-guard lock contention'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Installing an unchanged frozen workspace in a sanctioned worktree should complete when dependency linking succeeds. Hook setup should tolerate ordinary contention on the repository's existing storage-guard lock or retry within a bounded interval.
+
+## Current Behavior
+
+The install completes dependency linking, then the prepare hook invokes hook installation and exits nonzero when another repository process briefly owns the storage-guard lock. The caller receives an install failure even though package installation itself completed.
+
+## Possible Solution
+
+Make the prepare-owned hook installation acquire the existing lock with a bounded retry, or treat a concurrently held lock as a deferred hook-refresh outcome when the already-installed global hook remains valid.
+
+## Minimal Reproducible Example
+
+1. Create a sanctioned task worktree with `scripts/create-worktree`.
+2. While another repository process holds the worktree-storage guard lock, run `pnpm install --frozen-lockfile` in the task worktree.
+3. Observe dependency linking complete, followed by a prepare failure from the contended guard lock.
+
+## Context
+
+This turns normal concurrent repository work into a false dependency-install failure and forces callers to distinguish a completed link step from a failed hook-refresh step before running focused tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Murph Architecture
 
-Last verified: 2026-08-10
+Last verified: 2026-08-12
 
 ## Accepted-Message Targeting
 
@@ -1194,7 +1194,13 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   admission state. Metric families normalize independently: an unavailable
   family stays null and its canonical allowlisted name is retained, while
   available families continue to drive their own conditions. Missing data is
-  never treated as zero. A telemetry-only notification opens after two
+  never treated as zero. Unusable collections receive one bounded confirmation
+  attempt. Usable partial collections stay single-pass whenever available
+  evidence is unsafe; a safe observation missing only the direct-error counter
+  uses the same confirmation budget. The confirmation's available signals are
+  evaluated, a recovered counter joins the original complete gauge evidence,
+  and failure or continued absence retains the original incomplete observation.
+  A telemetry-only notification opens after two
   consecutive incomplete or failed collections. The first two-check threshold
   window counts incomplete versus unavailable observations, unions only
   canonical missing families observed on partial checks, and uses the threshold

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-08-11
+Last verified: 2026-08-12
 
 ## Current Guardrails
 
@@ -219,9 +219,16 @@ Last verified: 2026-08-11
   A collection that fails before producing a usable observation, including a
   scrape with every required family absent, receives one bounded retry after one
   second, outside any storage transaction. Only an exhausted two-attempt
-  collection increments the consecutive-failure state; partial observations
-  with any usable family remain single-pass so their available unsafe evidence
-  is evaluated without delay.
+  collection increments the consecutive-failure state. A usable partial
+  observation remains single-pass when any available signal is unsafe, so
+  concrete evidence is evaluated without delay. When the only absent family is
+  the direct-error counter and every available signal is safe, the monitor uses
+  that same bounded retry as a confirmation scrape. Every available confirmation
+  signal is evaluated; a recovered direct counter is merged with the original
+  complete gauge evidence, while a failed or still-incomplete confirmation
+  retains the original partial observation. This makes transient counter-family
+  omission less noisy without converting unknown to zero or weakening the
+  two-check telemetry fallback.
   Discovery, scrape, parse, or incomplete required metrics must recur on two
   consecutive runs before paging the monitoring condition. Crossing that
   threshold persists one bounded telemetry-page obligation in the existing

--- a/agent-docs/exec-plans/active/2026-08-12-database-monitor-direct-counter-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-12-database-monitor-direct-counter-retry.md
@@ -1,0 +1,68 @@
+# Reduce direct-counter telemetry flapping
+
+Status: active
+Created: 2026-08-12
+Updated: 2026-08-12
+
+## Goal
+
+- Absorb a transient omission of PlanetScale's direct connection-error counter
+  without weakening database-pressure paging, missing-telemetry detection, or
+  the direct migration admission-failure signal.
+
+## Success criteria
+
+- A safe partial scrape that is missing only the direct-error counter receives
+  one bounded same-run retry before it contributes to monitoring-failure state.
+- Any concrete condition available on the first scrape still pages immediately
+  without waiting for a retry.
+- A recovered direct-error counter still advances its baseline and pages on a
+  positive delta.
+- A failed or still-incomplete confirmation preserves the original partial
+  observation, and two consecutive exhausted checks retain the existing
+  telemetry-only page.
+- Focused Node and Workers-runtime tests, Cloudflare typecheck, required guards,
+  ReviewGPT gates, and exact-head CI pass.
+
+## Evidence and constraints
+
+- The parser distinguishes an absent counter family from a present zero-valued
+  counter. The confirmation path must preserve that distinction when family
+  presence changes between bounded scrapes.
+- Missing values remain unknown; no omission is converted to zero.
+- The Cloudflare singleton, five-minute cron, two-check telemetry threshold,
+  immediate concrete-pressure admission, hourly provider fence, exact-body
+  retry, two-destination fan-out, and SQLite state owner remain unchanged.
+- No new queue, scheduler, fallback service, credential, threshold, or durable
+  state is introduced.
+
+## Tasks
+
+1. Add failing unit and Workers-runtime regressions for transient direct-counter
+   omission, immediate available pressure, recovered positive deltas, and
+   persistent incomplete telemetry.
+2. Add one monitor-owned partial-confirmation path that evaluates every retry
+   signal, recovers the missing direct counter, and otherwise preserves the
+   first observation.
+3. Update the database-monitor owner contracts and verification map.
+4. Run focused verification, inspect the complete diff for privacy and alert
+   regressions, commit, push, and open the PR.
+5. Run the preliminary specialist and sensitive final ReviewGPT gates
+   concurrently with exact-head CI, resolve accepted findings, and close the
+   plan through the scoped final commit.
+
+## Deployment
+
+- Cloudflare Worker only. No Web or Temporal ordering, migration, or container
+  drain is required. After rollout, verify a successful scheduled sample and
+  the absence of repeated direct-counter-only telemetry pages while retaining
+  direct-error delta and persistent-gap coverage.
+
+## Verification
+
+- Focused Node database-health suites passed: 3 files, 82 tests.
+- The real Workers-runtime database-health suite passed: 1 file, 3 tests.
+- Cloudflare typecheck, log-payload guard, documentation drift check,
+  `git diff --check`, and the changed-file identifier scan passed.
+- Preliminary specialists, final ReviewGPT, and exact-head CI remain pending on
+  the pushed PR candidate.

--- a/agent-docs/exec-plans/completed/2026-08-12-database-monitor-direct-counter-retry.md
+++ b/agent-docs/exec-plans/completed/2026-08-12-database-monitor-direct-counter-retry.md
@@ -1,6 +1,6 @@
 # Reduce direct-counter telemetry flapping
 
-Status: active
+Status: completed
 Created: 2026-08-12
 Updated: 2026-08-12
 
@@ -64,5 +64,18 @@ Updated: 2026-08-12
 - The real Workers-runtime database-health suite passed: 1 file, 3 tests.
 - Cloudflare typecheck, log-payload guard, documentation drift check,
   `git diff --check`, and the changed-file identifier scan passed.
-- Preliminary specialists, final ReviewGPT, and exact-head CI remain pending on
-  the pushed PR candidate.
+- The preliminary specialist pass accepted the operator-experience shape and
+  identified one coverage-only gap. Its inspected test patch added the two
+  missing family-shape boundary cases; the final Node slice passed 3 files and
+  84 tests, and the Workers-runtime suite still passed 1 file and 3 tests.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no findings after
+  verifying the bounded retry, immediate unsafe-signal path, recovered delta,
+  persistent-gap page, and unchanged state and delivery contracts.
+- The changed Cloudflare app's full verification passed locally: 141 Node files
+  with 2,414 passing tests and 2 skips, plus 5 Workers files with 12 passing
+  tests. Cloudflare also passed its exact-head CI tests. The umbrella app shard
+  failed only in the unchanged Web Next.js build while resolving an internal
+  Google-font module; the failed target is outside this patch.
+
+Completed: 2026-08-12
+Completed: 2026-08-12

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -1,6 +1,6 @@
 # Murph Agent Docs Index
 
-Last verified: 2026-08-11
+Last verified: 2026-08-12
 
 ## Purpose
 
@@ -72,8 +72,9 @@ provider-no-replay recovery, are jointly specified by
 `agent-docs/references/hosted-runtime-protocol.md`.
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
-evidence, continued evaluation of available database signals, and one-shot
-telemetry-only operator paging with unresolved-window coalescing, current-pressure
+evidence, continued evaluation of available database signals, bounded safe
+direct-counter-only confirmation without suppressing unsafe observations, and
+one-shot telemetry-only operator paging with unresolved-window coalescing, current-pressure
 priority including direct errors in one combined pre-first-page incident,
 post-ack recurrence suppression, durable owed-page preservation inside
 non-replayable direct-error admission, truthful direct-error and mixed telemetry

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -73,8 +73,9 @@ provider-no-replay recovery, are jointly specified by
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
 evidence, continued evaluation of available database signals, bounded safe
-direct-counter-only confirmation without suppressing unsafe observations, and
-one-shot telemetry-only operator paging with unresolved-window coalescing, current-pressure
+direct-counter-only confirmation with cross-scrape evidence composition and
+without suppressing unsafe observations, and one-shot telemetry-only operator
+paging with unresolved-window coalescing, current-pressure
 priority including direct errors in one combined pre-first-page incident,
 post-ack recurrence suppression, durable owed-page preservation inside
 non-replayable direct-error admission, truthful direct-error and mixed telemetry

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -564,7 +564,8 @@ supported provider credential.
   required series, continued evaluation of available signals, positive
   direct-port counter deltas with reset/new-series suppression across complete
   and partial samples, one bounded confirmation for a safe direct-counter-only
-  omission, immediate unsafe-signal paging before that confirmation, unsafe
+  omission, multi-family confirmation rejection, cross-scrape evidence
+  composition, immediate unsafe-signal paging before that confirmation, unsafe
   confirmation-signal paging, failed-confirmation retention, positive
   recovered-counter deltas, persistent-gap telemetry paging, and the scheduled
   Durable Object boundary for that retry,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -1,6 +1,6 @@
 # Testing And CI Map
 
-Last verified: 2026-08-10
+Last verified: 2026-08-12
 
 ## Current Repo Checks
 
@@ -563,7 +563,12 @@ supported provider credential.
   prove strict per-family metric normalization, explicit unknowns for missing
   required series, continued evaluation of available signals, positive
   direct-port counter deltas with reset/new-series suppression across complete
-  and partial samples, SQLite sample persistence and 30-day pruning, concrete
+  and partial samples, one bounded confirmation for a safe direct-counter-only
+  omission, immediate unsafe-signal paging before that confirmation, unsafe
+  confirmation-signal paging, failed-confirmation retention, positive
+  recovered-counter deltas, persistent-gap telemetry paging, and the scheduled
+  Durable Object boundary for that retry,
+  SQLite sample persistence and 30-day pruning, concrete
   connection thresholds, two-failure collection hysteresis, one acknowledged
   page per unresolved telemetry-notification window, recovered threshold
   coalescing before acknowledgment, truthful partial-then-unavailable,

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -221,9 +221,15 @@ without retaining labels or raw scrape data. Unsafe available signals therefore
 still open an incident immediately. A collection that fails before producing a
 usable observation, including a scrape with every required family absent,
 receives one bounded retry after one second; only an exhausted two-attempt
-collection counts as a failed check. Partial observations with any usable family
-are not delayed by that retry. Two consecutive incomplete or failed collections
-open the fallback monitoring incident. An acknowledged
+collection counts as a failed check. A usable partial observation ordinarily
+remains single-pass so available unsafe evidence pages without delay. The sole
+exception is a safe observation missing only the direct-error counter family:
+the monitor makes one confirmation scrape after the same one-second delay,
+evaluates every available confirmation signal, and merges a recovered direct
+counter with the original complete gauge evidence. A failed or still-missing
+confirmation retains the original incomplete observation, so absence never
+becomes zero and two persistently incomplete checks still open the fallback
+monitoring incident. An acknowledged
 telemetry-only page is one-shot for one unresolved operator-notification window.
 Crossing the two-failure threshold records one bounded alert obligation in the
 existing incident row. The first two-check window counts incomplete versus

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -27,6 +27,9 @@ const DATABASE_HEALTH_RUN_LEASE_MS = 2 * 60 * 1_000;
 const DATABASE_HEALTH_SAMPLE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
 const DATABASE_HEALTH_FETCH_TIMEOUT_MS = 10_000;
 const DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS = 1_000;
+const DIRECT_CONNECTION_ERROR_METRIC_NAME =
+  "planetscale_edge_postgres_connection_errors_total" satisfies
+    DatabaseHealthRequiredMetricName;
 const PLANETSCALE_DISCOVERY_BODY_LIMIT_BYTES = 256 * 1_024;
 const PLANETSCALE_METRICS_BODY_LIMIT_BYTES = 2 * 1_024 * 1_024;
 const LINQ_HEALTH_BODY_LIMIT_BYTES = 256 * 1_024;
@@ -406,16 +409,49 @@ export class DatabaseHealthMonitor {
   }
 
   private async collectMetricObservation(): Promise<DatabaseMetricObservation> {
+    let observation: DatabaseMetricObservation;
     try {
-      const observation = await this.collectMetricObservationOnce();
-      if (hasUsableDatabaseHealthMetric(observation)) {
+      observation = await this.collectMetricObservationOnce();
+    } catch {
+      await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
+      return await this.collectMetricObservationOnce();
+    }
+    if (!hasUsableDatabaseHealthMetric(observation)) {
+      await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
+      return await this.collectMetricObservationOnce();
+    }
+    if (!shouldConfirmMissingDirectConnectionErrors(observation)) {
+      return observation;
+    }
+
+    await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
+    try {
+      const confirmation = await this.collectMetricObservationOnce();
+      if (
+        evaluateDatabaseMetricSnapshot(confirmation.snapshot, null).length > 0
+      ) {
+        return confirmation;
+      }
+      const directConnectionErrorCounters =
+        confirmation.snapshot.directConnectionErrorCounters;
+      if (directConnectionErrorCounters === null) {
         return observation;
       }
+      if (confirmation.missingMetrics.length === 0) {
+        return confirmation;
+      }
+      return {
+        missingMetrics: observation.missingMetrics.filter(
+          (name) => name !== DIRECT_CONNECTION_ERROR_METRIC_NAME,
+        ),
+        snapshot: {
+          ...observation.snapshot,
+          directConnectionErrorCounters,
+        },
+      };
     } catch {
-      // Retry below when the first attempt produced no usable observation.
+      return observation;
     }
-    await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
-    return await this.collectMetricObservationOnce();
   }
 
   private async collectMetricObservationOnce(): Promise<
@@ -1451,6 +1487,14 @@ function hasUsableDatabaseHealthMetric(
 ): boolean {
   return observation.missingMetrics.length
     < DATABASE_HEALTH_REQUIRED_METRIC_NAMES.length;
+}
+
+function shouldConfirmMissingDirectConnectionErrors(
+  observation: DatabaseMetricObservation,
+): boolean {
+  return observation.missingMetrics.length === 1
+    && observation.missingMetrics[0] === DIRECT_CONNECTION_ERROR_METRIC_NAME
+    && evaluateDatabaseMetricSnapshot(observation.snapshot, null).length === 0;
 }
 
 async function readBoundedResponseText(

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1053,6 +1053,218 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toEqual([]);
   });
 
+  it("retries a safe partial scrape when only the direct-error counter is missing", async () => {
+    const completeMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
+    const partialMetricsBody = completeMetricsBody.replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return scrapeAttempt === 1
+          ? partialMetricsBody
+          : completeMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        directConnectionErrorDelta: 0,
+        failureCode: null,
+        scrapeStatus: "ok",
+      }),
+    ]);
+    expect(harness.primaryLinqRequests).toEqual([]);
+  });
+
+  it("retains the original incomplete observation when direct-error confirmation fails", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const harness = createMonitorHarness({
+      metricsBody: partialMetricsBody,
+      serviceDiscoveryResponses: [
+        createServiceDiscoveryResponse,
+        () => new Response(null, { status: 503 }),
+      ],
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(3);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        failureCode: "required_metrics_missing",
+        scrapeStatus: "failed",
+      }),
+    ]);
+    expect(harness.primaryLinqRequests).toEqual([]);
+  });
+
+  it("pages an available unsafe signal without retrying a missing direct-error counter", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const harness = createMonitorHarness({ metricsBody: partialMetricsBody });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({
+        conditions: [{ kind: "client_wait", seconds: 8 }],
+        outcome: "alert_sent",
+        sampleStatus: "failed",
+      });
+
+    expect(harness.planetScaleRequests).toHaveLength(2);
+    expect(harness.retryWaits).toEqual([]);
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+  });
+
+  it("pages a positive direct-error delta recovered by the partial retry", async () => {
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+    });
+    const partialMetricsBody = baselineMetricsBody.replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const incrementedMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 6,
+    });
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1) {
+          return baselineMetricsBody;
+        }
+        return scrapeAttempt === 2
+          ? partialMetricsBody
+          : incrementedMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(6);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      directConnectionErrorDelta: 2,
+      failureCode: null,
+      scrapeStatus: "ok",
+    });
+  });
+
+  it("pages pressure that appears while confirming the missing direct-error counter", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const unsafePartialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return scrapeAttempt === 1
+          ? partialMetricsBody
+          : unsafePartialMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({
+        conditions: [{ kind: "client_wait", seconds: 8 }],
+        outcome: "alert_sent",
+        sampleStatus: "failed",
+      });
+
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+  });
+
+  it("retains the two-check telemetry page when direct-error retries stay incomplete", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const harness = createMonitorHarness({ metricsBody: partialMetricsBody });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        {
+          failures: 2,
+          kind: "monitoring_unavailable",
+          missingMetrics: [
+            "planetscale_edge_postgres_connection_errors_total",
+          ],
+        },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(8);
+    expect(harness.retryWaits).toEqual([1_000, 1_000]);
+    const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
+    expect(alert.message.parts[0]?.value).toBe(
+      "Database monitor telemetry was incomplete for 2 checks "
+      + "(missing PlanetScale metric observed: direct connection errors). "
+      + "Window ended 00:10 UTC.",
+    );
+  });
+
   it("pages concrete pressure returned by the retry without delay", async () => {
     const harness = createMonitorHarness({
       metricsBody: buildMetricsBody({

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1087,6 +1087,72 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toEqual([]);
   });
 
+  it("keeps multi-family omissions single-pass when the direct-error counter is also missing", async () => {
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    ).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const harness = createMonitorHarness({ metricsBody: partialMetricsBody });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(2);
+    expect(harness.retryWaits).toEqual([]);
+    expect(harness.monitor.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        failureCode: "required_metrics_missing",
+        scrapeStatus: "failed",
+      }),
+    ]);
+  });
+
+  it("joins a recovered direct-error counter to first-scrape gauges when confirmation loses another family", async () => {
+    const completeMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
+    const missingDirectErrorMetricsBody = completeMetricsBody.replace(
+      /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+      "",
+    );
+    const missingMaxConnectionsMetricsBody = completeMetricsBody.replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return scrapeAttempt === 1
+          ? missingDirectErrorMetricsBody
+          : missingMaxConnectionsMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        directConnectionErrorDelta: 0,
+        failureCode: null,
+        postgresMaxConnections: 50,
+        scrapeStatus: "ok",
+      }),
+    ]);
+  });
+
   it("retains the original incomplete observation when direct-error confirmation fails", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,

--- a/apps/cloudflare/test/workers/database-health-e2e.test.ts
+++ b/apps/cloudflare/test/workers/database-health-e2e.test.ts
@@ -19,6 +19,7 @@ import {
   readDatabaseHealthPlanetScaleRequestCounts,
   resetDatabaseHealthMessageRequests,
   setDatabaseHealthClientWaitSeconds,
+  setDatabaseHealthMissingDirectErrorScrapesRemaining,
   setDatabaseHealthNowMs,
   setDatabaseHealthZeroEvidenceScrapesRemaining,
 } from "./database-health-fetch.ts";
@@ -36,6 +37,41 @@ describe("database health scheduled Worker path", () => {
 
     const namespace = readDatabaseHealthNamespace();
     const monitor = namespace.getByName("transient-retry");
+    await monitor.runScheduledCheck({ scheduledAtMs });
+
+    await expect(
+      monitor.readRecentSamples({ limit: 10 }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        failureCode: null,
+        observedAtMs: scheduledAtMs,
+        scrapeStatus: "ok",
+      }),
+    ]);
+    await expect(
+      monitor.readAlertState(),
+    ).resolves.toMatchObject({
+      consecutiveScrapeFailures: 0,
+      incidentOpen: false,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+    expect(readDatabaseHealthPlanetScaleRequestCounts()).toEqual({
+      discovery: 2,
+      metrics: 2,
+    });
+    expect(readDatabaseHealthMessageRequests()).toEqual([]);
+  });
+
+  it("retries one safe direct-counter omission inside the scheduled Durable Object run", async () => {
+    resetDatabaseHealthMessageRequests();
+    const scheduledAtMs = Date.now();
+    setDatabaseHealthNowMs(scheduledAtMs);
+    setDatabaseHealthClientWaitSeconds(0);
+    setDatabaseHealthMissingDirectErrorScrapesRemaining(1);
+
+    const namespace = readDatabaseHealthNamespace();
+    const monitor = namespace.getByName("direct-counter-retry");
     await monitor.runScheduledCheck({ scheduledAtMs });
 
     await expect(

--- a/apps/cloudflare/test/workers/database-health-fetch.ts
+++ b/apps/cloudflare/test/workers/database-health-fetch.ts
@@ -14,6 +14,7 @@ const recordedDatabaseHealthMessageRequests:
 let databaseHealthClientWaitSeconds = 8;
 let databaseHealthDiscoveryRequestCount = 0;
 let databaseHealthMetricsRequestCount = 0;
+let databaseHealthMissingDirectErrorScrapesRemaining = 0;
 let databaseHealthNowMs = Date.now();
 let databaseHealthZeroEvidenceScrapesRemaining = 0;
 
@@ -40,6 +41,7 @@ export function resetDatabaseHealthMessageRequests(): void {
   databaseHealthClientWaitSeconds = 8;
   databaseHealthDiscoveryRequestCount = 0;
   databaseHealthMetricsRequestCount = 0;
+  databaseHealthMissingDirectErrorScrapesRemaining = 0;
   databaseHealthNowMs = Date.now();
   databaseHealthZeroEvidenceScrapesRemaining = 0;
 }
@@ -50,6 +52,12 @@ export function readDatabaseHealthNowMs(): number {
 
 export function setDatabaseHealthClientWaitSeconds(value: number): void {
   databaseHealthClientWaitSeconds = value;
+}
+
+export function setDatabaseHealthMissingDirectErrorScrapesRemaining(
+  value: number,
+): void {
+  databaseHealthMissingDirectErrorScrapesRemaining = value;
 }
 
 export function setDatabaseHealthZeroEvidenceScrapesRemaining(
@@ -112,10 +120,18 @@ export async function handleDatabaseHealthEgress(
       databaseHealthZeroEvidenceScrapesRemaining -= 1;
       return new Response("", { status: 200 });
     }
-    return new Response(buildMetricsBody({
+    const metricsBody = buildMetricsBody({
       branchId: "branch_worker_test",
       clientWaitSeconds: databaseHealthClientWaitSeconds,
-    }));
+    });
+    if (databaseHealthMissingDirectErrorScrapesRemaining > 0) {
+      databaseHealthMissingDirectErrorScrapesRemaining -= 1;
+      return new Response(metricsBody.replace(
+        /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
+        "",
+      ));
+    }
+    return new Response(metricsBody);
   }
   if (
     method === "GET"


### PR DESCRIPTION
## Why this PR exists

PlanetScale can transiently omit the documented direct connection-error counter family while the remaining database metrics are healthy. Counting that one scrape immediately toward the monitoring-failure threshold creates avoidable operator noise even though the monitor can confirm the counter within its existing bounded retry budget.

## User goal / user-visible behavior

Operators should receive fewer telemetry-only database pages caused by a one-scrape direct-counter omission, without losing any pressure signal, direct-error delta, persistent telemetry-gap alert, or alert-delivery guarantee.

## User experience

This has no member-facing UI or message change. The existing five-minute Cloudflare monitor remains the entry point. An unsafe available signal still pages immediately. A safe observation missing only the direct-error counter waits one second for a monitor-owned confirmation; the Durable Object then records a complete sample when the counter returns, or records the original incomplete sample when confirmation fails or remains incomplete. Two exhausted checks still page the existing operator chats, and a positive recovered counter delta still pages in the confirming run.

## Invariants the PR must preserve

- Missing telemetry remains unknown and is never substituted with zero.
- Every available pressure signal from both the original and confirmation scrape is evaluated.
- Unsafe first-scrape evidence is never delayed by confirmation.
- Positive direct-error deltas and two-check persistent telemetry gaps retain their existing alert paths.
- Cron cadence, thresholds, SQLite state, hourly provider fence, exact-body retry, Linq health gates, and two-recipient delivery remain unchanged.

## Non-obvious affected surfaces

- PlanetScale monitor egress: a safe direct-counter-only partial observation now uses the existing maximum of two discovery/scrape pairs in one run. Focused request-count tests prove unsafe observations remain one pair and confirmation remains bounded.
- Durable Object runtime integration: the Workers-runtime test proves the scheduled singleton records a healthy sample after one transient omission without sending a page.
- Alert documentation and CI ownership: architecture, reliability, Cloudflare owner docs, and the testing map now state the narrow confirmation contract.

## Architecture and reuse

- **Existing systems reused:** the current monitor collection method, one-second retry budget, per-family parser, condition evaluator, Durable Object SQLite owner, and alert admission path.
- **New logic:** one predicate admits confirmation only when the direct-error family is the sole absence and all first-scrape evidence is safe; confirmation evidence is evaluated before the recovered counter is joined to the original complete gauges.
- **New abstractions:** no new service, state owner, queue, schema, dependency, or durable abstraction was added; the existing observation contract is sufficient.
- **Complexity intentionally avoided:** no threshold changes, synthetic zero, provider fallback, background retry process, or duplicate alert lifecycle.

## Changelog

- Changelog: not applicable

- Reason: this changes internal operator monitoring behavior and has no member-visible product behavior.

## Hot reply path impact

Not applicable. The change runs only in the independent database-health Cron Durable Object and does not touch foreground reply acceptance or delivery.

## Database collection fanout impact

Not applicable. The path performs no application-database query or transaction. PlanetScale metrics egress remains bounded at the existing per-run maximum: before and after, at most two serial discovery requests plus two serial metric scrapes, with the existing 10-second per-request timeout and one one-second retry delay outside storage transactions.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool, skill, model, or provider-request assembly changed.
- Group Murph: Not applicable; no prompt, tool, skill, model, or provider-request assembly changed.

## Preliminary specialist lenses

- **Product experience: applicable.** Intended outcome: a quieter but equally protective operator alert journey. Direct evidence: focused tests cover immediate unsafe paging, one-second confirmation, recovered direct-error paging, confirmation failure, and persistent-gap recovery.
- **Prompt: not applicable.** No prompt or tool-description surface changed.
- **Frontend: not applicable.** No user-facing Web UI changed and no rendered evidence is required.
- **Coverage: applicable.** Focused local proof passed: 3 Node files / 82 tests, 1 Workers-runtime file / 3 tests, Cloudflare typecheck, log-payload guard, docs drift, and patch checks. Exact-head CI is pending and will run concurrently with both review gates.

ReviewGPT context sensitivity: sensitive

Reason: this is an operational alert retry change at an external provider boundary.

ReviewGPT first-reviewed head: b55a4872dd7d9617c069b2f518ba95fc8010f76e

## Change-shape breakdown

Classification uses production implementation as source, test files and fake egress as tests/fixtures, authored owner/process Markdown as docs, the Frog record as config/tooling, and no generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 49 | 5 |
| Tests/fixtures | 266 | 2 |
| Docs | 107 | 14 |
| Config/tooling | 26 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **448** | **21** |

Binary files: none.

## Review remediation ledger

- Preliminary coverage finding: **accepted**. The exact reviewer-supplied test-only patch was inspected, apply-checked, and applied. It adds owner-boundary proof that multi-family omissions stay single-pass and that a recovered direct counter composes with first-scrape gauges when the confirmation loses a different family.
- Focused remediation proof: the final database-health Node slice passed (3 files, 84 tests), the Workers-runtime suite passed (1 file, 3 tests), and Cloudflare typecheck, log-payload guard, documentation drift, and patch hygiene passed.
- Production source growth from remediation: 0 added / 0 deleted. The remediation changes only tests and their verification-map/index documentation, so the clean round-1 final audit remains the production-behavior baseline.

Current pushed head: `d8524a046ec093813c5b191ebb0fd6833b235f07`

| Current category | Added | Deleted |
| --- | ---: | ---: |
| Source | 49 | 5 |
| Tests/fixtures | 332 | 2 |
| Docs | 122 | 14 |
| Config/tooling | 26 | 0 |
| Generated/other | 0 | 0 |
| **Current total** | **529** | **21** |

## Design proof

Not applicable. No user-facing frontend UI changed.

## Deployment

Cloudflare Worker only. No Web deploy, database migration, Temporal ordering, or compatibility window is required. After rollout, verify one successful scheduled sample and no repeated direct-counter-only telemetry page while preserving direct-error delta and persistent-gap coverage.
