### PR TITLE
Remind operators about stalled hosted runtimes

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1447,15 +1447,25 @@ Last verified: 2026-08-16
   runtime/lane counts, pending counts, timings, and invalid/truncated evidence
   only; they never contain member, mailbox, phone, message, trace, or exception
   identifiers. The progress and latency incidents rearm independently, so one
-  continuous anomaly cannot hide the first alert for the other.
+  continuous anomaly cannot hide the first alert for the other. A continuing
+  progress incident also becomes eligible for one fresh aggregate reminder six
+  hours after its prior successful email plus stable bounded jitter. The
+  existing health reread, quiet-hours check, send lease, and singleton
+  compare-and-swap apply unchanged. Each reminder generation derives its
+  persisted body and Resend idempotency suffix from the previous successful
+  send boundary; an ambiguous retry therefore cannot acquire a new provider
+  effect. Successful delivery advances that boundary and schedules the next
+  generation. The latency incident retains one email per continuous anomaly,
+  and both monitors recover silently.
   Outbound paging requires the shared Resend operational-email sender and
   recipients plus a valid IANA operator timezone; it never falls back to
   Linq/iMessage. It suppresses sends from 11 PM through 7 AM local time and
   applies stable bounded jitter after quiet hours and after every provider
-  attempt. No retry or post-healthy recurrence may call the provider less than
-  ten minutes after the prior attempt or accepted-send boundary. A retry that
-  may already have succeeded preserves the exact body and incident-scoped
-  idempotency key. The key does not vary with mutable email configuration:
+  attempt. No retry, reminder, or post-healthy recurrence may call the provider
+  less than ten minutes after the prior attempt or accepted-send boundary. A
+  retry that may already have succeeded preserves the exact body and
+  incident-and-generation-scoped idempotency key. The key does not vary with
+  mutable email configuration:
   within Resend's idempotency retention window, identical retries deduplicate
   and a changed payload under the same key fails closed instead of acquiring a
   second send identity. The monitor does not claim provider-side exactly-once

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1451,21 +1451,21 @@ Last verified: 2026-08-16
   progress incident also becomes eligible for one fresh aggregate reminder six
   hours after its prior successful email plus stable bounded jitter. The
   existing health reread, quiet-hours check, send lease, and singleton
-  compare-and-swap apply unchanged. Each reminder generation derives its
-  persisted body and Resend idempotency suffix from the previous successful
-  send boundary; an ambiguous retry therefore cannot acquire a new provider
-  effect. Successful delivery advances that boundary and schedules the next
-  generation. The latency incident retains one email per continuous anomaly,
-  and both monitors recover silently.
+  compare-and-swap apply unchanged. Each fresh reminder claim persists a new
+  generation identity and exact body before provider entry; an ambiguous retry
+  reuses both and therefore cannot acquire a new provider effect. Successful
+  delivery advances the send boundary that schedules the next generation. The
+  latency incident retains one email per continuous anomaly, and both monitors
+  recover silently.
   Outbound paging requires the shared Resend operational-email sender and
   recipients plus a valid IANA operator timezone; it never falls back to
   Linq/iMessage. It suppresses sends from 11 PM through 7 AM local time and
   applies stable bounded jitter after quiet hours and after every provider
   attempt. No retry, reminder, or post-healthy recurrence may call the provider
   less than ten minutes after the prior attempt or accepted-send boundary. A
-  retry that may already have succeeded preserves the exact body and
-  incident-and-generation-scoped idempotency key. The key does not vary with
-  mutable email configuration:
+  retry that may already have succeeded preserves the exact body and current
+  generation-scoped idempotency key. The key does not vary with mutable email
+  configuration:
   within Resend's idempotency retention window, identical retries deduplicate
   and a changed payload under the same key fails closed instead of acquiring a
   second send identity. The monitor does not claim provider-side exactly-once

--- a/agent-docs/exec-plans/active/2026-08-18-recurring-runtime-progress-alerts.md
+++ b/agent-docs/exec-plans/active/2026-08-18-recurring-runtime-progress-alerts.md
@@ -28,8 +28,9 @@ queue, database schema, or per-member alert owner.
   runtime, mailbox item, connection, provider, message, or health-data values.
 - Reuse the singleton incident row and five-minute cron. Add no scheduler,
   queue, migration, table, or per-runtime state.
-- Keep initial and retried Resend effects idempotent, and give each reminder a
-  stable generation key that survives ambiguous provider outcomes.
+- Keep initial and retried Resend effects idempotent. Persist one fresh
+  generation identity for each new reminder and reuse it across ambiguous
+  provider outcomes.
 - Leave latency alerts at one email per continuous incident.
 
 ## Product UX Plan
@@ -99,14 +100,23 @@ body and persisted detail remains aggregate-only.
 - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage
   apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
   apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
-  apps/web/test/hosted-runtime-latency-alert-cron.test.ts` passes 60 tests.
+  apps/web/test/hosted-runtime-latency-alert-cron.test.ts` passes 62 tests.
 - `pnpm --dir apps/web typecheck` passes after generating the local Prisma
   client in the isolated worktree.
 - Focused ESLint passes for the shared incident owner, progress monitor, and
   progress-monitor test; `git diff --check` passes.
-- ReviewGPT recommended the existing aggregate owner plus six-hour reminders,
-  no separate device-sync monitor, no recovery email, and no manual reset of an
-  already-active production row.
+- The planning ReviewGPT pass recommended the existing aggregate owner plus
+  six-hour reminders, no separate device-sync monitor, no recovery email, and
+  no manual reset of an already-active production row.
+- Final ReviewGPT round 1 found that a separate persisted reminder kind and key
+  suffix duplicated the existing persisted generation identity. The accepted
+  simplification gives every fresh reminder a new incident-generation id and
+  reuses that id plus the exact body for retries, deleting the parser, schema
+  bump, and correlated JSON sub-state.
+- The accepted specialist coverage finding is resolved by proving the latency
+  monitor still sends only one email after the progress monitor's six-hour
+  reminder horizon. Focused progress coverage also proves overlapping reminder
+  scans admit one provider effect.
 - ReviewGPT's declared patch artifact was not downloadable after two canonical
   recovery attempts. Existing Frog entries already cover the exact missing-tab
   and declared-without-downloadable-artifact failures; the implementation was

--- a/agent-docs/exec-plans/active/2026-08-18-recurring-runtime-progress-alerts.md
+++ b/agent-docs/exec-plans/active/2026-08-18-recurring-runtime-progress-alerts.md
@@ -1,0 +1,136 @@
+# Recurring Runtime Progress Alerts
+
+## Goal
+
+Make an ongoing hosted runtime progress incident email the operations mailbox
+again when durable mailbox work remains stuck, without adding a new scheduler,
+queue, database schema, or per-member alert owner.
+
+## Evidence
+
+- The existing five-minute runtime-progress monitor already detects live system
+  and conversation mailbox work that remains beyond the durable handled
+  high-water for at least 15 minutes.
+- Its singleton incident currently sends once and stays active until every
+  alertable runtime recovers, so one long-running aggregate incident can
+  suppress later stalls indefinitely.
+- The existing monitor already owns bounded scanning, active-runtime and
+  usage-block exclusions, quiet hours, Resend transport, compare-and-swap
+  claims, send leases, retry pacing, and aggregate-only evidence.
+- ReviewGPT recommended bounded reminders on that existing incident rather than
+  a second device-sync correlation monitor.
+
+## Constraints
+
+- Preserve the current 15-minute stall predicate, bounded database scan, active
+  runtime access check, usage-block exclusion, and silent recovery behavior.
+- Keep email and persisted alert evidence aggregate-only. Do not include member,
+  runtime, mailbox item, connection, provider, message, or health-data values.
+- Reuse the singleton incident row and five-minute cron. Add no scheduler,
+  queue, migration, table, or per-runtime state.
+- Keep initial and retried Resend effects idempotent, and give each reminder a
+  stable generation key that survives ambiguous provider outcomes.
+- Leave latency alerts at one email per continuous incident.
+
+## Product UX Plan
+
+Classification: Product change. The existing operator alert changes from one
+email per continuous incident to bounded reminders while the same incident
+remains unresolved.
+
+### Outcome
+
+The operations recipient regains timely awareness of an ongoing runtime stall
+through fresh aggregate evidence without receiving member-identifying details
+or noisy recovery messages.
+
+### Entry And Promise
+
+The existing five-minute monitor opens an alert after the current 15-minute
+stall boundary. While the incident remains anomalous, it may send another
+aggregate reminder after six hours plus stable jitter, outside the existing
+quiet-hours window. Recovery silently rearms the next incident.
+
+### Affected People
+
+- An operator during a long-running aggregate incident receives a clearly
+  labeled reminder with current counts and age, not stale first-alert evidence.
+- An operator during quiet hours receives no email until the existing morning
+  admission boundary permits the next attempt.
+- An operator after recovery receives no extra message; a later recurrence is
+  a new incident with a new initial-alert identity.
+- Members receive no new message or disclosure, and no member, runtime,
+  connection, provider, mailbox, message, or health-data value enters the
+  alert.
+
+Challenge: recurring mail can become noise during a persistent broad outage.
+The six-hour cadence, quiet hours, aggregate-only body, stable per-generation
+idempotency, and silent recovery keep the signal bounded while preventing
+week-long suppression.
+
+### Proof
+
+Focused monitor tests must prove initial alert, short-window coalescing, fresh
+six-hour reminder evidence, quiet-hour deferral, exact retry identity, privacy,
+silent recovery, and unchanged latency-monitor cadence.
+
+### Done When
+
+An unresolved progress incident cannot suppress email indefinitely; no
+duplicate provider effect is admitted for one reminder generation; and every
+body and persisted detail remains aggregate-only.
+
+## Plan
+
+1. Add an optional reminder policy to the shared operational email incident
+   owner, retaining the existing compare-and-swap, lease, quiet-hours, and retry
+   paths.
+2. Opt only the runtime-progress monitor into six-hour reminders with stable
+   jitter and fresh aggregate evidence immediately before provider admission.
+3. Add focused coverage for reminder eligibility, fresh evidence, stable retry
+   identity, concurrency/quiet-hour behavior, privacy, recovery, and unchanged
+   latency semantics.
+4. Update the runtime alert, reliability, and verification contracts.
+5. Run focused tests and typecheck, inspect the final diff, then use the normal
+   exact-head ReviewGPT, CI, commit, and PR workflow.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage
+  apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
+  apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
+  apps/web/test/hosted-runtime-latency-alert-cron.test.ts` passes 60 tests.
+- `pnpm --dir apps/web typecheck` passes after generating the local Prisma
+  client in the isolated worktree.
+- Focused ESLint passes for the shared incident owner, progress monitor, and
+  progress-monitor test; `git diff --check` passes.
+- ReviewGPT recommended the existing aggregate owner plus six-hour reminders,
+  no separate device-sync monitor, no recovery email, and no manual reset of an
+  already-active production row.
+- ReviewGPT's declared patch artifact was not downloadable after two canonical
+  recovery attempts. Existing Frog entries already cover the exact missing-tab
+  and declared-without-downloadable-artifact failures; the implementation was
+  therefore re-derived and verified locally rather than applying an unverified
+  artifact.
+
+## Product UX Walkthrough
+
+- Long-running incident: the first alert keeps its existing 15-minute boundary;
+  a reminder after six hours plus jitter contains fresh aggregate runtime, lane,
+  pending-item, age, and checked-at evidence. Ready.
+- Quiet hours: an overdue reminder is deferred and resumes after the existing
+  morning jitter boundary without advancing provider-attempt state. Ready.
+- Ambiguous Resend outcome: the retry reuses the exact persisted body and
+  reminder-generation key. Ready.
+- Recovery and recurrence: recovery sends no email and returns the singleton to
+  healthy; a later stall receives a new initial incident identity. Ready.
+- Member privacy: reminder bodies and persisted evidence exclude private-looking
+  runtime keys and carry no member, connection, provider, mailbox, message, or
+  health-data values. Ready.
+
+Product purpose verdict: Ready.
+
+## State
+
+Status: active
+Updated: 2026-08-18

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -605,8 +605,10 @@ supported provider credential.
   the 20,000 eligible-row cap after exclusions. The hosted-local
   foreground-priority leg drives this monitor through authenticated cron HTTP
   and the same isolated Resend stub, proving paced lost-ack retry,
-  identifier-free aggregation, active-incident coalescing, recovery/rearm, and
-  independence from the latency monitor.
+  identifier-free aggregation, short-window active-incident coalescing,
+  six-hour fresh-evidence reminders with stable per-generation identity,
+  quiet-hour deferral, recovery/rearm, and independence from the latency
+  monitor.
 - `apps/web/test/hosted-runtime-latency-alert-query-postgres.test.ts` is an
   opt-in local-PostgreSQL plan and cardinality proof for the five-minute reply
   latency monitor. It runs the production query against 50,000 stale rows per

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -903,7 +903,13 @@ Hosted onboarding extras:
   The monitor reports aggregate runtime,
   lane, age, and pending-item counts only. It has its own singleton incident
   row, so an active reply-latency incident cannot suppress a newly discovered
-  progress stall; recovery silently rearms each monitor independently.
+  progress stall. While one progress incident remains anomalous, the same row
+  sends a fresh aggregate reminder every six hours plus stable jitter, outside
+  quiet hours. Each reminder generation derives its Resend idempotency key from
+  the incident identity and previous successful-send boundary, so an ambiguous
+  retry preserves the exact body and provider identity. The latency monitor
+  remains one email per continuous incident. Recovery silently rearms each
+  monitor independently and sends no recovery email.
 - `HOSTED_EXECUTION_CONTROL_URL`
 - `HOSTED_DEVICE_WEBHOOK_QUEUE_PROVIDERS` is an optional comma-separated
   provider rollout gate for the encrypted Cloudflare Queue transport. Leave it

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -905,11 +905,10 @@ Hosted onboarding extras:
   row, so an active reply-latency incident cannot suppress a newly discovered
   progress stall. While one progress incident remains anomalous, the same row
   sends a fresh aggregate reminder every six hours plus stable jitter, outside
-  quiet hours. Each reminder generation derives its Resend idempotency key from
-  the incident identity and previous successful-send boundary, so an ambiguous
-  retry preserves the exact body and provider identity. The latency monitor
-  remains one email per continuous incident. Recovery silently rearms each
-  monitor independently and sends no recovery email.
+  quiet hours. Each fresh reminder claim persists a new generation identity
+  before Resend, while an ambiguous retry reuses that identity and the exact
+  body. The latency monitor remains one email per continuous incident. Recovery
+  silently rearms each monitor independently and sends no recovery email.
 - `HOSTED_EXECUTION_CONTROL_URL`
 - `HOSTED_DEVICE_WEBHOOK_QUEUE_PROVIDERS` is an optional comma-separated
   provider rollout gate for the encrypted Cloudflare Queue transport. Leave it

--- a/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
+++ b/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
@@ -41,11 +41,6 @@ interface HostedOperationalAlertHealth {
 
 export type HostedOperationalAlertNotificationKind = "alert" | "reminder";
 
-export interface HostedOperationalAlertNotification {
-  idempotencyKeySuffix: string;
-  kind: HostedOperationalAlertNotificationKind;
-}
-
 export interface HostedOperationalAlertMonitorSpec<
   Health extends HostedOperationalAlertHealth,
   Client extends HostedOperationalAlertPrismaClient,
@@ -54,7 +49,6 @@ export interface HostedOperationalAlertMonitorSpec<
     health: Health;
     incidentId: string | null;
     message?: string | null;
-    notification?: HostedOperationalAlertNotification | null;
     now: Date;
     phase: "alert" | "healthy";
   }): Prisma.InputJsonObject;
@@ -149,7 +143,7 @@ export async function runHostedOperationalEmailIncident<
     const sent = await sendAlert({
       config: input.alertConfig.email.resend,
       idempotencyKey:
-        `${input.spec.idempotencyScope}/${action.incidentId}/${action.idempotencyKeySuffix}`,
+        `${input.spec.idempotencyScope}/${action.incidentId}/alert`,
       signal: input.signal,
       subject: input.spec.subject,
       text: action.message,
@@ -369,9 +363,11 @@ async function claimHostedOperationalAlertSend<
     };
   }
 
-  const incidentId = input.state.status === input.spec.status.healthy
-    ? randomUUID()
-    : readHostedOperationalAlertIncidentId(input.state);
+  const retrying = input.state.status === input.spec.status.alertSending
+    || input.state.status === input.spec.status.alertFailed;
+  const incidentId = retrying
+    ? readHostedOperationalAlertIncidentId(input.state)
+    : randomUUID();
   if (!incidentId) {
     throw hostedOnboardingError({
       code: input.spec.error.incidentInvalidCode,
@@ -380,17 +376,13 @@ async function claimHostedOperationalAlertSend<
     });
   }
 
-  const notification = readHostedOperationalAlertNotificationForClaim({
-    spec: input.spec,
-    state: input.state,
-  });
-  const retrying = input.state.status === input.spec.status.alertSending
-    || input.state.status === input.spec.status.alertFailed;
+  const notificationKind: HostedOperationalAlertNotificationKind =
+    input.state.status === input.spec.status.alerting ? "reminder" : "alert";
   const message = retrying
     ? readHostedOperationalAlertMessage(input.state)
     : input.spec.buildMessage({
         health,
-        notificationKind: notification.kind,
+        notificationKind,
         now: admissionCheckedAt,
       });
   if (!message) {
@@ -415,7 +407,6 @@ async function claimHostedOperationalAlertSend<
         health,
         incidentId,
         message,
-        notification,
         now: admissionCheckedAt,
         phase: "alert",
       }),
@@ -432,7 +423,6 @@ async function claimHostedOperationalAlertSend<
   return {
     action: {
       attemptedAt: admissionCheckedAt,
-      idempotencyKeySuffix: notification.idempotencyKeySuffix,
       incidentId,
       message,
     },
@@ -443,7 +433,6 @@ async function claimHostedOperationalAlertSend<
 
 interface HostedOperationalAlertClaimedAction {
   attemptedAt: Date;
-  idempotencyKeySuffix: string;
   incidentId: string;
   message: string;
 }
@@ -528,99 +517,6 @@ function readHostedOperationalAlertMessage(
   return details
     ? normalizeNullableString(readJsonString(details.message))
     : null;
-}
-
-function readHostedOperationalAlertNotificationForClaim<
-  Health extends HostedOperationalAlertHealth,
-  Client extends HostedOperationalAlertPrismaClient,
->(input: {
-  spec: HostedOperationalAlertMonitorSpec<Health, Client>;
-  state: HostedLinqAlert;
-}): HostedOperationalAlertNotification {
-  if (input.state.status === input.spec.status.alerting) {
-    if (
-      input.spec.reminderIntervalMs === undefined
-      || input.state.sentAt === null
-    ) {
-      throw hostedOnboardingError({
-        code: input.spec.error.incidentInvalidCode,
-        httpStatus: 500,
-        message: input.spec.error.incidentInvalidMessage,
-      });
-    }
-    return {
-      idempotencyKeySuffix: `reminder/${input.state.sentAt.getTime()}`,
-      kind: "reminder",
-    };
-  }
-
-  if (
-    input.state.status !== input.spec.status.alertSending
-    && input.state.status !== input.spec.status.alertFailed
-  ) {
-    return {
-      idempotencyKeySuffix: "alert",
-      kind: "alert",
-    };
-  }
-
-  const persisted = readHostedOperationalAlertNotification(input.state);
-  if (persisted === undefined) {
-    return {
-      idempotencyKeySuffix: "alert",
-      kind: "alert",
-    };
-  }
-  if (
-    persisted === null
-    || (
-      persisted.kind === "reminder"
-      && (
-        input.spec.reminderIntervalMs === undefined
-        || input.state.sentAt === null
-        || persisted.idempotencyKeySuffix
-          !== `reminder/${input.state.sentAt.getTime()}`
-      )
-    )
-  ) {
-    throw hostedOnboardingError({
-      code: input.spec.error.stateInvalidCode,
-      httpStatus: 500,
-      message: input.spec.error.stateInvalidMessage,
-    });
-  }
-  return persisted;
-}
-
-function readHostedOperationalAlertNotification(
-  state: HostedLinqAlert,
-): HostedOperationalAlertNotification | null | undefined {
-  const details = readJsonObject(state.detailsJson);
-  if (!details || details.notification === undefined) {
-    return undefined;
-  }
-  const notification = readJsonObject(details.notification);
-  if (!notification) {
-    return null;
-  }
-  const kind = readJsonString(notification.kind);
-  const idempotencyKeySuffix = normalizeNullableString(
-    readJsonString(notification.idempotencyKeySuffix),
-  );
-  if (
-    kind === "alert"
-    && idempotencyKeySuffix === "alert"
-  ) {
-    return { idempotencyKeySuffix, kind };
-  }
-  if (
-    kind === "reminder"
-    && idempotencyKeySuffix !== null
-    && /^reminder\/\d+$/u.test(idempotencyKeySuffix)
-  ) {
-    return { idempotencyKeySuffix, kind };
-  }
-  return null;
 }
 
 function readHostedOperationalAlertFailure(input: {

--- a/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
+++ b/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
@@ -39,6 +39,13 @@ interface HostedOperationalAlertHealth {
   anomalous: boolean;
 }
 
+export type HostedOperationalAlertNotificationKind = "alert" | "reminder";
+
+export interface HostedOperationalAlertNotification {
+  idempotencyKeySuffix: string;
+  kind: HostedOperationalAlertNotificationKind;
+}
+
 export interface HostedOperationalAlertMonitorSpec<
   Health extends HostedOperationalAlertHealth,
   Client extends HostedOperationalAlertPrismaClient,
@@ -47,10 +54,15 @@ export interface HostedOperationalAlertMonitorSpec<
     health: Health;
     incidentId: string | null;
     message?: string | null;
+    notification?: HostedOperationalAlertNotification | null;
     now: Date;
     phase: "alert" | "healthy";
   }): Prisma.InputJsonObject;
-  buildMessage(input: { health: Health; now: Date }): string;
+  buildMessage(input: {
+    health: Health;
+    notificationKind: HostedOperationalAlertNotificationKind;
+    now: Date;
+  }): string;
   error: {
     incidentInvalidCode: string;
     incidentInvalidMessage: string;
@@ -66,6 +78,7 @@ export interface HostedOperationalAlertMonitorSpec<
   idempotencyScope: string;
   kind: string;
   readHealth(input: { now: Date; prisma: Client }): Promise<Health>;
+  reminderIntervalMs?: number;
   status: {
     alertFailed: string;
     alertSending: string;
@@ -136,7 +149,7 @@ export async function runHostedOperationalEmailIncident<
     const sent = await sendAlert({
       config: input.alertConfig.email.resend,
       idempotencyKey:
-        `${input.spec.idempotencyScope}/${action.incidentId}/alert`,
+        `${input.spec.idempotencyScope}/${action.incidentId}/${action.idempotencyKeySuffix}`,
       signal: input.signal,
       subject: input.spec.subject,
       text: action.message,
@@ -237,7 +250,16 @@ async function prepareHostedOperationalAlertTransition<
 }> {
   if (input.health.anomalous) {
     if (input.state.status === input.spec.status.alerting) {
-      return { candidateState: null, outcome: "incident_active" };
+      const reminderDueAtMs = readHostedOperationalAlertReminderDueAtMs({
+        spec: input.spec,
+        state: input.state,
+      });
+      if (
+        reminderDueAtMs === null
+        || input.now.getTime() < reminderDueAtMs
+      ) {
+        return { candidateState: null, outcome: "incident_active" };
+      }
     }
     const deferred = readHostedOperationalAlertDeferral({
       now: input.now,
@@ -358,11 +380,17 @@ async function claimHostedOperationalAlertSend<
     });
   }
 
-  const message = input.state.status === input.spec.status.alertSending
-    || input.state.status === input.spec.status.alertFailed
+  const notification = readHostedOperationalAlertNotificationForClaim({
+    spec: input.spec,
+    state: input.state,
+  });
+  const retrying = input.state.status === input.spec.status.alertSending
+    || input.state.status === input.spec.status.alertFailed;
+  const message = retrying
     ? readHostedOperationalAlertMessage(input.state)
     : input.spec.buildMessage({
         health,
+        notificationKind: notification.kind,
         now: admissionCheckedAt,
       });
   if (!message) {
@@ -387,6 +415,7 @@ async function claimHostedOperationalAlertSend<
         health,
         incidentId,
         message,
+        notification,
         now: admissionCheckedAt,
         phase: "alert",
       }),
@@ -403,6 +432,7 @@ async function claimHostedOperationalAlertSend<
   return {
     action: {
       attemptedAt: admissionCheckedAt,
+      idempotencyKeySuffix: notification.idempotencyKeySuffix,
       incidentId,
       message,
     },
@@ -413,6 +443,7 @@ async function claimHostedOperationalAlertSend<
 
 interface HostedOperationalAlertClaimedAction {
   attemptedAt: Date;
+  idempotencyKeySuffix: string;
   incidentId: string;
   message: string;
 }
@@ -499,6 +530,99 @@ function readHostedOperationalAlertMessage(
     : null;
 }
 
+function readHostedOperationalAlertNotificationForClaim<
+  Health extends HostedOperationalAlertHealth,
+  Client extends HostedOperationalAlertPrismaClient,
+>(input: {
+  spec: HostedOperationalAlertMonitorSpec<Health, Client>;
+  state: HostedLinqAlert;
+}): HostedOperationalAlertNotification {
+  if (input.state.status === input.spec.status.alerting) {
+    if (
+      input.spec.reminderIntervalMs === undefined
+      || input.state.sentAt === null
+    ) {
+      throw hostedOnboardingError({
+        code: input.spec.error.incidentInvalidCode,
+        httpStatus: 500,
+        message: input.spec.error.incidentInvalidMessage,
+      });
+    }
+    return {
+      idempotencyKeySuffix: `reminder/${input.state.sentAt.getTime()}`,
+      kind: "reminder",
+    };
+  }
+
+  if (
+    input.state.status !== input.spec.status.alertSending
+    && input.state.status !== input.spec.status.alertFailed
+  ) {
+    return {
+      idempotencyKeySuffix: "alert",
+      kind: "alert",
+    };
+  }
+
+  const persisted = readHostedOperationalAlertNotification(input.state);
+  if (persisted === undefined) {
+    return {
+      idempotencyKeySuffix: "alert",
+      kind: "alert",
+    };
+  }
+  if (
+    persisted === null
+    || (
+      persisted.kind === "reminder"
+      && (
+        input.spec.reminderIntervalMs === undefined
+        || input.state.sentAt === null
+        || persisted.idempotencyKeySuffix
+          !== `reminder/${input.state.sentAt.getTime()}`
+      )
+    )
+  ) {
+    throw hostedOnboardingError({
+      code: input.spec.error.stateInvalidCode,
+      httpStatus: 500,
+      message: input.spec.error.stateInvalidMessage,
+    });
+  }
+  return persisted;
+}
+
+function readHostedOperationalAlertNotification(
+  state: HostedLinqAlert,
+): HostedOperationalAlertNotification | null | undefined {
+  const details = readJsonObject(state.detailsJson);
+  if (!details || details.notification === undefined) {
+    return undefined;
+  }
+  const notification = readJsonObject(details.notification);
+  if (!notification) {
+    return null;
+  }
+  const kind = readJsonString(notification.kind);
+  const idempotencyKeySuffix = normalizeNullableString(
+    readJsonString(notification.idempotencyKeySuffix),
+  );
+  if (
+    kind === "alert"
+    && idempotencyKeySuffix === "alert"
+  ) {
+    return { idempotencyKeySuffix, kind };
+  }
+  if (
+    kind === "reminder"
+    && idempotencyKeySuffix !== null
+    && /^reminder\/\d+$/u.test(idempotencyKeySuffix)
+  ) {
+    return { idempotencyKeySuffix, kind };
+  }
+  return null;
+}
+
 function readHostedOperationalAlertFailure(input: {
   error: unknown;
   unknownErrorCode: string;
@@ -566,6 +690,34 @@ function readHostedOperationalAlertDeferral<
   return input.state.status === input.spec.status.alertSending
     ? "coalesced"
     : "deferred_rate_limit";
+}
+
+function readHostedOperationalAlertReminderDueAtMs<
+  Health extends HostedOperationalAlertHealth,
+  Client extends HostedOperationalAlertPrismaClient,
+>(input: {
+  spec: HostedOperationalAlertMonitorSpec<Health, Client>;
+  state: HostedLinqAlert;
+}): number | null {
+  const intervalMs = input.spec.reminderIntervalMs;
+  if (intervalMs === undefined) {
+    return null;
+  }
+  if (
+    !Number.isSafeInteger(intervalMs)
+    || intervalMs <= 0
+    || input.state.sentAt === null
+  ) {
+    throw hostedOnboardingError({
+      code: input.spec.error.stateInvalidCode,
+      httpStatus: 500,
+      message: input.spec.error.stateInvalidMessage,
+    });
+  }
+  const jitterMs = stableHostedOperationalAlertJitterMs(
+    `${input.spec.id}:reminder:${input.state.sentAt.toISOString()}`,
+  );
+  return input.state.sentAt.getTime() + intervalMs + jitterMs;
 }
 
 function isHostedOperationalAlertQuietTime<

--- a/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
+++ b/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
@@ -24,7 +24,7 @@ export const HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS = 6 * 60 * 60_000;
 const HOSTED_RUNTIME_PROGRESS_MONITOR_ID = "hosted-runtime-progress-monitor:v1";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_KIND = "hosted_runtime_progress_monitor";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_SCHEMA =
-  "murph.hosted-runtime-progress-monitor.v2";
+  "murph.hosted-runtime-progress-monitor.v1";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_SUBJECT =
   "Hosted runtime progress stalled";
 const HOSTED_RUNTIME_PROGRESS_READ_LIMIT = 20_000;
@@ -506,10 +506,6 @@ function buildHostedRuntimeProgressAlertDetails(input: {
   health: HostedRuntimeProgressHealth;
   incidentId: string | null;
   message?: string | null;
-  notification?: {
-    idempotencyKeySuffix: string;
-    kind: "alert" | "reminder";
-  } | null;
   now: Date;
   phase: "alert" | "healthy";
 }): Prisma.InputJsonObject {
@@ -531,12 +527,6 @@ function buildHostedRuntimeProgressAlertDetails(input: {
     incidentId: input.incidentId,
     lastEvaluatedAt: input.now.toISOString(),
     message: input.message ?? null,
-    notification: input.notification
-      ? {
-          idempotencyKeySuffix: input.notification.idempotencyKeySuffix,
-          kind: input.notification.kind,
-        }
-      : null,
     phase: input.phase,
     schema: HOSTED_RUNTIME_PROGRESS_MONITOR_SCHEMA,
     thresholdMs: input.health.thresholdMs,

--- a/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
+++ b/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
@@ -19,11 +19,12 @@ import {
 import { getPrisma } from "../prisma";
 
 export const HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS = 15 * 60_000;
+export const HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS = 6 * 60 * 60_000;
 
 const HOSTED_RUNTIME_PROGRESS_MONITOR_ID = "hosted-runtime-progress-monitor:v1";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_KIND = "hosted_runtime_progress_monitor";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_SCHEMA =
-  "murph.hosted-runtime-progress-monitor.v1";
+  "murph.hosted-runtime-progress-monitor.v2";
 const HOSTED_RUNTIME_PROGRESS_MONITOR_SUBJECT =
   "Hosted runtime progress stalled";
 const HOSTED_RUNTIME_PROGRESS_READ_LIMIT = 20_000;
@@ -100,6 +101,7 @@ const HOSTED_RUNTIME_PROGRESS_MONITOR_SPEC: HostedOperationalAlertMonitorSpec<
   idempotencyScope: "murph/runtime-progress",
   kind: HOSTED_RUNTIME_PROGRESS_MONITOR_KIND,
   readHealth: readHostedRuntimeProgressHealth,
+  reminderIntervalMs: HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS,
   status: MONITOR_STATUS,
   subject: HOSTED_RUNTIME_PROGRESS_MONITOR_SUBJECT,
 };
@@ -504,6 +506,10 @@ function buildHostedRuntimeProgressAlertDetails(input: {
   health: HostedRuntimeProgressHealth;
   incidentId: string | null;
   message?: string | null;
+  notification?: {
+    idempotencyKeySuffix: string;
+    kind: "alert" | "reminder";
+  } | null;
   now: Date;
   phase: "alert" | "healthy";
 }): Prisma.InputJsonObject {
@@ -525,6 +531,12 @@ function buildHostedRuntimeProgressAlertDetails(input: {
     incidentId: input.incidentId,
     lastEvaluatedAt: input.now.toISOString(),
     message: input.message ?? null,
+    notification: input.notification
+      ? {
+          idempotencyKeySuffix: input.notification.idempotencyKeySuffix,
+          kind: input.notification.kind,
+        }
+      : null,
     phase: input.phase,
     schema: HOSTED_RUNTIME_PROGRESS_MONITOR_SCHEMA,
     thresholdMs: input.health.thresholdMs,
@@ -533,6 +545,7 @@ function buildHostedRuntimeProgressAlertDetails(input: {
 
 function buildHostedRuntimeProgressAlertMessage(input: {
   health: HostedRuntimeProgressHealth;
+  notificationKind: "alert" | "reminder";
   now: Date;
 }): string {
   const evidence = [
@@ -559,7 +572,9 @@ function buildHostedRuntimeProgressAlertMessage(input: {
   ].filter((value): value is string => value !== null);
 
   return [
-    "Murph runtime progress alert.",
+    input.notificationKind === "reminder"
+      ? "Murph runtime progress reminder."
+      : "Murph runtime progress alert.",
     `${evidence.join("; ")}.`,
     timing.length > 0 ? `${timing.join(". ")}.` : null,
     `Checked ${formatAlertTime(input.now)}.`,

--- a/apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-latency-alert-monitor.test.ts
@@ -646,6 +646,35 @@ describe("hosted runtime latency alert monitor", () => {
     });
   });
 
+  it("keeps a latency incident to one email beyond the progress reminder horizon", async () => {
+    const fixture = createMonitorPrismaFixture([
+      latencyRow({
+        acceptedAt: "2026-07-26T15:58:00.000Z",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      return { providerMessageId: "resend-email-long-incident" };
+    });
+
+    const opened = await runHostedRuntimeLatencyAlertMonitor({
+      env: alertEnv,
+      now,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const stillActive = await runHostedRuntimeLatencyAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-07-26T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(opened.outcome).toBe("alert_sent");
+    expect(stillActive.outcome).toBe("incident_active");
+    expect(sendAlert).toHaveBeenCalledTimes(1);
+  });
+
   it("names overdue terminal checkpoint acknowledgement in the alert", async () => {
     const fixture = createMonitorPrismaFixture([
       latencyRow({

--- a/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
@@ -22,6 +22,17 @@ const alertEnv = {
   RESEND_API_KEY: "re_test",
 };
 
+function createVoidDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("hosted runtime progress health", () => {
   it("detects the exact 15-minute durable progress boundary across both lanes", () => {
     const health = summarizeHostedRuntimeProgressRows({
@@ -298,16 +309,33 @@ describe("hosted runtime progress alert monitor", () => {
       prisma: fixture.prisma,
       sendAlert,
     });
+    const remindedAgain = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-11T04:30:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
 
     expect(HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS).toBe(6 * 60 * 60_000);
     expect(opened.outcome).toBe("alert_sent");
     expect(exactBoundary.outcome).toBe("incident_active");
     expect(reminded.outcome).toBe("alert_sent");
-    expect(fixture.queryRaw).toHaveBeenCalledTimes(5);
-    expect(sendAlert).toHaveBeenCalledTimes(2);
+    expect(remindedAgain.outcome).toBe("alert_sent");
+    expect(fixture.queryRaw).toHaveBeenCalledTimes(7);
+    expect(sendAlert).toHaveBeenCalledTimes(3);
+    const initialKey = sendAlert.mock.calls[0]?.[0].idempotencyKey ?? "";
+    const firstReminderKey = sendAlert.mock.calls[1]?.[0].idempotencyKey ?? "";
+    const secondReminderKey = sendAlert.mock.calls[2]?.[0].idempotencyKey ?? "";
+    expect(initialKey).toMatch(/^murph\/runtime-progress\/[0-9a-f-]+\/alert$/u);
+    expect(firstReminderKey).toMatch(
+      /^murph\/runtime-progress\/[0-9a-f-]+\/alert$/u,
+    );
+    expect(secondReminderKey).toMatch(
+      /^murph\/runtime-progress\/[0-9a-f-]+\/alert$/u,
+    );
+    expect(firstReminderKey).not.toBe(initialKey);
+    expect(secondReminderKey).not.toBe(firstReminderKey);
     expect(sendAlert.mock.calls[1]?.[0]).toMatchObject({
-      idempotencyKey:
-        `murph/runtime-progress/${readIncidentId(fixture.readState())}/reminder/${now.getTime()}`,
       subject: "Hosted runtime progress stalled",
       to: ["operator@example.test"],
     });
@@ -324,11 +352,7 @@ describe("hosted runtime progress alert monitor", () => {
     expect(persisted).not.toContain("runtime_private_reminder_a");
     expect(persisted).not.toContain("runtime_private_reminder_b");
     expect(fixture.readState()?.detailsJson).toMatchObject({
-      notification: {
-        idempotencyKeySuffix: `reminder/${now.getTime()}`,
-        kind: "reminder",
-      },
-      schema: "murph.hosted-runtime-progress-monitor.v2",
+      schema: "murph.hosted-runtime-progress-monitor.v1",
     });
   });
 
@@ -391,6 +415,53 @@ describe("hosted runtime progress alert monitor", () => {
     });
   });
 
+  it("admits one provider effect when due reminder scans overlap", async () => {
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-10T15:00:00.000Z",
+        lane: "system",
+        runtimeKey: "runtime_private",
+      }),
+    ]);
+    let sendOrdinal = 0;
+    const reminderStarted = createVoidDeferred();
+    const reminderRelease = createVoidDeferred();
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      sendOrdinal += 1;
+      if (sendOrdinal === 2) {
+        reminderStarted.resolve();
+        await reminderRelease.promise;
+      }
+      return { providerMessageId: `provider-message-${sendOrdinal}` };
+    });
+
+    await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const firstReminder = runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    await reminderStarted.promise;
+    const overlapping = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    reminderRelease.resolve();
+
+    expect((await firstReminder).outcome).toBe("alert_sent");
+    expect(overlapping.outcome).toBe("coalesced");
+    expect(sendAlert).toHaveBeenCalledTimes(2);
+  });
+
   it("defers an overdue reminder through quiet hours and resumes in the morning", async () => {
     const initialNow = instant("2026-08-11T00:00:00.000Z");
     const fixture = createProgressMonitorFixture([
@@ -432,7 +503,7 @@ describe("hosted runtime progress alert monitor", () => {
     );
   });
 
-  it("upgrades an already-active v1 incident in place", async () => {
+  it("reminds from an already-active v1 incident without a migration", async () => {
     const fixture = createProgressMonitorFixture([
       progressRow({
         progressOriginAt: "2026-08-10T15:00:00.000Z",
@@ -455,6 +526,7 @@ describe("hosted runtime progress alert monitor", () => {
     if (!activeState) {
       throw new Error("Expected an active progress incident.");
     }
+    const legacyIncidentId = readIncidentId(activeState);
     fixture.setState({
       ...activeState,
       detailsJson: {
@@ -480,12 +552,9 @@ describe("hosted runtime progress alert monitor", () => {
 
     expect(reminded.outcome).toBe("alert_sent");
     expect(sendAlert).toHaveBeenCalledTimes(2);
+    expect(readIncidentId(fixture.readState())).not.toBe(legacyIncidentId);
     expect(fixture.readState()?.detailsJson).toMatchObject({
-      notification: {
-        idempotencyKeySuffix: `reminder/${now.getTime()}`,
-        kind: "reminder",
-      },
-      schema: "murph.hosted-runtime-progress-monitor.v2",
+      schema: "murph.hosted-runtime-progress-monitor.v1",
     });
   });
 

--- a/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
@@ -1,8 +1,12 @@
 import type { HostedLinqAlert } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import type { sendHostedResendPlainTextEmail } from "@/src/lib/hosted-onboarding/resend-plain-text-email";
 import {
+  HostedResendPlainTextEmailError,
+  type sendHostedResendPlainTextEmail,
+} from "@/src/lib/hosted-onboarding/resend-plain-text-email";
+import {
+  HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS,
   HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
   readHostedRuntimeProgressHealth,
   runHostedRuntimeProgressAlertMonitor,
@@ -248,6 +252,243 @@ describe("hosted runtime progress alert monitor", () => {
     });
   });
 
+  it("refreshes aggregate evidence in a six-hour reminder", async () => {
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-10T15:30:00.000Z",
+        lane: "system",
+        pendingCount: 2n,
+        runtimeKey: "runtime_private_initial",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (input: AlertSendInput) => {
+      void input;
+      return { providerMessageId: "provider-message" };
+    });
+
+    const opened = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    fixture.setRows([
+      progressRow({
+        progressOriginAt: "2026-08-10T14:00:00.000Z",
+        lane: "system",
+        pendingCount: 4n,
+        runtimeKey: "runtime_private_reminder_a",
+      }),
+      progressRow({
+        progressOriginAt: "2026-08-10T15:00:00.000Z",
+        lane: "conversation",
+        pendingCount: 3n,
+        runtimeKey: "runtime_private_reminder_b",
+      }),
+    ]);
+    const exactBoundary = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:00:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const reminded = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS).toBe(6 * 60 * 60_000);
+    expect(opened.outcome).toBe("alert_sent");
+    expect(exactBoundary.outcome).toBe("incident_active");
+    expect(reminded.outcome).toBe("alert_sent");
+    expect(fixture.queryRaw).toHaveBeenCalledTimes(5);
+    expect(sendAlert).toHaveBeenCalledTimes(2);
+    expect(sendAlert.mock.calls[1]?.[0]).toMatchObject({
+      idempotencyKey:
+        `murph/runtime-progress/${readIncidentId(fixture.readState())}/reminder/${now.getTime()}`,
+      subject: "Hosted runtime progress stalled",
+      to: ["operator@example.test"],
+    });
+    const reminderMessage = sendAlert.mock.calls[1]?.[0].text ?? "";
+    const persisted = JSON.stringify(fixture.readState()?.detailsJson);
+    expect(reminderMessage).toContain("Murph runtime progress reminder.");
+    expect(reminderMessage).toContain("2 active runtimes");
+    expect(reminderMessage).toContain("Affected lanes: 1 system, 1 conversation");
+    expect(reminderMessage).toContain("Pending live items: 7");
+    expect(reminderMessage).not.toContain("runtime_private_initial");
+    expect(reminderMessage).not.toContain("runtime_private_reminder_a");
+    expect(reminderMessage).not.toContain("runtime_private_reminder_b");
+    expect(persisted).not.toContain("runtime_private_initial");
+    expect(persisted).not.toContain("runtime_private_reminder_a");
+    expect(persisted).not.toContain("runtime_private_reminder_b");
+    expect(fixture.readState()?.detailsJson).toMatchObject({
+      notification: {
+        idempotencyKeySuffix: `reminder/${now.getTime()}`,
+        kind: "reminder",
+      },
+      schema: "murph.hosted-runtime-progress-monitor.v2",
+    });
+  });
+
+  it("retries one reminder with its exact persisted body and Resend key", async () => {
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-10T15:00:00.000Z",
+        lane: "system",
+        runtimeKey: "runtime_private",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      return { providerMessageId: "provider-message" };
+    })
+      .mockResolvedValueOnce({ providerMessageId: "initial-message" })
+      .mockRejectedValueOnce(new HostedResendPlainTextEmailError(
+        "Hosted Resend email send failed.",
+        {
+          code: "RESEND_SEND_FAILED",
+          providerStatus: 503,
+        },
+      ))
+      .mockResolvedValueOnce({ providerMessageId: "reminder-message" });
+
+    await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    await expect(runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    })).rejects.toMatchObject({
+      code: "HOSTED_RUNTIME_PROGRESS_ALERT_SEND_FAILED",
+    });
+    const retried = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:35:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(retried.outcome).toBe("alert_sent");
+    expect(sendAlert).toHaveBeenCalledTimes(3);
+    expect(sendAlert.mock.calls[2]?.[0].idempotencyKey).toBe(
+      sendAlert.mock.calls[1]?.[0].idempotencyKey,
+    );
+    expect(sendAlert.mock.calls[2]?.[0].text).toBe(
+      sendAlert.mock.calls[1]?.[0].text,
+    );
+    expect(fixture.readState()).toMatchObject({
+      attemptCount: 3,
+      lastErrorCode: null,
+      lastProviderStatus: null,
+      status: "progress_alerting",
+    });
+  });
+
+  it("defers an overdue reminder through quiet hours and resumes in the morning", async () => {
+    const initialNow = instant("2026-08-11T00:00:00.000Z");
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-10T23:00:00.000Z",
+        lane: "system",
+        runtimeKey: "runtime_private",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      return { providerMessageId: "provider-message" };
+    });
+
+    await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: initialNow,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const overnight = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-11T06:20:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const morning = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-11T14:20:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(overnight.outcome).toBe("deferred_quiet_hours");
+    expect(morning.outcome).toBe("alert_sent");
+    expect(sendAlert).toHaveBeenCalledTimes(2);
+    expect(sendAlert.mock.calls[1]?.[0].text).toContain(
+      "Murph runtime progress reminder.",
+    );
+  });
+
+  it("upgrades an already-active v1 incident in place", async () => {
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-10T15:00:00.000Z",
+        lane: "system",
+        runtimeKey: "runtime_private",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      return { providerMessageId: "provider-message" };
+    });
+
+    await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+    const activeState = fixture.readState();
+    if (!activeState) {
+      throw new Error("Expected an active progress incident.");
+    }
+    fixture.setState({
+      ...activeState,
+      detailsJson: {
+        health: {
+          pendingItemCount: 1,
+          stalledRuntimeCount: 1,
+        },
+        incidentId: readIncidentId(activeState),
+        lastEvaluatedAt: now.toISOString(),
+        message: sendAlert.mock.calls[0]?.[0].text ?? null,
+        phase: "alert",
+        schema: "murph.hosted-runtime-progress-monitor.v1",
+        thresholdMs: HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
+      },
+    });
+
+    const reminded = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: instant("2026-08-10T22:15:00.000Z"),
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(reminded.outcome).toBe("alert_sent");
+    expect(sendAlert).toHaveBeenCalledTimes(2);
+    expect(fixture.readState()?.detailsJson).toMatchObject({
+      notification: {
+        idempotencyKeySuffix: `reminder/${now.getTime()}`,
+        kind: "reminder",
+      },
+      schema: "murph.hosted-runtime-progress-monitor.v2",
+    });
+  });
+
   it("silently rearms after recovery and gives a later stall a new identity", async () => {
     const fixture = createProgressMonitorFixture([
       progressRow({
@@ -411,7 +652,23 @@ function createProgressMonitorFixture(
     setRows(nextRows: readonly HostedRuntimeProgressHealthRow[]) {
       rows = [...nextRows];
     },
+    setState(nextState: HostedLinqAlert) {
+      state = nextState;
+    },
   };
+}
+
+function readIncidentId(state: HostedLinqAlert | null): string {
+  const details = state?.detailsJson;
+  if (
+    !details
+    || typeof details !== "object"
+    || Array.isArray(details)
+    || typeof details.incidentId !== "string"
+  ) {
+    throw new TypeError("Expected an incident identity.");
+  }
+  return details.incidentId;
 }
 
 type AlertSendInput = Parameters<typeof sendHostedResendPlainTextEmail>[0];


### PR DESCRIPTION
## Outcome
- Remind the operational email recipients every six hours plus stable jitter while a hosted runtime progress incident remains unresolved.
- Reuse the existing singleton state, five-minute cron, quiet hours, send lease, Resend transport, and bounded aggregate health read.
- Preserve one-email-per-incident latency alerts and silent recovery.

## Product UX
Ready: operators receive current aggregate evidence during long incidents, quiet hours remain respected, ambiguous retries keep one provider identity, and members receive no new message or identifying disclosure.

## Evidence
- 62 focused runtime progress, latency, and cron tests pass.
- Web typecheck passes.
- Focused ESLint and diff whitespace checks pass.
- No schema, migration, queue, scheduler, or recipient configuration change.

## Changelog
- Changelog: not applicable
- Reason: Internal operational reliability only; no member-visible behavior changes.

ReviewGPT context sensitivity: sensitive — changes runtime incident lifecycle and external Resend email egress.

ReviewGPT first-reviewed head: e3b0149f8d8533362c81c636cb1ac9816114a5b5