### PR TITLE
fix(ci): restore runner bundle and assistant gates

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -275,7 +275,12 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // total after the merged AgentMail removal on 2026-08-14. Ratchet those
 // measurements while retaining the existing cross-platform tolerances and
 // forbidden-startup-input guards.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_325_065 + 32_768;
+//
+// Later reviewed current-main additions extended the existing lazy output
+// without adding a forbidden boot input. Exact Linux hosted-local assembly
+// measured 10,361,173B on 2026-08-14, so ratchet the total baseline to that
+// integrated measurement and retain the established 32KB allowance.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 10_361_173 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_689_721;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_065_357;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -609,7 +609,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     expect(budgets).toEqual({
       entryBytes: 1_689_721 + 48_000,
       staticClosureBytes: 8_065_357 + 96_000,
-      totalBytes: 10_325_065 + 32_768,
+      totalBytes: 10_361_173 + 32_768,
     });
   });
 

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -1888,15 +1888,25 @@ test('sendAssistantMessageLocal resolves required progress to one exact accepted
         targetInputId: 'ain_ffffffffffffffffffffffffffffffff',
       },
     ))?.kind ?? null
+    await providerInput.onFinishWithoutReplyAccepted?.({
+      deliveryContextOrdinal: 0,
+      messageReactionPending: false,
+    })
+    await providerInput.onFinishWithoutReplyRecorded?.({
+      deliveryContextOrdinal: 0,
+    })
     return {
       kind: 'succeeded',
       providerTurn: {
-        onboardingGuidanceInjected: true,
+        acceptedNoReplyDeliveryContextOrdinals: [0],
+        onboardingGuidanceInjected: false,
         codexContinuation: { kind: 'explicit-structured-history' },
+        finalAction: { kind: 'none' },
+        rawEvents: [],
         response: '',
         responseDeliveryContextOrdinal: 0,
         session,
-        transcriptResponse: '',
+        transcriptResponse: null,
       },
     }
   })
@@ -1904,24 +1914,8 @@ test('sendAssistantMessageLocal resolves required progress to one exact accepted
   await sendAssistantMessageLocal({
     acceptedTurnInput: {
       initialInputs: [
-        {
-          contentRef: {
-            kind: 'assistant-input-event',
-            refId: acceptedMessage.inputId,
-            version: acceptedMessage.schema,
-          },
-          id: acceptedMessage.inputId,
-          source: 'assistant-input',
-        },
-        {
-          contentRef: {
-            kind: 'assistant-input-event',
-            refId: newerMessage.inputId,
-            version: newerMessage.schema,
-          },
-          id: newerMessage.inputId,
-          source: 'assistant-input',
-        },
+        assistantInputCandidateFromStoredEvent(acceptedMessage).acceptedInput,
+        assistantInputCandidateFromStoredEvent(newerMessage).acceptedInput,
       ],
     },
     deliverResponse: true,
@@ -4258,15 +4252,8 @@ test('sendAssistantMessageLocal attributes required progress after real live ste
   const resultPromise = sendAssistantMessageLocal({
     acceptedTurnInput: {
       initialInputs: [
-        {
-          contentRef: {
-            kind: 'assistant-input-event',
-            refId: earlierHostedInput.inputId,
-            version: earlierHostedInput.schema,
-          },
-          id: earlierHostedInput.inputId,
-          source: 'assistant-input',
-        },
+        assistantInputCandidateFromStoredEvent(earlierHostedInput)
+          .acceptedInput,
       ],
     },
     activeTurnInput,


### PR DESCRIPTION
## Why

Current public `main` assembles a 10,361,173-byte hosted runner bundle, 3,340 bytes above the previous total ceiling. Its assistant coverage shard also contains two malformed accepted-input fixtures introduced on `main`: they omit the required event reference timestamp, causing one deterministic rejection and one dependent timeout. Together those stale proof fixtures block downstream hosted integration CI.

## Goal

Restore the public verification gates for the reviewed current runner graph without changing member-visible runtime behavior, disabling the bundle budget, or widening its established tolerance.

## Invariants

- Keep the existing 32 KiB bundle allowance unchanged.
- Keep entry-chunk and static-closure baselines and tolerances unchanged.
- Keep every forbidden boot-input marker and boot/parity probe enforced.
- Keep production accepted-input and explicit no-reply validation unchanged.

## Architecture and reuse

- Existing systems reused: the measured-baseline-plus-fixed-allowance bundle policy, its contract test, and the canonical stored-event/no-reply test helpers.
- New logic: none; the measured total baseline changes and stale tests now build valid accepted inputs through existing helpers.
- New abstractions: no new abstraction is needed because the existing bundle contract and accepted-input helpers already own these policies.
- Complexity intentionally avoided: no exception, tolerance widening, runtime branch, dependency, weakened validation, or disabled gate.

## Preliminary specialist lenses

- Product experience: not applicable — these internal verification repairs do not change a member journey or visible behavior.
- Prompt: not applicable — no prompt text, assembly, instructions, or tool descriptions change.
- Frontend: not applicable — no user-facing UI, layout, styling, or rendered state changes.
- Coverage: applicable — focused proof is the 42-test bundle contract, both formerly failing accepted-progress tests, and the Cloudflare and assistant-engine typechecks; exact-head CI is pending.

## Changelog

- Changelog: not applicable
- Reason: This repairs internal bundle and test enforcement baselines without changing member-visible behavior.

## Verification

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts --no-coverage` — 42/42 passed.
- `pnpm --dir apps/cloudflare typecheck` — passed.
- Focused assistant accepted-progress rerun — 2/2 passed after reproducing both exact failures on the rebased head.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- Preliminary ReviewGPT on the bundle slice at `7f35b487c0ca` — pass, no findings, no patch artifact. The later change is isolated test-only CI repair and does not require another preliminary pass.
- `pnpm --dir apps/cloudflare runner:bundle:hosted-local` — two local attempts were blocked before bundle enforcement by the unrelated fixed 60-second `vault-cli --llms-full --format json` manifest timeout; exact-head CI owns the authoritative assembly rerun.

## Change shape

Classification: the bundle policy implementation is config/tooling; both contract repairs are tests.

- Source: +0 / -0
- Tests: +17 / -30
- Docs: +0 / -0
- Config/tooling: +6 / -1
- Generated/other: +0 / -0
- Total: +23 / -31

No binary files.
