### PR TITLE
chore(ci): expose safe WHOOP auth diagnostics

### DIFF
--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -393,15 +393,27 @@ async function readAuthorizationActionState(
 
 async function describeAuthorizationSurface(page: Page): Promise<string> {
   const countScope = async (scope: Pick<Page, "getByRole">) => {
-    let actions = 0;
-    let enabledActions = 0;
-    for (const role of ["button", "link"] as const) {
-      const controls = scope.getByRole(role, { name: AUTH_ACTION_PATTERN });
+    const countActions = async (controls: Locator) => {
+      let actions = 0;
+      let enabledActions = 0;
       for (let index = 0; index < await controls.count(); index += 1) {
         const state = await readAuthorizationActionState(controls.nth(index));
         if (state !== null) actions += 1;
         if (state === "enabled") enabledActions += 1;
       }
+      return { actions, enabledActions };
+    };
+    let actions = 0;
+    let allActions = 0;
+    let enabledActions = 0;
+    for (const role of ["button", "link"] as const) {
+      const all = await countActions(scope.getByRole(role));
+      const recognized = await countActions(
+        scope.getByRole(role, { name: AUTH_ACTION_PATTERN }),
+      );
+      allActions += all.actions;
+      actions += recognized.actions;
+      enabledActions += recognized.enabledActions;
     }
     const checkboxes = scope.getByRole("checkbox");
     let uncheckedCheckboxes = 0;
@@ -414,7 +426,12 @@ async function describeAuthorizationSurface(page: Page): Promise<string> {
         uncheckedCheckboxes += 1;
       }
     }
-    return { actions, enabledActions, uncheckedCheckboxes };
+    return {
+      actions,
+      enabledActions,
+      otherActions: Math.max(0, allActions - actions),
+      uncheckedCheckboxes,
+    };
   };
   const mainFrame = page.mainFrame();
   const childFrames = page.frames().filter((frame) => frame !== mainFrame);
@@ -425,16 +442,24 @@ async function describeAuthorizationSurface(page: Page): Promise<string> {
   const child = children.reduce((total, current) => ({
     actions: total.actions + current.actions,
     enabledActions: total.enabledActions + current.enabledActions,
+    otherActions: total.otherActions + current.otherActions,
     uncheckedCheckboxes:
       total.uncheckedCheckboxes + current.uncheckedCheckboxes,
-  }), { actions: 0, enabledActions: 0, uncheckedCheckboxes: 0 });
+  }), {
+    actions: 0,
+    enabledActions: 0,
+    otherActions: 0,
+    uncheckedCheckboxes: 0,
+  });
   return [
     "Authorization surface:",
     `childFrames=${childFrames.length}`,
     `mainActions=${main.actions}`,
     `mainEnabledActions=${main.enabledActions}`,
+    `mainOtherActions=${main.otherActions}`,
     `childActions=${child.actions}`,
     `childEnabledActions=${child.enabledActions}`,
+    `childOtherActions=${child.otherActions}`,
     `mainUncheckedCheckboxes=${main.uncheckedCheckboxes}`,
     `childUncheckedCheckboxes=${child.uncheckedCheckboxes}.`,
   ].join(" ");

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -50,6 +50,10 @@ const AUTH_ACTIONS = [
   /\bconfirm\b/i,
   /\bconnect\b/i,
 ] as const;
+const AUTH_ACTION_PATTERN = new RegExp(
+  AUTH_ACTIONS.map((pattern) => pattern.source).join("|"),
+  "iu",
+);
 const NEGATIVE_AUTH_ACTION_PATTERN =
   /\b(?:cancel|decline|deny|disallow|do not|don't|not now|reject|skip)\b/iu;
 const TRUSTED_AUTHORIZATION_DOMAINS = [
@@ -360,15 +364,7 @@ async function clickFirstVisibleAction(
       const controls = page.getByRole(role, { name });
       for (let index = 0; index < await controls.count(); index += 1) {
         const control = controls.nth(index);
-        const actionText = [
-          await control.getAttribute("aria-label").catch(() => null),
-          await control.innerText().catch(() => ""),
-        ].filter(Boolean).join(" ");
-        if (
-          NEGATIVE_AUTH_ACTION_PATTERN.test(actionText)
-          || !await control.isVisible().catch(() => false)
-          || !await control.isEnabled().catch(() => false)
-        ) {
+        if (await readAuthorizationActionState(control) !== "enabled") {
           continue;
         }
         await control.click();
@@ -379,29 +375,68 @@ async function clickFirstVisibleAction(
   return false;
 }
 
+async function readAuthorizationActionState(
+  control: Locator,
+): Promise<"disabled" | "enabled" | null> {
+  const actionText = [
+    await control.getAttribute("aria-label").catch(() => null),
+    await control.innerText().catch(() => ""),
+  ].filter(Boolean).join(" ");
+  if (
+    NEGATIVE_AUTH_ACTION_PATTERN.test(actionText)
+    || !await control.isVisible().catch(() => false)
+  ) {
+    return null;
+  }
+  return await control.isEnabled().catch(() => false) ? "enabled" : "disabled";
+}
+
 async function describeAuthorizationSurface(page: Page): Promise<string> {
-  const actionSelectors = [
-    "button:visible",
-    'input[type="button"]:visible',
-    'input[type="submit"]:visible',
-    '[role="button"]:visible',
-    'a[href]:visible',
-  ];
-  const visibleActions = actionSelectors.join(", ");
-  const enabledVisibleActions = actionSelectors
-    .map((selector) => `${selector}:not(:disabled)`)
-    .join(", ");
-  const [actions, enabledActions, uncheckedCheckboxes] = await Promise.all([
-      page.locator(visibleActions).count(),
-      page.locator(enabledVisibleActions).count(),
-      page.locator('input[type="checkbox"]:visible:not(:checked)').count(),
-    ]);
+  const countScope = async (scope: Pick<Page, "getByRole">) => {
+    let actions = 0;
+    let enabledActions = 0;
+    for (const role of ["button", "link"] as const) {
+      const controls = scope.getByRole(role, { name: AUTH_ACTION_PATTERN });
+      for (let index = 0; index < await controls.count(); index += 1) {
+        const state = await readAuthorizationActionState(controls.nth(index));
+        if (state !== null) actions += 1;
+        if (state === "enabled") enabledActions += 1;
+      }
+    }
+    const checkboxes = scope.getByRole("checkbox");
+    let uncheckedCheckboxes = 0;
+    for (let index = 0; index < await checkboxes.count(); index += 1) {
+      const checkbox = checkboxes.nth(index);
+      if (
+        await checkbox.isVisible().catch(() => false)
+        && !await checkbox.isChecked().catch(() => false)
+      ) {
+        uncheckedCheckboxes += 1;
+      }
+    }
+    return { actions, enabledActions, uncheckedCheckboxes };
+  };
+  const mainFrame = page.mainFrame();
+  const childFrames = page.frames().filter((frame) => frame !== mainFrame);
+  const [main, ...children] = await Promise.all([
+    countScope(mainFrame),
+    ...childFrames.map(countScope),
+  ]);
+  const child = children.reduce((total, current) => ({
+    actions: total.actions + current.actions,
+    enabledActions: total.enabledActions + current.enabledActions,
+    uncheckedCheckboxes:
+      total.uncheckedCheckboxes + current.uncheckedCheckboxes,
+  }), { actions: 0, enabledActions: 0, uncheckedCheckboxes: 0 });
   return [
     "Authorization surface:",
-    `frames=${page.frames().length}`,
-    `actions=${actions}`,
-    `enabledActions=${enabledActions}`,
-    `uncheckedCheckboxes=${uncheckedCheckboxes}.`,
+    `childFrames=${childFrames.length}`,
+    `mainActions=${main.actions}`,
+    `mainEnabledActions=${main.enabledActions}`,
+    `childActions=${child.actions}`,
+    `childEnabledActions=${child.enabledActions}`,
+    `mainUncheckedCheckboxes=${main.uncheckedCheckboxes}`,
+    `childUncheckedCheckboxes=${child.uncheckedCheckboxes}.`,
   ].join(" ");
 }
 

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -260,8 +260,9 @@ async function completeExternalAuthorization(
           `${config.label} authorization was blocked by an external provider challenge.`,
         );
       }
+      const surface = await describeAuthorizationSurface(page);
       throw new Error(
-        `${config.label} did not expose an automated authorization action. Manual completion is available only in a headed non-CI run.`,
+        `${config.label} did not expose an automated authorization action. ${surface} Manual completion is available only in a headed non-CI run.`,
       );
     }
     await page.waitForTimeout(1_000);
@@ -376,6 +377,32 @@ async function clickFirstVisibleAction(
     }
   }
   return false;
+}
+
+async function describeAuthorizationSurface(page: Page): Promise<string> {
+  const actionSelectors = [
+    "button:visible",
+    'input[type="button"]:visible',
+    'input[type="submit"]:visible',
+    '[role="button"]:visible',
+    'a[href]:visible',
+  ];
+  const visibleActions = actionSelectors.join(", ");
+  const enabledVisibleActions = actionSelectors
+    .map((selector) => `${selector}:not(:disabled)`)
+    .join(", ");
+  const [actions, enabledActions, uncheckedCheckboxes] = await Promise.all([
+      page.locator(visibleActions).count(),
+      page.locator(enabledVisibleActions).count(),
+      page.locator('input[type="checkbox"]:visible:not(:checked)').count(),
+    ]);
+  return [
+    "Authorization surface:",
+    `frames=${page.frames().length}`,
+    `actions=${actions}`,
+    `enabledActions=${enabledActions}`,
+    `uncheckedCheckboxes=${uncheckedCheckboxes}.`,
+  ].join(" ");
 }
 
 async function assertWearableConnectionState(

--- a/apps/web/test/hosted-headed-browser-smoke.test.ts
+++ b/apps/web/test/hosted-headed-browser-smoke.test.ts
@@ -1,6 +1,11 @@
 import { chromium } from "@playwright/test";
 import { describe, expect, it } from "vitest";
 
+import {
+  completeExternalJunctionAuthorizationForTest,
+  readHostedLocalJunctionBrowserConfigForTest,
+} from "../scripts/run-hosted-local-junction-wearable-browser";
+
 const smokeEnabled = process.env.MURPH_E2E_HEADED_BROWSER_SMOKE === "1";
 
 describe("hosted headed browser boundary", () => {
@@ -15,4 +20,82 @@ describe("hosted headed browser boundary", () => {
       await browser.close();
     }
   });
+
+  it.runIf(smokeEnabled)(
+    "reports Playwright authorization semantics across frames without content",
+    async () => {
+      const browser = await chromium.launch({ headless: false });
+      try {
+        const page = await browser.newPage();
+        await page.route("https://id.whoop.com/**", (route) => route.fulfill({
+          body: [
+            '<span id="continue-label">Continue synthetic-private-marker</span>',
+            '<div style="width:10px;height:10px" role="button"',
+            ' aria-labelledby="continue-label" aria-disabled="true"></div>',
+            '<a href="#">Privacy policy synthetic-private-marker</a>',
+            '<iframe srcdoc="<button>Authorize synthetic-private-marker</button>',
+            '<input type=checkbox aria-label=&quot;Required consent',
+            ' synthetic-private-marker&quot;>"></iframe>',
+          ].join(""),
+          contentType: "text/html",
+        }));
+        await page.goto("https://id.whoop.com/sign-in");
+        await page.waitForFunction(() =>
+          document.querySelector("iframe")?.contentDocument?.readyState === "complete"
+        );
+        await expect(page.getByRole("button", { name: /continue/iu }).isEnabled())
+          .resolves.toBe(false);
+
+        let now = 0;
+        const timedPage = new Proxy(page, {
+          get(target, property) {
+            if (property === "waitForTimeout") {
+              return async (duration: number) => {
+                now += duration;
+              };
+            }
+            const value = Reflect.get(target, property, target);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+        const config = readHostedLocalJunctionBrowserConfigForTest({
+          CI: "1",
+          NODE_ENV: "test",
+          MURPH_E2E_CONNECT_URL:
+            "https://app.example.test/connect#deviceConnectIntent=opaque&connectSource=whoop",
+          MURPH_E2E_HOSTED_SESSION_COOKIE: "opaque-session",
+          MURPH_E2E_PROVIDER_EMAIL: "browser-canary@example.invalid",
+          MURPH_E2E_PROVIDER_HEADLESS: "0",
+          MURPH_E2E_PROVIDER_PASSWORD: "opaque-password",
+          MURPH_E2E_PROVIDER_SOURCE: "whoop",
+          MURPH_E2E_PROVIDER_TIMEOUT_MS: "30000",
+          MURPH_E2E_WEB_BASE_URL: "https://app.example.test",
+        });
+
+        let failure: Error | undefined;
+        try {
+          await completeExternalJunctionAuthorizationForTest(
+            timedPage,
+            config,
+            () => now,
+          );
+        } catch (error) {
+          if (error instanceof Error) failure = error;
+        }
+
+        expect(failure?.message).toContain([
+          "Authorization surface: childFrames=1 mainActions=1",
+          "mainEnabledActions=0 childActions=1 childEnabledActions=1",
+          "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=1.",
+        ].join(" "));
+        expect(failure?.message).not.toContain("synthetic-private-marker");
+        expect(failure?.message).not.toContain("id.whoop.com");
+        expect(failure?.message).not.toContain("browser-canary@example.invalid");
+        expect(failure?.message).not.toContain("opaque-password");
+        expect(now).toBe(15_000);
+      } finally {
+        await browser.close();
+      }
+    },
+  );
 });

--- a/apps/web/test/hosted-headed-browser-smoke.test.ts
+++ b/apps/web/test/hosted-headed-browser-smoke.test.ts
@@ -32,8 +32,10 @@ describe("hosted headed browser boundary", () => {
             '<span id="continue-label">Continue synthetic-private-marker</span>',
             '<div style="width:10px;height:10px" role="button"',
             ' aria-labelledby="continue-label" aria-disabled="true"></div>',
+            '<button>Proceed synthetic-private-marker</button>',
             '<a href="#">Privacy policy synthetic-private-marker</a>',
             '<iframe srcdoc="<button>Authorize synthetic-private-marker</button>',
+            '<button>Proceed synthetic-private-marker</button>',
             '<input type=checkbox aria-label=&quot;Required consent',
             ' synthetic-private-marker&quot;>"></iframe>',
           ].join(""),
@@ -46,18 +48,6 @@ describe("hosted headed browser boundary", () => {
         await expect(page.getByRole("button", { name: /continue/iu }).isEnabled())
           .resolves.toBe(false);
 
-        let now = 0;
-        const timedPage = new Proxy(page, {
-          get(target, property) {
-            if (property === "waitForTimeout") {
-              return async (duration: number) => {
-                now += duration;
-              };
-            }
-            const value = Reflect.get(target, property, target);
-            return typeof value === "function" ? value.bind(target) : value;
-          },
-        });
         const config = readHostedLocalJunctionBrowserConfigForTest({
           CI: "1",
           NODE_ENV: "test",
@@ -71,28 +61,69 @@ describe("hosted headed browser boundary", () => {
           MURPH_E2E_PROVIDER_TIMEOUT_MS: "30000",
           MURPH_E2E_WEB_BASE_URL: "https://app.example.test",
         });
+        const readFailure = async (subjectPage: typeof page) => {
+          let now = 0;
+          const timedPage = new Proxy(subjectPage, {
+            get(target, property) {
+              if (property === "waitForTimeout") {
+                return async (duration: number) => {
+                  now += duration;
+                };
+              }
+              const value = Reflect.get(target, property, target);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+          let failure: Error | undefined;
+          try {
+            await completeExternalJunctionAuthorizationForTest(
+              timedPage,
+              config,
+              () => now,
+            );
+          } catch (error) {
+            if (error instanceof Error) failure = error;
+          }
+          return { failure, now };
+        };
 
-        let failure: Error | undefined;
-        try {
-          await completeExternalJunctionAuthorizationForTest(
-            timedPage,
-            config,
-            () => now,
-          );
-        } catch (error) {
-          if (error instanceof Error) failure = error;
-        }
-
-        expect(failure?.message).toContain([
+        const complex = await readFailure(page);
+        expect(complex.failure?.message).toContain([
           "Authorization surface: childFrames=1 mainActions=1",
-          "mainEnabledActions=0 childActions=1 childEnabledActions=1",
+          "mainEnabledActions=0 mainOtherActions=2 childActions=1",
+          "childEnabledActions=1 childOtherActions=1",
           "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=1.",
         ].join(" "));
-        expect(failure?.message).not.toContain("synthetic-private-marker");
-        expect(failure?.message).not.toContain("id.whoop.com");
-        expect(failure?.message).not.toContain("browser-canary@example.invalid");
-        expect(failure?.message).not.toContain("opaque-password");
-        expect(now).toBe(15_000);
+        expect(complex.failure?.message).not.toContain("synthetic-private-marker");
+        expect(complex.failure?.message).not.toContain("id.whoop.com");
+        expect(complex.failure?.message).not.toContain("browser-canary@example.invalid");
+        expect(complex.failure?.message).not.toContain("opaque-password");
+        expect(complex.now).toBe(15_000);
+
+        const emptyPage = await browser.newPage();
+        await emptyPage.route("https://id.whoop.com/empty", (route) =>
+          route.fulfill({ body: "", contentType: "text/html" })
+        );
+        await emptyPage.goto("https://id.whoop.com/empty");
+        const empty = await readFailure(emptyPage);
+
+        const unknownPage = await browser.newPage();
+        await unknownPage.route("https://id.whoop.com/unknown", (route) =>
+          route.fulfill({
+            body: "<button>Proceed synthetic-private-marker</button>",
+            contentType: "text/html",
+          })
+        );
+        await unknownPage.goto("https://id.whoop.com/unknown");
+        const unknown = await readFailure(unknownPage);
+
+        expect(empty.failure?.message).toContain(
+          "mainOtherActions=0 childActions=0",
+        );
+        expect(unknown.failure?.message).toContain(
+          "mainOtherActions=1 childActions=0",
+        );
+        expect(unknown.failure?.message).not.toContain("synthetic-private-marker");
       } finally {
         await browser.close();
       }

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -212,7 +212,8 @@ describe("hosted-local Junction wearable browser authorization", () => {
       [
         "WHOOP did not expose an automated authorization action.",
         "Authorization surface: childFrames=0 mainActions=0",
-        "mainEnabledActions=0 childActions=0 childEnabledActions=0",
+        "mainEnabledActions=0 mainOtherActions=0 childActions=0",
+        "childEnabledActions=0 childOtherActions=0",
         "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=0.",
       ].join(" "),
     );
@@ -223,11 +224,14 @@ describe("hosted-local Junction wearable browser authorization", () => {
   it("uses Playwright action state and attributes child-frame controls", async () => {
     let now = 0;
     const mainFrame = authorizationFrame({
-      buttons: [{ accessibleName: "Continue", enabled: false, text: "" }],
+      buttons: [
+        { accessibleName: "Continue", enabled: false, text: "" },
+        { text: "Proceed" },
+      ],
       links: [{ text: "Privacy policy" }],
     });
     const childFrame = authorizationFrame({
-      buttons: [{ text: "Authorize" }],
+      buttons: [{ text: "Authorize" }, { text: "Proceed" }],
       checkboxes: [{ checked: false, text: "Required consent" }],
     });
     const page = {
@@ -248,7 +252,8 @@ describe("hosted-local Junction wearable browser authorization", () => {
       () => now,
     )).rejects.toThrow([
       "Authorization surface: childFrames=1 mainActions=1",
-      "mainEnabledActions=0 childActions=1 childEnabledActions=1",
+      "mainEnabledActions=0 mainOtherActions=2 childActions=1",
+      "childEnabledActions=1 childOtherActions=1",
       "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=1.",
     ].join(" "));
   });

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -162,7 +162,11 @@ describe("hosted-local Junction wearable browser authorization", () => {
       config,
       () => now,
     )).rejects.toThrow(
-      "WHOOP did not expose an automated authorization action.",
+      [
+        "WHOOP did not expose an automated authorization action.",
+        "Authorization surface: frames=1 actions=0 enabledActions=0",
+        "uncheckedCheckboxes=0.",
+      ].join(" "),
     );
     expect(now).toBe(15_000);
     },

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -46,6 +46,51 @@ function actionLocator(click: () => void) {
   };
 }
 
+function roleLocator(
+  controls: Array<{
+    accessibleName?: string;
+    checked?: boolean;
+    enabled?: boolean;
+    text: string;
+    visible?: boolean;
+  }>,
+) {
+  return {
+    count: vi.fn(async () => controls.length),
+    nth: vi.fn((index: number) => ({
+      getAttribute: vi.fn(async () => null),
+      innerText: vi.fn(async () => controls[index]?.text ?? ""),
+      isChecked: vi.fn(async () => controls[index]?.checked ?? false),
+      isEnabled: vi.fn(async () => controls[index]?.enabled ?? true),
+      isVisible: vi.fn(async () => controls[index]?.visible ?? true),
+    })),
+  };
+}
+
+function authorizationFrame(input: {
+  buttons?: Parameters<typeof roleLocator>[0];
+  checkboxes?: Parameters<typeof roleLocator>[0];
+  links?: Parameters<typeof roleLocator>[0];
+}) {
+  return {
+    getByRole: vi.fn((role: string, options?: { name?: RegExp }) => {
+      const controls = role === "button"
+        ? input.buttons ?? []
+        : role === "link"
+        ? input.links ?? []
+        : role === "checkbox"
+        ? input.checkboxes ?? []
+        : [];
+      return roleLocator(options?.name
+        ? controls.filter((control) => options.name?.test(
+          control.accessibleName ?? control.text,
+        ))
+        : controls);
+    }),
+    url: () => "https://id.whoop.com/sign-in",
+  };
+}
+
 describe("hosted-local Junction wearable browser authorization", () => {
   it("fails a continuous external challenge after the bounded grace period", async () => {
     let now = 0;
@@ -145,10 +190,12 @@ describe("hosted-local Junction wearable browser authorization", () => {
     async (ci) => {
     let now = 0;
     const config = createConfig({ CI: ci });
+    const mainFrame = authorizationFrame({});
     const page = {
-      frames: () => [{ url: () => "https://id.whoop.com/sign-in" }],
-      getByRole: vi.fn(() => emptyLocator()),
+      frames: () => [mainFrame],
+      getByRole: mainFrame.getByRole,
       locator: vi.fn(() => emptyLocator()),
+      mainFrame: () => mainFrame,
       title: vi.fn(async () => "Sign in"),
       url: () => "https://id.whoop.com/sign-in",
       waitForTimeout: vi.fn(async (duration: number) => {
@@ -164,13 +211,47 @@ describe("hosted-local Junction wearable browser authorization", () => {
     )).rejects.toThrow(
       [
         "WHOOP did not expose an automated authorization action.",
-        "Authorization surface: frames=1 actions=0 enabledActions=0",
-        "uncheckedCheckboxes=0.",
+        "Authorization surface: childFrames=0 mainActions=0",
+        "mainEnabledActions=0 childActions=0 childEnabledActions=0",
+        "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=0.",
       ].join(" "),
     );
     expect(now).toBe(15_000);
     },
   );
+
+  it("uses Playwright action state and attributes child-frame controls", async () => {
+    let now = 0;
+    const mainFrame = authorizationFrame({
+      buttons: [{ accessibleName: "Continue", enabled: false, text: "" }],
+      links: [{ text: "Privacy policy" }],
+    });
+    const childFrame = authorizationFrame({
+      buttons: [{ text: "Authorize" }],
+      checkboxes: [{ checked: false, text: "Required consent" }],
+    });
+    const page = {
+      frames: () => [mainFrame, childFrame],
+      getByRole: mainFrame.getByRole,
+      locator: vi.fn(() => emptyLocator()),
+      mainFrame: () => mainFrame,
+      title: vi.fn(async () => "Sign in"),
+      url: () => "https://id.whoop.com/sign-in",
+      waitForTimeout: vi.fn(async (duration: number) => {
+        now += duration;
+      }),
+    };
+
+    await expect(completeExternalJunctionAuthorizationForTest(
+      page as never,
+      createConfig(),
+      () => now,
+    )).rejects.toThrow([
+      "Authorization surface: childFrames=1 mainActions=1",
+      "mainEnabledActions=0 childActions=1 childEnabledActions=1",
+      "mainUncheckedCheckboxes=0 childUncheckedCheckboxes=1.",
+    ].join(" "));
+  });
 
   it("always disables manual completion in headless mode", () => {
     expect(createConfig({


### PR DESCRIPTION
## Why this PR exists

The protected WHOOP-through-Junction canary reaches the provider authorization page but reports only that no automated action was available. That evidence cannot distinguish an unrecognized action, a disabled authorization control, or a control moved into a child frame, so changing selectors without a bounded diagnostic would be guesswork.

## User goal / user-visible behavior

No member-facing behavior changes. When the protected canary cannot continue after its existing 15-second grace period, maintainers receive fixed-label numeric evidence that distinguishes recognized and other visible actions, main-frame and child-frame location, enabled state, and unchecked checkboxes without publishing provider content.

## User experience

This is an internal protected-main verification path. The existing browser automation still uses the same accessible roles, prioritized action names, visibility checks, enabled checks, trusted-host gate, and exact callback proof. Only the terminal failure text changes, after the canary can no longer continue automatically.

## Invariants the PR must preserve

- Emit only fixed labels and numeric counts from the authorization-surface diagnostic; never record page text, account identity, credentials, DOM, screenshots, traces, or provider artifacts. The existing outer failure prefix may retain only its sanitized origin-and-path location.
- Preserve Playwright accessible-name, visibility, and enabled semantics for the actual click path.
- Keep provider credentials scoped to the existing protected Environment and browser child.
- Leave trusted authorization hosts, exact callback proof, retry timing, and fail-closed challenge handling unchanged.

## Non-obvious affected surfaces

- clickFirstVisibleAction now calls the shared state reader used by the diagnostic. This is an extraction of its existing negative-label, visibility, and enabled checks; action priority and accessible-name selection remain unchanged. The focused unit test and synthetic real-Playwright scenarios prove the disabled accessible-name and unknown-label paths.
- Child frames are read only after the terminal grace boundary. They contribute numeric aggregates only and cannot change authorization or click behavior.
- The existing action vocabulary still owns clicking. The terminal diagnostic separately reports visible, non-negative button/link controls outside that vocabulary as numeric `mainOtherActions` and `childOtherActions` counts, so a provider label change is distinguishable from an empty page without recording labels.

## Architecture and reuse

- Existing systems reused: the current 15-second no-action boundary, Playwright role/accessibility semantics, existing action vocabulary, and sanitized failure boundary.
- New logic: one combined accessible-name matcher for the recognized subset and one local numeric main/child-frame surface counter, including two derived other-action counts, at the existing terminal failure boundary.
- New abstractions: one local action-state helper shared by clicking and failure diagnosis; no cross-file or durable abstraction.
- Complexity intentionally avoided: no screenshot, DOM capture, provider text, artifact, retry path, state, dependency, workflow authority, or alternate browser owner.

## Changelog

- Changelog: not applicable
- Reason: Internal protected-main verification only; no member-visible behavior changes.

## Hot reply path impact

Not applicable. This code runs only in the protected external-provider canary and is not part of member message admission, provider start, or reply delivery.

## Database collection fanout impact

Not applicable. The change performs no database read, write, transaction, or collection work.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, provider request assembly, model configuration, or generated guidance changed.
- Group Murph: Not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: applicable only to the maintainer canary outcome; no member-facing journey changes.
- Prompt: not applicable; no prompt or instruction changes.
- Frontend: not applicable; no user-facing Web presentation changes.
- Coverage: applicable; focused unit proof plus the committed real-Chromium smoke cover the terminal numeric schema, disabled accessible-name action, empty-versus-unknown action diagnosis, main/child attribution, unchecked checkboxes, and content exclusion. Required exact-head CI passed on the base-only rebased head.

ReviewGPT context sensitivity: sensitive
Reason: The code runs inside a protected external-provider browser canary with credential-adjacent execution.

ReviewGPT first-reviewed head: 9d65b694f18b04540a3c3687bac59921f6994079

## ReviewGPT head ledger

| Stage | Head | Source | Tests |
| --- | --- | ---: | ---: |
| First reviewed | 9d65b694f18b04540a3c3687bac59921f6994079 | +28 / -1 | +5 / -1 |
| Final reviewed remediation | 8e1fea1b47e11237a8eea28c6df72f8d84a88e60 | +97 / -10 | +207 / -3 |
| Current base-only rebased head | 9be84d61517dfcda5659071e0eac19edf170478e | +97 / -10 | +207 / -3 |

Final round 1 accepted one finding: the first diagnostic used CSS disabled-state semantics and main-frame-only action counts, which diverged from the automation's Playwright accessibility semantics. The remediation deletes that CSS classifier, reuses the click path's state reader, and reports main/child aggregates.

Final round 2 verified that correction and accepted one review-induced finding: filtering the entire diagnostic inventory through the known action matcher made an enabled unknown-label control indistinguishable from an empty page. The current remediation keeps the click matcher unchanged and adds only two derived numeric other-action counts. Authored source changed by +69 additions and +9 deletions from the immutable first-reviewed head; no new owner, state, retry, or artifact path was added.

Final round 3 returned PASS for the full patch at `8e1fea1b47e11237a8eea28c6df72f8d84a88e60`. The later base-only rebase produced current head `9be84d61517dfcda5659071e0eac19edf170478e` with the same patch ID (`5c49a7f64760ba5072df4d1840919049c47fd439`); intervening base changes did not touch the three PR files, so ReviewGPT was not rerun for that history-only update.

## Review anomaly retrospective

Decision: explicitly justified continuation of the current local terminal-diagnostic design. This retrospective is recorded against immutable first-reviewed head `9d65b694f18b04540a3c3687bac59921f6994079` and current head `8e1fea1b47e11237a8eea28c6df72f8d84a88e60` before retrying substantive round 3.

The irreducible requirement remains fixed-label numeric evidence that distinguishes: an empty surface from an unknown action label; a disabled from an enabled recognized action; a main-frame from a child-frame control; and an unchecked consent control. The prioritized click vocabulary and privacy boundary must remain unchanged.

The first-reviewed PR shape was source +28/-1 and tests +5/-1. The current PR shape is source +97/-10 and tests +207/-3. The direct review-remediation delta from first-reviewed to current is source +89/-29 and tests +204/-4. Round 1 caused the CSS-to-Playwright semantic correction, shared action-state reader, frame attribution, and real-browser proof. Round 2 caused the recognized-versus-other inventory split and empty-versus-unknown browser scenarios. The mechanisms are distinct; neither added durable state, an owner, retry behavior, workflow authority, artifacts, dependencies, or a new lifecycle.

Deletion or reversion would restore the proven disabled-state or unknown-label ambiguity. Splitting the logic would add an owner boundary around one failure-only call site. A redesign cannot remove the four required dimensions: the shared state reader is necessary to keep diagnosis aligned with clicking; the recognized/other split is necessary to distinguish an unknown label without recording it; frame aggregation is necessary to locate moved controls without DOM capture; and real Chromium proof is necessary because the original failure came from mocks and CSS disagreeing with Playwright accessibility semantics. The current implementation keeps all of those concepts local to the existing terminal boundary, so continuation is smaller and safer than reverting, splitting, or introducing replacement machinery.

## Verification

- PASS: focused hosted Web browser-driver and headed-browser test files, 16 tests.
- PASS: hosted Web typecheck.
- PASS: focused ESLint and git diff check.
- PASS: committed headed-Chromium terminal scenarios distinguish an empty page from an enabled unknown-label control, exercise an ARIA-disabled accessible-name control, other main/child controls, and a child-frame action/checkbox, and exclude synthetic content from the emitted diagnostic.
- PASS: final ReviewGPT round 3 on the full patch at the final reviewed remediation head.
- PASS: required GitHub Actions on current base-only rebased head `9be84d61517dfcda5659071e0eac19edf170478e`.

## Change-shape breakdown

Classification: production browser driver is source; its focused Vitest files are tests/fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 97 | 10 |
| Tests/fixtures | 207 | 3 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 304 | 13 |

## Design proof

Not applicable; no user-facing frontend UI is changed.

## Deployment skew / compatibility

No production runtime, binding, environment, schema, or wire contract changes. The diagnostic runs only after the protected canary is already terminally blocked. The shipped click path remains behavior-compatible; the next protected-main canary is the required live proof.
