### PR TITLE
Fix hosted browser canary navigation

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-13-fix-hosted-browser-canaries.md
+++ b/agent-docs/exec-plans/active/2026-08-13-fix-hosted-browser-canaries.md
@@ -1,0 +1,63 @@
+# Fix hosted browser canaries
+
+Status: active
+Created: 2026-08-13
+Updated: 2026-08-13
+
+## Goal
+
+- Restore the protected-main Junction and Stripe browser canaries by making
+  their Playwright drivers follow the current product navigation contracts.
+
+## Success criteria
+
+- The Junction driver confirms the required Vital disclosure before waiting
+  for the provider authorization redirect.
+- The Stripe driver waits for a complete settings document instead of racing
+  a committed-but-still-loading navigation.
+- Focused support tests and affected Web/Cloudflare typechecks pass.
+- Exact-head CI and required ReviewGPT gates pass before merge.
+- Fresh protected-main canaries pass after merge, or any unrelated external
+  blocker is reported with secret-safe evidence.
+
+## Scope
+
+- In scope: hosted-local Junction and Stripe browser drivers, focused proof,
+  and the owning canary contract tests.
+- Out of scope: provider business logic, production UI behavior, credentials,
+  and unrelated canary scenarios.
+
+## Constraints
+
+- Technical constraints: preserve credential redaction and secret-free
+  artifacts; do not weaken either live provider proof.
+- Product/process constraints: pin fixes to the existing UI contracts, run
+  ReviewGPT concurrently with PR CI, and merge only after the routed gates.
+
+## Risks and mitigations
+
+1. Risk: a driver-only workaround could bypass the journey under test.
+   Mitigation: perform the same accessible button action a member must take
+   and continue asserting the external provider and callback boundaries.
+2. Risk: broader navigation waits could hide a broken settings response.
+   Mitigation: require DOM readiness and validate the navigation response
+   before asserting the settings projection.
+
+## Tasks
+
+1. Fix both browser-driver sequencing defects and add focused contract proof.
+2. Run focused tests and affected typechecks, then inspect the full diff.
+3. Commit, push, open the PR, and launch specialist/final ReviewGPT with CI.
+4. Resolve accepted findings, merge, and monitor fresh main canaries.
+
+## Decisions
+
+- Keep production application code unchanged: both failures are stale browser
+  automation assumptions, while the current member-facing contracts are valid.
+
+## Verification
+
+- Commands to run: focused Web support and hosted-local canary workflow tests;
+  Web and Cloudflare typechecks; exact-head required GitHub checks; protected-
+  main Junction and Stripe canaries after merge.
+- Expected outcomes: deterministic local checks and both live canaries pass.

--- a/agent-docs/exec-plans/completed/2026-08-13-fix-hosted-browser-canaries.md
+++ b/agent-docs/exec-plans/completed/2026-08-13-fix-hosted-browser-canaries.md
@@ -1,6 +1,6 @@
 # Fix hosted browser canaries
 
-Status: active
+Status: completed
 Created: 2026-08-13
 Updated: 2026-08-13
 
@@ -54,6 +54,10 @@ Updated: 2026-08-13
 
 - Keep production application code unchanged: both failures are stale browser
   automation assumptions, while the current member-facing contracts are valid.
+- Keep distinct Junction display values for the disclosure button (`Whoop`) and
+  the post-connect heading (`WHOOP`) because both are real UI contracts.
+- Replace implementation-text billing checks with behavioral Page/Response
+  doubles so branch and ordering regressions fail before the live lane.
 
 ## Verification
 
@@ -61,3 +65,15 @@ Updated: 2026-08-13
   Web and Cloudflare typechecks; exact-head required GitHub checks; protected-
   main Junction and Stripe canaries after merge.
 - Expected outcomes: deterministic local checks and both live canaries pass.
+- Completed focused proof:
+  - Connect page: 100/100 passed.
+  - Hosted billing support: 13/13 passed.
+  - Junction workflow: 6/6 passed.
+  - Web, hosted-local harness, and Cloudflare typechecks passed.
+  - Exact-head GitHub required checks passed.
+- Review outcome:
+  - Preliminary specialists found the WHOOP/Whoop selector mismatch and weak
+    source-scan billing proof; both were accepted and corrected.
+  - Final ReviewGPT round 2 performed a fresh full-patch audit and passed with
+    no findings.
+Completed: 2026-08-13

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -13,6 +13,7 @@ import {
 } from "./hosted-local-browser-process.ts";
 
 interface BrowserConfig {
+  disclosureSourceName: "Oura" | "Whoop";
   email: string;
   headless: boolean;
   hostedSessionCookie: string;
@@ -117,7 +118,7 @@ async function main(): Promise<void> {
       .getByRole("dialog")
       .getByRole("button", {
         exact: true,
-        name: `Continue to ${config.label}`,
+        name: `Continue to ${config.disclosureSourceName}`,
       })
       .click({ timeout: config.timeoutMs });
 
@@ -389,6 +390,7 @@ function readBrowserConfig(environment: NodeJS.ProcessEnv): BrowserConfig {
   }
 
   return {
+    disclosureSourceName: source === "oura" ? "Oura" : "Whoop",
     email: readHostedLocalBrowserEnvironmentValue(
       environment,
       "MURPH_E2E_PROVIDER_EMAIL",

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -482,7 +482,7 @@ function sanitizeFailure(error: unknown, config: BrowserConfig | null): string {
       message = message.replaceAll(secret, "[redacted]");
     }
   }
-  message = message.replace(/https?:\/\/[^\s)]+/gu, (rawUrl) => {
+  message = message.replace(/https?:\/\/[^\s)"']+/gu, (rawUrl) => {
     try {
       const url = new URL(rawUrl);
       return `${url.origin}${url.pathname}`;

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -112,6 +112,15 @@ async function main(): Promise<void> {
       waitUntil: "domcontentloaded",
     });
 
+    stage = "murph_vital_disclosure";
+    await page
+      .getByRole("dialog")
+      .getByRole("button", {
+        exact: true,
+        name: `Continue to ${config.label}`,
+      })
+      .click({ timeout: config.timeoutMs });
+
     stage = "murph_connect_start";
     await page.waitForURL((url) => url.origin !== config.webOrigin, {
       timeout: config.timeoutMs,

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -3476,7 +3476,7 @@ test("ConnectSourcesGrid redeems an initial device connect intent through the ap
   await rendered.cleanup();
 });
 
-test("ConnectSourcesGrid explains Vital before redeeming an initial device connect intent", async () => {
+test("ConnectSourcesGrid explains Vital before redeeming a WHOOP device connect intent", async () => {
   const claim = "dc_12345678901234567890123456789012";
   let resolveAuthorizationResponse:
     | ((response: Response) => void)
@@ -3499,23 +3499,23 @@ test("ConnectSourcesGrid explains Vital before redeeming an initial device conne
     createElement(ConnectSourcesGrid, {
       sources: [
         {
-          connectTarget: "fitbit",
-          description: "Sleep, activity, heart rate, and daily readiness.",
-          id: "fitbit",
+          connectTarget: "whoop_v2",
+          description: "Recovery, strain, sleep, and heart rate.",
+          id: "whoop",
           logo: {
             className: "size-11 object-contain",
             height: 44,
-            src: "/brand-logos/connect/fitbit.svg",
+            src: "/brand-logos/connect/whoop.svg",
             width: 44,
           },
-          name: "Fitbit",
+          name: "Whoop",
         },
       ],
     }),
     {
       location: {
-        hash: `#deviceConnectIntent=${claim}&connectSource=fitbit&connectProvider=junction`,
-        href: `https://join.example.test/connect#deviceConnectIntent=${claim}&connectSource=fitbit&connectProvider=junction`,
+        hash: `#deviceConnectIntent=${claim}&connectSource=whoop&connectProvider=junction`,
+        href: `https://join.example.test/connect#deviceConnectIntent=${claim}&connectSource=whoop&connectProvider=junction`,
       },
     },
   );
@@ -3523,7 +3523,7 @@ test("ConnectSourcesGrid explains Vital before redeeming an initial device conne
   await vi.waitFor(() => {
     assert.match(
       rendered.container.textContent ?? "",
-      /Connect Fitbit to Murph/u,
+      /Connect Whoop to Murph/u,
     );
   });
   assert.equal(fetch.mock.calls.length, 0);
@@ -3531,7 +3531,7 @@ test("ConnectSourcesGrid explains Vital before redeeming an initial device conne
 
   const continueButton = [
     ...rendered.container.querySelectorAll("button"),
-  ].find((button) => button.textContent === "Continue to Fitbit");
+  ].find((button) => button.textContent === "Continue to Whoop");
   assert.ok(continueButton instanceof rendered.window.HTMLButtonElement);
   await act(async () => {
     continueButton.dispatchEvent(
@@ -3541,7 +3541,7 @@ test("ConnectSourcesGrid explains Vital before redeeming an initial device conne
 
   await vi.waitFor(() => {
     assert.equal(fetch.mock.calls.length, 1);
-    assert.match(rendered.container.textContent ?? "", /Connecting Fitbit/u);
+    assert.match(rendered.container.textContent ?? "", /Connecting Whoop/u);
   });
   assert.equal(rendered.assign.mock.calls.length, 0);
   assert.equal(fetch.mock.calls[0]?.[0], `/device/connect/${claim}`);
@@ -3560,14 +3560,14 @@ test("ConnectSourcesGrid explains Vital before redeeming an initial device conne
   await act(async () => {
     resolveAuthorizationResponse?.(
       Response.json({
-        authorizationUrl: "https://junction.example.test/link/fitbit",
+        authorizationUrl: "https://junction.example.test/link/whoop",
       }),
     );
   });
   await vi.waitFor(() => {
     assert.equal(
       rendered.assign.mock.calls[0]?.[0],
-      "https://junction.example.test/link/fitbit",
+      "https://junction.example.test/link/whoop",
     );
   });
   assert.equal(fetch.mock.calls.length, 1);

--- a/apps/web/test/hosted-billing-live-support.test.ts
+++ b/apps/web/test/hosted-billing-live-support.test.ts
@@ -99,6 +99,23 @@ describe("hosted billing live browser support", () => {
     );
   });
 
+  it("settles browser navigations before reading billing projections", async () => {
+    const driverSource = await readFile(
+      new URL("./support/hosted-billing-browser-driver.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(driverSource).toContain(
+      'await actor.page.waitForLoadState("domcontentloaded");',
+    );
+    expect(driverSource).toContain(
+      'navigation = await actor.page.reload({ waitUntil: "domcontentloaded" });',
+    );
+    expect(driverSource).toContain(
+      'assertSuccessfulNavigation(navigation, "Murph settings");',
+    );
+  });
+
   it("finds interrupted Checkout metadata through the opaque run correlation", () => {
     const runId = "billing_pr_123_run_456";
     const token = buildHostedStripeRunCorrelationToken(runId);

--- a/apps/web/test/hosted-billing-live-support.test.ts
+++ b/apps/web/test/hosted-billing-live-support.test.ts
@@ -1,9 +1,10 @@
 import { readFile } from "node:fs/promises";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildSanitizedBrowserEnvironmentForTest,
+  HostedBillingBrowserDriver,
   readStripeSurfaceForTest,
   redactHostedBillingBrowserErrorForTest,
 } from "./support/hosted-billing-browser-driver";
@@ -99,20 +100,115 @@ describe("hosted billing live browser support", () => {
     );
   });
 
-  it("settles browser navigations before reading billing projections", async () => {
-    const driverSource = await readFile(
-      new URL("./support/hosted-billing-browser-driver.ts", import.meta.url),
-      "utf8",
-    );
+  it.each([
+    ["different path", "https://app.example.test/home", "goto"],
+    ["same path", "https://app.example.test/settings", "reload"],
+  ] as const)("waits for a complete settings document from a %s", async (
+    _label,
+    currentUrl,
+    expectedNavigation,
+  ) => {
+    const navigation = createNavigationResponse({ ok: true, status: 200 });
+    const subscriptionWaitFor = vi.fn(async () => undefined);
+    const page = createSettingsPageDouble({
+      currentUrl,
+      navigation,
+      subscriptionWaitFor,
+    });
+    const driver = new HostedBillingBrowserDriver({
+      diagnosticsPath: "/tmp/hosted-billing-browser-diagnostics.json",
+      runId: "billing-navigation-proof",
+      webBaseUrl: "https://app.example.test",
+    });
 
-    expect(driverSource).toContain(
-      'await actor.page.waitForLoadState("domcontentloaded");',
+    await driver.openSettings({
+      context: {} as never,
+      page: page as never,
+      close: vi.fn(),
+    });
+
+    expect(page[expectedNavigation]).toHaveBeenCalledWith(
+      ...(expectedNavigation === "goto"
+        ? ["https://app.example.test/settings#subscription", {
+            waitUntil: "domcontentloaded",
+          }]
+        : [{ waitUntil: "domcontentloaded" }]),
     );
-    expect(driverSource).toContain(
-      'navigation = await actor.page.reload({ waitUntil: "domcontentloaded" });',
+    expect(subscriptionWaitFor).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["missing", null],
+    ["unsuccessful", createNavigationResponse({ ok: false, status: 503 })],
+  ] as const)("rejects a %s settings response before reading billing projections", async (
+    _label,
+    navigation,
+  ) => {
+    const subscriptionWaitFor = vi.fn(async () => undefined);
+    const page = createSettingsPageDouble({
+      currentUrl: "https://app.example.test/home",
+      navigation,
+      subscriptionWaitFor,
+    });
+    const driver = new HostedBillingBrowserDriver({
+      diagnosticsPath: "/tmp/hosted-billing-browser-diagnostics.json",
+      runId: "billing-navigation-failure-proof",
+      webBaseUrl: "https://app.example.test",
+    });
+
+    await expect(driver.openSettings({
+      context: {} as never,
+      page: page as never,
+      close: vi.fn(),
+    })).rejects.toThrow(/Murph settings navigation/u);
+    expect(subscriptionWaitFor).not.toHaveBeenCalled();
+  });
+
+  it("waits for the enrolled home document before opening settings", async () => {
+    const enrollmentResponse = createApiResponse({
+      method: "POST",
+      ok: true,
+      pathname: "/api/hosted-onboarding/starter/enroll",
+      status: 200,
+    });
+    const navigation = createNavigationResponse({ ok: true, status: 200 });
+    const waitForURL = vi.fn(async (
+      predicate: (url: URL) => boolean,
+    ) => {
+      expect(predicate(new URL("https://app.example.test/home"))).toBe(true);
+    });
+    const waitForLoadState = vi.fn(async () => undefined);
+    const page = {
+      goto: vi.fn(async () => navigation),
+      waitForLoadState,
+      waitForResponse: vi.fn(async (
+        predicate: (response: ReturnType<typeof createApiResponse>) => boolean,
+      ) => {
+        expect(predicate(enrollmentResponse)).toBe(true);
+        return enrollmentResponse;
+      }),
+      waitForURL,
+    };
+    const driver = new HostedBillingBrowserDriver({
+      diagnosticsPath: "/tmp/hosted-billing-browser-diagnostics.json",
+      runId: "billing-enrollment-navigation-proof",
+      webBaseUrl: "https://app.example.test",
+    });
+
+    await driver.activateStarterUsage({
+      context: {} as never,
+      page: page as never,
+      close: vi.fn(),
+    }, "starter-invite");
+
+    expect(page.goto).toHaveBeenCalledWith(
+      "https://app.example.test/join/starter-invite",
+      { waitUntil: "commit" },
     );
-    expect(driverSource).toContain(
-      'assertSuccessfulNavigation(navigation, "Murph settings");',
+    expect(waitForURL).toHaveBeenCalledOnce();
+    expect(waitForLoadState).toHaveBeenCalledWith("domcontentloaded");
+    expect(waitForLoadState.mock.invocationCallOrder[0]).toBeGreaterThan(
+      waitForURL.mock.invocationCallOrder[0] ?? 0,
     );
   });
 
@@ -150,3 +246,39 @@ describe("hosted billing live browser support", () => {
     })).rejects.toThrow(/requires a member id/u);
   });
 });
+
+function createNavigationResponse(input: { ok: boolean; status: number }) {
+  return {
+    ok: vi.fn(() => input.ok),
+    status: vi.fn(() => input.status),
+  };
+}
+
+function createApiResponse(input: {
+  method: string;
+  ok: boolean;
+  pathname: string;
+  status: number;
+}) {
+  return {
+    ok: vi.fn(() => input.ok),
+    request: vi.fn(() => ({ method: vi.fn(() => input.method) })),
+    status: vi.fn(() => input.status),
+    url: vi.fn(() => `https://app.example.test${input.pathname}`),
+  };
+}
+
+function createSettingsPageDouble(input: {
+  currentUrl: string;
+  navigation: ReturnType<typeof createNavigationResponse> | null;
+  subscriptionWaitFor: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    getByText: vi.fn(() => ({
+      first: vi.fn(() => ({ waitFor: input.subscriptionWaitFor })),
+    })),
+    goto: vi.fn(async () => input.navigation),
+    reload: vi.fn(async () => input.navigation),
+    url: vi.fn(() => input.currentUrl),
+  };
+}

--- a/apps/web/test/support/hosted-billing-browser-driver.ts
+++ b/apps/web/test/support/hosted-billing-browser-driver.ts
@@ -123,6 +123,7 @@ export class HostedBillingBrowserDriver {
         (url) => url.origin === new URL(this.webBaseUrl).origin
           && url.pathname === "/home",
       );
+      await actor.page.waitForLoadState("domcontentloaded");
     });
   }
 
@@ -361,14 +362,18 @@ export class HostedBillingBrowserDriver {
   async openSettings(actor: HostedBillingBrowserActor): Promise<void> {
     const target = new URL(this.murphUrl("/settings#subscription"));
     const current = new URL(actor.page.url());
+    let navigation: Response | null;
     if (current.origin === target.origin && current.pathname === target.pathname) {
       // A navigation that differs only by the subscription hash is a
       // same-document navigation and preserves a stale server projection.
       // Force a request when a workflow has mutated billing in another page.
-      await actor.page.reload({ waitUntil: "commit" });
+      navigation = await actor.page.reload({ waitUntil: "domcontentloaded" });
     } else {
-      await actor.page.goto(target.toString(), { waitUntil: "commit" });
+      navigation = await actor.page.goto(target.toString(), {
+        waitUntil: "domcontentloaded",
+      });
     }
+    assertSuccessfulNavigation(navigation, "Murph settings");
     await actor.page.getByText("Subscription", { exact: true }).first().waitFor();
   }
 

--- a/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
+++ b/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
@@ -113,4 +113,10 @@ describe("live Junction wearable canary workflow", () => {
     expect(disclosureStep).toContain('name: `Continue to ${config.label}`');
     expect(disclosureStep).toContain(".click({ timeout: config.timeoutMs })");
   });
+
+  it("keeps Playwright's closing quote out of redacted navigation URLs", () => {
+    expect(browserRunner).toContain(
+      'message.replace(/https?:\\/\\/[^\\s)"\']+/gu, (rawUrl) => {',
+    );
+  });
 });

--- a/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
+++ b/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
@@ -110,8 +110,13 @@ describe("live Junction wearable canary workflow", () => {
     expect(connectOffset).toBeGreaterThan(disclosureOffset);
     const disclosureStep = browserRunner.slice(disclosureOffset, connectOffset);
     expect(disclosureStep).toContain('.getByRole("dialog")');
-    expect(disclosureStep).toContain('name: `Continue to ${config.label}`');
+    expect(disclosureStep).toContain(
+      'name: `Continue to ${config.disclosureSourceName}`',
+    );
     expect(disclosureStep).toContain(".click({ timeout: config.timeoutMs })");
+    expect(browserRunner).toContain(
+      'disclosureSourceName: source === "oura" ? "Oura" : "Whoop"',
+    );
   });
 
   it("keeps Playwright's closing quote out of redacted navigation URLs", () => {

--- a/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
+++ b/packages/hosted-local-harness/test/junction-wearable-canary-workflow.test.ts
@@ -14,6 +14,16 @@ const workflow = readFileSync(
   path.join(repoRoot, ".github", "workflows", "junction-wearable-canary.yml"),
   "utf8",
 );
+const browserRunner = readFileSync(
+  path.join(
+    repoRoot,
+    "apps",
+    "web",
+    "scripts",
+    "run-hosted-local-junction-wearable-browser.ts",
+  ),
+  "utf8",
+);
 
 describe("live Junction wearable canary workflow", () => {
   it("admits secrets only after protected main updates or manual retries", () => {
@@ -88,5 +98,19 @@ describe("live Junction wearable canary workflow", () => {
     for (const actionRef of actionRefs) {
       expect(actionRef[1]).toMatch(/^[a-f0-9]{40}$/u);
     }
+  });
+
+  it("confirms the required Vital disclosure before waiting for provider authorization", () => {
+    const disclosureOffset = browserRunner.indexOf(
+      'stage = "murph_vital_disclosure";',
+    );
+    const connectOffset = browserRunner.indexOf('stage = "murph_connect_start";');
+
+    expect(disclosureOffset).toBeGreaterThan(0);
+    expect(connectOffset).toBeGreaterThan(disclosureOffset);
+    const disclosureStep = browserRunner.slice(disclosureOffset, connectOffset);
+    expect(disclosureStep).toContain('.getByRole("dialog")');
+    expect(disclosureStep).toContain('name: `Continue to ${config.label}`');
+    expect(disclosureStep).toContain(".click({ timeout: config.timeoutMs })");
   });
 });


### PR DESCRIPTION
## Why this PR exists

Protected-main Junction and Stripe browser canaries are following stale navigation assumptions. The Junction journey now requires the Vital disclosure action, while the Stripe driver can race a committed but still-loading document before reading settings.

## User goal / user-visible behavior

No production UI or member behavior changes. The live canaries once again exercise the current member journeys accurately so deploy health is trustworthy.

## User experience

Not applicable: this changes only Playwright canary drivers and their contract tests.

## Invariants

- The Junction canary must perform the same required disclosure action as a member, then continue proving the external provider and callback boundaries.
- The Stripe canary must validate a successful, DOM-ready settings response before reading billing state.
- Browser processes must retain their existing credential isolation and redacted diagnostics.

## Non-obvious affected surfaces

- Protected-main Junction wearable canary: regression proof is the runner sequencing contract plus its workflow test.
- Protected-main Stripe billing matrix: regression proof is the DOM-ready navigation contract plus billing support test.

## Architecture and reuse

- **Existing systems reused:** Playwright accessible-role locators, the existing Vital dialog contract, and the existing successful-navigation assertion.
- **New logic:** one required disclosure click and DOM-ready waits for billing document navigation.
- **New abstractions:** none; the current browser drivers already own these interactions.
- **Complexity intentionally avoided:** no product-code workaround, retry loop, provider bypass, or additional state owner.

## Changelog

- Changelog: not applicable

- Reason: no member-visible behavior changes; only protected-main canary automation is corrected.

## Hot reply path impact

Not applicable: no conversation or reply path changes.

## Database collection fanout impact

Not applicable: no database-touching collection path changes.

## Murph initial provider input impact

Not applicable for individual and group Murph: no prompt, tool, model, provider-request assembly, or provider-visible input changed.

## Preliminary specialist lenses

- Product experience: not applicable; member-facing actions and outcomes are unchanged.
- Prompt: not applicable; no prompt or tool description changed.
- Frontend: not applicable; no production UI or presentation code changed.
- Coverage: applicable; focused proof is 6/6 Junction workflow tests, 9/9 billing support tests, Web typecheck, and Cloudflare typecheck. Exact-head CI is pending.

ReviewGPT first-reviewed head: ee2d61b8234a4ff21962d578a089635bd98c37f1
ReviewGPT context sensitivity: sensitive

Reason: the patch changes protected-main live provider and billing canary execution across an external browser boundary.

## Change-shape breakdown

Classification rule: Playwright runner/driver code is source; Vitest files are tests; the execution plan is docs; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 16 | 2 |
| Tests/fixtures | 41 | 0 |
| Docs | 63 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **120** | **2** |

## Design proof

Not applicable: there is no user-facing frontend UI diff.

## Deployment skew / compatibility

No deploy ordering requirement. These canary drivers run from one checked-out commit and do not change Web, Worker, container, persisted-state, or credential contracts.

## Verification

- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts --no-coverage test/junction-wearable-canary-workflow.test.ts` — 6/6 passed
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-billing-live-support.test.ts` — 9/9 passed
- `pnpm --dir apps/web typecheck:prepared` — passed
- `pnpm --dir apps/cloudflare typecheck` — passed

PR metadata validation: exact-head checks remain authoritative.

## Current candidate after diagnostic remediation

Current candidate head: da3cfb59e3387c22dcc6ad5156cc2019a097d41f

The second commit excludes Playwright's closing quote from redacted navigation URLs; the historical %22 suffix was a sanitizer artifact over a real connect-page wait. Authored source growth since the immutable first-reviewed baseline is +1/-1, with one focused regression test (+6/-0).

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 17 | 3 |
| Tests/fixtures | 47 | 0 |
| Docs | 63 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **127** | **3** |

## Review remediation candidate

Current candidate head: 14b02b917ae9d95539750a5c4019847e3ca57c97

Accepted specialist/final finding: the exact disclosure selector used the completion-heading label WHOOP while the dialog renders Whoop. Fixed by adding the narrow disclosure-facing source name and proving the real WHOOP Connect UI path. Accepted specialist coverage finding: the Stripe proof scanned implementation text. Replaced it with behavioral doubles covering both DOM-ready settings branches, missing/failed responses before projection reads, and post-enrollment load ordering.

Current focused proof: connect page 100/100; billing support 13/13; Junction workflow 6/6; Web, hosted-local harness, and Cloudflare typechecks pass.

## Final plan-closure head

Current candidate head: 0dea732c360f6292ef4c605726b088f7e6f859f3

The only change after the passing full-patch audit is the execution plan's move from active to completed plus its recorded verification/review outcomes; executable behavior is unchanged.
