### PR TITLE
Ratchet hosted runner budget for source-complete group sharing

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -262,7 +262,13 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // measured 10,053,341B on macOS; preserve the boot-path ratchets and the
 // established 32KB total allowance. Exhaustive Junction activation then
 // measured 10,136,931B on macOS, so ratchet the combined integrated baseline.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_136_931 + 32_768;
+//
+// Source-complete group health sharing extends the existing hosted projection
+// and parser outputs without adding a forbidden boot input. Exact merged
+// production assembly measured 10,174,998B on Linux and 10,218,245B on macOS
+// on 2026-08-13, so ratchet the total to the larger cross-platform measurement
+// and retain the established 32KB allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_218_245 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_689_721;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_992_470;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -609,7 +609,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_689_721 + 48_000,
       staticClosureBytes: 7_992_470 + 96_000,
-      totalBytes: 10_136_931 + 32_768,
+      totalBytes: 10_218_245 + 32_768,
     });
   });
 


### PR DESCRIPTION
## Why

The source-complete group health-sharing change in #1765 intentionally grew the hosted runner bundle. The production Cloudflare predeploy gate measured the exact merged Linux artifact at 10,174,998 bytes, 5,299 bytes above the prior total budget, so deployment failed closed before any production mutation.

## User-visible goal and UX

Unblock the hosted runner rollout for #1765 so every authorized source-tagged group-health observation reaches ordinary group reads and scheduled group email. This follow-up changes no consent, permissions, grants, revocation, audience, copy, or presentation.

## Invariants

- The total baseline uses the larger exact cross-platform measurement: 10,218,245 bytes on macOS versus 10,174,998 bytes on Linux.
- The existing 32 KiB cross-platform allowance is unchanged.
- Entry-chunk and static-boot-closure budgets remain independently enforced.
- Forbidden boot-input guards, runner permissions, and runtime behavior are unchanged.
- One byte above the composed budget still fails closed.

## Architecture and reuse

This updates the existing bundle-budget owner and its explicit policy test only. It adds no service, state, queue, selection rule, dependency, or compatibility path.

- Existing systems reused: the current total, entry-chunk, static-closure, and forbidden-input bundle guards plus their policy test.
- New logic: none; only the total budget's exact measured baseline changes.
- New abstractions: none because the existing bundle-budget owner already models this exact measured baseline.
- Complexity intentionally avoided: no platform-specific budgets, dynamic bypass, new configuration owner, or weakened independent guard.

## Validation

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts` — 42 passed
- `pnpm --dir apps/cloudflare runner:bundle` — passed; 10,218,245-byte total, entry/static budgets and parity probes passed
- `pnpm --dir apps/cloudflare typecheck` — passed
- `git diff --check` — passed
- Local deep review — no verified findings; confirmed the larger measured baseline plus unchanged tolerance is the smallest maintainable correction

No additional ReviewGPT round was run, per request.

## Change size

- Source: 0 added / 0 deleted
- Tests: 1 added / 1 deleted
- Docs: 0 added / 0 deleted
- Config/tooling: 7 added / 1 deleted
- Generated/other: 0 added / 0 deleted
- Total: 8 added / 2 deleted

## Design proof

Not applicable; no frontend or user-facing visual change.

## Changelog

- Changelog: not applicable
- Reason: This follow-up only corrects an internal deployment budget; #1765 owns the user-facing change.

## Deployment

Vercel for #1765 is already ready. After this follow-up merges, rerun the protected production Cloudflare workflow with an immediate container rollout and require the exact runner-bundle fingerprint plus endpoint, managed-container, direct-R2, and live-model smoke.
