### PR TITLE
Fix retained hosted device-sync retries

### DIFF
--- a/apps/web/changelog/entries/2026-08-19/retained-wearable-sync-retries.json
+++ b/apps/web/changelog/entries/2026-08-19/retained-wearable-sync-retries.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-19",
+  "order": 200,
+  "item": {
+    "id": "retained-wearable-sync-retries",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Connected health retries keep their place",
+    "summary": "Connected-health updates now resume the same queued retry after a temporary interruption, preserving progress instead of starting that work over.",
+    "details": "Recovery stays limited to the affected connection, while fresh conversations continue to take priority.",
+    "relevanceTags": ["connected-health", "wearables", "sync", "reliability"],
+    "sourcePullRequests": [2021]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -686,15 +686,18 @@ async function applyHostedDeviceSyncWakeHint(input: {
     return false;
   }
 
+  const jobHints = normalizeHostedDeviceSyncJobHints(wake.hint);
+  // manual_reconcile is one-shot root creation. Once recovery has attached
+  // exact jobs, those jobs own retry history and provider continuation cursors;
+  // recreating the root would reset both on every cold restore.
   if (
     input.wake.reason === "reconcile_due"
     && wake.hint?.reason === "manual_reconcile"
+    && jobHints.length === 0
   ) {
     input.service.queueManualReconcile(localAccountId);
     return false;
   }
-
-  const jobHints = normalizeHostedDeviceSyncJobHints(wake.hint);
 
   for (const [index, hint] of jobHints.entries()) {
     const job = hostedJobHintToDeviceSyncJobInput(

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -61,7 +61,10 @@ import {
   HostedRuntimeArtifactWriteError,
   type HostedRuntimeDeviceSyncPort,
 } from "../src/hosted-runtime/platform.ts";
-import { recordHostedDeviceSyncDirtyPostCheckpointRecord } from "../src/hosted-runtime/system-mailbox.ts";
+import {
+  recordHostedDeviceSyncDirtyPostCheckpointRecord,
+  recordHostedSystemMailboxItemAfterCheckpoint,
+} from "../src/hosted-runtime/system-mailbox.ts";
 import {
   readHostedSystemMailboxState,
   updateHostedSystemMailboxState,
@@ -10491,7 +10494,7 @@ describe("hosted device-sync runtime", () => {
     }), null);
   });
 
-  test("retains a Junction summary cursor through mailbox persistence and cold reconstruction", async () => {
+  test("retains a failed Junction summary continuation from a manual reconcile wake through cold reconstruction", async () => {
     const firstWorkspace = await createHostedRuntimeWorkspace(
       "hosted-device-sync-junction-child-first-",
     );
@@ -10507,11 +10510,14 @@ describe("hosted device-sync runtime", () => {
           throw new Error("Junction network access is not expected in child recovery proof.");
         },
         region: "us",
+        summaryBackfillDays: 0,
         summaryResources: ["activity"],
         timeseriesResources: [],
       },
     });
     assert.ok(junctionProvider);
+    const occurredAt = "2026-04-04T09:10:00.000Z";
+    const retryAt = "2026-04-04T09:12:00.000Z";
     const firstService = createDeviceSyncServiceForVault(
       firstWorkspace.vaultRoot,
       [junctionProvider],
@@ -10520,22 +10526,11 @@ describe("hosted device-sync runtime", () => {
       restoredWorkspace.vaultRoot,
       [junctionProvider],
     );
-    const occurredAt = "2026-04-04T09:10:00.000Z";
-    const retryAt = "2026-04-04T09:12:00.000Z";
+    const failedRetryAt = "2026-04-04T09:13:00.000Z";
     const connectionId = "hosted_conn_junction_child";
     const wake = buildDeviceSyncWake({
       connectionId,
-      hint: {
-        jobs: [{
-          availableAt: occurredAt,
-          dedupeKey: "junction-seed-window",
-          kind: "reconcile",
-          payload: {
-            windowEnd: "2026-04-04T00:00:00.000Z",
-            windowStart: "2026-03-01T00:00:00.000Z",
-          },
-        }],
-      },
+      hint: { reason: "manual_reconcile" },
       occurredAt,
       provider: "junction",
       reason: "reconcile_due",
@@ -10559,11 +10554,19 @@ describe("hosted device-sync runtime", () => {
           externalAccountId: "junction-child-recovery",
           hostedUpdatedAt: occurredAt,
           localState: { nextReconcileAt: "2026-04-04T15:00:00.000Z" },
+          metadata: {
+            hosted: true,
+            junctionHistoricalBackfillStatus: "coverage_v3_complete",
+            junctionHistoricalBackfillWindowEnd: "2026-04-04T00:00:00.000Z",
+            junctionHistoricalBackfillWindowStart: "2026-04-04T00:00:00.000Z",
+          },
           provider: "junction",
         });
       },
     });
 
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(occurredAt));
     try {
       const firstState = await syncHostedDeviceSyncControlPlaneState({
         deviceSyncPort: createPort(),
@@ -10576,8 +10579,11 @@ describe("hosted device-sync runtime", () => {
       const firstStore = getStore(firstService);
       const account = firstStore.getAccountById(firstAccountId);
       assert.ok(account);
+      assert.equal(readJobsForAccount(firstService, firstAccountId).length, 1);
       const parent = firstStore.claimDueJob("worker_junction_child", occurredAt, 60_000);
       assert.ok(parent);
+      assert.equal(parent.maxAttempts, 5);
+      assert.equal(parent.priority, 80);
       assert.equal(firstStore.completeJobsMarkSyncSucceededAndEnqueueJobs({
         accountId: firstAccountId,
         completedAt: occurredAt,
@@ -10587,7 +10593,7 @@ describe("hosted device-sync runtime", () => {
           availableAt: retryAt,
           dedupeKey: "junction-child-window-cursor",
           kind: "reconcile",
-          maxAttempts: 3,
+          maxAttempts: 5,
           payload: {
             sourceProviderSlug: "garmin",
             summaryResourceCursor: "sleep",
@@ -10601,6 +10607,30 @@ describe("hosted device-sync runtime", () => {
         syncSuccessOptions: {},
         workerId: "worker_junction_child",
       }), true);
+      const failedChild = firstStore.claimDueJob(
+        "worker_junction_child_retry",
+        retryAt,
+        60_000,
+      );
+      assert.ok(failedChild);
+      assert.equal(failedChild.dedupeKey, "junction-child-window-cursor");
+      assert.deepEqual(
+        firstStore.failJobIfOwned(
+          failedChild.id,
+          "worker_junction_child_retry",
+          retryAt,
+          "JUNCTION_API_REQUEST_FAILED",
+          "retryable",
+          failedRetryAt,
+          true,
+        ),
+        {
+          attempts: 1,
+          disposition: "queued",
+          maxAttempts: 5,
+          remainingAttempts: 4,
+        },
+      );
 
       const recovery = resolveHostedDeviceSyncWakeRecovery({
         service: firstService,
@@ -10608,11 +10638,13 @@ describe("hosted device-sync runtime", () => {
         wake,
       });
       assert.ok(recovery);
+      assert.equal(recovery.retryAt, failedRetryAt);
+      assert.equal(recovery.wake.hint?.reason, "manual_reconcile");
       assert.deepEqual(recovery.wake.hint?.jobs, [{
-        availableAt: retryAt,
+        availableAt: failedRetryAt,
         dedupeKey: "junction-child-window-cursor",
         kind: "reconcile",
-        maxAttempts: 3,
+        maxAttempts: 4,
         payload: {
           sourceProviderSlug: "garmin",
           summaryResourceCursor: "sleep",
@@ -10631,13 +10663,14 @@ describe("hosted device-sync runtime", () => {
         lastErrorMessage: null,
         mailboxDedupeKey: "device-sync.wake:junction-summary-cursor",
         mailboxLaneSeq: "1",
-        nextAttemptAt: retryAt,
+        nextAttemptAt: failedRetryAt,
         occurredAt,
         postCheckpointRecord: {
           kind: "device-sync.dirty-processed-batch",
-          nextWakeAt: retryAt,
+          nextWakeAt: failedRetryAt,
           records: [],
           retainedWake: recovery.wake,
+          retainMailboxItemUntil: failedRetryAt,
         },
         preferenceCausalSeq: null,
         requestId: null,
@@ -10648,18 +10681,26 @@ describe("hosted device-sync runtime", () => {
       await updateHostedSystemMailboxState(firstWorkspace.vaultRoot, () => ({
         pending: [retainedMailboxItem],
       }));
+      const recordResult = await recordHostedSystemMailboxItemAfterCheckpoint({
+        item: retainedMailboxItem,
+        runtime: createDeviceSyncPostCheckpointRuntime(createPort()),
+        vaultRoot: firstWorkspace.vaultRoot,
+      });
+      assert.equal(recordResult.nextWakeAt, failedRetryAt);
       const [reloadedMailboxItem] = (
         await readHostedSystemMailboxState(firstWorkspace.vaultRoot)
       ).pending;
-      const reloadedRecord = reloadedMailboxItem?.postCheckpointRecord;
-      assert.equal(reloadedRecord?.kind, "device-sync.dirty-processed-batch");
-      if (reloadedRecord?.kind !== "device-sync.dirty-processed-batch") {
-        throw new Error("Expected the retained device-sync recovery record after reload.");
+      assert.ok(reloadedMailboxItem);
+      assert.equal(reloadedMailboxItem.status, "pending");
+      assert.equal(reloadedMailboxItem.postCheckpointRecord, null);
+      const retainedWake = reloadedMailboxItem.wake;
+      assert.equal(retainedWake.kind, "device-sync.wake");
+      if (retainedWake.kind !== "device-sync.wake") {
+        throw new Error("Expected the retained mailbox item to carry a device-sync wake.");
       }
-      assert.ok(reloadedRecord.retainedWake);
-      assert.deepEqual(reloadedRecord.retainedWake, recovery.wake);
+      assert.deepEqual(retainedWake, recovery.wake);
       assert.equal(
-        reloadedRecord.retainedWake?.hint?.jobs?.[0]?.payload?.summaryResourceCursor,
+        retainedWake.hint?.jobs?.[0]?.payload?.summaryResourceCursor,
         "sleep",
       );
 
@@ -10667,14 +10708,17 @@ describe("hosted device-sync runtime", () => {
         deviceSyncPort: createPort(),
         secret: DEVICE_SYNC_SECRET,
         service: restoredService,
-        wake: reloadedRecord.retainedWake,
+        wake: retainedWake,
       });
       const restoredAccountId = restoredState.hostedToLocalAccountIds.get(connectionId);
       assert.ok(restoredAccountId);
-      const [restoredChild] = readJobsForAccount(restoredService, restoredAccountId);
+      const restoredJobs = readJobsForAccount(restoredService, restoredAccountId);
+      assert.equal(restoredJobs.length, 1);
+      const [restoredChild] = restoredJobs;
       assert.equal(restoredChild?.dedupeKey, "junction-child-window-cursor");
-      assert.equal(restoredChild?.availableAt, retryAt);
-      assert.equal(restoredChild?.maxAttempts, 3);
+      assert.equal(restoredChild?.availableAt, failedRetryAt);
+      assert.equal(restoredChild?.maxAttempts, 4);
+      assert.equal(restoredChild?.priority, 50);
       assert.deepEqual(JSON.parse(restoredChild?.payloadJson ?? "{}"), {
         sourceProviderSlug: "garmin",
         summaryResourceCursor: "sleep",
@@ -10682,6 +10726,7 @@ describe("hosted device-sync runtime", () => {
         windowStart: "2026-02-01T00:00:00.000Z",
       });
     } finally {
+      vi.useRealTimers();
       closeHostedRuntimeDeviceSyncService(firstService);
       closeHostedRuntimeDeviceSyncService(restoredService);
       await firstWorkspace.cleanup();


### PR DESCRIPTION
Restores retained connected-health retry work after a cold hosted-runtime reconstruction. Exact retained jobs now keep their retry budget, priority, dedupe identity, and provider continuation cursor instead of being replaced by a fresh manual-reconcile root.

## Product UX

- Effort: Patch
- Result: Ready
- Affected journey: An existing member whose manual connected-health reconciliation creates a retryable child job can resume that exact work after mailbox persistence and cold restore.
- Direct proof: The focused regression exercises the failed child, post-checkpoint mailbox retention, a separate cold workspace, and ordinary manual-root creation.

## Evidence

- Focused regression failed before the source fix on the reconstructed dedupe identity and passes afterward.
- The focused cold-restore regression and the existing manual-reconcile root regression both pass.
- `pnpm --dir packages/assistant-runtime typecheck` passes.
- `git diff --check` passes.

## Changelog

- Changelog: updated
- Items: 2026-08-19 · retained-wearable-sync-retries

## Deployment concerns

- Deployment: applicable
- Supported skew: Web and old or new runner bundles use the same mailbox wake and job-hint shapes.
- Safe order: Deploy the Cloudflare Worker and runner bundle with immediate container rollout; no Web deployment is required.
- Rollback floor: No persisted or wire shape changes, so an older runner remains readable, although rollback restores the retry-loss defect.
- Expected exposure: Warm old runner containers may retain the old hydration behavior until fleet recycle completes.
- Reversibility: The runner can be rolled back without data conversion; forward redeployment restores correct retained-job hydration.
- Convergence proof: Managed-container smoke reports the new runner-bundle fingerprint across the active fleet.
- Post-deploy checks: Confirm fleet fingerprint convergence and inspect bounded device-sync completion, terminal-failure, and retained-mailbox backlog aggregates.

## Risks

- The change intentionally preserves retained exact jobs ahead of one-shot manual-root creation; it does not alter provider timeouts, retry delays, pass budgets, foreground priority, mailbox ordering, or Web cadence ownership.

ReviewGPT context sensitivity: sensitive — this changes hosted retry reconstruction and ordering.


ReviewGPT first-reviewed head: 908605e1519eddccf81c0823548f3b26cbd44de2
