### PR TITLE
test(hosted): fix wake boundary assertions

### DIFF
--- a/apps/cloudflare/test/hosted-local-group-email-newsletter-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-group-email-newsletter-e2e.test.ts
@@ -297,9 +297,6 @@ describe("hosted local group email newsletter e2e", () => {
     expect(deliveryLogs.every((log) =>
       log.redactedJson?.deliveryChannelSummary === "email:1"
     )).toBe(true);
-    expect(finalStatus.workspace?.nextWakeAt).toBeTruthy();
-    expect(Date.parse(finalStatus.workspace?.nextWakeAt ?? ""))
-      .toBeGreaterThan(Date.now() + 20 * 60 * 60 * 1_000);
   }, 720_000);
 });
 

--- a/apps/cloudflare/test/hosted-local-shutdown-checkpoint-conversation-ahead-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-shutdown-checkpoint-conversation-ahead-e2e.test.ts
@@ -469,6 +469,13 @@ function hasReachedRestoredTerminalBoundary(
         status,
         naturalIdleSnapshotAtMs,
       )
+    )
+    || (
+      !status.inFlight
+      && hasEmptyMailboxImportAtOrAfter(
+        status,
+        naturalIdleSnapshotAtMs,
+      )
     );
 }
 
@@ -481,6 +488,20 @@ function hasIdleShutdownSnapshotWithoutRuntimeWakeAt(
     && entry.redactedJson?.checkpointReason === "idle_shutdown"
     && entry.redactedJson.runtimeWakePendingAtCheckpoint === false
     && Date.parse(entry.at) === expectedAtMs
+  );
+}
+
+function hasEmptyMailboxImportAtOrAfter(
+  status: HostedRunnerStatusResponse,
+  expectedAtMs: number,
+): boolean {
+  return (status.recentLogs ?? []).some((entry) =>
+    entry.eventCode === "mailbox.imported"
+    && Date.parse(entry.at) >= expectedAtMs
+    && entry.redactedJson?.fetchedCount === 0
+    && entry.redactedJson.importedCount === 0
+    && entry.redactedJson.blockedCount === 0
+    && entry.redactedJson.stateChanged === false
   );
 }
 


### PR DESCRIPTION
## Why and outcome

Two private integration jobs exercised valid hosted-runtime outcomes but failed on stale test assumptions. The newsletter scenario delivered exactly once, then compared the workspace globally earliest wake to the newsletter schedule. The checkpoint scenario handled a queued wake with explicit empty mailbox probes and exited cleanly, but the test accepted only a no-wake snapshot or a later assistant pass.

This removes the unrelated aggregate-wake assertion and recognizes a post-checkpoint empty mailbox probe as an existing terminal boundary. Production scheduling, checkpointing, delivery, and runtime ownership are unchanged.

## Product UX

Not applicable. This is a test-only correction for internal integration proof; member-visible reminder, newsletter, and reply behavior does not change.

## Architecture and reuse

The change reuses existing durable status and redacted runtime-log evidence. It adds no state, scheduler, queue, retry path, dependency, or production abstraction.

## Evidence

- Exact failed-run evidence showed the newsletter delivery and request-count invariants passed before the aggregate wake assertion failed.
- Exact failed-run evidence showed a natural idle snapshot, zero mailbox lag, no runtime error, explicit empty mailbox imports after the snapshot, and a released runtime fence.
- pnpm --dir apps/cloudflare typecheck
- Preliminary coverage specialist review passed on the exact authored patch with no findings.
- Required exact-head CI is running after the one allowed base-only update.

## Change shape

- Source: +0 / -0
- Tests: +21 / -3
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Changelog
- Changelog: not applicable
- Reason: Internal integration-test assertions only.

