### PR TITLE
Fix browser-vault recovery fixture namespace

### DIFF
--- a/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-canonical-receipt-lost-ack-recovery-e2e.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@murphai/runtime-state/node";
 import { createIntegratedVaultServices } from "@murphai/vault-usecases/vault-services";
 
+import { hostedBrowserVaultReplicaObjectKey } from "../src/storage-paths.js";
 import {
   buildAssistantProviderMurphToolCall,
   buildAssistantProviderShellCommandCall,
@@ -453,7 +454,7 @@ async function seedPreferenceReceiptRecoveryIncident(): Promise<
     receiptLogArtifact.bytes,
   );
   const checkpoint = await seedHostedWorkspaceCheckpointForTest({
-    browserVaultReplicaRef: createPreferenceRecoveryBrowserVaultReplicaRef(
+    browserVaultReplicaRef: await createPreferenceRecoveryBrowserVaultReplicaRef(
       snapshotHash,
     ),
     environment: requireScenario().runtimeEnv,
@@ -629,16 +630,21 @@ function createSnapshotBundleRef(input: {
   };
 }
 
-function createPreferenceRecoveryBrowserVaultReplicaRef(
+async function createPreferenceRecoveryBrowserVaultReplicaRef(
   sourceBundleHash: string,
-): HostedBrowserVaultReplicaRef {
+): Promise<HostedBrowserVaultReplicaRef> {
+  const dataVersion = `preference-receipt-${sourceBundleHash.slice(0, 16)}`;
+  const generatedAt = new Date().toISOString();
   return {
     byteLength: 256,
-    dataVersion: `preference-receipt-${sourceBundleHash.slice(0, 16)}`,
-    generatedAt: new Date().toISOString(),
+    dataVersion,
+    generatedAt,
     keyId: "browser-vault-replica:preference-receipt-recovery",
-    objectKey:
-      `browser-vault/${preferenceRecoveryUserId}/preference-receipt-recovery.json`,
+    objectKey: await hostedBrowserVaultReplicaObjectKey({
+      dataVersion,
+      generatedAt,
+      userId: preferenceRecoveryUserId,
+    }),
     replicaSchema: "murph.browser-vault-replica",
     runtimeRootKeyId: "udrk:runtime:preference-receipt-recovery",
     schema: "murph.hosted-browser-vault-replica-ref.v1",


### PR DESCRIPTION
## Why

The private production deployment prerequisite runs the hosted-local canonical-receipt scenario against public `main`. Its preference-recovery fixture still constructed a legacy browser-vault object key with a raw user segment, so the current per-user namespace guard rejected the fixture before the scenario could exercise recovery.

## Goal and UX

Restore truthful deployment-gate coverage for canonical receipt recovery. This is test-only and has no member-visible UX change.

## Invariants

- Browser-vault replica keys remain derived by the production storage-path owner.
- The per-user namespace guard stays strict; the test no longer bypasses or weakens it.
- No runtime, persistence, retry, or deployment behavior changes.

## Architecture and reuse

- Existing systems reused: `hostedBrowserVaultReplicaObjectKey`, the production storage-path owner already used by runtime code.
- New logic: the fixture freezes its synthetic data version and generation time, then asks the production owner for the scoped object key.
- New abstractions: None are needed because this fixture should reuse the existing production storage-path owner directly.
- Complexity intentionally avoided: no test-only key encoder, compatibility path, guard exception, or runtime change.

## Preliminary specialist lenses

- Product experience: not applicable - test-only fixture correction with no user-visible behavior change.
- Prompt: not applicable - no prompt, tool description, or provider instruction changes.
- Frontend: not applicable - no `apps/web` UI or rendered state changes.
- Coverage: applicable - focused proof is `pnpm --filter @murphai/cloudflare-runner typecheck` plus the production-shaped canonical-receipt hosted-local scenario; exact-head CI is pending after a PR-description-only correction.

## Change shape

Classification is by base-to-head authored diff; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 13 | 7 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 13 | 7 |

## Verification

- `pnpm --filter @murphai/cloudflare-runner typecheck` - pass.
- `MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR=<private-worker> pnpm hosted-local e2e canonical-receipt-lost-ack-recovery` - advanced past the prior namespace rejection and passed the Cloudflare deploy smoke; later blocked by a local MinIO health-check restart followed by Temporal retry/protocol timeouts. The prior `outside the bound user namespace` failure did not recur.
- Exact-head GitHub Actions own the broad gate.


## Changelog

- Changelog: not applicable
- Reason: This PR only corrects an internal test fixture and does not change member-visible behavior.
