### PR TITLE
fix(ci): simplify Vercel build ownership

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-18-vercel-build-success-exit.md
+++ b/agent-docs/exec-plans/active/2026-08-18-vercel-build-success-exit.md
@@ -1,4 +1,4 @@
-# Restore Vercel build completion on Standard machines
+# Simplify Vercel builds on Standard machines
 
 Status: active
 Created: 2026-08-18
@@ -6,17 +6,18 @@ Updated: 2026-08-18
 
 ## Goal
 
-- Let a successful hosted Web production build return immediately after the
-  package-build leader exits, while preserving whole-group termination for
-  timed-out, cancelled, and failed commands so Vercel Standard builders can
-  complete instead of waiting for the platform ceiling.
+- Give Next and Vercel sole ownership of the hosted Web production build:
+  compile Webpack in the Next CLI process and remove the production-only local
+  verification supervisor, deadline, and process-group reaper.
 
 ## Success criteria
 
-- A configured deadline does not make a successful command reap or wait on a
-  residual descendant process.
-- Deadline, cancellation, and failed-command process-group cleanup remains
-  targeted at the owned group and covered by the supervisor tests.
+- Production builds do not use the shared-host verification slot or custom
+  command deadlines.
+- The Workflow-customized Webpack build runs in the Next CLI process instead
+  of a separately forced build worker.
+- The local verification slot retains admission, status propagation, and
+  external-signal forwarding without production lifecycle behavior.
 - Focused supervisor and production build-contract tests pass.
 - The required direct-main acceptance gate passes on the final reconciled
   candidate.
@@ -26,20 +27,21 @@ Updated: 2026-08-18
 ## Scope
 
 - In scope:
-  - `scripts/run-with-host-verification-slot.mjs` success-path ownership.
-  - A focused integration regression for a successful leader with a live
-    same-group descendant.
+  - Hosted Web package, Vercel entrypoint, Next config, and production runner.
+  - Deletion of production deadline/reaper behavior from the local verification
+    slot.
+  - Focused build-contract and verification-slot regressions.
 - Out of scope:
-  - Next.js compiler, cache, and heap-policy changes.
   - Vercel project machine-size configuration.
-  - Changes to non-production deadline admission.
+  - Changes to shared-host slot admission.
 
 ## Constraints
 
 - Technical constraints:
-  - Keep timeout and external-cancellation cleanup targeted at the exact
-    detached process group created by the supervisor.
-  - Preserve the successful command's exit status and shared-slot release.
+  - Keep the cold Webpack cache policy that prevents the proven warm-cache OOM.
+  - Preserve explicit route-aware TypeScript validation before compilation.
+  - Keep Webpack and TypeScript heap limits sequential and within the Standard
+    builder's 8 GB boundary.
 - Product/process constraints:
   - Preserve unrelated primary-checkout work by implementing in the sanctioned
     task worktree.
@@ -48,32 +50,30 @@ Updated: 2026-08-18
 
 ## Risks and mitigations
 
-1. Risk: Skipping cleanup too broadly could leave failed build descendants
-   running.
-   Mitigation: Exempt only clean exit code zero; retain reaping for timeout,
-   cancellation, signal, and nonzero exit paths.
-2. Risk: A timing-only regression could pass without proving the descendant
-   survived.
-   Mitigation: Capture the exact descendant PID, assert it remains alive after
-   the successful supervisor exit, then terminate that owned test process.
+1. Risk: The in-process compiler could exhaust its heap.
+   Mitigation: Give the single compiler the previously proven 3 GiB worker
+   budget, retain Next's memory optimizations and cold Webpack cache, and prove
+   the exact path locally and on a Standard deployment.
+2. Risk: Removing the supervisor could weaken local verification admission.
+   Mitigation: Keep the slot's local admission and signal-forwarding behavior
+   intact and run its focused suite.
 
 ## Tasks
 
-1. Add a failing clean-success residual-descendant regression.
-2. Restrict post-exit process-group reaping to unsuccessful or forced exits.
-3. Run focused syntax, supervisor, and production build-contract checks.
-4. Complete the routed review, reconcile the exact candidate, and run
-   `pnpm verify:acceptance` once for the direct-main attempt.
-5. Land the exact commit on `main` and monitor the production deployment.
+1. Remove the production wrapper and timeout environment contract.
+2. Delete deadline/reaper machinery from the local verification slot.
+3. Let Next's custom-Webpack default keep compilation in-process and use one
+   compiler heap budget.
+4. Run focused syntax, supervisor, build-contract, and production-build proof.
+5. Complete routed review and CI, land the exact commit, and monitor Standard.
 
 ## Decisions
 
-- Keep the existing 15-minute production deadline and cold-Webpack memory
-  policy; live deployment evidence shows the application build itself completes
-  comfortably within the Standard-machine window.
-- Do not infer group liveness after a clean package-build exit as unfinished
-  application compilation. Vercel owns residual platform process cleanup once
-  the successful command returns.
+- Keep the cold-Webpack cache policy; prior live deployments prove restored warm
+  Webpack caches can exceed the Standard builder memory boundary.
+- Do not force `webpackBuildWorker`: Next 16.3 disables it when the application
+  supplies custom Webpack configuration, which keeps one compiler owner.
+- Vercel owns production cancellation and build deadlines.
 
 ## Verification
 
@@ -84,9 +84,7 @@ Updated: 2026-08-18
     current app test configuration.
   - `pnpm verify:acceptance`
 - Expected outcomes:
-  - The clean-success regression proves the wrapper exits without signaling its
-    residual descendant.
-  - Existing timeout and cancellation tests continue proving full group
-    cleanup and their exact exit codes.
-  - Production build scripts retain the intended Webpack, cache, heap, migration,
-    and deadline contract.
+  - Local verification-slot tests prove admission, status propagation, and
+    signal forwarding without any production deadline contract.
+  - Production build scripts retain the intended Webpack, cache, heap,
+    migration, and prepared-TypeScript contract with one compiler process.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1666,33 +1666,25 @@ machine: 4 vCPUs, 8 GB RAM, and 32 GB disk. The CI guard currently observes the
 production `next build` in a root-level cgroup-v2 child for accounting only. It
 does not write `memory.max`, `memory.swap.max`, or `memory.oom.group`.
 
-The production build launches the parent Next process explicitly through Node
-with `--max-old-space-size=1024` while appending
-`--max-old-space-size=3072` to `NODE_OPTIONS` for the Webpack build worker. The
-same runner first performs route type generation and an explicit app-local
-generated-contract TypeScript check with a 3.5 GiB limit, then marks only that
-prepared check complete before starting the Webpack build. Node gives the direct
-CLI flag precedence in the parent. Next 16.3 reconstructs non-isolated child
-options from the parent arguments followed by `NODE_OPTIONS`, so the sequential
-Webpack compiler workers receive the 3 GiB limit while the separate TypeScript
-validation child receives 3.5 GiB. Next removes that option from its isolated
-static workers. The existing caller options are preserved. The shared script is
-used by the Vercel package build and the CI
-memory-observation lane. This bounds the compile parent without starving the
-later validation worker or changing the compiled application. The worker was
-ratcheted from 3 GiB only after an exact cold generated-contract check
-deterministically exhausted that heap and passed at the next 512 MiB step.
-Repeated
-forced-cold Standard previews remain the direct acceptance evidence, and a Next
-upgrade must revalidate this worker boundary.
+The production runner first performs route type generation and an explicit
+app-local generated-contract TypeScript check with a 3.5 GiB limit. It marks
+only that prepared check complete before starting Webpack. Compilation then
+runs in the Next CLI process with a 3 GiB old-space limit; the runner preserves
+unrelated inherited Node options while replacing inherited old-space flags.
+These phases are sequential, so their limits do not compose. The same runner is
+used by the Vercel package build and the CI memory-observation lane. Forced-cold
+Standard previews remain the direct acceptance evidence, and a Next upgrade
+must revalidate the heap boundary.
 
 Production builds use Next 16.3's supported Webpack fallback. The production
-script passes `--webpack`, and the Next config explicitly enables
-`webpackBuildWorker` plus `webpackMemoryOptimizations` because the Workflow
-integration contributes Webpack configuration that otherwise prevents Next
-from selecting the isolated build worker automatically. The hosted local-
-development wrapper remains on Turbopack and rejects an explicit Webpack flag.
-The production runner also owns a versioned cache epoch inside `.next/cache`.
+script passes `--webpack` and enables `webpackMemoryOptimizations`. The Workflow
+integration contributes custom Webpack configuration, so Next's canonical
+default is to compile in the CLI process. Do not force `webpackBuildWorker`:
+that creates a second compiler-process owner and previously left Standard
+deployments stuck inside an opaque worker after compilation stopped making
+progress. The hosted local-development wrapper remains on Turbopack and rejects
+an explicit Webpack flag. The production runner also owns a versioned cache
+epoch inside `.next/cache`.
 When that stamp is absent or differs, it removes the incompatible cache before
 compilation and writes the epoch only after Next succeeds. Production Webpack
 compiles are additionally cold-cache by policy: the runner removes
@@ -1702,23 +1694,11 @@ Webpack cache can never reach the compiler regardless of what an earlier
 deployment uploaded. Warm restored Webpack caches on Vercel's 8 GB Standard builder
 were the trigger for the August 2026 steady-state OOM kills and silent
 compile hangs; only the cold path is proven. Other cache subtrees such as SWC
-remain warm. On Vercel production builds (`VERCEL=1` with
-`VERCEL_ENV=production`), `scripts/vercel-build.sh` arms a 15-minute
-whole-build deadline (`MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS=900000`) that the
-package-build process owner, `scripts/run-with-host-verification-slot.mjs`,
-enforces on the one detached process group it already creates: at the deadline
-it TERMs the entire group, force-kills survivors with KILL (each phase bounded
-by a 30-second grace, so a leader that exits mid-grace hands surviving
-descendants to one fresh grace before their KILL), waits until the group has
-fully exited, and returns exit 124 with an explicit
-diagnostic. Because the deadline owns the whole group, a wedged Webpack
-compiler worker descendant is terminated too, and an externally cancelled
-build is reaped with the same escalation instead of orphaning the compile.
-Either way a wedged compile fails the build in minutes instead of occupying
-the deploy queue until Vercel's 45-minute ceiling. Local and CI verify
-invocations build
-with `VERCEL_ENV=preview` and never arm the deadline. Bump the epoch only
-when a proven compiler/cache transition requires another full invalidation.
+remain warm. Vercel owns cancellation and build deadlines. The production
+package script therefore runs directly instead of passing through the local
+shared-host verification slot or adding a second watchdog and process-group
+reaper. Bump the epoch only when a proven compiler/cache transition requires
+another full invalidation.
 
 Next 16.3 no longer exposes `experimental.turbopackMemoryLimit`. Its replacement,
 `experimental.turbopackMemoryEviction`, is documented for development sessions

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -313,10 +313,8 @@ export function buildHostedWebNextConfig(
       turbopackFileSystemCacheForDev: isHostedWebDevFileSystemCacheEnabled(environment),
       // Source-map emission is the largest proven build-memory cost.
       turbopackSourceMaps: false,
-      // Workflow contributes Webpack configuration, so select Next's isolated
-      // build worker explicitly and enable its memory-optimized compiler path.
-      // This is the repeatedly proven production path on Vercel's 8-GB builder.
-      webpackBuildWorker: true,
+      // Workflow contributes Webpack configuration, so Next keeps compilation
+      // in the CLI process unless webpackBuildWorker is explicitly forced.
       webpackMemoryOptimizations: true,
     },
     outputFileTracingIncludes: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "dev:local-env": "bash -c 'pnpm legal:pdf && pnpm changelog:generate && pnpm health-commons:generate && pnpm prisma:generate && pnpm --dir ../.. exec tsx apps/web/scripts/dev-local.ts \"$@\"' --",
     "dev:prepared-local-env": "bash -c 'pnpm changelog:generate && pnpm --dir ../.. exec tsx apps/web/scripts/dev-local.ts \"$@\"' --",
     "prebuild": "pnpm --dir ../../packages/runtime-state build",
-    "build": "node ../../scripts/run-with-host-verification-slot.mjs 'apps/web build' -- bash -c 'pnpm public-routes:waf-check && pnpm product-labels:env-check && pnpm hosted-crypto:env-check && pnpm legal:pdf && pnpm changelog:generate && pnpm health-commons:generate && pnpm prisma:generate:build && pnpm typecheck:prepared && bash scripts/run-production-next-build.sh && pnpm --dir ../.. workflow:clean-web-artifacts -- --quiet && pnpm health-commons:trace-check && pnpm og-assets:trace-check && pnpm og-assets:runtime-check'",
+    "build": "pnpm public-routes:waf-check && pnpm product-labels:env-check && pnpm hosted-crypto:env-check && pnpm legal:pdf && pnpm changelog:generate && pnpm health-commons:generate && pnpm prisma:generate:build && pnpm typecheck:prepared && bash scripts/run-production-next-build.sh && pnpm --dir ../.. workflow:clean-web-artifacts -- --quiet && pnpm health-commons:trace-check && pnpm og-assets:trace-check && pnpm og-assets:runtime-check",
     "changelog:generate": "pnpm --dir ../.. exec tsx apps/web/scripts/generate-changelog-fragments.ts",
     "health-commons:generate": "pnpm --dir ../.. health-commons:generate",
     "health-commons:trace-check": "pnpm --dir ../.. exec tsx apps/web/scripts/check-health-commons-traces.ts",

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-parent_old_space_mb=1024
-build_worker_old_space_mb=3072
+build_old_space_mb=3072
 typecheck_old_space_mb=3584
-build_cache_epoch=webpack-next-16.3-v3-prepared-typecheck-cold-webpack
+build_cache_epoch=webpack-next-16.3-v4-in-process-cold-webpack
 build_cache_stamp=.next/cache/murph-production-build-epoch
 webpack_cache_dir=.next/cache/webpack
 prepared_typecheck_env=MURPH_HOSTED_WEB_PREPARED_TYPECHECK
@@ -45,17 +44,16 @@ else
   node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
 fi
 
-printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s build_worker_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=cold\n' \
-  "$parent_old_space_mb" \
-  "$build_worker_old_space_mb" \
+printf '[apps/web build] Next memory policy: compiler=webpack build_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=cold webpack_build_worker=off\n' \
+  "$build_old_space_mb" \
   "$typecheck_old_space_mb"
 
 # Generate the route declarations before running Next's app-local TypeScript 5
-# compatibility check. Keeping that check separate prevents the Webpack worker
-# from inheriting the larger heap without replacing the route/page contract
-# proof with the repository's TypeScript 7 source check.
-set_node_old_space "$build_worker_old_space_mb"
-node "--max-old-space-size=$parent_old_space_mb" "$next_bin" typegen
+# compatibility check. Keeping that check separate gives validation its own
+# heap limit without replacing the route/page contract proof with the
+# repository's TypeScript 7 source check.
+set_node_old_space "$build_old_space_mb"
+node "--max-old-space-size=$build_old_space_mb" "$next_bin" typegen
 
 set_node_old_space "$typecheck_old_space_mb"
 node "--max-old-space-size=$typecheck_old_space_mb" \
@@ -64,8 +62,8 @@ node "--max-old-space-size=$typecheck_old_space_mb" \
   --pretty false
 
 export MURPH_HOSTED_WEB_PREPARED_TYPECHECK=complete
-set_node_old_space "$build_worker_old_space_mb"
-node "--max-old-space-size=$parent_old_space_mb" "$next_bin" build --webpack
+set_node_old_space "$build_old_space_mb"
+node "--max-old-space-size=$build_old_space_mb" "$next_bin" build --webpack
 
 if [[ "$cache_reset" == 1 ]]; then
   mkdir -p "$(dirname "$build_cache_stamp")"

--- a/apps/web/scripts/vercel-build.sh
+++ b/apps/web/scripts/vercel-build.sh
@@ -9,14 +9,5 @@ if [ "${VERCEL_TARGET_ENV:-}" = "native-ios-e2e" ]; then
   MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS=1 pnpm prisma:migrate:deploy
 fi
 
-# Production builds arm the package-build process owner's whole-group
-# deadline so a wedged compile (including a Webpack compiler worker
-# descendant) fails the build in minutes instead of holding the deploy queue
-# until Vercel's 45-minute ceiling. Preview and local builds stay unbounded.
-if [ "${VERCEL:-}" = "1" ] && [ "${VERCEL_ENV:-}" = "production" ]; then
-  MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS="${MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS:-900000}"
-  export MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS
-fi
-
 pnpm release:production:migrate
 MURPH_HOSTED_WEB_PRISMA_GENERATED_BY_MIGRATIONS=1 pnpm build

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -386,10 +386,10 @@ test("next.config leaves agent guidance under repository ownership", () => {
   assert.equal(productionNextConfig.agentRules, false);
 });
 
-test("production build config enables the bounded Webpack worker path", () => {
+test("production build config keeps Webpack compilation in the Next process", () => {
   assert.equal(productionNextConfig.experimental?.turbopackFileSystemCacheForBuild, false);
   assert.equal(productionNextConfig.experimental?.turbopackSourceMaps, false);
-  assert.equal(productionNextConfig.experimental?.webpackBuildWorker, true);
+  assert.equal(productionNextConfig.experimental?.webpackBuildWorker, undefined);
   assert.equal(productionNextConfig.experimental?.webpackMemoryOptimizations, true);
 });
 

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1437,17 +1437,15 @@ describe("hosted web production migration guard", () => {
       buildScript,
       /pnpm typecheck:prepared && bash scripts\/run-production-next-build\.sh/u,
     );
-    assert.match(
-      buildScript,
-      /^node \.\.\/\.\.\/scripts\/run-with-host-verification-slot\.mjs 'apps\/web build' -- bash -c /u,
-    );
+    assert.match(buildScript, /^pnpm public-routes:waf-check/u);
+    assert.doesNotMatch(buildScript, /run-with-host-verification-slot/u);
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
-    assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
-    assert.match(productionNextBuildScript, /build_worker_old_space_mb=3072/u);
+    assert.match(productionNextBuildScript, /build_old_space_mb=3072/u);
+    assert.doesNotMatch(productionNextBuildScript, /build_worker_old_space_mb/u);
     assert.match(productionNextBuildScript, /typecheck_old_space_mb=3584/u);
     assert.match(
       productionNextBuildScript,
-      /build_cache_epoch=webpack-next-16\.3-v3-prepared-typecheck-cold-webpack/u,
+      /build_cache_epoch=webpack-next-16\.3-v4-in-process-cold-webpack/u,
     );
     assert.match(productionNextBuildScript, /webpack_cache_dir=\.next\/cache\/webpack/u);
     assert.match(
@@ -1465,41 +1463,28 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(
       productionNextBuildScript,
-      /node "--max-old-space-size=\$parent_old_space_mb" "\$next_bin" build --webpack/u,
+      /node "--max-old-space-size=\$build_old_space_mb" "\$next_bin" build --webpack/u,
     );
     assert.match(
       productionNextBuildScript,
       /node \.\.\/\.\.\/scripts\/rm-paths\.mjs "\$webpack_cache_dir"/u,
     );
 
-    // The production build deadline lives in the package-build process owner,
-    // not in the runner: vercel-build.sh arms it for production deployments
-    // only, and the supervisor owns whole-group termination and reaping.
+    // Vercel owns the production build lifecycle. The application does not
+    // add a second deadline or route production through the local host slot.
     const vercelBuildScript = await readFile(
       path.join(appRoot, "scripts", "vercel-build.sh"),
       "utf8",
     );
-    assert.match(
-      vercelBuildScript,
-      /if \[ "\$\{VERCEL:-\}" = "1" \] && \[ "\$\{VERCEL_ENV:-\}" = "production" \]; then/u,
-    );
-    assert.match(
-      vercelBuildScript,
-      /MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS="\$\{MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS:-900000\}"/u,
-    );
-    assert.match(vercelBuildScript, /export MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS/u);
+    assert.doesNotMatch(vercelBuildScript, /MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS/u);
     assert.doesNotMatch(productionNextBuildScript, /timeout /u);
     assert.doesNotMatch(productionNextBuildScript, /VERCEL/u);
     const verificationSlotScript = await readFile(
       path.join(appRoot, "..", "..", "scripts", "run-with-host-verification-slot.mjs"),
       "utf8",
     );
-    assert.match(
-      verificationSlotScript,
-      /COMMAND_TIMEOUT_ENV = "MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS"/u,
-    );
-    assert.match(verificationSlotScript, /COMMAND_TIMEOUT_EXIT_CODE = 124/u);
-    assert.match(verificationSlotScript, /reapCommandProcessGroup/u);
+    assert.doesNotMatch(verificationSlotScript, /MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS/u);
+    assert.doesNotMatch(verificationSlotScript, /reapCommandProcessGroup/u);
 
     // apps/web/README.md § "Production build memory guard" is the single prose
     // owner of the mutable runner contract (cache policy, epoch stamping, and
@@ -1517,7 +1502,7 @@ describe("hosted web production migration guard", () => {
       "utf8",
     );
     assert.match(readmeDoc, /## Production build memory guard/u);
-    assert.match(readmeDoc, /`VERCEL=1` with\s+`VERCEL_ENV=production`/u);
+    assert.match(readmeDoc, /Vercel owns cancellation and build deadlines/u);
     assert.match(readmeDoc, /`\.next\/cache\/webpack` before every compile/u);
     for (const [docName, doc] of [
       ["verification-and-runtime.md", verificationDoc],

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -11,7 +11,7 @@ const productionBuildScript = path.join(
   "scripts",
   "run-production-next-build.sh",
 );
-const buildCacheEpoch = "webpack-next-16.3-v3-prepared-typecheck-cold-webpack";
+const buildCacheEpoch = "webpack-next-16.3-v4-in-process-cold-webpack";
 
 async function createRunnerFixture(): Promise<{
   appDir: string;
@@ -141,7 +141,7 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
       `Resetting incompatible Next build cache for epoch=${buildCacheEpoch}`,
     );
     expect(coldBuild.stdout).toContain(
-      "compiler=webpack parent_old_space_mb=1024 build_worker_old_space_mb=3072 typecheck_old_space_mb=3584 webpack_cache=cold",
+      "compiler=webpack build_old_space_mb=3072 typecheck_old_space_mb=3584 webpack_cache=cold webpack_build_worker=off",
     );
     await expect(readFile(staleCacheEntry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
@@ -149,12 +149,12 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=",
-      "--max-old-space-size=1024",
+      "--max-old-space-size=3072",
       "/fixture/next",
       "typegen",
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=complete",
-      "--max-old-space-size=1024",
+      "--max-old-space-size=3072",
       "/fixture/next",
       "build",
       "--webpack",
@@ -232,7 +232,7 @@ test("production Next runner fails closed before compilation when the prepared t
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=",
-      "--max-old-space-size=1024",
+      "--max-old-space-size=3072",
       "/fixture/next",
       "typegen",
       "",

--- a/scripts/run-with-host-verification-slot.mjs
+++ b/scripts/run-with-host-verification-slot.mjs
@@ -21,30 +21,13 @@ const ENABLED_ENV = "MURPH_VERIFY_SHARED_HOST";
 const HELD_ENV = "MURPH_VERIFY_HOST_SLOT_HELD";
 const TEST_STATE_ROOT_ENV = "MURPH_VERIFY_SHARED_HOST_TEST_STATE_ROOT";
 const CODEX_THREAD_ENV = "CODEX_THREAD_ID";
-const COMMAND_TIMEOUT_ENV = "MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS";
-const COMMAND_KILL_GRACE_ENV = "MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS";
 const DEFAULT_POLL_INTERVAL_MS = 250;
 const DEFAULT_STALE_METADATA_GRACE_MS = 10_000;
-const DEFAULT_COMMAND_KILL_GRACE_MS = 30_000;
-const COMMAND_TIMEOUT_EXIT_CODE = 124;
-const GROUP_EXIT_POLL_INTERVAL_MS = 100;
 const WAIT_LOG_INTERVAL_MS = 60_000;
 const OWNER_FILE_NAME = "owner.json";
 const invocationCwd = process.cwd();
 const invocation = parseInvocation(process.argv.slice(2));
 const useDetachedChildProcessGroup = process.platform !== "win32";
-// A configured command deadline arms whole-process-group termination: timeout,
-// cancellation, and failed-command cleanup act on the one detached group this
-// supervisor creates, so a wedged descendant (for example a Webpack compiler
-// worker) cannot outlive an unsuccessful command. A clean command exit returns
-// directly so platform-owned residual process state cannot stall completion.
-const commandTimeoutMs = useDetachedChildProcessGroup
-  ? readPositiveInteger(process.env[COMMAND_TIMEOUT_ENV], 0)
-  : 0;
-const commandKillGraceMs = readPositiveInteger(
-  process.env[COMMAND_KILL_GRACE_ENV],
-  DEFAULT_COMMAND_KILL_GRACE_MS,
-);
 let activeChild = null;
 let forcedExitCode = null;
 let heldSlot = null;
@@ -248,49 +231,15 @@ async function runCommand(commandArgs, env) {
       writeOwnerMetadata(heldSlot.slotPath, heldSlot.owner);
     }
 
-    let deadlineTimer = null;
-    let killTimer = null;
-    if (commandTimeoutMs > 0) {
-      deadlineTimer = setTimeout(() => {
-        forcedExitCode = COMMAND_TIMEOUT_EXIT_CODE;
-        console.error(
-          `[host-verification] Command exceeded ${commandTimeoutMs}ms; terminating its process group before the platform build ceiling.`,
-        );
-        signalProcessGroup(child.pid, "SIGTERM");
-        killTimer = setTimeout(
-          () => signalProcessGroup(child.pid, "SIGKILL"),
-          commandKillGraceMs,
-        );
-      }, commandTimeoutMs);
-    }
-
     child.on("error", (error) => {
       activeChild = null;
-      clearTimeout(deadlineTimer);
-      clearTimeout(killTimer);
       reject(error);
     });
-    // Classify the direct child's result before releasing process ownership.
-    // Unsuccessful commands still reap surviving descendants, and a
-    // termination signal arriving during that cleanup must keep targeting the
-    // detached group instead of exiting immediately.
     child.on("exit", (code, signal) => {
-      clearTimeout(deadlineTimer);
-      clearTimeout(killTimer);
-      resolve({ code, pid: child.pid ?? null, signal });
+      activeChild = null;
+      resolve({ code, signal });
     });
   });
-
-  const commandSucceeded = forcedExitCode === null
-    && exitState.signal === null
-    && exitState.code === 0;
-  try {
-    if (!commandSucceeded && commandTimeoutMs > 0 && exitState.pid !== null) {
-      await reapCommandProcessGroup(exitState.pid);
-    }
-  } finally {
-    activeChild = null;
-  }
 
   if (forcedExitCode !== null) {
     return forcedExitCode;
@@ -301,11 +250,6 @@ async function runCommand(commandArgs, env) {
   return exitState.code ?? 1;
 }
 
-// Group signals tolerate EPERM as well as ESRCH: on macOS a killed group
-// member that has not been reaped yet (a zombie) makes kill(-pgid, ...)
-// return EPERM even though there is nothing left to signal. The group probe
-// treats that same state as "still draining" so the reaper keeps waiting
-// until the member is reaped and the group reports ESRCH.
 function signalProcessGroup(pid, signalName) {
   if (!pid) {
     return;
@@ -316,39 +260,6 @@ function signalProcessGroup(pid, signalName) {
     if (!isMissingProcessError(error) && !isNotPermittedProcessError(error)) {
       throw error;
     }
-  }
-}
-
-function isProcessGroupRunning(pid) {
-  if (!pid) {
-    return false;
-  }
-  try {
-    process.kill(-pid, 0);
-    return true;
-  } catch (error) {
-    return !isMissingProcessError(error);
-  }
-}
-
-// With a command deadline configured, the direct child's exit is not enough:
-// a wedged descendant in the detached group must also be gone before the
-// supervisor returns and releases any held slot.
-async function reapCommandProcessGroup(pid) {
-  if (!isProcessGroupRunning(pid)) {
-    return;
-  }
-  signalProcessGroup(pid, "SIGTERM");
-  const killDeadline = Date.now() + commandKillGraceMs;
-  while (Date.now() < killDeadline) {
-    if (!isProcessGroupRunning(pid)) {
-      return;
-    }
-    await delay(GROUP_EXIT_POLL_INTERVAL_MS);
-  }
-  signalProcessGroup(pid, "SIGKILL");
-  while (isProcessGroupRunning(pid)) {
-    await delay(GROUP_EXIT_POLL_INTERVAL_MS);
   }
 }
 
@@ -458,13 +369,6 @@ function handleTerminationSignal(signalName, exitCode) {
     }
   }
 
-  // With a command deadline configured, external cancellation must also be
-  // bounded: a group member that ignores the forwarded signal is force-killed
-  // after the same grace the deadline path uses.
-  if (commandTimeoutMs > 0) {
-    const cancelledPid = activeChild.pid;
-    setTimeout(() => signalProcessGroup(cancelledPid, "SIGKILL"), commandKillGraceMs).unref();
-  }
 }
 
 function parseInvocation(argv) {

--- a/scripts/run-with-host-verification-slot.test.ts
+++ b/scripts/run-with-host-verification-slot.test.ts
@@ -24,44 +24,6 @@ const holderSource = `
   process.stdout.write("ready\\n");
   process.stdin.resume();
 `;
-// A TERM-ignoring parent with a TERM-ignoring grandchild: the wedged-compile
-// topology the command deadline must terminate as one process group.
-const wedgedTreeSource = `
-  import { spawn } from "node:child_process";
-  process.on("SIGTERM", () => {});
-  const grandchild = spawn(process.execPath, [
-    "-e",
-    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
-  ], { stdio: "ignore" });
-  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
-  setInterval(() => {}, 1000);
-`;
-// A leader that exits on the deadline's TERM while its grandchild ignores it:
-// the descendant-outlives-leader topology that motivated supervisor-owned
-// group reaping.
-const exitingLeaderTreeSource = `
-  import { spawn } from "node:child_process";
-  const grandchild = spawn(process.execPath, [
-    "-e",
-    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
-  ], { stdio: "ignore" });
-  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
-  setInterval(() => {}, 1000);
-`;
-// A successful leader can leave a platform-owned process-group member behind.
-// The supervisor must return the successful result instead of treating that
-// residual member as unfinished application work.
-const residualDescendantTreeSource = `
-  import { spawn } from "node:child_process";
-  const grandchild = spawn(process.execPath, [
-    "-e",
-    "setInterval(() => {}, 1000);",
-  ], { stdio: "ignore" });
-  grandchild.unref();
-  process.stdout.write("pids " + process.pid + " " + grandchild.pid + "\\n");
-  process.exitCode = Number(process.env.MURPH_TEST_LEADER_EXIT_CODE ?? "0");
-`;
-
 afterEach(async () => {
   for (const child of children) {
     child.stdin?.end();
@@ -318,125 +280,15 @@ describe("shared-host verification slots", () => {
     expect(readdirSync(targetRoot)).toEqual(["marker.txt"]);
   });
 
-  it("preserves a child failure code while reaping its residual process group", async () => {
+  it("preserves a child failure code and releases the slot", () => {
     const stateRoot = makeTempRoot();
-    const child = startCommand("failing command", stateRoot, residualDescendantTreeSource, {
-      MURPH_TEST_LEADER_EXIT_CODE: "7",
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
-    });
+    const result = runSync(
+      "failing command",
+      [process.execPath, "-e", "process.exit(7)"],
+      stateRoot,
+    );
 
-    const [, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(grandchildPid);
-
-    expect(await waitForExit(child)).toBe(7);
-    await waitForOwnedProcessExit(grandchildPid);
-    expect(readdirSync(stateRoot)).toEqual([]);
-  });
-
-  it("does not reap a residual process-group member after a successful command", async () => {
-    const stateRoot = makeTempRoot();
-    const child = startCommand("successful command", stateRoot, residualDescendantTreeSource, {
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
-    });
-
-    const [, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(grandchildPid);
-
-    expect(await waitForExit(child)).toBe(0);
-    expect(isProcessRunning(grandchildPid)).toBe(true);
-    expect(readdirSync(stateRoot)).toEqual([]);
-
-    process.kill(grandchildPid, "SIGTERM");
-    await waitForOwnedProcessExit(grandchildPid);
-  });
-
-  it("a configured command deadline reaps the whole process group", async () => {
-    const stateRoot = makeTempRoot();
-    const child = startCommand("deadline command", stateRoot, wedgedTreeSource, {
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
-    });
-
-    const [parentPid, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(parentPid);
-    ownedDescendantPids.add(grandchildPid);
-
-    await waitForStderrLine(child, "terminating its process group");
-    const status = await waitForExit(child);
-    expect(status).toBe(124);
-    await waitForOwnedProcessExit(parentPid);
-    await waitForOwnedProcessExit(grandchildPid);
-    expect(readdirSync(stateRoot)).toEqual([]);
-  });
-
-  it("a deadline whose group leader exits on TERM still reaps a surviving descendant", async () => {
-    const stateRoot = makeTempRoot();
-    const child = startCommand("exiting leader", stateRoot, exitingLeaderTreeSource, {
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
-    });
-
-    const [parentPid, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(parentPid);
-    ownedDescendantPids.add(grandchildPid);
-
-    const status = await waitForExit(child);
-    expect(status).toBe(124);
-    await waitForOwnedProcessExit(parentPid);
-    await waitForOwnedProcessExit(grandchildPid);
-    expect(readdirSync(stateRoot)).toEqual([]);
-  });
-
-  it("a cancellation during post-leader reaping keeps ownership until the descendant is dead", async () => {
-    const stateRoot = makeTempRoot();
-    const child = startCommand("cancelled during reap", stateRoot, exitingLeaderTreeSource, {
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "600",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "300",
-    });
-
-    const [parentPid, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(parentPid);
-    ownedDescendantPids.add(grandchildPid);
-
-    // Wait for the deadline to fell the leader while the TERM-ignoring
-    // grandchild survives into the reaping grace, then cancel externally.
-    const reapWindowDeadline = Date.now() + 2_000;
-    while (isProcessRunning(parentPid) || !isProcessRunning(grandchildPid)) {
-      if (Date.now() > reapWindowDeadline) {
-        throw new Error("Never reached the post-leader reaping window");
-      }
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
-    child.kill("SIGTERM");
-
-    const status = await waitForExit(child);
-    expect(status).toBe(143);
-    // Ownership must have been held until the whole group was gone: the
-    // grandchild is already dead by the time the supervisor returns.
-    expect(isProcessRunning(grandchildPid)).toBe(false);
-    ownedDescendantPids.delete(grandchildPid);
-    await waitForOwnedProcessExit(parentPid);
-    expect(readdirSync(stateRoot)).toEqual([]);
-  });
-
-  it("external cancellation with a configured deadline escalates to KILL and reaps the group", async () => {
-    const stateRoot = makeTempRoot();
-    const child = startCommand("cancelled command", stateRoot, wedgedTreeSource, {
-      MURPH_VERIFY_HOST_COMMAND_KILL_GRACE_MS: "300",
-      MURPH_VERIFY_HOST_COMMAND_TIMEOUT_MS: "600000",
-    });
-
-    const [parentPid, grandchildPid] = await waitForPids(child);
-    ownedDescendantPids.add(parentPid);
-    ownedDescendantPids.add(grandchildPid);
-
-    child.kill("SIGTERM");
-    const status = await waitForExit(child);
-    expect(status).toBe(143);
-    await waitForOwnedProcessExit(parentPid);
-    await waitForOwnedProcessExit(grandchildPid);
+    expect(result.status, result.stderr).toBe(7);
     expect(readdirSync(stateRoot)).toEqual([]);
   });
 });
@@ -528,27 +380,6 @@ function startRawCommand(source: string): ChildProcess {
 
 async function waitForLine(child: ChildProcess, line: string): Promise<void> {
   await waitForStreamLine(child, child.stdout, line);
-}
-
-async function waitForPids(child: ChildProcess): Promise<[number, number]> {
-  let output = "";
-  return await new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error(`Timed out waiting for pids; output=${output}`)),
-      2_000,
-    );
-    const onData = (chunk: Buffer | string) => {
-      output += chunk.toString();
-      const match = output.match(/pids (\d+) (\d+)/u);
-      if (match) {
-        clearTimeout(timeout);
-        child.stdout?.off("data", onData);
-        resolve([Number(match[1]), Number(match[2])]);
-      }
-    };
-    child.stdout?.on("data", onData);
-    child.once("error", reject);
-  });
 }
 
 async function waitForStderrLine(child: ChildProcess, line: string): Promise<void> {


### PR DESCRIPTION
Outcome
- Remove the hosted Web production build from the local shared-host supervisor.
- Let Next compile custom Webpack configuration in its CLI process with one 3 GiB compiler heap.
- Delete the production watchdog and detached-group reaper contract.

Product UX
- No user-facing behavior changes.

Evidence
- Focused build and supervisor tests: 111 passed.
- Full hosted Web production build passed; Webpack compiled in 71 seconds with no build worker.
- Canonical diff verification encountered unrelated existing workspace-boundary and Frog-tooling failures.

Changelog
- None; internal build infrastructure only.

Risk
- Production deploy boundary; cold Webpack cache and explicit prepared TypeScript checks remain unchanged.

ReviewGPT context sensitivity: sensitive — changes the production deployment boundary and compiler process ownership.
ReviewGPT first-reviewed head: df5a52c44780246dd45f7a0b36fa65aa7833bd55