### PR TITLE
Fix hosted runner bundle size gate

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -76,14 +76,14 @@ const VAULT_CLI_IMPORT_SURFACE_HOOK_SOURCE = [
 // current main on 2026-08-14. The reviewed Junction temporal-fidelity and
 // source-authority graph measured 9,128,211 B on Linux CI and 9,175,594 B on
 // macOS after merging current main on 2026-08-14; no package entered the graph.
-// The reviewed cross-session context reply work measured 9,119,111 B after
-// normalizing the esbuild working directory on 2026-08-15; it grows the
-// existing Assistant Engine graph without adding a package. The static
-// startup closure measured 24,950 B. Keep total output inside a narrow 32 KiB
-// allowance and static startup inside an 8 KiB allowance. If a
+// The reviewed Telegram rich-response work measured 9,159,100 B in the Linux
+// deploy lane on 2026-08-16; it grows the existing Assistant Engine graph
+// without adding a package. The static startup closure still measured 24,950 B.
+// Keep total output inside a narrow 32 KiB allowance and static startup inside
+// an 8 KiB allowance. If a
 // violation fires, investigate the listed largest inputs first; only raise the
 // budget deliberately for understood, intended growth.
-const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_152_000;
+const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_192_000;
 const VAULT_CLI_BUNDLE_ENTRY_BYTES_BUDGET = 20_000;
 const VAULT_CLI_BUNDLE_STATIC_CLOSURE_BYTES_BUDGET = 33_200;
 


### PR DESCRIPTION
## Why this PR exists

The production hosted deploy for PR #1926 stopped because its intended runner bundle was 7,100 bytes above the previous size ratchet. This updates that ratchet to the measured bundle size while keeping narrow headroom.

## User goal / user-visible behavior

The already-approved richer Telegram replies can reach production. This follow-up does not change their content or behavior.

## User experience

No new user experience is introduced here. The production deploy remains blocked on focused checks and live smoke proof if the measured bundle is not valid.

## Invariants the PR must preserve

- The runner bundle contents and runtime code stay unchanged.
- The total budget reflects the measured 9,159,100-byte Linux bundle and keeps about 32 KiB of headroom.
- The separate entry and static-startup limits remain unchanged.
- Unexpected future bundle growth still fails closed.

## Non-obvious affected surfaces

- Cloudflare hosted deploy admission: the size ratchet now accepts the intentional bundle from PR #1926. Proof: `pnpm --dir apps/cloudflare runner:bundle` completed with all parity probes and bundle checks.

## Architecture and reuse

- **Existing systems reused:** The existing vault CLI bundle measurement and fail-closed size ratchet remain the sole deploy gate.
- **New logic:** No runtime logic was added. One measured budget constant was updated.
- **New abstractions:** No abstraction was added because the existing byte-budget contract is sufficient.
- **Complexity intentionally avoided:** No bypass, retry path, or second deployment mechanism was added.

## Changelog

- Changelog: not applicable
- Reason: Internal deploy-gate correction only; PR #1926 owns the member-visible behavior.

## Hot reply path impact

Not applicable. This does not change the foreground reply path or add any awaited work.

## Database collection fanout impact

Not applicable. This does not change database access.

## Murph initial provider input impact

- Individual Murph: Not applicable. No prompt, tool schema, model configuration, or provider request input changed.
- Group Murph: Not applicable. No prompt, tool schema, model configuration, or provider request input changed.

## Preliminary specialist lenses

- Product experience: not applicable. This follow-up changes only a deploy size ratchet.
- Prompt: not applicable. No prompt text or prompt assembly changed.
- Frontend: not applicable. No web UI changed.
- Coverage: applicable. Focused local proof is `pnpm --dir apps/cloudflare runner:bundle`; exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Reason: The change affects the fail-closed Cloudflare hosted deploy gate.

ReviewGPT first-reviewed head: 52cb7bb9b4b1021a188a968b08cce5beaf25ff00

## Change-shape breakdown

Classification rule: the runner-bundle script is config/tooling. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 6 | 6 |
| Generated/other | 0 | 0 |
| **Total** | **6** | **6** |

## Design proof

Not applicable. No user-facing frontend UI changed.

## Motion proof

Not applicable. No user-visible state transition changed.

## Deployment skew / compatibility

This PR changes no Worker, runner, credential, or persisted-state shape. After merge, the protected deploy for PR #1926 must still use `container_rollout=immediate` and prove the exact runner fingerprint plus a live model turn.