### PR TITLE
Update ReviewGPT to 0.5.131

### DIFF
--- a/.agents/friction-log/20260815135307-dependency-audit-does/friction.md
+++ b/.agents/friction-log/20260815135307-dependency-audit-does/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Dependency audit does not distinguish unchanged advisory backlog'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A dependency-only update should have a deterministic audit check that identifies advisories introduced or worsened by the candidate lockfile while still reporting the existing repository backlog.
+
+## Current Behavior
+
+`pnpm deps:audit` exits unsuccessfully on the full existing high and critical advisory set. A three-file package bump with no transitive lockfile changes therefore requires a manual baseline comparison to prove that the candidate introduced no advisory or vulnerable version.
+
+## Possible Solution
+
+Add a committed audit baseline or a lockfile-aware comparison mode that fails only for new or worsened findings while keeping the complete report visible for remediation.
+
+## Minimal Reproducible Example
+
+1. Start from the current protected branch.
+2. Update one direct development dependency between releases whose transitive lock entries are unchanged.
+3. Run `pnpm deps:audit`.
+4. Observe that the command fails on the unchanged advisory backlog without identifying the candidate delta.
+
+## Context
+
+This makes narrow supply-chain updates slower to validate and easier to misclassify, even when the manifest and lockfile prove no transitive dependency changed.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.17",
-    "@cobuild/review-gpt": "^0.5.127",
+    "@cobuild/review-gpt": "^0.5.131",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1097,13 +1097,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.127')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.131')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.127'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.131'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1165,7 +1165,10 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptDriver).toContain('`CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain('`Nested CDP socket command timed out: ${method}`')
     expect(reviewGptDriver).toContain(
-      'const MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS = 5 * 60 * 1000;',
+      'const minimumMarkedResponseMs = Number(process.env.ORACLE_DRAFT_MINIMUM_MARKED_RESPONSE_MS || 5 * 60 * 1000);',
+    )
+    expect(reviewGptDriver).toContain(
+      "throw new Error('Invalid ORACLE_DRAFT_MINIMUM_MARKED_RESPONSE_MS: expected a positive integer.');",
     )
     const solTarget: ReviewGptModelPickerTarget = {
       desiredVersion: '5-6',
@@ -1246,7 +1249,7 @@ describe('monorepo release flow coverage audit', () => {
       ),
     ).toBe(false)
     expect(reviewGptDriver).toContain(
-      'const MODEL_CONFIRMATION_UNKNOWN_FALLBACK_MS = MIN_MARKED_CONCRETE_MODEL_RESPONSE_MS;',
+      'const MODEL_CONFIRMATION_UNKNOWN_FALLBACK_MS = 5 * 60 * 1000;',
     )
     expect(reviewGptDriver).toContain("status: 'response-too-fast'")
     expect(reviewGptDriver).toContain('markedResponseDurationFailure({')
@@ -1258,7 +1261,10 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptReadme).toContain('An ephemeral per-run nonce')
     expect(reviewGptReadme).toContain('after at least 5 minutes of observed generation')
     expect(reviewGptReadme).toContain(
-      'A marked concrete-model response that completes in under 5 minutes fails closed as untrusted',
+      'A marked concrete-model response shorter than the trust threshold fails closed as untrusted',
+    )
+    expect(reviewGptReadme).toContain(
+      'The threshold defaults to 5 minutes and can be raised or lowered',
     )
     expect(reviewGptDriver).toContain('REVIEW_GPT_TURN_NONCE:')
     expect(reviewGptDriver).not.toContain("value.includes('MODEL_CONFIRMATION:')")
@@ -1312,19 +1318,25 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(responseDurationGuardStart).toBeGreaterThan(-1)
     expect(responseAttestationStart).toBeGreaterThan(responseDurationGuardStart)
-    const tooFastBranchStart = reviewGptDriver.indexOf(
-      "} else if (responseResult?.status === 'response-too-fast') {",
+    const tooFastGuardStart = reviewGptDriver.indexOf(
+      'function assertMarkedResponseDurationTrusted(',
     )
-    const tooFastBranchEnd = reviewGptDriver.indexOf('} else {', tooFastBranchStart)
-    const tooFastBranch = reviewGptDriver.slice(tooFastBranchStart, tooFastBranchEnd)
-    expect(tooFastBranchStart).toBeGreaterThan(-1)
-    expect(tooFastBranchEnd).toBeGreaterThan(tooFastBranchStart)
-    expect(tooFastBranch).toContain(
-      'writeCapturedResponseFile(responseFile, responseResult.responseText);',
+    const tooFastGuardEnd = reviewGptDriver.indexOf(
+      '\n}\n\nfunction capturedResponseFileText',
+      tooFastGuardStart,
     )
-    expect(tooFastBranch).toContain('throw new Error(responseResult.responseDurationFailure')
-    expect(tooFastBranch).not.toContain('writeCompletedResponseArtifacts')
-    expect(tooFastBranch).not.toContain('modelVerification')
+    const tooFastGuard = reviewGptDriver.slice(tooFastGuardStart, tooFastGuardEnd)
+    expect(tooFastGuardStart).toBeGreaterThan(-1)
+    expect(tooFastGuardEnd).toBeGreaterThan(tooFastGuardStart)
+    expect(tooFastGuard).toContain(
+      'writeCapturedResponseFile(responseFilePath, responseResult.responseText);',
+    )
+    expect(tooFastGuard).toContain('throw new Error(responseResult.responseDurationFailure')
+    expect(tooFastGuard).not.toContain('writeCompletedResponseArtifacts')
+    expect(tooFastGuard).not.toContain('modelVerification')
+    expect(reviewGptDriver).toContain(
+      'assertMarkedResponseDurationTrusted(responseResult, responseFile);',
+    )
     expect(reviewGptDriver).toContain('process.exit(1);')
     expect(reviewGptDriver).toContain(
       [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       '@cobuild/review-gpt':
-        specifier: ^0.5.127
-        version: 0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.131
+        version: 0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1472,8 +1472,8 @@ packages:
     resolution: {integrity: sha512-cq+LzXoKNOn+KXLBm9+N9QMTEwbIXzki5AZXP/cHnAex3+3LnyhJ7zMxB5InZVgQgqI9hEs0dsXoJX/tNxlW3Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.127':
-    resolution: {integrity: sha512-8jauRUCLI+nrIMUrcRii/xXmtJUXxfsD2kizddq6vc7Z2mrOqLr9LU5fq9rIrBk62q12Y5o/nO3IM5SPC2fcbw==}
+  '@cobuild/review-gpt@0.5.131':
+    resolution: {integrity: sha512-pISZlwkytD8ObJFB3eRFKwfxkPOiC/dbOUfychwE7Yjmi57kzCiLD4yiUxgB7rCV/6Wr2uWt9sstB/El8XmnBg==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10816,7 +10816,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17': {}
 
-  '@cobuild/review-gpt@0.5.127(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.131(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
 minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/repo-tools@0.1.17'
-  - '@cobuild/review-gpt@0.5.127'
+  - '@cobuild/review-gpt@0.5.131'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why this PR exists

Murph pins ReviewGPT 0.5.127 while npm's current `latest` dist-tag is 0.5.131. The newer releases harden canonical thread URL capture, attachment submission verification, nested turn alias handling, and marked-response thresholds used by the repository's review gates.

## User goal / user-visible behavior

Repository review runs use ReviewGPT 0.5.131 through the existing `pnpm review:gpt` command. Product runtime and member-visible behavior do not change.

## Invariants

- Keep ReviewGPT a public-registry development dependency resolved through the committed pnpm lockfile.
- Keep the existing preflight wrapper, package scripts, prompts, browser configuration, and review policy unchanged.
- Keep the minimum-release-age exception exact and limited to the selected ReviewGPT release.
- Introduce no transitive dependency version changes, build-script approvals, runtime dependency, or new state owner.

## Architecture and reuse

- Existing systems reused: the current `scripts/review-gpt-pr-head-preflight.sh`, `scripts/review-gpt.config.sh`, package script, exact-version control test, pnpm lockfile, and release-age policy.
- New logic: none; the change advances the one existing package pin and the two control-test literals that enforce it.
- New abstractions: none; the existing dependency declaration, lockfile, preflight wrapper, and package-control test remain the only owners.
- Complexity intentionally avoided: no wrapper, installer, compatibility layer, configuration surface, state owner, or transitive dependency churn.

## Dependency review

- Registry source: npm `@cobuild/review-gpt@0.5.131`.
- Lockfile: updated in the same commit; only the direct ReviewGPT resolution and integrity changed.
- Transitive versions: unchanged.
- Build-script policy: unchanged; no new approval added.
- Audit: the repository's existing advisory backlog still makes `pnpm deps:audit` exit 1. The audit does not name ReviewGPT 0.5.131 itself; it does retain existing advisories in ReviewGPT's unchanged transitive graph, including `tar` through `repomix`. The missing baseline/delta behavior is recorded through the repository's Frog workflow.

## Changelog

Not applicable. This is internal review tooling only.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 30 | 18 |
| Docs/process | 27 | 0 |
| Config/tooling | 7 | 7 |
| Generated/other | 0 | 0 |
| **Total** | **64** | **25** |

## Design proof

Not applicable. No user-facing frontend or design-catalog surface changes.

## Preliminary specialist lenses

- Product experience: not applicable; no product behavior changes.
- Prompt: not applicable; no assistant or review prompt changes.
- Frontend: not applicable; no rendered surface changes.
- Coverage: the existing package-control test now ratchets the manifest pin, release-age exception, configurable positive response-trust threshold, fail-closed response capture, and unchanged five-minute default; installation, policy checks, and direct CLI version/help smoke checks exercise the package itself.

## ReviewGPT dispositions

- Preflight-invalid first attempt: the submitted attachment disappeared from the accepted user turn, so ReviewGPT correctly refused to attest or advance the round. The retained assistant response still identified stale package/release-age assertions and old hard-coded threshold ratchets; those advisory findings were reproduced locally and fixed. The existing test now verifies 0.5.131's configurable positive threshold and its refactored fail-closed capture helper without weakening the five-minute default or model-attestation boundary.

## Verification

- `pnpm install --frozen-lockfile` passed.
- `pnpm deps:guard` passed for all 30 package manifests.
- `pnpm deps:ignored-builds` confirmed the existing ignored-build set; no build approval changed.
- `pnpm deps:audit` reported the pre-existing repository advisory backlog and exited 1; the changed direct release is not itself named in an advisory, while unchanged ReviewGPT transitive versions retain their existing findings.
- Focused package-control test passed: 1 passed, 45 skipped.
- `pnpm review:gpt --help` passed.
- `pnpm exec cobuild-review-gpt --version` returned `0.5.131`.
- Direct installed-package inspection returned `0.5.131`.
- `git diff --check` and the identifier/privacy scan passed.

ReviewGPT context sensitivity: routine
ReviewGPT first-reviewed head: 4600032df5fea14792193a98e0a51eef37ae07b0
Current candidate head: 4600032df5fea14792193a98e0a51eef37ae07b0
