### PR TITLE
Fix Cloudflare public ECDH JWK resealing

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
+++ b/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
@@ -103,6 +103,17 @@ Updated: 2026-08-14
   to this diagnostic projection, vocabulary ownership, or stage cardinality
   requires requirement-level reconsideration instead of another tactical
   branch. The immutable first-reviewed baseline remains unchanged.
+- The post-deploy Junction canary reached `persistence_reseal_failed`
+  consistently. A focused workerd reproduction proved the root cause: workerd
+  exports an ECDH public JWK with an own `d` property whose value is
+  `undefined`, while the shared public-JWK normalizer rejected the property by
+  presence alone. Node omits the property, so the previous Node-only proof did
+  not exercise the deployed shape.
+- Requirement-level reconsideration is satisfied by the smallest correction:
+  continue rejecting every defined private scalar, accept only the
+  platform-equivalent `d: undefined` public shape, and add a workerd
+  open/reseal/reopen regression. This changes no diagnostic vocabulary, owner,
+  state, compatibility path, or Queue behavior.
 
 ## Verification
 
@@ -114,5 +125,7 @@ Updated: 2026-08-14
   admission, and no unexplained DLQ growth or rejected-query alert.
 - Current focused proof: hosted-control 75 tests, Worker Queue 8 tests, and Web
   Queue/route/device-sync HTTP 46 tests pass; hosted-control, Cloudflare, and
-  prepared Web typechecks pass. Exact-head CI and corrected production canary
-  remain pending.
+  prepared Web typechecks pass. The first protected deploy and smoke passed;
+  live main/DLQ metrics were both zero with 14-day retention and the alert
+  bindings configured. The workerd reseal regression now passes; its follow-up
+  PR, protected redeploy, and corrected production canary remain pending.

--- a/apps/cloudflare/test/workers/device-webhook-queue-persistence-e2e.test.ts
+++ b/apps/cloudflare/test/workers/device-webhook-queue-persistence-e2e.test.ts
@@ -1,0 +1,72 @@
+import {
+  createDeviceWebhookTransportPrivateKeyring,
+  openDeviceWebhookQueueEnvelope,
+  reencryptDeviceWebhookQueueEnvelopeForPersistence,
+  sealDeviceWebhookQueueEnvelope,
+} from "@murphai/cloudflare-hosted-control/device-webhook-queue";
+import { describe, expect, it } from "vitest";
+
+describe("device webhook Queue persistence in workerd", () => {
+  it("opens a transport envelope and reseals it to the active key", async () => {
+    const transportKeys = await createRecipientKeys();
+    const persistenceKeys = await createRecipientKeys();
+    expect("d" in transportKeys.publicJwk).toBe(true);
+    expect(transportKeys.publicJwk.d).toBeUndefined();
+    const envelope = await sealDeviceWebhookQueueEnvelope({
+      env: "test",
+      preparedWebhook: {
+        acceptanceMode: "level_dirty_hint",
+        eventType: "demo.updated",
+        externalAccountId: "opaque-account",
+        jobs: [],
+        provider: "junction",
+        receivedAt: "2026-08-15T00:00:00.000Z",
+        schema: "murph.device-sync-prepared-webhook.v1",
+        traceId: "1".repeat(64),
+      },
+      recipientKeyId: "automation:transport",
+      recipientPublicJwk: transportKeys.publicJwk,
+    });
+    const keyring = createDeviceWebhookTransportPrivateKeyring({
+      activePrivateJwk: persistenceKeys.privateJwk,
+      activeRecipientKeyId: "automation:persistence",
+      keyringJson: JSON.stringify({
+        "automation:transport": {
+          privateJwk: transportKeys.privateJwk,
+          recipient: "cloudflare-automation-secret",
+          status: "decrypt_only",
+        },
+      }),
+    });
+
+    const persisted = await reencryptDeviceWebhookQueueEnvelopeForPersistence({
+      activeRecipientKeyId: "automation:persistence",
+      env: "test",
+      envelope,
+      privateKeyring: keyring,
+    });
+
+    await expect(openDeviceWebhookQueueEnvelope({
+      env: "test",
+      envelope: persisted,
+      privateKeyring: keyring,
+    })).resolves.toMatchObject({
+      preparedWebhook: { provider: "junction" },
+    });
+  });
+});
+
+async function createRecipientKeys(): Promise<{
+  privateJwk: JsonWebKey;
+  publicJwk: JsonWebKey;
+}> {
+  const keys = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"],
+  );
+  return {
+    privateJwk: await crypto.subtle.exportKey("jwk", keys.privateKey),
+    publicJwk: await crypto.subtle.exportKey("jwk", keys.publicKey),
+  };
+}

--- a/packages/runtime-state/src/hosted-domain-crypto.ts
+++ b/packages/runtime-state/src/hosted-domain-crypto.ts
@@ -1049,7 +1049,7 @@ function normalizeP256PublicJwk(jwk: JsonWebKey, label: string): JsonWebKey {
     || typeof jwk.y !== "string"
     || jwk.x.length === 0
     || jwk.y.length === 0
-    || "d" in jwk
+    || jwk.d !== undefined
   ) {
     throw new TypeError(`${label} must be a public P-256 EC JWK.`);
   }


### PR DESCRIPTION
## Why this PR exists

The first production Junction Queue canary reached the Worker but failed while resealing the already-opened transport envelope. A workerd reproduction proved that Cloudflare exports a public ECDH JWK with an own `d` property set to `undefined`, while Node omits that property.

## User goal / user-visible behavior

Device webhooks can enter the durable Queue path and continue to normal admission instead of returning a retryable response at the Worker persistence boundary.

## User experience

There is no new UI or copy. Providers continue using the existing webhook endpoint; successful requests receive the existing accepted response, while failures remain generic and retryable. Queue processing owns the asynchronous continuation to the existing Web admission endpoint.

## Invariants the PR must preserve

- Any defined private scalar remains rejected at the public-JWK boundary.
- Transport payloads remain encrypted before and after Worker processing.
- The Worker continues resealing to the active persistence key before Queue storage.
- No diagnostic detail or key material is exposed to providers.

## Non-obvious affected surfaces

- Shared hosted-domain crypto normalization: required because workerd's standards-compatible public-key export differs from Node's object shape. The regression proof executes open/reseal/reopen inside the Cloudflare Vitest pool.
- Cloudflare Worker Queue persistence: exercised end to end with synthetic provider data and both transport and persistence recipients.

## Architecture and reuse

- **Existing systems reused:** The existing P-256 JWK normalizer, transport keyring, Queue envelope seal/open helpers, and Cloudflare Vitest pool remain the only owners.
- **New logic:** Public JWK validation now rejects `d` only when its value is defined, matching Web Crypto exports across Node and workerd.
- **New abstractions:** None; the existing normalization boundary is sufficient.
- **Complexity intentionally avoided:** No compatibility adapter, new key shape, fallback crypto path, state, queue, or diagnostic vocabulary was added.

## Changelog

- Changelog: not applicable
- Reason: This repairs an internal gated delivery path without changing member-facing product behavior or copy.

## Hot reply path impact

Not applicable. This does not change the foreground conversation acceptance, provider-start, or reply-handoff path.

## Database collection fanout impact

Not applicable. The diff adds no database read, write, transaction, collection, or fanout behavior.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, model mode, provider adapter, skill rendering, or request-assembly surface changes.
- Group Murph: Not applicable; no prompt, tool schema, model mode, provider adapter, skill rendering, or request-assembly surface changes.

## Preliminary specialist lenses

- Product experience: applicable because durable webhook acceptance is the intended outcome; focused workerd open/reseal/reopen proof is green, while corrected production canary proof remains pending until merge and protected deployment.
- Prompt: not applicable; no provider-visible prompt or tool surface changes.
- Frontend: not applicable; no rendered UI changes.
- Coverage: applicable; the workerd regression passes, all runtime-state tests pass, and affected package typechecks pass. Exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: This is a cryptographic trust-boundary and production Worker runtime compatibility change.

ReviewGPT first-reviewed head: e675ee325f97e503b8219af015074ded8378f9a1

## Change-shape breakdown

Classification uses authored file purpose; generated files and binaries are absent.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests/fixtures | 72 | 0 |
| Docs | 15 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **88** | **3** |

## Design proof

Not applicable; this PR changes no frontend UI.

