### PR TITLE
Update ReviewGPT to 0.5.133

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/parser": "^7.29.3",
     "@babel/types": "^7.29.0",
     "@cobuild/repo-tools": "^0.1.17",
-    "@cobuild/review-gpt": "^0.5.132",
+    "@cobuild/review-gpt": "^0.5.133",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1169,13 +1169,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.132')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.133')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.132'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.133'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       '@cobuild/review-gpt':
-        specifier: ^0.5.132
-        version: 0.5.132(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.133
+        version: 0.5.133(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1472,8 +1472,8 @@ packages:
     resolution: {integrity: sha512-cq+LzXoKNOn+KXLBm9+N9QMTEwbIXzki5AZXP/cHnAex3+3LnyhJ7zMxB5InZVgQgqI9hEs0dsXoJX/tNxlW3Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.132':
-    resolution: {integrity: sha512-UJrMVW2LUXnGOorFZKmOs7KaC4lRqUodQacBsb3Vbi9dzLSoslZKdmr/HXyuSLlIsShBoYvZK3JD1hstGsOz4w==}
+  '@cobuild/review-gpt@0.5.133':
+    resolution: {integrity: sha512-z3OxCTPb/z6eFaG6JPxsYzHGlrytOp7FyuoBDwAezEEJtL9sjOsY5LD4+qMBZMQDGyNcgutEDrNKFf2Qfz0ueQ==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10816,7 +10816,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17': {}
 
-  '@cobuild/review-gpt@0.5.132(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.133(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
 minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/repo-tools@0.1.17'
-  - '@cobuild/review-gpt@0.5.132'
+  - '@cobuild/review-gpt@0.5.133'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why this PR exists

Murph still installs ReviewGPT 0.5.132, so local review runs cannot use the published Brave lifecycle fixes in 0.5.133.

## User goal / user-visible behavior

Local review automation uses ReviewGPT 0.5.133. It can open Brave in the background and close the managed browser after the last completed review when machine-local settings enable those options.

## User experience

Not applicable. This changes internal developer tooling only.

## Architecture and reuse

- **Existing systems reused:** The existing ReviewGPT dependency, pnpm lockfile, minimum-release-age exception, and machine-local ReviewGPT configuration remain the owners.
- **New logic:** No Murph runtime logic was added. The dependency reference now selects the published 0.5.133 package.
- **New abstractions:** No abstraction was added. The existing package boundary is sufficient.
- **Complexity intentionally avoided:** No browser lifecycle code was copied into Murph, and no production configuration changed.

## Changelog

- Changelog: not applicable
- Reason: Internal tooling only; no member-visible behavior changed.

## Hot reply path impact

Not applicable. This PR does not change the Foreground Reply Critical Path.

## Database collection fanout impact

Not applicable. This PR does not change database access.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool schema, model setting, or request assembly changed.
- Group Murph: Not applicable. No prompt, tool schema, model setting, or request assembly changed.

## Preliminary specialist lenses

- Product experience: not applicable. No product-owned behavior changes.
- Prompt: not applicable. No prompt content or provider input changes.
- Frontend: not applicable. No frontend files or rendered UI change.
- Coverage: applicable. The published package passed 236 upstream tests, Murph installed it with a frozen lockfile, and a real signed-in Brave smoke test returned the expected response and closed the browser. Exact-head CI is pending.

ReviewGPT context sensitivity: routine

Reason: This is a narrow developer-tool dependency update with no production, trust-boundary, persisted-state, runtime, or deploy behavior change.

## Change-shape breakdown

Classification rule: dependency manifests and the lockfile are config/tooling. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 2 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 7 | 7 |
| Generated/other | 0 | 0 |
| Total | 9 | 9 |

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm deps:guard`
- `pnpm deps:ignored-builds`
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` (45 passed, 1 skipped)
- Installed CLI reports `cobuild-review-gpt@0.5.133`.
- Real Brave smoke test returned `PUBLISHED_SMOKE_PASS` and closed the managed browser.
- `pnpm deps:audit` reports the same 77 existing advisories on base and head. ReviewGPT 0.5.132 and 0.5.133 have the same dependency graph.