### PR TITLE
Fix stale doc-gardening index target

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -443,8 +443,7 @@ webhook admission fence for app-bound connections, is jointly specified by
 | `agent-docs/PLANS.md` | Execution-plan lifecycle and storage rules. | Plan workflow | Medium | 2026-03-31 |
 | `agent-docs/exec-plans/completed/README.md` | Marks completed plans as immutable, non-operative historical snapshots and routes current implementation, deployment, rollback, and incident guidance to live owner docs. | Completed-plan archive interpretation | Medium | 2026-07-22 |
 | `agent-docs/generated/README.md` | Meaning and expectations for generated doc artifacts. | Generated-doc conventions | Low | 2026-04-02 |
-| `agent-docs/exec-plans/active/` | Task-owned in-flight execution plans, including the current PR #1705 final review and target/destination refactor. | Active plan lifecycle | Medium | 2026-08-13 |
-| `agent-docs/exec-plans/completed/2026-08-13-pr-1705-final-review.md` | PR #1705 unified current-sender target refactor, bounded compatibility drain, final review, exact-head CI, and merge-boundary proof. | PR #1705 completion plan | High | 2026-08-13 |
+| `agent-docs/exec-plans/active/` | Task-owned in-flight execution plans. | Active plan lifecycle | Medium | 2026-08-14 |
 | `agent-docs/exec-plans/tech-debt-tracker.md` | Current debt register with owner/priority/status. | Rolling debt tracker | Medium | 2026-03-12 |
 | `agent-docs/prompts/` | Reusable completion-review lenses and local audit prompts, including the preliminary ReviewGPT product-experience/prompt/frontend/coverage references, the frontend simplicity and Steve Jobs taste bar, and the fallback local deep-review prompt. | Workflow prompt library | Low | 2026-07-30 |
 | `agent-docs/prompts/seam-audits/` | One-pass bespoke seam prompts governed by a shared review-only, evidence, correction, and zero-finding contract. | Seam-audit prompt library | Low | 2026-07-13 |


### PR DESCRIPTION
## Why this PR exists

The release build/typecheck workflow fails its final documentation check because the canonical agent-doc index still points at an execution plan after that plan was archived.

## User goal / user-visible behavior

Keep the release workflow green when the documentation index and tracked documentation tree are consistent.

## User experience

No user-facing effect. This only repairs an internal documentation reference used by CI.

## Invariants

- The canonical index lists current documentation rather than completed execution snapshots.
- Completed plans remain immutable in the completed-plan archive.
- Doc gardening continues to fail on genuine broken index targets.

## Changelog

- Changelog: not applicable
- Reason: This changes only an internal documentation index and CI result; no member-visible behavior changes.

## ReviewGPT later-round context

ReviewGPT context sensitivity: routine

- Classification reason: This is a one-file stale documentation-reference removal with no runtime, product, security, data, or deployment behavior.

## Non-obvious affected surfaces

- Release CI: the existing doc-gardening fail-on-issues gate now completes with zero findings.

## Architecture and reuse

- Existing systems reused: The canonical agent-doc index and existing doc-gardening checker remain the sole owners.
- New logic: None; the stale active-plan entry is removed and the active-plan directory description is made generic.
- New abstractions: None; the existing index convention is sufficient.
- Complexity intentionally avoided: No checker exception, compatibility alias, generated artifact override, or completed-plan mutation was added.

## Hot reply path impact

- Path status: Not applicable — no executable runtime path changes.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable; the diff is documentation-only.

## Database collection fanout impact

Not applicable — no database-touching code changes.

## Murph initial provider input impact

Not applicable — no provider-input surface changes.

## Design proof

Not applicable — no user-facing web UI changes.

## Change-shape breakdown

Classification rule: Markdown under agent-docs is classified as docs. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 1 | 2 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1** | **2** |

## Verification

- bash scripts/doc-gardening.sh --fail-on-issues — passed with zero issues.
- git diff --check — passed.
- Direct scenario: reproduced the stale active-plan target on merged main, removed it from the live-doc index, and reran the exact failing command successfully.
