### PR TITLE
chore: update ReviewGPT to 0.5.127

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.15",
-    "@cobuild/review-gpt": "^0.5.126",
+    "@cobuild/review-gpt": "^0.5.127",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       '@cobuild/review-gpt':
-        specifier: ^0.5.126
-        version: 0.5.126(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.127
+        version: 0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1475,8 +1475,8 @@ packages:
     resolution: {integrity: sha512-CjzP5OHu6RhOOjmPl/1djZNVEbjttt62rBSzvuPK7u9NrZ37F2lkHT+QmZ4Lb+ZDmMhPTqlwdyqnzwD0Gkhm1Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.126':
-    resolution: {integrity: sha512-YUaiP44+iMFdbyslFnuqm3uB+Eb0HUIRhqM5pfi9DTJzrxPjU4OUb7E7j+yAbMyTTIhOeeKEfSY5dn2aLn1m8A==}
+  '@cobuild/review-gpt@0.5.127':
+    resolution: {integrity: sha512-8jauRUCLI+nrIMUrcRii/xXmtJUXxfsD2kizddq6vc7Z2mrOqLr9LU5fq9rIrBk62q12Y5o/nO3IM5SPC2fcbw==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10819,7 +10819,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)': {}
 
-  '@cobuild/review-gpt@0.5.126(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.15(patch_hash=1bb6f46e87ffa3e712f0ba9bad95ca93fb6e118c4d5c2e64a7fc3fbce9825547)
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ overrides:
   'fast-xml-parser@5.7.2>fast-xml-builder': 1.2.0
 minimumReleaseAgeExclude:
   - incur@0.4.4
-  - '@cobuild/review-gpt@0.5.126'
+  - '@cobuild/review-gpt@0.5.127'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why
Murph should consume ReviewGPT 0.5.127 so future unsent draft tabs inherit automatic idle cleanup instead of accumulating stale Brave renderers.

## User goal / user-visible behavior
Review operators keep the same workflow, while successful draft-only tabs are registered for exact-target cleanup after the package default idle window. Murph members see no product change.

## User experience
No member-facing effect. A developer starts ReviewGPT normally; waited and sent runs retain their existing ownership behavior, while future unsent hidden and inactive drafts use the package default 30-minute cleanup window.

## Invariants
- Keep ReviewGPT registry-sourced and represented in the committed lockfile.
- Keep the release-age exception exact to the reviewed package version.
- Preserve sent and waited target ownership.
- Never close an unrelated browser target.

## Non-obvious affected surfaces
- Developer-only ReviewGPT browser runs consume the updated CLI.
- The package-backed CLI release audit reads the installed ReviewGPT driver directly and now exercises its idle-cleaner handoff with fake CDP.

## Architecture and reuse
- Existing systems reused: the root ReviewGPT dependency, pnpm lockfile, exact `minimumReleaseAgeExclude` entry, existing VM-loaded ReviewGPT harness, and package idle cleaner.
- New logic: test-only successful-draft state and cleaner registration hooks prove that one unsent draft registers one exact-target lease and that the real cleaner closes only that target.
- New abstractions: none beyond small test-only types for the installed package boundary.
- Complexity intentionally avoided: no Murph runtime wrapper, custom cleanup process, unrelated dependency refresh, or broad lockfile churn.

## Changelog
- Changelog: not applicable
- Reason: internal developer review tooling only; no member-visible behavior changes.

## Hot reply path impact
Not applicable — this does not change Murph runtime code or the foreground reply critical path.

## Database collection fanout impact
Not applicable — this adds or changes no database-touching path.

## Murph initial provider input impact
- Individual Murph: Not applicable — no prompt, tool schema, model configuration, or provider-request assembly changed.
- Group Murph: Not applicable — no prompt, tool schema, model configuration, or provider-request assembly changed.

## Preliminary Specialist Applicability
- Product experience: not applicable — internal developer tooling only; no member journey changed.
- Prompt: not applicable — no prompt or instruction-stack changes.
- Frontend: not applicable — no user-facing UI changes and no rendered evidence is required.
- Coverage: applicable.
- Preliminary review at `8ee34785f5`: `SPECIALIST_OUTCOME: FINDINGS`; one medium finding identified stale version assertions and missing successful-draft cleanup proof.
- Resolution at `e8435c0f57`: updated the installed-driver contract expectations and added package-backed proof for the 30-minute default, a shortened override, successful unsent-draft registration, exact-target closure, unrelated-target preservation, and sent-run ownership.
- Corrected-head parent revalidation: the six changed lifecycle tests and CLI package typecheck pass. Per the completion workflow, this is parent-owned corrected-head revalidation rather than a second preliminary invocation.

## Verification
- PASS: `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts`
- PASS: `pnpm deps:guard`
- PASS: `pnpm deps:ignored-builds` (none)
- PASS: `pnpm --dir packages/cli typecheck`
- PASS: six focused package-backed ReviewGPT lifecycle tests
- PASS: the existing response-timeout dry-run test also proves the 1800000 ms default and 2000 ms per-run override
- PASS: resolved CLI reports `0.5.127` and exposes `--idle-draft-timeout`
- PASS: `git diff --check` and privacy scans
- LOCAL LIMITATION: the complete release audit file reaches unrelated shell/archive fixture timeouts under current machine pressure; the changed tests pass independently and exact-head CI is authoritative.
- KNOWN BASELINE: `pnpm deps:audit` reports 77 existing workspace advisories, including the existing `review-gpt > repomix > tar` path; this patch changes no transitive lock entries.

## ReviewGPT context sensitivity
ReviewGPT context sensitivity: routine
- Reason: a developer-tool dependency update plus package-boundary tests, with no product runtime, auth, data, deployment, prompt, or public API change.

## Change-shape breakdown
| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 266 | 22 |
| Docs | 0 | 0 |
| Config/tooling | 7 | 7 |
| Generated/other | 0 | 0 |
| Total | 273 | 29 |

Classification rule: root manifests and lockfile are config/tooling; the CLI audit file is tests/fixtures. No binary files.

## Design proof
Not applicable — no user-facing frontend UI changed.