### PR TITLE
Restore Cloudflare runner CPU and memory

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-19-restore-cloudflare-container-resources.md
+++ b/agent-docs/exec-plans/active/2026-08-19-restore-cloudflare-container-resources.md
@@ -1,0 +1,80 @@
+# Restore Cloudflare container resources
+
+Status: active
+
+## Outcome
+
+Deploy the hosted Cloudflare execution plane with each runner container at
+2 vCPU and 6,144 MiB memory while preserving the existing 6,000 MB ephemeral
+disk allocation and ten-minute post-completion conversation idle lease.
+
+## Invariants
+
+- The checked-in Wrangler scaffold, deploy-automation defaults, production
+  GitHub Environment override, and deploy documentation remain aligned.
+- Both the normal runner and deploy-smoke runner use the same custom instance
+  type.
+- `HOSTED_EXECUTION_RUNNER_IDLE_TTL_MS` remains `600000` in source and
+  production; this change must not lengthen the warm lease.
+- The custom instance type remains within Cloudflare's current custom-container
+  CPU, memory, and disk ratios.
+- Production uses the protected private deployment workflow and an immediate
+  container rollout, then proves the deployed Worker and runner version with
+  the existing smoke contract.
+
+## Product UX Plan
+
+Effort: Product change. The resource rollback targets measured cold-start and
+workspace-restore regressions without changing message semantics, recovery, or
+the ten-minute conversation warmth policy.
+
+- Outcome: cold hosted conversations recover the prior CPU and memory capacity;
+  warm conversations retain the current ten-minute idle lease.
+- Entry and promise: ordinary hosted conversation ingress and delivery remain
+  unchanged, while cold container startup and large workspace restores should
+  improve.
+- Reaches: cold conversations and CPU-heavy hosted reads. Follow-ups after ten
+  idle minutes remain eligible for the cold path exactly as they are today.
+- Proof: focused deploy-contract tests and a generated-config check must prove
+  the resource object and unchanged idle TTL, followed by protected deployment
+  smoke on the exact merged source.
+
+## Evidence
+
+- Production changed from 2 vCPU / 6,144 MiB to 1 vCPU / 3,072 MiB on
+  2026-08-18 while the warm lease changed from twenty minutes to ten minutes.
+- Production cold-start traces after that change show slower container startup,
+  Node startup, and same-size workspace restore than the preceding profile.
+- Cloudflare's current custom-container limits accept 2 vCPU, 6,144 MiB memory,
+  and 6,000 MB disk.
+- Production defines `CF_CONTAINER_INSTANCE_TYPE` and
+  `HOSTED_EXECUTION_RUNNER_IDLE_TTL_MS` as separate GitHub Environment vars, so
+  the instance override can change while the ten-minute TTL stays fixed.
+
+## Steps
+
+1. Update both checked-in container objects, the deploy default, focused tests,
+   and operator documentation to 2 vCPU / 6,144 MiB.
+2. Run focused Cloudflare contract tests, typecheck, generated-config proof, and
+   the supported Wrangler dry run while asserting the idle TTL remains 600,000
+   milliseconds.
+3. Inspect the privacy-safe diff, commit and push the review candidate, open the
+   PR, and run exact-head CI plus the required ReviewGPT gates.
+4. Merge the reviewed source change into `main`.
+5. Set only the production `CF_CONTAINER_INSTANCE_TYPE` GitHub Environment var,
+   confirm the idle-TTL var remains 600,000 milliseconds, and dispatch the
+   protected deployment with an immediate container rollout.
+6. Verify the live deployment and runner smoke before asking for a cold test.
+
+## Verification
+
+- Focused deploy-automation and container-image contract tests pass.
+- Cloudflare package typecheck passes.
+- Rendered deploy config contains the 2-vCPU custom instance object and the
+  unchanged 600,000-millisecond idle TTL.
+- Wrangler accepts both container bindings in a deployment dry run.
+- Required exact-head CI and routed ReviewGPT gates pass with no unresolved
+  accepted findings.
+- Protected production deployment and live smoke succeed on the merged source.
+
+Updated: 2026-08-19

--- a/agent-docs/exec-plans/active/2026-08-19-restore-cloudflare-container-resources.md
+++ b/agent-docs/exec-plans/active/2026-08-19-restore-cloudflare-container-resources.md
@@ -24,20 +24,28 @@ disk allocation and ten-minute post-completion conversation idle lease.
 
 ## Product UX Plan
 
-Effort: Product change. The resource rollback targets measured cold-start and
+Effort: Patch. The resource rollback targets measured cold-start and
 workspace-restore regressions without changing message semantics, recovery, or
 the ten-minute conversation warmth policy.
 
-- Outcome: cold hosted conversations recover the prior CPU and memory capacity;
-  warm conversations retain the current ten-minute idle lease.
+Status: Hold until the protected production workflow accepts the generated
+Wrangler config, deploy smoke passes, and a de-identified cold-path walkthrough
+confirms correct reply delivery with the restored profile.
+
+- Outcome: same-size cold workspace restore and accepted-to-reply timing return
+  toward the preceding 2-vCPU profile's measured band, with correct reply
+  delivery and the current ten-minute idle lease retained.
 - Entry and promise: ordinary hosted conversation ingress and delivery remain
-  unchanged, while cold container startup and large workspace restores should
-  improve.
+  unchanged; the first post-deploy cold conversation must complete normally and
+  its container-start, Node-start, workspace-restore, and accepted-to-reply
+  phases must be compared with the privacy-safe pre-cut trace.
 - Reaches: cold conversations and CPU-heavy hosted reads. Follow-ups after ten
   idle minutes remain eligible for the cold path exactly as they are today.
-- Proof: focused deploy-contract tests and a generated-config check must prove
-  the resource object and unchanged idle TTL, followed by protected deployment
-  smoke on the exact merged source.
+- Proof: focused deploy-contract tests and a generated-config check prove the
+  resource object and unchanged idle TTL before merge. The protected workflow
+  intentionally resolves only public `main`, so its platform-native generated
+  Wrangler dry run, deployment smoke, and de-identified cold-path comparison
+  are post-merge release gates before this patch is called Ready.
 
 ## Evidence
 
@@ -72,9 +80,13 @@ the ten-minute conversation warmth policy.
 - Cloudflare package typecheck passes.
 - Rendered deploy config contains the 2-vCPU custom instance object and the
   unchanged 600,000-millisecond idle TTL.
-- Wrangler accepts both container bindings in a deployment dry run.
+- The protected production workflow's generated Wrangler dry run accepts both
+  container bindings on the exact merged source.
 - Required exact-head CI and routed ReviewGPT gates pass with no unresolved
   accepted findings.
 - Protected production deployment and live smoke succeed on the merged source.
+- A de-identified cold conversation completes through final reply delivery, and
+  its phase timings are compared with the available pre-cut 2-vCPU trace; a hot
+  follow-up inside the ten-minute lease remains warm.
 
 Updated: 2026-08-19

--- a/agent-docs/exec-plans/completed/2026-08-19-restore-cloudflare-container-resources.md
+++ b/agent-docs/exec-plans/completed/2026-08-19-restore-cloudflare-container-resources.md
@@ -1,6 +1,6 @@
 # Restore Cloudflare container resources
 
-Status: active
+Status: completed
 
 ## Outcome
 
@@ -28,7 +28,7 @@ Effort: Patch. The resource rollback targets measured cold-start and
 workspace-restore regressions without changing message semantics, recovery, or
 the ten-minute conversation warmth policy.
 
-Status: Hold until the protected production workflow accepts the generated
+Status: completed
 Wrangler config, deploy smoke passes, and a de-identified cold-path walkthrough
 confirms correct reply delivery with the restored profile.
 
@@ -89,4 +89,18 @@ confirms correct reply delivery with the restored profile.
   its phase timings are compared with the available pre-cut 2-vCPU trace; a hot
   follow-up inside the ten-minute lease remains warm.
 
+## Completion
+
+- The resource/config implementation, focused tests, full Cloudflare verify,
+  exact-head CI, clean current-base merge proof, and final ReviewGPT round are
+  complete.
+- ReviewGPT's preliminary coverage and Product UX findings were accepted. The
+  plan and PR now classify this as a Patch and do not claim platform-native or
+  member-observable proof before it exists.
+- Production release remains on Hold until the protected post-merge workflow
+  passes its generated Wrangler dry run and deploy smoke, followed by the
+  de-identified cold-path and warm-follow-up checks above.
+
 Updated: 2026-08-19
+Completed: 2026-08-19
+Completed: 2026-08-19

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1192,7 +1192,7 @@ than assuming one attempt per group.
 Core execution tuning:
 
 - `CF_COMPATIBILITY_DATE` defaults to `2026-03-27`
-- `CF_CONTAINER_INSTANCE_TYPE` defaults to `{"vcpu":1,"memory_mib":3072,"disk_mb":6000}`. This restores the production shape used before the two-vCPU upgrade; heavier hosted reads can take longer on the smaller CPU and memory allocation, so deployment smoke proves function and recovery rather than claiming latency neutrality.
+- `CF_CONTAINER_INSTANCE_TYPE` defaults to `{"vcpu":2,"memory_mib":6144,"disk_mb":6000}`. This restores the two-vCPU production shape after measured cold-start and same-size workspace-restore regressions on the smaller allocation. The post-completion conversation idle lease remains independently configured at ten minutes.
 - `CF_CONTAINER_MAX_INSTANCES` defaults to `1000`
 - `CF_MAX_EVENT_ATTEMPTS` defaults to `3`
 - `CF_RETRY_DELAY_MS` defaults to `30000`
@@ -1459,7 +1459,7 @@ Device-sync provider runtime overrides:
 
 If the selected GitHub environment already defines container sizing overrides, update these existing vars there as well:
 
-- `CF_CONTAINER_INSTANCE_TYPE={"vcpu":1,"memory_mib":3072,"disk_mb":6000}`
+- `CF_CONTAINER_INSTANCE_TYPE={"vcpu":2,"memory_mib":6144,"disk_mb":6000}`
 - `CF_CONTAINER_MAX_INSTANCES=1000`
 
 When hosted email sender identity is configured, deploy automation renders one native `send_email` binding named `HOSTED_EMAIL` and constrains it with `allowed_sender_addresses` to that resolved sender address. Hosted email outbound send no longer requires a runtime Cloudflare account id or email-send API token inside the Worker.

--- a/apps/cloudflare/scripts/deploy-automation/environment.ts
+++ b/apps/cloudflare/scripts/deploy-automation/environment.ts
@@ -44,8 +44,8 @@ export type HostedContainerInstanceType =
 
 const DEFAULT_CONTAINER_INSTANCE_TYPE: HostedContainerInstanceType = {
   disk_mb: 6000,
-  memory_mib: 3072,
-  vcpu: 1,
+  memory_mib: 6144,
+  vcpu: 2,
 };
 const DEFAULT_CONTAINER_MAX_INSTANCES = 1000;
 const RUNNER_COMMIT_RESPONSE_MARGIN_MS = 5_000;

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -50,8 +50,8 @@ function createDeployEnvironment() {
     compatibilityDate: "2026-03-27",
     containerInstanceType: {
       disk_mb: 6000,
-      memory_mib: 3072,
-      vcpu: 1,
+      memory_mib: 6144,
+      vcpu: 2,
     },
     containerMaxInstances: 1000,
     logHeadSamplingRate: 1,
@@ -963,8 +963,8 @@ describe("hosted runner container image contract", () => {
     expect(container.image_build_context).toBe("..");
     expect(container.instance_type).toEqual({
       disk_mb: 6000,
-      memory_mib: 3072,
-      vcpu: 1,
+      memory_mib: 6144,
+      vcpu: 2,
     });
     expect(container.max_instances).toBe(1000);
   });

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -629,8 +629,8 @@ describe("hosted deploy automation helpers", () => {
 
     const expectedDefaultInstanceType = {
       disk_mb: 6000,
-      memory_mib: 3072,
-      vcpu: 1,
+      memory_mib: 6144,
+      vcpu: 2,
     };
     expect(generatedConfig.containers.map(({ instance_type }) => instance_type)).toEqual([
       expectedDefaultInstanceType,

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -13,8 +13,8 @@
       "image": "../../Dockerfile.cloudflare-hosted-runner",
       "image_build_context": ".",
       "instance_type": {
-        "vcpu": 1,
-        "memory_mib": 3072,
+        "vcpu": 2,
+        "memory_mib": 6144,
         "disk_mb": 6000
       },
       "max_instances": 1000,
@@ -27,8 +27,8 @@
       "image": "../../Dockerfile.cloudflare-hosted-runner",
       "image_build_context": ".",
       "instance_type": {
-        "vcpu": 1,
-        "memory_mib": 3072,
+        "vcpu": 2,
+        "memory_mib": 6144,
         "disk_mb": 6000
       },
       "max_instances": 1,


### PR DESCRIPTION
## Outcome

Restore both Cloudflare hosted runner containers to 2 vCPU and 6,144 MiB while preserving the 6,000 MB disk and 600,000 ms post-completion idle lease.

## Product UX

Patch — Hold pending the protected generated-Wrangler dry run, deployment smoke, and a de-identified post-deploy cold-path comparison. The code restores capacity without changing message behavior or the ten-minute lease.

## Evidence

- Focused deploy/container contract tests: 36 passed
- Cloudflare verify: 148 Node files / 2,598 tests passed; 6 Workers files / 15 tests passed
- Cloudflare typecheck and runner-bundle assembly passed
- Rendered config: both containers are 2 vCPU / 6,144 MiB / 6,000 MB, idle TTL remains 600,000 ms
- Local Wrangler image dry run is blocked because the Docker daemon is not running; exact-head CI and protected deploy smoke own native image proof

## Deployment concerns

- Deployment: applicable
- Supported skew: The control plane accepts both the old and restored resource profiles while the immediate container rollout converges.
- Safe order: Merge the public defaults, update only the private production instance override, then dispatch the protected immediate Cloudflare rollout.
- Rollback floor: Restore 1 vCPU, 3,072 MiB, and 6,000 MB in the production override and public defaults, then redeploy; keep the idle TTL at 600,000 ms.
- Expected exposure: The immediate rollout restarts existing containers, so an in-flight or next conversation may pay one cold start; no schema or durable-state migration occurs.
- Reversibility: Resource sizing is configuration-only and can be restored by reverting the override and deployment without transforming persistent data.
- Convergence proof: The protected deploy renders the exact resource tuple and its smoke lane starts the deployed runner image; all replacement instances use that rendered tuple.
- Post-deploy checks: Confirm deploy smoke, verify the production instance tuple and 600,000 ms idle TTL, then test one cold reply and one hot follow-up.

## Changelog

- Changelog: not applicable
- Reason: This restores hosted runtime capacity without changing member-visible product behavior or release notes.

ReviewGPT context sensitivity: sensitive

Sensitive because this changes the production Cloudflare deployment profile.

ReviewGPT first-reviewed head: 820e78e1edf952a80ffe096a4f19f08f632890da

