### PR TITLE
test(cloudflare): scope Telegram rich tool expectation

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -243,6 +243,7 @@ export function expectAdvertisedMurphDynamicTools(
     phoneCallsAvailable?: boolean;
     progressUpdatesAvailable?: boolean;
     responseCardAvailable?: boolean;
+    telegramRichContentResponseCardAvailable?: boolean;
     vaultFileSendAvailable?: boolean;
     askGrokAvailable?: boolean;
   } = {},
@@ -314,6 +315,13 @@ export function expectAdvertisedMurphDynamicTools(
       if (
         options.exerciseRoutineResponseCardAvailable !== true
         && name === "murph.attach_exercise_routine_card"
+      ) {
+        return false;
+      }
+
+      if (
+        options.telegramRichContentResponseCardAvailable !== true
+        && name === "murph.attach_telegram_rich_content"
       ) {
         return false;
       }

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -571,6 +571,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
       && name !== "murph.ask_grok"
       && name !== "murph.attach_response_card"
       && name !== "murph.attach_exercise_routine_card"
+      && name !== "murph.attach_telegram_rich_content"
     );
     const baseToolNamesWithoutProgress = baseToolNames.filter((name) =>
       name !== "murph.send_progress_update"
@@ -587,6 +588,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     expect(allToolNames).toContain("murph.ask_grok");
     expect(allToolNames).toContain("murph.attach_response_card");
     expect(allToolNames).toContain("murph.attach_exercise_routine_card");
+    expect(allToolNames).toContain("murph.attach_telegram_rich_content");
 
     expectAdvertisedMurphDynamicTools([
       buildResponsesRequest(baseToolNames),
@@ -637,6 +639,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
         phoneCallsAvailable: true,
         progressUpdatesAvailable: true,
         responseCardAvailable: true,
+        telegramRichContentResponseCardAvailable: true,
         vaultFileSendAvailable: true,
         askGrokAvailable: true,
       },

--- a/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-telegram-first-contact-e2e.test.ts
@@ -305,6 +305,7 @@ describe("hosted local Telegram auto-reply e2e", () => {
       phoneCallsAvailable: true,
       progressUpdatesAvailable: true,
       responseCardAvailable: true,
+      telegramRichContentResponseCardAvailable: true,
     });
 
     const reactionRequests = await requireTelegramStub().waitForRequestCount({


### PR DESCRIPTION
## Why this PR exists

The Cloudflare deploy gate expected the Telegram-only rich-content tool during a Linq scenario. That stale expectation blocked production before deployment started.

## User goal / user-visible behavior

No user-facing behavior changes. Production deployment can pass its channel-specific tool advertisement check.

## User experience

No user-facing effect. The helper now expects the Telegram rich-content tool only when the tested channel supports it.

## Invariants

- Telegram still advertises the rich-content tool.
- Linq and other channels do not advertise Telegram-only tools.
- Production runtime code is unchanged.

## Changelog

- Changelog: not applicable
- Reason: Test-only correction to a deployment assertion; no member-visible behavior changed.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: Test-only channel expectation with no production behavior change.

## Non-obvious affected surfaces

- Cloudflare hosted-local deployment E2E helper.
- Telegram and Linq tool advertisement assertions.

## Architecture and reuse

- Existing systems reused: Existing channel capability flags and hosted-local tool advertisement helper.
- New logic: One test option describes Telegram rich-content availability.
- New abstractions: None. The existing helper option pattern is sufficient.
- Complexity intentionally avoided: No runtime branch, compatibility shim, or production fallback was added.

## Hot reply path impact

- Path status: Not applicable. Production code is unchanged.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The focused helper test passes.

## Database collection fanout impact

Not applicable. Production code is unchanged.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run. Only test assertions changed.

## Preliminary specialist lenses

- Product experience: not applicable. Production behavior is unchanged.
- Prompt: not applicable. No prompt or tool description changed.
- Frontend: not applicable. No UI changed.
- Coverage: applicable. The focused helper test proves the corrected channel split. Exact-head CI is pending.

## Design proof

- Design page: Not applicable.
- Coverage: No frontend change.
- Desktop screenshot: Not applicable.
- Mobile screenshot: Not applicable.

## Change-shape breakdown

Classification rule: All changed paths are tests or test helpers. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 12 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **12** | **0** |

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/hosted-local-e2e-support.test.ts` (23 passed)
- `git diff --check`
