### PR TITLE
chore: update ReviewGPT to 0.5.131

### DIFF
--- a/.agents/friction-log/20260815150017-reviewgpt-recovery-rejects/friction.md
+++ b/.agents/friction-log/20260815150017-reviewgpt-recovery-rejects/friction.md
@@ -1,0 +1,21 @@
+---
+title: 'ReviewGPT recovery rejects a duplicated exact assistant response'
+severity: 'minor'
+target: 'cobuildwithus/review-gpt'
+---
+
+## Observed
+
+ReviewGPT 0.5.131 confirmed the ZIP before sending, then failed closed because the committed user turn reportedly retained 0/1 attachments. Its persisted exact-target recovery later found two assistant response snapshots and refused the wake as ambiguous. A structured diagnostic export showed one user turn with the expected codebase ZIP and one substantive completed response rendered twice under different DOM identifiers; both response snapshots had the same marker and content, and one owned the returned artifact button.
+
+## Expected
+
+Committed-turn verification should recognize the retained attachment. Exact-target recovery should canonicalize duplicate DOM representations of the same assistant response before enforcing uniqueness.
+
+## Impact
+
+A required preliminary review completed, but automatic response capture, exact wake, and artifact download all failed. Manual diagnostic inspection was required, and the returned test-only patch could not be downloaded.
+
+## Workaround
+
+Run `thread diagnose` against the exact browser endpoint and thread, validate the single user turn and duplicated response content manually, then implement an accepted textual finding without consuming the artifact. Do not resend the original review prompt.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.17",
-    "@cobuild/review-gpt": "^0.5.127",
+    "@cobuild/review-gpt": "^0.5.131",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1329,9 +1329,12 @@ describe('monorepo release flow coverage audit', () => {
     expect(tooFastGuard).toContain('throw new Error(responseResult.responseDurationFailure')
     expect(tooFastGuard).not.toContain('writeCompletedResponseArtifacts')
     expect(tooFastGuard).not.toContain('modelVerification')
-    expect(
-      reviewGptDriver.indexOf('assertMarkedResponseDurationTrusted(responseResult'),
-    ).toBeLessThan(completedArtifactWriteStart)
+    const tooFastGuardInvocationStart = reviewGptDriver.indexOf(
+      'assertMarkedResponseDurationTrusted(responseResult',
+      tooFastGuardEnd,
+    )
+    expect(tooFastGuardInvocationStart).toBeGreaterThan(tooFastGuardEnd)
+    expect(tooFastGuardInvocationStart).toBeLessThan(completedArtifactWriteStart)
     expect(reviewGptDriver).toContain('process.exit(1);')
     expect(reviewGptDriver).toContain(
       [

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1097,13 +1097,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.127')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.131')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.127'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.131'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1165,7 +1165,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptDriver).toContain('`CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain('`Nested CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain(
-      'const MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS = 5 * 60 * 1000;',
+      'const minimumMarkedResponseMs = Number(process.env.ORACLE_DRAFT_MINIMUM_MARKED_RESPONSE_MS || 5 * 60 * 1000);',
     )
     const solTarget: ReviewGptModelPickerTarget = {
       desiredVersion: '5-6',
@@ -1246,7 +1246,7 @@ describe('monorepo release flow coverage audit', () => {
       ),
     ).toBe(false)
     expect(reviewGptDriver).toContain(
-      'const MODEL_CONFIRMATION_UNKNOWN_FALLBACK_MS = MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS;',
+      'const MODEL_CONFIRMATION_UNKNOWN_FALLBACK_MS = 5 * 60 * 1000;',
     )
     expect(reviewGptDriver).toContain("status: 'response-too-fast'")
     expect(reviewGptDriver).toContain('markedResponseDurationFailure({')
@@ -1258,7 +1258,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptReadme).toContain('An ephemeral per-run nonce')
     expect(reviewGptReadme).toContain('after at least 5 minutes of observed generation')
     expect(reviewGptReadme).toContain(
-      'A marked concrete-model response that completes in under 5 minutes fails closed as untrusted',
+      'A marked concrete-model response shorter than the trust threshold fails closed as untrusted',
     )
     expect(reviewGptDriver).toContain('REVIEW_GPT_TURN_NONCE:')
     expect(reviewGptDriver).not.toContain("value.includes('MODEL_CONFIRMATION:')")
@@ -1312,19 +1312,26 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(responseDurationGuardStart).toBeGreaterThan(-1)
     expect(responseAttestationStart).toBeGreaterThan(responseDurationGuardStart)
-    const tooFastBranchStart = reviewGptDriver.indexOf(
-      "} else if (responseResult?.status === 'response-too-fast') {",
+    const tooFastGuardStart = reviewGptDriver.indexOf(
+      'function assertMarkedResponseDurationTrusted(',
     )
-    const tooFastBranchEnd = reviewGptDriver.indexOf('} else {', tooFastBranchStart)
-    const tooFastBranch = reviewGptDriver.slice(tooFastBranchStart, tooFastBranchEnd)
-    expect(tooFastBranchStart).toBeGreaterThan(-1)
-    expect(tooFastBranchEnd).toBeGreaterThan(tooFastBranchStart)
-    expect(tooFastBranch).toContain(
-      'writeCapturedResponseFile(responseFile, responseResult.responseText);',
+    const tooFastGuardEnd = reviewGptDriver.indexOf(
+      'function capturedResponseFileText(',
+      tooFastGuardStart,
     )
-    expect(tooFastBranch).toContain('throw new Error(responseResult.responseDurationFailure')
-    expect(tooFastBranch).not.toContain('writeCompletedResponseArtifacts')
-    expect(tooFastBranch).not.toContain('modelVerification')
+    const tooFastGuard = reviewGptDriver.slice(tooFastGuardStart, tooFastGuardEnd)
+    expect(tooFastGuardStart).toBeGreaterThan(-1)
+    expect(tooFastGuardEnd).toBeGreaterThan(tooFastGuardStart)
+    expect(tooFastGuard).toContain("responseResult?.status !== 'response-too-fast'")
+    expect(tooFastGuard).toContain(
+      'writeCapturedResponseFile(responseFilePath, responseResult.responseText);',
+    )
+    expect(tooFastGuard).toContain('throw new Error(responseResult.responseDurationFailure')
+    expect(tooFastGuard).not.toContain('writeCompletedResponseArtifacts')
+    expect(tooFastGuard).not.toContain('modelVerification')
+    expect(
+      reviewGptDriver.indexOf('assertMarkedResponseDurationTrusted(responseResult'),
+    ).toBeLessThan(completedArtifactWriteStart)
     expect(reviewGptDriver).toContain('process.exit(1);')
     expect(reviewGptDriver).toContain(
       [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       '@cobuild/review-gpt':
-        specifier: ^0.5.127
-        version: 0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.131
+        version: 0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1472,8 +1472,8 @@ packages:
     resolution: {integrity: sha512-cq+LzXoKNOn+KXLBm9+N9QMTEwbIXzki5AZXP/cHnAex3+3LnyhJ7zMxB5InZVgQgqI9hEs0dsXoJX/tNxlW3Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.127':
-    resolution: {integrity: sha512-8jauRUCLI+nrIMUrcRii/xXmtJUXxfsD2kizddq6vc7Z2mrOqLr9LU5fq9rIrBk62q12Y5o/nO3IM5SPC2fcbw==}
+  '@cobuild/review-gpt@0.5.131':
+    resolution: {integrity: sha512-pISZlwkytD8ObJFB3eRFKwfxkPOiC/dbOUfychwE7Yjmi57kzCiLD4yiUxgB7rCV/6Wr2uWt9sstB/El8XmnBg==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10816,7 +10816,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17': {}
 
-  '@cobuild/review-gpt@0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
 minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/repo-tools@0.1.17'
-  - '@cobuild/review-gpt@0.5.127'
+  - '@cobuild/review-gpt@0.5.131'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why

The repository was pinned to ReviewGPT 0.5.127 while the public registry's latest release is 0.5.131. Keeping the reviewed manifest and lockfile current lets the remaining PR review rounds use the requested release.

## User goal and experience

No member-facing behavior changes. Developers and CI use ReviewGPT 0.5.131 for repository review workflows; the command entrypoint and review flow remain unchanged.

## Invariants

- Keep the dependency on the public registry.
- Update the manifest, lockfile, pnpm minimum-release-age exception, and package contract test together.
- Preserve the existing fail-closed response-duration and model-attestation checks.
- Do not change review prompts, browser-lane ownership, or production runtime dependencies.

## Non-obvious affected surfaces

- ReviewGPT developer workflow: the installed browser driver refactored its marked-response duration guard. The package-contract test now verifies the released configuration, extracted helper, and helper invocation ordering.
- Review recovery diagnostics: the Frog note records a 0.5.131 duplicate-response recovery failure without changing runtime behavior.

## Architecture and reuse

- Existing systems reused: the current root dev dependency, pnpm lockfile, package-contract test, and existing ReviewGPT wrapper/configuration.
- New logic: none; the test assertions follow the released package's refactored timing guard without changing Murph runtime behavior.
- New abstractions: none are needed because the existing package-backed ReviewGPT boundary already owns review packaging and browser automation.
- Complexity intentionally avoided: no wrapper, prompt, workflow, or production configuration changes.

## Operational impact

- Hot reply path impact: Not applicable; no production reply-path files or dependencies changed.
- Database collection fanout impact: Not applicable; this diff performs no database work.
- Murph initial provider input impact: Not applicable for individual and group Murph; no prompt, tool-schema, provider adapter, model configuration, or request-assembly surface changed.

## Preliminary specialist lenses

- Product experience: not applicable; this is internal developer tooling with no member journey change.
- Prompt: not applicable; no prompt or provider-visible instruction changed.
- Frontend: not applicable; no frontend file or rendered state changed.
- Coverage: applicable. ReviewGPT 0.5.131 found one medium package-contract coverage gap; it was accepted and remediated by proving the duration-guard helper invocation exists after the guard and before completed-artifact persistence.

The final cross-cutting ReviewGPT gate is not applicable because the meaningful diff is limited to developer tooling and its package-contract test and does not change production behavior. The explanatory Frog note added after remediation does not change that reviewed behavior.

## Verification

- `pnpm install --frozen-lockfile`: passed
- `pnpm install --lockfile-only --frozen-lockfile`: passed
- `pnpm exec cobuild-review-gpt --version`: `0.5.131`
- ReviewGPT dry run with `--no-zip`: passed
- Focused CLI release contract test: passed
- ReviewGPT PR-head preflight tests: 9 passed
- CLI typecheck: passed
- Dependency policy: passed for all 30 package manifests
- Ignored-build audit: passed with the repository's existing expected list
- Dependency audit: unchanged from the 0.5.127 base (6 low, 38 moderate, 32 high, 1 critical); the lockfile has no transitive dependency changes
- Diff check: passed
- Preliminary ReviewGPT 0.5.131 coverage review: completed; one finding accepted and remediated
- Exact-head required CI: in progress

## Review remediation

- Updated Murph's package-contract assertions for the released 0.5.131 timing configuration and extracted fail-closed duration helper.
- Added explicit ordering assertions that prove the helper invocation exists in the expected fail-closed path.

## Design proof

- Not applicable: no frontend files or member-visible UI changed.

## Changelog

- Changelog: not applicable
- Reason: Internal developer tooling only; no member-visible behavior changed.

## Change shape

Classification rule: authored test assertions are tests; the Frog entry is documentation; package manifest, workspace policy, and lockfile are config/tooling. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 28 | 18 |
| Docs | 21 | 0 |
| Config / tooling | 7 | 7 |
| Generated / other | 0 | 0 |
| **Total** | **56** | **25** |
