### PR TITLE
Ratchet measured runner bundle budget

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -86,12 +86,15 @@ const VAULT_CLI_IMPORT_SURFACE_HOOK_SOURCE = [
 // without adding a package. The reviewed Telegram phone-call result route adds
 // only bounded schemas and delivery handling within the already-bundled Hosted
 // Execution and Assistant Engine graphs; the combined graph measured
-// 9,165,765 B on 2026-08-16. The static startup closure still measured 24,950 B.
+// 9,165,765 B on 2026-08-16. The merged assistant execution graph, including
+// the session-routing SQLite projection, measured 9,209,386 B in the Linux
+// deploy lane on 2026-08-18; it extends existing graphs without adding a
+// package. The static startup closure still measured 24,950 B.
 // Keep total output inside a narrow 32 KiB allowance and static startup inside
 // an 8 KiB allowance. If a violation fires, investigate the listed largest
 // inputs first; only raise the budget deliberately for understood, intended
 // growth.
-const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_198_500;
+const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_242_200;
 const VAULT_CLI_BUNDLE_ENTRY_BYTES_BUDGET = 20_000;
 const VAULT_CLI_BUNDLE_STATIC_CLOSURE_BYTES_BUDGET = 33_200;
 


### PR DESCRIPTION
## Why this PR exists

The protected production Cloudflare deploy for #1910 measured the current Linux `vault-cli` bundle at 9,209,386 bytes, 10,886 bytes above the previous checked-in ceiling. The guard stopped every runner-bearing predeploy lane before production mutation.

This follow-up records that measured current-main baseline and restores the existing narrow 32 KiB allowance. The growth remains inside already-bundled Assistant Engine/runtime graphs; no runner dependency, package, runtime mechanism, or startup import is added.

## User goal / user-visible behavior

Allow the already-reviewed session-routing release to pass the production runner assembly gate. No member-visible behavior changes.

## Invariants

- The bundle-size guard remains fail-closed.
- Total output retains only a narrow approximately 32 KiB allowance above the measured Linux bundle.
- Entry-chunk and static-startup-closure budgets are unchanged.
- Production deployment still requires the full runner assembly, immediate rollout, and managed-container smoke.

## Changelog

- Changelog: not applicable
- Reason: internal deployment guard baseline only.

## Architecture and reuse

- Existing systems reused: the current esbuild metafile budget guard and protected Cloudflare deployment workflow.
- New logic: none.
- New abstractions: none.
- Complexity intentionally avoided: no bypass flag, conditional guard, platform exception, or extra deployment path.

## Verification

- `runner-bundle-cli-bundle.test.ts`: 9/9 passed.
- Full `pnpm --dir apps/cloudflare runner:bundle`: passed.
- Local total bundle: 9,204,664 bytes.
- Linux deploy-lane total bundle: 9,209,386 bytes.
- Static startup closure: 24,950 bytes, unchanged and within its independent 33,200-byte budget.
- CLI bundled/unbundled parity probes: passed.
- Runner entrypoint size gates: passed.
- `git diff --check`: passed.

## Design proof

Not applicable — no UI changed.

## Change-shape breakdown

Classification: the deployment guard source is Source.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 2 |
| Tests / fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Deployment concerns

No runtime compatibility change is introduced by this follow-up. After merge, rerun the protected Cloudflare deployment for public Murph `main` with `container_rollout=immediate`; the session-routing release remains the forward-only runner floor after first projection publication.