### PR TITLE
Restore scheduled device-sync wakes

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-13-device-wake-v3.md
+++ b/agent-docs/exec-plans/completed/2026-08-13-device-wake-v3.md
@@ -1,0 +1,89 @@
+# Device scheduled-wake recovery cutover
+
+Status: completed
+Created: 2026-08-13
+Updated: 2026-08-13
+
+## Goal
+
+- Restore provider reconcile cadence for connections whose exact scheduled wake
+  was already consumed under the pre-retention runtime semantics, without
+  mutating production rows or adding another scheduler.
+
+## Success criteria
+
+- New due-reconcile retries use one deterministic `v3` event identity that is
+  distinct from the consumed `v2` identity for the same connection deadline.
+- Focused tests prove the compatibility cutover, deterministic retry identity,
+  bounded sweep behavior, and existing wake admission behavior.
+- The compatibility contract documents why the revision moved and preserves
+  exact mailbox duplicate comparison.
+- The exact pushed candidate passes required ReviewGPT gates and GitHub checks.
+- The merged Web deployment is live and bounded production evidence shows new
+  wake admission and deadline advancement, or the remaining external blocker is
+  reported precisely.
+
+## Scope
+
+- In scope: scheduled-reconcile event identity, focused Web tests, the owning
+  orchestration contract, and a privacy-safe public reliability note.
+- Out of scope: provider token or account mutation, database repair writes,
+  Cloudflare runtime changes, a second scheduling owner, and unrelated runtime
+  checkpoint churn.
+
+## Constraints
+
+- Technical constraints: Web remains the source of canonical device-sync facts;
+  Temporal remains the only global due-reconcile cadence owner; event IDs remain
+  stable within the new revision; the sweep stays limited and concurrency-capped.
+- Product/process constraints: preserve consent and privacy boundaries, keep the
+  recovery generic, use the isolated PR lane, and verify live state before
+  describing production as recovered.
+
+## Risks and mitigations
+
+1. Risk: old and new envelopes are both pending during deploy skew.
+   Mitigation: existing runtime dedupe keeps provider jobs deterministic, and a
+   stale deadline cannot regress the canonical later deadline.
+2. Risk: the cutover restores cadence but the provider still returns no data.
+   Mitigation: verify scheduler recovery separately from upstream data arrival
+   and continue provider-specific diagnosis if the deadline advances without
+   usable records.
+3. Risk: the recovery cohort adds pressure while production database capacity is
+   already elevated.
+   Mitigation: retain the existing limit of 25 and concurrency of 5, deploy only
+   the identity cutover, and watch bounded aggregate health during convergence.
+
+## Tasks
+
+1. Advance the scheduled-reconcile compatibility revision from `v2` to `v3`.
+2. Add focused regression coverage for distinct legacy/current identities and
+   update sweeper expectations.
+3. Update the owning compatibility contract and public changelog fragment.
+4. Run focused tests, prepared Web typecheck, documentation checks, and inspect
+   the privacy-safe diff.
+5. Push the exact candidate, run specialist and final ReviewGPT with CI, resolve
+   findings, merge, and verify the production deployment and recovery cohort.
+
+## Decisions
+
+- Use the existing revision seam instead of database mutation or new runtime
+  machinery because the defect is an event-identity collision across changed
+  canonical handling semantics.
+- Keep the rollout Web-only; the deployed Cloudflare runtime already understands
+  the unchanged wake envelope and treats the event ID as opaque identity.
+
+## Verification
+
+- Commands to run: focused Web Vitest files, prepared Web typecheck, changelog
+  fragment validation, docs checks, exact-head CI, ReviewGPT gates, Vercel
+  deployment inspection, and narrow read-only production database/log queries.
+- Expected outcomes: `v3` identity assertions pass; all required gates are green;
+  production inserts/consumes the new wake revision and advances stale deadlines
+  without new scheduler or database-capacity errors.
+- Local results before candidate publication:
+  - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/device-sync-hosted-wake.test.ts apps/web/test/hosted-device-sync-due-reconcile-sweeper.test.ts` passed 133 tests.
+  - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/changelog-fragments.test.ts apps/web/test/changelog.test.ts` passed 45 tests.
+  - `pnpm --dir apps/web typecheck:prepared` passed after generating the existing Health Commons build artifacts required by a clean checkout.
+  - `pnpm docs:drift` passed.
+Completed: 2026-08-13

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -296,7 +296,11 @@ coalescing, and wake buckets. The scheduled-reconcile event revision is the
 compatibility boundary for its canonical mailbox envelope. Move that revision
 when envelope hashing or canonical payload semantics change so retries cannot
 collide with an older envelope under the same event id; never weaken the
-mailbox's exact duplicate comparison to bridge versions.
+mailbox's exact duplicate comparison to bridge versions. Revision `v3` is the
+one-time cutover for exact connection-scoped retained-work handling: it lets a
+due connection create one new canonical wake when its matching `v2` wake was
+already consumed under the older handling semantics, while retries within `v3`
+remain deterministic.
 
 The Vercel device-sync dirty-sweeper cron is not registered, and there is no
 Temporal dirty-row sweep replacement. Temporal is the single production owner of

--- a/apps/web/changelog/entries/2026-08-13/connected-health-scheduled-refresh-recovery.json
+++ b/apps/web/changelog/entries/2026-08-13/connected-health-scheduled-refresh-recovery.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-13",
+  "order": 200,
+  "item": {
+    "id": "connected-health-scheduled-refresh-recovery",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Connected health refreshes recover on schedule",
+    "summary": "A connected health source can now resume its scheduled refresh after an interrupted handoff instead of remaining stuck on an update Murph already handled.",
+    "details": "Recovery keeps the existing bounded schedule and connection ownership, respects health-data consent, and does not require the member to reconnect the source.",
+    "relevanceTags": ["wearables", "health-data", "reliability"],
+    "sourcePullRequests": [1776]
+  }
+}

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -86,7 +86,7 @@ import {
 } from "./shared";
 
 const HOSTED_DEVICE_SYNC_DIRTY_WAKE_EVENT_SCHEMA = "v1";
-const HOSTED_DEVICE_SYNC_SCHEDULED_RECONCILE_WAKE_EVENT_SCHEMA = "v2";
+const HOSTED_DEVICE_SYNC_SCHEDULED_RECONCILE_WAKE_EVENT_SCHEMA = "v3";
 const COMPANION_HEALTH_MAX_PENDING_PAYLOADS = 16;
 const HISTORICAL_RESET_REVOKE_WARNING_MESSAGE =
   "Provider revoke did not complete while a historical data reset is pending. "

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1406,14 +1406,21 @@ describe("hosted device-sync wakes", () => {
     });
   });
 
-  it("versions scheduled wake identity past legacy unhashed envelopes", () => {
-    expect(buildHostedDeviceSyncScheduledReconcileWakeEventId({
+  it("cuts scheduled wake identity over from consumed v2 envelopes", () => {
+    const input = {
       connectionId: "dsc_123",
       expectedConnectedAt: "2026-03-26T12:00:00.000Z",
       nextReconcileAt: "2026-03-26T12:30:00.000Z",
-    })).toBe(
-      "device-sync:scheduled-reconcile:v2:dsc_123:2026-03-26T12:00:00.000Z:2026-03-26T12:30:00.000Z",
+    };
+    const legacyConsumedEventId =
+      "device-sync:scheduled-reconcile:v2:dsc_123:2026-03-26T12:00:00.000Z:2026-03-26T12:30:00.000Z";
+    const currentEventId = buildHostedDeviceSyncScheduledReconcileWakeEventId(input);
+
+    expect(currentEventId).toBe(
+      "device-sync:scheduled-reconcile:v3:dsc_123:2026-03-26T12:00:00.000Z:2026-03-26T12:30:00.000Z",
     );
+    expect(currentEventId).not.toBe(legacyConsumedEventId);
+    expect(buildHostedDeviceSyncScheduledReconcileWakeEventId(input)).toBe(currentEventId);
   });
 
   it("does not append scheduled reconcile work after explicit consent withdrawal", async () => {

--- a/apps/web/test/hosted-device-sync-due-reconcile-sweeper.test.ts
+++ b/apps/web/test/hosted-device-sync-due-reconcile-sweeper.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/src/lib/device-sync/wake-service", () => ({
   }) => [
     "device-sync",
     "scheduled-reconcile",
-    "v2",
+    "v3",
     input.connectionId,
     input.expectedConnectedAt,
     input.nextReconcileAt,
@@ -60,7 +60,7 @@ describe("hosted device-sync due reconcile sweeper", () => {
     expect(mocks.appendHostedDeviceSyncScheduledReconcileWake).toHaveBeenCalledWith({
       connectionId: "dsc_due_1",
       createdAt: "2026-05-05T00:01:00.000Z",
-      eventId: "device-sync:scheduled-reconcile:v2:dsc_due_1:2026-05-04T12:00:00.000Z:2026-05-05T00:00:00.000Z",
+      eventId: "device-sync:scheduled-reconcile:v3:dsc_due_1:2026-05-04T12:00:00.000Z:2026-05-05T00:00:00.000Z",
       expectedConnectedAt: "2026-05-04T12:00:00.000Z",
       nextReconcileAt: "2026-05-05T00:00:00.000Z",
       provider: "whoop",
@@ -144,7 +144,7 @@ describe("hosted device-sync due reconcile sweeper", () => {
       [{
         connectionId: "dsc_due_1",
         createdAt: "2026-05-05T00:01:00.000Z",
-        eventId: "device-sync:scheduled-reconcile:v2:dsc_due_1:2026-05-04T12:00:00.000Z:2026-05-05T00:00:00.000Z",
+        eventId: "device-sync:scheduled-reconcile:v3:dsc_due_1:2026-05-04T12:00:00.000Z:2026-05-05T00:00:00.000Z",
         expectedConnectedAt: "2026-05-04T12:00:00.000Z",
         nextReconcileAt: "2026-05-05T00:00:00.000Z",
         provider: "whoop",
@@ -154,7 +154,7 @@ describe("hosted device-sync due reconcile sweeper", () => {
       [{
         connectionId: "dsc_due_2",
         createdAt: "2026-05-05T00:01:00.000Z",
-        eventId: "device-sync:scheduled-reconcile:v2:dsc_due_2:2026-05-04T12:05:00.000Z:2026-05-05T00:00:00.000Z",
+        eventId: "device-sync:scheduled-reconcile:v3:dsc_due_2:2026-05-04T12:05:00.000Z:2026-05-05T00:00:00.000Z",
         expectedConnectedAt: "2026-05-04T12:05:00.000Z",
         nextReconcileAt: "2026-05-05T00:00:00.000Z",
         provider: "whoop",

--- a/apps/web/test/hosted-mailbox-store.test.ts
+++ b/apps/web/test/hosted-mailbox-store.test.ts
@@ -12,6 +12,10 @@ import {
 import { serializeHostedEmailThreadTarget } from "@murphai/runtime-state";
 import { describe, expect, it, vi } from "vitest";
 
+import { buildHostedDeviceSyncWake } from "@/src/lib/device-sync/wake";
+import {
+  buildHostedDeviceSyncScheduledReconcileWakeEventId,
+} from "@/src/lib/device-sync/wake-service";
 import {
   advanceHostedMailboxConsumedSeqByLane,
   appendHostedMailboxEnvelopeTx,
@@ -1514,6 +1518,95 @@ describe("appendHostedMailboxEnvelopeTx", () => {
       /^hbidx:assistant-input:v[0-9]+:[a-f0-9]{64}$/u,
     );
     expect(hostedMailboxItem.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("admits a scheduled v3 wake after its matching v2 wake was consumed", async () => {
+    const rows: HostedMailboxItemRow[] = [];
+    const hostedMailboxItem = createHostedMailboxItemDelegate({
+      create: vi.fn<HostedMailboxCreate>(async (args) => {
+        const row = buildHostedMailboxItemRow(args.data);
+        rows.push(row);
+        return row;
+      }),
+      findUnique: vi.fn<HostedMailboxFindUnique>(async (args) => {
+        const where = readHostedMailboxFindUniqueWhere(args);
+        return rows.find((row) => (
+          row.userId === where.userId && row.dedupeKey === where.dedupeKey
+        )) ?? null;
+      }),
+    });
+    const tx = createHostedMailboxTx({
+      hostedMailboxItem,
+      hostedMailboxPayload: createHostedMailboxPayloadDelegate(),
+    });
+    const identity = {
+      connectionId: "dsc_scheduled_cutover",
+      expectedConnectedAt: "2026-04-25T00:00:00.000Z",
+      nextReconcileAt: "2026-04-26T00:00:00.000Z",
+    };
+    const legacyEventId = [
+      "device-sync",
+      "scheduled-reconcile",
+      "v2",
+      identity.connectionId,
+      identity.expectedConnectedAt,
+      identity.nextReconcileAt,
+    ].join(":");
+    const currentEventId = buildHostedDeviceSyncScheduledReconcileWakeEventId(identity);
+    const buildEnvelope = (eventId: string) => buildHostedDeviceSyncWake({
+      connectionId: identity.connectionId,
+      eventId,
+      expectedConnectedAt: identity.expectedConnectedAt,
+      occurredAt: identity.nextReconcileAt,
+      provider: "oura",
+      source: "scheduled-reconcile",
+      userId: "member_mailbox_1",
+    });
+
+    const legacy = await appendHostedMailboxEnvelopeTx({
+      envelope: buildEnvelope(legacyEventId),
+      tx,
+    });
+    const legacyRow = rows[0];
+    if (!legacyRow) {
+      throw new TypeError("Expected the legacy scheduled wake to be stored.");
+    }
+    rows[0] = {
+      ...legacyRow,
+      consumedAt: new Date("2026-04-26T00:01:00.000Z"),
+    };
+    const recovered = await appendHostedMailboxEnvelopeTx({
+      envelope: buildEnvelope(currentEventId),
+      tx,
+    });
+    const retry = await appendHostedMailboxEnvelopeTx({
+      envelope: buildEnvelope(currentEventId),
+      tx,
+    });
+
+    expect(legacy.inserted).toBe(true);
+    expect(currentEventId).not.toBe(legacyEventId);
+    expect(recovered).toMatchObject({
+      dedupeConflict: false,
+      duplicate: false,
+      inserted: true,
+    });
+    expect(retry).toMatchObject({
+      dedupeConflict: false,
+      duplicate: true,
+      inserted: false,
+      item: {
+        id: recovered.item.id,
+      },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.dedupeKey)).toEqual([
+      legacyEventId,
+      currentEventId,
+    ]);
+    expect(rows[0]?.consumedAt).toEqual(new Date("2026-04-26T00:01:00.000Z"));
+    expect(rows[1]?.consumedAt).toBeNull();
+    expect(hostedMailboxItem.create).toHaveBeenCalledTimes(2);
   });
 
   it("rejects group email when the target group names another runtime workspace", async () => {


### PR DESCRIPTION
## Why this PR exists

A compatibility collision can leave a due device connection retrying an already-consumed scheduled wake without admitting provider cadence. This PR moves the existing deterministic event-identity revision so current retained-work semantics receive one fresh wake.

## User goal / user-visible behavior

Connected wearable data resumes its ordinary scheduled refresh without requiring the member to reconnect the source.

## User experience

- Entry point: the existing Temporal reconciler finds a Web-owned connection whose scheduled refresh deadline is due; there is no new member action or screen.
- Immediate feedback and timing: this remains background work. The new identity is admitted on the next eligible sweep; the existing five-minute bucket, 25-connection limit, and concurrency cap of 5 remain unchanged, so a larger recovery cohort may drain over successive sweeps.
- Continuation and destination: Web appends the existing encrypted connection-specific wake, Temporal signals the member runtime, and the runtime runs that provider account. Existing terminal checkpoint and import owners advance the canonical deadline and make private health data available to the same personal and consented group reads as before.
- Failure and recovery: retries within v3 keep one deterministic identity; v3 is distinct from a matching consumed v2 wake. Consent withdrawal still blocks admission. Provider errors retain their existing bounded retry and reporting behavior, so this change restores cadence but does not promise that an upstream provider will return data.

## Invariants

- Web remains the sole owner of canonical device connection facts and next-reconcile deadlines; Temporal remains the only global due-reconcile cadence owner.
- Mailbox duplicate comparison stays exact. The new revision changes identity once and remains deterministic for same-revision retries.
- Connection-scoped wake admission, retained-job dedupe, terminal checkpoint fencing, and stale-deadline non-regression remain unchanged.
- Health-data consent and private mailbox payload boundaries remain unchanged.
- The existing sweep limit of 25 and concurrency cap of 5 remain unchanged; no database repair write, new query, scheduler, queue, or timer is added.

## Non-obvious affected surfaces

- Public changelog: adds a privacy-safe reliability outcome backed by this PR; fragment and registry tests cover publication.
- Web-to-runtime deploy compatibility: only the opaque event ID changes. The encrypted wake envelope and parser contract are unchanged; focused wake and sweeper tests cover the new identity and existing admission.

## Architecture and reuse

- **Existing systems reused:** the Temporal global reconciler, Web due-connection selector, encrypted mailbox append, per-user runtime signal, connection-scoped runtime scheduler, and terminal checkpoint projection remain the complete flow.
- **New logic:** one scheduled-reconcile revision value changes from v2 to v3, creating a new deterministic identity for an otherwise unchanged canonical wake.
- **New abstractions:** none; the existing documented event-revision compatibility seam is sufficient.
- **Complexity intentionally avoided:** no production-row mutation, backfill table, alternate scheduler, timer, queue, compatibility parser, or weakened mailbox dedupe.

## Changelog

- Changelog: updated
- Items: 2026-08-13 · connected-health-scheduled-refresh-recovery

## Hot reply path impact

Not applicable. The change affects the background device due-reconcile sweep and adds no work between current-message acceptance, provider start, or durable reply handoff.

## Database collection fanout impact

Not applicable. The existing bounded due-connection query and mailbox transaction are unchanged. Query count, pooled-connection use, transaction concurrency, provider concurrency, the 25-row admission limit, and the concurrency cap of 5 are identical before and after.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool schema, model configuration, skill, or provider-request assembly changes.
- Group Murph: Not applicable. No prompt, tool schema, model configuration, skill, or provider-request assembly changes.

## Preliminary specialist lenses

- Product experience: applicable. Intended outcome is automatic scheduled-refresh recovery without reconnecting; the identity, sweep, and consumed-v2 mailbox owner boundary are covered by the focused 205-test run, with live production convergence intentionally pending deployment.
- Prompt: not applicable. No provider-visible instruction or tool surface changes.
- Frontend: not applicable. No rendered UI or presentation code changes.
- Coverage: applicable. Focused wake/sweeper/mailbox-owner tests passed 205 tests, changelog fragment/registry tests passed 45 tests, prepared Web typecheck passed, docs drift passed, and exact-head CI passed on the original candidate and is rerunning for the coverage-only remediation head.

ReviewGPT context sensitivity: sensitive

Reason: this is a health-data background-runtime, deploy, retry, idempotency, and recovery change.

ReviewGPT first-reviewed head: 1a48982483b3cca3c4878bc12f1a8ddbef7a7c06

## Change-shape breakdown

Classification rule: production TypeScript is source; Vitest files are tests/fixtures; the compatibility contract, completed execution plan, and public changelog fragment are docs/content; no config/tooling or generated files changed. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests/fixtures | 108 | 8 |
| Docs/content | 108 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **217** | **10** |

## Design proof

Not applicable. This PR has no user-facing frontend UI diff.

## Deployment skew / compatibility

This is a Web-only deployment. Current Cloudflare runners already parse the unchanged wake envelope and treat the event ID as opaque identity, so old and warm runners accept v3 without a tandem deploy or immediate container rollout. During Vercel rollout, an older Web instance may still retry v2; the next eligible request through the new deployment admits v3, and mailbox/runtime dedupe keeps effective provider work bounded. The observed recovery cohort was 44 due connections, so the unchanged 25-per-sweep limit should drain it over roughly two sweeps if deadlines advance normally. Rollback does not corrupt state, but it would restore the v2 collision for any connection not yet recovered, so forward verification is preferred. Post-deploy checks will confirm v3 append and consumption, deadline advancement, bounded due-count reduction, and absence of new database-capacity or device-sync runtime errors.