### PR TITLE
Fix successful Vercel build completion

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-18-vercel-build-success-exit.md
+++ b/agent-docs/exec-plans/active/2026-08-18-vercel-build-success-exit.md
@@ -1,0 +1,92 @@
+# Restore Vercel build completion on Standard machines
+
+Status: active
+Created: 2026-08-18
+Updated: 2026-08-18
+
+## Goal
+
+- Let a successful hosted Web production build return immediately after the
+  package-build leader exits, while preserving whole-group termination for
+  timed-out, cancelled, and failed commands so Vercel Standard builders can
+  complete instead of waiting for the platform ceiling.
+
+## Success criteria
+
+- A configured deadline does not make a successful command reap or wait on a
+  residual descendant process.
+- Deadline, cancellation, and failed-command process-group cleanup remains
+  targeted at the owned group and covered by the supervisor tests.
+- Focused supervisor and production build-contract tests pass.
+- The required direct-main acceptance gate passes on the final reconciled
+  candidate.
+- The landed production deployment reaches Vercel's completed state; Standard
+  machine proof is captured when the project setting permits it.
+
+## Scope
+
+- In scope:
+  - `scripts/run-with-host-verification-slot.mjs` success-path ownership.
+  - A focused integration regression for a successful leader with a live
+    same-group descendant.
+- Out of scope:
+  - Next.js compiler, cache, and heap-policy changes.
+  - Vercel project machine-size configuration.
+  - Changes to non-production deadline admission.
+
+## Constraints
+
+- Technical constraints:
+  - Keep timeout and external-cancellation cleanup targeted at the exact
+    detached process group created by the supervisor.
+  - Preserve the successful command's exit status and shared-slot release.
+- Product/process constraints:
+  - Preserve unrelated primary-checkout work by implementing in the sanctioned
+    task worktree.
+  - Treat the build wrapper as a production deploy boundary and complete the
+    routed reliability review and verification gates.
+
+## Risks and mitigations
+
+1. Risk: Skipping cleanup too broadly could leave failed build descendants
+   running.
+   Mitigation: Exempt only clean exit code zero; retain reaping for timeout,
+   cancellation, signal, and nonzero exit paths.
+2. Risk: A timing-only regression could pass without proving the descendant
+   survived.
+   Mitigation: Capture the exact descendant PID, assert it remains alive after
+   the successful supervisor exit, then terminate that owned test process.
+
+## Tasks
+
+1. Add a failing clean-success residual-descendant regression.
+2. Restrict post-exit process-group reaping to unsuccessful or forced exits.
+3. Run focused syntax, supervisor, and production build-contract checks.
+4. Complete the routed review, reconcile the exact candidate, and run
+   `pnpm verify:acceptance` once for the direct-main attempt.
+5. Land the exact commit on `main` and monitor the production deployment.
+
+## Decisions
+
+- Keep the existing 15-minute production deadline and cold-Webpack memory
+  policy; live deployment evidence shows the application build itself completes
+  comfortably within the Standard-machine window.
+- Do not infer group liveness after a clean package-build exit as unfinished
+  application compilation. Vercel owns residual platform process cleanup once
+  the successful command returns.
+
+## Verification
+
+- Commands to run:
+  - `node --check scripts/run-with-host-verification-slot.mjs`
+  - `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/run-with-host-verification-slot.test.ts`
+  - Focused hosted Web production build-contract tests selected from the
+    current app test configuration.
+  - `pnpm verify:acceptance`
+- Expected outcomes:
+  - The clean-success regression proves the wrapper exits without signaling its
+    residual descendant.
+  - Existing timeout and cancellation tests continue proving full group
+    cleanup and their exact exit codes.
+  - Production build scripts retain the intended Webpack, cache, heap, migration,
+    and deadline contract.

--- a/scripts/run-with-host-verification-slot.mjs
+++ b/scripts/run-with-host-verification-slot.mjs
@@ -33,10 +33,11 @@ const OWNER_FILE_NAME = "owner.json";
 const invocationCwd = process.cwd();
 const invocation = parseInvocation(process.argv.slice(2));
 const useDetachedChildProcessGroup = process.platform !== "win32";
-// A configured command deadline arms whole-process-group ownership: the
-// deadline, KILL escalation, and post-exit group reaping all act on the one
-// detached group this supervisor already creates, so a wedged descendant
-// (for example a Webpack compiler worker) cannot outlive the command.
+// A configured command deadline arms whole-process-group termination: timeout,
+// cancellation, and failed-command cleanup act on the one detached group this
+// supervisor creates, so a wedged descendant (for example a Webpack compiler
+// worker) cannot outlive an unsuccessful command. A clean command exit returns
+// directly so platform-owned residual process state cannot stall completion.
 const commandTimeoutMs = useDetachedChildProcessGroup
   ? readPositiveInteger(process.env[COMMAND_TIMEOUT_ENV], 0)
   : 0;
@@ -269,10 +270,10 @@ async function runCommand(commandArgs, env) {
       clearTimeout(killTimer);
       reject(error);
     });
-    // The direct child's exit must not release process ownership yet: with a
-    // command deadline configured, a surviving descendant in the detached
-    // group is still owned work, and a termination signal arriving during
-    // reaping must keep targeting that group instead of exiting immediately.
+    // Classify the direct child's result before releasing process ownership.
+    // Unsuccessful commands still reap surviving descendants, and a
+    // termination signal arriving during that cleanup must keep targeting the
+    // detached group instead of exiting immediately.
     child.on("exit", (code, signal) => {
       clearTimeout(deadlineTimer);
       clearTimeout(killTimer);
@@ -280,8 +281,11 @@ async function runCommand(commandArgs, env) {
     });
   });
 
+  const commandSucceeded = forcedExitCode === null
+    && exitState.signal === null
+    && exitState.code === 0;
   try {
-    if (commandTimeoutMs > 0 && exitState.pid !== null) {
+    if (!commandSucceeded && commandTimeoutMs > 0 && exitState.pid !== null) {
       await reapCommandProcessGroup(exitState.pid);
     }
   } finally {

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -48,6 +48,19 @@ const exitingLeaderTreeSource = `
   process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
   setInterval(() => {}, 1000);
 `;
+// A successful leader can leave a platform-owned process-group member behind.
+// The supervisor must return the successful result instead of treating that
+// residual member as unfinished application work.
+const residualDescendantTreeSource = `
+  import { spawn } from "node:child_process";
+  const grandchild = spawn(process.execPath, [
+    "-e",
+    "setInterval(() => {}, 1000);",
+  ], { stdio: "ignore" });
+  grandchild.unref();
+  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
+  process.exitCode = Number(process.env.MURPH_TEST_LEADER_EXIT_CODE ?? "0");
+`;
 
 afterEach(async () => {
   for (const child of children) {
@@ -305,16 +318,38 @@ describe("shared-host verification slots", () => {
     expect(readdirSync(targetRoot)).toEqual(["marker.txt"]);
   });
 
-  it("preserves a child failure code and releases its slot", () => {
+  it("preserves a child failure code while reaping its residual process group", async () => {
     const stateRoot = makeTempRoot();
-    const result = runSync(
-      "failing child",
-      [process.execPath, "-e", "process.exit(7)"],
-      stateRoot,
-    );
+    const child = startCommand("failing command", stateRoot, residualDescendantTreeSource, {
+      MURPH_TEST_LEADER_EXIT_CODE: "7",
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
+    });
 
-    expect(result.status).toBe(7);
+    const [, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(grandchildPid);
+
+    expect(await waitForExit(child)).toBe(7);
+    await waitForOwnedProcessExit(grandchildPid);
     expect(readdirSync(stateRoot)).toEqual([]);
+  });
+
+  it("does not reap a residual process-group member after a successful command", async () => {
+    const stateRoot = makeTempRoot();
+    const child = startCommand("successful command", stateRoot, residualDescendantTreeSource, {
+      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
+      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
+    });
+
+    const [, grandchildPid] = await waitForPids(child);
+    ownedDescendantPids.add(grandchildPid);
+
+    expect(await waitForExit(child)).toBe(0);
+    expect(isProcessRunning(grandchildPid)).toBe(true);
+    expect(readdirSync(stateRoot)).toEqual([]);
+
+    process.kill(grandchildPid, "SIGTERM");
+    await waitForOwnedProcessExit(grandchildPid);
   });
 
   it("a configured command deadline reaps the whole process group", async () => {


### PR DESCRIPTION
## Why and outcome

A successful hosted Web build could finish its application command but remain stuck in post-exit process-group cleanup until the Vercel platform ceiling. Clean exit code zero now returns immediately, while timeout, cancellation, signal, and nonzero exits retain owned-group cleanup.

## Product UX

- Product UX: not applicable
- Reason: Internal deployment supervision only; no member-facing behavior or interface changes.

## Evidence

- Supervisor integration suite: 15 passed.
- Hosted Web production build contracts: 56 passed.
- Workspace wrapper suite: 33 passed.
- Syntax checks passed for the Node supervisor and production build shell entrypoints.

## Changelog

- Changelog: not applicable
- Reason: Internal Vercel build-process supervision only; no member-visible behavior changed.

## Risks

- This is a Web deploy-boundary change with no cross-service protocol or persisted-state skew.
- Rollback restores the prior post-success cleanup behavior and can restore the build hang.
- Post-deploy proof requires the package build to emit its terminal route check followed by Vercel Build Completed.

ReviewGPT context sensitivity: sensitive — changes the production Vercel build supervisor success path.
ReviewGPT first-reviewed head: 52f76a0828d00b0069b6bc3794531a9ecf6ac84a