### PR TITLE
fix(assistant): retain direct welcome context

### DIFF
--- a/apps/web/changelog/entries/2026-08-15/first-replies-finish-account-setup.json
+++ b/apps/web/changelog/entries/2026-08-15/first-replies-finish-account-setup.json
@@ -7,7 +7,7 @@
     "priority": 3,
     "title": "First replies now finish account setup cleanly",
     "summary": "When someone messages Murph immediately after joining, Murph can answer without leaving the new conversation's setup work behind.",
-    "details": "This improves the first-conversation handoff while keeping welcome messages and shared-room setup on their existing durable delivery path.",
+    "details": "Welcome messages stay on their durable delivery path and remain available as context for the member's first direct reply, while shared-room setup keeps its existing isolated path.",
     "relevanceTags": ["assistant", "messaging", "onboarding", "reliability"],
     "sourcePullRequests": [1864]
   }

--- a/packages/assistant-engine/src/assistant/automation/cross-session-route-state.ts
+++ b/packages/assistant-engine/src/assistant/automation/cross-session-route-state.ts
@@ -137,9 +137,12 @@ export function resolveAssistantAutoReplyInputExactRoute(input: {
       : null
   }
 
-  const actorId = normalizeNullableString(input.conversation.actorId)
+  const actorScope = resolveAssistantAutoReplyActorScope({
+    actorId: input.conversation.actorId,
+    threadIsDirect: input.conversation.threadIsDirect,
+  })
   const threadId = normalizeNullableString(input.conversation.threadId)
-  if (!actorId || !threadId) {
+  if (!actorScope || !threadId) {
     return null
   }
 
@@ -149,7 +152,7 @@ export function resolveAssistantAutoReplyInputExactRoute(input: {
       ? buildAssistantAutoReplyExactRoute([
           'email',
           identityId,
-          actorId,
+          actorScope,
           threadId,
         ])
       : null
@@ -162,7 +165,7 @@ export function resolveAssistantAutoReplyInputExactRoute(input: {
     ? buildAssistantAutoReplyExactRoute([
         'channel',
         channel,
-        actorId,
+        actorScope,
         threadId,
         deliveryTarget,
       ])
@@ -195,9 +198,12 @@ export function resolveAssistantAutoReplyOutboxExactRoute(
       : null
   }
 
-  const actorId = normalizeNullableString(intent.actorId)
+  const actorScope = resolveAssistantAutoReplyActorScope({
+    actorId: intent.actorId,
+    threadIsDirect: intent.threadIsDirect,
+  })
   const threadId = normalizeNullableString(intent.threadId)
-  if (!actorId || !threadId) {
+  if (!actorScope || !threadId) {
     return null
   }
 
@@ -207,7 +213,7 @@ export function resolveAssistantAutoReplyOutboxExactRoute(
       ? buildAssistantAutoReplyExactRoute([
           'email',
           identityId,
-          actorId,
+          actorScope,
           threadId,
         ])
       : null
@@ -218,7 +224,7 @@ export function resolveAssistantAutoReplyOutboxExactRoute(
     ? buildAssistantAutoReplyExactRoute([
         'channel',
         channel,
-        actorId,
+        actorScope,
         threadId,
         deliveryTarget,
       ])
@@ -1144,6 +1150,14 @@ function resolveExactLinqProviderThreadTarget(
   return delivery.targetKind === 'thread'
     ? readAssistantTargetProviderScalar(delivery.target)
     : null
+}
+
+function resolveAssistantAutoReplyActorScope(input: {
+  actorId: string | null | undefined
+  threadIsDirect: boolean | null | undefined
+}): string | null {
+  return normalizeNullableString(input.actorId)
+    ?? (input.threadIsDirect === true ? '@direct' : null)
 }
 
 function normalizeRouteChannel(value: string | null | undefined): string | null {

--- a/packages/assistant-engine/test/assistant-auto-reply-route-state.test.ts
+++ b/packages/assistant-engine/test/assistant-auto-reply-route-state.test.ts
@@ -97,10 +97,29 @@ describe('assistant auto-reply exact route state', () => {
       conversation: createConversation({ source: 'telegram' }),
       deliveryTarget: 'telegram-target-2',
     })).digest).not.toBe(telegramRoute.digest)
+    const actorlessDirectTelegramInput = requireRoute(
+      resolveAssistantAutoReplyInputExactRoute({
+        conversation: createConversation({
+          actorId: null,
+          source: 'telegram',
+        }),
+        deliveryTarget: 'telegram-target-1',
+      }),
+    )
+    const actorlessDirectTelegramOutbox = requireRoute(
+      resolveAssistantAutoReplyOutboxExactRoute(createOutboxIntent({
+        actorId: null,
+        channel: 'telegram',
+        target: 'telegram-target-1',
+      })),
+    )
+    expect(actorlessDirectTelegramOutbox.digest)
+      .toBe(actorlessDirectTelegramInput.digest)
     expect(resolveAssistantAutoReplyInputExactRoute({
       conversation: createConversation({
         actorId: null,
         source: 'telegram',
+        threadIsDirect: false,
       }),
       deliveryTarget: 'telegram-target-1',
     })).toBeNull()
@@ -108,6 +127,7 @@ describe('assistant auto-reply exact route state', () => {
       actorId: null,
       channel: 'telegram',
       target: 'telegram-target-1',
+      threadIsDirect: false,
     }))).toBeNull()
     expect(resolveAssistantAutoReplyOutboxExactRoute(createOutboxIntent({
       channel: 'linq',
@@ -1419,6 +1439,7 @@ function createOutboxIntent(input: {
   target?: string
   targetKind?: 'explicit' | 'participant' | 'thread'
   threadId?: string | null
+  threadIsDirect?: boolean | null
 } = {}): AssistantOutboxIntent {
   const channel = input.channel ?? 'email'
   const intentId = input.intentId ?? 'intent-default'
@@ -1445,7 +1466,9 @@ function createOutboxIntent(input: {
       : input.identityId,
     actorId: input.actorId === undefined ? 'actor-1' : input.actorId,
     threadId: input.threadId === undefined ? 'thread-1' : input.threadId,
-    threadIsDirect: true,
+    threadIsDirect: input.threadIsDirect === undefined
+      ? true
+      : input.threadIsDirect,
     bindingDelivery: null,
     explicitTarget: target,
     delivery: {

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -3263,6 +3263,50 @@ describe('assistant auto-reply event-first path', () => {
     }))
   })
 
+  it('injects prior delivery context for an actor-less direct Telegram route', async () => {
+    const vault = await createTempVault()
+    replyEventPathMocks.resolveAssistantSession.mockResolvedValue({
+      created: false,
+      session: {
+        lastTurnAt: '2026-04-08T00:02:00.000Z',
+        sessionId: 'session-chat',
+      },
+    })
+    replyEventPathMocks.listAssistantOutboxIntents.mockResolvedValue([
+      createOutboxMessage({
+        actorId: null,
+        channel: 'telegram',
+        intentId: 'intent-signup-welcome',
+        message: 'Welcome to the direct chat.',
+        sentAt: '2026-04-08T00:05:00.000Z',
+        sessionId: 'session-activation',
+        threadIsDirect: true,
+      }),
+    ])
+    await completeAutoReplyRouteMigration(vault)
+    const candidate = createAssistantInputCandidate({
+      actorId: null,
+      occurredAt: '2026-04-08T00:10:00.000Z',
+      optionalInboxCaptureId: null,
+      source: 'telegram',
+      text: 'What can you help me with?',
+      threadIsDirect: true,
+    })
+
+    await processAssistantAutoReplyGroup({
+      allowSelfAuthored: false,
+      context: createReplyContext(candidate),
+      enabledChannels: ['telegram'],
+      inboxServices: createInboxServices(),
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault,
+    })
+
+    const sendInput = replyEventPathMocks.sendAssistantMessage.mock.calls[0]?.[0]
+    expect(sendInput.turnContext).toContain('Welcome to the direct chat.')
+  })
+
   it('injects cross-session context across provider and local clock skew', async () => {
     const vault = await createTempVault()
     replyEventPathMocks.resolveAssistantSession.mockResolvedValue({
@@ -5172,6 +5216,7 @@ function createOutboxMessage(input: {
   status?: 'pending' | 'sent'
   target?: string
   threadId?: string | null
+  threadIsDirect?: boolean | null
   turnId?: string
 }) {
   const status = input.status ?? 'sent'
@@ -5213,6 +5258,9 @@ function createOutboxMessage(input: {
     sessionId: input.sessionId,
     status,
     threadId: input.threadId === undefined ? providerThreadId : input.threadId,
+    threadIsDirect: input.threadIsDirect === undefined
+      ? true
+      : input.threadIsDirect,
     turnId: input.turnId ?? `turn-${input.intentId}`,
   }
 }


### PR DESCRIPTION
## Why

The cross-session route-state change merged immediately before #1864 requires an exact actor partition for non-Linq routes. Direct Telegram conversations intentionally have no actor ID because the direct thread already proves the single participant. As a result, a delivered signup welcome was present in the outbox but excluded from the member's first inbound provider context.

## User-visible goal

Keep an already-delivered welcome available as context when a member sends the first message in the same direct conversation.

## Product journey

- Initiating actor: a newly activated member replying in their direct Telegram conversation.
- Entry point and timing: the welcome is delivered in the activation wake; the member's first inbound arrives in a later wake.
- Feedback and destination: the normal first reply can interpret the welcome that Murph already sent.
- Continuation owner: the existing exact-route state and assistant reply path.
- Permission boundary: missing actor scope is accepted only when the persisted route proves `threadIsDirect === true`.
- Recovery contract: group and unknown routes with no actor remain fail-closed; actor-bearing exact-route digests are unchanged.

## Invariants

- A proven direct thread can be exact without an actor partition.
- Non-direct and unknown routes still require an actor ID.
- Actor-bearing direct and group routes retain their existing exact digest.
- Route-state reads, claims, migration, and retry ownership remain unchanged.
- No new queue, retry owner, state store, service, or dependency is introduced.

## Architecture and reuse

- Existing systems reused: the input and outbox exact-route resolvers, route digest, watermark, claim, and migration machinery remain the sole owners.
- New logic: one shared actor-scope derivation keeps an existing actor value or substitutes the reserved direct-thread scope only when `threadIsDirect === true`.
- New abstractions: one narrow pure helper; no new service, state owner, persisted shape, or dependency.
- Complexity intentionally avoided: no compatibility path, queue, retry loop, route manager, or second source of truth.

## Non-obvious affected surfaces

- Signup welcome continuity for direct Telegram first contact.
- Actor-less direct email routes can use the same proven-direct rule.
- Mixed actor partitions, groups, and legacy wildcard matches remain isolated.

## Review remediation ledger

- #1864's exact-head matrix exposed the failure after the activation-order correction itself had passed focused review.
- Root cause proof: direct Telegram import and welcome delivery both intentionally carry `actorId: null`; the new exact-route resolver returned no route before reading the direct-thread proof.
- Correction: preserve actor partitions when present and substitute a reserved scope only for a proven direct thread.

## Review lenses

- Product experience: applicable; restores first-contact conversation continuity, with the direct Telegram cross-repository scenario as journey evidence.
- Prompt: not applicable; no prompt or tool-description changes.
- Frontend: not applicable; no user-facing frontend UI changed and no rendered evidence is required.
- Coverage: applicable; 114 focused exact-route and reply-path tests pass, and exact-head CI is in progress.

## Line breakdown

Classification rule: executable production code is source; regression cases are tests; the changelog entry is docs/process; no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 22 | 8 |
| Tests/fixtures | 72 | 1 |
| Docs/process | 1 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 95 | 10 |

## Verification

- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/assistant-auto-reply-route-state.test.ts test/assistant-automation-reply-event-path.test.ts` from `packages/assistant-engine` (114 passed)
- `pnpm --filter @murphai/assistant-engine typecheck`
- `pnpm --dir apps/web typecheck:prepared`
- `pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/changelog-fragments.test.ts` (7 passed)
- `git diff --check`
- Exact cross-repository correction proof: the direct Telegram scenario passed in run 31895428855; a later full retry is being evaluated separately.

## Changelog

- Changelog: updated
- Items: 2026-08-15 · first-replies-finish-account-setup
- Member outcome: a delivered welcome remains available as direct-conversation context for the first reply.

ReviewGPT context sensitivity: sensitive

This PR changes exact-route privacy partitioning, so every substantive final review uses a full snapshot.

ReviewGPT first-reviewed head: 533cd3786608298b3111c53065ef860beae0a1cd
