### PR TITLE
Index pending image completions for hot replies

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-15-hot-reply-pending-image-completion-index.md
+++ b/agent-docs/exec-plans/active/2026-08-15-hot-reply-pending-image-completion-index.md
@@ -1,0 +1,97 @@
+# Index image-completion candidates for hot replies
+
+Status: active
+Created: 2026-08-15
+Updated: 2026-08-15
+
+## Goal
+
+- Remove pending-event file hydration from ordinary hosted foreground replies
+  when the canonical pending-input index can prove no generated-image
+  completion is waiting, without changing completion ordering or introducing a
+  second durable owner.
+
+## Success criteria
+
+- Ordinary pending inputs require one pending-index read and no pending-event
+  hydration in the image-completion recovery precheck.
+- A trusted image completion keeps the full pending cohort available to the
+  existing route, origin, follow-up, and newest-message selector.
+- State written before the projection defaults conservatively positive and the
+  existing maintenance compaction computes the exact value.
+- Focused assistant-runtime typecheck and Vitest proof pass.
+- Exact-head CI is green, the preliminary coverage specialist has no unresolved
+  accepted finding, and final ReviewGPT returns `ROUND_OUTCOME: PASS`.
+
+## Scope
+
+- In scope: the existing hosted pending-input index, generated-image completion
+  recovery selection, focused regression tests, and the owner documentation
+  needed to state persisted-state and rollout behavior.
+- Out of scope: a second index or summary artifact, queue, scheduler, service,
+  migration job, reconciliation loop, route index, or elimination of the
+  existing pending-index JSON parse.
+
+## Constraints
+
+- Technical constraints: preserve completion-first ordering, same-route
+  follow-ups after the trusted image origin, newest-message authority, missing
+  event fail-safe behavior, and background-only repair/compaction ownership.
+- Product/process constraints: use the sanctioned task worktree, preserve the
+  supplied patch intent, keep identifiers out of durable artifacts, run focused
+  local proof, and complete both exact-head ReviewGPT stages plus CI.
+
+## Risks and mitigations
+
+1. Risk: a false-negative projection could suppress a real image completion.
+   Mitigation: missing pre-projection state and missing newly enqueued event data
+   are positive; compaction clears the hint only from known inspected events,
+   while missing indexed events preserve an existing positive value.
+2. Risk: changing persisted v2 state creates a rollback floor for the prior
+   strict reader after the first projected state is written.
+   Mitigation: keep the field additive and old-state-readable, require immediate
+   runner rollout, document the forward-fix rollback posture, and avoid a second
+   compatibility owner for a derived projection.
+3. Risk: optimizing the negative path changes positive completion semantics.
+   Mitigation: the projection returns the complete pending cohort on a positive
+   hint and leaves the established selector unchanged; focused tests retain the
+   existing positive route/cohort cases.
+
+## Tasks
+
+1. Apply and inspect the supplied patch against current `origin/main` in the
+   sanctioned worktree.
+2. Confirm the state transition and rollout contract at the existing owner.
+3. Run focused typecheck, regression tests, direct call-count proof, diff checks,
+   and privacy scan.
+4. Create and push the scoped review candidate, then open a draft PR with the
+   complete intent, architecture, hot-path, state, and change-shape contract.
+5. Run the preliminary coverage specialist and final ReviewGPT round 1 in
+   parallel with exact-head CI; resolve accepted findings through later final
+   rounds until pass.
+6. Perform the parent final review, close this plan through `scripts/finish-task`,
+   push the final head, prove clean mergeability, and confirm final-head CI.
+
+## Decisions
+
+- Reuse the hosted pending-input index as the sole canonical owner. The smaller
+  O(n)-byte index parse remains; removing it would require another durable
+  summary and synchronization protocol.
+- Treat `hasImageCompletionCandidate` as an additive, conservative derived hint
+  within the existing v2 exact-ack index. Do not add a v3 migration lane or
+  compatibility subsystem; document the strict-reader rollback floor instead.
+- Coverage is the only applicable preliminary specialist lens. Product
+  experience, prompt, and frontend are not changed. The final cross-cutting
+  ReviewGPT gate applies because persisted hosted-runtime state and foreground
+  ordering are affected.
+
+## Verification
+
+- `pnpm --filter @murphai/assistant-runtime typecheck`
+- `pnpm --filter @murphai/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-pending-input-index.test.ts test/hosted-runtime-turn-input.test.ts`
+- `git diff --check`
+- Secret-safe diff/path privacy scan and supplied-patch SHA-256 verification.
+- Expected: typecheck succeeds; both focused test files pass; the ordinary path
+  records no pending-event hydration; completion, legacy-state, compaction, and
+  established positive recovery cases pass; no whitespace or identifier leak is
+  present.

--- a/agent-docs/exec-plans/completed/2026-08-15-hot-reply-pending-image-completion-index.md
+++ b/agent-docs/exec-plans/completed/2026-08-15-hot-reply-pending-image-completion-index.md
@@ -1,6 +1,6 @@
 # Index image-completion candidates for hot replies
 
-Status: active
+Status: completed
 Created: 2026-08-15
 Updated: 2026-08-15
 
@@ -80,10 +80,11 @@ Updated: 2026-08-15
 - Treat `hasImageCompletionCandidate` as an additive, conservative derived hint
   within the existing v2 exact-ack index. Do not add a v3 migration lane or
   compatibility subsystem; document the strict-reader rollback floor instead.
-- Coverage is the only applicable preliminary specialist lens. Product
-  experience, prompt, and frontend are not changed. The final cross-cutting
-  ReviewGPT gate applies because persisted hosted-runtime state and foreground
-  ordering are affected.
+- Coverage and product experience are the applicable preliminary specialist
+  lenses: the member-visible interaction and recovery semantics do not change,
+  but removing foreground hydration changes ordinary reply timing. Prompt and
+  frontend are not changed. The final cross-cutting ReviewGPT gate applies
+  because persisted hosted-runtime state and foreground ordering are affected.
 
 ## Verification
 
@@ -91,7 +92,39 @@ Updated: 2026-08-15
 - `pnpm --filter @murphai/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-pending-input-index.test.ts test/hosted-runtime-turn-input.test.ts`
 - `git diff --check`
 - Secret-safe diff/path privacy scan and supplied-patch SHA-256 verification.
-- Expected: typecheck succeeds; both focused test files pass; the ordinary path
-  records no pending-event hydration; completion, legacy-state, compaction, and
-  established positive recovery cases pass; no whitespace or identifier leak is
-  present.
+- Result: typecheck passed; both focused test files passed with 73 tests on the
+  corrected head. The ordinary path records no pending-event hydration;
+  completion, legacy-state, compaction, missing-event fail-safe, and established
+  positive recovery cases passed.
+- Result: the supplied patch SHA-256 matched
+  `1493bdbe301e5c4404a10f5c81487b14d56ddfda8c18fbf2e7fc5f35bf49951f`;
+  diff/whitespace and secret-safe privacy checks passed.
+
+## Review disposition
+
+- The preliminary specialist reviewed the immutable production candidate
+  `e4587d839c4fbc8f306c9a9e4e4cac88da437dda` for 20m46s. Captured metadata
+  bound the response to `gpt-5-6-pro`. Product experience passed with no
+  findings; prompt and frontend were not applicable; coverage produced one
+  medium finding requesting direct proof of the missing-event conservative
+  branch.
+- The finding was accepted and resolved at
+  `ca03c9df662f545bb26e7ab63724a1e48a15f93f` with six test-only assertion
+  lines proving the complete recovery cohort immediately after enqueue and
+  after compaction. The specialist attachment could not be downloaded, so its
+  narrowly stated correction was implemented manually and verified locally.
+- Final ReviewGPT round 1 reviewed the same immutable production candidate for
+  22m25s, with captured `gpt-5-6-pro` metadata, and returned
+  `ROUND_OUTCOME: PASS`, `REVIEW_COMPLETE`, and no qualifying findings. The
+  later correction is test-only, so the repository workflow does not require a
+  new substantive final round.
+- Parent review traced enqueue, parsing, merge, backfill, compaction, exact
+  acknowledgement, foreground selection, and positive completion recovery. It
+  found no unresolved correctness or architectural issue and confirmed that a
+  stale projection can only retain old work, not suppress a completion.
+- All required GitHub checks passed on the corrected candidate
+  `ca03c9df662f545bb26e7ab63724a1e48a15f93f`, including release build and
+  typecheck, assistant/CLI/platform coverage, release app verification, the CLI
+  host matrix, billing boundaries, frontend proof, fixture coverage, and
+  tracked-artifact checks.
+Completed: 2026-08-15

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -62,9 +62,18 @@ cursor, so an earlier unresolved sequence cannot starve later terminal rows.
 V1 migration preserves recorded pending IDs and recovers omitted events only
 when terminal evidence proves they are safe to acknowledge; ambiguous omitted
 nonterminal history stays nonreplyable instead of becoming stale work after a
-channel is enabled. Once an accepted snapshot contains the v2 envelope, its
-runner bundle is a hard rollback floor because the preceding v1-only reader
-cannot restore that state.
+channel is enabled. V2 also carries the conservative derived
+`hasImageCompletionCandidate` projection. A missing projection reads as
+positive, enqueue classifies only the newly added immutable event, and existing
+maintenance compaction recomputes the exact value. A negative projection lets
+ordinary foreground selection skip pending-event hydration; a positive value
+still exposes the complete cohort to the existing route and ordering selector.
+Once an accepted snapshot contains the v2 envelope, its runner bundle is a hard
+rollback floor because the preceding v1-only reader cannot restore that state.
+The first snapshot containing the additive projection similarly requires the
+projection-aware runner because the preceding v2 value reader is strict; deploy
+this runner with immediate container rollout and use a forward fix below that
+floor rather than adding a second compatibility owner for a derived hint.
 
 For hosted conversation traffic, the mailbox importer is the source adapter. It
 stages bounded `AssistantInputEvent` records in the warm live workspace.

--- a/packages/assistant-runtime/src/hosted-runtime/pending-input-index.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/pending-input-index.ts
@@ -12,6 +12,7 @@ import {
   compareAssistantInputCursors,
   createStoreBackedAssistantInputSource,
   DEFAULT_ASSISTANT_AUTOMATION_SCAN_LIMIT,
+  isAssistantHostedImageCompletionEvent,
   listAssistantInputEvents,
   readAssistantInputEvent,
   readHostedMailboxAssistantInputItemDetails,
@@ -47,6 +48,7 @@ export const HOSTED_PENDING_ASSISTANT_INPUT_STATE_RELATIVE_PATH =
 
 export interface HostedPendingAssistantInputState {
   backfilled: boolean;
+  hasImageCompletionCandidate: boolean;
   handledBatchCursorInputId: string | null;
   inputIds: string[];
 }
@@ -102,7 +104,12 @@ const HOSTED_PENDING_ASSISTANT_INPUT_LEGACY_STATE_SCHEMA =
   "murph.hosted-pending-assistant-inputs.v1";
 const HOSTED_PENDING_ASSISTANT_INPUT_LEGACY_STATE_SCHEMA_VERSION = 1;
 const HOSTED_PENDING_ASSISTANT_INPUT_STATE_KEYS =
-  new Set(["backfilled", "handledBatchCursorInputId", "inputIds"]);
+  new Set([
+    "backfilled",
+    "handledBatchCursorInputId",
+    "hasImageCompletionCandidate",
+    "inputIds",
+  ]);
 const HOSTED_PENDING_ASSISTANT_INPUT_INSPECTION_WAVE_SIZE = 8;
 const HOSTED_PENDING_INPUT_RETENTION_DELIVERABLE_STATUSES = [
   "awaiting_approval",
@@ -127,6 +134,18 @@ export async function readHostedPendingAssistantInputIds(input: {
   vaultRoot: string;
 }): Promise<string[]> {
   return [...(await readHostedPendingAssistantInputState(input)).inputIds];
+}
+
+export async function readHostedPendingAssistantImageCompletionRecoveryInputIds(
+  input: {
+    vaultRoot: string;
+  },
+): Promise<string[]> {
+  const state = await readHostedPendingAssistantInputState(input);
+  // Return the complete pending cohort only when completion recovery can use
+  // it. This keeps route and post-origin selection in its existing owner while
+  // making the ordinary foreground case a single index-file read.
+  return state.hasImageCompletionCandidate ? [...state.inputIds] : [];
 }
 
 export async function readExistingHostedPendingAssistantInputIds(input: {
@@ -521,6 +540,13 @@ export async function enqueueHostedPendingAssistantInputId(input: {
   vaultRoot: string;
 }): Promise<string[]> {
   const inputId = parseHostedPendingAssistantInputId(input.inputId);
+  const indexedEvent = await readAssistantInputEvent({
+    inputId,
+    vault: input.vaultRoot,
+  });
+  const hasImageCompletionCandidate =
+    indexedEvent === null
+    || isAssistantHostedImageCompletionEvent(indexedEvent);
   return await withAssistantRuntimeWriteLock(input.vaultRoot, async (paths) => {
     const existing = await readHostedPendingAssistantInputStateForWrite({
       filePath: resolveHostedPendingAssistantInputStatePathFromRoot(
@@ -532,6 +558,7 @@ export async function enqueueHostedPendingAssistantInputId(input: {
     });
     const state = existing.state;
     const nextState = appendHostedPendingAssistantInputId({
+      hasImageCompletionCandidate,
       inputId,
       state,
     });
@@ -814,6 +841,7 @@ async function compactHostedPendingAssistantInputStateForWrite(input: {
   const runnable: { cursor: AssistantInputCursor; inputId: string }[] = [];
   const unresolved: { cursor: AssistantInputCursor; inputId: string }[] = [];
   const missingInputIds: string[] = [];
+  let hasImageCompletionCandidate = false;
   const handledConversationInputs: {
     cursor: AssistantInputCursor;
     inputId: string;
@@ -843,6 +871,9 @@ async function compactHostedPendingAssistantInputStateForWrite(input: {
         cursor: event.cursor,
         inputId,
       });
+      if (isAssistantHostedImageCompletionEvent(event)) {
+        hasImageCompletionCandidate = true;
+      }
       if (
         isHostedPendingAssistantInputStillReplyable({
           enabledAutoReplyChannels,
@@ -885,6 +916,12 @@ async function compactHostedPendingAssistantInputStateForWrite(input: {
       }
     }
   }
+  if (
+    missingInputIds.length > 0
+    && input.state.hasImageCompletionCandidate
+  ) {
+    hasImageCompletionCandidate = true;
+  }
 
   const runnableInputIds = runnable
     .sort((left, right) => compareAssistantInputCursors(left.cursor, right.cursor))
@@ -899,6 +936,7 @@ async function compactHostedPendingAssistantInputStateForWrite(input: {
     ],
     {
       backfilled: input.backfilled,
+      hasImageCompletionCandidate,
       handledBatchCursorInputId:
         input.state.handledBatchCursorInputId !== null
         && unresolvedInputIds.includes(input.state.handledBatchCursorInputId)
@@ -975,6 +1013,16 @@ export function parseHostedPendingAssistantInputState(
       "hosted pending assistant input state backfilled",
     )
     : false;
+  const hasImageCompletionCandidate =
+    "hasImageCompletionCandidate" in state
+      ? parseHostedPendingAssistantInputBoolean(
+        state.hasImageCompletionCandidate,
+        "hosted pending assistant input image completion candidate",
+      )
+      : true;
+  // State written before this projection existed is conservatively positive.
+  // That preserves completion-first rollout behavior; the existing background
+  // compaction pass rewrites the exact value without a foreground migration.
   const handledBatchCursorInputId = "handledBatchCursorInputId" in state
     ? parseHostedPendingAssistantInputNullableId(
       state.handledBatchCursorInputId,
@@ -992,6 +1040,7 @@ export function parseHostedPendingAssistantInputState(
 
   return {
     backfilled,
+    hasImageCompletionCandidate,
     handledBatchCursorInputId,
     inputIds,
   };
@@ -1118,6 +1167,7 @@ async function createBackfilledHostedPendingAssistantInputState(input: {
   const source = createStoreBackedAssistantInputSource({
     vault: input.vaultRoot,
   });
+  let hasImageCompletionCandidate = false;
   const pending: { cursor: AssistantInputCursor; inputId: string }[] = [];
 
   for (const channelState of automationState.autoReply) {
@@ -1157,6 +1207,9 @@ async function createBackfilledHostedPendingAssistantInputState(input: {
             cursor: candidate.event.cursor,
             inputId: candidate.event.inputId,
           });
+          if (isAssistantHostedImageCompletionEvent(candidate.event)) {
+            hasImageCompletionCandidate = true;
+          }
         }
       }
 
@@ -1184,6 +1237,7 @@ async function createBackfilledHostedPendingAssistantInputState(input: {
 
   return createHostedPendingAssistantInputState(inputIds, {
     backfilled: true,
+    hasImageCompletionCandidate,
   });
 }
 
@@ -1244,6 +1298,7 @@ function createEmptyHostedPendingAssistantInputState(input: {
 }): HostedPendingAssistantInputState {
   return {
     backfilled: input.backfilled,
+    hasImageCompletionCandidate: false,
     handledBatchCursorInputId: null,
     inputIds: [],
   };
@@ -1253,11 +1308,13 @@ function createHostedPendingAssistantInputState(
   inputIds: readonly string[],
   input?: {
     backfilled?: boolean;
+    hasImageCompletionCandidate?: boolean;
     handledBatchCursorInputId?: string | null;
   },
 ): HostedPendingAssistantInputState {
   return {
     backfilled: input?.backfilled ?? false,
+    hasImageCompletionCandidate: input?.hasImageCompletionCandidate ?? false,
     handledBatchCursorInputId:
       parseHostedPendingAssistantInputNullableId(
         input?.handledBatchCursorInputId ?? null,
@@ -1268,11 +1325,21 @@ function createHostedPendingAssistantInputState(
 }
 
 function appendHostedPendingAssistantInputId(input: {
+  hasImageCompletionCandidate: boolean;
   inputId: string;
   state: HostedPendingAssistantInputState;
 }): HostedPendingAssistantInputState {
   const existingIndex = input.state.inputIds.indexOf(input.inputId);
   if (existingIndex >= 0) {
+    if (
+      input.hasImageCompletionCandidate
+      && !input.state.hasImageCompletionCandidate
+    ) {
+      return {
+        ...input.state,
+        hasImageCompletionCandidate: true,
+      };
+    }
     return input.state;
   }
   return createHostedPendingAssistantInputState([
@@ -1280,6 +1347,9 @@ function appendHostedPendingAssistantInputId(input: {
     input.inputId,
   ], {
     backfilled: input.state.backfilled,
+    hasImageCompletionCandidate:
+      input.state.hasImageCompletionCandidate
+      || input.hasImageCompletionCandidate,
     handledBatchCursorInputId: input.state.handledBatchCursorInputId,
   });
 }
@@ -1295,6 +1365,9 @@ function mergeHostedPendingAssistantInputBackfill(input: {
     ]),
     {
       backfilled: true,
+      hasImageCompletionCandidate:
+        input.state.hasImageCompletionCandidate
+        || input.backfilledState.hasImageCompletionCandidate,
       handledBatchCursorInputId: input.state.handledBatchCursorInputId,
     },
   );
@@ -1385,6 +1458,7 @@ function sameHostedPendingAssistantInputState(
   right: HostedPendingAssistantInputState,
 ): boolean {
   return left.backfilled === right.backfilled
+    && left.hasImageCompletionCandidate === right.hasImageCompletionCandidate
     && left.handledBatchCursorInputId === right.handledBatchCursorInputId
     && sameStringArray(left.inputIds, right.inputIds);
 }

--- a/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
@@ -28,7 +28,7 @@ import { assistantPreferenceCausalSeqSchema } from "@murphai/contracts";
 import {
   compactHostedPendingAssistantInputIds,
   isHostedPendingAssistantInputStillReplyable,
-  readHostedPendingAssistantInputIds,
+  readHostedPendingAssistantImageCompletionRecoveryInputIds,
   runHostedPendingAssistantInputContentRetention,
 } from "./pending-input-index.ts";
 
@@ -366,9 +366,12 @@ export async function selectHostedAssistantInputIds(
   let restoredCompletionRequiredInputIds: string[] | undefined;
   if (!hasFreshImageCompletion) {
     try {
-      const pendingInputIds = await readHostedPendingAssistantInputIds({
-        vaultRoot: input.vaultRoot,
-      });
+      const pendingInputIds =
+        await readHostedPendingAssistantImageCompletionRecoveryInputIds({
+          vaultRoot: input.vaultRoot,
+        });
+      // A positive hint deliberately keeps the existing full cohort recovery:
+      // same-route events after the trusted origin must remain eligible.
       const pendingEvents =
         await readHostedReplyablePendingAssistantInputEvents({
           inputIds: pendingInputIds,

--- a/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
@@ -1697,6 +1697,9 @@ describe("hosted pending assistant input index", () => {
       inputId: valid.inputId,
       vaultRoot,
     });
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([missingInputId, valid.inputId]);
     await expect(readHostedPendingAssistantInputIds({ vaultRoot })).resolves.toEqual([
       missingInputId,
       valid.inputId,
@@ -1709,6 +1712,9 @@ describe("hosted pending assistant input index", () => {
       missingInputId,
       valid.inputId,
     ]);
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([missingInputId, valid.inputId]);
   });
 
   it("retains nonterminal indexed inputs whose source cannot currently use the reply channel", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
@@ -41,6 +41,7 @@ import {
   enqueueHostedPendingAssistantInputId,
   ensureHostedPendingAssistantInputIndex,
   inspectHostedPendingAssistantInputWakeCandidate,
+  readHostedPendingAssistantImageCompletionRecoveryInputIds,
   readHostedPendingAssistantInputIds,
   resolveHostedPendingAssistantInputStatePath,
   runHostedPendingAssistantInputContentRetention,
@@ -185,6 +186,107 @@ describe("hosted pending assistant input index", () => {
         value: {
           backfilled: true,
           inputIds: [inputId],
+        },
+      });
+  });
+
+  it("keeps image-completion discovery in the canonical pending index", async () => {
+    const vaultRoot = await createTempVault();
+    const ordinary = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        dedupeKey: "dedupe_completion_hint_ordinary",
+        eventId: "evt_completion_hint_ordinary",
+        itemId: "item_completion_hint_ordinary",
+        laneSeq: "10",
+        messageId: "msg_completion_hint_ordinary",
+        occurredAt: "2026-04-23T00:00:01.000Z",
+        receivedAt: "2026-04-23T00:00:02.000Z",
+        text: "ordinary pending input",
+      }),
+    });
+    const completion = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        dedupeKey: "dedupe_completion_hint_image",
+        eventId: "evt_completion_hint_image",
+        itemId: "item_completion_hint_image",
+        lane: "system",
+        laneSeq: "image-completion:hint",
+        messageId: "msg_completion_hint_image",
+        occurredAt: "2026-04-23T00:00:03.000Z",
+        payloadSchema: "murph.hosted-image-completion.v1",
+        receivedAt: "2026-04-23T00:00:04.000Z",
+        text: "trusted image completion",
+        wakeSchema: "murph.hosted-image-completion.v1",
+      }),
+    });
+
+    await enqueueHostedPendingAssistantInputId({
+      inputId: ordinary.inputId,
+      vaultRoot,
+    });
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([]);
+
+    await enqueueHostedPendingAssistantInputId({
+      inputId: completion.inputId,
+      vaultRoot,
+    });
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([ordinary.inputId, completion.inputId]);
+  });
+
+  it("keeps old state conservative until existing compaction rebuilds the hint", async () => {
+    const vaultRoot = await createTempVault();
+    await saveAssistantAutomationState(vaultRoot, {
+      autoReply: [{
+        channel: "linq",
+        eligibleAfter: null,
+        enabledAt: "2026-04-23T00:00:00.000Z",
+      }],
+      updatedAt: "2026-04-23T00:00:00.000Z",
+      version: 1,
+    });
+    const ordinary = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        dedupeKey: "dedupe_completion_hint_migration",
+        eventId: "evt_completion_hint_migration",
+        itemId: "item_completion_hint_migration",
+        laneSeq: "10",
+        messageId: "msg_completion_hint_migration",
+        occurredAt: "2026-04-23T00:00:01.000Z",
+        receivedAt: "2026-04-23T00:00:02.000Z",
+        text: "ordinary pre-hint pending input",
+      }),
+    });
+    const filePath = resolveHostedPendingAssistantInputStatePath(vaultRoot);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${JSON.stringify({
+      schema: "murph.hosted-pending-assistant-inputs.v2",
+      schemaVersion: 2,
+      value: {
+        backfilled: true,
+        handledBatchCursorInputId: null,
+        inputIds: [ordinary.inputId],
+      },
+    }, null, 2)}\n`, "utf8");
+
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([ordinary.inputId]);
+    await expect(compactHostedPendingAssistantInputIds({ vaultRoot }))
+      .resolves.toEqual([ordinary.inputId]);
+    await expect(
+      readHostedPendingAssistantImageCompletionRecoveryInputIds({ vaultRoot }),
+    ).resolves.toEqual([]);
+    await expect(readFile(filePath, "utf8").then((value) => JSON.parse(value)))
+      .resolves.toMatchObject({
+        value: {
+          hasImageCompletionCandidate: false,
         },
       });
   });
@@ -2029,10 +2131,12 @@ function createAssistantInputEvent(input: {
   laneSeq: string;
   messageId: string;
   occurredAt: string;
+  payloadSchema?: string;
   receivedAt: string;
   replyTarget?: "linq" | "telegram" | null;
   source?: "linq" | "telegram";
   text: string;
+  wakeSchema?: string;
 }) {
   const source = input.source ?? "linq";
   const replyTarget = input.replyTarget === null
@@ -2082,10 +2186,10 @@ function createAssistantInputEvent(input: {
       kind: "hosted-mailbox" as const,
       lane: input.lane ?? "conversation",
       laneSeq: input.laneSeq,
-      payloadSchema: "murph.hosted-mailbox-payload.v1",
+      payloadSchema: input.payloadSchema ?? "murph.hosted-mailbox-payload.v1",
       payloadSource: "inline" as const,
       source: "hosted-mailbox" as const,
-      wakeSchema: "murph.hosted-execution-wake.v1",
+      wakeSchema: input.wakeSchema ?? "murph.hosted-execution-wake.v1",
     },
   };
 }

--- a/packages/assistant-runtime/test/hosted-runtime-turn-input.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-turn-input.test.ts
@@ -776,6 +776,7 @@ describe("selectHostedAssistantInputIds", () => {
       inputId: pending.inputId,
       vaultRoot,
     });
+    const readInputSpy = vi.spyOn(assistantEngine, "readAssistantInputEvent");
 
     const selection = await selectHostedAssistantInputIds({
       freshAssistantInputIds: [fresh.inputId],
@@ -785,6 +786,9 @@ describe("selectHostedAssistantInputIds", () => {
 
     expect(selection.inputIds).toEqual([fresh.inputId]);
     expect(selection.pendingInputIds).toEqual([]);
+    expect(readInputSpy.mock.calls.map((call) => call[0].inputId)).toEqual([
+      fresh.inputId,
+    ]);
   });
 
   it("batches rapid same-wake messages in cursor order", async () => {


### PR DESCRIPTION
## Why this PR exists

Ordinary hosted foreground replies currently hydrate every event file named by the pending-input index merely to determine that no generated-image completion needs recovery. This removes that O(n) file-read fanout while keeping the existing pending index as the sole durable owner.

## User goal / user-visible behavior

Ordinary messages can reach Murph's provider-start path without delay from unrelated pending-event hydration. Generated-image completions retain exactly the current completion-first, same-route follow-up, and newest-message behavior.

## User experience

There is no new action, screen, copy, or continuation. The entry point, feedback, delivery destination, permissions, and recovery behavior are unchanged; this is an internal latency optimization on the existing foreground reply path.

## Invariants the PR must preserve

- The index cannot report a negative hint while a known unresolved trusted image completion exists.
- State without the projection and newly enqueued inputs whose event data is missing remain conservatively positive.
- A positive hint exposes the complete pending cohort to the existing route/origin/follow-up selector.
- Foreground selection remains read-only; backfill and compaction stay background-maintenance owned.
- Fresh input and newest-message authority continue to win under the established selector.

## Non-obvious affected surfaces

- Persisted assistant-runtime residue: the existing v2 pending-input index gains one additive derived projection. Focused legacy-state and compaction coverage proves conservative read compatibility and exact repair.
- Foreground reply critical path: the ordinary negative case stops hydrating pending event files. A deterministic call-count regression proves the new boundary.
- Runner deployment compatibility: the prior v2 value reader is strict, so the first persisted projection is a runner rollback floor. The owner README documents immediate rollout and forward-fix posture.

## Architecture and reuse

- **Existing systems reused:** the hosted pending-input index, immutable assistant input events, existing image-completion classifier, maintenance compaction, and established full-cohort recovery selector.
- **New logic:** one conservative `hasImageCompletionCandidate` projection maintained on enqueue, backfill, merge, and compaction.
- **New abstractions:** no new durable owner or service; one narrowly named index reader returns the full cohort only when recovery may be relevant.
- **Complexity intentionally avoided:** no queue, sidecar, route index, migration job, scheduler, reconciliation loop, or second summary synchronization protocol; the smaller O(n)-byte index parse deliberately remains.

## Hot reply path impact

This PR changes the Foreground Reply Critical Path.

- Before, the ordinary negative recovery precheck awaited one local pending-index JSON read, then `n` sequential local pending-event file reads (`n` = the complete index length), followed by one local automation-state read when events existed.
- After, that precheck awaits one local pending-index JSON read, zero pending-event reads, and zero automation-state reads when the projection is negative.
- The positive path remains unchanged: it hydrates the complete cohort and delegates selection to the existing owner.
- Enqueue adds one sequential local event-file read for only the newly added input. It has no explicit retry or timeout; a missing event fails safe by setting the projection positive.
- Database calls added or moved: 0. Network/provider calls added or moved: 0. Other awaited calls: the single enqueue-local event read above; the ordinary selector removes `n` event reads and the conditional automation-state read.
- Latency proof is deterministic call count rather than a wall-clock benchmark: the focused turn-input test observes only the fresh input read for an ordinary negative case.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, message assembly, tool/schema, generated guidance, model/tool mode, or provider-request boundary changed.
- Group Murph: Not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: **applicable** — the member-visible interaction and recovery semantics are unchanged, but removing ordinary foreground hydration changes reply timing. Intended outcome: ordinary replies reach provider start without delay from unrelated pending events. The focused call-count scenario proves that path while positive completion-recovery scenarios remain unchanged.
- Prompt: **not applicable** — no prompt or provider-visible instruction surface changed.
- Frontend: **not applicable** — no `apps/web` UI changed; rendered evidence is not applicable.
- Coverage: **applicable** — focused proof is assistant-runtime typecheck plus 73 passing tests across the pending-index and turn-input files. The corrected production candidate and final documentation-only head passed all required CI.

Direct scenario evidence: the ordinary-path spy proves no pending-event hydration; positive completion and pre-projection state tests prove full-cohort recovery and conservative repair.

ReviewGPT context sensitivity: sensitive

Reason: this changes persisted hosted-runtime state plus foreground ordering/performance behavior.

ReviewGPT first-reviewed head: e4587d839c4fbc8f306c9a9e4e4cac88da437dda

Current candidate head: 7b7191fa3d9cef09648a06fbf2fd8e1e5bc00050

Review remediation authored-source growth: 0 added, 0 deleted; the accepted specialist correction adds six test lines only. The later plan-closure commit is documentation-only.

## Review results

- Preliminary specialists reviewed the immutable production candidate for 20m46s. Product experience passed; prompt and frontend were not applicable; coverage produced one medium finding requesting direct proof of the missing-event fail-safe branch.
- The accepted finding was resolved with six test-only assertions proving the full recovery cohort both before and after compaction; the corrected two-file suite passes all 73 tests.
- Final ReviewGPT round 1 reviewed the immutable production candidate for 22m25s and returned `ROUND_OUTCOME: PASS`, `REVIEW_COMPLETE`, and no qualifying findings. Captured response metadata binds both substantive reviews to `gpt-5-6-pro`.
- The repository workflow does not require a new substantive round for the test-only correction or the documentation-only plan closure.

## Change-shape breakdown

Classification uses path ownership: production TypeScript is source, `test/**` is tests/fixtures, Markdown is docs, and no config/tooling or generated files changed. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 82 | 5 |
| Tests/fixtures | 116 | 2 |
| Docs | 142 | 3 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **340** | **10** |

## Verification

- `pnpm --filter @murphai/assistant-runtime typecheck` — passed.
- `pnpm --filter @murphai/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-pending-input-index.test.ts test/hosted-runtime-turn-input.test.ts` — 2 files, 73 tests passed.
- Post-specialist `pending-input-index` proof — 1 file, 37 tests passed; package typecheck passed.
- `git diff --check` — passed.
- Supplied patch SHA-256 and secret-safe identifier scan — passed.
- Corrected production candidate and final documentation-only exact-head required CI — all passed. One unrelated Cloudflare deadline test timed out under full-matrix contention on the first final-head run; its isolated local file passed, and the failed-job rerun passed without a code change.

## Deployment skew / compatibility

Only the runner bundle and its encrypted workspace residue change; there is no Web/Worker wire-contract change. A new runner reads older state conservatively. Once a new runner persists the projection, the preceding strict v2 value reader cannot restore that snapshot, so `container_rollout=immediate` is required and the projection-aware runner becomes the rollback floor. Do not route a projected snapshot back to an older warm runner; below the floor, use a forward fix rather than adding dual state owners or reconciliation machinery.

The safe order is: build and verify the projection-aware runner, deploy it with immediate container rollout, confirm managed-container bundle convergence, then smoke an ordinary negative reply and a generated-image completion recovery. The rollout duration and current production operation count are deploy-time facts owned by the protected deployment status and logs, not asserted by this code-only PR; deployment must stop rather than proceed if immediate convergence cannot be proved. The state is derived and reversible only by a stopped-runner offline rewrite, so normal rollback posture is forward fix.

## Design proof

Not applicable — no user-facing frontend UI changed.

## Changelog

- Changelog: not applicable
- Reason: Internal hosted reply-path performance work; no member-visible behavior changed.




