### PR TITLE
Polish the group funding success mark

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -587,14 +587,14 @@ terminal receipt. Never use a browser alert or confirm prompt for sponsorship
 changes.
 
 When group funding is fulfilled, switch from the payment-status composition to
-one confident success hierarchy: a compact sage confirmation mark and mono
-`NICE ONE` label, the Fraunces headline `This group has more Murph`, one
-sentence confirming that the contribution is ready, and one full-width **Open
-Messages** action. State that Messages opens without a group deep link and the
-member must choose the group. Keep the desktop dialog and mobile drawer at
-content height, and use their standard close control as the only separate exit.
-Do not add a divider band, a second dismissal action, a bordered status card,
-payment-pending copy, an invented amount, or celebration graphics. Once
+one confident success hierarchy: a compact sage confirmation mark, the
+Fraunces headline `This group has more Murph`, one sentence confirming that the
+contribution is ready, and one full-width **Open Messages** action. State that
+Messages opens without a group deep link and the member must choose the group.
+Keep the desktop dialog and mobile drawer at content height, and use their
+standard close control as the only separate exit. Do not add a congratulatory
+kicker, divider band, second dismissal action, bordered status card,
+payment-pending copy, invented amount, or celebration graphics. Once
 fulfillment is verified, do not carry frozen sponsor details or their
 payment-recovery instructions into the success receipt.
 

--- a/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
+++ b/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
@@ -78,6 +78,10 @@ Updated: 2026-08-20
 - Keep the confirmation mark but remove its visible kicker. The headline already
   communicates the success outcome, while the mark retains the visual and
   accessible status signal.
+- Let each responsive surface own alignment: the fulfilled drawer header
+  centers the mark and headline at every drawer width, while the desktop dialog
+  retains its left-aligned hierarchy. Do not couple this boundary to a smaller
+  unrelated Tailwind breakpoint.
 - The initial redesign landed in PR #2034. Follow-up PR #2046 owns the final
   hierarchy polish and preserves both source PRs in the existing changelog item.
 
@@ -99,8 +103,19 @@ Updated: 2026-08-20
 - Phone contributor: the same study rendered a content-height 390×361 drawer.
   The mark centered with the phone headline, the chooser instruction wrapped
   without clipping, and the Messages action remained fully visible.
+- Intermediate-width contributor: a 700×900 Playwright viewport still selected
+  the drawer and directly proved that the mark and headline content share the
+  same horizontal center.
 - Direct proof: 101 focused component tests passed; the fulfilled state retained
   one live status announcement and the semantic `sms:` link. Web typecheck,
   focused ESLint, Playwright desktop/mobile capture, and diff hygiene passed.
+- Preliminary ReviewGPT returned two accepted findings: the mark crossed to
+  left alignment before the drawer ended, and the icon-only status semantics
+  were under-asserted. The drawer now owns centering throughout its range, the
+  success title drops obsolete close-button padding, and the focused test pins
+  the exact label, polite live region, hidden icon, and one-status invariant.
+- Remediation proof: 108 focused component and changelog tests, Web typecheck,
+  focused ESLint, diff hygiene, and Playwright captures at 1440×900, 700×900,
+  and 390×844 passed.
 - Result: Ready. The follow-up removes repeated success copy without changing
   payment, routing, dismissal, or recovery behavior.

--- a/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
+++ b/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
@@ -78,6 +78,8 @@ Updated: 2026-08-20
 - Keep the confirmation mark but remove its visible kicker. The headline already
   communicates the success outcome, while the mark retains the visual and
   accessible status signal.
+- The initial redesign landed in PR #2034. Follow-up PR #2046 owns the final
+  hierarchy polish and preserves both source PRs in the existing changelog item.
 
 ## Verification
 

--- a/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
+++ b/agent-docs/exec-plans/active/2026-08-19-group-funding-success-receipt.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-08-19
-Updated: 2026-08-19
+Updated: 2026-08-20
 
 ## Goal
 
@@ -18,6 +18,8 @@ Updated: 2026-08-19
   the existing `sms:` destination and accessible success announcement intact.
 - The heading, supporting copy, and action fit without overflow at desktop and
   narrow-phone widths and preserve keyboard focus and close behavior.
+- The compact success mark stands on its own without a redundant congratulatory
+  label competing with the receipt headline.
 - Focused component tests, Web typecheck, rendered browser proof, the applicable
   preliminary ReviewGPT lenses, exact-head CI, and parent final review pass.
 
@@ -73,12 +75,30 @@ Updated: 2026-08-19
 - Do not add illustration or celebratory motion. The success mark, type
   hierarchy, and tighter composition are sufficient and match Murph's explicit
   anti-gamification rules.
+- Keep the confirmation mark but remove its visible kicker. The headline already
+  communicates the success outcome, while the mark retains the visual and
+  accessible status signal.
 
 ## Verification
 
 - Commands to run: the focused hosted-usage dialog Vitest file, Web typecheck,
-  `git diff --check`, and in-app Browser walkthroughs at desktop and narrow
-  phone widths; exact-head required GitHub checks after push.
+  `git diff --check`, and Playwright walkthroughs at desktop and narrow phone
+  widths; exact-head required GitHub checks after push.
 - Expected outcomes: unchanged payment behavior, one accessible success status,
   a semantic `sms:` continuation link, no duplicate desktop dismissal action,
   no overflow or clipped action on phone, and all routed review/CI gates green.
+
+## Product UX walkthrough
+
+- Desktop contributor: the production receipt study rendered a 512×346 dialog
+  with one compact confirmation mark, one headline, one explanatory sentence,
+  and the full-width Messages action. The standard close control remained the
+  only separate exit.
+- Phone contributor: the same study rendered a content-height 390×361 drawer.
+  The mark centered with the phone headline, the chooser instruction wrapped
+  without clipping, and the Messages action remained fully visible.
+- Direct proof: 101 focused component tests passed; the fulfilled state retained
+  one live status announcement and the semantic `sms:` link. Web typecheck,
+  focused ESLint, Playwright desktop/mobile capture, and diff hygiene passed.
+- Result: Ready. The follow-up removes repeated success copy without changing
+  payment, routing, dismissal, or recovery behavior.

--- a/agent-docs/exec-plans/completed/2026-08-19-group-funding-success-receipt.md
+++ b/agent-docs/exec-plans/completed/2026-08-19-group-funding-success-receipt.md
@@ -1,6 +1,6 @@
 # Group funding success receipt redesign
 
-Status: active
+Status: completed
 Created: 2026-08-19
 Updated: 2026-08-20
 
@@ -27,7 +27,7 @@ Updated: 2026-08-20
 
 - In scope: the fulfilled group presentation in
   `HostedUsageTopUpDialog`, its focused tests, the matching design-system
-  guidance, a public changelog item, and the task-owned Frog entry.
+  guidance, a public changelog item, and the existing Frog registry review.
 - Out of scope: Stripe/payment state, purchase polling, sponsorship selection,
   billing authority, group deep-link capability, and non-group success states.
 
@@ -106,9 +106,9 @@ Updated: 2026-08-20
 - Intermediate-width contributor: a 700×900 Playwright viewport still selected
   the drawer and directly proved that the mark and headline content share the
   same horizontal center.
-- Direct proof: 101 focused component tests passed; the fulfilled state retained
-  one live status announcement and the semantic `sms:` link. Web typecheck,
-  focused ESLint, Playwright desktop/mobile capture, and diff hygiene passed.
+- Direct proof: the fulfilled state retained one live status announcement and
+  the semantic `sms:` link. Web typecheck, focused ESLint, Playwright responsive
+  capture, and diff hygiene passed.
 - Preliminary ReviewGPT returned two accepted findings: the mark crossed to
   left alignment before the drawer ended, and the icon-only status semantics
   were under-asserted. The drawer now owns centering throughout its range, the
@@ -117,5 +117,10 @@ Updated: 2026-08-20
 - Remediation proof: 108 focused component and changelog tests, Web typecheck,
   focused ESLint, diff hygiene, and Playwright captures at 1440×900, 700×900,
   and 390×844 passed.
-- Result: Ready. The follow-up removes repeated success copy without changing
-  payment, routing, dismissal, or recovery behavior.
+- Shipping proof: the preview reached Ready and its authenticated design-study
+  route returned HTTP 200. All required checks passed on the exact code head;
+  the parent review found no remaining product issue, and the current-base
+  merge-tree was clean.
+- Result: Complete. The follow-up removes repeated success copy without
+  changing payment, routing, dismissal, or recovery behavior.
+Completed: 2026-08-20

--- a/apps/web/changelog/entries/2026-08-19/group-contribution-success-receipt.json
+++ b/apps/web/changelog/entries/2026-08-19/group-contribution-success-receipt.json
@@ -9,6 +9,6 @@
     "summary": "After adding usage to a group, the confirmation is now compact and keeps the next step into Messages clear on computers and phones.",
     "details": "Messages still opens without a direct group link, so the receipt reminds you to choose the group before continuing.",
     "relevanceTags": ["groups", "billing", "design"],
-    "sourcePullRequests": [2034]
+    "sourcePullRequests": [2034, 2046]
   }
 }

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -283,7 +283,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
   const confirmationIndicator =
     showGroupMessagesAction && statusContent ? (
       <div
-        className="flex size-10 shrink-0 self-center items-center justify-center rounded-full bg-primary/10 text-primary sm:self-auto"
+        className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
         role="status"
         aria-live="polite"
         aria-label={`${statusContent.title}. ${statusContent.message}`}
@@ -671,7 +671,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
           <DrawerHeader
             className={cn(
               "relative items-start gap-2 px-6 pb-2 pt-2 text-left",
-              showGroupMessagesAction && "gap-3",
+              showGroupMessagesAction && "items-center gap-3",
             )}
           >
             {confirmationIndicator}
@@ -681,7 +681,7 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
               className={cn(
                 "pr-10 font-serif text-3xl font-semibold leading-[1.1] tracking-tight text-foreground outline-none",
                 showGroupMessagesAction &&
-                  "max-w-md text-4xl leading-[1.05] tracking-[-0.03em]",
+                  "max-w-md pr-0 text-4xl leading-[1.05] tracking-[-0.03em]",
               )}
             >
               {headerTitle}

--- a/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
+++ b/apps/web/src/components/settings/hosted-usage-top-up-dialog.tsx
@@ -283,20 +283,12 @@ function HostedUsageTopUpDialog(props: HostedUsageTopUpDialogProps) {
   const confirmationIndicator =
     showGroupMessagesAction && statusContent ? (
       <div
-        className="flex items-center gap-2.5"
+        className="flex size-10 shrink-0 self-center items-center justify-center rounded-full bg-primary/10 text-primary sm:self-auto"
         role="status"
         aria-live="polite"
         aria-label={`${statusContent.title}. ${statusContent.message}`}
       >
-        <span
-          className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
-          aria-hidden="true"
-        >
-          <CheckIcon className="size-4 stroke-[2.5]" />
-        </span>
-        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-primary">
-          Nice one
-        </span>
+        <CheckIcon aria-hidden="true" className="size-4 stroke-[2.5]" />
       </div>
     ) : null;
   const screenContent = (

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -4922,10 +4922,6 @@ test("reconciles a fulfilled Settings return without presenting a confirmation",
     });
 
     assert.equal(rendered.container.querySelector('[role="dialog"]'), null);
-    assert.equal(
-      rendered.container.querySelectorAll('[role="status"]').length,
-      1,
-    );
     const status = rendered.container.querySelector('[role="status"]');
     assert.ok(status);
     assert.equal(status.getAttribute("aria-live"), "polite");

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -5169,7 +5169,7 @@ test("offers Open Messages on a fulfilled group top-up return", async () => {
       await Promise.resolve();
     });
 
-    assert.match(rendered.container.textContent ?? "", /Nice one/);
+    assert.doesNotMatch(rendered.container.textContent ?? "", /Nice one/);
     assert.match(
       rendered.container.textContent ?? "",
       /This group has more Murph/,
@@ -5211,6 +5211,7 @@ test("offers Open Messages on a fulfilled group top-up return", async () => {
       rendered.container.querySelectorAll('[role="status"]').length,
       1,
     );
+    assert.ok(rendered.container.querySelector('[role="status"] svg'));
   } finally {
     await rendered.cleanup();
   }

--- a/apps/web/test/hosted-usage-top-up-dialog.test.tsx
+++ b/apps/web/test/hosted-usage-top-up-dialog.test.tsx
@@ -4922,6 +4922,10 @@ test("reconciles a fulfilled Settings return without presenting a confirmation",
     });
 
     assert.equal(rendered.container.querySelector('[role="dialog"]'), null);
+    assert.equal(
+      rendered.container.querySelectorAll('[role="status"]').length,
+      1,
+    );
     const status = rendered.container.querySelector('[role="status"]');
     assert.ok(status);
     assert.equal(status.getAttribute("aria-live"), "polite");
@@ -5211,7 +5215,17 @@ test("offers Open Messages on a fulfilled group top-up return", async () => {
       rendered.container.querySelectorAll('[role="status"]').length,
       1,
     );
-    assert.ok(rendered.container.querySelector('[role="status"] svg'));
+    const status = rendered.container.querySelector('[role="status"]');
+    assert.ok(status);
+    assert.equal(
+      status.getAttribute("aria-label"),
+      "This group has more Murph. Your contribution is ready.",
+    );
+    assert.equal(status.getAttribute("aria-live"), "polite");
+    assert.equal(
+      status.querySelector("svg")?.getAttribute("aria-hidden"),
+      "true",
+    );
   } finally {
     await rendered.cleanup();
   }


### PR DESCRIPTION
## Why and outcome

The fulfilled group-funding receipt repeated its success state with a separate congratulatory kicker. This patch removes that competing label, keeps a compact sage confirmation mark as the accessible live status, and aligns the receipt by surface: centered in every drawer width and left aligned in the desktop dialog. Payment, fulfillment, dismissal, and the existing `sms:` Messages handoff are unchanged.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: The production receipt study was exercised at phone, intermediate drawer, and desktop-dialog widths. Billing, payment recovery, sponsorship selection, and non-group return states remain unchanged.

## Evidence

- Playwright opened `/screenshots/groups#group-funding-receipt`, blocked non-loopback requests, asserted the fulfilled title and absent kicker, and captured the real production component at 390×844, 700×900, and 1440×900.
- At both drawer widths, text-range geometry proved the status mark and actual headline content are centered within 1 px; the desktop surface retains its left-aligned composition.
- The focused test pins the exact accessible status label, polite live region, hidden decorative SVG, absent kicker, and semantic `sms:` link.
- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/changelog-fragments.test.ts apps/web/test/hosted-usage-top-up-dialog.test.tsx` — 108 passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm --dir apps/web exec eslint src/components/settings/hosted-usage-top-up-dialog.tsx test/hosted-usage-top-up-dialog.test.tsx` — passed.
- `git diff --check` — passed.
- The product-identical preview is Ready; authenticated `/screenshots/groups` returned HTTP 200. Subsequent commits only narrowed a test assertion and archived the execution plan.

## Review

- Preliminary frontend and coverage specialist review completed on the candidate head.
- Resolved: intermediate drawer widths now center the mark through the drawer surface owner instead of a `sm:` viewport assumption.
- Resolved: fulfilled-state tests now pin the status announcement and decorative-icon semantics.
- Parent final review found no remaining product issue; the current-base merge-tree is clean.

## Design proof

- Design page: [Group funding receipt](https://murph-1w9ht40q9-cobuildwithus.vercel.app/screenshots/groups#group-funding-receipt)
- Evidence: Playwright asserted the changed fulfilled state and captured only its production dialog or drawer surface; drawer text geometry also pinned the responsive alignment risk.
- Coverage: 390×844 phone drawer and 700×900 intermediate drawer cover both drawer widths around the former breakpoint issue; 1440×900 covers the materially different desktop dialog.

## Architecture and reuse

- Existing systems reused: the current `HostedUsageTopUpDialog`, Lucide check icon, Base UI Dialog and Drawer owners, and hash-addressable production design study.
- New logic: none; the existing fulfilled-group predicate retains ownership of the same presentation and status announcement.
- New abstractions: none were needed because the existing dialog and drawer surface owners already express the responsive boundary.
- Complexity intentionally avoided: no new component, state, dependency, copy layer, animation, or durable capture spec.
- The design contract now prohibits a separate congratulatory kicker so the simplified hierarchy does not drift back.

## Deployment concerns

- Deployment: not applicable
- Reason: compatible client presentation and design-guidance changes introduce no route, schema, persistence, Cloudflare, or cross-version contract.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 12 |
| Tests / fixtures | 12 | 1 |
| Docs | 56 | 14 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **72** | **27** |

## Changelog

- Changelog: updated
- Items: 2026-08-19 · group-contribution-success-receipt
