### PR TITLE
Recover queued device sync after stale assistant wakes

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
+++ b/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
@@ -48,14 +48,19 @@ continuation instead of the workspace repeating no-work checkpoints.
 ## Verification
 
 - `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-assistant-phase.test.ts`
-  passes all 298 focused assistant-phase tests.
+  passes all 299 focused assistant-phase tests, including no-work recovery,
+  fresh-input priority, real assistant-progress priority, and foreground yield.
 - `pnpm --dir packages/assistant-runtime typecheck` passes.
 - Product UX journeys: an idle member with a shadowed durable sync item resumes
   that item after a no-work assistant pass; fresh member input and actual
   assistant progress retain priority; no durable device item produces no
   synthetic sync work.
-- Exact pushed-head ReviewGPT, required CI, protected deployment, and production
-  convergence proof remain pending.
+- The first preliminary ReviewGPT result was `INVALID`: it requested a direct
+  assistant-progress regression and rendered proof for changed changelog copy.
+  The regression is added. The published copy is restored unchanged and this
+  PR now only appends its source reference, so there is no rendered UI claim.
+- Exact corrected-head ReviewGPT, required CI, protected deployment, and
+  production convergence proof remain pending.
 
 ## State
 

--- a/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
+++ b/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
@@ -1,0 +1,63 @@
+# Device Sync Assistant-Wake Starvation
+
+## Goal
+
+Restore queued hosted device-sync progress when an obsolete due assistant wake
+produces no assistant work. Success means foreground work retains priority, then
+one already-durable device-sync mailbox item can run and project its canonical
+continuation instead of the workspace repeating no-work checkpoints.
+
+## Evidence
+
+- The deployed bounded-resource fix advances connections that enter the device
+  lane, but a remaining production cohort repeatedly checkpoints without any
+  device-pass marker.
+- An affected workspace has queued device-sync mailbox work beyond its handled
+  system-lane frontier while its persisted wake remains assistant-labeled.
+- The assistant phase explicitly declines device maintenance for an
+  assistant-labeled wake, and the outer wake resolver preserves that due wake
+  after a no-progress assistant pass.
+- The idle-maintenance refactor removed the former post-assistant legacy
+  recovery path without adding an equivalent handoff for already-queued
+  canonical device-sync items.
+
+## Constraints
+
+- Preserve fresh conversation, accepted completion, and real due assistant work
+  ahead of device maintenance.
+- Execute only the existing canonical `device-sync.wake` mailbox owner; do not
+  add a scheduler, queue, persisted field, polling loop, or broad resync.
+- Keep provider payloads, member identifiers, and production row contents out
+  of code, tests, docs, logs, and PR artifacts.
+- Preserve the exact wake/checkpoint and mailbox completion fences.
+
+## Plan
+
+1. Add a focused production-shape regression for a due no-progress assistant
+   wake shadowing a queued device-sync mailbox item.
+2. After the assistant lane proves it has no current work, rerun the existing
+   system-mailbox phase with a background device-sync selection that preserves
+   the live foreground-yield hook.
+3. Merge the resulting checkpoint and wake through existing phase-result
+   composition and retain foreground-yield behavior.
+4. Run focused tests, assistant-runtime typecheck, scoped coverage verification,
+   ReviewGPT, required CI, and protected deployment.
+5. Confirm runtime device-pass markers and sync frontiers resume for the
+   affected production cohort.
+
+## Verification
+
+- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-assistant-phase.test.ts`
+  passes all 298 focused assistant-phase tests.
+- `pnpm --dir packages/assistant-runtime typecheck` passes.
+- Product UX journeys: an idle member with a shadowed durable sync item resumes
+  that item after a no-work assistant pass; fresh member input and actual
+  assistant progress retain priority; no durable device item produces no
+  synthetic sync work.
+- Exact pushed-head ReviewGPT, required CI, protected deployment, and production
+  convergence proof remain pending.
+
+## State
+
+Status: active
+Updated: 2026-08-18

--- a/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
+++ b/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
@@ -6,8 +6,8 @@
     "kind": "improvement",
     "priority": 4,
     "title": "Connected health updates keep moving",
-    "summary": "Default connected-health syncs now stay within a bounded health-data set, and queued updates resume after higher-priority conversation work instead of remaining stalled.",
-    "details": "Explicitly configured integrations keep their exact data selections, fresh messages still take priority over background sync, and existing consent and disconnect safeguards still apply.",
+    "summary": "Default connected-health syncs now stay within a bounded health-data set so new readings can continue arriving instead of getting stuck behind oversized catch-up work.",
+    "details": "Explicitly configured integrations keep their exact data selections, and existing consent and disconnect safeguards still apply.",
     "relevanceTags": ["connected-health", "wearables", "sync", "reliability"],
     "sourcePullRequests": [1980, 1984]
   }

--- a/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
+++ b/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 4,
     "title": "Connected health updates keep moving",
-    "summary": "Default connected-health syncs now stay within a bounded health-data set so new readings can continue arriving instead of getting stuck behind oversized catch-up work.",
-    "details": "Explicitly configured integrations keep their exact data selections, and existing consent and disconnect safeguards still apply.",
+    "summary": "Default connected-health syncs now stay within a bounded health-data set, and queued updates resume after higher-priority conversation work instead of remaining stalled.",
+    "details": "Explicitly configured integrations keep their exact data selections, fresh messages still take priority over background sync, and existing consent and disconnect safeguards still apply.",
     "relevanceTags": ["connected-health", "wearables", "sync", "reliability"],
-    "sourcePullRequests": [1980]
+    "sourcePullRequests": [1980, 1984]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -292,6 +292,12 @@ const HOSTED_POST_FOREGROUND_MEMBER_MAINTENANCE_WAKE_KINDS = [
   "member.activated",
   "member.action.requested",
 ] as const;
+const HOSTED_SHADOWED_DEVICE_SYNC_ROUTE_ACTIONS = [
+  "run-device-sync-wake",
+] as const;
+const HOSTED_SHADOWED_DEVICE_SYNC_WAKE_KINDS = [
+  "device-sync.wake",
+] as const;
 const HOSTED_GROUP_ROOM_MODEL_PRE_PLANNING_ROUTE_ACTIONS = [
   "initialize-group-room-model",
 ] as const;
@@ -2623,6 +2629,29 @@ export async function runHostedWorkspaceAssistantPhase(
         backgroundMaintenanceYielded
         || deferredPendingSystemMailboxMaintenance.backgroundMaintenanceYielded;
     }
+    const shadowedDeviceSyncMaintenance =
+      await runShadowedDeviceSyncAfterNoProgressAssistantWake({
+        assistantMetrics,
+        executionContext,
+        foregroundAssistantPass,
+        hasFreshConversationInput,
+        input,
+        systemMailboxMaintenance,
+        wake,
+      });
+    if (shadowedDeviceSyncMaintenance) {
+      continuingSystemMailboxDrainsProviderCleanup =
+        continuingSystemMailboxDrainsProviderCleanup
+        || shadowedDeviceSyncMaintenance.result?.checkpointReason === "outbox_sending";
+      continuingSystemMailboxResult = mergeHostedAssistantPhaseResults(
+        continuingSystemMailboxResult,
+        shadowedDeviceSyncMaintenance.result,
+      );
+      deviceSyncMaintenanceRan = deviceSyncMaintenanceRan
+        || shadowedDeviceSyncMaintenance.deviceSyncMaintenanceRan;
+      backgroundMaintenanceYielded = backgroundMaintenanceYielded
+        || shadowedDeviceSyncMaintenance.backgroundMaintenanceYielded;
+    }
     const deviceSyncFollowUpWake = await resolveHostedDeviceSyncFollowUpWake({
       deviceSyncMaintenanceRan,
       input,
@@ -4898,6 +4927,58 @@ async function runBackgroundMaintenanceAfterDeferredPendingAssistantInput(input:
   });
 }
 
+async function runShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
+  assistantMetrics: HostedAssistantMetrics;
+  executionContext: AssistantExecutionContext;
+  foregroundAssistantPass: boolean;
+  hasFreshConversationInput: boolean;
+  input: HostedWorkspaceRuntimeAssistantPhaseInput;
+  systemMailboxMaintenance: Awaited<ReturnType<typeof runSystemMailboxMaintenancePhase>>;
+  wake: ReturnType<typeof buildHostedExecutionRuntimeTimerWake>;
+}): Promise<Awaited<ReturnType<typeof runSystemMailboxMaintenancePhase>> | null> {
+  if (!shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input)) {
+    return null;
+  }
+
+  const maintenance = await runSystemMailboxMaintenancePhase({
+    backgroundRouteActions: HOSTED_SHADOWED_DEVICE_SYNC_ROUTE_ACTIONS,
+    backgroundWakeKinds: HOSTED_SHADOWED_DEVICE_SYNC_WAKE_KINDS,
+    executionContext: input.executionContext,
+    hasFreshConversationInput: false,
+    input: input.input,
+    pendingAssistantInputBlocksMaintenance: false,
+    pendingAssistantInputWakeAt: null,
+    wake: input.wake,
+  });
+  return maintenance.result ? maintenance : null;
+}
+
+function shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
+  assistantMetrics: HostedAssistantMetrics;
+  foregroundAssistantPass: boolean;
+  hasFreshConversationInput: boolean;
+  input: HostedWorkspaceRuntimeAssistantPhaseInput;
+  systemMailboxMaintenance: Awaited<ReturnType<typeof runSystemMailboxMaintenancePhase>>;
+}): boolean {
+  if (
+    input.hasFreshConversationInput
+    || input.foregroundAssistantPass
+    || input.systemMailboxMaintenance.pendingAssistantInputWakeAt !== null
+    || input.systemMailboxMaintenance.deviceSyncMaintenanceRan
+    || input.input.shouldYieldBackgroundMaintenance?.() === true
+    || !isDueHostedLegacyDeviceSyncRecoveryAlarm(input.input)
+  ) {
+    return false;
+  }
+
+  return (
+    input.assistantMetrics.activeTurnInputIngested !== true
+    && input.assistantMetrics.assistantAutomationProgressed !== true
+    && (input.assistantMetrics.assistantAutomationCurrentTurnDeliveryIntentIds?.length ?? 0)
+      === 0
+  );
+}
+
 function withPostForegroundMemberMaintenanceAfterCheckpoint(input: {
   executionContext: AssistantExecutionContext;
   input: HostedWorkspaceRuntimeAssistantPhaseInput;
@@ -5357,6 +5438,8 @@ function resolveDeferredPendingAssistantInputWakeAt(input: {
 }
 
 async function runSystemMailboxMaintenancePhase(input: {
+  backgroundRouteActions?: readonly HostedSystemMailboxRouteAction[];
+  backgroundWakeKinds?: readonly HostedExecutionSystemWake["kind"][];
   exclusiveRouteActions?: readonly HostedSystemMailboxRouteAction[];
   exclusiveWakeKinds?: readonly HostedExecutionSystemWake["kind"][];
   executionContext: AssistantExecutionContext;
@@ -5397,6 +5480,8 @@ async function runSystemMailboxMaintenancePhase(input: {
       });
   const hasExclusiveSelection = input.exclusiveRouteActions !== undefined
     || input.exclusiveWakeKinds !== undefined;
+  const hasBackgroundSelection = input.backgroundRouteActions !== undefined
+    || input.backgroundWakeKinds !== undefined;
   let foregroundCausalPreparation = hasExclusiveSelection
     ? await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: input.exclusiveRouteActions ?? null,
@@ -5570,6 +5655,7 @@ async function runSystemMailboxMaintenancePhase(input: {
   if (
     pendingAssistantInputBlocksMaintenance
     && !foregroundCausalAttempted
+    && !hasBackgroundSelection
     && shouldPreflightHostedAssistantCronWakeBeforeSystemMailbox(phaseInput)
   ) {
     const preflightAssistantCronWakeState = await readAssistantCronWakeState();
@@ -5618,6 +5704,12 @@ async function runSystemMailboxMaintenancePhase(input: {
 
   const systemMailboxPreparation = foregroundCausalPreparation
     ?? await prepareHostedSystemMailboxItemForCheckpoint({
+      ...(input.backgroundRouteActions
+        ? { allowedRouteActions: input.backgroundRouteActions }
+        : {}),
+      ...(input.backgroundWakeKinds
+        ? { allowedWakeKinds: input.backgroundWakeKinds }
+        : {}),
       executionContext: input.executionContext,
       operatorHomeRoot: phaseInput.restored.operatorHomeRoot,
       runtime: phaseInput.runtime,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2632,6 +2632,7 @@ export async function runHostedWorkspaceAssistantPhase(
     const shadowedDeviceSyncMaintenance =
       await runShadowedDeviceSyncAfterNoProgressAssistantWake({
         assistantMetrics,
+        assistantNextWakeAt,
         executionContext,
         foregroundAssistantPass,
         hasFreshConversationInput,
@@ -4929,6 +4930,7 @@ async function runBackgroundMaintenanceAfterDeferredPendingAssistantInput(input:
 
 async function runShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   assistantMetrics: HostedAssistantMetrics;
+  assistantNextWakeAt: string | null;
   executionContext: AssistantExecutionContext;
   foregroundAssistantPass: boolean;
   hasFreshConversationInput: boolean;
@@ -4955,6 +4957,7 @@ async function runShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
 
 function shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   assistantMetrics: HostedAssistantMetrics;
+  assistantNextWakeAt: string | null;
   foregroundAssistantPass: boolean;
   hasFreshConversationInput: boolean;
   input: HostedWorkspaceRuntimeAssistantPhaseInput;
@@ -4963,7 +4966,9 @@ function shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   if (
     input.hasFreshConversationInput
     || input.foregroundAssistantPass
+    || input.assistantNextWakeAt !== null
     || input.systemMailboxMaintenance.pendingAssistantInputWakeAt !== null
+    || input.systemMailboxMaintenance.result !== null
     || input.systemMailboxMaintenance.deviceSyncMaintenanceRan
     || input.input.shouldYieldBackgroundMaintenance?.() === true
     || !isDueHostedLegacyDeviceSyncRecoveryAlarm(input.input)

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -7160,6 +7160,160 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     expect("nextWakeReason" in result).toBe(false);
   });
 
+  it("services a queued device-sync wake after a legacy assistant alarm has no work", async () => {
+    const dueAt = "2026-04-27T00:00:00.000Z";
+    const deviceContinuationAt = "2026-04-27T00:05:00.000Z";
+    const shouldYieldBackgroundMaintenance = vi.fn(() => false);
+    const deviceSyncItem = {
+      ...createSystemMailboxItem(),
+      routeAction: "run-device-sync-wake" as const,
+      wake: {
+        eventId: "device-sync.wake:assistant-shadow-recovery",
+        kind: "device-sync.wake" as const,
+        occurredAt: dueAt,
+        reason: "reconcile_due" as const,
+        userId: "member_synthetic_phase",
+      },
+    };
+    mocks.getAssistantCronStatus
+      .mockResolvedValueOnce({
+        dueJobs: 1,
+        enabledJobs: 1,
+        nextRunAt: dueAt,
+        runningJobs: 0,
+        totalJobs: 1,
+      })
+      .mockResolvedValue({
+        dueJobs: 0,
+        enabledJobs: 1,
+        nextRunAt: "2026-04-28T00:00:00.000Z",
+        runningJobs: 0,
+        totalJobs: 1,
+      });
+    mocks.runHostedAssistantAutomationLane.mockResolvedValueOnce({
+      assistantAutomationProgressed: false,
+      assistantAutomationCurrentTurnDeliveryIntentIds: [],
+      deviceSyncProcessed: 0,
+      deviceSyncSkipped: true,
+      nextWakeAt: null,
+      parserProcessed: 0,
+      postCheckpointRecord: null,
+      progressed: false,
+      redactedLogEntries: [],
+    });
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+      item: deviceSyncItem,
+      itemId: "system_mailbox_item_assistant_shadow_recovery",
+      metrics: {
+        bootstrapResult: null,
+        conversationMetrics: null,
+        deviceSyncProcessed: 1,
+        deviceSyncSkipped: false,
+        mailboxLane: "device-sync",
+        nextWakeAt: deviceContinuationAt,
+        nextWakeReason: "device-sync.reconcile",
+        parserProcessed: 0,
+        postCheckpointRecord: null,
+        redactedLogEntries: [],
+      },
+      status: "processed",
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      importedCount: 0,
+      now: () => dueAt,
+      resolvedDeviceSync: {
+        providerConfigs: {
+          whoop: {
+            clientId: "synthetic-whoop-client",
+            clientSecret: "synthetic-whoop-secret",
+          },
+        },
+        publicBaseUrl: "https://device-sync.example.test",
+        secret: "synthetic-device-sync-secret",
+      },
+      shouldYieldBackgroundMaintenance,
+      workspace: createDueAssistantWorkspace(),
+    }));
+
+    expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedRouteActions: ["run-device-sync-wake"],
+        allowedWakeKinds: ["device-sync.wake"],
+        shouldYieldBackgroundMaintenance,
+      }),
+    );
+    expect(
+      mocks.runHostedAssistantAutomationLane.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.prepareHostedSystemMailboxItemForCheckpoint.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(result).toEqual(expect.objectContaining({
+      checkpointReason: "canonical_runtime_commit",
+      deviceSyncMaintenanceRan: true,
+      nextWakeAt: deviceContinuationAt,
+      nextWakeReason: "device-sync.reconcile",
+      progressed: true,
+    }));
+    await result.afterCheckpoint?.();
+    expect(mocks.recordHostedSystemMailboxItemAfterCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: deviceSyncItem,
+      }),
+    );
+  });
+
+  it("keeps queued device-sync recovery behind fresh assistant input", async () => {
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+      item: {
+        ...createSystemMailboxItem(),
+        routeAction: "run-device-sync-wake" as const,
+        wake: {
+          eventId: "device-sync.wake:fresh-input-priority",
+          kind: "device-sync.wake" as const,
+          occurredAt: "2026-04-27T00:00:00.000Z",
+          reason: "reconcile_due" as const,
+          userId: "member_synthetic_phase",
+        },
+      },
+      itemId: "system_mailbox_item_fresh_input_priority",
+      metrics: {
+        bootstrapResult: null,
+        conversationMetrics: null,
+        deviceSyncProcessed: 1,
+        deviceSyncSkipped: false,
+        mailboxLane: "device-sync",
+        nextWakeAt: "2026-04-27T00:05:00.000Z",
+        nextWakeReason: "device-sync.reconcile",
+        parserProcessed: 0,
+        postCheckpointRecord: null,
+        redactedLogEntries: [],
+      },
+      status: "processed",
+    });
+
+    await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      importedCount: 1,
+      now: () => "2026-04-27T00:00:00.000Z",
+      resolvedDeviceSync: {
+        providerConfigs: {
+          whoop: {
+            clientId: "synthetic-whoop-client",
+            clientSecret: "synthetic-device-sync-secret",
+          },
+        },
+        publicBaseUrl: "https://device-sync.example.test",
+        secret: "synthetic-device-sync-secret",
+      },
+      workspace: createDueAssistantWorkspace(),
+    }));
+
+    expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).not.toHaveBeenCalled();
+    expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
+  });
+
   it("does not run deferred device-sync work from an assistant-labeled wake", async () => {
     const shouldYieldBackgroundMaintenance = vi.fn(() => true);
     mocks.runHostedAssistantAutomationLane.mockResolvedValueOnce({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -7264,6 +7264,84 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     );
   });
 
+  it("keeps queued device-sync recovery behind real assistant progress", async () => {
+    const dueAt = "2026-04-27T00:00:00.000Z";
+    mocks.getAssistantCronStatus
+      .mockResolvedValueOnce({
+        dueJobs: 1,
+        enabledJobs: 1,
+        nextRunAt: dueAt,
+        runningJobs: 0,
+        totalJobs: 1,
+      })
+      .mockResolvedValue({
+        dueJobs: 0,
+        enabledJobs: 1,
+        nextRunAt: "2026-04-28T00:00:00.000Z",
+        runningJobs: 0,
+        totalJobs: 1,
+      });
+    mocks.runHostedAssistantAutomationLane.mockResolvedValueOnce({
+      assistantAutomationProgressed: true,
+      assistantAutomationCurrentTurnDeliveryIntentIds: [],
+      deviceSyncProcessed: 0,
+      deviceSyncSkipped: true,
+      nextWakeAt: null,
+      parserProcessed: 0,
+      postCheckpointRecord: null,
+      progressed: true,
+      redactedLogEntries: [],
+    });
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+      item: {
+        ...createSystemMailboxItem(),
+        routeAction: "run-device-sync-wake" as const,
+        wake: {
+          eventId: "device-sync.wake:assistant-progress-priority",
+          kind: "device-sync.wake" as const,
+          occurredAt: dueAt,
+          reason: "reconcile_due" as const,
+          userId: "member_synthetic_phase",
+        },
+      },
+      itemId: "system_mailbox_item_assistant_progress_priority",
+      metrics: {
+        bootstrapResult: null,
+        conversationMetrics: null,
+        deviceSyncProcessed: 1,
+        deviceSyncSkipped: false,
+        mailboxLane: "device-sync",
+        nextWakeAt: "2026-04-27T00:05:00.000Z",
+        nextWakeReason: "device-sync.reconcile",
+        parserProcessed: 0,
+        postCheckpointRecord: null,
+        redactedLogEntries: [],
+      },
+      status: "processed",
+    });
+
+    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+      importedCount: 0,
+      now: () => dueAt,
+      resolvedDeviceSync: {
+        providerConfigs: {
+          whoop: {
+            clientId: "synthetic-whoop-client",
+            clientSecret: "synthetic-whoop-secret",
+          },
+        },
+        publicBaseUrl: "https://device-sync.example.test",
+        secret: "synthetic-device-sync-secret",
+      },
+      workspace: createDueAssistantWorkspace(),
+    }));
+
+    expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).not.toHaveBeenCalled();
+    expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ progressed: true }));
+  });
+
   it("keeps queued device-sync recovery behind fresh assistant input", async () => {
     mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
       item: {


### PR DESCRIPTION
## Outcome

Queued connected-health sync work now resumes after an obsolete assistant wake produces no assistant work. Fresh member input and real assistant progress keep priority.

## Product UX

- An idle member with a shadowed durable sync item resumes that existing item after a no-work assistant pass.
- Fresh member messages stay ahead of background sync.
- No durable device item produces no synthetic sync or additional persisted state.
- No rendered visual is needed: this is a headless recovery path, and the published changelog copy is unchanged; only its source PR list changes.

## Evidence

- Focused assistant-phase suite: 299/299 passing, including fresh-input and real assistant-progress priority.
- Affected assistant-runtime package: 2,384 tests passing (4 skipped).
- Affected web app: 10,621 tests passing (490 skipped), typecheck, lint, dev smoke, and production build passing.
- Affected Cloudflare runner: 2,608 tests passing (2 skipped) and typecheck passing.
- Production evidence showed queued canonical device-sync items beyond handled frontiers while affected workspaces repeated assistant-labeled checkpoints without device-pass markers.

## Changelog

- Changelog: updated
- Items: 2026-08-18 · bounded-connected-health-sync

## Risk and deployment

This changes a hosted wake/checkpoint path. It executes only an already-durable canonical device-sync mailbox item, keeps the live foreground-yield hook, and adds no scheduler, queue, persisted field, or resync path.

The Cloudflare runtime change is backward-compatible with existing mailbox items and has no schema or environment change. Vercel serves only the independent changelog copy, so either skew order is safe; deploy Cloudflare promptly after merge. Rollback to the prior runner image remains safe. Post-deploy proof is a new device-pass marker plus handled-frontier advancement for the observed shadowed cohort.

ReviewGPT context sensitivity: sensitive — hosted wake ordering and durable mailbox completion fences are operationally sensitive.
ReviewGPT first-reviewed head: 8b1d1a385b8b070b03debbeae8d4e3f78116847a
