### PR TITLE
Update ReviewGPT to 0.5.125

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-14-review-gpt-0-5-125.md
+++ b/agent-docs/exec-plans/active/2026-08-14-review-gpt-0-5-125.md
@@ -1,0 +1,50 @@
+# Update ReviewGPT dependency to 0.5.125
+
+Status: active
+Created: 2026-08-14
+Updated: 2026-08-14
+
+## Goal
+
+- Adopt ReviewGPT 0.5.125 so Murph wake jobs stop reading Codex session contents while preserving the current managed-browser behavior.
+
+## Success criteria
+
+- The workspace catalog, root dependency range, and lockfile resolve `@cobuild/review-gpt` 0.5.125.
+- Murph keeps its settled-performance default headful and exposes headless only as an explicit local override.
+- Focused configuration/dependency proof passes, required ReviewGPT review gates pass, and exact-head CI is green.
+
+## Scope
+
+- In scope: dependency metadata, lockfile, ReviewGPT browser configuration, and the durable ReviewGPT workflow note.
+- Out of scope: changing Murph's default browser lane, browser background throttling, production runtime behavior, or application dependencies.
+
+## Constraints
+
+- Technical constraints: use the published 0.5.125 tarball and preserve the existing shared pnpm store and browser-profile lanes.
+- Product/process constraints: keep headful as the default because the settled A/B showed headless increased CPU and memory; follow the PR and ReviewGPT completion workflow.
+
+## Risks and mitigations
+
+1. Risk: a broad install changes unrelated dependency resolutions.
+   Mitigation: use the existing catalog version seam, inspect the complete lockfile diff, and reject unrelated churn.
+2. Risk: headless is mistaken for a low-resource default.
+   Mitigation: keep headful explicit and document headless as UI-only opt-in with measured resource caveats.
+
+## Tasks
+
+1. Update the ReviewGPT catalog/range and regenerate only the corresponding lockfile resolution.
+2. Add the headful default plus opt-in headless configuration and align the durable ReviewGPT workflow note.
+3. Run focused proof, inspect the final diff, commit and push the exact candidate, and open the required PR.
+4. Run the preliminary specialist and final ReviewGPT gates concurrently with exact-head CI, resolve any accepted findings, and complete the plan.
+
+## Decisions
+
+- The performance fix is the upstream session-scan deletion; Murph will not default to headless because the settled benchmark showed worse resource use.
+
+## Verification
+
+- Passed: `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` (43 passed, 1 skipped).
+- Passed: `pnpm --filter @murphai/murph typecheck`, `pnpm deps:guard`, `pnpm deps:ignored-builds`, `bash -n scripts/review-gpt.config.sh`, installed-package version proof, and `git diff --check`.
+- `pnpm deps:audit` reported the repository's existing advisory set. The complete lockfile diff changes only the ReviewGPT package version/integrity and leaves every transitive dependency resolution unchanged.
+- Pending: exact-head required CI, preliminary specialist ReviewGPT, and final ReviewGPT round 1.

--- a/agent-docs/exec-plans/completed/2026-08-14-review-gpt-0-5-125.md
+++ b/agent-docs/exec-plans/completed/2026-08-14-review-gpt-0-5-125.md
@@ -1,6 +1,6 @@
 # Update ReviewGPT dependency to 0.5.125
 
-Status: active
+Status: completed
 Created: 2026-08-14
 Updated: 2026-08-14
 
@@ -33,18 +33,23 @@ Updated: 2026-08-14
 
 ## Tasks
 
-1. Update the ReviewGPT catalog/range and regenerate only the corresponding lockfile resolution.
-2. Add the headful default plus opt-in headless configuration and align the durable ReviewGPT workflow note.
-3. Run focused proof, inspect the final diff, commit and push the exact candidate, and open the required PR.
-4. Run the preliminary specialist and final ReviewGPT gates concurrently with exact-head CI, resolve any accepted findings, and complete the plan.
+1. Completed: update the ReviewGPT catalog/range and regenerate only the corresponding lockfile resolution.
+2. Completed: add the headful default plus opt-in headless configuration and align the durable ReviewGPT workflow note.
+3. Completed: run focused proof, inspect the final diff, commit and push the exact candidate, and open the required PR.
+4. Completed: run the preliminary specialist and final ReviewGPT gates concurrently with exact-head CI, triage the specialist recommendation, and complete the plan.
 
 ## Decisions
 
 - The performance fix is the upstream session-scan deletion; Murph will not default to headless because the settled benchmark showed worse resource use.
+- The specialist coverage recommendation was rejected after owner-boundary triage. ReviewGPT 0.5.125 directly tests inherited-home resolution without session-file discovery, the absence of history-content parsing, filename-only fallback evidence, display-mode parsing, and headless launch arguments. Murph's live installed-package review run also proved its default reaches the package as headful. Duplicating dependency-internal behavior tests in Murph would create cross-repository drift without protecting a Murph-owned invariant.
+- Parent final review found the patch limited to the intended dependency, lockfile, configuration, tests, and workflow documentation, with no unrelated transitive-resolution churn.
 
 ## Verification
 
 - Passed: `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` (43 passed, 1 skipped).
 - Passed: `pnpm --filter @murphai/murph typecheck`, `pnpm deps:guard`, `pnpm deps:ignored-builds`, `bash -n scripts/review-gpt.config.sh`, installed-package version proof, and `git diff --check`.
 - `pnpm deps:audit` reported the repository's existing advisory set. The complete lockfile diff changes only the ReviewGPT package version/integrity and leaves every transitive dependency resolution unchanged.
-- Pending: exact-head required CI, preliminary specialist ReviewGPT, and final ReviewGPT round 1.
+- Passed: exact-head required CI, including the release package/app matrix, host matrix, dependency-adjacent coverage, repository hygiene, and PR-body/design gates.
+- Preliminary specialist ReviewGPT completed on the first-reviewed head with one rejected owner-boundary coverage recommendation and no accepted findings.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` on the same exact head with no qualifying findings; the requested Pro-model response metadata, full-snapshot attachment, seven-file patch, immutable change-shape baseline, and trust duration were verified.
+Completed: 2026-08-14

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -64,6 +64,11 @@ can still deprioritize unrelated renderers and occluded windows. Balanced mode
 passes none of Chromium's background-timer, occluded-window, or renderer
 backgrounding opt-out flags; use the fully unthrottled fallback only for a
 browser version with a proven capture stall.
+The lanes also default to headful display mode. Headless is an explicit local
+override for removing visible UI, not a resource-saving default: it preserves
+ChatGPT's renderer and page JavaScript, and the settled one-page comparison used
+more CPU and memory than headful. A fresh profile must complete sign-in once in
+headful mode before it can run headless.
 Leaving completed waited targets open still accumulates active renderers across
 rounds even when ordinary browser history and site data have been cleared.
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.124",
+    "@cobuild/review-gpt": "^0.5.125",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -944,13 +944,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.124')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.125')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.124'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.125'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1276,6 +1276,9 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(reviewGptConfig).toContain(
       'managed_browser_background_mode="${managed_browser_background_mode:-balanced}"',
+    )
+    expect(reviewGptConfig).toContain(
+      'managed_browser_display_mode="${managed_browser_display_mode:-headful}"',
     )
     expect(reviewGptConfig).toContain(
       'review_gpt_installed_browser_binary="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"',
@@ -1859,13 +1862,14 @@ set -euo pipefail
 review_gpt_register_dir_preset() { :; }
 review_gpt_register_preset_group() { :; }
 source "$CONFIG_PATH"
-printf '%s|%s|%s|%s|%s|%s\n' \
+printf '%s|%s|%s|%s|%s|%s|%s\n' \
   "$review_gpt_selected_browser_lane" \
   "$browser_binary_path" \
   "$managed_browser_user_data_dir" \
   "$managed_browser_profile" \
   "$managed_browser_port" \
-  "$managed_browser_background_mode"
+  "$managed_browser_background_mode" \
+  "$managed_browser_display_mode"
 `
     const runConfig = () =>
       spawnSync('bash', ['-c', configHarness], {
@@ -1879,6 +1883,7 @@ printf '%s|%s|%s|%s|%s|%s\n' \
           XDG_CONFIG_HOME: path.join(harnessRoot, 'config'),
           browser_binary_path: '',
           managed_browser_background_mode: '',
+          managed_browser_display_mode: '',
         },
       })
     const laneUserDataDir = path.join(
@@ -1900,6 +1905,7 @@ printf '%s|%s|%s|%s|%s|%s\n' \
           'Default',
           '9448',
           'balanced',
+          'headful',
         ].join('|'),
       )
 
@@ -1919,6 +1925,7 @@ printf '%s|%s|%s|%s|%s|%s\n' \
           'Default',
           '9448',
           'balanced',
+          'headful',
         ].join('|'),
       )
     } finally {
@@ -1936,11 +1943,12 @@ curl() { return 1; }
 review_gpt_register_dir_preset() { :; }
 review_gpt_register_preset_group() { :; }
 source "$REPO_ROOT/scripts/review-gpt.config.sh"
-printf '%s|%s|%s|%s\n' \
+printf '%s|%s|%s|%s|%s\n' \
   "$review_gpt_selected_browser_lane" \
   "$review_gpt_browser_lane_count" \
   "$browser_binary_path" \
-  "$managed_browser_background_mode"
+  "$managed_browser_background_mode" \
+  "$managed_browser_display_mode"
 `
     const cleanBrowserPreferenceEnv = () => {
       const env = withoutNodeV8Coverage()
@@ -1951,6 +1959,7 @@ printf '%s|%s|%s|%s\n' \
       delete env.MURPH_REVIEW_GPT_BROWSER_LANE_COUNT
       delete env.browser_binary_path
       delete env.managed_browser_background_mode
+      delete env.managed_browser_display_mode
       return env
     }
 
@@ -1962,6 +1971,7 @@ printf '%s|%s|%s|%s\n' \
           'REVIEW_GPT_BROWSER_LANE_COUNT=1',
           'browser_binary_path="/tmp/custom-brave"',
           'managed_browser_background_mode="unthrottled"',
+          'managed_browser_display_mode="headless"',
           '',
         ].join('\n'),
       )
@@ -1976,7 +1986,9 @@ printf '%s|%s|%s|%s\n' \
         },
       })
       expect(localResult.status, localResult.stderr).toBe(0)
-      expect(localResult.stdout.trim()).toBe('eragon|1|/tmp/custom-brave|unthrottled')
+      expect(localResult.stdout.trim()).toBe(
+        'eragon|1|/tmp/custom-brave|unthrottled|headless',
+      )
 
       rmSync(path.join(localConfigRoot, 'murph', 'review-gpt.conf'))
       for (const lane of ['Eragon', 'Phlebas', 'Hercules']) {
@@ -1997,14 +2009,20 @@ printf '%s|%s|%s|%s\n' \
         },
       })
       expect(defaultResult.status, defaultResult.stderr).toBe(0)
-      const [defaultLane, defaultLaneCount, defaultBrowser, defaultBackgroundMode] =
-        defaultResult.stdout.trim().split('|')
+      const [
+        defaultLane,
+        defaultLaneCount,
+        defaultBrowser,
+        defaultBackgroundMode,
+        defaultDisplayMode,
+      ] = defaultResult.stdout.trim().split('|')
       expect(defaultLane).toBe('mountain')
       expect(defaultLaneCount).toBe('4')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
       expect(defaultBackgroundMode).toBe('balanced')
+      expect(defaultDisplayMode).toBe('headful')
 
       const mainResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,
@@ -2019,7 +2037,7 @@ printf '%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced',
+        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       '@cobuild/review-gpt':
-        specifier: ^0.5.124
-        version: 0.5.124(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.125
+        version: 0.5.125(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1475,8 +1475,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.124':
-    resolution: {integrity: sha512-nNMbdXfPn6GQH2L1y6tvHOMB8KQEX9fDtDoHctWxqefzjIfjSKcAxFAz8zmkTZk0GQmkbOEQV8NaI0/9qzA4uw==}
+  '@cobuild/review-gpt@0.5.125':
+    resolution: {integrity: sha512-faaLe0VRyRnMPLqvjrIYE61GwnyoxdmKwVrORcGplEBL5fGJw/up85lw5fialYTk3hkoXT40/WTE+LiF1mgH6Q==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10819,7 +10819,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)': {}
 
-  '@cobuild/review-gpt@0.5.124(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.125(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.124'
+  - '@cobuild/review-gpt@0.5.125'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -163,6 +163,10 @@ managed_browser_port="${managed_browser_port:-$review_gpt_selected_browser_port}
 # occluded lane window to run at foreground priority. Set this to unthrottled
 # only when a specific browser version has a proven background-capture stall.
 managed_browser_background_mode="${managed_browser_background_mode:-balanced}"
+# Headless removes visible UI but does not remove ChatGPT's renderer or page
+# JavaScript. Settled local measurement used more CPU and memory, so keep the
+# resource-efficient default headful and leave headless as an explicit override.
+managed_browser_display_mode="${managed_browser_display_mode:-headful}"
 export REVIEW_GPT_SELECTED_BROWSER_LANE="$review_gpt_selected_browser_lane"
 
 name_prefix="murph-$review_gpt_selected_browser_lane-chatgpt-audit"


### PR DESCRIPTION
## Why this PR exists

ReviewGPT wake jobs previously opened and parsed Codex session/history contents to rediscover a home that the detached process already knows. Version 0.5.125 deletes that hot-path scan and adds an opt-in headless display mode.

## User goal / user-visible behavior

Local ReviewGPT review and wake work should stop causing avoidable session-log I/O. A developer can explicitly choose headless when visible UI is undesirable, while Murph keeps the measured headful default because headless used more CPU and memory in the settled comparison.

## User experience

No member-facing effect. This changes internal review tooling only: existing ReviewGPT commands keep the same default lane and visible browser behavior; a local config may opt into headless after the profile has been signed in headfully once.

## Invariants

- The persistent signed-in browser profiles and lane/CDP isolation remain unchanged.
- Headless is opt-in and is not described as a resource-saving mode.
- ReviewGPT stays a public-registry dev dependency with the committed lockfile and narrow minimum-age exception aligned.
- No production runtime, prompts, provider input, database path, or deploy surface changes.

## Non-obvious affected surfaces

- ReviewGPT workflow documentation: records the headful default and the measured reason not to default headless.
- CLI release/config coverage: proves the exact dependency version plus default and local display-mode behavior.

## Architecture and reuse

- **Existing systems reused:** the root devDependency/catalog seam, the existing four managed-browser lanes, the local ReviewGPT config file, and the CLI release/config coverage suite.
- **New logic:** one explicit `managed_browser_display_mode` default in the existing shell config and matching assertions.
- **New abstractions:** none; the published ReviewGPT config key fits the existing managed-browser configuration contract.
- **Complexity intentionally avoided:** no extra browser service, no automatic mode switching, no Chromium neutering flags, and no Murph-owned session resolver.

## Changelog

- Changelog: not applicable

- Reason: this is internal developer review tooling with no member-visible product behavior.

## Verification

- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` — 43 passed, 1 skipped.
- `pnpm --filter @murphai/murph typecheck` — passed.
- `pnpm deps:guard` — passed.
- `pnpm deps:ignored-builds` — reviewed; no new allow-build exception.
- `bash -n scripts/review-gpt.config.sh` — passed.
- Installed package version proof — 0.5.125.
- `git diff --check` — passed.
- `pnpm deps:audit` — reports the existing repository advisory set. The lockfile diff changes only the ReviewGPT version/integrity and leaves all transitive resolutions unchanged.
- Exact-head CI — pending.

## Hot reply path impact

Not applicable: no product runtime code or foreground reply path changes.

## Database collection fanout impact

Not applicable: no database-touching path changes.

## Murph initial provider input impact

- Individual Murph: not applicable; no prompt, tool/schema, skill, Codex runtime/configuration, model tool mode, or provider-request assembly changes.
- Group Murph: not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: not applicable; no product-owned dimension changes.
- Prompt: applicable; agent-consumed ReviewGPT workflow guidance changed. The specialist pass reviewed it with no prompt-quality finding.
- Frontend: not applicable; no `apps/web` presentation changes or rendered evidence.
- Coverage: applicable; focused config/dependency proof is green and exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: the dependency is an external code-review/browser boundary even though it is dev-only; run the final full-patch gate.

## Change shape

Classification: authored runtime source is source; Vitest files are tests/fixtures; Markdown is docs; manifests and shell configuration are config/tooling; the lockfile is generated/other. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 28 | 10 |
| Docs | 55 | 0 |
| Config/tooling | 6 | 2 |
| Generated/other | 5 | 5 |
| **Total** | **94** | **17** |

## Design proof

Not applicable: no user-facing frontend UI diff.

ReviewGPT first-reviewed head: 88cd23c28aade1641610e0c3604b2149870a3ae1

## ReviewGPT results and finding dispositions

- Preliminary specialists: `SPECIALIST_OUTCOME: FINDINGS` at `88cd23c28aade1641610e0c3604b2149870a3ae1`; one coverage recommendation was rejected after owner-boundary triage. ReviewGPT 0.5.125 already directly tests inherited `CODEX_HOME`, no history-content parsing, filename-only fallback evidence, display-mode parsing, and headless Chromium arguments. Its full release suite passed; the live A/B exercised both display modes; and this PR's installed-package ReviewGPT run reported `Managed browser display mode: headful`. Duplicating dependency-internal tests in Murph would create cross-repository drift without proving a Murph-owned invariant. No accepted findings.
- Final round 1: `ROUND_OUTCOME: PASS` at the same exact head, with no qualifying findings. Requested Pro-model response metadata was verified, the guarded full snapshot matched all seven changed files and the 94/17 baseline, and the review cleared the repository trust-duration floor.