### PR TITLE
Complete stale assistant-wake device recovery

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
+++ b/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
@@ -65,9 +65,9 @@ continuation instead of the workspace repeating no-work checkpoints.
   unrelated maintenance when no device item matched. The follow-up removes the
   overly broad future-wake blocker, preserves that continuation through the
   existing wake merge, and makes background selection owner-only.
-- Pull request #1984 merged before those findings returned. A focused follow-up
-  pull request, its exact-head ReviewGPT and CI gates, protected deployment, and
-  production convergence proof remain pending.
+- Pull request #1984 merged before those findings returned. Follow-up pull
+  request #1985, its exact-head ReviewGPT and CI gates, protected deployment,
+  and production convergence proof remain pending.
 
 ## State
 

--- a/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
+++ b/agent-docs/exec-plans/active/2026-08-18-device-sync-assistant-wake-starvation.md
@@ -48,7 +48,8 @@ continuation instead of the workspace repeating no-work checkpoints.
 ## Verification
 
 - `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-assistant-phase.test.ts`
-  passes all 299 focused assistant-phase tests, including no-work recovery,
+  passes all 300 focused assistant-phase tests, including no-work recovery with
+  a preserved future assistant continuation, no-match owner isolation,
   fresh-input priority, real assistant-progress priority, and foreground yield.
 - `pnpm --dir packages/assistant-runtime typecheck` passes.
 - Product UX journeys: an idle member with a shadowed durable sync item resumes
@@ -59,7 +60,13 @@ continuation instead of the workspace repeating no-work checkpoints.
   assistant-progress regression and rendered proof for changed changelog copy.
   The regression is added. The published copy is restored unchanged and this
   PR now only appends its source reference, so there is no rendered UI claim.
-- Exact corrected-head ReviewGPT, required CI, protected deployment, and
+- The substantive preliminary ReviewGPT pass found that a future assistant
+  continuation still blocked recovery and that the selected fallback could run
+  unrelated maintenance when no device item matched. The follow-up removes the
+  overly broad future-wake blocker, preserves that continuation through the
+  existing wake merge, and makes background selection owner-only.
+- Pull request #1984 merged before those findings returned. A focused follow-up
+  pull request, its exact-head ReviewGPT and CI gates, protected deployment, and
   production convergence proof remain pending.
 
 ## State

--- a/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
+++ b/apps/web/changelog/entries/2026-08-18/bounded-connected-health-sync.json
@@ -9,6 +9,6 @@
     "summary": "Default connected-health syncs now stay within a bounded health-data set so new readings can continue arriving instead of getting stuck behind oversized catch-up work.",
     "details": "Explicitly configured integrations keep their exact data selections, and existing consent and disconnect safeguards still apply.",
     "relevanceTags": ["connected-health", "wearables", "sync", "reliability"],
-    "sourcePullRequests": [1980, 1984]
+    "sourcePullRequests": [1980, 1984, 1985]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2632,7 +2632,6 @@ export async function runHostedWorkspaceAssistantPhase(
     const shadowedDeviceSyncMaintenance =
       await runShadowedDeviceSyncAfterNoProgressAssistantWake({
         assistantMetrics,
-        assistantNextWakeAt,
         executionContext,
         foregroundAssistantPass,
         hasFreshConversationInput,
@@ -4930,7 +4929,6 @@ async function runBackgroundMaintenanceAfterDeferredPendingAssistantInput(input:
 
 async function runShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   assistantMetrics: HostedAssistantMetrics;
-  assistantNextWakeAt: string | null;
   executionContext: AssistantExecutionContext;
   foregroundAssistantPass: boolean;
   hasFreshConversationInput: boolean;
@@ -4957,7 +4955,6 @@ async function runShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
 
 function shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   assistantMetrics: HostedAssistantMetrics;
-  assistantNextWakeAt: string | null;
   foregroundAssistantPass: boolean;
   hasFreshConversationInput: boolean;
   input: HostedWorkspaceRuntimeAssistantPhaseInput;
@@ -4966,7 +4963,6 @@ function shouldRunShadowedDeviceSyncAfterNoProgressAssistantWake(input: {
   if (
     input.hasFreshConversationInput
     || input.foregroundAssistantPass
-    || input.assistantNextWakeAt !== null
     || input.systemMailboxMaintenance.pendingAssistantInputWakeAt !== null
     || input.systemMailboxMaintenance.result !== null
     || input.systemMailboxMaintenance.deviceSyncMaintenanceRan
@@ -5677,6 +5673,7 @@ async function runSystemMailboxMaintenancePhase(input: {
   }
 
   const memberPreferencesPrePlanning = foregroundCausalAttempted
+    || hasBackgroundSelection
     ? {
         continueAssistantLane: true,
         result: null,
@@ -5734,6 +5731,16 @@ async function runSystemMailboxMaintenancePhase(input: {
     && !foregroundCausalPreparationSelected;
   if (!hasPendingAssistantInputWakeOverride && !pendingAssistantInputWakeAt) {
     pendingAssistantInputWakeAt = await resolvePendingAssistantInputWakeAt(phaseInput);
+  }
+  if (!systemMailboxPreparation && hasBackgroundSelection) {
+    return {
+      backgroundMaintenanceYielded,
+      continueAssistantLane: false,
+      deviceSyncMaintenanceRan: false,
+      initialProviderCleanupCheckpoint,
+      pendingAssistantInputWakeAt,
+      result: null,
+    };
   }
   const shouldRunDirtyDeviceSyncWorkSource = shouldRunIdleDeviceSyncMaintenance({
     phaseInput,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.test.ts
@@ -7162,6 +7162,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
 
   it("services a queued device-sync wake after a legacy assistant alarm has no work", async () => {
     const dueAt = "2026-04-27T00:00:00.000Z";
+    const assistantContinuationAt = "2026-04-27T00:03:00.000Z";
     const deviceContinuationAt = "2026-04-27T00:05:00.000Z";
     const shouldYieldBackgroundMaintenance = vi.fn(() => false);
     const deviceSyncItem = {
@@ -7195,7 +7196,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
       assistantAutomationCurrentTurnDeliveryIntentIds: [],
       deviceSyncProcessed: 0,
       deviceSyncSkipped: true,
-      nextWakeAt: null,
+      nextWakeAt: assistantContinuationAt,
       parserProcessed: 0,
       postCheckpointRecord: null,
       progressed: false,
@@ -7252,16 +7253,108 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     expect(result).toEqual(expect.objectContaining({
       checkpointReason: "canonical_runtime_commit",
       deviceSyncMaintenanceRan: true,
-      nextWakeAt: deviceContinuationAt,
-      nextWakeReason: "device-sync.reconcile",
+      nextWakeAt: assistantContinuationAt,
       progressed: true,
     }));
+    expect("nextWakeReason" in result).toBe(false);
     await result.afterCheckpoint?.();
     expect(mocks.recordHostedSystemMailboxItemAfterCheckpoint).toHaveBeenCalledWith(
       expect.objectContaining({
         item: deviceSyncItem,
       }),
     );
+  });
+
+  it("leaves unrelated maintenance untouched when shadow recovery finds no device wake", async () => {
+    const dueAt = "2026-04-27T00:00:00.000Z";
+    const parentRoot = await mkdtemp(path.join(tmpdir(), "hosted-shadow-recovery-"));
+    const vaultRoot = path.join(parentRoot, "vault");
+    mocks.getAssistantCronStatus
+      .mockResolvedValueOnce({
+        dueJobs: 1,
+        enabledJobs: 1,
+        nextRunAt: dueAt,
+        runningJobs: 0,
+        totalJobs: 1,
+      })
+      .mockResolvedValue({
+        dueJobs: 0,
+        enabledJobs: 1,
+        nextRunAt: "2026-04-28T00:00:00.000Z",
+        runningJobs: 0,
+        totalJobs: 1,
+      });
+    mocks.runHostedAssistantAutomationLane.mockResolvedValueOnce({
+      assistantAutomationProgressed: false,
+      assistantAutomationCurrentTurnDeliveryIntentIds: [],
+      deviceSyncProcessed: 0,
+      deviceSyncSkipped: true,
+      nextWakeAt: null,
+      parserProcessed: 0,
+      postCheckpointRecord: null,
+      progressed: false,
+      redactedLogEntries: [],
+    });
+    mocks.queueHostedAssistantPendingMessageVolumeReceiptsForVault.mockResolvedValueOnce(1);
+
+    try {
+      await initializeVault({
+        createdAt: dueAt,
+        timezone: "America/New_York",
+        vaultRoot,
+      });
+      await writeHostedPhaseExperimentSource(vaultRoot);
+      await markAssistantContextSnapshotDirty({
+        domains: ["experiments"],
+        vaultRoot,
+      });
+
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        importedCount: 0,
+        now: () => dueAt,
+        resolvedDeviceSync: {
+          providerConfigs: {
+            whoop: {
+              clientId: "synthetic-whoop-client",
+              clientSecret: "synthetic-whoop-secret",
+            },
+          },
+          publicBaseUrl: "https://device-sync.example.test",
+          secret: "synthetic-device-sync-secret",
+        },
+        vaultRoot,
+        workspace: createDueAssistantWorkspace(),
+      }));
+
+      expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
+      expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).toHaveBeenCalledTimes(1);
+      expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedRouteActions: ["run-device-sync-wake"],
+          allowedWakeKinds: ["device-sync.wake"],
+        }),
+      );
+      expect(mocks.queueHostedAssistantPendingMessageVolumeReceiptsForVault)
+        .not.toHaveBeenCalled();
+      expect(mocks.resolveHostedSystemMailboxNextWakeCandidate).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedRouteActions: ["apply-member-preferences"],
+        }),
+      );
+      expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
+      expect("deviceSyncMaintenanceRan" in result).toBe(false);
+      expect(result.redactedStatus).toEqual(expect.objectContaining({
+        hostedSystemMailboxPrepared: 0,
+      }));
+      await expect(readAssistantContextSnapshotState(vaultRoot)).resolves.toMatchObject({
+        pendingDirtyDomains: ["experiments"],
+      });
+    } finally {
+      await rm(parentRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
   });
 
   it("keeps queued device-sync recovery behind real assistant progress", async () => {


### PR DESCRIPTION
## Outcome

- Allow queued device-sync work to resume after a no-progress legacy assistant wake even when a future assistant continuation exists.
- Keep the recovery selection strictly scoped to the canonical device mailbox owner when no device item matches.

## Product UX

- Idle connected-health updates resume without delaying fresh input, active assistant work, or future scheduled work.

## Evidence

- Focused assistant-phase suite: 300/300 passing.
- Assistant-runtime typecheck passes.
- Changelog registry and fragment suites: 45/45 passing.

## Changelog

- Changelog: updated
- Items: 2026-08-18 · bounded-connected-health-sync

## Risk

- Sensitive hosted scheduler path; no schema, environment, or Web ordering change. Protected Cloudflare deployment will use immediate container convergence and production frontier checks.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 2cdf77a387928c51d05c3a419580094e7affe810