### PR TITLE
Stop re-signaling imported mailbox handoffs

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
+++ b/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
@@ -1,7 +1,7 @@
 # Retire Persistent Hosted Runtime Wakes
 
 Status: active
-Updated: 2026-08-19
+Updated: 2026-08-20
 
 ## Goal
 
@@ -40,6 +40,24 @@ boundaries between Web, Temporal, and the Cloudflare runtime.
 
 All evidence is aggregate and contains no production identifiers.
 
+## Residual Production Evidence
+
+- The first public/private rollout removed the one-to-three-second checkpoint
+  loop, but production retained roughly 15 to 30 successful no-op system
+  imports per minute across 15 to 18 runtimes.
+- Those invocations fetched and imported zero items, did not change runtime
+  state, and repeatedly reported the same mailbox and workspace frontiers.
+- The shared recovery schedule runs every minute. Its mailbox-handoff query
+  compared system item sequence numbers with the lane counter `consumed_seq`,
+  even though system handoff ownership transfers at the workspace's imported
+  frontier and `consumed_seq` does not represent that boundary.
+- The live query selected nineteen runtime-control candidates. All nineteen
+  first candidates were already imported, while an imported-frontier version
+  of the query retained only one genuinely unimported handoff candidate.
+- Imported-but-unhandled items remain durable in runtime state with their own
+  retry timestamp. Re-signaling them from Web bypassed that owner and recreated
+  the minute-level no-op loop.
+
 ## Product UX Patch
 
 - Runnable scheduled work must continue to execute promptly.
@@ -76,13 +94,16 @@ All evidence is aggregate and contains no production identifiers.
 7. Merge and deploy in compatibility order, then verify multiple complete
    production windows until churn collapses and the retained system gap drains
    without lost assistant wakes or shifted errors.
+8. Retire the Web recovery sweep's ownership at the persisted system imported
+   frontier, preserve recovery for never-imported items, and verify production
+   quiescence after the follow-up Web deployment.
 
 ## Verification
 
-- Root cause: proven from current production aggregates, authoritative Web
-  reconciliation logs, exact deployed code, and the existing runtime guard
-  regression.
-- Independent ReviewGPT root-cause audit: running.
-- Public contract/Cloudflare tests, private Temporal/replay tests, typechecks,
-  bundle proof, exact-head ReviewGPT gates, CI, deploy, and production
-  convergence: pending.
+- Initial cross-runtime ownership correction: merged and deployed.
+- Residual root cause: proven from current production aggregates, the exact
+  minute-sweep query, persisted workspace frontiers, and repeated no-op runtime
+  logs.
+- Follow-up focused regression and Web typecheck: passed.
+- Follow-up exact-head ReviewGPT gates, CI, deploy, and production convergence:
+  pending.

--- a/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
+++ b/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
@@ -104,6 +104,7 @@ All evidence is aggregate and contains no production identifiers.
 - Residual root cause: proven from current production aggregates, the exact
   minute-sweep query, persisted workspace frontiers, and repeated no-op runtime
   logs.
-- Follow-up focused regression and Web typecheck: passed.
+- Follow-up focused regressions, real-PostgreSQL imported-frontier proof, Web
+  typecheck, and focused lint: passed.
 - Follow-up exact-head ReviewGPT gates, CI, deploy, and production convergence:
   pending.

--- a/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
+++ b/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
@@ -171,11 +171,23 @@ function createHostedPreferenceHandoffCandidateStore(
             "item"."created_at" AS "createdAt",
             "item"."lane_seq" AS "laneSeq"
           FROM "hosted_mailbox_item" AS "item"
-          LEFT JOIN "hosted_mailbox_lane_counter" AS "lane_counter"
-            ON "lane_counter"."user_id" = "item"."user_id"
-            AND "lane_counter"."lane" = "item"."lane"
+          LEFT JOIN "hosted_workspace" AS "workspace"
+            ON "workspace"."user_id" = "item"."user_id"
           WHERE "item"."kind" = 'member.preferences.updated'
-            AND "item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)
+            -- Import transfers retry ownership from this handoff sweep to the
+            -- runtime. Handled-through can remain behind while runtime-owned
+            -- work waits for its persisted retry timestamp.
+            AND "item"."lane_seq" > CASE
+              WHEN (
+                "workspace"."redacted_status_json"
+                  ->> 'hostedMailboxSystemImportedSeq'
+              ) ~ '^(0|[1-9][0-9]*)$'
+                THEN (
+                  "workspace"."redacted_status_json"
+                    ->> 'hostedMailboxSystemImportedSeq'
+                )::bigint
+              ELSE 0
+            END
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" >= ${retainedAt}
           ORDER BY "item"."user_id", "item"."lane_seq" ASC
@@ -187,16 +199,25 @@ function createHostedPreferenceHandoffCandidateStore(
             "item"."created_at" AS "createdAt",
             "item"."lane_seq" AS "laneSeq"
           FROM "hosted_mailbox_item" AS "item"
-          LEFT JOIN "hosted_mailbox_lane_counter" AS "lane_counter"
-            ON "lane_counter"."user_id" = "item"."user_id"
-            AND "lane_counter"."lane" = "item"."lane"
+          LEFT JOIN "hosted_workspace" AS "workspace"
+            ON "workspace"."user_id" = "item"."user_id"
           WHERE "item"."kind" IN (
               'device-sync.wake',
               'health.daily-metric.reported',
               'runtime.browser-vault-refresh-requested',
               'runtime.maintenance-requested'
             )
-            AND "item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)
+            AND "item"."lane_seq" > CASE
+              WHEN (
+                "workspace"."redacted_status_json"
+                  ->> 'hostedMailboxSystemImportedSeq'
+              ) ~ '^(0|[1-9][0-9]*)$'
+                THEN (
+                  "workspace"."redacted_status_json"
+                    ->> 'hostedMailboxSystemImportedSeq'
+                )::bigint
+              ELSE 0
+            END
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" >= ${retainedAt}
           ORDER BY "item"."user_id", "item"."lane_seq" ASC
@@ -219,12 +240,21 @@ function createHostedPreferenceHandoffCandidateStore(
             AND "item"."dedupe_key" = (
               'clinical-records:sync:v1:' || "run"."id" || ':' || "run"."generation"::text
             )
-          LEFT JOIN "hosted_mailbox_lane_counter" AS "lane_counter"
-            ON "lane_counter"."user_id" = "item"."user_id"
-            AND "lane_counter"."lane" = "item"."lane"
+          LEFT JOIN "hosted_workspace" AS "workspace"
+            ON "workspace"."user_id" = "item"."user_id"
           WHERE "run"."status" = 'queued'
             AND "run"."completed_at" IS NULL
-            AND "item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)
+            AND "item"."lane_seq" > CASE
+              WHEN (
+                "workspace"."redacted_status_json"
+                  ->> 'hostedMailboxSystemImportedSeq'
+              ) ~ '^(0|[1-9][0-9]*)$'
+                THEN (
+                  "workspace"."redacted_status_json"
+                    ->> 'hostedMailboxSystemImportedSeq'
+                )::bigint
+              ELSE 0
+            END
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" > ${retainedAt}
         ),

--- a/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
+++ b/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
@@ -151,6 +151,20 @@ export async function runHostedPreferenceHandoffSweeper(input: {
 function createHostedPreferenceHandoffCandidateStore(
   prisma: PrismaClient,
 ): HostedPreferenceHandoffCandidateStore {
+  const systemMailboxImportedSeq = Prisma.sql`
+    CASE
+      WHEN (
+        "workspace"."redacted_status_json"
+          ->> 'hostedMailboxSystemImportedSeq'
+      ) ~ '^(0|[1-9][0-9]*)$'
+        THEN (
+          "workspace"."redacted_status_json"
+            ->> 'hostedMailboxSystemImportedSeq'
+        )::bigint
+      ELSE 0
+    END
+  `;
+
   return {
     async listCandidates(input) {
       const retainedAt = new Date(input.now.getTime() - HOSTED_MAILBOX_RETENTION_MS);
@@ -177,17 +191,7 @@ function createHostedPreferenceHandoffCandidateStore(
             -- Import transfers retry ownership from this handoff sweep to the
             -- runtime. Handled-through can remain behind while runtime-owned
             -- work waits for its persisted retry timestamp.
-            AND "item"."lane_seq" > CASE
-              WHEN (
-                "workspace"."redacted_status_json"
-                  ->> 'hostedMailboxSystemImportedSeq'
-              ) ~ '^(0|[1-9][0-9]*)$'
-                THEN (
-                  "workspace"."redacted_status_json"
-                    ->> 'hostedMailboxSystemImportedSeq'
-                )::bigint
-              ELSE 0
-            END
+            AND "item"."lane_seq" > ${systemMailboxImportedSeq}
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" >= ${retainedAt}
           ORDER BY "item"."user_id", "item"."lane_seq" ASC
@@ -207,17 +211,7 @@ function createHostedPreferenceHandoffCandidateStore(
               'runtime.browser-vault-refresh-requested',
               'runtime.maintenance-requested'
             )
-            AND "item"."lane_seq" > CASE
-              WHEN (
-                "workspace"."redacted_status_json"
-                  ->> 'hostedMailboxSystemImportedSeq'
-              ) ~ '^(0|[1-9][0-9]*)$'
-                THEN (
-                  "workspace"."redacted_status_json"
-                    ->> 'hostedMailboxSystemImportedSeq'
-                )::bigint
-              ELSE 0
-            END
+            AND "item"."lane_seq" > ${systemMailboxImportedSeq}
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" >= ${retainedAt}
           ORDER BY "item"."user_id", "item"."lane_seq" ASC
@@ -244,17 +238,7 @@ function createHostedPreferenceHandoffCandidateStore(
             ON "workspace"."user_id" = "item"."user_id"
           WHERE "run"."status" = 'queued'
             AND "run"."completed_at" IS NULL
-            AND "item"."lane_seq" > CASE
-              WHEN (
-                "workspace"."redacted_status_json"
-                  ->> 'hostedMailboxSystemImportedSeq'
-              ) ~ '^(0|[1-9][0-9]*)$'
-                THEN (
-                  "workspace"."redacted_status_json"
-                    ->> 'hostedMailboxSystemImportedSeq'
-                )::bigint
-              ELSE 0
-            END
+            AND "item"."lane_seq" > ${systemMailboxImportedSeq}
             AND ("item"."expires_at" IS NULL OR "item"."expires_at" > ${input.now})
             AND "item"."created_at" > ${retainedAt}
         ),

--- a/apps/web/test/hosted-preference-handoff-sweeper-postgres.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper-postgres.test.ts
@@ -245,7 +245,7 @@ describe.skipIf(!runPostgresProof)(
       ]);
     });
 
-    it("selects an unconsumed device-sync wake for scheduled handoff recovery", async () => {
+    it("retains recovery when the imported frontier is malformed", async () => {
       const client = requirePrisma(prisma);
       const now = new Date();
       const memberId = createId("member_handoff_device_sync");
@@ -256,6 +256,14 @@ describe.skipIf(!runPostgresProof)(
         data: {
           billingStatus: "active",
           id: memberId,
+        },
+      });
+      await client.hostedWorkspace.create({
+        data: {
+          redactedStatusJson: {
+            hostedMailboxSystemImportedSeq: "not-a-sequence",
+          },
+          userId: memberId,
         },
       });
       await client.hostedMailboxItem.create({

--- a/apps/web/test/hosted-preference-handoff-sweeper-postgres.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper-postgres.test.ts
@@ -299,6 +299,84 @@ describe.skipIf(!runPostgresProof)(
         `handoff:${memberId}`,
       ]);
     });
+
+    it("signals only system items beyond the persisted imported frontier", async () => {
+      const client = requirePrisma(prisma);
+      const now = new Date();
+      const memberId = createId("member_handoff_imported_frontier");
+      const importedMailboxItemId = createId("mailbox_handoff_imported");
+      const pendingMailboxItemId = createId("mailbox_handoff_pending");
+      memberIds.push(memberId);
+
+      await client.hostedMember.create({
+        data: {
+          billingStatus: "active",
+          id: memberId,
+        },
+      });
+      await client.hostedWorkspace.create({
+        data: {
+          redactedStatusJson: {
+            hostedMailboxSystemImportedSeq: "1",
+          },
+          userId: memberId,
+        },
+      });
+      await client.hostedMailboxItem.createMany({
+        data: [
+          mailboxItem({
+            createdAt: new Date(now.getTime() - 120_000),
+            id: importedMailboxItemId,
+            kind: "member.preferences.updated",
+            laneSeq: 1n,
+            userId: memberId,
+          }),
+          mailboxItem({
+            createdAt: new Date(now.getTime() - 60_000),
+            id: pendingMailboxItemId,
+            kind: "device-sync.wake",
+            laneSeq: 2n,
+            userId: memberId,
+          }),
+        ],
+      });
+      const order: string[] = [];
+      const hasActiveAccess = vi.fn(async (userId: string) => {
+        order.push(`access:${userId}`);
+        const active = await hasHostedRuntimeActiveAccess(userId, {
+          prisma: client,
+        });
+        order.push(`access-complete:${userId}`);
+        return active;
+      });
+      const requestHandoff = buildRequestHandoff(order);
+
+      await expect(runHostedPreferenceHandoffSweeper({
+        hasActiveAccess,
+        logger: buildLogger(),
+        now,
+        requestHandoff,
+      })).resolves.toMatchObject({
+        candidateUsers: 1,
+        handoffAccepted: 1,
+        handoffAttempted: 1,
+      });
+
+      expect(requestHandoff).toHaveBeenCalledTimes(1);
+      expect(requestHandoff).toHaveBeenCalledWith({
+        abortSignal: expect.any(AbortSignal),
+        expectedUserId: memberId,
+        mailboxItemId: pendingMailboxItemId,
+      });
+      expect(requestHandoff).not.toHaveBeenCalledWith(
+        expect.objectContaining({ mailboxItemId: importedMailboxItemId }),
+      );
+      expect(order).toEqual([
+        `access:${memberId}`,
+        `access-complete:${memberId}`,
+        `handoff:${memberId}`,
+      ]);
+    });
   },
 );
 
@@ -309,6 +387,7 @@ function mailboxItem(input: {
   dedupeKey?: string;
   id: string;
   kind: string;
+  laneSeq?: bigint;
   userId: string;
 }) {
   return {
@@ -317,7 +396,7 @@ function mailboxItem(input: {
     id: input.id,
     kind: input.kind,
     lane: "system",
-    laneSeq: 1n,
+    laneSeq: input.laneSeq ?? 1n,
     occurredAt: input.createdAt,
     payloadSchema: "murph.test.preference-handoff-postgres.v1",
     userId: input.userId,

--- a/apps/web/test/hosted-preference-handoff-sweeper.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper.test.ts
@@ -244,7 +244,7 @@ describe("hosted preference handoff sweeper", () => {
     const sql = query?.strings?.join("?") ?? "";
     expect(sql).not.toContain('"lane_counter"."consumed_seq"');
     expect(sql.match(/LEFT JOIN "hosted_workspace" AS "workspace"/gu)).toHaveLength(3);
-    expect(sql.match(/"item"\."lane_seq" > CASE/gu)).toHaveLength(3);
+    expect(sql.match(/"item"\."lane_seq" >\s+CASE/gu)).toHaveLength(3);
     expect(sql.match(/hostedMailboxSystemImportedSeq/gu)).toHaveLength(6);
   });
 
@@ -283,7 +283,7 @@ describe("hosted preference handoff sweeper", () => {
     expect(sql).toContain(
       '\'clinical-records:sync:v1:\' || "run"."id" || \':\' || "run"."generation"::text',
     );
-    expect(sql).toContain('"item"."lane_seq" > CASE');
+    expect(sql).toMatch(/"item"\."lane_seq" >\s+CASE/u);
     expect(sql).toContain("hostedMailboxSystemImportedSeq");
     expect(sql).toContain('"item"."expires_at" IS NULL OR "item"."expires_at" > ?');
     expect(sql).toContain('"item"."created_at" > ?');
@@ -330,9 +330,7 @@ describe("hosted preference handoff sweeper", () => {
     expect(sql).toContain(
       "'health.daily-metric.reported'",
     );
-    expect(sql).toContain(
-      '"item"."lane_seq" > CASE',
-    );
+    expect(sql).toMatch(/"item"\."lane_seq" >\s+CASE/u);
     expect(sql).toContain("hostedMailboxSystemImportedSeq");
     expect(requestHandoff).toHaveBeenCalledWith({
       abortSignal: expect.any(AbortSignal),

--- a/apps/web/test/hosted-preference-handoff-sweeper.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper.test.ts
@@ -232,6 +232,22 @@ describe("hosted preference handoff sweeper", () => {
     });
   });
 
+  it("stops handoff recovery after the runtime imports a system item", async () => {
+    await runHostedPreferenceHandoffSweeper({
+      hasActiveAccess: vi.fn(async () => true),
+      logger: buildLogger(),
+    });
+
+    const query = mocks.queryRaw.mock.calls[0]?.[0] as {
+      strings?: readonly string[];
+    } | undefined;
+    const sql = query?.strings?.join("?") ?? "";
+    expect(sql).not.toContain('"lane_counter"."consumed_seq"');
+    expect(sql.match(/LEFT JOIN "hosted_workspace" AS "workspace"/gu)).toHaveLength(3);
+    expect(sql.match(/"item"\."lane_seq" > CASE/gu)).toHaveLength(3);
+    expect(sql.match(/hostedMailboxSystemImportedSeq/gu)).toHaveLength(6);
+  });
+
   it("selects exact current Clinical Records wakes in the shared mailbox sweep", async () => {
     const now = new Date("2026-08-12T12:00:00.000Z");
     mocks.queryRaw.mockResolvedValueOnce([{
@@ -267,7 +283,8 @@ describe("hosted preference handoff sweeper", () => {
     expect(sql).toContain(
       '\'clinical-records:sync:v1:\' || "run"."id" || \':\' || "run"."generation"::text',
     );
-    expect(sql).toContain('"item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)');
+    expect(sql).toContain('"item"."lane_seq" > CASE');
+    expect(sql).toContain("hostedMailboxSystemImportedSeq");
     expect(sql).toContain('"item"."expires_at" IS NULL OR "item"."expires_at" > ?');
     expect(sql).toContain('"item"."created_at" > ?');
     expect(query?.values).toContainEqual(
@@ -314,8 +331,9 @@ describe("hosted preference handoff sweeper", () => {
       "'health.daily-metric.reported'",
     );
     expect(sql).toContain(
-      '"item"."lane_seq" > COALESCE("lane_counter"."consumed_seq", 0)',
+      '"item"."lane_seq" > CASE',
     );
+    expect(sql).toContain("hostedMailboxSystemImportedSeq");
     expect(requestHandoff).toHaveBeenCalledWith({
       abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_browser_refresh",


### PR DESCRIPTION
## Why and outcome

The minute recovery sweep kept re-signaling system mailbox items after the runtime had already imported them. Retire Web handoff ownership at the persisted system imported frontier while preserving recovery for items that never reached the runtime.

## Product UX

Not applicable: this is an internal orchestration reliability correction with no member-facing UI or workflow change. Scheduled work keeps its existing runtime-owned retry timing.

## Evidence

- Focused Web tests: 15 passed, including the real-PostgreSQL imported-frontier selection proof.
- Web typecheck: passed.
- Focused lint and diff checks: passed.
- Read-only production projection: 19 currently selected runtime-control users are reduced to 1 genuinely unimported handoff; all 19 prior first candidates had already crossed the imported frontier.

## Non-obvious affected surfaces

- The shared Temporal-triggered device-sync recovery command also runs preference/runtime-control/Clinical Records mailbox handoff recovery each minute. The regression test proves all three query branches use the imported ownership frontier.
- No Temporal workflow, Cloudflare runtime, mailbox contract, or persisted state shape changes.

## Architecture and reuse

- Existing systems reused: the persisted `hostedMailboxSystemImportedSeq` workspace fact remains the handoff ownership boundary.
- New logic: each system handoff candidate branch compares its lane sequence with that imported frontier.
- New abstractions: none; the existing bounded SQL query and signal path are sufficient.
- Complexity intentionally avoided: no new scheduler, cursor, queue, state field, migration, or cross-runtime compatibility layer.

## Hot reply path impact

Not applicable: the scheduled recovery query is outside the Foreground Reply Critical Path and adds no work from durable conversation acceptance through provider start or reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool, schema, or provider-visible request assembly changed.
- Codex runtime: Not applicable; no prompt, tool, schema, or provider-visible request assembly changed.

## Change-shape breakdown

Classification is by repository path; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 26 | 12 |
| Tests/fixtures | 109 | 6 |
| Docs | 30 | 8 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 165 | 26 |

## Risks

The query remains fail-safe for missing or malformed imported status by treating the frontier as zero and retaining recovery ownership. Maximum sweep cardinality and concurrency are unchanged: the existing query returns at most 26 candidates before the 25-user handoff cap, opens no transaction, and performs no external or cryptographic work while a database connection is pinned.

## Deployment concerns
- Deployment: applicable
- Supported skew: No contract or state-shape change; old and new Web instances can coexist during the Vercel rollout.
- Safe order: Deploy the Web change only; no tandem Cloudflare or Temporal release is required.
- Rollback floor: A Web rollback is safe and only restores redundant recovery signals.
- Expected exposure: Mixed instances may emit the prior redundant signal during one rollout window; they do not drop durable work.
- Reversibility: Revert the single Web deployment.
- Convergence proof: Observe complete minute-sweep windows after rollout and confirm already-imported candidates disappear.
- Post-deploy checks: Verify no-op system imports collapse, real unimported handoffs still drain, and error/warn aggregates do not shift.

## Changelog
- Changelog: not applicable
- Reason: Internal orchestration reliability correction with no member-visible behavior change.

ReviewGPT context sensitivity: sensitive — changes retry ownership and a production runtime sweep boundary.
ReviewGPT first-reviewed head: d0e57c60b34c8c3f57fa332a266984081684328f
