### PR TITLE
Fix later reminder wake handoff

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-18-assistant-wake-shadow-followup.md
+++ b/agent-docs/exec-plans/completed/2026-08-18-assistant-wake-shadow-followup.md
@@ -1,0 +1,105 @@
+# Prevent a stale assistant wake from delaying a newer reminder
+
+Status: completed
+Created: 2026-08-18
+Updated: 2026-08-18
+
+## Goal
+
+- Ensure a reminder created inside an already-running hosted invocation is
+  serviced at its due time even when an older assistant wake remains the
+  invocation's carried projection.
+
+## Success criteria
+
+- A focused regression reproduces the observed sequence: foreground turns
+  defer cron work, an idle checkpoint persists an older due assistant wake, a
+  runtime nudge performs an empty mailbox probe, and a newer reminder becomes
+  due before the next idle checkpoint.
+- The newer due reminder is scanned without waiting for the next idle
+  checkpoint or another inbound message.
+- Existing foreground-message priority, outbox retry wakes, durable checkpoint
+  barriers, and the single Temporal/Web/Cloudflare/runtime owner chain remain
+  intact.
+- The correction introduces no scheduler, queue, polling loop, persisted field,
+  or alternate wake owner.
+- Focused tests, exact-head CI, preliminary specialist review, final ReviewGPT,
+  and a deployed reminder canary pass.
+
+## Evidence
+
+- A short reminder arrived more than three minutes late even though provider
+  delivery followed Murph's outbound send immediately.
+- The active runtime checkpointed an older assistant wake. Its due projection
+  was dispatched, but the runtime imported no mailbox work and did not scan
+  scheduled work.
+- The next idle checkpoint exposed the newer overdue reminder wake. The
+  orchestrator dispatched it immediately and delivery followed promptly.
+- The preceding stale-wake fix deliberately covered carried non-assistant wakes
+  only. Its assistant-wake preservation rule still allows an older due assistant
+  token to shadow a newer assistant obligation inside one dirty invocation.
+
+## Scope
+
+- In scope: hosted runtime wake projection/consumption, dirty-window wake
+  handling, focused runtime tests, and the existing hosted reminder scenario if
+  needed for end-to-end proof.
+- Out of scope: reminder copy, automation storage format, Temporal workflow
+  ownership, provider delivery, new persistence, and unrelated maintenance
+  scheduling.
+
+## Tasks
+
+1. Build a synthetic, test-only reproduction on the current main branch.
+2. Ask ReviewGPT to validate the evidence, reproduce independently, and identify
+   the smallest invariant-level correction.
+3. Apply only the accepted existing-owner fix and retain the red regression.
+4. Run focused assistant-runtime and Cloudflare proof plus required typechecks.
+5. Push the exact candidate, open the PR, and run specialist/final ReviewGPT
+   gates concurrently with CI.
+6. Resolve accepted findings, merge, deploy the affected runtime surface, and
+   verify a fresh reminder canary.
+
+## Decisions
+
+- Treat the production trace as evidence, not repository content; tests use
+  synthetic times, ids, and messages only.
+- Require a failing repository regression before changing production code.
+- Prefer deleting or relaxing the incorrect wake-preservation branch at the
+  existing owner boundary over adding coordination state.
+- Do not make Temporal repeatedly dispatch the same due token; the runtime must
+  make progress under the already-accepted owner handoff.
+- Retain the later assistant obligation in the existing
+  `pendingWakeAfterDueAssistantService` slot while the older due assistant wake
+  crosses its service/checkpoint barrier.
+- Promote and immediately checkpoint that retained successor after the exact
+  predecessor's hot attempt is committed. Do not add a scheduler, queue,
+  persisted field, or polling path.
+
+## Progress
+
+- A production-shape regression reaches the distinct later reminder, the empty
+  persisted-wake dispatch, and the exact lost-owner assertion.
+- ReviewGPT isolated the assistant-to-assistant projection loss. Two proposed
+  harness corrections were rejected after local execution because they still
+  let the live foreground watcher consume the only wake notification; the third
+  correction established the outer-loop ownership barrier used by the final
+  regression.
+- The existing held-wake owner now retains and promotes the later assistant
+  obligation after the predecessor is checkpointed.
+
+## Verification
+
+- Run the narrow assistant-runtime entrypoint/workspace-runner regression first.
+- Run the affected assistant-runtime package tests and typecheck after the fix.
+- Run the hosted-local scheduled-reminder scenario when the synthetic harness
+  proves the exact boundary.
+- Require green exact-head CI and both routed ReviewGPT stages before merge.
+
+Completed local proof:
+
+- Focused wake-barrier tests: 4 passed.
+- Assistant-runtime typecheck: passed.
+- Full assistant-runtime suite: 89 files passed; 2,375 tests passed and 4
+  skipped.
+Completed: 2026-08-18

--- a/apps/web/changelog/entries/2026-08-18/reminders-keep-their-time.json
+++ b/apps/web/changelog/entries/2026-08-18/reminders-keep-their-time.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-18",
+  "order": 100,
+  "item": {
+    "id": "reminders-keep-their-time",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Reminders keep their time",
+    "summary": "Murph now keeps a newer reminder scheduled while earlier assistant work finishes.",
+    "details": "The earlier work still completes its checkpoint first, and the later reminder stays armed without needing another message to wake it.",
+    "relevanceTags": ["assistant", "reminders", "reliability"],
+    "sourcePullRequests": [1979]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -4164,6 +4164,17 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         wake: deferredDeviceSyncWake,
       };
     };
+    const resolveCanonicalWriteDueAssistantServiceBarrierKey = (): string | null => {
+      if (
+        pendingWakeAfterDueAssistantService === null
+        || hotProjectedAssistantWakeAttemptedKey === null
+        || buildHostedRuntimeWakeKey(pendingWake)
+          !== hotProjectedAssistantWakeAttemptedKey
+      ) {
+        return null;
+      }
+      return hotProjectedAssistantWakeAttemptedKey;
+    };
     const overlayPendingWakeOnCommittedWorkspace = (
       checkpointPendingBeforePass: boolean,
       presentedInvocationLocalProjectedAssistantWakeKey: string | null,
@@ -4220,7 +4231,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         const canonicalWriteCount = await controller.flushCanonicalWrites(
           async (write, metadata) => {
             const workspace = mergeGeneratedImageRetentionWakeIntoWorkspace(
-              overlayPendingWakeOnCommittedWorkspace(runtimeStateDirty, null),
+              overlayPendingWakeOnCommittedWorkspace(
+                runtimeStateDirty,
+                resolveCanonicalWriteDueAssistantServiceBarrierKey(),
+              ),
               metadata.retentionWakeAt,
             );
             const persisted = await runHostedWorkspaceCanonicalWriteAtBoundary({
@@ -5322,7 +5336,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               persistGeneratedImageRetention: async (write) => {
                 const workspace = overlayPendingWakeOnCommittedWorkspace(
                   runtimeStateDirty,
-                  null,
+                  resolveCanonicalWriteDueAssistantServiceBarrierKey(),
                 );
                 const persisted = await runHostedWorkspaceCanonicalWriteAtBoundary({
                   previousRedactedStatus:

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -5574,10 +5574,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         // re-mutating it here would be a duplicate state owner and is the seam
         // that previously let inboxMediaRetentionWakeAt drift.
         resumeDetachedAssistantAskAfterWorkspaceBoundary();
-        if (runtimeStateDirty) {
-          pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
-          continue;
-        }
         const mayRunPostCheckpointWork = (): boolean =>
           idleCheckpointPhaseLogDetails.idleCheckpointTrigger !== "shutdown_signal"
           && options.shutdownSignal?.aborted !== true;
@@ -5604,6 +5600,15 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             throw error;
           }
         };
+        const preserveImmediateDurableCheckpointFollowUp = (): void => {
+          if (!durableCheckpointFollowUpPending) {
+            return;
+          }
+          pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
+          // Foreground work rearms the ordinary idle window; the promoted
+          // successor still needs its immediate durable checkpoint.
+          setIdleCheckpointStartBy(Date.now());
+        };
         if (conversationInputAhead && mayRunPostCheckpointWork()) {
           await runOptionalPostCheckpointWork(
             async () =>
@@ -5613,6 +5618,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               }),
           );
           if (runtimeStateDirty) {
+            preserveImmediateDurableCheckpointFollowUp();
             continue;
           }
         }
@@ -5680,10 +5686,14 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             if (checkpointWakeHandled === null && !mayRunPostCheckpointWork()) {
               mailboxWakeNeedsReplacement = true;
             }
-            if (runtimeStateDirty) {
-              continue;
+            if (checkpointWakeHandled !== null) {
+              checkpointWakeLatencySeed = null;
             }
           }
+        }
+        if (runtimeStateDirty) {
+          preserveImmediateDurableCheckpointFollowUp();
+          continue;
         }
         let vaultShareOpportunity: HostedVaultShareProjectionOpportunity | null = null;
         if (

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -4363,6 +4363,19 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           result: passResult,
           workspace: passWorkspace,
         });
+        const assistantContinuationWakeAt =
+          passResult.assistantPhaseResult?.nextWakeAt ?? null;
+        const assistantContinuationWake =
+          assistantContinuationWakeAt !== null
+          && hostedRuntimeWakeReasonIsAssistant(
+            passResult.assistantPhaseResult?.nextWakeReason ?? null,
+          )
+            ? {
+                nextWakeAt: assistantContinuationWakeAt,
+                nextWakeReason:
+                  passResult.assistantPhaseResult?.nextWakeReason ?? null,
+              }
+            : null;
         const passWake = resolveHostedWorkspaceRunNextWake({
           assistantPhaseResult: passResult.assistantPhaseResult,
           committedWorkspace: committedPassWorkspace,
@@ -4418,12 +4431,14 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         if (
           checkpointPendingBeforePass
           && presentedInvocationLocalProjectedAssistantWakeKey === null
-          && passProjectedAssistantWakeKey !== null
+          && assistantContinuationWake !== null
+          && hotProjectedAssistantWakeAttemptedKey !== null
+          && buildHostedRuntimeWakeKey(previousPendingWake)
+            === hotProjectedAssistantWakeAttemptedKey
           && previousPendingWake.nextWakeAt !== null
           && hostedRuntimeWakeReasonIsAssistant(previousPendingWake.nextWakeReason)
           && hostedRuntimeWakeIsDue(previousPendingWake.nextWakeAt)
-          && passWake.nextWakeAt !== null
-          && Date.parse(passWake.nextWakeAt)
+          && Date.parse(assistantContinuationWake.nextWakeAt)
             > Date.parse(previousPendingWake.nextWakeAt)
           && hostedRuntimePendingWakeMatches(pendingWake, previousPendingWake)
         ) {
@@ -4435,8 +4450,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                   pendingWakeAfterDueAssistantService?.durableWake.nextWakeReason ?? null,
               },
               {
-                at: passWake.nextWakeAt,
-                reason: passWake.nextWakeReason,
+                at: assistantContinuationWake.nextWakeAt,
+                reason: assistantContinuationWake.nextWakeReason,
               },
             ]),
           };

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -4398,6 +4398,35 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           nowMs: Date.now(),
         });
         pendingWake = wakeResolution.pendingWake;
+        // The older due token remains checkpoint authority until its hot
+        // service attempt is committed. Retain a distinct later assistant
+        // obligation in the existing successor slot instead of dropping it.
+        if (
+          checkpointPendingBeforePass
+          && presentedInvocationLocalProjectedAssistantWakeKey === null
+          && passProjectedAssistantWakeKey !== null
+          && previousPendingWake.nextWakeAt !== null
+          && hostedRuntimeWakeReasonIsAssistant(previousPendingWake.nextWakeReason)
+          && hostedRuntimeWakeIsDue(previousPendingWake.nextWakeAt)
+          && passWake.nextWakeAt !== null
+          && Date.parse(passWake.nextWakeAt)
+            > Date.parse(previousPendingWake.nextWakeAt)
+          && hostedRuntimePendingWakeMatches(pendingWake, previousPendingWake)
+        ) {
+          pendingWakeAfterDueAssistantService = {
+            durableWake: selectEarliestHostedRuntimeWake([
+              {
+                at: pendingWakeAfterDueAssistantService?.durableWake.nextWakeAt ?? null,
+                reason:
+                  pendingWakeAfterDueAssistantService?.durableWake.nextWakeReason ?? null,
+              },
+              {
+                at: passWake.nextWakeAt,
+                reason: passWake.nextWakeReason,
+              },
+            ]),
+          };
+        }
         if (passProducedDefaultWake && passWake.nextWakeAt !== null) {
           recordUnservicedRecheckWake(passWake);
         }
@@ -5511,13 +5540,27 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         const conversationInputAhead = checkpoint.conversationInputAhead === true;
         const hotProjectedAssistantWakeKeyPresentedBeforeCheckpoint =
           hotProjectedAssistantWakeAttemptedKey;
+        const checkpointCompletedDueAssistantServiceBarrier =
+          pendingWakeAfterDueAssistantService !== null
+          && hotProjectedAssistantWakeKeyPresentedBeforeCheckpoint !== null
+          && buildHostedRuntimeWakeKey({
+            nextWakeAt: checkpoint.workspace.nextWakeAt ?? null,
+            nextWakeReason: checkpoint.workspace.nextWakeReason ?? null,
+          }) === hotProjectedAssistantWakeKeyPresentedBeforeCheckpoint;
         rebaseCommittedWorkspace(checkpoint.workspace);
         runtimeStateDirty = false;
         idleCheckpointStartByMs = null;
         hotProjectedAssistantWakeAttemptedKey = null;
         durableCheckpointFollowUpPending = false;
+        if (checkpointCompletedDueAssistantServiceBarrier) {
+          reconcilePendingWakeAfterDueAssistantPass({
+            preservedDueAssistantWakeOnNoProgress: true,
+          });
+          durableCheckpointFollowUpPending = true;
+        }
         if (
-          latestCheckpointSnapshotCleanForWarmReuse
+          !runtimeStateDirty
+          && latestCheckpointSnapshotCleanForWarmReuse
           && durableCheckpointEffectCount === 0
         ) {
           await writeHostedWorkspaceCleanCheckpointMarkerBestEffort({
@@ -5531,6 +5574,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         // re-mutating it here would be a duplicate state owner and is the seam
         // that previously let inboxMediaRetentionWakeAt drift.
         resumeDetachedAssistantAskAfterWorkspaceBoundary();
+        if (runtimeStateDirty) {
+          pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
+          continue;
+        }
         const mayRunPostCheckpointWork = (): boolean =>
           idleCheckpointPhaseLogDetails.idleCheckpointTrigger !== "shutdown_signal"
           && options.shutdownSignal?.aborted !== true;

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1478,7 +1478,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         )
       ) {
         preCheckpointExternalCompletionImported = true;
-        foregroundPriorityWorkOrdinal += 1;
       }
     };
     const importMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item, context) =>
@@ -3109,6 +3108,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       });
       try {
         let currentAssistantInputId: string | null = null;
+        let acceptedReadyImageCompletion = false;
         const passPromise = runHostedWorkspaceUntilIdleOrBudget({
           ...baseRunnerInput,
           initialAssistantInputBatch: passInput.initialAssistantInputBatch ?? null,
@@ -3217,7 +3217,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                       acceptedInputContext.conversationActivity,
                     );
                   }
-                  consumeReadyImageCompletionInputs(assistantInputIds);
+                  acceptedReadyImageCompletion ||=
+                    consumeReadyImageCompletionInputs(assistantInputIds);
                   return () => {
                     currentAssistantInputId = null;
                   };
@@ -3273,6 +3274,16 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             workspace: passInput.workspace,
           });
         recordBrowserVaultReplicaRefreshIntent(passResult);
+        if (
+          passResult.runtimeStateDirty
+          && (
+            acceptedReadyImageCompletion
+            || passResult.assistantPhaseResult
+              ?.foregroundPrioritySystemCompletionProcessed === true
+          )
+        ) {
+          foregroundPriorityWorkOrdinal += 1;
+        }
         return passResult;
       } catch (error) {
         emitPhaseLog({
@@ -4330,25 +4341,25 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       };
       const consumeReadyImageCompletionInputs = (
         acceptedInputIds: readonly string[],
-      ): void => {
+      ): boolean => {
         const readyBatch = readyImageCompletionInputBatch;
         if (!readyBatch) {
-          return;
+          return false;
         }
         const acceptedInputIdSet = new Set(acceptedInputIds);
         const retainedInputIds = readyBatch.assistantInputIds.filter(
           (inputId) => !acceptedInputIdSet.has(inputId),
         );
         if (retainedInputIds.length === readyBatch.assistantInputIds.length) {
-          return;
+          return false;
         }
-        foregroundPriorityWorkOrdinal += 1;
         readyImageCompletionInputBatch = retainedInputIds.length === 0
           ? null
           : {
               ...readyBatch,
               assistantInputIds: retainedInputIds,
             };
+        return true;
       };
       const absorbForegroundPassResult = (
         passResult: HostedWorkspaceRunnerResult,

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3217,8 +3217,9 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                       acceptedInputContext.conversationActivity,
                     );
                   }
-                  acceptedReadyImageCompletion ||=
+                  const consumedReadyImageCompletion =
                     consumeReadyImageCompletionInputs(assistantInputIds);
+                  acceptedReadyImageCompletion ||= consumedReadyImageCompletion;
                   return () => {
                     currentAssistantInputId = null;
                   };

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1431,6 +1431,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
     );
     const mailboxBudgetExhausted = () => mailboxBudget.exhausted;
     let preCheckpointExternalCompletionImported = false;
+    let conversationInputStagedOrdinal = 0;
     let deviceSyncMessagingReturnTarget: HostedRuntimeDeviceSyncMessagingReturnTarget | null =
       null;
     const createMailboxImportContext = (
@@ -1449,9 +1450,13 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       onConversationActivityObserved: () => {
         options.onConversationActivityObserved?.("observed");
       },
-      onConversationInputStaged:
-        context?.onConversationInputStaged
-        ?? startCodexProcessPreparationForConversation,
+      onConversationInputStaged: (channel) => {
+        conversationInputStagedOrdinal += 1;
+        const notifyConversationInputStaged =
+          context?.onConversationInputStaged
+          ?? startCodexProcessPreparationForConversation;
+        notifyConversationInputStaged?.(channel);
+      },
       runtimeAttemptId: input.request.attemptId,
       signal: context?.signal ?? runtimeAbortController.signal,
     });
@@ -5641,6 +5646,12 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           }
           return buildHostedRuntimeWakeKey(pendingWake);
         };
+        const checkpointStartByAtBarrierRelease =
+          checkpointCompletedDueAssistantServiceBarrier
+            ? idleCheckpointStartByMs
+            : null;
+        const conversationInputStagedOrdinalAtBarrierRelease =
+          conversationInputStagedOrdinal;
         if (conversationInputAhead && mayRunPostCheckpointWork()) {
           await runOptionalPostCheckpointWork(
             async () =>
@@ -5729,7 +5740,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         const dueAssistantServiceBarrierSuccessorKey =
           resolveDueAssistantServiceBarrierSuccessorKey();
         if (dueAssistantServiceBarrierSuccessorKey !== null) {
-          const checkpointStartByBeforeService = idleCheckpointStartByMs;
           const dueAssistantWakeResult = await runOptionalPostCheckpointWork(
             async () =>
               await runForegroundPass({
@@ -5743,12 +5753,11 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           );
           if (
             dueAssistantWakeResult !== null
-            && checkpointStartByBeforeService !== null
-            && !hostedMailboxImportStagedConversationInput(
-              dueAssistantWakeResult.latestMailboxImport,
-            )
+            && checkpointStartByAtBarrierRelease !== null
+            && conversationInputStagedOrdinal
+              === conversationInputStagedOrdinalAtBarrierRelease
           ) {
-            setIdleCheckpointStartBy(checkpointStartByBeforeService);
+            setIdleCheckpointStartBy(checkpointStartByAtBarrierRelease);
           }
         }
         if (runtimeStateDirty) {

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -4177,13 +4177,13 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
     };
     const overlayPendingWakeOnCommittedWorkspace = (
       checkpointPendingBeforePass: boolean,
-      presentedInvocationLocalProjectedAssistantWakeKey: string | null,
+      presentedProjectedAssistantWakeKey: string | null,
     ): HostedWorkspaceState | null => {
         if (committedWorkspace === null) {
           return null;
         }
         let passWake = pendingWake;
-        if (presentedInvocationLocalProjectedAssistantWakeKey !== null) {
+        if (presentedProjectedAssistantWakeKey !== null) {
           return {
             ...committedWorkspace,
             nextWakeAt: pendingWake.nextWakeAt,
@@ -4347,7 +4347,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         passResult: HostedWorkspaceRunnerResult,
         passWorkspace: HostedWorkspaceState | null,
         previousPendingWake: HostedRuntimePendingWake,
-        presentedInvocationLocalProjectedAssistantWakeKey: string | null,
+        presentedProjectedAssistantWakeKey: string | null,
         preserveDueAssistantWakeOnNoProgress: boolean,
       ): void => {
         const checkpointPendingBeforePass = runtimeStateDirty;
@@ -4418,7 +4418,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           assistantProjectedWakeKey: passProjectedAssistantWakeKey,
           checkpointPendingBeforePass,
           passWake,
-          presentedInvocationLocalProjectedAssistantWakeKey,
+          presentedProjectedAssistantWakeKey,
           previousPendingWake,
           preserveDueAssistantWakeOnNoProgress,
           replaceWake,
@@ -4430,7 +4430,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         // obligation in the existing successor slot instead of dropping it.
         if (
           checkpointPendingBeforePass
-          && presentedInvocationLocalProjectedAssistantWakeKey === null
+          && presentedProjectedAssistantWakeKey === null
           && assistantContinuationWake !== null
           && hotProjectedAssistantWakeAttemptedKey !== null
           && buildHostedRuntimeWakeKey(previousPendingWake)
@@ -4515,7 +4515,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         initialMailboxPrefetch?: HostedMailboxPrefixPrefetch | null;
         providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null;
         latencySeed?: HostedRuntimeWakeLatencySeed | null;
-        invocationLocalProjectedAssistantWakeKey?: string | null;
+        projectedAssistantWakeKey?: string | null;
         preserveDueAssistantWakeOnNoProgress?: boolean;
         requestIdKind: "checkpoint-interrupt" | "checkpoint-wake" | "idle-wake";
         signal?: AbortSignal;
@@ -4542,19 +4542,19 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           idleWakeOrdinal += 1;
           const previousPendingWake = pendingWake;
           const checkpointPendingBeforePass = runtimeStateDirty;
-          const requestedInvocationLocalProjectedAssistantWakeKey =
-            singleWakeInput.invocationLocalProjectedAssistantWakeKey ?? null;
-          const presentedInvocationLocalProjectedAssistantWakeKey =
-            requestedInvocationLocalProjectedAssistantWakeKey !== null
-            && requestedInvocationLocalProjectedAssistantWakeKey
+          const requestedProjectedAssistantWakeKey =
+            singleWakeInput.projectedAssistantWakeKey ?? null;
+          const presentedProjectedAssistantWakeKey =
+            requestedProjectedAssistantWakeKey !== null
+            && requestedProjectedAssistantWakeKey
               === buildHostedRuntimeWakeKey(previousPendingWake)
             && hostedRuntimeWakeReasonIsAssistant(previousPendingWake.nextWakeReason)
             && hostedRuntimeWakeIsDue(previousPendingWake.nextWakeAt)
-              ? requestedInvocationLocalProjectedAssistantWakeKey
+              ? requestedProjectedAssistantWakeKey
               : null;
           const passWorkspace = overlayPendingWakeOnCommittedWorkspace(
             checkpointPendingBeforePass,
-            presentedInvocationLocalProjectedAssistantWakeKey,
+            presentedProjectedAssistantWakeKey,
           );
           result = await runWorkspaceForegroundPass({
             foregroundCausalOnly:
@@ -4579,7 +4579,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             result,
             passWorkspace,
             previousPendingWake,
-            presentedInvocationLocalProjectedAssistantWakeKey,
+            presentedProjectedAssistantWakeKey,
             singleWakeInput.preserveDueAssistantWakeOnNoProgress === true,
           );
           return result;
@@ -5205,7 +5205,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         ) {
           hotProjectedAssistantWakeAttemptedKey = hotProjectedAssistantWake.key;
           await runForegroundPass({
-            invocationLocalProjectedAssistantWakeKey: hotProjectedAssistantWake.key,
+            projectedAssistantWakeKey: hotProjectedAssistantWake.key,
             latencySeed: null,
             preserveDueAssistantWakeOnNoProgress: true,
             requestIdKind: "idle-wake",
@@ -5629,6 +5629,18 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             throw error;
           }
         };
+        const resolveDueAssistantServiceBarrierSuccessorKey = (): string | null => {
+          if (
+            !checkpointCompletedDueAssistantServiceBarrier
+            || !mayRunPostCheckpointWork()
+            || invocationStatus === "budget_exhausted"
+            || !hostedRuntimeWakeReasonIsAssistant(pendingWake.nextWakeReason)
+            || !hostedRuntimeWakeIsDue(pendingWake.nextWakeAt)
+          ) {
+            return null;
+          }
+          return buildHostedRuntimeWakeKey(pendingWake);
+        };
         if (conversationInputAhead && mayRunPostCheckpointWork()) {
           await runOptionalPostCheckpointWork(
             async () =>
@@ -5637,7 +5649,10 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 signal: postCheckpointWorkSignal,
               }),
           );
-          if (runtimeStateDirty) {
+          if (
+            runtimeStateDirty
+            && resolveDueAssistantServiceBarrierSuccessorKey() === null
+          ) {
             pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
             continue;
           }
@@ -5709,6 +5724,31 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             if (checkpointWakeHandled !== null) {
               checkpointWakeLatencySeed = null;
             }
+          }
+        }
+        const dueAssistantServiceBarrierSuccessorKey =
+          resolveDueAssistantServiceBarrierSuccessorKey();
+        if (dueAssistantServiceBarrierSuccessorKey !== null) {
+          const checkpointStartByBeforeService = idleCheckpointStartByMs;
+          const dueAssistantWakeResult = await runOptionalPostCheckpointWork(
+            async () =>
+              await runForegroundPass({
+                latencySeed: null,
+                preserveDueAssistantWakeOnNoProgress: true,
+                projectedAssistantWakeKey:
+                  dueAssistantServiceBarrierSuccessorKey,
+                requestIdKind: "checkpoint-wake",
+                signal: postCheckpointWorkSignal,
+              }),
+          );
+          if (
+            dueAssistantWakeResult !== null
+            && checkpointStartByBeforeService !== null
+            && !hostedMailboxImportStagedConversationInput(
+              dueAssistantWakeResult.latestMailboxImport,
+            )
+          ) {
+            setIdleCheckpointStartBy(checkpointStartByBeforeService);
           }
         }
         if (runtimeStateDirty) {
@@ -6705,7 +6745,7 @@ function resolvePendingWakeAfterForegroundPass(input: {
   checkpointPendingBeforePass: boolean;
   nowMs: number;
   passWake: HostedRuntimePendingWake;
-  presentedInvocationLocalProjectedAssistantWakeKey: string | null;
+  presentedProjectedAssistantWakeKey: string | null;
   previousPendingWake: HostedRuntimePendingWake;
   preserveDueAssistantWakeOnNoProgress: boolean;
   replaceWake: boolean;
@@ -6725,7 +6765,7 @@ function resolvePendingWakeAfterForegroundPass(input: {
     && hostedRuntimeWakeIsDue(input.passWake.nextWakeAt, input.nowMs);
   const preservePendingWakeThroughPreCheckpointPass =
     input.checkpointPendingBeforePass
-    && input.presentedInvocationLocalProjectedAssistantWakeKey === null
+    && input.presentedProjectedAssistantWakeKey === null
     && input.previousPendingWake.nextWakeAt !== null
     && (
       !hostedRuntimeWakeReasonIsAssistant(input.previousPendingWake.nextWakeReason)
@@ -6741,7 +6781,7 @@ function resolvePendingWakeAfterForegroundPass(input: {
 
   const previousWakeAt =
     input.checkpointPendingBeforePass
-      && input.presentedInvocationLocalProjectedAssistantWakeKey === null
+      && input.presentedProjectedAssistantWakeKey === null
       && !freshDueSupersedesCarriedDue
     ? input.previousPendingWake.nextWakeAt
     : normalizeHostedFutureWakeAt(input.previousPendingWake.nextWakeAt, input.nowMs);
@@ -6759,7 +6799,7 @@ function resolvePendingWakeAfterForegroundPass(input: {
 
   if (
     input.preserveDueAssistantWakeOnNoProgress
-    && input.presentedInvocationLocalProjectedAssistantWakeKey !== null
+    && input.presentedProjectedAssistantWakeKey !== null
     && input.assistantProjectedWakeKey === null
     && input.previousPendingWake.nextWakeAt !== null
     && hostedRuntimeWakeReasonIsAssistant(input.previousPendingWake.nextWakeReason)

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -5600,15 +5600,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             throw error;
           }
         };
-        const preserveImmediateDurableCheckpointFollowUp = (): void => {
-          if (!durableCheckpointFollowUpPending) {
-            return;
-          }
-          pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
-          // Foreground work rearms the ordinary idle window; the promoted
-          // successor still needs its immediate durable checkpoint.
-          setIdleCheckpointStartBy(Date.now());
-        };
         if (conversationInputAhead && mayRunPostCheckpointWork()) {
           await runOptionalPostCheckpointWork(
             async () =>
@@ -5618,7 +5609,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               }),
           );
           if (runtimeStateDirty) {
-            preserveImmediateDurableCheckpointFollowUp();
+            pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
             continue;
           }
         }
@@ -5692,7 +5683,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           }
         }
         if (runtimeStateDirty) {
-          preserveImmediateDurableCheckpointFollowUp();
+          pendingCheckpointWakeLatencySeed ??= checkpointWakeLatencySeed;
           continue;
         }
         let vaultShareOpportunity: HostedVaultShareProjectionOpportunity | null = null;

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1431,7 +1431,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
     );
     const mailboxBudgetExhausted = () => mailboxBudget.exhausted;
     let preCheckpointExternalCompletionImported = false;
-    let conversationInputStagedOrdinal = 0;
+    let foregroundPriorityWorkOrdinal = 0;
     let deviceSyncMessagingReturnTarget: HostedRuntimeDeviceSyncMessagingReturnTarget | null =
       null;
     const createMailboxImportContext = (
@@ -1451,7 +1451,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         options.onConversationActivityObserved?.("observed");
       },
       onConversationInputStaged: (channel) => {
-        conversationInputStagedOrdinal += 1;
+        foregroundPriorityWorkOrdinal += 1;
         const notifyConversationInputStaged =
           context?.onConversationInputStaged
           ?? startCodexProcessPreparationForConversation;
@@ -1478,6 +1478,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         )
       ) {
         preCheckpointExternalCompletionImported = true;
+        foregroundPriorityWorkOrdinal += 1;
       }
     };
     const importMailboxItem: HostedWorkspaceRunnerInput["importItem"] = (item, context) =>
@@ -4341,6 +4342,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         if (retainedInputIds.length === readyBatch.assistantInputIds.length) {
           return;
         }
+        foregroundPriorityWorkOrdinal += 1;
         readyImageCompletionInputBatch = retainedInputIds.length === 0
           ? null
           : {
@@ -5650,8 +5652,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           checkpointCompletedDueAssistantServiceBarrier
             ? idleCheckpointStartByMs
             : null;
-        const conversationInputStagedOrdinalAtBarrierRelease =
-          conversationInputStagedOrdinal;
+        const foregroundPriorityWorkOrdinalAtBarrierRelease =
+          foregroundPriorityWorkOrdinal;
         if (conversationInputAhead && mayRunPostCheckpointWork()) {
           await runOptionalPostCheckpointWork(
             async () =>
@@ -5754,8 +5756,8 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           if (
             dueAssistantWakeResult !== null
             && checkpointStartByAtBarrierRelease !== null
-            && conversationInputStagedOrdinal
-              === conversationInputStagedOrdinalAtBarrierRelease
+            && foregroundPriorityWorkOrdinal
+              === foregroundPriorityWorkOrdinalAtBarrierRelease
           ) {
             setIdleCheckpointStartBy(checkpointStartByAtBarrierRelease);
           }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -3836,6 +3836,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const afterCheckpointKeepsForegroundImportLoop =
     input.systemMailboxResult.afterCheckpointKeepsForegroundImportLoop === true
     || input.assistantResult.afterCheckpointKeepsForegroundImportLoop === true;
+  const foregroundPrioritySystemCompletionProcessed =
+    input.systemMailboxResult.foregroundPrioritySystemCompletionProcessed === true
+    || input.assistantResult.foregroundPrioritySystemCompletionProcessed === true;
   const afterCheckpoint = composeHostedAssistantPhaseAfterCheckpoint({
     callbacks: [
       input.systemMailboxResult.afterCheckpoint,
@@ -3866,6 +3869,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
         : {}),
       checkpointReason: progressedResult.checkpointReason,
       ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
+      ...(foregroundPrioritySystemCompletionProcessed
+        ? { foregroundPrioritySystemCompletionProcessed: true }
+        : {}),
       ...(invocationLocalAssistantWakeAt
         ? { invocationLocalAssistantWakeAt }
         : {}),
@@ -3885,6 +3891,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
       : {}),
     ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
     ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
+    ...(foregroundPrioritySystemCompletionProcessed
+      ? { foregroundPrioritySystemCompletionProcessed: true }
+      : {}),
     ...(invocationLocalAssistantWakeAt
       ? { invocationLocalAssistantWakeAt }
       : {}),
@@ -4310,6 +4319,17 @@ function isPhoneCallResultSystemMailboxPreparation(
     && preparation.item.wake.kind === "assistant.notification.requested"
     && preparation.item.mailboxDedupeKey.startsWith(
       HOSTED_PHONE_CALL_RESULT_MAILBOX_DEDUPE_KEY_PREFIX,
+    );
+}
+
+function isForegroundPrioritySystemCompletionProcessed(
+  preparation: HostedSystemMailboxPreparation,
+): boolean {
+  return preparation.status === "processed"
+    && preparation.item.routeAction === "dispatch-assistant-notification"
+    && preparation.item.wake.kind === "assistant.notification.requested"
+    && HOSTED_PRE_CHECKPOINT_EXTERNAL_COMPLETION_DEDUPE_KEY_PREFIXES.some(
+      (prefix) => preparation.item.mailboxDedupeKey.startsWith(prefix),
     );
 }
 
@@ -5940,6 +5960,8 @@ async function runSystemMailboxMaintenancePhase(input: {
     || systemMailboxPreparation.status === "recording";
   const browserVaultReplicaRefreshRequested =
     isBrowserVaultReplicaRefreshSystemMailboxPreparation(systemMailboxPreparation);
+  const foregroundPrioritySystemCompletionProcessed =
+    isForegroundPrioritySystemCompletionProcessed(systemMailboxPreparation);
   const shouldRunPostSystemCheckpoint = shouldRecordSystemMailbox
     || cleanupPlan.requiresCheckpoint
     || (dirtyDeviceSyncMetrics?.postCheckpointRecord ?? null) !== null;
@@ -6002,6 +6024,9 @@ async function runSystemMailboxMaintenancePhase(input: {
     result: mergeMemberPreferencesPrePlanningResult({
       ...(browserVaultReplicaRefreshRequested
         ? { browserVaultReplicaRefreshRequested: true }
+        : {}),
+      ...(foregroundPrioritySystemCompletionProcessed
+        ? { foregroundPrioritySystemCompletionProcessed: true }
         : {}),
       ...(shouldRunPostSystemCheckpoint
         ? {

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -280,6 +280,10 @@ interface HostedWorkspaceRunnerAssistantPhaseResultBase {
   // ran the foreground assistant reply phase; selected-prefix repair uses it
   // to distinguish clean completion from retryable reply work.
   foregroundReplyFailed?: number | null;
+  // Ephemeral provenance for one successfully processed, foreground-priority
+  // system completion in this pass. The outer runtime combines this with the
+  // pass dirty bit before advancing its idle-checkpoint activity ordinal.
+  foregroundPrioritySystemCompletionProcessed?: true;
   // Ephemeral provenance for an assistant wake created by work selected in
   // this invocation. This is never persisted; the runner and outer hot-wake
   // gate use it instead of inferring ownership from a merged wake timestamp.

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -36817,6 +36817,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: false,
+      checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "no-signal reconciliation",
     },
@@ -36824,6 +36825,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: true,
       checkpointConversationInputAhead: true,
       checkpointRuntimeWake: false,
+      checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "conversation input hint",
     },
@@ -36831,6 +36833,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: true,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: true,
+      checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "retained checkpoint wake",
     },
@@ -36838,14 +36841,24 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: false,
+      checkpointSystemControl: false,
       generatedImageRetention: true,
       handoff: "no-signal reconciliation after a status commit",
+    },
+    {
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      checkpointSystemControl: true,
+      generatedImageRetention: false,
+      handoff: "system-only runtime control",
     },
   ])("older due assistant carry honors $handoff before persisting a later reminder", async (
     {
       checkpointConversation,
       checkpointConversationInputAhead,
       checkpointRuntimeWake,
+      checkpointSystemControl,
       generatedImageRetention,
     },
   ) => {
@@ -36967,8 +36980,21 @@ describe("hosted workspace runtime entrypoint", () => {
               }),
             };
           },
-          async importItem(item) {
+          async importItem(item, context) {
             events.push(`mailbox.importItem:${item.item.id}`);
+            if (item.item.lane === "system") {
+              return await importRuntimeControlSystemMailboxItemForTest({
+                item: item.item,
+                vaultRoot,
+              });
+            }
+            if (
+              item.item.id === "mailbox_item_entrypoint_assistant_carry_mask_003"
+              || item.item.id === "mailbox_item_entrypoint_assistant_carry_mask_004"
+            ) {
+              assert.ok(context?.onConversationInputStaged);
+              context.onConversationInputStaged("linq");
+            }
             return { status: "imported" };
           },
           platform: createPlatform({
@@ -37002,6 +37028,14 @@ describe("hosted workspace runtime entrypoint", () => {
                     mailboxItems.push(createMailboxItem({
                       id: "mailbox_item_entrypoint_assistant_carry_mask_003",
                       laneSeq: "3",
+                    }));
+                  }
+                  if (checkpointSystemControl) {
+                    mailboxItems.push(createMailboxItem({
+                      id: "mailbox_item_entrypoint_assistant_carry_mask_system_001",
+                      kind: "runtime.manual-requested",
+                      lane: "system",
+                      laneSeq: "1",
                     }));
                   }
                   olderWakePersisted.resolve();
@@ -37249,13 +37283,6 @@ describe("hosted workspace runtime entrypoint", () => {
           events[secondSnapshotIndex],
           `snapshot:2:idle_shutdown:${Date.parse(TEST_NOW) + idleCheckpointDelayMs}`,
         );
-        assert.equal(
-          events.slice(persistedDispatchIndex + 1).some((event) =>
-            event.startsWith("mailbox.importItem:")
-          ),
-          false,
-          events.join(","),
-        );
         const reconciliationAssistantIndex = events.findIndex((event) =>
           event.includes(`:${reconciliationWakeAt}:`)
         );
@@ -37264,6 +37291,22 @@ describe("hosted workspace runtime entrypoint", () => {
           events.join(","),
         );
         assert.ok(reconciliationAssistantIndex < secondSnapshotIndex, events.join(","));
+        const systemControlImportIndex = events.indexOf(
+          "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_system_001",
+        );
+        if (checkpointSystemControl) {
+          assert.ok(systemControlImportIndex > persistedDispatchIndex, events.join(","));
+          assert.ok(systemControlImportIndex < reconciliationAssistantIndex, events.join(","));
+        } else {
+          assert.equal(systemControlImportIndex, -1, events.join(","));
+          assert.equal(
+            events.slice(persistedDispatchIndex + 1).some((event) =>
+              event.startsWith("mailbox.importItem:")
+            ),
+            false,
+            events.join(","),
+          );
+        }
         return;
       }
       const firstForegroundAssistantIndex = events.findIndex((event) =>

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -7581,18 +7581,6 @@ describe("hosted workspace runtime entrypoint", () => {
           },
           async importItem(item) {
             events.push(`mailbox.importItem:${item.item.id}`);
-            if (
-              item.item.id
-                === "mailbox_item_entrypoint_assistant_carry_mask_002"
-            ) {
-              return {
-                assistantInputId: await stagePendingLinqAssistantInputForMailboxItem({
-                  item: item.item,
-                  vaultRoot,
-                }),
-                status: "imported",
-              };
-            }
             return { status: "imported" };
           },
           platform: createPlatform({
@@ -36847,9 +36835,7 @@ describe("hosted workspace runtime entrypoint", () => {
         laneSeq: "1",
       }),
     ];
-    const assistantPresentedWakeAts: string[] = [];
     let assistantPass = 0;
-    let completedNextWakeAt: string | null | undefined;
     let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
 
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
@@ -36918,7 +36904,6 @@ describe("hosted workspace runtime entrypoint", () => {
           async runAssistantPhase(input) {
             assistantPass += 1;
             const presentedWakeAt = input.workspace?.nextWakeAt ?? "none";
-            assistantPresentedWakeAts.push(presentedWakeAt);
             events.push(`assistant:${assistantPass}:${presentedWakeAt}:${Date.now()}`);
 
             if (assistantPass === 1) {
@@ -36958,10 +36943,7 @@ describe("hosted workspace runtime entrypoint", () => {
           signal: runtimeAbortController.signal,
           vaultRoot,
         },
-      ).then((result) => {
-        completedNextWakeAt = result.nextWakeAt;
-        return result;
-      });
+      );
 
       await withRealTimeout(
         olderWakeHotAttemptComplete.promise,
@@ -37001,32 +36983,19 @@ describe("hosted workspace runtime entrypoint", () => {
         events.join(","),
       );
 
-      await vi.advanceTimersByTimeAsync(5_000);
       await withRealTimeout(
         reminderWakePersisted.promise,
-        1_000,
+        15_000,
         () => events.join(","),
-      ).catch(() => undefined);
+      );
       const persistedWakes = checkpointRequests.map((request) => [
         request.nextWakeAt,
         request.nextWakeReason,
       ]);
-      assert.deepEqual(persistedWakes[0], [olderDueWakeAt, "assistant"]);
-      const reminderStillOwned =
-        completedNextWakeAt === reminderWakeAt
-        || assistantPresentedWakeAts.includes(reminderWakeAt)
-        || persistedWakes.some(([wakeAt, reason]) =>
-          wakeAt === reminderWakeAt && reason === "assistant"
-        );
-      assert.equal(
-        reminderStillOwned,
-        true,
-        `later reminder wake was masked: ${JSON.stringify({
-          assistantPresentedWakeAts,
-          completedNextWakeAt,
-          persistedWakes,
-        })}`,
-      );
+      assert.deepEqual(persistedWakes.slice(0, 2), [
+        [olderDueWakeAt, "assistant"],
+        [reminderWakeAt, "assistant"],
+      ]);
     } finally {
       runtimeAbortController.abort();
       vi.useRealTimers();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -37047,7 +37047,6 @@ describe("hosted workspace runtime entrypoint", () => {
               reminderCreated.resolve();
               return {
                 checkpointReason: "assistant_runtime_commit",
-                invocationLocalAssistantWakeAt: reminderWakeAt,
                 nextWakeAt: reminderWakeAt,
                 nextWakeReason: "assistant",
                 progressed: true,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -36811,10 +36811,31 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
-  test("older due assistant carry cannot mask a later reminder through an empty persisted-wake dispatch", async () => {
+  test.each([
+    {
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      handoff: "empty persisted-wake dispatch",
+    },
+    {
+      checkpointConversation: true,
+      checkpointConversationInputAhead: true,
+      checkpointRuntimeWake: false,
+      handoff: "conversation input hint",
+    },
+    {
+      checkpointConversation: true,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      handoff: "retained checkpoint wake",
+    },
+  ])("older due assistant carry yields to a $handoff before persisting a later reminder", async (
+    { checkpointConversation, checkpointConversationInputAhead, checkpointRuntimeWake },
+  ) => {
     // The predecessor already received its one hot attempt. A later reminder
-    // appears before checkpoint, then the predecessor's persisted dispatch
-    // reaches the same active invocation with empty mailboxes.
+    // appears before checkpoint; when conversation input arrives while that
+    // checkpoint commits, it must retain foreground priority.
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -36855,7 +36876,10 @@ describe("hosted workspace runtime entrypoint", () => {
         }),
         {
           async createCheckpointSnapshot(snapshotInput) {
-            events.push(`snapshot:${snapshotInput.reason}:${Date.now()}`);
+            events.push(
+              `snapshot:${checkpointRequests.length + 1}:`
+              + `${snapshotInput.reason}:${Date.now()}`,
+            );
             return {
               snapshotRef: createBundleRef({
                 hash: `${checkpointRequests.length + 1}`.repeat(64).slice(0, 64),
@@ -36877,7 +36901,7 @@ describe("hosted workspace runtime entrypoint", () => {
             }),
             workspacePort: createWorkspacePort({
               checkpointRequests,
-              checkpointWorkspace(request) {
+              checkpointResponse(request) {
                 const workspace = createWorkspaceState({
                   inboxMediaRetentionWakeAt: request.inboxMediaRetentionWakeAt ?? null,
                   nextWakeAt: request.nextWakeAt ?? null,
@@ -36888,13 +36912,27 @@ describe("hosted workspace runtime entrypoint", () => {
                 });
                 if (checkpointRequests.length === 1) {
                   events.push("runtime-wake:persisted-older-assistant");
+                  if (checkpointConversation) {
+                    mailboxItems.push(createMailboxItem({
+                      id: "mailbox_item_entrypoint_assistant_carry_mask_003",
+                      laneSeq: "3",
+                    }));
+                  }
                   olderWakePersisted.resolve();
-                  runtimeWakeSignal.notify(Date.now());
+                  if (checkpointRuntimeWake) {
+                    runtimeWakeSignal.notify(Date.now());
+                  }
                 }
                 if (request.nextWakeAt === reminderWakeAt) {
                   reminderWakePersisted.resolve();
                 }
-                return workspace;
+                return {
+                  conversationInputAhead:
+                    checkpointRequests.length === 1
+                    && checkpointConversationInputAhead,
+                  checkpointed: true,
+                  workspace,
+                };
               },
               events,
               workspace: createWorkspaceState({ version: "0" }),
@@ -36927,6 +36965,21 @@ describe("hosted workspace runtime entrypoint", () => {
               return {
                 checkpointReason: "assistant_runtime_commit",
                 invocationLocalAssistantWakeAt: reminderWakeAt,
+                nextWakeAt: reminderWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
+
+            if (assistantPass === 4) {
+              assert.ok(
+                events.includes(
+                  "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_003",
+                ),
+                events.join(","),
+              );
+              return {
+                checkpointReason: "assistant_runtime_commit",
                 nextWakeAt: reminderWakeAt,
                 nextWakeReason: "assistant",
                 progressed: true,
@@ -36966,22 +37019,6 @@ describe("hosted workspace runtime entrypoint", () => {
         "runtime-wake:persisted-older-assistant",
       );
       assert.notEqual(persistedDispatchIndex, -1, events.join(","));
-      assert.equal(
-        events.slice(persistedDispatchIndex + 1).some((event) =>
-          event.startsWith("mailbox.importItem:")
-        ),
-        false,
-        events.join(","),
-      );
-      // A source-blind empty wake still cannot authorize cron replay; the
-      // successor must survive at the existing wake owner instead.
-      assert.equal(
-        events.slice(persistedDispatchIndex + 1).some((event) =>
-          event.startsWith("assistant:")
-        ),
-        false,
-        events.join(","),
-      );
 
       await withRealTimeout(
         reminderWakePersisted.promise,
@@ -36996,6 +37033,42 @@ describe("hosted workspace runtime entrypoint", () => {
         [olderDueWakeAt, "assistant"],
         [reminderWakeAt, "assistant"],
       ]);
+      if (!checkpointConversation) {
+        assert.equal(
+          events.slice(persistedDispatchIndex + 1).some((event) =>
+            event.startsWith("mailbox.importItem:")
+          ),
+          false,
+          events.join(","),
+        );
+        assert.equal(
+          events.slice(persistedDispatchIndex + 1).some((event) =>
+            event.startsWith("assistant:")
+          ),
+          false,
+          events.join(","),
+        );
+        return;
+      }
+      const secondSnapshotIndex = events.findIndex((event) =>
+        event.startsWith("snapshot:2:")
+      );
+      const foregroundAssistantIndex = events.findIndex((event) =>
+        event.startsWith("assistant:4:")
+      );
+      assert.notEqual(secondSnapshotIndex, -1, events.join(","));
+      assert.notEqual(foregroundAssistantIndex, -1, events.join(","));
+      assert.ok(
+        requireEventIndex(
+          events,
+          "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_003",
+        ) < secondSnapshotIndex,
+        events.join(","),
+      );
+      assert.ok(
+        foregroundAssistantIndex < secondSnapshotIndex,
+        events.join(","),
+      );
     } finally {
       runtimeAbortController.abort();
       vi.useRealTimers();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -8009,10 +8009,16 @@ describe("hosted workspace runtime entrypoint", () => {
       const telegramPhoneResultHasPendingInput =
         completion.label === "generation-scoped phone-call result"
         && transport.channel === "telegram";
+      const completionRetriesOnce =
+        completion.label === "usage-referral reward"
+        && transport.channel === "linq";
       const requestId = `aask_req_${"a".repeat(64)}`;
       let activeVaultRoot = vaultRoot;
       let assistantPhaseCalls = 0;
+      let completionAuthorityAttempts = 0;
+      let completionProcessedPassObserved = false;
       let currentPhaseIsForegroundCausal = false;
+      let phaseNow = TEST_NOW;
       let newerPendingInputId: string | null = null;
       let providerDispatchWasForegroundCausal: boolean | null = null;
       const providerFetch = vi.fn<typeof fetch>(async (request, init) => {
@@ -8301,6 +8307,13 @@ describe("hosted workspace runtime entrypoint", () => {
                 async assertExternalThreadRouteAuthority(authority) {
                   assert.equal(completion.privateCompletion, false);
                   assert.equal(authority.threadId, transport.target);
+                  completionAuthorityAttempts += 1;
+                  if (
+                    completionRetriesOnce
+                    && completionAuthorityAttempts === 1
+                  ) {
+                    throw new Error("Synthetic retryable completion failure.");
+                  }
                 },
                 async assertLinqRecentInboundEngagement(request) {
                   assert.equal(request.target, transport.target);
@@ -8446,7 +8459,29 @@ describe("hosted workspace runtime entrypoint", () => {
                   vaultRoot: activeVaultRoot,
                 });
               }
-              const phaseResult = await runHostedWorkspaceAssistantPhase(input);
+              const phaseResult = await runHostedWorkspaceAssistantPhase({
+                ...input,
+                ...(completionRetriesOnce ? { now: () => phaseNow } : {}),
+              });
+              if (
+                phaseResult.redactedStatus
+                  ?.hostedSystemMailboxRetryableFailed === 1
+              ) {
+                assert.equal(completionRetriesOnce, true);
+                assert.equal(
+                  phaseResult.foregroundPrioritySystemCompletionProcessed,
+                  undefined,
+                );
+                phaseNow = new Date(
+                  Date.parse(phaseNow) + 60_000,
+                ).toISOString();
+                runtimeWakeSignal.notify(Date.parse(phaseNow));
+              }
+              if (
+                phaseResult.foregroundPrioritySystemCompletionProcessed === true
+              ) {
+                completionProcessedPassObserved = true;
+              }
               if (
                 telegramPhoneResultHasPendingInput
                 && assistantPhaseCalls === 2
@@ -8572,6 +8607,7 @@ describe("hosted workspace runtime entrypoint", () => {
           1,
           events.join(","),
         );
+        assert.equal(completionProcessedPassObserved, true, events.join(","));
         assert.ok(
           requireEventIndex(events, "outbox.completion.after-phase:sending")
             < requireEventIndex(events, providerEvent),
@@ -36867,12 +36903,23 @@ describe("hosted workspace runtime entrypoint", () => {
       generatedImageRetention: false,
       handoff: "trusted completion quiet window",
     },
+    {
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      checkpointTrustedCompletion: false,
+      checkpointTrustedCompletionRetry: true,
+      checkpointSystemControl: false,
+      generatedImageRetention: false,
+      handoff: "retried trusted completion quiet window",
+    },
   ])("older due assistant carry honors $handoff before persisting a later reminder", async (
     {
       checkpointConversation,
       checkpointConversationInputAhead,
       checkpointRuntimeWake,
       checkpointTrustedCompletion,
+      checkpointTrustedCompletionRetry,
       checkpointSystemControl,
       generatedImageRetention,
     },
@@ -36902,6 +36949,7 @@ describe("hosted workspace runtime entrypoint", () => {
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
     const trustedCompletionHandled = createDeferred<void>();
+    const trustedCompletionRetryFailed = createDeferred<void>();
     const firstCheckpointConversationHandled = createDeferred<void>();
     const secondCheckpointConversationHandled = createDeferred<void>();
     const mailboxItems = [
@@ -37000,6 +37048,10 @@ describe("hosted workspace runtime entrypoint", () => {
             events.push(`mailbox.importItem:${item.item.id}`);
             if (item.item.lane === "system") {
               if (item.item.kind === "assistant.notification.requested") {
+                if (checkpointTrustedCompletionRetry) {
+                  events.push("trusted-completion:retryable-failed");
+                  trustedCompletionRetryFailed.resolve();
+                }
                 return { status: "imported" };
               }
               return await importRuntimeControlSystemMailboxItemForTest({
@@ -37057,7 +37109,10 @@ describe("hosted workspace runtime entrypoint", () => {
                       laneSeq: "1",
                     }));
                   }
-                  if (checkpointTrustedCompletion) {
+                  if (
+                    checkpointTrustedCompletion
+                    && !checkpointTrustedCompletionRetry
+                  ) {
                     mailboxItems.push(createMailboxItem({
                       dedupeKey:
                         "assistant.notification.requested:phone-call-result:"
@@ -37101,7 +37156,7 @@ describe("hosted workspace runtime entrypoint", () => {
             events.push(`assistant:${assistantPass}:${presentedWakeAt}:${Date.now()}`);
 
             const handlesTrustedCompletion =
-              checkpointTrustedCompletion
+              (checkpointTrustedCompletion || checkpointTrustedCompletionRetry)
               && events.includes(
                 "mailbox.importItem:"
                 + "mailbox_item_entrypoint_assistant_carry_mask_"
@@ -37111,9 +37166,15 @@ describe("hosted workspace runtime entrypoint", () => {
             if (handlesTrustedCompletion) {
               events.push("trusted-completion:handled");
               trustedCompletionHandled.resolve();
+              if (checkpointTrustedCompletionRetry) {
+                reminderReconciled = true;
+              }
               return {
                 checkpointReason: "assistant_runtime_commit",
-                nextWakeAt: reconciliationWakeAt,
+                foregroundPrioritySystemCompletionProcessed: true,
+                nextWakeAt: checkpointTrustedCompletionRetry
+                  ? reminderWakeAt
+                  : reconciliationWakeAt,
                 nextWakeReason: "assistant",
                 progressed: true,
               };
@@ -37158,6 +37219,20 @@ describe("hosted workspace runtime entrypoint", () => {
                 vaultRoot: input.restored.vaultRoot,
               });
               reminderCreated.resolve();
+              if (checkpointTrustedCompletionRetry) {
+                mailboxItems.push(createMailboxItem({
+                  dedupeKey:
+                    "assistant.notification.requested:usage-referral-reward:"
+                    + "assistant_carry_mask_retry",
+                  id:
+                    "mailbox_item_entrypoint_assistant_carry_mask_"
+                    + "trusted_completion_001",
+                  kind: "assistant.notification.requested",
+                  lane: "system",
+                  laneSeq: "1",
+                }));
+                runtimeWakeSignal.notify(Date.now());
+              }
               return {
                 checkpointReason: "assistant_runtime_commit",
                 nextWakeAt: reconciliationWakeAt,
@@ -37184,7 +37259,11 @@ describe("hosted workspace runtime entrypoint", () => {
               };
             }
 
-            if (checkpointConversation || checkpointTrustedCompletion) {
+            if (
+              checkpointConversation
+              || checkpointTrustedCompletion
+              || checkpointTrustedCompletionRetry
+            ) {
               const handlingSecondConversation = events.includes(
                 "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_004",
               );
@@ -37240,6 +37319,13 @@ describe("hosted workspace runtime entrypoint", () => {
       await waitForFakeTimerScheduled(() => events.join(","));
       await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
       await withRealTimeout(olderWakePersisted.promise, 15_000, () => events.join(","));
+      if (checkpointTrustedCompletionRetry) {
+        await withRealTimeout(
+          trustedCompletionRetryFailed.promise,
+          15_000,
+          () => events.join(","),
+        );
+      }
       if (generatedImageRetention) {
         assert.deepEqual(
           (await readHostedSystemMailboxState(vaultRoot)).pending,
@@ -37276,7 +37362,7 @@ describe("hosted workspace runtime entrypoint", () => {
       );
       assert.notEqual(persistedDispatchIndex, -1, events.join(","));
 
-      if (checkpointTrustedCompletion) {
+      if (checkpointTrustedCompletion || checkpointTrustedCompletionRetry) {
         await withRealTimeout(
           trustedCompletionHandled.promise,
           15_000,
@@ -37366,7 +37452,7 @@ describe("hosted workspace runtime entrypoint", () => {
         event.startsWith("snapshot:2:")
       );
       assert.notEqual(secondSnapshotIndex, -1, events.join(","));
-      if (checkpointTrustedCompletion) {
+      if (checkpointTrustedCompletion || checkpointTrustedCompletionRetry) {
         const trustedCompletionImportIndex = requireEventIndex(
           events,
           "mailbox.importItem:"
@@ -37378,11 +37464,32 @@ describe("hosted workspace runtime entrypoint", () => {
           "trusted-completion:handled",
         );
         const reconciliationAssistantIndex = events.findIndex((event) =>
-          event.includes(`:${reconciliationWakeAt}:`)
+          event.startsWith("assistant:")
+          && event.includes(`:${reconciliationWakeAt}:`)
         );
-        assert.ok(trustedCompletionImportIndex > persistedDispatchIndex, events.join(","));
+        if (checkpointTrustedCompletionRetry) {
+          assert.ok(
+            trustedCompletionImportIndex < persistedDispatchIndex,
+            events.join(","),
+          );
+        } else {
+          assert.ok(
+            trustedCompletionImportIndex > persistedDispatchIndex,
+            events.join(","),
+          );
+        }
         assert.ok(trustedCompletionHandledIndex > trustedCompletionImportIndex, events.join(","));
-        assert.ok(reconciliationAssistantIndex >= trustedCompletionHandledIndex, events.join(","));
+        if (checkpointTrustedCompletionRetry) {
+          assert.ok(
+            reconciliationAssistantIndex < trustedCompletionHandledIndex,
+            events.join(","),
+          );
+        } else {
+          assert.ok(
+            reconciliationAssistantIndex >= trustedCompletionHandledIndex,
+            events.join(","),
+          );
+        }
         assert.ok(reconciliationAssistantIndex < secondSnapshotIndex, events.join(","));
         assert.ok(
           requireEventIndex(

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -36850,6 +36850,8 @@ describe("hosted workspace runtime entrypoint", () => {
     const olderWakePersisted = createDeferred<void>();
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
+    const firstCheckpointConversationHandled = createDeferred<void>();
+    const secondCheckpointConversationHandled = createDeferred<void>();
     const mailboxItems = [
       createMailboxItem({
         id: "mailbox_item_entrypoint_assistant_carry_mask_001",
@@ -36971,13 +36973,21 @@ describe("hosted workspace runtime entrypoint", () => {
               };
             }
 
-            if (assistantPass === 4) {
+            if (assistantPass === 4 || assistantPass === 5) {
+              const expectedMailboxItemId = assistantPass === 4
+                ? "mailbox_item_entrypoint_assistant_carry_mask_003"
+                : "mailbox_item_entrypoint_assistant_carry_mask_004";
               assert.ok(
                 events.includes(
-                  "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_003",
+                  `mailbox.importItem:${expectedMailboxItemId}`,
                 ),
                 events.join(","),
               );
+              if (assistantPass === 4) {
+                firstCheckpointConversationHandled.resolve();
+              } else {
+                secondCheckpointConversationHandled.resolve();
+              }
               return {
                 checkpointReason: "assistant_runtime_commit",
                 nextWakeAt: reminderWakeAt,
@@ -37020,6 +37030,43 @@ describe("hosted workspace runtime entrypoint", () => {
       );
       assert.notEqual(persistedDispatchIndex, -1, events.join(","));
 
+      if (checkpointConversation) {
+        await withRealTimeout(
+          firstCheckpointConversationHandled.promise,
+          15_000,
+          () => events.join(","),
+        );
+        await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+        await waitForFakeTimerScheduled(() => events.join(","));
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        mailboxItems.push(createMailboxItem({
+          id: "mailbox_item_entrypoint_assistant_carry_mask_004",
+          laneSeq: "4",
+        }));
+        runtimeWakeSignal.notify(Date.now());
+        await withRealTimeout(
+          secondCheckpointConversationHandled.promise,
+          15_000,
+          () => events.join(","),
+        );
+        await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+        await waitForFakeTimerScheduled(() => events.join(","));
+
+        await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs - 1);
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+        await vi.advanceTimersByTimeAsync(1);
+      }
+
       await withRealTimeout(
         reminderWakePersisted.promise,
         15_000,
@@ -37033,7 +37080,15 @@ describe("hosted workspace runtime entrypoint", () => {
         [olderDueWakeAt, "assistant"],
         [reminderWakeAt, "assistant"],
       ]);
+      const secondSnapshotIndex = events.findIndex((event) =>
+        event.startsWith("snapshot:2:")
+      );
+      assert.notEqual(secondSnapshotIndex, -1, events.join(","));
       if (!checkpointConversation) {
+        assert.equal(
+          events[secondSnapshotIndex],
+          `snapshot:2:idle_shutdown:${Date.parse(TEST_NOW) + idleCheckpointDelayMs}`,
+        );
         assert.equal(
           events.slice(persistedDispatchIndex + 1).some((event) =>
             event.startsWith("mailbox.importItem:")
@@ -37050,14 +37105,20 @@ describe("hosted workspace runtime entrypoint", () => {
         );
         return;
       }
-      const secondSnapshotIndex = events.findIndex((event) =>
-        event.startsWith("snapshot:2:")
-      );
-      const foregroundAssistantIndex = events.findIndex((event) =>
+      const firstForegroundAssistantIndex = events.findIndex((event) =>
         event.startsWith("assistant:4:")
       );
-      assert.notEqual(secondSnapshotIndex, -1, events.join(","));
-      assert.notEqual(foregroundAssistantIndex, -1, events.join(","));
+      const secondForegroundAssistantIndex = events.findIndex((event) =>
+        event.startsWith("assistant:5:")
+      );
+      assert.notEqual(firstForegroundAssistantIndex, -1, events.join(","));
+      assert.notEqual(secondForegroundAssistantIndex, -1, events.join(","));
+      assert.equal(
+        events[secondSnapshotIndex],
+        `snapshot:2:idle_shutdown:${
+          Date.parse(TEST_NOW) + idleCheckpointDelayMs + 1_000 + idleCheckpointDelayMs
+        }`,
+      );
       assert.ok(
         requireEventIndex(
           events,
@@ -37066,7 +37127,18 @@ describe("hosted workspace runtime entrypoint", () => {
         events.join(","),
       );
       assert.ok(
-        foregroundAssistantIndex < secondSnapshotIndex,
+        firstForegroundAssistantIndex < secondSnapshotIndex,
+        events.join(","),
+      );
+      assert.ok(
+        requireEventIndex(
+          events,
+          "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_004",
+        ) < secondSnapshotIndex,
+        events.join(","),
+      );
+      assert.ok(
+        secondForegroundAssistantIndex < secondSnapshotIndex,
         events.join(","),
       );
     } finally {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -7581,6 +7581,18 @@ describe("hosted workspace runtime entrypoint", () => {
           },
           async importItem(item) {
             events.push(`mailbox.importItem:${item.item.id}`);
+            if (
+              item.item.id
+                === "mailbox_item_entrypoint_assistant_carry_mask_002"
+            ) {
+              return {
+                assistantInputId: await stagePendingLinqAssistantInputForMailboxItem({
+                  item: item.item,
+                  vaultRoot,
+                }),
+                status: "imported",
+              };
+            }
             return { status: "imported" };
           },
           platform: createPlatform({
@@ -36806,6 +36818,218 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(result.nextWakeAt, null);
     } finally {
       foregroundAfterCheckpointGate.resolve();
+      await resultPromise?.catch(() => undefined);
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("older due assistant carry cannot mask a later reminder through an empty persisted-wake dispatch", async () => {
+    // The predecessor already received its one hot attempt. A later reminder
+    // appears before checkpoint, then the predecessor's persisted dispatch
+    // reaches the same active invocation with empty mailboxes.
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const idleCheckpointDelayMs = 180_000;
+    const olderDueWakeAt = TEST_NOW;
+    const reminderWakeAt = new Date(
+      Date.parse(TEST_NOW) + idleCheckpointDelayMs + 5_000,
+    ).toISOString();
+    const runtimeAbortController = new AbortController();
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    const olderWakeHotAttemptComplete = createDeferred<void>();
+    const olderWakePersisted = createDeferred<void>();
+    const reminderCreated = createDeferred<void>();
+    const reminderWakePersisted = createDeferred<void>();
+    const mailboxItems = [
+      createMailboxItem({
+        id: "mailbox_item_entrypoint_assistant_carry_mask_001",
+        laneSeq: "1",
+      }),
+    ];
+    const assistantPresentedWakeAts: string[] = [];
+    let assistantPass = 0;
+    let completedNextWakeAt: string | null | undefined;
+    let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
+
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+
+      resultPromise = runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_assistant_carry_mask",
+            idleCheckpointDelayMs,
+            leaseGeneration: "3",
+            userId: TEST_USER_ID,
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot(snapshotInput) {
+            events.push(`snapshot:${snapshotInput.reason}:${Date.now()}`);
+            return {
+              snapshotRef: createBundleRef({
+                hash: `${checkpointRequests.length + 1}`.repeat(64).slice(0, 64),
+                key:
+                  "users/bundles/member-synthetic/"
+                  + `assistant-carry-mask-${checkpointRequests.length + 1}.bundle.json`,
+                size: 512,
+              }),
+            };
+          },
+          async importItem(item) {
+            events.push(`mailbox.importItem:${item.item.id}`);
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({
+              events,
+              items: mailboxItems,
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              checkpointWorkspace(request) {
+                const workspace = createWorkspaceState({
+                  inboxMediaRetentionWakeAt: request.inboxMediaRetentionWakeAt ?? null,
+                  nextWakeAt: request.nextWakeAt ?? null,
+                  nextWakeReason: request.nextWakeReason ?? null,
+                  redactedStatus: request.redactedStatus ?? null,
+                  snapshotRef: request.snapshotRef,
+                  version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
+                });
+                if (checkpointRequests.length === 1) {
+                  events.push("runtime-wake:persisted-older-assistant");
+                  olderWakePersisted.resolve();
+                  runtimeWakeSignal.notify(Date.now());
+                }
+                if (request.nextWakeAt === reminderWakeAt) {
+                  reminderWakePersisted.resolve();
+                }
+                return workspace;
+              },
+              events,
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          runtimeWakeSignal,
+          async runAssistantPhase(input) {
+            assistantPass += 1;
+            const presentedWakeAt = input.workspace?.nextWakeAt ?? "none";
+            assistantPresentedWakeAts.push(presentedWakeAt);
+            events.push(`assistant:${assistantPass}:${presentedWakeAt}:${Date.now()}`);
+
+            if (assistantPass === 1) {
+              return {
+                checkpointReason: "assistant_runtime_commit",
+                invocationLocalAssistantWakeAt: olderDueWakeAt,
+                nextWakeAt: olderDueWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
+
+            if (assistantPass === 2) {
+              olderWakeHotAttemptComplete.resolve();
+              return { progressed: false };
+            }
+
+            if (assistantPass === 3) {
+              assert.equal(presentedWakeAt, "none");
+              reminderCreated.resolve();
+              return {
+                checkpointReason: "assistant_runtime_commit",
+                invocationLocalAssistantWakeAt: reminderWakeAt,
+                nextWakeAt: reminderWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
+
+            return {
+              checkpointReason: "assistant_runtime_commit",
+              nextWakeAt: null,
+              nextWakeReason: null,
+              progressed: true,
+            };
+          },
+          signal: runtimeAbortController.signal,
+          vaultRoot,
+        },
+      ).then((result) => {
+        completedNextWakeAt = result.nextWakeAt;
+        return result;
+      });
+
+      await withRealTimeout(
+        olderWakeHotAttemptComplete.promise,
+        15_000,
+        () => events.join(","),
+      );
+      await waitForFakeTimerScheduled(() => events.join(","));
+      mailboxItems.push(createMailboxItem({
+        id: "mailbox_item_entrypoint_assistant_carry_mask_002",
+        laneSeq: "2",
+      }));
+      runtimeWakeSignal.notify(Date.parse(TEST_NOW));
+      await withRealTimeout(reminderCreated.promise, 15_000, () => events.join(","));
+      await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+      await waitForFakeTimerScheduled(() => events.join(","));
+      await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
+      await withRealTimeout(olderWakePersisted.promise, 15_000, () => events.join(","));
+
+      const persistedDispatchIndex = events.indexOf(
+        "runtime-wake:persisted-older-assistant",
+      );
+      assert.notEqual(persistedDispatchIndex, -1, events.join(","));
+      assert.equal(
+        events.slice(persistedDispatchIndex + 1).some((event) =>
+          event.startsWith("mailbox.importItem:")
+        ),
+        false,
+        events.join(","),
+      );
+      // A source-blind empty wake still cannot authorize cron replay; the
+      // successor must survive at the existing wake owner instead.
+      assert.equal(
+        events.slice(persistedDispatchIndex + 1).some((event) =>
+          event.startsWith("assistant:")
+        ),
+        false,
+        events.join(","),
+      );
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await withRealTimeout(
+        reminderWakePersisted.promise,
+        1_000,
+        () => events.join(","),
+      ).catch(() => undefined);
+      const persistedWakes = checkpointRequests.map((request) => [
+        request.nextWakeAt,
+        request.nextWakeReason,
+      ]);
+      assert.deepEqual(persistedWakes[0], [olderDueWakeAt, "assistant"]);
+      const reminderStillOwned =
+        completedNextWakeAt === reminderWakeAt
+        || assistantPresentedWakeAts.includes(reminderWakeAt)
+        || persistedWakes.some(([wakeAt, reason]) =>
+          wakeAt === reminderWakeAt && reason === "assistant"
+        );
+      assert.equal(
+        reminderStillOwned,
+        true,
+        `later reminder wake was masked: ${JSON.stringify({
+          assistantPresentedWakeAts,
+          completedNextWakeAt,
+          persistedWakes,
+        })}`,
+      );
+    } finally {
+      runtimeAbortController.abort();
+      vi.useRealTimers();
       await resultPromise?.catch(() => undefined);
       await removeTempRoot(vaultRoot);
     }

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -36816,27 +36816,47 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: true,
+      generatedImageRetention: false,
       handoff: "empty persisted-wake dispatch",
     },
     {
       checkpointConversation: true,
       checkpointConversationInputAhead: true,
       checkpointRuntimeWake: false,
+      generatedImageRetention: false,
       handoff: "conversation input hint",
     },
     {
       checkpointConversation: true,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: true,
+      generatedImageRetention: false,
       handoff: "retained checkpoint wake",
     },
+    {
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      generatedImageRetention: true,
+      handoff: "empty persisted-wake dispatch after a status commit",
+    },
   ])("older due assistant carry yields to a $handoff before persisting a later reminder", async (
-    { checkpointConversation, checkpointConversationInputAhead, checkpointRuntimeWake },
+    {
+      checkpointConversation,
+      checkpointConversationInputAhead,
+      checkpointRuntimeWake,
+      generatedImageRetention,
+    },
   ) => {
     // The predecessor already received its one hot attempt. A later reminder
     // appears before checkpoint; when conversation input arrives while that
     // checkpoint commits, it must retain foreground priority.
-    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const workspaceRoot = await mkdtemp(
+      path.join(tmpdir(), "murph-workspace-entrypoint-"),
+    );
+    const sourceVaultRoot = path.join(workspaceRoot, "source-vault");
+    const vaultRoot = path.join(workspaceRoot, "live-vault");
+    const artifactBytesByHash = new Map<string, Uint8Array>();
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const idleCheckpointDelayMs = 180_000;
@@ -36850,6 +36870,7 @@ describe("hosted workspace runtime entrypoint", () => {
     const olderWakePersisted = createDeferred<void>();
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
+    const canonicalWriteObserved = createDeferred<HostedWorkspaceCheckpointRequest>();
     const firstCheckpointConversationHandled = createDeferred<void>();
     const secondCheckpointConversationHandled = createDeferred<void>();
     const mailboxItems = [
@@ -36859,12 +36880,58 @@ describe("hosted workspace runtime entrypoint", () => {
       }),
     ];
     let assistantPass = 0;
+    let snapshotCount = 0;
     let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
 
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
       vi.setSystemTime(new Date(TEST_NOW));
-      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      let initialSnapshotRef: HostedWorkspaceState["snapshotRef"] = null;
+      if (generatedImageRetention) {
+        const recordedAt = "2026-04-01T00:00:00.000Z";
+        const sourceImagePath = path.join(workspaceRoot, "generated-image-source.webp");
+        await initializeVault({ createdAt: recordedAt, vaultRoot: sourceVaultRoot });
+        await writeFile(sourceImagePath, "generated image bytes");
+        await addCaptureWithLookup({
+          attachments: [{ role: "media_1", sourcePath: sourceImagePath }],
+          draft: {
+            note: "Assistant-generated image saved for later visual reuse.",
+            occurredAt: recordedAt,
+            recordedAt,
+            source: "derived",
+            tags: ["assistant-generated-image", "generated-image"],
+            title: "Generated image",
+          },
+          lookupAttachmentRole: "media_1",
+          lookupKey: "generated:assistant-carry-status-commit",
+          rawImport: {
+            importKind: "capture",
+            importedAt: recordedAt,
+            provenance: {
+              family: "capture",
+              generatedImage: { schema: "murph.generated-image.v1" },
+              mediaCount: 1,
+            },
+            source: "murph.generate_image",
+          },
+          vaultRoot: sourceVaultRoot,
+        });
+        await rm(sourceImagePath);
+        const baseBundle = await snapshotHostedBundleRoots({
+          kind: "vault",
+          roots: [{ root: sourceVaultRoot, rootKey: "vault" }],
+        });
+        assert.ok(baseBundle);
+        const baseHash = sha256HostedBundleHex(baseBundle);
+        artifactBytesByHash.set(baseHash, baseBundle);
+        initialSnapshotRef = createBundleRef({
+          hash: baseHash,
+          key: `synthetic/assistant-carry-status-commit/${baseHash}.bundle`,
+          size: baseBundle.byteLength,
+        });
+      } else {
+        await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      }
 
       resultPromise = runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
@@ -36878,16 +36945,17 @@ describe("hosted workspace runtime entrypoint", () => {
         }),
         {
           async createCheckpointSnapshot(snapshotInput) {
+            snapshotCount += 1;
             events.push(
-              `snapshot:${checkpointRequests.length + 1}:`
+              `snapshot:${snapshotCount}:`
               + `${snapshotInput.reason}:${Date.now()}`,
             );
             return {
               snapshotRef: createBundleRef({
-                hash: `${checkpointRequests.length + 1}`.repeat(64).slice(0, 64),
+                hash: `${snapshotCount}`.repeat(64).slice(0, 64),
                 key:
                   "users/bundles/member-synthetic/"
-                  + `assistant-carry-mask-${checkpointRequests.length + 1}.bundle.json`,
+                  + `assistant-carry-mask-${snapshotCount}.bundle.json`,
                 size: 512,
               }),
             };
@@ -36897,6 +36965,7 @@ describe("hosted workspace runtime entrypoint", () => {
             return { status: "imported" };
           },
           platform: createPlatform({
+            artifactBytesByHash,
             mailboxPort: createMailboxPort({
               events,
               items: mailboxItems,
@@ -36912,7 +36981,16 @@ describe("hosted workspace runtime entrypoint", () => {
                   snapshotRef: request.snapshotRef,
                   version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
                 });
-                if (checkpointRequests.length === 1) {
+                if (request.reason === "canonical_runtime_commit") {
+                  events.push(
+                    `workspace.checkpoint:canonical_runtime_commit:${request.nextWakeAt ?? "none"}`,
+                  );
+                  canonicalWriteObserved.resolve(request);
+                }
+                const idleCheckpointCount = checkpointRequests.filter(
+                  (checkpointRequest) => checkpointRequest.reason === "idle_shutdown",
+                ).length;
+                if (request.reason === "idle_shutdown" && idleCheckpointCount === 1) {
                   events.push("runtime-wake:persisted-older-assistant");
                   if (checkpointConversation) {
                     mailboxItems.push(createMailboxItem({
@@ -36937,7 +37015,10 @@ describe("hosted workspace runtime entrypoint", () => {
                 };
               },
               events,
-              workspace: createWorkspaceState({ version: "0" }),
+              workspace: createWorkspaceState({
+                snapshotRef: initialSnapshotRef,
+                version: "0",
+              }),
             }),
           }),
           runtimeWakeSignal,
@@ -37023,7 +37104,29 @@ describe("hosted workspace runtime entrypoint", () => {
       await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
       await waitForFakeTimerScheduled(() => events.join(","));
       await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
+      if (generatedImageRetention) {
+        const canonicalWrite = await withRealTimeout(
+          canonicalWriteObserved.promise,
+          15_000,
+          () => events.join(","),
+        );
+        assert.equal(canonicalWrite.nextWakeAt, olderDueWakeAt);
+        assert.equal(canonicalWrite.nextWakeReason, "assistant");
+      }
       await withRealTimeout(olderWakePersisted.promise, 15_000, () => events.join(","));
+      if (generatedImageRetention) {
+        const firstSnapshotIndex = events.findIndex((event) =>
+          event.startsWith("snapshot:1:idle_shutdown:")
+        );
+        assert.notEqual(firstSnapshotIndex, -1, events.join(","));
+        assert.ok(
+          requireEventIndex(
+            events,
+            `workspace.checkpoint:canonical_runtime_commit:${olderDueWakeAt}`,
+          ) < firstSnapshotIndex,
+          events.join(","),
+        );
+      }
 
       const persistedDispatchIndex = events.indexOf(
         "runtime-wake:persisted-older-assistant",
@@ -37072,10 +37175,9 @@ describe("hosted workspace runtime entrypoint", () => {
         15_000,
         () => events.join(","),
       );
-      const persistedWakes = checkpointRequests.map((request) => [
-        request.nextWakeAt,
-        request.nextWakeReason,
-      ]);
+      const persistedWakes = checkpointRequests
+        .filter((request) => request.reason === "idle_shutdown")
+        .map((request) => [request.nextWakeAt, request.nextWakeReason]);
       assert.deepEqual(persistedWakes.slice(0, 2), [
         [olderDueWakeAt, "assistant"],
         [reminderWakeAt, "assistant"],
@@ -37145,7 +37247,7 @@ describe("hosted workspace runtime entrypoint", () => {
       runtimeAbortController.abort();
       vi.useRealTimers();
       await resultPromise?.catch(() => undefined);
-      await removeTempRoot(vaultRoot);
+      await removeTempRoot(workspaceRoot);
     }
   });
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -36817,6 +36817,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: false,
+      checkpointTrustedCompletion: false,
       checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "no-signal reconciliation",
@@ -36825,6 +36826,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: true,
       checkpointConversationInputAhead: true,
       checkpointRuntimeWake: false,
+      checkpointTrustedCompletion: false,
       checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "conversation input hint",
@@ -36833,6 +36835,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: true,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: true,
+      checkpointTrustedCompletion: false,
       checkpointSystemControl: false,
       generatedImageRetention: false,
       handoff: "retained checkpoint wake",
@@ -36841,6 +36844,7 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: false,
+      checkpointTrustedCompletion: false,
       checkpointSystemControl: false,
       generatedImageRetention: true,
       handoff: "no-signal reconciliation after a status commit",
@@ -36849,15 +36853,26 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
       checkpointRuntimeWake: true,
+      checkpointTrustedCompletion: false,
       checkpointSystemControl: true,
       generatedImageRetention: false,
       handoff: "system-only runtime control",
+    },
+    {
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: true,
+      checkpointTrustedCompletion: true,
+      checkpointSystemControl: false,
+      generatedImageRetention: false,
+      handoff: "trusted completion quiet window",
     },
   ])("older due assistant carry honors $handoff before persisting a later reminder", async (
     {
       checkpointConversation,
       checkpointConversationInputAhead,
       checkpointRuntimeWake,
+      checkpointTrustedCompletion,
       checkpointSystemControl,
       generatedImageRetention,
     },
@@ -36886,6 +36901,7 @@ describe("hosted workspace runtime entrypoint", () => {
     const olderWakePersisted = createDeferred<void>();
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
+    const trustedCompletionHandled = createDeferred<void>();
     const firstCheckpointConversationHandled = createDeferred<void>();
     const secondCheckpointConversationHandled = createDeferred<void>();
     const mailboxItems = [
@@ -36983,6 +36999,9 @@ describe("hosted workspace runtime entrypoint", () => {
           async importItem(item, context) {
             events.push(`mailbox.importItem:${item.item.id}`);
             if (item.item.lane === "system") {
+              if (item.item.kind === "assistant.notification.requested") {
+                return { status: "imported" };
+              }
               return await importRuntimeControlSystemMailboxItemForTest({
                 item: item.item,
                 vaultRoot,
@@ -37038,6 +37057,19 @@ describe("hosted workspace runtime entrypoint", () => {
                       laneSeq: "1",
                     }));
                   }
+                  if (checkpointTrustedCompletion) {
+                    mailboxItems.push(createMailboxItem({
+                      dedupeKey:
+                        "assistant.notification.requested:phone-call-result:"
+                        + "assistant_carry_mask:generation:1",
+                      id:
+                        "mailbox_item_entrypoint_assistant_carry_mask_"
+                        + "trusted_completion_001",
+                      kind: "assistant.notification.requested",
+                      lane: "system",
+                      laneSeq: "1",
+                    }));
+                  }
                   olderWakePersisted.resolve();
                   if (checkpointRuntimeWake) {
                     runtimeWakeSignal.notify(Date.now());
@@ -37067,6 +37099,25 @@ describe("hosted workspace runtime entrypoint", () => {
             assistantPass += 1;
             const presentedWakeAt = input.workspace?.nextWakeAt ?? "none";
             events.push(`assistant:${assistantPass}:${presentedWakeAt}:${Date.now()}`);
+
+            const handlesTrustedCompletion =
+              checkpointTrustedCompletion
+              && events.includes(
+                "mailbox.importItem:"
+                + "mailbox_item_entrypoint_assistant_carry_mask_"
+                + "trusted_completion_001",
+              )
+              && !events.includes("trusted-completion:handled");
+            if (handlesTrustedCompletion) {
+              events.push("trusted-completion:handled");
+              trustedCompletionHandled.resolve();
+              return {
+                checkpointReason: "assistant_runtime_commit",
+                nextWakeAt: reconciliationWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
 
             if (assistantPass === 1) {
               return {
@@ -37133,7 +37184,7 @@ describe("hosted workspace runtime entrypoint", () => {
               };
             }
 
-            if (checkpointConversation) {
+            if (checkpointConversation || checkpointTrustedCompletion) {
               const handlingSecondConversation = events.includes(
                 "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_004",
               );
@@ -37225,6 +37276,43 @@ describe("hosted workspace runtime entrypoint", () => {
       );
       assert.notEqual(persistedDispatchIndex, -1, events.join(","));
 
+      if (checkpointTrustedCompletion) {
+        await withRealTimeout(
+          trustedCompletionHandled.promise,
+          15_000,
+          () => events.join(","),
+        );
+        await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+        await waitForFakeTimerScheduled(() => events.join(","));
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        mailboxItems.push(createMailboxItem({
+          id: "mailbox_item_entrypoint_assistant_carry_mask_004",
+          laneSeq: "3",
+        }));
+        runtimeWakeSignal.notify(Date.now());
+        await withRealTimeout(
+          secondCheckpointConversationHandled.promise,
+          15_000,
+          () => events.join(","),
+        );
+        await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+        await waitForFakeTimerScheduled(() => events.join(","));
+
+        await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs - 1);
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+        await vi.advanceTimersByTimeAsync(1);
+      }
+
       if (checkpointConversation) {
         await withRealTimeout(
           firstCheckpointConversationHandled.promise,
@@ -37278,6 +37366,42 @@ describe("hosted workspace runtime entrypoint", () => {
         event.startsWith("snapshot:2:")
       );
       assert.notEqual(secondSnapshotIndex, -1, events.join(","));
+      if (checkpointTrustedCompletion) {
+        const trustedCompletionImportIndex = requireEventIndex(
+          events,
+          "mailbox.importItem:"
+          + "mailbox_item_entrypoint_assistant_carry_mask_"
+          + "trusted_completion_001",
+        );
+        const trustedCompletionHandledIndex = requireEventIndex(
+          events,
+          "trusted-completion:handled",
+        );
+        const reconciliationAssistantIndex = events.findIndex((event) =>
+          event.includes(`:${reconciliationWakeAt}:`)
+        );
+        assert.ok(trustedCompletionImportIndex > persistedDispatchIndex, events.join(","));
+        assert.ok(trustedCompletionHandledIndex > trustedCompletionImportIndex, events.join(","));
+        assert.ok(reconciliationAssistantIndex >= trustedCompletionHandledIndex, events.join(","));
+        assert.ok(reconciliationAssistantIndex < secondSnapshotIndex, events.join(","));
+        assert.ok(
+          requireEventIndex(
+            events,
+            "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_004",
+          ) < secondSnapshotIndex,
+          events.join(","),
+        );
+        assert.equal(
+          events[secondSnapshotIndex],
+          `snapshot:2:idle_shutdown:${
+            Date.parse(TEST_NOW)
+            + idleCheckpointDelayMs
+            + 1_000
+            + idleCheckpointDelayMs
+          }`,
+        );
+        return;
+      }
       if (!checkpointConversation) {
         assert.equal(
           events[secondSnapshotIndex],

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -24705,7 +24705,7 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   }, 30_000);
 
-  test("admits a ready image completion before newly arrived conversation input", async () => {
+  test("accepts separately grouped ready image completions before newly arrived conversation input", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-image-completion-preemption-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -24713,16 +24713,28 @@ describe("hosted workspace runtime entrypoint", () => {
       id: "mailbox_item_image_completion_preemption_origin",
       laneSeq: "1",
     })];
-    const generatedMedia = {
-      alt: "Generated landscape",
-      contentType: "image/webp" as const,
-      filename: "generated-landscape.webp",
-      kind: "vault_image" as const,
-      ref: "raw/captures/2026/04/generated-landscape.webp",
-      sha256: "c".repeat(64),
-      sizeBytes: 18,
-      source: "gpt-image-2",
-    };
+    const generatedMedia = [
+      {
+        alt: "Generated landscape",
+        contentType: "image/webp" as const,
+        filename: "generated-landscape.webp",
+        kind: "vault_image" as const,
+        ref: "raw/captures/2026/04/generated-landscape.webp",
+        sha256: "c".repeat(64),
+        sizeBytes: 18,
+        source: "gpt-image-2",
+      },
+      {
+        alt: "Generated portrait",
+        contentType: "image/webp" as const,
+        filename: "generated-portrait.webp",
+        kind: "vault_image" as const,
+        ref: "raw/captures/2026/04/generated-portrait.webp",
+        sha256: "d".repeat(64),
+        sizeBytes: 20,
+        source: "gpt-image-2",
+      },
+    ];
     const imageReady = createDeferred<void>();
     const combinedPhaseObserved = createDeferred<void>();
     const runtimeAbortController = new AbortController();
@@ -24730,7 +24742,7 @@ describe("hosted workspace runtime entrypoint", () => {
     const originalAutomationPass =
       mocks.runAssistantAutomationPass.getMockImplementation();
     let assistantPhaseCalls = 0;
-    let completionInputId: string | null = null;
+    let completionInputIds: readonly string[] = [];
     let freshInputId: string | null = null;
     let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
 
@@ -24758,7 +24770,10 @@ describe("hosted workspace runtime entrypoint", () => {
           assistantPhaseCalls += 1;
           const providerInputDetails = await Promise.all(
             assistantInputIds.map(async (inputId) => {
-              const event = await readAssistantInputEvent({ inputId, vault: vaultRoot });
+              const event = await readAssistantInputEvent({
+                inputId,
+                vault: vaultRoot,
+              });
               return {
                 inputId,
                 payloadSchema: event?.sourceRef.kind === "hosted-mailbox"
@@ -24771,48 +24786,64 @@ describe("hosted workspace runtime entrypoint", () => {
           );
           assert.equal(
             assistantInputIds.length,
-            assistantPhaseCalls === 1 ? 1 : 2,
-            `provider turn ${assistantPhaseCalls}: ${JSON.stringify({ freshInputId, providerInputDetails })}`,
+            assistantPhaseCalls === 1 ? 1 : 3,
+            `provider turn ${assistantPhaseCalls}: ${JSON.stringify({
+              freshInputId,
+              providerInputDetails,
+            })}`,
           );
-          const releaseProviderInputs =
-            await input.beforeProviderAcceptedInputs?.({
-              turnId: "turn_hosted_runtime_test",
-              acceptedInputs: assistantInputIds.map((id) => ({
-                id,
-                source: "assistant-input" as const,
-              })),
-            });
+          const acceptedInputGroups = assistantPhaseCalls === 1
+            ? [assistantInputIds]
+            : assistantInputIds.map((assistantInputId) => [assistantInputId]);
+          const releaseProviderInputGroups = [];
+          for (const acceptedInputIds of acceptedInputGroups) {
+            releaseProviderInputGroups.push(
+              await input.beforeProviderAcceptedInputs?.({
+                turnId: "turn_hosted_runtime_test",
+                acceptedInputs: acceptedInputIds.map((id) => ({
+                  id,
+                  source: "assistant-input" as const,
+                })),
+              }),
+            );
+          }
 
           if (assistantPhaseCalls === 1) {
             const assistantInputId = assistantInputIds[0]!;
             const imageGenerationLauncher =
               input.executionContext?.hosted?.imageGenerationLauncher;
             assert.ok(imageGenerationLauncher);
-            assert.equal(
-              imageGenerationLauncher.launch({
-                continuationSessionId: "asst_image_completion_preemption",
-                operationId: "image_operation_completion_preemption",
-                originAssistantInputId: assistantInputId,
-                originAssistantInputIdExact: false,
-                scopeId: "session_image_completion_preemption",
-                async run() {
-                  await imageReady.promise;
-                  return {
-                    media: generatedMedia,
-                    runtimeIssue: null,
-                    savedImageRef: generatedMedia.ref,
-                  };
-                },
-              }),
-              "started",
-            );
+            for (const [index, media] of generatedMedia.entries()) {
+              assert.equal(
+                imageGenerationLauncher.launch({
+                  continuationSessionId:
+                    `asst_image_completion_preemption_${index + 1}`,
+                  operationId:
+                    `image_operation_completion_preemption_${index + 1}`,
+                  originAssistantInputId: assistantInputId,
+                  originAssistantInputIdExact: false,
+                  scopeId: `session_image_completion_preemption_${index + 1}`,
+                  async run() {
+                    await imageReady.promise;
+                    return {
+                      media,
+                      runtimeIssue: null,
+                      savedImageRef: media.ref,
+                    };
+                  },
+                }),
+                "started",
+              );
+            }
             imageReady.resolve();
             await withRealTimeout(
               (async () => {
                 while (
-                  imageGenerationLauncher.readStatus?.(
-                    "session_image_completion_preemption",
-                  ) !== "queued"
+                  generatedMedia.some((_media, index) =>
+                    imageGenerationLauncher.readStatus?.(
+                      `session_image_completion_preemption_${index + 1}`,
+                    ) !== "queued"
+                  )
                 ) {
                   await new Promise<void>((resolve) => setImmediate(resolve));
                 }
@@ -24827,19 +24858,24 @@ describe("hosted workspace runtime entrypoint", () => {
             }));
             runtimeWakeSignal.notify();
           } else if (assistantPhaseCalls === 2) {
-            completionInputId = assistantInputIds[0]!;
-            const completion = await readAssistantInputEvent({
-              inputId: completionInputId,
-              vault: vaultRoot,
-            });
-            assert.equal(
-              completion?.sourceRef.kind === "hosted-mailbox"
-                ? completion.sourceRef.payloadSchema
-                : null,
-              "murph.hosted-image-completion.v1",
-            );
+            completionInputIds = assistantInputIds.slice(0, 2);
+            for (const completionInputId of completionInputIds) {
+              const completion = await readAssistantInputEvent({
+                inputId: completionInputId,
+                vault: vaultRoot,
+              });
+              assert.equal(
+                completion?.sourceRef.kind === "hosted-mailbox"
+                  ? completion.sourceRef.payloadSchema
+                  : null,
+                "murph.hosted-image-completion.v1",
+              );
+            }
             assert.ok(freshInputId);
-            assert.deepEqual(assistantInputIds, [completionInputId, freshInputId]);
+            assert.deepEqual(assistantInputIds, [
+              ...completionInputIds,
+              freshInputId,
+            ]);
             combinedPhaseObserved.resolve();
           } else {
             throw new Error("Unexpected extra image completion preemption phase.");
@@ -24851,7 +24887,14 @@ describe("hosted workspace runtime entrypoint", () => {
               vaultRoot,
             });
           }
-          await releaseProviderInputs?.();
+          for (const releaseProviderInputs of releaseProviderInputGroups) {
+            await releaseProviderInputs?.();
+          }
+          if (assistantPhaseCalls === 2) {
+            runtimeAbortController.abort(
+              new DOMException("Synthetic test completed.", "AbortError"),
+            );
+          }
           return {
             currentTurnDeliveryIntentIds: [],
             nextWakeAt: null,
@@ -24923,7 +24966,9 @@ describe("hosted workspace runtime entrypoint", () => {
         15_000,
         () => events.join(","),
       );
+      await withRealTimeout(resultPromise, 15_000, () => events.join(","));
       assert.equal(assistantPhaseCalls, 2);
+      assert.equal(completionInputIds.length, 2);
     } finally {
       runtimeAbortController.abort(
         new DOMException("Synthetic test cleanup.", "AbortError"),

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -52,6 +52,7 @@ import {
   listAssistantOutboxIntents,
   markAssistantOutboxIntentSentById,
   readAssistantContextSnapshotState,
+  refreshAssistantContextSnapshotBestEffort,
   recordHostedMailboxAssistantInputItem,
   saveAssistantOutboxIntent,
   saveAssistantSession,
@@ -36815,9 +36816,9 @@ describe("hosted workspace runtime entrypoint", () => {
     {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
-      checkpointRuntimeWake: true,
+      checkpointRuntimeWake: false,
       generatedImageRetention: false,
-      handoff: "empty persisted-wake dispatch",
+      handoff: "no-signal reconciliation",
     },
     {
       checkpointConversation: true,
@@ -36836,11 +36837,11 @@ describe("hosted workspace runtime entrypoint", () => {
     {
       checkpointConversation: false,
       checkpointConversationInputAhead: false,
-      checkpointRuntimeWake: true,
+      checkpointRuntimeWake: false,
       generatedImageRetention: true,
-      handoff: "empty persisted-wake dispatch after a status commit",
+      handoff: "no-signal reconciliation after a status commit",
     },
-  ])("older due assistant carry yields to a $handoff before persisting a later reminder", async (
+  ])("older due assistant carry honors $handoff before persisting a later reminder", async (
     {
       checkpointConversation,
       checkpointConversationInputAhead,
@@ -36860,17 +36861,18 @@ describe("hosted workspace runtime entrypoint", () => {
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const idleCheckpointDelayMs = 180_000;
-    const olderDueWakeAt = TEST_NOW;
+    const olderDueWakeAt = new Date(Date.parse(TEST_NOW) - 60_000).toISOString();
+    const reconciliationWakeAt = TEST_NOW;
     const reminderWakeAt = new Date(
-      Date.parse(TEST_NOW) + idleCheckpointDelayMs + 5_000,
+      Date.parse(TEST_NOW) + 5 * 60_000,
     ).toISOString();
+    const reminderAutomationId = "automation_01JQ8PWXP5A68SQM1W0GYM41V7";
     const runtimeAbortController = new AbortController();
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
     const olderWakeHotAttemptComplete = createDeferred<void>();
     const olderWakePersisted = createDeferred<void>();
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
-    const canonicalWriteObserved = createDeferred<HostedWorkspaceCheckpointRequest>();
     const firstCheckpointConversationHandled = createDeferred<void>();
     const secondCheckpointConversationHandled = createDeferred<void>();
     const mailboxItems = [
@@ -36880,6 +36882,7 @@ describe("hosted workspace runtime entrypoint", () => {
       }),
     ];
     let assistantPass = 0;
+    let reminderReconciled = false;
     let snapshotCount = 0;
     let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
 
@@ -36890,7 +36893,7 @@ describe("hosted workspace runtime entrypoint", () => {
       if (generatedImageRetention) {
         const recordedAt = "2026-04-01T00:00:00.000Z";
         const sourceImagePath = path.join(workspaceRoot, "generated-image-source.webp");
-        await initializeVault({ createdAt: recordedAt, vaultRoot: sourceVaultRoot });
+        await initializeVault({ createdAt: TEST_NOW, vaultRoot: sourceVaultRoot });
         await writeFile(sourceImagePath, "generated image bytes");
         await addCaptureWithLookup({
           attachments: [{ role: "media_1", sourcePath: sourceImagePath }],
@@ -36917,6 +36920,10 @@ describe("hosted workspace runtime entrypoint", () => {
           vaultRoot: sourceVaultRoot,
         });
         await rm(sourceImagePath);
+        assert.deepEqual(
+          (await readHostedSystemMailboxState(sourceVaultRoot)).pending,
+          [],
+        );
         const baseBundle = await snapshotHostedBundleRoots({
           kind: "vault",
           roots: [{ root: sourceVaultRoot, rootKey: "vault" }],
@@ -36985,7 +36992,6 @@ describe("hosted workspace runtime entrypoint", () => {
                   events.push(
                     `workspace.checkpoint:canonical_runtime_commit:${request.nextWakeAt ?? "none"}`,
                   );
-                  canonicalWriteObserved.resolve(request);
                 }
                 const idleCheckpointCount = checkpointRequests.filter(
                   (checkpointRequest) => checkpointRequest.reason === "idle_shutdown",
@@ -37008,7 +37014,8 @@ describe("hosted workspace runtime entrypoint", () => {
                 }
                 return {
                   conversationInputAhead:
-                    checkpointRequests.length === 1
+                    request.reason === "idle_shutdown"
+                    && idleCheckpointCount === 1
                     && checkpointConversationInputAhead,
                   checkpointed: true,
                   workspace,
@@ -37044,7 +37051,46 @@ describe("hosted workspace runtime entrypoint", () => {
 
             if (assistantPass === 3) {
               assert.equal(presentedWakeAt, "none");
+              await upsertAutomation({
+                automationId: reminderAutomationId,
+                continuityPolicy: "fresh",
+                instructions: "Send the scheduled reminder.",
+                now: new Date(TEST_NOW),
+                route: {
+                  channel: "linq",
+                  deliveryTarget: "synthetic_direct_chat",
+                  identityId: null,
+                  participantId: null,
+                  threadId: "synthetic_direct_chat",
+                  threadIsDirect: true,
+                },
+                schedule: {
+                  at: reminderWakeAt,
+                  kind: "at",
+                },
+                status: "active",
+                title: "Synthetic reminder",
+                vaultRoot: input.restored.vaultRoot,
+              });
               reminderCreated.resolve();
+              return {
+                checkpointReason: "assistant_runtime_commit",
+                nextWakeAt: reconciliationWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
+
+            if (presentedWakeAt === reconciliationWakeAt) {
+              if (generatedImageRetention) {
+                const refresh = await refreshAssistantContextSnapshotBestEffort({
+                  now: () => new Date(Date.now()).toISOString(),
+                  vaultRoot: input.restored.vaultRoot,
+                });
+                assert.equal(refresh.refreshed, true);
+                assert.deepEqual(refresh.pendingDirtyDomains, []);
+              }
+              reminderReconciled = true;
               return {
                 checkpointReason: "assistant_runtime_commit",
                 nextWakeAt: reminderWakeAt,
@@ -37053,24 +37099,29 @@ describe("hosted workspace runtime entrypoint", () => {
               };
             }
 
-            if (assistantPass === 4 || assistantPass === 5) {
-              const expectedMailboxItemId = assistantPass === 4
-                ? "mailbox_item_entrypoint_assistant_carry_mask_003"
-                : "mailbox_item_entrypoint_assistant_carry_mask_004";
+            if (checkpointConversation) {
+              const handlingSecondConversation = events.includes(
+                "mailbox.importItem:mailbox_item_entrypoint_assistant_carry_mask_004",
+              );
+              const expectedMailboxItemId = handlingSecondConversation
+                ? "mailbox_item_entrypoint_assistant_carry_mask_004"
+                : "mailbox_item_entrypoint_assistant_carry_mask_003";
               assert.ok(
                 events.includes(
                   `mailbox.importItem:${expectedMailboxItemId}`,
                 ),
                 events.join(","),
               );
-              if (assistantPass === 4) {
-                firstCheckpointConversationHandled.resolve();
-              } else {
+              if (handlingSecondConversation) {
                 secondCheckpointConversationHandled.resolve();
+              } else {
+                firstCheckpointConversationHandled.resolve();
               }
               return {
                 checkpointReason: "assistant_runtime_commit",
-                nextWakeAt: reminderWakeAt,
+                nextWakeAt: reminderReconciled
+                  ? reminderWakeAt
+                  : reconciliationWakeAt,
                 nextWakeReason: "assistant",
                 progressed: true,
               };
@@ -37103,17 +37154,25 @@ describe("hosted workspace runtime entrypoint", () => {
       await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
       await waitForFakeTimerScheduled(() => events.join(","));
       await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
-      if (generatedImageRetention) {
-        const canonicalWrite = await withRealTimeout(
-          canonicalWriteObserved.promise,
-          15_000,
-          () => events.join(","),
-        );
-        assert.equal(canonicalWrite.nextWakeAt, olderDueWakeAt);
-        assert.equal(canonicalWrite.nextWakeReason, "assistant");
-      }
       await withRealTimeout(olderWakePersisted.promise, 15_000, () => events.join(","));
       if (generatedImageRetention) {
+        assert.deepEqual(
+          (await readHostedSystemMailboxState(vaultRoot)).pending,
+          [],
+        );
+        const cronStatus = await getAssistantCronStatus(vaultRoot);
+        assert.equal(cronStatus.dueJobs, 0);
+        assert.equal(cronStatus.nextRunAt, reminderWakeAt);
+        const firstIdleCheckpointIndex = checkpointRequests.findIndex(
+          (request) => request.reason === "idle_shutdown",
+        );
+        const retentionCanonicalWrite = checkpointRequests
+          .slice(0, firstIdleCheckpointIndex)
+          .filter((request) => request.reason === "canonical_runtime_commit")
+          .at(-1);
+        assert.ok(retentionCanonicalWrite);
+        assert.equal(retentionCanonicalWrite.nextWakeAt, olderDueWakeAt);
+        assert.equal(retentionCanonicalWrite.nextWakeReason, "assistant");
         const firstSnapshotIndex = events.findIndex((event) =>
           event.startsWith("snapshot:1:idle_shutdown:")
         );
@@ -37172,7 +37231,7 @@ describe("hosted workspace runtime entrypoint", () => {
       await withRealTimeout(
         reminderWakePersisted.promise,
         15_000,
-        () => events.join(","),
+        () => JSON.stringify({ checkpointRequests, events }, null, 2),
       );
       const persistedWakes = checkpointRequests
         .filter((request) => request.reason === "idle_shutdown")
@@ -37197,23 +37256,28 @@ describe("hosted workspace runtime entrypoint", () => {
           false,
           events.join(","),
         );
-        assert.equal(
-          events.slice(persistedDispatchIndex + 1).some((event) =>
-            event.startsWith("assistant:")
-          ),
-          false,
+        const reconciliationAssistantIndex = events.findIndex((event) =>
+          event.includes(`:${reconciliationWakeAt}:`)
+        );
+        assert.ok(
+          reconciliationAssistantIndex > persistedDispatchIndex,
           events.join(","),
         );
+        assert.ok(reconciliationAssistantIndex < secondSnapshotIndex, events.join(","));
         return;
       }
       const firstForegroundAssistantIndex = events.findIndex((event) =>
         event.startsWith("assistant:4:")
       );
       const secondForegroundAssistantIndex = events.findIndex((event) =>
-        event.startsWith("assistant:5:")
+        event.startsWith("assistant:6:")
+      );
+      const reconciliationAssistantIndex = events.findIndex((event) =>
+        event.includes(`:${reconciliationWakeAt}:`)
       );
       assert.notEqual(firstForegroundAssistantIndex, -1, events.join(","));
       assert.notEqual(secondForegroundAssistantIndex, -1, events.join(","));
+      assert.notEqual(reconciliationAssistantIndex, -1, events.join(","));
       assert.equal(
         events[secondSnapshotIndex],
         `snapshot:2:idle_shutdown:${
@@ -37229,6 +37293,10 @@ describe("hosted workspace runtime entrypoint", () => {
       );
       assert.ok(
         firstForegroundAssistantIndex < secondSnapshotIndex,
+        events.join(","),
+      );
+      assert.ok(
+        reconciliationAssistantIndex < secondSnapshotIndex,
         events.join(","),
       );
       assert.ok(


### PR DESCRIPTION
## Why and outcome

A reminder created inside an active hosted invocation could be hidden for one idle-checkpoint window when an older due assistant wake still owned the workspace projection. This keeps the older wake's service barrier intact while retaining and promptly checkpointing the distinct later reminder, so it remains scheduled without another inbound message.

## Product UX

Effort: low. Walkthrough: Ready. This affects members who use scheduled reminders; delivery timing recovers without any new UI, copy, setup, or member action. Reminder lateness rules and foreground-message priority are unchanged.

## Architecture

The runtime reuses `pendingWakeAfterDueAssistantService`, its existing in-memory successor slot. When the foreground resolver must preserve an older due assistant wake that already received its exact hot service attempt, a distinct later assistant continuation is retained there. After the exact predecessor's hot attempt is checkpointed, the existing post-commit conversation hint and retained-wake paths run first. The successor is then promoted and immediately checkpointed through the same projection owner. Status-only canonical writes derive and carry that same exact predecessor key until the barrier checkpoint completes.

No scheduler, queue, persisted field, polling loop, dependency, database call, network call, or provider call was added. Patch shape: source +200/-31, tests +884/-58, docs/changelog +119; config/tooling/generated +0/-0.

## Evidence

- Production-shape regression performs the real canonical reminder write, observes its immediate cron-reconciliation wake, services that wake after the predecessor checkpoint, and persists the derived reminder deadline before sleeping. It covers no-signal, conversation-hint, retained-wake, real generated-image-retention status-commit, system-only runtime-control, and trusted-completion interleavings.
- A real expired generated-image retention write proves its canonical status checkpoint preserves the predecessor before snapshot one, then persists the successor in snapshot two.
- The production-shaped reminder omits invocation-local retry provenance; the separate assistant-phase contract tests remain green and the full entrypoint file passes 333 tests on the round 8 remediation head.
- Exact-head assistant-runtime typecheck: passed.
- Changelog archive tests: 19 passed; canonical web typecheck passed.
- Full pre-base-update assistant-runtime suite: 89 files passed; 2,375 tests passed and 4 skipped. Required exact-head CI owns the broad rerun.

## Risks

The wake/checkpoint path is production-critical. Existing outbox and durable-effect barriers remain ahead of assistant wake replacement, and an empty source-blind wake still cannot authorize scheduled work by itself. The change is protocol- and schema-compatible across Worker/container skew: old warm containers keep the previous behavior until recycled, while new containers retain the successor; rollback requires no data migration.

ReviewGPT context sensitivity: sensitive - production reminder scheduling and checkpoint ownership change.
ReviewGPT first-reviewed head: cfa7a46e00b35120eb0df1580f73a5f6bee8a919

## ReviewGPT

- Preliminary specialists: FINDINGS. Accepted one medium coverage gap. The regression now requires the successor checkpoint before the reminder due time, asserts predecessor then successor persistence, and deletes unreachable test scaffolding. Test-only correction; no runtime or architectural complexity added.
- Final round 1: FINDINGS. Accepted the foreground-priority ordering finding. The post-commit owner now runs the existing conversation hint or retained-wake path before the reminder follow-up checkpoint, retains only unconsumed wake classifications, and reasserts the existing immediate checkpoint timer afterward. No new state, queue, scheduler, or owner; one local helper centralizes the timer reset.
- Final round 2: RETROSPECTIVE_REQUIRED. Accepted the repeated checkpoint-ownership mechanism. The landed correction deletes the review-added immediate post-foreground timer override, keeps only the unconsumed wake-hint handoff, and leaves the existing foreground quiet-window timer as the sole checkpoint owner. The regression proves two rapid messages each run before snapshot two and reset that timer while the reminder remains retained. Source remediation is net -7 lines from round 2, with no replacement state or machinery.
- Rejected the rendered changelog screenshot gap as not applicable: this PR changes only changelog data, not presentation behavior; the preliminary frontend lens was not applicable and the changelog tests pass. No fix or complexity added.

## Changelog

- Changelog: updated
- Items: 2026-08-18 · reminders-keep-their-time

### Round 3 retrospective

The original requirement is unchanged: keep a later reminder durable when an older due assistant wake still owns the exact checkpoint barrier. The first-reviewed and current implementations both reuse the existing in-memory successor slot; review-driven source work has reordered existing post-checkpoint ownership and then deleted the competing timer override. Current source shape is +67/-5, far below the churn thresholds.

Round 3 found one more edge of the same requirement at an existing canonical-write boundary: a status-only image write can rebase the predecessor projection before the successor is promoted. The continuation decision is to keep this PR and derive the exact predecessor key from the existing barrier state at the two canonical-write call sites. This adds no state, owner, queue, scheduler, polling, or lifecycle mechanism. The correction was proved red-to-green through the real retention write path before it landed.

- Final round 3: FINDINGS. Accepted the canonical-write predecessor finding. The real retention path failed with a null canonical wake before the correction and now carries the exact predecessor before snapshot one, then checkpoints the held reminder in snapshot two. The landed fix derives an existing key at the two status-only write call sites; no new state, owner, queue, scheduler, polling, or lifecycle mechanism was added.

### Round 4 retrospective

The original requirement remains to preserve a later canonical reminder behind the exact older due-assistant checkpoint barrier. The current source shape before this correction is +67/-5; it still uses one existing successor slot and one existing checkpoint owner. Round 4 identified that the original successor branch and its synthetic regression shared the wrong eligibility signal: invocationLocalAssistantWakeAt represents a selected-input retry, while a normal reminder is the assistant phase's aggregate continuation.

The continuation decision is to keep the same architecture and replace that mismatched eligibility check with the already-produced assistant continuation before wake classes are blended. The regression deletes the fabricated invocation-local field and retains all predecessor/successor, foreground-priority, quiet-window, and canonical-write assertions. This adds no state, owner, queue, scheduler, polling, lifecycle, or fallback path.

- Final round 4: FINDINGS. Accepted the aggregate-reminder eligibility finding. Removing the fabricated invocation-local field reproduced successor loss in the two no-new-message variants. The landed correction derives the existing assistant continuation before wake classes are blended and retains it only behind the exact already-attempted predecessor. A full-suite conflict proved and added that exact-attempt guard; no new state, owner, timer, queue, scheduler, polling, lifecycle, or fallback path was added.

### Round 5 retrospective

The original requirement remains unchanged. Current source shape before this correction is +82/-5 and still uses the existing successor slot, exact predecessor key, cron-reconciliation owner, and idle-checkpoint timer. Round 5 found that the Round 4 correction retained the production aggregate continuation correctly but the regression still skipped its first real value: a canonical reminder write emits an immediate cron-reconciliation wake before reconciliation derives the final reminder time. Treating that due reconciliation wake as a future reminder added an unnecessary intermediate snapshot and recreated the lateness window.

The continuation decision is to keep the same owners and reorder the existing barrier-release path. A due held successor will run through the existing post-checkpoint assistant service path after conversation handoffs; its derived future reminder will use the already-satisfied barrier checkpoint deadline unless fresh conversation work actually resets the quiet window. The regression will perform a real canonical automation write and prove A -> reconcile -> B rather than manufacturing B directly. No state, owner, timer, queue, scheduler, polling, lifecycle, or fallback is added.

- Final round 5: FINDINGS. Accepted the review-induced immediate-reconciliation finding. The real canonical write reproduced A -> immediate reconciliation R -> reminder B; the landed correction services due R through the existing post-checkpoint foreground owner before snapshot two, then preserves the already-satisfied checkpoint deadline unless actual conversation work reset it. No new state, owner, timer, queue, scheduler, polling, lifecycle, or fallback path was added.



### Round 6 retrospective

The original requirement is still unchanged: after the exact older due-assistant barrier is checkpointed, only actual conversation work may earn a new quiet window before the canonical reminder successor is projected. The current source shape is +141/-24 and still reuses one successor slot, one post-checkpoint foreground owner, and the sole idle-checkpoint timer.

Round 6 identified a review-induced boundary error in the Round 5 ordering: the code captures the barrier deadline after earlier post-checkpoint mailbox handoffs. A system-only control row can therefore move that deadline even though no conversation was staged. The continuation decision is to keep the same architecture, capture the already-satisfied deadline before all post-checkpoint handoffs, and aggregate the existing conversation-staged fact across those handoffs. A real runtime.manual-requested system-lane regression must fail before any production correction lands. No new state owner, timer, queue, scheduler, polling, lifecycle, persisted field, or fallback is allowed.

- Final round 6: FINDINGS. Accepted the review-induced system-only timer-reset finding. An actual runtime.manual-requested system-lane item reproduced the extra quiet-window delay before the fix. The landed correction captures the already-satisfied barrier deadline before post-checkpoint handoffs and uses the existing conversation-staged callback to preserve a later deadline only when real conversation input arrived. The fifth interleaving is red-to-green and all four prior variants remain green. This adds one ephemeral observation counter, not a new state owner, timer, queue, scheduler, polling, lifecycle, persisted field, or fallback.

### Round 7 cap retrospective

The requirement and architecture remain unchanged at the seven-round cap: retain a later reminder behind the exact older due-assistant barrier while preserving established foreground priority. Current source shape is +155/-27. The correction still uses the existing successor slot, post-checkpoint foreground owner, and sole idle-checkpoint timer; it generalizes the one Round 6 ephemeral observation counter instead of adding another mechanism.

Round 7 found that the Round 6 observation was too narrow: an allowlisted trusted completion or accepted ready-image completion could correctly earn a new quiet window, but the subsequent reminder-reconciliation pass restored the old expired barrier deadline because no conversation message had been staged. A generation-scoped phone-call-result mailbox item reproduced the immediate second checkpoint before production code changed. The accepted correction gives those already-defined foreground-priority inputs the same observation as conversation input. System-only runtime control remains excluded. The six reminder interleavings are green, including a member reply immediately after the trusted completion, the full entrypoint file passes 332 tests, the two assistant wake invariants pass, and assistant-runtime typecheck passes.

- Final round 7: FINDINGS. Accepted the review-induced trusted-completion quiet-window finding. The regression failed with snapshot two starting at the completion instant and now waits through the completion/member-reply quiet window while still persisting reminder B. The production correction is two net source lines and adds no state owner, timer, queue, scheduler, polling, lifecycle, persisted field, network call, or fallback. Per the seven-round cap, the ReviewGPT loop is paused pending an explicit continuation decision before round 8.


### Round 8 retrospective

The requirement and architecture remain unchanged: preserve the canonical reminder successor behind the exact older due-assistant checkpoint barrier while allowing genuine foreground-priority work to earn the full idle floor. Current source shape is +199/-31. The correction still uses the existing successor slot, post-checkpoint foreground owner, sole idle-checkpoint timer, and one ephemeral activity ordinal.

Round 8 found a review-induced retry boundary in the Round 7 generalization. Importing an allowlisted completion advanced the ordinal before the completion actually ran. If that first execution failed retryably, the persisted retry could later succeed without another import, so the successful dirty pass had no activity observation and reminder reconciliation restored the expired predecessor deadline. The accepted correction removes import-time advancement and emits ephemeral success provenance from the existing system-mailbox phase; the outer owner advances the ordinal only when that pass is dirty. Ready-image completion observation now uses the same completed dirty-pass boundary. A real usage-referral mailbox attempt fails retryably, remains pending, and succeeds on retry; the timer regression is red-to-green across completion, reconciliation, a subsequent member message, and the 180-second floor. Generic system work and retryable failures remain excluded. No persisted field, new state owner, timer, queue, scheduler, polling, lifecycle, network call, or fallback was added.

- Final round 8: FINDINGS. Accepted the review-induced trusted-completion retry finding. The old code began snapshot two at the successful retry instant; the landed correction waits through the completion and member-message quiet windows. All 333 entrypoint tests, assistant-runtime typecheck, and assistant-runtime build pass on the remediation head.

### Round 9 retrospective

The requirement and architecture remain unchanged: retain the later canonical reminder behind the exact older due-assistant barrier while preserving every genuine foreground-priority quiet window. Current patch shape is source +200/-31, tests +884/-58, and docs/changelog +119/-0. The correction continues to use the existing successor slot, post-checkpoint foreground owner, sole idle-checkpoint timer, and ephemeral activity ordinal.

Round 9 found a separate ready-image batching edge in the Round 8 observation change. One assistant pass can accept ready image completions through separate provider groups. After the first group set the pass-level observation, `||=` short-circuited the later consumer call, leaving a terminal completion in the invocation-local ready batch and allowing a no-progress rerun loop. The accepted correction always drains each accepted group, then merges the consumed result into the existing pass-level boolean. It adds no state owner, timer, queue, scheduler, polling, lifecycle, persisted field, network call, or fallback.

- Final round 9: FINDINGS. Accepted the grouped ready-image completion finding. The regression now launches two real image operations, presents both completions ahead of newly arrived conversation input, and accepts each provider group separately. The focused regression passes, all 333 entrypoint tests pass, assistant-runtime typecheck passes, and the canonical remote `test:diff` succeeds on the exact frozen two-file candidate, including affected Cloudflare and Web verification.
