### PR TITLE
Stop ReviewGPT from auditing PR body discrepancies

### DIFF
--- a/.agents/friction-log/20260817182716-privacy-hook-rejects/friction.md
+++ b/.agents/friction-log/20260817182716-privacy-hook-rejects/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Privacy hook rejects synthetic Git fixture identity'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Repo-tools tests can create synthetic Git repositories using a neutral test-only identity that satisfies the repository privacy guard.
+
+## Current Behavior
+
+Multiple Frog autofix tests fail during synthetic Git commits because the fixture email uses a non-noreply example address that the privacy hook rejects.
+
+## Possible Solution
+
+Use a neutral GitHub noreply-form fixture address for synthetic repositories.
+
+## Minimal Reproducible Example
+
+Run `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/frog-autofix.test.ts` in a clean worktree.
+
+## Context
+
+This blocks the repo-internal fast-path verification for unrelated workflow prompt changes after all static guards and typechecking pass.

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1653,8 +1653,9 @@ describe('monorepo release flow coverage audit', () => {
       'A later full audit also\nuses `INVALID` for the mandatory prior-finding summary gap',
     )
     expect(prDeepReviewPrompt).toContain(
-      'Do not stop for a discrepancy confined to the descriptive content of',
+      'Do not audit or report discrepancies confined to descriptive PR-body content',
     )
+    expect(prDeepReviewPrompt).not.toContain('Body discrepancy:')
     expect(prDeepReviewPrompt).not.toContain('repo.snapshot.zip')
     expect(prDeepReviewPrompt).not.toContain('repo.repomix.zip')
     expect(prDeepReviewPrompt.toLowerCase()).not.toContain('repomix')

--- a/scripts/chatgpt-review-presets/pr-deep-review.md
+++ b/scripts/chatgpt-review-presets/pr-deep-review.md
@@ -74,13 +74,10 @@ not `true`. A delta round also requires
 uses `INVALID` for the mandatory prior-finding summary gap defined below. State
 the exact evidence gap and stop.
 
-Do not stop for a discrepancy confined to the descriptive content of
-`review-gpt-pr-context/pr-body.md` — validation claims or prose that has drifted
-behind the current head. Those degrade the author's
-account of the change, not your ability to read the code. Record them as notes
-(see Output) and complete the substantive review. A stale table is never a
-reason to leave real defects unreviewed; say what is wrong with it and review
-anyway.
+Do not audit or report discrepancies confined to descriptive PR-body content,
+such as stale validation claims or prose from an earlier head. They are neither
+findings nor invalid evidence. Continue the substantive code review; report an
+issue only when the current patch independently meets the finding bar below.
 
 For round 2 or later the invocation must state the same first-reviewed head as
 the artifact and summarize every prior finding, its local disposition, any
@@ -395,15 +392,6 @@ For an Experience Collapse, also state the removed words, actions, screens,
 choices, concepts, or waits and the clarity, accessibility, consent, trust, and
 control that the smaller experience preserves.
 
-When `pr-body.md` describes the change inaccurately — a validation claim
-contradicted by the snapshot or prose describing an earlier head — add
-`Body discrepancy: <claim and contradiction>` after the findings and before the
-outcome, one line per discrepancy. Report every one you find. These are
-notes, not qualifying findings, and they do not prevent `PASS`: they tell the
-author what to correct in the document without withholding the review of the
-code. Apply the same treatment when the invocation omits its prior-round
-summary.
-
 When a user-facing frontend change has no readable rendered artifacts inside
 `codebase.zip`, add `Rendered evidence gap: <exact gap>` after the findings and
 before the outcome. The gap is not independently a qualifying finding and does
@@ -424,12 +412,11 @@ End with exactly one of these lines:
 `ROUND_OUTCOME: INVALID`
 
 Use `PASS` only when there are no qualifying findings and every claimed prior
-correction is proven effective; body discrepancies and rendered evidence gaps
-are notes and do not withhold it. Use `INVALID` only when the code evidence will
+correction is proven effective; rendered evidence gaps are notes and do not
+withhold it. Use `INVALID` only when the code evidence will
 not support a review or a later full audit lacks its mandatory prior-finding
 summary, as defined in Evidence and round scope; it does not count as a
-substantive round. An inaccurate PR body is never grounds for `INVALID`. Put
-the selected outcome immediately before this exact final line, and do not use
-the token elsewhere:
+substantive round. Put the selected outcome immediately before this exact final
+line, and do not use the token elsewhere:
 
 REVIEW_COMPLETE


### PR DESCRIPTION
## Why and outcome

The final ReviewGPT prompt explicitly required the model to find and print every stale or inaccurate PR-body claim even though those notes could not affect the outcome. That duplicated review effort and distracted from qualifying code findings.

Remove the mismatch-reporting contract. Descriptive PR-body drift is now out of scope unless the current patch independently meets the existing finding bar. Exact-head, ancestry, prior-finding-summary, Purpose Drift, and substantive review gates remain unchanged.

## Product UX

Not applicable. This changes internal review-process behavior only and does not alter a member-facing journey.

## ReviewGPT lenses

- Product UX: not applicable — internal review tooling only.
- Prompt: applicable — simplifies the final PR-review prompt and removes redundant output instructions.
- Frontend: not applicable — no UI changes.
- Coverage: applicable — the existing CLI release audit statically proves the prompt contract.

## Architecture and reuse

- Existing systems reused: the current guarded ZIP, intent-contract review, finding bar, exact-head evidence gates, and CLI release audit.
- New logic: none.
- New abstractions: none.
- Complexity intentionally avoided: no replacement validator, parser, status, or PR-body reconciliation path.

## Risks

The prompt still treats the PR body as the intent contract and still reports qualifying Purpose Drift. It no longer audits or emits non-qualifying descriptive mismatches.

## Evidence

- Current official OpenAI GPT-5.6 prompt guidance reviewed; it recommends lean prompts and stating each instruction once.
- Preliminary ReviewGPT prompt/coverage review found one stale positive assertion for the deleted wording. The existing assertion now requires the replacement instruction and also proves `Body discrepancy:` stays absent.
- Focused static-contract test passed:
  `MURPH_PREPARED_CLI_RUNTIME_ARTIFACTS=1 MURPH_CLI_RELEASE_TARBALL_TEST=1 pnpm exec vitest run --config packages/cli/vitest.workspace.ts packages/cli/test/release-script-coverage-audit.test.ts --no-coverage -t "exposes only the package-backed review-gpt runner"`
- Direct prompt-contract readback confirms the `Body discrepancy:` output and exhaustive-report language are absent while `ROUND_OUTCOME` and `REVIEW_COMPLETE` remain.
- `git diff --check` passed.
- `pnpm test:diff scripts/chatgpt-review-presets/pr-deep-review.md`: static guards and repo-tools typecheck passed; the shared suite completed 37/38 files and 656/665 tests. Nine unrelated Frog autofix fixtures were blocked by the privacy hook because their synthetic Git email is not a noreply address. That friction is recorded in this PR.
- Exact-head CI is green for `7afaaa9a8e64`, including the corrected CLI coverage shard and final release aggregate.
- A fresh `git merge-tree --write-tree HEAD origin/main` completed cleanly against the current fetched base.

## Change shape

Classification rule: the ReviewGPT preset is config/tooling; the CLI release assertion is a test; the Frog Markdown entry is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests | 2 | 1 |
| Docs | 24 | 0 |
| Config/tooling | 8 | 21 |
| Generated/other | 0 | 0 |

## Changelog

- Changelog: not applicable
- Reason: Internal review prompt, its static contract test, and developer-friction documentation only.
