### PR TITLE
Add a farewell after account deletion

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-19-account-deletion-farewell.md
+++ b/agent-docs/exec-plans/active/2026-08-19-account-deletion-farewell.md
@@ -1,0 +1,98 @@
+# Account deletion farewell
+
+Status: active
+Created: 2026-08-19
+Updated: 2026-08-19
+
+## Goal
+
+- After account deletion succeeds, immediately replace the invalidated dashboard
+  with a calm public farewell experience while preserving browser-session
+  cleanup and the durable external-cleanup contract.
+
+## Success criteria
+
+- A successful delete never exposes the dashboard's signed-out error state.
+- The departing member sees one public, responsive farewell page with a clear
+  confirmation and a quiet route back to Murph.
+- Privy browser logout still completes best effort before navigation, with a
+  bounded fallback when its SDK does not settle.
+- Pending external cleanup remains automatic and does not block the farewell.
+- Focused component/page tests, Web typecheck, and phone/desktop browser proof
+  pass.
+
+## Scope
+
+- In scope: the post-delete client handoff, a public `/farewell` page, focused
+  regression coverage, and a member-visible changelog entry.
+- Out of scope: changing deletion ownership, vendor cleanup ordering, retry
+  semantics, retained exit-feedback policy, or authentication behavior for any
+  other route.
+
+## Constraints
+
+- Technical constraints: preserve the authoritative app-session cookie clear
+  and best-effort Privy logout; do not depend on deleted member state; keep the
+  destination public and noindex; use existing design tokens and assets.
+- Product/process constraints: no private feedback or identifying details in
+  code, tests, docs, screenshots, or PR text; no additional ReviewGPT run per
+  the user's instruction.
+
+## Product UX plan
+
+- Effort: Product change.
+- Outcome: a departing member receives a composed ending instead of an error
+  from a dashboard whose account was just removed.
+- Entry and promise: completing the existing irreversible deletion flow moves
+  directly into a full-page farewell, clears the remaining browser login best
+  effort, and settles on the public `/farewell` route.
+- Affected people: a departing member on a narrow phone or desktop, including
+  both immediately completed cleanup and background-cleanup outcomes. A person
+  who later visits the public page is not signed out or shown private state.
+- Proof: render the public destination at phone and desktop widths; exercise the
+  successful deletion state and prove Privy completion navigates immediately;
+  prove the bounded fallback uses the same destination.
+- Done when: no dashboard content is visible after success, the farewell copy
+  remains legible and centered at both widths, navigation is public and
+  history-replacing, and existing deletion failure/recovery states are
+  unchanged.
+
+## Risks and mitigations
+
+1. Risk: navigating before Privy logout could leave a stale browser session.
+   Mitigation: make the farewell a full-viewport takeover while the existing
+   best-effort logout runs, then replace the URL immediately on completion.
+2. Risk: a slow or unavailable Privy SDK could strand the member on an
+   authenticated URL.
+   Mitigation: retain the bounded hard-navigation fallback to the public page.
+3. Risk: a public farewell route could become a logout-CSRF surface.
+   Mitigation: keep logout ownership in the successful deletion component; the
+   public page renders no logout side effect.
+
+## Tasks
+
+1. Verify the production deletion's canonical and external-cleanup state using
+   aggregate, read-only evidence.
+2. Add a reusable farewell presentation and public noindex page.
+3. Replace the post-delete dashboard delay with an immediate full-page handoff
+   and history-replacing navigation after Privy cleanup.
+4. Add focused component/page coverage and a changelog entry.
+5. Run focused tests, typecheck, direct browser proof, and completion checks.
+6. Commit, open and merge the PR without another ReviewGPT run, verify the live
+   route and deletion handoff contract, then retire the worktree.
+
+## Decisions
+
+- Keep browser logout on the successful deletion surface rather than on the
+  public page, so an ordinary `/farewell` visit cannot sign out another member.
+- Use a full-viewport takeover before navigation to hide invalidated dashboard
+  state without introducing a second server-side session mechanism.
+
+## Verification
+
+- Commands to run: focused Vitest files for data-privacy settings and the
+  farewell page; Web typecheck; relevant changelog validation; phone and desktop
+  browser render; scoped diff/privacy inspection.
+- Expected outcomes: immediate `/farewell` replacement after logout, bounded
+  fallback, no dashboard error exposure, noindex metadata, responsive public
+  rendering, and no regression in deletion error or retry behavior.

--- a/agent-docs/exec-plans/completed/2026-08-19-account-deletion-farewell.md
+++ b/agent-docs/exec-plans/completed/2026-08-19-account-deletion-farewell.md
@@ -1,6 +1,6 @@
 # Account deletion farewell
 
-Status: active
+Status: completed
 Created: 2026-08-19
 Updated: 2026-08-19
 
@@ -90,9 +90,16 @@ Updated: 2026-08-19
 
 ## Verification
 
-- Commands to run: focused Vitest files for data-privacy settings and the
-  farewell page; Web typecheck; relevant changelog validation; phone and desktop
-  browser render; scoped diff/privacy inspection.
-- Expected outcomes: immediate `/farewell` replacement after logout, bounded
-  fallback, no dashboard error exposure, noindex metadata, responsive public
-  rendering, and no regression in deletion error or retry behavior.
+- Focused Vitest passed 74 tests across the farewell, privacy-settings, and
+  changelog suites.
+- Web typecheck passed. Scoped ESLint passed after removing its only warning.
+- Browser proof passed at 1440px, 390px, and 320px, plus 200% text scaling,
+  without horizontal overflow.
+- Impeccable audit scored 19/20 with no blocking, major, or minor findings. The
+  only polish note was the 24px-tall logo link, which still meets the WCAG AA
+  minimum target size.
+- Production read-only evidence confirmed the account row was removed and
+  Privy, billing, and runtime-log deletion completed. Cloudflare user-data
+  cleanup remains owned by the durable retry receipt and does not block the
+  farewell.
+Completed: 2026-08-19

--- a/apps/web/app/design/account-exit-reason-study.tsx
+++ b/apps/web/app/design/account-exit-reason-study.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 
 import { AccountExitReasonStep } from "@/src/components/settings/account-exit-reason-step";
-import { HostedAccountDeletionStatus } from "@/src/components/settings/hosted-data-privacy-settings";
 import type { HostedAccountExitReasonCode } from "@/src/lib/hosted-privacy/account-data-shared";
 
 export function AccountExitReasonStudy() {
@@ -19,8 +18,8 @@ export function AccountExitReasonStudy() {
         to the confirmation step, and Continue only turns on once a reason is
         picked. The note field appears after a reason is chosen so a written note
         always arrives attached to one. The live step is interactive here; the
-        two previews below are inert. The terminal states show the same
-        production status component for completed and still-converging cleanup.
+        two previews below are inert. Successful deletion leaves this dashboard
+        for the public farewell page.
       </p>
 
       <StepFrame label="Interactive">
@@ -49,15 +48,6 @@ export function AccountExitReasonStudy() {
           />
         </StepFrame>
       </div>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        <StatusFrame label="External cleanup converged" state="cleanup-complete">
-          <HostedAccountDeletionStatus cleanupPending={false} />
-        </StatusFrame>
-        <StatusFrame label="External cleanup still retrying" state="cleanup-pending">
-          <HostedAccountDeletionStatus cleanupPending />
-        </StatusFrame>
-      </div>
     </div>
   );
 }
@@ -78,21 +68,6 @@ function InteractiveExitReasonStep() {
         setNote("");
       }}
     />
-  );
-}
-
-function StatusFrame(props: {
-  children: React.ReactNode;
-  label: string;
-  state: string;
-}) {
-  return (
-    <div className="flex max-w-md flex-col gap-3" data-design-state={props.state}>
-      <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-        {props.label}
-      </p>
-      {props.children}
-    </div>
   );
 }
 

--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -166,7 +166,6 @@ import {
 import { ConnectCallbackErrorNotice } from "@/src/components/device-sync/connect-callback-error-notice";
 import {
   HostedAccountDeletionErrorAlert,
-  HostedAccountDeletionStatus,
 } from "@/src/components/settings/hosted-data-privacy-settings";
 import { HOSTED_STRIPE_EFFECT_PENDING_MESSAGE } from "@/src/lib/hosted-onboarding/errors";
 import { VitalConnectionDialog } from "../(dashboard)/connect/connect-page-dialogs";
@@ -1392,15 +1391,6 @@ export function ComponentsContent() {
               sourceLabel="Oura"
               title="Unable to finish connection"
             />
-          </div>
-        </Section>
-
-        <Separator />
-
-        <Section title="Account Deletion Status">
-          <div className="grid gap-4 lg:grid-cols-2">
-            <HostedAccountDeletionStatus cleanupPending={false} />
-            <HostedAccountDeletionStatus cleanupPending />
           </div>
         </Section>
 

--- a/apps/web/app/farewell/page.tsx
+++ b/apps/web/app/farewell/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+import { AccountDeletionFarewell } from "@/src/components/settings/account-deletion-farewell";
+
+export const metadata: Metadata = {
+  description: "A quiet farewell after closing a Murph account.",
+  robots: { follow: false, index: false },
+  title: "Farewell for now | Murph",
+};
+
+export default async function FarewellPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cleanup?: string | string[] }>;
+}) {
+  const { cleanup } = await searchParams;
+
+  return (
+    <main>
+      <AccountDeletionFarewell
+        cleanupPending={cleanup === "pending"}
+      />
+    </main>
+  );
+}

--- a/apps/web/changelog/entries/2026-08-19/account-deletion-farewell.json
+++ b/apps/web/changelog/entries/2026-08-19/account-deletion-farewell.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-19",
+  "order": 110,
+  "item": {
+    "id": "account-deletion-farewell",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "A gentler finish after account deletion",
+    "summary": "After deleting your account, Murph now leaves the dashboard immediately and opens a simple farewell page instead of showing an unavailable dashboard.",
+    "details": "The page confirms deletion, explains when small technical cleanup is still finishing automatically, and keeps a clear path back to Murph if you decide to return.",
+    "relevanceTags": ["account", "privacy", "settings"],
+    "sourcePullRequests": [2012]
+  }
+}

--- a/apps/web/src/components/settings/account-deletion-farewell.tsx
+++ b/apps/web/src/components/settings/account-deletion-farewell.tsx
@@ -1,0 +1,105 @@
+import Image from "next/image";
+import Link from "next/link";
+import { forwardRef } from "react";
+
+import { cn } from "@/src/lib/utils";
+
+export const ACCOUNT_DELETION_FAREWELL_PATH = "/farewell";
+
+export function buildAccountDeletionFarewellPath(
+  cleanupPending: boolean,
+): string {
+  return cleanupPending
+    ? `${ACCOUNT_DELETION_FAREWELL_PATH}?cleanup=pending`
+    : ACCOUNT_DELETION_FAREWELL_PATH;
+}
+
+export const AccountDeletionFarewell = forwardRef<HTMLDivElement, {
+  cleanupPending: boolean;
+  takeover?: boolean;
+}>(function AccountDeletionFarewell({ cleanupPending, takeover = false }, ref) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "min-h-dvh overflow-y-auto bg-background px-6 py-7 text-foreground sm:px-10 sm:py-9 lg:px-16",
+        takeover && "fixed inset-0 z-[100]",
+      )}
+      data-account-deletion-farewell="true"
+      tabIndex={-1}
+    >
+      <div className="mx-auto flex min-h-[calc(100dvh-3.5rem)] max-w-6xl flex-col sm:min-h-[calc(100dvh-4.5rem)]">
+        {takeover ? (
+          <Image
+            alt="Murph"
+            className="h-6 w-auto"
+            height={24}
+            priority
+            src="/logo.svg"
+            width={107}
+          />
+        ) : (
+          <Link
+            aria-label="Murph home"
+            className="w-fit rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background"
+            href="/"
+          >
+            <Image
+              alt="Murph"
+              className="h-6 w-auto"
+              height={24}
+              priority
+              src="/logo.svg"
+              width={107}
+            />
+          </Link>
+        )}
+
+        <div className="flex flex-1 items-center py-14 sm:py-20">
+          <section
+            aria-live={takeover ? "polite" : undefined}
+            className="w-full max-w-2xl"
+          >
+            <div className="mb-7 flex items-center gap-3 font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:mb-9">
+              <span
+                aria-hidden="true"
+                className="size-1.5 rounded-full bg-primary"
+              />
+              Account closed
+            </div>
+
+            <h1 className="max-w-xl text-balance font-serif text-5xl font-semibold leading-[1.02] tracking-[-0.035em] sm:text-6xl lg:text-7xl">
+              Farewell for now.
+            </h1>
+            <div className="mt-7 max-w-xl space-y-4 text-base leading-7 text-muted-foreground sm:mt-9 sm:text-lg sm:leading-8">
+              <p>
+                {cleanupPending
+                  ? "Your account has been deleted. Murph is finishing a small amount of technical cleanup in the background; no action is needed."
+                  : "Your Murph account and live data have been deleted."}
+              </p>
+              <p>
+                Thank you for spending some time with us. If you ever decide to
+                come back, we&apos;ll be here.
+              </p>
+            </div>
+
+            <div className="mt-10 border-t border-border pt-6 sm:mt-12">
+              {takeover ? (
+                <p className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                  Clearing this browser session
+                </p>
+              ) : (
+                <Link
+                  className="inline-flex min-h-11 items-center rounded-lg bg-foreground px-5 text-sm font-medium text-background transition-colors hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  href="/"
+                >
+                  Return to Murph
+                </Link>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
+++ b/apps/web/src/components/settings/hosted-data-privacy-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Download, Trash2 } from "lucide-react";
 import Link from "next/link";
 
@@ -37,6 +37,10 @@ import {
   type HostedAccountExitReasonCode,
 } from "@/src/lib/hosted-privacy/account-data-shared";
 
+import {
+  AccountDeletionFarewell,
+  buildAccountDeletionFarewellPath,
+} from "./account-deletion-farewell";
 import { AccountExitReasonStep } from "./account-exit-reason-step";
 import { HostedSettingsSessionState } from "./hosted-settings-session-state";
 
@@ -63,7 +67,6 @@ interface HostedAccountDeleteResponse {
 }
 
 const DEFAULT_VAULT_EXPORT_FILENAME = "murph-vault-export.json";
-const POST_DELETE_REDIRECT_DELAY_MS = 2_500;
 const POST_DELETE_REDIRECT_FALLBACK_MS = 8_000;
 
 export function HostedDataPrivacySettings(props: {
@@ -103,8 +106,7 @@ function HostedDataPrivacySettingsAuthorized(props: {
   const [providerAccessRemovalConfirmationToken, setProviderAccessRemovalConfirmationToken] = useState<string | null>(null);
   const [deleted, setDeleted] = useState(false);
   const [cleanupPending, setCleanupPending] = useState(false);
-  const [privyLogoutDone, setPrivyLogoutDone] = useState(false);
-  const deletedAlertRef = useRef<HTMLDivElement | null>(null);
+  const deletedPageRef = useRef<HTMLDivElement | null>(null);
 
   const exportReady = acknowledgedSensitiveDownload && !exportPending;
   const phraseMatches = confirmationPhrase === HOSTED_ACCOUNT_DELETION_CONFIRMATION_PHRASE;
@@ -118,31 +120,25 @@ function HostedDataPrivacySettingsAuthorized(props: {
     )
     && !deletePending;
 
+  const redirectToFarewell = useCallback(() => {
+    window.location.replace(buildAccountDeletionFarewellPath(cleanupPending));
+  }, [cleanupPending]);
+
   useEffect(() => {
     if (!deleted) {
       return;
     }
 
-    // Anchor focus so keyboard and screen-reader users land on the
-    // confirmation after the dialog unmounts, and keep a hard redirect
-    // fallback in case the best-effort Privy client logout never settles.
-    deletedAlertRef.current?.focus();
-    const fallbackTimer = window.setTimeout(() => {
-      window.location.assign("/");
-    }, POST_DELETE_REDIRECT_FALLBACK_MS);
+    // Replace the invalidated dashboard with the farewell immediately, then
+    // keep a hard navigation fallback in case Privy's best-effort browser
+    // logout never settles.
+    deletedPageRef.current?.focus();
+    const fallbackTimer = window.setTimeout(
+      redirectToFarewell,
+      POST_DELETE_REDIRECT_FALLBACK_MS,
+    );
     return () => window.clearTimeout(fallbackTimer);
-  }, [deleted]);
-
-  useEffect(() => {
-    if (!deleted || !privyLogoutDone) {
-      return;
-    }
-
-    const redirectTimer = window.setTimeout(() => {
-      window.location.assign("/");
-    }, POST_DELETE_REDIRECT_DELAY_MS);
-    return () => window.clearTimeout(redirectTimer);
-  }, [deleted, privyLogoutDone]);
+  }, [deleted, redirectToFarewell]);
 
   async function handleExportConfirmed() {
     if (!exportReady) {
@@ -322,11 +318,12 @@ function HostedDataPrivacySettingsAuthorized(props: {
   if (deleted) {
     return (
       <>
-        <HostedAccountDeletionStatus
+        <AccountDeletionFarewell
           cleanupPending={cleanupPending}
-          ref={deletedAlertRef}
+          ref={deletedPageRef}
+          takeover
         />
-        <HostedPrivyLogout onDone={() => setPrivyLogoutDone(true)} />
+        <HostedPrivyLogout onDone={redirectToFarewell} />
       </>
     );
   }
@@ -636,26 +633,6 @@ function HostedDataPrivacyUnavailable(props: { authenticated: boolean }) {
     </div>
   );
 }
-
-export const HostedAccountDeletionStatus = forwardRef<HTMLDivElement, {
-  cleanupPending: boolean;
-}>(function HostedAccountDeletionStatus(props, ref) {
-  return (
-    <Alert
-      ref={ref}
-      role="status"
-      aria-live="polite"
-      tabIndex={-1}
-    >
-      <AlertTitle>Account deleted</AlertTitle>
-      <AlertDescription>
-        {props.cleanupPending
-          ? "Your account was deleted. We're finishing some cleanup on our side, no action needed. Redirecting to the home page."
-          : "Your account and live Murph data have been deleted. Redirecting to the home page."}
-      </AlertDescription>
-    </Alert>
-  );
-});
 
 export function hasIncompleteHostedAccountDeletionCleanup(
   result: HostedAccountDeleteResponse["result"],

--- a/apps/web/src/lib/observability/analytics-redaction.ts
+++ b/apps/web/src/lib/observability/analytics-redaction.ts
@@ -13,6 +13,7 @@ export const VERCEL_TELEMETRY_PATHNAMES = [
   "/environment/print",
   "/experiments",
   "/family/setup",
+  "/farewell",
   "/groups/start",
   "/growth",
   "/history",

--- a/apps/web/test/account-deletion-farewell-page.test.tsx
+++ b/apps/web/test/account-deletion-farewell-page.test.tsx
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import FarewellPage, { metadata } from "@/app/farewell/page";
+
+describe("account deletion farewell page", () => {
+  test("renders the public completed-deletion destination", async () => {
+    const markup = renderToStaticMarkup(await FarewellPage({
+      searchParams: Promise.resolve({}),
+    }));
+
+    assert.match(markup, /Farewell for now\./u);
+    assert.match(markup, /Your Murph account and live data have been deleted\./u);
+    assert.match(markup, /If you ever decide to come back, we&#x27;ll be here\./u);
+    assert.match(markup, /href="\/"/u);
+    assert.doesNotMatch(markup, /Clearing this browser session/u);
+    expect(metadata.robots).toEqual({ follow: false, index: false });
+  });
+
+  test("keeps background cleanup clear without requiring another action", async () => {
+    const markup = renderToStaticMarkup(await FarewellPage({
+      searchParams: Promise.resolve({ cleanup: "pending" }),
+    }));
+
+    assert.match(markup, /technical cleanup in the background/u);
+    assert.match(markup, /no action is needed/u);
+  });
+});

--- a/apps/web/test/hosted-data-privacy-settings.test.ts
+++ b/apps/web/test/hosted-data-privacy-settings.test.ts
@@ -60,8 +60,11 @@ vi.mock("react", async () => {
 });
 
 vi.mock("next/image", () => ({
-  default: ({ priority: _priority, ...props }: Record<string, unknown>) =>
-    createElement("img", props),
+  default: (props: Record<string, unknown>) => {
+    const imageProps = { ...props };
+    delete imageProps.priority;
+    return createElement("img", imageProps);
+  },
 }));
 
 vi.mock("@/src/components/hosted-onboarding/client-api", async (importOriginal) => {

--- a/apps/web/test/hosted-data-privacy-settings.test.ts
+++ b/apps/web/test/hosted-data-privacy-settings.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
   publishBrowserVaultSessionEnding: vi.fn(),
   publishBrowserVaultSessionInvalidation: vi.fn(),
+  privyLogoutOnDone: null as (() => void) | null,
   reloadCurrentHostedAuthDocument: vi.fn(),
   requestHostedOnboardingJson: vi.fn(),
   loadBrowserVaultExport: vi.fn(),
@@ -57,6 +58,11 @@ vi.mock("react", async () => {
     }) as typeof actual.useState,
   };
 });
+
+vi.mock("next/image", () => ({
+  default: ({ priority: _priority, ...props }: Record<string, unknown>) =>
+    createElement("img", props),
+}));
 
 vi.mock("@/src/components/hosted-onboarding/client-api", async (importOriginal) => {
   const actual = await importOriginal<
@@ -99,7 +105,10 @@ vi.mock("../src/components/settings/hosted-settings-session-state", () => ({
 }));
 
 vi.mock("@/src/components/hosted-onboarding/hosted-privy-logout", () => ({
-  HostedPrivyLogout: () => null,
+  HostedPrivyLogout: ({ onDone }: { onDone: () => void }) => {
+    mocks.privyLogoutOnDone = onDone;
+    return null;
+  },
 }));
 
 vi.mock("@/src/components/ui/alert", () => ({
@@ -149,6 +158,7 @@ beforeEach(() => {
   mocks.useStateRecords = [];
   mocks.useStateSetters = [];
   mocks.useStateValues = [];
+  mocks.privyLogoutOnDone = null;
   mocks.authorize.mockResolvedValue({
     signature: `0x${"11".repeat(65)}`,
     token: "sac_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
@@ -998,10 +1008,81 @@ describe("HostedDataPrivacySettings", () => {
 
     assert.ok(
       container.textContent?.includes(
-        "Your account and live Murph data have been deleted",
+        "Your Murph account and live data have been deleted.",
       ),
     );
+    assert.ok(container.textContent?.includes("Farewell for now."));
+    assert.ok(container.querySelector('[data-account-deletion-farewell="true"]'));
     assert.equal([...container.querySelectorAll("button")].length, 0);
+  });
+
+  test("replaces the deleted dashboard with the public farewell after Privy logout", async () => {
+    mockHostedDataPrivacyDeletedState();
+
+    const { document, window } = loadLinkedom().parseHTML(
+      "<html><body><div id='root'></div></body></html>",
+    );
+    const replace = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { replace },
+    });
+    installGlobals(window, document);
+    const container = document.getElementById("root");
+    assert.ok(container);
+
+    const root: Root = createRoot(container);
+    cleanupRender = async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    };
+
+    await act(async () => {
+      root.render(createElement(HostedDataPrivacySettings, { authenticated: true }));
+    });
+    assert.ok(mocks.privyLogoutOnDone);
+
+    await act(async () => {
+      mocks.privyLogoutOnDone?.();
+    });
+
+    expect(replace).toHaveBeenCalledWith("/farewell");
+  });
+
+  test("falls back to the pending-cleanup farewell when Privy logout does not settle", async () => {
+    vi.useFakeTimers();
+    mockHostedDataPrivacyDeletedState({ cleanupPending: true });
+
+    const { document, window } = loadLinkedom().parseHTML(
+      "<html><body><div id='root'></div></body></html>",
+    );
+    const replace = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { replace },
+    });
+    installGlobals(window, document);
+    const container = document.getElementById("root");
+    assert.ok(container);
+
+    const root: Root = createRoot(container);
+    cleanupRender = async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    };
+
+    await act(async () => {
+      root.render(createElement(HostedDataPrivacySettings, { authenticated: true }));
+    });
+    expect(replace).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(8_000);
+    });
+
+    expect(replace).toHaveBeenCalledWith("/farewell?cleanup=pending");
   });
 
   test("reports durable external cleanup as pending after account deletion", async () => {
@@ -1027,8 +1108,14 @@ describe("HostedDataPrivacySettings", () => {
 
     assert.ok(
       container.textContent?.includes(
-        "Your account was deleted. We're finishing some cleanup on our side",
+        "Your account has been deleted. Murph is finishing a small amount of technical cleanup in the background; no action is needed.",
       ),
+    );
+    assert.equal(
+      container.querySelector('[data-account-deletion-farewell="true"]')
+        ?.getAttribute("class")
+        ?.includes("fixed"),
+      true,
     );
     assert.equal([...container.querySelectorAll("button")].length, 0);
   });
@@ -1039,7 +1126,7 @@ describe("HostedDataPrivacySettings", () => {
 // exportSuccess, deletePending, dialogOpen, dialogStep, exitReason, exitNote,
 // confirmationPhrase, dialogError, deviceReconnectRequired, providerAccessRemovalRequired,
 // providerAccessRemovalConfirmed, providerAccessRemovalConfirmationToken,
-// deleted, cleanupPending, privyLogoutDone.
+// deleted, cleanupPending.
 function mockHostedVaultExportFlowState(input: {
   acknowledgedSensitiveDownload?: boolean;
 } = {}) {
@@ -1060,7 +1147,6 @@ function mockHostedVaultExportFlowState(input: {
     false,
     false,
     null,
-    false,
     false,
     false,
   ];
@@ -1097,7 +1183,6 @@ function mockHostedDataPrivacyDeleteFlowState(input: {
     input.providerAccessRemovalConfirmationToken ?? null,
     false,
     false,
-    false,
   ];
 }
 
@@ -1123,7 +1208,6 @@ function mockHostedDataPrivacyDeletedState(input: {
     null,
     true,
     input.cleanupPending ?? false,
-    false,
   ];
 }
 


### PR DESCRIPTION
## Outcome

- Replaces the invalidated dashboard immediately after a successful account deletion.
- Adds a public, noindex farewell route for both completed and background-cleanup states.
- Preserves best-effort Privy logout with a bounded history-replacing fallback.

## Product UX

Departing members now receive a calm, responsive ending instead of a signed-out dashboard error. No private account state is required by the destination.

## Evidence

- Direct: Rendered the real `/farewell` route locally and verified the deletion takeover replaces the dashboard before Privy logout completes.
- Coverage: Checked completed and cleanup-pending states at 1440px, 390px, and 320px plus 200% text, covering the two materially distinct outcomes and supported responsive range with no horizontal overflow.
- Tests: 74 focused Vitest checks passed across farewell, privacy-settings, and changelog suites; Web typecheck and scoped ESLint also passed.
- Audit: Impeccable scored 19/20 with no blocking, major, or minor findings.

## Changelog

- Changelog: updated
- Items: 2026-08-19 · account-deletion-farewell

## Deployment concerns

- Deployment: not applicable
- Reason: This is a Web-only public route and client handoff with no cross-service contract or staged deployment dependency.