### PR TITLE
Fix native iOS E2E Vercel deployment request

### DIFF
--- a/.agents/friction-log/20260817200256-native-ios-vercel/friction.md
+++ b/.agents/friction-log/20260817200256-native-ios-vercel/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Native iOS Vercel deploy test did not cover the strict request body'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The native iOS hosted E2E controller contract test should fail when its Vercel deployment payload contains a field rejected by the current strict create-deployment API.
+
+## Current Behavior
+
+The tests validate returned deployment identity but do not execute deployment creation or assert the exact request body. A removed optional field can therefore remain in the controller until the first live sweep returns HTTP 400.
+
+## Possible Solution
+
+Mock the provider boundary in the focused controller suite and assert the complete allowlisted request object, including the absence of legacy fields.
+
+## Minimal Reproducible Example
+
+Send a synthetic create-deployment request containing `public: false` to an endpoint whose schema uses `additionalProperties: false`; the request is rejected before a deployment is created even though the remaining Git source and custom-environment fields are valid.
+
+## Context
+
+This delayed activation of the protected hosted Web plus real native iOS acceptance lane and required another trusted-controller rollout before the private iOS workflow could run.

--- a/.agents/friction-log/20260817200703-native-e2e-database/friction.md
+++ b/.agents/friction-log/20260817200703-native-e2e-database/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Native E2E database reset bypasses the canonical migration owner'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The dedicated native iOS E2E database reset should recreate the schema under the same canonical `postgres` role enforced by hosted Web migrations.
+
+## Current Behavior
+
+The controller validates the dedicated database URL but passes it directly to `prisma migrate reset`. When the credential logs in through an administrative wrapper role, Prisma recreates the migration ledger and application tables under that login role. The subsequent hosted migration owner guard then fails closed.
+
+## Possible Solution
+
+Add the canonical role connection option before invoking Prisma reset and cover preservation of existing connection options in the focused controller suite.
+
+## Minimal Reproducible Example
+
+Reset a synthetic E2E database using a credential role that may assume `postgres`, then run the hosted migration owner check. The ledger exists but is owned by the credential role unless the reset connection explicitly assumes `postgres`.
+
+## Context
+
+The first isolated Vercel candidate build proved this mismatch after the protected controller had already completed safe cleanup and exact-commit deployment creation.

--- a/scripts/native-ios-hosted-e2e-identity.mjs
+++ b/scripts/native-ios-hosted-e2e-identity.mjs
@@ -13,6 +13,7 @@ import {
 const APPLE_HEALTH_PROVIDER = "apple_health_kit";
 const CLOCK_SKEW_MS = 2 * 60_000;
 const DB_CONNECTION_TIMEOUT_MS = 5_000;
+const DB_OWNER_CONNECTION_OPTION = "-c role=postgres";
 const DB_QUERY_TIMEOUT_MS = 10_000;
 const DB_STATEMENT_TIMEOUT_MS = 10_000;
 const JUNCTION_USER_PAGE_LIMIT = 500;
@@ -56,6 +57,18 @@ export function buildDedicatedDatabasePoolOptions(connectionString) {
     query_timeout: DB_QUERY_TIMEOUT_MS,
     statement_timeout: DB_STATEMENT_TIMEOUT_MS,
   };
+}
+
+export function withDedicatedDatabaseOwner(connectionString) {
+  const parsed = new URL(connectionString);
+  const existingOptions = parsed.searchParams.get("options")?.trim();
+  parsed.searchParams.set(
+    "options",
+    existingOptions
+      ? `${existingOptions} ${DB_OWNER_CONNECTION_OPTION}`
+      : DB_OWNER_CONNECTION_OPTION,
+  );
+  return parsed.toString();
 }
 
 export function buildJunctionClientUserId(secret, memberId, namespace = "") {
@@ -336,8 +349,9 @@ async function resetDedicatedDatabase(directDatabaseUrl) {
   for (const name of Object.keys(childEnv)) {
     if (name.startsWith("NATIVE_IOS_E2E_")) delete childEnv[name];
   }
-  childEnv.DATABASE_URL = directDatabaseUrl;
-  childEnv.DIRECT_DATABASE_URL = directDatabaseUrl;
+  const ownerDatabaseUrl = withDedicatedDatabaseOwner(directDatabaseUrl);
+  childEnv.DATABASE_URL = ownerDatabaseUrl;
+  childEnv.DIRECT_DATABASE_URL = ownerDatabaseUrl;
   await runBoundedCommand({
     argv: ["--dir", "apps/web", "exec", "prisma", "migrate", "reset", "--force"],
     command: "pnpm",

--- a/scripts/native-ios-hosted-e2e-vercel.mjs
+++ b/scripts/native-ios-hosted-e2e-vercel.mjs
@@ -134,7 +134,6 @@ export async function createE2eDeployment({ correlationId, ref, sha }) {
       },
       name: requiredEnv("NATIVE_IOS_E2E_VERCEL_PROJECT_NAME"),
       project: projectId,
-      public: false,
     }),
     headers: vercelHeaders(token),
     method: "POST",

--- a/scripts/native-ios-hosted-e2e.test.mjs
+++ b/scripts/native-ios-hosted-e2e.test.mjs
@@ -21,6 +21,7 @@ import {
   inspectJunctionAppleHealthConnection,
   inspectNamespacedJunctionUsers,
   inspectResolvedJunctionUser,
+  withDedicatedDatabaseOwner,
 } from "./native-ios-hosted-e2e-identity.mjs";
 import {
   buildDispatchInputs,
@@ -425,6 +426,17 @@ test("destructive database reset is limited to an explicitly E2E-named database"
       directDatabaseUrl: `postgresql://owner@db.example.test/${databaseName}`,
     }), /explicitly E2E\/test database/u);
   }
+});
+
+test("destructive database reset assumes the canonical schema owner", () => {
+  const ownedUrl = new URL(withDedicatedDatabaseOwner(
+    "postgresql://credential@db.example.test/native_ios_e2e?sslmode=require&options=-c%20statement_timeout%3D10000",
+  ));
+  assert.equal(ownedUrl.searchParams.get("sslmode"), "require");
+  assert.equal(
+    ownedUrl.searchParams.get("options"),
+    "-c statement_timeout=10000 -c role=postgres",
+  );
 });
 
 test("Junction cleanup isolates one E2E namespace inside a shared sandbox team", () => {

--- a/scripts/native-ios-hosted-e2e.test.mjs
+++ b/scripts/native-ios-hosted-e2e.test.mjs
@@ -33,6 +33,7 @@ import {
   runBoundedCommand,
 } from "./native-ios-hosted-e2e-support.mjs";
 import {
+  createE2eDeployment,
   inspectPublicCandidateResponse,
   inspectRetirableE2eDeployment,
   inspectVercelCustomEnvironment,
@@ -221,6 +222,60 @@ test("Vercel proof binds project, custom environment, ref, and exact PR SHA", ()
       url: "native-e2e.vercel.app",
       ...mutation,
     }, expected));
+  }
+});
+
+test("Vercel deployment creation sends only current strict API fields", async () => {
+  const env = {
+    GITHUB_REPOSITORY_ID: "123456789",
+    NATIVE_IOS_E2E_VERCEL_CUSTOM_ENVIRONMENT_ID: "env_e2e",
+    NATIVE_IOS_E2E_VERCEL_PROJECT_ID: "prj_e2e",
+    NATIVE_IOS_E2E_VERCEL_PROJECT_NAME: "murph-native-ios-e2e",
+    NATIVE_IOS_E2E_VERCEL_TOKEN: "vercel_test_token",
+  };
+  const originalEnv = new Map(Object.keys(env).map((name) => [name, process.env[name]]));
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  let requestBody;
+  try {
+    Object.assign(process.env, env);
+    globalThis.fetch = async (_url, init) => {
+      requestBody = JSON.parse(init.body);
+      return new Response(JSON.stringify({ id: "dpl_123" }), {
+        headers: { "content-type": "application/json" },
+      });
+    };
+    console.log = () => undefined;
+
+    assert.deepEqual(await createE2eDeployment({
+      correlationId: "murph-pr-test",
+      ref: "feature/native-e2e",
+      sha: SHA,
+    }), { id: "dpl_123" });
+    assert.deepEqual(requestBody, {
+      customEnvironmentSlugOrId: "env_e2e",
+      gitSource: {
+        ref: "feature/native-e2e",
+        repoId: 123456789,
+        sha: SHA,
+        type: "github",
+      },
+      meta: {
+        murphNativeIosE2e: NATIVE_IOS_HOSTED_E2E_LANE_MARKER,
+        murphNativeIosE2eContract: NATIVE_IOS_HOSTED_E2E_CONTRACT_VERSION,
+        murphNativeIosE2eCorrelationId: "murph-pr-test",
+      },
+      name: "murph-native-ios-e2e",
+      project: "prj_e2e",
+    });
+    assert.equal(Object.hasOwn(requestBody, "public"), false);
+  } finally {
+    console.log = originalLog;
+    globalThis.fetch = originalFetch;
+    for (const [name, value] of originalEnv) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
   }
 });
 


### PR DESCRIPTION
## Why

The first provisioned native iOS hosted E2E sweep reached Vercel candidate creation and failed because the current strict Vercel API rejects the legacy `public` property. A corrected isolated request then proved the next boundary: database reset recreated the Prisma ledger under the credential login role instead of Murph's canonical `postgres` schema owner, so the hosted migration guard correctly failed closed.

## User-visible goal

Allow the protected hosted Web + real native iOS acceptance lane to build the exact PR commit in its dedicated Vercel custom environment. There is no member-facing UI change.

## Invariants

- The requested Git ref and exact SHA remain explicit.
- The deployment remains bound to the dedicated project and custom environment.
- Production deployments remain rejected by response validation and the build wrapper.
- Database reset still targets only an explicitly E2E-named isolated database.
- Reset and hosted migrations use the same canonical `postgres` schema owner.
- Provider errors and credentials remain secret-safe.
- Cleanup continues to retire only lane-marked deployments owned by the isolated project/environment.

## Architecture and reuse

Delete the obsolete Vercel request property from the existing controller. Extend the focused suite to execute the provider boundary with a mocked response and assert the complete allowlisted request body. Before Prisma reset, add the same PostgreSQL role connection option already enforced by the hosted Web migration owner contract, while preserving existing URL options. No new dependency, service, state owner, or broad abstraction is added.

## Change breakdown

- Source: 16 additions, 3 deletions
- Tests: 67 additions
- Docs/process: 48 additions across two Frog entries
- Config/tooling: none
- Generated/other: none

## Changelog

- Changelog: not applicable
- Reason: internal CI provider- and database-contract repair only.

## Review lenses

- Product UX: not applicable; internal CI only.
- Prompt: not applicable.
- Frontend: not applicable.
- Coverage: exact Vercel request-body and database owner-option tests added.
- Security/trust boundary: exact-commit deployment, dedicated-environment scope, destructive database admission, and canonical schema ownership remain fail closed.

## Sensitivity

Sensitive trusted-controller repair because it affects destructive reset connection role selection. Authority is not expanded: the existing credential must already be allowed to assume the canonical owner, and the reset remains limited to the dedicated E2E database.

## Design proof

Not applicable; no rendered UI changed.

## Deployment proof

- The original live controller reached safe cleanup and received Vercel's explicit additional-property rejection: https://github.com/cobuildwithus/murph/actions/runs/32085935177
- The same isolated-project request without the field was accepted for the exact activation SHA.
- Vercel's one-time first-deployment behavior was allowed to fail closed; the next custom-environment request was classified non-production.
- That exact candidate build reached the hosted migration owner guard and proved reset had recreated the ledger under the login role. The current head corrects that mechanism; a fresh live sweep remains required before merge.

## Verification

- `pnpm exec node --test scripts/native-ios-hosted-e2e.test.mjs` — 30/30 passed.
- `pnpm install --frozen-lockfile --ignore-scripts` — passed with unchanged lockfile.
- `git diff --check` — passed.
- Focused ESLint command unavailable because this repository does not expose an `eslint` binary at the root.

## ReviewGPT baseline

ReviewGPT first-reviewed head: 0b7faf128a6fea63102f3d6ba9b226e1972f74ec
