### PR TITLE
Page pooled database connection errors to operator phones

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Murph Architecture
 
-Last verified: 2026-08-12
+Last verified: 2026-08-13
 
 ## Accepted-Message Targeting
 
@@ -1243,13 +1243,19 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   family stays null and its canonical allowlisted name is retained, while
   available families continue to drive their own conditions. Missing data is
   never treated as zero. Unusable collections receive one bounded confirmation
-  attempt. Usable partial collections stay single-pass whenever available
-  evidence is unsafe; a safe observation missing only the direct-error counter
-  uses the same confirmation budget. The confirmation's available signals are
-  evaluated, a recovered counter joins the original complete gauge evidence,
-  and failure or continued absence retains the original incomplete observation.
-  A telemetry-only notification opens after two
-  consecutive incomplete or failed collections. The first two-check threshold
+  attempt. The connection-error family retains the expected ports 5432
+  and 6432 as independent region-plus-port monotonic series. Missing either
+  port leaves that family unknown, while an observed port can still contribute
+  unsafe evidence. Usable partial collections stay single-pass whenever
+  available evidence is unsafe; a safe observation missing only part or all of
+  the connection-error family uses the same confirmation budget. The
+  confirmation's available signals are evaluated, complementary observed ports
+  may join the original complete gauge evidence, and failure or continued
+  absence retains the original incomplete observation. Each observed port
+  advances only its usable baseline; an omitted port retains its prior baseline,
+  and new or reset region series are independently suppressed so an old delta is
+  never replayed. A telemetry-only notification opens after two consecutive
+  incomplete or failed collections. The first two-check threshold
   window counts incomplete versus unavailable observations, unions only
   canonical missing families observed on partial checks, and uses the threshold
   time as the window end; one bounded evidence value on each existing sample
@@ -1257,48 +1263,53 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   existing incident row survives a busy pending slot, restart, and recovery
   until a telemetry-bearing page is acknowledged. Recovery and another metric
   gap before that acknowledgment coalesce into the same unresolved operator
-  notification instead of creating a backlog; the first threshold window remains
-  authoritative. An owed telemetry page
-  alone does not occupy a closed provider fence. Before an incident admits its
-  first page, concrete evidence—including a direct-error delta—that appears on
-  the threshold or a later sample persists in one combined immutable body, so
-  the exact pressure and truthful
-  telemetry facts share the next eligible attempt and one acknowledgment cycle.
+  notification instead of creating a backlog; the first threshold window
+  remains authoritative. An owed telemetry page alone does not occupy a closed
+  provider fence. Before an incident admits its
+  first page, concrete evidence—including either connection-error category—that
+  appears on the threshold or a later sample persists in one combined immutable
+  body, so the exact pressure and truthful telemetry facts share the next
+  eligible attempt and one acknowledgment cycle.
   An acknowledged-incident recurrence waits for the eligible sample, which
-  includes any still-current unsafe evidence and labels
-  historical telemetry by its own observation time. A later complete collection rearms
-  telemetry only after the obligation is acknowledged. Its additive alert-state
-  and sample-evidence columns
-  preserve the existing schema
-  version; current code also recognizes a telemetry pending body cleared by the
+  includes any still-current unsafe evidence and labels historical telemetry by
+  its own observation time. A later complete collection rearms telemetry only
+  after the obligation is acknowledged. Its additive alert-state and
+  sample-evidence columns preserve the existing schema version; current code
+  also recognizes a telemetry pending body cleared by the
   prior Worker, preventing a duplicate after rollback and re-upgrade. Concrete
   unsafe conditions retain paced recurrence, but acknowledged monitoring
   evidence cannot enter their later pages without a currently owed obligation.
-  First-incident
-  and non-replayable direct-error alert
-  admission shares one synchronous SQLite transaction with sample/baseline
-  persistence; an inside-fence direct-error body excludes co-occurring
+  Port 5432 retains the direct migration-admission interpretation. Port 6432 is
+  reported only as pooled application connection errors because the provider
+  metric has no reason label and cannot identify a specific rejection cause.
+  First-incident and non-replayable connection-error alert admission shares one
+  synchronous SQLite transaction with sample/baseline
+  persistence; an inside-fence connection-error body excludes co-occurring
   replayable evidence, and acknowledged replayable recurrence is admitted only
-  from the current sample once the attempt fence opens. Any direct-error delta
-  observed while the single immutable message slot is occupied accumulates as
-  count-plus-check-time evidence in the same alert row and transaction that
-  advances the persisted sample baseline. After the older message is
-  acknowledged, the next run atomically promotes that evidence into the one
-  pending message slot; provider pacing still applies, and retry never mutates
-  a provider-entered body. Before posting, the monitor resolves both direct
-  chats and requires two distinct sole external recipients. Primary recipient
+  from the current sample once the attempt fence opens. Any connection-error
+  delta observed while the single immutable message slot is occupied
+  accumulates as category-specific count-plus-check-time evidence in the same
+  alert row and transaction that advances the persisted sample baseline. After
+  the older message is acknowledged, the next run atomically promotes that
+  evidence into the one pending message slot; provider pacing still applies,
+  and retry never mutates a provider-entered body. Before posting, the monitor
+  resolves both direct chats and requires two distinct sole external recipients.
+  Primary recipient
   identity is a prerequisite for secondary provider entry, so an unresolved
   primary identity suppresses both operations while an unresolved secondary
   identity may still allow the primary. Delivery health is independent from
   identity: a known but unhealthy primary destination does not block a healthy,
   distinct secondary. If distinct chats resolve to the same recipient, only
   the primary operation may enter Linq and the page stays pending until
-  configuration is corrected. Otherwise the two
-  direct-chat deliveries settle independently: the primary retains the existing
+  configuration is corrected. Otherwise the two direct-chat deliveries settle
+  independently: the primary retains the existing
   idempotency key, the secondary uses a stable derived key, and a partial
   failure retains the pending page for a later globally paced replay. Only
-  acknowledged entry to both distinct recipients clears a pending page. SQLite
-  contains no connection URL,
+  acknowledged entry to both distinct recipients clears a pending page. The
+  legacy physical SQLite sample column names remain deliberately compatible;
+  current code stores the generalized two-port baseline and aggregate delta in
+  them, while additive pooled-defer columns keep schema version 1 rollback-safe.
+  SQLite contains no connection URL,
   credential, query, member identifier, phone number, or raw response. This is
   operational monitoring history, never health truth, routing authority, or a
   product control plane.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-08-12
+Last verified: 2026-08-13
 
 ## Current Guardrails
 
@@ -260,14 +260,20 @@ Last verified: 2026-08-12
   second, outside any storage transaction. Only an exhausted two-attempt
   collection increments the consecutive-failure state. A usable partial
   observation remains single-pass when any available signal is unsafe, so
-  concrete evidence is evaluated without delay. When the only absent family is
-  the direct-error counter and every available signal is safe, the monitor uses
-  that same bounded retry as a confirmation scrape. Every available confirmation
-  signal is evaluated; a recovered direct counter is merged with the original
-  complete gauge evidence, while a failed or still-incomplete confirmation
-  retains the original partial observation. This makes transient counter-family
-  omission less noisy without converting unknown to zero or weakening the
-  two-check telemetry fallback.
+  concrete evidence is evaluated without delay. The connection-error family
+  expects direct port 5432 and pooled application port 6432, keyed by port and
+  region so their counters cannot collide. Missing either expected port leaves
+  the family unknown. An observed port can still produce a positive
+  non-replayable condition; when every available signal is safe and only this
+  family is incomplete, the monitor uses that same bounded retry as a
+  confirmation scrape. Every available confirmation signal is evaluated;
+  complementary observed ports can be composed with the original complete
+  gauge evidence, while a failed or still-incomplete confirmation retains the
+  original partial observation. Each observed port replaces and advances only
+  its own usable series baseline, an omitted port retains its prior baseline,
+  and new or reset region series are independently suppressed. This makes
+  transient counter-family omission less noisy without converting unknown to
+  zero, replaying an old delta, or weakening the two-check telemetry fallback.
   Discovery, scrape, parse, or incomplete required metrics must recur on two
   consecutive runs before paging the monitoring condition. Crossing that
   threshold persists one bounded telemetry-page obligation in the existing
@@ -276,47 +282,53 @@ Last verified: 2026-08-12
   partial checks, and uses the threshold time as its window end. One bounded
   evidence value on each existing sample preserves that aggregate provenance
   across restart. The obligation survives an occupied pending-message slot,
-  restart, recovery, and direct-error-only prioritization; only acknowledgment
-  of a pending body that includes the monitoring condition clears it. Recovery
-  and another threshold before acknowledgment deliberately coalesce into that
-  unresolved notification, retaining the first threshold window; this monitor
-  does not maintain an outage backlog. The additive columns retain the existing
-  schema version so a rollback Worker can ignore them. Current code recognizes
-  the prior Worker's cleared pending key/body with the telemetry marker still set
-  as an acknowledgment and removes the stale obligation before re-admission.
-  A newly opened incident or one-shot direct migration admission failure admits
-  its exact body and idempotency key in the same synchronous SQLite transaction
-  that persists the sample and advances any direct-error counter baseline.
-  If another immutable page already owns the single pending-message slot, the
-  same transaction advances the sample baseline and accumulates the later
-  direct-error count plus latest check time in the existing alert row instead
-  of dropping it. An acknowledged older page cannot close the incident while
-  that evidence remains. The next run with a free slot atomically promotes the
-  accumulated count into one non-replayable page, retaining any owed telemetry
-  condition in the same body, which then follows the ordinary attempt fence,
-  health preflight, exact-body retry, and restart contract.
-  When a direct error forces admission inside an acknowledged incident's
-  closed attempt fence, that pending body contains the non-replayable direct
-  error plus any durable telemetry obligation already available at admission;
-  co-occurring replayable gauges remain in the persisted sample but cannot
-  become stale pending claims. Pure deferred evidence keeps its stored check
-  time; when a current direct-error delta joins the promoted count, the page uses
-  the latest included check. Historical telemetry carries its separate
-  observation time. That exact combined page owns the next eligible attempt and
+  restart, recovery, and connection-error-only prioritization; only
+  acknowledgment of a pending body that includes the monitoring condition
+  clears it. Recovery and another threshold before acknowledgment deliberately
+  coalesce into that unresolved notification, retaining the first threshold
+  window; this monitor does not maintain an outage backlog. The additive
+  columns retain the existing schema version so a rollback Worker can ignore
+  them. Current code recognizes the prior Worker's cleared pending key/body with
+  the telemetry marker still set as an acknowledgment and removes the stale
+  obligation before re-admission.
+  A newly opened incident or one-shot connection-error condition admits its
+  exact body and idempotency key in the same synchronous SQLite transaction
+  that persists the sample and advances the generalized connection-error
+  counter baseline. Port 5432 retains direct migration-admission wording. Port
+  6432 is a distinct pooled application connection-error condition; the metric
+  has no reason label, so the page cannot claim a specific provider rejection
+  reason. If another immutable page already owns the single pending-message
+  slot, the same transaction advances the sample baseline and accumulates each
+  later category's count plus latest check time in the existing alert row
+  instead of dropping it. An acknowledged older page cannot close the incident
+  while that evidence remains. The next run with a free slot atomically
+  promotes the accumulated categories into one non-replayable page, retaining
+  any owed telemetry condition in the same body, which then follows the
+  ordinary attempt fence, health preflight, exact-body retry, and restart
+  contract.
+  When a connection error forces admission inside an acknowledged incident's
+  closed attempt fence, that pending body contains only the non-replayable
+  connection-error categories plus any durable telemetry obligation already
+  available at admission; co-occurring replayable gauges remain in the
+  persisted sample but cannot become stale pending claims. Pure deferred
+  evidence keeps the latest stored check time among its included categories;
+  when a current connection-error delta joins the promoted counts, the page
+  uses the current check. Historical telemetry carries its separate observation
+  time. That exact combined page owns the next eligible attempt and
   acknowledgment clears the represented telemetry obligation, avoiding a
   second notification lifecycle.
   A replayable condition still unsafe at that boundary remains eligible for the
   following paced recurrence. The same one-slot ordering applies in reverse: a
-  later direct-error obligation waits behind an older page but cannot be consumed
-  by the counter baseline. This explicit prioritization keeps admitted bodies
-  immutable without another message queue or delivery lifecycle.
+  later connection-error obligation waits behind an older page but cannot be
+  consumed by the counter baseline. This explicit prioritization keeps admitted
+  bodies immutable without another message queue or delivery lifecycle.
   An acknowledged incident's replayable gauge does not admit stale evidence
   while the attempt fence is closed; once the fence opens, a still-unsafe
   current gauge admits the recurrence. An unadmitted monitoring obligation does
   not occupy a closed provider fence. Until an incident admits its first page,
-  concrete evidence, including a direct-error delta, that appears on the
-  threshold or a later sample persists in one combined immutable body with
-  exact identity, concrete check time, and
+  concrete evidence, including either connection-error category, that appears
+  on the threshold or a later sample persists in one combined immutable body
+  with exact identity, concrete check time, and
   condition-local telemetry time; both facts share the first eligible attempt
   and one acknowledgment cycle. For an acknowledged-incident
   recurrence, the first eligible sample supplies any still-current concrete
@@ -369,6 +381,11 @@ Last verified: 2026-08-12
   filtering: at the hourly cap, one incident traverses one hundred reviewed
   leads before repeating one. Literal reviewed data avoids a prose generator,
   provider dependency, or second runtime copy owner.
+  The physical SQLite sample columns deliberately retain their schema-v1
+  `direct_connection_error_*` names for rollback compatibility. Current code
+  stores the generalized two-port baseline and aggregate delta in those columns;
+  pooled deferred evidence uses additive category-specific columns without a
+  schema-version increment.
   Telemetry-only copy instead states that monitoring is incomplete or
   unavailable and cannot claim that the database itself is under pressure.
   Message variation must remain contextual and deterministic, never random

--- a/agent-docs/exec-plans/active/2026-08-13-db-rejection-phone-alert.md
+++ b/agent-docs/exec-plans/active/2026-08-13-db-rejection-phone-alert.md
@@ -1,0 +1,53 @@
+# Page pooled database connection errors to operator phones
+
+Status: active
+Created: 2026-08-13
+Updated: 2026-08-13
+
+## Goal
+
+- Every observed pooled application connection-error delta reaches the existing independent operator phone-alert owner even while the primary Web database is refusing clients, without leaking query, credential, member, or route data.
+
+## Success criteria
+
+- A positive pooled-port provider connection-error delta, including the signal produced by a PgBouncer `max_client_conn` rejection, produces one durable, coalesced alert obligation and delivery to both configured operator destinations.
+- Repeated failures coalesce without suppressing a later recurrence after recovery.
+- Alert ingestion and persistence require no primary Postgres connection.
+- Existing database-health paging, retry, acknowledgement, and telemetry-outage semantics remain intact.
+- Focused tests, typecheck, ReviewGPT specialist/final gates, and required PR CI pass.
+
+## Scope
+
+- In scope: provider connection-error counters for direct port 5432 and pooled application port 6432; independent Cloudflare database-health persistence and phone delivery; bounded metadata-only evidence; deployment and monitoring documentation.
+- Out of scope: increasing database limits, changing application retry authority, alerting on ordinary query/application errors, or making the alert path a database recovery owner.
+
+## Constraints
+
+- Technical constraints: the reporting path must survive primary-database exhaustion, preserve non-replayable counter evidence, pace pages, and add no database call to failure reporting.
+- Product/process constraints: reuse the existing operator phone conversation and avoid copying confidential incident evidence into repository artifacts.
+
+## Risks and mitigations
+
+1. Risk: a per-failure bridge amplifies an outage into another request storm.
+   Mitigation: prefer provider counters or a bounded coalescing owner and prove maximum event/page fanout.
+2. Risk: counter reset or delayed delivery creates a false or lost page.
+   Mitigation: retain the existing monotonic-series baseline, reset handling, durable owed-page, and recurrence tests.
+3. Risk: alert text leaks driver or query detail.
+   Mitigation: persist and render only allowlisted category/count/time metadata.
+
+## Tasks
+
+1. Inspect the exact Prisma classifier, PlanetScale pooled-port metrics, and Cloudflare database-health lifecycle.
+2. Have ReviewGPT select and implement the smallest independent durable signal path with focused tests and docs.
+3. Inspect the patch, verify failure/recovery/coalescing/privacy behavior, and remediate findings.
+4. Push the exact candidate, run specialist and final ReviewGPT gates with CI, and open the PR.
+
+## Decisions
+
+- The alert owner remains the Cloudflare database-health singleton; Postgres cannot be the signal store because this alert specifically covers its admission failure.
+- Scope is exact connection admission/limit rejection, not every SQL failure.
+
+## Verification
+
+- Commands to run: focused Cloudflare database-health and Web Prisma classifier tests; affected package typechecks; `git diff --check`; required exact-head CI.
+- Expected outcomes: one durable two-destination page for a new rejection window, no page replay on unchanged/reset counters, no secret-bearing metadata, and a later recovered recurrence pages again.

--- a/agent-docs/exec-plans/completed/2026-08-13-db-rejection-phone-alert.md
+++ b/agent-docs/exec-plans/completed/2026-08-13-db-rejection-phone-alert.md
@@ -1,6 +1,6 @@
 # Page pooled database connection errors to operator phones
 
-Status: active
+Status: completed
 Created: 2026-08-13
 Updated: 2026-08-13
 
@@ -37,17 +37,21 @@ Updated: 2026-08-13
 
 ## Tasks
 
-1. Inspect the exact Prisma classifier, PlanetScale pooled-port metrics, and Cloudflare database-health lifecycle.
-2. Have ReviewGPT select and implement the smallest independent durable signal path with focused tests and docs.
-3. Inspect the patch, verify failure/recovery/coalescing/privacy behavior, and remediate findings.
-4. Push the exact candidate, run specialist and final ReviewGPT gates with CI, and open the PR.
+1. [x] Inspect the exact Prisma classifier, PlanetScale pooled-port metrics, and Cloudflare database-health lifecycle.
+2. [x] Have ReviewGPT select and implement the smallest independent durable signal path with focused tests and docs.
+3. [x] Inspect the patch, verify failure/recovery/coalescing/privacy behavior, and remediate findings.
+4. [x] Push the exact candidate, run specialist and final ReviewGPT gates with CI, and open the PR.
 
 ## Decisions
 
 - The alert owner remains the Cloudflare database-health singleton; Postgres cannot be the signal store because this alert specifically covers its admission failure.
 - Scope is exact connection admission/limit rejection, not every SQL failure.
+- The PlanetScale counter lacks a rejection-reason label, so port 6432 alerts use factual pooled application connection-error wording rather than claiming every delta was specifically `max_client_conn`.
+- A legacy region-only 5432 baseline cannot be compared safely with the new region-plus-port key. The upgrade therefore establishes a new direct-port baseline once, suppressing that first ambiguous delta without replaying it.
 
 ## Verification
 
-- Commands to run: focused Cloudflare database-health and Web Prisma classifier tests; affected package typechecks; `git diff --check`; required exact-head CI.
-- Expected outcomes: one durable two-destination page for a new rejection window, no page replay on unchanged/reset counters, no secret-bearing metadata, and a later recovered recurrence pages again.
+- Passed: focused Cloudflare metric, monitor, store, Worker-boundary, and scheduled Durable Object tests; Cloudflare typecheck; `git diff --check`; and exact-head required GitHub Actions.
+- ReviewGPT: preliminary product/coverage specialist pass and final full-patch audit both passed with no qualifying findings.
+- Direct proof: one durable two-destination page for a new pooled-error window, no replay on unchanged/reset counters, no secret-bearing metadata, and a later recovered recurrence pages again.
+Completed: 2026-08-13

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -101,14 +101,17 @@ provider-no-replay recovery, are jointly specified by
 `agent-docs/references/hosted-runtime-protocol.md`.
 
 Independent partial PlanetScale metric normalization, explicit unknown-family
-evidence, continued evaluation of available database signals, bounded safe
-direct-counter-only confirmation with cross-scrape evidence composition and
-without suppressing unsafe observations, and one-shot telemetry-only operator
-paging with unresolved-window coalescing, current-pressure
-priority including direct errors in one combined pre-first-page incident,
-post-ack recurrence suppression, durable owed-page preservation inside
-non-replayable direct-error admission, truthful direct-error and mixed telemetry
-window provenance, and rollback-compatible additive state are
+evidence when either expected connection-error port is missing, continued
+evaluation of available database signals, per-port baseline advancement with
+new/reset suppression, bounded safe connection-error confirmation with
+cross-scrape port composition and without suppressing unsafe observations, and
+one-shot telemetry-only operator paging with unresolved-window coalescing,
+current-pressure priority including direct and pooled connection errors in one
+combined pre-first-page incident, post-ack recurrence suppression, durable
+owed-page preservation inside non-replayable category-specific admission,
+truthful connection-error and mixed telemetry window provenance, and
+rollback-compatible additive state with deliberately compatible physical sample
+columns are
 jointly specified by `ARCHITECTURE.md`,
 `agent-docs/RELIABILITY.md`, `agent-docs/references/testing-ci-map.md`, and
 `apps/cloudflare/README.md`.

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -567,31 +567,35 @@ supported provider credential.
   bounded monitor query. It also proves that recent resumed activity survives
   seven-day trace cleanup through quiet-hour deferral and alerts after quiet
   hours, while a fully stale trace is deleted.
-- `apps/cloudflare/test/database-health-{metrics,monitor,worker}.test.ts`
-  covers the independent PlanetScale/Linq database-health plane. The tests
-  prove strict per-family metric normalization, explicit unknowns for missing
-  required series, continued evaluation of available signals, positive
-  direct-port counter deltas with reset/new-series suppression across complete
-  and partial samples, one bounded confirmation for a safe direct-counter-only
-  omission, multi-family confirmation rejection, cross-scrape evidence
-  composition, immediate unsafe-signal paging before that confirmation, unsafe
-  confirmation-signal paging, failed-confirmation retention, positive
-  recovered-counter deltas, persistent-gap telemetry paging, and the scheduled
-  Durable Object boundary for that retry,
+- `apps/cloudflare/test/database-health-{metrics,monitor,store,worker}.test.ts`
+  and `apps/cloudflare/test/workers/database-health-e2e.test.ts` cover the
+  independent PlanetScale/Linq database-health plane. The tests prove strict
+  per-family metric normalization, explicit unknowns when either expected
+  connection-error port is missing, collision-free region-plus-port series,
+  continued evaluation of available signals, positive 5432 and 6432 deltas,
+  and independent reset/new-series suppression across complete and partial
+  samples. They also prove per-port baseline advancement with omitted-port
+  retention, one bounded confirmation for a safe connection-error-family
+  omission, multi-family confirmation rejection, cross-scrape port composition,
+  immediate unsafe-signal paging before that confirmation, unsafe confirmation
+  paging without losing the complementary baseline, failed-confirmation
+  retention, positive recovered-counter deltas, persistent-gap telemetry
+  paging, and the scheduled Durable Object boundary for that retry,
   SQLite sample persistence and 30-day pruning, concrete
   connection thresholds, two-failure collection hysteresis, one acknowledged
   page per unresolved telemetry-notification window, recovered threshold
   coalescing before acknowledgment, truthful partial-then-unavailable,
   unavailable-then-partial, and different-family partial-window summaries with
   bounded observed evidence, failed-scrape incident preservation,
-  telemetry obligation retention behind older pending and direct-error-only
+  telemetry obligation retention behind older pending and connection-error-only
   pages across restart and recovery, current-pressure priority at the first
   eligible provider slot with historical observation time, exact combined
-  pressure, telemetry, and direct-error retention when concrete evidence appears
-  at or after the unadmitted threshold across recovery and restart,
-  rollback-compatible additive SQLite alert-state migration and legacy-ack
-  normalization, recovery reset and rearming, post-ack monitoring suppression
-  inside concrete-pressure
+  pressure, telemetry, and category-specific connection-error retention when
+  concrete evidence appears at or after the unadmitted threshold across
+  recovery and restart, rollback-compatible additive SQLite alert-state
+  migration, generalized-baseline storage in legacy physical sample columns,
+  and legacy-ack normalization, recovery reset and rearming, post-ack monitoring
+  suppression inside concrete-pressure
   recurrence, stale pressure retry isolation from a later rearmed obligation,
   global one-hour wall-time provider-attempt pacing across incident recovery,
   current actual-check-time and full reachability of the one-hundred-opening
@@ -599,18 +603,23 @@ supported provider credential.
   across condition families, and delayed post-recovery delivery through the
   scheduled Worker and real SQLite Durable Object boundary,
   no stale fenced gauge page after recovery, exact body/idempotency reuse after
-  an ambiguous Linq send, transactional rollback before direct
-  counter-baseline advancement, one-sample direct errors admitted inside the
+  an ambiguous Linq send, transactional rollback before connection-error
+  baseline advancement, one-sample connection errors admitted inside the
   attempt fence and retained across clean samples, mixed inside-fence pages
-  limited to direct-error evidence, full current mixed evidence when no older
-  pending obligation owns the open boundary, and later direct-error evidence
-  retained behind an older health-suppressed page across baseline advancement,
-  recovery, provider pacing, and monitor restarts,
-  documented formatted/deprecated Linq inventory shapes with duplicate and
-  mismatch rejection, zero message POSTs for unhealthy or indeterminate
-  chat/line health, healthy auto-selected Linq delivery, discovery-only
-  PlanetScale service authorization plus bounded signed scrape parameters,
-  unsafe discovered-target rejection, and singleton cron dispatch.
+  limited to non-replayable connection-error evidence, full current mixed
+  evidence when no older pending obligation owns the open boundary, and later
+  category-specific evidence retained behind an older health-suppressed page
+  across baseline advancement, recovery, provider pacing, and monitor restarts.
+  The pooled-path cases additionally prove factual 6432 copy at zero wait and
+  low server/Postgres utilization, unchanged 5432 wording, category-specific
+  pending/deferred/restart/ack behavior, stable two-recipient idempotency, and
+  the five-minute scheduled Durable Object path. Existing
+  coverage continues to prove documented formatted/deprecated Linq inventory
+  shapes with duplicate and mismatch rejection, zero message POSTs for
+  unhealthy or indeterminate chat/line health, healthy auto-selected Linq
+  delivery, discovery-only PlanetScale service authorization plus bounded
+  signed scrape parameters, unsafe discovered-target rejection, and singleton
+  cron dispatch.
   The deploy-automation test keeps the five-minute trigger, v4 SQLite class
   migration, Durable Object binding, required vars/secrets, checked-in scaffold,
   and generated Wrangler config aligned.

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -201,7 +201,8 @@ to retain 30 days of:
 - the most saturated primary pod's current PgBouncer-to-Postgres connections
   against `max_connections`, plus server-pool state counts;
 - primary Postgres connection states and total utilization; and
-- per-region direct-port 5432 connection-error counters and positive deltas.
+- per-region connection-error counters and positive deltas for direct port 5432
+  and pooled application port 6432.
 
 Discovery selects exactly one target by organization, database name, and branch
 name. The configured branch ID then filters the selected Prometheus payload's
@@ -209,10 +210,11 @@ metric series. Both selectors are required because one organization can have
 several production branches with the same branch name while discovery does not
 publish branch IDs.
 
-The direct-port signal is named a migration admission failure because production
-application traffic is required to use transaction-mode PgBouncer on 6432 and
-the direct endpoint is migration-only. Adding another direct production client
-requires splitting that signal first.
+Port 5432 retains the direct migration-admission interpretation because
+production application traffic is required to use transaction-mode PgBouncer
+on 6432 and the direct endpoint is migration-only. Port 6432 is reported as the
+broader pooled application connection-error condition. The provider metric has
+no reason label, so the page cannot identify a specific pooled rejection cause.
 
 Each metric family is normalized independently. When a documented family is
 absent, the sample keeps that family unknown instead of substituting zero, still
@@ -222,62 +224,69 @@ still open an incident immediately. A collection that fails before producing a
 usable observation, including a scrape with every required family absent,
 receives one bounded retry after one second; only an exhausted two-attempt
 collection counts as a failed check. A usable partial observation ordinarily
-remains single-pass so available unsafe evidence pages without delay. The sole
-exception is a safe observation missing only the direct-error counter family:
-the monitor makes one confirmation scrape after the same one-second delay,
-evaluates every available confirmation signal, and merges a recovered direct
-counter with the original complete gauge evidence. A failed or still-missing
-confirmation retains the original incomplete observation, so absence never
-becomes zero and two persistently incomplete checks still open the fallback
-monitoring incident. An acknowledged
-telemetry-only page is one-shot for one unresolved operator-notification window.
+remains single-pass so available unsafe evidence pages without delay. The
+connection-error family expects both ports, keyed by port and region so their
+series cannot collide. Missing either port keeps that family unknown. When a
+safe observation is otherwise complete, the monitor makes one confirmation
+scrape after the same one-second delay, evaluates every available confirmation
+signal, and composes complementary observed ports with the original complete
+gauge evidence. Each observed port advances only its own usable baseline; an
+omitted port retains its prior baseline, and new or reset region series are
+suppressed independently. A failed or still-incomplete confirmation retains
+the original incomplete observation, so absence never becomes zero, an old
+counter delta is never replayed, and two persistently incomplete checks still
+open the fallback monitoring incident. An acknowledged telemetry-only page is
+one-shot for one unresolved operator-notification window.
 Crossing the two-failure threshold records one bounded alert obligation in the
 existing incident row. The first two-check window counts incomplete versus
 unavailable observations, unions only canonical missing families observed on
 partial checks, and identifies the threshold time as the window end. A bounded
 per-sample evidence value preserves that provenance across restart. An older
-pending page or direct-error priority cannot lose the obligation; recovery and
-another gap before acknowledgment coalesce into that same notification while
-the first threshold window remains authoritative. The obligation does not occupy
-a closed provider fence.
+pending page or connection-error priority cannot lose the obligation; recovery
+and another gap before acknowledgment coalesce into that same notification
+while the first threshold window remains authoritative. The obligation does
+not occupy a closed provider fence.
 At the same time, until an incident admits its first page, concrete evidence
-that appears on the threshold or a later sample, including a direct-error delta,
-persists in one combined immutable body. The exact pressure and truthful
-telemetry facts therefore share
-the next eligible attempt and one acknowledgment cycle. For
-acknowledged-incident recurrence, the next eligible sample
-supplies any still-current unsafe evidence while historical telemetry keeps its
-own observation time. Only acknowledgment of a
+that appears on the threshold or a later sample, including either
+connection-error category, persists in one combined immutable body. The exact
+pressure and truthful telemetry facts therefore share the next eligible attempt
+and one acknowledgment cycle. For acknowledged-incident recurrence, the next
+eligible sample supplies any still-current unsafe evidence while historical
+telemetry keeps its own observation time. Only acknowledgment of a
 telemetry-bearing page clears the obligation; a later complete sample then
 closes and rearms the incident. After acknowledgment, incomplete samples remain
-queryable but cannot repeat telemetry copy inside concrete-pressure pages unless
-a later rearmed threshold creates a new obligation. When a direct-error delta
-takes admission priority after an earlier page, any currently owed telemetry
-travels in that same immutable body while replayable gauges remain excluded;
-pure deferred evidence keeps its stored check time, an aggregate containing a
-new current delta uses the latest included check, and telemetry keeps its own
-condition-local observation time. Concrete unsafe conditions retain an hourly
-recurrence. The object writes Linq provider-attempt admission before egress,
-never attempts more than once per hour across all incidents, and reuses the
+queryable but cannot repeat telemetry copy inside concrete-pressure pages
+unless a later rearmed threshold creates a new obligation. When a
+connection-error condition takes admission priority after an earlier page, any
+currently owed telemetry travels in that same immutable body while replayable
+gauges remain excluded; pure deferred evidence keeps the latest stored check
+time among its included categories, an aggregate containing a new current delta
+uses the current check, and telemetry keeps its own condition-local observation
+time. Concrete unsafe conditions retain an hourly recurrence. The object writes
+Linq provider-attempt admission before egress, never attempts more than once per
+hour across all incidents, and reuses the
 exact body plus idempotency key after an ambiguous send. Concrete-pressure
 bodies select deterministically by persisted incident and alert identity from
 one hundred reviewed, observation-scoped openings. Those openings say only
 that the recorded check met alert criteria; condition-specific and current-
 state claims come from evidence that proves them. Retries therefore keep a
 truthful body after recovery, while consecutive pages avoid broadcast-shaped
-repetition without padding or filler. Telemetry-
-only pages remain evidence-led and one-shot for each unresolved monitoring
+repetition without padding or filler. Telemetry-only pages remain evidence-led
+and one-shot for each unresolved monitoring
 window. The one-hundred-entry size is a bounded operator deliverability
 requirement, not a guarantee about carrier or platform filtering: at the hourly
 cap, one incident traverses one hundred reviewed leads before repeating one.
 The bank stays literal reviewed data rather than generated prose or another
-runtime dependency. The alert-state and sample-evidence columns are added idempotently without advancing the
-schema version, so the previously deployed Worker can ignore them during a
-rollback. If that Worker acknowledges a telemetry pending body, current code
-recognizes its cleared key/body plus retained marker and prevents duplicate
-re-admission after re-upgrade. The message reports actual collection time rather than the scheduled Cron
-slot and describes partial or unavailable telemetry without claiming database
-pressure.
+runtime dependency. The alert-state and sample-evidence columns are added
+idempotently without advancing the schema version, so the previously deployed
+Worker can ignore them during a rollback. The physical sample columns retain
+their legacy `direct_connection_error_*` names, while current code stores the
+generalized two-port baseline and aggregate delta in them. Category-specific
+pooled-defer state uses additive columns. If the prior Worker acknowledges a
+telemetry pending body, current code recognizes its cleared key/body plus
+retained marker and prevents duplicate re-admission after re-upgrade. The
+message reports actual collection time rather than the scheduled Cron slot and
+describes partial or unavailable telemetry without claiming database pressure.
 Before each message POST it requires the configured direct
 [Linq chat health](https://docs.linqapp.com/guides/chats/chat-health/) and its
 current [line reputation](https://docs.linqapp.com/guides/phone-numbers/phone-reputation/)

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -23,6 +23,15 @@ const PGBOUNCER_POOL_LABEL = "planetscale_pgbouncer_pool";
 const PORT_LABEL = "planetscale_port";
 const REGION_LABEL = "planetscale_region";
 
+export const DATABASE_CONNECTION_ERROR_PORTS = ["5432", "6432"] as const;
+
+export type DatabaseConnectionErrorPort =
+  typeof DATABASE_CONNECTION_ERROR_PORTS[number];
+
+export type DatabaseConnectionErrorDeltas = Readonly<
+  Record<DatabaseConnectionErrorPort, number | null>
+>;
+
 export const DATABASE_CLIENT_WAIT_ALERT_SECONDS = 5;
 export const DATABASE_CONNECTION_UTILIZATION_ALERT_RATIO = 0.9;
 export const DATABASE_IDLE_IN_TRANSACTION_ALERT_COUNT = 5;
@@ -31,7 +40,7 @@ export const DATABASE_SERVER_POOL_ALERT_RATIO = 0.9;
 export interface DatabaseMetricSnapshot {
   clientWaitSeconds: number;
   clientWaitingConnections: number;
-  directConnectionErrorCounters: Record<string, number>;
+  connectionErrorCounters: Record<string, number>;
   postgresConnections: number;
   postgresConnectionStates: Record<string, number>;
   postgresMaxConnections: number;
@@ -44,7 +53,7 @@ export interface DatabaseMetricSnapshot {
 export interface DatabaseMetricObservationSnapshot {
   clientWaitSeconds: number | null;
   clientWaitingConnections: number | null;
-  directConnectionErrorCounters: Record<string, number> | null;
+  connectionErrorCounters: Record<string, number> | null;
   postgresConnections: number | null;
   postgresConnectionStates: Record<string, number> | null;
   postgresMaxConnections: number | null;
@@ -92,6 +101,10 @@ export type DatabaseHealthCondition =
   | {
       count: number;
       kind: "direct_migration_admission_failures";
+    }
+  | {
+      count: number;
+      kind: "pooled_application_connection_errors";
     }
   | {
       failures: number;
@@ -146,7 +159,7 @@ export function requireCompleteDatabaseMetricSnapshot(
   if (
     snapshot.clientWaitSeconds === null
     || snapshot.clientWaitingConnections === null
-    || snapshot.directConnectionErrorCounters === null
+    || snapshot.connectionErrorCounters === null
     || snapshot.postgresConnections === null
     || snapshot.postgresConnectionStates === null
     || snapshot.postgresMaxConnections === null
@@ -160,8 +173,7 @@ export function requireCompleteDatabaseMetricSnapshot(
   return {
     clientWaitSeconds: snapshot.clientWaitSeconds,
     clientWaitingConnections: snapshot.clientWaitingConnections,
-    directConnectionErrorCounters:
-      snapshot.directConnectionErrorCounters,
+    connectionErrorCounters: snapshot.connectionErrorCounters,
     postgresConnections: snapshot.postgresConnections,
     postgresConnectionStates: snapshot.postgresConnectionStates,
     postgresMaxConnections: snapshot.postgresMaxConnections,
@@ -200,14 +212,21 @@ export function parsePlanetScaleDatabaseMetricObservation(
     (point) =>
       point.name === "planetscale_postgres_settings_max_connections",
   );
-  const directErrorPoints = points.filter(
+  const connectionErrorPoints = points.filter(
     (point) =>
       point.name === "planetscale_edge_postgres_connection_errors_total"
-      && point.labels[PORT_LABEL] === "5432",
+      && isDatabaseConnectionErrorPort(point.labels[PORT_LABEL]),
+  );
+  const observedConnectionErrorPorts = new Set(
+    connectionErrorPoints.map((point) => point.labels[PORT_LABEL]),
   );
 
   const missingMetricSet = new Set<DatabaseHealthRequiredMetricName>();
-  if (directErrorPoints.length === 0) {
+  if (
+    DATABASE_CONNECTION_ERROR_PORTS.some(
+      (port) => !observedConnectionErrorPorts.has(port),
+    )
+  ) {
     missingMetricSet.add(
       "planetscale_edge_postgres_connection_errors_total",
     );
@@ -310,13 +329,9 @@ export function parsePlanetScaleDatabaseMetricObservation(
         ? null
         : maximumMetricValue(clientWaitPoints),
       clientWaitingConnections,
-      directConnectionErrorCounters: directErrorPoints.length === 0
+      connectionErrorCounters: connectionErrorPoints.length === 0
         ? null
-        : sumByOptionalLabel(
-          directErrorPoints,
-          REGION_LABEL,
-          "unknown",
-        ),
+        : sumConnectionErrorsByPortAndRegion(connectionErrorPoints),
       postgresConnections: postgresConnectionStates
         ? sumMapValues(new Map(Object.entries(postgresConnectionStates)))
         : null,
@@ -333,32 +348,73 @@ export function parsePlanetScaleDatabaseMetricObservation(
   };
 }
 
-export function calculateDirectConnectionErrorDelta(
+export function calculateConnectionErrorDeltas(
   current: Readonly<Record<string, number>>,
   previous: Readonly<Record<string, number>> | null,
-): number {
-  if (!previous) {
-    return 0;
+): DatabaseConnectionErrorDeltas {
+  const deltas: Record<DatabaseConnectionErrorPort, number | null> = {
+    "5432": null,
+    "6432": null,
+  };
+  for (const port of DATABASE_CONNECTION_ERROR_PORTS) {
+    const currentSeries = Object.entries(current).filter(([series]) =>
+      readConnectionErrorSeriesPort(series) === port
+    );
+    if (currentSeries.length === 0) {
+      continue;
+    }
+    if (!previous) {
+      deltas[port] = 0;
+      continue;
+    }
+    deltas[port] = Math.trunc(
+      currentSeries.reduce((total, [series, currentValue]) => {
+        const previousValue = previous[series];
+        if (
+          typeof previousValue !== "number"
+          || !Number.isFinite(previousValue)
+          || currentValue < previousValue
+        ) {
+          return total;
+        }
+        return total + currentValue - previousValue;
+      }, 0),
+    );
   }
+  return deltas;
+}
 
-  return Math.trunc(
-    Object.entries(current).reduce((total, [series, currentValue]) => {
-      const previousValue = previous[series];
-      if (
-        typeof previousValue !== "number"
-        || !Number.isFinite(previousValue)
-        || currentValue < previousValue
-      ) {
-        return total;
-      }
-      return total + currentValue - previousValue;
-    }, 0),
+export function advanceConnectionErrorCounterBaseline(
+  current: Readonly<Record<string, number>>,
+  previous: Readonly<Record<string, number>> | null,
+): Record<string, number> {
+  const nextBaseline: Record<string, number> = {};
+  for (const port of DATABASE_CONNECTION_ERROR_PORTS) {
+    const currentEntries = readConnectionErrorEntriesForPort(current, port);
+    const entries = currentEntries.length > 0
+      ? currentEntries
+      : readConnectionErrorEntriesForPort(previous ?? {}, port);
+    for (const [series, value] of entries) {
+      nextBaseline[series] = value;
+    }
+  }
+  return nextBaseline;
+}
+
+export function hasExpectedConnectionErrorPorts(
+  counters: Readonly<Record<string, number>>,
+): boolean {
+  const observedPorts = new Set(
+    Object.keys(counters).map(readConnectionErrorSeriesPort),
+  );
+  return DATABASE_CONNECTION_ERROR_PORTS.every(
+    (port) => observedPorts.has(port),
   );
 }
 
 export function evaluateDatabaseMetricSnapshot(
   snapshot: DatabaseMetricObservationSnapshot,
-  directConnectionErrorDelta: number | null,
+  connectionErrorDeltas: DatabaseConnectionErrorDeltas | null,
 ): DatabaseHealthCondition[] {
   const conditions: DatabaseHealthCondition[] = [];
   if (
@@ -434,13 +490,26 @@ export function evaluateDatabaseMetricSnapshot(
       kind: "postgres_idle_in_transaction",
     });
   }
+  const directConnectionErrorDelta = connectionErrorDeltas?.["5432"];
   if (
     directConnectionErrorDelta !== null
+    && directConnectionErrorDelta !== undefined
     && directConnectionErrorDelta > 0
   ) {
     conditions.push({
       count: directConnectionErrorDelta,
       kind: "direct_migration_admission_failures",
+    });
+  }
+  const pooledConnectionErrorDelta = connectionErrorDeltas?.["6432"];
+  if (
+    pooledConnectionErrorDelta !== null
+    && pooledConnectionErrorDelta !== undefined
+    && pooledConnectionErrorDelta > 0
+  ) {
+    conditions.push({
+      count: pooledConnectionErrorDelta,
+      kind: "pooled_application_connection_errors",
     });
   }
   return conditions;
@@ -577,17 +646,57 @@ function sumByLabel(
   return totals;
 }
 
-function sumByOptionalLabel(
+function sumConnectionErrorsByPortAndRegion(
   points: readonly PrometheusMetricPoint[],
-  label: string,
-  fallback: string,
 ): Record<string, number> {
   const totals: Record<string, number> = {};
   for (const point of points) {
-    const key = point.labels[label] ?? fallback;
+    const port = point.labels[PORT_LABEL];
+    if (!isDatabaseConnectionErrorPort(port)) {
+      continue;
+    }
+    const key = JSON.stringify([
+      port,
+      point.labels[REGION_LABEL] ?? "unknown",
+    ]);
     totals[key] = (totals[key] ?? 0) + point.value;
   }
   return totals;
+}
+
+function isDatabaseConnectionErrorPort(
+  value: string | undefined,
+): value is DatabaseConnectionErrorPort {
+  return DATABASE_CONNECTION_ERROR_PORTS.some((port) => port === value);
+}
+
+function readConnectionErrorSeriesPort(
+  series: string,
+): DatabaseConnectionErrorPort | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(series);
+  } catch {
+    return null;
+  }
+  if (
+    !Array.isArray(value)
+    || value.length !== 2
+    || !isDatabaseConnectionErrorPort(value[0])
+    || typeof value[1] !== "string"
+  ) {
+    return null;
+  }
+  return value[0];
+}
+
+function readConnectionErrorEntriesForPort(
+  counters: Readonly<Record<string, number>>,
+  port: DatabaseConnectionErrorPort,
+): Array<[string, number]> {
+  return Object.entries(counters).filter(
+    ([series]) => readConnectionErrorSeriesPort(series) === port,
+  );
 }
 
 function sumByPod(

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -1,11 +1,14 @@
 import type { DurableObjectSqlStorageLike } from "../user-runner/types.js";
 import {
-  calculateDirectConnectionErrorDelta,
+  advanceConnectionErrorCounterBaseline,
+  calculateConnectionErrorDeltas,
   DATABASE_HEALTH_REQUIRED_METRIC_NAMES,
   DatabaseMetricsParseError,
   evaluateDatabaseMetricSnapshot,
+  hasExpectedConnectionErrorPorts,
   parsePlanetScaleDatabaseMetricObservation,
   requireCompleteDatabaseMetricSnapshot,
+  type DatabaseConnectionErrorDeltas,
   type DatabaseHealthCondition,
   type DatabaseHealthRequiredMetricName,
   type DatabaseMetricObservation,
@@ -27,7 +30,7 @@ const DATABASE_HEALTH_RUN_LEASE_MS = 2 * 60 * 1_000;
 const DATABASE_HEALTH_SAMPLE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
 const DATABASE_HEALTH_FETCH_TIMEOUT_MS = 10_000;
 const DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS = 1_000;
-const DIRECT_CONNECTION_ERROR_METRIC_NAME =
+const CONNECTION_ERROR_METRIC_NAME =
   "planetscale_edge_postgres_connection_errors_total" satisfies
     DatabaseHealthRequiredMetricName;
 const PLANETSCALE_DISCOVERY_BODY_LIMIT_BYTES = 256 * 1_024;
@@ -149,7 +152,7 @@ const DATABASE_METRIC_ALERT_LABELS: Readonly<
   Record<DatabaseHealthRequiredMetricName, string>
 > = {
   planetscale_edge_postgres_connection_errors_total:
-    "direct connection errors",
+    "connection errors on ports 5432 and 6432",
   planetscale_pgbouncer_current_connections:
     "PgBouncer current connections",
   planetscale_pgbouncer_pools_client: "PgBouncer client pools",
@@ -214,20 +217,31 @@ interface DatabaseHealthTransactionalStorage {
 
 type DatabaseHealthCollectedSample =
   | {
+    connectionErrorCounterBaseline: Record<string, number>;
+    connectionErrorDelta: number;
     conditions: DatabaseHealthCondition[];
-    directConnectionErrorDelta: number;
     snapshot: DatabaseMetricSnapshot;
     status: "ok";
   }
   | {
+    connectionErrorCounterBaseline: Record<string, number>;
+    connectionErrorDelta: number | null;
     conditions: DatabaseHealthCondition[];
-    directConnectionErrorDelta: number | null;
     failureCode: DatabaseHealthFailureCode;
     failures: number;
     monitoringEvidence: DatabaseHealthMonitoringEvidence;
     snapshot: DatabaseMetricObservationSnapshot | null;
     status: "failed";
   };
+
+type DatabaseConnectionErrorCondition = Extract<
+  DatabaseHealthCondition,
+  {
+    kind:
+      | "direct_migration_admission_failures"
+      | "pooled_application_connection_errors";
+  }
+>;
 
 type DatabaseHealthFetch = (
   input: RequestInfo | URL,
@@ -317,19 +331,31 @@ export class DatabaseHealthMonitor {
   }
 
   private async collectSample(): Promise<DatabaseHealthCollectedSample> {
+    const previousConnectionErrorCounterBaseline =
+      this.store.readLatestConnectionErrorCounterBaseline();
     try {
-      const observation = await this.collectMetricObservation();
+      const observation = await this.collectMetricObservation(
+        previousConnectionErrorCounterBaseline,
+      );
+      const observedConnectionErrorCounters =
+        observation.snapshot.connectionErrorCounters;
+      const connectionErrorCounterBaseline = observedConnectionErrorCounters
+        ? advanceConnectionErrorCounterBaseline(
+          observedConnectionErrorCounters,
+          previousConnectionErrorCounterBaseline,
+        )
+        : (previousConnectionErrorCounterBaseline ?? {});
       if (observation.missingMetrics.length > 0) {
-        const directConnectionErrorDelta =
-          observation.snapshot.directConnectionErrorCounters === null
+        const connectionErrorDeltas =
+          observedConnectionErrorCounters === null
             ? null
-            : calculateDirectConnectionErrorDelta(
-              observation.snapshot.directConnectionErrorCounters,
-              this.store.readLatestDirectConnectionErrorCounters(),
+            : calculateConnectionErrorDeltas(
+              observedConnectionErrorCounters,
+              previousConnectionErrorCounterBaseline,
             );
         const conditions = evaluateDatabaseMetricSnapshot(
           observation.snapshot,
-          directConnectionErrorDelta,
+          connectionErrorDeltas,
         );
         const priorFailures =
           this.store.readAlertState().consecutiveScrapeFailures;
@@ -347,8 +373,10 @@ export class DatabaseHealthMonitor {
           missingMetrics: observation.missingMetrics,
         });
         return {
+          connectionErrorCounterBaseline,
+          connectionErrorDelta:
+            sumKnownConnectionErrorDeltas(connectionErrorDeltas),
           conditions,
-          directConnectionErrorDelta,
           failureCode: "required_metrics_missing",
           failures,
           monitoringEvidence: {
@@ -360,18 +388,26 @@ export class DatabaseHealthMonitor {
         };
       }
       const snapshot = requireCompleteDatabaseMetricSnapshot(observation);
-      const directConnectionErrorDelta =
-        calculateDirectConnectionErrorDelta(
-          snapshot.directConnectionErrorCounters,
-          this.store.readLatestDirectConnectionErrorCounters(),
-        );
+      const connectionErrorDeltas = calculateConnectionErrorDeltas(
+        snapshot.connectionErrorCounters,
+        previousConnectionErrorCounterBaseline,
+      );
       const conditions = evaluateDatabaseMetricSnapshot(
         snapshot,
-        directConnectionErrorDelta,
+        connectionErrorDeltas,
       );
+      const connectionErrorDelta = sumKnownConnectionErrorDeltas(
+        connectionErrorDeltas,
+      );
+      if (connectionErrorDelta === null) {
+        throw new Error(
+          "Complete database metrics are missing connection-error deltas.",
+        );
+      }
       return {
+        connectionErrorCounterBaseline,
+        connectionErrorDelta,
         conditions,
-        directConnectionErrorDelta,
         snapshot,
         status: "ok",
       };
@@ -394,8 +430,10 @@ export class DatabaseHealthMonitor {
         missingMetrics,
       });
       return {
+        connectionErrorCounterBaseline:
+          previousConnectionErrorCounterBaseline ?? {},
+        connectionErrorDelta: null,
         conditions,
-        directConnectionErrorDelta: null,
         failureCode,
         failures,
         monitoringEvidence: {
@@ -408,7 +446,10 @@ export class DatabaseHealthMonitor {
     }
   }
 
-  private async collectMetricObservation(): Promise<DatabaseMetricObservation> {
+  private async collectMetricObservation(
+    previousConnectionErrorCounterBaseline:
+      Readonly<Record<string, number>> | null,
+  ): Promise<DatabaseMetricObservation> {
     let observation: DatabaseMetricObservation;
     try {
       observation = await this.collectMetricObservationOnce();
@@ -420,35 +461,68 @@ export class DatabaseHealthMonitor {
       await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
       return await this.collectMetricObservationOnce();
     }
-    if (!shouldConfirmMissingDirectConnectionErrors(observation)) {
+    const observationConnectionErrorDeltas =
+      observation.snapshot.connectionErrorCounters === null
+        ? null
+        : calculateConnectionErrorDeltas(
+          observation.snapshot.connectionErrorCounters,
+          previousConnectionErrorCounterBaseline,
+        );
+    if (
+      !shouldConfirmMissingConnectionErrors(
+        observation,
+        observationConnectionErrorDeltas,
+      )
+    ) {
       return observation;
     }
 
     await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
     try {
       const confirmation = await this.collectMetricObservationOnce();
+      const confirmedObservation = composeConnectionErrorConfirmation(
+        observation,
+        confirmation,
+      );
+      const confirmedCounters =
+        confirmedObservation.snapshot.connectionErrorCounters;
       if (
-        evaluateDatabaseMetricSnapshot(confirmation.snapshot, null).length > 0
+        evaluateDatabaseMetricSnapshot(
+          confirmedObservation.snapshot,
+          null,
+        ).length > 0
       ) {
-        return confirmation;
+        return confirmedObservation;
       }
-      const directConnectionErrorCounters =
-        confirmation.snapshot.directConnectionErrorCounters;
-      if (directConnectionErrorCounters === null) {
-        return observation;
+      if (
+        confirmedCounters !== null
+        && hasExpectedConnectionErrorPorts(confirmedCounters)
+      ) {
+        if (confirmedObservation.missingMetrics.length === 0) {
+          return confirmedObservation;
+        }
+        return {
+          missingMetrics: observation.missingMetrics.filter(
+            (name) => name !== CONNECTION_ERROR_METRIC_NAME,
+          ),
+          snapshot: {
+            ...observation.snapshot,
+            connectionErrorCounters: confirmedCounters,
+          },
+        };
       }
-      if (confirmation.missingMetrics.length === 0) {
-        return confirmation;
-      }
-      return {
-        missingMetrics: observation.missingMetrics.filter(
-          (name) => name !== DIRECT_CONNECTION_ERROR_METRIC_NAME,
-        ),
-        snapshot: {
-          ...observation.snapshot,
-          directConnectionErrorCounters,
-        },
-      };
+      const confirmedConnectionErrorDeltas = confirmedCounters === null
+        ? null
+        : calculateConnectionErrorDeltas(
+          confirmedCounters,
+          previousConnectionErrorCounterBaseline,
+        );
+      return evaluateDatabaseMetricSnapshot(
+        confirmedObservation.snapshot,
+        confirmedConnectionErrorDeltas,
+      ).length > 0
+        ? confirmedObservation
+        : observation;
     } catch {
       return observation;
     }
@@ -507,33 +581,39 @@ export class DatabaseHealthMonitor {
     }
 
     let alertState = this.store.readAlertState();
-    const currentDirectError = sample.conditions.find(
-      (condition) =>
-        condition.kind === "direct_migration_admission_failures",
+    const currentConnectionErrors = sample.conditions.filter(
+      isConnectionErrorCondition,
+    );
+    const currentConnectionErrorCounts = summarizeConnectionErrorConditions(
+      currentConnectionErrors,
     );
     const hasExistingPendingAlert =
       alertState.pendingAlertIdempotencyKey !== null
       && alertState.pendingAlertMessage !== null;
-    if (currentDirectError && hasExistingPendingAlert) {
-      alertState = this.store.deferDirectConnectionErrors({
+    if (currentConnectionErrors.length > 0 && hasExistingPendingAlert) {
+      alertState = this.store.deferConnectionErrors({
         checkedAtMs: input.checkedAtMs,
-        count: currentDirectError.count,
+        directCount: currentConnectionErrorCounts.direct,
+        pooledCount: currentConnectionErrorCounts.pooled,
       });
     }
 
-    const directErrorCountAvailableForAdmission =
-      hasExistingPendingAlert
-        ? 0
-        : (
+    const connectionErrorsAvailableForAdmission = hasExistingPendingAlert
+      ? []
+      : buildConnectionErrorConditions({
+        directCount:
           alertState.deferredDirectErrorCount
-          + (currentDirectError?.count ?? 0)
-        );
-    const isPromotingDeferredDirectError =
+          + currentConnectionErrorCounts.direct,
+        pooledCount:
+          alertState.deferredPooledErrorCount
+          + currentConnectionErrorCounts.pooled,
+      });
+    const isPromotingDeferredConnectionErrors =
       !hasExistingPendingAlert
-      && alertState.deferredDirectErrorCount > 0;
+      && hasDeferredConnectionErrors(alertState);
     if (
       sample.conditions.length > 0
-      || directErrorCountAvailableForAdmission > 0
+      || connectionErrorsAvailableForAdmission.length > 0
       || alertState.monitoringAlertObligation !== null
     ) {
       const isNewIncident = !alertState.incidentOpen;
@@ -553,23 +633,18 @@ export class DatabaseHealthMonitor {
         : null;
       const currentReplayableConditions = sample.conditions.filter(
         (condition) =>
-          condition.kind !== "direct_migration_admission_failures"
+          !isConnectionErrorCondition(condition)
           && condition.kind !== "monitoring_unavailable",
       );
-      const conditionsWithDeferredDirectErrors = [
+      const conditionsWithDeferredConnectionErrors = [
         ...currentReplayableConditions,
         ...(monitoringConditionForAdmission
           ? [monitoringConditionForAdmission]
           : []),
-        ...(directErrorCountAvailableForAdmission > 0
-          ? [{
-            count: directErrorCountAvailableForAdmission,
-            kind: "direct_migration_admission_failures" as const,
-          }]
-          : []),
+        ...connectionErrorsAvailableForAdmission,
       ];
-      const hasDirectConnectionError =
-        directErrorCountAvailableForAdmission > 0;
+      const hasConnectionError =
+        connectionErrorsAvailableForAdmission.length > 0;
       const attemptFenceOpen =
         alertState.lastAlertAttemptedAtMs === null
         || (
@@ -578,36 +653,37 @@ export class DatabaseHealthMonitor {
         );
       const admittedConditions =
         (
-          isPromotingDeferredDirectError
+          isPromotingDeferredConnectionErrors
           || (
             alertState.alertSequence > 0
             && !attemptFenceOpen
-            && hasDirectConnectionError
+            && hasConnectionError
           )
         )
-          ? conditionsWithDeferredDirectErrors.filter(
+          ? conditionsWithDeferredConnectionErrors.filter(
             (condition) =>
-              condition.kind === "direct_migration_admission_failures"
+              isConnectionErrorCondition(condition)
               || condition.kind === "monitoring_unavailable",
           )
-          : conditionsWithDeferredDirectErrors;
+          : conditionsWithDeferredConnectionErrors;
       const shouldHoldMonitoringForFence =
         monitoringAlertObligation !== null
         && !attemptFenceOpen
-        && !hasDirectConnectionError
+        && !hasConnectionError
         && (
           alertState.alertSequence > 0
           || currentReplayableConditions.length === 0
         );
+      const deferredCheckedAtMs = latestDeferredConnectionErrorCheckedAtMs(
+        alertState,
+        admittedConditions,
+      );
       const admittedCheckedAtMs =
-        isPromotingDeferredDirectError
-        && admittedConditions.some(
-          (condition) =>
-            condition.kind === "direct_migration_admission_failures",
-        )
-        && currentDirectError === undefined
-        && alertState.deferredDirectErrorCheckedAtMs !== null
-          ? alertState.deferredDirectErrorCheckedAtMs
+        isPromotingDeferredConnectionErrors
+        && admittedConditions.some(isConnectionErrorCondition)
+        && currentConnectionErrors.length === 0
+        && deferredCheckedAtMs !== null
+          ? deferredCheckedAtMs
           : admittedConditions.length === 1
             && admittedConditions[0]?.kind === "monitoring_unavailable"
             && monitoringAlertObligation
@@ -622,7 +698,7 @@ export class DatabaseHealthMonitor {
         && !shouldHoldMonitoringForFence
         && (
           isNewIncident
-          || hasDirectConnectionError
+          || hasConnectionError
           || attemptFenceOpen
           || monitoringAlertObligation !== null
         )
@@ -656,15 +732,19 @@ export class DatabaseHealthMonitor {
 
     if (sample.status === "ok") {
       this.store.recordSuccessfulSample({
+        connectionErrorCounterBaseline:
+          sample.connectionErrorCounterBaseline,
+        connectionErrorDelta: sample.connectionErrorDelta,
         conditions: sample.conditions,
-        directConnectionErrorDelta: sample.directConnectionErrorDelta,
         observedAtMs: input.observedAtMs,
         snapshot: sample.snapshot,
       });
     } else {
       this.store.recordFailedSample({
+        connectionErrorCounterBaseline:
+          sample.connectionErrorCounterBaseline,
+        connectionErrorDelta: sample.connectionErrorDelta,
         conditions: sample.conditions,
-        directConnectionErrorDelta: sample.directConnectionErrorDelta,
         failureCode: sample.failureCode,
         monitoringEvidence: sample.monitoringEvidence,
         observedAtMs: input.observedAtMs,
@@ -686,6 +766,7 @@ export class DatabaseHealthMonitor {
       input.conditions.length === 0
       && !hasPendingAlert
       && alertState.deferredDirectErrorCount === 0
+      && alertState.deferredPooledErrorCount === 0
       && alertState.monitoringAlertObligation === null
     ) {
       if (
@@ -815,6 +896,7 @@ export class DatabaseHealthMonitor {
         input.sampleStatus === "ok"
         && input.conditions.length === 0
         && stateAfterSuccess.deferredDirectErrorCount === 0
+        && stateAfterSuccess.deferredPooledErrorCount === 0
         && stateAfterSuccess.monitoringAlertObligation === null
       ) {
         this.store.closeIncident();
@@ -835,6 +917,94 @@ export class DatabaseHealthMonitor {
       };
     }
   }
+}
+
+function isConnectionErrorCondition(
+  condition: DatabaseHealthCondition,
+): condition is DatabaseConnectionErrorCondition {
+  return condition.kind === "direct_migration_admission_failures"
+    || condition.kind === "pooled_application_connection_errors";
+}
+
+function summarizeConnectionErrorConditions(
+  conditions: readonly DatabaseConnectionErrorCondition[],
+): { direct: number; pooled: number } {
+  return conditions.reduce(
+    (counts, condition) => {
+      if (condition.kind === "direct_migration_admission_failures") {
+        counts.direct += condition.count;
+      } else {
+        counts.pooled += condition.count;
+      }
+      return counts;
+    },
+    { direct: 0, pooled: 0 },
+  );
+}
+
+function buildConnectionErrorConditions(input: {
+  directCount: number;
+  pooledCount: number;
+}): DatabaseConnectionErrorCondition[] {
+  return [
+    ...(input.directCount > 0
+      ? [{
+        count: input.directCount,
+        kind: "direct_migration_admission_failures" as const,
+      }]
+      : []),
+    ...(input.pooledCount > 0
+      ? [{
+        count: input.pooledCount,
+        kind: "pooled_application_connection_errors" as const,
+      }]
+      : []),
+  ];
+}
+
+function hasDeferredConnectionErrors(
+  state: DatabaseHealthAlertState,
+): boolean {
+  return state.deferredDirectErrorCount > 0
+    || state.deferredPooledErrorCount > 0;
+}
+
+function latestDeferredConnectionErrorCheckedAtMs(
+  state: DatabaseHealthAlertState,
+  conditions: readonly DatabaseHealthCondition[],
+): number | null {
+  const checkedAtValues = [
+    conditions.some(
+      (condition) =>
+        condition.kind === "direct_migration_admission_failures",
+    )
+      && state.deferredDirectErrorCount > 0
+      ? state.deferredDirectErrorCheckedAtMs
+      : null,
+    conditions.some(
+      (condition) => condition.kind === "pooled_application_connection_errors",
+    )
+      && state.deferredPooledErrorCount > 0
+      ? state.deferredPooledErrorCheckedAtMs
+      : null,
+  ].filter((value): value is number => value !== null);
+  return checkedAtValues.length === 0
+    ? null
+    : Math.max(...checkedAtValues);
+}
+
+function sumKnownConnectionErrorDeltas(
+  deltas: DatabaseConnectionErrorDeltas | null,
+): number | null {
+  if (deltas === null) {
+    return null;
+  }
+  const knownDeltas = Object.values(deltas).filter(
+    (value): value is number => value !== null,
+  );
+  return knownDeltas.length === 0
+    ? null
+    : Math.trunc(knownDeltas.reduce((total, value) => total + value, 0));
 }
 
 async function fetchPlanetScaleMetrics(input: {
@@ -1296,6 +1466,10 @@ function formatDatabaseHealthCondition(
       return `${formatCount(condition.count)} direct migration ${
         condition.count === 1 ? "connection error" : "connection errors"
       }`;
+    case "pooled_application_connection_errors":
+      return `${formatCount(condition.count)} pooled application ${
+        condition.count === 1 ? "connection error" : "connection errors"
+      } (port 6432)`;
     case "monitoring_unavailable":
       return formatMonitoringUnavailableCondition(
         condition,
@@ -1489,12 +1663,47 @@ function hasUsableDatabaseHealthMetric(
     < DATABASE_HEALTH_REQUIRED_METRIC_NAMES.length;
 }
 
-function shouldConfirmMissingDirectConnectionErrors(
+function shouldConfirmMissingConnectionErrors(
   observation: DatabaseMetricObservation,
+  connectionErrorDeltas: DatabaseConnectionErrorDeltas | null,
 ): boolean {
   return observation.missingMetrics.length === 1
-    && observation.missingMetrics[0] === DIRECT_CONNECTION_ERROR_METRIC_NAME
-    && evaluateDatabaseMetricSnapshot(observation.snapshot, null).length === 0;
+    && observation.missingMetrics[0] === CONNECTION_ERROR_METRIC_NAME
+    && evaluateDatabaseMetricSnapshot(
+      observation.snapshot,
+      connectionErrorDeltas,
+    ).length === 0;
+}
+
+function composeConnectionErrorConfirmation(
+  observation: DatabaseMetricObservation,
+  confirmation: DatabaseMetricObservation,
+): DatabaseMetricObservation {
+  const originalCounters = observation.snapshot.connectionErrorCounters;
+  const confirmationCounters = confirmation.snapshot.connectionErrorCounters;
+  const connectionErrorCounters = confirmationCounters === null
+    ? originalCounters
+    : advanceConnectionErrorCounterBaseline(
+      confirmationCounters,
+      originalCounters,
+    );
+  const hasCompleteConnectionErrors = connectionErrorCounters !== null
+    && hasExpectedConnectionErrorPorts(connectionErrorCounters);
+  const missingMetricSet = new Set(confirmation.missingMetrics);
+  if (hasCompleteConnectionErrors) {
+    missingMetricSet.delete(CONNECTION_ERROR_METRIC_NAME);
+  } else {
+    missingMetricSet.add(CONNECTION_ERROR_METRIC_NAME);
+  }
+  return {
+    missingMetrics: DATABASE_HEALTH_REQUIRED_METRIC_NAMES.filter(
+      (name) => missingMetricSet.has(name),
+    ),
+    snapshot: {
+      ...confirmation.snapshot,
+      connectionErrorCounters,
+    },
+  };
 }
 
 async function readBoundedResponseText(

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -30,6 +30,8 @@ export interface DatabaseHealthAlertState {
   consecutiveScrapeFailures: number;
   deferredDirectErrorCheckedAtMs: number | null;
   deferredDirectErrorCount: number;
+  deferredPooledErrorCheckedAtMs: number | null;
+  deferredPooledErrorCount: number;
   incidentOpen: boolean;
   incidentSequence: number;
   lastAlertAttemptedAtMs: number | null;
@@ -41,8 +43,8 @@ export interface DatabaseHealthAlertState {
 
 export interface DatabaseHealthStoredSample {
   clientWaitSeconds: number | null;
+  connectionErrorDelta: number | null;
   conditions: DatabaseHealthCondition[];
-  directConnectionErrorDelta: number | null;
   failureCode: string | null;
   observedAtMs: number;
   postgresConnections: number | null;
@@ -58,6 +60,8 @@ interface DatabaseHealthMetaRow extends Record<string, DurableObjectSqlValue> {
   consecutive_scrape_failures: number;
   deferred_direct_error_checked_at_ms: number | null;
   deferred_direct_error_count: number;
+  deferred_pooled_error_checked_at_ms: number | null;
+  deferred_pooled_error_count: number;
   incident_open: number;
   incident_sequence: number;
   last_alert_attempted_at_ms: number | null;
@@ -69,6 +73,8 @@ interface DatabaseHealthMetaRow extends Record<string, DurableObjectSqlValue> {
 }
 
 interface DatabaseHealthCounterRow extends Record<string, DurableObjectSqlValue> {
+  // Physical name retained for rollback compatibility. The value is the
+  // generalized 5432/6432 counter baseline used by current Workers.
   direct_connection_error_counters_json: string;
 }
 
@@ -122,6 +128,9 @@ export class DatabaseHealthStore {
       deferredDirectErrorCheckedAtMs:
         row.deferred_direct_error_checked_at_ms,
       deferredDirectErrorCount: row.deferred_direct_error_count,
+      deferredPooledErrorCheckedAtMs:
+        row.deferred_pooled_error_checked_at_ms,
+      deferredPooledErrorCount: row.deferred_pooled_error_count,
       incidentOpen: row.incident_open === 1,
       incidentSequence: row.incident_sequence,
       lastAlertAttemptedAtMs: row.last_alert_attempted_at_ms,
@@ -186,7 +195,9 @@ export class DatabaseHealthStore {
          pending_alert_idempotency_key = ?,
          pending_alert_message = ?,
          deferred_direct_error_count = 0,
-         deferred_direct_error_checked_at_ms = NULL
+         deferred_direct_error_checked_at_ms = NULL,
+         deferred_pooled_error_count = 0,
+         deferred_pooled_error_checked_at_ms = NULL
        WHERE singleton = 1`,
       input.includesMonitoring ? 1 : 0,
       input.idempotencyKey,
@@ -208,18 +219,32 @@ export class DatabaseHealthStore {
     return this.readAlertState();
   }
 
-  deferDirectConnectionErrors(input: {
+  deferConnectionErrors(input: {
     checkedAtMs: number;
-    count: number;
+    directCount: number;
+    pooledCount: number;
   }): DatabaseHealthAlertState {
     this.sql.exec(
       `UPDATE database_health_meta
        SET
          deferred_direct_error_count =
            deferred_direct_error_count + ?,
-         deferred_direct_error_checked_at_ms = ?
+         deferred_direct_error_checked_at_ms = CASE
+           WHEN ? > 0 THEN ?
+           ELSE deferred_direct_error_checked_at_ms
+         END,
+         deferred_pooled_error_count =
+           deferred_pooled_error_count + ?,
+         deferred_pooled_error_checked_at_ms = CASE
+           WHEN ? > 0 THEN ?
+           ELSE deferred_pooled_error_checked_at_ms
+         END
        WHERE singleton = 1`,
-      input.count,
+      input.directCount,
+      input.directCount,
+      input.checkedAtMs,
+      input.pooledCount,
+      input.pooledCount,
       input.checkedAtMs,
     );
     return this.readAlertState();
@@ -249,11 +274,10 @@ export class DatabaseHealthStore {
     );
   }
 
-  readLatestDirectConnectionErrorCounters(): Record<string, number> | null {
+  readLatestConnectionErrorCounterBaseline(): Record<string, number> | null {
     const row = this.sql.exec<DatabaseHealthCounterRow>(
       `SELECT direct_connection_error_counters_json
        FROM database_health_samples
-       WHERE direct_connection_error_counters_json <> '{}'
        ORDER BY observed_at_ms DESC
        LIMIT 1`,
     ).toArray()[0];
@@ -263,8 +287,9 @@ export class DatabaseHealthStore {
   }
 
   recordSuccessfulSample(input: {
+    connectionErrorCounterBaseline: Readonly<Record<string, number>>;
+    connectionErrorDelta: number;
     conditions: readonly DatabaseHealthCondition[];
-    directConnectionErrorDelta: number;
     observedAtMs: number;
     snapshot: DatabaseMetricSnapshot;
   }): void {
@@ -314,15 +339,16 @@ export class DatabaseHealthStore {
       input.snapshot.postgresConnections,
       input.snapshot.postgresMaxConnections,
       JSON.stringify(input.snapshot.postgresConnectionStates),
-      input.directConnectionErrorDelta,
-      JSON.stringify(input.snapshot.directConnectionErrorCounters),
+      input.connectionErrorDelta,
+      JSON.stringify(input.connectionErrorCounterBaseline),
       JSON.stringify(input.conditions),
     );
   }
 
   recordFailedSample(input: {
+    connectionErrorCounterBaseline: Readonly<Record<string, number>>;
+    connectionErrorDelta: number | null;
     conditions: readonly DatabaseHealthCondition[];
-    directConnectionErrorDelta: number | null;
     failureCode: string;
     monitoringEvidence: DatabaseHealthMonitoringEvidence;
     observedAtMs: number;
@@ -378,8 +404,8 @@ export class DatabaseHealthStore {
       snapshot?.postgresConnections ?? null,
       snapshot?.postgresMaxConnections ?? null,
       JSON.stringify(snapshot?.postgresConnectionStates ?? {}),
-      input.directConnectionErrorDelta,
-      JSON.stringify(snapshot?.directConnectionErrorCounters ?? {}),
+      input.connectionErrorDelta,
+      JSON.stringify(input.connectionErrorCounterBaseline),
       JSON.stringify(input.monitoringEvidence),
       JSON.stringify(input.conditions),
     );
@@ -438,8 +464,8 @@ export class DatabaseHealthStore {
       safeLimit,
     ).toArray().map((row) => ({
       clientWaitSeconds: row.client_wait_seconds,
+      connectionErrorDelta: row.direct_connection_error_delta,
       conditions: parseConditions(row.conditions_json),
-      directConnectionErrorDelta: row.direct_connection_error_delta,
       failureCode: row.failure_code,
       observedAtMs: row.observed_at_ms,
       postgresConnections: row.postgres_connections,
@@ -461,6 +487,8 @@ export class DatabaseHealthStore {
          alert_sequence,
          deferred_direct_error_count,
          deferred_direct_error_checked_at_ms,
+         deferred_pooled_error_count,
+         deferred_pooled_error_checked_at_ms,
          last_alert_attempted_at_ms,
          monitoring_alert_owed_json,
          pending_alert_includes_monitoring,
@@ -508,6 +536,8 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       alert_sequence INTEGER NOT NULL DEFAULT 0,
       deferred_direct_error_count INTEGER NOT NULL DEFAULT 0,
       deferred_direct_error_checked_at_ms INTEGER,
+      deferred_pooled_error_count INTEGER NOT NULL DEFAULT 0,
+      deferred_pooled_error_checked_at_ms INTEGER,
       last_alert_attempted_at_ms INTEGER,
       monitoring_alert_owed_json TEXT,
       pending_alert_includes_monitoring INTEGER NOT NULL DEFAULT 0
@@ -568,6 +598,18 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
       "Database health Durable Object schema is newer than this Worker.",
     );
   }
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_meta",
+    "deferred_pooled_error_count",
+    "INTEGER NOT NULL DEFAULT 0",
+  );
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_meta",
+    "deferred_pooled_error_checked_at_ms",
+    "INTEGER",
+  );
   ensureDatabaseHealthTableColumn(
     sql,
     "database_health_meta",

--- a/apps/cloudflare/test/database-health-metrics.test.ts
+++ b/apps/cloudflare/test/database-health-metrics.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  calculateDirectConnectionErrorDelta,
+  advanceConnectionErrorCounterBaseline,
+  calculateConnectionErrorDeltas,
   DatabaseMetricsParseError,
   evaluateDatabaseMetricSnapshot,
+  parsePlanetScaleDatabaseMetricObservation,
   parsePlanetScaleDatabaseMetrics,
 } from "../src/database-health/metrics.ts";
 import { buildMetricsBody } from "./helpers/database-health.ts";
@@ -30,8 +32,9 @@ describe("PlanetScale database health metrics", () => {
     expect(snapshot).toEqual({
       clientWaitSeconds: 7,
       clientWaitingConnections: 3,
-      directConnectionErrorCounters: {
-        "us-east": 4,
+      connectionErrorCounters: {
+        '["5432","us-east"]': 4,
+        '["6432","us-east"]': 0,
       },
       postgresConnections: 47,
       postgresConnectionStates: {
@@ -50,7 +53,7 @@ describe("PlanetScale database health metrics", () => {
     });
   });
 
-  it("alerts on wait, local server saturation, Postgres state, and direct-error deltas", () => {
+  it("alerts on wait, local server saturation, Postgres state, and connection-error deltas", () => {
     const snapshot = parsePlanetScaleDatabaseMetrics(
       buildMetricsBody({
         branchId: BRANCH_ID,
@@ -66,7 +69,10 @@ describe("PlanetScale database health metrics", () => {
       BRANCH_ID,
     );
 
-    expect(evaluateDatabaseMetricSnapshot(snapshot, 2)).toEqual([
+    expect(evaluateDatabaseMetricSnapshot(snapshot, {
+      "5432": 2,
+      "6432": 0,
+    })).toEqual([
       {
         kind: "client_wait",
         seconds: 7,
@@ -122,35 +128,154 @@ describe("PlanetScale database health metrics", () => {
       serverPoolCapacity: 10,
       serverPoolSaturationRatio: 0.9,
     });
-    expect(evaluateDatabaseMetricSnapshot(snapshot, 0)).toContainEqual({
+    expect(evaluateDatabaseMetricSnapshot(snapshot, {
+      "5432": 0,
+      "6432": 0,
+    })).toContainEqual({
       connections: 9,
       kind: "server_pool_saturation",
       limit: 10,
       ratio: 0.9,
     });
-    expect(evaluateDatabaseMetricSnapshot(snapshot, 0)).not.toContainEqual(
+    expect(evaluateDatabaseMetricSnapshot(snapshot, {
+      "5432": 0,
+      "6432": 0,
+    })).not.toContainEqual(
       expect.objectContaining({
         kind: "postgres_connection_saturation",
       }),
     );
   });
 
-  it("does not turn a new or reset direct-error series into a false admission failure", () => {
-    expect(calculateDirectConnectionErrorDelta(
+  it("suppresses new and reset series independently for each expected port", () => {
+    expect(calculateConnectionErrorDeltas(
       {
-        "new-region": 9,
-        "reset-region": 2,
-        "stable-region": 8,
+        '["5432","new-region"]': 9,
+        '["5432","reset-region"]': 2,
+        '["5432","stable-region"]': 8,
+        '["6432","new-region"]': 12,
+        '["6432","reset-region"]': 1,
+        '["6432","stable-region"]': 6,
       },
       {
-        "reset-region": 10,
-        "stable-region": 5,
+        '["5432","reset-region"]': 10,
+        '["5432","stable-region"]': 5,
+        '["6432","reset-region"]': 4,
+        '["6432","stable-region"]': 4,
       },
-    )).toBe(3);
-    expect(calculateDirectConnectionErrorDelta(
-      { "new-region": 9 },
+    )).toEqual({
+      "5432": 3,
+      "6432": 2,
+    });
+    expect(calculateConnectionErrorDeltas(
+      {
+        '["5432","new-region"]': 9,
+        '["6432","new-region"]': 12,
+      },
       null,
-    )).toBe(0);
+    )).toEqual({
+      "5432": 0,
+      "6432": 0,
+    });
+  });
+
+  it("suppresses the legacy direct-only key shape during baseline upgrade", () => {
+    const current = {
+      '["5432","us-east"]': 7,
+      '["6432","us-east"]': 8,
+    };
+
+    expect(calculateConnectionErrorDeltas(
+      current,
+      { "us-east": 6 },
+    )).toEqual({
+      "5432": 0,
+      "6432": 0,
+    });
+    expect(advanceConnectionErrorCounterBaseline(
+      current,
+      { "us-east": 6 },
+    )).toEqual(current);
+  });
+
+  it("advances observed port baselines while retaining an omitted port", () => {
+    const previous = {
+      '["5432","removed-region"]': 9,
+      '["5432","us-east"]': 5,
+      '["6432","us-east"]': 8,
+    };
+
+    const afterDirectOnly = advanceConnectionErrorCounterBaseline(
+      { '["5432","us-east"]': 7 },
+      previous,
+    );
+    expect(afterDirectOnly).toEqual({
+      '["5432","us-east"]': 7,
+      '["6432","us-east"]': 8,
+    });
+    expect(calculateConnectionErrorDeltas(
+      { '["6432","us-east"]': 10 },
+      afterDirectOnly,
+    )).toEqual({
+      "5432": null,
+      "6432": 2,
+    });
+
+    expect(advanceConnectionErrorCounterBaseline(
+      { '["6432","us-east"]': 10 },
+      afterDirectOnly,
+    )).toEqual({
+      '["5432","us-east"]': 7,
+      '["6432","us-east"]': 10,
+    });
+  });
+
+  it("keeps one missing expected port unknown while retaining the other baseline", () => {
+    const body = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 5,
+      pooledErrors: 8,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="6432".*$/mu,
+      "",
+    );
+
+    const observation = parsePlanetScaleDatabaseMetricObservation(
+      body,
+      BRANCH_ID,
+    );
+
+    expect(observation.missingMetrics).toContain(
+      "planetscale_edge_postgres_connection_errors_total",
+    );
+    expect(observation.snapshot.connectionErrorCounters).toEqual({
+      '["5432","us-east"]': 5,
+    });
+    expect(calculateConnectionErrorDeltas(
+      observation.snapshot.connectionErrorCounters ?? {},
+      {
+        '["5432","us-east"]': 3,
+        '["6432","us-east"]': 7,
+      },
+    )).toEqual({
+      "5432": 2,
+      "6432": null,
+    });
+  });
+
+  it("emits a distinct pooled application condition for positive port 6432 deltas", () => {
+    const snapshot = parsePlanetScaleDatabaseMetrics(
+      buildMetricsBody({ branchId: BRANCH_ID }),
+      BRANCH_ID,
+    );
+
+    expect(evaluateDatabaseMetricSnapshot(snapshot, {
+      "5432": 0,
+      "6432": 3,
+    })).toContainEqual({
+      count: 3,
+      kind: "pooled_application_connection_errors",
+    });
   });
 
   it("identifies the canonical required metric families that are missing", () => {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -76,7 +76,7 @@ describe("database health monitor", () => {
     expect(harness.monitor.readRecentSamples()).toEqual([
       expect.objectContaining({
         clientWaitSeconds: 0,
-        directConnectionErrorDelta: 0,
+        connectionErrorDelta: 0,
         observedAtMs: FIVE_MINUTES_MS,
         scrapeStatus: "ok",
         serverPoolSaturationRatio: 0.2,
@@ -1053,7 +1053,7 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toEqual([]);
   });
 
-  it("retries a safe partial scrape when only the direct-error counter is missing", async () => {
+  it("retries a safe partial scrape when the connection-error family is missing", async () => {
     const completeMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
     const partialMetricsBody = completeMetricsBody.replace(
       /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
@@ -1079,7 +1079,7 @@ describe("database health monitor", () => {
     expect(harness.retryWaits).toEqual([1_000]);
     expect(harness.monitor.readRecentSamples()).toEqual([
       expect.objectContaining({
-        directConnectionErrorDelta: 0,
+        connectionErrorDelta: 0,
         failureCode: null,
         scrapeStatus: "ok",
       }),
@@ -1087,7 +1087,137 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toEqual([]);
   });
 
-  it("keeps multi-family omissions single-pass when the direct-error counter is also missing", async () => {
+  it("composes safe single-port scrapes and advances both counter baselines", async () => {
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+      pooledErrors: 8,
+    });
+    const directOnlyMetricsBody = baselineMetricsBody.replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="6432".*$/mu,
+      "",
+    );
+    const pooledOnlyMetricsBody = baselineMetricsBody.replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="5432".*$/mu,
+      "",
+    );
+    const incrementedMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 5,
+      pooledErrors: 9,
+    });
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1) {
+          return baselineMetricsBody;
+        }
+        if (scrapeAttempt === 2) {
+          return directOnlyMetricsBody;
+        }
+        return scrapeAttempt === 3
+          ? pooledOnlyMetricsBody
+          : incrementedMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 1, kind: "direct_migration_admission_failures" },
+        { count: 1, kind: "pooled_application_connection_errors" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      connectionErrorDelta: 2,
+      scrapeStatus: "ok",
+    });
+  });
+
+  it("keeps an observed reset baseline when the complementary port pages on confirmation", async () => {
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+      pooledErrors: 5,
+    });
+    const resetDirectOnlyMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 1,
+      pooledErrors: 5,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="6432".*$/mu,
+      "",
+    );
+    const incrementedPooledOnlyMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 1,
+      pooledErrors: 7,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="5432".*$/mu,
+      "",
+    );
+    const nextCompleteMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 2,
+      pooledErrors: 7,
+    });
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1) {
+          return baselineMetricsBody;
+        }
+        if (scrapeAttempt === 2) {
+          return resetDirectOnlyMetricsBody;
+        }
+        return scrapeAttempt === 3
+          ? incrementedPooledOnlyMetricsBody
+          : nextCompleteMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "pooled_application_connection_errors" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + ONE_HOUR_MS),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 1, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(
+      harness.monitor
+        .readRecentSamples(3)
+        .map((sample) => sample.connectionErrorDelta),
+    ).toEqual([1, 2, 0]);
+  });
+
+  it("keeps multi-family omissions single-pass when the connection-error family is also missing", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
@@ -1115,9 +1245,9 @@ describe("database health monitor", () => {
     ]);
   });
 
-  it("joins a recovered direct-error counter to first-scrape gauges when confirmation loses another family", async () => {
+  it("joins recovered connection-error counters to first-scrape gauges when confirmation loses another family", async () => {
     const completeMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
-    const missingDirectErrorMetricsBody = completeMetricsBody.replace(
+    const missingConnectionErrorMetricsBody = completeMetricsBody.replace(
       /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
       "",
     );
@@ -1130,7 +1260,7 @@ describe("database health monitor", () => {
       readMetricsBody() {
         scrapeAttempt += 1;
         return scrapeAttempt === 1
-          ? missingDirectErrorMetricsBody
+          ? missingConnectionErrorMetricsBody
           : missingMaxConnectionsMetricsBody;
       },
     });
@@ -1145,7 +1275,7 @@ describe("database health monitor", () => {
     expect(harness.retryWaits).toEqual([1_000]);
     expect(harness.monitor.readRecentSamples()).toEqual([
       expect.objectContaining({
-        directConnectionErrorDelta: 0,
+        connectionErrorDelta: 0,
         failureCode: null,
         postgresMaxConnections: 50,
         scrapeStatus: "ok",
@@ -1153,7 +1283,7 @@ describe("database health monitor", () => {
     ]);
   });
 
-  it("retains the original incomplete observation when direct-error confirmation fails", async () => {
+  it("retains the original incomplete observation when connection-error confirmation fails", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
@@ -1185,7 +1315,7 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toEqual([]);
   });
 
-  it("pages an available unsafe signal without retrying a missing direct-error counter", async () => {
+  it("pages an available unsafe signal without retrying a missing connection-error family", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
       clientWaitSeconds: 8,
@@ -1205,6 +1335,42 @@ describe("database health monitor", () => {
     expect(harness.planetScaleRequests).toHaveLength(2);
     expect(harness.retryWaits).toEqual([]);
     expect(harness.primaryLinqRequests).toHaveLength(1);
+  });
+
+  it("does not delay a known pooled delta when the direct port is missing", async () => {
+    let metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      pooledErrors: 5,
+    });
+    const harness = createMonitorHarness({
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      pooledErrors: 7,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="5432".*$/mu,
+      "",
+    );
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "pooled_application_connection_errors" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.retryWaits).toEqual([]);
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      connectionErrorDelta: 2,
+      failureCode: "required_metrics_missing",
+    });
   });
 
   it("pages a positive direct-error delta recovered by the partial retry", async () => {
@@ -1249,13 +1415,13 @@ describe("database health monitor", () => {
     expect(harness.retryWaits).toEqual([1_000]);
     expect(harness.primaryLinqRequests).toHaveLength(1);
     expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
-      directConnectionErrorDelta: 2,
+      connectionErrorDelta: 2,
       failureCode: null,
       scrapeStatus: "ok",
     });
   });
 
-  it("pages pressure that appears while confirming the missing direct-error counter", async () => {
+  it("pages pressure that appears while confirming the missing connection-error family", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
@@ -1291,7 +1457,7 @@ describe("database health monitor", () => {
     expect(harness.primaryLinqRequests).toHaveLength(1);
   });
 
-  it("retains the two-check telemetry page when direct-error retries stay incomplete", async () => {
+  it("retains the two-check telemetry page when connection-error retries stay incomplete", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
@@ -1326,7 +1492,8 @@ describe("database health monitor", () => {
     const alert = await readLinqRequestBody(harness.primaryLinqRequests[0]);
     expect(alert.message.parts[0]?.value).toBe(
       "Database monitor telemetry was incomplete for 2 checks "
-      + "(missing PlanetScale metric observed: direct connection errors). "
+      + "(missing PlanetScale metric observed: connection errors on ports "
+      + "5432 and 6432). "
       + "Window ended 00:10 UTC.",
     );
   });
@@ -2445,7 +2612,7 @@ describe("database health monitor", () => {
       });
 
     expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
-      directConnectionErrorDelta: 0,
+      connectionErrorDelta: 0,
       failureCode: "required_metrics_missing",
     });
   });
@@ -2685,6 +2852,151 @@ describe("database health monitor", () => {
     expect(directErrorMessage)
       .not.toMatch(/\b(?:capacity|headroom|pressure|utilization)\b/iu);
     expectObservationScopedDatabaseOpening(directErrorMessage);
+  });
+
+  it("pages pooled application errors at low utilization with two stable deliveries", async () => {
+    let metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 0,
+      pooledErrors: 5,
+      postgresStates: { active: 5, idle: 5 },
+      serverConnections: 10,
+    });
+    const harness = createMonitorHarness({
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 0,
+      pooledErrors: 7,
+      postgresStates: { active: 5, idle: 5 },
+      serverConnections: 10,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "pooled_application_connection_errors" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+
+    const deliveredBodies = await Promise.all(
+      harness.allLinqRequests.map(readLinqRequestBody),
+    );
+    expect(deliveredBodies).toHaveLength(2);
+    expect(deliveredBodies[0]?.message.parts)
+      .toEqual(deliveredBodies[1]?.message.parts);
+    expect(deliveredBodies.map((body) => body.message.idempotency_key).sort())
+      .toEqual([
+        "murph-db-1-1",
+        "murph-db-1-1-recipient-2",
+      ]);
+    const message = deliveredBodies[0]?.message.parts[0]?.value;
+    expect(message).toContain(
+      "2 pooled application connection errors (port 6432)",
+    );
+    expect(message).not.toContain("direct migration");
+    expect(message)
+      .not.toMatch(/\b(?:capacity|headroom|pressure|utilization)\b/iu);
+    expectObservationScopedDatabaseOpening(message);
+  });
+
+  it("preserves pooled errors behind a pending page across restart and acknowledgment", async () => {
+    let metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      clientWaitSeconds: 8,
+      pooledErrors: 5,
+    });
+    const harness = createMonitorHarness({
+      linqHealthResponses: [
+        () => new Response(null, { status: 503 }),
+      ],
+      readMetricsBody: () => metricsBody,
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "alert_failed" });
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      pooledErrors: 7,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "pooled_application_connection_errors" },
+      ],
+      outcome: "alert_deferred",
+    });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      deferredPooledErrorCheckedAtMs: FIVE_MINUTES_MS * 2,
+      deferredPooledErrorCount: 2,
+      pendingAlertMessage: expect.stringContaining("PgBouncer wait 8s"),
+    });
+
+    metricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      pooledErrors: 7,
+    });
+    harness.restartMonitor();
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + ONE_HOUR_MS),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      deferredPooledErrorCount: 2,
+      pendingAlertMessage: null,
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2 + ONE_HOUR_MS),
+    ).resolves.toMatchObject({ outcome: "alert_deferred" });
+    const pooledPending = harness.monitor.readAlertState();
+    const pooledIdempotencyKey = pooledPending.pendingAlertIdempotencyKey;
+    const pooledMessage = pooledPending.pendingAlertMessage;
+    if (!pooledIdempotencyKey || !pooledMessage) {
+      throw new Error("Expected a persisted pooled connection-error alert.");
+    }
+    expect(pooledPending).toMatchObject({
+      deferredPooledErrorCheckedAtMs: null,
+      deferredPooledErrorCount: 0,
+      pendingAlertMessage: expect.stringContaining(
+        "2 pooled application connection errors (port 6432)",
+      ),
+    });
+
+    harness.restartMonitor();
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      pendingAlertIdempotencyKey: pooledIdempotencyKey,
+      pendingAlertMessage: pooledMessage,
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS + ONE_HOUR_MS * 2),
+    ).resolves.toMatchObject({ outcome: "alert_sent" });
+
+    const pooledDeliveries = await Promise.all(
+      harness.allLinqRequests.slice(-2).map(readLinqRequestBody),
+    );
+    expect(pooledDeliveries.map((body) => body.message.idempotency_key).sort())
+      .toEqual([
+        pooledIdempotencyKey,
+        `${pooledIdempotencyKey}-recipient-2`,
+      ].sort());
+    expect(pooledDeliveries.map((body) => body.message.parts[0]?.value))
+      .toEqual([
+        pooledMessage,
+        pooledMessage,
+      ]);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      deferredPooledErrorCount: 0,
+      incidentOpen: false,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
   });
 
   it("delivers a one-sample direct error admitted inside the attempt fence", async () => {
@@ -2929,7 +3241,7 @@ describe("database health monitor", () => {
       .not.toContain("PgBouncer wait");
     expect(
       harness.monitor.readRecentSamples(10)
-        .filter((sample) => sample.directConnectionErrorDelta === 2),
+        .filter((sample) => sample.connectionErrorDelta === 2),
     ).toHaveLength(1);
     expect(harness.monitor.readAlertState()).toMatchObject({
       deferredDirectErrorCount: 0,
@@ -3166,7 +3478,7 @@ describe("database health monitor", () => {
       .toBe(`${combinedBodies[0]?.message.idempotency_key}-recipient-2`);
     expect(
       harness.monitor.readRecentSamples(20)
-        .filter((sample) => sample.directConnectionErrorDelta === 2),
+        .filter((sample) => sample.connectionErrorDelta === 2),
     ).toHaveLength(2);
     expect(harness.monitor.readAlertState()).toMatchObject({
       deferredDirectErrorCheckedAtMs: null,

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -50,6 +50,8 @@ describe("database health store", () => {
 
     expect(store.readAlertState()).toMatchObject({
       alertSequence: 1,
+      deferredPooledErrorCheckedAtMs: null,
+      deferredPooledErrorCount: 0,
       incidentOpen: true,
       incidentSequence: 7,
       monitoringAlertObligation: null,
@@ -57,11 +59,68 @@ describe("database health store", () => {
       pendingAlertIncludesMonitoring: false,
       pendingAlertMessage: "existing alert",
     });
+    expect(sql.exec<{ name: string }>(
+      "PRAGMA table_info(database_health_meta)",
+    ).toArray().map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "deferred_pooled_error_count",
+        "deferred_pooled_error_checked_at_ms",
+      ]),
+    );
     expect(sql.exec<{ value: number }>(
       `SELECT value
        FROM database_health_schema_meta
        WHERE key = 'schema_version'`,
     ).one().value).toBe(1);
+  });
+
+  it("stores a generalized counter baseline in the compatible sample column", () => {
+    const sql = createTestSqlStorage();
+    const store = new DatabaseHealthStore(sql);
+    const connectionErrorCounterBaseline = {
+      '["5432","us-east"]': 7,
+      '["6432","us-east"]': 8,
+    };
+
+    store.recordFailedSample({
+      connectionErrorCounterBaseline,
+      connectionErrorDelta: 2,
+      conditions: [
+        { count: 2, kind: "direct_migration_admission_failures" },
+      ],
+      failureCode: "required_metrics_missing",
+      monitoringEvidence: {
+        availability: "incomplete",
+        missingMetrics: [
+          "planetscale_edge_postgres_connection_errors_total",
+        ],
+      },
+      observedAtMs: 300_000,
+      snapshot: {
+        clientWaitSeconds: 0,
+        clientWaitingConnections: 0,
+        connectionErrorCounters: {
+          '["5432","us-east"]': 7,
+        },
+        postgresConnections: 10,
+        postgresConnectionStates: { active: 5, idle: 5 },
+        postgresMaxConnections: 50,
+        serverConnections: 10,
+        serverPoolCapacity: 50,
+        serverPoolSaturationRatio: 0.2,
+        serverPoolStates: { active: 5, idle: 5 },
+      },
+    });
+
+    expect(store.readLatestConnectionErrorCounterBaseline()).toEqual(
+      connectionErrorCounterBaseline,
+    );
+    expect(store.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        connectionErrorDelta: 2,
+        failureCode: "required_metrics_missing",
+      }),
+    ]);
   });
 
   it("adds bounded monitoring evidence to version-one sample history", () => {

--- a/apps/cloudflare/test/helpers/database-health.ts
+++ b/apps/cloudflare/test/helpers/database-health.ts
@@ -2,6 +2,7 @@ export function buildMetricsBody(input: {
   branchId: string;
   clientWaitSeconds?: number;
   directErrors?: number;
+  pooledErrors?: number;
   postgresStates?: Readonly<Record<string, number>>;
   serverConnections?: number;
 }): string {
@@ -37,6 +38,10 @@ export function buildMetricsBody(input: {
       + `planetscale_database_branch_id="${input.branchId}",`
       + 'planetscale_port="5432",planetscale_region="us-east"} '
       + `${input.directErrors ?? 0}`,
+    "planetscale_edge_postgres_connection_errors_total{"
+      + `planetscale_database_branch_id="${input.branchId}",`
+      + 'planetscale_port="6432",planetscale_region="us-east"} '
+      + `${input.pooledErrors ?? 0}`,
     "",
   ].join("\n");
 }

--- a/apps/cloudflare/test/workers/database-health-e2e.test.ts
+++ b/apps/cloudflare/test/workers/database-health-e2e.test.ts
@@ -19,8 +19,9 @@ import {
   readDatabaseHealthPlanetScaleRequestCounts,
   resetDatabaseHealthMessageRequests,
   setDatabaseHealthClientWaitSeconds,
-  setDatabaseHealthMissingDirectErrorScrapesRemaining,
+  setDatabaseHealthMissingConnectionErrorScrapesRemaining,
   setDatabaseHealthNowMs,
+  setDatabaseHealthPooledErrors,
   setDatabaseHealthZeroEvidenceScrapesRemaining,
 } from "./database-health-fetch.ts";
 
@@ -63,12 +64,12 @@ describe("database health scheduled Worker path", () => {
     expect(readDatabaseHealthMessageRequests()).toEqual([]);
   });
 
-  it("retries one safe direct-counter omission inside the scheduled Durable Object run", async () => {
+  it("retries one safe connection-error-family omission inside the scheduled Durable Object run", async () => {
     resetDatabaseHealthMessageRequests();
     const scheduledAtMs = Date.now();
     setDatabaseHealthNowMs(scheduledAtMs);
     setDatabaseHealthClientWaitSeconds(0);
-    setDatabaseHealthMissingDirectErrorScrapesRemaining(1);
+    setDatabaseHealthMissingConnectionErrorScrapesRemaining(1);
 
     const namespace = readDatabaseHealthNamespace();
     const monitor = namespace.getByName("direct-counter-retry");
@@ -96,6 +97,44 @@ describe("database health scheduled Worker path", () => {
       metrics: 2,
     });
     expect(readDatabaseHealthMessageRequests()).toEqual([]);
+  });
+
+  it("pages a pooled connection-error delta through a scheduled monitor", async () => {
+    resetDatabaseHealthMessageRequests();
+    const scheduledAtMs = Date.now();
+    setDatabaseHealthNowMs(scheduledAtMs);
+    setDatabaseHealthClientWaitSeconds(0);
+    setDatabaseHealthPooledErrors(5);
+    const monitor = readDatabaseHealthNamespace().getByName("pooled-errors");
+    await monitor.runScheduledCheck({ scheduledAtMs });
+    expect(readDatabaseHealthMessageRequests()).toEqual([]);
+
+    setDatabaseHealthNowMs(scheduledAtMs + FIVE_MINUTES_MS);
+    setDatabaseHealthPooledErrors(7);
+    await monitor.runScheduledCheck({
+      scheduledAtMs: scheduledAtMs + FIVE_MINUTES_MS,
+    });
+
+    const messageRequests = readDatabaseHealthMessageRequests();
+    expect(messageRequests).toHaveLength(2);
+    expect(messageRequests.map((request) => request.idempotencyKey).sort())
+      .toEqual([
+        "murph-db-1-1",
+        "murph-db-1-1-recipient-2",
+      ]);
+    expect(messageRequests[1]?.messageParts)
+      .toEqual(messageRequests[0]?.messageParts);
+    const message = messageRequests[0]?.messageParts[0]?.value;
+    expect(message).toContain(
+      "2 pooled application connection errors (port 6432)",
+    );
+    await expect(
+      monitor.readAlertState(),
+    ).resolves.toMatchObject({
+      incidentOpen: true,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
   });
 
   it("retains a truthful page through recovery and the hourly fence", async () => {

--- a/apps/cloudflare/test/workers/database-health-fetch.ts
+++ b/apps/cloudflare/test/workers/database-health-fetch.ts
@@ -14,8 +14,9 @@ const recordedDatabaseHealthMessageRequests:
 let databaseHealthClientWaitSeconds = 8;
 let databaseHealthDiscoveryRequestCount = 0;
 let databaseHealthMetricsRequestCount = 0;
-let databaseHealthMissingDirectErrorScrapesRemaining = 0;
+let databaseHealthMissingConnectionErrorScrapesRemaining = 0;
 let databaseHealthNowMs = Date.now();
+let databaseHealthPooledErrors = 0;
 let databaseHealthZeroEvidenceScrapesRemaining = 0;
 
 export function readDatabaseHealthMessageRequests():
@@ -41,8 +42,9 @@ export function resetDatabaseHealthMessageRequests(): void {
   databaseHealthClientWaitSeconds = 8;
   databaseHealthDiscoveryRequestCount = 0;
   databaseHealthMetricsRequestCount = 0;
-  databaseHealthMissingDirectErrorScrapesRemaining = 0;
+  databaseHealthMissingConnectionErrorScrapesRemaining = 0;
   databaseHealthNowMs = Date.now();
+  databaseHealthPooledErrors = 0;
   databaseHealthZeroEvidenceScrapesRemaining = 0;
 }
 
@@ -54,10 +56,10 @@ export function setDatabaseHealthClientWaitSeconds(value: number): void {
   databaseHealthClientWaitSeconds = value;
 }
 
-export function setDatabaseHealthMissingDirectErrorScrapesRemaining(
+export function setDatabaseHealthMissingConnectionErrorScrapesRemaining(
   value: number,
 ): void {
-  databaseHealthMissingDirectErrorScrapesRemaining = value;
+  databaseHealthMissingConnectionErrorScrapesRemaining = value;
 }
 
 export function setDatabaseHealthZeroEvidenceScrapesRemaining(
@@ -68,6 +70,10 @@ export function setDatabaseHealthZeroEvidenceScrapesRemaining(
 
 export function setDatabaseHealthNowMs(value: number): void {
   databaseHealthNowMs = value;
+}
+
+export function setDatabaseHealthPooledErrors(value: number): void {
+  databaseHealthPooledErrors = value;
 }
 
 export async function handleDatabaseHealthEgress(
@@ -123,9 +129,10 @@ export async function handleDatabaseHealthEgress(
     const metricsBody = buildMetricsBody({
       branchId: "branch_worker_test",
       clientWaitSeconds: databaseHealthClientWaitSeconds,
+      pooledErrors: databaseHealthPooledErrors,
     });
-    if (databaseHealthMissingDirectErrorScrapesRemaining > 0) {
-      databaseHealthMissingDirectErrorScrapesRemaining -= 1;
+    if (databaseHealthMissingConnectionErrorScrapesRemaining > 0) {
+      databaseHealthMissingConnectionErrorScrapesRemaining -= 1;
       return new Response(metricsBody.replace(
         /^planetscale_edge_postgres_connection_errors_total.*$/gmu,
         "",
@@ -221,7 +228,12 @@ function readValidDatabaseHealthMessageRequest(input: {
     || !isObjectRecord(value.message.parts[0])
     || value.message.parts[0].type !== "text"
     || typeof value.message.parts[0].value !== "string"
-    || !value.message.parts[0].value.includes("PgBouncer wait ")
+    || !(
+      value.message.parts[0].value.includes("PgBouncer wait ")
+      || value.message.parts[0].value.includes(
+        "pooled application connection",
+      )
+    )
     || !Array.isArray(value.to)
     || value.to.length !== 1
     || (


### PR DESCRIPTION
## Why this PR exists

Application traffic uses PgBouncer on port 6432, but the independent database-health monitor only retained the provider connection-error counter for direct port 5432. A pooled connection-admission rejection could therefore exhaust the application pool without creating the existing durable operator phone page.

## User goal / user-visible behavior

When PlanetScale reports a new pooled application connection error, both configured operators receive the existing paced database-health phone alert even if primary Postgres is refusing new clients. The message states only the supported evidence: a count of pooled application connection errors on port 6432, not an unobservable provider reason.

## User experience

The five-minute Cloudflare database-health check reads provider metrics, compares the durable per-port baseline, and durably admits one immutable pending page before Linq egress. A first observation or counter reset establishes a baseline without paging. Positive 6432 deltas page both existing direct chats; failed or ambiguous delivery retains the exact body and idempotency keys for the next paced attempt. Later deltas coalesce behind an occupied pending slot, and recovery rearms later incidents without replaying old counters.

## Invariants

- Alert detection, pending state, and delivery require no primary Postgres connection.
- Ports 5432 and 6432 remain independent region-plus-port monotonic series; missing data stays unknown.
- New/reset series are suppressed independently, while a temporarily omitted port retains its prior baseline.
- Pending bodies remain immutable and clear only after both distinct configured recipients acknowledge provider entry.
- SQLite stores no connection URL, query, credential, member identifier, phone number, or raw provider response.
- Existing schema-v1 physical sample columns remain rollback-compatible; pooled deferred state is additive.

## Architecture and reuse

- Existing systems reused: the Cloudflare `DatabaseHealthMonitor`, its SQLite Durable Object, confirmation scrape, incident lifecycle, hourly attempt fence, pending-message durability, Linq health preflight, and two-recipient idempotency.
- New logic: preserve independent 5432 and 6432 region-plus-port counter baselines, classify positive pooled-port deltas factually, and defer each non-replayable category independently behind an occupied message slot.
- New abstractions: one typed two-port delta/baseline helper; the existing monitor, store, alert state, and delivery owner remain sufficient.
- Complexity intentionally avoided: no application-to-alert bridge, new queue, database table, service, or per-failure request path that could depend on exhausted Postgres or amplify an incident.

## Non-obvious affected surfaces

- Safe incomplete-metric confirmation now composes complementary 5432/6432 observations; covered by partial-scrape and cross-scrape tests.
- Existing schema-v1 physical sample columns now store the generalized two-port baseline and aggregate delta; covered by SQLite migration and restart tests.
- Direct-port 5432 alert wording and steady-state behavior remain unchanged. The first post-upgrade 5432 delta against a legacy region-only baseline is deliberately suppressed while the monitor establishes the new region-plus-port baseline; the legacy-upgrade regression covers that rollback-safe transition.

## Changelog

- Changelog: not applicable
- Reason: this changes private operator infrastructure paging and does not change member-visible product behavior.

## Review lenses

- Product experience: applicable — proactive operator delivery, wording, pacing, two-recipient audience, and recovery behavior change.
- Prompt: not applicable.
- Frontend: not applicable; no rendered evidence is required.
- Coverage: applicable — focused parser, baseline, partial-scrape, suppression, persistence, restart, pending/deferred, delivery, and Worker-boundary cases are included.

ReviewGPT context sensitivity: sensitive

- Classification reason: this changes persisted alert state, provider egress, recovery, ordering, and idempotency behavior.

ReviewGPT first-reviewed head: 30aee305a4a56f130b0bdd25587296f57ce1f051

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/database-health-metrics.test.ts apps/cloudflare/test/database-health-monitor.test.ts apps/cloudflare/test/database-health-store.test.ts --no-coverage` — 95 passed.
- `pnpm exec vitest run --config apps/cloudflare/vitest.workers.config.ts apps/cloudflare/test/workers/database-health-e2e.test.ts --no-coverage` — 4 passed.
- `pnpm --filter @murphai/cloudflare-runner typecheck` — passed.
- Direct scenario: a scheduled monitor establishes a 6432 baseline, observes a positive delta at the next five-minute check, creates exactly two stable-idempotency Linq requests, and retains no pending page after both acknowledgements.
- Final-head required CI passed, including full app verification, package coverage, typecheck/build, fixtures, CLI matrices, artifact checks, billing boundaries, and frontend metadata proof.

## Change shape

- Source: +498 / -138
- Tests and fixtures: +597 / -45
- Docs and active execution plan: +260 / -158
- Config/tooling/generated/other: +0 / -0

## Design proof

Not applicable; this PR changes no `apps/web` UI.
