### PR TITLE
docs(workflow): preserve release guard wording

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -7,8 +7,8 @@ Last verified: 2026-08-19
 This index is the table of contents for the current canonical docs in this repository.
 It intentionally lists live architecture, product, verification, and package-boundary docs only.
 
-Every pull request carries one mechanically validated deployment-concerns
-disposition. Applicable deploy boundaries record supported skew, safe order,
+Every pull request carries one mechanically validated, field-complete
+deployment-concerns disposition. Applicable deploy boundaries record supported skew, safe order,
 rollback floor, expected exposure, reversibility, convergence proof, and
 post-deploy checks; other changes record one concrete not-applicable reason.
 The contract and its proof are specified by

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -336,8 +336,8 @@ sends a full guarded snapshot. PRs that do not enter that gate do not need the
 line.
 
 The applicable invariant and review docs own the required content for each
-risk and deploy boundary. Do not paste empty risk sections, a manual line-count
-table, the full work plan, or a repeated list of review lenses into every PR.
+risk and deploy boundary. Do not paste empty risk sections, a manual line-count table,
+the full work plan, or a repeated list of review lenses into every PR.
 
 ## Review-Resolution Loop
 


### PR DESCRIPTION
## Why and outcome

The deployment-concerns requirement merged with a harmless line wrap that split a stable phrase consumed by the existing CLI release-documentation audit. Keep that guard green while retaining the new mandatory PR requirement.

## Product UX

- Effort: Not applicable — repository workflow documentation only
- Result: Not applicable
- Walkthrough: No product behavior or member-visible interface changes

## Evidence

- Direct: The focused CLI release audit passes with 45 tests passed and 1 skipped; PR policy tests pass 27 of 27; agent documentation drift checks pass.
- Coverage: These checks exercise the exact wording contract, the new deployment declaration validator, the PR evidence validators, and documentation ownership.

## Deployment concerns

- Deployment: not applicable
- Reason: This restores wording required by a repository-only release audit and does not change runtime behavior or a deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal repository workflow documentation correction only.