### PR TITLE
fix(hosted): drain activation after foreground reply

### DIFF
--- a/apps/web/changelog/entries/2026-08-15/onboarding-stays-caught-up-after-fast-replies.json
+++ b/apps/web/changelog/entries/2026-08-15/onboarding-stays-caught-up-after-fast-replies.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-15",
+  "order": 200,
+  "item": {
+    "id": "onboarding-stays-caught-up-after-fast-replies",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Onboarding stays caught up after fast replies",
+    "summary": "Murph now finishes account activation immediately after prioritizing an incoming message, so onboarding setup does not wait for another message.",
+    "details": "The current reply still completes first. Activation then reuses the existing bounded onboarding path after that reply is durably recorded.",
+    "relevanceTags": ["assistant", "messaging", "onboarding", "reliability"],
+    "sourcePullRequests": [1872]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -201,6 +201,7 @@ export async function executeHostedMemberActivatedWake(input: {
   );
   let seededOnboardingFollowupWakeAt: string | null = null;
   let notificationDecisionKind: string | null = null;
+  let deliveryIntentIds: string[] = [];
 
   try {
     const notificationResult = await sendAssistantNotification(
@@ -216,6 +217,12 @@ export async function executeHostedMemberActivatedWake(input: {
       ),
     );
     notificationDecisionKind = notificationResult?.decision.kind ?? null;
+    const deliveryOutcome = notificationResult?.deliveryOutcome ?? null;
+    const deliveryIntentId =
+      deliveryOutcome && "intentId" in deliveryOutcome
+        ? deliveryOutcome.intentId
+        : null;
+    deliveryIntentIds = deliveryIntentId ? [deliveryIntentId] : [];
     seededOnboardingFollowupWakeAt = await maybeSeedOnboardingFollowupAutomation({
       logDetails: buildHostedMemberActivationSignupWelcomeLogDetails(input.wake),
       notificationResult,
@@ -249,6 +256,7 @@ export async function executeHostedMemberActivatedWake(input: {
 
   return createNoopMailboxEffect({
     conversationMetrics: null,
+    deliveryIntentIds,
     mailboxLane: "member-activated",
     nextWakeAt: seededOnboardingFollowupWakeAt,
     nextWakeReason: seededOnboardingFollowupWakeAt ? HOSTED_ASSISTANT_WAKE_REASON : null,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -5627,7 +5627,8 @@ async function runSystemMailboxMaintenancePhase(input: {
     })
       ? await collectHostedAssistantDeliverySideEffects({
         actionApprovalPort: phaseInput.runtime.platform.actionApprovalPort ?? null,
-        includeBackgroundDueIntents: phaseInput.foregroundCausalOnly !== true,
+        includeBackgroundDueIntents:
+          phaseInput.foregroundCausalOnly !== true && !hasExclusiveSelection,
         preferredEffectIds: resolveHostedSystemMailboxPreferredEffectIds(
           systemMailboxPreparation,
         ),

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -279,10 +279,12 @@ const HOSTED_MEMBER_CHANNEL_UPDATE_ROUTE_ACTIONS = ["apply-member-channels-updat
 const HOSTED_MEMBER_PREFERENCE_PRE_PLANNING_ROUTE_ACTIONS = [
   "apply-member-preferences",
 ] as const;
-const HOSTED_POST_FOREGROUND_MEMBER_ACTION_ROUTE_ACTIONS = [
+const HOSTED_POST_FOREGROUND_MEMBER_ROUTE_ACTIONS = [
+  "apply-member-activation",
   "apply-member-action",
 ] as const;
-const HOSTED_POST_FOREGROUND_MEMBER_ACTION_WAKE_KINDS = [
+const HOSTED_POST_FOREGROUND_MEMBER_WAKE_KINDS = [
+  "member.activated",
   "member.action.requested",
 ] as const;
 const HOSTED_GROUP_ROOM_MODEL_PRE_PLANNING_ROUTE_ACTIONS = [
@@ -2703,7 +2705,7 @@ export async function runHostedWorkspaceAssistantPhase(
           result: timedForegroundAssistantResult,
         }),
       );
-      const result = withPostForegroundMemberActionAfterCheckpoint({
+      const result = withPostForegroundMemberWorkAfterCheckpoint({
         executionContext,
         input,
         result: foregroundResult,
@@ -4772,7 +4774,7 @@ async function runBackgroundMaintenanceAfterDeferredPendingAssistantInput(input:
   });
 }
 
-function withPostForegroundMemberActionAfterCheckpoint(input: {
+function withPostForegroundMemberWorkAfterCheckpoint(input: {
   executionContext: AssistantExecutionContext;
   input: HostedWorkspaceRuntimeAssistantPhaseInput;
   result: HostedWorkspaceRunnerAssistantPhaseResult;
@@ -4794,9 +4796,9 @@ function withPostForegroundMemberActionAfterCheckpoint(input: {
         async () => {
           const maintenance = await runSystemMailboxMaintenancePhase({
             exclusiveRouteActions:
-              HOSTED_POST_FOREGROUND_MEMBER_ACTION_ROUTE_ACTIONS,
+              HOSTED_POST_FOREGROUND_MEMBER_ROUTE_ACTIONS,
             exclusiveWakeKinds:
-              HOSTED_POST_FOREGROUND_MEMBER_ACTION_WAKE_KINDS,
+              HOSTED_POST_FOREGROUND_MEMBER_WAKE_KINDS,
             executionContext: input.executionContext,
             hasFreshConversationInput: false,
             input: input.input,
@@ -4804,14 +4806,14 @@ function withPostForegroundMemberActionAfterCheckpoint(input: {
             pendingAssistantInputWakeAt: null,
             wake: input.wake,
           });
-          return deferPostForegroundMemberActionResult(maintenance.result);
+          return deferPostForegroundMemberWorkResult(maintenance.result);
         },
       ],
     }),
   };
 }
 
-function deferPostForegroundMemberActionResult(
+function deferPostForegroundMemberWorkResult(
   result: HostedWorkspaceRunnerAssistantPhaseResult | null,
 ): HostedWorkspaceRunnerAssistantPhasePostCheckpoint | null {
   if (!result || result.progressed !== true) {

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -2346,6 +2346,7 @@ describe("executeHostedMailboxEvent", () => {
       }),
     );
     expect(result).toMatchObject({
+      deliveryIntentIds: ["intent_notification"],
       mailboxLane: "member-activated",
       nextWakeAt: seededNextWakeAt,
       nextWakeReason: "assistant",
@@ -2411,6 +2412,7 @@ describe("executeHostedMailboxEvent", () => {
       }),
     );
     expect(result).toMatchObject({
+      deliveryIntentIds: [],
       mailboxLane: "member-activated",
       nextWakeAt: seededNextWakeAt,
       nextWakeReason: "assistant",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -15866,26 +15866,43 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     });
   });
 
-  it("runs one requested member action after the current foreground reply", async () => {
+  it.each([
+    {
+      item: createMemberActivationSignupWelcomeSystemMailboxItem(),
+      label: "member activation",
+      mailboxLane: "member-activated" as const,
+      routeAction: "apply-member-activation" as const,
+    },
+    {
+      item: createMemberActionSystemMailboxItem(),
+      label: "requested member action",
+      mailboxLane: "member-action" as const,
+      routeAction: "apply-member-action" as const,
+    },
+  ])("runs one $label after the current foreground reply", async ({
+    item,
+    label,
+    mailboxLane,
+    routeAction,
+  }) => {
     const sequence: string[] = [];
     let newerForegroundInputArrived = false;
     const deliveryEffect = createDeliveryEffect();
-    const memberActionItem = createMemberActionSystemMailboxItem();
     mocks.prepareHostedSystemMailboxItemForCheckpoint.mockImplementation(
       async (preparationInput) => {
         if (
-          preparationInput.allowedRouteActions?.length === 1
-          && preparationInput.allowedRouteActions[0] === "apply-member-action"
+          preparationInput.allowedRouteActions?.length === 2
+          && preparationInput.allowedRouteActions.includes(routeAction)
         ) {
-          sequence.push("member-action");
+          sequence.push(label);
           return {
-            item: memberActionItem,
-            itemId: memberActionItem.itemId,
+            item,
+            itemId: item.itemId,
             metrics: {
               bootstrapResult: null,
               conversationMetrics: null,
-              mailboxLane: "member-action" as const,
-              postCheckpointRecord: memberActionItem.postCheckpointRecord,
+              mailboxLane,
+              postCheckpointRecord: item.postCheckpointRecord,
               redactedLogEntries: [],
             },
             status: "processed" as const,
@@ -15930,13 +15947,13 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     expect(sequence).toEqual([
       "provider",
       "foreground-delivery",
-      "member-action",
+      label,
     ]);
     expect(
       mocks.prepareHostedSystemMailboxItemForCheckpoint.mock.calls.at(-1)?.[0],
     ).toEqual(expect.objectContaining({
-      allowedRouteActions: ["apply-member-action"],
-      allowedWakeKinds: ["member.action.requested"],
+      allowedRouteActions: ["apply-member-activation", "apply-member-action"],
+      allowedWakeKinds: ["member.activated", "member.action.requested"],
       shouldYieldBackgroundMaintenance: null,
     }));
     expect(postCheckpoint).toEqual(expect.objectContaining({
@@ -15950,7 +15967,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     );
 
     expect(mocks.recordHostedSystemMailboxItemAfterCheckpoint).toHaveBeenCalledWith({
-      item: memberActionItem,
+      item,
       operatorHomeRoot: "/tmp/murph-operator-home",
       runtime: expect.any(Object),
       vaultRoot: "/tmp/murph-vault",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -15868,18 +15868,21 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
 
   it.each([
     {
+      deliveryIntentIds: ["intent_activation_welcome"],
       item: createMemberActivationSignupWelcomeSystemMailboxItem(),
       label: "member activation",
       mailboxLane: "member-activated" as const,
       routeAction: "apply-member-activation" as const,
     },
     {
+      deliveryIntentIds: [],
       item: createMemberActionSystemMailboxItem(),
       label: "requested member action",
       mailboxLane: "member-action" as const,
       routeAction: "apply-member-action" as const,
     },
   ])("runs one $label after the current foreground reply", async ({
+    deliveryIntentIds,
     item,
     label,
     mailboxLane,
@@ -15901,6 +15904,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
             metrics: {
               bootstrapResult: null,
               conversationMetrics: null,
+              deliveryIntentIds,
               mailboxLane,
               postCheckpointRecord: item.postCheckpointRecord,
               redactedLogEntries: [],
@@ -15960,6 +15964,23 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       afterDurableCheckpoint: expect.any(Function),
       checkpointReason: "system_mailbox_receipt",
     }));
+    expect(mocks.collectHostedAssistantDeliverySideEffects).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeBackgroundDueIntents: true,
+      }),
+    );
+    if (deliveryIntentIds.length > 0) {
+      expect(
+        mocks.collectHostedAssistantDeliverySideEffects.mock.calls.at(-1)?.[0],
+      ).toEqual({
+        actionApprovalPort: null,
+        includeBackgroundDueIntents: false,
+        preferredEffectIds: [],
+        preferredIntentIds: deliveryIntentIds,
+        vaultRoot: "/tmp/murph-vault",
+      });
+    }
+    expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
     expect(mocks.recordHostedSystemMailboxItemAfterCheckpoint).not.toHaveBeenCalled();
 
     await runHostedWorkspaceDurableCheckpointEffects(


### PR DESCRIPTION
## Why

The hosted foreground-priority E2E reproduced twice because an activation wake imported while the current conversation reply was running remained unhandled after that reply completed. The existing post-foreground drain admitted requested member actions only, so activation bookkeeping could wait for a later wake.

## Member outcome and smallest complete flow

A member still receives the current conversational reply first. Immediately after that durable reply checkpoint, Murph completes one already-imported activation item in the same bounded continuation instead of leaving onboarding work behind until later traffic. The reply is the immediate feedback; the existing post-checkpoint owner controls continuation and terminal recording. If no eligible item exists or it cannot progress, existing later-wake recovery remains unchanged.

## Invariants

- The current foreground reply remains first and keeps its existing durable checkpoint.
- Only one eligible system-mailbox item runs after that checkpoint.
- Activation and requested-action work reuse the same system-mailbox preparation and post-checkpoint recording owner.
- An exclusive post-foreground item can collect only its own delivery intent, never unrelated due deliveries or device-sync work.
- No provider call, database transaction, queue, retry loop, or new persisted state is introduced.

## Architecture and reuse

- Existing systems reused: foreground reply checkpoint, bounded system-mailbox maintenance phase, delivery-effect filtering, and durable post-checkpoint record owner.
- New logic: admit member activation through the existing post-foreground route and carry its existing delivery intent into the exclusive continuation.
- New abstractions: none; helper names are broadened to match the two existing work kinds.
- Complexity intentionally avoided: no second wake authority, scheduler, queue, compatibility shim, or special-case state machine.

## Preliminary specialist lenses

- Product experience: applicable. The specialist found no source-level product flaw.
- Prompt: not applicable. No prompt, tool description, instruction stack, or provider-visible input changes.
- Frontend: not applicable. The only Web change is isolated changelog content; no UI component, state, interaction, or presentation logic changes.
- Coverage: applicable. The specialist found no scaffolding gap and identified the existing protected hosted-local foreground-priority scenario as the canonical production-faithful proof. Local execution was blocked before assertions because Docker was unavailable, so exact-head protected E2E remains required.

ReviewGPT context sensitivity: sensitive
Reason: this is hosted-runtime ordering and continuation behavior even though the patch is narrow.

ReviewGPT first-reviewed head: 344907380c06daa9abc96fa72e2ea9e51321b2df
ReviewGPT current authored head: 2c080fc1d8e11fef789f6dc9df21e7f51c9316e4\nBase-only head after the single protected-branch update: 76a42aebdbb8159d1643b778dd2d6cc633b163e2

## ReviewGPT rounds

- Preliminary specialists: no code, product, or test-scaffolding finding. The outcome was INVALID solely for missing production-faithful journey evidence; accepted as a verification requirement, with no code added.
- Final round 1: found that the new exclusive activation continuation could collect unrelated background delivery intents and also suggested device-sync work could run. Accepted the delivery-intent finding and fixed it by reusing the existing exclusive-selection flag plus the activation effect's existing preferred intent ID. Rejected the device-sync portion because the selected activation already sets foregroundCausalAttempted, which makes that branch unreachable. The accepted fix adds no state, owner, retry, queue, or abstraction.

## Verification

- PASS: complete assistant-runtime event and workspace-assistant-phase files, 336 tests.
- PASS: assistant-runtime package typecheck.
- PASS: changelog generation and 38 focused changelog tests.
- PASS: diff and privacy checks.\n- PASS: authored patch identity preserved across the single current-main rebase; no substantive ReviewGPT rerun required.
- BLOCKED before assertions: local hosted foreground E2E could not start because the Docker daemon was unavailable. Exact-head protected GitHub E2E is the canonical runtime proof.

## First-reviewed change shape

Classification is by file role in the base-to-first-reviewed-head diff; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 8 |
| Tests/fixtures | 30 | 13 |
| Docs/content | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 54 | 21 |

## Current change shape

Classification is by file role in the base-to-current-head diff; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 20 | 9 |
| Tests/fixtures | 53 | 13 |
| Docs/content | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 87 | 22 |

## Changelog

- Changelog: updated
- Items: 2026-08-15 · onboarding-stays-caught-up-after-fast-replies

Design proof: not applicable; no frontend UI is changed.

## Deployment compatibility

The change is backward compatible across gradual Worker and warm runner-container skew. Old bundles may defer activation until a later wake; new bundles drain it after the foreground reply. No environment, binding, credential, persisted-shape, or wire-contract change requires an immediate container rollout.