### PR TITLE
Trim ReviewGPT audit packages

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-12-trim-review-gpt-audit-package.md
+++ b/agent-docs/exec-plans/active/2026-08-12-trim-review-gpt-audit-package.md
@@ -1,0 +1,77 @@
+# Trim ReviewGPT audit packages
+
+Status: active
+Created: 2026-08-12
+Updated: 2026-08-12
+
+## Goal
+
+- Reduce ReviewGPT audit attachment size without weakening the full-review test,
+  documentation, CI, or changed-file context needed for useful reviews.
+
+## Success criteria
+
+- Full audit packages exclude Web audio binaries.
+- Full audit packages exclude the Health Commons source corpus unless the PR
+  changes Health Commons.
+- Full audit packages continue to include tests and the rest of Health Commons.
+- Focused CLI coverage, shell syntax checks, direct ZIP-content proof, exact-head
+  CI, and the required preliminary ReviewGPT specialist pass are green.
+
+## Scope
+
+- In scope: Murph's ReviewGPT audit-package configuration, PR-aware packaging
+  behavior, focused regression coverage, and package-size evidence.
+- Out of scope: the separately owned `@cobuild/review-gpt` Repomix dependency
+  graph and any member-facing product behavior.
+
+## Constraints
+
+- Technical constraints: preserve changed Health Commons review context, full
+  test coverage, sensitive-path exclusions, and later-round delta packaging.
+- Product/process constraints: use the isolated worktree/PR lane, preserve
+  private-data boundaries, and record the internal-only changelog decision in
+  the PR body.
+
+## Risks and mitigations
+
+1. Risk: excluding the source corpus could hide relevant evidence from a Health
+   Commons review.
+   Mitigation: derive relevance from the exact PR changed-file manifest and keep
+   the corpus whenever any Health Commons path changes.
+2. Risk: broad binary exclusions could hide reviewable source assets.
+   Mitigation: exclude only the known Web audio subtree and verify ordinary
+   Health Commons source and test files remain packaged.
+
+## Tasks
+
+1. Add the narrow audio exclusion and PR-aware Health Commons source exclusion.
+2. Extend the existing package-audit test owner with direct regression proof.
+3. Run focused tests, syntax checks, and before/after package measurements.
+4. Commit and push the candidate, open the PR, run specialist review and CI,
+   resolve findings, and close this plan through `scripts/finish-task`.
+
+## Decisions
+
+- Keep tests in every full audit; they are review evidence, not package excess.
+- Do not patch or override Repomix in Murph. Its dependency ownership belongs in
+  the separate ReviewGPT package repository.
+- Treat the changelog as not applicable because this changes internal review
+  tooling only and cannot affect members.
+
+## Verification
+
+- Commands to run: focused `release-script-coverage-audit` Vitest, `bash -n` for
+  changed shell scripts, `git diff --check`, and direct ZIP inventory/size
+  measurements, followed by exact-head required GitHub checks.
+- Expected outcomes: the configured audio and unrelated Health Commons corpus
+  paths are absent, Health Commons PRs retain the corpus, tests remain present,
+  and all required checks pass.
+- Local results:
+  - Focused CLI packaging suite: 43 passed, 1 skipped.
+  - CLI typecheck: passed.
+  - Repo-tool helper suite: 527 passed.
+  - Same-head package proof: 60,270,658 bytes and 18,930 entries before;
+    36,222,640 bytes and 11,337 entries after, a 39.9% byte reduction.
+  - ZIP inventory confirmed Web audio and the unrelated Health Commons source
+    corpus are absent while Health Commons runtime code and tests remain.

--- a/agent-docs/exec-plans/active/2026-08-12-trim-review-gpt-audit-package.md
+++ b/agent-docs/exec-plans/active/2026-08-12-trim-review-gpt-audit-package.md
@@ -37,8 +37,9 @@ Updated: 2026-08-12
 
 1. Risk: excluding the source corpus could hide relevant evidence from a Health
    Commons review.
-   Mitigation: derive relevance from the exact PR changed-file manifest and keep
-   the corpus whenever any Health Commons path changes.
+   Mitigation: derive relevance from a no-renames PR diff so both sides of a
+   rename remain visible, and keep the corpus whenever either side touches
+   Health Commons.
 2. Risk: broad binary exclusions could hide reviewable source assets.
    Mitigation: exclude only the known Web audio subtree and verify ordinary
    Health Commons source and test files remain packaged.
@@ -75,3 +76,8 @@ Updated: 2026-08-12
     36,222,640 bytes and 11,337 entries after, a 39.9% byte reduction.
   - ZIP inventory confirmed Web audio and the unrelated Health Commons source
     corpus are absent while Health Commons runtime code and tests remain.
+  - Preliminary ReviewGPT requested one correction: rename-out changes could be
+    represented by only their destination in the changed-file manifest. The
+    predicate now uses a no-renames diff, falls back to retaining the corpus when
+    local history is incomplete, and has real-ZIP proof that an unchanged corpus
+    sibling remains present after a Health Commons file is renamed elsewhere.

--- a/agent-docs/exec-plans/completed/2026-08-12-trim-review-gpt-audit-package.md
+++ b/agent-docs/exec-plans/completed/2026-08-12-trim-review-gpt-audit-package.md
@@ -1,6 +1,6 @@
 # Trim ReviewGPT audit packages
 
-Status: active
+Status: completed
 Created: 2026-08-12
 Updated: 2026-08-12
 
@@ -81,3 +81,4 @@ Updated: 2026-08-12
     predicate now uses a no-renames diff, falls back to retaining the corpus when
     local history is incomplete, and has real-ZIP proof that an unchanged corpus
     sibling remains present after a Health Commons file is renamed elsewhere.
+Completed: 2026-08-12

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -3404,6 +3404,16 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
       writeHarnessFile(harnessRoot, 'apps/demo/unrelated.ts', 'export const unrelated = true\n')
       writeHarnessFile(
         harnessRoot,
+        'packages/health-commons/content/sources/demo/moved.md',
+        'health source to move\n',
+      )
+      writeHarnessFile(
+        harnessRoot,
+        'packages/health-commons/content/sources/demo/sibling.md',
+        'unchanged health source\n',
+      )
+      writeHarnessFile(
+        harnessRoot,
         'packages/demo/test/unrelated.test.ts',
         'export const unrelatedTest = true\n',
       )
@@ -3475,6 +3485,26 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
         cwd: harnessRoot,
       })
       const healthCommonsHead = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: harnessRoot,
+        encoding: 'utf8',
+      }).trim()
+      execFileSync('git', ['checkout', '-q', '--detach', currentHead], {
+        cwd: harnessRoot,
+      })
+
+      execFileSync(
+        'git',
+        [
+          'mv',
+          'packages/health-commons/content/sources/demo/moved.md',
+          'apps/demo/moved-health-source.md',
+        ],
+        { cwd: harnessRoot },
+      )
+      execFileSync('git', ['commit', '-q', '-m', 'move health source'], {
+        cwd: harnessRoot,
+      })
+      const healthCommonsRenameOutHead = execFileSync('git', ['rev-parse', 'HEAD'], {
         cwd: harnessRoot,
         encoding: 'utf8',
       }).trim()
@@ -3674,6 +3704,51 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
       ).toBe(0)
       expect(healthCommonsPreliminary.excludeGlobs).not.toContain(
         'packages/health-commons/content/sources/**',
+      )
+
+      execFileSync('git', ['checkout', '-q', '--detach', healthCommonsRenameOutHead], {
+        cwd: harnessRoot,
+      })
+      const healthCommonsRenameOutPreliminary = invokePackager(
+        'health-commons-rename-out-preliminary',
+        healthCommonsRenameOutHead,
+        {
+          REVIEW_GPT_REVIEW_PHASE: 'preliminary',
+          REVIEW_GPT_FIRST_REVIEWED_HEAD: '',
+          REVIEW_GPT_PREVIOUS_REVIEWED_HEAD: '',
+          REVIEW_GPT_ROUND_NUMBER: '',
+        },
+      )
+      expect(
+        healthCommonsRenameOutPreliminary.result.status,
+        healthCommonsRenameOutPreliminary.result.stderr,
+      ).toBe(0)
+      expect(healthCommonsRenameOutPreliminary.excludeGlobs).not.toContain(
+        'packages/health-commons/content/sources/**',
+      )
+      const healthCommonsRenameOutReal = invokePackager(
+        'health-commons-rename-out-real',
+        healthCommonsRenameOutHead,
+        {
+          COBUILD_AUDIT_CONTEXT_SCAN_SPECS: 'packages',
+          REVIEW_GPT_REVIEW_PHASE: 'preliminary',
+          REVIEW_GPT_FIRST_REVIEWED_HEAD: '',
+          REVIEW_GPT_PREVIOUS_REVIEWED_HEAD: '',
+          REVIEW_GPT_ROUND_NUMBER: '',
+          TEST_REAL_PACKAGER_BIN: path.join(
+            repoRoot,
+            'node_modules',
+            '.bin',
+            'cobuild-package-audit-context',
+          ),
+        },
+      )
+      expect(
+        healthCommonsRenameOutReal.result.status,
+        healthCommonsRenameOutReal.result.stderr,
+      ).toBe(0)
+      expect(listZipEntries(healthCommonsRenameOutReal.zipPath)).toContain(
+        'packages/health-commons/content/sources/demo/sibling.md',
       )
       execFileSync('git', ['checkout', '-q', '--detach', currentHead], {
         cwd: harnessRoot,
@@ -4251,7 +4326,7 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
     } finally {
       rmSync(harnessRoot, { force: true, recursive: true })
     }
-  }, 30_000)
+  }, 45_000)
 
   it('keeps audit bundles scoped while preserving durable agent docs', () => {
     const leanBundle = createAuditZip('package-audit-context.sh', 'murph-lean-audit')

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -3241,6 +3241,7 @@ Updated: 2026-04-24
     expect(repoToolsConfig).toContain("export COBUILD_AUDIT_CONTEXT_INCLUDE_CI_DEFAULT='0'")
     expect(repoToolsConfig).toContain('repo_tools_join_lines COBUILD_AUDIT_CONTEXT_BINARY_EXCLUDE_GLOBS')
     expect(repoToolsConfig).toContain('"apps/*/public/design-assets/**"')
+    expect(repoToolsConfig).toContain('"apps/*/public/audio/**"')
     expect(repoToolsConfig).toContain('"docs/assets/*.jpg"')
     expect(repoToolsConfig).toContain('repo_tools_join_lines COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS')
     expect(repoToolsConfig).toContain('"PRODUCT.md"')
@@ -3272,6 +3273,9 @@ Updated: 2026-04-24
     expect(fullPackageScript).toContain('$review_gpt_pr_context_dir/pr-body.md')
     expect(fullPackageScript).toContain(
       'export COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS="${COBUILD_AUDIT_CONTEXT_BINARY_EXCLUDE_GLOBS:-}"',
+    )
+    expect(fullPackageScript).toContain(
+      'packages/health-commons/content/sources/**',
     )
   })
 
@@ -3374,6 +3378,7 @@ while (( "$#" )); do
   esac
 done
 mkdir -p "$out_dir"
+printf '%s' "\${COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS:-}" > "$out_dir/exclude-globs.txt"
 entries=()
 while IFS= read -r entry; do
   [[ -z "$entry" ]] || entries+=("$entry")
@@ -3460,6 +3465,23 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
         encoding: 'utf8',
       }).trim()
 
+      writeHarnessFile(
+        harnessRoot,
+        'packages/health-commons/content/sources/demo/source.md',
+        'health source\n',
+      )
+      execFileSync('git', ['add', '.'], { cwd: harnessRoot })
+      execFileSync('git', ['commit', '-q', '-m', 'health commons review'], {
+        cwd: harnessRoot,
+      })
+      const healthCommonsHead = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: harnessRoot,
+        encoding: 'utf8',
+      }).trim()
+      execFileSync('git', ['checkout', '-q', '--detach', currentHead], {
+        cwd: harnessRoot,
+      })
+
       execFileSync('git', ['checkout', '-q', '-b', 'non-ancestor', baseHead], {
         cwd: harnessRoot,
       })
@@ -3523,6 +3545,9 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
           ? readdirSync(outDir).find((entry) => entry.endsWith('.zip'))
           : undefined
         return {
+          excludeGlobs: existsSync(path.join(outDir, 'exclude-globs.txt'))
+            ? readFileSync(path.join(outDir, 'exclude-globs.txt'), 'utf8')
+            : '',
           outDir,
           result,
           zipPath: existsSync(exactZipPath)
@@ -3543,6 +3568,9 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
         ].join('\n'),
       })
       expect(preliminary.result.status, preliminary.result.stderr).toBe(0)
+      expect(preliminary.excludeGlobs).toContain(
+        'packages/health-commons/content/sources/**',
+      )
       const preliminaryMetadata = JSON.parse(
         execFileSync(
           'unzip',
@@ -3625,6 +3653,31 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
       expect(preliminaryEntries).not.toContain(
         'review-gpt-pr-context/review-round.json',
       )
+      expect(existsSync(path.join(harnessRoot, 'review-gpt-pr-context'))).toBe(false)
+
+      execFileSync('git', ['checkout', '-q', '--detach', healthCommonsHead], {
+        cwd: harnessRoot,
+      })
+      const healthCommonsPreliminary = invokePackager(
+        'health-commons-preliminary',
+        healthCommonsHead,
+        {
+          REVIEW_GPT_REVIEW_PHASE: 'preliminary',
+          REVIEW_GPT_FIRST_REVIEWED_HEAD: '',
+          REVIEW_GPT_PREVIOUS_REVIEWED_HEAD: '',
+          REVIEW_GPT_ROUND_NUMBER: '',
+        },
+      )
+      expect(
+        healthCommonsPreliminary.result.status,
+        healthCommonsPreliminary.result.stderr,
+      ).toBe(0)
+      expect(healthCommonsPreliminary.excludeGlobs).not.toContain(
+        'packages/health-commons/content/sources/**',
+      )
+      execFileSync('git', ['checkout', '-q', '--detach', currentHead], {
+        cwd: harnessRoot,
+      })
       expect(existsSync(path.join(harnessRoot, 'review-gpt-pr-context'))).toBe(false)
 
       const finalWithSupplementalEvidence = invokePackager(
@@ -4200,7 +4253,7 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
     }
   }, 30_000)
 
-  it('keeps the lean audit bundle smaller than the full one while preserving durable agent docs', () => {
+  it('keeps audit bundles scoped while preserving durable agent docs', () => {
     const leanBundle = createAuditZip('package-audit-context.sh', 'murph-lean-audit')
     const fullBundle = createAuditZip('package-audit-context-full.sh', 'murph-full-audit')
 
@@ -4253,10 +4306,15 @@ done <<< "\${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"
       expect(fullEntries).toContain('agent-docs/PRODUCT_CONSTITUTION.md')
       expect(fullEntries).toContain('agent-docs/PRODUCT_SENSE.md')
       expect(fullEntries).not.toContain('apps/web/public/design-assets/hero-02.png')
+      expect(fullEntries).not.toContain('apps/web/public/audio/challenge-roast.mp3')
       expect(fullEntries).not.toContain('apps/web/public/hero.jpg')
       expect(fullEntries).not.toContain('apps/web/public/legal/privacy.pdf')
       expect(fullEntries).not.toContain('docs/assets/readme-hero.jpg')
-      expect(leanEntries.length).toBeLessThan(fullEntries.length)
+      expect(fullEntries).not.toContain(
+        'packages/health-commons/content/sources/cognitive-offload-before-bed/pmid-29058942.md',
+      )
+      expect(fullEntries).toContain('packages/health-commons/src/runtime.ts')
+      expect(fullEntries).toContain('packages/health-commons/test/runtime.test.ts')
     } finally {
       rmSync(leanBundle.outDir, { force: true, recursive: true })
       rmSync(fullBundle.outDir, { force: true, recursive: true })

--- a/scripts/package-audit-context-full.sh
+++ b/scripts/package-audit-context-full.sh
@@ -353,12 +353,23 @@ if [[ -n "$review_gpt_pr_ref" ]]; then
       > "$review_gpt_pr_context_dir/pr.diff"
     git diff --name-only "$review_gpt_base_oid...$review_gpt_head_oid" \
       > "$review_gpt_pr_context_dir/changed-files.txt"
+    if git diff --quiet --no-renames \
+      "$review_gpt_base_oid...$review_gpt_head_oid" -- packages/health-commons/; then
+      :
+    else
+      review_gpt_health_commons_diff_status="$?"
+      if [[ "$review_gpt_health_commons_diff_status" != "1" ]]; then
+        echo "Error: could not determine whether the PR touches Health Commons." >&2
+        exit "$review_gpt_health_commons_diff_status"
+      fi
+      review_gpt_pr_touches_health_commons=1
+    fi
   else
     echo "Warning: local PR base/head commits are incomplete; falling back to gh pr diff." >&2
     gh pr diff "$review_gpt_pr_ref" --patch > "$review_gpt_pr_context_dir/pr.diff"
     gh pr diff "$review_gpt_pr_ref" --name-only > "$review_gpt_pr_context_dir/changed-files.txt"
-  fi
-  if grep -q '^packages/health-commons/' "$review_gpt_pr_context_dir/changed-files.txt"; then
+    # Without both commits, rename detection cannot reliably expose both paths.
+    # Retain the corpus rather than omit relevant context on an uncertain fallback.
     review_gpt_pr_touches_health_commons=1
   fi
 

--- a/scripts/package-audit-context-full.sh
+++ b/scripts/package-audit-context-full.sh
@@ -20,6 +20,7 @@ review_gpt_rendered_evidence_paths="${REVIEW_GPT_RENDERED_EVIDENCE_PATHS:-}"
 review_gpt_supplemental_evidence_paths="${REVIEW_GPT_SUPPLEMENTAL_EVIDENCE_PATHS:-}"
 review_gpt_full_review_reason="${REVIEW_GPT_FULL_REVIEW_REASON:-}"
 review_gpt_context_mode="full_snapshot"
+review_gpt_pr_touches_health_commons=0
 
 if [[ -n "$review_gpt_full_review_reason" ]] \
   && [[ -z "${review_gpt_full_review_reason//[[:space:]]/}" ]]; then
@@ -357,6 +358,9 @@ if [[ -n "$review_gpt_pr_ref" ]]; then
     gh pr diff "$review_gpt_pr_ref" --patch > "$review_gpt_pr_context_dir/pr.diff"
     gh pr diff "$review_gpt_pr_ref" --name-only > "$review_gpt_pr_context_dir/changed-files.txt"
   fi
+  if grep -q '^packages/health-commons/' "$review_gpt_pr_context_dir/changed-files.txt"; then
+    review_gpt_pr_touches_health_commons=1
+  fi
 
   COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS="${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"$'\n'"$review_gpt_pr_context_dir/pr-body.md"$'\n'"$review_gpt_pr_context_dir/pr.diff"$'\n'"$review_gpt_pr_context_dir/changed-files.txt"
   if [[ "$review_gpt_review_phase" == "preliminary" ]]; then
@@ -508,6 +512,11 @@ else
   export COBUILD_AUDIT_CONTEXT_INCLUDE_CI_DEFAULT='1'
 fi
 export COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS="${COBUILD_AUDIT_CONTEXT_BINARY_EXCLUDE_GLOBS:-}"
+if [[ "$review_gpt_context_mode" != "same_thread_delta" ]] \
+  && [[ "$review_gpt_pr_touches_health_commons" != "1" ]]; then
+  COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS+=$'\n'"packages/health-commons/content/sources/**"
+  export COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS
+fi
 if [[ "$review_gpt_context_mode" != "same_thread_delta" ]]; then
   repo_tools_join_lines COBUILD_AUDIT_CONTEXT_SCAN_SPECS \
     "agent-docs/product-specs" \

--- a/scripts/repo-tools.config.sh
+++ b/scripts/repo-tools.config.sh
@@ -69,6 +69,7 @@ export COBUILD_AUDIT_CONTEXT_INCLUDE_DOCS_DEFAULT='0'
 export COBUILD_AUDIT_CONTEXT_INCLUDE_CI_DEFAULT='0'
 audit_context_binary_exclude_globs=(
   "apps/*/public/design-assets/**"
+  "apps/*/public/audio/**"
   "apps/*/public/legal/*.pdf"
   "apps/*/public/*.jpg"
   "apps/*/public/*.jpeg"


### PR DESCRIPTION
## Why

ReviewGPT full snapshots carried non-reviewable web audio and thousands of Health Commons source documents into unrelated PR reviews. That increased attachment size and upload/run time without adding useful review context.

## User goal / user-visible behavior

Keep ReviewGPT review packages focused and materially smaller. Developers use the same commands; the full package is 39.9% smaller on the same commit. There is no member-facing behavior change.

## User experience

No member-facing UX changes. Reviewers receive smaller artifacts with the executable source, tests, configuration, and documentation they still need.

## Invariants

- Source, tests, documentation, and CI configuration remain available to reviewers.
- The Health Commons authored corpus remains included whenever either side of a PR change touches `packages/health-commons/**`, including rename-out changes.
- If local base/head history is unavailable, packaging retains the Health Commons corpus rather than omitting context on an uncertain fallback.
- Later-round same-thread delta packaging remains driven by the explicit changed-path set.
- Existing sensitive and generated-output exclusions remain unchanged.

## Non-obvious affected surfaces

The shared binary exclusion list also applies to lean audit packages, so web audio is excluded there as well. The actual ZIP coverage tests prove that representative runtime source and tests remain present and that an unchanged Health Commons corpus sibling remains present after another corpus file is renamed outside the package.

## Architecture and reuse

- Existing systems reused: the existing exclude-glob configuration, PR diff, generated changed-files manifest, and ReviewGPT packaging test harness.
- New logic: one no-renames path-scoped diff check conditionally adds one Health Commons corpus exclusion for unrelated full snapshots.
- New abstractions: none; the existing packaging environment contract is sufficient.
- Complexity intentionally avoided: no manifest engine, dependency allowlist, package-graph machinery, or dependency changes.

## Changelog

- Changelog: not applicable
- Reason: internal review tooling only; no member-visible behavior changes.

## Operational impacts

- Hot reply path impact: not applicable; no runtime messaging path changes.
- Database collection fanout impact: not applicable; no database or collection work.
- Murph initial provider input impact:
  - Individual: not applicable; no provider input changes.
  - Group: not applicable; no provider input changes.
- Deployment skew: not applicable; no deployable runtime behavior changes.

## Preliminary specialist lenses

- Product experience: not applicable; no product behavior or member UX.
- Prompt: not applicable; no assistant or provider prompt changes.
- Frontend: not applicable; no frontend code or rendered surface changes.
- Coverage: applicable; ReviewGPT found one rename-out edge case. It was resolved by inspecting both sides through a no-renames diff and adding actual-ZIP regression proof. The preliminary pass is not rerun after substantive remediation.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 136 | 3 |
| Docs | 84 | 0 |
| Config/tooling | 21 | 0 |
| Generated/other | 0 | 0 |
| Total | 241 | 3 |

No binary files changed.

## Verification

- `bash -n scripts/repo-tools.config.sh scripts/package-audit-context-full.sh`
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` — 43 passed, 1 skipped
- `pnpm --dir packages/cli typecheck`
- `pnpm test:repo-tools` — 527 passed
- Same-head packaging proof: 60,270,658 bytes / 18,930 entries before; 36,222,640 bytes / 11,337 entries after (39.9% reduction)
- Representative Health Commons runtime source and test remain present; representative web audio and unrelated Health Commons corpus files are absent.
- Rename-out proof generates a real ZIP and confirms the unchanged Health Commons corpus sibling remains present.

## Design proof

Not applicable; no frontend or user-facing UI changes.
