### PR TITLE
fix(runtime): preserve foreground retry quiet window

### DIFF
--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3140,7 +3140,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       });
       try {
         let currentAssistantInputId: string | null = null;
-        let acceptedReadyImageCompletion = false;
+        let acceptedForegroundPriorityAssistantInput = false;
         const passPromise = runHostedWorkspaceUntilIdleOrBudget({
           ...baseRunnerInput,
           initialAssistantInputBatch: passInput.initialAssistantInputBatch ?? null,
@@ -3249,9 +3249,9 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                       acceptedInputContext.conversationActivity,
                     );
                   }
-                  const consumedReadyImageCompletion =
-                    consumeReadyImageCompletionInputs(assistantInputIds);
-                  acceptedReadyImageCompletion ||= consumedReadyImageCompletion;
+                  acceptedForegroundPriorityAssistantInput ||=
+                    acceptedInputContext.foregroundPriorityInputAccepted;
+                  consumeReadyImageCompletionInputs(assistantInputIds);
                   return () => {
                     currentAssistantInputId = null;
                   };
@@ -3310,7 +3310,7 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         if (
           passResult.runtimeStateDirty
           && (
-            acceptedReadyImageCompletion
+            acceptedForegroundPriorityAssistantInput
             || passResult.assistantPhaseResult
               ?.foregroundPrioritySystemCompletionProcessed === true
           )
@@ -4374,17 +4374,17 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
       };
       const consumeReadyImageCompletionInputs = (
         acceptedInputIds: readonly string[],
-      ): boolean => {
+      ): void => {
         const readyBatch = readyImageCompletionInputBatch;
         if (!readyBatch) {
-          return false;
+          return;
         }
         const acceptedInputIdSet = new Set(acceptedInputIds);
         const retainedInputIds = readyBatch.assistantInputIds.filter(
           (inputId) => !acceptedInputIdSet.has(inputId),
         );
         if (retainedInputIds.length === readyBatch.assistantInputIds.length) {
-          return false;
+          return;
         }
         readyImageCompletionInputBatch = retainedInputIds.length === 0
           ? null
@@ -4392,7 +4392,6 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               ...readyBatch,
               assistantInputIds: retainedInputIds,
             };
-        return true;
       };
       const absorbForegroundPassResult = (
         passResult: HostedWorkspaceRunnerResult,

--- a/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/turn-input.ts
@@ -70,18 +70,21 @@ export async function resolveHostedCurrentInputIdForAcceptedInputs(input: {
 }): Promise<{
   conversationActivity: HostedConversationActivityObservation;
   currentInputId: string | null;
+  foregroundPriorityInputAccepted: boolean;
 }> {
   const inputIds = uniqueStrings(input.assistantInputIds);
   if (inputIds.length === 0) {
     return {
       conversationActivity: "not_observed",
       currentInputId: null,
+      foregroundPriorityInputAccepted: false,
     };
   }
   if (inputIds.length !== input.assistantInputIds.length) {
     return {
       conversationActivity: "uncertain",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     };
   }
   let events: AssistantInputEventRecord[];
@@ -94,17 +97,23 @@ export async function resolveHostedCurrentInputIdForAcceptedInputs(input: {
     return {
       conversationActivity: "uncertain",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     };
   }
   if (events.length !== inputIds.length) {
     return {
       conversationActivity: "uncertain",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     };
   }
   const conversationActivity = events.some(isHostedConversationActivityInputEvent)
     ? "observed"
     : "not_observed";
+  const foregroundPriorityInputAccepted = events.some((event) =>
+    isHostedConversationActivityInputEvent(event)
+    || isAssistantHostedImageCompletionEvent(event)
+  );
   let batch: AssistantInputEventRecord[];
   try {
     batch = await selectHostedImageCompletionInputEventBatch({
@@ -121,6 +130,7 @@ export async function resolveHostedCurrentInputIdForAcceptedInputs(input: {
     return {
       conversationActivity,
       currentInputId: null,
+      foregroundPriorityInputAccepted,
     };
   }
   return {
@@ -128,6 +138,7 @@ export async function resolveHostedCurrentInputIdForAcceptedInputs(input: {
     currentInputId: batch.length === events.length
       ? batch.at(-1)?.inputId ?? null
       : null,
+    foregroundPriorityInputAccepted,
   };
 }
 

--- a/packages/assistant-runtime/test/hosted-runtime-turn-input.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-turn-input.test.ts
@@ -972,6 +972,7 @@ describe("selectHostedAssistantInputIds", () => {
     expect(acceptedContext).toEqual({
       conversationActivity: "observed",
       currentInputId: fresh.inputId,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -1144,6 +1145,7 @@ describe("selectHostedAssistantInputIds", () => {
     expect(foregroundContext).toEqual({
       conversationActivity: "observed",
       currentInputId: newestFresh.inputId,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -1619,6 +1621,7 @@ describe("selectHostedAssistantInputIds", () => {
     })).resolves.toEqual({
       conversationActivity: "observed",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -1965,6 +1968,7 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
     })).resolves.toEqual({
       conversationActivity: "not_observed",
       currentInputId: null,
+      foregroundPriorityInputAccepted: false,
     });
   });
 
@@ -1997,6 +2001,7 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
     })).resolves.toEqual({
       conversationActivity: "observed",
       currentInputId: second.inputId,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -2029,6 +2034,7 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
     })).resolves.toEqual({
       conversationActivity: "observed",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -2041,6 +2047,7 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
     })).resolves.toEqual({
       conversationActivity: "uncertain",
       currentInputId: null,
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -2056,6 +2063,47 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
       vaultRoot,
     })).resolves.toMatchObject({
       conversationActivity: "not_observed",
+      foregroundPriorityInputAccepted: false,
+    });
+  });
+
+  it("treats an accepted hosted image completion as foreground-priority input", async () => {
+    const vaultRoot = await createTempVault();
+    const origin = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        dedupeKey: "dedupe_accepted_image_origin",
+        eventId: "event_accepted_image_origin",
+        itemId: "item_accepted_image_origin",
+        routeAuthority: true,
+        sessionId: "asst_accepted_image",
+        threadIsDirect: false,
+      }),
+    });
+    const completion = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        actorId: null,
+        dedupeKey: "dedupe_accepted_image_completion",
+        eventId: "event_accepted_image_completion",
+        itemId: "item_accepted_image_completion",
+        lane: "system",
+        laneSeq: "image-completion:accepted",
+        payloadSchema: "murph.hosted-image-completion.v1",
+        routeAuthority: true,
+        sessionId: "asst_accepted_image",
+        text: createHostedImageCompletionText(origin.inputId),
+        threadIsDirect: false,
+        wakeSchema: "murph.hosted-image-completion.v1",
+      }),
+    });
+
+    await expect(resolveHostedCurrentInputIdForAcceptedInputs({
+      assistantInputIds: [completion.inputId],
+      vaultRoot,
+    })).resolves.toMatchObject({
+      conversationActivity: "not_observed",
+      foregroundPriorityInputAccepted: true,
     });
   });
 
@@ -2071,6 +2119,7 @@ describe("resolveHostedCurrentInputIdForAcceptedInputs", () => {
       vaultRoot,
     })).resolves.toMatchObject({
       conversationActivity: "observed",
+      foregroundPriorityInputAccepted: true,
     });
   });
 });

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -37399,8 +37399,29 @@ describe("hosted workspace runtime entrypoint", () => {
       generatedImageRetention: false,
       handoff: "retried trusted completion quiet window",
     },
+    {
+      checkpointAssistantInputRetry: "conversation" as const,
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: false,
+      checkpointTrustedCompletion: false,
+      checkpointSystemControl: false,
+      generatedImageRetention: false,
+      handoff: "retried conversation input quiet window",
+    },
+    {
+      checkpointAssistantInputRetry: "hosted-image" as const,
+      checkpointConversation: false,
+      checkpointConversationInputAhead: false,
+      checkpointRuntimeWake: false,
+      checkpointTrustedCompletion: false,
+      checkpointSystemControl: false,
+      generatedImageRetention: false,
+      handoff: "retried hosted image completion quiet window",
+    },
   ])("older due assistant carry honors $handoff before persisting a later reminder", async (
     {
+      checkpointAssistantInputRetry,
       checkpointConversation,
       checkpointConversationInputAhead,
       checkpointRuntimeWake,
@@ -37434,6 +37455,8 @@ describe("hosted workspace runtime entrypoint", () => {
     const olderWakePersisted = createDeferred<void>();
     const reminderCreated = createDeferred<void>();
     const reminderWakePersisted = createDeferred<void>();
+    const assistantInputRetryFailed = createDeferred<void>();
+    const assistantInputRetryHandled = createDeferred<void>();
     const trustedCompletionHandled = createDeferred<void>();
     const trustedCompletionRetryFailed = createDeferred<void>();
     const firstCheckpointConversationHandled = createDeferred<void>();
@@ -37445,6 +37468,8 @@ describe("hosted workspace runtime entrypoint", () => {
       }),
     ];
     let assistantPass = 0;
+    let assistantInputRetryAttempts = 0;
+    let assistantInputRetryId: string | null = null;
     let reminderReconciled = false;
     let snapshotCount = 0;
     let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
@@ -37532,6 +37557,29 @@ describe("hosted workspace runtime entrypoint", () => {
           },
           async importItem(item, context) {
             events.push(`mailbox.importItem:${item.item.id}`);
+            if (
+              item.item.id
+                === "mailbox_item_entrypoint_assistant_carry_mask_input_retry"
+            ) {
+              assistantInputRetryId = checkpointAssistantInputRetry === "hosted-image"
+                ? await stagePendingHostedImageCompletionInputForMailboxItem({
+                    item: item.item,
+                    vaultRoot,
+                  })
+                : await stagePendingLinqAssistantInputForMailboxItem({
+                    causalSeq: item.item.laneSeq,
+                    item: item.item,
+                    vaultRoot,
+                  });
+              if (checkpointAssistantInputRetry === "conversation") {
+                assert.ok(context?.onConversationInputStaged);
+                context.onConversationInputStaged("linq");
+              }
+              return {
+                assistantInputId: assistantInputRetryId,
+                status: "imported",
+              };
+            }
             if (item.item.lane === "system") {
               if (item.item.kind === "assistant.notification.requested") {
                 if (checkpointTrustedCompletionRetry) {
@@ -37641,6 +37689,55 @@ describe("hosted workspace runtime entrypoint", () => {
             const presentedWakeAt = input.workspace?.nextWakeAt ?? "none";
             events.push(`assistant:${assistantPass}:${presentedWakeAt}:${Date.now()}`);
 
+            if (
+              assistantInputRetryId !== null
+              && !events.includes("assistant-input-retry:handled")
+            ) {
+              assistantInputRetryAttempts += 1;
+              const release = await input.beforeProviderAcceptedInputs?.({
+                turnId: "turn_hosted_runtime_test",
+                acceptedInputs: [{
+                  id: assistantInputRetryId,
+                  source: "assistant-input",
+                }],
+              });
+              await release?.();
+              events.push(
+                `assistant-input-retry:attempt:${assistantInputRetryAttempts}`,
+              );
+              if (assistantInputRetryAttempts === 1) {
+                if (checkpointAssistantInputRetry === "hosted-image") {
+                  assistantInputRetryFailed.resolve();
+                }
+                return {
+                  checkpointReason: "assistant_runtime_commit",
+                  invocationLocalAssistantWakeAt: olderDueWakeAt,
+                  nextWakeAt: olderDueWakeAt,
+                  nextWakeReason: "assistant",
+                  progressed: true,
+                };
+              }
+              if (
+                assistantInputRetryAttempts === 2
+                && checkpointAssistantInputRetry === "conversation"
+              ) {
+                assistantInputRetryFailed.resolve();
+                return { progressed: false };
+              }
+              await writeSyntheticAssistantAutoReplyTerminalEvidence({
+                inputId: assistantInputRetryId,
+                vaultRoot,
+              });
+              events.push("assistant-input-retry:handled");
+              assistantInputRetryHandled.resolve();
+              return {
+                checkpointReason: "assistant_runtime_commit",
+                nextWakeAt: reconciliationWakeAt,
+                nextWakeReason: "assistant",
+                progressed: true,
+              };
+            }
+
             const handlesTrustedCompletion =
               (checkpointTrustedCompletion || checkpointTrustedCompletionRetry)
               && events.includes(
@@ -37716,6 +37813,14 @@ describe("hosted workspace runtime entrypoint", () => {
                   kind: "assistant.notification.requested",
                   lane: "system",
                   laneSeq: "1",
+                }));
+                runtimeWakeSignal.notify(Date.now());
+              }
+              if (checkpointAssistantInputRetry) {
+                mailboxItems.push(createMailboxItem({
+                  id:
+                    "mailbox_item_entrypoint_assistant_carry_mask_input_retry",
+                  laneSeq: "3",
                 }));
                 runtimeWakeSignal.notify(Date.now());
               }
@@ -37801,6 +37906,13 @@ describe("hosted workspace runtime entrypoint", () => {
       }));
       runtimeWakeSignal.notify(Date.parse(TEST_NOW));
       await withRealTimeout(reminderCreated.promise, 15_000, () => events.join(","));
+      if (checkpointAssistantInputRetry) {
+        await withRealTimeout(
+          assistantInputRetryFailed.promise,
+          15_000,
+          () => events.join(","),
+        );
+      }
       await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
       await waitForFakeTimerScheduled(() => events.join(","));
       await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
@@ -37883,6 +37995,52 @@ describe("hosted workspace runtime entrypoint", () => {
           events.join(","),
         );
         await vi.advanceTimersByTimeAsync(1);
+      }
+
+      if (checkpointAssistantInputRetry) {
+        await withRealTimeout(
+          assistantInputRetryHandled.promise,
+          15_000,
+          () => events.join(","),
+        );
+        await new Promise((resolve) => REAL_SET_TIMEOUT(resolve, 0));
+        await waitForFakeTimerScheduled(() => events.join(","));
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+        await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs - 1);
+        assert.equal(
+          events.some((event) => event.startsWith("snapshot:2:")),
+          false,
+          events.join(","),
+        );
+        await vi.advanceTimersByTimeAsync(1);
+        await withRealTimeout(
+          (async () => {
+            while (!events.some((event) => event.startsWith("snapshot:2:"))) {
+              await new Promise<void>((resolve) => setImmediate(resolve));
+            }
+          })(),
+          15_000,
+          () => events.join(","),
+        );
+        const secondSnapshotIndex = events.findIndex((event) =>
+          event.startsWith("snapshot:2:")
+        );
+        assert.equal(
+          events[secondSnapshotIndex],
+          `snapshot:2:idle_shutdown:${
+            Date.parse(TEST_NOW) + 2 * idleCheckpointDelayMs
+          }`,
+        );
+        assert.ok(
+          requireEventIndex(events, "assistant-input-retry:handled")
+            < secondSnapshotIndex,
+          events.join(","),
+        );
+        return;
       }
 
       if (checkpointConversation) {
@@ -40197,6 +40355,86 @@ async function stagePendingLinqAssistantInputForMailboxItem(input: {
     vaultRoot: input.vaultRoot,
   });
   return inputId;
+}
+
+async function stagePendingHostedImageCompletionInputForMailboxItem(input: {
+  item: HostedMailboxItem;
+  vaultRoot: string;
+}): Promise<string> {
+  const originAssistantInputId = await stageAssistantInputEventForMailboxItem({
+    item: createMailboxItem({
+      id: `${input.item.id}_origin`,
+      laneSeq: "2",
+    }),
+    sessionId: "asst_assistant_carry_mask_image_retry",
+    threadId: "thread_assistant_carry_mask_image_retry",
+    threadIsDirect: false,
+    vaultRoot: input.vaultRoot,
+  });
+  const text = [
+    "System note: synthetic trusted hosted image completion.",
+    `<hosted_image_result>${JSON.stringify({
+      originAssistantInputId,
+      originAssistantInputIdExact: true,
+      status: "failed",
+    })}</hosted_image_result>`,
+  ].join("\n");
+  const staged = await upsertAssistantInputEvent({
+    event: {
+      content: {
+        text,
+        transcriptText: text,
+        userMessageContent: [{ text, type: "text" as const }],
+      },
+      conversation: {
+        accountId: "acct_1",
+        actorId: null,
+        actorIsSelf: false,
+        sessionId: "asst_assistant_carry_mask_image_retry",
+        source: "linq",
+        threadId: "thread_assistant_carry_mask_image_retry",
+        threadIsDirect: false,
+      },
+      occurredAt: input.item.occurredAt,
+      receivedAt: input.item.createdAt,
+      replyTarget: {
+        channel: "linq",
+        messageId: `msg_${input.item.id}`,
+        threadId: "thread_assistant_carry_mask_image_retry",
+      },
+      sourceMetadata: {
+        externalThreadRouteAuthorityPresent: true,
+        kind: "linq" as const,
+        partCount: 1,
+        reactionEligible: false,
+        replyToMessageId: null,
+        service: "iMessage",
+      },
+      sourceRef: {
+        dedupeKey: input.item.dedupeKey,
+        eventId: input.item.dedupeKey,
+        itemId: input.item.id,
+        kind: "hosted-mailbox" as const,
+        lane: "system" as const,
+        laneSeq: "image-completion:assistant-carry-mask-retry",
+        payloadSchema: "murph.hosted-image-completion.v1",
+        payloadSource: "inline" as const,
+        source: "hosted-mailbox" as const,
+        wakeSchema: "murph.hosted-image-completion.v1",
+      },
+    },
+    vault: input.vaultRoot,
+  });
+  await updateAssistantInputProjection({
+    inputId: staged.inputId,
+    projection: { status: "pending" },
+    vault: input.vaultRoot,
+  });
+  await enqueueHostedPendingAssistantInputId({
+    inputId: staged.inputId,
+    vaultRoot: input.vaultRoot,
+  });
+  return staged.inputId;
 }
 
 async function writeSyntheticAssistantAutoReplyTerminalEvidence(input: {


### PR DESCRIPTION
## Outcome

Preserves the full foreground quiet window when an already-staged conversation input or runtime-attested hosted-image completion succeeds on a post-checkpoint retry. This is the Round 10 follow-up to merged PR #1979.

## Product UX

Patch / Ready — A recovered reply no longer begins the next routine workspace snapshot immediately, keeping a member’s natural follow-up ahead of checkpoint work. System-only runtime control still does not earn a foreground delay.

## Direct evidence

- assistant-runtime workspace-entrypoint: 336/336 tests passed
- hosted turn-input resolver: 37/37 tests passed
- assistant-runtime typecheck passed
- regression rows cover conversation and hosted-image retries across the real checkpoint barrier
- exact-head assistant-runtime coverage passed in GitHub Actions
- ReviewGPT full-patch audit: PASS with no findings
- Product UX and coverage specialist: PASS with no findings or patch artifact

## Changelog
- Changelog: not applicable
- Reason: The member-visible reminder reliability entry shipped with PR #1979; this follow-up only completes its internal retry correctness.

## Deployment concerns
- Deployment: not applicable
- Reason: The single runner behavior change adds no cross-component contract, schema, binding, or coordinated rollout dependency; rollout order is unchanged.

## Risk

The change reuses the existing pass-local accepted-input resolver, dirty-pass bit, ordinal, and idle-checkpoint timer. It adds no persisted state, schema, queue, network call, or deployment dependency.

## ReviewGPT continuity

This follow-up contains the accepted Round 10 correction from merged PR #1979. That round found that successful retries of already-staged conversation and hosted-image inputs could lose the fresh foreground quiet window because timing authority depended on initial staging or one-shot ready-batch removal. The correction derives priority from the durable accepted events at the dirty-pass boundary and leaves ready-batch mutation as drain-only bookkeeping.

The prior PR's round-seven cap retrospective chose continuation because the member requirement and single-owner architecture remained unchanged: one existing ordinal, accepted-input resolver, dirty-pass bit, and idle-checkpoint timer; no new durable state, queue, lifecycle, scheduler, or reconciliation owner. The user explicitly authorized continued ReviewGPT review. This new PR starts a fresh full-patch baseline because PR #1979 merged before its Round 10 remediation could land.

ReviewGPT first-reviewed head: 920430ad060619bc3db150f969c01c0716ea34a1
ReviewGPT context sensitivity: sensitive