### PR TITLE
Stop sponsorship near-cap notices

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-08-16
+Last verified: 2026-08-20
 
 ## Local Frog autofix scheduling
 
@@ -1664,7 +1664,8 @@ Last verified: 2026-08-16
   bounded retry/reconciliation. Lazy month rollover never expires ledger
   credit, never clears recovery, and applies a deferred cap decrease only at
   the next anchored boundary. Activation owns the sole public sponsorship
-  moment; refill fulfillment is silent and private notices are period-deduped.
+  moment; refill fulfillment is silent and sends no near-cap notice. Payment
+  failure recovery notices remain purchase-deduped and direct-only.
   Payment authority rechecks the current payer suspension fence immediately
   before a bound automatic refill can be confirmed. Payer-owned cancellation
   remains available even when the beneficiary is inactive or the live funding

--- a/agent-docs/product-specs/hosted-usage-topups.md
+++ b/agent-docs/product-specs/hosted-usage-topups.md
@@ -1,7 +1,7 @@
 # Hosted Usage Top-Ups
 
 Status: Implemented personal, Family-member, and hosted-group funding
-Last verified: 2026-08-10
+Last verified: 2026-08-20
 
 ## Decision
 
@@ -200,12 +200,12 @@ Ordinary participants see only whether the chat is sponsored. They do not see
 the payer, maximum, amount charged or pending, credit, percentage, message
 count, or automatic refill events. The exact payer privately sees the current
 period's fulfilled and pending amounts, maximum, period end, status, and
-management controls. A near-cap notice is private and revalidated against the
-current authorization. The room is notified only when the existing usage gate
-actually pauses work. Every exhausted room receives the ordinary pause copy and
-the current first-party funding link. The message does not branch on or expose
-the current funding setup; the funding page separately preserves any active
-automatic sponsor and the single-sponsor billing invariant.
+management controls. Automatic refill fulfillment does not send a near-cap
+notice. The room is notified only when the existing usage gate actually pauses
+work. Every exhausted room receives the ordinary pause copy and the current
+first-party funding link. The message does not branch on or expose the current
+funding setup; the funding page separately preserves any active automatic
+sponsor and the single-sponsor billing invariant.
 
 ## Group Sponsorship Moment
 
@@ -296,9 +296,9 @@ fulfilled group purchase, Web idempotently:
 Permanent schema validation failure in a decrypted optional creative envelope
 projects as no creative request at this notification boundary. Activation,
 including an otherwise valid running bit, commits and Stripe receipt completion
-continues through the independent near-cap owner. Creator recovery stays strict,
-and secure-box, decryption, database, and other operational failures continue to
-propagate for ordinary retry rather than being mislabeled as quiet content.
+continues. Creator recovery stays strict, and secure-box, decryption, database,
+and other operational failures continue to propagate for ordinary retry rather
+than being mislabeled as quiet content.
 
 A monthly activation is the actual `$5` purchase eligible for the optional
 social response. Its private monthly maximum never changes the public

--- a/apps/web/changelog/entries/2026-08-20/quieter-sponsorship-refills.json
+++ b/apps/web/changelog/entries/2026-08-20/quieter-sponsorship-refills.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-20",
+  "order": 100,
+  "item": {
+    "id": "quieter-sponsorship-refills",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Quieter sponsorship refills",
+    "summary": "Monthly group sponsorships no longer send a private heads-up when one automatic refill remains before the monthly maximum.",
+    "details": "Current spending and controls remain on the private management page, and Murph still reaches out privately when a payment actually needs attention.",
+    "relevanceTags": ["groups", "billing"],
+    "sourcePullRequests": [2038]
+  }
+}

--- a/apps/web/src/lib/hosted-groups/group-sponsorship-authorization.ts
+++ b/apps/web/src/lib/hosted-groups/group-sponsorship-authorization.ts
@@ -1644,66 +1644,6 @@ export async function readHostedGroupSponsorshipCommittedMinor(input: {
   return aggregate._sum.cashAmountMinor ?? 0;
 }
 
-export async function isHostedGroupSponsorshipNearCapNotificationCurrentTx(
-  input: {
-    authorizationId: string;
-    beneficiaryMemberId: string;
-    monthlyCapMinor: HostedGroupSponsorshipMonthlyCapMinor;
-    now: Date;
-    payerMemberId: string;
-    periodStartedAt: Date;
-    purchaseId: string;
-    tx: Prisma.TransactionClient;
-  },
-): Promise<boolean> {
-  const purchase = await input.tx.hostedUsageCreditPurchase.findUnique({
-    select: {
-      beneficiaryMemberId: true,
-      groupSponsorshipAuthorizationId: true,
-      groupSponsorshipPeriodStartedAt: true,
-      payerMemberId: true,
-      status: true,
-    },
-    where: { id: input.purchaseId },
-  });
-  if (
-    !purchase ||
-    purchase.status !== HostedUsageCreditPurchaseStatus.fulfilled ||
-    purchase.payerMemberId !== input.payerMemberId ||
-    purchase.beneficiaryMemberId !== input.beneficiaryMemberId ||
-    purchase.groupSponsorshipAuthorizationId !== input.authorizationId ||
-    purchase.groupSponsorshipPeriodStartedAt?.getTime() !==
-      input.periodStartedAt.getTime()
-  ) {
-    return false;
-  }
-  const current = await input.tx.hostedGroupSponsorshipAuthorization.findUnique({
-    where: { id: input.authorizationId },
-  });
-  if (!current) {
-    return false;
-  }
-  const authorization = await normalizeHostedGroupSponsorshipAuthorizationTx({
-    authorization: current,
-    now: requireValidDate(input.now),
-    tx: input.tx,
-  });
-  if (
-    authorization.status !== HostedGroupSponsorshipAuthorizationStatus.active ||
-    authorization.payerMemberId !== input.payerMemberId ||
-    authorization.beneficiaryMemberId !== input.beneficiaryMemberId ||
-    authorization.periodStartedAt.getTime() !== input.periodStartedAt.getTime() ||
-    authorization.monthlyCapMinor !== input.monthlyCapMinor ||
-    authorization.monthlyCapMinor <= 500
-  ) {
-    return false;
-  }
-  return (await readHostedGroupSponsorshipCommittedMinorTx({
-    authorization,
-    tx: input.tx,
-  })) === authorization.monthlyCapMinor - 500;
-}
-
 export function addHostedGroupSponsorshipCalendarMonth(input: {
   anchorDay: number;
   anchorEndOfMonth: boolean;

--- a/apps/web/src/lib/hosted-groups/group-sponsorship-notification.ts
+++ b/apps/web/src/lib/hosted-groups/group-sponsorship-notification.ts
@@ -36,7 +36,6 @@ import {
   buildHostedGroupUsageFundingUrl,
 } from "./group-usage-funding";
 import {
-  isHostedGroupSponsorshipNearCapNotificationCurrentTx,
   readHostedGroupSponsorshipAuthorizationByPurchase,
 } from "./group-sponsorship-authorization";
 import type {
@@ -204,71 +203,6 @@ export async function materializeHostedGroupSponsorshipIfApplicable(input: {
     prisma: input.prisma,
   });
   return true;
-}
-
-export async function materializeHostedGroupSponsorshipNearCapNotification(
-  input: {
-    now?: Date;
-    prisma: PrismaClient;
-    purchaseId: string;
-  },
-): Promise<boolean> {
-  const now = input.now ?? new Date();
-  const purchase = await input.prisma.hostedUsageCreditPurchase.findUnique({
-    select: { status: true },
-    where: { id: input.purchaseId },
-  });
-  if (purchase?.status !== HostedUsageCreditPurchaseStatus.fulfilled) {
-    return false;
-  }
-  const sponsorship = await readHostedGroupSponsorshipAuthorizationByPurchase({
-    prisma: input.prisma,
-    purchaseId: input.purchaseId,
-  });
-  if (!sponsorship || sponsorship.monthlyCapMinor <= 500) {
-    return false;
-  }
-  const authorization =
-    await input.prisma.hostedGroupSponsorshipAuthorization.findUnique({
-      select: { beneficiaryMemberId: true },
-      where: { id: sponsorship.authorizationId },
-    });
-  if (!authorization) {
-    return false;
-  }
-  const managementUrl = buildPrivateManagementUrl(
-    authorization.beneficiaryMemberId,
-  );
-  return materializePrivateSponsorshipNotification({
-    beneficiaryMemberId: authorization.beneficiaryMemberId,
-    eventIdentity: [
-      "near-cap",
-      sponsorship.authorizationId,
-      sponsorship.periodStartedAt.toISOString(),
-      String(sponsorship.monthlyCapMinor),
-    ].join(":"),
-    instructions: [
-      "Send one concise private billing notice to the sponsor only.",
-      `One more $5 usage-credit refill would reach their $${sponsorship.monthlyCapMinor / 100} monthly maximum.`,
-      "Say that no action is required, and that they can change or pause the sponsorship from its private management page.",
-      managementUrl ? `Management page: ${managementUrl}` : null,
-      "Do not send this to the group or reveal sponsorship details to participants.",
-    ].filter((line): line is string => Boolean(line)).join("\n"),
-    now,
-    payerMemberId: sponsorship.payerMemberId,
-    prisma: input.prisma,
-    validateBeforeAppendTx: (tx) =>
-      isHostedGroupSponsorshipNearCapNotificationCurrentTx({
-        authorizationId: sponsorship.authorizationId,
-        beneficiaryMemberId: authorization.beneficiaryMemberId,
-        monthlyCapMinor: sponsorship.monthlyCapMinor,
-        now,
-        payerMemberId: sponsorship.payerMemberId,
-        periodStartedAt: sponsorship.periodStartedAt,
-        purchaseId: input.purchaseId,
-        tx,
-      }),
-  });
 }
 
 export async function materializeHostedGroupSponsorshipRecoveryNotification(

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -129,7 +129,6 @@ import {
 import { signalHostedRuntimeRecheckRuntime } from "../hosted-orchestration/signal-runtime";
 import {
   materializeHostedGroupSponsorshipIfApplicable,
-  materializeHostedGroupSponsorshipNearCapNotification,
 } from "../hosted-groups/group-sponsorship-notification";
 
 // Top-up reads use no SDK retries, hard per-request/KMS bounds, an aggregate
@@ -979,10 +978,6 @@ async function processClaimedHostedStripeEvent(
       usageCreditReconciliation.purchaseId
     ) {
       await materializeHostedGroupSponsorshipIfApplicable({
-        prisma,
-        purchaseId: usageCreditReconciliation.purchaseId,
-      });
-      await materializeHostedGroupSponsorshipNearCapNotification({
         prisma,
         purchaseId: usageCreditReconciliation.purchaseId,
       });

--- a/apps/web/test/hosted-group-sponsorship-authorization.test.ts
+++ b/apps/web/test/hosted-group-sponsorship-authorization.test.ts
@@ -76,7 +76,6 @@ import {
   cancelHostedGroupSponsorshipsForPayerAccountDeletionTx,
   createHostedGroupSponsorshipAuthorizationTx,
   hasHostedGroupAutomaticRefillAvailable,
-  isHostedGroupSponsorshipNearCapNotificationCurrentTx,
   manageHostedGroupSponsorshipAuthorization,
   markHostedGroupSponsorshipRecoveryRequiredForPurchase,
   parseHostedGroupSponsorshipManagementAction,
@@ -1320,89 +1319,6 @@ describe("hosted capped group sponsorship authorization", () => {
       pendingThisPeriodMinor: 500,
       pendingMonthlyCapMinor: 500,
     });
-  });
-
-  it("validates near-cap notices against the exact active payer, period, cap, and committed spend", async () => {
-    const authorization = buildAuthorization();
-    const purchase = {
-      beneficiaryMemberId: authorization.beneficiaryMemberId,
-      groupSponsorshipAuthorizationId: authorization.id,
-      groupSponsorshipPeriodStartedAt: authorization.periodStartedAt,
-      payerMemberId: authorization.payerMemberId,
-      status: HostedUsageCreditPurchaseStatus.fulfilled,
-    };
-    const tx = {
-      hostedGroupSponsorshipAuthorization: {
-        findUnique: vi.fn(async () => authorization),
-      },
-      hostedUsageCreditPurchase: {
-        aggregate: vi.fn(async () => ({ _sum: { cashAmountMinor: 500 } })),
-        findUnique: vi.fn(async () => purchase),
-      },
-    };
-
-    await expect(isHostedGroupSponsorshipNearCapNotificationCurrentTx({
-      authorizationId: authorization.id,
-      beneficiaryMemberId: authorization.beneficiaryMemberId,
-      monthlyCapMinor: 1_000,
-      now: NOW,
-      payerMemberId: "member_payer",
-      periodStartedAt: PERIOD_START,
-      purchaseId: "hucp_refill_123456",
-      tx: tx as never,
-    })).resolves.toBe(true);
-  });
-
-  it.each([
-    {
-      label: "a canceled authorization",
-      authorization: buildAuthorization({
-        canceledAt: NOW,
-        status: HostedGroupSponsorshipAuthorizationStatus.canceled,
-      }),
-      purchasePeriodStartedAt: PERIOD_START,
-      requestedPeriodStartedAt: PERIOD_START,
-    },
-    {
-      label: "a delayed prior-period fulfillment",
-      authorization: buildAuthorization({
-        periodEndsAt: new Date("2026-09-30T12:00:00.000Z"),
-        periodStartedAt: PERIOD_END,
-      }),
-      purchasePeriodStartedAt: PERIOD_START,
-      requestedPeriodStartedAt: PERIOD_START,
-    },
-  ])("rejects a near-cap notice for $label", async ({
-    authorization,
-    purchasePeriodStartedAt,
-    requestedPeriodStartedAt,
-  }) => {
-    const tx = {
-      hostedGroupSponsorshipAuthorization: {
-        findUnique: vi.fn(async () => authorization),
-      },
-      hostedUsageCreditPurchase: {
-        aggregate: vi.fn(async () => ({ _sum: { cashAmountMinor: 500 } })),
-        findUnique: vi.fn(async () => ({
-          beneficiaryMemberId: "member_group_runtime",
-          groupSponsorshipAuthorizationId: "hgsa_abcdefghijklmnop",
-          groupSponsorshipPeriodStartedAt: purchasePeriodStartedAt,
-          payerMemberId: "member_payer",
-          status: HostedUsageCreditPurchaseStatus.fulfilled,
-        })),
-      },
-    };
-
-    await expect(isHostedGroupSponsorshipNearCapNotificationCurrentTx({
-      authorizationId: "hgsa_abcdefghijklmnop",
-      beneficiaryMemberId: "member_group_runtime",
-      monthlyCapMinor: 1_000,
-      now: NOW,
-      payerMemberId: "member_payer",
-      periodStartedAt: requestedPeriodStartedAt,
-      purchaseId: "hucp_refill_123456",
-      tx: tx as never,
-    })).resolves.toBe(false);
   });
 
   it("applies confirmed increases immediately and preserves pause, resume, and cancel state", async () => {

--- a/apps/web/test/hosted-group-sponsorship-notification.test.ts
+++ b/apps/web/test/hosted-group-sponsorship-notification.test.ts
@@ -8,12 +8,10 @@ const mocks = vi.hoisted(() => ({
   activateMoment: vi.fn(),
   appendMailbox: vi.fn(),
   hasCustomizationAuthority: vi.fn(),
-  isNearCapCurrent: vi.fn(),
   lockHostedMemberRow: vi.fn(),
   projectTarget: vi.fn(),
   readMailboxItem: vi.fn(),
   readAuthorizationByPurchase: vi.fn(),
-  readCommittedMinor: vi.fn(),
   readMoment: vi.fn(),
   resolveDestination: vi.fn(),
   signalRuntime: vi.fn(),
@@ -69,18 +67,14 @@ vi.mock(
     >();
     return {
       ...actual,
-      isHostedGroupSponsorshipNearCapNotificationCurrentTx:
-        mocks.isNearCapCurrent,
       readHostedGroupSponsorshipAuthorizationByPurchase:
         mocks.readAuthorizationByPurchase,
-      readHostedGroupSponsorshipCommittedMinor: mocks.readCommittedMinor,
     };
   },
 );
 
 import {
   materializeHostedGroupSponsorshipIfApplicable,
-  materializeHostedGroupSponsorshipNearCapNotification,
   materializeHostedGroupSponsorshipRecoveryNotification,
 } from "@/src/lib/hosted-groups/group-sponsorship-notification";
 
@@ -125,11 +119,9 @@ beforeEach(() => {
     item: { id: "mailbox_item" },
   });
   mocks.hasCustomizationAuthority.mockResolvedValue(true);
-  mocks.isNearCapCurrent.mockResolvedValue(true);
   mocks.lockHostedMemberRow.mockResolvedValue(undefined);
   mocks.projectTarget.mockReturnValue({ kind: "group" });
   mocks.readAuthorizationByPurchase.mockResolvedValue(null);
-  mocks.readCommittedMinor.mockResolvedValue(0);
   mocks.readMailboxItem.mockResolvedValue(null);
   mocks.readMoment.mockResolvedValue({
     celebrationScale: "medium",
@@ -431,7 +423,7 @@ describe("group sponsorship notification", () => {
     expect(mocks.appendMailbox).not.toHaveBeenCalled();
   });
 
-  it("keeps automatic refill fulfillment silent in the group", async () => {
+  it("keeps automatic refill fulfillment silent", async () => {
     const prisma = createPrismaHarness({
       chargeOrdinal: 1,
       hasMoment: false,
@@ -446,120 +438,7 @@ describe("group sponsorship notification", () => {
 
     expect(mocks.activateMoment).not.toHaveBeenCalled();
     expect(mocks.appendMailbox).not.toHaveBeenCalled();
-  });
-
-  it("sends one period-scoped near-cap notice only to the payer", async () => {
-    const prisma = createPrismaHarness({
-      authorizationStatus: HostedGroupSponsorshipAuthorizationStatus.active,
-    });
-    mocks.readAuthorizationByPurchase.mockResolvedValue({
-      authorizationId: "hgsa_abcdefghijklmnop",
-      chargeOrdinal: 1,
-      monthlyCapMinor: 1_000,
-      payerMemberId: "member_sponsor",
-      periodStartedAt: new Date("2026-07-27T12:00:00.000Z"),
-    });
-    mocks.readCommittedMinor.mockResolvedValue(500);
-    mocks.resolveDestination.mockResolvedValueOnce(DIRECT_DESTINATION);
-
-    await expect(materializeHostedGroupSponsorshipNearCapNotification({
-      now: new Date("2026-07-27T12:05:00.000Z"),
-      prisma: prisma as never,
-      purchaseId: "purchase_private_123",
-    })).resolves.toBe(true);
-
-    const envelope = mocks.appendMailbox.mock.calls[0]?.[0]?.envelope;
-    expect(envelope).toMatchObject({
-      kind: "assistant.notification.requested",
-      userId: "member_sponsor",
-      notification: {
-        deliveryDedupeToken: expect.stringMatching(
-          /^group-sponsorship-private:v1:[a-f0-9]{40}$/u,
-        ),
-        externalThreadRouteAuthority: null,
-        route: DIRECT_DESTINATION.route,
-      },
-    });
-    expect(envelope.notification.instructions).toContain(
-      "One more $5 usage-credit refill",
-    );
-    expect(envelope.notification.instructions).toContain("$10 monthly maximum");
-    expect(envelope.notification.instructions).toContain("sponsor only");
-    expect(JSON.stringify(envelope)).not.toContain("member_group_runtime");
-  });
-
-  it("uses a fresh near-cap notice identity after the payer raises the cap", async () => {
-    const prisma = createPrismaHarness({
-      authorizationStatus: HostedGroupSponsorshipAuthorizationStatus.active,
-    });
-    mocks.resolveDestination.mockResolvedValue(DIRECT_DESTINATION);
-    mocks.readAuthorizationByPurchase
-      .mockResolvedValueOnce({
-        authorizationId: "hgsa_abcdefghijklmnop",
-        chargeOrdinal: 1,
-        monthlyCapMinor: 1_000,
-        payerMemberId: "member_sponsor",
-        periodStartedAt: new Date("2026-07-27T12:00:00.000Z"),
-      })
-      .mockResolvedValueOnce({
-        authorizationId: "hgsa_abcdefghijklmnop",
-        chargeOrdinal: 3,
-        monthlyCapMinor: 2_000,
-        payerMemberId: "member_sponsor",
-        periodStartedAt: new Date("2026-07-27T12:00:00.000Z"),
-      });
-
-    await materializeHostedGroupSponsorshipNearCapNotification({
-      prisma: prisma as never,
-      purchaseId: "purchase_cap_10",
-    });
-    await materializeHostedGroupSponsorshipNearCapNotification({
-      prisma: prisma as never,
-      purchaseId: "purchase_cap_20",
-    });
-
-    const keys = new Set(mocks.readMailboxItem.mock.calls.map(
-      ([input]) => input.dedupeKey,
-    ));
-    expect(keys.size).toBe(2);
-    for (const key of keys) {
-      expect(key).toMatch(/^assistant\.notification\.requested:/u);
-    }
-  });
-
-  it.each([
-    "a canceled authorization",
-    "a delayed prior-period fulfillment",
-  ])("drops a near-cap notice after locked revalidation finds %s", async () => {
-    const prisma = createPrismaHarness({
-      authorizationStatus: HostedGroupSponsorshipAuthorizationStatus.active,
-    });
-    mocks.readAuthorizationByPurchase.mockResolvedValue({
-      authorizationId: "hgsa_abcdefghijklmnop",
-      chargeOrdinal: 1,
-      monthlyCapMinor: 1_000,
-      payerMemberId: "member_sponsor",
-      periodStartedAt: new Date("2026-07-27T12:00:00.000Z"),
-    });
-    mocks.resolveDestination.mockResolvedValueOnce(DIRECT_DESTINATION);
-    mocks.isNearCapCurrent.mockResolvedValueOnce(false);
-
-    await expect(materializeHostedGroupSponsorshipNearCapNotification({
-      now: new Date("2026-08-27T12:05:00.000Z"),
-      prisma: prisma as never,
-      purchaseId: "purchase_private_123",
-    })).resolves.toBe(false);
-
-    expect(mocks.isNearCapCurrent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        authorizationId: "hgsa_abcdefghijklmnop",
-        beneficiaryMemberId: "member_group_runtime",
-        payerMemberId: "member_sponsor",
-        purchaseId: "purchase_private_123",
-        tx: prisma,
-      }),
-    );
-    expect(mocks.appendMailbox).not.toHaveBeenCalled();
+    expect(mocks.resolveDestination).not.toHaveBeenCalled();
   });
 
   it("sends payment recovery privately and never to a thread container", async () => {

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -43,7 +43,6 @@ const mocks = vi.hoisted(() => ({
   lookupHostedAccountGroupIdByStripeSubscriptionId: vi.fn(),
   cleanupHostedStandardCheckoutLoser: vi.fn(),
   materializeHostedGroupSponsorshipIfApplicable: vi.fn(),
-  materializeHostedGroupSponsorshipNearCapNotification: vi.fn(),
   prepareHostedCryptoDomainRootCandidates: vi.fn(),
   prepareHostedStripeDirectMemberActivationCrypto: vi.fn(),
   prepareHostedFamilyStripeActivationCryptoDomainRoots: vi.fn(),
@@ -301,8 +300,6 @@ vi.mock(
 vi.mock("@/src/lib/hosted-groups/group-sponsorship-notification", () => ({
   materializeHostedGroupSponsorshipIfApplicable:
     mocks.materializeHostedGroupSponsorshipIfApplicable,
-  materializeHostedGroupSponsorshipNearCapNotification:
-    mocks.materializeHostedGroupSponsorshipNearCapNotification,
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
@@ -424,7 +421,6 @@ describe("hosted Stripe event reconciliation", () => {
       null,
     );
     mocks.materializeHostedGroupSponsorshipIfApplicable.mockResolvedValue(true);
-    mocks.materializeHostedGroupSponsorshipNearCapNotification.mockResolvedValue(false);
     mocks.prepareHostedCryptoDomainRootCandidates.mockResolvedValue(new Map());
     mocks.prepareHostedStripeDirectMemberActivationCrypto.mockResolvedValue(
       new Map(),
@@ -819,7 +815,7 @@ describe("hosted Stripe event reconciliation", () => {
     errorSpy.mockRestore();
   });
 
-  it("completes usage-credit reconciliation after quiet sponsorship materialization", async () => {
+  it("completes usage-credit reconciliation without a near-cap sponsor notice", async () => {
     const prisma = createStripeEventPrismaHarness();
     const event = makeCheckoutCompletedEvent();
     mocks.stripe.events.retrieve.mockResolvedValue(event);
@@ -853,12 +849,6 @@ describe("hosted Stripe event reconciliation", () => {
     });
     expect(
       mocks.materializeHostedGroupSponsorshipIfApplicable,
-    ).toHaveBeenCalledWith({
-      prisma: prisma.client,
-      purchaseId: "hucp_purchase_123",
-    });
-    expect(
-      mocks.materializeHostedGroupSponsorshipNearCapNotification,
     ).toHaveBeenCalledWith({
       prisma: prisma.client,
       purchaseId: "hucp_purchase_123",


### PR DESCRIPTION
## Why and outcome

Monthly group sponsors currently receive a private notice when one more automatic $5 refill would reach their cap. This removes that nonessential proactive message while keeping payment-failure recovery notices intact.

## Product UX

- Effort: Product change
- Result: Ready
- Walkthrough: A sponsor one refill below the cap receives no message; group participants still receive no refill details; a sponsor whose refill actually fails still receives the existing private recovery path. The private management page remains the source for current spend, cap, and controls.

## Evidence

- Direct: Fulfilled Stripe reconciliation no longer calls a near-cap materializer, the materializer and validator are deleted, and stale-string searches find no remaining send instruction.
- Coverage: Billing/notification focused Vitest set passed 150 tests; changelog focused Vitest set passed 57 tests; `pnpm --filter @murphai/hosted-web typecheck` passed.

## Non-obvious affected surfaces

- Stripe usage-credit receipt reconciliation no longer schedules the optional near-cap mailbox side effect; focused reconciliation coverage proves grant/runtime continuation remains unchanged.
- Group sponsorship recovery notifications remain direct-only and purchase-deduplicated; focused notification coverage preserves that path.
- The hosted usage top-up product and reliability contracts now state that automatic refill fulfillment is silent.

## Architecture and reuse

- Existing systems reused: Existing Stripe reconciliation, group sponsorship accounting, private management projection, usage-gate pause message, and payment-recovery notification remain authoritative.
- New logic: None; the unwanted near-cap send path is deleted.
- New abstractions: None; the existing management and recovery owners cover the remaining product needs.
- Complexity intentionally avoided: No preference flag, suppression state, compatibility shim, queue branch, or replacement message was added.

## Hot reply path impact

- Path status: Not applicable; this removes a detached post-payment notification and does not change foreground conversation acceptance, provider start, or durable reply handoff.
- Database calls: None added; near-cap reads and its validation transaction are removed.
- Network/provider calls: None added; the optional private assistant delivery is removed.
- Other awaited latency: None added.
- Before/after proof: Focused Stripe reconciliation and notification tests pass with the near-cap owner absent.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Not applicable; no initial provider-input builder or prompt surface changes.
- Tool/schema/generated guidance: Not applicable; no tool or schema changes.
- Other provider-visible input: Not applicable; the deleted content was a detached notification request, not initial turn input.
- Measurement method: Not run because no initial provider-input surface changed.

## Risks

- Billing behavior is unchanged: automatic refills, cap enforcement, management controls, and payment-failure recovery remain in their existing owners.

ReviewGPT context sensitivity: sensitive
Classification reason: The diff removes a private billing notification from post-payment reconciliation.
ReviewGPT first-reviewed head: 8f45b37aaf9f0f5d9270e73b501cc8bac49fbc01

## Deployment concerns

- Deployment: not applicable
- Reason: This is a single-Web-revision behavior deletion with no schema, record-shape, cross-service, or mixed-version contract; old and new instances are independently safe during rollout.

## Change-shape breakdown

Classification rule: TypeScript production paths are source, Vitest files are tests, Markdown contracts and authored changelog content are docs, and there are no binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 131 |
| Tests / fixtures | 3 | 218 |
| Docs | 27 | 12 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **30** | **361** |

## Changelog

- Changelog: updated
- Items: 2026-08-20 · quieter-sponsorship-refills
