### PR TITLE
fix(ci): encode native E2E database options

### DIFF
--- a/.agents/friction-log/20260817204022-prisma-url-options/friction.md
+++ b/.agents/friction-log/20260817204022-prisma-url-options/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Native E2E owner option test normalized away its transport encoding'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The native iOS hosted E2E controller test should prove that PostgreSQL startup options are serialized in the exact URL form Prisma forwards successfully.
+
+## Current Behavior
+
+The test parsed the generated URL before asserting the `options` value. That normalization made `+` and `%20` look identical even though Prisma forwarded `+` literally and PostgreSQL rejected the resulting `+role` configuration parameter.
+
+## Possible Solution
+
+Assert both the decoded option value and the raw query string, keeping spaces percent-encoded for the Prisma connection boundary.
+
+## Minimal Reproducible Example
+
+Serialize `-c role=postgres` with `URLSearchParams`, pass the resulting `options=-c+role%3Dpostgres` URL through Prisma, and observe PostgreSQL reject the unknown `+role` parameter. The equivalent `%20` encoding connects successfully.
+
+## Context
+
+The first live sweep after the canonical-owner correction failed closed during the dedicated database reset, before deployment or native dispatch.

--- a/.agents/friction-log/20260817204022-prisma-url-options/friction.md
+++ b/.agents/friction-log/20260817204022-prisma-url-options/friction.md
@@ -9,11 +9,11 @@ The native iOS hosted E2E controller test should prove that PostgreSQL startup o
 
 ## Current Behavior
 
-The test parsed the generated URL before asserting the `options` value. That normalization made `+` and `%20` look identical even though Prisma forwarded `+` literally and PostgreSQL rejected the resulting `+role` configuration parameter.
+The controller test parsed the generated URL before asserting the `options` value, while the downstream hosted migration test expected the raw `+` form. The normalization made `+` and `%20` look identical at one boundary and encoded the broken transport as expected behavior at the next, even though Prisma forwarded `+` literally and PostgreSQL rejected the resulting `+role` configuration parameter.
 
 ## Possible Solution
 
-Assert both the decoded option value and the raw query string, keeping spaces percent-encoded for the Prisma connection boundary.
+Assert both the decoded option value and raw query string at both existing owner-composition boundaries, keeping spaces percent-encoded for Prisma.
 
 ## Minimal Reproducible Example
 

--- a/apps/web/scripts/hosted-web-migration-owner.ts
+++ b/apps/web/scripts/hosted-web-migration-owner.ts
@@ -32,6 +32,7 @@ export function withHostedWebMigrationOwner(databaseUrl: string): string {
       ? HOSTED_WEB_MIGRATION_OWNER_CONNECTION_OPTION
       : `${existingOptions} ${HOSTED_WEB_MIGRATION_OWNER_CONNECTION_OPTION}`,
   );
+  parsed.search = parsed.searchParams.toString().replaceAll("+", "%20");
   return parsed.toString();
 }
 

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -824,6 +824,10 @@ describe("hosted web production migration guard", () => {
       parsed.searchParams.get("options"),
       `-c statement_timeout=5000 -c role=${hostedWebMigrationOwnerRole}`,
     );
+    assert.equal(
+      parsed.search,
+      "?sslmode=require&options=-c%20statement_timeout%3D5000%20-c%20role%3Dpostgres",
+    );
   });
 
   test("fails closed on ownership drift while allowing canonical bootstrap", async () => {
@@ -924,7 +928,7 @@ describe("hosted web production migration guard", () => {
     );
 
     const expectedOwnerUrl =
-      "postgresql://direct.example.com:5432/app?sslmode=require&options=-c+role%3Dpostgres";
+      "postgresql://direct.example.com:5432/app?sslmode=require&options=-c%20role%3Dpostgres";
     assert.deepEqual(events, ["verify:start", "verify:complete", "run"]);
     assert.deepEqual(verifiedUrls, [expectedOwnerUrl]);
     assert.deepEqual(calls, [

--- a/scripts/native-ios-hosted-e2e-identity.mjs
+++ b/scripts/native-ios-hosted-e2e-identity.mjs
@@ -68,6 +68,7 @@ export function withDedicatedDatabaseOwner(connectionString) {
       ? `${existingOptions} ${DB_OWNER_CONNECTION_OPTION}`
       : DB_OWNER_CONNECTION_OPTION,
   );
+  parsed.search = parsed.searchParams.toString().replaceAll("+", "%20");
   return parsed.toString();
 }
 

--- a/scripts/native-ios-hosted-e2e.test.mjs
+++ b/scripts/native-ios-hosted-e2e.test.mjs
@@ -429,13 +429,18 @@ test("destructive database reset is limited to an explicitly E2E-named database"
 });
 
 test("destructive database reset assumes the canonical schema owner", () => {
-  const ownedUrl = new URL(withDedicatedDatabaseOwner(
+  const ownedConnectionString = withDedicatedDatabaseOwner(
     "postgresql://credential@db.example.test/native_ios_e2e?sslmode=require&options=-c%20statement_timeout%3D10000",
-  ));
+  );
+  const ownedUrl = new URL(ownedConnectionString);
   assert.equal(ownedUrl.searchParams.get("sslmode"), "require");
   assert.equal(
     ownedUrl.searchParams.get("options"),
     "-c statement_timeout=10000 -c role=postgres",
+  );
+  assert.equal(
+    ownedUrl.search,
+    "?sslmode=require&options=-c%20statement_timeout%3D10000%20-c%20role%3Dpostgres",
   );
 });
 


### PR DESCRIPTION
## Why

The first live sweep after #1969 failed closed during the dedicated database reset. The canonical owner option was semantically correct, but `URLSearchParams` serialized its spaces as `+`; Prisma forwarded that form literally and PostgreSQL rejected the resulting `+role` setting before migrations could start. ReviewGPT then found the same encoding defect in the downstream hosted migration owner boundary, which would otherwise have moved the failure into the Vercel build.

## User-visible goal

No product UI changes. Restore the required native iOS hosted E2E lane so every selected Web PR can prove the real signup, HealthKit, provider, sign-out, and returning-sign-in journey before merge.

## Invariants

- Destructive reset remains limited to the explicitly E2E-named isolated database.
- Reset and hosted migration assume only the existing canonical `postgres` role; no new authority, service, state, or lifecycle owner is added.
- Existing connection options and TLS parameters remain intact.
- Shared staging and production are never cleanup targets.
- Command failures remain secret-safe and fail closed before deployment or native dispatch.

## Architecture and reuse

Keep the two existing pure owner-URL composition boundaries and their current ownership. After each composes query parameters, normalize query-space encoding to `%20`, the transport form accepted through Prisma/PostgreSQL. The regression tests check both decoded values and exact raw query strings, closing the normalization gap without adding a cross-layer abstraction.

## Verification

- `pnpm exec node --test scripts/native-ios-hosted-e2e.test.mjs` — 30/30 passed.
- `pnpm --dir apps/web test:prepared -- production-migration-guard.test.ts` — 54/54 passed.
- Real Prisma reset against the isolated PlanetScale E2E database — passed.
- Real hosted `prisma:migrate:deploy` wrapper against that database — passed.
- Post-reset and post-deploy migration-ledger owner proofs — canonical owner confirmed.
- Short-lived proof roles — retired.
- `git diff --check` — passed.

## ReviewGPT

ReviewGPT first-reviewed head: 840d6e236943e7f1c265c15d14328b59cb5c1ec6

- Preliminary specialists: PASS; no findings; coverage deemed sufficient.
- Final round 1: one accepted high-severity finding that the downstream hosted migration owner helper retained the same `+` encoding.
- Remediation: corrected that existing helper and both helper/integrated raw URL expectations at head `2697fe623c5281eea73da3192ab6af672837f54a`.
- Final round 2: PASS; the prior finding is resolved and no new qualifying findings were reported.

## Changelog

- Changelog: not applicable
- Reason: This only repairs the internal protected CI controller and migration wrapper and does not change member-visible product behavior.

## Design proof

Not applicable; controller/test-only change with no frontend surface.

## Change breakdown

- Source: +2 / -0
- Tests: +12 / -3
- Docs/process (Frog): +24 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
