### PR TITLE
Diagnose Junction workout-stream 500 failures

### DIFF
--- a/.agents/friction-log/20260817155719-concurrent-reviewgpt-gates/friction.md
+++ b/.agents/friction-log/20260817155719-concurrent-reviewgpt-gates/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Concurrent ReviewGPT gates race while refreshing origin/main'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The required preliminary specialist and final ReviewGPT gates can start concurrently against one clean pushed PR head without competing over Git remote-tracking refs.
+
+## Current Behavior
+
+When both canonical ReviewGPT commands begin together, their preparation can refresh the same remote-tracking ref concurrently. One process can fail with a Git ref-lock compare-and-swap error before browser submission, forcing callers to serialize packaging even though the review workflow requires the resulting audits to run concurrently.
+
+## Possible Solution
+
+Coordinate the guarded fetch/preflight phase under one repository-local lock, fetch once before both packages, or treat a concurrently advanced remote-tracking ref as a retryable preparation condition.
+
+## Minimal Reproducible Example
+
+1. Use a clean task branch whose pushed head matches an open pull request.
+2. Start the canonical completion-specialists and round-one pr-review commands at the same time.
+3. Observe that one preparation can fail while updating the same origin/main remote-tracking ref.
+
+## Context
+
+The completion workflow deliberately launches both review stages against the same exact pushed head. Serializing only their preparation is a safe workaround, but the canonical concurrent path should not require caller orchestration.

--- a/agent-docs/exec-plans/active/2026-08-17-junction-workout-500-diagnostics.md
+++ b/agent-docs/exec-plans/active/2026-08-17-junction-workout-500-diagnostics.md
@@ -1,0 +1,81 @@
+# Junction workout-stream 500 diagnostics
+
+## Goal
+
+Make recurring Junction workout-stream HTTP 500 failures diagnosable without
+exposing provider or member identifiers, and report the actual durable job
+disposition after each failed attempt.
+
+## Proven production symptom
+
+- Hosted runtime telemetry recorded repeated retryable Junction workout-stream
+  failures across six connections after the current production deploy.
+- The provider response is an HTTP 500 from the dedicated per-workout stream
+  endpoint; bounded aggregate evidence cannot yet distinguish one poison
+  workout from a broader provider defect.
+- One retryable stream failure stops the current serial resource attempt, so
+  later candidate workouts may wait behind it.
+- `device-sync.job_failed` has multiple writers, while the worker-side entry
+  currently derives `failureDisposition` from retryability instead of the
+  durable queue result.
+
+## Protected invariants
+
+- Never log or persist raw member, connection, account, source-instance,
+  workout, request payload, credential, or provider-response identifiers.
+- Keep the existing bounded one-day index and serial stream-call limits.
+- Do not silently skip retryable provider failures or add another retry,
+  scheduler, queue, or state owner.
+- Preserve job retry, continuation, canonical import, and source-disconnect
+  behavior.
+
+## Current owners and evidence gap
+
+- `packages/device-syncd` owns candidate selection, provider egress, durable
+  job attempts, retry scheduling, and terminal job disposition.
+- `packages/assistant-runtime` owns hosted per-attempt runtime-log projection.
+- Existing provider-request diagnostics identify endpoint kind and status but
+  do not supply a privacy-safe candidate correlation seam or the actual
+  post-failure durable job state.
+- The next correction should extend those existing owners rather than create a
+  parallel observability or retry subsystem.
+
+## Implementation
+
+1. Ask the existing ReviewGPT investigation to inspect the current exact source
+   and return the smallest compilable diagnostics patch with focused tests.
+2. Verify every returned hunk against the real job and logging paths; reject
+   raw identifiers, inferred disposition, speculative retry-policy changes,
+   and new state owners.
+3. Apply only the accepted bounded diagnostics, then run focused device-sync
+   and assistant-runtime tests, affected typechecks, and privacy-safe direct
+   scenario proof.
+4. Push an exact candidate, run required CI and ReviewGPT completion gates,
+   resolve accepted findings, and close this plan with the final scoped commit.
+
+## Verification
+
+- A retryable failed attempt records whether the durable job was requeued or
+  became terminal, including bounded attempt-budget facts from the existing
+  store result.
+- Provider-request evidence distinguishes the diagnostic origin and supplies
+  only bounded candidate position and alias-source metadata from the existing
+  privacy-safe owner.
+- Focused tests prove no raw candidate identifier or provider payload enters
+  runtime telemetry.
+- Existing workout continuation, optional 404/422 retirement, retry, and
+  terminal-failure tests remain green.
+
+## Completed proof
+
+- ReviewGPT returned a 19-file diagnostics patch against the exact task base;
+  the parent inspected every hunk, verified its SHA-256, and proved the applied
+  tree with a reverse apply check and `git diff --check`.
+- Focused Vitest passed for importers (9 tests), device-syncd (450 tests),
+  assistant-runtime (476 tests), and hosted Web authority (75 tests).
+- Owner typechecks passed for importers, device-syncd, assistant-runtime, and
+  hosted Web.
+- Tests prove the fifth retryable attempt is reported as durably `dead`, earlier
+  attempts are reported as `queued`, lease loss produces no fabricated
+  transition, retained accepted work still extends its existing attempt fence,
+  and raw workout/request/payload identifiers do not enter runtime telemetry.

--- a/agent-docs/exec-plans/active/2026-08-17-junction-workout-500-diagnostics.md
+++ b/agent-docs/exec-plans/active/2026-08-17-junction-workout-500-diagnostics.md
@@ -79,3 +79,13 @@ disposition after each failed attempt.
   attempts are reported as `queued`, lease loss produces no fabricated
   transition, retained accepted work still extends its existing attempt fence,
   and raw workout/request/payload identifiers do not enter runtime telemetry.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no qualifying
+  production-code, architecture, privacy, or purpose finding. It identified
+  two overbroad coverage claims that matched the preliminary specialist pass.
+- The preliminary specialist pass found missing executable proof for the
+  runner-to-Web candidate-field projection boundary and the `checkpoint` and
+  `device_activity_automation` failure origins. The accepted remediation adds
+  only focused regression tests; production code and runtime architecture are
+  unchanged.
+- The two directly affected assistant-runtime test files pass all 396 tests,
+  and the assistant-runtime owner typecheck remains green after remediation.

--- a/agent-docs/exec-plans/completed/2026-08-17-junction-workout-500-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-08-17-junction-workout-500-diagnostics.md
@@ -89,3 +89,6 @@ disposition after each failed attempt.
   unchanged.
 - The two directly affected assistant-runtime test files pass all 396 tests,
   and the assistant-runtime owner typecheck remains green after remediation.
+Status: completed
+Updated: 2026-08-17
+Completed: 2026-08-17

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -5,7 +5,10 @@ import {
   requiresHistoricalResetDeviceSyncSource,
   sanitizeStoredDeviceSyncMetadata,
 } from "@murphai/device-syncd/public-account";
-import type { PublicDeviceSyncAccount } from "@murphai/device-syncd/types";
+import type {
+  DeviceSyncJobFailureEventOrigin,
+  PublicDeviceSyncAccount,
+} from "@murphai/device-syncd/types";
 import type {
   SerializableConfiguredDeviceSyncProviderConfigs,
 } from "@murphai/device-syncd/config";
@@ -1842,6 +1845,7 @@ function buildHostedRuntimeFailureApplyRedactedJson(input: {
 
   return {
     failureCode: toHostedRuntimeApplyLogCode(input.nextAccount.lastErrorCode ?? diagnostic?.code ?? null),
+    failureEventOrigin: "canonical_apply" satisfies DeviceSyncJobFailureEventOrigin,
     failureSummary: summary ?? "Hosted device-sync runtime failure state advanced.",
     ...buildHostedRuntimeFailureDiagnosticRedactedJson(diagnostic),
     hadPriorFailure: Boolean(input.baseline.localState.lastSyncErrorAt),

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -3101,6 +3101,7 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
         phase: "invoke",
         redactedJson: expect.objectContaining({
         failureCode: "WHOOP_TOKEN_REQUEST_FAILED",
+        failureEventOrigin: "canonical_apply",
         failureRetryable: false,
         failureSummary: "WHOOP token request failed. Provider reason: Refresh token expired. Reconnect WHOOP.",
         hadPriorFailure: true,

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -2601,10 +2601,17 @@ function toHostedRuntimeFailureDiagnostic(
     return null;
   }
 
+  const details = { ...diagnostic.details };
+  // Candidate position is incident telemetry only. Keep it out of the Web apply
+  // contract so a newer warm runner remains compatible with an older Web deploy.
+  delete details.providerRequestCandidateAliasSource;
+  delete details.providerRequestCandidateCount;
+  delete details.providerRequestCandidateOrdinal;
+
   return {
     accountStatus: diagnostic.accountStatus,
     code: diagnostic.code,
-    details: { ...diagnostic.details },
+    details,
     retryable: diagnostic.retryable,
   };
 }

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
@@ -4,7 +4,10 @@ import {
 import type {
   SerializableConfiguredDeviceSyncProviderConfigs,
 } from "@murphai/device-syncd/config";
-import type { DeviceSyncJobFailureDiagnostic } from "@murphai/device-syncd/types";
+import type {
+  DeviceSyncJobFailureDiagnostic,
+  DeviceSyncJobFailureEventOrigin,
+} from "@murphai/device-syncd/types";
 import {
   resolveDeviceSyncStoreNextJobWakeAt,
   resolveDeviceSyncStoreNextWakeAt,
@@ -1227,12 +1230,21 @@ function buildHostedDeviceSyncFailureLogRedactedJson(input: {
 
   return {
     failureCode: toHostedRuntimeLogCode(input.failureDiagnostic.code),
-    failureDisposition: input.failureDiagnostic.retryable ? "retry" : "drop",
+    failureEventOrigin: "worker_attempt" satisfies DeviceSyncJobFailureEventOrigin,
+    ...(input.failureDiagnostic.jobDisposition
+      ? { failureDisposition: input.failureDiagnostic.jobDisposition }
+      : {}),
     ...(typeof input.failureDiagnostic.attempts === "number"
       ? { failureJobAttempts: input.failureDiagnostic.attempts }
       : {}),
     ...(input.failureDiagnostic.jobKind
       ? { failureJobKind: toHostedRuntimeLogCode(input.failureDiagnostic.jobKind) }
+      : {}),
+    ...(typeof input.failureDiagnostic.maxAttempts === "number"
+      ? { failureJobMaxAttempts: input.failureDiagnostic.maxAttempts }
+      : {}),
+    ...(typeof input.failureDiagnostic.remainingAttempts === "number"
+      ? { failureJobRemainingAttempts: input.failureDiagnostic.remainingAttempts }
       : {}),
     ...(input.failureDiagnostic.resource
       ? { failureResource: toHostedRuntimeLogCode(input.failureDiagnostic.resource) }
@@ -1282,6 +1294,7 @@ const DEVICE_SYNC_FAILURE_DIAGNOSTIC_CODE_FIELDS = [
   "providerRequestAuthPlacement",
   "providerRequestBodyFieldNames",
   "providerRequestBodyKind",
+  "providerRequestCandidateAliasSource",
   "providerRequestContentType",
   "providerRequestEndpointKind",
   "providerRequestMethod",
@@ -1311,6 +1324,8 @@ const DEVICE_SYNC_FAILURE_DIAGNOSTIC_REASON_FIELDS = [
 const DEVICE_SYNC_FAILURE_DIAGNOSTIC_NUMBER_FIELDS = [
   "providerHttpStatus",
   "providerRequestBodyFieldCount",
+  "providerRequestCandidateCount",
+  "providerRequestCandidateOrdinal",
   "providerRequestQueryParameterCount",
   "providerOAuthRequestDuplicateParameterCount",
   "providerOAuthRequestParameterCount",

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -89,6 +89,7 @@ import {
 import {
   resolveDeliveryCandidates,
 } from "@murphai/assistant-engine/assistant-channel-adapters";
+import type { DeviceSyncJobFailureEventOrigin } from "@murphai/device-syncd/types";
 import {
   isDeviceConnectSourceAvailableForConnection,
   listConfiguredDeviceSyncConnectTargets,
@@ -4115,6 +4116,7 @@ function deferHostedDeviceSyncDirtyPostCheckpointRecord(input: Parameters<
             phase: "checkpoint",
             redactedJson: {
               ...failure.redactedJson,
+              failureEventOrigin: "checkpoint" satisfies DeviceSyncJobFailureEventOrigin,
               nextWakeAtPresent: true,
             },
           },
@@ -4742,6 +4744,7 @@ async function writeHostedIdleDeviceSyncFailureRuntimeLog(input: {
         errorMessagePresent: input.error instanceof Error
           ? input.error.message.length > 0
           : input.error !== null && input.error !== undefined,
+        failureEventOrigin: "idle_maintenance" satisfies DeviceSyncJobFailureEventOrigin,
         idleMaintenanceFailed: true,
         retryAt: input.retryAt,
       },
@@ -4772,6 +4775,7 @@ async function writeHostedDeviceActivityAutomationScheduleFailureRuntimeLog(inpu
         errorMessagePresent: input.error instanceof Error
           ? input.error.message.length > 0
           : input.error !== null && input.error !== undefined,
+        failureEventOrigin: "device_activity_automation" satisfies DeviceSyncJobFailureEventOrigin,
         wakeKind: input.wake.kind,
       },
     },

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -3540,7 +3540,7 @@ describe("hosted device-sync runtime", () => {
     }
   });
 
-  test("reconciliation includes provider failure diagnostics when sync failure advances", async () => {
+  test("reconciliation strips worker-only workout candidate context from Web diagnostics", async () => {
     const { cleanup, vaultRoot } = await createHostedRuntimeWorkspace(
       "hosted-device-sync-runtime-",
     );
@@ -3558,37 +3558,17 @@ describe("hosted device-sync runtime", () => {
           jobExecutor: {
             async executeJob() {
               throw deviceSyncError({
-                accountStatus: "disconnected",
-                code: "TOKEN_REQUEST_FAILED",
+                code: "JUNCTION_API_REQUEST_FAILED",
                 details: {
-                  httpStatusText: "Bad Request",
-                  oauthErrorCode: "invalid_grant",
-                  oauthErrorDescription: "Refresh token expired. Reconnect provider.",
-                  oauthGrantType: "refresh_token",
-                  oauthRequestBodyBuilderKind: "url_search_params_record",
-                  oauthRequestClientAuthPlacement: "body_parameters",
-                  oauthRequestClientCredentialPresent: true,
-                  oauthRequestClientIdPresent: true,
-                  oauthRequestContentType: "application_x_www_form_urlencoded",
-                  oauthRequestDuplicateParameterCount: 0,
-                  oauthRequestEncodingKind: "form_urlencoded",
-                  oauthRequestHasDuplicateParameters: false,
-                  oauthRequestMethod: "POST",
-                  oauthRequestOfflineScopePresent: true,
-                  oauthRequestParameterCount: 5,
-                  oauthRequestParameterNames: "client_id.client_secret.grant_type.refresh_token.scope",
-                  oauthRequestRefreshCredentialPresent: true,
-                  oauthRequestScopeCount: 1,
-                  oauthRequestScopePresent: true,
-                  oauthRequestScopeValue: "offline",
-                  oauthRequestTokenEndpointKind: "whoop_oauth_token",
-                  oauthResponseErrorDescriptionFieldPresent: true,
-                  oauthResponseErrorFieldPresent: true,
-                  oauthResponseShapeKind: "json_object",
+                  requestCandidateAliasSource: "id",
+                  requestCandidateCount: 8,
+                  requestCandidateOrdinal: 3,
+                  requestEndpointKind: "junction_workout_stream",
+                  requestMethod: "GET",
                 },
-                httpStatus: 400,
-                message: "Provider token request failed.",
-                retryable: false,
+                httpStatus: 500,
+                message: "Junction workout stream request failed.",
+                retryable: true,
               });
             },
           },
@@ -3650,8 +3630,8 @@ describe("hosted device-sync runtime", () => {
 
       const failed = getStore(service).getAccountById(localAccountId);
       assert.ok(failed);
-      assert.equal(failed.lastErrorCode, "TOKEN_REQUEST_FAILED");
-      assert.equal(failed.status, "disconnected");
+      assert.equal(failed.lastErrorCode, "JUNCTION_API_REQUEST_FAILED");
+      assert.equal(failed.status, "active");
       assert.ok(failed.lastSyncErrorAt);
 
       await reconcileHostedDeviceSyncControlPlaneState({
@@ -3667,40 +3647,23 @@ describe("hosted device-sync runtime", () => {
       assert.equal(request.updates.length, 1);
       assert.equal(request.updates[0]?.connectionId, "hosted_conn_failure_diagnostic");
       assert.deepEqual(request.updates[0]?.failureDiagnostic, {
-        accountStatus: "disconnected",
-        code: "TOKEN_REQUEST_FAILED",
+        accountStatus: null,
+        code: "JUNCTION_API_REQUEST_FAILED",
         details: {
-          providerHttpStatus: 400,
-          providerHttpStatusText: "Bad Request",
-          providerOAuthErrorCode: "invalid_grant",
-          providerOAuthErrorDescription: "Refresh token expired. Reconnect provider.",
-          providerOAuthGrantType: "refresh_token",
-          providerOAuthRequestBodyBuilderKind: "url_search_params_record",
-          providerOAuthRequestClientAuthPlacement: "body_parameters",
-          providerOAuthRequestClientCredentialPresent: true,
-          providerOAuthRequestClientIdPresent: true,
-          providerOAuthRequestContentType: "application_x_www_form_urlencoded",
-          providerOAuthRequestDuplicateParameterCount: 0,
-          providerOAuthRequestEncodingKind: "form_urlencoded",
-          providerOAuthRequestHasDuplicateParameters: false,
-          providerOAuthRequestMethod: "POST",
-          providerOAuthRequestOfflineScopePresent: true,
-          providerOAuthRequestParameterCount: 5,
-          providerOAuthRequestParameterNames: "client_id.client_secret.grant_type.refresh_token.scope",
-          providerOAuthRequestRefreshCredentialPresent: true,
-          providerOAuthRequestScopeCount: 1,
-          providerOAuthRequestScopePresent: true,
-          providerOAuthRequestScopeValue: "offline",
-          providerOAuthRequestTokenEndpointKind: "whoop_oauth_token",
-          providerOAuthResponseErrorDescriptionFieldPresent: true,
-          providerOAuthResponseErrorFieldPresent: true,
-          providerOAuthResponseShapeKind: "json_object",
+          providerHttpStatus: 500,
+          providerRequestEndpointKind: "junction_workout_stream",
+          providerRequestMethod: "GET",
         },
-        retryable: false,
+        retryable: true,
       });
+      const failureDetails = request.updates[0]?.failureDiagnostic?.details;
+      assert.ok(failureDetails);
+      assert.equal("providerRequestCandidateAliasSource" in failureDetails, false);
+      assert.equal("providerRequestCandidateCount" in failureDetails, false);
+      assert.equal("providerRequestCandidateOrdinal" in failureDetails, false);
       assert.equal(
         request.updates[0]?.localState?.lastErrorMessage,
-        "Provider token request failed. Provider reason: Refresh token expired. Reconnect provider.",
+        "Junction workout stream request failed.",
       );
       assert.equal(request.updates[0]?.localState?.lastSyncErrorAt, failed.lastSyncErrorAt);
       assert.equal(request.updates[0]?.observedUpdatedAt, "2026-04-06T09:15:00.000Z");

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -5679,7 +5679,7 @@ describe("hosted device-sync runtime", () => {
         store.claimDueJob("lease-expired-worker", "2026-04-04T10:00:00.000Z", 60_000)?.id,
         retainedJob.id,
       );
-      assert.equal(
+      assert.deepEqual(
         store.failJobIfOwned(
           retainedJob.id,
           "lease-expired-worker",
@@ -5689,7 +5689,12 @@ describe("hosted device-sync runtime", () => {
           null,
           false,
         ),
-        true,
+        {
+          attempts: 1,
+          disposition: "dead",
+          maxAttempts: 1,
+          remainingAttempts: 0,
+        },
       );
       assert.equal(store.getJobById(retainedJob.id)?.status, "dead");
       state.pendingDirtyPayloadJobs.push({
@@ -10329,7 +10334,7 @@ describe("hosted device-sync runtime", () => {
       const claimed = firstStore.claimDueJob("worker_exact_recovery", occurredAt, 60_000);
       assert.ok(claimed);
       assert.equal(claimed.attempts, 1);
-      assert.equal(firstStore.failJobIfOwned(
+      assert.deepEqual(firstStore.failJobIfOwned(
         claimed.id,
         "worker_exact_recovery",
         occurredAt,
@@ -10337,7 +10342,12 @@ describe("hosted device-sync runtime", () => {
         "retryable",
         retryAt,
         true,
-      ), true);
+      ), {
+        attempts: 1,
+        disposition: "queued",
+        maxAttempts: 5,
+        remainingAttempts: 4,
+      });
 
       const recovery = resolveHostedDeviceSyncWakeRecovery({
         service: firstService,

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -3621,6 +3621,7 @@ describe("runHostedDeviceSyncPass", () => {
         {
           accountId: "local_account_sensitive",
           accountStatus: null,
+          attempts: 1,
           code: "SYNC_JOB_FAILED",
           details: {
             failureCauseCode: "UND_ERR_CONNECT_TIMEOUT",
@@ -3649,6 +3650,10 @@ describe("runHostedDeviceSyncPass", () => {
             providerOAuthResponseErrorFieldPresent: true,
             providerOAuthResponseShapeKind: "json_object",
           },
+          jobDisposition: "queued",
+          jobKind: "reconcile",
+          maxAttempts: 5,
+          remainingAttempts: 4,
           retryable: true,
         },
       ]),
@@ -3740,7 +3745,12 @@ describe("runHostedDeviceSyncPass", () => {
     assert.equal(entry.phase, "invoke");
     assert.deepEqual(entry.redactedJson, {
       failureCode: "SYNC_JOB_FAILED",
-      failureDisposition: "retry",
+      failureDisposition: "queued",
+      failureEventOrigin: "worker_attempt",
+      failureJobAttempts: 1,
+      failureJobKind: "reconcile",
+      failureJobMaxAttempts: 5,
+      failureJobRemainingAttempts: 4,
       failureSummary:
         "Importer failed reading <redacted-path> for <redacted-email> with <redacted-secret>",
       failureCauseCode: "UND_ERR_CONNECT_TIMEOUT",
@@ -3792,7 +3802,7 @@ describe("runHostedDeviceSyncPass", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it("logs webhook-triggered job failures even when a later success cleared account error state", async () => {
+  it("logs an exhausted retryable workout-stream attempt as dead with bounded safe candidate context", async () => {
     const close = vi.fn();
     const drainWorker = vi.fn(async () => 2);
     const runSchedulerOnce = vi.fn(async () => undefined);
@@ -3808,18 +3818,28 @@ describe("runHostedDeviceSyncPass", () => {
           accountId: "local_account_sleep_sensitive",
           accountStatus: null,
           at: "2026-06-08T02:00:02.000Z",
-          attempts: 3,
+          attempts: 5,
           code: "JUNCTION_API_REQUEST_FAILED",
           details: {
-            providerHttpStatus: 503,
-            providerRequestEndpointKind: "junction_summary",
+            providerHttpStatus: 500,
+            providerRequestCandidateAliasSource: "id",
+            providerRequestCandidateCount: 8,
+            providerRequestCandidateOrdinal: 3,
+            providerRequestEndpointKind: "junction_workout_stream",
             providerRequestMethod: "GET",
+            providerResponseRequestId: "private-provider-request-id-must-not-escape",
+            rawProviderPayload: "private-provider-payload-must-not-escape",
+            rawRequestUrl: "https://junction.example/private-workout-id-must-not-escape",
+            rawWorkoutId: "private-workout-id-must-not-escape",
           },
-          jobKind: "resource",
+          jobDisposition: "dead",
+          jobKind: "reconcile",
+          maxAttempts: 5,
           provider: "junction",
-          resource: "sleep",
+          remainingAttempts: 0,
+          resource: "workout_stream",
           retryable: true,
-          summary: "Junction summary request failed with an ambiguous provider error.",
+          summary: "Junction workout stream request failed with an ambiguous provider error.",
         },
       ]),
       listAccounts: vi.fn(() => [
@@ -3904,11 +3924,14 @@ describe("runHostedDeviceSyncPass", () => {
     assert.equal(entry.phase, "invoke");
     assert.deepEqual(entry.redactedJson, {
       failureCode: "JUNCTION_API_REQUEST_FAILED",
-      failureDisposition: "retry",
-      failureJobAttempts: 3,
-      failureJobKind: "resource",
-      failureResource: "sleep",
-      failureSummary: "Junction summary request failed with an ambiguous provider error.",
+      failureDisposition: "dead",
+      failureEventOrigin: "worker_attempt",
+      failureJobAttempts: 5,
+      failureJobKind: "reconcile",
+      failureJobMaxAttempts: 5,
+      failureJobRemainingAttempts: 0,
+      failureResource: "workout_stream",
+      failureSummary: "Junction workout stream request failed with an ambiguous provider error.",
       failureRetryable: true,
       hadPriorFailure: false,
       hadPriorSuccess: true,
@@ -3916,8 +3939,11 @@ describe("runHostedDeviceSyncPass", () => {
       nextReconcileAt: "2026-06-08T03:00:00.000Z",
       processedJobs: 2,
       provider: "junction",
-      providerHttpStatus: 503,
-      providerRequestEndpointKind: "junction_summary",
+      providerHttpStatus: 500,
+      providerRequestCandidateAliasSource: "id",
+      providerRequestCandidateCount: 8,
+      providerRequestCandidateOrdinal: 3,
+      providerRequestEndpointKind: "junction_workout_stream",
       providerRequestMethod: "GET",
       setupPhase: null,
       status: "active",
@@ -3930,6 +3956,10 @@ describe("runHostedDeviceSyncPass", () => {
     const serializedWebhookFailureLogs = JSON.stringify(logRequests);
     expect(serializedWebhookFailureLogs).not.toContain("local_account_sleep_sensitive");
     expect(serializedWebhookFailureLogs).not.toContain("hosted_connection_sleep_sensitive");
+    expect(serializedWebhookFailureLogs).not.toContain("private-workout-id-must-not-escape");
+    expect(serializedWebhookFailureLogs).not.toContain("private-provider-payload-must-not-escape");
+    expect(serializedWebhookFailureLogs).not.toContain("private-provider-request-id-must-not-escape");
+    expect(serializedWebhookFailureLogs).not.toContain("junction.example");
     expect(close).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -2163,6 +2163,76 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
   });
 
+  it("logs device activity automation scheduling failures and keeps device-sync continuation", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    mocks.runHostedDeviceSyncWakeLane.mockResolvedValueOnce({
+      deviceSyncProcessed: 1,
+      deviceSyncSkipped: false,
+      nextWakeAt: "2026-04-27T00:01:00.000Z",
+      nextWakeReason: "device-sync.reconcile",
+      parserProcessed: 0,
+      postCheckpointRecord: null,
+    });
+    mocks.scheduleDeviceActivityTriggeredAutomations.mockRejectedValueOnce(
+      new Error("synthetic device activity automation failure"),
+    );
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      importedCount: 0,
+      logRequests,
+      resolvedDeviceSync: {
+        providerConfigs: {
+          whoop: {
+            clientId: "synthetic-whoop-client",
+            clientSecret: "synthetic-whoop-secret",
+          },
+        },
+        publicBaseUrl: "https://device-sync.example.test",
+        secret: "synthetic-device-sync-secret",
+      },
+      workspace: {
+        checkpointedAt: "2026-04-27T00:00:00.000Z",
+        createdAt: "2026-04-27T00:00:00.000Z",
+        nextWakeAt: "2026-04-26T23:59:59.000Z",
+        nextWakeReason: "device-sync.reconcile",
+        redactedStatus: null,
+        snapshotRef: null,
+        updatedAt: "2026-04-27T00:00:00.000Z",
+        userId: "member_synthetic_phase",
+        version: "8",
+      },
+    }));
+
+    expect(result).toEqual(expect.objectContaining({
+      nextWakeAt: "2026-04-27T00:01:00.000Z",
+      nextWakeReason: "device-sync.reconcile",
+      progressed: true,
+    }));
+    const failureLog = logRequests
+      .flatMap((request) => request.entries)
+      .find((entry) =>
+        entry.redactedJson?.failureEventOrigin === "device_activity_automation"
+      );
+    expect(failureLog).toEqual(expect.objectContaining({
+      component: "runtime",
+      errorCode: "runtime_error",
+      eventCode: "device-sync.job_failed",
+      level: "warn",
+      phase: "idle",
+      redactedJson: expect.objectContaining({
+        deviceActivityAutomationScheduleFailed: true,
+        errorCode: "runtime_error",
+        errorMessagePresent: true,
+        failureEventOrigin: "device_activity_automation",
+        safeErrorMessage: "Hosted execution runtime failed.",
+        wakeKind: "runtime.timer",
+      }),
+    }));
+    expect(JSON.stringify(logRequests)).not.toContain(
+      "synthetic device activity automation failure",
+    );
+  });
+
   it("schedules an assistant wake when idle device sync matches device activity automation", async () => {
     mocks.runHostedDeviceSyncWakeLane.mockResolvedValueOnce({
       deviceSyncProcessed: 1,
@@ -17584,6 +17654,81 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
         hostedDeviceSyncDirtyStillPending: true,
       }),
     }));
+  });
+
+  it("logs dirty checkpoint failures and preserves the retry wake", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    mocks.runHostedDeviceSyncWakeLane.mockResolvedValueOnce({
+      deviceSyncProcessed: 2,
+      deviceSyncSkipped: false,
+      nextWakeAt: "not-a-timestamp",
+      parserProcessed: 0,
+      postCheckpointRecord: {
+        connectionId: "dsc_dirty",
+        kind: "device-sync.dirty-processed",
+        nextWakeAt: "2026-04-27T00:11:00.000Z",
+        processedRevision: "42",
+      },
+    });
+    mocks.recordHostedDeviceSyncDirtyPostCheckpointRecord.mockRejectedValueOnce(
+      new Error("synthetic dirty checkpoint failure"),
+    );
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      logRequests,
+      now: () => "2026-04-27T00:00:00.000Z",
+      resolvedDeviceSync: {
+        providerConfigs: {
+          whoop: {
+            clientId: "synthetic-whoop-client",
+            clientSecret: "synthetic-whoop-secret",
+          },
+        },
+        publicBaseUrl: "https://device-sync.example.test",
+        secret: "synthetic-device-sync-secret",
+      },
+      workspace: {
+        checkpointedAt: "2026-04-27T00:00:00.000Z",
+        createdAt: "2026-04-27T00:00:00.000Z",
+        nextWakeAt: "2026-04-26T23:59:59.000Z",
+        nextWakeReason: "device-sync.reconcile",
+        redactedStatus: null,
+        snapshotRef: null,
+        updatedAt: "2026-04-27T00:00:00.000Z",
+        userId: "member_synthetic_phase",
+        version: "8",
+      },
+    }));
+    const postCheckpoint = await result.afterCheckpoint?.();
+    const effects = postCheckpoint?.afterDurableCheckpoint;
+    const effect = typeof effects === "function" ? effects : effects?.[0];
+    if (!effect) {
+      throw new Error("Expected deferred device-sync dirty checkpoint effect.");
+    }
+
+    await expect(effect()).resolves.toEqual({
+      nextWakeAt: "2026-04-27T00:11:00.000Z",
+      nextWakeReason: "device-sync.reconcile",
+    });
+    const failureLog = logRequests
+      .flatMap((request) => request.entries)
+      .find((entry) => entry.redactedJson?.failureEventOrigin === "checkpoint");
+    expect(failureLog).toEqual(expect.objectContaining({
+      component: "device-sync",
+      errorCode: "checkpoint_error",
+      eventCode: "device-sync.job_failed",
+      level: "warn",
+      phase: "checkpoint",
+      redactedJson: expect.objectContaining({
+        errorCode: "checkpoint_error",
+        failureEventOrigin: "checkpoint",
+        nextWakeAtPresent: true,
+        safeErrorMessage: "Hosted execution failed while recording a checkpoint.",
+      }),
+    }));
+    expect(JSON.stringify(logRequests)).not.toContain(
+      "synthetic dirty checkpoint failure",
+    );
   });
 
   it("runs pending provider cleanup after a system mailbox receipt without delivery effects", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -2395,6 +2395,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       redactedJson: expect.objectContaining({
         errorCode: "runtime_error",
         errorMessagePresent: true,
+        failureEventOrigin: "idle_maintenance",
         idleMaintenanceFailed: true,
         retryAt: "2026-04-27T00:00:30.000Z",
         safeErrorMessage: "Hosted execution runtime failed.",

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -90,7 +90,15 @@ Current providers:
   Each present workout metric array must align with the timestamp array. A workout
   whose present metric arrays do not align is skipped so one malformed stream cannot
   block other workouts or replace a previously complete canonical measurement; the
-  skip emits a metadata-only cardinality warning for provider follow-up.
+  skip emits a metadata-only cardinality warning for provider follow-up. A
+  retryable per-workout request failure remains owned by the existing job retry
+  transition and still stops the serial loop. Its worker-attempt runtime
+  diagnostic records only the canonical-order candidate ordinal/count and which
+  supported summary-id alias selected the request; it never records the workout
+  id, summary, stream payload, URL, or provider response identifier.
+  Worker-attempt logs also report the committed `queued`/`dead` transition and
+  remaining bounded attempt budget, while a typed origin distinguishes them
+  from canonical-apply and checkpoint-side diagnostics.
 - Successful Junction resource/webhook jobs preserve the full-sync completion
   watermark. They still complete and clear their own failures, while only a
   terminal reconcile or backfill whose window ends at the current closed-day

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -142,6 +142,7 @@ import type {
   DeviceSyncJobInput,
   DeviceSyncJobRecord,
   DeviceSyncProvider,
+  DeviceSyncProviderRequestCandidateAliasSource,
   DeviceSyncRestDiagnosticContext,
   ProviderBeginConnectionContext,
   ProviderBeginConnectionResult,
@@ -4209,7 +4210,7 @@ export function createJunctionDeviceSyncProvider(
       [...completedIdentities].filter((identity) => candidateIdentities.has(identity)),
     );
 
-    for (const candidate of candidates) {
+    for (const [candidateIndex, candidate] of candidates.entries()) {
       if (completedIdentities.has(candidate.identity)) {
         continue;
       }
@@ -4243,7 +4244,13 @@ export function createJunctionDeviceSyncProvider(
           input.context.account.externalAccountId,
         );
         if (!failure) {
-          return carryTerminalProgressOrThrow(error);
+          return carryTerminalProgressOrThrow(
+            addJunctionWorkoutStreamCandidateFailureContext(error, {
+              aliasSource: candidate.workoutIdAliasSource,
+              candidateCount: candidates.length,
+              candidateOrdinal: candidateIndex + 1,
+            }),
+          );
         }
         logSkippedOptionalJunctionResource(
           input.context,
@@ -4968,6 +4975,34 @@ function hasCheckedJunctionProfileSummary(metadata: Record<string, unknown>): bo
     && Number.isFinite(Date.parse(checkedAt))
     && metadata[JUNCTION_PROFILE_SUMMARY_NORMALIZATION_REVISION_METADATA_KEY]
       === JUNCTION_PROFILE_SUMMARY_NORMALIZATION_REVISION;
+}
+
+function addJunctionWorkoutStreamCandidateFailureContext(
+  error: unknown,
+  input: {
+    aliasSource: DeviceSyncProviderRequestCandidateAliasSource;
+    candidateCount: number;
+    candidateOrdinal: number;
+  },
+): unknown {
+  if (!isDeviceSyncError(error) || error.code !== "JUNCTION_API_REQUEST_FAILED") {
+    return error;
+  }
+
+  return deviceSyncError({
+    accountStatus: error.accountStatus,
+    cause: error.cause,
+    code: error.code,
+    details: {
+      ...error.details,
+      requestCandidateAliasSource: input.aliasSource,
+      requestCandidateCount: input.candidateCount,
+      requestCandidateOrdinal: input.candidateOrdinal,
+    },
+    httpStatus: error.httpStatus,
+    message: error.message,
+    retryable: error.retryable,
+  });
 }
 
 function classifyOptionalJunctionResourceFailure(

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -1,3 +1,4 @@
+import { resolveJunctionTimeseriesResourcePolicy } from "@murphai/contracts";
 import {
   createImporters,
   JunctionSparseCalendarRepairNormalizationError,
@@ -125,6 +126,8 @@ const DEVICE_SYNC_CONNECTION_MUTATION_WAIT_TIMEOUT_MS = 15_000;
 const DEFAULT_PROVIDER_JOB_BATCH_MAX_JOBS = 50;
 const DEFAULT_PROVIDER_JOB_BATCH_MAX_ESTIMATED_BYTES = 2 * 1024 * 1024;
 const DEFAULT_PROVIDER_JOB_BATCH_CANDIDATE_SCAN_LIMIT = 200;
+const JUNCTION_WORKOUT_STREAM_CANDIDATE_DIAGNOSTIC_LIMIT =
+  resolveJunctionTimeseriesResourcePolicy("workout_stream")?.maxRecordsPerWindow ?? 0;
 const DEVICE_SYNC_VALIDATION_SENSITIVE_FIELD_PATTERN =
   /(?:authorization|bearer|cookie|password|secret|token|api[-_]?key|client[-_]?secret|access[-_]?token|refresh[-_]?token|id[-_]?token|email|phone|address|user(?:name)?|owner|account(?:id)?|external(?:id)?)/iu;
 const DEVICE_SYNC_VALIDATION_METADATA_FIELDS = Object.freeze([
@@ -825,15 +828,23 @@ class DeviceSyncServiceController {
       retryable: boolean,
     ): boolean => {
       const failedAt = currentNow();
-      const failed = this.store.failJobIfOwned(job.id, this.workerId, failedAt, code, message, retryAt, retryable);
+      const failureTransition = this.store.failJobIfOwned(
+        job.id,
+        this.workerId,
+        failedAt,
+        code,
+        message,
+        retryAt,
+        retryable,
+      );
 
-      if (!failed) {
+      if (!failureTransition) {
         this.logger.debug?.("Device sync job side effects skipped because execution was cancelled.", {
           provider: job.provider,
           accountId: job.accountId,
           jobId: job.id,
         });
-        return failed;
+        return false;
       }
 
       // No summary here: these repo-authored messages can embed the local
@@ -843,15 +854,18 @@ class DeviceSyncServiceController {
         accountId: job.accountId,
         accountStatus: null,
         at: failedAt,
-        attempts: job.attempts,
+        attempts: failureTransition.attempts,
         code,
         details: {},
+        jobDisposition: failureTransition.disposition,
         jobKind: job.kind,
+        maxAttempts: failureTransition.maxAttempts,
         provider: job.provider,
+        remainingAttempts: failureTransition.remainingAttempts,
         ...(failedJobResource ? { resource: failedJobResource } : {}),
         retryable,
       });
-      return failed;
+      return true;
     };
 
     const provider = this.registry.get(job.provider);
@@ -1336,39 +1350,46 @@ class DeviceSyncServiceController {
         return finishPass();
       }
 
-      const failed = activeJobs
-        .map((activeJob) => {
-          const retryAt = retainedFailureRetryable
-            ? addMilliseconds(failureNow, computeRetryDelayMs(activeJob.attempts))
-            : null;
-          return this.store.failJobIfOwned(
-            activeJob.id,
-            this.workerId,
-            failureNow,
-            failure.code,
-            failure.message,
-            retryAt,
-            retainedFailureRetryable,
-            retainsAcceptedWorkUntilSuccess,
-            activeJob.id === job.id ? replacementPayload : undefined,
-          );
-        })
-        .some(Boolean);
+      const failureTransitions = activeJobs.flatMap((activeJob) => {
+        const retryAt = retainedFailureRetryable
+          ? addMilliseconds(failureNow, computeRetryDelayMs(activeJob.attempts))
+          : null;
+        const transition = this.store.failJobIfOwned(
+          activeJob.id,
+          this.workerId,
+          failureNow,
+          failure.code,
+          failure.message,
+          retryAt,
+          retainedFailureRetryable,
+          retainsAcceptedWorkUntilSuccess,
+          activeJob.id === job.id ? replacementPayload : undefined,
+        );
+        return transition ? [{ activeJob, transition }] : [];
+      });
 
-      if (!failed) {
+      if (failureTransitions.length === 0) {
         return finishPass();
       }
 
-      const failedJobResource = readSafeDiagnosticToken(job.payload.resource);
+      const diagnosticTransition = failureTransitions.find(({ activeJob }) => activeJob.id === job.id)
+        ?? failureTransitions[0];
+      if (!diagnosticTransition) {
+        return finishPass();
+      }
+      const failedJobResource = readSafeDiagnosticToken(diagnosticTransition.activeJob.payload.resource);
       this.recordJobFailureDiagnostic({
         accountId: storedAccount.id,
         accountStatus: failure.accountStatus ?? null,
         at: failureNow,
-        attempts: job.attempts,
+        attempts: diagnosticTransition.transition.attempts,
         code: failure.code,
         details: failure.details,
-        jobKind: job.kind,
+        jobDisposition: diagnosticTransition.transition.disposition,
+        jobKind: diagnosticTransition.activeJob.kind,
+        maxAttempts: diagnosticTransition.transition.maxAttempts,
         provider: provider.provider,
+        remainingAttempts: diagnosticTransition.transition.remainingAttempts,
         ...(failedJobResource ? { resource: failedJobResource } : {}),
         retryable: retainedFailureRetryable,
         summary: failure.message,
@@ -2033,6 +2054,11 @@ function buildDeviceSyncErrorFailureDiagnostics(
   error: DeviceSyncError,
 ): DeviceSyncJobFailureDiagnostic["details"] {
   const cause = toPlainRecord(error.cause);
+  const providerRequestEndpointKind = readSafeDiagnosticToken(error.details?.requestEndpointKind);
+  const workoutCandidateContext = readSafeWorkoutCandidateFailureContext(
+    error,
+    providerRequestEndpointKind,
+  );
 
   return compactFailureDiagnostics({
     failureCauseCode: readSafeDiagnosticToken(cause?.code),
@@ -2045,9 +2071,10 @@ function buildDeviceSyncErrorFailureDiagnostics(
     providerRequestBodyFieldCount: readSafeDiagnosticNumber(error.details?.requestBodyFieldCount),
     providerRequestBodyFieldNames: readSafeDiagnosticToken(error.details?.requestBodyFieldNames),
     providerRequestBodyKind: readSafeDiagnosticToken(error.details?.requestBodyKind),
+    ...workoutCandidateContext,
     providerRequestContentType: readSafeDiagnosticToken(error.details?.requestContentType),
     providerRequestCredentialPresent: readSafeDiagnosticBoolean(error.details?.requestCredentialPresent),
-    providerRequestEndpointKind: readSafeDiagnosticToken(error.details?.requestEndpointKind),
+    providerRequestEndpointKind,
     providerRequestMethod: readSafeDiagnosticToken(error.details?.requestMethod),
     providerRequestQueryParameterCount: readSafeDiagnosticNumber(error.details?.requestQueryParameterCount),
     providerRequestQueryParameterNames: readSafeDiagnosticToken(error.details?.requestQueryParameterNames),
@@ -2142,6 +2169,67 @@ function readSafeDiagnosticToken(value: unknown): string | null {
 
 function readSafeDiagnosticBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
+}
+
+function readSafeWorkoutCandidateFailureContext(
+  error: DeviceSyncError,
+  providerRequestEndpointKind: string | null,
+): Partial<Pick<
+  DeviceSyncJobFailureDiagnostic["details"],
+  | "providerRequestCandidateAliasSource"
+  | "providerRequestCandidateCount"
+  | "providerRequestCandidateOrdinal"
+>> {
+  if (
+    error.code !== "JUNCTION_API_REQUEST_FAILED"
+    || providerRequestEndpointKind !== "junction_workout_stream"
+  ) {
+    return {};
+  }
+
+  const aliasSource = readSafeWorkoutCandidateAliasSource(
+    error.details?.requestCandidateAliasSource,
+  );
+  const candidateCount = readSafeWorkoutCandidateBoundedNumber(
+    error.details?.requestCandidateCount,
+  );
+  const candidateOrdinal = readSafeWorkoutCandidateBoundedNumber(
+    error.details?.requestCandidateOrdinal,
+  );
+  if (
+    !aliasSource
+    || candidateCount === null
+    || candidateOrdinal === null
+    || candidateOrdinal > candidateCount
+  ) {
+    return {};
+  }
+
+  return {
+    providerRequestCandidateAliasSource: aliasSource,
+    providerRequestCandidateCount: candidateCount,
+    providerRequestCandidateOrdinal: candidateOrdinal,
+  };
+}
+
+function readSafeWorkoutCandidateAliasSource(
+  value: unknown,
+): DeviceSyncJobFailureDiagnostic["details"]["providerRequestCandidateAliasSource"] | null {
+  return value === "id"
+    || value === "multiple_equal"
+    || value === "workoutId"
+    || value === "workout_id"
+    ? value
+    : null;
+}
+
+function readSafeWorkoutCandidateBoundedNumber(value: unknown): number | null {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value >= 1
+    && value <= JUNCTION_WORKOUT_STREAM_CANDIDATE_DIAGNOSTIC_LIMIT
+    ? value
+    : null;
 }
 
 function readSafeDiagnosticNumber(value: unknown): number | null {

--- a/packages/device-syncd/src/store.ts
+++ b/packages/device-syncd/src/store.ts
@@ -93,6 +93,7 @@ import type {
   DiscardUnconsumedOAuthStateResult,
   DeviceSyncWebhookTraceClaimResult,
   DeviceSyncAccountStatus,
+  DeviceSyncJobFailureTransition,
   DeviceSyncJobInput,
   DeviceSyncJobRecord,
   DeviceSyncServiceSummary,
@@ -706,7 +707,7 @@ export class SqliteDeviceSyncStore {
     retryable: boolean,
     retainUntilSuccess = false,
     replacementPayload?: Record<string, unknown>,
-  ): boolean {
+  ): DeviceSyncJobFailureTransition | null {
     return failDeviceSyncJobIfOwned(this.database, {
       code,
       jobId,

--- a/packages/device-syncd/src/store/jobs.ts
+++ b/packages/device-syncd/src/store/jobs.ts
@@ -19,7 +19,12 @@ import {
   type DeviceSyncCredentialIndependentImportJobClassifier,
 } from "../hosted-runtime.ts";
 import { isJunctionRetainedAcceptedWorkJob } from "../junction-resources.ts";
-import type { DeviceSyncJobInput, DeviceSyncJobRecord } from "../types.ts";
+import type {
+  DeviceSyncJobFailureDisposition,
+  DeviceSyncJobFailureTransition,
+  DeviceSyncJobInput,
+  DeviceSyncJobRecord,
+} from "../types.ts";
 
 export interface DeviceSyncEnqueueJobInput extends DeviceSyncJobInput {
   provider: string;
@@ -710,7 +715,7 @@ export function failDeviceSyncJobIfOwned(
     retainUntilSuccess?: boolean;
     workerId: string;
   },
-): boolean {
+): DeviceSyncJobFailureTransition | null {
   if (input.retryable) {
     const replacementPayloadJson = input.replacementPayload === undefined
       ? null
@@ -732,7 +737,8 @@ export function failDeviceSyncJobIfOwned(
         and lease_expires_at is not null
         and lease_expires_at > ?
         and (attempts < max_attempts or ? = 1)
-    `).run(
+      returning attempts, max_attempts
+    `).get(
       input.retryAt ?? input.now,
       input.retainUntilSuccess ? 1 : 0,
       replacementPayloadJson === null ? 0 : 1,
@@ -744,10 +750,10 @@ export function failDeviceSyncJobIfOwned(
       input.workerId,
       input.now,
       input.retainUntilSuccess ? 1 : 0,
-    ) as { changes: number };
+    ) as Record<string, unknown> | undefined;
 
-    if ((retryResult.changes ?? 0) > 0) {
-      return true;
+    if (retryResult) {
+      return decodeDeviceSyncJobFailureTransition(retryResult, "queued");
     }
   }
 
@@ -765,7 +771,8 @@ export function failDeviceSyncJobIfOwned(
       and lease_owner = ?
       and lease_expires_at is not null
       and lease_expires_at > ?
-  `).run(
+    returning attempts, max_attempts
+  `).get(
     input.code,
     input.message,
     input.now,
@@ -773,9 +780,33 @@ export function failDeviceSyncJobIfOwned(
     input.jobId,
     input.workerId,
     input.now,
-  ) as { changes: number };
+  ) as Record<string, unknown> | undefined;
 
-  return (deadResult.changes ?? 0) > 0;
+  return deadResult
+    ? decodeDeviceSyncJobFailureTransition(deadResult, "dead")
+    : null;
+}
+
+function decodeDeviceSyncJobFailureTransition(
+  row: Record<string, unknown>,
+  disposition: DeviceSyncJobFailureDisposition,
+): DeviceSyncJobFailureTransition {
+  const attempts = requireJobRowNumber(row, "attempts");
+  const maxAttempts = requireJobRowNumber(row, "max_attempts");
+
+  if (!Number.isSafeInteger(attempts) || attempts < 1) {
+    throw new TypeError("Expected device_job.attempts to be a positive safe integer.");
+  }
+  if (!Number.isSafeInteger(maxAttempts) || maxAttempts < attempts) {
+    throw new TypeError("Expected device_job.max_attempts to cover the committed attempt count.");
+  }
+
+  return {
+    attempts,
+    disposition,
+    maxAttempts,
+    remainingAttempts: disposition === "queued" ? maxAttempts - attempts : 0,
+  };
 }
 
 export function markPendingDeviceSyncJobsDeadForAccount(

--- a/packages/device-syncd/src/types.ts
+++ b/packages/device-syncd/src/types.ts
@@ -56,6 +56,28 @@ export interface DeviceSyncServiceConfig {
   shouldYieldJobExecution?: (() => boolean) | null;
 }
 
+export type DeviceSyncJobFailureDisposition = "queued" | "dead";
+
+export interface DeviceSyncJobFailureTransition {
+  attempts: number;
+  disposition: DeviceSyncJobFailureDisposition;
+  maxAttempts: number;
+  remainingAttempts: number;
+}
+
+export type DeviceSyncJobFailureEventOrigin =
+  | "canonical_apply"
+  | "checkpoint"
+  | "device_activity_automation"
+  | "idle_maintenance"
+  | "worker_attempt";
+
+export type DeviceSyncProviderRequestCandidateAliasSource =
+  | "id"
+  | "multiple_equal"
+  | "workoutId"
+  | "workout_id";
+
 export interface DeviceSyncJobFailureDiagnosticDetails {
   failureCauseCode?: string;
   failureCauseName?: string;
@@ -68,6 +90,9 @@ export interface DeviceSyncJobFailureDiagnosticDetails {
   providerRequestBodyFieldCount?: number;
   providerRequestBodyFieldNames?: string;
   providerRequestBodyKind?: string;
+  providerRequestCandidateAliasSource?: DeviceSyncProviderRequestCandidateAliasSource;
+  providerRequestCandidateCount?: number;
+  providerRequestCandidateOrdinal?: number;
   providerRequestContentType?: string;
   providerRequestCredentialPresent?: boolean;
   providerRequestEndpointKind?: string;
@@ -113,9 +138,15 @@ export interface DeviceSyncJobFailureDiagnostic {
   attempts?: number;
   code: string;
   details: DeviceSyncJobFailureDiagnosticDetails;
+  /** Actual committed queue transition for this failed attempt, when known. */
+  jobDisposition?: DeviceSyncJobFailureDisposition;
   /** Job kind of the failing job (for example `resource`, `reconcile`), when known. */
   jobKind?: string;
+  /** Maximum attempt budget committed on the failing job row, when known. */
+  maxAttempts?: number;
   provider?: string;
+  /** Attempts still available after the committed failure transition, when known. */
+  remainingAttempts?: number;
   /** Provider resource name from the failing job payload, when known. */
   resource?: string;
   retryable: boolean;

--- a/packages/device-syncd/test/junction-provider.test.ts
+++ b/packages/device-syncd/test/junction-provider.test.ts
@@ -19049,13 +19049,17 @@ test("Junction workout_stream carries the owning day when retryable failure prec
   assert.deepEqual(harness.streamRequests, ["workout-1"]);
 });
 
-test("Junction workout_stream carries exact progress with its retryable provider failure", async () => {
+test("Junction workout_stream carries exact progress and bounded context with its retryable provider failure", async () => {
   const importedWorkoutIds: string[] = [];
   const harness = createJunctionWorkoutStreamTestProvider({
     listWorkoutIds: () => ["workout-1", "workout-2"],
     streamResponse: (workoutId) => workoutId === "workout-2"
-      ? new Response(JSON.stringify({ error: "temporary provider failure" }), {
-          status: 503,
+      ? new Response(JSON.stringify({
+          error: "temporary provider failure",
+          privatePayloadMarker: "raw-workout-payload-must-not-escape",
+          workoutId,
+        }), {
+          status: 500,
           headers: {
             "Content-Type": "application/json",
             "Retry-After": "0",
@@ -19086,6 +19090,13 @@ test("Junction workout_stream carries exact progress with its retryable provider
       assert.ok(error instanceof JunctionTimeseriesProgressError);
       assert.ok(error.failure instanceof DeviceSyncError);
       assert.equal(error.failure.retryable, true);
+      assert.equal(error.failure.details?.status, 500);
+      assert.equal(error.failure.details?.requestCandidateAliasSource, "id");
+      assert.equal(error.failure.details?.requestCandidateCount, 2);
+      assert.equal(error.failure.details?.requestCandidateOrdinal, 2);
+      const serializedDetails = JSON.stringify(error.failure.details);
+      assert.equal(serializedDetails.includes("workout-2"), false);
+      assert.equal(serializedDetails.includes("raw-workout-payload-must-not-escape"), false);
       assert.deepEqual(readJunctionWorkoutProgressIdentities({
         workoutStreamCursor: error.workoutStreamCursor,
       }), [junctionWorkoutCandidateIdentity("workout-1")]);

--- a/packages/device-syncd/test/service.test.ts
+++ b/packages/device-syncd/test/service.test.ts
@@ -1604,12 +1604,25 @@ test.each(["resource"] as const)(
       assert.equal(streamRequests.filter((workoutId) => workoutId === "day-one-b").length, 1);
       assert.equal(streamRequests.filter((workoutId) => workoutId === "day-two-a").length, 1);
       assert.equal(streamRequests.filter((workoutId) => workoutId === "day-two-b").length, 5);
+      const failureDiagnostics = service.listJobFailureDiagnostics();
       assert.deepEqual(
-        service.listJobFailureDiagnostics().map((diagnostic) => diagnostic.attempts),
+        failureDiagnostics.map((diagnostic) => diagnostic.attempts),
         [1, 2, 3, 4, 5],
       );
+      assert.deepEqual(
+        failureDiagnostics.map((diagnostic) => diagnostic.jobDisposition),
+        ["queued", "queued", "queued", "queued", "dead"],
+      );
+      assert.deepEqual(
+        failureDiagnostics.map((diagnostic) => diagnostic.maxAttempts),
+        [5, 5, 5, 5, 5],
+      );
+      assert.deepEqual(
+        failureDiagnostics.map((diagnostic) => diagnostic.remainingAttempts),
+        [4, 3, 2, 1, 0],
+      );
       assert.ok(
-        service.listJobFailureDiagnostics().every((diagnostic) =>
+        failureDiagnostics.every((diagnostic) =>
           diagnostic.code === "TEST_WORKOUT_STREAM_RETRYABLE"
         ),
       );
@@ -7299,7 +7312,7 @@ test("device sync scheduler rematerializes dead Junction metadata retries", asyn
     now = new Date(retryDueAt);
     const claimedRetry = store.claimDueJob("worker-dead-junction-retry", retryDueAt, 60_000);
     assert.equal(claimedRetry?.id, retryJob.id);
-    assert.equal(
+    assert.deepEqual(
       store.failJobIfOwned(
         retryJob.id,
         "worker-dead-junction-retry",
@@ -7309,7 +7322,12 @@ test("device sync scheduler rematerializes dead Junction metadata retries", asyn
         null,
         true,
       ),
-      true,
+      {
+        attempts: 1,
+        disposition: "dead",
+        maxAttempts: 1,
+        remainingAttempts: 0,
+      },
     );
     assert.equal(store.getJobById(retryJob.id)?.status, "dead");
 
@@ -9460,6 +9478,9 @@ test("device sync service exposes safe structured diagnostics for provider failu
   assert.equal(diagnostics[0]?.provider, "demo");
   assert.equal(diagnostics[0]?.jobKind, "backfill");
   assert.equal(diagnostics[0]?.attempts, 1);
+  assert.equal(diagnostics[0]?.jobDisposition, "dead");
+  assert.equal(diagnostics[0]?.maxAttempts, 5);
+  assert.equal(diagnostics[0]?.remainingAttempts, 0);
   assert.equal(typeof diagnostics[0]?.at, "string");
   assert.equal(
     diagnostics[0]?.summary,
@@ -9581,12 +9602,24 @@ test("device sync service keeps per-attempt failure diagnostics after a later jo
     providers: [
       createFakeProvider({
         async executeJob(_context, job) {
-          if (job.kind === "resource") {
+          if (job.kind === "reconcile") {
             throw deviceSyncError({
               code: "JUNCTION_API_REQUEST_FAILED",
-              message: "Junction summary request failed.",
+              details: {
+                requestCandidateAliasSource: "id",
+                requestCandidateCount: 8,
+                requestCandidateOrdinal: 3,
+                requestEndpointKind: "junction_workout_stream",
+                requestMethod: "GET",
+                responseBody: {
+                  privatePayloadMarker: "private-provider-payload-must-not-escape",
+                  workoutId: "private-workout-id-must-not-escape",
+                },
+                status: 500,
+              },
+              message: "Junction workout stream request failed.",
               retryable: true,
-              httpStatus: 503,
+              httpStatus: 500,
             });
           }
           return {};
@@ -9608,17 +9641,14 @@ test("device sync service keeps per-attempt failure diagnostics after a later jo
     store.enqueueJob({
       accountId: connected.account.id,
       provider: "demo",
-      kind: "resource",
-      payload: {
-        resource: "sleep",
-        resourceCategory: "summary",
-      },
+      kind: "reconcile",
+      payload: {},
+      priority: 100,
       availableAt: "2026-06-08T02:00:00.000Z",
     });
 
-    // The webhook-style resource job fails first; the initial backfill job for
-    // the same account succeeds afterwards and clears the account-level error
-    // state, mirroring the webhook-wake drains from the June 2026 incident.
+    // The high-priority reconcile fails first; the initial backfill job for the
+    // same account succeeds afterwards and clears the account-level error state.
     await service.drainWorker(10);
 
     const account = store.getAccountById(connected.account.id);
@@ -9631,12 +9661,26 @@ test("device sync service keeps per-attempt failure diagnostics after a later jo
     assert.equal(diagnostics[0]?.accountId, connected.account.id);
     assert.equal(diagnostics[0]?.code, "JUNCTION_API_REQUEST_FAILED");
     assert.equal(diagnostics[0]?.provider, "demo");
-    assert.equal(diagnostics[0]?.jobKind, "resource");
-    assert.equal(diagnostics[0]?.resource, "sleep");
+    assert.equal(diagnostics[0]?.jobKind, "reconcile");
+    assert.equal(diagnostics[0]?.resource, undefined);
     assert.equal(diagnostics[0]?.attempts, 1);
+    assert.equal(diagnostics[0]?.jobDisposition, "queued");
+    assert.equal(diagnostics[0]?.maxAttempts, 5);
+    assert.equal(diagnostics[0]?.remainingAttempts, 4);
     assert.equal(diagnostics[0]?.retryable, true);
     assert.equal(typeof diagnostics[0]?.at, "string");
-    assert.equal(diagnostics[0]?.summary, "Junction summary request failed.");
+    assert.equal(diagnostics[0]?.summary, "Junction workout stream request failed.");
+    assert.deepEqual(diagnostics[0]?.details, {
+      providerHttpStatus: 500,
+      providerRequestCandidateAliasSource: "id",
+      providerRequestCandidateCount: 8,
+      providerRequestCandidateOrdinal: 3,
+      providerRequestEndpointKind: "junction_workout_stream",
+      providerRequestMethod: "GET",
+    });
+    const serializedDiagnostics = JSON.stringify(diagnostics);
+    assert.equal(serializedDiagnostics.includes("private-workout-id-must-not-escape"), false);
+    assert.equal(serializedDiagnostics.includes("private-provider-payload-must-not-escape"), false);
   } finally {
     close();
   }

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -360,7 +360,7 @@ test("device sync store preserves failed calendar work across a later correction
       60_000,
     );
     assert.equal(failedDayOne?.payload.calendarRefreshDay, "2026-04-01");
-    assert.equal(store.failJobIfOwned(
+    assert.deepEqual(store.failJobIfOwned(
       failedDayOne!.id,
       workerId,
       "2026-04-04T00:02:10.000Z",
@@ -368,7 +368,12 @@ test("device sync store preserves failed calendar work across a later correction
       "Calendar fetch failed.",
       "2026-04-05T00:00:00.000Z",
       true,
-    ), true);
+    ), {
+      attempts: 1,
+      disposition: "queued",
+      maxAttempts: 5,
+      remainingAttempts: 4,
+    });
     const afterV2 = store.getAccountById(account.id);
     assert.ok(afterV2);
 
@@ -2847,7 +2852,7 @@ test("device sync store failure transitions requeue, replace only owned progress
       store.claimDueJob("worker-a", "2026-04-07T00:05:00.000Z", 60_000)?.id,
       retryableJob.id,
     );
-    assert.equal(
+    assert.deepEqual(
       store.failJobIfOwned(
         retryableJob.id,
         "worker-b",
@@ -2859,11 +2864,11 @@ test("device sync store failure transitions requeue, replace only owned progress
         false,
         { phase: "foreign" },
       ),
-      false,
+      null,
     );
     assert.deepEqual(store.getJobById(retryableJob.id)?.payload, { phase: "original" });
 
-    assert.equal(
+    assert.deepEqual(
       store.failJobIfOwned(
         retryableJob.id,
         "worker-a",
@@ -2875,7 +2880,12 @@ test("device sync store failure transitions requeue, replace only owned progress
         false,
         { phase: "bounded-progress" },
       ),
-      true,
+      {
+        attempts: 2,
+        disposition: "queued",
+        maxAttempts: 3,
+        remainingAttempts: 1,
+      },
     );
     const ownedRetry = store.getJobById(retryableJob.id);
     assert.equal(ownedRetry?.status, "queued");
@@ -2887,7 +2897,7 @@ test("device sync store failure transitions requeue, replace only owned progress
       store.claimDueJob("worker-b", "2026-04-07T00:05:20.000Z", 60_000)?.id,
       retryableJob.id,
     );
-    assert.equal(
+    assert.deepEqual(
       store.failJobIfOwned(
         retryableJob.id,
         "worker-b",
@@ -2899,7 +2909,12 @@ test("device sync store failure transitions requeue, replace only owned progress
         false,
         { phase: "must-not-replace-on-dead" },
       ),
-      true,
+      {
+        attempts: 3,
+        disposition: "dead",
+        maxAttempts: 3,
+        remainingAttempts: 0,
+      },
     );
     const exhausted = store.getJobById(retryableJob.id);
     assert.equal(exhausted?.status, "dead");
@@ -3216,7 +3231,7 @@ test("device sync store preserves retained calendar work across account cleanup 
       60_000,
     );
     assert.equal(claimedRetained?.id, retained.id);
-    assert.equal(store.failJobIfOwned(
+    assert.deepEqual(store.failJobIfOwned(
       retained.id,
       "worker-disconnected",
       "2026-04-09T00:00:01.000Z",
@@ -3225,12 +3240,17 @@ test("device sync store preserves retained calendar work across account cleanup 
       "2026-04-10T00:00:00.000Z",
       true,
       true,
-    ), true);
+    ), {
+      attempts: 1,
+      disposition: "queued",
+      maxAttempts: 5,
+      remainingAttempts: 4,
+    });
     assert.equal(
       store.claimDueJob("worker-unrelated-failure", "2026-04-09T00:00:01.000Z", 60_000)?.id,
       unrelatedFailure.id,
     );
-    assert.equal(store.failJobIfOwned(
+    assert.deepEqual(store.failJobIfOwned(
       unrelatedFailure.id,
       "worker-unrelated-failure",
       "2026-04-09T00:00:02.000Z",
@@ -3239,7 +3259,12 @@ test("device sync store preserves retained calendar work across account cleanup 
       "2026-04-10T00:00:00.000Z",
       true,
       true,
-    ), true);
+    ), {
+      attempts: 1,
+      disposition: "queued",
+      maxAttempts: 5,
+      remainingAttempts: 4,
+    });
 
     const database = openSqliteRuntimeDatabase(store.databasePath);
     try {
@@ -4404,7 +4429,7 @@ test("device sync store hydrates new hosted accounts, guards token updates, and 
     assert.equal(claimed?.id, job.id);
     assert.equal(store.completeJobIfOwned(job.id, "worker-b", "2026-04-07T01:00:30.000Z"), false);
     assert.equal(store.completeJobIfOwned(job.id, "worker-a", "2026-04-07T01:01:00.000Z"), false);
-    assert.equal(
+    assert.deepEqual(
       store.failJobIfOwned(
         job.id,
         "worker-a",
@@ -4416,7 +4441,7 @@ test("device sync store hydrates new hosted accounts, guards token updates, and 
         false,
         { windowStart: "2026-04-08T00:00:00.000Z" },
       ),
-      false,
+      null,
     );
     assert.equal(store.getJobById(job.id)?.status, "running");
     assert.deepEqual(store.getJobById(job.id)?.payload, {});

--- a/packages/importers/src/device-providers/junction-bounded-features.ts
+++ b/packages/importers/src/device-providers/junction-bounded-features.ts
@@ -31,10 +31,15 @@ export interface JunctionElectrocardiogramVoltageReductionLimits {
   readonly maxSamples: number;
 }
 
+export type JunctionWorkoutStreamCandidateAliasSource =
+  | (typeof WORKOUT_IDS)[number]
+  | "multiple_equal";
+
 export interface JunctionWorkoutStreamCandidate {
   readonly identity: string;
   readonly summary: PlainObject;
   readonly workoutId: string;
+  readonly workoutIdAliasSource: JunctionWorkoutStreamCandidateAliasSource;
 }
 
 export interface JunctionWorkoutStreamReductionInput {
@@ -99,14 +104,18 @@ export function selectJunctionWorkoutStreamCandidates(
   records.forEach((value, index) => {
     const summary = record(value, `workout index ${index}`);
     const workoutId = consistentId(summary, WORKOUT_IDS, "workout index");
+    const workoutIdAliases = WORKOUT_IDS.filter((path) => firstString(summary, [path]));
+    const workoutIdAliasSource = workoutIdAliases.length > 1
+      ? "multiple_equal"
+      : workoutIdAliases[0];
     const provider = resolveJunctionOrigin(summary).sourceProviderSlug;
-    if (!workoutId || !provider) invalid("workout index lacked identity");
+    if (!workoutId || !provider || !workoutIdAliasSource) invalid("workout index lacked identity");
     const key = buildJunctionBoundedFeatureIdentity("workout_stream", summary);
     const existing = selected.get(key);
     if (existing && stableStringify(existing.summary) !== stableStringify(summary)) {
       invalid(`workout index contained conflicting workout ${workoutId}`);
     }
-    selected.set(key, { identity: key, summary, workoutId });
+    selected.set(key, { identity: key, summary, workoutId, workoutIdAliasSource });
   });
   if (selected.size > maxWorkouts) {
     invalid(`workout index exceeded ${maxWorkouts} workouts`);

--- a/packages/importers/test/device-providers-junction-bounded-features.test.ts
+++ b/packages/importers/test/device-providers-junction-bounded-features.test.ts
@@ -12,6 +12,7 @@ import {
   reduceJunctionElectrocardiogramVoltageRecords,
   reduceJunctionWorkoutStreamPayload,
   resolveJunctionBoundedFeatureRecords,
+  selectJunctionWorkoutStreamCandidates,
 } from "../src/device-providers/junction-bounded-features.ts";
 
 function assertNoSampleSizedValue(value: unknown): void {
@@ -172,6 +173,28 @@ test("raw receipt retention accepts only pre-reduced dense features", async () =
     assertNoSampleSizedValue(part.content);
     assert.equal(Buffer.byteLength(JSON.stringify(part.content), "utf8") < 16_384, true);
   }
+});
+
+test("workout stream candidates expose only the supported identifier alias source", () => {
+  const candidates = selectJunctionWorkoutStreamCandidates([
+    workoutFeature({ id: undefined, workoutId: "workout-camel" }),
+    workoutFeature({ id: undefined, workoutId: undefined, workout_id: "workout-snake" }),
+    workoutFeature({ workoutId: undefined, id: "workout-id" }),
+    workoutFeature({ id: "workout-equal", workoutId: "workout-equal" }),
+  ], 4);
+
+  assert.deepEqual(
+    Object.fromEntries(candidates.map((candidate) => [
+      candidate.workoutId,
+      candidate.workoutIdAliasSource,
+    ])),
+    {
+      "workout-camel": "workoutId",
+      "workout-equal": "multiple_equal",
+      "workout-id": "id",
+      "workout-snake": "workout_id",
+    },
+  );
 });
 
 test("workout stream reduction is bounded by admitted samples and never preserves points", () => {


### PR DESCRIPTION
## Why this PR exists

Recurring Junction workout-stream HTTP 500s cannot currently be distinguished by failing candidate, and worker telemetry reports retry intent instead of the job state actually committed by SQLite. This makes terminal sync gaps look retryable and double-written failure logs hard to interpret.

## User goal / user-visible behavior

Operators can distinguish a durably requeued job from an exhausted dead job and determine whether repeated workout-stream failures occupy the same bounded candidate position, without exposing workout, member, request, or provider identifiers. There is no member-facing UI or workflow change.

## User experience

No user-facing effect. This change improves internal failure telemetry for the existing background device-sync flow; it does not alter member-visible sync states, timing, or recovery behavior.

## Invariants

- Never log or persist raw member, account, connection, source-instance, workout, request, payload, credential, URL, or provider-response identifiers.
- Preserve the one-day window, 32-workout cap, 100,000-sample cap, serial stream reads, exact continuation, and completed-identity preservation.
- Keep retryable HTTP 500 as a failure that stops the serial loop; do not silently skip or retire it.
- Preserve optional 404/422 retirement, canonical import, disconnect behavior, retained accepted work, and the existing device-job retry owner.
- Derive disposition from the same committed SQLite mutation without a race-prone reread.
- Keep worker-only candidate telemetry out of the runner-to-Web apply contract for rolling-deploy compatibility.

## Non-obvious affected surfaces

- **Device job store contract:** `failJobIfOwned` now returns the committed `queued`/`dead` transition and bounded attempt facts instead of a boolean. Store, service, retained-work, lease-loss, and hosted-runtime tests cover the change.
- **Hosted runtime log writers:** worker, canonical-apply, checkpoint, idle-maintenance, and device-activity writers now emit a typed origin so aggregate queries do not conflate different owners. Focused runtime and Web authority tests cover these writers.
- **Runner/Web deploy seam:** bounded candidate position is used only in worker-attempt logs and removed before canonical apply. Hosted runtime tests cover the projection boundary.
- **Junction candidate selection:** records which supported summary alias supplied an already-validated workout ID, without retaining the ID. Importer and provider tests cover aliases, ordering, bounds, and privacy.

## Architecture and reuse

- **Existing systems reused:** The existing Junction candidate selector, `DeviceSyncError` details, SQLite job mutation owner, failure-diagnostic sanitizer, and hosted runtime log pipeline remain the only owners.
- **New logic:** The failure mutation returns its committed row facts via `UPDATE … RETURNING`; Junction adds bounded ordinal/count/alias context; log projections add actual disposition, attempt budget, and writer origin.
- **New abstractions:** Two narrow shared types describe committed failure transitions and event origins; no service, queue, scheduler, persistence layer, or dependency was added.
- **Complexity intentionally avoided:** The patch does not scan beyond a retryable 500, add per-workout jobs, create another retry loop, hash private identifiers, retain provider trace headers, or reread mutable job state.

## Verification

- Importers focused Vitest: 9 passed.
- Device-syncd focused Vitest: 450 passed.
- Assistant-runtime focused Vitest: 476 passed.
- Hosted Web authority focused Vitest: 75 passed after the app-owned Prisma generation step.
- Typechecks passed for importers, device-syncd, assistant-runtime, and hosted Web.
- After ReviewGPT remediation, the two directly affected assistant-runtime files pass all 396 tests and the assistant-runtime typecheck remains green.
- Direct deterministic scenarios prove attempts 1–4 commit `queued`, attempt 5 commits `dead`, lease loss emits no fabricated transition, retained work extends its existing fence, and private workout/request/payload values do not reach runtime telemetry.
- `git diff --check` and reverse patch applicability passed.

## ReviewGPT resolution

- Final round 1 reviewed the full patch at `d37608f85caf9a42d8caf92e1588edc4798e7c13` and returned `ROUND_OUTCOME: PASS` with no qualifying production-code, architecture, privacy, purpose, or complexity finding.
- The preliminary specialist pass found missing executable proof for the runner-to-Web candidate-field stripping boundary and the `checkpoint` and `device_activity_automation` failure origins.
- Both coverage findings were accepted and resolved with focused regression tests only. Production code, runtime behavior, and architecture are unchanged; no additional substantive final round is required for isolated proof additions.
- Current head: `6d730e0b6683a50dadbd31ef163837cde655778e`. Review remediation changed authored source by 0 additions and 0 deletions.

## Changelog

- Changelog: not applicable
- Reason: Internal device-sync diagnostics only; no member-visible behavior changed.

## Hot reply path impact

Not applicable. The change is confined to background device-sync provider failure handling and runtime-log projection; it adds nothing to the foreground reply critical path.

## Database collection fanout impact

Not applicable. No database-touching collection path or query cardinality changes. The existing single owned failure `UPDATE` now uses `RETURNING` on that same statement; query count, pooled connections, transaction concurrency, and external work remain unchanged.

## Murph initial provider input impact

- Individual Murph: Not applicable; no prompt, tool schema, model configuration, or provider-request assembly changed.
- Group Murph: Not applicable; no prompt, tool schema, model configuration, or provider-request assembly changed.

## Preliminary specialist lenses

- Product experience: **not applicable** — internal observability only; no product-owned journey or semantic behavior changed.
- Prompt: **not applicable** — no instruction, prompt stack, tool description, or prompt regression surface changed.
- Frontend: **not applicable** — the `apps/web` change is a server-side runtime-log writer with no rendered UI or design-catalog surface.
- Coverage: **applicable** — the original candidate passed 1,010 focused tests and four owner typechecks; the test-only ReviewGPT remediation passes all 396 directly affected tests and the assistant-runtime typecheck. Current exact-head CI is pending.

ReviewGPT context sensitivity: sensitive

Classification reason: Cross-owner runtime, retry/disposition, privacy-sensitive telemetry, SQLite mutation, and external provider failure boundaries changed.

ReviewGPT first-reviewed head: d37608f85caf9a42d8caf92e1588edc4798e7c13

## Change shape

Classification rule: production TypeScript is source; `*.test.ts` is tests/fixtures; the package README, execution plan, and Frog entry are docs; no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 271 | 46 |
| Tests/fixtures | 369 | 116 |
| Docs | 126 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **766** | **163** |

Binary files: none.


