### PR TITLE
CI: preserve native iOS E2E failure stages

### DIFF
--- a/.agents/friction-log/20260817184410-native-ios-e2e/friction.md
+++ b/.agents/friction-log/20260817184410-native-ios-e2e/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Native iOS E2E lifecycle discards both cleanup failure causes'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+When both the primary lifecycle and fail-closed finalization fail, the controller should retain secret-safe phase or error-code evidence for each failure.
+
+## Current Behavior
+
+The lifecycle replaces both causes with one generic message. A live failure therefore exposes only the last successful stage markers, forcing repeated full reruns and external resource inspection to distinguish command failure from postcondition failure.
+
+## Possible Solution
+
+Surface allowlisted internal failure messages or structured phase codes while continuing to discard provider payloads, command output, and credentials.
+
+## Minimal Reproducible Example
+
+Call runPrLifecycle with a cleanup callback that throws during the primary attempt and again during finalization. The rejected error says only that final cleanup did not complete and omits both controlled callback errors.
+
+## Context
+
+This blocks focused diagnosis of the protected hosted Web plus native iOS acceptance lane and lengthens recovery while its required status remains red.

--- a/scripts/native-ios-hosted-e2e-identity.mjs
+++ b/scripts/native-ios-hosted-e2e-identity.mjs
@@ -187,7 +187,15 @@ export async function cleanupE2e(junctionClientUserIdNamespace) {
   }
   console.log(`::notice::native-ios-e2e stage=junction_cleanup result=${junction ? "success" : "absent"}`);
 
-  await resetDedicatedDatabase(config.directDatabaseUrl);
+  console.log("::notice::native-ios-e2e stage=database_reset result=started");
+  try {
+    await resetDedicatedDatabase(config.directDatabaseUrl);
+  } catch (error) {
+    console.log(`::error::native-ios-e2e stage=database_reset result=failure reason=${boundedCommandFailureReason(error)}`);
+    throw error;
+  }
+  console.log("::notice::native-ios-e2e stage=database_reset result=success");
+  console.log("::notice::native-ios-e2e stage=database_validation result=started");
   if (await readDedicatedMemberRecord(config)) {
     throw new Error("Dedicated E2E database still contains a member after reset.");
   }
@@ -401,6 +409,15 @@ function privyHeaders() {
 function requireE164(value) {
   if (!/^\+[1-9][0-9]{7,14}$/u.test(value)) throw new Error("NATIVE_IOS_E2E_PRIVY_TEST_PHONE must be an E.164 phone number.");
   return value;
+}
+
+function boundedCommandFailureReason(error) {
+  const message = error instanceof Error ? error.message : "";
+  if (message === "E2E database reset timed out.") return "timeout";
+  if (message === "E2E database reset could not start.") return "spawn";
+  if (message === "E2E database reset process supervision failed.") return "supervision";
+  if (message === "E2E database reset failed.") return "command_exit";
+  return "unknown";
 }
 
 function assertUuid(value, label) {

--- a/scripts/native-ios-hosted-e2e.mjs
+++ b/scripts/native-ios-hosted-e2e.mjs
@@ -29,13 +29,19 @@ export {
 
 export async function runPrLifecycle({ cleanup, deploy, dispatch, now, postconditions, retire }) {
   let primaryError = null;
+  let primaryStage = "retire_before_run";
   let finalizationError = null;
+  let finalizationStage = "retire_after_run";
   try {
     await retire();
+    primaryStage = "cleanup_before_run";
     await cleanup();
     const startedAtMs = now();
+    primaryStage = "deploy";
     const webBaseUrl = await deploy();
+    primaryStage = "dispatch";
     await dispatch(webBaseUrl);
+    primaryStage = "postconditions";
     await postconditions(startedAtMs);
   } catch (error) {
     primaryError = error;
@@ -43,6 +49,7 @@ export async function runPrLifecycle({ cleanup, deploy, dispatch, now, postcondi
     try {
       // Retire callback-capable Web deployments before provider or database state.
       await retire();
+      finalizationStage = "cleanup_after_run";
       await cleanup();
     } catch (error) {
       finalizationError = error;
@@ -50,8 +57,8 @@ export async function runPrLifecycle({ cleanup, deploy, dispatch, now, postcondi
   }
   if (finalizationError) {
     throw new Error(primaryError
-      ? "Native iOS E2E failed and fail-closed final cleanup did not complete."
-      : "Native iOS E2E final cleanup did not complete.");
+      ? `Native iOS E2E failed at ${primaryStage}; fail-closed finalization failed at ${finalizationStage}.`
+      : `Native iOS E2E finalization failed at ${finalizationStage}.`);
   }
   if (primaryError) throw primaryError;
 }

--- a/scripts/native-ios-hosted-e2e.test.mjs
+++ b/scripts/native-ios-hosted-e2e.test.mjs
@@ -14,6 +14,7 @@ import {
 import {
   buildDedicatedDatabasePoolOptions,
   buildJunctionClientUserId,
+  cleanupE2e,
   inspectDedicatedMemberIdentity,
   inspectE2eDatabaseUrls,
   inspectFreshPrivyPrincipal,
@@ -465,6 +466,59 @@ test("cleanup ownership enumerates the namespace before and after deletion", asy
     cleanupConfigSource,
     /NATIVE_IOS_E2E_JUNCTION_CLIENT_USER_ID_NAMESPACE/u,
   );
+});
+
+test("database reset failure emits only the allowlisted command reason", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "native-ios-database-reset-"));
+  const binDir = path.join(tempDir, "bin");
+  const fakePnpm = path.join(binDir, "pnpm");
+  const envNames = [
+    "NATIVE_IOS_E2E_DATABASE_URL",
+    "NATIVE_IOS_E2E_DIRECT_DATABASE_URL",
+    "NATIVE_IOS_E2E_JUNCTION_API_KEY",
+    "NATIVE_IOS_E2E_JUNCTION_TEAM_ID",
+    "PATH",
+  ];
+  const originalEnv = new Map(envNames.map((name) => [name, process.env[name]]));
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const logs = [];
+  try {
+    await mkdir(binDir, { recursive: true });
+    await writeFile(fakePnpm, [
+      "#!/bin/sh",
+      "printf 'provider output must stay hidden\\n' >&2",
+      "exit 42",
+    ].join("\n") + "\n", { mode: 0o755 });
+    process.env.NATIVE_IOS_E2E_DATABASE_URL = "postgresql://owner@db.example.test/native_ios_e2e";
+    process.env.NATIVE_IOS_E2E_DIRECT_DATABASE_URL = "postgresql://owner@db.example.test/native_ios_e2e";
+    process.env.NATIVE_IOS_E2E_JUNCTION_API_KEY = "sk_us_test";
+    process.env.NATIVE_IOS_E2E_JUNCTION_TEAM_ID = "11111111-1111-4111-8111-111111111111";
+    process.env.PATH = `${binDir}:${originalEnv.get("PATH") ?? ""}`;
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      limit: 500,
+      offset: 0,
+      total: 0,
+      users: [],
+    }), { headers: { "content-type": "application/json" } });
+    console.log = (...args) => logs.push(args.join(" "));
+
+    await assert.rejects(() => cleanupE2e("e2e"), /E2E database reset failed/u);
+    assert.deepEqual(logs, [
+      "::notice::native-ios-e2e stage=junction_cleanup result=absent",
+      "::notice::native-ios-e2e stage=database_reset result=started",
+      "::error::native-ios-e2e stage=database_reset result=failure reason=command_exit",
+    ]);
+    assert.doesNotMatch(logs.join("\n"), /provider output/u);
+  } finally {
+    console.log = originalLog;
+    globalThis.fetch = originalFetch;
+    for (const [name, value] of originalEnv) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    await rm(tempDir, { force: true, recursive: true });
+  }
 });
 
 test("database and child-command timeout contracts are explicit and fail closed", () => {

--- a/scripts/native-ios-hosted-e2e.test.mjs
+++ b/scripts/native-ios-hosted-e2e.test.mjs
@@ -775,7 +775,29 @@ test("PR lifecycle stays red when final cleanup fails", async () => {
     now: () => 123,
     postconditions: async () => undefined,
     retire: async () => undefined,
-  }), /final cleanup did not complete/u);
+  }), /finalization failed at cleanup_after_run/u);
+});
+
+test("PR lifecycle retains secret-safe primary and finalization stage names", async () => {
+  let cleanupCalls = 0;
+  await assert.rejects(() => runPrLifecycle({
+    cleanup: async () => {
+      cleanupCalls += 1;
+      if (cleanupCalls === 2) throw new Error("provider payload must stay hidden");
+    },
+    deploy: async () => { throw new Error("candidate payload must stay hidden"); },
+    dispatch: async () => undefined,
+    now: () => 123,
+    postconditions: async () => undefined,
+    retire: async () => undefined,
+  }), (error) => {
+    assert.equal(
+      error.message,
+      "Native iOS E2E failed at deploy; fail-closed finalization failed at cleanup_after_run.",
+    );
+    assert.doesNotMatch(error.message, /provider payload|candidate payload/u);
+    return true;
+  });
 });
 
 function runWorkflowSelector(workflow, file) {


### PR DESCRIPTION
## Why this PR exists

The first protected native iOS sweeps failed safely during repeated cleanup, but the lifecycle replaced both controlled causes with one generic message. That made it impossible to distinguish a database command failure from its post-reset validation without repeated full runs.

## User goal / user-visible behavior

Maintainers get secret-safe stage and reason codes when the real native iOS CI lane fails. There is no member-facing product change.

## Invariants

- Raw provider errors, command output, credentials, URLs, and payloads remain discarded.
- Cleanup order and fail-closed behavior are unchanged.
- The status remains red whenever either the primary lifecycle or finalization fails.
- Only fixed internal stage names and an allowlisted bounded-command reason code reach logs.

## Architecture and reuse

The existing lifecycle now records which existing callback was active, and database cleanup emits start/success markers around the existing Prisma reset and validation. No service, state owner, dependency, retry, or compatibility path was added.

## Changelog

- Changelog: not applicable
- Reason: internal CI diagnostics only.

## Preliminary specialist lenses

- Product experience: not applicable.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: applicable; the stage-redaction contract has a focused regression test.

ReviewGPT context sensitivity: sensitive

ReviewGPT first-reviewed head: fbc14581b13513c72493bd98ded47e6939196041

Reason: protected CI trust boundary and destructive isolated-resource cleanup diagnostics.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 27 | 3 |
| Tests/fixtures | 77 | 1 |
| Docs | 24 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **128** | **4** |

Binary files: none.

## Design proof

Not applicable. No user-facing frontend changed.

## Motion proof

Not applicable. No user-visible state transition changed.


## ReviewGPT results

- Preliminary completion-specialists at `fbc14581b13513c72493bd98ded47e6939196041`: FINDINGS.
  - Found that the new database-reset reason mapping lacked direct executable coverage at the exported cleanup boundary.
  - Accepted. Added a test that runs cleanup with an empty Junction namespace and a failing fake Prisma launcher, proves `reason=command_exit`, proves validation never starts, and proves raw command output stays hidden.
  - Complexity: test-only; no production source, state owner, service, dependency, or runtime branch was added. The returned patch artifact was unavailable through the guarded same-thread downloader, so the equivalent focused test was implemented and reviewed locally.
- Final round 1 at `fbc14581b13513c72493bd98ded47e6939196041`: PASS with no findings.
  - Accepted/rejected: none.
  - Complexity: none. The subsequent specialist remediation is isolated regression coverage, so it does not require another substantive final round.

## Deployment skew / compatibility

No product deployment is required. The diagnostics take effect only after the trusted default-branch controller contains this patch.

## Verification

- node --test scripts/native-ios-hosted-e2e.test.mjs — 27 passed.
- git diff --check — passed.
- Focused ESLint was unavailable because the repository root does not expose an eslint binary; exact-head hosted CI owns the configured broad checks.