### PR TITLE
chore(review): require material production harm

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1718,6 +1718,9 @@ describe('monorepo release flow coverage audit', () => {
     expect(prDeepReviewPrompt).toContain('at least 3,000 lines')
     expect(prDeepReviewPrompt).toContain('This is neither an automatic merge rejection')
     expect(prDeepReviewPrompt).toContain('do not emit a standalone Invariant Violation')
+    expect(prDeepReviewPrompt).toMatch(
+      /A contract mismatch, undisclosed surface,\s+or theoretical concern is evidence, not a finding/u,
+    )
     expect(prDeepReviewPrompt).toContain('current scale, event volume,')
     expect(prDeepReviewPrompt).toContain('never assume hypothetical future or internet')
     expect(prDeepReviewPrompt).toMatch(

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1719,7 +1719,10 @@ describe('monorepo release flow coverage audit', () => {
     expect(prDeepReviewPrompt).toContain('This is neither an automatic merge rejection')
     expect(prDeepReviewPrompt).toContain('do not emit a standalone Invariant Violation')
     expect(prDeepReviewPrompt).toMatch(
-      /A contract mismatch, undisclosed surface,\s+or theoretical concern is evidence, not a finding/u,
+      /For this category, only report a finding when merging the PR would\s+cause concrete, realistically reachable, material production harm/u,
+    )
+    expect(prDeepReviewPrompt).toMatch(
+      /A contract\s+mismatch or theoretical concern is evidence, not a finding, unless it\s+establishes that harm/u,
     )
     expect(prDeepReviewPrompt).toContain('current scale, event volume,')
     expect(prDeepReviewPrompt).toContain('never assume hypothetical future or internet')

--- a/scripts/chatgpt-review-presets/pr-deep-review.md
+++ b/scripts/chatgpt-review-presets/pr-deep-review.md
@@ -288,15 +288,15 @@ chosen direction, require a new retrospective.
 
 Report only:
 
-Only report a finding when merging the PR would cause concrete, realistically
-reachable, material production harm. A contract mismatch, undisclosed surface,
-or theoretical concern is evidence, not a finding, unless it causes that harm.
-
 - **Critical** or **High**: a PR-caused, production-faithful, realistically
   reachable path to data loss or corruption, auth/privacy/security exposure,
   race/retry/idempotency failure, deploy/runtime breakage, billing or other
   irreversible effects, broken core flows, or another serious user-visible
-  failure. A theoretical interleaving or contract mismatch alone is not High.
+  failure. For this category, only report a finding when merging the PR would
+  cause concrete, realistically reachable, material production harm. A contract
+  mismatch or theoretical concern is evidence, not a finding, unless it
+  establishes that harm. A theoretical interleaving or contract mismatch alone
+  is not High.
   State the ordinary runtime sequence or externally controllable path and the
   material impact.
 - **Complexity Collapse**: the same required behavior can be implemented with

--- a/scripts/chatgpt-review-presets/pr-deep-review.md
+++ b/scripts/chatgpt-review-presets/pr-deep-review.md
@@ -288,6 +288,10 @@ chosen direction, require a new retrospective.
 
 Report only:
 
+Only report a finding when merging the PR would cause concrete, realistically
+reachable, material production harm. A contract mismatch, undisclosed surface,
+or theoretical concern is evidence, not a finding, unless it causes that harm.
+
 - **Critical** or **High**: a PR-caused, production-faithful, realistically
   reachable path to data loss or corruption, auth/privacy/security exposure,
   race/retry/idempotency failure, deploy/runtime breakage, billing or other


### PR DESCRIPTION
## Why this PR exists

The final ReviewGPT prompt says that a theoretical interleaving or contract mismatch alone is not High, but it did not state the positive threshold clearly enough. That ambiguity can turn review evidence into a merge-blocking Critical or High finding without a concrete production failure.

## Goal

Require Critical and High findings to show concrete, realistically reachable, material production harm.

## Invariants

- Preserve every existing finding category and its own materiality criteria.
- Keep contract mismatches and theoretical concerns available as evidence.
- Keep necessary but undisclosed scope reportable as Purpose Drift.
- Do not add a separate later-round scope rule or change review workflow behavior.

## Architecture and reuse

- Existing systems reused: the current final ReviewGPT deep-review preset and its CLI prompt-contract test.
- New logic: one category-local material-harm rule inside the existing Critical/High definition.
- New abstractions: none.
- Complexity intentionally avoided: no new outcome, exception list, workflow state, or later-round policy.

## Changelog

- Changelog: not applicable
- Reason: internal review-process calibration with no member-visible product behavior.

## Hot reply path impact

Not applicable. This changes only the internal PR review prompt.

## Database collection fanout impact

Not applicable. No runtime or database path changes.

## Murph initial provider input impact

- Individual Murph: not applicable; no Murph assistant prompt, tool schema, model mode, or provider-request assembly changes.
- Group Murph: not applicable for the same reason.

## Preliminary specialist lenses

- Product experience: not applicable; no product behavior changes.
- Prompt: applicable. The specialist found that the first universal wording conflicted with retained Complexity Collapse, Purpose Drift, and Experience Collapse categories. Accepted: the rule now applies only to Critical/High. The fix moved the sentence into an existing category and added no new machinery.
- Frontend: not applicable.
- Coverage: not applicable beyond the existing prompt-contract assertion.

Two infrastructure attempts failed before submission and did not count as review rounds: Eragon had a profile lock with no debugging endpoint, and Vonneumann did not launch its debugging endpoint. The valid Hercules specialist run reviewed the exact initial candidate head and returned the finding above. Per the completion workflow, the preliminary pass is not rerun after remediation.

## Change shape

Classification: the prompt preset is config/tooling; the Vitest assertion is tests. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 6 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 5 | 1 |
| Generated / other | 0 | 0 |
| **Total** | **11** | **1** |

## Verification

- CLI typecheck passed on the corrected head.
- `git diff --check` passed.
- Direct prompt-contract checks passed for the category scope, material-harm threshold, and evidence treatment.
- The focused prompt-contract assertion reaches and passes. The containing current-main test remains red because a separate pre-existing assertion expects obsolete non-obvious-surface wording.
- The commit hook also reported the current pre-existing CLI schema-generation failure and allowed CI to remain authoritative.

## Design proof

Not applicable. No rendered UI changes.
