### PR TITLE
chore: update ReviewGPT to 0.5.132 and guard timing options

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.17",
-    "@cobuild/review-gpt": "^0.5.131",
+    "@cobuild/review-gpt": "^0.5.132",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1097,13 +1097,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.131')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.132')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.131'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.132'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]

--- a/packages/cli/test/review-gpt-pr-head-preflight.test.ts
+++ b/packages/cli/test/review-gpt-pr-head-preflight.test.ts
@@ -184,20 +184,22 @@ describe('ReviewGPT PR context guard', () => {
   })
 
   it.each([
-    '--minimum-marked-response-time',
-    '--minimumMarkedResponseTime',
-  ])('keeps PR context guarded when %s precedes the preset', option => {
+    ['--idle-draft-timeout', '30m'],
+    ['--idleDraftTimeout', '30m'],
+    ['--minimum-marked-response-time', '5m'],
+    ['--minimumMarkedResponseTime', '5m'],
+  ])('keeps PR context guarded when %s precedes the preset', (option, value) => {
     const harness = createHarness()
     const result = runHarness(harness, [
       option,
-      '5m',
+      value,
       'completion-specialists',
       '--dry-run',
     ])
 
     expect(result.status).toBe(0)
     expect(readFileSync(harness.capturePath, 'utf8')).toBe(
-      `pr=42\nphase=preliminary\nargs=exec cobuild-review-gpt --config scripts/review-gpt.config.sh ${option} 5m completion-specialists --dry-run\n`,
+      `pr=42\nphase=preliminary\nargs=exec cobuild-review-gpt --config scripts/review-gpt.config.sh ${option} ${value} completion-specialists --dry-run\n`,
     )
   })
 

--- a/packages/cli/test/review-gpt-pr-head-preflight.test.ts
+++ b/packages/cli/test/review-gpt-pr-head-preflight.test.ts
@@ -183,6 +183,24 @@ describe('ReviewGPT PR context guard', () => {
     expect(() => readFileSync(harness.capturePath, 'utf8')).toThrow()
   })
 
+  it.each([
+    '--minimum-marked-response-time',
+    '--minimumMarkedResponseTime',
+  ])('keeps PR context guarded when %s precedes the preset', option => {
+    const harness = createHarness()
+    const result = runHarness(harness, [
+      option,
+      '5m',
+      'completion-specialists',
+      '--dry-run',
+    ])
+
+    expect(result.status).toBe(0)
+    expect(readFileSync(harness.capturePath, 'utf8')).toBe(
+      `pr=42\nphase=preliminary\nargs=exec cobuild-review-gpt --config scripts/review-gpt.config.sh ${option} 5m completion-specialists --dry-run\n`,
+    )
+  })
+
   it('counts the accepted camelCase promptFile spelling in the specialist budget', () => {
     const harness = createHarness()
     const promptPath = path.join(harness.harnessRoot, 'oversized-prompt.md')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       '@cobuild/review-gpt':
-        specifier: ^0.5.131
-        version: 0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.132
+        version: 0.5.132(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1472,8 +1472,8 @@ packages:
     resolution: {integrity: sha512-cq+LzXoKNOn+KXLBm9+N9QMTEwbIXzki5AZXP/cHnAex3+3LnyhJ7zMxB5InZVgQgqI9hEs0dsXoJX/tNxlW3Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.131':
-    resolution: {integrity: sha512-pISZlwkytD8ObJFB3eRFKwfxkPOiC/dbOUfychwE7Yjmi57kzCiLD4yiUxgB7rCV/6Wr2uWt9sstB/El8XmnBg==}
+  '@cobuild/review-gpt@0.5.132':
+    resolution: {integrity: sha512-UJrMVW2LUXnGOorFZKmOs7KaC4lRqUodQacBsb3Vbi9dzLSoslZKdmr/HXyuSLlIsShBoYvZK3JD1hstGsOz4w==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10816,7 +10816,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17': {}
 
-  '@cobuild/review-gpt@0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.132(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
 minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/repo-tools@0.1.17'
-  - '@cobuild/review-gpt@0.5.131'
+  - '@cobuild/review-gpt@0.5.132'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'

--- a/scripts/review-gpt-pr-head-preflight.sh
+++ b/scripts/review-gpt-pr-head-preflight.sh
@@ -92,6 +92,8 @@ review_gpt_option_requires_value() {
       | --wait-timeout \
       | --waitTimeout \
       | --timeout \
+      | --idle-draft-timeout \
+      | --idleDraftTimeout \
       | --response-file \
       | --responseFile \
       | --response-marker \

--- a/scripts/review-gpt-pr-head-preflight.sh
+++ b/scripts/review-gpt-pr-head-preflight.sh
@@ -104,7 +104,9 @@ review_gpt_option_requires_value() {
       | --token-limit \
       | --tokenLimit \
       | --token-offset \
-      | --tokenOffset)
+      | --tokenOffset \
+      | --minimum-marked-response-time \
+      | --minimumMarkedResponseTime)
       return 0
       ;;
   esac


### PR DESCRIPTION
## Why this PR exists

Murph should use the current ReviewGPT release, 0.5.132. The 0.5.131/0.5.132 CLI also exposes `--minimum-marked-response-time` and `--idle-draft-timeout` as value-taking options, while Murph's PR-head preflight did not yet recognize them. When either timing option preceded `completion-specialists` or a final-review preset, its duration could be mistaken for the preset and the PR phase/head guard could be omitted.

## User goal / user-visible behavior

Repository operators use ReviewGPT 0.5.132 and can place either supported spelling of both timing options before a PR review preset without bypassing exact-head and phase validation. Members see no product behavior change.

## Invariants

- Every PR ReviewGPT run still derives and validates its review phase and exact pushed head.
- Both ReviewGPT's kebab-case and camelCase option spellings remain supported.
- The ReviewGPT package remains the owner of timing-policy parsing and enforcement.
- The manifest, lockfile, release-age exception, and package contract stay aligned on one public-registry release.
- No production runtime, prompt, browser-lane, or member-facing behavior changes.

## Non-obvious affected surfaces

The wrapper accepts options before the positional preset. Its small option-shape table must know which options consume the following argument so values cannot be classified as presets. Upstream 0.5.132 only broadens timestamped attachment-name matching and removes a deep-research conversation-state skip; it does not change the CLI option schema or dependency graph.

## Architecture and reuse

- **Existing systems reused:** The existing dependency boundary, release audit, `review_gpt_option_requires_value` parser, and PR-head preflight harness remain the only owners.
- **New logic:** Four aliases are added to the existing value-taking option case, and the existing package pin is advanced to 0.5.132.
- **New abstractions:** None are needed because the existing option-shape table and preflight harness already own this behavior.
- **Complexity intentionally avoided:** No duration parser, duplicate timeout policy, environment override, or second preflight path is introduced.

## Hot reply path impact

Not applicable. No production assistant, provider, delivery, or mailbox path changes.

## Database collection fanout impact

Not applicable. No database-touching path changes.

## Murph initial provider input impact

- Individual Murph: Not applicable; no provider-request assembly changes.
- Group Murph: Not applicable; no provider-request assembly changes.

## Preliminary specialist lenses

- Product experience: **not applicable** — internal repository tooling only.
- Prompt: **not applicable** — no prompt or instruction surface changed.
- Frontend: **not applicable** — no `apps/web` UI changed.
- Coverage: **applicable** — a parameterized regression proves both supported spellings of both timing options preserve derived PR and preliminary-phase context when placed before the preset; the package-backed release audit verifies the 0.5.132 pin.

The final cross-cutting ReviewGPT gate is not applicable because this is a narrow developer-tooling guard and test with no production behavior or trust-boundary change.

## Verification

- `bash -n scripts/review-gpt-pr-head-preflight.sh` — passed.
- `pnpm exec vitest run packages/cli/test/review-gpt-pr-head-preflight.test.ts --project cli-schemas-smoke --maxWorkers=1` — 13 tests passed on the exact candidate.
- `pnpm exec vitest run packages/cli/test/release-script-coverage-audit.test.ts --project cli-release-smoke -t "exposes only the package-backed review-gpt runner" --no-coverage` — passed.
- `pnpm install --frozen-lockfile` — passed; ReviewGPT reports `0.5.132`.
- `pnpm deps:guard` and `pnpm deps:ignored-builds` — passed; the ignored-build set is unchanged.
- `git diff --check origin/main...HEAD` — passed.
- ReviewGPT preliminary specialist pass on the guard correction — `SPECIALIST_OUTCOME: PASS`; no findings. Per the completion workflow, the preliminary pass was not rerun after the package-only 0.5.132 update; the parent inspected the complete 0.5.131-to-0.5.132 installed-source delta and reran its package contract.
- Local deep review — no remaining findings after adding the adjacent idle-draft timeout aliases and inspecting the upstream 0.5.132 source delta.
- Exact-head required GitHub checks — running.

## Review remediation

- Accepted the concrete ReviewGPT compatibility finding that unrecognized value-taking timing options could hide the later PR preset from the wrapper.
- Kept the correction at the existing option-shape boundary instead of adding a second timing-policy implementation.
- Folded the newly published 0.5.132 package bump into this update instead of creating another duplicate PR.

## Design proof

Not applicable: no frontend files or member-visible UI changed.

## Changelog

- Changelog: not applicable
- Reason: Internal repository review tooling only; no member-visible behavior changed.

## Change shape

Classification rule: the wrapper, manifests, and lockfile are developer tooling/configuration; the Vitest assertions are test coverage. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 22 | 2 |
| Docs | 0 | 0 |
| Config / tooling | 12 | 8 |
| Generated / other | 0 | 0 |
| **Total** | **34** | **10** |
