### PR TITLE
chore(cloudflare): ratchet runner bundle budgets

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -98,12 +98,15 @@ const VAULT_CLI_IMPORT_SURFACE_HOOK_SOURCE = [
 // 9,165,765 B on 2026-08-16. The merged assistant execution graph, including
 // the session-routing SQLite projection, measured 9,209,386 B in the Linux
 // deploy lane on 2026-08-18; it extends existing graphs without adding a
-// package. The static startup closure still measured 24,950 B.
+// package. The bounded foreground outbox and pending-input projections measured
+// 9,272,172 B in the Linux deploy lane on 2026-08-19; they extend the same
+// Assistant Engine and hosted-runtime graphs without adding a package. The
+// static startup closure still measured 24,950 B.
 // Keep total output inside a narrow 32 KiB allowance and static startup inside
 // an 8 KiB allowance. If a violation fires, investigate the listed largest
 // inputs first; only raise the budget deliberately for understood, intended
 // growth.
-const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_242_200;
+const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_305_000;
 const VAULT_CLI_BUNDLE_ENTRY_BYTES_BUDGET = 20_000;
 const VAULT_CLI_BUNDLE_STATIC_CLOSURE_BYTES_BUDGET = 33_200;
 

--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -285,9 +285,14 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // runtime and Web-control graph without adding a forbidden boot input. Exact
 // macOS production assembly measured an 8,266,461B static closure on
 // 2026-08-16; ratchet the integrated baseline and retain the same tolerance.
+// The bounded foreground outbox and pending-input projections extend the
+// existing Assistant Engine and hosted-runtime chunks without adding a
+// forbidden boot input. Exact macOS production assembly measured an 8,395,518B
+// static closure on 2026-08-19; ratchet that authored-code baseline and retain
+// the same cross-platform tolerance.
 const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_393_617;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_689_721;
-const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_266_461;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_395_518;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES = 96_000;
 // The @murphai package markers are path suffixes, not node_modules-anchored:

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -401,9 +401,41 @@ describe("runner bundle vault-cli esbuild step", () => {
     await expect(bundleInstalledVaultCliBinary(bundleDir)).rejects.toThrow();
   });
 
-  // Budget enforcement is unit-tested with injected budgets against synthetic
-  // metafiles; the production call site inside bundleInstalledVaultCliBinary
-  // uses the real constants against the real esbuild metafile.
+  // The production call site inside bundleInstalledVaultCliBinary uses the
+  // default budgets against the real esbuild metafile. Pin the exact default
+  // total ceiling here so a future ratchet cannot silently widen it.
+  it("accepts the default total budget exactly and rejects one byte over", () => {
+    const createMetafile = (totalBytes: number): Metafile => ({
+      inputs: {},
+      outputs: {
+        ".bundle/bin.js": {
+          bytes: 1,
+          entryPoint: "packages/cli/src/bin.ts",
+          exports: [],
+          imports: [{ kind: "dynamic-import", path: "./chunk-heavy.js" }],
+          inputs: {},
+        },
+        ".bundle/chunk-heavy.js": {
+          bytes: totalBytes - 1,
+          exports: [],
+          imports: [],
+          inputs: {},
+        },
+      },
+    });
+
+    expect(assertVaultCliBundleWithinBudgets(createMetafile(9_305_000))).toEqual({
+      entryBytes: 1,
+      staticClosureBytes: 1,
+      totalBytes: 9_305_000,
+    });
+    expect(() =>
+      assertVaultCliBundleWithinBudgets(createMetafile(9_305_001))
+    ).toThrow(/total output 9305001B exceeds budget 9305000B/u);
+  });
+
+  // Cross-dimension budget enforcement is unit-tested with injected budgets
+  // against synthetic metafiles.
   it("fails the byte budgets with actual-vs-budget numbers and the largest inputs", () => {
     const metafile: Metafile = {
       inputs: {

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -608,7 +608,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     // budget-policy changes remain explicit and reviewed.
     expect(budgets).toEqual({
       entryBytes: 1_689_721 + 48_000,
-      staticClosureBytes: 8_266_461 + 96_000,
+      staticClosureBytes: 8_395_518 + 96_000,
       totalBytes: 11_393_617,
     });
   });


### PR DESCRIPTION
## Outcome

Unblock the protected Cloudflare deployment of the merged foreground-reply bounding work by ratcheting the two existing runner-bundle byte guards to measured, intended authored-code growth. No dependency, import boundary, startup path, or runtime behavior changes.

## Product UX

Not applicable. This changes deployment verification constants and their direct contract test only.

## Evidence

- The protected production workflow failed closed before deployment in all four predeploy lanes at the same vault-CLI total: 9,272,172 bytes versus the prior 9,242,200-byte budget.
- The last successful deployment measured 9,235,923 bytes. The merged outbox and pending-input projection code explains the bounded increase; the listed largest inputs and package graph are unchanged.
- Focused runner-bundle tests pass: 56/56, including the default vault total accepting exactly 9,305,000 bytes and rejecting 9,305,001 bytes.
- Full local production bundle assembly passes. Vault CLI: 9,265,283 bytes total, 671-byte entry, 24,950-byte static closure. Runner entrypoint: 1,703,603-byte entry and 8,395,518-byte static closure. Forbidden boot-input guards remain enabled.
- The protected Linux deployment workflow remains the exact cross-platform proof before promotion.

## Changelog

- Changelog: not applicable
- Reason: Internal deployment-verification ratchet with no intentional member-visible behavior change.

## Deployment concerns

- Deployment: applicable
- Supported skew: A new Worker may meet an old warm runner only during the immediate drain; fingerprint admission rejects that shell before workspace invocation.
- Safe order: Merge this correction, then deploy the Cloudflare Worker and projection-capable runner together with `container_rollout=immediate` and hold assistant testing until managed-container smoke passes.
- Rollback floor: The prior bundle is safe only before the first `session-routing.sqlite` or `outbox-dedupe.sqlite` publication; afterward the projection-capable runner is the hard floor.
- Expected exposure: During drain and replacement, assistant turns may be briefly delayed or unavailable, but stale runners must not execute workspace work.
- Reversibility: Roll back only before first projection publication; after publication, keep this runner release or newer and forward-fix any incident.
- Convergence proof: The protected workflow must pass all predeploy E2Es, report the exact new managed-runner fingerprint, prove the assistant CLI surface, and reject stale warm shells.
- Post-deploy checks: Confirm immediate rollout completion and the exact fingerprint, then verify no stale-fingerprint, projection-rebuild, projection-corruption, or strict outbox-parse errors before member testing.

ReviewGPT context sensitivity: sensitive
Classification reason: production Cloudflare runner deployment guard and rollback-floor release.

ReviewGPT first-reviewed head: f55f7d498dd65cc930e261defafbbfc285a1556a
