### PR TITLE
fix(cloudflare): ratchet runner entrypoint budget

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-13-hosted-canary-runner-bundle-budget.md
+++ b/agent-docs/exec-plans/active/2026-08-13-hosted-canary-runner-bundle-budget.md
@@ -1,0 +1,76 @@
+# Unblock hosted browser canaries at runner bundle assembly
+
+Status: active
+Created: 2026-08-13
+Updated: 2026-08-13
+
+## Goal
+
+- Restore the protected-main Junction and Stripe browser canaries by accepting
+  the already-reviewed hosted runner graph at its current measured byte size.
+
+## Success criteria
+
+- The production runner bundle assembles within its explicit total byte budget.
+- The entry-chunk and static-closure ratchets remain unchanged and the existing
+  forbidden-boot-input guard still passes.
+- Focused bundle tests, Cloudflare typecheck, exact-head CI, preliminary
+  specialist ReviewGPT, and final ReviewGPT all pass.
+- The change is merged and fresh protected-main Junction and Stripe canaries
+  reach their browser scenarios without the pre-browser budget failure.
+
+## Scope
+
+- In scope: the runner entrypoint total-byte baseline, its mirrored policy test,
+  PR verification/review, merge, and post-merge canary monitoring.
+- Out of scope: changing runner behavior, removing runtime features, weakening
+  entry/static closure budgets, or altering Junction/Stripe browser behavior.
+
+## Constraints
+
+- Technical constraints: use the larger exact macOS production measurement of
+  10,204,553 bytes as the integrated baseline, retain the existing 32 KiB
+  allowance, and confirm the Linux measurement remains below that baseline.
+- Product/process constraints: preserve existing worktree edits, keep diagnostics
+  metadata-only, and use the guarded task-worktree/PR/ReviewGPT path.
+
+## Risks and mitigations
+
+1. Risk: raising the budget could hide an accidental eager dependency.
+   Mitigation: retain the stricter entry/static ratchets and forbidden-input
+   guard, inspect the metafile report, and update only the total baseline.
+2. Risk: the canaries could still contain a browser-level defect after assembly.
+   Mitigation: merge only after exact-head CI/review and monitor both fresh
+   protected-main canaries through their terminal browser outcomes.
+
+## Tasks
+
+1. [done] Record the CI reproduction and confirm both workflows share the same blocker.
+2. [done] Ratchet the total-byte baseline and mirrored test to the measured value.
+3. [done] Run focused bundle assembly, tests, typecheck, and inspect the final diff.
+4. [active] Commit/push/open the PR; run preliminary and final ReviewGPT with CI.
+5. [pending] Resolve findings, merge, and monitor fresh protected-main canaries.
+
+## Decisions
+
+- Use a measured baseline update rather than deleting or restructuring runtime
+  code: the overage is 624 bytes, the provider graph is already reviewed and
+  required, and no forbidden boot subsystem entered the graph.
+- The direct macOS assembly measured 10,204,553 bytes, 34,230 bytes above Linux;
+  use that larger cross-platform measurement because the Linux-only baseline
+  still exceeded the existing allowance on macOS by 1,462 bytes.
+- Treat this as one deploy blocker because both Junction and Stripe stopped at
+  the identical runner assembly boundary before either browser scenario began.
+
+## Verification
+
+- Commands to run:
+  - `pnpm --dir apps/cloudflare exec vitest run --config vitest.node.workspace.ts --no-coverage test/runner-bundle-entrypoint-bundle.test.ts`
+  - `pnpm --dir apps/cloudflare runner:bundle`
+  - `pnpm --dir apps/cloudflare typecheck`
+  - `git diff --check`
+  - exact-head required GitHub checks and both ReviewGPT passes
+  - fresh protected-main Junction and Stripe canary workflows
+- Expected outcomes: every command passes; bundle output reports the measured
+  total under the new baseline plus unchanged allowance; both canaries proceed
+  beyond assembly and finish successfully.

--- a/agent-docs/exec-plans/completed/2026-08-13-hosted-canary-runner-bundle-budget.md
+++ b/agent-docs/exec-plans/completed/2026-08-13-hosted-canary-runner-bundle-budget.md
@@ -1,6 +1,6 @@
 # Unblock hosted browser canaries at runner bundle assembly
 
-Status: active
+Status: completed
 Created: 2026-08-13
 Updated: 2026-08-13
 
@@ -48,8 +48,8 @@ Updated: 2026-08-13
 1. [done] Record the CI reproduction and confirm both workflows share the same blocker.
 2. [done] Ratchet the total-byte baseline and mirrored test to the measured value.
 3. [done] Run focused bundle assembly, tests, typecheck, and inspect the final diff.
-4. [active] Commit/push/open the PR; run preliminary and final ReviewGPT with CI.
-5. [pending] Resolve findings, merge, and monitor fresh protected-main canaries.
+4. [done] Commit/push/open the PR; run preliminary and final ReviewGPT with CI.
+5. [active] Resolve findings, merge, and monitor fresh protected-main canaries.
 
 ## Decisions
 
@@ -74,3 +74,14 @@ Updated: 2026-08-13
 - Expected outcomes: every command passes; bundle output reports the measured
   total under the new baseline plus unchanged allowance; both canaries proceed
   beyond assembly and finish successfully.
+- Results before plan closure:
+  - focused runner entrypoint policy: 42/42 passed
+  - Cloudflare typecheck: passed
+  - production runner assembly: passed at 1,699,473B entry, 8,074,787B static
+    closure, and 10,204,553B total under the retained per-surface allowances
+  - preliminary specialist ReviewGPT: PASS, no findings or patch artifact
+  - final ReviewGPT round 1: PASS, no findings
+  - exact-head release, runner-permission, billing-hermetic, hygiene, viewport,
+    and Vercel checks: passed; PR metadata rerun pending after body-only fixes
+  - post-merge Junction and Stripe canaries remain the final operational proof
+Completed: 2026-08-13

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -261,8 +261,11 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // already installed in the runner payload. Its lazy device-sync provider graph
 // measured 10,053,341B on macOS; preserve the boot-path ratchets and the
 // established 32KB total allowance. Exhaustive Junction activation then
-// measured 10,136,931B on macOS, so ratchet the combined integrated baseline.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_136_931 + 32_768;
+// measured 10,136,931B on macOS. The subsequent merged-main hosted runtime
+// graph measured 10,170,323B on Linux CI and 10,204,553B on macOS without
+// adding a forbidden boot input, so ratchet the combined integrated baseline
+// to the larger measurement and retain the 32KB allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_204_553 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_689_721;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 7_992_470;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -609,7 +609,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_689_721 + 48_000,
       staticClosureBytes: 7_992_470 + 96_000,
-      totalBytes: 10_136_931 + 32_768,
+      totalBytes: 10_204_553 + 32_768,
     });
   });
 


### PR DESCRIPTION
## Why

Protected-main Junction and Stripe browser canaries both stopped before browser startup because the current runner entrypoint bundle measured 10,170,323B on Linux, 624B above its reviewed total ceiling. Direct macOS production assembly measured 10,204,553B, showing the Linux-only baseline would also exceed the established cross-platform allowance.

## Outcome

Ratchet only the integrated total-output baseline to the larger exact macOS measurement while preserving the existing 32 KiB allowance. Entry-chunk, static-closure, and forbidden-boot-input guards remain unchanged.

## Invariants

- No runner behavior, permissions, dependency graph, provider logic, or browser journey changes.
- Entry and static boot-path ratchets remain independent and unchanged.
- The forbidden boot-input guard continues to reject accidental eager subsystem growth.
- Diagnostics remain metadata-only.

## Architecture and reuse

- Existing systems reused: current esbuild metafile accounting, per-surface byte ratchets, forbidden-input policy, production assembly parity probes, and protected-main canaries.
- New logic: no new runtime logic is needed because the existing guard already measures and rejects each bundle surface; this patch updates only its observed total baseline.
- New abstractions: no abstraction is added because the current baseline-plus-tolerance policy already owns cross-platform bundle growth.
- Complexity intentionally avoided: no runtime restructuring or feature deletion for a measured 624B CI overage in an already-reviewed required graph.

## Verification

- Focused runner entrypoint policy: 42/42 passed.
- Cloudflare typecheck: passed.
- Production runner assembly: passed.
  - entry: 1,699,473B under unchanged 1,689,721B + 48,000B limit
  - static closure: 8,074,787B under unchanged 7,992,470B + 96,000B limit
  - total: 10,204,553B under 10,204,553B + 32,768B limit
- Exact-head CI: pending.
- Protected-main Junction and Stripe canaries: post-merge proof required.

## Preliminary specialist lenses

- Product experience: not applicable; no member-facing behavior changes.
- Prompt: not applicable; no prompt or model-input changes.
- Frontend: not applicable; no UI changes.
- Coverage: applicable; the mirrored budget-policy test and direct production assembly prove the changed configuration.

ReviewGPT first-reviewed head: 3f1bb1a0b28a438312b8ac57eb4298faeac6ceaf

ReviewGPT context sensitivity: sensitive

Classification reason: internal deploy/runtime configuration gates whether protected hosted browser canaries can start.

## Changelog

Changelog: not applicable — internal runner bundle guard calibration only; no member-visible outcome.

## Change shape

Classification rule: runtime bundle policy code is config/tooling; its focused Vitest file is tests/fixtures; execution-plan Markdown is docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 1 | 1 |
| Docs | 87 | 0 |
| Config/tooling | 5 | 2 |
| Generated/other | 0 | 0 |
| Total | 93 | 3 |

Design proof: not applicable; no frontend UI changes.
