### PR TITLE
Constrain hosted device-sync cadence publication

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-13-device-sync-clock-provenance.md
+++ b/agent-docs/exec-plans/completed/2026-08-13-device-sync-clock-provenance.md
@@ -1,0 +1,86 @@
+# Separate device-sync provider cadence from local execution clocks
+
+Status: completed
+Created: 2026-08-13
+Updated: 2026-08-13
+
+## Goal
+
+- Make the provider-owned canonical reconciliation cadence visibly distinct
+  from runner-local execution, mailbox-continuation, and checkpoint retry
+  clocks at the narrow control-plane write boundary.
+
+## Success criteria
+
+- The private hosted canonical publication helper accepts provider account
+  state plus the existing Web baseline, not an unconstrained raw timestamp.
+- Local job availability, lease expiry, workspace wake, mailbox continuation,
+  and checkpoint retry timestamps remain ordinary values under their existing
+  owners and cannot be passed accidentally through that typed boundary.
+- Wire/database schemas remain unchanged and no migration or compatibility
+  layer is introduced.
+- The change stays narrow, composable, and self-explanatory without branding
+  every timestamp in the repository.
+- Focused tests, typecheck, exact-head CI, required ReviewGPT stages, and parent
+  final review pass.
+
+## Scope
+
+- In scope: the smallest internal type/constructor boundary around hosted
+  provider-cadence publication, direct compile/runtime proof, and matching
+  durable architecture wording only if the existing owner contract needs a
+  precise update.
+- Out of scope: wire-format changes, database changes, new scheduling logic,
+  recovery behavior, new services, global timestamp refactors, production
+  rollout guards, or the closed-loop scenario in the companion PR.
+
+## Constraints
+
+- Technical constraints: no as-any or double assertions, no sibling-internal
+  imports, no dependency, and no broad value-object hierarchy. Keep conversion
+  at the semantic owner boundary.
+- Product/process constraints: ReviewGPT authors the patch; the parent treats
+  it as untrusted intent, inspects every hunk, verifies it, and lands it as its
+  own PR.
+
+## Risks and mitigations
+
+1. Risk: a brand that can be constructed from any string provides ceremony but
+   no provenance.
+   Mitigation: expose only a narrow constructor or derivation that accepts the
+   provider-owned account/scheduling output.
+2. Risk: branding serialized values causes repository-wide churn.
+   Mitigation: unwrap at the existing control-plane wire boundary and keep
+   persistence/contracts unchanged.
+
+## Tasks
+
+1. [x] Ask ReviewGPT for the smallest maintainable patch against the exact base.
+2. [x] Inspect and apply the returned patch deliberately.
+3. [x] Run focused proof and candidate review; remove unnecessary abstraction.
+4. [ ] Commit, push, open the PR, and run required specialist/final gates and CI.
+5. [ ] Resolve findings, perform parent final review, and merge when authorized
+   and green.
+
+## Decisions
+
+- This PR is independent of the quiescence-contract PR.
+- The boundary is deliberately local to canonical publication rather than a
+  general timestamp type system.
+- ReviewGPT selected deletion/dataflow narrowing: the private builder no longer
+  receives `nextReconcileAt: string | null`. It derives ordinary publication
+  from the provider-owned account and completion-fence deferral from the
+  already-observed baseline.
+
+## Verification
+
+- `pnpm --filter @murphai/assistant-runtime typecheck`
+  - Passed.
+- `pnpm --filter @murphai/assistant-runtime test -- test/hosted-device-sync-runtime.test.ts -t "reconciliation keeps local continuation clocks out of canonical cadence publication"`
+  - Passed. The package runner selected all 86 files; 2,286 tests passed and 4
+    were skipped.
+- `git diff --check`
+  - Passed.
+- Required exact-head GitHub Actions and routed ReviewGPT gates run after the
+  candidate commit is pushed.
+Completed: 2026-08-13

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -466,11 +466,10 @@ export async function reconcileHostedDeviceSyncControlPlaneState(input: {
       account,
       baseline,
       codec,
+      deferNextReconcileAtToBaseline:
+        input.deferNextReconcileAtForLocalAccountId === localAccountId,
       failureDiagnostic: failureDiagnosticByLocalAccountId.get(localAccountId) ?? null,
       hostedConnectionId,
-      nextReconcileAt: input.deferNextReconcileAtForLocalAccountId === localAccountId
-        ? baseline?.localState.nextReconcileAt ?? null
-        : account.nextReconcileAt ?? null,
       observedTokenVersion: input.state.observedTokenVersions.get(hostedConnectionId) ?? null,
       sourceApplyEnabled: input.state.snapshot?.capabilities?.connectionSourceApply === true,
       sources: store.listConnectionSources({
@@ -1413,9 +1412,9 @@ function buildHostedDeviceSyncRuntimeConnectionUpdate(input: {
   account: StoredDeviceSyncAccount;
   baseline: HostedDeviceSyncRuntimeConnectionSnapshot | null;
   codec: ReturnType<typeof createSecretCodec>;
+  deferNextReconcileAtToBaseline: boolean;
   failureDiagnostic: DeviceSyncJobFailureDiagnostic | null;
   hostedConnectionId: string;
-  nextReconcileAt: string | null;
   observedTokenVersion: number | null;
   sourceApplyEnabled: boolean;
   sources: readonly StoredDeviceConnectionSource[];
@@ -1482,12 +1481,11 @@ function buildHostedDeviceSyncRuntimeConnectionUpdate(input: {
     }
 
     assignErrorFieldUpdate(update, input.account, baselineLocalState);
-    assignNextReconcileAtUpdate(
-      update,
-      input.account.status,
-      input.nextReconcileAt,
-      baselineLocalState?.nextReconcileAt ?? null,
-    );
+    assignCanonicalNextReconcileAtUpdate(update, {
+      account: input.account,
+      baseline: baselineLocalState,
+      deferToBaseline: input.deferNextReconcileAtToBaseline,
+    });
     assignFailureDiagnosticUpdate(
       update,
       input.account.lastSyncErrorAt ?? null,
@@ -1540,12 +1538,11 @@ function buildHostedDeviceSyncRuntimeConnectionUpdate(input: {
     };
   }
 
-  assignNextReconcileAtUpdate(
-    update,
-    input.account.status,
-    input.nextReconcileAt,
-    baselineLocalState?.nextReconcileAt ?? null,
-  );
+  assignCanonicalNextReconcileAtUpdate(update, {
+    account: input.account,
+    baseline: baselineLocalState,
+    deferToBaseline: input.deferNextReconcileAtToBaseline,
+  });
 
   if (!equalHostedDeviceSyncRuntimeCredentials(credential, baselineCredential)) {
     if (credential.kind === "none" && baselineTokenBundle !== null) {
@@ -2550,15 +2547,23 @@ function resolveHostedWakeNextReconcileAt(
     : null;
 }
 
-function assignNextReconcileAtUpdate(
+function assignCanonicalNextReconcileAtUpdate(
   update: HostedDeviceSyncRuntimeConnectionUpdate,
-  status: StoredDeviceSyncAccount["status"],
-  localValue: string | null,
-  baselineValue: string | null,
+  input: {
+    account: Pick<StoredDeviceSyncAccount, "nextReconcileAt" | "status">;
+    baseline: HostedDeviceSyncRuntimeLocalStateSnapshot | null;
+    deferToBaseline: boolean;
+  },
 ): void {
+  const baselineValue = input.baseline?.nextReconcileAt ?? null;
+  const nextReconcileAt = input.deferToBaseline
+    ? baselineValue
+    : input.account.nextReconcileAt ?? null;
+
   if (
-    (status === "reauthorization_required" || status === "disconnected")
-    && localValue === null
+    (input.account.status === "reauthorization_required"
+      || input.account.status === "disconnected")
+    && nextReconcileAt === null
     && baselineValue !== null
   ) {
     update.localState = {
@@ -2568,17 +2573,17 @@ function assignNextReconcileAtUpdate(
     return;
   }
 
-  if (!localValue || localValue === baselineValue) {
+  if (!nextReconcileAt || nextReconcileAt === baselineValue) {
     return;
   }
 
-  // `nextReconcileAt` is owned by device-sync execution, not an append-only
-  // event timestamp. Empty-backfill retry floors may intentionally pull it
-  // earlier; stale hosted replays are still rejected by the web apply
-  // observedUpdatedAt/version fence before localState mutates hosted state.
+  // Canonical publication derives only from the provider-owned account. The
+  // completion fence may retain the already observed Web baseline until its
+  // exact work has been checkpointed; runner-local wake clocks never enter
+  // this boundary.
   update.localState = {
     ...(update.localState ?? {}),
-    nextReconcileAt: localValue,
+    nextReconcileAt,
   } satisfies HostedDeviceSyncRuntimeLocalStateUpdate;
 }
 

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -9567,7 +9567,7 @@ describe("hosted device-sync runtime", () => {
     }
   });
 
-  test("reconciliation keeps queued-job continuation in the runtime wake projection", async () => {
+  test("reconciliation keeps local continuation clocks out of canonical cadence publication", async () => {
     const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
       "hosted-device-sync-schedule-owner-",
     );
@@ -9576,11 +9576,11 @@ describe("hosted device-sync runtime", () => {
     const service = createDeviceSyncServiceForVault(vaultRoot);
     const localJobWakeAt = "2026-04-04T12:15:00.000Z";
     const providerReconcileAt = "2026-04-04T14:00:00.000Z";
-    let appliedRequest: ApplyUpdatesRequest | null = null;
+    const appliedRequests: ApplyUpdatesRequest[] = [];
     const deviceSyncPort: HostedRuntimeDeviceSyncPort = {
       ...createNoDirtyStateDeviceSyncPortMethods(),
       async applyUpdates(input): Promise<HostedExecutionDeviceSyncRuntimeApplyResponse> {
-        appliedRequest = input;
+        appliedRequests.push(input);
         return {
           appliedAt: "2026-04-04T09:11:01.000Z",
           updates: input.updates.map((update) => ({
@@ -9643,10 +9643,34 @@ describe("hosted device-sync runtime", () => {
         state,
       });
 
-      const request = requireApplyUpdatesRequest(appliedRequest);
+      const request = requireApplyUpdatesRequest(appliedRequests[0] ?? null);
       assert.equal(request.updates.length, 1);
       assert.deepEqual(request.updates[0]?.localState, {
         nextReconcileAt: providerReconcileAt,
+      });
+
+      getStore(service).patchAccount(localAccountId, {
+        displayName: "Local cadence owner",
+      });
+      await reconcileHostedDeviceSyncControlPlaneState({
+        deferNextReconcileAtForLocalAccountId: localAccountId,
+        deviceSyncPort,
+        wake: buildCronWake("2026-04-04T09:12:00.000Z"),
+        secret: DEVICE_SYNC_SECRET,
+        service,
+        state,
+      });
+
+      assert.deepEqual(appliedRequests[1], {
+        occurredAt: "2026-04-04T09:12:00.000Z",
+        updates: [{
+          connection: {
+            displayName: "Local cadence owner",
+          },
+          connectionId: "hosted_conn_schedule_owner",
+          observedConnectedAt: "2026-04-04T09:00:00.000Z",
+          observedUpdatedAt: "2026-04-04T09:05:00.000Z",
+        }],
       });
     } finally {
       closeHostedRuntimeDeviceSyncService(service);


### PR DESCRIPTION
## Why this PR exists

A prior retry incident showed that an unconstrained raw timestamp handoff made it too easy for a runner-local wake clock to be published as the canonical device-provider reconciliation cadence. The repaired behavior exists today; this PR makes that ownership boundary structural.

## User goal / user-visible behavior

Keep device sync scheduling stable by ensuring only provider-owned cadence can update canonical `nextReconcileAt`.

## User experience

No user-facing effect. This is a behavior-preserving reliability hardening of the hosted device-sync reconciliation boundary. Background provider reconciliation, local queued continuation, and terminal checkpoint recovery retain their existing timing and owners; no member action or new recovery step is introduced.

## Preliminary specialist lenses

- Product experience: applicable — the intended outcome is stable background device sync without duplicate global work; the focused queued-job and terminal-fence scenario is the direct timing/continuation evidence.
- Prompt: not applicable — no prompts, instruction stacks, tool descriptions, or provider request assembly changed.
- Frontend: not applicable — no user-facing Web UI changed and no rendered evidence is required.
- Coverage: applicable — runtime ownership and its direct proof changed; assistant-runtime typecheck and all 86 package test files passed locally, while exact-head CI is pending.

## Invariants

- Ordinary canonical cadence publication derives from the provider-owned account.
- The terminal completion fence may retain only the already-observed Web baseline until exact work is checkpointed.
- Local job availability, lease expiry, workspace wakes, mailbox continuation, and checkpoint retry clocks stay under their existing owners.
- The serialized `nextReconcileAt` field remains `string | null`; no schema, wire, database, or deployment migration is introduced.

## Changelog

- Changelog: not applicable
- Reason: No member-visible behavior changes; this narrows an internal scheduling API while preserving repaired runtime behavior.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: This changes a hosted-runtime scheduling ownership boundary and its completion-fence regression proof.

ReviewGPT first-reviewed head: 6a4d35d43180a22112faad44879ed76516f08532

## Non-obvious affected surfaces

- Hosted device-sync terminal checkpoint deferral: the focused test proves unrelated updates still publish while an advanced cadence remains deferred to the observed baseline.
- Local queued-job continuation: the focused test proves its earlier wake time cannot replace provider cadence.

## Architecture and reuse

- Existing systems reused: Provider account state, the Web-observed runtime snapshot baseline, and the existing completion-fence deferral signal.
- New logic: None; the existing selection is moved inside the canonical publication helper.
- New abstractions: None. The private builder's unconstrained `nextReconcileAt: string | null` input is deleted.
- Complexity intentionally avoided: No branded timestamp system, clock framework, constructor hierarchy, schema, service, queue, or compatibility layer.

## Hot reply path impact

- Path status: Not applicable — this path is hosted device sync reconciliation, not foreground conversation reply handling.
- Database calls: None
- Network/provider calls: None
- Other awaited latency: None
- Before/after proof: Assistant-runtime package tests preserve existing behavior.

## Database collection fanout impact

Not applicable — this PR adds or changes no database-touching collection path. It narrows an in-memory connection-update builder and extends an existing runtime test.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: Not applicable — no frontend UI changed.
- Coverage: Not applicable
- Desktop screenshot: Not applicable
- Mobile screenshot: Not applicable

## Deployment skew / compatibility

Not applicable — runtime behavior and serialized contracts are unchanged, so old and new deployed components remain compatible.

## Change-shape breakdown

Classification rule: Runtime implementation is Source, the regression is Tests / fixtures, and the archived execution plan is Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 33 | 28 |
| Tests / fixtures | 28 | 4 |
| Docs | 86 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **147** | **32** |

## Verification

- `pnpm --filter @murphai/assistant-runtime typecheck`
- `pnpm --filter @murphai/assistant-runtime test -- test/hosted-device-sync-runtime.test.ts -t "reconciliation keeps local continuation clocks out of canonical cadence publication"`
  - The package runner selected all 86 files: 2,286 passed and 4 skipped.
- `git diff --check`
- ReviewGPT Pro authored the apply-ready patch; routed ReviewGPT gates and GitHub Actions are running against the exact pushed head.
