### PR TITLE
fix(device-sync): restore first-time Apple Health connections

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-14-junction-minified-optional-404.md
+++ b/agent-docs/exec-plans/active/2026-08-14-junction-minified-optional-404.md
@@ -1,0 +1,76 @@
+# Restore first-time Junction device connections in production
+
+Status: active
+Created: 2026-08-14
+Updated: 2026-08-14
+
+## Goal
+
+- Restore first-time Apple Health connection setup when Junction correctly
+  reports that the deterministic provider user does not exist yet.
+
+## Success criteria
+
+- A Junction user lookup that receives an upstream 404 returns `null` even
+  when production bundling changes SDK error class names.
+- The existing create-or-resolve flow proceeds to provider-user creation after
+  that optional lookup.
+- Abort and timeout authority still take precedence over optional-response
+  handling, and the unread response body remains cancelled.
+- Focused regression tests, package typecheck, exact-head review, and required
+  CI pass before the production deployment is considered complete.
+- Production logs no longer show the diagnosed optional lookup failure after
+  the fixed deployment becomes active.
+
+## Scope
+
+- In scope: Junction client optional-404 classification, focused regression
+  coverage, and production deployment verification.
+- Out of scope: provider data imports, account mutation, provider SDK upgrades,
+  Apple HealthKit behavior, or unrelated Junction resource work.
+
+## Constraints
+
+- Keep the transport response as the source of truth; do not depend on class
+  names that a production minifier may rewrite.
+- Preserve the existing bounded retry, timeout, cancellation, and secret-safe
+  provider diagnostic behavior.
+- Use only synthetic test identifiers and metadata-only production evidence.
+
+## Risks and mitigations
+
+1. Risk: treating a late 404 as optional could mask a caller cancellation.
+   Mitigation: keep parent-abort and timeout checks ahead of the optional-404
+   return and assert that ordering in existing abort coverage.
+2. Risk: an ordinary source-level test could miss the production-only failure.
+   Mitigation: make the regression reproduce the SDK class-name rewrite caused
+   by minification and retain the existing response-body cancellation proof.
+3. Risk: unrelated provider behavior could change during an urgent fix.
+   Mitigation: limit the runtime change to the already-declared optional-404
+   path and leave general SDK error handling unchanged.
+
+## Tasks
+
+1. Reproduce the minified SDK error-name failure on current `main`.
+2. Add a focused failing regression and the smallest transport-owned fix.
+3. Run focused tests, package typecheck, and a minified-bundle scenario proof.
+4. Commit and push the candidate, open the PR, and complete required ReviewGPT
+   and exact-head CI gates.
+5. Merge, verify the Vercel production deployment and logs, close this plan,
+   and retire the worktree.
+
+## Decisions
+
+- Record the observed optional 404 inside the injected transport. The transport
+  directly owns the HTTP response and remains stable when the SDK bundle's
+  constructor names are minified.
+
+## Verification
+
+- Commands to run: focused `device-syncd` Junction tests, package typecheck, a
+  minified-bundle reproduction, exact-head CI, preliminary
+  `completion-specialists` ReviewGPT, final ReviewGPT, clean merge-tree proof,
+  and metadata-only production log inspection after deployment.
+- Expected outcomes: a first-time lookup returns `null`, create-or-resolve can
+  create the provider user, all required checks pass, and the production route
+  stops emitting the diagnosed lookup failure.

--- a/apps/web/changelog/entries/2026-08-14/first-time-apple-health-connection-recovery.json
+++ b/apps/web/changelog/entries/2026-08-14/first-time-apple-health-connection-recovery.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-14",
+  "order": 100,
+  "item": {
+    "id": "first-time-apple-health-connection-recovery",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "First-time Apple Health connections can continue",
+    "summary": "Connecting Apple Health for the first time no longer stops when Murph still needs to create the connected-health account.",
+    "details": "The expected first-time account check now proceeds into setup while preserving cancellation and timeout safeguards.",
+    "relevanceTags": ["apple-health", "wearables", "connections", "reliability"],
+    "sourcePullRequests": [1813]
+  }
+}

--- a/packages/device-syncd/src/providers/junction-client.ts
+++ b/packages/device-syncd/src/providers/junction-client.ts
@@ -833,12 +833,14 @@ export class JunctionClient {
         timeoutMs: options.timeoutMs ?? this.requestTimeoutMs,
       });
       let capturedResponse: JunctionSdkResponseCapture | null = null;
+      let observedOptionalNotFound = false;
       const sdkFetch: typeof fetch = async (input, init) => {
         const response = await this.fetchImpl(input, {
           ...init,
           signal: requestAbort.signal,
         });
         if (options.optional404 && response.status === 404) {
+          observedOptionalNotFound = true;
           await response.body?.cancel().catch(() => undefined);
           return new Response(null, {
             headers: response.headers,
@@ -902,6 +904,11 @@ export class JunctionClient {
           && isProviderTimeoutError(providerError, requestAbort.signal)
         ) {
           break;
+        }
+
+        if (observedOptionalNotFound) {
+          throwIfProviderRequestAborted(requestAbort.signal);
+          return null as T;
         }
 
         const sdkFailure = readJunctionSdkHttpFailure(error)

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac } from "node:crypto";
 import { readFile, rm } from "node:fs/promises";
+import { JunctionError } from "@junction-api/sdk";
 import { HistoricalPullCompleted as JunctionHistoricalPullCompletedSchema } from "@junction-api/sdk/serialization";
 import {
   importDeviceProviderSnapshot,
@@ -7314,6 +7315,29 @@ test("Junction optional user lookup cancels unread 404 response bodies", async (
 
   assert.equal(await client.resolveUser("missing-client-user"), null);
   assert.equal(bodyCancelled, true);
+});
+
+test("Junction optional user lookup survives minified SDK error names", async () => {
+  const originalName = Object.getOwnPropertyDescriptor(JunctionError, "name");
+  Object.defineProperty(JunctionError, "name", {
+    configurable: true,
+    value: "r",
+  });
+
+  try {
+    const client = new JunctionClient({
+      apiKey: "sk_us_test_123",
+      environment: "sandbox",
+      region: "us",
+      fetchImpl: async () => new Response(null, { status: 404 }),
+    });
+
+    assert.equal(await client.resolveUser("missing-client-user"), null);
+  } finally {
+    if (originalName) {
+      Object.defineProperty(JunctionError, "name", originalName);
+    }
+  }
 });
 
 test("Junction client deregisters provider connections by normalized provider slug", async () => {


### PR DESCRIPTION
## Why

First-time Apple Health connection setup is failing in production when the provider correctly reports that its deterministic user does not exist yet. Production bundling rewrites the provider SDK error class name, so the expected optional 404 is misclassified as an application failure.

## User-visible goal

A member who connects Apple Health for the first time can proceed from the initial account lookup into provider-user creation without an app-side error.

## Smallest complete flow

- Immediate feedback: the existing companion connection UI remains unchanged.
- Timing and continuation owner: the hosted Web connection route immediately performs the existing provider-user lookup, creation, and sign-in token minting in the same request.
- Terminal outcome: the existing Link setup opens after successful token minting; existing cancellation, timeout, and provider-error recovery remain unchanged.

## Invariants

- Caller cancellation and request timeout take precedence over optional-response handling.
- Unread optional 404 bodies are cancelled.
- Only the explicitly optional lookup treats 404 as absence.
- Provider diagnostics remain metadata-only.
- No account schema, token authority, consent, or imported health-data behavior changes.

## Architecture and reuse

- Existing systems reused: Junction client transport wrapper, existing create-or-resolve flow, provider abort/timeout guards, and Junction test harness.
- New logic: one attempt-local observation that the injected transport received the already-declared optional 404.
- New abstractions: none.
- Complexity intentionally avoided: no SDK fork, dependency change, retry expansion, provider-specific route branch, or broad error-classification rewrite.

## Non-obvious affected surfaces

- Hosted Junction Link first-establishment and companion SDK first-establishment both reuse the deterministic `createOrResolveUser` owner, so the correction necessarily restores the same minified first-time 404 path for Apple Health and other Junction-backed sources.
- Keeping the correction in the shared transport avoids an Apple-specific route branch that would duplicate response classification and leave equivalent hosted Link or companion SDK failures unresolved.
- Regression evidence includes the minified SDK error-name case, the existing 404 → provider-user creation → Link-token journey, and the SDK deterministic-owner composition coverage.

## Specialist lenses

- Product experience: applicable; this restores the existing first-time connection journey without adding steps, changing permissions, or changing visible copy. Direct journey proof executes the first-time lookup in a production-minified bundle.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: applicable; the focused regression reproduces a minified SDK constructor name and proves the optional lookup remains successful.

## Verification

- Junction provider test file: 257 tests passed under Node 24.
- Device-sync package typecheck: passed.
- Minified production-bundle scenario: passed; an upstream optional 404 resolves to null.
- Focused changelog suite: 57 tests passed.
- Canonical hosted Web typecheck: passed.
- Exact-head CI: pending.

## Direct scenario evidence

A minified bundle of the production client was executed with a synthetic first-time lookup returning 404. Before the fix it threw the diagnosed provider request error; after the fix it returned the expected absence result.

## Changelog

- Changelog: updated
- Items: 2026-08-14 · first-time-apple-health-connection-recovery

## Change shape

Classification rule: runtime TypeScript is source; Vitest is tests; the execution plan and changelog fragment are docs/content; no config, generated, or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 7 | 0 |
| Tests | 24 | 0 |
| Docs/content | 90 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Binary files: none.

## Design proof

Not applicable; no user-facing frontend UI changed.

ReviewGPT context sensitivity: sensitive

Reason: this is a provider egress and health-device connection reliability path.

ReviewGPT first-reviewed head: e344b6c9f03e0c9ceefdadf91ea3fb4961a44ce7

## Deployment skew

Web-only, backward-compatible runtime change. No Cloudflare, schema, environment, credential, or persisted-state counterpart changes. Old and new deployments can overlap safely; each request stays within one deployment. Post-deploy proof will inspect metadata-only route status and provider failure classification.
