### PR TITLE
Simplify the group funding success receipt

### DIFF
--- a/.agents/friction-log/20260819232656-frontend-guide-points/friction.md
+++ b/.agents/friction-log/20260819232656-frontend-guide-points/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Frontend guide points to removed repo-local design skill paths'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Frontend guidance should point agents to an available Impeccable and shadcn skill entrypoint before UI work.
+
+## Current Behavior
+
+`agent-docs/FRONTEND.md` names repo-local skill directories that are absent from a clean checkout, forcing agents to discover an installed fallback before satisfying the documented frontend workflow.
+
+## Possible Solution
+
+Route the guide to the canonical available skill names instead of checkout-local directories.
+
+## Minimal Reproducible Example
+
+1. Start from a clean checkout.
+2. Read `agent-docs/FRONTEND.md` before an `apps/web` change.
+3. Attempt to open the two referenced skill entrypoints.
+4. Observe that neither path exists.
+
+## Context
+
+This adds avoidable ambiguity before frontend implementation and can cause agents to skip current design-system or Base UI guidance.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -589,12 +589,14 @@ changes.
 When group funding is fulfilled, switch from the payment-status composition to
 one confident success hierarchy: a compact sage confirmation mark and mono
 `NICE ONE` label, the Fraunces headline `This group has more Murph`, one
-sentence confirming that the contribution is ready, then a warm-divider handoff
-to **Open Messages**. State that Messages opens without a group deep link and
-the member must choose the group. Do not repeat the confirmation in a bordered
-status card, keep payment-pending copy visible, invent an amount, or add
-celebration graphics. Once fulfillment is verified, do not carry frozen sponsor
-details or their payment-recovery instructions into the success receipt.
+sentence confirming that the contribution is ready, and one full-width **Open
+Messages** action. State that Messages opens without a group deep link and the
+member must choose the group. Keep the desktop dialog and mobile drawer at
+content height, and use their standard close control as the only separate exit.
+Do not add a divider band, a second dismissal action, a bordered status card,
+payment-pending copy, an invented amount, or celebration graphics. Once
+fulfillment is verified, do not carry frozen sponsor details or their
+payment-recovery instructions into the success receipt.
 
 ### Hosted AI Usage Activity
 On authenticated Settings, keep this read-only surface mission-first and

--- a/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
+++ b/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
@@ -1,0 +1,84 @@
+# Group funding success receipt redesign
+
+Status: active
+Created: 2026-08-19
+Updated: 2026-08-19
+
+## Goal
+
+- Turn the verified group-funding success state into a compact, confident
+  receipt that makes the next action obvious without changing payment,
+  fulfillment, dismissal, or Messages-routing behavior.
+
+## Success criteria
+
+- The fulfilled group state no longer expands into an oversized two-section
+  dialog on desktop or a full-height receipt drawer on mobile.
+- One primary `Open Messages` action and one quiet dismissal path remain, with
+  the existing `sms:` destination and accessible success announcement intact.
+- The heading, supporting copy, and action fit without overflow at desktop and
+  narrow-phone widths and preserve keyboard focus and close behavior.
+- Focused component tests, Web typecheck, rendered browser proof, the applicable
+  preliminary ReviewGPT lenses, exact-head CI, and parent final review pass.
+
+## Scope
+
+- In scope: the fulfilled group presentation in
+  `HostedUsageTopUpDialog`, its focused tests, the matching design-system
+  guidance, a public changelog item, and the task-owned Frog entry.
+- Out of scope: Stripe/payment state, purchase polling, sponsorship selection,
+  billing authority, group deep-link capability, and non-group success states.
+
+## Constraints
+
+- Technical constraints: reuse the existing shadcn Base UI Dialog, Drawer, and
+  Button owners; add no dependency or new component; preserve semantic link and
+  dialog title/description composition.
+- Product/process constraints: Product UX Patch. Outcome: the receipt is calm,
+  rewarding, and immediately legible. Reaches: existing desktop and phone group
+  contribution returns. Proof: focused behavior tests plus real rendered
+  desktop and mobile walkthroughs. Keep Murph's warm-paper palette, sage-only
+  affirmative signal, restrained motion, and non-cheerleader voice.
+
+## Risks and mitigations
+
+1. Risk: collapsing the receipt could hide the fact that Messages cannot open
+   the exact group thread.
+   Mitigation: retain a concise chooser instruction immediately beside the
+   primary action and keep the `sms:` link unchanged.
+2. Risk: removing a visible `Done` action could weaken dismissal or keyboard
+   control.
+   Mitigation: keep the standard close control in the dialog and drawer, then
+   prove both paths.
+
+## Tasks
+
+1. Inspect the current production state, component owners, tests, and design
+   catalog at the exact `origin/main` base.
+2. Implement the smallest compact fulfilled-state composition and align the
+   focused assertions and durable design guidance.
+3. Add the member-visible changelog item and verify public-data/privacy bounds.
+4. Run focused tests, Web typecheck, and desktop/mobile browser walkthroughs.
+5. Commit and push the candidate, open the PR, run preliminary specialist
+   ReviewGPT with CI, resolve findings, close the plan, and prove current-base
+   mergeability.
+
+## Decisions
+
+- Preserve the existing modal/drawer owner because fulfillment follows an
+  external checkout return; this is a terminal receipt, not a simple inline
+  edit that should be moved out of an overlay.
+- Delete the desktop `Done` action instead of styling it. The standard close
+  control already owns dismissal, while `Open Messages` owns continuation.
+- Do not add illustration or celebratory motion. The success mark, type
+  hierarchy, and tighter composition are sufficient and match Murph's explicit
+  anti-gamification rules.
+
+## Verification
+
+- Commands to run: the focused hosted-usage dialog Vitest file, Web typecheck,
+  `git diff --check`, and in-app Browser walkthroughs at desktop and narrow
+  phone widths; exact-head required GitHub checks after push.
+- Expected outcomes: unchanged payment behavior, one accessible success status,
+  a semantic `sms:` continuation link, no duplicate desktop dismissal action,
+  no overflow or clipped action on phone, and all routed review/CI gates green.

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -220,6 +220,27 @@ product-decision owners.
    material visual claim cannot be judged after the applicable fallback. For
    user-facing `apps/web` work, package only the selected redacted rendered
    evidence that helps a reviewer judge the changed claim.
+
+   For the Playwright fallback, prefer an existing design-proof capture spec.
+   If none covers the state, use the established `apps/web/e2e/pr-*-design-proof.spec.ts`
+   pattern for one task-scoped spec: run through `apps/web/playwright.config.ts`
+   so its smoke environment owns the dev server, open the anchored `/design` or
+   `/screenshots` state, block non-loopback requests, wait for fonts and two
+   animation frames, assert the production surface, and capture that surface
+   rather than a long full page. In a secondary worktree, choose a task-unique
+   port and Next dist suffix. For example:
+
+   ```bash
+   VIEWPORT_OVERFLOW_PORT=<unique-port> \
+   NEXT_DIST_DIR_SUFFIX=<task-slug>-proof \
+   DESIGN_PROOF_OUTPUT_DIR=../../.artifacts/review-gpt/<task-slug> \
+     pnpm --dir apps/web exec playwright test \
+       e2e/<capture-spec>.spec.ts --config playwright.config.ts --project chromium
+   ```
+
+   Inspect each selected image at native resolution, keep it ignored and
+   redacted under `.artifacts/review-gpt/`, and remove a one-off capture spec
+   after proof unless it adds durable regression value.
 7. Commit and push a review candidate from the task worktree, open or update the PR, and keep any active plan open. For plan-bearing work this is an intermediate scoped commit, not the final task commit; `scripts/finish-task` still owns plan closure later. Ensure the PR body contains the outcome, Product UX result, direct evidence, non-obvious surfaces, architecture and reuse, hot reply path impact, provider-input impact, deployment and changelog decisions, the change-shape breakdown, and applicable design proof required below.
 8. Prepare exactly one preliminary `completion-specialists` ReviewGPT pass against that pushed head using `agent-docs/operations/pr-reviewgpt-loop.md` § Preliminary Specialist Pass. This pass applies every relevant Product UX, prompt, frontend, and coverage lens together and does not establish or advance the final ReviewGPT round baseline. A tooling/evidence `INVALID` result is corrected and retried as the same pass; a substantive result is one specialist pass, not four audits.
 9. When the final ReviewGPT gate is selected, establish its immutable round-one baseline on the same exact pushed candidate head and launch the preliminary pass and final round 1 concurrently. When the final gate does not apply, launch the preliminary pass by itself. The candidate must already have focused local proof and a parent candidate review, but preliminary findings, plan closure, and the parent's final review do not need to finish before both ReviewGPT jobs start. Run both jobs concurrently with CI and keep their outputs and state separate.

--- a/apps/web/app/design/group-usage-funding-study.tsx
+++ b/apps/web/app/design/group-usage-funding-study.tsx
@@ -280,18 +280,20 @@ const DESIGN_FAMILY_EXHAUSTED_USAGE_STATUS: HostedPlanUsageAvailableStatus = {
 
 function GroupUsageFundingStudy() {
   const endpoint = "/api/design/group-sponsorship-management";
-  const [previewMode, setPreviewMode] = useState<"monthly" | "one_time" | null>(
-    null,
-  );
+  const [previewMode, setPreviewMode] = useState<
+    "fulfilled" | "monthly" | "one_time" | null
+  >(null);
 
   useEffect(() => {
     function syncActivationPreview() {
       setPreviewMode(
-        window.location.hash === "#group-usage-funding"
-          ? "monthly"
-          : window.location.hash === "#group-one-time-contribution"
-            ? "one_time"
-            : null,
+        window.location.hash === "#group-funding-receipt"
+          ? "fulfilled"
+          : window.location.hash === "#group-usage-funding"
+            ? "monthly"
+            : window.location.hash === "#group-one-time-contribution"
+              ? "one_time"
+              : null,
       );
     }
 
@@ -423,6 +425,35 @@ function GroupUsageFundingStudy() {
       </DesignSponsorshipState>
 
       <div className="grid gap-6 xl:grid-cols-2">
+        <DesignSponsorshipState
+          label="Fulfilled group contribution receipt"
+          state="fulfilled-receipt"
+        >
+          <div id="group-funding-receipt">
+            <Button
+              variant="outline"
+              onClick={() => setPreviewMode("fulfilled")}
+            >
+              Preview success receipt
+            </Button>
+            {previewMode === "fulfilled" ? (
+              <HostedUsageTopUpDialog
+                activePurchase={{
+                  offerCode: "usage_10_usd",
+                  purchaseId: "hucp_design_group_fulfilled",
+                  retryAllowed: false,
+                  status: "fulfilled",
+                }}
+                inert
+                initialOpen
+                offers={[]}
+                payerMemberId={DESIGN_PAYER_MEMBER_ID}
+                scope="group"
+              />
+            ) : null}
+          </div>
+        </DesignSponsorshipState>
+
         <DesignSponsorshipState
           label="Ordinary sponsored participant + one-time action"
           state="ordinary-sponsored-one-time"

--- a/apps/web/changelog/entries/2026-08-19/group-contribution-success-receipt.json
+++ b/apps/web/changelog/entries/2026-08-19/group-contribution-success-receipt.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-19",
+  "order": 120,
+  "item": {
+    "id": "group-contribution-success-receipt",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "A cleaner finish after group contributions",
+    "summary": "After adding usage to a group, the confirmation is now compact and keeps the next step into Messages clear on computers and phones.",
+    "details": "Messages still opens without a direct group link, so the receipt reminds you to choose the group before continuing.",
+    "relevanceTags": ["groups", "billing", "design"],
+    "sourcePullRequests": [2034]
+  }
+}

--- a/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
+++ b/apps/web/src/components/settings/hosted-usage-top-up-contract.ts
@@ -298,7 +298,7 @@ function readStatusContent(input: {
       return input.scope === "group"
         ? content(
             "This group has more Murph",
-            "Your contribution landed. The group has more room to talk.",
+            "Your contribution is ready.",
           )
         : content(
             "Usage added",

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -283,16 +283,16 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
   const confirmationIndicator =
     showGroupMessagesAction && statusContent ? (
       <div
-        className="flex items-center gap-3"
+        className="flex items-center gap-2.5"
         role="status"
         aria-live="polite"
         aria-label={`${statusContent.title}. ${statusContent.message}`}
       >
         <span
-          className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+          className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
           aria-hidden="true"
         >
-          <CheckIcon className="size-5 stroke-[2.5]" />
+          <CheckIcon className="size-4 stroke-[2.5]" />
         </span>
         <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-primary">
           Nice one
@@ -324,115 +324,112 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           <FieldError>{purchase.checkoutError}</FieldError>
           <div className="flex flex-col gap-2">
             {showGroupMessagesAction ? (
-              <div className="grid gap-5 border-y border-border py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:py-6">
-                <div className="space-y-1.5">
-                  <p className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                    Back to the chat
-                  </p>
-                  <p className="text-pretty text-sm leading-6 text-foreground">
-                    Messages will open. Choose this group to keep going.
-                  </p>
-                </div>
+              <div className="flex flex-col gap-3 pt-1">
+                <p className="text-pretty text-sm leading-6 text-muted-foreground">
+                  Open Messages, then choose this group to keep going.
+                </p>
                 {/* Messages has no deep link into an existing group thread, so
                   the group follow-up can only open the app itself. */}
                 <a
                   href="sms:"
                   className={cn(
                     buttonVariants({ size: "xl" }),
-                    "w-full sm:w-auto",
+                    "w-full",
                   )}
                 >
                   <MessageCircle
-                    className="size-4 shrink-0"
+                    data-icon="inline-start"
                     aria-hidden="true"
                   />
                   Open Messages
                 </a>
               </div>
             ) : null}
-              {canResume ? (
-                <Button
-                  type="button"
-                  size="lg"
-                  className="w-full"
-                  disabled={controller.checkoutInFlight}
-                  onClick={() =>
-                    window.location.assign(purchase.checkoutUrl ?? "")
-                  }
-                >
-                  Resume checkout
-                </Button>
-              ) : null}
-              {canCancel ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="lg"
-                  className="w-full"
-                  aria-busy={purchase.operation === "canceling_checkout"}
-                  disabled={controller.checkoutInFlight}
-                  onClick={() => {
-                    focusTitleAfterPurchaseActionRef.current = true;
-                    void controller.cancelRecoveredCheckout();
-                  }}
-                >
-                  {purchase.operation === "canceling_checkout"
-                    ? purchase.status === "payment_pending"
-                      ? "Canceling payment…"
-                      : "Canceling checkout…"
-                    : purchase.status === "payment_pending"
-                      ? "Cancel payment"
-                      : "Cancel checkout"}
-                </Button>
-              ) : null}
-              {canRetry ? (
-                <Button
-                  type="button"
-                  size="lg"
-                  className="w-full"
-                  aria-busy={purchase.operation === "opening_checkout"}
-                  disabled={controller.checkoutInFlight}
-                  onClick={() => {
-                    focusTitleAfterPurchaseActionRef.current = true;
-                    void controller.startCheckout(purchase.retryOfferCode);
-                  }}
-                >
-                  {purchase.operation === "opening_checkout"
-                    ? purchase.status === "payment_pending" || props.scope === "group"
-                      ? "Continuing payment…"
-                      : "Opening checkout…"
-                    : purchase.status === "payment_pending" || props.scope === "group"
-                      ? "Retry payment"
-                      : "Retry checkout"}
-                </Button>
-              ) : null}
-              {canCheckAgain ? (
-                <Button
-                  type="button"
-                  size="lg"
-                  className="w-full"
-                  disabled={controller.checkoutInFlight}
-                  onClick={() => {
-                    focusTitleAfterPurchaseActionRef.current = true;
-                    controller.retryStatusCheck();
-                  }}
-                >
-                  Check again
-                </Button>
-              ) : null}
+            {canResume ? (
+              <Button
+                type="button"
+                size="lg"
+                className="w-full"
+                disabled={controller.checkoutInFlight}
+                onClick={() =>
+                  window.location.assign(purchase.checkoutUrl ?? "")
+                }
+              >
+                Resume checkout
+              </Button>
+            ) : null}
+            {canCancel ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                className="w-full"
+                aria-busy={purchase.operation === "canceling_checkout"}
+                disabled={controller.checkoutInFlight}
+                onClick={() => {
+                  focusTitleAfterPurchaseActionRef.current = true;
+                  void controller.cancelRecoveredCheckout();
+                }}
+              >
+                {purchase.operation === "canceling_checkout"
+                  ? purchase.status === "payment_pending"
+                    ? "Canceling payment…"
+                    : "Canceling checkout…"
+                  : purchase.status === "payment_pending"
+                    ? "Cancel payment"
+                    : "Cancel checkout"}
+              </Button>
+            ) : null}
+            {canRetry ? (
+              <Button
+                type="button"
+                size="lg"
+                className="w-full"
+                aria-busy={purchase.operation === "opening_checkout"}
+                disabled={controller.checkoutInFlight}
+                onClick={() => {
+                  focusTitleAfterPurchaseActionRef.current = true;
+                  void controller.startCheckout(purchase.retryOfferCode);
+                }}
+              >
+                {purchase.operation === "opening_checkout"
+                  ? purchase.status === "payment_pending" ||
+                    props.scope === "group"
+                    ? "Continuing payment…"
+                    : "Opening checkout…"
+                  : purchase.status === "payment_pending" ||
+                      props.scope === "group"
+                    ? "Retry payment"
+                    : "Retry checkout"}
+              </Button>
+            ) : null}
+            {canCheckAgain ? (
+              <Button
+                type="button"
+                size="lg"
+                className="w-full"
+                disabled={controller.checkoutInFlight}
+                onClick={() => {
+                  focusTitleAfterPurchaseActionRef.current = true;
+                  controller.retryStatusCheck();
+                }}
+              >
+                Check again
+              </Button>
+            ) : null}
+            {showGroupMessagesAction ? null : (
               <Button
                 type="button"
                 variant="ghost"
                 size="lg"
-                className={cn(
-                  showGroupMessagesAction ? "mt-3 self-center px-8" : "w-full",
-                )}
+                className="w-full"
                 onClick={() => controller.handleOpenChange(false)}
               >
-                {showGroupMessagesAction ? "Done" : "Close"}
+                Close
               </Button>
-            </div>
+            )}
           </div>
+        </div>
         ) : capacityConflict ? (
           <div data-slot="usage-top-up-capacity-conflict">
             <Button
@@ -671,14 +668,18 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           <DrawerTrigger asChild>{drawerTriggerButton}</DrawerTrigger>
         ) : null}
         <DrawerContent
-          className="h-[calc(100dvh-0.75rem)] border-border data-[vaul-drawer-direction=bottom]:mt-3 data-[vaul-drawer-direction=bottom]:max-h-[calc(100dvh-0.75rem)] data-[vaul-drawer-direction=bottom]:rounded-t-[2rem]"
+          className={cn(
+            "border-border data-[vaul-drawer-direction=bottom]:mt-3 data-[vaul-drawer-direction=bottom]:rounded-t-[2rem]",
+            !showGroupMessagesAction &&
+              "h-[calc(100dvh-0.75rem)] data-[vaul-drawer-direction=bottom]:max-h-[calc(100dvh-0.75rem)]",
+          )}
           data-inert={props.inert ? "true" : undefined}
           inert={props.inert ? true : undefined}
         >
           <DrawerHeader
             className={cn(
               "relative items-start gap-2 px-6 pb-2 pt-2 text-left",
-              showGroupMessagesAction && "gap-4",
+              showGroupMessagesAction && "gap-3",
             )}
           >
             {confirmationIndicator}
@@ -688,7 +689,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
               className={cn(
                 "pr-10 font-serif text-3xl font-semibold leading-[1.1] tracking-tight text-foreground outline-none",
                 showGroupMessagesAction &&
-                  "max-w-lg text-[2.5rem] leading-[1.02] tracking-[-0.035em]",
+                  "max-w-md text-4xl leading-[1.05] tracking-[-0.03em]",
               )}
             >
               {headerTitle}
@@ -697,7 +698,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
               className={cn(
                 "max-w-md text-left text-base leading-6",
                 showGroupMessagesAction &&
-                  "max-w-lg text-[1.0625rem] leading-7 text-muted-foreground",
+                  "text-muted-foreground",
               )}
             >
               {headerDescription}
@@ -716,7 +717,12 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           </DrawerHeader>
           <div
             ref={scrollContentRef}
-            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pt-4"
+            className={cn(
+              "px-6 pt-4",
+              showGroupMessagesAction
+                ? "pb-[max(env(safe-area-inset-bottom),1.5rem)]"
+                : "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+            )}
           >
             {screenContent}
           </div>
@@ -777,13 +783,13 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           inert={props.inert ? true : undefined}
           className={cn(
             "max-h-[calc(100dvh-2rem)] gap-7 overflow-y-auto border border-border bg-popover p-6 sm:max-w-xl sm:p-8",
-            showGroupMessagesAction && "sm:max-w-2xl sm:gap-8 sm:p-10",
+            showGroupMessagesAction && "gap-5 sm:max-w-lg",
             compactStatusPresentation && "sm:max-w-md",
           )}
           initialFocus={titleRef}
         >
           <DialogHeader
-            className={cn("pr-10", showGroupMessagesAction && "gap-4")}
+            className={cn("pr-10", showGroupMessagesAction && "gap-3")}
           >
             {confirmationIndicator}
             <DialogTitle
@@ -792,7 +798,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
               className={cn(
                 "text-3xl font-semibold leading-[1.1] tracking-tight outline-none",
                 showGroupMessagesAction &&
-                  "max-w-lg text-[2.5rem] leading-[1.02] tracking-[-0.035em] sm:text-5xl",
+                  "max-w-md text-4xl leading-[1.05] tracking-[-0.03em]",
               )}
             >
               {headerTitle}
@@ -803,7 +809,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
                   ? cn(
                       "max-w-md text-base leading-6",
                       showGroupMessagesAction &&
-                        "max-w-lg text-[1.0625rem] leading-7 text-muted-foreground",
+                        "text-muted-foreground",
                     )
                   : "sr-only"
               }

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -718,10 +718,10 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           <div
             ref={scrollContentRef}
             className={cn(
-              "px-6 pt-4",
+              "min-h-0 overflow-y-auto overscroll-contain px-6 pt-4",
               showGroupMessagesAction
                 ? "pb-[max(env(safe-area-inset-bottom),1.5rem)]"
-                : "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+                : "flex-1",
             )}
           >
             {screenContent}

--- a/apps/web/test/biomarker-design-studies.test.tsx
+++ b/apps/web/test/biomarker-design-studies.test.tsx
@@ -300,7 +300,8 @@ test("screenshot categories keep the production studies available without one gi
     new URL("../app/design/group-usage-funding-study.tsx", import.meta.url),
     "utf8",
   );
-  expect(groupFundingStudySource.match(/\binitialOpen\b/gu)).toHaveLength(4);
+  expect(groupFundingStudySource.match(/\binitialOpen\b/gu)).toHaveLength(5);
+  expect(groupFundingStudySource).toContain('"#group-funding-receipt"');
   expect(groupFundingStudySource).toContain('returnPreview === "failed"');
   expect(groupFundingStudySource).toContain('returnPreview === "family"');
   expect(groupFundingStudySource).toContain('returnPreview === "inactive"');

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -2379,8 +2379,12 @@ test("removes frozen sponsor recovery details once group usage is fulfilled", as
       rendered.container.querySelectorAll('[role="status"]').length,
       1,
     );
-    await clickButton(rendered.container, rendered.window, "Done");
-    assert.equal(rendered.container.querySelector('[role="dialog"]'), null);
+    assert.equal(
+      Array.from(rendered.container.querySelectorAll("button")).some(
+        (button) => button.textContent?.trim() === "Done",
+      ),
+      false,
+    );
   } finally {
     await rendered.cleanup();
   }
@@ -5172,18 +5176,93 @@ test("offers Open Messages on a fulfilled group top-up return", async () => {
     );
     assert.match(
       rendered.container.textContent ?? "",
-      /Your contribution landed\. The group has more room to talk\./,
+      /Your contribution is ready\./,
     );
     assert.match(
       rendered.container.textContent ?? "",
-      /Messages will open\. Choose this group to keep going\./,
+      /Open Messages, then choose this group to keep going\./,
+    );
+    assert.doesNotMatch(
+      rendered.container.textContent ?? "",
+      /Back to the chat/,
     );
     const contactLink = rendered.container.querySelector("a");
     assert.ok(contactLink);
     assert.equal(contactLink.textContent, "Open Messages");
     assert.equal(contactLink.getAttribute("href"), "sms:");
+    assert.match(contactLink.className, /w-full/);
+    assert.ok(contactLink.querySelector('[data-icon="inline-start"]'));
+    const dialog = rendered.container.querySelector('[role="dialog"]');
+    assert.ok(dialog);
+    assert.match(dialog.className, /sm:max-w-lg/);
+    assert.doesNotMatch(dialog.className, /sm:max-w-2xl/);
+    const title = dialog.querySelector("h2");
+    assert.ok(title);
+    assert.match(title.className, /text-4xl/);
+    assert.doesNotMatch(title.className, /sm:text-5xl/);
     assert.doesNotMatch(rendered.container.textContent ?? "", /Text Murph/);
-    assert.equal(buttonByText(rendered.container, "Done").disabled, false);
+    assert.equal(
+      Array.from(rendered.container.querySelectorAll("button")).some(
+        (button) => button.textContent?.trim() === "Done",
+      ),
+      false,
+    );
+    assert.equal(
+      rendered.container.querySelectorAll('[role="status"]').length,
+      1,
+    );
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
+test("keeps the fulfilled group receipt content-height on mobile", async () => {
+  mocks.isMobile.mockReturnValue(true);
+  const { HostedUsageTopUpDialog } = await import(
+    "@/src/components/settings/hosted-usage-top-up-dialog"
+  );
+  const rendered = await renderClientComponent(
+    createElement(HostedUsageTopUpDialog, {
+      payerMemberId: TEST_PAYER_MEMBER_ID,
+      activePurchase: {
+        offerCode: "usage_10_usd",
+        purchaseId: "hucp_group_mobile_fulfilled",
+        retryAllowed: false,
+        status: "fulfilled",
+      },
+      initialOpen: true,
+      offers: [],
+      scope: "group",
+    }),
+    {
+      location: {
+        href: "https://example.test/groups/fund/group_join_code_1234",
+      },
+      requireButton: false,
+    },
+  );
+
+  try {
+    const drawer = rendered.container.querySelector(
+      '[data-slot="drawer-content"]',
+    );
+    assert.ok(drawer);
+    assert.doesNotMatch(drawer.className, /h-\[calc\(100dvh-0\.75rem\)\]/);
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Your contribution is ready/,
+    );
+    assert.match(
+      rendered.container.textContent ?? "",
+      /Open Messages, then choose this group to keep going/,
+    );
+    assert.equal(
+      Array.from(rendered.container.querySelectorAll("button")).some(
+        (button) => button.textContent?.trim() === "Done",
+      ),
+      false,
+    );
+    assert.equal(buttonByText(rendered.container, "Close").disabled, false);
     assert.equal(
       rendered.container.querySelectorAll('[role="status"]').length,
       1,

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -5256,6 +5256,12 @@ test("keeps the fulfilled group receipt content-height on mobile", async () => {
       rendered.container.textContent ?? "",
       /Open Messages, then choose this group to keep going/,
     );
+    const contactLink = rendered.container.querySelector('a[href="sms:"]');
+    assert.ok(contactLink);
+    const scrollBody = contactLink.closest(".overflow-y-auto");
+    assert.ok(scrollBody);
+    assert.match(scrollBody.className, /min-h-0/);
+    assert.match(scrollBody.className, /overscroll-contain/);
     assert.equal(
       Array.from(rendered.container.querySelectorAll("button")).some(
         (button) => button.textContent?.trim() === "Done",


### PR DESCRIPTION
## Why and outcome

The verified group-funding success state expanded into an oversized desktop dialog and a nearly full-height mobile drawer, with a separate handoff band and a redundant Done exit.

This patch turns it into a compact receipt: restrained success mark, clear title and confirmation, one full-width Open Messages action, and the standard overlay close control. Payment, fulfillment, and the existing `sms:` destination are unchanged. The compact drawer also owns bounded vertical scrolling so that action remains reachable on short screens and with enlarged text.

## Product UX

Patch. Walkthrough result: Ready. The exact production component was rendered and inspected at desktop, ordinary phone, short phone, and enlarged-text phone sizes. Affected people are existing group contributors returning from verified checkout on desktop and phone. Payment recovery, sponsorship selection, billing authority, and non-group success states are excluded. The implementation matches the plan.

## Evidence

- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/hosted-usage-top-up-dialog.test.tsx apps/web/test/biomarker-design-studies.test.tsx` — 111 passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm --dir apps/web exec eslint src/components/settings/hosted-usage-top-up-dialog.tsx test/hosted-usage-top-up-dialog.test.tsx` — passed.
- `git diff --check` — passed.
- Repository Playwright rendered and asserted the exact production fulfilled-group component across desktop, ordinary phone, 390×420 short-phone, and 125%-text phone journeys — 1 passed.
- All selected surface captures were inspected at native resolution. The short-phone case owns real overflow, scrolls to the full Messages action, retains the close control, and stays within the shared 80vh drawer cap.
- The exact-head UI preview completed successfully; authenticated verification of `/screenshots/groups` returned HTTP 200. The later pushed commits change tests and the bounded-scroll class only; the anchored state and ordinary presentation remain the same.

## Non-obvious affected surfaces

- Group-only fulfilled status copy is shortened to one confirmation sentence; focused return and recovery-transition tests pin that branch.
- The fulfilled mobile body now owns bounded overflow while preserving content height at ordinary sizes.
- The design catalog gains an inert hash-addressable fulfilled state; it makes no requests and does not alter production routing.
- The completion workflow now includes an operational recipe for task-scoped Playwright design-proof capture; it has no product runtime effect.
- Payment status, purchase polling, billing state, and the `sms:` handoff destination are unchanged.

## Architecture and reuse

- Existing systems reused: the current Base UI Dialog, Drawer, Button variants, `HostedUsageTopUpDialog` state owner, and repository Playwright config remain in place.
- New logic: the existing fulfilled-group predicate now selects content-height responsive classes, one Messages action composition, and the current drawer body as its bounded scroll owner.
- New abstractions: none; the current status contract, overlay owner, and test harness are sufficient.
- Complexity intentionally avoided: no new component, dependency, animation, state owner, deep-link fiction, duplicate dismissal path, or durable one-off capture spec.

## Hot reply path impact

Not applicable. This changes a hosted Web receipt after payment fulfillment and does not touch durable message acceptance, provider start, or reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool schema, instruction, or provider-visible assembly surface changed.
- Codex runtime: The completion-process guidance adds a Playwright fallback recipe for visual proof when no in-app browser tab is available. No product prompt, tool schema, or runtime behavior changes.

## Design proof

- Design page: [Group funding receipt](https://murph-17abmpfmc-cobuildwithus.vercel.app/screenshots/groups#group-funding-receipt)
- Evidence: Playwright opened the anchored synthetic state, blocked non-loopback requests, asserted the production title, close control, `sms:` action, and removal of redundant exits, then captured the receipt surface only. Native inspection covered ordinary and constrained states without Next.js developer chrome.
- Coverage: 1440×900 desktop dialog; 390×844 phone drawer; 390×420 short-phone drawer with real bounded overflow and the full action reachable; and 390×844 at 125% root text. All retain one Messages action and the standard close control.

## Change-shape breakdown

Classification rule: runtime TS/TSX is source; `apps/web/test` is tests/fixtures; Markdown, changelog JSON, the exec plan, workflow guidance, and the Frog entry are docs; no binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 144 | 107 |
| Tests/fixtures | 92 | 6 |
| Docs | 154 | 6 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 390 | 119 |

## Changelog

- Changelog: updated
- Items: 2026-08-19 · group-contribution-success-receipt

## Deployment concerns

- Deployment: not applicable
- Reason: This is a compatible client presentation change in `apps/web`. No route, schema, shared record, runner bundle, or Cloudflare surface changes, so Vercel and Cloudflare have no cross-version contract to coordinate.
