### PR TITLE
fix(tooling): exclude worktrees before checkout

### DIFF
--- a/.agents/friction-log/20260813201916-worktree-spotlight-exclusion/friction.md
+++ b/.agents/friction-log/20260813201916-worktree-spotlight-exclusion/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Worktree Spotlight exclusion is installed after checkout population'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A sanctioned worktree should be excluded from Spotlight before Git materializes tracked checkout files.
+
+## Current Behavior
+
+The creation helper completes git worktree add and writes .metadata_never_index afterward, allowing the initial checkout population to enter the Spotlight indexing queue.
+
+## Possible Solution
+
+Register the worktree without checkout, validate and authorize it, write the exclusion marker, and then materialize the checkout.
+
+## Minimal Reproducible Example
+
+Create a repository whose required smudge filter fails unless .metadata_never_index already exists, then create a linked worktree through scripts/create-worktree. The current helper invokes the filter before writing the marker.
+
+## Context
+
+Large repositories and concurrent task worktrees can create avoidable metadata-indexing work during initial checkout.

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -89,13 +89,14 @@ variables, sets Git's exec path and empty prefix, prepends the exec path to
 real creation lock instead of inheriting authority to bypass it. It also gives
 the hook native end-of-file standard input while preserving standard output and
 error. Manual materialization may invoke `post-index-change`; after that boundary
-and again after `post-checkout`, the helper restores only the marker's captured
-checkout-tree index and worktree entry with hooks suppressed. It preserves every
-unrelated hook-created index or worktree effect. The helper then preserves the
-shared exclude file's identity and metadata while appending one exact rule when
-needed for final effective precedence, restores the marker, and verifies no
-marker delta before final storage-guard authorization. Keep the marker in place
-for the worktree's lifetime.
+and again after `post-checkout`, the helper uses Git's path-scoped reset and
+checkout primitives to restore only the marker from the captured checkout tree
+with hooks suppressed. It preserves every unrelated hook-created index or
+worktree effect. The helper then preserves the shared exclude file's identity
+and metadata while appending one exact rule when needed for final effective
+precedence, restores an absent marker, and verifies no marker delta before final
+storage-guard authorization. Keep the marker in place for the worktree's
+lifetime.
 
 Marker creation, materialization, hook completion, marker restoration, and
 final authorization publication form one post-registration boundary. If any

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -84,6 +84,15 @@ checkout contents before the exclusion exists. It also adds the root marker to
 the repository's common local exclude file so the marker never appears as
 worktree dirt. Keep the marker in place for the worktree's lifetime.
 
+After materialization, the helper invokes the configured `post-checkout` hook
+once from the canonical worktree root with Git's repository-local environment
+variables cleared, matching native `git worktree add` behavior. If
+materialization fails, the helper removes only the exact worktree it just
+registered while the creation lock is still held, preserves the created branch
+for retry, skips `post-checkout`, and returns the materialization failure. A
+failed rollback is reported explicitly and leaves the target registered for
+manual diagnosis instead of hiding the partial state.
+
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the
 current repository by normalized origin. Tests and specialized hosts can set

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -88,9 +88,9 @@ variables, sets Git's exec path and empty prefix, prepends the exec path to
 `PATH`, and removes Murph's lock-held flags so hook descendants must acquire the
 real creation lock instead of inheriting authority to bypass it. It also gives
 the hook native end-of-file standard input while preserving standard output and
-error. After the hook terminates, the helper preserves hook-owned exclude
-content, removes duplicate exact sentinel rules, and appends one exact rule as
-the final effective match. A successful hook then proceeds through marker
+error. After the hook terminates, the helper preserves the shared exclude
+file's identity and metadata while appending one exact rule when needed for
+final effective precedence. A successful hook then proceeds through marker
 restoration and final storage-guard authorization. Keep the marker in place for
 the worktree's lifetime.
 

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -85,17 +85,20 @@ from the canonical target root with Git's worktree-add arguments and launch
 environment. The launcher clears repository-local variables, sets Git's exec
 path and empty prefix, prepends the exec path to `PATH`, and removes Murph's
 lock-held flags so hook descendants must acquire the real creation lock instead
-of inheriting authority to bypass it. After the hook succeeds, the helper
-restores the marker in case hook cleanup removed ignored files. Keep the marker
-in place for the worktree's lifetime.
+of inheriting authority to bypass it. It also gives the hook native end-of-file
+standard input while preserving standard output and error. After the hook
+succeeds, the helper restores the marker in case hook cleanup removed ignored
+files, then publishes storage-guard authorization as the final completion step.
+Keep the marker in place for the worktree's lifetime.
 
-Authorization, marker creation, materialization, and hook completion form one
-post-registration boundary. If any step fails or the helper receives a
-catchable interruption, it removes only the exact worktree it just registered
-while the creation lock is still held, preserves the created branch for retry,
-and returns the failure or signal status. A failed rollback is reported
-explicitly and leaves the target registered for manual diagnosis instead of
-hiding the partial state.
+Marker creation, materialization, hook completion, marker restoration, and
+final authorization publication form one post-registration boundary. If any
+step fails or the helper receives a catchable interruption, it removes only the
+exact worktree it just registered while the creation lock is still held,
+preserves the created branch for retry, and returns the failure or signal
+status. A failed rollback is reported explicitly and leaves the target
+registered but unauthorized for manual diagnosis instead of hiding the partial
+state.
 
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -77,21 +77,23 @@ Use `scripts/create-worktree`; use `--data-research <reason>` only for genuinely
 large data or research work. Registered worktrees remain visible to the normal
 open-PR, plan, cleanliness, process-CWD, and retirement gates.
 
-The creation helper registers each worktree with checkout materialization
-suppressed, writes `.metadata_never_index` at the worktree root, and only then
-materializes tracked files so macOS Spotlight cannot observe the initial
-checkout contents before the exclusion exists. It also adds the root marker to
-the repository's common local exclude file so the marker never appears as
-worktree dirt. Keep the marker in place for the worktree's lifetime.
+The creation helper prepares the shared local exclude rule before registration,
+registers each worktree with checkout materialization suppressed, and writes
+`.metadata_never_index` at the worktree root before tracked files exist. It then
+materializes the checkout and invokes the configured `post-checkout` hook once
+from the canonical target root with Git's worktree-add arguments and launch
+environment. The launcher clears repository-local variables, sets Git's exec
+path and empty prefix, prepends the exec path to `PATH`, and removes Murph's
+lock-held flags so hook descendants must acquire the real creation lock instead
+of inheriting authority to bypass it. Keep the marker in place for the
+worktree's lifetime.
 
-After materialization, the helper invokes the configured `post-checkout` hook
-once from the canonical worktree root with Git's repository-local environment
-variables cleared, matching native `git worktree add` behavior. If
-materialization fails, the helper removes only the exact worktree it just
-registered while the creation lock is still held, preserves the created branch
-for retry, skips `post-checkout`, and returns the materialization failure. A
-failed rollback is reported explicitly and leaves the target registered for
-manual diagnosis instead of hiding the partial state.
+Authorization, marker creation, materialization, and hook completion form one
+post-registration boundary. If any step fails, the helper removes only the
+exact worktree it just registered while the creation lock is still held,
+preserves the created branch for retry, and returns the failure. A failed
+rollback is reported explicitly and leaves the target registered for manual
+diagnosis instead of hiding the partial state.
 
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -85,15 +85,17 @@ from the canonical target root with Git's worktree-add arguments and launch
 environment. The launcher clears repository-local variables, sets Git's exec
 path and empty prefix, prepends the exec path to `PATH`, and removes Murph's
 lock-held flags so hook descendants must acquire the real creation lock instead
-of inheriting authority to bypass it. Keep the marker in place for the
-worktree's lifetime.
+of inheriting authority to bypass it. After the hook succeeds, the helper
+restores the marker in case hook cleanup removed ignored files. Keep the marker
+in place for the worktree's lifetime.
 
 Authorization, marker creation, materialization, and hook completion form one
-post-registration boundary. If any step fails, the helper removes only the
-exact worktree it just registered while the creation lock is still held,
-preserves the created branch for retry, and returns the failure. A failed
-rollback is reported explicitly and leaves the target registered for manual
-diagnosis instead of hiding the partial state.
+post-registration boundary. If any step fails or the helper receives a
+catchable interruption, it removes only the exact worktree it just registered
+while the creation lock is still held, preserves the created branch for retry,
+and returns the failure or signal status. A failed rollback is reported
+explicitly and leaves the target registered for manual diagnosis instead of
+hiding the partial state.
 
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -1,6 +1,6 @@
 # Local Storage Lifecycle
 
-Last verified: 2026-08-10
+Last verified: 2026-08-13
 
 ## Purpose
 
@@ -77,10 +77,12 @@ Use `scripts/create-worktree`; use `--data-research <reason>` only for genuinely
 large data or research work. Registered worktrees remain visible to the normal
 open-PR, plan, cleanliness, process-CWD, and retirement gates.
 
-The creation helper writes `.metadata_never_index` at each worktree root so
-macOS Spotlight does not crawl rebuildable checkout contents. It also adds the
-root marker to the repository's common local exclude file so the marker never
-appears as worktree dirt. Keep the marker in place for the worktree's lifetime.
+The creation helper registers each worktree with checkout materialization
+suppressed, writes `.metadata_never_index` at the worktree root, and only then
+materializes tracked files so macOS Spotlight cannot observe the initial
+checkout contents before the exclusion exists. It also adds the root marker to
+the repository's common local exclude file so the marker never appears as
+worktree dirt. Keep the marker in place for the worktree's lifetime.
 
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -88,11 +88,14 @@ variables, sets Git's exec path and empty prefix, prepends the exec path to
 `PATH`, and removes Murph's lock-held flags so hook descendants must acquire the
 real creation lock instead of inheriting authority to bypass it. It also gives
 the hook native end-of-file standard input while preserving standard output and
-error. After the hook terminates, the helper preserves the shared exclude
-file's identity and metadata while appending one exact rule when needed for
-final effective precedence. A successful hook then proceeds through marker
-restoration and final storage-guard authorization. Keep the marker in place for
-the worktree's lifetime.
+error. Manual materialization may invoke `post-index-change`; after that boundary
+and again after `post-checkout`, the helper restores only the marker's captured
+checkout-tree index and worktree entry with hooks suppressed. It preserves every
+unrelated hook-created index or worktree effect. The helper then preserves the
+shared exclude file's identity and metadata while appending one exact rule when
+needed for final effective precedence, restores the marker, and verifies no
+marker delta before final storage-guard authorization. Keep the marker in place
+for the worktree's lifetime.
 
 Marker creation, materialization, hook completion, marker restoration, and
 final authorization publication form one post-registration boundary. If any

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -88,19 +88,21 @@ variables, sets Git's exec path and empty prefix, prepends the exec path to
 `PATH`, and removes Murph's lock-held flags so hook descendants must acquire the
 real creation lock instead of inheriting authority to bypass it. It also gives
 the hook native end-of-file standard input while preserving standard output and
-error. After the hook succeeds, the helper restores the shared exclude rule and
-the marker in case hook cleanup changed either one, then publishes storage-guard
-authorization as the final completion step. Keep the marker in place for the
-worktree's lifetime.
+error. After the hook terminates, the helper preserves hook-owned exclude
+content, removes duplicate exact sentinel rules, and appends one exact rule as
+the final effective match. A successful hook then proceeds through marker
+restoration and final storage-guard authorization. Keep the marker in place for
+the worktree's lifetime.
 
 Marker creation, materialization, hook completion, marker restoration, and
 final authorization publication form one post-registration boundary. If any
 step fails or the helper receives a catchable interruption, it removes only the
 exact worktree it just registered while the creation lock is still held,
-preserves the created branch for retry, and returns the failure or signal
-status. A failed rollback is reported explicitly and leaves the target
-registered but unauthorized for manual diagnosis instead of hiding the partial
-state.
+repairs shared Spotlight precedence before removal, preserves the created branch
+for retry, and returns the original failure or signal status. A failed shared
+repair is reported alongside that status. A failed rollback is reported
+explicitly and leaves the target registered but unauthorized for manual
+diagnosis instead of hiding the partial state.
 
 `scripts/worktree-storage-guard` scans only conventional direct-child
 `murph-*` Git checkouts in the system `/tmp` roots by default and matches the

--- a/agent-docs/operations/local-storage-lifecycle.md
+++ b/agent-docs/operations/local-storage-lifecycle.md
@@ -80,16 +80,18 @@ open-PR, plan, cleanliness, process-CWD, and retirement gates.
 The creation helper prepares the shared local exclude rule before registration,
 registers each worktree with checkout materialization suppressed, and writes
 `.metadata_never_index` at the worktree root before tracked files exist. It then
-materializes the checkout and invokes the configured `post-checkout` hook once
-from the canonical target root with Git's worktree-add arguments and launch
-environment. The launcher clears repository-local variables, sets Git's exec
-path and empty prefix, prepends the exec path to `PATH`, and removes Murph's
-lock-held flags so hook descendants must acquire the real creation lock instead
-of inheriting authority to bypass it. It also gives the hook native end-of-file
-standard input while preserving standard output and error. After the hook
-succeeds, the helper restores the marker in case hook cleanup removed ignored
-files, then publishes storage-guard authorization as the final completion step.
-Keep the marker in place for the worktree's lifetime.
+materializes the checkout under Git's linked-worktree directory and work-tree
+environment with submodule recursion disabled, then invokes the configured
+`post-checkout` hook once from the canonical target root with Git's worktree-add
+arguments and launch environment. The launcher clears repository-local
+variables, sets Git's exec path and empty prefix, prepends the exec path to
+`PATH`, and removes Murph's lock-held flags so hook descendants must acquire the
+real creation lock instead of inheriting authority to bypass it. It also gives
+the hook native end-of-file standard input while preserving standard output and
+error. After the hook succeeds, the helper restores the shared exclude rule and
+the marker in case hook cleanup changed either one, then publishes storage-guard
+authorization as the final completion step. Keep the marker in place for the
+worktree's lifetime.
 
 Marker creation, materialization, hook completion, marker restoration, and
 final authorization publication form one post-registration boundary. If any

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -53,24 +53,22 @@ mkdir -p "$state_dir"
 prepare_worktree_spotlight_exclusion() {
   local exclude_file="$common_dir/info/exclude"
   local exclude_rule='/.metadata_never_index'
-  local temp_file
+  local final_line
 
   mkdir -p "$common_dir/info" || return
-  if [[ -e "$exclude_file" && ! -f "$exclude_file" ]]; then
-    return 1
-  fi
-  if [[ ! -e "$exclude_file" ]]; then
+  if [[ -e "$exclude_file" || -L "$exclude_file" ]]; then
+    [[ -f "$exclude_file" ]] || return 1
+  else
     : >"$exclude_file" || return
   fi
-  temp_file="$(mktemp "$common_dir/info/exclude.murph.XXXXXX")" || return
-  if ! awk -v rule="$exclude_rule" '$0 != rule { print }' "$exclude_file" >"$temp_file" \
-    || ! printf '%s\n' "$exclude_rule" >>"$temp_file"; then
-    rm -f "$temp_file"
-    return 1
-  fi
-  if ! mv "$temp_file" "$exclude_file"; then
-    rm -f "$temp_file"
-    return 1
+  if [[ -s "$exclude_file" ]]; then
+    final_line="$(tail -n 1 "$exclude_file")" || return
+    if [[ "$final_line" == "$exclude_rule" ]]; then
+      return 0
+    fi
+    printf '\n%s\n' "$exclude_rule" >>"$exclude_file" || return
+  else
+    printf '%s\n' "$exclude_rule" >>"$exclude_file" || return
   fi
 }
 

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -112,7 +112,7 @@ if (( registered_before == 1 )); then
 fi
 
 set +e
-git -C "$repo_root" worktree add "${args[@]}"
+git -C "$repo_root" worktree add --no-checkout "${args[@]}"
 add_status=$?
 set -e
 
@@ -135,4 +135,26 @@ elif (( add_status == 0 )); then
   exit 1
 fi
 
-exit "$add_status"
+if (( add_status != 0 )); then
+  exit "$add_status"
+fi
+
+set +e
+git -C "$target_path" reset --hard
+checkout_status=$?
+set -e
+
+if (( checkout_status != 0 )); then
+  exit "$checkout_status"
+fi
+
+head_oid="$(git -C "$target_path" rev-parse HEAD)"
+null_oid="$(printf '%0*d' "${#head_oid}" 0)"
+
+set +e
+git -C "$target_path" hook run --ignore-missing post-checkout -- \
+  "$null_oid" "$head_oid" 1
+hook_status=$?
+set -e
+
+exit "$hook_status"

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -145,15 +145,39 @@ checkout_status=$?
 set -e
 
 if (( checkout_status != 0 )); then
+  set +e
+  git -C "$repo_root" worktree remove --force --force "$target_path"
+  cleanup_status=$?
+  set -e
+
+  if (( cleanup_status != 0 )); then
+    printf 'create-worktree: checkout materialization failed (status %d); rollback failed (status %d), leaving the target registered\n' \
+      "$checkout_status" "$cleanup_status" >&2
+    exit "$cleanup_status"
+  fi
   exit "$checkout_status"
 fi
 
 head_oid="$(git -C "$target_path" rev-parse HEAD)"
 null_oid="$(printf '%0*d' "${#head_oid}" 0)"
+hook_path="$(git -C "$target_path" rev-parse --path-format=absolute --git-path hooks/post-checkout)"
 
-set +e
-git -C "$target_path" hook run --ignore-missing post-checkout -- \
-  "$null_oid" "$head_oid" 1
+if [[ -x "$hook_path" ]]; then
+  local_env_vars="$(git -C "$target_path" rev-parse --local-env-vars)"
+  hook_env=(env)
+  while IFS= read -r local_env_var; do
+    [[ -n "$local_env_var" ]] && hook_env+=(-u "$local_env_var")
+  done <<<"$local_env_vars"
+  set +e
+  (
+    cd -P "$target_path"
+    "${hook_env[@]}" "$hook_path" "$null_oid" "$head_oid" 1
+  )
+else
+  set +e
+  git -C "$target_path" hook run --ignore-missing post-checkout -- \
+    "$null_oid" "$head_oid" 1
+fi
 hook_status=$?
 set -e
 

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -213,8 +213,10 @@ if [[ -d "$target_path" ]] \
     "$common_dir"/worktrees/*)
       set +e
       mark_worktree_non_indexable \
-        && git -C "$target_path" reset --hard \
+        && GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+          git -C "$target_path" reset --hard --no-recurse-submodules \
         && run_post_checkout_hook \
+        && prepare_worktree_spotlight_exclusion \
         && mark_worktree_non_indexable \
         && : >"$admin_dir/murph-storage-guard-authorized"
       setup_status=$?

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -72,6 +72,7 @@ rollback_registered_worktree() {
   local failure_status="$1"
   local rollback_status
 
+  trap - EXIT INT TERM HUP
   set +e
   git -C "$repo_root" worktree remove --force --force "$target_path"
   rollback_status=$?
@@ -83,6 +84,15 @@ rollback_registered_worktree() {
     exit "$rollback_status"
   fi
   exit "$failure_status"
+}
+
+rollback_registered_worktree_on_exit() {
+  local failure_status="$?"
+
+  if (( failure_status == 0 )); then
+    failure_status=1
+  fi
+  rollback_registered_worktree "$failure_status"
 }
 
 run_post_checkout_hook() {
@@ -102,6 +112,9 @@ run_post_checkout_hook() {
 
   if IFS= read -r first_line <"$hook_path" && [[ "$first_line" == '#!'* ]]; then
     interpreter="${first_line#\#!}"
+    while [[ "$interpreter" == ' '* || "$interpreter" == $'\t'* ]]; do
+      interpreter="${interpreter:1}"
+    done
     interpreter="${interpreter%%[[:space:]]*}"
     if [[ "$interpreter" != /* || ! -f "$interpreter" || ! -x "$interpreter" ]]; then
       printf 'create-worktree: post-checkout hook interpreter is unavailable\n' >&2
@@ -186,6 +199,11 @@ if (( add_status != 0 )); then
   exit "$add_status"
 fi
 
+trap rollback_registered_worktree_on_exit EXIT
+trap 'rollback_registered_worktree 130' INT
+trap 'rollback_registered_worktree 143' TERM
+trap 'rollback_registered_worktree 129' HUP
+
 setup_status=0
 if [[ -d "$target_path" ]] \
   && admin_dir="$(git -C "$target_path" rev-parse --path-format=absolute --git-dir 2>/dev/null)" \
@@ -197,7 +215,8 @@ if [[ -d "$target_path" ]] \
       : >"$admin_dir/murph-storage-guard-authorized" \
         && mark_worktree_non_indexable \
         && git -C "$target_path" reset --hard \
-        && run_post_checkout_hook
+        && run_post_checkout_hook \
+        && mark_worktree_non_indexable
       setup_status=$?
       set -e
       ;;
@@ -215,4 +234,5 @@ if (( setup_status != 0 )); then
   rollback_registered_worktree "$setup_status"
 fi
 
+trap - EXIT INT TERM HUP
 exit 0

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -49,6 +49,11 @@ common_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-
 state_dir="${MURPH_WORKTREE_GUARD_STATE_DIR:-$common_dir/murph-worktree-storage-guard}"
 lock_file="$state_dir/lock"
 mkdir -p "$state_dir"
+spotlight_marker_path='.metadata_never_index'
+spotlight_tree_head=''
+spotlight_tree_mode=''
+spotlight_tree_oid=''
+spotlight_tree_present=0
 
 prepare_worktree_spotlight_exclusion() {
   local exclude_file="$common_dir/info/exclude"
@@ -73,7 +78,56 @@ prepare_worktree_spotlight_exclusion() {
 }
 
 mark_worktree_non_indexable() {
-  touch "$target_path/.metadata_never_index"
+  touch "$target_path/$spotlight_marker_path"
+}
+
+capture_worktree_spotlight_index_state() {
+  local tree_entry tree_type tree_path
+
+  spotlight_tree_head="$(git -C "$target_path" rev-parse HEAD)" || return
+  tree_entry="$(git -C "$target_path" ls-tree "$spotlight_tree_head" -- "$spotlight_marker_path")" \
+    || return
+  if [[ -z "$tree_entry" ]]; then
+    spotlight_tree_present=0
+    return 0
+  fi
+  IFS=$' \t' read -r spotlight_tree_mode tree_type spotlight_tree_oid tree_path \
+    <<<"$tree_entry"
+  if [[ ( "$spotlight_tree_mode" != 100644 && "$spotlight_tree_mode" != 100755 ) \
+    || ! "$spotlight_tree_oid" =~ ^[0-9a-f]{40,64}$ \
+    || "$tree_type" != blob \
+    || "$tree_path" != "$spotlight_marker_path" ]]; then
+    return 1
+  fi
+  spotlight_tree_present=1
+}
+
+restore_worktree_spotlight_state() {
+  local -a index_args
+
+  if (( spotlight_tree_present == 1 )); then
+    index_args=(--add --cacheinfo "$spotlight_tree_mode,$spotlight_tree_oid,$spotlight_marker_path")
+  else
+    index_args=(--force-remove -- "$spotlight_marker_path")
+  fi
+  GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+    git -C "$target_path" -c core.hooksPath=/dev/null update-index "${index_args[@]}" \
+    || return
+  if (( spotlight_tree_present == 1 )); then
+    GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+      git -C "$target_path" -c core.hooksPath=/dev/null checkout-index --force -- \
+        "$spotlight_marker_path" \
+      || return
+  fi
+  GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+    git -C "$target_path" -c core.hooksPath=/dev/null diff --cached --quiet \
+      "$spotlight_tree_head" -- "$spotlight_marker_path" \
+    || return
+  prepare_worktree_spotlight_exclusion \
+    && mark_worktree_non_indexable \
+    && GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+      git -C "$target_path" -c core.hooksPath=/dev/null diff --quiet -- \
+        "$spotlight_marker_path"
 }
 
 rollback_registered_worktree() {
@@ -227,12 +281,13 @@ if [[ -d "$target_path" ]] \
   case "$admin_dir" in
     "$common_dir"/worktrees/*)
       set +e
-      mark_worktree_non_indexable \
+      capture_worktree_spotlight_index_state \
+        && mark_worktree_non_indexable \
         && GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
           git -C "$target_path" reset --hard --no-recurse-submodules \
+        && restore_worktree_spotlight_state \
         && run_post_checkout_hook \
-        && prepare_worktree_spotlight_exclusion \
-        && mark_worktree_non_indexable \
+        && restore_worktree_spotlight_state \
         && : >"$admin_dir/murph-storage-guard-authorized"
       setup_status=$?
       set -e

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -50,7 +50,7 @@ state_dir="${MURPH_WORKTREE_GUARD_STATE_DIR:-$common_dir/murph-worktree-storage-
 lock_file="$state_dir/lock"
 mkdir -p "$state_dir"
 
-mark_worktree_non_indexable() {
+prepare_worktree_spotlight_exclusion() {
   local exclude_file="$common_dir/info/exclude"
   local exclude_rule='/.metadata_never_index'
 
@@ -62,7 +62,71 @@ mark_worktree_non_indexable() {
       printf '%s\n' "$exclude_rule" >>"$exclude_file"
     fi
   fi
+}
+
+mark_worktree_non_indexable() {
   touch "$target_path/.metadata_never_index"
+}
+
+rollback_registered_worktree() {
+  local failure_status="$1"
+  local rollback_status
+
+  set +e
+  git -C "$repo_root" worktree remove --force --force "$target_path"
+  rollback_status=$?
+  set -e
+
+  if (( rollback_status != 0 )); then
+    printf 'create-worktree: setup failed (status %d); rollback failed (status %d), leaving the target registered\n' \
+      "$failure_status" "$rollback_status" >&2
+    exit "$rollback_status"
+  fi
+  exit "$failure_status"
+}
+
+run_post_checkout_hook() {
+  local head_oid null_oid hook_path git_exec_path local_env_vars
+  local first_line interpreter local_env_var
+  local -a hook_env
+
+  head_oid="$(git -C "$target_path" rev-parse HEAD)" || return
+  null_oid="$(printf '%0*d' "${#head_oid}" 0)"
+  hook_path="$(git -C "$target_path" rev-parse --path-format=absolute --git-path hooks/post-checkout)" || return
+
+  if [[ ! -x "$hook_path" ]]; then
+    git -C "$target_path" hook run --ignore-missing post-checkout -- \
+      "$null_oid" "$head_oid" 1
+    return
+  fi
+
+  if IFS= read -r first_line <"$hook_path" && [[ "$first_line" == '#!'* ]]; then
+    interpreter="${first_line#\#!}"
+    interpreter="${interpreter%%[[:space:]]*}"
+    if [[ "$interpreter" != /* || ! -f "$interpreter" || ! -x "$interpreter" ]]; then
+      printf 'create-worktree: post-checkout hook interpreter is unavailable\n' >&2
+      return 1
+    fi
+  fi
+
+  git_exec_path="$(git -C "$target_path" --exec-path)" || return
+  local_env_vars="$(git -C "$target_path" rev-parse --local-env-vars)" || return
+  hook_env=(env)
+  while IFS= read -r local_env_var; do
+    [[ -n "$local_env_var" ]] && hook_env+=(-u "$local_env_var")
+  done <<<"$local_env_vars"
+  hook_env+=(
+    -u MURPH_CREATE_WORKTREE_LOCK_HELD
+    -u MURPH_WORKTREE_GUARD_LOCK_HELD
+    "GIT_EXEC_PATH=$git_exec_path"
+    'GIT_PREFIX='
+    "PATH=$git_exec_path:${PATH:-}"
+  )
+
+  (
+    cd -P "$target_path"
+    "${hook_env[@]}" "$hook_path" "$null_oid" "$head_oid" 1
+  )
 }
 
 if [[ "${MURPH_CREATE_WORKTREE_LOCK_HELD:-0}" != 1 ]]; then
@@ -111,74 +175,44 @@ if (( registered_before == 1 )); then
   exit 1
 fi
 
+prepare_worktree_spotlight_exclusion
+
 set +e
 git -C "$repo_root" worktree add --no-checkout "${args[@]}"
 add_status=$?
 set -e
 
+if (( add_status != 0 )); then
+  exit "$add_status"
+fi
+
+setup_status=0
 if [[ -d "$target_path" ]] \
   && admin_dir="$(git -C "$target_path" rev-parse --path-format=absolute --git-dir 2>/dev/null)" \
   && [[ -d "$admin_dir" ]]; then
   admin_dir="$(cd "$admin_dir" && pwd -P)"
   case "$admin_dir" in
     "$common_dir"/worktrees/*)
-      : >"$admin_dir/murph-storage-guard-authorized"
-      mark_worktree_non_indexable
+      set +e
+      : >"$admin_dir/murph-storage-guard-authorized" \
+        && mark_worktree_non_indexable \
+        && git -C "$target_path" reset --hard \
+        && run_post_checkout_hook
+      setup_status=$?
+      set -e
       ;;
     *)
       printf 'create-worktree: new checkout has an unexpected administrative directory\n' >&2
-      exit 1
+      setup_status=1
       ;;
   esac
-elif (( add_status == 0 )); then
-  printf 'create-worktree: new checkout has an unexpected administrative directory\n' >&2
-  exit 1
-fi
-
-if (( add_status != 0 )); then
-  exit "$add_status"
-fi
-
-set +e
-git -C "$target_path" reset --hard
-checkout_status=$?
-set -e
-
-if (( checkout_status != 0 )); then
-  set +e
-  git -C "$repo_root" worktree remove --force --force "$target_path"
-  cleanup_status=$?
-  set -e
-
-  if (( cleanup_status != 0 )); then
-    printf 'create-worktree: checkout materialization failed (status %d); rollback failed (status %d), leaving the target registered\n' \
-      "$checkout_status" "$cleanup_status" >&2
-    exit "$cleanup_status"
-  fi
-  exit "$checkout_status"
-fi
-
-head_oid="$(git -C "$target_path" rev-parse HEAD)"
-null_oid="$(printf '%0*d' "${#head_oid}" 0)"
-hook_path="$(git -C "$target_path" rev-parse --path-format=absolute --git-path hooks/post-checkout)"
-
-if [[ -x "$hook_path" ]]; then
-  local_env_vars="$(git -C "$target_path" rev-parse --local-env-vars)"
-  hook_env=(env)
-  while IFS= read -r local_env_var; do
-    [[ -n "$local_env_var" ]] && hook_env+=(-u "$local_env_var")
-  done <<<"$local_env_vars"
-  set +e
-  (
-    cd -P "$target_path"
-    "${hook_env[@]}" "$hook_path" "$null_oid" "$head_oid" 1
-  )
 else
-  set +e
-  git -C "$target_path" hook run --ignore-missing post-checkout -- \
-    "$null_oid" "$head_oid" 1
+  printf 'create-worktree: new checkout has an unexpected administrative directory\n' >&2
+  setup_status=1
 fi
-hook_status=$?
-set -e
 
-exit "$hook_status"
+if (( setup_status != 0 )); then
+  rollback_registered_worktree "$setup_status"
+fi
+
+exit 0

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -53,14 +53,24 @@ mkdir -p "$state_dir"
 prepare_worktree_spotlight_exclusion() {
   local exclude_file="$common_dir/info/exclude"
   local exclude_rule='/.metadata_never_index'
+  local temp_file
 
-  mkdir -p "$common_dir/info"
-  if ! grep -Fqx "$exclude_rule" "$exclude_file" 2>/dev/null; then
-    if [[ -s "$exclude_file" ]]; then
-      printf '\n%s\n' "$exclude_rule" >>"$exclude_file"
-    else
-      printf '%s\n' "$exclude_rule" >>"$exclude_file"
-    fi
+  mkdir -p "$common_dir/info" || return
+  if [[ -e "$exclude_file" && ! -f "$exclude_file" ]]; then
+    return 1
+  fi
+  if [[ ! -e "$exclude_file" ]]; then
+    : >"$exclude_file" || return
+  fi
+  temp_file="$(mktemp "$common_dir/info/exclude.murph.XXXXXX")" || return
+  if ! awk -v rule="$exclude_rule" '$0 != rule { print }' "$exclude_file" >"$temp_file" \
+    || ! printf '%s\n' "$exclude_rule" >>"$temp_file"; then
+    rm -f "$temp_file"
+    return 1
+  fi
+  if ! mv "$temp_file" "$exclude_file"; then
+    rm -f "$temp_file"
+    return 1
   fi
 }
 
@@ -70,14 +80,21 @@ mark_worktree_non_indexable() {
 
 rollback_registered_worktree() {
   local failure_status="$1"
+  local repair_status
   local rollback_status
 
   trap - EXIT INT TERM HUP
   set +e
+  prepare_worktree_spotlight_exclusion
+  repair_status=$?
   git -C "$repo_root" worktree remove --force --force "$target_path"
   rollback_status=$?
   set -e
 
+  if (( repair_status != 0 )); then
+    printf 'create-worktree: setup failed (status %d); Spotlight exclude repair failed (status %d)\n' \
+      "$failure_status" "$repair_status" >&2
+  fi
   if (( rollback_status != 0 )); then
     printf 'create-worktree: setup failed (status %d); rollback failed (status %d), leaving the target registered\n' \
       "$failure_status" "$rollback_status" >&2

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -51,9 +51,6 @@ lock_file="$state_dir/lock"
 mkdir -p "$state_dir"
 spotlight_marker_path='.metadata_never_index'
 spotlight_tree_head=''
-spotlight_tree_mode=''
-spotlight_tree_oid=''
-spotlight_tree_present=0
 
 prepare_worktree_spotlight_exclusion() {
   local exclude_file="$common_dir/info/exclude"
@@ -81,39 +78,21 @@ mark_worktree_non_indexable() {
   touch "$target_path/$spotlight_marker_path"
 }
 
-capture_worktree_spotlight_index_state() {
-  local tree_entry tree_type tree_path
-
+capture_worktree_spotlight_tree() {
   spotlight_tree_head="$(git -C "$target_path" rev-parse HEAD)" || return
-  tree_entry="$(git -C "$target_path" ls-tree "$spotlight_tree_head" -- "$spotlight_marker_path")" \
-    || return
-  if [[ -z "$tree_entry" ]]; then
-    spotlight_tree_present=0
-    return 0
-  fi
-  IFS=$' \t' read -r spotlight_tree_mode tree_type spotlight_tree_oid tree_path \
-    <<<"$tree_entry"
-  if [[ ( "$spotlight_tree_mode" != 100644 && "$spotlight_tree_mode" != 100755 ) \
-    || ! "$spotlight_tree_oid" =~ ^[0-9a-f]{40,64}$ \
-    || "$tree_type" != blob \
-    || "$tree_path" != "$spotlight_marker_path" ]]; then
-    return 1
-  fi
-  spotlight_tree_present=1
 }
 
 restore_worktree_spotlight_state() {
-  local -a index_args
+  local marker_tracked=0
 
-  if (( spotlight_tree_present == 1 )); then
-    index_args=(--add --cacheinfo "$spotlight_tree_mode,$spotlight_tree_oid,$spotlight_marker_path")
-  else
-    index_args=(--force-remove -- "$spotlight_marker_path")
-  fi
   GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
-    git -C "$target_path" -c core.hooksPath=/dev/null update-index "${index_args[@]}" \
+    git -C "$target_path" -c core.hooksPath=/dev/null reset --quiet \
+      "$spotlight_tree_head" -- "$spotlight_marker_path" \
     || return
-  if (( spotlight_tree_present == 1 )); then
+  if GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+    git -C "$target_path" -c core.hooksPath=/dev/null ls-files \
+      --error-unmatch -- "$spotlight_marker_path" >/dev/null 2>&1; then
+    marker_tracked=1
     GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
       git -C "$target_path" -c core.hooksPath=/dev/null checkout-index --force -- \
         "$spotlight_marker_path" \
@@ -123,11 +102,13 @@ restore_worktree_spotlight_state() {
     git -C "$target_path" -c core.hooksPath=/dev/null diff --cached --quiet \
       "$spotlight_tree_head" -- "$spotlight_marker_path" \
     || return
-  prepare_worktree_spotlight_exclusion \
-    && mark_worktree_non_indexable \
-    && GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
-      git -C "$target_path" -c core.hooksPath=/dev/null diff --quiet -- \
-        "$spotlight_marker_path"
+  prepare_worktree_spotlight_exclusion || return
+  if (( marker_tracked == 0 )); then
+    mark_worktree_non_indexable || return
+  fi
+  GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
+    git -C "$target_path" -c core.hooksPath=/dev/null diff --quiet -- \
+      "$spotlight_marker_path"
 }
 
 rollback_registered_worktree() {
@@ -281,7 +262,7 @@ if [[ -d "$target_path" ]] \
   case "$admin_dir" in
     "$common_dir"/worktrees/*)
       set +e
-      capture_worktree_spotlight_index_state \
+      capture_worktree_spotlight_tree \
         && mark_worktree_non_indexable \
         && GIT_DIR="$target_path/.git" GIT_WORK_TREE=. \
           git -C "$target_path" reset --hard --no-recurse-submodules \

--- a/scripts/create-worktree
+++ b/scripts/create-worktree
@@ -138,7 +138,7 @@ run_post_checkout_hook() {
 
   (
     cd -P "$target_path"
-    "${hook_env[@]}" "$hook_path" "$null_oid" "$head_oid" 1
+    "${hook_env[@]}" "$hook_path" "$null_oid" "$head_oid" 1 </dev/null
   )
 }
 
@@ -212,11 +212,11 @@ if [[ -d "$target_path" ]] \
   case "$admin_dir" in
     "$common_dir"/worktrees/*)
       set +e
-      : >"$admin_dir/murph-storage-guard-authorized" \
-        && mark_worktree_non_indexable \
+      mark_worktree_non_indexable \
         && git -C "$target_path" reset --hard \
         && run_post_checkout_hook \
-        && mark_worktree_non_indexable
+        && mark_worktree_non_indexable \
+        && : >"$admin_dir/murph-storage-guard-authorized"
       setup_status=$?
       set -e
       ;;

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -739,7 +739,7 @@ touch hook-installed
 printf '%s|%s|%s\n' "$1" "$2" "$3" >>${JSON.stringify(hookInvocations)}
 git clean -fdX
 exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
-printf '/hook-owned-only\n' >"$exclude"
+printf '# hook comment\n/hook-owned-only\n/.metadata_never_index\n!.*\n/.metadata_never_index\n!.*\n' >"$exclude"
 `,
     )
 
@@ -762,10 +762,12 @@ printf '/hook-owned-only\n' >"$exclude"
       'info/exclude',
     ])
     const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
+    expect(excludeRules).toContain('# hook comment')
     expect(excludeRules).toContain('/hook-owned-only')
     expect(
       excludeRules.filter((rule) => rule === '/.metadata_never_index'),
     ).toHaveLength(1)
+    expect(excludeRules.at(-1)).toBe('/.metadata_never_index')
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
     expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
       '.metadata_never_index',
@@ -775,6 +777,152 @@ printf '/hook-owned-only\n' >"$exclude"
     )
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
     expect(runGit(sibling, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('repairs shared Spotlight state before rolling back a failed hook', () => {
+    const harness = createHarness()
+    const sibling = path.join(harness.root, 'failed-hook-sibling')
+    expect(
+      runScript(harness, 'create-worktree', [
+        '-b',
+        'failed-hook-sibling',
+        sibling,
+      ]).status,
+    ).toBe(0)
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '# failed hook\n/hook-failure-owned\n' >"$exclude"
+exit 23
+`,
+    )
+    const target = path.join(harness.root, 'failed-hook-target')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'failed-hook-target',
+      target,
+    ])
+
+    expect(creation.status).toBe(23)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/failed-hook-target',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
+    const excludeFile = runGit(sibling, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-path',
+      'info/exclude',
+    ])
+    const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
+    expect(excludeRules).toContain('# failed hook')
+    expect(excludeRules).toContain('/hook-failure-owned')
+    expect(
+      excludeRules.filter((rule) => rule === '/.metadata_never_index'),
+    ).toHaveLength(1)
+    expect(excludeRules.at(-1)).toBe('/.metadata_never_index')
+    expect(runGit(sibling, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+    expect(runGit(sibling, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('repairs shared Spotlight state before rolling back an interrupted hook', async () => {
+    const harness = createHarness()
+    const sibling = path.join(harness.root, 'interrupted-shared-rule-sibling')
+    expect(
+      runScript(harness, 'create-worktree', [
+        '-b',
+        'interrupted-shared-rule-sibling',
+        sibling,
+      ]).status,
+    ).toBe(0)
+    const hookStarted = path.join(harness.root, 'shared-rule-hook-started')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '# interrupted hook\n/hook-interruption-owned\n!.*\n' >"$exclude"
+touch ${JSON.stringify(hookStarted)}
+sleep 2
+`,
+    )
+    const target = path.join(harness.root, 'interrupted-shared-rule-target')
+
+    const creation = await interruptScriptAfterPath(
+      harness,
+      ['-b', 'interrupted-shared-rule-target', target],
+      hookStarted,
+    )
+
+    expect(
+      creation.status === 130 ||
+        (creation.status === null && creation.signal === 'SIGINT'),
+      creation.stderr,
+    ).toBe(true)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    const excludeFile = runGit(sibling, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-path',
+      'info/exclude',
+    ])
+    const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
+    expect(excludeRules).toContain('# interrupted hook')
+    expect(excludeRules).toContain('/hook-interruption-owned')
+    expect(excludeRules.at(-1)).toBe('/.metadata_never_index')
+    expect(runGit(sibling, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+    expect(runGit(sibling, ['status', '--porcelain'])).toBe('')
+  }, 15_000)
+
+  it('reports shared Spotlight repair failure alongside hook failure', () => {
+    const harness = createHarness()
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+rm -f "$exclude"
+mkdir "$exclude"
+exit 23
+`,
+    )
+    const target = path.join(harness.root, 'shared-rule-repair-failure')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'shared-rule-repair-failure',
+      target,
+    ])
+
+    expect(creation.status).toBe(23)
+    expect(creation.stderr).toContain(
+      'setup failed (status 23); Spotlight exclude repair failed',
+    )
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/shared-rule-repair-failure',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
   })
 
   it('rolls back when final authorization publication fails', () => {

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import {
   chmodSync,
   existsSync,
@@ -120,6 +120,49 @@ function runScript(
     encoding: 'utf8',
     env: guardEnvironment(harness, overrides),
   })
+}
+
+async function interruptScriptAfterPath(
+  harness: Harness,
+  args: string[],
+  readyPath: string,
+): Promise<{ status: number | null; stderr: string }> {
+  const child = spawn('bash', [path.join('scripts', 'create-worktree'), ...args], {
+    cwd: harness.primary,
+    detached: true,
+    env: guardEnvironment(harness),
+    stdio: ['ignore', 'ignore', 'pipe'],
+  })
+  let stderr = ''
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  const completed = new Promise<{ status: number | null; stderr: string }>(
+    (resolve, reject) => {
+      child.once('error', reject)
+      child.once('close', (status) => resolve({ status, stderr }))
+    },
+  )
+
+  try {
+    const deadline = Date.now() + 10_000
+    while (!existsSync(readyPath)) {
+      if (Date.now() >= deadline) {
+        throw new Error(`timed out waiting for ${path.basename(readyPath)}`)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    if (child.pid === undefined) throw new Error('create-worktree did not start')
+    process.kill(-child.pid, 'SIGINT')
+    return await completed
+  } catch (error) {
+    if (child.exitCode === null && child.pid !== undefined) {
+      process.kill(-child.pid, 'SIGTERM')
+      await completed
+    }
+    throw error
+  }
 }
 
 function installLegacyWorktreeEntrypoints(primary: string): void {
@@ -469,6 +512,60 @@ touch hook-installed
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
+  it('restores the Spotlight marker after a successful cleanup hook', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'cleanup-hook-spotlight')
+    const markerObserved = path.join(harness.root, 'cleanup-hook-marker-observed')
+    const hookInvocations = path.join(harness.root, 'cleanup-hook-invocations')
+    runGit(harness.primary, [
+      'config',
+      'filter.cleanup-hook-marker.smudge',
+      `test -f .metadata_never_index && touch ${JSON.stringify(markerObserved)} && cat`,
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.cleanup-hook-marker.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.cleanup-hook-marker.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'cleanup-hook-probe.txt filter=cleanup-hook-marker\n',
+    )
+    writeFileSync(path.join(harness.primary, 'cleanup-hook-probe.txt'), 'probe\n')
+    runGit(harness.primary, ['add', '.gitattributes', 'cleanup-hook-probe.txt'])
+    runGit(harness.primary, ['commit', '-m', 'add cleanup hook marker probe'])
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+printf '%s|%s|%s\n' "$1" "$2" "$3" >>${JSON.stringify(hookInvocations)}
+git clean -fdX
+`,
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'cleanup-hook-spotlight',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(existsSync(markerObserved)).toBe(true)
+    expect(readFileSync(hookInvocations, 'utf8').trim().split('\n')).toHaveLength(1)
+    expect(readFileSync(hookInvocations, 'utf8')).toMatch(
+      new RegExp(`^0{40,64}\\|[0-9a-f]{40,64}\\|1\\n$`),
+    )
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  })
+
   it('rolls back a marked worktree when checkout materialization fails', () => {
     const harness = createHarness()
     const target = path.join(harness.root, 'partial-materialization')
@@ -543,6 +640,129 @@ touch ${JSON.stringify(hookInvoked)}
     expect(existsSync(hookInvoked)).toBe(true)
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
+
+  it('rolls back an interrupted materialization and preserves retry state', async () => {
+    const harness = createHarness()
+    const unrelatedTarget = path.join(harness.root, 'unrelated-existing')
+    expect(
+      runScript(harness, 'create-worktree', [
+        '-b',
+        'unrelated-existing',
+        unrelatedTarget,
+      ]).status,
+    ).toBe(0)
+
+    const target = path.join(harness.root, 'interrupted-materialization')
+    const filterStarted = path.join(harness.root, 'materialization-started')
+    const hookInvoked = path.join(harness.root, 'interrupted-hook-invoked')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+touch ${JSON.stringify(hookInvoked)}
+`,
+    )
+    runGit(harness.primary, [
+      'config',
+      'filter.interrupted-materialization.smudge',
+      `test -f .metadata_never_index && touch ${JSON.stringify(filterStarted)} && sleep 2`,
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.interrupted-materialization.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.interrupted-materialization.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'interrupted-probe.txt filter=interrupted-materialization\n',
+    )
+    writeFileSync(path.join(harness.primary, 'interrupted-probe.txt'), 'probe\n')
+    runGit(harness.primary, ['add', '.gitattributes', 'interrupted-probe.txt'])
+    runGit(harness.primary, ['commit', '-m', 'add interrupted materialization probe'])
+
+    const creation = await interruptScriptAfterPath(
+      harness,
+      ['-b', 'interrupted-materialization', target],
+      filterStarted,
+    )
+
+    expect(creation.status, creation.stderr).toBe(130)
+    const listing = runGit(harness.primary, ['worktree', 'list', '--porcelain'])
+    expect(listing).not.toContain(target)
+    expect(listing).toContain(unrelatedTarget)
+    expect(existsSync(target)).toBe(false)
+    expect(existsSync(unrelatedTarget)).toBe(true)
+    expect(existsSync(hookInvoked)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/interrupted-materialization',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
+
+    runGit(harness.primary, [
+      'config',
+      'filter.interrupted-materialization.smudge',
+      'cat',
+    ])
+    const retry = runScript(harness, 'create-worktree', [
+      '-B',
+      'interrupted-materialization',
+      target,
+    ])
+    expect(retry.status, retry.stderr).toBe(0)
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(existsSync(hookInvoked)).toBe(true)
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  }, 15_000)
+
+  it('rolls back an interrupted post-checkout hook and permits retry', async () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'interrupted-post-checkout')
+    const hookStarted = path.join(harness.root, 'post-checkout-started')
+    const postCheckout = path.join(harness.primary, '.githooks', 'post-checkout')
+    executable(
+      postCheckout,
+      `#!/bin/sh
+touch ${JSON.stringify(hookStarted)}
+sleep 2
+`,
+    )
+
+    const creation = await interruptScriptAfterPath(
+      harness,
+      ['-b', 'interrupted-post-checkout', target],
+      hookStarted,
+    )
+
+    expect(creation.status, creation.stderr).toBe(130)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/interrupted-post-checkout',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
+
+    executable(postCheckout, '#!/bin/sh\nexit 0\n')
+    const retry = runScript(harness, 'create-worktree', [
+      '-B',
+      'interrupted-post-checkout',
+      target,
+    ])
+    expect(retry.status, retry.stderr).toBe(0)
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  }, 15_000)
 
   it('does not register a worktree when shared Spotlight exclusion setup fails', () => {
     const harness = createHarness()
@@ -1631,6 +1851,64 @@ git -C ${JSON.stringify(secondary)} add secondary-only.txt
       runGit(helperHarness.primary, ['worktree', 'list', '--porcelain']),
     ).not.toContain(helperTarget)
     expect(existsSync(helperTarget)).toBe(false)
+  })
+
+  it('matches native executable post-checkout shebang handling', () => {
+    const variants = [
+      { name: 'compact', prefix: '#!/bin/sh\n' },
+      { name: 'space', prefix: '#! /bin/sh\n' },
+      { name: 'tab', prefix: '#!\t/bin/sh\n' },
+      { name: 'env-argument', prefix: '#!/usr/bin/env sh\n' },
+      { name: 'no-shebang', prefix: '' },
+    ]
+
+    for (const variant of variants) {
+      const nativeHarness = createHarness()
+      const nativeInvocation = path.join(
+        nativeHarness.root,
+        `${variant.name}-native-invocation`,
+      )
+      executable(
+        path.join(nativeHarness.primary, '.githooks', 'post-checkout'),
+        `${variant.prefix}printf '%s|%s|%s\\n' "$1" "$2" "$3" >${JSON.stringify(nativeInvocation)}\n`,
+      )
+      expect(runScript(nativeHarness, 'install-git-hooks').status).toBe(0)
+      const nativeHead = runGit(nativeHarness.primary, ['rev-parse', 'HEAD'])
+      const nativeTarget = path.join(nativeHarness.root, `${variant.name}-native`)
+      const nativeCreation = spawnSync(
+        'git',
+        ['worktree', 'add', '-b', `${variant.name}-native`, nativeTarget],
+        { cwd: nativeHarness.primary, encoding: 'utf8' },
+      )
+
+      const helperHarness = createHarness()
+      const helperInvocation = path.join(
+        helperHarness.root,
+        `${variant.name}-helper-invocation`,
+      )
+      executable(
+        path.join(helperHarness.primary, '.githooks', 'post-checkout'),
+        `${variant.prefix}printf '%s|%s|%s\\n' "$1" "$2" "$3" >${JSON.stringify(helperInvocation)}\n`,
+      )
+      const helperHead = runGit(helperHarness.primary, ['rev-parse', 'HEAD'])
+      const helperTarget = path.join(helperHarness.root, `${variant.name}-helper`)
+      const helperCreation = runScript(helperHarness, 'create-worktree', [
+        '-b',
+        `${variant.name}-helper`,
+        helperTarget,
+      ])
+
+      expect(nativeCreation.status, nativeCreation.stderr).toBe(0)
+      expect(helperCreation.status, helperCreation.stderr).toBe(nativeCreation.status)
+      expect(readFileSync(nativeInvocation, 'utf8')).toBe(
+        `${'0'.repeat(nativeHead.length)}|${nativeHead}|1\n`,
+      )
+      expect(readFileSync(helperInvocation, 'utf8')).toBe(
+        `${'0'.repeat(helperHead.length)}|${helperHead}|1\n`,
+      )
+      expect(existsSync(path.join(helperTarget, '.metadata_never_index'))).toBe(true)
+      expect(runGit(helperTarget, ['status', '--porcelain'])).toBe('')
+    }
   })
 
   it('preserves ignored non-executable post-checkout hook behavior', () => {

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -469,6 +469,63 @@ touch hook-installed
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
+  it('keeps a marked authorized worktree when checkout materialization fails', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'partial-materialization')
+    const markerObserved = path.join(harness.root, 'marker-observed-before-failure')
+    const hookInvoked = path.join(harness.root, 'post-checkout-after-failure')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+touch ${JSON.stringify(hookInvoked)}
+`,
+    )
+    runGit(harness.primary, [
+      'config',
+      'filter.materialization-failure.smudge',
+      `test -f .metadata_never_index && touch ${JSON.stringify(markerObserved)} && exit 29`,
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.materialization-failure.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.materialization-failure.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'materialization-probe.txt filter=materialization-failure\n',
+    )
+    writeFileSync(path.join(harness.primary, 'materialization-probe.txt'), 'probe\n')
+    runGit(harness.primary, ['add', '.gitattributes', 'materialization-probe.txt'])
+    runGit(harness.primary, ['commit', '-m', 'add failing materialization probe'])
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'partial-materialization-failure',
+      target,
+    ])
+
+    expect(creation.status).not.toBe(0)
+    expect(creation.stderr).toContain('smudge filter materialization-failure failed')
+    expect(existsSync(markerObserved)).toBe(true)
+    expect(existsSync(hookInvoked)).toBe(false)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(target)
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    const adminDir = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(adminDir, 'murph-storage-guard-authorized'))).toBe(true)
+
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status, guard.stderr).toBe(0)
+  })
+
   it('ratchets unmanaged temporary clones to zero and rejects new paths', () => {
     const harness = createHarness()
     const origin = 'https://example.test/example/murph.git'

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -126,7 +126,11 @@ async function interruptScriptAfterPath(
   harness: Harness,
   args: string[],
   readyPath: string,
-): Promise<{ status: number | null; stderr: string }> {
+): Promise<{
+  signal: NodeJS.Signals | null
+  status: number | null
+  stderr: string
+}> {
   const child = spawn('bash', [path.join('scripts', 'create-worktree'), ...args], {
     cwd: harness.primary,
     detached: true,
@@ -138,10 +142,14 @@ async function interruptScriptAfterPath(
   child.stderr.on('data', (chunk: string) => {
     stderr += chunk
   })
-  const completed = new Promise<{ status: number | null; stderr: string }>(
+  const completed = new Promise<{
+    signal: NodeJS.Signals | null
+    status: number | null
+    stderr: string
+  }>(
     (resolve, reject) => {
       child.once('error', reject)
-      child.once('close', (status) => resolve({ status, stderr }))
+      child.once('close', (status, signal) => resolve({ signal, status, stderr }))
     },
   )
 
@@ -690,7 +698,11 @@ touch ${JSON.stringify(hookInvoked)}
       filterStarted,
     )
 
-    expect(creation.status, creation.stderr).toBe(130)
+    expect(
+      creation.status === 130 ||
+        (creation.status === null && creation.signal === 'SIGINT'),
+      creation.stderr,
+    ).toBe(true)
     const listing = runGit(harness.primary, ['worktree', 'list', '--porcelain'])
     expect(listing).not.toContain(target)
     expect(listing).toContain(unrelatedTarget)
@@ -740,7 +752,11 @@ sleep 2
       hookStarted,
     )
 
-    expect(creation.status, creation.stderr).toBe(130)
+    expect(
+      creation.status === 130 ||
+        (creation.status === null && creation.signal === 'SIGINT'),
+      creation.stderr,
+    ).toBe(true)
     expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
       target,
     )

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   realpathSync,
   rmSync,
   statSync,
@@ -713,6 +714,75 @@ git add .metadata_never_index
         '.metadata_never_index',
       ]),
     ).toBe('')
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('restores a tracked executable Spotlight marker through hook index changes', () => {
+    const harness = createHarness()
+    const marker = path.join(harness.primary, '.metadata_never_index')
+    writeFileSync(marker, 'executable marker\n')
+    chmodSync(marker, 0o755)
+    runGit(harness.primary, ['config', 'core.filemode', 'true'])
+    runGit(harness.primary, ['add', '.metadata_never_index'])
+    runGit(harness.primary, ['commit', '-m', 'track executable marker'])
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+printf 'hook marker\n' >.metadata_never_index
+chmod 0644 .metadata_never_index
+git add .metadata_never_index
+`,
+    )
+    const target = path.join(harness.root, 'tracked-executable-marker')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'tracked-executable-marker',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(
+      runGit(target, ['ls-files', '--stage', '--', '.metadata_never_index']),
+    ).toMatch(/^100755 /)
+    expect(readFileSync(path.join(target, '.metadata_never_index'), 'utf8')).toBe(
+      'executable marker\n',
+    )
+    expect(lstatSync(path.join(target, '.metadata_never_index')).mode & 0o777).toBe(
+      0o755,
+    )
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('restores a tracked symlink Spotlight marker without touching its target', () => {
+    const harness = createHarness()
+    symlinkSync(
+      'missing-spotlight-target',
+      path.join(harness.primary, '.metadata_never_index'),
+    )
+    runGit(harness.primary, ['add', '.metadata_never_index'])
+    runGit(harness.primary, ['commit', '-m', 'track symlink marker'])
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+rm .metadata_never_index
+printf 'hook marker\n' >.metadata_never_index
+git add .metadata_never_index
+`,
+    )
+    const target = path.join(harness.root, 'tracked-symlink-marker')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'tracked-symlink-marker',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    const targetMarker = path.join(target, '.metadata_never_index')
+    expect(lstatSync(targetMarker).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(targetMarker)).toBe('missing-spotlight-target')
+    expect(existsSync(path.join(target, 'missing-spotlight-target'))).toBe(false)
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -469,7 +469,7 @@ touch hook-installed
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
-  it('keeps a marked authorized worktree when checkout materialization fails', () => {
+  it('rolls back a marked worktree when checkout materialization fails', () => {
     const harness = createHarness()
     const target = path.join(harness.root, 'partial-materialization')
     const markerObserved = path.join(harness.root, 'marker-observed-before-failure')
@@ -513,17 +513,35 @@ touch ${JSON.stringify(hookInvoked)}
     expect(creation.stderr).toContain('smudge filter materialization-failure failed')
     expect(existsSync(markerObserved)).toBe(true)
     expect(existsSync(hookInvoked)).toBe(false)
-    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(target)
-    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
-    const adminDir = runGit(target, [
-      'rev-parse',
-      '--path-format=absolute',
-      '--git-dir',
-    ])
-    expect(existsSync(path.join(adminDir, 'murph-storage-guard-authorized'))).toBe(true)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/partial-materialization-failure',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
 
     const guard = runScript(harness, 'worktree-storage-guard')
     expect(guard.status, guard.stderr).toBe(0)
+
+    runGit(harness.primary, [
+      'config',
+      'filter.materialization-failure.smudge',
+      'cat',
+    ])
+    const retry = runScript(harness, 'create-worktree', [
+      '-B',
+      'partial-materialization-failure',
+      target,
+    ])
+    expect(retry.status, retry.stderr).toBe(0)
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(existsSync(hookInvoked)).toBe(true)
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
   it('ratchets unmanaged temporary clones to zero and rejects new paths', () => {
@@ -1433,6 +1451,65 @@ exit 23
     expect(guard.status, guard.stderr).toBe(0)
   })
 
+  it('matches native post-checkout repository-local environment behavior', () => {
+    const harness = createHarness()
+    const secondary = path.join(harness.root, 'secondary')
+    mkdirSync(secondary)
+    runGit(secondary, ['init', '-b', 'main'])
+    runGit(secondary, ['config', 'user.name', 'Worktree Guard Test'])
+    runGit(secondary, [
+      'config',
+      'user.email',
+      'worktree-guard@users.noreply.github.com',
+    ])
+    const secondaryFile = path.join(secondary, 'secondary-only.txt')
+    writeFileSync(secondaryFile, 'baseline\n')
+    runGit(secondary, ['add', 'secondary-only.txt'])
+    runGit(secondary, ['commit', '-m', 'baseline'])
+    writeFileSync(secondaryFile, 'changed\n')
+
+    const hookEnvironments = path.join(harness.root, 'post-checkout-environments')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+printf '%s|%s\n' "$PWD" "\${GIT_DIR-unset}" >>${JSON.stringify(hookEnvironments)}
+git -C ${JSON.stringify(secondary)} add secondary-only.txt
+`,
+    )
+    expect(runScript(harness, 'install-git-hooks').status).toBe(0)
+
+    const nativeTarget = path.join(harness.root, 'native-hook-environment')
+    runGit(harness.primary, [
+      'worktree',
+      'add',
+      '-b',
+      'native-hook-environment',
+      nativeTarget,
+    ])
+    expect(runGit(nativeTarget, ['status', '--porcelain'])).toBe('')
+    expect(runGit(secondary, ['status', '--porcelain'])).toBe(
+      'M  secondary-only.txt',
+    )
+
+    runGit(secondary, ['reset', 'HEAD', '--', 'secondary-only.txt'])
+    const target = path.join(harness.root, 'helper-hook-environment')
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'helper-hook-environment',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(readFileSync(hookEnvironments, 'utf8').trim().split('\n')).toEqual([
+      `${realpathSync(nativeTarget)}|unset`,
+      `${realpathSync(target)}|unset`,
+    ])
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+    expect(runGit(secondary, ['status', '--porcelain'])).toBe(
+      'M  secondary-only.txt',
+    )
+  })
+
   it('ignores a stale advisory-lock file after its owner exits', () => {
     const harness = createHarness()
     mkdirSync(harness.state, { recursive: true })
@@ -1488,5 +1565,65 @@ printf '%s\\n' 'testfs 200000000 1 10000000 95% /'
     })
     expect(lowDisk.status).toBe(1)
     expect(lowDisk.stderr).toContain('only 9 GiB free')
+  })
+
+  it('rolls back a locked data worktree when checkout materialization fails', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'failed-data-materialization')
+    runGit(harness.primary, [
+      'config',
+      'filter.data-materialization-failure.smudge',
+      'exit 29',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.data-materialization-failure.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.data-materialization-failure.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'data-materialization-probe.txt filter=data-materialization-failure\n',
+    )
+    writeFileSync(
+      path.join(harness.primary, 'data-materialization-probe.txt'),
+      'probe\n',
+    )
+    runGit(harness.primary, [
+      'add',
+      '.gitattributes',
+      'data-materialization-probe.txt',
+    ])
+    runGit(harness.primary, ['commit', '-m', 'add failing data materialization probe'])
+
+    const creation = runScript(harness, 'create-worktree', [
+      '--data-research',
+      'failure cleanup proof',
+      '-b',
+      'failed-data-materialization',
+      target,
+    ])
+
+    expect(creation.status).not.toBe(0)
+    expect(creation.stderr).toContain(
+      'smudge filter data-materialization-failure failed',
+    )
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/failed-data-materialization',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status, guard.stderr).toBe(0)
   })
 })

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -126,6 +126,7 @@ async function interruptScriptAfterPath(
   harness: Harness,
   args: string[],
   readyPath: string,
+  signal: NodeJS.Signals = 'SIGINT',
 ): Promise<{
   signal: NodeJS.Signals | null
   status: number | null
@@ -162,7 +163,7 @@ async function interruptScriptAfterPath(
       await new Promise((resolve) => setTimeout(resolve, 10))
     }
     if (child.pid === undefined) throw new Error('create-worktree did not start')
-    process.kill(-child.pid, 'SIGINT')
+    process.kill(-child.pid, signal)
     return await completed
   } catch (error) {
     if (child.exitCode === null && child.pid !== undefined) {
@@ -171,6 +172,46 @@ async function interruptScriptAfterPath(
     }
     throw error
   }
+}
+
+async function runWithHeldOpenInput(
+  command: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{
+  signal: NodeJS.Signals | null
+  status: number | null
+  stderr: string
+  timedOut: boolean
+}> {
+  const child = spawn(command, args, {
+    cwd,
+    detached: true,
+    env,
+    stdio: ['pipe', 'ignore', 'pipe'],
+  })
+  let stderr = ''
+  let timedOut = false
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      timedOut = true
+      if (child.pid !== undefined) process.kill(-child.pid, 'SIGTERM')
+    }, 5_000)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('close', (status, signal) => {
+      clearTimeout(timeout)
+      resolve({ signal, status, stderr, timedOut })
+    })
+  })
 }
 
 function installLegacyWorktreeEntrypoints(primary: string): void {
@@ -503,6 +544,14 @@ touch hook-installed
 
     expect(creation.status, creation.stderr).toBe(0)
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      true,
+    )
     expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
       '.metadata_never_index',
     )
@@ -572,6 +621,37 @@ git clean -fdX
       '.metadata_never_index',
     )
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('rolls back when final authorization publication fails', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'authorization-publication-failure')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+admin=$(git rev-parse --path-format=absolute --git-dir)
+mkdir "$admin/murph-storage-guard-authorized"
+`,
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'authorization-publication-failure',
+      target,
+    ])
+
+    expect(creation.status).not.toBe(0)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/authorization-publication-failure',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
   })
 
   it('rolls back a marked worktree when checkout materialization fails', () => {
@@ -779,6 +859,160 @@ sleep 2
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   }, 15_000)
+
+  it('leaves an uncatchably interrupted materialization unauthorized', async () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'killed-materialization')
+    const filterStarted = path.join(harness.root, 'killed-materialization-started')
+    const hookInvoked = path.join(harness.root, 'killed-materialization-hook')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+touch ${JSON.stringify(hookInvoked)}
+`,
+    )
+    runGit(harness.primary, [
+      'config',
+      'filter.killed-materialization.smudge',
+      `admin=$(git rev-parse --path-format=absolute --git-dir) && test ! -e "$admin/murph-storage-guard-authorized" && touch ${JSON.stringify(filterStarted)} && sleep 30`,
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.killed-materialization.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.killed-materialization.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'killed-materialization.txt filter=killed-materialization\n',
+    )
+    writeFileSync(path.join(harness.primary, 'killed-materialization.txt'), 'probe\n')
+    runGit(harness.primary, [
+      'add',
+      '.gitattributes',
+      'killed-materialization.txt',
+    ])
+    runGit(harness.primary, ['commit', '-m', 'add killed materialization probe'])
+
+    const creation = await interruptScriptAfterPath(
+      harness,
+      ['-b', 'killed-materialization', target],
+      filterStarted,
+      'SIGKILL',
+    )
+
+    expect(creation.status).toBe(null)
+    expect(creation.signal).toBe('SIGKILL')
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(true)
+    expect(existsSync(hookInvoked)).toBe(false)
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      false,
+    )
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status).toBe(1)
+    expect(guard.stderr).toContain('bypassed scripts/create-worktree')
+    const retry = runScript(harness, 'create-worktree', [
+      '-B',
+      'killed-materialization',
+      target,
+    ])
+    expect(retry.status).toBe(1)
+    expect(retry.stderr).toContain('target is already a registered checkout')
+  }, 15_000)
+
+  it('leaves an uncatchably interrupted post-checkout hook unauthorized', async () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'killed-post-checkout')
+    const hookStarted = path.join(harness.root, 'killed-post-checkout-started')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+admin=$(git rev-parse --path-format=absolute --git-dir)
+test ! -e "$admin/murph-storage-guard-authorized" || exit 25
+touch ${JSON.stringify(hookStarted)}
+sleep 30
+`,
+    )
+
+    const creation = await interruptScriptAfterPath(
+      harness,
+      ['-b', 'killed-post-checkout', target],
+      hookStarted,
+      'SIGKILL',
+    )
+
+    expect(creation.status).toBe(null)
+    expect(creation.signal).toBe('SIGKILL')
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(
+      target,
+    )
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      false,
+    )
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status).toBe(1)
+    expect(guard.stderr).toContain('bypassed scripts/create-worktree')
+  }, 15_000)
+
+  it('keeps a retained rollback failure unauthorized', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'rollback-removal-failure')
+    executable(
+      path.join(harness.fakeBin, 'git'),
+      `#!/bin/sh
+if [ "\${1-}" = -C ] && [ "\${3-}" = worktree ] && [ "\${4-}" = remove ]; then
+  exit 31
+fi
+PATH=/usr/bin:/bin exec git "$@"
+`,
+    )
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      '#!/bin/sh\nexit 29\n',
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'rollback-removal-failure',
+      target,
+    ])
+
+    expect(creation.status).toBe(31)
+    expect(creation.stderr).toContain(
+      'setup failed (status 29); rollback failed (status 31)',
+    )
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(
+      target,
+    )
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      false,
+    )
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status).toBe(1)
+    expect(guard.stderr).toContain('bypassed scripts/create-worktree')
+  })
 
   it('does not register a worktree when shared Spotlight exclusion setup fails', () => {
     const harness = createHarness()
@@ -1825,6 +2059,101 @@ git -C ${JSON.stringify(secondary)} add secondary-only.txt
       'M  secondary-only.txt',
     )
   })
+
+  it('matches native post-checkout end-of-file input behavior', async () => {
+    const hookContents = `#!/bin/sh
+if IFS= read -r line; then
+  printf 'line:%s\\n' "$line" >"$MURPH_TEST_STDIN_LOG"
+else
+  printf 'eof\\n' >"$MURPH_TEST_STDIN_LOG"
+fi
+`
+
+    const nativeHarness = createHarness()
+    executable(
+      path.join(nativeHarness.primary, '.githooks', 'post-checkout'),
+      hookContents,
+    )
+    expect(runScript(nativeHarness, 'install-git-hooks').status).toBe(0)
+    const nativeBytesLog = path.join(nativeHarness.root, 'native-bytes-input')
+    const nativeBytesTarget = path.join(nativeHarness.root, 'native-bytes-target')
+    const nativeBytes = spawnSync(
+      'git',
+      ['worktree', 'add', '-b', 'native-bytes-input', nativeBytesTarget],
+      {
+        cwd: nativeHarness.primary,
+        encoding: 'utf8',
+        env: {
+          ...guardEnvironment(nativeHarness),
+          MURPH_TEST_STDIN_LOG: nativeBytesLog,
+        },
+        input: 'secret-input\n',
+      },
+    )
+    expect(nativeBytes.status, nativeBytes.stderr).toBe(0)
+    expect(readFileSync(nativeBytesLog, 'utf8')).toBe('eof\n')
+
+    const nativeOpenLog = path.join(nativeHarness.root, 'native-open-input')
+    const nativeOpenTarget = path.join(nativeHarness.root, 'native-open-target')
+    const nativeOpen = await runWithHeldOpenInput(
+      'git',
+      ['worktree', 'add', '-b', 'native-open-input', nativeOpenTarget],
+      nativeHarness.primary,
+      {
+        ...guardEnvironment(nativeHarness),
+        MURPH_TEST_STDIN_LOG: nativeOpenLog,
+      },
+    )
+    expect(nativeOpen.timedOut, nativeOpen.stderr).toBe(false)
+    expect(nativeOpen.status, nativeOpen.stderr).toBe(0)
+    expect(readFileSync(nativeOpenLog, 'utf8')).toBe('eof\n')
+
+    const helperHarness = createHarness()
+    executable(
+      path.join(helperHarness.primary, '.githooks', 'post-checkout'),
+      hookContents,
+    )
+    const helperBytesLog = path.join(helperHarness.root, 'helper-bytes-input')
+    const helperBytesTarget = path.join(helperHarness.root, 'helper-bytes-target')
+    const helperBytes = spawnSync(
+      'bash',
+      [
+        path.join('scripts', 'create-worktree'),
+        '-b',
+        'helper-bytes-input',
+        helperBytesTarget,
+      ],
+      {
+        cwd: helperHarness.primary,
+        encoding: 'utf8',
+        env: guardEnvironment(helperHarness, {
+          MURPH_TEST_STDIN_LOG: helperBytesLog,
+        }),
+        input: 'secret-input\n',
+      },
+    )
+    expect(helperBytes.status, helperBytes.stderr).toBe(0)
+    expect(readFileSync(helperBytesLog, 'utf8')).toBe('eof\n')
+
+    const helperOpenLog = path.join(helperHarness.root, 'helper-open-input')
+    const helperOpenTarget = path.join(helperHarness.root, 'helper-open-target')
+    const helperOpen = await runWithHeldOpenInput(
+      'bash',
+      [
+        path.join('scripts', 'create-worktree'),
+        '-b',
+        'helper-open-input',
+        helperOpenTarget,
+      ],
+      helperHarness.primary,
+      guardEnvironment(helperHarness, {
+        MURPH_TEST_STDIN_LOG: helperOpenLog,
+      }),
+    )
+    expect(helperOpen.timedOut, helperOpen.stderr).toBe(false)
+    expect(helperOpen.status, helperOpen.stderr).toBe(0)
+    expect(readFileSync(helperOpenLog, 'utf8')).toBe('eof\n')
+  }, 15_000)
 
   it('matches native unavailable post-checkout interpreter status', () => {
     const nativeHarness = createHarness()

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -569,8 +569,145 @@ touch hook-installed
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
-  it('restores the Spotlight marker after a successful cleanup hook', () => {
+  it('matches native checkout-filter worktree context', () => {
+    const configureFilter = (harness: Harness, output: string): void => {
+      const attributes = runGit(harness.primary, [
+        'rev-parse',
+        '--path-format=absolute',
+        '--git-path',
+        'info/attributes',
+      ])
+      writeFileSync(attributes, 'tracked.txt filter=materialization-contract\n')
+      runGit(harness.primary, [
+        'config',
+        'filter.materialization-contract.smudge',
+        `test -n "\${GIT_DIR-}" && test -n "\${GIT_WORK_TREE-}" && printf '%s|%s|%s\\n' "$PWD" "$GIT_DIR" "$GIT_WORK_TREE" >${JSON.stringify(output)} && cat`,
+      ])
+      runGit(harness.primary, [
+        'config',
+        'filter.materialization-contract.clean',
+        'cat',
+      ])
+      runGit(harness.primary, [
+        'config',
+        'filter.materialization-contract.required',
+        'true',
+      ])
+    }
+    const normalizeContext = (context: string, target: string): string => {
+      const admin = runGit(target, [
+        'rev-parse',
+        '--path-format=absolute',
+        '--git-dir',
+      ])
+      return context
+        .replaceAll(realpathSync(target), '<TARGET>')
+        .replaceAll(realpathSync(admin), '<GIT_DIR>')
+    }
+
+    const nativeHarness = createHarness()
+    const nativeOutput = path.join(nativeHarness.root, 'native-filter-context')
+    configureFilter(nativeHarness, nativeOutput)
+    const nativeTarget = path.join(nativeHarness.root, 'native-filter-target')
+    const nativeCreation = spawnSync(
+      'git',
+      ['worktree', 'add', '-b', 'native-filter-context', nativeTarget],
+      { cwd: nativeHarness.primary, encoding: 'utf8' },
+    )
+
+    const helperHarness = createHarness()
+    const helperOutput = path.join(helperHarness.root, 'helper-filter-context')
+    configureFilter(helperHarness, helperOutput)
+    const helperTarget = path.join(helperHarness.root, 'helper-filter-target')
+    const helperCreation = runScript(helperHarness, 'create-worktree', [
+      '-b',
+      'helper-filter-context',
+      helperTarget,
+    ])
+
+    expect(nativeCreation.status, nativeCreation.stderr).toBe(0)
+    expect(helperCreation.status, helperCreation.stderr).toBe(0)
+    expect(
+      normalizeContext(readFileSync(helperOutput, 'utf8'), helperTarget),
+    ).toBe(normalizeContext(readFileSync(nativeOutput, 'utf8'), nativeTarget))
+    expect(readFileSync(path.join(helperTarget, 'tracked.txt'), 'utf8')).toBe(
+      'baseline\n',
+    )
+    expect(existsSync(path.join(helperTarget, '.metadata_never_index'))).toBe(true)
+  })
+
+  it('matches native non-recursive worktree materialization', () => {
+    const addSubmoduleFixture = (harness: Harness): void => {
+      const source = path.join(harness.root, 'submodule-source')
+      mkdirSync(source)
+      runGit(source, ['init', '-b', 'main'])
+      runGit(source, ['config', 'user.name', 'Worktree Guard Test'])
+      runGit(source, [
+        'config',
+        'user.email',
+        'worktree-guard@users.noreply.github.com',
+      ])
+      writeFileSync(path.join(source, 'submodule.txt'), 'submodule\n')
+      runGit(source, ['add', 'submodule.txt'])
+      runGit(source, ['commit', '-m', 'submodule baseline'])
+      const addition = spawnSync(
+        'git',
+        [
+          '-c',
+          'protocol.file.allow=always',
+          'submodule',
+          'add',
+          source,
+          'nested',
+        ],
+        { cwd: harness.primary, encoding: 'utf8' },
+      )
+      if (addition.status !== 0) {
+        throw new Error(`submodule fixture failed: ${addition.stderr}`)
+      }
+      runGit(harness.primary, ['commit', '-am', 'add submodule fixture'])
+      runGit(harness.primary, ['config', 'submodule.recurse', 'true'])
+    }
+
+    const nativeHarness = createHarness()
+    addSubmoduleFixture(nativeHarness)
+    const nativeTarget = path.join(nativeHarness.root, 'native-submodule-target')
+    const nativeCreation = spawnSync(
+      'git',
+      ['worktree', 'add', '-b', 'native-submodule-context', nativeTarget],
+      { cwd: nativeHarness.primary, encoding: 'utf8' },
+    )
+
+    const helperHarness = createHarness()
+    addSubmoduleFixture(helperHarness)
+    const helperTarget = path.join(helperHarness.root, 'helper-submodule-target')
+    const helperCreation = runScript(helperHarness, 'create-worktree', [
+      '-b',
+      'helper-submodule-context',
+      helperTarget,
+    ])
+
+    expect(nativeCreation.status, nativeCreation.stderr).toBe(0)
+    expect(helperCreation.status, helperCreation.stderr).toBe(0)
+    expect(existsSync(path.join(nativeTarget, 'nested', 'submodule.txt'))).toBe(
+      false,
+    )
+    expect(existsSync(path.join(helperTarget, 'nested', 'submodule.txt'))).toBe(
+      false,
+    )
+    expect(runGit(helperTarget, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('restores shared and checkout Spotlight state after a successful hook', () => {
     const harness = createHarness()
+    const sibling = path.join(harness.root, 'cleanup-hook-sibling')
+    expect(
+      runScript(harness, 'create-worktree', [
+        '-b',
+        'cleanup-hook-sibling',
+        sibling,
+      ]).status,
+    ).toBe(0)
     const target = path.join(harness.root, 'cleanup-hook-spotlight')
     const markerObserved = path.join(harness.root, 'cleanup-hook-marker-observed')
     const hookInvocations = path.join(harness.root, 'cleanup-hook-invocations')
@@ -601,6 +738,8 @@ touch hook-installed
       `#!/bin/sh
 printf '%s|%s|%s\n' "$1" "$2" "$3" >>${JSON.stringify(hookInvocations)}
 git clean -fdX
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '/hook-owned-only\n' >"$exclude"
 `,
     )
 
@@ -616,11 +755,26 @@ git clean -fdX
     expect(readFileSync(hookInvocations, 'utf8')).toMatch(
       new RegExp(`^0{40,64}\\|[0-9a-f]{40,64}\\|1\\n$`),
     )
+    const excludeFile = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-path',
+      'info/exclude',
+    ])
+    const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
+    expect(excludeRules).toContain('/hook-owned-only')
+    expect(
+      excludeRules.filter((rule) => rule === '/.metadata_never_index'),
+    ).toHaveLength(1)
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
     expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
       '.metadata_never_index',
     )
+    expect(runGit(sibling, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
+    expect(runGit(sibling, ['status', '--porcelain'])).toBe('')
   })
 
   it('rolls back when final authorization publication fails', () => {

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -2,12 +2,14 @@ import { spawn, spawnSync } from 'node:child_process'
 import {
   chmodSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
@@ -764,9 +766,6 @@ printf '# hook comment\n/hook-owned-only\n/.metadata_never_index\n!.*\n/.metadat
     const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
     expect(excludeRules).toContain('# hook comment')
     expect(excludeRules).toContain('/hook-owned-only')
-    expect(
-      excludeRules.filter((rule) => rule === '/.metadata_never_index'),
-    ).toHaveLength(1)
     expect(excludeRules.at(-1)).toBe('/.metadata_never_index')
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
     expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
@@ -777,6 +776,94 @@ printf '# hook comment\n/hook-owned-only\n/.metadata_never_index\n!.*\n/.metadat
     )
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
     expect(runGit(sibling, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('preserves a shared exclude symlink while establishing final precedence', () => {
+    const harness = createHarness()
+    const commonDir = runGit(harness.primary, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-common-dir',
+    ])
+    const excludeFile = path.join(commonDir, 'info', 'exclude')
+    const sharedExclude = path.join(harness.root, 'shared-exclude')
+    writeFileSync(sharedExclude, '/shared-only\n')
+    rmSync(excludeFile)
+    symlinkSync(sharedExclude, excludeFile)
+    const target = path.join(harness.root, 'symlink-exclude-target')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'symlink-exclude-target',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(lstatSync(excludeFile).isSymbolicLink()).toBe(true)
+    expect(readFileSync(sharedExclude, 'utf8').trim().split('\n').at(-1)).toBe(
+      '/.metadata_never_index',
+    )
+    expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+  })
+
+  it('preserves shared exclude inode and mode while establishing precedence', () => {
+    const harness = createHarness()
+    const commonDir = runGit(harness.primary, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-common-dir',
+    ])
+    const excludeFile = path.join(commonDir, 'info', 'exclude')
+    const linkedExclude = path.join(harness.root, 'linked-exclude')
+    chmodSync(excludeFile, 0o644)
+    linkSync(excludeFile, linkedExclude)
+    const before = statSync(excludeFile)
+    const target = path.join(harness.root, 'linked-exclude-target')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'linked-exclude-target',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    const after = statSync(excludeFile)
+    expect(after.ino).toBe(before.ino)
+    expect(after.mode & 0o777).toBe(0o644)
+    expect(statSync(linkedExclude).ino).toBe(before.ino)
+    expect(readFileSync(linkedExclude, 'utf8').trim().split('\n').at(-1)).toBe(
+      '/.metadata_never_index',
+    )
+  })
+
+  it('preserves a shared exclude symlink when registration fails', () => {
+    const harness = createHarness()
+    const commonDir = runGit(harness.primary, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-common-dir',
+    ])
+    const excludeFile = path.join(commonDir, 'info', 'exclude')
+    const sharedExclude = path.join(harness.root, 'failed-shared-exclude')
+    writeFileSync(sharedExclude, '/shared-only\n')
+    rmSync(excludeFile)
+    symlinkSync(sharedExclude, excludeFile)
+    const target = path.join(harness.root, 'failed-symlink-exclude-target')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'main',
+      target,
+    ])
+
+    expect(creation.status).not.toBe(0)
+    expect(lstatSync(excludeFile).isSymbolicLink()).toBe(true)
+    expect(readFileSync(sharedExclude, 'utf8').trim().split('\n').at(-1)).toBe(
+      '/.metadata_never_index',
+    )
+    expect(existsSync(target)).toBe(false)
   })
 
   it('repairs shared Spotlight state before rolling back a failed hook', () => {
@@ -826,9 +913,6 @@ exit 23
     const excludeRules = readFileSync(excludeFile, 'utf8').trim().split('\n')
     expect(excludeRules).toContain('# failed hook')
     expect(excludeRules).toContain('/hook-failure-owned')
-    expect(
-      excludeRules.filter((rule) => rule === '/.metadata_never_index'),
-    ).toHaveLength(1)
     expect(excludeRules.at(-1)).toBe('/.metadata_never_index')
     expect(runGit(sibling, ['check-ignore', '.metadata_never_index'])).toBe(
       '.metadata_never_index',

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -421,6 +421,28 @@ touch hook-installed
     )
     writeFileSync(excludeFile, '/custom-local-only')
     writeFileSync(path.join(harness.primary, 'custom-local-only'), 'ignored\n')
+    runGit(harness.primary, [
+      'config',
+      'filter.spotlight-marker.smudge',
+      'test -f .metadata_never_index && cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.spotlight-marker.clean',
+      'cat',
+    ])
+    runGit(harness.primary, [
+      'config',
+      'filter.spotlight-marker.required',
+      'true',
+    ])
+    writeFileSync(
+      path.join(harness.primary, '.gitattributes'),
+      'spotlight-probe.txt filter=spotlight-marker\n',
+    )
+    writeFileSync(path.join(harness.primary, 'spotlight-probe.txt'), 'probe\n')
+    runGit(harness.primary, ['add', '.gitattributes', 'spotlight-probe.txt'])
+    runGit(harness.primary, ['commit', '-m', 'add Spotlight ordering probe'])
 
     const creation = runScript(harness, 'create-worktree', [
       '-b',
@@ -435,6 +457,9 @@ touch hook-installed
     )
     expect(runGit(harness.primary, ['check-ignore', 'custom-local-only'])).toBe(
       'custom-local-only',
+    )
+    expect(readFileSync(path.join(target, 'spotlight-probe.txt'), 'utf8')).toBe(
+      'probe\n',
     )
     expect(
       readFileSync(excludeFile, 'utf8')
@@ -1323,8 +1348,16 @@ done
   it('does not wedge when a checkout hook fails after worktree registration', () => {
     const harness = createHarness()
     const postCheckout = path.join(harness.primary, '.githooks', 'post-checkout')
-    executable(postCheckout, '#!/bin/sh\nexit 23\n')
+    const hookInvocations = path.join(harness.root, 'post-checkout-invocations')
+    executable(
+      postCheckout,
+      `#!/bin/sh
+printf '%s|%s|%s|%s\\n' "$PWD" "$1" "$2" "$3" >>${JSON.stringify(hookInvocations)}
+exit 23
+`,
+    )
     const target = path.join(harness.root, 'partial')
+    const expectedHead = runGit(harness.primary, ['rev-parse', 'HEAD'])
 
     const creation = runScript(harness, 'create-worktree', [
       '-b',
@@ -1334,6 +1367,9 @@ done
     expect(creation.status).toBe(23)
     expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(target)
     expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(readFileSync(hookInvocations, 'utf8').trim().split('\n')).toEqual([
+      `${realpathSync(target)}|${'0'.repeat(expectedHead.length)}|${expectedHead}|1`,
+    ])
     rmSync(postCheckout)
 
     const guard = runScript(harness, 'worktree-storage-guard')

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -544,6 +544,69 @@ touch ${JSON.stringify(hookInvoked)}
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
+  it('does not register a worktree when shared Spotlight exclusion setup fails', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'exclude-setup-failure')
+    const excludeFile = runGit(harness.primary, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-path',
+      'info/exclude',
+    ])
+    rmSync(excludeFile)
+    mkdirSync(excludeFile)
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'exclude-setup-failure',
+      target,
+    ])
+
+    expect(creation.status).not.toBe(0)
+    expect(existsSync(target)).toBe(false)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(runGit(harness.primary, ['branch', '--format=%(refname:short)'])).not.toContain(
+      'exclude-setup-failure',
+    )
+  })
+
+  it('rolls back the complete post-registration setup boundary', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'marker-setup-failure')
+    executable(
+      path.join(harness.fakeBin, 'touch'),
+      `#!/bin/sh
+if [ "\${1-}" = ${JSON.stringify(path.join(target, '.metadata_never_index'))} ]; then
+  exit 29
+fi
+PATH=/usr/bin:/bin exec touch "$@"
+`,
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'marker-setup-failure',
+      target,
+    ])
+
+    expect(creation.status).toBe(29)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/marker-setup-failure',
+      ]),
+    ).toMatch(/^[0-9a-f]{40,64}$/)
+    const guard = runScript(harness, 'worktree-storage-guard')
+    expect(guard.status, guard.stderr).toBe(0)
+  })
+
   it('ratchets unmanaged temporary clones to zero and rejects new paths', () => {
     const harness = createHarness()
     const origin = 'https://example.test/example/murph.git'
@@ -1420,7 +1483,7 @@ done
     expect(result.stderr).toContain('bypassed scripts/create-worktree')
   })
 
-  it('does not wedge when a checkout hook fails after worktree registration', () => {
+  it('rolls back when the native checkout hook fails', () => {
     const harness = createHarness()
     const postCheckout = path.join(harness.primary, '.githooks', 'post-checkout')
     const hookInvocations = path.join(harness.root, 'post-checkout-invocations')
@@ -1440,11 +1503,20 @@ exit 23
       target,
     ])
     expect(creation.status).toBe(23)
-    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).toContain(target)
-    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
+    expect(runGit(harness.primary, ['worktree', 'list', '--porcelain'])).not.toContain(
+      target,
+    )
+    expect(existsSync(target)).toBe(false)
     expect(readFileSync(hookInvocations, 'utf8').trim().split('\n')).toEqual([
-      `${realpathSync(target)}|${'0'.repeat(expectedHead.length)}|${expectedHead}|1`,
+      `${realpathSync(harness.root)}/partial|${'0'.repeat(expectedHead.length)}|${expectedHead}|1`,
     ])
+    expect(
+      runGit(harness.primary, [
+        'rev-parse',
+        '--verify',
+        'refs/heads/partial-hook-failure',
+      ]),
+    ).toBe(expectedHead)
     rmSync(postCheckout)
 
     const guard = runScript(harness, 'worktree-storage-guard')
@@ -1469,10 +1541,18 @@ exit 23
     writeFileSync(secondaryFile, 'changed\n')
 
     const hookEnvironments = path.join(harness.root, 'post-checkout-environments')
+    const expectedHead = runGit(harness.primary, ['rev-parse', 'HEAD'])
+    const expectedExecPath = runGit(harness.primary, ['--exec-path'])
     executable(
       path.join(harness.primary, '.githooks', 'post-checkout'),
       `#!/bin/sh
-printf '%s|%s\n' "$PWD" "\${GIT_DIR-unset}" >>${JSON.stringify(hookEnvironments)}
+printf '%s|%s|%s:%s|%s|%s|%s|%s|%s|%s|%s\n' \
+  "$PWD" "\${GIT_DIR-unset}" "\${GIT_PREFIX+set}" "\${GIT_PREFIX-}" \
+  "\${GIT_EXEC_PATH-unset}" "\${PATH%%:*}" \
+  "\${MURPH_CREATE_WORKTREE_LOCK_HELD-unset}" \
+  "\${MURPH_WORKTREE_GUARD_LOCK_HELD-unset}" \
+  "$1" "$2" "$3" >>${JSON.stringify(hookEnvironments)}
+( . "$GIT_EXEC_PATH/git-sh-setup" )
 git -C ${JSON.stringify(secondary)} add secondary-only.txt
 `,
     )
@@ -1501,13 +1581,75 @@ git -C ${JSON.stringify(secondary)} add secondary-only.txt
 
     expect(creation.status, creation.stderr).toBe(0)
     expect(readFileSync(hookEnvironments, 'utf8').trim().split('\n')).toEqual([
-      `${realpathSync(nativeTarget)}|unset`,
-      `${realpathSync(target)}|unset`,
+      `${realpathSync(nativeTarget)}|unset|set:|${expectedExecPath}|${expectedExecPath}|unset|unset|${'0'.repeat(expectedHead.length)}|${expectedHead}|1`,
+      `${realpathSync(target)}|unset|set:|${expectedExecPath}|${expectedExecPath}|unset|unset|${'0'.repeat(expectedHead.length)}|${expectedHead}|1`,
     ])
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
     expect(runGit(secondary, ['status', '--porcelain'])).toBe(
       'M  secondary-only.txt',
     )
+  })
+
+  it('matches native unavailable post-checkout interpreter status', () => {
+    const nativeHarness = createHarness()
+    const nativeHook = path.join(
+      nativeHarness.primary,
+      '.githooks',
+      'post-checkout',
+    )
+    executable(nativeHook, '#!/definitely/missing/murph-interpreter\n')
+    expect(runScript(nativeHarness, 'install-git-hooks').status).toBe(0)
+    const nativeTarget = path.join(nativeHarness.root, 'native-missing-interpreter')
+    const nativeCreation = spawnSync(
+      'git',
+      [
+        'worktree',
+        'add',
+        '-b',
+        'native-missing-interpreter',
+        nativeTarget,
+      ],
+      { cwd: nativeHarness.primary, encoding: 'utf8' },
+    )
+
+    const helperHarness = createHarness()
+    executable(
+      path.join(helperHarness.primary, '.githooks', 'post-checkout'),
+      '#!/definitely/missing/murph-interpreter\n',
+    )
+    const helperTarget = path.join(helperHarness.root, 'helper-missing-interpreter')
+    const helperCreation = runScript(helperHarness, 'create-worktree', [
+      '-b',
+      'helper-missing-interpreter',
+      helperTarget,
+    ])
+
+    expect(nativeCreation.status).toBe(1)
+    expect(helperCreation.status).toBe(nativeCreation.status)
+    expect(helperCreation.stderr).toContain('hook interpreter is unavailable')
+    expect(
+      runGit(helperHarness.primary, ['worktree', 'list', '--porcelain']),
+    ).not.toContain(helperTarget)
+    expect(existsSync(helperTarget)).toBe(false)
+  })
+
+  it('preserves ignored non-executable post-checkout hook behavior', () => {
+    const harness = createHarness()
+    writeFileSync(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      '#!/bin/sh\nexit 23\n',
+    )
+    const target = path.join(harness.root, 'non-executable-hook')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'non-executable-hook',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+    expect(existsSync(path.join(target, '.metadata_never_index'))).toBe(true)
   })
 
   it('ignores a stale advisory-lock file after its owner exits', () => {

--- a/scripts/worktree-storage-guard.test.ts
+++ b/scripts/worktree-storage-guard.test.ts
@@ -571,6 +571,151 @@ touch hook-installed
     expect(runGit(target, ['status', '--porcelain'])).toBe('')
   })
 
+  it('removes a Spotlight marker staged by post-index-change without discarding other hook effects', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'post-index-change-marker')
+    const hookInvocations = path.join(
+      harness.root,
+      'post-index-change-invocations',
+    )
+    executable(
+      path.join(harness.primary, '.githooks', 'post-index-change'),
+      `#!/bin/sh
+if [ -e ${JSON.stringify(hookInvocations)} ]; then
+  exit 0
+fi
+printf 'invoked\n' >>${JSON.stringify(hookInvocations)}
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '!/.metadata_never_index\n' >"$exclude"
+printf 'generated\n' >hook-generated.txt
+git add -A
+`,
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'post-index-change-marker',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(readFileSync(hookInvocations, 'utf8')).toBe('invoked\n')
+    expect(
+      runGit(target, ['ls-files', '--stage', '--', '.metadata_never_index']),
+    ).toBe('')
+    expect(runGit(target, ['status', '--porcelain'])).toBe(
+      'A  hook-generated.txt',
+    )
+    const excludeFile = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-path',
+      'info/exclude',
+    ])
+    expect(readFileSync(excludeFile, 'utf8')).toMatch(
+      /(?:^|\n)\/\.metadata_never_index\n$/,
+    )
+    expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      true,
+    )
+  })
+
+  it('removes a Spotlight marker staged by post-checkout without discarding other hook effects', () => {
+    const harness = createHarness()
+    const target = path.join(harness.root, 'post-checkout-marker')
+    const hookInvocations = path.join(harness.root, 'marker-hook-invocations')
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+printf 'invoked\n' >>${JSON.stringify(hookInvocations)}
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '!/.metadata_never_index\n' >"$exclude"
+printf 'generated\n' >hook-generated.txt
+git add -A
+`,
+    )
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'post-checkout-marker',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    expect(readFileSync(hookInvocations, 'utf8')).toBe('invoked\n')
+    expect(
+      runGit(target, ['ls-files', '--stage', '--', '.metadata_never_index']),
+    ).toBe('')
+    expect(runGit(target, ['status', '--porcelain'])).toBe(
+      'A  hook-generated.txt',
+    )
+    expect(runGit(target, ['check-ignore', '.metadata_never_index'])).toBe(
+      '.metadata_never_index',
+    )
+    const admin = runGit(target, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-dir',
+    ])
+    expect(existsSync(path.join(admin, 'murph-storage-guard-authorized'))).toBe(
+      true,
+    )
+  })
+
+  it('restores the checked-out tree entry when the Spotlight marker is tracked', () => {
+    const harness = createHarness()
+    writeFileSync(
+      path.join(harness.primary, '.metadata_never_index'),
+      'tracked marker\n',
+    )
+    runGit(harness.primary, ['add', '.metadata_never_index'])
+    runGit(harness.primary, ['commit', '-m', 'track Spotlight marker'])
+    executable(
+      path.join(harness.primary, '.githooks', 'post-checkout'),
+      `#!/bin/sh
+exclude=$(git rev-parse --path-format=absolute --git-path info/exclude)
+printf '!/.metadata_never_index\n' >"$exclude"
+printf 'hook marker\n' >.metadata_never_index
+git add .metadata_never_index
+`,
+    )
+    const target = path.join(harness.root, 'tracked-spotlight-marker')
+
+    const creation = runScript(harness, 'create-worktree', [
+      '-b',
+      'tracked-spotlight-marker',
+      target,
+    ])
+
+    expect(creation.status, creation.stderr).toBe(0)
+    const expectedOid = runGit(harness.primary, [
+      'rev-parse',
+      'HEAD:.metadata_never_index',
+    ])
+    expect(
+      runGit(target, ['ls-files', '--stage', '--', '.metadata_never_index']),
+    ).toContain(expectedOid)
+    expect(
+      runGit(target, [
+        'diff',
+        '--cached',
+        '--name-only',
+        'HEAD',
+        '--',
+        '.metadata_never_index',
+      ]),
+    ).toBe('')
+    expect(runGit(target, ['status', '--porcelain'])).toBe('')
+  })
+
   it('matches native checkout-filter worktree context', () => {
     const configureFilter = (harness: Harness, output: string): void => {
       const attributes = runGit(harness.primary, [


### PR DESCRIPTION
## Why this PR exists

New Murph worktrees were marked with `.metadata_never_index` only after Git populated tracked files, leaving an initial window for Spotlight to discover and index the checkout.

## User goal / user-visible behavior

Keep new and existing local Murph worktrees out of Spotlight indexing so repository automation does not contribute avoidable indexing load.

## User experience

No member-facing effect. Developers keep using `scripts/create-worktree`; the helper establishes the Spotlight sentinel before tracked files appear and publishes authorization only after the full setup boundary succeeds.

## Invariants

- The shared ignore prerequisite completes before registration, the Spotlight sentinel exists before tracked files materialize, and effective shared-rule precedence is repaired after every hook termination or catchable interruption before success or rollback.
- Sentinel creation, materialization, hook completion, final sentinel restoration, and final authorization publication form one post-registration boundary with one exact-target rollback.
- The configured `post-checkout` hook runs once from the canonical target root with null/current/1 arguments, a normalized repository-independent environment including end-of-file standard input, executable preflight for valid hooks, and exact propagation of the invoked hook's exit status.
- Descendants of the manually forwarded `post-checkout` hook do not inherit Murph's lock-held authority flags; native `post-index-change` remains under Git's materialization environment.
- A setup failure or catchable interruption removes only the exact newly registered target under the creation lock, preserves the branch for retry, and returns the failure or signal status.
- Existing worktrees and agent processes are never signaled, terminated, pruned, or retired by this change.
- The storage guard remains fail-closed.

## Changelog

- Changelog: not applicable
- Reason: Internal repository tooling only; no member-visible behavior changed.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

ReviewGPT first-reviewed head: a07e3d26135fc0b6c8792ecda9c50d99ff0593eb

- Classification reason: Worktree checkout ordering, authorization ordering, hook forwarding, and failure behavior change.

## ReviewGPT finding ledger

- Round 1 — repository-local hook environment: accepted. The initial direct hook call leaked `GIT_DIR` and could corrupt another repository's index.
- Round 1 — stranded materialization failure: accepted. A failed smudge filter left a registered dirty worktree that supported creation and retirement could not recover.
- Round 2 — outcome `RETROSPECTIVE_REQUIRED`. It confirmed both round-one corrections, then found the same mechanisms in pre-materialization setup failures and incomplete hook-launch emulation. Tactical work stopped until the requirement-level retrospective below was recorded.
- Round 3 — catchable interruption cleanup: accepted. A foreground interruption during materialization or the hook could escape the status-only rollback and strand a registered partial worktree.
- Round 3 — cleanup hook marker removal: accepted. A successful hook could remove ignored files, including the Spotlight sentinel, before the helper reported success.
- Round 3 — spaced shebang handling: accepted. The interpreter preflight rejected native-valid spaces or tabs after `#!`.
- Round 4 — premature authorization publication: accepted. An uncatchable termination could retain a partial worktree that the storage guard incorrectly accepted as complete.
- Round 4 — inherited hook standard input: accepted. The direct launcher could consume caller bytes or block where native Git supplies EOF.
- Round 4 — malformed executable status variants: rejected below the material-finding bar; the reviewer explicitly classified those deterministic malformed-hook differences as non-material.
- Round 5 — post-hook shared exclude mutation: accepted. A successful hook could replace the common ignore file and expose every worktree sentinel before authorization.
- Round 5 — checkout-filter materialization contract: accepted. Manual reset omitted native linked-worktree environment and `--no-recurse-submodules`.
- Round 6 — conditional shared-exclude repair: accepted as review-induced. Exact-line presence did not prove effective precedence, and failed/interrupted hooks skipped repair before rollback.
- Round 7 — shared exclude file replacement: accepted as review-induced. The round-six repair replaced the developer-owned `info/exclude` inode, which could sever a valid symlink and discard permissions, hard links, ACLs, or extended attributes.
- Round 8 — helper-owned marker index state: accepted as an original PR gap. A successful `post-index-change` or manually forwarded `post-checkout` hook can temporarily unignore and stage `.metadata_never_index`; final ignore repair and `touch` did not remove that index entry, yet authorization was still published. The user explicitly authorized remediation and continuation. The correction captures the checked-out marker entry before materialization, then after both hook boundaries restores only that path in the index and worktree with hooks suppressed, re-establishes effective ignore precedence and marker presence, verifies no staged or unstaged marker delta, and publishes authorization last. Focused proof covers `post-index-change`, `post-checkout`, preserved unrelated hook effects, and a deliberately tracked marker.
- Round 9 — manual tree-entry reconstruction: accepted as a review-induced simplification. The round-eight behavior was effective, but the shell parsed `ls-tree` fields, object IDs, types, and modes and rebuilt cache entries, rejecting valid symlink markers. The correction deletes that machinery in favor of Git-owned, hook-suppressed path-scoped `reset` plus conditional `checkout-index`, with tracked regular, executable, and dangling-symlink proof and no new owner, state, or dependency.
- Round 10 — full-snapshot final audit: passed. ReviewGPT verified every accepted round-one through round-nine mechanism on exact head `214875c335ee17ea7b060051405bbab337440569`, found no qualifying correctness, UX, purpose, experience, or complexity issue, and returned `ROUND_OUTCOME: PASS` with `REVIEW_COMPLETE`.
- Current correction: shared ignore setup stays before registration and is precedence-repaired after every hook termination or catchable interruption by appending through the existing path only when the sentinel is not already final. It preserves unrelated content, symlink targets, inode identity, permissions, and hard links while preserving the original hook/signal status. All post-registration steps share one exact-target rollback; materialization uses native-equivalent linked `GIT_DIR`, `GIT_WORK_TREE=.`, and non-recursive reset. The helper captures only the checkout-tree head, then delegates marker index restoration to Git's path-scoped reset and restores tracked worktree representations with `checkout-index`, all with hooks suppressed after `post-index-change` and `post-checkout`. Unrelated hook effects survive before final ignore repair, marker verification, and authorization. The direct hook receives `/dev/null` stdin, and interpreter preflight trims native-valid leading shebang whitespace. Differential tests cover native/helper filter, submodule, environment, stdin and index behavior, absent, regular, executable, and symlink marker restoration, successful/failed/interrupted shared-rule mutation, symlink and hard-link ownership, registration failure, repair failure reporting, negation, executable variants, hook failure, regular and locked rollback, catchable and uncatchable interruption, unauthorized retained failure, retry, sibling preservation, and both sides of registration.

## Anomaly retrospective

- **Original requirement:** Ensure the Spotlight sentinel exists before tracked checkout files materialize, while keeping sanctioned worktree creation retryable and preserving the existing storage guard.
- **Shape comparison at trigger:** The immutable first-reviewed head added 24/deleted 2 source lines. The round-two head added 48/deleted 2; review remediation had added 28/deleted 4 source lines, plus focused tests and docs. The size threshold was not implicated.
- **Repeated mechanisms:** Cleanup covered only `git reset --hard` instead of the whole registration-to-usable boundary, and direct hook execution reconstructed native Git launch semantics variable by variable.
- **Rejected design after focused proof:** Native `git checkout --force HEAD` still exports the linked worktree's `GIT_DIR` to `post-checkout` and returns a different unavailable-interpreter status than native `git worktree add`. It therefore does not satisfy the required hook boundary.
- **Decision:** Redesign and shrink within this PR using the complete-differential-contract option. Prepare the shared exclude rule before registration; after successful registration, treat authorization, sentinel creation, materialization, and hook completion as one boundary with one exact-target rollback. Keep `git reset --hard` for materialization, then use one explicit hook launcher that sets the normalized native worktree-add contract in one place: canonical root, null/current/1 arguments, every Git-local variable cleared, `GIT_EXEC_PATH` and empty `GIT_PREFIX` set, Git's exec path prepended to `PATH`, Murph lock-authority flags cleared, and native missing/non-executable/interpreter status behavior.
- **Continuation decision:** Continue the same PR only with that single lifecycle boundary and one differential launcher contract. Delete operation-specific cleanup and variable-by-variable hook patches; require native/helper environment, cross-repository index, interpreter, descendant-authority, and pre/post-registration setup-failure proof.

## Round-seven hard-cap retrospective

- **Original requirement:** Keep new and existing Murph worktrees out of Spotlight by establishing the sentinel before tracked materialization, without disturbing existing worktrees or developer-owned Git state.
- **Shape at the cap:** The immutable first-reviewed head added 24/deleted 2 source lines; the corrected round-seven head adds 131/deletes 14. Tests moved from 94/1 to 1450/69 and docs from 31/5 to 51/5. The growth is focused lifecycle proof rather than a new runtime owner.
- **Repeated mechanism:** The worktree lifecycle needed exact cleanup and native-hook parity, but the round-six precedence repair overreached by taking ownership of the shared exclude file's inode rather than only establishing the final rule.
- **Round-seven correction:** Delete the temporary-file, deduplication, replacement, and cleanup lifecycle. Append through the existing path, skip only when the exact sentinel is already final, and preserve symlink, inode, permission, and hard-link identity. The source shape shrinks from the round-six head while focused proof covers both successful and failed registration.
- **Continuation decision:** The current user explicitly asked to resume and continue this exact saved session. Continue to round eight only on this deletion-based correction; add no metadata-copying or file-ownership abstraction. If round eight finds another accepted issue, stop and return to the user rather than extending the loop autonomously. That stop occurred after the marker-index finding, and the user then explicitly authorized its correction and continued exact-head review. Round nine found review-induced reconstruction complexity rather than a new behavior gap; the user's explicit instruction to fix the issue and keep rolling authorizes the deletion-based collapse and continued exact-head review.

## Non-obvious affected surfaces

- Git `post-checkout` hook forwarding: the normalized launcher is required because `--no-checkout` suppresses Git's normal worktree-add hook; regression proof covers arguments, environment, EOF stdin, conventional Git shell setup, executable behavior, exit code, descendant authority, and cross-repository index behavior.
- Shared exclude authority: `post-checkout` can rewrite or negate the common `info/exclude`; the helper restores final effective precedence after success, failure, or catchable interruption before success/rollback by appending through the existing path. Regression proof covers negation, repair failure reporting, symlink and hard-link identity, permissions, failed registration, an existing sibling, and the new target.
- Checkout-filter launch: manual materialization supplies native-equivalent linked-worktree Git/work-tree context and disables submodule recursion; differential proof covers required local filters and `submodule.recurse=true`.
- Registration failure ownership: exclude-rule preparation happens before registration; authorization is the final success step; every marker, materialization, hook, shared-rule restoration, final-marker, authorization failure, or catchable interruption uses the same exact-target rollback and preserves the branch. Uncatchable termination leaves the retained target unauthorized so the guard fails closed.
- Marker index authority: materialization and forwarded hooks can stage or modify the helper-owned marker. The helper captures the checkout-tree head and delegates restoration of only that path to Git's reset/checkout primitives with hooks suppressed after both hook boundaries. Unrelated hook-created state survives, tracked regular/executable/symlink entries retain Git semantics, and no staged or unstaged marker delta remains before authorization.
- No product runtime, deploy surface, database, provider, frontend, or member-facing behavior changes.

## Architecture and reuse

- **Existing systems reused:** `git worktree add --no-checkout`, the existing creation lock, worktree admin authorization, `.metadata_never_index` sentinel, `git reset --hard`, Git hook-path/local-environment discovery, and `git worktree remove`.
- **New logic:** Complete the shared exclude prerequisite before registration, capture the checkout-tree head, materialize under native linked-worktree and non-recursive reset context, run all fallible post-registration setup under one cleanup boundary, delegate restoration of only the marker path to Git with hooks suppressed after both hook surfaces, restore final shared-rule precedence after every hook termination or catchable interruption, verify the sentinel has no delta, publish authorization last, and launch executable `post-checkout` hooks under one normalized repository-independent contract with EOF stdin.
- **New abstractions:** No new service, owner, persistent state, or dependency; script-local functions centralize the rollback boundary, hook contract, and marker-path restoration.
- **Complexity intentionally avoided:** No daemon, process manager, reconciliation state, worktree pruning, recursive reindex, compatibility layer, dependency, or second source of worktree truth.

The existing local-storage lifecycle owner doc records the ordering, hook, and rollback guarantees. Backfill was applied locally to every accessible registered worktree missing the sentinel; no worktree was pruned or retired.

## Hot reply path impact

- Path status: Not applicable — local developer worktree tooling does not run on the foreground reply path.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The diff contains no product runtime path changes.

## Database collection fanout impact

Not applicable — this diff adds or changes no database-touching collection path.

## Murph initial provider input impact

- Individual Murph: Not applicable — no prompt, tool/schema, provider adapter, model mode, or request-assembly surface changed.
- Group Murph: Not applicable — no prompt, tool/schema, provider adapter, model mode, or request-assembly surface changed.
- Measurement method: Not run because no provider-visible input surface changed.

## Preliminary specialist lenses

- Product experience: not applicable — there is no member journey change.
- Prompt: not applicable — there is no prompt or provider-input change.
- Frontend: not applicable — there is no `apps/web` UI change.
- Coverage: applicable — the 59-test storage-guard suite covers both sides of registration, effective shared precedence after successful/failed/interrupted hooks, repair failure reporting, marker index and worktree restoration across `post-index-change`, `post-checkout`, absent, regular, executable, and symlink tree entries, native filter and submodule materialization, final authorization, the hook contract including EOF stdin, executable shebang variants, regular and signal rollback/retry, uncatchable fail-closed state, sibling/unrelated-worktree preservation, and locked rollback; current exact-head CI is pending.
- Outcome: Preliminary ReviewGPT found one missing materialization-failure case. Its focused patch was inspected and evolved into the single rollback-boundary proof.

## Design proof

Not applicable — no user-facing `apps/web` UI changed.

## Immutable round-one change shape

Classification rule: executable shell is source; test harness code is tests; lifecycle guidance and the Frog entry are docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 24 | 2 |
| Tests / fixtures | 94 | 1 |
| Docs | 31 | 5 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **149** | **8** |

## Current head after remediation

Current head: `214875c335ee17ea7b060051405bbab337440569`

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 168 | 15 |
| Tests / fixtures | 1665 | 69 |
| Docs | 55 | 5 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1888** | **89** |

Authored remediation growth since the immutable first-reviewed head: source +165/-34, tests +1600/-97, docs +30/-6; total +1795/-137.

## Verification

- `bash -n scripts/create-worktree`
- Marker restoration focus: 5/5 passed across `post-index-change`, `post-checkout`, tracked regular, tracked executable, and tracked symlink shapes; the tracked-regular case also passed 1/1 in an isolated rerun
- `pnpm test:diff`: shell/Node and architecture guards plus repo-tool typecheck passed. Under severe host contention, the repo-tools phase reported only the existing interrupted-materialization test's hardcoded 15-second timeout and two unrelated Crabbox repeated-signal timing failures; after the runner then slept at 0% CPU for 25 minutes, this session gracefully stopped only its exact owned process tree to release the artifact lock
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree HEAD origin/main`: clean current-base merge tree after final ReviewGPT completion
- ReviewGPT round 10: exact-head full-snapshot `PASS`, `REVIEW_COMPLETE`, and matching requested-model verification
- Linux CI represented the owned process-group interruption as `signal=SIGINT` rather than exit code 130; the isolated regression assertion now accepts both native forms before proving identical cleanup, branch preservation, unrelated-worktree preservation, and retry behavior.
- Required GitHub checks: 15 passed and 1 intentionally skipped on exact head `214875c335ee17ea7b060051405bbab337440569`




