### PR TITLE
Add Vonneumann ReviewGPT lane

### DIFF
--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -12,7 +12,7 @@ completion:
 2. The separate `pr-review` loop is the final cross-cutting gate for eligible work
    and replaces local `deep-review`.
 
-Both stages use the managed Eragon, Phlebas, Hercules, and Mountain browser
+Both stages use the managed Eragon, Phlebas, Hercules, Vonneumann, and Mountain browser
 lanes. They
 never share round state: the preliminary pass does not create or advance the
 final gate's immutable first-reviewed-head baseline. After focused local proof
@@ -400,7 +400,7 @@ the current user explicitly asks for it.
 
    The repo wrapper runs the current installed Brave binary with one usable
    ReviewGPT browser lane per run: Eragon on CDP port `9448`, Phlebas on `9442`,
-   Hercules on `9444`, or Mountain on `9450`, always with profile `Default` and
+   Hercules on `9444`, Vonneumann on `9446`, or Mountain on `9450`, always with profile `Default` and
    `app_connector=current` so review context comes from the guarded ZIP and
    not a ChatGPT connector. ReviewGPT attaches that snapshot as
    `codebase.zip`; Repomix is disabled by default and is not part of this flow.
@@ -409,7 +409,7 @@ the current user explicitly asks for it.
    authority.
 
    `REVIEW_GPT_BROWSER_LANE_COUNT` limits the automatic pool to the first one
-   through four lanes and defaults to four. A local
+   through five lanes and defaults to five. A local
    `$XDG_CONFIG_HOME/murph/review-gpt.conf` may set this without committing
    machine-specific preferences or account details.
 
@@ -426,7 +426,7 @@ the current user explicitly asks for it.
    downgrading the model.
 
    To pin a specific lane, preserve a conversation's workspace, or debug one
-   profile, set `REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain` on
+   profile, set `REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|vonneumann|mountain` on
    that command.
    `aragon` is accepted as an alias for `eragon`. A first round may leave it
    unset to select a usable lane automatically, but its handoff must record the

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1455,8 +1455,10 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptConfig).toContain('thinking="current"')
     expect(reviewGptConfig).toContain('hercules) printf \'%s\\n\' "Hercules" ;;')
     expect(reviewGptConfig).toContain('hercules) printf \'%s\\n\' "9444" ;;')
+    expect(reviewGptConfig).toContain('vonneumann) printf \'%s\\n\' "Vonneumann" ;;')
+    expect(reviewGptConfig).toContain('vonneumann) printf \'%s\\n\' "9446" ;;')
     expect(reviewGptConfig).toContain(
-      'review_gpt_all_browser_lanes=(eragon phlebas hercules mountain)',
+      'review_gpt_all_browser_lanes=(eragon phlebas hercules vonneumann mountain)',
     )
     expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
@@ -1723,16 +1725,17 @@ describe('monorepo release flow coverage audit', () => {
       'The `pr-review` prompt lives at',
     )
     expect(prReviewGptLoop).toContain(
-      'Both stages use the managed Eragon, Phlebas, Hercules, and Mountain browser',
+      'Both stages use the managed Eragon, Phlebas, Hercules, Vonneumann, and Mountain browser',
     )
     expect(prReviewGptLoop).toContain('default randomized usable managed')
     expect(prReviewGptLoop).toContain('Hercules on `9444`')
+    expect(prReviewGptLoop).toContain('Vonneumann on `9446`')
     expect(prReviewGptLoop).toContain('current installed Brave binary')
     expect(prReviewGptLoop).toContain(
       "passes none of Chromium's background-timer, occluded-window, or renderer",
     )
     expect(prReviewGptLoop).toContain(
-      '`REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|mountain`',
+      '`REVIEW_GPT_BROWSER_LANE=eragon|phlebas|hercules|vonneumann|mountain`',
     )
     expect(prReviewGptLoop).toContain('6,500 UTF-8 bytes')
     expect(prReviewGptLoop).toContain(
@@ -2219,7 +2222,7 @@ printf '%s|%s|%s|%s|%s\n' \
       )
 
       rmSync(path.join(localConfigRoot, 'murph', 'review-gpt.conf'))
-      for (const lane of ['Eragon', 'Phlebas', 'Hercules']) {
+      for (const lane of ['Eragon', 'Phlebas', 'Hercules', 'Vonneumann']) {
         writeHarnessFile(
           harnessRoot,
           `Library/Application Support/MurphReviewGPT/${lane}/SingletonLock`,
@@ -2245,7 +2248,7 @@ printf '%s|%s|%s|%s|%s\n' \
         defaultDisplayMode,
       ] = defaultResult.stdout.trim().split('|')
       expect(defaultLane).toBe('mountain')
-      expect(defaultLaneCount).toBe('4')
+      expect(defaultLaneCount).toBe('5')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
@@ -2265,8 +2268,41 @@ printf '%s|%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        'main|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
+
+      const vonneumannResult = spawnSync(
+        'bash',
+        [
+          '-c',
+          `${configHarness}\nprintf '%s|%s\\n' "$managed_browser_port" "$managed_browser_user_data_dir"`,
+        ],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...cleanBrowserPreferenceEnv(),
+            HOME: harnessRoot,
+            REPO_ROOT: repoRoot,
+            REVIEW_GPT_BROWSER_LANE: 'vonneumann',
+            XDG_CONFIG_HOME: localConfigRoot,
+          },
+        },
+      )
+      expect(vonneumannResult.status, vonneumannResult.stderr).toBe(0)
+      expect(vonneumannResult.stdout.trim().split('\n')).toEqual([
+        'vonneumann|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        [
+          '9446',
+          path.join(
+            harnessRoot,
+            'Library',
+            'Application Support',
+            'MurphReviewGPT',
+            'Vonneumann',
+          ),
+        ].join('|'),
+      ])
 
       const missingThreadResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -2255,6 +2255,36 @@ printf '%s|%s|%s|%s|%s\n' \
       expect(defaultBackgroundMode).toBe('balanced')
       expect(defaultDisplayMode).toBe('headful')
 
+      rmSync(
+        path.join(
+          harnessRoot,
+          'Library',
+          'Application Support',
+          'MurphReviewGPT',
+          'Vonneumann',
+          'SingletonLock',
+        ),
+      )
+      writeHarnessFile(
+        harnessRoot,
+        'Library/Application Support/MurphReviewGPT/Mountain/SingletonLock',
+        'locked\n',
+      )
+      const autoVonneumannResult = spawnSync('bash', ['-c', configHarness], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...cleanBrowserPreferenceEnv(),
+          HOME: harnessRoot,
+          REPO_ROOT: repoRoot,
+          XDG_CONFIG_HOME: localConfigRoot,
+        },
+      })
+      expect(autoVonneumannResult.status, autoVonneumannResult.stderr).toBe(0)
+      expect(autoVonneumannResult.stdout.trim()).toBe(
+        'vonneumann|5|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+      )
+
       const mainResult = spawnSync('bash', ['-c', configHarness], {
         cwd: repoRoot,
         encoding: 'utf8',

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -12,7 +12,7 @@ if [[ -r "$review_gpt_local_config" ]]; then
 fi
 
 review_gpt_invalid_browser_lane() {
-  echo "Error: unsupported ReviewGPT browser lane '$1'. Use main, random, eragon, phlebas, hercules, or mountain." >&2
+  echo "Error: unsupported ReviewGPT browser lane '$1'. Use main, random, eragon, phlebas, hercules, vonneumann, or mountain." >&2
 }
 
 review_gpt_browser_lane_display_name() {
@@ -21,6 +21,7 @@ review_gpt_browser_lane_display_name() {
     eragon) printf '%s\n' "Eragon" ;;
     phlebas) printf '%s\n' "Phlebas" ;;
     hercules) printf '%s\n' "Hercules" ;;
+    vonneumann) printf '%s\n' "Vonneumann" ;;
     mountain) printf '%s\n' "Mountain" ;;
     *)
       review_gpt_invalid_browser_lane "$1"
@@ -35,6 +36,7 @@ review_gpt_browser_lane_port() {
     eragon) printf '%s\n' "9448" ;;
     phlebas) printf '%s\n' "9442" ;;
     hercules) printf '%s\n' "9444" ;;
+    vonneumann) printf '%s\n' "9446" ;;
     mountain) printf '%s\n' "9450" ;;
     *)
       review_gpt_invalid_browser_lane "$1"
@@ -123,7 +125,7 @@ else
   review_gpt_requested_browser_lane="${REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_BROWSER_LANE:-${MURPH_REVIEW_GPT_PROFILE_SLUG:-auto}}}"
 fi
 review_gpt_requested_browser_lane="$(printf '%s' "$review_gpt_requested_browser_lane" | tr '[:upper:]' '[:lower:]')"
-review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
+review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-5}}"
 
 if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then
   case "$review_gpt_requested_browser_lane" in
@@ -134,8 +136,8 @@ if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then
   esac
 fi
 
-if [[ ! "$review_gpt_browser_lane_count" =~ ^[1-4]$ ]]; then
-  echo "Error: REVIEW_GPT_BROWSER_LANE_COUNT must be an integer from 1 to 4." >&2
+if [[ ! "$review_gpt_browser_lane_count" =~ ^[1-5]$ ]]; then
+  echo "Error: REVIEW_GPT_BROWSER_LANE_COUNT must be an integer from 1 to 5." >&2
   return 1 2>/dev/null || exit 1
 fi
 
@@ -144,7 +146,7 @@ case "$review_gpt_requested_browser_lane" in
     review_gpt_selected_browser_lane="main"
     ;;
   "" | auto | random)
-    review_gpt_all_browser_lanes=(eragon phlebas hercules mountain)
+    review_gpt_all_browser_lanes=(eragon phlebas hercules vonneumann mountain)
     review_gpt_browser_lanes=("${review_gpt_all_browser_lanes[@]:0:review_gpt_browser_lane_count}")
     review_gpt_usable_browser_lanes=()
 
@@ -164,7 +166,7 @@ case "$review_gpt_requested_browser_lane" in
   aragon | eragon)
     review_gpt_selected_browser_lane="eragon"
     ;;
-  phlebas | hercules | mountain)
+  phlebas | hercules | vonneumann | mountain)
     review_gpt_selected_browser_lane="$review_gpt_requested_browser_lane"
     ;;
   *)


### PR DESCRIPTION
## Why this PR exists

Vonneumann already has an isolated managed Brave profile, but ReviewGPT cannot select it. This adds it to the same lane registry used by the four existing profiles.

## User goal / user-visible behavior

An operator can pin `REVIEW_GPT_BROWSER_LANE=vonneumann`, and automatic selection can use all five managed lanes. Vonneumann keeps its own login/profile state on CDP port `9446`.

## User experience

This has no member-facing product effect. ReviewGPT operators use the existing command and receive the existing lane/endpoint diagnostics; same-thread continuations remain pinned to the recorded lane, while lock and unavailable-endpoint failures keep the existing fail-loud behavior.

## Invariants the PR must preserve

- Each lane keeps a unique user-data directory and CDP port.
- Existing lane names, ports, and the `aragon` alias remain unchanged.
- Same-thread ReviewGPT continuation still requires an explicit original lane.
- The installed current Brave binary remains browser-version authority.

## Non-obvious affected surfaces

- Default random selection expands from four to five lanes. The config harness locks the first four profiles and proves Mountain remains the only usable result, while the explicit Vonneumann case proves its isolated directory and port.

## Architecture and reuse

- **Existing systems reused:** The existing stateless lane registry, availability filter, local preference file, and managed-browser lifecycle.
- **New logic:** One display-name mapping, one free port mapping, one selector value, and a five-lane pool/count bound.
- **New abstractions:** No new abstraction; the current case-based lane registry already owns this behavior.
- **Complexity intentionally avoided:** No scheduler, persisted usage state, profile migration, copied login state, or second browser owner.

## Changelog

- Changelog: not applicable
- Reason: Internal ReviewGPT operator tooling only; no member-visible behavior changed.

## Hot reply path impact

Not applicable. This changes local review tooling only and does not enter Murph's conversation runtime.

## Database collection fanout impact

Not applicable. No database code or collection path changes.

## Murph initial provider input impact

- Individual Murph: Not applicable; no provider-input builder, prompt, tool schema, model mode, or request assembly changes.
- Group Murph: Not applicable; no provider-input builder, prompt, tool schema, model mode, or request assembly changes.

## Preliminary specialist lenses

- **Product experience:** not applicable — no member journey or semantic product behavior changes.
- **Prompt:** not applicable — no prompt or instruction stack changes.
- **Frontend:** not applicable — no `apps/web` presentation changes or rendered evidence.
- **Coverage:** applicable — shell syntax, explicit Vonneumann ReviewGPT dry run, focused lane regression, and canonical CLI typecheck passed locally; exact-head CI is pending.

ReviewGPT context sensitivity: routine

Reason: Narrow internal tooling/configuration change with no production runtime, trust-boundary, persisted-state, or deploy effect.

## Change-shape breakdown

Classification: test files are tests/fixtures, the workflow guide is docs, and the shell lane registry is config/tooling. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 42 | 6 |
| Docs | 4 | 4 |
| Config/tooling | 8 | 6 |
| Generated/other | 0 | 0 |
| **Total** | **54** | **16** |

## Verification

- `bash -n scripts/review-gpt.config.sh`
- Explicit `vonneumann` dry run: selected port `9446` and the isolated Vonneumann profile.
- Focused regression: 1 passed, 45 skipped with a 180-second timeout sized to observed local filesystem latency.
- `pnpm --dir packages/cli typecheck`
- Full release-audit file: 41 passed, 1 skipped; four timeout failures under severe local filesystem latency, including three untouched packaging/timeout tests.