### PR TITLE
Add Vonneumann ReviewGPT browser lane

### DIFF
--- a/.agents/friction-log/20260815150339-reviewgpt-accepted-new/friction.md
+++ b/.agents/friction-log/20260815150339-reviewgpt-accepted-new/friction.md
@@ -1,0 +1,28 @@
+---
+title: 'ReviewGPT accepted new conversation is not bound after send'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+After a managed-browser run auto-submits a new ChatGPT conversation, the wrapper should bind the accepted `/c/` URL and continue response capture without resending.
+
+## Current Behavior
+
+A clean exact-head `completion-specialists --wait` run can confirm the attachment, requested model selection, and committed auto-send, then fail because it cannot prove one exact accepted conversation URL. The browser has exactly one newly accepted conversation and the response completes there, but the wrapper exits with an unknown staging result and forbids a resend. A second exact-head attempt reproduces the same failure. Manual same-lane export recovers the response text but loses the waited-send model attestation required by the review gate.
+
+## Possible Solution
+
+After committed auto-send, add a bounded recovery that compares the owned target set before and after submission, binds the single new authenticated `/c/` target, and resumes the existing waited capture without submitting again.
+
+## Minimal Reproducible Example
+
+1. Use an authenticated managed browser profile with a live CDP endpoint and no active generated response.
+2. Run the repository `completion-specialists --wait` command for a clean pushed pull-request head.
+3. Observe attachment readiness, requested-model selection, and committed auto-send.
+4. Observe the wrapper fail to bind the accepted conversation URL while exactly one new `/c/` target contains the submitted request.
+5. Export that target from the same managed lane and observe the response complete there without any second send.
+
+## Context
+
+This blocks attestation of a mandatory preliminary review even though browser launch, attachment upload, send, and response generation all succeed. Retrying consumes another model run but does not improve the transport evidence.

--- a/agent-docs/exec-plans/active/2026-08-15-vonneumann-browser-lane.md
+++ b/agent-docs/exec-plans/active/2026-08-15-vonneumann-browser-lane.md
@@ -14,8 +14,9 @@ Updated: 2026-08-15
 
 - `REVIEW_GPT_BROWSER_LANE=vonneumann` resolves to the Vonneumann app/profile
   and an unused dedicated CDP port.
-- Automatic lane selection supports all five isolated lanes and preserves the
-  existing availability/lock checks.
+- Automatic lane selection supports all five isolated lanes after a
+  provisioned host opts into lane count five, while the portable repository
+  default remains the existing four lanes.
 - Focused tooling tests, shell syntax validation, and a ReviewGPT dry run pass.
 - The local Vonneumann app bundle has a unique bundle identifier, display name,
   custom icon, executable Brave binary, and valid ad-hoc code signature.
@@ -70,6 +71,9 @@ Updated: 2026-08-15
   `vonneumann`.
 - Use port `9446`; it is distinct from Phlebas `9442`, Hercules `9444`, Eragon
   `9448`, Mountain `9450`, and Main `9452`.
+- Keep the portable repository default at four lanes. Hosts opt into all five
+  through the existing machine-local lane-count preference only after the
+  Vonneumann profile is provisioned.
 - Keep the generated icon and full app bundle local rather than committing
   machine-specific binary assets.
 - Use a small bundle-local launcher to supply the lane's CDP port and profile
@@ -86,13 +90,16 @@ Updated: 2026-08-15
 - The local app bundle is installed with a unique identifier, launcher,
   isolated profile, ad-hoc signature, and generated icon. Its CDP endpoint is
   live on port `9446`.
+- The preliminary specialist review identified the unprovisioned-host default
+  risk and missing dynamic pin/isolation proof. Both findings were accepted and
+  remediated without adding a provisioning detector or new abstraction.
 
 ## Verification
 
 - `bash -n scripts/review-gpt.config.sh`
 - Focused `release-script-coverage-audit` test invocation.
-- `REVIEW_GPT_BROWSER_LANE=vonneumann pnpm --silent review:gpt pr-review --dry-run`
-  with safe PR-preflight inputs once a PR exists.
+- An exact-head `completion-specialists` run pinned to
+  `REVIEW_GPT_BROWSER_LANE=vonneumann` with safe PR-preflight inputs.
 - `codesign --verify --deep --strict`, `plutil -lint`, bundle metadata readback,
   executable/icon checks, port mapping readback, and privacy-safe diff review.
 
@@ -101,8 +108,13 @@ Current evidence:
 - Shell syntax checks pass for the repository config, machine-local selector,
   and bundle launcher.
 - Focused static and dynamic `release-script-coverage-audit` tests pass,
-  including automatic selection of Vonneumann when the first four lanes are
-  unavailable.
+  including portable four-lane default behavior, host opt-in selection of
+  Vonneumann, explicit pinning, unique ports/profile isolation, and later-round
+  prompt reuse.
 - `pnpm --filter @murphai/murph typecheck` passes.
 - Bundle signature, plist, executable, icon, version, wrapper-equivalent lane
   readback, older-worktree compatibility, and live CDP checks pass.
+- The exact-head specialist run packaged and submitted through the existing
+  Vonneumann profile on port `9446`. Its two findings were accepted and fixed;
+  the exported response reported unknown model confirmation, so model
+  provenance remains an explicit ReviewGPT evidence gap rather than a pass.

--- a/agent-docs/exec-plans/active/2026-08-15-vonneumann-browser-lane.md
+++ b/agent-docs/exec-plans/active/2026-08-15-vonneumann-browser-lane.md
@@ -1,0 +1,108 @@
+# Add the Vonneumann ReviewGPT browser lane
+
+Status: active
+Created: 2026-08-15
+Updated: 2026-08-15
+
+## Goal
+
+- Add `Vonneumann` as a fifth isolated ReviewGPT managed-browser lane, backed
+  by its own local Brave app bundle, profile directory, CDP port, and custom
+  icon, without changing the existing four lanes.
+
+## Success criteria
+
+- `REVIEW_GPT_BROWSER_LANE=vonneumann` resolves to the Vonneumann app/profile
+  and an unused dedicated CDP port.
+- Automatic lane selection supports all five isolated lanes and preserves the
+  existing availability/lock checks.
+- Focused tooling tests, shell syntax validation, and a ReviewGPT dry run pass.
+- The local Vonneumann app bundle has a unique bundle identifier, display name,
+  custom icon, executable Brave binary, and valid ad-hoc code signature.
+
+## Scope
+
+- In scope: ReviewGPT lane config, focused regression assertions, the canonical
+  ReviewGPT operating doc, machine-local lane preferences, and the local app
+  bundle/profile mapping.
+- Out of scope: browser automation behavior, ChatGPT account migration, changes
+  to existing lane profiles, and committed browser binaries or generated icon
+  artwork.
+
+## Constraints
+
+- Technical constraints: preserve `main`, the `aragon` alias, existing ports,
+  availability-aware random selection, and same-thread lane pinning. Use CDP
+  port `9446`, which is currently unclaimed and fits the existing port series.
+- Product/process constraints: keep browser/profile data machine-local, do not
+  expose personal identifiers, and run the required PR-lane specialist review
+  concurrently with CI once the exact candidate head is pushed.
+
+## Risks and mitigations
+
+1. Risk: enabling a fifth random choice can break older worktrees that do not
+   recognize `vonneumann`.
+   Mitigation: make the machine-local selector include Vonneumann only when the
+   calling checkout's config declares that lane; older worktrees retain their
+   four-lane pool.
+2. Risk: cloning or re-signing the app bundle can corrupt its executable
+   layout.
+   Mitigation: clone a current matching Brave lane bundle, change only bundle
+   identity/icon metadata, ad-hoc sign it, and verify the signature, executable,
+   icon, and version before launch.
+3. Risk: a live port/profile collision could mix browser state.
+   Mitigation: verify port `9446` has no listener and use the dedicated
+   `MurphReviewGPT/Vonneumann` profile directory.
+
+## Tasks
+
+1. Extend lane display, port, count, automatic selection, and explicit pinning.
+2. Update focused release-script assertions and dynamic selection proof.
+3. Update the canonical ReviewGPT lane documentation.
+4. Build the local custom-icon Vonneumann app bundle and update the guarded
+   machine-local five-lane selector.
+5. Run focused tests, shell/bundle checks, and a Vonneumann dry run.
+6. Review, commit, push, open the PR, and complete required ReviewGPT/CI gates.
+
+## Decisions
+
+- Use the exact user-supplied display spelling `Vonneumann` and lowercase slug
+  `vonneumann`.
+- Use port `9446`; it is distinct from Phlebas `9442`, Hercules `9444`, Eragon
+  `9448`, Mountain `9450`, and Main `9452`.
+- Keep the generated icon and full app bundle local rather than committing
+  machine-specific binary assets.
+- Use a small bundle-local launcher to supply the lane's CDP port and profile
+  defaults while preserving caller overrides. The launcher also uses Brave's
+  mock keychain mode so a newly isolated local profile can reach CDP without a
+  blocking macOS Keychain prompt.
+
+## Progress
+
+- Repository config, focused assertions, and operating documentation now
+  recognize Vonneumann as the fifth lane.
+- The machine-local selector admits Vonneumann only for checkouts whose config
+  supports it, so older worktrees keep their existing four-lane pool.
+- The local app bundle is installed with a unique identifier, launcher,
+  isolated profile, ad-hoc signature, and generated icon. Its CDP endpoint is
+  live on port `9446`.
+
+## Verification
+
+- `bash -n scripts/review-gpt.config.sh`
+- Focused `release-script-coverage-audit` test invocation.
+- `REVIEW_GPT_BROWSER_LANE=vonneumann pnpm --silent review:gpt pr-review --dry-run`
+  with safe PR-preflight inputs once a PR exists.
+- `codesign --verify --deep --strict`, `plutil -lint`, bundle metadata readback,
+  executable/icon checks, port mapping readback, and privacy-safe diff review.
+
+Current evidence:
+
+- Shell syntax checks pass for the repository config, machine-local selector,
+  and bundle launcher.
+- Focused static and dynamic `release-script-coverage-audit` tests pass,
+  including automatic selection of Vonneumann when the first four lanes are
+  unavailable.
+- `pnpm --filter @murphai/murph typecheck` passes.
+- Bundle signature, plist, executable, icon, version, wrapper-equivalent lane
+  readback, older-worktree compatibility, and live CDP checks pass.

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -410,9 +410,10 @@ the current user explicitly asks for it.
    authority.
 
    `REVIEW_GPT_BROWSER_LANE_COUNT` limits the automatic pool to the first one
-   through five lanes and defaults to five. A local
-   `$XDG_CONFIG_HOME/murph/review-gpt.conf` may set this without committing
-   machine-specific preferences or account details.
+   through five lanes and defaults to four. A host with a provisioned
+   Vonneumann profile opts into all five by setting it in the local
+   `$XDG_CONFIG_HOME/murph/review-gpt.conf`, without committing machine-specific
+   preferences or account details.
 
    A lane is considered usable when its managed profile is unlocked, or when its
    configured CDP endpoint is already alive. The default random path skips a

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -12,7 +12,7 @@ completion:
 2. The separate `pr-review` loop is the final cross-cutting gate for eligible work
    and replaces local `deep-review`.
 
-Both stages use the managed Eragon, Phlebas, Hercules, and Mountain browser
+Both stages use the managed Eragon, Phlebas, Hercules, Mountain, and Vonneumann browser
 lanes. They
 never share round state: the preliminary pass does not create or advance the
 final gate's immutable first-reviewed-head baseline. After focused local proof
@@ -400,7 +400,8 @@ the current user explicitly asks for it.
 
    The repo wrapper runs the current installed Brave binary with one usable
    ReviewGPT browser lane per run: Eragon on CDP port `9448`, Phlebas on `9442`,
-   Hercules on `9444`, or Mountain on `9450`, always with profile `Default` and
+   Hercules on `9444`, Mountain on `9450`, or Vonneumann on `9446`, always with
+   profile `Default` and
    `app_connector=current` so review context comes from the guarded ZIP and
    not a ChatGPT connector. ReviewGPT attaches that snapshot as
    `codebase.zip`; Repomix is disabled by default and is not part of this flow.
@@ -409,7 +410,7 @@ the current user explicitly asks for it.
    authority.
 
    `REVIEW_GPT_BROWSER_LANE_COUNT` limits the automatic pool to the first one
-   through four lanes and defaults to four. A local
+   through five lanes and defaults to five. A local
    `$XDG_CONFIG_HOME/murph/review-gpt.conf` may set this without committing
    machine-specific preferences or account details.
 
@@ -426,7 +427,7 @@ the current user explicitly asks for it.
    downgrading the model.
 
    To pin a specific lane, preserve a conversation's workspace, or debug one
-   profile, set `REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain` on
+   profile, set `REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain|vonneumann` on
    that command.
    `aragon` is accepted as an alias for `eragon`. A first round may leave it
    unset to select a usable lane automatically, but its handoff must record the

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1462,6 +1462,7 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
+    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4')
     expect(reviewGptConfig).toContain('REVIEW_GPT_THREAD_URL')
     expect(reviewGptConfig).toContain('review_gpt_reuses_existing_thread=1')
     expect(reviewGptConfig).toContain(
@@ -1730,6 +1731,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(prReviewGptLoop).toContain('default randomized usable managed')
     expect(prReviewGptLoop).toContain('Hercules on `9444`')
     expect(prReviewGptLoop).toContain('Vonneumann on `9446`')
+    expect(prReviewGptLoop).toContain('through five lanes and defaults to four')
     expect(prReviewGptLoop).toContain('current installed Brave binary')
     expect(prReviewGptLoop).toContain(
       "passes none of Chromium's background-timer, occluded-window, or renderer",
@@ -2247,8 +2249,8 @@ printf '%s|%s|%s|%s|%s\n' \
         defaultBackgroundMode,
         defaultDisplayMode,
       ] = defaultResult.stdout.trim().split('|')
-      expect(defaultLane).toBe('vonneumann')
-      expect(defaultLaneCount).toBe('5')
+      expect(['eragon', 'phlebas', 'hercules', 'mountain']).toContain(defaultLane)
+      expect(defaultLaneCount).toBe('4')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
@@ -2268,8 +2270,89 @@ printf '%s|%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
+
+      writeHarnessFile(
+        localConfigRoot,
+        'murph/review-gpt.conf',
+        'REVIEW_GPT_BROWSER_LANE_COUNT=5\n',
+      )
+      const optedInResult = spawnSync('bash', ['-c', configHarness], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...cleanBrowserPreferenceEnv(),
+          HOME: harnessRoot,
+          REPO_ROOT: repoRoot,
+          XDG_CONFIG_HOME: localConfigRoot,
+        },
+      })
+      expect(optedInResult.status, optedInResult.stderr).toBe(0)
+      expect(optedInResult.stdout.trim()).toBe(
+        'vonneumann|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+      )
+
+      const vonneumannFollowupHarness = `${configHarness}
+printf '%s|%s|%s|%s|%s\n' \
+  "$review_gpt_selected_browser_lane" \
+  "$review_gpt_selected_browser_display" \
+  "$review_gpt_selected_browser_port" \
+  "$managed_browser_user_data_dir" \
+  "$review_gpt_pr_review_prompt_file"
+review_gpt_managed_ports=()
+for review_gpt_lane in main eragon phlebas hercules mountain vonneumann; do
+  review_gpt_managed_ports+=("$(review_gpt_browser_lane_port "$review_gpt_lane")")
+done
+printf '%s\n' "\${review_gpt_managed_ports[*]}"
+`
+      const vonneumannFollowupResult = spawnSync(
+        'bash',
+        ['-c', vonneumannFollowupHarness],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...cleanBrowserPreferenceEnv(),
+            HOME: harnessRoot,
+            REPO_ROOT: repoRoot,
+            REVIEW_GPT_BROWSER_LANE: 'vonneumann',
+            REVIEW_GPT_REVIEW_PHASE: 'final',
+            REVIEW_GPT_ROUND_NUMBER: '2',
+            REVIEW_GPT_THREAD_URL: 'https://chatgpt.com/c/review-thread',
+            XDG_CONFIG_HOME: localConfigRoot,
+          },
+        },
+      )
+      expect(
+        vonneumannFollowupResult.status,
+        vonneumannFollowupResult.stderr,
+      ).toBe(0)
+      const vonneumannFollowupLines = vonneumannFollowupResult.stdout
+        .trim()
+        .split('\n')
+      expect(vonneumannFollowupLines.at(-2)).toBe(
+        [
+          'vonneumann',
+          'Vonneumann',
+          '9446',
+          path.join(
+            harnessRoot,
+            'Library/Application Support/MurphReviewGPT/Vonneumann',
+          ),
+          'pr-followup-review.md',
+        ].join('|'),
+      )
+      const managedPorts = vonneumannFollowupLines.at(-1)?.split(' ') ?? []
+      expect(managedPorts).toEqual([
+        '9452',
+        '9448',
+        '9442',
+        '9444',
+        '9450',
+        '9446',
+      ])
+      expect(new Set(managedPorts).size).toBe(managedPorts.length)
 
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -2293,67 +2293,6 @@ printf '%s|%s|%s|%s|%s\n' \
         'vonneumann|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
-      const vonneumannFollowupHarness = `${configHarness}
-printf '%s|%s|%s|%s|%s\n' \
-  "$review_gpt_selected_browser_lane" \
-  "$review_gpt_selected_browser_display" \
-  "$review_gpt_selected_browser_port" \
-  "$managed_browser_user_data_dir" \
-  "$review_gpt_pr_review_prompt_file"
-review_gpt_managed_ports=()
-for review_gpt_lane in main eragon phlebas hercules mountain vonneumann; do
-  review_gpt_managed_ports+=("$(review_gpt_browser_lane_port "$review_gpt_lane")")
-done
-printf '%s\n' "\${review_gpt_managed_ports[*]}"
-`
-      const vonneumannFollowupResult = spawnSync(
-        'bash',
-        ['-c', vonneumannFollowupHarness],
-        {
-          cwd: repoRoot,
-          encoding: 'utf8',
-          env: {
-            ...cleanBrowserPreferenceEnv(),
-            HOME: harnessRoot,
-            REPO_ROOT: repoRoot,
-            REVIEW_GPT_BROWSER_LANE: 'vonneumann',
-            REVIEW_GPT_REVIEW_PHASE: 'final',
-            REVIEW_GPT_ROUND_NUMBER: '2',
-            REVIEW_GPT_THREAD_URL: 'https://chatgpt.com/c/review-thread',
-            XDG_CONFIG_HOME: localConfigRoot,
-          },
-        },
-      )
-      expect(
-        vonneumannFollowupResult.status,
-        vonneumannFollowupResult.stderr,
-      ).toBe(0)
-      const vonneumannFollowupLines = vonneumannFollowupResult.stdout
-        .trim()
-        .split('\n')
-      expect(vonneumannFollowupLines.at(-2)).toBe(
-        [
-          'vonneumann',
-          'Vonneumann',
-          '9446',
-          path.join(
-            harnessRoot,
-            'Library/Application Support/MurphReviewGPT/Vonneumann',
-          ),
-          'pr-followup-review.md',
-        ].join('|'),
-      )
-      const managedPorts = vonneumannFollowupLines.at(-1)?.split(' ') ?? []
-      expect(managedPorts).toEqual([
-        '9452',
-        '9448',
-        '9442',
-        '9444',
-        '9450',
-        '9446',
-      ])
-      expect(new Set(managedPorts).size).toBe(managedPorts.length)
-
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,
         encoding: 'utf8',
@@ -2460,7 +2399,14 @@ printf '%s\n' "\${review_gpt_managed_ports[*]}"
         'https://chatgpt.com/c/fallback-thread',
       )
 
-      const correctionPresetHarness = `${configHarness}\nprintf '%s\\n' "$review_gpt_pr_review_prompt_file"`
+      const correctionPresetHarness = `${configHarness}
+printf '%s|%s|%s|%s|%s\n' "$review_gpt_selected_browser_lane" "$review_gpt_selected_browser_display" "$review_gpt_selected_browser_port" "$managed_browser_user_data_dir" "$review_gpt_pr_review_prompt_file"
+review_gpt_managed_ports=()
+for review_gpt_lane in main eragon phlebas hercules mountain vonneumann; do
+  review_gpt_managed_ports+=("$(review_gpt_browser_lane_port "$review_gpt_lane")")
+done
+printf '%s\n' "\${review_gpt_managed_ports[*]}"
+`
       const correctionPresetResult = spawnSync('bash', ['-c', correctionPresetHarness], {
         cwd: repoRoot,
         encoding: 'utf8',
@@ -2468,7 +2414,7 @@ printf '%s\n' "\${review_gpt_managed_ports[*]}"
           ...cleanBrowserPreferenceEnv(),
           HOME: harnessRoot,
           REPO_ROOT: repoRoot,
-          REVIEW_GPT_BROWSER_LANE: 'eragon',
+          REVIEW_GPT_BROWSER_LANE: 'vonneumann',
           REVIEW_GPT_REVIEW_PHASE: 'final',
           REVIEW_GPT_ROUND_NUMBER: '2',
           REVIEW_GPT_THREAD_URL: 'https://chatgpt.com/c/review-thread',
@@ -2476,9 +2422,29 @@ printf '%s\n' "\${review_gpt_managed_ports[*]}"
         },
       })
       expect(correctionPresetResult.status, correctionPresetResult.stderr).toBe(0)
-      expect(correctionPresetResult.stdout.trim().split('\n').at(-1)).toBe(
-        'pr-followup-review.md',
+      const correctionPresetLines = correctionPresetResult.stdout.trim().split('\n')
+      expect(correctionPresetLines.at(-2)).toBe(
+        [
+          'vonneumann',
+          'Vonneumann',
+          '9446',
+          path.join(
+            harnessRoot,
+            'Library/Application Support/MurphReviewGPT/Vonneumann',
+          ),
+          'pr-followup-review.md',
+        ].join('|'),
       )
+      const managedPorts = correctionPresetLines.at(-1)?.split(' ') ?? []
+      expect(managedPorts).toEqual([
+        '9452',
+        '9448',
+        '9442',
+        '9444',
+        '9450',
+        '9446',
+      ])
+      expect(new Set(managedPorts).size).toBe(managedPorts.length)
 
       const explicitFullHarness = `${configHarness}\nprintf '%s\\n' "$review_gpt_pr_review_prompt_file"\nprintf '%s\\n' "\${chatgpt_url:-new-conversation}"`
       const explicitFullResult = spawnSync('bash', ['-c', explicitFullHarness], {

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1455,8 +1455,10 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptConfig).toContain('thinking="current"')
     expect(reviewGptConfig).toContain('hercules) printf \'%s\\n\' "Hercules" ;;')
     expect(reviewGptConfig).toContain('hercules) printf \'%s\\n\' "9444" ;;')
+    expect(reviewGptConfig).toContain('vonneumann) printf \'%s\\n\' "Vonneumann" ;;')
+    expect(reviewGptConfig).toContain('vonneumann) printf \'%s\\n\' "9446" ;;')
     expect(reviewGptConfig).toContain(
-      'review_gpt_all_browser_lanes=(eragon phlebas hercules mountain)',
+      'review_gpt_all_browser_lanes=(eragon phlebas hercules mountain vonneumann)',
     )
     expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
@@ -1723,16 +1725,17 @@ describe('monorepo release flow coverage audit', () => {
       'The `pr-review` prompt lives at',
     )
     expect(prReviewGptLoop).toContain(
-      'Both stages use the managed Eragon, Phlebas, Hercules, and Mountain browser',
+      'Both stages use the managed Eragon, Phlebas, Hercules, Mountain, and Vonneumann browser',
     )
     expect(prReviewGptLoop).toContain('default randomized usable managed')
     expect(prReviewGptLoop).toContain('Hercules on `9444`')
+    expect(prReviewGptLoop).toContain('Vonneumann on `9446`')
     expect(prReviewGptLoop).toContain('current installed Brave binary')
     expect(prReviewGptLoop).toContain(
       "passes none of Chromium's background-timer, occluded-window, or renderer",
     )
     expect(prReviewGptLoop).toContain(
-      '`REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain`',
+      '`REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain|vonneumann`',
     )
     expect(prReviewGptLoop).toContain('6,500 UTF-8 bytes')
     expect(prReviewGptLoop).toContain(
@@ -2219,7 +2222,7 @@ printf '%s|%s|%s|%s|%s\n' \
       )
 
       rmSync(path.join(localConfigRoot, 'murph', 'review-gpt.conf'))
-      for (const lane of ['Eragon', 'Phlebas', 'Hercules']) {
+      for (const lane of ['Eragon', 'Phlebas', 'Hercules', 'Mountain']) {
         writeHarnessFile(
           harnessRoot,
           `Library/Application Support/MurphReviewGPT/${lane}/SingletonLock`,
@@ -2244,8 +2247,8 @@ printf '%s|%s|%s|%s|%s\n' \
         defaultBackgroundMode,
         defaultDisplayMode,
       ] = defaultResult.stdout.trim().split('|')
-      expect(defaultLane).toBe('mountain')
-      expect(defaultLaneCount).toBe('4')
+      expect(defaultLane).toBe('vonneumann')
+      expect(defaultLaneCount).toBe('5')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
@@ -2265,7 +2268,7 @@ printf '%s|%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        'main|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -2293,6 +2293,31 @@ printf '%s|%s|%s|%s|%s\n' \
         'vonneumann|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
+      writeHarnessFile(
+        localConfigRoot,
+        'murph/review-gpt.conf',
+        'REVIEW_GPT_BROWSER_LANE_COUNT=6\n',
+      )
+      const invalidLaneCountResult = spawnSync('bash', ['-c', configHarness], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...cleanBrowserPreferenceEnv(),
+          HOME: harnessRoot,
+          REPO_ROOT: repoRoot,
+          XDG_CONFIG_HOME: localConfigRoot,
+        },
+      })
+      expect(invalidLaneCountResult.status).not.toBe(0)
+      expect(invalidLaneCountResult.stderr).toContain(
+        'REVIEW_GPT_BROWSER_LANE_COUNT must be an integer from 1 to 5',
+      )
+      writeHarnessFile(
+        localConfigRoot,
+        'murph/review-gpt.conf',
+        'REVIEW_GPT_BROWSER_LANE_COUNT=5\n',
+      )
+
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,
         encoding: 'utf8',
@@ -2407,22 +2432,28 @@ for review_gpt_lane in main eragon phlebas hercules mountain vonneumann; do
 done
 printf '%s\n' "\${review_gpt_managed_ports[*]}"
 `
-      const correctionPresetResult = spawnSync('bash', ['-c', correctionPresetHarness], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        env: {
-          ...cleanBrowserPreferenceEnv(),
-          HOME: harnessRoot,
-          REPO_ROOT: repoRoot,
-          REVIEW_GPT_BROWSER_LANE: 'vonneumann',
-          REVIEW_GPT_REVIEW_PHASE: 'final',
-          REVIEW_GPT_ROUND_NUMBER: '2',
-          REVIEW_GPT_THREAD_URL: 'https://chatgpt.com/c/review-thread',
-          XDG_CONFIG_HOME: localConfigRoot,
+      const correctionPresetResult = spawnSync(
+        'bash',
+        ['-c', correctionPresetHarness],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...cleanBrowserPreferenceEnv(),
+            HOME: harnessRoot,
+            REPO_ROOT: repoRoot,
+            REVIEW_GPT_BROWSER_LANE: 'vonneumann',
+            REVIEW_GPT_REVIEW_PHASE: 'final',
+            REVIEW_GPT_ROUND_NUMBER: '2',
+            REVIEW_GPT_THREAD_URL: 'https://chatgpt.com/c/review-thread',
+            XDG_CONFIG_HOME: localConfigRoot,
+          },
         },
-      })
+      )
       expect(correctionPresetResult.status, correctionPresetResult.stderr).toBe(0)
-      const correctionPresetLines = correctionPresetResult.stdout.trim().split('\n')
+      const correctionPresetLines = correctionPresetResult.stdout
+        .trim()
+        .split('\n')
       expect(correctionPresetLines.at(-2)).toBe(
         [
           'vonneumann',

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -12,7 +12,7 @@ if [[ -r "$review_gpt_local_config" ]]; then
 fi
 
 review_gpt_invalid_browser_lane() {
-  echo "Error: unsupported ReviewGPT browser lane '$1'. Use main, random, eragon, phlebas, hercules, or mountain." >&2
+  echo "Error: unsupported ReviewGPT browser lane '$1'. Use main, random, eragon, phlebas, hercules, mountain, or vonneumann." >&2
 }
 
 review_gpt_browser_lane_display_name() {
@@ -22,6 +22,7 @@ review_gpt_browser_lane_display_name() {
     phlebas) printf '%s\n' "Phlebas" ;;
     hercules) printf '%s\n' "Hercules" ;;
     mountain) printf '%s\n' "Mountain" ;;
+    vonneumann) printf '%s\n' "Vonneumann" ;;
     *)
       review_gpt_invalid_browser_lane "$1"
       return 1
@@ -36,6 +37,7 @@ review_gpt_browser_lane_port() {
     phlebas) printf '%s\n' "9442" ;;
     hercules) printf '%s\n' "9444" ;;
     mountain) printf '%s\n' "9450" ;;
+    vonneumann) printf '%s\n' "9446" ;;
     *)
       review_gpt_invalid_browser_lane "$1"
       return 1
@@ -123,7 +125,7 @@ else
   review_gpt_requested_browser_lane="${REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_PROFILE_SLUG:-auto}}}"
 fi
 review_gpt_requested_browser_lane="$(printf '%s' "$review_gpt_requested_browser_lane" | tr '[:upper:]' '[:lower:]')"
-review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
+review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-5}}"
 
 if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then
   case "$review_gpt_requested_browser_lane" in
@@ -134,8 +136,8 @@ if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then
   esac
 fi
 
-if [[ ! "$review_gpt_browser_lane_count" =~ ^[1-4]$ ]]; then
-  echo "Error: REVIEW_GPT_BROWSER_LANE_COUNT must be an integer from 1 to 4." >&2
+if [[ ! "$review_gpt_browser_lane_count" =~ ^[1-5]$ ]]; then
+  echo "Error: REVIEW_GPT_BROWSER_LANE_COUNT must be an integer from 1 to 5." >&2
   return 1 2>/dev/null || exit 1
 fi
 
@@ -144,7 +146,7 @@ case "$review_gpt_requested_browser_lane" in
     review_gpt_selected_browser_lane="main"
     ;;
   "" | auto | random)
-    review_gpt_all_browser_lanes=(eragon phlebas hercules mountain)
+    review_gpt_all_browser_lanes=(eragon phlebas hercules mountain vonneumann)
     review_gpt_browser_lanes=("${review_gpt_all_browser_lanes[@]:0:review_gpt_browser_lane_count}")
     review_gpt_usable_browser_lanes=()
 
@@ -164,7 +166,7 @@ case "$review_gpt_requested_browser_lane" in
   aragon | eragon)
     review_gpt_selected_browser_lane="eragon"
     ;;
-  phlebas | hercules | mountain)
+  phlebas | hercules | mountain | vonneumann)
     review_gpt_selected_browser_lane="$review_gpt_requested_browser_lane"
     ;;
   *)

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -125,7 +125,7 @@ else
   review_gpt_requested_browser_lane="${REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_PROFILE_SLUG:-auto}}}"
 fi
 review_gpt_requested_browser_lane="$(printf '%s' "$review_gpt_requested_browser_lane" | tr '[:upper:]' '[:lower:]')"
-review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-5}}"
+review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
 
 if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then
   case "$review_gpt_requested_browser_lane" in


### PR DESCRIPTION
## Why

Murph's managed ReviewGPT pool had four isolated browser lanes. Add a fifth lane, `Vonneumann`, so provisioned hosts have another independent browser/profile workspace without disrupting machines that still have only the established four.

## What changed

- Add `vonneumann` display-name, CDP-port (`9446`), explicit-selection, and automatic-pool mappings.
- Support an opt-in automatic lane count of five while keeping the portable repository default at four.
- Extend static and dynamic regression assertions for host opt-in, explicit Vonneumann pinning, distinct profile/port ownership, unique managed ports, and later-round reuse.
- Update the canonical ReviewGPT operating documentation.

The custom-icon Brave app bundle, generated icon, isolated profile, and machine-local five-lane preference remain local and are not committed.

## Architecture and reuse

- Existing systems reused: the current lane mapping functions, profile lock/CDP availability checks, random usable-lane selection, same-thread pinning, and machine-local config hook.
- New logic: one fifth mapping entry, a `1..5` supported count, and focused proof that only a provisioned host opts into count five.
- New abstractions: none; the existing lane mapping and local-preference contracts are sufficient.
- Complexity intentionally avoided: no new dependency, browser manager, provisioning detector, persisted state, or committed binary asset.

Existing lane names, ports, profiles, `main`, `aragon`, and later-round thread pinning remain unchanged. Vonneumann uses its own profile directory and port so browser state cannot mix with another managed lane.

## Impact and UX

Internal developer tooling only. ReviewGPT can be pinned with `REVIEW_GPT_BROWSER_LANE=vonneumann`; a provisioned host can include it in automatic selection by setting the existing local lane count to five. There is no member-visible UI or product behavior change.

## Operational impact

- Non-obvious affected surfaces: the internal ReviewGPT operator workflow and its local managed-browser selection only; focused config tests cover it.
- Hot reply path impact: not applicable; no conversation acceptance or reply handoff code changed.
- Database collection fanout impact: not applicable; no database path changed.
- Murph initial provider input impact: not applicable; no provider-visible prompt, schema, skill instruction, or request assembly changed.

## Changelog

- Changelog: not applicable
- Reason: Internal ReviewGPT tooling only; no member-visible behavior changed.

## Preliminary specialist lenses

- Product experience: not applicable; internal review tooling only.
- Prompt: not applicable; no provider-visible prompt, tool schema, or request assembly changed.
- Frontend: not applicable; no UI code or rendered surface changed.
- Coverage: applicable; focused static/dynamic lane tests and direct bundle/CDP proof pass, while exact-head CI is pending on the remediated head.

ReviewGPT context sensitivity: routine
Reason: narrow internal tooling/configuration change with no runtime, auth, data, deploy, or trust-boundary impact.

## Verification

- `bash -n scripts/review-gpt.config.sh`: pass.
- Focused dynamic `release-script-coverage-audit` test for local preferences, selection, isolation, and later-round reuse: pass.
- Focused static `release-script-coverage-audit` test for config/docs mappings: pass.
- `pnpm --filter @murphai/murph typecheck`: pass.
- Wrapper-equivalent Murph config readback: `vonneumann`, `Vonneumann`, port `9446`, count `5` on this provisioned host.
- Older-worktree compatibility harness: retains a four-lane local pool.
- Local bundle `codesign --verify --deep --strict`, plist, executable, icon, and browser-version checks: pass.
- Live Vonneumann CDP endpoint on `127.0.0.1:9446`: pass (Chrome protocol 1.3).
- `git diff --check` and privacy-safe diff scan: pass.
- Local follow-up proof that lane count `6` fails with the `1 to 5` error: pass and committed on the current head.
- Exact-head GitHub Actions: pending on the remediated head.

The diff-focused verifier completed 661 repository-tool tests and CLI typecheck, then waited for the shared host slot; it also reported the repository's existing workspace-boundary baseline outside this change. Exact-head CI owns the remaining broad proof.

## Preliminary specialist result

The first exact-head request was packaged and submitted through Vonneumann on port `9446`. Two findings were accepted and fixed on the pushed head: keep the portable default at four until a host opts into the provisioned fifth lane, and dynamically prove explicit Vonneumann pinning plus its isolation boundary. The evidence retry found one additional low-severity coverage gap for rejecting lane count `6`; that proof is committed on the current head. Both recovered responses reported `MODEL_CONFIRMATION: UNKNOWN`, so the mandatory specialist model attestation remains blocked by the recorded accepted-URL race and is not claimed as a pass.

## Provider-visible input measurement

Not applicable for both runtimes. This change does not alter prompts, tool descriptions/schemas, skill instructions, provider request assembly, or model/tool mode.

## Design proof

Not applicable; no user-facing frontend UI changed.

## Change shape

Classification rule: authored files are grouped by their repository role; the execution plan and operating guide are docs, the shell lane selector is config/tooling, and the Vitest file is tests/fixtures. No binary or generated files are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 104 | 21 |
| Docs | 128 | 6 |
| Config/tooling | 7 | 5 |
| Generated/other | 28 | 0 |
| Total | 267 | 32 |