### PR TITLE
Give scheduled reminder phases unique identities

### DIFF
--- a/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-scheduled-reminder-e2e.test.ts
@@ -82,6 +82,9 @@ const scheduledReminderInstructions =
   "Send the user the hosted-local sleep reminder: go to sleep.";
 const scheduledImageReminderInstructions =
   "Send the user the hosted-local sleep reminder with a simple sleep illustration.";
+const scheduledImageReminderTitle = "Sleep image reminder";
+const overlapReminderTitle = "Overlapping sleep reminder";
+const scheduledNutritionCardTitle = "Daily nutrition card reminder";
 const scheduledReminderMinimumRunwayMs = 5_000;
 const scheduledReminderSendWaitMs = 60_000;
 const scheduledReminderCompletionWaitMs = 60_000;
@@ -155,6 +158,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         dueAtIso: scheduledReminderTimes.dueAtIso,
         instructions: scheduledImageReminderInstructions,
         text: setupReplyText,
+        title: scheduledImageReminderTitle,
       }),
       { matchInputContains: scheduledImageSetupRequestText },
     );
@@ -340,6 +344,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         dueAtIso: overlapSetupTimes.dueAtIso,
         instructions: scheduledReminderInstructions,
         text: setupReplyText,
+        title: overlapReminderTitle,
       }),
       { matchInputContains: setupRequestText },
     );
@@ -484,6 +489,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
         dueAtIso: scheduledCardSetupTimes.dueAtIso,
         instructions: scheduledNutritionCardInstructions,
         text: setupReplyText,
+        title: scheduledNutritionCardTitle,
       }),
       { matchInputContains: scheduledNutritionCardSetupRequestText },
     );
@@ -584,7 +590,7 @@ describe("hosted local Linq scheduled reminder e2e", () => {
     })).toBe(scheduledCardCapabilityBaselineCount + 1);
     expect(requireLinqStub().countObservedSends(reminderPath))
       .toBe(scheduledCardTotalSendBaselineCount + 1);
-  }, 900_000);
+  }, 720_000);
 });
 
 describe("hosted local Linq scheduled reminder timing helpers", () => {
@@ -629,6 +635,47 @@ describe("hosted local Linq scheduled reminder timing helpers", () => {
     expect(() => resolveScheduledReminderLocalAt("2026-06-18T12:02:30.000Z"))
       .toThrow("Expected a minute-aligned scheduled reminder timestamp");
     expect(scheduledReminderLeadMs).toBeGreaterThan(scheduledReminderMinimumRunwayMs);
+  });
+
+  it("uses distinct create-only automation identities across scenario phases", () => {
+    const dueAtIso = "2026-06-18T12:02:00.000Z";
+    const scriptedSaves = [
+      {
+        instructions: scheduledImageReminderInstructions,
+        title: scheduledImageReminderTitle,
+      },
+      {
+        instructions: scheduledReminderInstructions,
+        title: overlapReminderTitle,
+      },
+      {
+        instructions: scheduledNutritionCardInstructions,
+        title: scheduledNutritionCardTitle,
+      },
+    ].map(({ instructions, title }) => buildHostedAssistantAutomationSaveResponses({
+      dueAtIso,
+      instructions,
+      text: setupReplyText,
+      title,
+    })[0]);
+
+    expect(scriptedSaves).toEqual([
+      expect.objectContaining({
+        customToolCall: expect.objectContaining({
+          input: expect.stringContaining(`"title":"${scheduledImageReminderTitle}"`),
+        }),
+      }),
+      expect.objectContaining({
+        customToolCall: expect.objectContaining({
+          input: expect.stringContaining(`"title":"${overlapReminderTitle}"`),
+        }),
+      }),
+      expect.objectContaining({
+        customToolCall: expect.objectContaining({
+          input: expect.stringContaining(`"title":"${scheduledNutritionCardTitle}"`),
+        }),
+      }),
+    ]);
   });
 });
 
@@ -851,6 +898,7 @@ function buildHostedAssistantAutomationSaveResponses(input: {
   dueAtIso: string;
   instructions: string;
   text: string;
+  title: string;
 }): readonly HostedLocalAssistantProviderScriptedResponse[] {
   return [
     buildAssistantProviderMurphToolCall("automation", {
@@ -863,7 +911,7 @@ function buildHostedAssistantAutomationSaveResponses(input: {
       },
       summary: "One-shot sleep reminder.",
       tags: ["assistant", "scheduled"],
-      title: "Sleep reminder",
+      title: input.title,
     }),
     input.text,
   ];


### PR DESCRIPTION
## Why this PR exists

The scheduled-reminder predeploy fixture creates three sequential one-shot automations. Hosted generic automation saves are now create-only, but the fixture gave every phase the same title-derived identity, so the second save conflicted and the test waited for a scheduled response that could never start.

## User goal / user-visible behavior

Restore the protected reminder deployment proof without changing production behavior. Each scenario phase now creates its own automation identity and continues to prove image delivery, foreground overlap ordering, and native nutrition-card delivery.

## User experience

No user-facing effect. This test-only correction makes the fixture follow the production create-only contract and fail locally if its three automation identities collapse again.

## Invariants

- Generic hosted automation saves remain create-only; the fixture must not weaken or bypass that contract.
- Model-authored one-shots continue to use canonical `schedule.localAt` input.
- The three scenario phases remain distinct reminders with the same existing timing, route, and delivery assertions.
- The per-test budget returns to 12 minutes; a fixture collision must fail through bounded waits rather than be hidden by a larger wrapper timeout.

## Changelog

- Changelog: not applicable
- Reason: This changes only an internal predeploy test fixture and has no member-visible behavior.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: The diff is test-only, but it protects a production deployment boundary and should retain full context if later review is required.

## Review lenses

- Product experience: not applicable; member timing, feedback, permissions, and recovery behavior do not change.
- Prompt: not applicable; no production prompt, tool description, schema, or instruction stack changes.
- Frontend: not applicable; no UI, interaction, or design-catalog surface changes.
- Coverage: applicable; the added helper proof asserts three distinct create-only identities before the Docker-backed scenario runs.
- Direct scenario evidence: the failed protected run selected the merged public commit, passed every sibling gate, then timed out without an assertion after its second create-only save collided. Focused identity/timing tests, Cloudflare typecheck, and all diff-aware tests pass locally; the protected gate remains the authoritative Docker-backed proof.
- Exact-head CI status: pending on the pushed candidate.
- Rendered evidence: not applicable because the frontend lens is not applicable.
- Affected prompt stack: none.

## Non-obvious affected surfaces

The private production workflow selects this public hosted-local test as a predeploy gate. The fixture builds generic saves whose title supplies the default automation identity, so repeated titles now conflict by design.

## Architecture and reuse

- Existing systems reused: The existing hosted-local scripted-provider helper, production automation tool, and protected deployment gate remain the sole owners.
- New logic: Each of the three fixture phases passes an explicit unique title to the existing save-response builder.
- New abstractions: No shared abstraction is added; the file-local builder simply requires the identity it already emits.
- Complexity intentionally avoided: No production compatibility shim, upsert fallback, workflow bypass, retry layer, or timeout expansion is introduced.

## Hot reply path impact

- Path status: Not applicable because only a hosted-local E2E fixture changes.
- Database calls: None in production.
- Network/provider calls: None in production.
- Other awaited latency: None in production.
- Before/after proof: `pnpm test:diff` passes the affected Cloudflare Node and Worker suites.

## Murph initial provider input impact

Not applicable. The diff changes only scripted provider responses in a hosted-local test and does not alter production provider-visible instructions, tools, schemas, history, or generated guidance.

## Design proof

- Design page: Not applicable because no frontend UI changed.
- Coverage: Not applicable.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: The only tracked file is a hosted-local `*.test.ts` fixture, so every changed line is Tests / fixtures. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 50 | 2 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **50** | **2** |

## Verification

- focused scheduled-reminder timing and create-only identity tests — pass (2 tests; full scenario excluded)
- Cloudflare typecheck — pass
- `pnpm test:diff` — pass (143 Node-test files / 2,433 tests; 5 Worker-test files / 12 tests)
- full local hosted scenario — unavailable because Docker is not installed locally; the protected deployment gate remains the authoritative Docker-backed validation
- diff check and direct-identifier privacy scan — pass

## Review disposition

- Root cause is confirmed in production code: hosted generic saves pass `createOnly: true`, identity derives from title when no slug is supplied, and the old fixture reused one title for all three saves.
- This isolated test-only correction follows the prior completion-specialists review and protected-gate evidence. Per the completion-audit workflow, no additional preliminary specialist pass or final ReviewGPT gate is required; exact-head CI and parent review still apply.
