### PR TITLE
Introduce Murph on the referral share card

### DIFF
--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -253,7 +253,10 @@ export function SectionsContent() {
 
       {/* Card image routes must live in ungrouped app segments: metadata
           images inside a route group emit hash-suffixed URLs in production,
-          which 404s the exact URL the pages advertise. */}
+          which 404s the exact URL the pages advertise. Each entry renders
+          the production card component with its shipped alt text as the
+          caption, so card copy changes (like the referral card's
+          "Meet Murph." headline) surface here without a separate study. */}
       <StudySection title="Share link previews">
         <div data-design-section="share-link-previews">
           <ShareLinkPreviewsStudy />

--- a/apps/web/app/design/share-link-previews-study.tsx
+++ b/apps/web/app/design/share-link-previews-study.tsx
@@ -25,9 +25,9 @@ const PREVIEWS = [
     route: "/r/[referralCode]",
     note:
       "The referral link members text friends. The recipient has no Murph "
-      + "conversation yet, so the card frames the brand line instead of "
-      + "speaking as Murph, and stays capability-neutral so it remains true "
-      + "for expired links.",
+      + "conversation yet, so the card introduces Murph instead of speaking "
+      + "as it, and stays capability-neutral so it remains true for expired "
+      + "links.",
     alt: REFERRAL_OG_ALT,
     card: <ReferralShareCard logoDataUri="/logo.svg" />,
   },

--- a/apps/web/app/r/[referralCode]/referral-share-card.tsx
+++ b/apps/web/app/r/[referralCode]/referral-share-card.tsx
@@ -1,24 +1,23 @@
 import { MurphHeroOg } from "../../_og/murph-hero-og";
 
-export const REFERRAL_OG_ALT =
-  "Murph, your private health assistant. Don’t do it alone.";
+export const REFERRAL_OG_ALT = "Meet Murph, your private health assistant.";
 
 /**
  * The /r/[referralCode] link unfurl. Members text this link to friends, so
- * the card frames the brand line rather than speaking as Murph: the
- * recipient has no Murph conversation yet. The copy is deliberately
- * capability-neutral so it stays true when a link has expired or been
- * revoked; the landing page owns the valid/unavailable/busy states.
- * Rendered by the opengraph-image route (satori) and the /design catalog
- * share-preview study, so the preview cannot drift from production.
+ * the card introduces Murph rather than speaking as it: the recipient has no
+ * Murph conversation yet. The copy is deliberately capability-neutral so it
+ * stays true when a link has expired or been revoked; the landing page owns
+ * the valid/unavailable/busy states. Rendered by the opengraph-image route
+ * (satori) and the /design catalog share-preview study, so the preview
+ * cannot drift from production.
  */
 export function ReferralShareCard({ logoDataUri }: { logoDataUri: string }) {
   return (
     <MurphHeroOg
       logoDataUri={logoDataUri}
-      headline={"Don’t do it\nalone."}
+      headline="Meet Murph."
       headlineFontSize={96}
-      subtext="Murph, your private health assistant."
+      subtext="Your private health assistant."
       subtextFontSize={30}
     />
   );

--- a/apps/web/test/share-preview-metadata.test.ts
+++ b/apps/web/test/share-preview-metadata.test.ts
@@ -67,7 +67,7 @@ describe("share preview metadata", () => {
 
     expect(metadata.title).toBe("Join Murph");
     expectDedicatedImage(metadata, {
-      alt: "Murph, your private health assistant. Don’t do it alone.",
+      alt: "Meet Murph, your private health assistant.",
       url: "/r/ref-code/opengraph-image",
     });
     expect(metadata.robots).toEqual({ follow: false, index: false });


### PR DESCRIPTION
## Why this PR exists

The referral card that shipped in #1920 used "Don't do it alone." as its headline — the second line of the brand tagline, which loses its antecedent without "Health is hard." in front of it. The owner reviewed rendered alternatives and selected "Meet Murph." This PR applies that selection.

## User goal / user-visible behavior

A friend receiving a referral link (`/r/[referralCode]`) sees "Meet Murph." / "Your private health assistant." in the unfurl. Alt text follows: "Meet Murph, your private health assistant."

## User experience

- Copy-only change on the existing referral unfurl; entry point, journey, timing, and recovery are unchanged.
- The framing remains capability-neutral and not in Murph's first-person voice (the recipient has no Murph conversation yet): introducing Murph stays true even when a specific referral link has expired or been revoked — the landing page owns the valid/unavailable/busy states.
- Rendered evidence: satori render of the exact route module at 1200x630, plus updated `/design?tab=sections` study captures (below).

## Invariants the PR must preserve

- Capability neutrality: no claim of a live invitation or reward on a link that may be dead.
- No member data in previews; the dynamic segment shapes only the image URL.
- `/r/` keeps `noindex` + `strict-origin` (unchanged, still asserted in `hosted-signup-referral-ux.test.tsx`).

## Non-obvious affected surfaces

None. The change touches the shared card component, its catalog study caption, and the focused alt assertion; no metadata wiring, routes, or guards change.

## Architecture and reuse

- Existing systems reused: the `ReferralShareCard` component and `MurphHeroOg` frame; the catalog study renders the same production component, so the preview cannot drift.
- New logic: none — copy and alt text only.
- New abstractions: none added — the existing share-card contract carries the change; no structural work was needed.
- Complexity intentionally avoided: no per-referrer personalization (previews are unauthenticated) and no reintroduction of invitation claims the review rounds rejected.

## Changelog

- Changelog: not applicable
- Reason: Copy refinement on a preview card whose member-visible outcome ("referral links unfurl with a dedicated card") is already recorded under 2026-08-15 · share-link-preview-sweep; the outcome is unchanged.

## Hot reply path impact

Not applicable. No conversation-path or runtime code changes.

## Database collection fanout impact

Not applicable. No database-touching path changed.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. No prompt, tool, schema, or provider-request surface changed.

## Preliminary specialist lenses

- Product experience: applicable — semantic user-facing copy on the referral journey, selected by the product owner from rendered alternatives. Intended outcome: the recipient immediately understands what Murph is; the intro framing reads standalone, unlike the tagline fragment it replaces. Direct journey evidence: satori render of the exact route module packaged as rendered evidence.
- Prompt: not applicable — no prompt surface changed.
- Frontend: applicable — rendered evidence packaged for ReviewGPT: the 1200x630 route render plus hosted desktop (1440@2x) and mobile (390@3x) study captures listed in the Design proof section.
- Coverage: applicable — focused local proof: `run-hosted-web-vitest` over `test/share-preview-metadata.test.ts` and `test/hosted-signup-referral-ux.test.tsx` (17/17 pass; the alt assertion pins the new copy), eslint clean. Exact-head CI: pending.

Preliminary pass disposition: `SPECIALIST_OUTCOME: PASS` with `NO FINDINGS` on `09b69466d1f0` (positive product purpose verdict). The follow-up commit `555f827c5f7b` adds only a design-catalog registration comment required by the design-proof gate; it contains no behavioral change.

ReviewGPT context sensitivity: routine

Classification reason: copy-only change to a static share-preview asset; no auth, privacy, billing, persisted-state, API, runtime/deploy, ordering, or trust-boundary behavior changes.

## Change-shape breakdown

Classification rule: `apps/web/app/**` = source; `apps/web/test/**` = tests/fixtures; no docs, config, generated files, or binaries in the diff.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 16 | 14 |
| Tests/fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **17** | **15** |

## Design proof

- Design page: [/design?tab=sections](https://www.withmurph.ai/design?tab=sections) — "Share link previews" study; the referral entry renders the updated production card and caption.
- Desktop screenshot: ![Share link previews study, desktop 1440@2x](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/e239f2fe-43f5-47ed-cc72-138c35159c00/designproof)
- Mobile screenshot: ![Share link previews study, mobile 390@3x, clipped below the sticky catalog nav](https://imagedelivery.net/TDuhqfLDl0Fb8RGwGw6mYw/9a478e52-b980-4a13-6b34-1555da83e400/designproof)

## Deployment skew / compatibility

Not applicable. Single-sided `apps/web` copy change; scrapers pick up the new card on their normal refetch.
