### PR TITLE
chore: update review-gpt to 0.5.134

### DIFF
--- a/.agents/friction-log/20260818002151-cli-test-commits/friction.md
+++ b/.agents/friction-log/20260818002151-cli-test-commits/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'CLI test commits trigger an unprepared config-schema build'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Committing a CLI test-only change either skips config-schema generation or prepares the workspace dependencies required by that generator.
+
+## Current Behavior
+
+The pre-commit hook treats every packages/cli change as a config-schema input. In a fresh sanctioned worktree, it runs the generator, which invokes the CLI package build before dependent workspace package artifacts exist. TypeScript reports many missing workspace entrypoints, the hook prints a generation-failed warning, and then deliberately continues.
+
+## Possible Solution
+
+Narrow the generator trigger to actual schema inputs, or route the hook through the existing prepared-runtime owner before building the CLI.
+
+## Minimal Reproducible Example
+
+1. Create a fresh sanctioned task worktree and install dependencies.
+2. Change only a test under packages/cli/test.
+3. Commit through scripts/committer.
+4. Observe config-schema generation attempt an unprepared standalone CLI build and then continue after failure.
+
+## Context
+
+This does not invalidate the commit because the hook is explicitly fail-open to CI, but it creates noisy false-negative local feedback for unrelated CLI test changes.

--- a/agent-docs/exec-plans/active/2026-08-17-review-gpt-0-5-134.md
+++ b/agent-docs/exec-plans/active/2026-08-17-review-gpt-0-5-134.md
@@ -53,6 +53,13 @@ Updated: 2026-08-17
 - Retain the existing caret dependency style while forcing the lockfile to the
   new release.
 - Treat this as internal engineering tooling with no member-facing changelog.
+- Accept the specialist, final-review, and CI finding that the CLI package-owner
+  audit still pinned `0.5.133`; update those expectations and assert the
+  installed driver's ten-minute interval and cache-bypassing reload directly.
+- Keep timer/reload execution tests in the ReviewGPT package that owns those
+  internals rather than duplicating its private runtime harness in Murph. The
+  published package's test suite covers the timer boundary, and both live PR
+  review waits exercised the hard refresh after ten minutes.
 
 ## Verification
 
@@ -67,4 +74,7 @@ Updated: 2026-08-17
   reports the repository's existing advisory baseline; registry metadata and
   the before/after lock snapshots confirm ReviewGPT `0.5.133` and `0.5.134`
   have the same dependency versions, so this update introduces no audit-path
-  change.
+  change. The focused CLI package-owner assertion passes after remediation. A
+  full local release-audit file run passed 45 of 46 tests; its unrelated
+  release-tarball test requires the CI-prepared assistant-engine build artifact,
+  and exact-head CI owns that prepared lane.

--- a/agent-docs/exec-plans/active/2026-08-17-review-gpt-0-5-134.md
+++ b/agent-docs/exec-plans/active/2026-08-17-review-gpt-0-5-134.md
@@ -1,0 +1,70 @@
+# Update ReviewGPT to 0.5.134
+
+Status: active
+Created: 2026-08-17
+Updated: 2026-08-17
+
+## Goal
+
+- Update Murph's ReviewGPT development dependency to the published `0.5.134`
+  release so repository review workflows inherit the ten-minute ChatGPT hard
+  refresh recovery behavior.
+
+## Success criteria
+
+- The root manifest and lockfile resolve `@cobuild/review-gpt` at `0.5.134`.
+- The minimum-release-age exception remains exact and moves from `0.5.133` to
+  `0.5.134`.
+- Dependency policy checks and the focused ReviewGPT workflow test pass.
+- The exact pushed PR head passes the required review and CI gates.
+
+## Scope
+
+- In scope: root dependency metadata, lockfile resolution, dependency policy
+  verification, and the normal PR review workflow.
+- Out of scope: Murph product behavior, runtime dependencies, and further
+  changes to ReviewGPT itself.
+
+## Constraints
+
+- Technical constraints: preserve the public-registry dependency and keep the
+  supply-chain exception pinned to one exact package version.
+- Product/process constraints: use the isolated worktree/PR lane and preserve
+  all unrelated repository work.
+
+## Risks and mitigations
+
+1. Risk: a newly published development dependency could bypass release-age
+   protections or alter the review CLI unexpectedly.
+   Mitigation: keep the existing exception package- and version-specific, audit
+   the lockfile-only delta, run dependency policy checks, and exercise the
+   focused ReviewGPT integration test before the PR gates.
+
+## Tasks
+
+1. Update the root manifest, release-age exception, and lockfile to `0.5.134`.
+2. Run dependency guards, audit/build-script checks, and focused integration
+   proof.
+3. Commit and push the candidate, then complete required ReviewGPT and CI gates.
+4. Archive this plan in the final scoped commit.
+
+## Decisions
+
+- Retain the existing caret dependency style while forcing the lockfile to the
+  new release.
+- Treat this as internal engineering tooling with no member-facing changelog.
+
+## Verification
+
+- Commands to run: `pnpm deps:guard`, `pnpm deps:audit`,
+  `pnpm deps:ignored-builds`, the focused ReviewGPT package-concurrency test,
+  and `git diff --check`.
+- Expected outcomes: dependency inspection reports `@cobuild/review-gpt` at
+  `0.5.134`; every changed-surface check passes, and any unrelated repository
+  baseline failure is documented with before/after evidence.
+- Results so far: the frozen install, dependency policy, ignored-build report,
+  focused four-test integration suite, and diff checks pass. The audit command
+  reports the repository's existing advisory baseline; registry metadata and
+  the before/after lock snapshots confirm ReviewGPT `0.5.133` and `0.5.134`
+  have the same dependency versions, so this update introduces no audit-path
+  change.

--- a/agent-docs/exec-plans/completed/2026-08-17-review-gpt-0-5-134.md
+++ b/agent-docs/exec-plans/completed/2026-08-17-review-gpt-0-5-134.md
@@ -1,8 +1,8 @@
 # Update ReviewGPT to 0.5.134
 
-Status: active
+Status: completed
 Created: 2026-08-17
-Updated: 2026-08-17
+Updated: 2026-08-18
 
 ## Goal
 
@@ -42,11 +42,14 @@ Updated: 2026-08-17
 
 ## Tasks
 
-1. Update the root manifest, release-age exception, and lockfile to `0.5.134`.
-2. Run dependency guards, audit/build-script checks, and focused integration
-   proof.
-3. Commit and push the candidate, then complete required ReviewGPT and CI gates.
-4. Archive this plan in the final scoped commit.
+1. Completed: update the root manifest, release-age exception, and lockfile to
+   `0.5.134`.
+2. Completed: run dependency guards, audit/build-script checks, and focused
+   integration proof.
+3. Completed: commit and push the candidate, resolve the specialist/final
+   finding, and obtain a final full-snapshot ReviewGPT pass.
+4. Completed: perform the parent final review and prepare this plan for archival
+   in the final scoped commit.
 
 ## Decisions
 
@@ -77,4 +80,15 @@ Updated: 2026-08-17
   change. The focused CLI package-owner assertion passes after remediation. A
   full local release-audit file run passed 45 of 46 tests; its unrelated
   release-tarball test requires the CI-prepared assistant-engine build artifact,
-  and exact-head CI owns that prepared lane.
+  and exact-head CI owns that prepared lane. The preliminary specialist pass
+  returned one accepted stale-version finding with no patch artifact; final
+  round 1 independently found the same issue. After the focused correction,
+  final round 2 reviewed a fresh sensitive/full snapshot for commit
+  `42b8f9de1f` and returned `ROUND_OUTCOME: PASS` with zero findings. Each live
+  review capture that exceeded ten minutes logged and recovered through the new
+  hard-refresh path. One candidate CI runner-bundle job observed a transient
+  merge-ref window containing an upstream bundle-growth commit before its
+  paired budget-ratchet commit; current `main` contains both and its equivalent
+  sandbox gate passes. Normal exact-head CI after the plan-closure push owns the
+  final composed result.
+Completed: 2026-08-18

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@babel/types": "^7.29.0",
     "@types/babel__traverse": "^7.28.0",
     "@cobuild/repo-tools": "^0.1.17",
-    "@cobuild/review-gpt": "^0.5.133",
+    "@cobuild/review-gpt": "^0.5.134",
     "@elevenlabs/elevenlabs-js": "2.62.0",
     "@murphai/health-metrics": "workspace:*",
     "@murphai/hosted-local-harness": "workspace:*",

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1169,13 +1169,13 @@ describe('monorepo release flow coverage audit', () => {
     expect(existsSync(path.join(repoRoot, 'scripts', 'chatgpt-managed-browser.test.mjs'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt.sh'))).toBe(false)
     expect(existsSync(path.join(repoRoot, 'scripts', 'review-gpt-cli.sh'))).toBe(false)
-    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.133')
+    expect(rootPackageJson.devDependencies?.['@cobuild/review-gpt']).toBe('^0.5.134')
     expect(
       pnpmWorkspace
         .match(/^minimumReleaseAgeExclude:\n((?:  - .+\n)+)/mu)?.[1]
         ?.split('\n')
         .filter((line) => line.includes('@cobuild/review-gpt')),
-    ).toEqual(["  - '@cobuild/review-gpt@0.5.133'"])
+    ).toEqual(["  - '@cobuild/review-gpt@0.5.134'"])
     expect(
       pnpmWorkspace
         .match(/^patchedDependencies:\n((?:  .+\n)+)/mu)?.[1]
@@ -1239,6 +1239,8 @@ describe('monorepo release flow coverage audit', () => {
     expect(reviewGptDriver).toContain(
       'const minimumMarkedResponseMs = Number(process.env.ORACLE_DRAFT_MINIMUM_MARKED_RESPONSE_MS || 5 * 60 * 1000);',
     )
+    expect(reviewGptDriver).toContain('const HARD_REFRESH_INTERVAL_MS = 10 * 60 * 1000;')
+    expect(reviewGptDriver).toContain("await cdp('Page.reload', { ignoreCache: true });")
     const attachmentNameMatcher = reviewGptDraftHelpersModule.buildAttachmentNameMatcher(
       'codebase.zip',
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^0.1.17
         version: 0.1.17
       '@cobuild/review-gpt':
-        specifier: ^0.5.133
-        version: 0.5.133(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        specifier: ^0.5.134
+        version: 0.5.134(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1484,8 +1484,8 @@ packages:
     resolution: {integrity: sha512-cq+LzXoKNOn+KXLBm9+N9QMTEwbIXzki5AZXP/cHnAex3+3LnyhJ7zMxB5InZVgQgqI9hEs0dsXoJX/tNxlW3Q==}
     hasBin: true
 
-  '@cobuild/review-gpt@0.5.133':
-    resolution: {integrity: sha512-z3OxCTPb/z6eFaG6JPxsYzHGlrytOp7FyuoBDwAezEEJtL9sjOsY5LD4+qMBZMQDGyNcgutEDrNKFf2Qfz0ueQ==}
+  '@cobuild/review-gpt@0.5.134':
+    resolution: {integrity: sha512-sDupM7zWuLpfiSUXLAmJsqZYZ1vs3j26NeFdqNsNsQIKTCpSnvQNiUfOSNmtI4Ezwpy9sO0rjeCsSzj6uGeOFw==}
     hasBin: true
 
   '@coinbase/cdp-sdk@1.48.3':
@@ -10831,7 +10831,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17': {}
 
-  '@cobuild/review-gpt@0.5.133(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.134(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17
       incur: 0.4.5(patch_hash=d02ac1808a7524a97aaea12822966726a31acaf4c5b5064d56ca03730c790b5e)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ overrides:
 minimumReleaseAgeExclude:
   - incur@0.4.4
   - '@cobuild/repo-tools@0.1.17'
-  - '@cobuild/review-gpt@0.5.133'
+  - '@cobuild/review-gpt@0.5.134'
   - '@next/env@16.3.0'
   - '@next/eslint-plugin-next@16.3.0'
   - '@next/swc-darwin-arm64@16.3.0'


### PR DESCRIPTION
## Why and outcome

Update Murph's internal ReviewGPT CLI to 0.5.134 so long-running ChatGPT capture and wake pages can recover from stalls with a cache-bypassing hard refresh every ten minutes.

## Product UX

Product UX does not apply: this changes repository review tooling only and does not alter member-facing behavior.

## Evidence

- Frozen workspace install accepts the narrowly updated lockfile.
- Dependency policy and ignored-build inspection pass with no new package dependency or build-script surface.
- The focused ReviewGPT package-concurrency suite passes (4 tests).
- The focused CLI package-owner assertion passes and verifies the installed ten-minute interval and cache-bypassing reload code.
- Both live ReviewGPT PR waits exercised the hard refresh after ten minutes and preserved their accepted review turns.
- `pnpm deps:audit` reports the repository's pre-existing advisory baseline. Registry metadata and before/after lock snapshots confirm 0.5.133 and 0.5.134 have identical dependency versions, so this PR adds no advisory path.

Review findings: accepted and fixed the stale 0.5.133 CLI audit expectations. Kept timer-execution unit coverage in the owning ReviewGPT package instead of duplicating its private harness in Murph; the installed-source contract and live waits provide Murph-side proof.

ReviewGPT context sensitivity: sensitive
Reason: this is a dependency supply-chain update with an exact release-age exception and lockfile integrity change.

ReviewGPT first-reviewed head: 7ae89509116f1ddce2ebe0c2a647e795c43e69a1

## Changelog

- Changelog: not applicable
- Reason: This changes internal repository review tooling only and has no member-visible behavior.
