### PR TITLE
Raise runner bundle cap by ten percent

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -272,15 +272,10 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // Generation-10 Browser Vault projection adds the replica builder to lazy
 // runner output. A dedicated Query server facade keeps that graph off startup;
 // exact macOS assembly measured an 8,065,357B static closure and 10,325,065B
-// total after the merged AgentMail removal on 2026-08-14. Ratchet those
-// measurements while retaining the existing cross-platform tolerances and
-// forbidden-startup-input guards.
-//
-// Later reviewed current-main additions extended the existing lazy output
-// without adding a forbidden boot input. Exact Linux hosted-local assembly
-// measured 10,361,173B on 2026-08-14, so ratchet the total baseline to that
-// integrated measurement and retain the established 32KB allowance.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_361_173 + 32_768;
+// total after the merged AgentMail removal on 2026-08-14. Keep the entry and
+// static-closure ratchets below, while giving the previous 10,357,833B total
+// cap 10% headroom and retaining the forbidden-startup-input guards.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_393_617;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_689_721;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_065_357;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -609,7 +609,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_689_721 + 48_000,
       staticClosureBytes: 8_065_357 + 96_000,
-      totalBytes: 10_361_173 + 32_768,
+      totalBytes: 11_393_617,
     });
   });
 


### PR DESCRIPTION
## Why this PR exists

The initial protected Cloudflare deployment was blocked because the 10,404,812-byte assembled runner was 46,979 bytes over the then-current 10,357,833-byte cap. Current main contains an interim 10,393,941-byte ratchet that still leaves that artifact 10,871 bytes over. This PR preserves the requested final cap: 11,393,617 bytes, exactly 10% above the original deployment-blocking cap, rounded up.

## User goal / user-visible behavior

Production deployment can complete instead of stopping at runner-bundle validation. There is no direct member-facing behavior change.

## User experience

Not applicable. This changes an internal deployment guard only.

## Invariants the PR must preserve

- Entry-chunk and static-startup-closure ratchets remain unchanged.
- Forbidden startup dependencies remain rejected.
- The cap increase does not change bundle contents or runtime behavior.
- The existing bundle-policy test continues to pin the reviewed value.

## Non-obvious affected surfaces

- Cloudflare runner artifact validation: the current-base total-byte ceiling changes from 10,393,941 bytes to 11,393,617 bytes. The final value remains exactly 10% above the original deployment-blocking 10,357,833-byte cap. Regression proof is the focused 42-test bundle suite plus a real assembled artifact at 10,404,812 bytes.

## Architecture and reuse

- **Existing systems reused:** The existing runner bundle budget resolver, entry/static-closure ratchets, forbidden-input guards, and bundle-policy test remain the only owners.
- **New logic:** The total byte cap is raised by exactly 10%, rounded up to the next whole byte.
- **New abstractions:** None; the existing numeric policy constant is sufficient.
- **Policy disposition:** The total budget intentionally changes from the prior measured-total-plus-32-KB ratchet to a one-time 10% headroom cap. Entry and static-closure ratchets continue to detect startup growth.
- **Complexity intentionally avoided:** No bundle refactor, dependency change, new validation path, or runtime compatibility mechanism.

## Changelog

- Changelog: not applicable

- Reason: This is an internal deployment-budget adjustment with no member-visible behavior change.

## Hot reply path impact

Not applicable. The diff does not change runtime execution or the foreground reply critical path.

## Database collection fanout impact

Not applicable. The diff performs no database work.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompts, tools, schemas, model configuration, or request assembly changed.
- Group Murph: Not applicable; no prompts, tools, schemas, model configuration, or request assembly changed.

## Preliminary specialist lenses

- Product experience: not applicable; no member journey or semantic behavior changes.
- Prompt: not applicable; no prompt or provider-visible input changes.
- Frontend: not applicable; no UI changes.
- Coverage: applicable; the existing budget-policy assertion changes. Focused proof: 42/42 bundle-policy tests passed before and after the base-only conflict resolution, Cloudflare typecheck passed before and after that update, and the real assembled artifact passed at 10,404,812 of 11,393,617 bytes. Exact-head CI is pending on the base-updated head.

ReviewGPT context sensitivity: sensitive

Reason: The patch is tiny but changes a production deploy-boundary guard.

ReviewGPT first-reviewed head: 02f3ada650c675b9c5d247c8ca899c331aaa6212

## Change-shape breakdown

Classification rule: production TypeScript is source; the Vitest assertion is tests/fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 9 |
| Tests/fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **5** | **10** |

## ReviewGPT and base-update ledger

- Preliminary specialist pass reviewed 02f3ada650c675b9c5d247c8ca899c331aaa6212: PASS, no findings, no coverage patch.
- Final round 1 reviewed that same production head: PASS after valid model, attachment, exact-head, duration, and substantive-path checks; no accepted findings.
- The body discrepancy identified during review was accepted and corrected from 382 bytes to 46,979 bytes.
- Current base merged the separate assistant CI-fixture repair. The single allowed base update conflicted only in the two reviewed runner-budget files; both resolutions retained the reviewed PR versions byte-for-byte, and the duplicate test-only commit was dropped because its patch was already upstream.
ReviewGPT current head after base-only update: ad77d3b37640125e48bc13d946b0b6f05c5db6b2

## Design proof

Not applicable. There is no user-facing frontend diff.

## Deployment skew / compatibility

The patch changes validation policy only; it does not alter Worker code, runner contents, environment shape, or persisted state. Web/Worker and Worker/container skew behavior is unchanged. After merge, the protected production workflow should use immediate container rollout for the already-merged queue transport change, then verify queue creation, Worker deployment, and endpoint smoke checks.