### PR TITLE
Fix Starter activation hard navigation

### DIFF
--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1326,13 +1326,15 @@ export function ComponentsContent() {
 
         <Separator />
 
-        <Section title="Setup Loader">
+        <Section id="setup-loader" title="Setup Loader">
           <p className="text-sm text-muted-foreground">
             Full-page loader shown on <code className="font-mono text-xs">/join/[inviteCode]</code> while
-            Starter usage is activated. The Murph mark fires a sonar ripple from its two
-            largest core dots outward — each dot&apos;s delay is proportional to its distance
-            from center, so the wave radiates through the constellation rather than pulsing
-            uniformly. Honors <code className="font-mono text-xs">prefers-reduced-motion</code>.
+            Starter usage is activated. Successful activation replaces the document so Home
+            re-evaluates the new access grant instead of retaining this loading tree. The Murph
+            mark fires a sonar ripple from its two largest core dots outward — each dot&apos;s delay
+            is proportional to its distance from center, so the wave radiates through the
+            constellation rather than pulsing uniformly. Honors{" "}
+            <code className="font-mono text-xs">prefers-reduced-motion</code>.
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col items-center justify-center gap-6 rounded-2xl bg-[#FAF8F4] px-8 py-16 ring-1 ring-[#1A1F16]/[0.06]">

--- a/apps/web/src/components/hosted-onboarding/join-invite-starter-usage-island.tsx
+++ b/apps/web/src/components/hosted-onboarding/join-invite-starter-usage-island.tsx
@@ -46,7 +46,11 @@ export function JoinInviteStarterUsageIsland({
 
     try {
       const enrollment = await requestHostedStarterUsageEnrollment({ inviteCode });
-      replace(
+      // Enrollment changes the member's server-side access boundary. A client
+      // router replacement can update the URL while leaving the pre-enrollment
+      // Join tree committed, so force a fresh document that re-evaluates Home
+      // with the newly granted access.
+      window.location.replace(
         consumeHostedGroupStartHandoff()
           ? HOSTED_GROUP_START_PATH
           : enrollment.redirectPath,
@@ -55,7 +59,7 @@ export function JoinInviteStarterUsageIsland({
       startedRef.current = false;
       setErrorState(buildStarterUsageErrorState(error));
     }
-  }, [inviteCode, replace]);
+  }, [inviteCode]);
 
   const startPaidCheckout = useCallback(async () => {
     setCheckoutPending(true);

--- a/apps/web/test/join-invite-islands.test.ts
+++ b/apps/web/test/join-invite-islands.test.ts
@@ -298,13 +298,13 @@ test("JoinInviteCheckoutPlanButtonIsland refreshes instead of redirecting when c
   await cleanup();
 });
 
-test("JoinInviteStarterUsageIsland redirects after successful enrollment", async () => {
+test("JoinInviteStarterUsageIsland reloads the document after successful enrollment", async () => {
   mocks.requestHostedStarterUsageEnrollment.mockResolvedValue({
     redirectPath: "/home",
     status: "enrolled",
   });
 
-  const { cleanup } = await renderClientComponent(
+  const { cleanup, replaceLocation } = await renderClientComponent(
     createElement(JoinInviteStarterUsageIsland, {
       inviteCode: "invite-code",
     }),
@@ -318,11 +318,12 @@ test("JoinInviteStarterUsageIsland redirects after successful enrollment", async
   expect(mocks.requestHostedStarterUsageEnrollment).toHaveBeenCalledWith({
     inviteCode: "invite-code",
   });
-  expect(mocks.replace).toHaveBeenCalledWith("/home");
+  expect(replaceLocation).toHaveBeenCalledWith("/home");
+  expect(mocks.replace).not.toHaveBeenCalled();
   await cleanup();
 });
 
-test("JoinInviteStarterUsageIsland preserves the enrollment redirect after unmount", async () => {
+test("JoinInviteStarterUsageIsland preserves the document reload after unmount", async () => {
   let resolveEnrollment!: (value: HostedStarterUsageEnrollmentResponse) => void;
   mocks.requestHostedStarterUsageEnrollment.mockReturnValue(
     new Promise<HostedStarterUsageEnrollmentResponse>((resolve) => {
@@ -330,7 +331,7 @@ test("JoinInviteStarterUsageIsland preserves the enrollment redirect after unmou
     }),
   );
 
-  const { cleanup } = await renderClientComponent(
+  const { cleanup, replaceLocation } = await renderClientComponent(
     createElement(JoinInviteStarterUsageIsland, {
       inviteCode: "invite-code",
     }),
@@ -347,7 +348,8 @@ test("JoinInviteStarterUsageIsland preserves the enrollment redirect after unmou
     await Promise.resolve();
   });
 
-  expect(mocks.replace).toHaveBeenCalledWith("/home");
+  expect(replaceLocation).toHaveBeenCalledWith("/home");
+  expect(mocks.replace).not.toHaveBeenCalled();
 });
 
 test("JoinInviteStarterUsageIsland renders a distinct retry state after enrollment fails", async () => {

--- a/apps/web/test/join-invite-islands.test.ts
+++ b/apps/web/test/join-invite-islands.test.ts
@@ -1,7 +1,10 @@
 import { act, createElement } from "react";
 import { beforeEach, expect, test, vi } from "vitest";
 
-import { renderClientComponent } from "./render-client-component";
+import {
+  createMemoryStorage,
+  renderClientComponent,
+} from "./render-client-component";
 
 import {
   JoinInviteCheckoutPlanButtonIsland,
@@ -23,6 +26,7 @@ import {
 import type { HostedInviteStatusPayload } from "@/src/lib/hosted-onboarding/types";
 import type { HostedConsentStatus } from "@/src/lib/legal/consent";
 import { buildJoinInviteStatusRefreshSnapshot } from "@/src/components/hosted-onboarding/join-invite-state";
+import { armHostedGroupStartHandoff } from "@/src/lib/hosted-groups/group-start-handoff";
 
 const mocks = vi.hoisted(() => ({
   privyLogout: vi.fn(),
@@ -350,6 +354,30 @@ test("JoinInviteStarterUsageIsland preserves the document reload after unmount",
 
   expect(replaceLocation).toHaveBeenCalledWith("/home");
   expect(mocks.replace).not.toHaveBeenCalled();
+});
+
+test("JoinInviteStarterUsageIsland reloads the armed group-start handoff", async () => {
+  mocks.requestHostedStarterUsageEnrollment.mockResolvedValue({
+    redirectPath: "/home",
+    status: "enrolled",
+  });
+  const sessionStorage = createMemoryStorage();
+  armHostedGroupStartHandoff({ storage: sessionStorage });
+
+  const { cleanup, replaceLocation } = await renderClientComponent(
+    createElement(JoinInviteStarterUsageIsland, {
+      inviteCode: "invite-code",
+    }),
+    { requireButton: false, sessionStorage },
+  );
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  expect(replaceLocation).toHaveBeenCalledWith("/groups/start");
+  expect(mocks.replace).not.toHaveBeenCalled();
+  await cleanup();
 });
 
 test("JoinInviteStarterUsageIsland renders a distinct retry state after enrollment fails", async () => {

--- a/apps/web/test/render-client-component.tsx
+++ b/apps/web/test/render-client-component.tsx
@@ -15,6 +15,7 @@ type RenderClientComponentResult<TButton extends HTMLButtonElement | null> = {
   container: HTMLElement;
   open: ReturnType<typeof vi.fn>;
   reload: ReturnType<typeof vi.fn>;
+  replaceLocation: ReturnType<typeof vi.fn>;
   replaceState: ReturnType<typeof vi.fn>;
   rerender: (element: ReactElement) => Promise<void>;
   rerenderInTransition: (element: ReactElement) => Promise<void>;
@@ -55,11 +56,13 @@ export async function renderClientComponent(
   const assign = vi.fn();
   const open = vi.fn();
   const reload = vi.fn();
+  const replaceLocation = vi.fn();
   Object.defineProperty(window, "location", {
     configurable: true,
     value: {
       assign,
       reload,
+      replace: replaceLocation,
       ...(options.location ?? {}),
     },
   });
@@ -135,6 +138,7 @@ export async function renderClientComponent(
     container,
     open,
     reload,
+    replaceLocation,
     replaceState,
     rerender: async (nextElement: ReactElement) => {
       await act(async () => {


### PR DESCRIPTION
## Why this PR exists

The protected-main Hosted Stripe canary proved that Starter enrollment returned success and changed the URL to `/home`, but Next's client router left the pre-enrollment Join tree committed until the browser timed out. This follow-up makes the post-access transition a full-document replacement.

## User goal / user-visible behavior

After Starter access activates, the member reaches the committed Home experience instead of remaining on the Join loading surface with a changed URL.

## User experience

The existing Join loading state remains visible while enrollment runs. On success, the browser replaces the current document with Home (or the existing group-start handoff), so server-side access is re-evaluated and the stale Join page is not retained in browser history. Existing retry, setup, paid-checkout, and support recovery states are unchanged.

## Invariants

- Navigate only after the Starter enrollment request succeeds.
- Preserve the fixed same-origin `/home` and `/groups/start` destinations.
- Preserve replace-history semantics so Back does not return to the stale activation page.
- Preserve completion after the initiating component unmounts.
- Do not weaken the live canary's committed-Home DOM assertion.

## Changelog

- Changelog: not applicable
- Reason: Corrective navigation behavior for the existing Starter activation flow; no new member-facing feature or copy.

## ReviewGPT later-round context

ReviewGPT context sensitivity: sensitive

- Classification reason: This is a hosted billing/access transition and changes the browser navigation boundary after a persisted access grant.

ReviewGPT first-reviewed head: 79117db046626c90cdfd80f10cc134acc9f77f2c

## Preliminary specialist lenses

- Product experience: applicable — the Starter activation journey now owns a deterministic full-document continuation after success; direct evidence is the protected-main live failure plus the focused component and browser-driver proofs.
- Prompt: not applicable — no prompt, model input, tool schema, or generated guidance changes.
- Frontend: not applicable — no rendered UI, layout, copy, state, or viewport output changes; only the navigation mechanism after an existing success state changes.
- Coverage: applicable — focused tests prove hard replacement, prohibit the stale client-router path, preserve post-unmount completion, and retain the committed-Home browser assertion.
- Exact-head CI: pending at PR creation.
- Rendered evidence: none; the frontend lens is not applicable because pixels and rendered states are unchanged.

## Non-obvious affected surfaces

- Hosted group-start handoff: still chooses `/groups/start`, now through the same full-document replacement; covered by the unchanged destination selection and focused island tests.
- Hosted Stripe main-only canary: remains the full-stack acceptance proof and must pass after merge.

## Architecture and reuse

- Existing systems reused: Starter enrollment API, existing fixed redirect paths, browser `location.replace`, existing client-component test harness, and protected-main Stripe workflow.
- New logic: Replace the soft Next router transition after access mutation with a hard same-origin document replacement.
- New abstractions: None; the shared test harness exposes one narrow `location.replace` spy.
- Complexity intentionally avoided: No polling, sleeps, retry loop, new route, compatibility layer, or weakened DOM assertion.

## Hot reply path impact

- Path status: Not applicable — this browser onboarding continuation is outside durable conversation reply handling.
- Database calls: None.
- Network/provider calls: No new calls; the browser performs a document navigation instead of an RSC client transition.
- Other awaited latency: None added.
- Before/after proof: Protected-main canary showed URL-only transition without a committed Home tree; focused tests prove the hard replacement and the live browser driver still requires the Home tree.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: Not applicable — no visual output changes.
- Coverage: Existing Join and Home states are unchanged.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## First-reviewed change-shape breakdown

Classification rule: Production component code is Source; component tests and their shared DOM harness are Tests / fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 2 |
| Tests / fixtures | 12 | 6 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **18** | **8** |

## Current-head remediation shape

Current reviewed head: `d87f6c2a539090efa8193d4f32cb43b63ae9664e`

Round 1 returned `PASS` with no findings and noted one body/coverage discrepancy: the group-start handoff was claimed as focused coverage without a direct branch assertion. The accepted test-only remediation arms the existing handoff and proves `window.location.replace("/groups/start")` while prohibiting Next router replacement. It adds 29 test lines and removes 1; authored production source is unchanged from the first-reviewed head.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 2 |
| Tests / fixtures | 41 | 7 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **47** | **9** |

## Verification

- `pnpm dlx node@24.14.1 \"$(command -v pnpm)\" exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/join-invite-islands.test.ts apps/web/test/hosted-billing-live-support.test.ts` — 36/36 passed.
- `pnpm dlx node@24.14.1 \"$(command -v pnpm)\" --dir apps/web typecheck:prepared` — passed.
- `git diff --check` — passed.
- Protected-main run `31782780551`: enrollment response and `/home` URL succeeded, then the committed-Home marker timed out; four other live billing cases passed. A fresh main-only run is required after merge.

