### PR TITLE
Fix device webhook Queue reseal in workerd

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
+++ b/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
@@ -42,9 +42,10 @@ Updated: 2026-08-14
 1. Risk: diagnostics disclose private webhook or cryptographic material.
    Mitigation: emit only a closed, value-free stage code derived at the owner
    boundary; never serialize the caught exception or envelope.
-2. Risk: a stale Vercel build re-enables the failed gate.
-   Mitigation: keep the gate removed and production pinned to the known direct
-   deployment until the correction is deployed and proved.
+2. Risk: the single-provider canary retries while the correction is prepared.
+   Mitigation: Junction remains the only enabled provider and receives the
+   existing fail-closed retryable response until Queue persistence succeeds;
+   remove the gate if the bounded correction cannot ship promptly.
 3. Risk: a provider receives a false success or duplicate processing.
    Mitigation: keep `Queue.send` acknowledgement as the only success boundary
    and retain provider redelivery plus existing trace idempotency.
@@ -57,6 +58,9 @@ Updated: 2026-08-14
 4. Run focused tests/typechecks, commit, push, and complete ReviewGPT/CI.
 5. Merge, deploy the Worker through the protected workflow, and re-run the
    one-provider production canary with Queue/DLQ/admission proof.
+6. Reproduce the observed persistence reseal failure in the real workerd crypto
+   runtime, correct the shared crypto boundary, and repeat review, CI, protected
+   deployment, and live one-provider proof.
 
 ## Decisions
 
@@ -103,6 +107,17 @@ Updated: 2026-08-14
   to this diagnostic projection, vocabulary ownership, or stage cardinality
   requires requirement-level reconsideration instead of another tactical
   branch. The immutable first-reviewed baseline remains unchanged.
+- The production canary reached `persistence_reseal_failed`, proving transport
+  authentication, initial unwrap, and payload open before Queue storage. A
+  workerd regression test then reproduced the underlying failure: its locally
+  generated ECDH public-key export carries runtime-specific metadata that the
+  strict public-JWK validator correctly rejects. Node's export shape had hidden
+  that runtime difference.
+- Keep strict validation for all external JWKs. Normalize only the public fields
+  of the locally generated ephemeral key before passing it into the existing
+  validator and envelope builder. This adds no compatibility owner, new error
+  taxonomy, or persistent state and prevents runtime metadata from entering the
+  authenticated envelope.
 
 ## Verification
 
@@ -114,5 +129,7 @@ Updated: 2026-08-14
   admission, and no unexplained DLQ growth or rejected-query alert.
 - Current focused proof: hosted-control 75 tests, Worker Queue 8 tests, and Web
   Queue/route/device-sync HTTP 46 tests pass; hosted-control, Cloudflare, and
-  prepared Web typechecks pass. Exact-head CI and corrected production canary
-  remain pending.
+  prepared Web typechecks pass. The focused Node crypto and Queue rotation suites
+  add 11 passing tests, the real workerd reseal regression passes, and the
+  runtime-state, hosted-control, and Cloudflare typechecks pass. Exact-head CI,
+  correction ReviewGPT, and the corrected production canary remain pending.

--- a/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
+++ b/agent-docs/exec-plans/active/2026-08-14-device-webhook-queue-runtime-proof.md
@@ -131,5 +131,6 @@ Updated: 2026-08-14
   Queue/route/device-sync HTTP 46 tests pass; hosted-control, Cloudflare, and
   prepared Web typechecks pass. The focused Node crypto and Queue rotation suites
   add 11 passing tests, the real workerd reseal regression passes, and the
-  runtime-state, hosted-control, and Cloudflare typechecks pass. Exact-head CI,
-  correction ReviewGPT, and the corrected production canary remain pending.
+  runtime-state, hosted-control, Cloudflare, and prepared Web typechecks pass.
+  The 45 focused changelog contract tests also pass. Exact-head CI, correction
+  ReviewGPT, and the corrected production canary remain pending.

--- a/apps/cloudflare/test/workers/device-webhook-queue-crypto-e2e.test.ts
+++ b/apps/cloudflare/test/workers/device-webhook-queue-crypto-e2e.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDeviceWebhookTransportPrivateKeyring,
+  openDeviceWebhookQueueEnvelope,
+  reencryptDeviceWebhookQueueEnvelopeForPersistence,
+  sealDeviceWebhookQueueEnvelope,
+} from "@murphai/cloudflare-hosted-control/device-webhook-queue";
+import {
+  DEVICE_SYNC_PREPARED_WEBHOOK_SCHEMA,
+  type PreparedDeviceSyncWebhookV1,
+} from "@murphai/device-syncd/prepared-webhook";
+
+describe("device webhook Queue crypto in workerd", () => {
+  it("opens an old transport envelope and reseals it to the active persistence key", async () => {
+    const oldKeys = await createRecipientKeys();
+    const activeKeys = await createRecipientKeys();
+    const envelope = await sealDeviceWebhookQueueEnvelope({
+      env: "test",
+      preparedWebhook: createPreparedWebhook(),
+      recipientKeyId: "automation:old",
+      recipientPublicJwk: oldKeys.publicJwk,
+    });
+    const privateKeyring = createDeviceWebhookTransportPrivateKeyring({
+      activePrivateJwk: activeKeys.privateJwk,
+      activeRecipientKeyId: "automation:active",
+      keyringJson: JSON.stringify({
+        "automation:old": {
+          privateJwk: oldKeys.privateJwk,
+          recipient: "cloudflare-automation-secret",
+          status: "decrypt_only",
+        },
+      }),
+    });
+
+    const persisted = await reencryptDeviceWebhookQueueEnvelopeForPersistence({
+      activeRecipientKeyId: "automation:active",
+      env: "test",
+      envelope,
+      privateKeyring,
+    });
+
+    await expect(openDeviceWebhookQueueEnvelope({
+      env: "test",
+      envelope: persisted,
+      privateKeyring: createDeviceWebhookTransportPrivateKeyring({
+        activePrivateJwk: activeKeys.privateJwk,
+        activeRecipientKeyId: "automation:active",
+      }),
+    })).resolves.toMatchObject({
+      preparedWebhook: { provider: "whoop" },
+    });
+  });
+});
+
+function createPreparedWebhook(): PreparedDeviceSyncWebhookV1 {
+  return {
+    acceptanceMode: "durable_webhook_work",
+    eventType: "demo.updated",
+    externalAccountId: "opaque-account",
+    jobs: [],
+    provider: "whoop",
+    receivedAt: "2026-02-02T00:00:00.000Z",
+    schema: DEVICE_SYNC_PREPARED_WEBHOOK_SCHEMA,
+    traceId: "1".repeat(64),
+  };
+}
+
+async function createRecipientKeys(): Promise<{
+  privateJwk: JsonWebKey;
+  publicJwk: JsonWebKey;
+}> {
+  const keys = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"],
+  );
+  const privateJwk = await crypto.subtle.exportKey("jwk", keys.privateKey);
+  const publicJwk = await crypto.subtle.exportKey("jwk", keys.publicKey);
+  return {
+    privateJwk,
+    publicJwk: {
+      crv: publicJwk.crv,
+      ext: true,
+      key_ops: [],
+      kty: publicJwk.kty,
+      x: publicJwk.x,
+      y: publicJwk.y,
+    },
+  };
+}

--- a/apps/web/changelog/entries/2026-08-13/reliable-wearable-sync-bursts.json
+++ b/apps/web/changelog/entries/2026-08-13/reliable-wearable-sync-bursts.json
@@ -9,6 +9,6 @@
     "summary": "Connected wearables now buffer large bursts of provider updates so they do not overwhelm sync admission.",
     "details": "Murph verifies and encrypts each supported update before durable handoff, processes updates with bounded database pressure, and retains failed work for recovery. Existing consent, connection, source, and duplicate checks still run before an update becomes sync work.",
     "relevanceTags": ["wearables", "reliability", "sync", "privacy"],
-    "sourcePullRequests": [1766]
+    "sourcePullRequests": [1766, 1869]
   }
 }

--- a/packages/runtime-state/src/hosted-domain-crypto.ts
+++ b/packages/runtime-state/src/hosted-domain-crypto.ts
@@ -553,7 +553,21 @@ export async function wrapHostedDomainRootKeyWithP256Ecdh(input: {
     ),
   );
   let wrapKey: CryptoKey;
-  const ephemeralPublicJwk = await crypto.subtle.exportKey("jwk", ephemeral.publicKey);
+  const exportedEphemeralPublicJwk = await crypto.subtle.exportKey(
+    "jwk",
+    ephemeral.publicKey,
+  );
+  const ephemeralPublicJwk = normalizeP256PublicJwk(
+    {
+      crv: exportedEphemeralPublicJwk.crv,
+      ext: true,
+      key_ops: [],
+      kty: exportedEphemeralPublicJwk.kty,
+      x: exportedEphemeralPublicJwk.x,
+      y: exportedEphemeralPublicJwk.y,
+    },
+    "Generated ECDH ephemeral public JWK",
+  );
   const wrapAad = buildHostedEcdhWrapAad({
     encryptionContext: input.encryptionContext,
     ephemeralPublicJwk,


### PR DESCRIPTION
## Why this PR exists

The one-provider production Queue canary reached the Worker, opened the encrypted transport payload, and then failed while resealing it for durable Queue storage. The real workerd runtime exports generated ECDH public keys with a shape that differs from Node, so the shared strict public-JWK validator rejected locally generated key metadata before `Queue.send`.

## User goal / user-visible behavior

Connected wearable webhook updates can complete their encrypted durable handoff instead of remaining in provider retry after authentication succeeds.

## User experience

This changes no screen or member action. A supported provider posts an authenticated update, Web forwards the encrypted prepared meaning, the Worker opens and reseals it, and `Queue.send` remains the only success boundary. Queue consumption and bounded Web admission continue asynchronously. A failure remains retryable and fail-closed; the provider never receives a false success.

## Invariants the PR must preserve

- External and persisted public JWKs remain strictly validated and cannot contain private key material.
- Provider payload meaning remains encrypted before durable Queue storage.
- `Queue.send` acknowledgement remains the only success boundary.
- Existing key rotation, old-key decryption, provider retry, consumer retry, idempotency, and DLQ ownership remain unchanged.

## Non-obvious affected surfaces

- Shared hosted-domain ECDH wrapping: locally generated ephemeral public-key exports are reduced to the canonical public fields before the existing validator and authenticated envelope builder. Node crypto and workerd regression proof cover the boundary.
- Cloudflare device-webhook Queue ingress: a real worker-pool test opens an old-key envelope, reseals it to the active key, and reopens it under workerd.

## Architecture and reuse

- **Existing systems reused:** The existing hosted-domain ECDH wrapper, strict JWK validator, transport keyring, rotation owner, encrypted Queue envelope, and Worker Vitest pool remain the only owners.
- **New logic:** One trusted, locally generated public-key export is projected onto its canonical public fields before validation.
- **New abstractions:** None. The existing strict validator and envelope contract are sufficient.
- **Complexity intentionally avoided:** No validator weakening, runtime-specific compatibility service, fallback encryption path, new error code, retry owner, persisted state, or dependency was added.

## Changelog

- Changelog: updated
- Items: 2026-08-13 · reliable-wearable-sync-bursts

## Hot reply path impact

Not applicable. This changes device-webhook encryption before Queue persistence, not current-conversation durable acceptance or reply handoff.

## Database collection fanout impact

Not applicable. The diff adds no database call, transaction, collection path, or concurrency.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool schema, model configuration, request assembly, or provider-visible wrapper changes.
- Group Murph: Not applicable. No prompt, tool schema, model configuration, request assembly, or provider-visible wrapper changes.

## Preliminary specialist lenses

- Product experience: applicable. The intended outcome is that connected-source updates proceed through encrypted durable handoff without a member reconnect. Focused Node/workerd round-trip proof is green; the corrected production canary is pending.
- Prompt: not applicable. No assistant/provider prompt or tool surface changes.
- Frontend: not applicable. No user-facing frontend diff or rendered evidence.
- Coverage: applicable. Eleven focused Node crypto/Queue tests, one real workerd reseal regression, and 45 changelog contract tests pass; affected package/app/Web typechecks pass. Exact-head CI is pending.

## ReviewGPT context sensitivity

ReviewGPT context sensitivity: sensitive

This is a cryptographic trust-boundary and production Queue runtime correction.

ReviewGPT first-reviewed head: 0c6d88448480127f95d503d69ef0a3358db8740c

## Change-shape breakdown

Classification is by repository role; authored runtime TypeScript is source, worker-pool proof is tests/fixtures, and the execution-plan record plus changelog fragment are docs/static content. No generated or binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 15 | 1 |
| Tests/fixtures | 91 | 0 |
| Docs/static content | 24 | 6 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **130** | **7** |

## Design proof

Not applicable. No user-facing frontend UI changes.

## Deployment skew / compatibility

Deploy the corrected Cloudflare Worker through the protected queue-first workflow before evaluating the existing Junction-only canary. The canonical ECDH envelope is unchanged, so the current Web deployment and previously produced transport envelopes remain compatible during skew. Warm runner containers do not execute this Queue-ingress crypto path and require no rollout. Expected exposure is limited to the single enabled provider, failures remain retryable, and rollback is the existing provider-gate removal. Post-deploy proof requires provider HTTP success, nonzero Queue ingestion and drain, successful signed Web batch admission, and no unexplained DLQ growth.
