### PR TITLE
test(device-sync): strengthen minified first-connect coverage

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-14-junction-minified-optional-404.md
+++ b/agent-docs/exec-plans/completed/2026-08-14-junction-minified-optional-404.md
@@ -1,6 +1,6 @@
 # Restore first-time Junction device connections in production
 
-Status: active
+Status: completed
 Created: 2026-08-14
 Updated: 2026-08-14
 
@@ -65,6 +65,26 @@ Updated: 2026-08-14
   directly owns the HTTP response and remains stable when the SDK bundle's
   constructor names are minified.
 
+## Progress
+
+- The production failure was traced to an upstream optional 404 whose SDK error
+  class name was rewritten by minification. A focused minified-bundle
+  reproduction proved the existing literal-name check was the failing boundary.
+- PR #1813 merged the transport-owned correction as commit `ea9d023663`. Focused
+  Junction tests, package and Web typechecks, changelog validation, the
+  minified-bundle proof, required CI, and the final cross-cutting review passed.
+- The preliminary coverage review requested stronger journey and cancellation
+  proof. The follow-up tests now exercise resolve-404 -> create-user ->
+  sign-in-token under a rewritten SDK class name, plus caller cancellation
+  during unread 404-body cleanup. The full Junction test file and package
+  typecheck pass locally.
+- The first production build of the merge commit was OOM-killed by Vercel's
+  Standard build machine during the Next.js compile. A later `main` deployment
+  containing the hotfix completed successfully and owns the public production
+  aliases. The homepage returned 200 after its canonical redirect, the
+  unauthenticated companion sign-in-token probe failed closed with 401, and the
+  deployment showed no device-sync server errors after activation.
+
 ## Verification
 
 - Commands to run: focused `device-syncd` Junction tests, package typecheck, a
@@ -74,3 +94,4 @@ Updated: 2026-08-14
 - Expected outcomes: a first-time lookup returns `null`, create-or-resolve can
   create the provider user, all required checks pass, and the production route
   stops emitting the diagnosed lookup failure.
+Completed: 2026-08-14

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -7317,8 +7317,69 @@ test("Junction optional user lookup cancels unread 404 response bodies", async (
   assert.equal(bodyCancelled, true);
 });
 
-test("Junction optional user lookup survives minified SDK error names", async () => {
+test("Junction first-time SDK connection survives minified SDK error names", async () => {
   const originalName = Object.getOwnPropertyDescriptor(JunctionError, "name");
+  const requests: Array<{ method: string; pathname: string }> = [];
+  Object.defineProperty(JunctionError, "name", {
+    configurable: true,
+    value: "r",
+  });
+
+  try {
+    const provider = createJunctionProvider(async (input, init) => {
+      const pathname = new URL(readUrl(input)).pathname;
+      requests.push({
+        method: String(init?.method ?? "GET"),
+        pathname: pathname.startsWith("/v2/user/resolve/")
+          ? "/v2/user/resolve/:clientUserId"
+          : pathname,
+      });
+
+      if (pathname.startsWith("/v2/user/resolve/")) {
+        return new Response(null, { status: 404 });
+      }
+      if (pathname === "/v2/user") {
+        return createJsonResponse({ user_id: "junction-user-1" });
+      }
+      if (pathname === "/v2/user/junction-user-1/sign_in_token") {
+        return createJsonResponse({ sign_in_token: "junction-sign-in-token" });
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const handler = requireValue(
+      provider.sdkConnectionHandler,
+      "Junction provider should expose an SDK connection handler.",
+    );
+
+    const connection = await handler.ensureConnection({
+      ownerId: "owner-internal-id-123",
+      now: "2026-08-14T00:00:00.000Z",
+    });
+    const token = await handler.createSignInToken({
+      externalAccountId: connection.externalAccountId,
+    });
+
+    assert.equal(connection.externalAccountId, "junction-user-1");
+    assert.equal(token.signInToken, "junction-sign-in-token");
+    assert.equal(token.environment, "sandbox");
+    assert.deepEqual(requests, [
+      { method: "GET", pathname: "/v2/user/resolve/:clientUserId" },
+      { method: "POST", pathname: "/v2/user" },
+      { method: "POST", pathname: "/v2/user/junction-user-1/sign_in_token" },
+    ]);
+  } finally {
+    if (originalName) {
+      Object.defineProperty(JunctionError, "name", originalName);
+    }
+  }
+});
+
+test("Junction optional user lookup keeps caller cancellation ahead of a minified 404", async () => {
+  const originalName = Object.getOwnPropertyDescriptor(JunctionError, "name");
+  const abortController = new AbortController();
+  const abortReason = new Error("foreground yield");
+  let bodyCancelled = false;
+  let requests = 0;
   Object.defineProperty(JunctionError, "name", {
     configurable: true,
     value: "r",
@@ -7329,10 +7390,25 @@ test("Junction optional user lookup survives minified SDK error names", async ()
       apiKey: "sk_us_test_123",
       environment: "sandbox",
       region: "us",
-      fetchImpl: async () => new Response(null, { status: 404 }),
+      fetchImpl: async () => {
+        requests += 1;
+        return new Response(new ReadableStream<Uint8Array>({
+          cancel() {
+            bodyCancelled = true;
+            abortController.abort(abortReason);
+          },
+        }), { status: 404 });
+      },
     });
 
-    assert.equal(await client.resolveUser("missing-client-user"), null);
+    await assert.rejects(
+      () => client.resolveUser("missing-client-user", {
+        signal: abortController.signal,
+      }),
+      (error) => error === abortReason,
+    );
+    assert.equal(requests, 1);
+    assert.equal(bodyCancelled, true);
   } finally {
     if (originalName) {
       Object.defineProperty(JunctionError, "name", originalName);


### PR DESCRIPTION
## Why

PR #1813 shipped the urgent production correction for first-time Apple Health connections. Its preliminary coverage review requested direct journey proof beyond the low-level optional lookup, plus explicit cancellation precedence during unread 404-body cleanup.

## User-visible goal and UX

No product behavior or interface changes in this follow-up. It locks in the already-shipped recovery so a first-time connection cannot regress when production minification rewrites the Junction SDK error class name.

## Invariants

- A first-time resolve 404 proceeds through provider-user creation and sign-in-token issuance even when the SDK constructor name is minified.
- Caller cancellation still wins if it occurs while the unread optional-404 response body is being cancelled.
- The tests use synthetic identifiers and do not touch production data.

## Architecture and reuse

- Existing systems reused: the Junction provider test harness, its injected fake transport, and the existing SDK connection handler.
- New logic: test-only assertions for the complete resolve -> create -> token journey and cancellation precedence.
- New abstractions: none are needed because the existing injected transport and SDK handler already expose every boundary under test.
- Complexity intentionally avoided: no runtime branches, new dependencies, duplicate provider logic, or additional test framework.

Runtime ownership and production code remain unchanged; this is the smallest coverage-only response to the accepted specialist finding.

## Verification

- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/junction-provider.test.ts` — 258 passed
- `pnpm typecheck` in `packages/device-syncd` — passed
- Clean current-`main` merge-tree proof
- Production deployment containing #1813 is Ready and owns the public aliases

## Change size

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 79 | 3 |
| Docs / task plan | 97 | 76 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Changelog

- Changelog: not applicable
- Reason: this follow-up changes automated regression coverage and archives the completed task plan without changing member-visible behavior.

## Design proof

Not applicable: no frontend or user-interface changes.

## ReviewGPT context sensitivity

Routine. The patch changes tests and archives the completed plan only, with no production behavior, authentication, data, prompt, or UI changes. It directly resolves the accepted specialist coverage finding from #1813.
