### PR TITLE
Keep production Webpack compiles cold and bound them with a build watchdog

### DIFF
--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -861,8 +861,8 @@ fallback through the same shared production-build selector, with the isolated
 Webpack build worker and memory optimizations enabled. Interactive development
 and the dev-smoke lane remain on Turbopack. A cache-local compiler epoch removes
 all of `.next/cache` when a restored cache predates the current epoch and writes
-the epoch only after a successful Next build, so a failed transition retries
-cold. Production Webpack compiles are additionally cold-cache by policy: the
+the epoch only after a successful Next build and a successful post-success
+Webpack-cache discard, so a failed transition retries cold. Production Webpack compiles are additionally cold-cache by policy: the
 runner clears `.next/cache/webpack` before every compile and discards it after
 a successful compile, because warm restored Webpack caches were the trigger for
 the August 2026 steady-state 8 GB container OOM kills and silent compile hangs

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -867,8 +867,8 @@ runner regression test are the behavioral authority. Warm restored Webpack
 caches were the trigger for the August 2026 steady-state 8 GB container OOM
 kills and silent compile hangs that followed the cutover. The verification
 implication here is that the verify lane intentionally builds with `VERCEL=1
-VERCEL_ENV=preview`, which compiles Webpack cold but never activates the
-production watchdog, so local macOS verify never needs GNU `timeout`. The Workflow
+VERCEL_ENV=preview`, which compiles Webpack cold but never arms the
+production-only build deadline. The Workflow
 integration runs through its native Next integration: exact-head CI proves the
 complete compile, type-validation, static-generation, and directive-discovery
 path, while focused Stripe and phone-call suites prove the existing

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -859,20 +859,16 @@ correction remains a boundary fix but was not sufficient capacity proof on
 Next 16.2.6. Production and Linux CI now use Next 16.3's supported Webpack
 fallback through the same shared production-build selector, with the isolated
 Webpack build worker and memory optimizations enabled. Interactive development
-and the dev-smoke lane remain on Turbopack. A cache-local compiler epoch removes
-all of `.next/cache` when a restored cache predates the current epoch and writes
-the epoch only after a successful Next build and a successful post-success
-Webpack-cache discard, so a failed transition retries cold. Production Webpack compiles are additionally cold-cache by policy: the
-runner clears `.next/cache/webpack` before every compile and discards it after
-a successful compile, because warm restored Webpack caches were the trigger for
-the August 2026 steady-state 8 GB container OOM kills and silent compile hangs
-that followed the cutover; SWC and other cache subtrees stay warm. On Vercel
-production builds (`VERCEL=1` with `VERCEL_ENV=production`) the runner wraps
-`next build` in a 15-minute `timeout` watchdog (SIGTERM, SIGKILL 30 seconds
-later, explicit exit-124 diagnostic) so a wedged compile releases the deploy
-queue in minutes instead of at Vercel's 45-minute ceiling. The verify lane
-intentionally builds with `VERCEL=1 VERCEL_ENV=preview`, so local and CI
-verify builds skip the watchdog and macOS never needs GNU `timeout`. The Workflow
+and the dev-smoke lane remain on Turbopack. The shared production runner owns
+the fail-closed cache-epoch, cold-Webpack-cache, and production build-watchdog
+contract; `apps/web/README.md` § "Production build memory guard" is the single
+prose owner for those mechanics, and `run-production-next-build.sh` plus its
+runner regression test are the behavioral authority. Warm restored Webpack
+caches were the trigger for the August 2026 steady-state 8 GB container OOM
+kills and silent compile hangs that followed the cutover. The verification
+implication here is that the verify lane intentionally builds with `VERCEL=1
+VERCEL_ENV=preview`, which compiles Webpack cold but never activates the
+production watchdog, so local macOS verify never needs GNU `timeout`. The Workflow
 integration runs through its native Next integration: exact-head CI proves the
 complete compile, type-validation, static-generation, and directive-discovery
 path, while focused Stripe and phone-call suites prove the existing

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -1,6 +1,6 @@
 # Verification And Runtime
 
-Last verified: 2026-08-15
+Last verified: 2026-08-16
 ## Verification Ownership By Delivery Path
 
 The delivery path decides who owns broad verification:
@@ -831,12 +831,13 @@ working directory, and stdio unchanged. In the current observe-only state it
 does not write `memory.max`, `memory.swap.max`, or `memory.oom.group`. The
 Vercel package build starts the parent Next process with a direct 1 GiB
 old-space flag and appends a 3 GiB old-space flag to `NODE_OPTIONS`. Node applies
-the direct flag to the parent; Next 16.3.0 rebuilds its non-isolated TypeScript
-worker options from the parent arguments followed by `NODE_OPTIONS`, so the
-mandatory generated-contract validation receives 3 GiB. Next removes the flag
-from isolated static workers. The same script owns the Vercel package build and
-CI memory-observation invocation. This bounds the compile parent without
-weakening validation, but only repeated forced-cold Standard previews prove the
+the direct flag to the parent; Next 16.3.0 rebuilds non-isolated child options
+from the parent arguments followed by `NODE_OPTIONS`, so the sequential Webpack
+compiler workers receive 3 GiB; the later TypeScript CLI child inherits the same
+limit. Next removes the flag from isolated static workers. The same script owns
+the Vercel package build and the CI memory-observation invocation. This bounds
+the compile parent without weakening validation, but only repeated forced-cold
+Standard previews prove the
 real Vercel boundary. A 2 GiB parent-bound candidate passed one forced-cold
 preview but the next identical build was still killed by the 8 GB container
 OOM boundary. Single
@@ -859,9 +860,19 @@ Next 16.2.6. Production and Linux CI now use Next 16.3's supported Webpack
 fallback through the same shared production-build selector, with the isolated
 Webpack build worker and memory optimizations enabled. Interactive development
 and the dev-smoke lane remain on Turbopack. A cache-local compiler epoch removes
-only `.next/cache` when a restored cache predates the Webpack cutover and writes
-the epoch only after a successful Next build, so a failed cold build retries
-cold while later successful builds retain normal warm caching. The Workflow
+all of `.next/cache` when a restored cache predates the current epoch and writes
+the epoch only after a successful Next build, so a failed transition retries
+cold. Production Webpack compiles are additionally cold-cache by policy: the
+runner clears `.next/cache/webpack` before every compile and discards it after
+a successful compile, because warm restored Webpack caches were the trigger for
+the August 2026 steady-state 8 GB container OOM kills and silent compile hangs
+that followed the cutover; SWC and other cache subtrees stay warm. On Vercel
+production builds (`VERCEL=1` with `VERCEL_ENV=production`) the runner wraps
+`next build` in a 15-minute `timeout` watchdog (SIGTERM, SIGKILL 30 seconds
+later, explicit exit-124 diagnostic) so a wedged compile releases the deploy
+queue in minutes instead of at Vercel's 45-minute ceiling. The verify lane
+intentionally builds with `VERCEL=1 VERCEL_ENV=preview`, so local and CI
+verify builds skip the watchdog and macOS never needs GNU `timeout`. The Workflow
 integration runs through its native Next integration: exact-head CI proves the
 complete compile, type-validation, static-generation, and directive-discovery
 path, while focused Stripe and phone-call suites prove the existing

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -859,16 +859,14 @@ correction remains a boundary fix but was not sufficient capacity proof on
 Next 16.2.6. Production and Linux CI now use Next 16.3's supported Webpack
 fallback through the same shared production-build selector, with the isolated
 Webpack build worker and memory optimizations enabled. Interactive development
-and the dev-smoke lane remain on Turbopack. The shared production runner owns
-the fail-closed cache-epoch, cold-Webpack-cache, and production build-watchdog
-contract; `apps/web/README.md` § "Production build memory guard" is the single
-prose owner for those mechanics, and `run-production-next-build.sh` plus its
-runner regression test are the behavioral authority. Warm restored Webpack
-caches were the trigger for the August 2026 steady-state 8 GB container OOM
-kills and silent compile hangs that followed the cutover. The verification
-implication here is that the verify lane intentionally builds with `VERCEL=1
-VERCEL_ENV=preview`, which compiles Webpack cold but never arms the
-production-only build deadline. The Workflow
+and the dev-smoke lane remain on Turbopack. `apps/web/README.md` § "Production
+build memory guard" is the single prose owner for the production build cache,
+epoch, and deadline contract. Warm restored Webpack caches were the trigger
+for the August 2026 steady-state 8 GB container OOM kills and silent compile
+hangs that followed the cutover. The verification implication here is that
+the verify lane intentionally builds with `VERCEL=1 VERCEL_ENV=preview`,
+which compiles Webpack cold but never arms the production-only build
+deadline. The Workflow
 integration runs through its native Next integration: exact-head CI proves the
 complete compile, type-validation, static-generation, and directive-discovery
 path, while focused Stripe and phone-call suites prove the existing

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -391,10 +391,17 @@ supported provider credential.
   `memory.swap.max`, or `memory.oom.group`. The Vercel package build gives the
   parent Next process a direct 1 GiB old-space flag and appends a 3 GiB flag to
   `NODE_OPTIONS`. Node applies the direct flag to the parent; Next 16.3.0
-  rebuilds its non-isolated TypeScript worker options from the parent arguments
-  followed by `NODE_OPTIONS`, while removing the flag from isolated static
-  workers. The same script owns the Vercel package build and CI memory-
-  observation invocation. The split reduces the compile-parent peak without
+  rebuilds non-isolated child options from the parent arguments followed by
+  `NODE_OPTIONS`, so the sequential Webpack compiler workers receive 3 GiB and
+  the later generated-contract TypeScript validation child inherits the same
+  limit, while isolated static workers have the flag removed. The same script
+  owns the Vercel package build and CI memory-observation invocation. The
+  production runner keeps Webpack compiles cold-cache (it clears
+  `.next/cache/webpack` before every compile and discards it after success)
+  and, on Vercel production builds only (`VERCEL_ENV=production`), bounds
+  `next build` with a 15-minute `timeout` watchdog so a wedged compile fails
+  fast instead of reaching Vercel's 45-minute ceiling. The verify lane's
+  `VERCEL=1 VERCEL_ENV=preview` build shape stays unbounded. The split reduces the compile-parent peak without
   weakening generated-contract validation, while repeated forced-cold Standard
   previews remain the real Vercel acceptance proof. A 2 GiB parent-bound
   candidate passed one forced-cold Standard preview but the next identical

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -395,12 +395,12 @@ supported provider credential.
   `NODE_OPTIONS`, so the sequential Webpack compiler workers receive 3 GiB and
   the later generated-contract TypeScript validation child inherits the same
   limit, while isolated static workers have the flag removed. The same script
-  owns the Vercel package build and CI memory-observation invocation, plus the
-  cold-Webpack-cache policy and the production-only build watchdog;
+  owns the Vercel package build and CI memory-observation invocation.
   `apps/web/README.md` § "Production build memory guard" is the single prose
-  owner for that mutable contract. The CI-relevant fact is that the verify
-  lane's `VERCEL=1 VERCEL_ENV=preview` build shape compiles Webpack cold
-  without activating the watchdog. The split reduces the compile-parent peak without
+  owner for the mutable production build cache, epoch, and deadline contract.
+  The CI-relevant fact is that the verify lane's `VERCEL=1 VERCEL_ENV=preview`
+  build shape compiles Webpack cold without arming the production-only build
+  deadline. The split reduces the compile-parent peak without
   weakening generated-contract validation, while repeated forced-cold Standard
   previews remain the real Vercel acceptance proof. A 2 GiB parent-bound
   candidate passed one forced-cold Standard preview but the next identical

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -398,10 +398,12 @@ supported provider credential.
   owns the Vercel package build and CI memory-observation invocation. The
   production runner keeps Webpack compiles cold-cache (it clears
   `.next/cache/webpack` before every compile and discards it after success)
-  and, on Vercel production builds only (`VERCEL_ENV=production`), bounds
-  `next build` with a 15-minute `timeout` watchdog so a wedged compile fails
-  fast instead of reaching Vercel's 45-minute ceiling. The verify lane's
-  `VERCEL=1 VERCEL_ENV=preview` build shape stays unbounded. The split reduces the compile-parent peak without
+  and, on Vercel production builds only (`VERCEL=1` with
+  `VERCEL_ENV=production`), bounds `next build` with a 15-minute `timeout`
+  watchdog so a wedged compile fails fast instead of reaching Vercel's
+  45-minute ceiling. The verify lane's `VERCEL=1 VERCEL_ENV=preview` build
+  shape stays unbounded. The cache epoch is stamped only after both the
+  successful compile and the post-success Webpack-cache discard. The split reduces the compile-parent peak without
   weakening generated-contract validation, while repeated forced-cold Standard
   previews remain the real Vercel acceptance proof. A 2 GiB parent-bound
   candidate passed one forced-cold Standard preview but the next identical

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -395,15 +395,12 @@ supported provider credential.
   `NODE_OPTIONS`, so the sequential Webpack compiler workers receive 3 GiB and
   the later generated-contract TypeScript validation child inherits the same
   limit, while isolated static workers have the flag removed. The same script
-  owns the Vercel package build and CI memory-observation invocation. The
-  production runner keeps Webpack compiles cold-cache (it clears
-  `.next/cache/webpack` before every compile and discards it after success)
-  and, on Vercel production builds only (`VERCEL=1` with
-  `VERCEL_ENV=production`), bounds `next build` with a 15-minute `timeout`
-  watchdog so a wedged compile fails fast instead of reaching Vercel's
-  45-minute ceiling. The verify lane's `VERCEL=1 VERCEL_ENV=preview` build
-  shape stays unbounded. The cache epoch is stamped only after both the
-  successful compile and the post-success Webpack-cache discard. The split reduces the compile-parent peak without
+  owns the Vercel package build and CI memory-observation invocation, plus the
+  cold-Webpack-cache policy and the production-only build watchdog;
+  `apps/web/README.md` § "Production build memory guard" is the single prose
+  owner for that mutable contract. The CI-relevant fact is that the verify
+  lane's `VERCEL=1 VERCEL_ENV=preview` build shape compiles Webpack cold
+  without activating the watchdog. The split reduces the compile-parent peak without
   weakening generated-contract validation, while repeated forced-cold Standard
   previews remain the real Vercel acceptance proof. A 2 GiB parent-bound
   candidate passed one forced-cold Standard preview but the next identical
@@ -433,12 +430,11 @@ supported provider credential.
   Webpack build worker and memory optimizations because Workflow contributes
   Webpack configuration. Three consecutive forced-cold Webpack previews, a
   later integration preview, and the final corrected head previously completed
-  on the Standard builder without OOM. A versioned `.next/cache` epoch clears an
-  incompatible restored cache
-  until one Webpack build succeeds and then preserves ordinary warm caching.
-  The epoch is owned by the shared production runner and changes only after a
-  proven compiler/cache transition; missing or mismatched stamps fail toward a
-  cold build instead of trusting cross-compiler state.
+  on the Standard builder without OOM. The shared production runner owns the
+  versioned `.next/cache` epoch and the per-build cold-Webpack-cache policy;
+  see `apps/web/README.md` § "Production build memory guard" for the exact
+  contract. Missing or mismatched stamps fail toward a cold build instead of
+  trusting cross-compiler state.
   Exact-head CI proves the complete compile, type-validation, static-generation,
   and directive-discovery path,
   while focused Stripe and phone-call suites prove the existing

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1641,12 +1641,12 @@ from selecting the isolated build worker automatically. The hosted local-
 development wrapper remains on Turbopack and rejects an explicit Webpack flag.
 The production runner also owns a versioned cache epoch inside `.next/cache`.
 When that stamp is absent or differs, it removes the incompatible cache before
-compilation and writes the epoch only after Next succeeds and the post-success
-Webpack-cache discard completes. Production Webpack compiles are additionally
-cold-cache by policy: the runner removes
-`.next/cache/webpack` before every compile and discards it again after a
-successful compile, so a READY deployment cannot seed the next build with warm
-Webpack state. Warm restored Webpack caches on Vercel's 8 GB Standard builder
+compilation and writes the epoch only after Next succeeds. Production Webpack
+compiles are additionally cold-cache by policy: the runner removes
+`.next/cache/webpack` before every compile, and because that removal precedes
+the only Next invocation and aborts the build on failure, a restored warm
+Webpack cache can never reach the compiler regardless of what an earlier
+deployment uploaded. Warm restored Webpack caches on Vercel's 8 GB Standard builder
 were the trigger for the August 2026 steady-state OOM kills and silent
 compile hangs; only the cold path is proven. Other cache subtrees such as SWC
 remain warm. On Vercel production builds (`VERCEL=1` with
@@ -1654,8 +1654,10 @@ remain warm. On Vercel production builds (`VERCEL=1` with
 whole-build deadline (`MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS=900000`) that the
 package-build process owner, `scripts/run-with-host-verification-slot.mjs`,
 enforces on the one detached process group it already creates: at the deadline
-it TERMs the entire group, escalates to KILL after a 30-second grace, waits
-until the group has fully exited, and returns exit 124 with an explicit
+it TERMs the entire group, force-kills survivors with KILL (each phase bounded
+by a 30-second grace, so a leader that exits mid-grace hands surviving
+descendants to one fresh grace before their KILL), waits until the group has
+fully exited, and returns exit 124 with an explicit
 diagnostic. Because the deadline owns the whole group, a wedged Webpack
 compiler worker descendant is terminated too, and an externally cancelled
 build is reaped with the same escalation instead of orphaning the compile.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1641,8 +1641,9 @@ from selecting the isolated build worker automatically. The hosted local-
 development wrapper remains on Turbopack and rejects an explicit Webpack flag.
 The production runner also owns a versioned cache epoch inside `.next/cache`.
 When that stamp is absent or differs, it removes the incompatible cache before
-compilation and writes the epoch only after Next succeeds. Production Webpack
-compiles are additionally cold-cache by policy: the runner removes
+compilation and writes the epoch only after Next succeeds and the post-success
+Webpack-cache discard completes. Production Webpack compiles are additionally
+cold-cache by policy: the runner removes
 `.next/cache/webpack` before every compile and discards it again after a
 successful compile, so a READY deployment cannot seed the next build with warm
 Webpack state. Warm restored Webpack caches on Vercel's 8 GB Standard builder

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1650,14 +1650,20 @@ Webpack state. Warm restored Webpack caches on Vercel's 8 GB Standard builder
 were the trigger for the August 2026 steady-state OOM kills and silent
 compile hangs; only the cold path is proven. Other cache subtrees such as SWC
 remain warm. On Vercel production builds (`VERCEL=1` with
-`VERCEL_ENV=production`) the runner also wraps `next build` in a 15-minute
-`timeout` watchdog (SIGTERM, SIGKILL after 30 more seconds) so a wedged
-compile fails the build in minutes instead of occupying the deploy queue until
-Vercel's 45-minute ceiling; exit 124 reports the timeout explicitly. Local and
-CI verify invocations set `VERCEL=1` with `VERCEL_ENV=preview` and skip the
-watchdog, which also keeps the runner off GNU `timeout` on macOS. Bump the
-epoch only when a proven compiler/cache transition requires another full
-invalidation.
+`VERCEL_ENV=production`), `scripts/vercel-build.sh` arms a 15-minute
+whole-build deadline (`MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS=900000`) that the
+package-build process owner, `scripts/run-with-host-verification-slot.mjs`,
+enforces on the one detached process group it already creates: at the deadline
+it TERMs the entire group, escalates to KILL after a 30-second grace, waits
+until the group has fully exited, and returns exit 124 with an explicit
+diagnostic. Because the deadline owns the whole group, a wedged Webpack
+compiler worker descendant is terminated too, and an externally cancelled
+build is reaped with the same escalation instead of orphaning the compile.
+Either way a wedged compile fails the build in minutes instead of occupying
+the deploy queue until Vercel's 45-minute ceiling. Local and CI verify
+invocations build
+with `VERCEL_ENV=preview` and never arm the deadline. Bump the epoch only
+when a proven compiler/cache transition requires another full invalidation.
 
 Next 16.3 no longer exposes `experimental.turbopackMemoryLimit`. Its replacement,
 `experimental.turbopackMemoryEviction`, is documented for development sessions

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1622,11 +1622,12 @@ does not write `memory.max`, `memory.swap.max`, or `memory.oom.group`.
 The production build launches the parent Next process explicitly through Node
 with `--max-old-space-size=1024` while appending
 `--max-old-space-size=3072` to `NODE_OPTIONS`. Node gives the direct CLI flag
-precedence in the parent. Next 16.3 reconstructs its non-isolated TypeScript
-worker options from the parent arguments followed by `NODE_OPTIONS`, so the
-mandatory generated-contract validation receives the 3 GiB limit. Next removes
-that option from its isolated static workers. The existing caller options are
-preserved. The shared script is used by the Vercel package build and the CI
+precedence in the parent. Next 16.3 reconstructs non-isolated child options
+from the parent arguments followed by `NODE_OPTIONS`, so the sequential Webpack
+compiler workers receive the 3 GiB limit and the later generated-contract
+TypeScript validation child inherits the same limit. Next removes that option
+from its isolated static workers. The existing caller options are preserved.
+The shared script is used by the Vercel package build and the CI
 memory-observation lane. This bounds the compile parent without starving the
 later validation worker or changing the compiled application. Repeated
 forced-cold Standard previews remain the direct acceptance evidence, and a Next
@@ -1640,10 +1641,22 @@ from selecting the isolated build worker automatically. The hosted local-
 development wrapper remains on Turbopack and rejects an explicit Webpack flag.
 The production runner also owns a versioned cache epoch inside `.next/cache`.
 When that stamp is absent or differs, it removes the incompatible cache before
-compilation and writes the epoch only after Next succeeds. This gives the
-Turbopack-to-Webpack rollout one cold build without permanently disabling warm
-Webpack caching; bump the epoch only when a proven compiler/cache transition
-requires another invalidation.
+compilation and writes the epoch only after Next succeeds. Production Webpack
+compiles are additionally cold-cache by policy: the runner removes
+`.next/cache/webpack` before every compile and discards it again after a
+successful compile, so a READY deployment cannot seed the next build with warm
+Webpack state. Warm restored Webpack caches on Vercel's 8 GB Standard builder
+were the trigger for the August 2026 steady-state OOM kills and silent
+compile hangs; only the cold path is proven. Other cache subtrees such as SWC
+remain warm. On Vercel production builds (`VERCEL=1` with
+`VERCEL_ENV=production`) the runner also wraps `next build` in a 15-minute
+`timeout` watchdog (SIGTERM, SIGKILL after 30 more seconds) so a wedged
+compile fails the build in minutes instead of occupying the deploy queue until
+Vercel's 45-minute ceiling; exit 124 reports the timeout explicitly. Local and
+CI verify invocations set `VERCEL=1` with `VERCEL_ENV=preview` and skip the
+watchdog, which also keeps the runner off GNU `timeout` on macOS. Bump the
+epoch only when a proven compiler/cache transition requires another full
+invalidation.
 
 Next 16.3 no longer exposes `experimental.turbopackMemoryLimit`. Its replacement,
 `experimental.turbopackMemoryEviction`, is documented for development sessions

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -53,7 +53,11 @@ next_build_command=(
 
 next_build_status=0
 if [[ "$active_next_build_timeout" != disabled ]]; then
-  timeout --verbose --signal=TERM --kill-after=30s "$active_next_build_timeout" \
+  # --foreground keeps timeout and Next inside the caller's process group so
+  # the package-build process owner's cancellation signals still reach the
+  # compile; without it GNU timeout detaches into its own group and a canceled
+  # build could orphan the compiler.
+  timeout --verbose --foreground --signal=TERM --kill-after=30s "$active_next_build_timeout" \
     "${next_build_command[@]}" || next_build_status=$?
 else
   "${next_build_command[@]}" || next_build_status=$?

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 parent_old_space_mb=1024
 next_child_old_space_mb=3072
-next_build_timeout=15m
-active_next_build_timeout=disabled
-if [[ "${VERCEL:-}" == "1" && "${VERCEL_ENV:-}" == "production" ]]; then
-  active_next_build_timeout="$next_build_timeout"
-fi
 build_cache_epoch=webpack-next-16.3-v2-cold-webpack
 build_cache_stamp=.next/cache/murph-production-build-epoch
 webpack_cache_dir=.next/cache/webpack
@@ -39,36 +34,10 @@ else
   node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
 fi
 
-printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s next_child_old_space_mb=%s webpack_cache=cold vercel_timeout=%s\n' \
+printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s next_child_old_space_mb=%s webpack_cache=cold\n' \
   "$parent_old_space_mb" \
-  "$next_child_old_space_mb" \
-  "$active_next_build_timeout"
-next_build_command=(
-  node
-  "--max-old-space-size=$parent_old_space_mb"
-  "$next_bin"
-  build
-  --webpack
-)
-
-next_build_status=0
-if [[ "$active_next_build_timeout" != disabled ]]; then
-  # --foreground keeps timeout and Next inside the caller's process group so
-  # the package-build process owner's cancellation signals still reach the
-  # compile; without it GNU timeout detaches into its own group and a canceled
-  # build could orphan the compiler.
-  timeout --verbose --foreground --signal=TERM --kill-after=30s "$active_next_build_timeout" \
-    "${next_build_command[@]}" || next_build_status=$?
-else
-  "${next_build_command[@]}" || next_build_status=$?
-fi
-if [[ "$next_build_status" != 0 ]]; then
-  if [[ "$next_build_status" == 124 ]]; then
-    printf "[apps/web build] ERROR: Next build exceeded %s and was terminated before Vercel's maximum build duration.\n" \
-      "$next_build_timeout" >&2
-  fi
-  exit "$next_build_status"
-fi
+  "$next_child_old_space_mb"
+node "--max-old-space-size=$parent_old_space_mb" "$next_bin" build --webpack
 
 printf '[apps/web build] Discarding Webpack cache after successful production compile\n'
 node ../../scripts/rm-paths.mjs "$webpack_cache_dir"

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -2,9 +2,15 @@
 set -euo pipefail
 
 parent_old_space_mb=1024
-typecheck_worker_old_space_mb=3072
-build_cache_epoch=webpack-next-16.3-v1
+next_child_old_space_mb=3072
+next_build_timeout=15m
+active_next_build_timeout=disabled
+if [[ "${VERCEL:-}" == "1" && "${VERCEL_ENV:-}" == "production" ]]; then
+  active_next_build_timeout="$next_build_timeout"
+fi
+build_cache_epoch=webpack-next-16.3-v2-cold-webpack
 build_cache_stamp=.next/cache/murph-production-build-epoch
+webpack_cache_dir=.next/cache/webpack
 
 strip_inherited_old_space_flags() {
   printf '%s\n' "${NODE_OPTIONS:-}" \
@@ -16,9 +22,9 @@ inherited_node_options="${inherited_node_options#"${inherited_node_options%%[![:
 inherited_node_options="${inherited_node_options%"${inherited_node_options##*[![:space:]]}"}"
 
 if [[ -n "$inherited_node_options" ]]; then
-  export NODE_OPTIONS="$inherited_node_options --max-old-space-size=$typecheck_worker_old_space_mb"
+  export NODE_OPTIONS="$inherited_node_options --max-old-space-size=$next_child_old_space_mb"
 else
-  export NODE_OPTIONS="--max-old-space-size=$typecheck_worker_old_space_mb"
+  export NODE_OPTIONS="--max-old-space-size=$next_child_old_space_mb"
 fi
 
 next_bin="$(node -p 'require.resolve("next/dist/bin/next")')"
@@ -28,12 +34,40 @@ if [[ ! -f "$build_cache_stamp" ]] || [[ "$(< "$build_cache_stamp")" != "$build_
     "$build_cache_epoch"
   node ../../scripts/rm-paths.mjs .next/cache
   cache_reset=1
+else
+  printf '[apps/web build] Resetting restored Webpack cache before production compile\n'
+  node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
 fi
 
-printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s typecheck_worker_old_space_mb=%s\n' \
+printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s next_child_old_space_mb=%s webpack_cache=cold vercel_timeout=%s\n' \
   "$parent_old_space_mb" \
-  "$typecheck_worker_old_space_mb"
-node "--max-old-space-size=$parent_old_space_mb" "$next_bin" build --webpack
+  "$next_child_old_space_mb" \
+  "$active_next_build_timeout"
+next_build_command=(
+  node
+  "--max-old-space-size=$parent_old_space_mb"
+  "$next_bin"
+  build
+  --webpack
+)
+
+next_build_status=0
+if [[ "$active_next_build_timeout" != disabled ]]; then
+  timeout --verbose --signal=TERM --kill-after=30s "$active_next_build_timeout" \
+    "${next_build_command[@]}" || next_build_status=$?
+else
+  "${next_build_command[@]}" || next_build_status=$?
+fi
+if [[ "$next_build_status" != 0 ]]; then
+  if [[ "$next_build_status" == 124 ]]; then
+    printf "[apps/web build] ERROR: Next build exceeded %s and was terminated before Vercel's maximum build duration.\n" \
+      "$next_build_timeout" >&2
+  fi
+  exit "$next_build_status"
+fi
+
+printf '[apps/web build] Discarding Webpack cache after successful production compile\n'
+node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
 
 if [[ "$cache_reset" == 1 ]]; then
   mkdir -p "$(dirname "$build_cache_stamp")"

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -39,9 +39,6 @@ printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_m
   "$next_child_old_space_mb"
 node "--max-old-space-size=$parent_old_space_mb" "$next_bin" build --webpack
 
-printf '[apps/web build] Discarding Webpack cache after successful production compile\n'
-node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
-
 if [[ "$cache_reset" == 1 ]]; then
   mkdir -p "$(dirname "$build_cache_stamp")"
   printf '%s\n' "$build_cache_epoch" > "$build_cache_stamp"

--- a/apps/web/scripts/vercel-build.sh
+++ b/apps/web/scripts/vercel-build.sh
@@ -9,5 +9,14 @@ if [ "${VERCEL_TARGET_ENV:-}" = "native-ios-e2e" ]; then
   MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS=1 pnpm prisma:migrate:deploy
 fi
 
+# Production builds arm the package-build process owner's whole-group
+# deadline so a wedged compile (including a Webpack compiler worker
+# descendant) fails the build in minutes instead of holding the deploy queue
+# until Vercel's 45-minute ceiling. Preview and local builds stay unbounded.
+if [ "${VERCEL:-}" = "1" ] && [ "${VERCEL_ENV:-}" = "production" ]; then
+  MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS="${MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS:-900000}"
+  export MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS
+fi
+
 pnpm release:production:migrate
 MURPH_HOSTED_WEB_PRISMA_GENERATED_BY_MIGRATIONS=1 pnpm build

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1440,11 +1440,6 @@ describe("hosted web production migration guard", () => {
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
     assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
     assert.match(productionNextBuildScript, /next_child_old_space_mb=3072/u);
-    assert.match(productionNextBuildScript, /next_build_timeout=15m/u);
-    assert.match(
-      productionNextBuildScript,
-      /if \[\[ "\$\{VERCEL:-\}" == "1" && "\$\{VERCEL_ENV:-\}" == "production" \]\]; then\s+active_next_build_timeout="\$next_build_timeout"/u,
-    );
     assert.match(
       productionNextBuildScript,
       /build_cache_epoch=webpack-next-16\.3-v2-cold-webpack/u,
@@ -1465,11 +1460,7 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(
       productionNextBuildScript,
-      /next_build_command=\(\s+node\s+"--max-old-space-size=\$parent_old_space_mb"\s+"\$next_bin"\s+build\s+--webpack\s+\)/u,
-    );
-    assert.match(
-      productionNextBuildScript,
-      /timeout --verbose --foreground --signal=TERM --kill-after=30s "\$active_next_build_timeout"/u,
+      /node "--max-old-space-size=\$parent_old_space_mb" "\$next_bin" build --webpack/u,
     );
     assert.match(
       productionNextBuildScript,
@@ -1479,6 +1470,35 @@ describe("hosted web production migration guard", () => {
       productionNextBuildScript,
       /Discarding Webpack cache after successful production compile/u,
     );
+
+    // The production build deadline lives in the package-build process owner,
+    // not in the runner: vercel-build.sh arms it for production deployments
+    // only, and the supervisor owns whole-group termination and reaping.
+    const vercelBuildScript = await readFile(
+      path.join(appRoot, "scripts", "vercel-build.sh"),
+      "utf8",
+    );
+    assert.match(
+      vercelBuildScript,
+      /if \[ "\$\{VERCEL:-\}" = "1" \] && \[ "\$\{VERCEL_ENV:-\}" = "production" \]; then/u,
+    );
+    assert.match(
+      vercelBuildScript,
+      /MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS="\$\{MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS:-900000\}"/u,
+    );
+    assert.match(vercelBuildScript, /export MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS/u);
+    assert.doesNotMatch(productionNextBuildScript, /timeout /u);
+    assert.doesNotMatch(productionNextBuildScript, /VERCEL/u);
+    const verificationSlotScript = await readFile(
+      path.join(appRoot, "..", "..", "scripts", "run-with-host-verification-slot.mjs"),
+      "utf8",
+    );
+    assert.match(
+      verificationSlotScript,
+      /COMMAND_TIMEOUT_ENV = "MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS"/u,
+    );
+    assert.match(verificationSlotScript, /COMMAND_TIMEOUT_EXIT_CODE = 124/u);
+    assert.match(verificationSlotScript, /reapCommandProcessGroup/u);
 
     // apps/web/README.md § "Production build memory guard" is the single prose
     // owner of the mutable runner contract (cache policy, epoch stamping, and

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1469,7 +1469,7 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(
       productionNextBuildScript,
-      /timeout --verbose --signal=TERM --kill-after=30s "\$active_next_build_timeout"/u,
+      /timeout --verbose --foreground --signal=TERM --kill-after=30s "\$active_next_build_timeout"/u,
     );
     assert.match(
       productionNextBuildScript,

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1439,8 +1439,17 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
     assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
-    assert.match(productionNextBuildScript, /typecheck_worker_old_space_mb=3072/u);
-    assert.match(productionNextBuildScript, /build_cache_epoch=webpack-next-16\.3-v1/u);
+    assert.match(productionNextBuildScript, /next_child_old_space_mb=3072/u);
+    assert.match(productionNextBuildScript, /next_build_timeout=15m/u);
+    assert.match(
+      productionNextBuildScript,
+      /if \[\[ "\$\{VERCEL:-\}" == "1" && "\$\{VERCEL_ENV:-\}" == "production" \]\]; then\s+active_next_build_timeout="\$next_build_timeout"/u,
+    );
+    assert.match(
+      productionNextBuildScript,
+      /build_cache_epoch=webpack-next-16\.3-v2-cold-webpack/u,
+    );
+    assert.match(productionNextBuildScript, /webpack_cache_dir=\.next\/cache\/webpack/u);
     assert.match(
       productionNextBuildScript,
       /node \.\.\/\.\.\/scripts\/rm-paths\.mjs \.next\/cache/u,
@@ -1456,7 +1465,19 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(
       productionNextBuildScript,
-      /node "--max-old-space-size=\$parent_old_space_mb" "\$next_bin" build --webpack/u,
+      /next_build_command=\(\s+node\s+"--max-old-space-size=\$parent_old_space_mb"\s+"\$next_bin"\s+build\s+--webpack\s+\)/u,
+    );
+    assert.match(
+      productionNextBuildScript,
+      /timeout --verbose --signal=TERM --kill-after=30s "\$active_next_build_timeout"/u,
+    );
+    assert.match(
+      productionNextBuildScript,
+      /node \.\.\/\.\.\/scripts\/rm-paths\.mjs "\$webpack_cache_dir"/u,
+    );
+    assert.match(
+      productionNextBuildScript,
+      /Discarding Webpack cache after successful production compile/u,
     );
     assert.match(productionNextBuildScript, /compiler=webpack/u);
     assert.match(

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1466,10 +1466,6 @@ describe("hosted web production migration guard", () => {
       productionNextBuildScript,
       /node \.\.\/\.\.\/scripts\/rm-paths\.mjs "\$webpack_cache_dir"/u,
     );
-    assert.match(
-      productionNextBuildScript,
-      /Discarding Webpack cache after successful production compile/u,
-    );
 
     // The production build deadline lives in the package-build process owner,
     // not in the runner: vercel-build.sh arms it for production deployments
@@ -1518,17 +1514,25 @@ describe("hosted web production migration guard", () => {
     assert.match(readmeDoc, /## Production build memory guard/u);
     assert.match(readmeDoc, /`VERCEL=1` with\s+`VERCEL_ENV=production`/u);
     assert.match(readmeDoc, /`\.next\/cache\/webpack` before every compile/u);
-    assert.match(readmeDoc, /post-success\s+Webpack-cache discard/u);
     for (const [docName, doc] of [
       ["verification-and-runtime.md", verificationDoc],
       ["testing-ci-map.md", testingCiMapDoc],
     ] as const) {
-      assert.match(doc, /Production build memory guard/u, `${docName} must reference the owner`);
+      assert.match(
+        doc,
+        /Production\s+build memory guard/u,
+        `${docName} must reference the owner`,
+      );
       for (const copiedMechanic of [
         /preserves ordinary warm caching/u,
         /15-minute `timeout`/u,
         /kill-after/u,
         /SIGKILL 30/u,
+        // The deadline is owned by vercel-build.sh arming plus the shared
+        // supervisor; secondary guidance must not assign watchdog ownership
+        // or behavioral authority to the build runner.
+        /watchdog/u,
+        /behavioral authority/u,
       ]) {
         assert.doesNotMatch(
           doc,

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1479,6 +1479,44 @@ describe("hosted web production migration guard", () => {
       productionNextBuildScript,
       /Discarding Webpack cache after successful production compile/u,
     );
+
+    // apps/web/README.md § "Production build memory guard" is the single prose
+    // owner of the mutable runner contract (cache policy, epoch stamping, and
+    // the production watchdog). Secondary guidance documents keep only
+    // purpose-level statements plus a reference to that owner, so drift like a
+    // stale "preserves ordinary warm caching" claim cannot recur unnoticed.
+    const readmeDoc = await readFile(path.join(appRoot, "README.md"), "utf8");
+    const repoRoot = path.join(appRoot, "..", "..");
+    const verificationDoc = await readFile(
+      path.join(repoRoot, "agent-docs", "operations", "verification-and-runtime.md"),
+      "utf8",
+    );
+    const testingCiMapDoc = await readFile(
+      path.join(repoRoot, "agent-docs", "references", "testing-ci-map.md"),
+      "utf8",
+    );
+    assert.match(readmeDoc, /## Production build memory guard/u);
+    assert.match(readmeDoc, /`VERCEL=1` with\s+`VERCEL_ENV=production`/u);
+    assert.match(readmeDoc, /`\.next\/cache\/webpack` before every compile/u);
+    assert.match(readmeDoc, /post-success\s+Webpack-cache discard/u);
+    for (const [docName, doc] of [
+      ["verification-and-runtime.md", verificationDoc],
+      ["testing-ci-map.md", testingCiMapDoc],
+    ] as const) {
+      assert.match(doc, /Production build memory guard/u, `${docName} must reference the owner`);
+      for (const copiedMechanic of [
+        /preserves ordinary warm caching/u,
+        /15-minute `timeout`/u,
+        /kill-after/u,
+        /SIGKILL 30/u,
+      ]) {
+        assert.doesNotMatch(
+          doc,
+          copiedMechanic,
+          `${docName} must not copy mutable runner mechanics (${String(copiedMechanic)})`,
+        );
+      }
+    }
     assert.match(productionNextBuildScript, /compiler=webpack/u);
     assert.match(
       verifyFastScript,

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -11,7 +11,19 @@ const productionBuildScript = path.join(
   "scripts",
   "run-production-next-build.sh",
 );
-const buildCacheEpoch = "webpack-next-16.3-v1";
+const buildCacheEpoch = "webpack-next-16.3-v2-cold-webpack";
+const vercelTimeoutInvocation = [
+  "--verbose",
+  "--signal=TERM",
+  "--kill-after=30s",
+  "15m",
+  "node",
+  "--max-old-space-size=1024",
+  "/fixture/next",
+  "build",
+  "--webpack",
+  "",
+].join("\n");
 
 async function createRunnerFixture(): Promise<{
   appDir: string;
@@ -20,6 +32,7 @@ async function createRunnerFixture(): Promise<{
   cleanup: () => Promise<void>;
   removeLog: string;
   scriptPath: string;
+  timeoutLog: string;
 }> {
   const testTempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
   if (!testTempRoot) {
@@ -32,6 +45,7 @@ async function createRunnerFixture(): Promise<{
   const scriptPath = path.join(appDir, "scripts", "run-production-next-build.sh");
   const buildLog = path.join(fixtureRoot, "build.log");
   const removeLog = path.join(fixtureRoot, "remove.log");
+  const timeoutLog = path.join(fixtureRoot, "timeout.log");
 
   await mkdir(path.dirname(scriptPath), { recursive: true });
   await mkdir(binDir, { recursive: true });
@@ -54,10 +68,28 @@ if [[ "\${1:-}" == "../../scripts/rm-paths.mjs" ]]; then
 fi
 printf 'NODE_OPTIONS=%s\\n' "\${NODE_OPTIONS:-}" > "\$MURPH_FAKE_BUILD_LOG"
 printf '%s\\n' "\$@" >> "\$MURPH_FAKE_BUILD_LOG"
+mkdir -p .next/cache/webpack
+printf 'generated\\n' > .next/cache/webpack/generated-cache-entry
 exit "\${MURPH_FAKE_BUILD_EXIT_CODE:-0}"
 `,
   );
   await chmod(fakeNodePath, 0o755);
+
+  const fakeTimeoutPath = path.join(binDir, "timeout");
+  await writeFile(
+    fakeTimeoutPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "\$@" > "\$MURPH_FAKE_TIMEOUT_LOG"
+if [[ "\${MURPH_FAKE_TIMEOUT_EXIT_CODE:-0}" != "0" ]]; then
+  exit "\$MURPH_FAKE_TIMEOUT_EXIT_CODE"
+fi
+while [[ "\${1:-}" == --* ]]; do shift; done
+shift
+"\$@"
+`,
+  );
+  await chmod(fakeTimeoutPath, 0o755);
 
   return {
     appDir,
@@ -66,6 +98,7 @@ exit "\${MURPH_FAKE_BUILD_EXIT_CODE:-0}"
     cleanup: () => rm(fixtureRoot, { force: true, recursive: true }),
     removeLog,
     scriptPath,
+    timeoutLog,
   };
 }
 
@@ -76,28 +109,44 @@ function runProductionBuild(input: {
   buildLog: string;
   removeLog: string;
   scriptPath: string;
+  timeoutExitCode?: number;
+  timeoutLog: string;
+  vercel?: boolean;
+  vercelEnv?: string;
 }) {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    MURPH_FAKE_BUILD_EXIT_CODE: String(input.buildExitCode ?? 0),
+    MURPH_FAKE_BUILD_LOG: input.buildLog,
+    MURPH_FAKE_NEXT_BIN: "/fixture/next",
+    MURPH_FAKE_REMOVE_LOG: input.removeLog,
+    MURPH_FAKE_TIMEOUT_EXIT_CODE: String(input.timeoutExitCode ?? 0),
+    MURPH_FAKE_TIMEOUT_LOG: input.timeoutLog,
+    NODE_OPTIONS: "--trace-warnings --max-old-space-size=99",
+    PATH: `${input.binDir}:${process.env.PATH ?? ""}`,
+  };
+  if (input.vercel === false) {
+    delete env.VERCEL;
+    delete env.VERCEL_ENV;
+  } else {
+    env.VERCEL = "1";
+    env.VERCEL_ENV = input.vercelEnv ?? "production";
+  }
   return spawnSync("bash", [input.scriptPath], {
     cwd: input.appDir,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      MURPH_FAKE_BUILD_EXIT_CODE: String(input.buildExitCode ?? 0),
-      MURPH_FAKE_BUILD_LOG: input.buildLog,
-      MURPH_FAKE_NEXT_BIN: "/fixture/next",
-      MURPH_FAKE_REMOVE_LOG: input.removeLog,
-      NODE_OPTIONS: "--trace-warnings --max-old-space-size=99",
-      PATH: `${input.binDir}:${process.env.PATH ?? ""}`,
-    },
+    env,
   });
 }
 
-test("production Next runner owns the Webpack cache epoch transition", async () => {
+test("production Next runner owns the cold Webpack cache and Vercel watchdog", async () => {
   const fixture = await createRunnerFixture();
   const cacheDir = path.join(fixture.appDir, ".next", "cache");
   const cacheStamp = path.join(cacheDir, "murph-production-build-epoch");
   const staleCacheEntry = path.join(cacheDir, "stale-cache-entry");
-  const warmCacheEntry = path.join(cacheDir, "warm-cache-entry");
+  const restoredWebpackEntry = path.join(cacheDir, "webpack", "restored-cache-entry");
+  const generatedWebpackEntry = path.join(cacheDir, "webpack", "generated-cache-entry");
+  const retainedSwcEntry = path.join(cacheDir, "swc", "retained-cache-entry");
 
   try {
     await mkdir(cacheDir, { recursive: true });
@@ -108,10 +157,21 @@ test("production Next runner owns the Webpack cache epoch transition", async () 
     expect(coldBuild.stdout).toContain(
       `Resetting incompatible Next build cache for epoch=${buildCacheEpoch}`,
     );
-    expect(coldBuild.stdout).toContain("compiler=webpack");
+    expect(coldBuild.stdout).toContain(
+      "compiler=webpack parent_old_space_mb=1024 next_child_old_space_mb=3072 webpack_cache=cold vercel_timeout=15m",
+    );
+    expect(coldBuild.stdout).toContain(
+      "Discarding Webpack cache after successful production compile",
+    );
     await expect(readFile(staleCacheEntry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
-    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(".next/cache\n");
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
+      ".next/cache\n.next/cache/webpack\n",
+    );
+    await expect(readFile(fixture.timeoutLog, "utf8")).resolves.toBe(vercelTimeoutInvocation);
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "--max-old-space-size=1024",
@@ -121,26 +181,72 @@ test("production Next runner owns the Webpack cache epoch transition", async () 
       "",
     ].join("\n"));
 
-    await writeFile(warmCacheEntry, "warm\n");
+    await mkdir(path.dirname(restoredWebpackEntry), { recursive: true });
+    await writeFile(restoredWebpackEntry, "restored\n");
+    await mkdir(path.dirname(retainedSwcEntry), { recursive: true });
+    await writeFile(retainedSwcEntry, "retained\n");
     await rm(fixture.removeLog, { force: true });
+    await rm(fixture.timeoutLog, { force: true });
     const warmBuild = runProductionBuild(fixture);
     expect(warmBuild.status, warmBuild.stderr).toBe(0);
     expect(warmBuild.stdout).not.toContain("Resetting incompatible Next build cache");
-    await expect(readFile(warmCacheEntry, "utf8")).resolves.toBe("warm\n");
-    await expect(readFile(fixture.removeLog, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(warmBuild.stdout).toContain(
+      "Resetting restored Webpack cache before production compile",
+    );
+    await expect(readFile(restoredWebpackEntry, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(retainedSwcEntry, "utf8")).resolves.toBe("retained\n");
+    await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
+      ".next/cache/webpack\n.next/cache/webpack\n",
+    );
 
     await writeFile(cacheStamp, "turbopack-old-epoch\n");
     await writeFile(staleCacheEntry, "stale-again\n");
+    await rm(fixture.removeLog, { force: true });
     const failedBuild = runProductionBuild({ ...fixture, buildExitCode: 23 });
     expect(failedBuild.status).toBe(23);
     expect(failedBuild.stdout).toContain("Resetting incompatible Next build cache");
     await expect(readFile(staleCacheEntry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(cacheStamp, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(".next/cache\n");
 
     const recoveredBuild = runProductionBuild(fixture);
     expect(recoveredBuild.status, recoveredBuild.stderr).toBe(0);
     expect(recoveredBuild.stdout).toContain("Resetting incompatible Next build cache");
+    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
+
+    await rm(fixture.timeoutLog, { force: true });
+    const localBuild = runProductionBuild({ ...fixture, vercel: false });
+    expect(localBuild.status, localBuild.stderr).toBe(0);
+    expect(localBuild.stdout).toContain("vercel_timeout=disabled");
+    await expect(readFile(fixture.timeoutLog, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await rm(fixture.timeoutLog, { force: true });
+    const previewBuild = runProductionBuild({ ...fixture, vercelEnv: "preview" });
+    expect(previewBuild.status, previewBuild.stderr).toBe(0);
+    expect(previewBuild.stdout).toContain("vercel_timeout=disabled");
+    await expect(readFile(fixture.timeoutLog, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await rm(fixture.timeoutLog, { force: true });
+    const timedOutBuild = runProductionBuild({ ...fixture, timeoutExitCode: 124 });
+    expect(timedOutBuild.status).toBe(124);
+    expect(timedOutBuild.stderr).toContain(
+      "Next build exceeded 15m and was terminated before Vercel's maximum build duration.",
+    );
+    await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
+    await expect(readFile(fixture.timeoutLog, "utf8")).resolves.toBe(vercelTimeoutInvocation);
   } finally {
     await fixture.cleanup();
   }

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -49,7 +49,7 @@ if [[ "\${1:-}" == "-p" ]]; then
 fi
 if [[ "\${1:-}" == "../../scripts/rm-paths.mjs" ]]; then
   printf '%s\\n' "\${2:-}" >> "\$MURPH_FAKE_REMOVE_LOG"
-  if [[ -n "\${MURPH_FAKE_REMOVE_FAIL_AFTER_BUILD:-}" && -f "\$MURPH_FAKE_BUILD_LOG" ]]; then
+  if [[ -n "\${MURPH_FAKE_REMOVE_FAIL:-}" ]]; then
     exit 31
   fi
   rm -rf "\${2:-}"
@@ -57,8 +57,6 @@ if [[ "\${1:-}" == "../../scripts/rm-paths.mjs" ]]; then
 fi
 printf 'NODE_OPTIONS=%s\\n' "\${NODE_OPTIONS:-}" > "\$MURPH_FAKE_BUILD_LOG"
 printf '%s\\n' "\$@" >> "\$MURPH_FAKE_BUILD_LOG"
-mkdir -p .next/cache/webpack
-printf 'generated\\n' > .next/cache/webpack/generated-cache-entry
 exit "\${MURPH_FAKE_BUILD_EXIT_CODE:-0}"
 `,
   );
@@ -79,7 +77,7 @@ function runProductionBuild(input: {
   binDir: string;
   buildExitCode?: number;
   buildLog: string;
-  removeFailAfterBuild?: boolean;
+  removeFail?: boolean;
   removeLog: string;
   scriptPath: string;
 }) {
@@ -92,8 +90,8 @@ function runProductionBuild(input: {
     NODE_OPTIONS: "--trace-warnings --max-old-space-size=99",
     PATH: `${input.binDir}:${process.env.PATH ?? ""}`,
   };
-  if (input.removeFailAfterBuild) {
-    env.MURPH_FAKE_REMOVE_FAIL_AFTER_BUILD = "1";
+  if (input.removeFail) {
+    env.MURPH_FAKE_REMOVE_FAIL = "1";
   }
   return spawnSync("bash", [input.scriptPath], {
     cwd: input.appDir,
@@ -108,7 +106,6 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
   const cacheStamp = path.join(cacheDir, "murph-production-build-epoch");
   const staleCacheEntry = path.join(cacheDir, "stale-cache-entry");
   const restoredWebpackEntry = path.join(cacheDir, "webpack", "restored-cache-entry");
-  const generatedWebpackEntry = path.join(cacheDir, "webpack", "generated-cache-entry");
   const retainedSwcEntry = path.join(cacheDir, "swc", "retained-cache-entry");
 
   try {
@@ -123,17 +120,9 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
     expect(coldBuild.stdout).toContain(
       "compiler=webpack parent_old_space_mb=1024 next_child_old_space_mb=3072 webpack_cache=cold",
     );
-    expect(coldBuild.stdout).toContain(
-      "Discarding Webpack cache after successful production compile",
-    );
     await expect(readFile(staleCacheEntry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
-    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
-      ".next/cache\n.next/cache/webpack\n",
-    );
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(".next/cache\n");
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "--max-old-space-size=1024",
@@ -157,14 +146,9 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
     await expect(readFile(restoredWebpackEntry, "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });
-    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
     await expect(readFile(retainedSwcEntry, "utf8")).resolves.toBe("retained\n");
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
-    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
-      ".next/cache/webpack\n.next/cache/webpack\n",
-    );
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(".next/cache/webpack\n");
 
     await writeFile(cacheStamp, "turbopack-old-epoch\n");
     await writeFile(staleCacheEntry, "stale-again\n");
@@ -179,26 +163,20 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
     const recoveredBuild = runProductionBuild(fixture);
     expect(recoveredBuild.status, recoveredBuild.stderr).toBe(0);
     expect(recoveredBuild.stdout).toContain("Resetting incompatible Next build cache");
-    await expect(readFile(generatedWebpackEntry, "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
 
-    await writeFile(cacheStamp, "turbopack-old-epoch\n");
+    // A failed pre-compile Webpack-cache removal must abort before Next runs:
+    // the pre-compile deletion is the sole cold-cache boundary.
     await rm(fixture.removeLog, { force: true });
     await rm(fixture.buildLog, { force: true });
-    const discardFailedBuild = runProductionBuild({ ...fixture, removeFailAfterBuild: true });
-    expect(discardFailedBuild.status).toBe(31);
-    await expect(readFile(cacheStamp, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
-      ".next/cache\n.next/cache/webpack\n",
-    );
+    const removalFailedBuild = runProductionBuild({ ...fixture, removeFail: true });
+    expect(removalFailedBuild.status).toBe(31);
+    await expect(readFile(fixture.buildLog, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(".next/cache/webpack\n");
+    await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
 
-    const recoveredAfterDiscardFailure = runProductionBuild(fixture);
-    expect(recoveredAfterDiscardFailure.status, recoveredAfterDiscardFailure.stderr).toBe(0);
-    expect(recoveredAfterDiscardFailure.stdout).toContain(
-      "Resetting incompatible Next build cache",
-    );
+    const recoveredAfterRemovalFailure = runProductionBuild(fixture);
+    expect(recoveredAfterRemovalFailure.status, recoveredAfterRemovalFailure.stderr).toBe(0);
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
   } finally {
     await fixture.cleanup();

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -12,19 +12,6 @@ const productionBuildScript = path.join(
   "run-production-next-build.sh",
 );
 const buildCacheEpoch = "webpack-next-16.3-v2-cold-webpack";
-const vercelTimeoutInvocation = [
-  "--verbose",
-  "--foreground",
-  "--signal=TERM",
-  "--kill-after=30s",
-  "15m",
-  "node",
-  "--max-old-space-size=1024",
-  "/fixture/next",
-  "build",
-  "--webpack",
-  "",
-].join("\n");
 
 async function createRunnerFixture(): Promise<{
   appDir: string;
@@ -33,7 +20,6 @@ async function createRunnerFixture(): Promise<{
   cleanup: () => Promise<void>;
   removeLog: string;
   scriptPath: string;
-  timeoutLog: string;
 }> {
   const testTempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
   if (!testTempRoot) {
@@ -46,7 +32,6 @@ async function createRunnerFixture(): Promise<{
   const scriptPath = path.join(appDir, "scripts", "run-production-next-build.sh");
   const buildLog = path.join(fixtureRoot, "build.log");
   const removeLog = path.join(fixtureRoot, "remove.log");
-  const timeoutLog = path.join(fixtureRoot, "timeout.log");
 
   await mkdir(path.dirname(scriptPath), { recursive: true });
   await mkdir(binDir, { recursive: true });
@@ -79,22 +64,6 @@ exit "\${MURPH_FAKE_BUILD_EXIT_CODE:-0}"
   );
   await chmod(fakeNodePath, 0o755);
 
-  const fakeTimeoutPath = path.join(binDir, "timeout");
-  await writeFile(
-    fakeTimeoutPath,
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "\$@" > "\$MURPH_FAKE_TIMEOUT_LOG"
-if [[ "\${MURPH_FAKE_TIMEOUT_EXIT_CODE:-0}" != "0" ]]; then
-  exit "\$MURPH_FAKE_TIMEOUT_EXIT_CODE"
-fi
-while [[ "\${1:-}" == --* ]]; do shift; done
-shift
-"\$@"
-`,
-  );
-  await chmod(fakeTimeoutPath, 0o755);
-
   return {
     appDir,
     binDir,
@@ -102,7 +71,6 @@ shift
     cleanup: () => rm(fixtureRoot, { force: true, recursive: true }),
     removeLog,
     scriptPath,
-    timeoutLog,
   };
 }
 
@@ -111,13 +79,9 @@ function runProductionBuild(input: {
   binDir: string;
   buildExitCode?: number;
   buildLog: string;
+  removeFailAfterBuild?: boolean;
   removeLog: string;
   scriptPath: string;
-  removeFailAfterBuild?: boolean;
-  timeoutExitCode?: number;
-  timeoutLog: string;
-  vercel?: boolean;
-  vercelEnv?: string;
 }) {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
@@ -125,20 +89,11 @@ function runProductionBuild(input: {
     MURPH_FAKE_BUILD_LOG: input.buildLog,
     MURPH_FAKE_NEXT_BIN: "/fixture/next",
     MURPH_FAKE_REMOVE_LOG: input.removeLog,
-    MURPH_FAKE_TIMEOUT_EXIT_CODE: String(input.timeoutExitCode ?? 0),
-    MURPH_FAKE_TIMEOUT_LOG: input.timeoutLog,
     NODE_OPTIONS: "--trace-warnings --max-old-space-size=99",
     PATH: `${input.binDir}:${process.env.PATH ?? ""}`,
   };
   if (input.removeFailAfterBuild) {
     env.MURPH_FAKE_REMOVE_FAIL_AFTER_BUILD = "1";
-  }
-  if (input.vercel === false) {
-    delete env.VERCEL;
-    delete env.VERCEL_ENV;
-  } else {
-    env.VERCEL = "1";
-    env.VERCEL_ENV = input.vercelEnv ?? "production";
   }
   return spawnSync("bash", [input.scriptPath], {
     cwd: input.appDir,
@@ -147,41 +102,7 @@ function runProductionBuild(input: {
   });
 }
 
-const gnuTimeoutAvailable = (() => {
-  const probe = spawnSync("timeout", ["--version"], { encoding: "utf8" });
-  return probe.status === 0 && probe.stdout.includes("GNU coreutils");
-})();
-
-test.skipIf(!gnuTimeoutAvailable)(
-  "GNU timeout --foreground keeps the compile in the caller's process group and still escalates to KILL",
-  () => {
-    const stubborn = spawnSync(
-      "timeout",
-      [
-        "--verbose",
-        "--foreground",
-        "--signal=TERM",
-        "--kill-after=1s",
-        "1s",
-        "bash",
-        "-c",
-        'trap "" TERM; ps -o pgid= -p $$; sleep 30',
-      ],
-      { encoding: "utf8" },
-    );
-    const ownPgid = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)], {
-      encoding: "utf8",
-    }).stdout.trim();
-    // --foreground keeps the timed command inside the caller's process group,
-    // so the package-build owner's group-directed cancellation still covers it.
-    expect(stubborn.stdout.trim()).toBe(ownPgid);
-    // A TERM-ignoring compile is force-killed at the kill-after boundary.
-    expect(stubborn.status).toBe(137);
-    expect(stubborn.stderr).toContain("sending signal KILL");
-  },
-);
-
-test("production Next runner owns the cold Webpack cache and Vercel watchdog", async () => {
+test("production Next runner owns the cold Webpack cache and fail-closed epoch", async () => {
   const fixture = await createRunnerFixture();
   const cacheDir = path.join(fixture.appDir, ".next", "cache");
   const cacheStamp = path.join(cacheDir, "murph-production-build-epoch");
@@ -200,7 +121,7 @@ test("production Next runner owns the cold Webpack cache and Vercel watchdog", a
       `Resetting incompatible Next build cache for epoch=${buildCacheEpoch}`,
     );
     expect(coldBuild.stdout).toContain(
-      "compiler=webpack parent_old_space_mb=1024 next_child_old_space_mb=3072 webpack_cache=cold vercel_timeout=15m",
+      "compiler=webpack parent_old_space_mb=1024 next_child_old_space_mb=3072 webpack_cache=cold",
     );
     expect(coldBuild.stdout).toContain(
       "Discarding Webpack cache after successful production compile",
@@ -213,7 +134,6 @@ test("production Next runner owns the cold Webpack cache and Vercel watchdog", a
     await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
       ".next/cache\n.next/cache/webpack\n",
     );
-    await expect(readFile(fixture.timeoutLog, "utf8")).resolves.toBe(vercelTimeoutInvocation);
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "--max-old-space-size=1024",
@@ -228,7 +148,6 @@ test("production Next runner owns the cold Webpack cache and Vercel watchdog", a
     await mkdir(path.dirname(retainedSwcEntry), { recursive: true });
     await writeFile(retainedSwcEntry, "retained\n");
     await rm(fixture.removeLog, { force: true });
-    await rm(fixture.timeoutLog, { force: true });
     const warmBuild = runProductionBuild(fixture);
     expect(warmBuild.status, warmBuild.stderr).toBe(0);
     expect(warmBuild.stdout).not.toContain("Resetting incompatible Next build cache");
@@ -264,31 +183,6 @@ test("production Next runner owns the cold Webpack cache and Vercel watchdog", a
       code: "ENOENT",
     });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
-
-    await rm(fixture.timeoutLog, { force: true });
-    const localBuild = runProductionBuild({ ...fixture, vercel: false });
-    expect(localBuild.status, localBuild.stderr).toBe(0);
-    expect(localBuild.stdout).toContain("vercel_timeout=disabled");
-    await expect(readFile(fixture.timeoutLog, "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-
-    await rm(fixture.timeoutLog, { force: true });
-    const previewBuild = runProductionBuild({ ...fixture, vercelEnv: "preview" });
-    expect(previewBuild.status, previewBuild.stderr).toBe(0);
-    expect(previewBuild.stdout).toContain("vercel_timeout=disabled");
-    await expect(readFile(fixture.timeoutLog, "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-
-    await rm(fixture.timeoutLog, { force: true });
-    const timedOutBuild = runProductionBuild({ ...fixture, timeoutExitCode: 124 });
-    expect(timedOutBuild.status).toBe(124);
-    expect(timedOutBuild.stderr).toContain(
-      "Next build exceeded 15m and was terminated before Vercel's maximum build duration.",
-    );
-    await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
-    await expect(readFile(fixture.timeoutLog, "utf8")).resolves.toBe(vercelTimeoutInvocation);
 
     await writeFile(cacheStamp, "turbopack-old-epoch\n");
     await rm(fixture.removeLog, { force: true });

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -14,6 +14,7 @@ const productionBuildScript = path.join(
 const buildCacheEpoch = "webpack-next-16.3-v2-cold-webpack";
 const vercelTimeoutInvocation = [
   "--verbose",
+  "--foreground",
   "--signal=TERM",
   "--kill-after=30s",
   "15m",
@@ -63,6 +64,9 @@ if [[ "\${1:-}" == "-p" ]]; then
 fi
 if [[ "\${1:-}" == "../../scripts/rm-paths.mjs" ]]; then
   printf '%s\\n' "\${2:-}" >> "\$MURPH_FAKE_REMOVE_LOG"
+  if [[ -n "\${MURPH_FAKE_REMOVE_FAIL_AFTER_BUILD:-}" && -f "\$MURPH_FAKE_BUILD_LOG" ]]; then
+    exit 31
+  fi
   rm -rf "\${2:-}"
   exit 0
 fi
@@ -109,6 +113,7 @@ function runProductionBuild(input: {
   buildLog: string;
   removeLog: string;
   scriptPath: string;
+  removeFailAfterBuild?: boolean;
   timeoutExitCode?: number;
   timeoutLog: string;
   vercel?: boolean;
@@ -125,6 +130,9 @@ function runProductionBuild(input: {
     NODE_OPTIONS: "--trace-warnings --max-old-space-size=99",
     PATH: `${input.binDir}:${process.env.PATH ?? ""}`,
   };
+  if (input.removeFailAfterBuild) {
+    env.MURPH_FAKE_REMOVE_FAIL_AFTER_BUILD = "1";
+  }
   if (input.vercel === false) {
     delete env.VERCEL;
     delete env.VERCEL_ENV;
@@ -138,6 +146,40 @@ function runProductionBuild(input: {
     env,
   });
 }
+
+const gnuTimeoutAvailable = (() => {
+  const probe = spawnSync("timeout", ["--version"], { encoding: "utf8" });
+  return probe.status === 0 && probe.stdout.includes("GNU coreutils");
+})();
+
+test.skipIf(!gnuTimeoutAvailable)(
+  "GNU timeout --foreground keeps the compile in the caller's process group and still escalates to KILL",
+  () => {
+    const stubborn = spawnSync(
+      "timeout",
+      [
+        "--verbose",
+        "--foreground",
+        "--signal=TERM",
+        "--kill-after=1s",
+        "1s",
+        "bash",
+        "-c",
+        'trap "" TERM; ps -o pgid= -p $$; sleep 30',
+      ],
+      { encoding: "utf8" },
+    );
+    const ownPgid = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)], {
+      encoding: "utf8",
+    }).stdout.trim();
+    // --foreground keeps the timed command inside the caller's process group,
+    // so the package-build owner's group-directed cancellation still covers it.
+    expect(stubborn.stdout.trim()).toBe(ownPgid);
+    // A TERM-ignoring compile is force-killed at the kill-after boundary.
+    expect(stubborn.status).toBe(137);
+    expect(stubborn.stderr).toContain("sending signal KILL");
+  },
+);
 
 test("production Next runner owns the cold Webpack cache and Vercel watchdog", async () => {
   const fixture = await createRunnerFixture();
@@ -247,6 +289,23 @@ test("production Next runner owns the cold Webpack cache and Vercel watchdog", a
     );
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
     await expect(readFile(fixture.timeoutLog, "utf8")).resolves.toBe(vercelTimeoutInvocation);
+
+    await writeFile(cacheStamp, "turbopack-old-epoch\n");
+    await rm(fixture.removeLog, { force: true });
+    await rm(fixture.buildLog, { force: true });
+    const discardFailedBuild = runProductionBuild({ ...fixture, removeFailAfterBuild: true });
+    expect(discardFailedBuild.status).toBe(31);
+    await expect(readFile(cacheStamp, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(fixture.removeLog, "utf8")).resolves.toBe(
+      ".next/cache\n.next/cache/webpack\n",
+    );
+
+    const recoveredAfterDiscardFailure = runProductionBuild(fixture);
+    expect(recoveredAfterDiscardFailure.status, recoveredAfterDiscardFailure.stderr).toBe(0);
+    expect(recoveredAfterDiscardFailure.stdout).toContain(
+      "Resetting incompatible Next build cache",
+    );
+    await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
   } finally {
     await fixture.cleanup();
   }

--- a/scripts/run-with-host-verification-slot.mjs
+++ b/scripts/run-with-host-verification-slot.mjs
@@ -269,16 +269,23 @@ async function runCommand(commandArgs, env) {
       clearTimeout(killTimer);
       reject(error);
     });
+    // The direct child's exit must not release process ownership yet: with a
+    // command deadline configured, a surviving descendant in the detached
+    // group is still owned work, and a termination signal arriving during
+    // reaping must keep targeting that group instead of exiting immediately.
     child.on("exit", (code, signal) => {
-      activeChild = null;
       clearTimeout(deadlineTimer);
       clearTimeout(killTimer);
       resolve({ code, pid: child.pid ?? null, signal });
     });
   });
 
-  if (commandTimeoutMs > 0 && exitState.pid !== null) {
-    await reapCommandProcessGroup(exitState.pid);
+  try {
+    if (commandTimeoutMs > 0 && exitState.pid !== null) {
+      await reapCommandProcessGroup(exitState.pid);
+    }
+  } finally {
+    activeChild = null;
   }
 
   if (forcedExitCode !== null) {
@@ -290,6 +297,11 @@ async function runCommand(commandArgs, env) {
   return exitState.code ?? 1;
 }
 
+// Group signals tolerate EPERM as well as ESRCH: on macOS a killed group
+// member that has not been reaped yet (a zombie) makes kill(-pgid, ...)
+// return EPERM even though there is nothing left to signal. The group probe
+// treats that same state as "still draining" so the reaper keeps waiting
+// until the member is reaped and the group reports ESRCH.
 function signalProcessGroup(pid, signalName) {
   if (!pid) {
     return;
@@ -297,7 +309,7 @@ function signalProcessGroup(pid, signalName) {
   try {
     process.kill(-pid, signalName);
   } catch (error) {
-    if (!isMissingProcessError(error)) {
+    if (!isMissingProcessError(error) && !isNotPermittedProcessError(error)) {
       throw error;
     }
   }
@@ -430,15 +442,15 @@ function handleTerminationSignal(signalName, exitCode) {
     process.exit(exitCode);
   }
 
-  try {
-    if (useDetachedChildProcessGroup) {
-      process.kill(-activeChild.pid, signalName);
-    } else {
+  if (useDetachedChildProcessGroup) {
+    signalProcessGroup(activeChild.pid, signalName);
+  } else {
+    try {
       activeChild.kill(signalName);
-    }
-  } catch (error) {
-    if (!isMissingProcessError(error)) {
-      throw error;
+    } catch (error) {
+      if (!isMissingProcessError(error)) {
+        throw error;
+      }
     }
   }
 
@@ -562,6 +574,10 @@ function isMissingPathError(error) {
 
 function isMissingProcessError(error) {
   return Boolean(error && typeof error === "object" && "code" in error && error.code === "ESRCH");
+}
+
+function isNotPermittedProcessError(error) {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
 }
 
 function delay(delayMs) {

--- a/scripts/run-with-host-verification-slot.mjs
+++ b/scripts/run-with-host-verification-slot.mjs
@@ -21,13 +21,29 @@ const ENABLED_ENV = "MURPH_VERIFY_SHARED_HOST";
 const HELD_ENV = "MURPH_VERIFY_HOST_SLOT_HELD";
 const TEST_STATE_ROOT_ENV = "MURPH_VERIFY_SHARED_HOST_TEST_STATE_ROOT";
 const CODEX_THREAD_ENV = "CODEX_THREAD_ID";
+const COMMAND_TIMEOUT_ENV = "MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS";
+const COMMAND_KILL_GRACE_ENV = "MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS";
 const DEFAULT_POLL_INTERVAL_MS = 250;
 const DEFAULT_STALE_METADATA_GRACE_MS = 10_000;
+const DEFAULT_COMMAND_KILL_GRACE_MS = 30_000;
+const COMMAND_TIMEOUT_EXIT_CODE = 124;
+const GROUP_EXIT_POLL_INTERVAL_MS = 100;
 const WAIT_LOG_INTERVAL_MS = 60_000;
 const OWNER_FILE_NAME = "owner.json";
 const invocationCwd = process.cwd();
 const invocation = parseInvocation(process.argv.slice(2));
 const useDetachedChildProcessGroup = process.platform !== "win32";
+// A configured command deadline arms whole-process-group ownership: the
+// deadline, KILL escalation, and post-exit group reaping all act on the one
+// detached group this supervisor already creates, so a wedged descendant
+// (for example a Webpack compiler worker) cannot outlive the command.
+const commandTimeoutMs = useDetachedChildProcessGroup
+  ? readPositiveInteger(process.env[COMMAND_TIMEOUT_ENV], 0)
+  : 0;
+const commandKillGraceMs = readPositiveInteger(
+  process.env[COMMAND_KILL_GRACE_ENV],
+  DEFAULT_COMMAND_KILL_GRACE_MS,
+);
 let activeChild = null;
 let forcedExitCode = null;
 let heldSlot = null;
@@ -214,10 +230,10 @@ function releaseHeldSlot() {
   }
 }
 
-function runCommand(commandArgs, env) {
+async function runCommand(commandArgs, env) {
   const [command, ...args] = commandArgs;
 
-  return new Promise((resolve, reject) => {
+  const exitState = await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: invocationCwd,
       detached: useDetachedChildProcessGroup,
@@ -231,23 +247,93 @@ function runCommand(commandArgs, env) {
       writeOwnerMetadata(heldSlot.slotPath, heldSlot.owner);
     }
 
+    let deadlineTimer = null;
+    let killTimer = null;
+    if (commandTimeoutMs > 0) {
+      deadlineTimer = setTimeout(() => {
+        forcedExitCode = COMMAND_TIMEOUT_EXIT_CODE;
+        console.error(
+          `[host-verification] Command exceeded ${commandTimeoutMs}ms; terminating its process group before the platform build ceiling.`,
+        );
+        signalProcessGroup(child.pid, "SIGTERM");
+        killTimer = setTimeout(
+          () => signalProcessGroup(child.pid, "SIGKILL"),
+          commandKillGraceMs,
+        );
+      }, commandTimeoutMs);
+    }
+
     child.on("error", (error) => {
       activeChild = null;
+      clearTimeout(deadlineTimer);
+      clearTimeout(killTimer);
       reject(error);
     });
     child.on("exit", (code, signal) => {
       activeChild = null;
-      if (forcedExitCode !== null) {
-        resolve(forcedExitCode);
-        return;
-      }
-      if (signal) {
-        resolve(signalToExitCode(signal));
-        return;
-      }
-      resolve(code ?? 1);
+      clearTimeout(deadlineTimer);
+      clearTimeout(killTimer);
+      resolve({ code, pid: child.pid ?? null, signal });
     });
   });
+
+  if (commandTimeoutMs > 0 && exitState.pid !== null) {
+    await reapCommandProcessGroup(exitState.pid);
+  }
+
+  if (forcedExitCode !== null) {
+    return forcedExitCode;
+  }
+  if (exitState.signal) {
+    return signalToExitCode(exitState.signal);
+  }
+  return exitState.code ?? 1;
+}
+
+function signalProcessGroup(pid, signalName) {
+  if (!pid) {
+    return;
+  }
+  try {
+    process.kill(-pid, signalName);
+  } catch (error) {
+    if (!isMissingProcessError(error)) {
+      throw error;
+    }
+  }
+}
+
+function isProcessGroupRunning(pid) {
+  if (!pid) {
+    return false;
+  }
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return !isMissingProcessError(error);
+  }
+}
+
+// With a command deadline configured, the direct child's exit is not enough:
+// a wedged descendant in the detached group must also be gone before the
+// supervisor returns and releases any held slot.
+async function reapCommandProcessGroup(pid) {
+  if (!isProcessGroupRunning(pid)) {
+    return;
+  }
+  signalProcessGroup(pid, "SIGTERM");
+  const killDeadline = Date.now() + commandKillGraceMs;
+  while (Date.now() < killDeadline) {
+    if (!isProcessGroupRunning(pid)) {
+      return;
+    }
+    await delay(GROUP_EXIT_POLL_INTERVAL_MS);
+  }
+  signalProcessGroup(pid, "SIGKILL");
+  while (isProcessGroupRunning(pid)) {
+    await delay(GROUP_EXIT_POLL_INTERVAL_MS);
+  }
 }
 
 function writeOwnerMetadata(slotPath, owner) {
@@ -354,6 +440,14 @@ function handleTerminationSignal(signalName, exitCode) {
     if (!isMissingProcessError(error)) {
       throw error;
     }
+  }
+
+  // With a command deadline configured, external cancellation must also be
+  // bounded: a group member that ignores the forwarded signal is force-killed
+  // after the same grace the deadline path uses.
+  if (commandTimeoutMs > 0) {
+    const cancelledPid = activeChild.pid;
+    setTimeout(() => signalProcessGroup(cancelledPid, "SIGKILL"), commandKillGraceMs).unref();
   }
 }
 

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -24,6 +24,18 @@ const holderSource = `
   process.stdout.write("ready\\n");
   process.stdin.resume();
 `;
+// A TERM-ignoring parent with a TERM-ignoring grandchild: the wedged-compile
+// topology the command deadline must terminate as one process group.
+const wedgedTreeSource = `
+  import { spawn } from "node:child_process";
+  process.on("SIGTERM", () => {});
+  const grandchild = spawn(process.execPath, [
+    "-e",
+    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+  ], { stdio: "ignore" });
+  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
+  setInterval(() => {}, 1000);
+`;
 
 afterEach(async () => {
   for (const child of children) {
@@ -292,6 +304,44 @@ describe("shared-host verification slots", () => {
     expect(result.status).toBe(7);
     expect(readdirSync(stateRoot)).toEqual([]);
   });
+
+  it("a configured command deadline reaps the whole process group", async () => {
+    const stateRoot = makeTempRoot();
+    const child = startCommand("deadline command", stateRoot, wedgedTreeSource, {
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
+    });
+
+    const [parentPid, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(parentPid);
+    ownedDescendantPids.add(grandchildPid);
+
+    await waitForStderrLine(child, "terminating its process group");
+    const status = await waitForExit(child);
+    expect(status).toBe(124);
+    await waitForOwnedProcessExit(parentPid);
+    await waitForOwnedProcessExit(grandchildPid);
+    expect(readdirSync(stateRoot)).toEqual([]);
+  });
+
+  it("external cancellation with a configured deadline escalates to KILL and reaps the group", async () => {
+    const stateRoot = makeTempRoot();
+    const child = startCommand("cancelled command", stateRoot, wedgedTreeSource, {
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
+    });
+
+    const [parentPid, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(parentPid);
+    ownedDescendantPids.add(grandchildPid);
+
+    child.kill("SIGTERM");
+    const status = await waitForExit(child);
+    expect(status).toBe(143);
+    await waitForOwnedProcessExit(parentPid);
+    await waitForOwnedProcessExit(grandchildPid);
+    expect(readdirSync(stateRoot)).toEqual([]);
+  });
 });
 
 function makeTempRoot(): string {
@@ -381,6 +431,27 @@ function startRawCommand(source: string): ChildProcess {
 
 async function waitForLine(child: ChildProcess, line: string): Promise<void> {
   await waitForStreamLine(child, child.stdout, line);
+}
+
+async function waitForPids(child: ChildProcess): Promise<[number, number]> {
+  let output = "";
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out waiting for pids; output=${output}`)),
+      2_000,
+    );
+    const onData = (chunk: Buffer | string) => {
+      output += chunk.toString();
+      const match = output.match(/pids (\d+) (\d+)/u);
+      if (match) {
+        clearTimeout(timeout);
+        child.stdout?.off("data", onData);
+        resolve([Number(match[1]), Number(match[2])]);
+      }
+    };
+    child.stdout?.on("data", onData);
+    child.once("error", reject);
+  });
 }
 
 async function waitForStderrLine(child: ChildProcess, line: string): Promise<void> {

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -354,6 +354,38 @@ describe("shared-host verification slots", () => {
     expect(readdirSync(stateRoot)).toEqual([]);
   });
 
+  it("a cancellation during post-leader reaping keeps ownership until the descendant is dead", async () => {
+    const stateRoot = makeTempRoot();
+    const child = startCommand("cancelled during reap", stateRoot, exitingLeaderTreeSource, {
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "600",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
+    });
+
+    const [parentPid, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(parentPid);
+    ownedDescendantPids.add(grandchildPid);
+
+    // Wait for the deadline to fell the leader while the TERM-ignoring
+    // grandchild survives into the reaping grace, then cancel externally.
+    const reapWindowDeadline = Date.now() + 2_000;
+    while (isProcessRunning(parentPid) || !isProcessRunning(grandchildPid)) {
+      if (Date.now() > reapWindowDeadline) {
+        throw new Error("Never reached the post-leader reaping window");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    child.kill("SIGTERM");
+
+    const status = await waitForExit(child);
+    expect(status).toBe(143);
+    // Ownership must have been held until the whole group was gone: the
+    // grandchild is already dead by the time the supervisor returns.
+    expect(isProcessRunning(grandchildPid)).toBe(false);
+    ownedDescendantPids.delete(grandchildPid);
+    await waitForOwnedProcessExit(parentPid);
+    expect(readdirSync(stateRoot)).toEqual([]);
+  });
+
   it("external cancellation with a configured deadline escalates to KILL and reaps the group", async () => {
     const stateRoot = makeTempRoot();
     const child = startCommand("cancelled command", stateRoot, wedgedTreeSource, {

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -36,6 +36,18 @@ const wedgedTreeSource = `
   process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
   setInterval(() => {}, 1000);
 `;
+// A leader that exits on the deadline's TERM while its grandchild ignores it:
+// the descendant-outlives-leader topology that motivated supervisor-owned
+// group reaping.
+const exitingLeaderTreeSource = `
+  import { spawn } from "node:child_process";
+  const grandchild = spawn(process.execPath, [
+    "-e",
+    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+  ], { stdio: "ignore" });
+  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
+  setInterval(() => {}, 1000);
+`;
 
 afterEach(async () => {
   for (const child of children) {
@@ -317,6 +329,24 @@ describe("shared-host verification slots", () => {
     ownedDescendantPids.add(grandchildPid);
 
     await waitForStderrLine(child, "terminating its process group");
+    const status = await waitForExit(child);
+    expect(status).toBe(124);
+    await waitForOwnedProcessExit(parentPid);
+    await waitForOwnedProcessExit(grandchildPid);
+    expect(readdirSync(stateRoot)).toEqual([]);
+  });
+
+  it("a deadline whose group leader exits on TERM still reaps a surviving descendant", async () => {
+    const stateRoot = makeTempRoot();
+    const child = startCommand("exiting leader", stateRoot, exitingLeaderTreeSource, {
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
+    });
+
+    const [parentPid, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(parentPid);
+    ownedDescendantPids.add(grandchildPid);
+
     const status = await waitForExit(child);
     expect(status).toBe(124);
     await waitForOwnedProcessExit(parentPid);


### PR DESCRIPTION
## Why this PR exists

Since the 2026-08-14 Webpack cutover, roughly half of production Vercel builds fail on the 8 GB Standard builder (last 100 production deployments: 28 READY, 17 silent ~46-minute max-duration timeouts, 8 fast OOM SIGKILLs, 47 queue-superseded CANCELED). Merged work silently stops reaching production, and each 46-minute hang blocks the deploy queue for hours.

## User goal / user-visible behavior

Merges to `main` reliably reach production again. Production builds stop OOMing and hanging, and any future wedged compile fails the build in about 15 minutes instead of occupying the queue until Vercel's 45-minute ceiling.

## User experience

No user-facing effect; this is production build tooling only.

## Root cause and evidence

The Aug 14 cutover proved only forced-cold builds; the failing steady state restores a warm cross-deployment `.next/cache/webpack` (Next configures it with `maxMemoryGenerations: Infinity`, and Next's own guidance warns webpack caching increases build memory). Under that pressure the sequential Webpack compiler worker — which inherits the 3 GiB `NODE_OPTIONS` old-space cap that was named as if it were typecheck-only — either gets OOM-killed by the container (fast fail: `Next.js build worker exited ... SIGKILL`) or wedges without exiting; Next supplies no hang timeout to the compiler worker call, so the parent waits until Vercel kills the build at 45 minutes. All four inspected failing logs stall at the identical point right after `Creating an optimized production build ...`; identical trees alternated among fast OOM, silent timeout, and success (for example one commit went OOM 3.7m → timeout 46.2m → timeout 46.2m → READY 11.7m).

## What the diff does

- Makes the proven cold path the steady state: clears `.next/cache/webpack` before every production compile. That removal precedes the only Next invocation and aborts the build on failure, so a restored warm Webpack cache can never reach the compiler regardless of what an earlier deployment uploaded. SWC and other cache subtrees stay warm. One-time full `.next/cache` reset via the epoch bump to `webpack-next-16.3-v2-cold-webpack`; the stamp is written only after a successful build (fail-closed).
- Bounds Vercel production builds (`VERCEL=1` with `VERCEL_ENV=production`) with a 15-minute deadline on the supervisor-wrapped `apps/web build` command (migrations and the brief `prebuild` step run before the supervisor and are not covered), owned by the existing package-build process owner (`scripts/run-with-host-verification-slot.mjs`), armed via `MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS` in `vercel-build.sh`. At the deadline the owner TERMs its entire detached process group, force-kills survivors with KILL (each phase bounded by a 30-second grace), waits for the group to fully exit before returning or releasing its slot, and reports exit 124 with an explicit diagnostic — so a wedged Webpack compiler worker descendant dies with the group instead of surviving as an orphan. Preview, CI, and local builds never arm the deadline and keep exact previous supervisor behavior.
- Renames `typecheck_worker_old_space_mb` to `next_child_old_space_mb` (same 3072 value) because every non-isolated Next child — the sequential Webpack compiler workers and the later TypeScript validation child — inherits it. The 1 GiB parent / 3 GiB child policy is unchanged.

## Invariants the PR must preserve

- Migrations, the full pre/post check chain, typecheck strictness, and generated artifacts run unchanged in sequence and strictness.
- Local dev stays on Turbopack; the verify lane's `VERCEL=1 VERCEL_ENV=preview` build shape keeps its previous unbounded behavior.
- The 1 GiB parent / 3 GiB non-isolated-child old-space policy is unchanged (rename only).
- Cache-epoch mechanics stay fail-closed: stamp written only after full success; a failed transition retries fully cold.
- Production builds stay well under the 45-minute ceiling (cold compile previously proven at 2.7 minutes; full local verify build through this runner: 169 seconds compile-and-checks step).

## Non-obvious affected surfaces

- `apps/web/scripts/verify-fast.sh` local/CI verify builds run this same runner: they now cold-compile Webpack each run (restored subtree cleared before every compile) but never arm the deadline. Proof: the runner itself has no environment branching (the guard test pins the absence of `VERCEL` references), and a complete local `pnpm test:diff` verify build runs through it with the deadline disarmed.
- The first production deploy after merge performs a one-time full `.next/cache` reset (a few extra cold-compile minutes on that build only).
- Vercel may still upload the Webpack cache a successful compile generates, but every later build deletes the restored subtree before compiling, so the upload is inert for compiler state.
- `scripts/run-with-host-verification-slot.mjs` is shared by every `apps/web` build invocation across local, CI, and Vercel. The deadline machinery is strictly env-armed: with `MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS` unset the supervisor's behavior is unchanged. Proof: its full 14-test suite including four new real process-tree integration tests (deadline, leader-exits-first, cancellation-during-reap, and external-cancellation paths), plus a complete local verify build through the disarmed path.

## Architecture and reuse

- Existing systems reused: the existing production runner seam (`run-production-next-build.sh`) with its fail-closed cache-epoch mechanics and `scripts/rm-paths.mjs` own the cache policy, proven by the existing runner-fixture regression test; the existing package-build process owner and its suite own the deadline behavior.
- New logic: the pre-compile Webpack-cache reset (cold-webpack policy) in the build runner, and an env-armed command deadline in the existing package-build process owner — deadline timer, TERM-to-KILL escalation on both the deadline and external-cancellation paths (each phase bounded by a 30-second grace, up to two graces when the leader exits during the first), post-exit whole-group reaping, and exit-124 projection, all inert unless `MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS` is set.
- New abstractions: none. No new owner, service, queue, or state: the deadline lives on the one detached process group the supervisor already creates, and the earlier nested GNU `timeout` lifecycle owner, its execution branch, and the fake-timeout test shim were deleted.
- Complexity intentionally avoided: no `next.config.ts` cache surgery (plugin-sensitive with the Workflow webpack integration), no separate compiler-vs-typecheck heap plumbing, no `VERCEL_FORCE_NO_BUILD_CACHE` (discards unrelated useful caches), no build-machine tier change.

## Changelog

- Changelog: not applicable
- Reason: Internal production build tooling; no member-visible behavior changed.

## Hot reply path impact

Not applicable — build tooling only; no runtime code path changes.

## Database collection fanout impact

Not applicable — the diff does not add or change any database-touching path.

## Murph initial provider input impact

Not applicable — no provider-visible input is affected.

## Preliminary specialist lenses

- product experience: not applicable — no product-owned journey, copy, or interaction change.
- prompt: applicable — the diff changes agent-readable operational guidance under `agent-docs/` (verification-and-runtime, testing-ci-map). Specialist round found duplicated runner-contract statements drifting; remediated across rounds by collapsing the mutable contract to one prose owner (`apps/web/README.md`) with an inventory guard-test proof over the secondary documents.
- frontend: not applicable — no user-facing `apps/web` UI diff.
- coverage: applicable — executable behavior changed. Focused local proof: `apps/web/test/production-next-build-runner.test.ts` drives the real script through cold, warm, failed-transition, recovered, and pre-compile-removal-failure paths; the deadline, leader-exits-first, and external-cancellation process-tree proofs live in `scripts/run-with-host-verification-slot.test.ts` (real process groups); `apps/web/test/production-migration-guard.test.ts` pins the runner, arming-script, and supervisor contract strings plus the doc-ownership inventory; full `pnpm test:diff` runs passed including a complete local production Next build through the runner. Exact-head CI: pending.

## Change-shape breakdown

Classification rule: the build shell script is config/tooling; `*.test.ts` files are tests/fixtures; `*.md` files are docs; no authored app source or generated files changed; no binary files.

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests/fixtures | 147 | 20 |
| Docs | 54 | 23 |
| Config/tooling | 41 | 7 |
| Generated/other | 0 | 0 |

Total: 242 added, 50 deleted.

## Design proof

Not applicable — no user-facing frontend UI diff.

## Deployment skew

Web-only build tooling with no runtime skew window. The first post-merge production build does a one-time cold `.next/cache` reset; if it fails it retries fully cold by design. Post-deploy checks on the first builds: the epoch-reset log line, `webpack_cache=cold` in the memory-policy line, the `Resetting restored Webpack cache before production compile` line on later builds, and compile duration returning toward the proven cold 2.7–4 minutes. A wedged build should now fail near 15 minutes with the supervisor's `[host-verification] Command exceeded` diagnostic and exit 124 — that means the deadline worked and a compiler wedge still exists. A fast OOM while the log shows `webpack_cache=cold` would falsify warm cache as the sufficient trigger and justify separate compiler/typecheck heap policies next.

## Retrospective (after round 2)

- Original requirement: production Vercel builds must stop OOMing and silently hanging, and the runner contract must be verifiable and consistently documented.
- Shape comparison: first-reviewed head added 242 and deleted 50 lines (292 total changed) with zero authored application source; the current head adds review-driven tests and docs plus a 5-line watchdog correction in the build script. No authored application source at any point.
- Repeated mechanism: the mutable runner-contract prose was copied across three documents and drifted twice — a stale pre-PR "preserves ordinary warm caching" claim survived the first alignment pass because that pass matched only the first occurrence per document instead of inventorying every statement.
- Decisions: (1) `apps/web/README.md` § "Production build memory guard" is the single prose owner of the mutable contract; the script and its runner regression test remain the behavioral authority. (2) `verification-and-runtime.md` and `testing-ci-map.md` retain only their unique verification/CI implications plus a reference to the owner; the competing mechanical copies were deleted (net prose deletion). (3) The regression proof inventories the contract by construction: the guard test asserts the owner carries the canonical statements and that both secondary documents reference the owner while containing none of the drift-prone mechanics markers.
- Disposition: explicitly justified continuation with a docs Complexity Collapse; that round's remediation changed no production source. (The later process-lifecycle direction is owned by the retrospective after round 4 below.)

## Retrospective (after round 4)

- Required bound scope: the 15-minute deadline applies to the entire supervisor-wrapped `apps/web build` command, not only the Next compile. This is sufficient for the observed hangs because every timed-out production build stalled inside that wrapped chain (all four inspected logs stall in the compile phase), the healthy wrapped chain completes in about 10 minutes hosted (169 seconds for the compile-and-checks step locally), and bounding at the existing owner needs no phase-arming IPC or second owner.
- Owner decision: the shared host-verification supervisor is the minimal correct owner for deadline, cancellation, escalation, and full-group disappearance. It already creates the one detached process group, already forwards external cancellation to that group, and already tracks the child for slot lifetime; the deadline is a property of that same group. A wrapper or forwarding guard reintroduces the fragmented process-lifetime ownership behind both the round-1 and round-3 findings.
- Shape and lifecycle accounting (first-reviewed 242/-50 to current 417/-66): added — env-armed deadline timer, KILL-grace escalation on the deadline and external-cancellation paths, post-exit group reap/wait, exit-124 projection (all inert without the arming env), production-only arming in `vercel-build.sh`, and the two real process-tree tests; removed — the nested GNU `timeout` lifecycle owner and its separate process group, the `--foreground` variant, the runner script's environment gating, and the fake-timeout shim with its lifecycle assumptions. The runner script returned to its pre-PR invocation shape; process-lifetime owners went from two to one.
- Minimality check on the supervisor machinery: each piece maps to a proven failure mode — the deadline timer to the 46-minute silent hangs; the cancellation-path KILL escalation to a TERM-ignoring group leader (without it, a cancelled wedged build never resolves and the reap never runs); the post-exit reap to a descendant that outlives its leader (the round-3 finding). None can be deleted while retaining the 15-minute production bound and descendant termination.
- Decision: continuation with the supervisor-owned deadline. Another timeout wrapper, forwarding guard, or second lifecycle owner is explicitly ruled out.

## Review remediation (current head 51ce69a969)

- Final round 1 (High): GNU `timeout` detaches into its own process group, escaping the package-build owner's cancellation. Fixed with `timeout --foreground` so the watchdog and Next stay inside the caller's group; a Linux-only integration test proves the composed semantics (same pgid, TERM→KILL escalation, exit 137 for a TERM-ignoring compile). The 15-minute deadline is preserved.
- Preliminary specialists (Coverage, medium): added an executable fail-closed proof for the then-present post-success discard; that mechanism was later deleted by the round-4 Complexity Collapse, and the retained proof is that a failed pre-compile removal aborts before Next runs.
- Preliminary specialists (Prompt, low): aligned all three guidance docs on the then-current mechanics; later rounds collapsed this to the single README prose owner and deleted the mechanics (including the since-removed discard rule) from secondary docs.

- Round 2 (RETROSPECTIVE_REQUIRED): the doc alignment left a second, stale warm-caching paragraph in `testing-ci-map.md`. Resolved per the retrospective above: single prose owner, trimmed secondary docs, and an inventory-style guard-test proof.
- Round 5 (High, review-induced): the exit listener released process ownership before post-exit reaping, so a cancellation during the reaping window exited immediately, released the slot, and could leave the wedged descendant alive. Fixed by holding the child identity until reaping completes; group signal/probe helpers now tolerate macOS zombie-member EPERM; a composed integration test covers the exact cancellation-during-reap interleaving. Remaining round-5 body inaccuracies (stale preview-case proof claim, runner-fixture scope, deadline scope wording) corrected.
- Round 4 (RETROSPECTIVE_REQUIRED, then FINDINGS on retry): the round-2 retrospective covered only the documentation direction; the retrospective after round 4 above covers the process-lifecycle direction. The retry's two Complexity Collapse findings were both accepted as deletions: the redundant post-success Webpack-cache discard (the pre-compile removal is the sole cold-cache boundary) and its fixture/proof/prose were deleted, and the secondary documents' stale watchdog-ownership claims were deleted with the guard-test inventory extended to reject them; a leader-exits-first process-tree test was added, and the sensitivity declaration was corrected to the parser format with `sensitive` per the deploy-boundary policy.
- Round 3 (High): `timeout --foreground` bounds only its direct command, so a wedged Webpack compiler worker descendant could outlive the watchdog. Fixed by deleting the nested GNU `timeout` and consolidating the deadline into the package-build process owner as described above; real process-tree integration tests replace the fake-timeout shim for both deadline and cancellation paths. Round 3 also corrected body accuracy: first-reviewed shape was 242 added / 50 deleted (292 total changed lines), and this PR's ReviewGPT context sensitivity is declared below.

ReviewGPT context sensitivity: sensitive
Reason: this PR changes the production deploy boundary (the Vercel build path and the shared package-build supervisor's process-lifecycle behavior).

Current-head change shape (base to 51ce69a969, same classification rule; the two build shell scripts and the supervisor are config/tooling):

| Category | Added | Deleted |
| --- | --- | --- |
| Source | 0 | 0 |
| Tests/fixtures | 271 | 18 |
| Docs | 62 | 30 |
| Config/tooling | 149 | 26 |
| Generated/other | 0 | 0 |

Total: 482 added, 74 deleted. Review-driven growth is tests, docs, and the deadline/reap path in the existing supervisor; the nested GNU `timeout` lifecycle, its execution branch, the fake-timeout shim, and the post-success cache discard with its failure/recovery machinery were all deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ReviewGPT first-reviewed head: ffb65226cd24080edfa8ad29c09b5110299e1d7e
