### PR TITLE
Add on-demand Gemini video analysis

### DIFF
--- a/.github/workflows/codex-source-export.yml
+++ b/.github/workflows/codex-source-export.yml
@@ -1,0 +1,29 @@
+name: Temporary Codex Source Export
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  export-source:
+    if: github.head_ref == 'codex/gemini-video-analysis'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Archive tracked source
+        run: git archive --format=zip --output=murph-source.zip HEAD
+
+      - name: Upload source archive
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: codex-murph-source
+          path: murph-source.zip
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
## Why and outcome

Murph currently stores group-chat video and may transcribe its audio, but it does not inspect the visual stream. This branch is implementing one explicit `murph.analyze_video` dynamic tool that analyzes an accepted message's stored video with Gemini 3.7 Flash at a trusted 1 FPS default.

## Product UX

- Effort: Product capability
- Result: In progress
- Walkthrough: A person sends a video, then asks Murph to inspect it. Murph invokes visual analysis only for that accepted message and returns bounded observational feedback. Ordinary video messages remain transcription-only and make no Gemini call.

## Evidence

- Direct and focused verification will be added before this draft is marked ready.

## Non-obvious affected surfaces

- Accepted-input attachment authority, Codex dynamic-tool definitions, hosted provider egress, provider usage accounting, and Cloudflare deployment configuration.

## Architecture and reuse

- Existing systems reused: Accepted assistant input events, turn-scoped dynamic tools, the provider-fetch interception boundary, and existing hosted usage recording.
- New logic: One on-demand video-analysis tool and one Gemini provider adapter.
- New abstractions: None planned beyond the narrow provider/tool types required by the current capability.
- Complexity intentionally avoided: No automatic analysis, parser replacement, queue, scheduler, cache, persisted analysis owner, upload service, or model-facing file path.

## Hot reply path impact

- Ordinary replies: no additional work.
- Explicit video analysis: one bounded local attachment read and one provider request after tool invocation.
- No database call, parser wait, or automatic enrichment is added to message admission.

## Murph initial provider input impact

- Dynamic tool schema: one new tool definition will be visible to eligible root turns, so tool-definition fingerprints and initial provider input will change.
- Measurement will be added before readiness.

## Risks

- Private video must remain authorized to the current accepted turn and the Google credential must remain outside model-controlled input and child environments.
- Provider output must be framed as untrusted visual evidence and bounded before returning to Murph.

## Deployment concerns

- Deployment: applicable
- Supported skew, rollout order, rollback floor, and post-deploy proof will be documented after the public/private runtime wiring is complete.

## Change-shape breakdown

Pending implementation.

## Changelog

- Changelog: planned
- Reason: This adds a member-visible ability to understand videos on request.
