### PR TITLE
Restore lighter homepage topic labels

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -112,7 +112,7 @@ export function SectionsContent() {
         <div
           id="homepage-solo-first-hero"
           data-design-section="homepage-solo-first-hero"
-          data-design-state="soft-topic-labels-mobile-narrow-phone"
+          data-design-state="light-topic-labels-mobile-narrow-phone"
           className="-mx-5 sm:-mx-8 lg:-mx-12"
           inert
         >

--- a/apps/web/changelog/entries/2026-08-13/lighter-homepage-topic-labels.json
+++ b/apps/web/changelog/entries/2026-08-13/lighter-homepage-topic-labels.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-13",
+  "order": 50,
+  "item": {
+    "id": "lighter-homepage-topic-labels",
+    "kind": "improvement",
+    "priority": 1,
+    "title": "Quieter homepage details",
+    "summary": "The floating health topics around the homepage hero are lighter again, keeping the main message in focus.",
+    "details": "People, hover feedback, and keyboard focus remain visually distinct.",
+    "relevanceTags": ["homepage", "design"],
+    "sourcePullRequests": [1774]
+  }
+}

--- a/apps/web/src/components/homepage/hero-clocks-in.tsx
+++ b/apps/web/src/components/homepage/hero-clocks-in.tsx
@@ -1545,7 +1545,7 @@ export function HeroClocksIn({
                   "hero-floater-btn pointer-events-auto cursor-pointer select-none whitespace-nowrap bg-transparent font-mono text-[10px] tracking-[0.18em] transition-colors duration-200 ease-out hover:text-[#5a6e32] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5a6e32] focus-visible:ring-offset-2 focus-visible:ring-offset-[#f5f0e8] disabled:cursor-default",
                   f.member
                     ? "inline-flex min-h-8 items-center gap-1.5 rounded-full border border-[#c4a882]/40 bg-[#f5f0e8]/90 py-1 pl-1 pr-2.5 text-[#736a58] backdrop-blur-sm"
-                    : "inline-flex min-h-8 items-center rounded-md px-2 py-1 uppercase text-[#756c5a]",
+                    : "inline-flex min-h-8 items-center rounded-md px-2 py-1 uppercase text-[#c1baae]",
                 )}
               >
                 {f.member ? (

--- a/apps/web/test/hero-clocks-in.test.tsx
+++ b/apps/web/test/hero-clocks-in.test.tsx
@@ -89,7 +89,7 @@ test("HeroClocksIn renders the solo exchange without animation for reduced motio
   assert.ok(composer);
   assert.ok(topic);
   assert.ok(member);
-  assert.ok(topic.classList.contains("text-[#756c5a]"));
+  assert.ok(topic.classList.contains("text-[#c1baae]"));
   assert.ok(topic.classList.contains("focus-visible:ring-2"));
   assert.ok(member.classList.contains("text-[#736a58]"));
   const phoneFrame = [...view.container.querySelectorAll("div")].find(


### PR DESCRIPTION
## Why this PR exists

The ambient topic labels around the homepage hero became substantially darker during recent performance work. This restores the lighter resting tone they used before that regression.

## User goal / user-visible behavior

Homepage topics such as Steps, Omega-3, B12, Sauna, and Daily walk sit quietly in the background again instead of competing with the hero message.

## User experience

The root homepage is the only entry point affected. The labels render immediately in the restored light tone; their positions, motion, click behavior, hover color, focus ring, member pills, and hero sequence are unchanged. No asynchronous continuation, wait, failure state, or recovery path changes.

Local rendered proof used the real `HeroClocksIn` production component on the Sections catalog. The desktop study rendered the topic labels as `rgb(193, 186, 174)` at 1200 CSS pixels with a 2x capture. The 390-pixel mobile composition remained unchanged and the computed topic color matched. Both local PNGs were inspected at native resolution.

## Invariants

- Topic buttons remain interactive and keep their existing accessible names and focus rings.
- Person pills retain their stronger `#736a58` tone.
- Hero timing, animation, layout, copy, and responsive behavior remain unchanged.

## Non-obvious affected surfaces

None. The design-catalog state label and focused component assertion change only so review and regression proof track the production style.

## Architecture and reuse

- **Existing systems reused:** The existing `HeroClocksIn` component, its Sections catalog study, and its focused reduced-motion test remain the complete implementation and proof surfaces.
- **New logic:** No logic was added; one existing topic-label color returns to its prior value.
- **New abstractions:** No abstraction was added because the existing conditional class already owns the distinction between topic labels and member pills.
- **Complexity intentionally avoided:** No new token, variant, state, wrapper, animation branch, or viewport-specific override was introduced.

## Changelog

- Changelog: updated
- Items: 2026-08-13 · lighter-homepage-topic-labels

## Hot reply path impact

Not applicable. This changes only client-rendered homepage styling and does not touch conversation acceptance, provider start, or reply handoff.

## Database collection fanout impact

Not applicable. No database-touching path changed.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool, schema, skill, model, provider configuration, or request assembly changed.
- Group Murph: Not applicable; no prompt, tool, schema, skill, model, provider configuration, or request assembly changed.

## Preliminary specialist lenses

- **Product experience:** Not applicable; the task changes implementation-only visual emphasis without changing purpose, actions, hierarchy, timing, or recovery.
- **Prompt:** Not applicable; no provider-visible input changed.
- **Frontend:** Applicable; the real homepage hero section was rendered and inspected at desktop and 390-pixel mobile widths. Hosted copies of the local redacted captures are pending because the configured image-upload credential is unavailable.
- **Coverage:** Applicable; `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hero-clocks-in.test.tsx` passed 12 tests, and exact-head CI is pending.

ReviewGPT context sensitivity: routine

This is a narrow frontend-only visual correction with no sensitive, persisted-state, backend, runtime, or cross-owner effect.

## Change shape

Classification rule: production component and design-catalog lines are source; the focused assertion is tests/fixtures; there are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 1 | 1 |
| Docs | 14 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **17** | **3** |

## Design proof

- Design page: [/design?tab=sections#homepage-solo-first-hero](https://www.withmurph.ai/design?tab=sections#homepage-solo-first-hero)
- Desktop screenshot: Pending hosted attachment; the inspected local capture is 2400 × 2400 PNG.
- Mobile screenshot: Pending hosted attachment; the inspected local capture is 780 × 2062 PNG.

## Verification

- `pnpm --dir apps/web exec vitest run --config vitest.workspace.ts --no-coverage test/hero-clocks-in.test.tsx` — 12 passed.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/changelog-fragments.test.ts` — 7 passed.
- `pnpm --dir apps/web typecheck` — passed.
- `git diff --check` — passed.
- Playwright Sections catalog render — desktop and mobile passed; computed topic color was `rgb(193, 186, 174)`.
