### PR TITLE
Fix blocked system mailbox handoff churn

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
+++ b/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
@@ -31,6 +31,12 @@ boundaries between Web, Temporal, and the Cloudflare runtime.
   `assistantExecutionBlocked: true` reaches the same invocation: eligible
   system work drains, assistant execution remains skipped, and the assistant
   reminder stays durable for policy restoration.
+- The retained system frontier is itself heterogeneous. At the current
+  imported-but-unhandled boundary, aggregate production proof found twelve
+  workspaces headed by operator-maintenance controls, three by browser-vault
+  refresh controls, and six by device-sync work. System mode advertised all of
+  those items as runnable but executed only device-sync, so the first fix alone
+  could not converge the dominant frontiers.
 
 All evidence is aggregate and contains no production identifiers.
 
@@ -56,15 +62,18 @@ All evidence is aggregate and contains no production identifiers.
    ensure-processing contract, valid only for explicit `system_mailbox` work.
 2. Forward the field through Cloudflare to the existing runtime invocation
    guard, without adding persisted state, another policy read, or a new owner.
-3. Publish the additive public contract and deploy the tolerant Cloudflare
+3. Align system-mode wake projection and execution on the same exact bounded
+   model-free set: device sync, operator maintenance, and browser-vault refresh.
+   Leave every other system item with its default owner.
+4. Publish the additive public contract and deploy the tolerant Cloudflare
    consumer before updating the private Temporal producer.
-4. Have Temporal derive the field from the current authoritative blocked fact
+5. Have Temporal derive the field from the current authoritative blocked fact
    only when it dispatches model-free system work. Preserve default/conversation
    processing, canonical wakes, mailbox pointers, and Temporal command order.
-5. Run focused contract, Cloudflare, runtime, Temporal, replay, typecheck, and
+6. Run focused contract, Cloudflare, runtime, Temporal, replay, typecheck, and
    production-bundle proof. Push exact candidates and run preliminary and final
    ReviewGPT gates alongside required CI.
-6. Merge and deploy in compatibility order, then verify multiple complete
+7. Merge and deploy in compatibility order, then verify multiple complete
    production windows until churn collapses and the retained system gap drains
    without lost assistant wakes or shifted errors.
 

--- a/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
+++ b/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
@@ -11,30 +11,26 @@ boundaries between Web, Temporal, and the Cloudflare runtime.
 
 ## Production Evidence
 
-- The previously deployed cross-mode controller correction did not materially
-  change churn.
-- A current five-minute sample contained 1,635 attempts, 1,625 empty mailbox
-  imports, 1,635 retained-wake idle checkpoints, and no errors.
-- The canonical workspace table still contained a small due cohort: 17
-  assistant wakes and 2 device-sync wakes.
-- Assistant-pass completion events were nearly absent relative to the repeated
-  runtime attempts, so the investigation is focused on the path that retains a
-  due assistant wake without executing assistant work.
-- A fifteen-minute export contained 10,075 typed or server-redacted runtime
-  events. Of 4,764 two-event attempts, 4,747 imported no mailbox work and 4,752
-  checkpointed a retained assistant wake; the repeated snapshots were otherwise
-  structurally unchanged.
-- Production still runs the commit immediately before the already-merged later
-  reminder handoff. Its production-shaped seven-interleaving regression passes
-  on current main, including the no-signal predecessor/successor case matching
-  the live trace.
-- The first deploy attempt containing that handoff resolved current main but
-  stopped before Cloudflare because later merged bounded foreground-state work
-  intentionally grew the existing vault CLI graph by 29,972 bytes without
-  rebaselining its narrow deployment ratchet. Local production assembly then
-  exposed the same reviewed graph's 35,529-byte static runner-entrypoint excess;
-  both existing ratchets require measured baseline updates, with entry and
-  platform tolerances unchanged.
+- The previously deployed cross-mode controller correction and exact new runner
+  bundle did not materially change churn: production continued to emit roughly
+  280 to 310 empty mailbox imports and idle checkpoints per minute.
+- Nineteen due workspaces had no mailbox rows beyond their imported system
+  frontier. Seventeen retained a gap between imported and handled-through state,
+  totaling 1,234 unconsumed model-free system items.
+- Current Web reconciliation logs prove those invocations are blocked by the
+  engagement policy while preserving a due assistant wake and two lagging
+  mailbox lanes.
+- The private Temporal worker correctly selects `system_mailbox` while Web is
+  blocked. Cloudflare currently forwards only the processing mode because its
+  separate workspace projection exposes no engagement-policy decision.
+- The runtime therefore sees the due assistant cron as runnable, checkpoints
+  the system-to-assistant handoff before processing a retained system item, and
+  wakes Temporal again. The empty checkpoint advances workspace version but not
+  the system handled-through frontier, reproducing the one-to-three-second loop.
+- An existing runtime regression proves the intended behavior when
+  `assistantExecutionBlocked: true` reaches the same invocation: eligible
+  system work drains, assistant execution remains skipped, and the assistant
+  reminder stays durable for policy restoration.
 
 All evidence is aggregate and contains no production identifiers.
 
@@ -56,30 +52,28 @@ All evidence is aggregate and contains no production identifiers.
 
 ## Plan
 
-1. Trace the exact no-progress wake path and obtain an independent ReviewGPT
-   diagnosis from the same code and aggregate evidence.
-2. Confirm the already-merged production-shaped predecessor/successor
-   regression covers the live no-signal churn before adding another wake owner.
-3. Rebaseline only the measured runner-bundle total-byte ratchet required to
-   deploy current main; preserve its entry and static-closure limits.
-4. Run the real bundle assembly, focused policy test, typecheck, and hosted
-   reminder proof.
-5. Push the exact unblocker candidate, run preliminary and final ReviewGPT gates
-   alongside required CI, and resolve every accepted finding.
-6. Merge, deploy the exact reviewed head with immediate container rollout, and
-   verify sustained convergence in at least two complete production windows
-   before retiring the worktree.
+1. Add an optional positive-only `assistantExecutionBlocked` field to the shared
+   ensure-processing contract, valid only for explicit `system_mailbox` work.
+2. Forward the field through Cloudflare to the existing runtime invocation
+   guard, without adding persisted state, another policy read, or a new owner.
+3. Publish the additive public contract and deploy the tolerant Cloudflare
+   consumer before updating the private Temporal producer.
+4. Have Temporal derive the field from the current authoritative blocked fact
+   only when it dispatches model-free system work. Preserve default/conversation
+   processing, canonical wakes, mailbox pointers, and Temporal command order.
+5. Run focused contract, Cloudflare, runtime, Temporal, replay, typecheck, and
+   production-bundle proof. Push exact candidates and run preliminary and final
+   ReviewGPT gates alongside required CI.
+6. Merge and deploy in compatibility order, then verify multiple complete
+   production windows until churn collapses and the retained system gap drains
+   without lost assistant wakes or shifted errors.
 
 ## Verification
 
-- Seven predecessor/successor wake interleavings: passed.
-- Independent ReviewGPT root-cause audit: current main's existing held-successor
-  correction matches the live loop; no new runtime owner or Cloudflare wake
-  suppression is warranted. It requested one empty checkpoint-runtime-recheck
-  coverage case, now included in the existing parameterized regression.
-- Local production bundle assembly: passed at 9,265,283 vault CLI bytes and an
-  8,397,990-byte static runner-entrypoint closure with the measured ratchets.
-- Cloudflare typecheck and 55 focused bundle-policy tests: passed.
-- Empty checkpoint-runtime-recheck wake regression: 8 parameterized cases
-  passed.
-- Exact-head ReviewGPT gates, CI, deploy, and production convergence: pending.
+- Root cause: proven from current production aggregates, authoritative Web
+  reconciliation logs, exact deployed code, and the existing runtime guard
+  regression.
+- Independent ReviewGPT root-cause audit: running.
+- Public contract/Cloudflare tests, private Temporal/replay tests, typechecks,
+  bundle proof, exact-head ReviewGPT gates, CI, deploy, and production
+  convergence: pending.

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -768,15 +768,15 @@ selection as well as during idle maintenance, so restored content cannot begin a
 reply after its deadline.
 If a `system_mailbox` invocation owns the active fence when foreground/default
 work arrives, the runner wakes that exact child and leaves its fence intact.
-System-mailbox mode may import and run one bounded model-free device-sync item;
+System-mailbox mode may import and run one bounded model-free device-sync,
+operator-maintenance, or browser-vault refresh item;
 it checkpoints any successfully applied unit, then observes the wake. When that
 wake contains a conversation while immutable projection delivery remains
 owned, the same invocation reuses the conversation prefetch and enters the
 ordinary foreground path without waiting for publication. Other wakes return
 before assistant admission, and the foreground request retries through the
-ordinary controller path after the system child releases its fence. Operator
-maintenance receipts are not system-mode recovery
-work and remain pending for their existing owner. A system-mailbox request
+ordinary controller path after the system child releases its fence. Other
+system items remain pending for their default owner. A system-mailbox request
 behind an active default runtime remains deferred and cannot broaden that
 child's admission authority.
 `parseHostedWorkspaceInvocationRequest` is the single wire parser for this
@@ -1304,6 +1304,12 @@ owner, Temporal derives the field from the current blocked reconciliation fact,
 and the runtime skips assistant admission while still draining model-free
 system work and retaining the canonical assistant wake. It is not durable
 Cloudflare state and cannot attach to default foreground processing.
+The optional workspace `systemMailboxFrontier` fact is a separate rollout seam.
+An omitted field means an older Web producer, `model_free` means the first live
+system item beyond the runtime's handled-through frontier is eligible for the
+bounded system-mailbox executor, `default_owned` leaves that item with ordinary
+default processing, and `null` proves no live retained frontier. Deploy the
+tolerant Temporal consumer before Web begins emitting the classification.
 Web-to-Temporal signal kinds have the same compatibility constraint: add
 workflow `patched()`/version gating for any new signal that changes wait or
 reconciliation behavior, deploy the Temporal worker before web emits that signal, and
@@ -2366,9 +2372,9 @@ An expected managed AI usage denial observed by the workspace read is not a
 transport preparation failure. Cloudflare binds the denied allowance to the
 fresh write fence and narrows a default invocation to the existing
 `system_mailbox` path, which imports system work, may run one bounded
-model-free deterministic device-sync item, and exits before foreground
-assistant admission. Operator maintenance receipts retain their existing owner
-and are not consumed by this recovery mode.
+model-free deterministic device-sync, operator-maintenance, or browser-vault
+refresh item, and exits before foreground assistant admission. Other system
+items retain their default owner and are not consumed by this recovery mode.
 It binds that effective processing mode into the same fence so controller
 priority, preemption, and the container job
 cannot diverge; the fence also rejects all metered provider egress if the runtime

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1297,6 +1297,13 @@ Because the Temporal worker can deploy automatically before the manual
 Cloudflare worker rollout, new Temporal-to-Cloudflare `ensure-processing` fields
 must either be accepted by the currently deployed worker or keep processing
 pending with `retry_later` until the consumer deployment catches up.
+The positive-only `assistantExecutionBlocked` field is therefore deployed to
+Cloudflare before Temporal begins sending it. It is valid only with an explicit
+`system_mailbox` mode and exists for one invocation: Web remains the policy
+owner, Temporal derives the field from the current blocked reconciliation fact,
+and the runtime skips assistant admission while still draining model-free
+system work and retaining the canonical assistant wake. It is not durable
+Cloudflare state and cannot attach to default foreground processing.
 Web-to-Temporal signal kinds have the same compatibility constraint: add
 workflow `patched()`/version gating for any new signal that changes wait or
 reconciliation behavior, deploy the Temporal worker before web emits that signal, and

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -358,11 +358,13 @@ The per-user workflow reads source-less reconciliation facts from web:
 - `blocked`: nullable product/access block with `reason` and `retryAt`
 - `mailboxLag`: lane lag counters only
 - `workspace`: nullable projection with `nextWakeAt`, `nextWakeReason`,
-  `inboxMediaRetentionWakeAt`, and `version`
+  `inboxMediaRetentionWakeAt`, optional `systemMailboxFrontier`, and `version`
 
-Facts do not contain run/idle decisions, producer source/reason, raw mailbox
-payloads, workspace redacted status, signed usage decisions, or direct wake
-flags. Temporal interprets the facts mechanically: fresh mailbox signals may
+Facts do not contain run/idle decisions, raw mailbox kinds, producer
+source/reason, raw mailbox payloads, workspace redacted status, signed usage
+decisions, or direct wake flags. The frontier classification exposes only
+whether the first retained system item is bounded model-free work or remains
+default-owned. Temporal interprets the facts mechanically: fresh mailbox signals may
 ensure processing directly; carried pointers and timers re-read facts;
 conversation lag or a due assistant workspace wake selects default processing;
 system-only lag selects `system_mailbox` processing; a due inbox media retention

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -439,6 +439,14 @@ Request summary:
 
 - `orchestrationAttemptId`: an opaque Temporal attempt id for observability and
   idempotency at the orchestration boundary.
+- `processingMode`: an optional narrow execution lane selected from current
+  reconciliation facts.
+- `assistantExecutionBlocked`: an optional positive-only execution guard valid
+  only with `system_mailbox`. Temporal includes it when Web blocks assistant
+  admission but retained model-free system work remains runnable. Cloudflare
+  forwards it to the runtime invocation without persisting a second policy
+  projection; the runtime drains eligible system work, skips assistant
+  execution, and preserves the canonical assistant wake for later restoration.
 
 The request does not carry signed AI usage decisions. Web reconciliation facts
 gate mailbox lag and workspace wakes that strongly imply foreground model work

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -156,6 +156,7 @@ const WORKSPACE_SNAPSHOT_PATH_HASH_SECRET_CONTEXT =
 const WORKSPACE_SNAPSHOT_PATH_HASH_SECRET_TEXT_ENCODER = new TextEncoder();
 
 export type RuntimeInvocationInput = {
+  assistantExecutionBlocked?: true;
   orchestration?: NonNullable<HostedRuntimeLatencyPhaseBreakdown["orchestration"]> | null;
   orchestrationAttemptId: string;
   processingMode?: HostedWorkspaceInvocationProcessingMode | null;
@@ -253,7 +254,7 @@ export class RuntimeInvocationService {
         })
       : null;
     let platformAiUsageAllowed: boolean | null = null;
-    let assistantExecutionBlocked = false;
+    let assistantExecutionBlocked = input.input.assistantExecutionBlocked === true;
     let invocationProcessingMode = input.input.processingMode ?? null;
     if (hostedAssistantCustomInferenceOverride) {
       if (typeof workspaceRead.platformAiUsageAllowed !== "boolean") {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -121,6 +121,9 @@ type FreshRuntimeStartPreparation =
 
 function toRuntimeInvocationInput(input: RuntimeProcessingInput): RuntimeInvocationInput {
   return {
+    ...(input.assistantExecutionBlocked
+      ? { assistantExecutionBlocked: true as const }
+      : {}),
     ...(input.orchestration ? { orchestration: input.orchestration } : {}),
     orchestrationAttemptId: input.orchestrationAttemptId,
     ...(input.processingMode ? { processingMode: input.processingMode } : {}),

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -509,6 +509,76 @@ describe("hosted runner container identity", () => {
     })).resolves.toEqual(runtimeTarget);
   });
 
+  it("preserves an orchestration-owned assistant block with custom inference", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const durable = createRunnerDurableState();
+    const stateStore = new RunnerStateStore(durable.state);
+    const override: HostedAssistantCustomInferenceOverride = {
+      contextWindowTokens: 131_072,
+      modelAlias: "murph-custom-r7",
+      protocol: "responses",
+      revision: 7,
+      supportsImages: false,
+      verificationProfile: "murph-codex-0.147.0-portable-responses-v1",
+    };
+    const runtimeTarget = {
+      auth: {
+        kind: "bearer" as const,
+        secret: "synthetic-upstream-secret",
+      },
+      contextWindowTokens: override.contextWindowTokens,
+      endpointUrl: "https://inference.example.com/v1/responses",
+      model: "synthetic-upstream-model",
+      protocol: override.protocol,
+      revision: override.revision,
+      schema: "murph.hosted-inference-runtime-target.v1" as const,
+      supportsImages: override.supportsImages,
+      verificationProfile: override.verificationProfile,
+    };
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () =>
+      Response.json(runtimeTarget)
+    ));
+    const service = createRuntimeInvocationService({
+      hostedAssistantCustomInferenceOverride: override,
+      invokedContainerNames: [],
+      platformAiUsageAllowed: true,
+      runnerRuntimeEnvSource: {
+        CF_VERSION_METADATA: { id: "version_1" },
+        HOSTED_ASSISTANT_MODEL: HOSTED_ASSISTANT_TERRA_MODEL,
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        HOSTED_PROVIDER_EGRESS_CREDENTIAL_SIGNING_SECRET:
+          "provider-egress-signing-secret",
+        OPENAI_API_KEY: "test-openai-key",
+      },
+      stateStore,
+      state: durable.state,
+    });
+    const token = await stateStore.beginWriteFence({
+      runnerContainerName: "member_123--v-version_1",
+      userId: TEST_USER_ID,
+    });
+
+    const prepared = await service.prepareWithFence({
+      input: {
+        assistantExecutionBlocked: true,
+        orchestrationAttemptId: "orchestration_attempt_blocked_custom_inference",
+        processingMode: "system_mailbox",
+        userId: TEST_USER_ID,
+      },
+      token,
+    });
+
+    expect(prepared.job.request).toMatchObject({
+      assistantExecutionBlocked: true,
+      processingMode: "system_mailbox",
+    });
+    expect(prepared.job.runtime?.forwardedEnv).toMatchObject({
+      HOSTED_ASSISTANT_MODEL: "murph-custom-r7",
+      HOSTED_ASSISTANT_PROVIDER: "hosted-custom-inference",
+    });
+  });
+
   it("narrows a denied managed default wake to model-free system mailbox work", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -3043,7 +3043,9 @@ describe("cloudflare worker routes", () => {
         await signWebCallbackControlRequest(
           new Request("https://runner.example.test/internal/users/test-user/runtime/ensure-processing", {
             body: JSON.stringify({
+              assistantExecutionBlocked: true,
               orchestrationAttemptId: "orchestration-attempt-test",
+              processingMode: "system_mailbox",
             }),
             headers: {
               "content-type": "application/json; charset=utf-8",
@@ -3068,6 +3070,7 @@ describe("cloudflare worker routes", () => {
         runtimeAttemptId: "runtime-attempt-test",
       });
       expect(stub.ensureRuntimeProcessingForUser).toHaveBeenCalledWith({
+        assistantExecutionBlocked: true,
         orchestrationAttemptId: "orchestration-attempt-test",
         commandStartedAtEpochMs: expect.any(Number),
         commandTimeoutMs: 10_000,
@@ -3078,6 +3081,7 @@ describe("cloudflare worker routes", () => {
           runtimeControlAuthStartedAtEpochMs: expect.any(Number),
           cloudflareRouteReceivedAtEpochMs: expect.any(Number),
         },
+        processingMode: "system_mailbox",
         userId: "test-user",
       });
     });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -2811,6 +2811,44 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("forwards an orchestration-owned assistant block to system mailbox execution", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const ensureReadyForProcessing = vi.fn<
+      NonNullable<HostedExecutionContainerStubLike["ensureReadyForProcessing"]>
+    >(async () => ({ kind: "ready" }));
+    const { invoke, runner, sql } = createRunnerHarness({
+      ensureReadyForProcessing,
+      platformAiUsageAllowed: true,
+      workspace: createWorkspaceState({ version: "5" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      assistantExecutionBlocked: true,
+      orchestrationAttemptId: "test-engagement-blocked-system-attempt",
+      processingMode: "system_mailbox",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledOnce();
+      expect(invoke.mock.calls[0]?.[0].job.request).toMatchObject({
+        assistantExecutionBlocked: true,
+        processingMode: "system_mailbox",
+      });
+      expect(readRunnerMeta(sql)).toMatchObject({
+        active_attempt_id: null,
+        failure_count: 0,
+        last_error_code: null,
+        wake_at: null,
+      });
+    });
+  });
+
   it("starts a default invocation on the restored-policy owner recheck", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/web/changelog/entries/2026-08-18/scheduled-support-resumes-after-sync.json
+++ b/apps/web/changelog/entries/2026-08-18/scheduled-support-resumes-after-sync.json
@@ -9,6 +9,6 @@
     "summary": "Reminders and other scheduled support now resume after connected-health maintenance checkpoints instead of being mistaken for work that is already running.",
     "details": "Fresh messages keep priority, and existing engagement, account-access, usage, and delivery-health safeguards still decide whether proactive support can run and send.",
     "relevanceTags": ["assistant", "automations", "connected-health", "reliability"],
-    "sourcePullRequests": [1993]
+    "sourcePullRequests": [1993, 2009]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -19,6 +19,9 @@ import {
   isHostedRuntimeFutureMailboxContinuation,
 } from "@murphai/hosted-execution/runtime-control";
 import {
+  HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS,
+} from "@murphai/hosted-execution/orchestration-control";
+import {
   detectVaultMetadataFormatVersion,
   VAULT_LAYOUT,
 } from "@murphai/contracts";
@@ -404,8 +407,10 @@ export {
 const HOSTED_INITIAL_CONVERSATION_MAILBOX_IMPORT_LANES = ["conversation"] as const;
 const HOSTED_INITIAL_BOOTSTRAP_MAILBOX_IMPORT_LANES = ["system", "conversation"] as const;
 const HOSTED_FOREGROUND_MAILBOX_PREFETCH_LANES = ["conversation", "system"] as const;
-const HOSTED_SYSTEM_MAILBOX_DEVICE_SYNC_ROUTE_ACTIONS = ["run-device-sync-wake"] as const;
-const HOSTED_SYSTEM_MAILBOX_DEVICE_SYNC_WAKE_KINDS = ["device-sync.wake"] as const;
+const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS = [
+  "apply-runtime-control-request",
+  "run-device-sync-wake",
+] as const;
 const HOSTED_INITIAL_BOOTSTRAP_PENDING_REASON_CODE = "bootstrap.pending";
 const HOSTED_RUNTIME_ISSUE_POST_CHECKPOINT_EXPORT_TIMEOUT_MS = 2_500;
 const HOSTED_VAULT_FORMAT_MIGRATION_MAX_BUNDLES = 500;
@@ -988,6 +993,8 @@ async function resolveHostedSystemMailboxProcessingModeWake(input: {
     vaultRoot: input.vaultRoot,
   });
   const systemMailboxWake = await resolveHostedSystemMailboxNextWakeCandidate({
+    allowedRouteActions: HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS,
+    allowedWakeKinds: HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS,
     vaultRoot: input.vaultRoot,
   });
   const assistantCronWake = await resolveHostedAssistantCronWakeAfterInitialImport({
@@ -2934,13 +2941,13 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
         return await returnSystemMailboxModeResult();
       }
 
-      const devicePass = await runSystemMailboxLifecycleItem({
-        allowedRouteActions: HOSTED_SYSTEM_MAILBOX_DEVICE_SYNC_ROUTE_ACTIONS,
-        allowedWakeKinds: HOSTED_SYSTEM_MAILBOX_DEVICE_SYNC_WAKE_KINDS,
-        stagePrefix: "system_mailbox.device_sync",
+      const modelFreePass = await runSystemMailboxLifecycleItem({
+        allowedRouteActions: HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS,
+        allowedWakeKinds: HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS,
+        stagePrefix: "system_mailbox.model_free",
       });
       assertRuntimeNotAborted();
-      if (devicePass.preempted) {
+      if (modelFreePass.preempted) {
         return await returnSystemMailboxModeResult();
       }
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -12677,11 +12677,18 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
-  test("fresh foreground input after device-sync apply checkpoints the bounded unit once", async () => {
+  test("foreground input during a blocked system pass upgrades after checkpointing the bounded unit once", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    const mailboxItems: HostedMailboxItem[] = [];
+    const foregroundItem = createMailboxItem({
+      id: "mailbox_item_system_mailbox_blocked_foreground_upgrade",
+      laneSeq: "1",
+      occurredAt: "2026-04-27T00:00:01.000Z",
+    });
+    let assistantPhaseCalls = 0;
     const deviceItem = createMailboxItem({
       dedupeKey: "device-sync.wake:preempt-during",
       id: "mailbox_item_system_mailbox_device_preempt_during",
@@ -12692,7 +12699,10 @@ describe("hosted workspace runtime entrypoint", () => {
     const deviceSyncPort = createSnapshotDeviceSyncPort({
       connectionId: "device_sync_connection_preempt_during",
       nextReconcileAt: "2026-04-27T00:05:00.000Z",
-      onApplyUpdates: () => runtimeWakeSignal.notify(),
+      onApplyUpdates: () => {
+        mailboxItems.push(foregroundItem);
+        runtimeWakeSignal.notify();
+      },
     });
 
     vi.useFakeTimers({ toFake: ["Date"] });
@@ -12716,6 +12726,7 @@ describe("hosted workspace runtime entrypoint", () => {
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
+            assistantExecutionBlocked: true,
             attemptId: "attempt_synthetic_system_mailbox_device_preempt_during",
             processingMode: "system_mailbox",
             workspaceVersion: "0",
@@ -12732,13 +12743,21 @@ describe("hosted workspace runtime entrypoint", () => {
               }),
             };
           },
-          async importItem() {
-            throw new Error("Already-imported system mailbox work should not import a new row.");
+          async importItem(item) {
+            assert.equal(item.item.id, foregroundItem.id);
+            const assistantInputId = await stageAssistantInputEventForMailboxItem({
+              item: item.item,
+              vaultRoot,
+            });
+            return {
+              assistantInputId,
+              status: "imported",
+            };
           },
           platform: createPlatform({
             artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
             deviceSyncPort,
-            mailboxPort: createMailboxPort({ events, items: [] }),
+            mailboxPort: createMailboxPort({ events, items: mailboxItems }),
             workspacePort: createWorkspacePort({
               checkpointRequests,
               events,
@@ -12749,21 +12768,33 @@ describe("hosted workspace runtime entrypoint", () => {
             }),
           }),
           runtimeWakeSignal,
-          async runAssistantPhase() {
-            throw new Error("System mailbox mode must not enter assistant phase.");
+          async runAssistantPhase(input) {
+            assistantPhaseCalls += 1;
+            const inputIds =
+              input.initialAssistantInputBatch?.assistantInputIds
+              ?? input.initialMailboxImport.importResult.assistantInputIds
+              ?? [];
+            assert.equal(inputIds.length, 1);
+            await writeSyntheticAssistantAutoReplyTerminalEvidence({
+              inputId: inputIds[0] ?? "",
+              vaultRoot,
+            });
+            return {
+              checkpointReason: "assistant_runtime_commit" as const,
+              progressed: true,
+            };
           },
           vaultRoot,
         },
       );
 
-      assert.equal(result.immediateRecheckRequested, true);
+      assert.equal(assistantPhaseCalls, 1);
       assert.equal(deviceSyncPort.fetchSnapshotCalls, 1);
       assert.equal(deviceSyncPort.applyUpdatesCalls, 1);
-      assert.equal(checkpointRequests.length, 1);
+      assert.ok(checkpointRequests.length >= 1);
       assert.equal(checkpointRequests[0]?.nextWakeAt, TEST_NOW);
       assert.equal(checkpointRequests[0]?.nextWakeReason, "device-sync.reconcile");
-      assert.equal(result.nextWakeAt, checkpointRequests[0]?.nextWakeAt);
-      assert.equal(result.nextWakeReason, checkpointRequests[0]?.nextWakeReason);
+      assert.notEqual(result.status, "failed");
       const state = await readHostedSystemMailboxState(vaultRoot);
       expect(state.pending).toEqual(expect.arrayContaining([
         expect.objectContaining({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -10768,7 +10768,10 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
-  test("system mailbox device recovery leaves operator maintenance receipts pending", async () => {
+  test.each([
+    "runtime.maintenance-requested",
+    "runtime.browser-vault-refresh-requested",
+  ] as const)("system mailbox mode drains model-free %s control work", async (kind) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
@@ -10776,7 +10779,7 @@ describe("hosted workspace runtime entrypoint", () => {
     const maintenanceItem = createMailboxItem({
       dedupeKey: "runtime.maintenance-requested:device-recovery-owner",
       id: "mailbox_item_system_mailbox_operator_maintenance",
-      kind: "runtime.maintenance-requested",
+      kind,
       lane: "system",
       laneSeq: "1",
     });
@@ -10790,7 +10793,7 @@ describe("hosted workspace runtime entrypoint", () => {
         vaultRoot,
         wake: buildHostedExecutionRuntimeControlWake({
           eventId: maintenanceItem.dedupeKey,
-          kind: "runtime.maintenance-requested",
+          kind,
           occurredAt: maintenanceItem.occurredAt,
           userId: TEST_USER_ID,
         }),
@@ -10803,7 +10806,7 @@ describe("hosted workspace runtime entrypoint", () => {
         vaultRoot,
       });
 
-      await runHostedWorkspaceRuntimeJobInProcess(
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
             attemptId: "attempt_synthetic_system_mailbox_operator_maintenance",
@@ -10847,10 +10850,14 @@ describe("hosted workspace runtime entrypoint", () => {
 
       assert.equal(deviceSyncPort.fetchSnapshotCalls, 0);
       assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
-      const state = await readHostedSystemMailboxState(vaultRoot);
-      assert.equal(state.pending.length, 1);
-      assert.equal(state.pending[0]?.itemId, maintenanceItem.id);
-      assert.equal(state.pending[0]?.status, "pending");
+      assert.deepEqual((await readHostedSystemMailboxState(vaultRoot)).pending, []);
+      assert.equal(result.nextWakeAt, null);
+      assert.equal(result.nextWakeReason ?? null, null);
+      assert.equal(result.status, "idle");
+      assert.equal(
+        checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "1",
+      );
     } finally {
       vi.useRealTimers();
       await removeTempRoot(vaultRoot);

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -1,5 +1,6 @@
 import {
   HOSTED_WORKSPACE_INVOCATION_PROCESSING_MODES,
+  type HostedMailboxKind,
   type HostedMailboxLane,
   type HostedMailboxLaneLag,
   type HostedWorkspaceInvocationProcessingMode,
@@ -65,11 +66,26 @@ export const HOSTED_RUNTIME_PROCESSING_MODES =
 
 export type HostedRuntimeProcessingMode = HostedWorkspaceInvocationProcessingMode;
 
+export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
+  "device-sync.wake",
+  "runtime.browser-vault-refresh-requested",
+  "runtime.maintenance-requested",
+] as const satisfies readonly HostedMailboxKind[];
+
+export const HOSTED_RUNTIME_SYSTEM_MAILBOX_FRONTIER_CLASSES = [
+  "default_owned",
+  "model_free",
+] as const;
+
+export type HostedRuntimeSystemMailboxFrontierClass =
+  (typeof HOSTED_RUNTIME_SYSTEM_MAILBOX_FRONTIER_CLASSES)[number];
+
 export interface HostedRuntimeReconciliationFactsWorkspace {
   hostedMailboxSystemHandledThroughSeq?: string;
   inboxMediaRetentionWakeAt: string | null;
   nextWakeAt: string | null;
   nextWakeReason: string | null;
+  systemMailboxFrontier?: HostedRuntimeSystemMailboxFrontierClass | null;
   version: string | null;
 }
 

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -85,6 +85,7 @@ export interface HostedRuntimeReconciliationFacts {
 }
 
 export interface HostedRuntimeEnsureProcessingRequest {
+  assistantExecutionBlocked?: true;
   orchestrationAttemptId: string;
   processingMode?: HostedRuntimeProcessingMode | null;
 }

--- a/packages/hosted-execution/src/parsers/orchestration-control.ts
+++ b/packages/hosted-execution/src/parsers/orchestration-control.ts
@@ -191,24 +191,39 @@ export function parseHostedRuntimeEnsureProcessingRequest(
 ): HostedRuntimeEnsureProcessingRequest {
   const record = requireObject(value, "Hosted runtime ensure-processing request");
   assertExactKeys(record, "Hosted runtime ensure-processing request", [
+    "assistantExecutionBlocked",
     "orchestrationAttemptId",
     "processingMode",
   ]);
 
+  const processingMode = record.processingMode === undefined
+    ? undefined
+    : parseNullableAllowedString(
+        record.processingMode,
+        "Hosted runtime ensure-processing request processingMode",
+        HOSTED_RUNTIME_PROCESSING_MODES,
+      );
+  const assistantExecutionBlocked = record.assistantExecutionBlocked === undefined
+    ? undefined
+    : requireExactTrue(
+        record.assistantExecutionBlocked,
+        "Hosted runtime ensure-processing request assistantExecutionBlocked",
+      );
+  if (assistantExecutionBlocked && processingMode !== "system_mailbox") {
+    throw new TypeError(
+      "Hosted runtime ensure-processing request assistantExecutionBlocked requires system_mailbox processingMode.",
+    );
+  }
+
   return {
+    ...(assistantExecutionBlocked === undefined
+      ? {}
+      : { assistantExecutionBlocked }),
     orchestrationAttemptId: requireOpaqueIdentifier(
       record.orchestrationAttemptId,
       "Hosted runtime ensure-processing request orchestrationAttemptId",
     ),
-    ...(record.processingMode === undefined
-      ? {}
-      : {
-          processingMode: parseNullableAllowedString(
-            record.processingMode,
-            "Hosted runtime ensure-processing request processingMode",
-            HOSTED_RUNTIME_PROCESSING_MODES,
-          ),
-        }),
+    ...(processingMode === undefined ? {} : { processingMode }),
   };
 }
 
@@ -403,6 +418,14 @@ function parseNullableAllowedString<T extends string>(
   }
 
   return parseAllowedString(value, label, allowed);
+}
+
+function requireExactTrue(value: unknown, label: string): true {
+  if (value !== true) {
+    throw new TypeError(`${label} must be true.`);
+  }
+
+  return true;
 }
 
 function assertExactKeys(

--- a/packages/hosted-execution/src/parsers/orchestration-control.ts
+++ b/packages/hosted-execution/src/parsers/orchestration-control.ts
@@ -7,6 +7,7 @@ import {
   HOSTED_RUNTIME_PROCESSING_MODES,
   HOSTED_RUNTIME_RECONCILIATION_BLOCKED_REASONS,
   HOSTED_RUNTIME_SIGNAL_KINDS,
+  HOSTED_RUNTIME_SYSTEM_MAILBOX_FRONTIER_CLASSES,
   type HostedRuntimeEnsureProcessingRequest,
   type HostedRuntimeEnsureProcessingResponse,
   type HostedRuntimeReconciliationFacts,
@@ -151,6 +152,7 @@ export function parseHostedRuntimeReconciliationFactsWorkspace(
     "inboxMediaRetentionWakeAt",
     "nextWakeAt",
     "nextWakeReason",
+    "systemMailboxFrontier",
     "version",
   ]);
 
@@ -179,6 +181,15 @@ export function parseHostedRuntimeReconciliationFactsWorkspace(
       record.nextWakeReason,
       "Hosted runtime reconciliation facts workspace nextWakeReason",
     ),
+    ...(record.systemMailboxFrontier === undefined
+      ? {}
+      : {
+          systemMailboxFrontier: parseNullableAllowedString(
+            record.systemMailboxFrontier,
+            "Hosted runtime reconciliation facts workspace systemMailboxFrontier",
+            HOSTED_RUNTIME_SYSTEM_MAILBOX_FRONTIER_CLASSES,
+          ),
+        }),
     version: readRequiredNullableBoundedString(
       record.version,
       "Hosted runtime reconciliation facts workspace version",

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -137,6 +137,7 @@ describe("hosted orchestration control contracts", () => {
       workspace: {
         ...workspace,
         hostedMailboxSystemHandledThroughSeq: "11",
+        systemMailboxFrontier: "model_free",
       },
     })).toEqual({
       blocked: null,
@@ -144,6 +145,7 @@ describe("hosted orchestration control contracts", () => {
       workspace: {
         ...workspace,
         hostedMailboxSystemHandledThroughSeq: "11",
+        systemMailboxFrontier: "model_free",
       },
     });
     expect(() => parseHostedRuntimeReconciliationFacts({
@@ -155,6 +157,16 @@ describe("hosted orchestration control contracts", () => {
       },
     })).toThrow(
       "Hosted runtime reconciliation facts workspace hostedMailboxSystemHandledThroughSeq must be a non-negative base-10 integer string.",
+    );
+    expect(() => parseHostedRuntimeReconciliationFacts({
+      blocked: null,
+      mailboxLag,
+      workspace: {
+        ...workspace,
+        systemMailboxFrontier: "device-sync.wake",
+      },
+    })).toThrow(
+      "Hosted runtime reconciliation facts workspace systemMailboxFrontier is not supported.",
     );
     expect(parseHostedRuntimeReconciliationFacts({
       blocked: null,

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -283,12 +283,34 @@ describe("hosted orchestration control contracts", () => {
       processingMode: "inbox_media_retention",
     });
     expect(parseHostedRuntimeEnsureProcessingRequest({
+      assistantExecutionBlocked: true,
       orchestrationAttemptId: "orchestration_attempt_test",
       processingMode: "system_mailbox",
     })).toEqual({
+      assistantExecutionBlocked: true,
       orchestrationAttemptId: "orchestration_attempt_test",
       processingMode: "system_mailbox",
     });
+    expect(() => parseHostedRuntimeEnsureProcessingRequest({
+      assistantExecutionBlocked: false,
+      orchestrationAttemptId: "orchestration_attempt_test",
+      processingMode: "system_mailbox",
+    })).toThrow(
+      "Hosted runtime ensure-processing request assistantExecutionBlocked must be true.",
+    );
+    expect(() => parseHostedRuntimeEnsureProcessingRequest({
+      assistantExecutionBlocked: true,
+      orchestrationAttemptId: "orchestration_attempt_test",
+    })).toThrow(
+      "Hosted runtime ensure-processing request assistantExecutionBlocked requires system_mailbox processingMode.",
+    );
+    expect(() => parseHostedRuntimeEnsureProcessingRequest({
+      assistantExecutionBlocked: true,
+      orchestrationAttemptId: "orchestration_attempt_test",
+      processingMode: "default",
+    })).toThrow(
+      "Hosted runtime ensure-processing request assistantExecutionBlocked requires system_mailbox processingMode.",
+    );
     expect(() => parseHostedRuntimeEnsureProcessingRequest({
       orchestrationAttemptId: "orchestration_attempt_test",
       processingMode: "assistant",


### PR DESCRIPTION
A Web-owned assistant-admission block was not reaching explicit system-mailbox invocations, so a due assistant wake could repeatedly hand off before retained model-free system work drained. The retained frontier also advertised every system item while the bounded executor accepted only device sync. This forwards one positive-only invocation guard and gives wake projection and execution one shared model-free allowlist.

Product UX: Patch · Ready. Blocked hosted assistants can clear eligible device-sync, operator-maintenance, and browser-vault work without consuming the preserved assistant reminder; current conversations and default-owned system work keep their existing owner.

## Evidence

- Hosted orchestration contract parser: 7 tests passed.
- Cloudflare runner controller: 153 tests passed.
- Cloudflare signed-ingress mapping: 116 tests passed; custom-inference block preservation: 19 tests passed.
- Assistant-runtime regressions: blocked reminder replay plus both production frontier control kinds passed.
- Hosted-execution, assistant-runtime, Cloudflare, and Web typechecks: passed.
- Changelog fragment validation: 7 tests passed.
- Private Temporal workflow: 130 tests passed with legacy producer fallback, model-free routing, default-owned routing, and blocked waiting coverage; replay proof remains required on its exact package-pinned head.
- Aggregate production frontier proof found 12 operator-maintenance, 3 browser-vault, and 6 device-sync heads; no production identifiers were retained.

## Deployment concerns

- Deployment: applicable
- Supported skew: The public Worker accepts old producer requests. The optional frontier classification is accepted when omitted, while an old Temporal parser rejects it when present; this PR does not begin Web production of that field.
- Safe order: Merge and deploy the public Cloudflare Worker and runner, publish the reviewed public contract, deploy the private Temporal consumer/guard producer pinned to it, then separately deploy the Web frontier-classification producer.
- Rollback floor: Once the private producer sends the invocation guard, the compatible public Worker and runner are the floor. Once Web emits frontier classification, the compatible private Temporal consumer is also the floor.
- Expected exposure: Before the private phase, production retains its current churn behavior. The private phase drains the current model-free frontiers through legacy classification fallback; the later Web producer prevents default-owned frontiers from entering system mode.
- Reversibility: Reverting the private producer removes the invocation field without a state migration. Revert the Web classifier before rolling back its Temporal consumer. Canonical wakes and mailbox pointers remain durable.
- Convergence proof: Exact-version deployment smoke plus bounded runtime aggregates must show the system handled-through frontier advancing and empty checkpoint churn collapsing.
- Post-deploy checks: Verify exact Worker, runner, and Temporal commits; inspect bounded event and error aggregates; confirm assistant wakes remain preserved through policy restoration.

## Changelog

- Changelog: updated
- Items: 2026-08-18 · scheduled-support-resumes-after-sync

ReviewGPT context sensitivity: sensitive
Reason: This changes a cross-owner runtime protocol, retry behavior, mailbox ownership, and production deployment order.
ReviewGPT first-reviewed head: 71aab6d72589d179ce158f2a5280316cd2b8dde9
