### PR TITLE
Confirm safe partial database telemetry before warning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1677,15 +1677,16 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   independent region-plus-port monotonic series. Any observed supported port
   makes the family available. An absent port is diagnostic sparse label
   cardinality, not a collection failure, while an observed port can still
-  contribute unsafe evidence. A safe observation with the complete
-  connection-error family absent receives one bounded confirmation after one
-  second. Usable partial collections stay single-pass whenever available
-  evidence is unsafe. PlanetScale's example 30-second Prometheus scrape
+  contribute unsafe evidence. Any usable partial observation with only safe
+  available evidence receives one bounded confirmation after one second;
+  partial observations with unsafe evidence stay single-pass. A complete
+  confirmation replaces the partial observation, an unsafe confirmation is
+  returned immediately, and an incomplete or failed confirmation retains the
+  original omission. PlanetScale's example 30-second Prometheus scrape
   configuration is not treated as a freshness guarantee or a basis for more
-  provider calls. The
-  confirmation's available signals are evaluated, any recovered supported port
-  may join the original complete gauge evidence, and failure retains the
-  original incomplete observation. Each
+  provider calls. When the original observation is missing only the whole
+  connection-error family, a safe incomplete confirmation may join recovered
+  supported-port counters to the original complete gauge evidence. Each
   observed port, including one first seen by confirmation, advances only its
   usable baseline; an omitted port retains its prior baseline,
   and new or reset region series are independently suppressed so an old delta is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1684,7 +1684,12 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   returned immediately, and an incomplete or failed confirmation retains the
   original omission. PlanetScale's example 30-second Prometheus scrape
   configuration is not treated as a freshness guarantee or a basis for more
-  provider calls. When the original observation is missing only the whole
+  provider calls. Parsed connection-error observations are evaluated in scrape
+  order against a run-local baseline before that baseline is persisted. A new
+  or reset series seen by the first partial is therefore initialized before the
+  confirmation is evaluated, an increment between the two scrapes remains
+  alerting evidence, and a series omitted by the selected final snapshot is not
+  forgotten. When the original observation is missing only the whole
   connection-error family, a safe incomplete confirmation may join recovered
   supported-port counters to the original complete gauge evidence. Each
   observed port, including one first seen by confirmation, advances only its

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -485,7 +485,12 @@ Last verified: 2026-08-20
   6432, keyed by port and region so their counters cannot collide. Any observed
   supported port makes the family available. An absent port is diagnostic sparse
   label cardinality, not a collection failure. An observed port can still
-  produce a positive non-replayable condition. PlanetScale's documented example
+  produce a positive non-replayable condition. Parsed counter observations are
+  evaluated in scrape order against a run-local baseline before persistence. A
+  new or reset series from the first partial is initialized before confirmation,
+  an increment between scrapes remains alerting evidence, and a series omitted
+  by the selected final snapshot remains in the next baseline. PlanetScale's
+  documented example
   30-second Prometheus scrape configuration is not a freshness guarantee, so it
   does not justify a longer delay or another provider call. Every available
   confirmation signal is evaluated. When the original observation is missing

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -477,31 +477,32 @@ Last verified: 2026-08-20
   second, outside any storage transaction. Only an exhausted two-attempt
   collection increments the consecutive-failure state. A usable partial
   observation remains single-pass when any available signal is unsafe, so
-  concrete evidence is evaluated without delay. The connection-error family
-  tracks direct port 5432 and pooled application port 6432, keyed by port and
-  region so their counters cannot collide. Any observed supported port makes
-  the family available. An absent port is diagnostic sparse label cardinality,
-  not a collection failure. An observed port can still produce a positive
-  non-replayable condition. When every available signal is safe and the whole
-  family is absent, the monitor waits one second before one confirmation
-  scrape. PlanetScale's documented example 30-second Prometheus scrape
-  configuration is not a freshness guarantee, so it does not justify a longer
-  delay or another provider call. Every available confirmation signal is
-  evaluated;
-  any recovered supported port can be composed with the original complete
-  gauge evidence, while a failed confirmation retains the original partial
-  observation. A port first observed by confirmation advances its baseline.
-  Each observed port replaces and advances
-  only its own usable series baseline, an omitted port retains its prior baseline,
-  and new or reset region series are independently suppressed. This makes
-  transient counter-family absence less noisy without converting unknown to
-  zero, replaying an old delta, or weakening the two-check telemetry fallback.
-  The confirmation retains the existing two-observation/four-request ceiling.
-  Including two sequential ten-second fetch timeouts per observation, its
-  41-second worst-case wall time remains below the persisted two-minute run
-  lease and the platform's 15-minute scheduled runtime. Structured failure
-  warnings include the actual parsed-observation count and per-port omission
-  counts, without raw provider payloads or signed scrape values.
+  concrete evidence is evaluated without delay. Otherwise it receives exactly
+  one confirmation after one second. A complete confirmation replaces the
+  partial observation, an unsafe confirmation is returned immediately, and an
+  incomplete or failed confirmation retains the original omission. The
+  connection-error family tracks direct port 5432 and pooled application port
+  6432, keyed by port and region so their counters cannot collide. Any observed
+  supported port makes the family available. An absent port is diagnostic sparse
+  label cardinality, not a collection failure. An observed port can still
+  produce a positive non-replayable condition. PlanetScale's documented example
+  30-second Prometheus scrape configuration is not a freshness guarantee, so it
+  does not justify a longer delay or another provider call. Every available
+  confirmation signal is evaluated. When the original observation is missing
+  only the whole connection-error family, a safe incomplete confirmation may
+  compose recovered supported-port counters with the original complete gauge
+  evidence. A port first observed by confirmation advances its baseline. Each
+  observed port replaces and advances only its own usable series baseline, an
+  omitted port retains its prior baseline, and new or reset region series are
+  independently suppressed. This makes transient counter-family absence less
+  noisy without converting unknown to zero, replaying an old delta, or weakening
+  the two-check telemetry fallback. The confirmation retains the existing
+  two-observation/four-request ceiling. Including two sequential ten-second
+  fetch timeouts per observation, its 41-second worst-case wall time remains
+  below the persisted two-minute run lease and the platform's 15-minute
+  scheduled runtime. Structured failure warnings include the actual
+  parsed-observation count and per-port omission counts, without raw provider
+  payloads or signed scrape values.
   Discovery, scrape, parse, or incomplete required metrics must recur on two
   consecutive runs before paging the monitoring condition. A failed check never
   erases a successfully parsed observation: even an all-family-

--- a/agent-docs/exec-plans/active/2026-08-20-database-health-required-metric-confirmation.md
+++ b/agent-docs/exec-plans/active/2026-08-20-database-health-required-metric-confirmation.md
@@ -1,0 +1,49 @@
+# Database Health Required-Metric Confirmation
+
+## Goal
+
+Prevent a single transient omission of one otherwise-required PlanetScale
+metric family from advancing the database monitor's consecutive-failure state,
+without treating unknown telemetry as zero or delaying concrete unsafe-signal
+evaluation.
+
+## Constraints
+
+- Keep the existing independent Cloudflare Durable Object owner and bounded
+  provider-call budget.
+- Preserve immediate evaluation and paging for every available unsafe signal.
+- Preserve the two-consecutive-check warning for a confirmed or persistent
+  telemetry gap.
+- Do not persist or log raw provider payloads, signed scrape parameters, metric
+  labels, or secrets.
+- Prefer the smallest change in the existing collection/confirmation flow.
+
+## Plan
+
+1. Ask ReviewGPT to implement a scoped patch and focused regression coverage.
+2. Inspect the returned artifact as untrusted intent and apply only the bounded
+   monitor/test changes that satisfy the repository invariants.
+3. Run the focused Cloudflare Node and Workers-runtime database-health tests,
+   package typecheck, and diff checks.
+4. Commit and push an exact candidate, open a draft PR, and run the required
+   coverage specialist and final cross-cutting ReviewGPT gates with CI.
+5. Resolve accepted findings, perform the parent final review, prove current-base
+   mergeability, and record the Cloudflare-only deployment contract.
+
+## Verification
+
+- A safe first scrape missing one required family receives one bounded
+  confirmation.
+- Recovery on confirmation produces a complete sample and does not advance the
+  consecutive-failure counter.
+- Persistent absence remains incomplete and still warns after two consecutive
+  scheduled checks.
+- Unsafe evidence from the first or confirmation scrape still pages immediately
+  and is not erased by recovered telemetry.
+- Provider requests remain bounded below the run lease and platform runtime.
+
+## Changelog Decision
+
+Not applicable: this changes internal operator-monitor collection behavior and
+does not create a member-visible product outcome.
+

--- a/agent-docs/exec-plans/completed/2026-08-20-database-health-required-metric-confirmation.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-database-health-required-metric-confirmation.md
@@ -42,8 +42,26 @@ evaluation.
   and is not erased by recovered telemetry.
 - Provider requests remain bounded below the run lease and platform runtime.
 
+## Completion
+
+- ReviewGPT authored the initial safe-partial confirmation patch. The
+  preliminary coverage pass identified one missing incomplete-confirmation
+  counter scenario, and final round 1 identified the shared persisted-baseline
+  comparison that could consume a reset/new-series increment.
+- The accepted corrections evaluate parsed counter observations in scrape order
+  against one run-local baseline, preserve first-scrape-only sparse series, and
+  retain the existing Durable Object, alert threshold, delay, and request bound.
+- Focused proof passed with 99 monitor tests, 24 supporting database-health
+  tests, 5 Workers-runtime boundary tests, the Cloudflare typecheck, and diff
+  hygiene.
+- Final ReviewGPT round 2 returned `PASS` with no remaining findings. Required
+  pull-request CI passed on the exact reviewed head, and a fresh current-base
+  merge-tree completed without conflicts.
+
 ## Changelog Decision
 
 Not applicable: this changes internal operator-monitor collection behavior and
 does not create a member-visible product outcome.
-
+Status: completed
+Updated: 2026-08-20
+Completed: 2026-08-20

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -305,8 +305,8 @@ provider-no-replay recovery, are jointly specified by
 Independent partial PlanetScale metric normalization, sparse connection-error
 port acceptance without false monitoring pages, continued evaluation of
 available database signals, per-port baseline advancement with new/reset
-suppression, bounded confirmation when the whole connection-error family is
-absent, transient diagnostic missing-port evidence with rollback-compatible
+suppression, bounded confirmation for safe usable partial observations,
+transient diagnostic missing-port evidence with rollback-compatible
 durable normalization, conservative legacy-window provenance,
 parsed-observation retention across later retry failure, and
 one-shot telemetry-only operator paging with unresolved-window coalescing,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -637,16 +637,18 @@ supported provider credential.
   continued evaluation of available signals, positive 5432 and 6432 deltas,
   and independent reset/new-series suppression across complete and partial
   samples. They also prove per-port baseline advancement with omitted-port
-  retention, one bounded confirmation when the whole connection-error family
-  is absent, confirmation-only port baseline advancement, transient diagnostic
-  port evidence with legacy-reader-compatible durable normalization,
+  retention, one bounded confirmation for any safe usable partial observation,
+  complete transient recovery, persistent-omission retention,
+  confirmation-only port baseline advancement, transient diagnostic port
+  evidence with legacy-reader-compatible durable normalization,
   alternating sparse-port observations, legacy single-port obligation parsing,
   and
   conservative legacy-plus-detailed window formatting,
   retention of an all-family-missing parsed observation across retry transport
   failure with exact window ratios and immutable restart delivery,
-  multi-family confirmation rejection, cross-scrape port composition,
-  immediate unsafe-signal paging before that confirmation, unsafe confirmation
+  safe multi-family confirmation with truthful persistent omission,
+  cross-scrape port composition, immediate unsafe-signal paging before that
+  confirmation, unsafe confirmation
   paging without losing the complementary baseline, failed-confirmation
   retention, positive recovered-counter deltas, persistent-gap telemetry
   paging, and the scheduled Durable Object boundary for that retry,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -641,6 +641,7 @@ supported provider credential.
   complete transient recovery, persistent-omission retention,
   confirmation-only port baseline advancement, transient diagnostic port
   evidence with legacy-reader-compatible durable normalization,
+  in-run reset increments and first-scrape-only sparse-series retention,
   alternating sparse-port observations, legacy single-port obligation parsing,
   and
   conservative legacy-plus-detailed window formatting,

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -230,31 +230,32 @@ without retaining labels or raw scrape data. Unsafe available signals therefore
 still open an incident immediately. A collection that fails before producing a
 usable observation, including a scrape with every required family absent,
 receives one bounded retry after one second; only an exhausted two-attempt
-collection counts as a failed check. A usable partial observation ordinarily
-remains single-pass so available unsafe evidence pages without delay. The
-monitor retains every successfully parsed observation even when it contains no
-usable required family and its retry fails before parsing; `unavailable` is
-reserved for checks that produced no parsed observation. The
-connection-error family tracks both supported ports, keyed by port and region
-so their series cannot collide. Any observed supported port makes the family
-available. An absent port is diagnostic sparse label cardinality, not a
-collection failure. When a safe observation has the whole family absent, the
-monitor makes one confirmation scrape after one second. PlanetScale's
+collection counts as a failed check. A usable partial observation with unsafe
+available evidence remains single-pass so paging is not delayed. Otherwise the
+monitor makes one bounded confirmation scrape after one second. A complete
+confirmation replaces the partial observation, while an unsafe confirmation is
+returned immediately. If the confirmation stays incomplete or fails, the
+original omission remains truthful. The monitor retains every successfully
+parsed observation even when it contains no usable required family and its retry
+fails before parsing; `unavailable` is reserved for checks that produced no
+parsed observation. The connection-error family tracks both supported ports,
+keyed by port and region so their series cannot collide. Any observed supported
+port makes the family available. An absent port is diagnostic sparse label
+cardinality, not a collection failure. PlanetScale's
 [documented example Prometheus scrape configuration](https://planetscale.com/docs/postgres/monitoring/prometheus-postgres)
 uses 30 seconds, but that is not a provider freshness guarantee and does not
 justify another provider call. The monitor evaluates every available
-confirmation signal
-and composes any recovered supported port with the original complete gauge
-evidence, so a port first seen there advances its baseline. Each observed port
-advances only its own usable baseline;
-an omitted port retains its prior baseline, and new or reset region series are
-suppressed independently. A failed confirmation retains the original
-incomplete observation, so absence never becomes zero and an old counter delta
-is never replayed. Two checks with the whole family absent still open the
-fallback monitoring incident. This keeps the existing maximum of two
-observations and four provider requests; even two sequential ten-second fetch
-timeouts per observation plus the one-second wait remain below the two-minute
-run lease.
+confirmation signal. When the original observation is missing only the whole
+connection-error family, a safe incomplete confirmation may still compose
+recovered supported-port counters with the original complete gauge evidence, so
+a port first seen there advances its baseline. Each observed port advances only
+its own usable baseline; an omitted port retains its prior baseline, and new or
+reset region series are suppressed independently. Absence never becomes zero
+and an old counter delta is never replayed. Persistent missing families still
+open the fallback monitoring incident after two consecutive checks. This keeps
+the existing maximum of two observations and four provider requests; even two
+sequential ten-second fetch timeouts per observation plus the one-second wait
+remain below the two-minute run lease.
 Structured failure warnings retain the parsed-observation count and exact
 per-port omission counts without raw scrape content. An acknowledged
 telemetry-only page is

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -241,7 +241,11 @@ fails before parsing; `unavailable` is reserved for checks that produced no
 parsed observation. The connection-error family tracks both supported ports,
 keyed by port and region so their series cannot collide. Any observed supported
 port makes the family available. An absent port is diagnostic sparse label
-cardinality, not a collection failure. PlanetScale's
+cardinality, not a collection failure. Parsed counter observations are evaluated
+in scrape order against a run-local baseline before persistence. A new or reset
+series from the first partial is initialized before confirmation, an increment
+between scrapes still pages, and a series omitted by the selected final snapshot
+remains available to the next check. PlanetScale's
 [documented example Prometheus scrape configuration](https://planetscale.com/docs/postgres/monitoring/prometheus-postgres)
 uses 30 seconds, but that is not a provider freshness guarantee and does not
 justify another provider call. The monitor evaluates every available

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -511,7 +511,12 @@ export class DatabaseHealthMonitor {
         });
       }
     }
-    if (!shouldConfirmMissingConnectionErrors(observation)) {
+    if (
+      !shouldConfirmPartialObservation(
+        observation,
+        previousConnectionErrorCounterBaseline,
+      )
+    ) {
       return buildDatabaseMetricCollection({
         attempts,
         observation,
@@ -524,24 +529,15 @@ export class DatabaseHealthMonitor {
     try {
       const confirmation = await this.collectMetricObservationOnce();
       parsedObservations.push(confirmation);
-      const confirmationCounters =
-        confirmation.snapshot.connectionErrorCounters;
       if (
-        evaluateDatabaseMetricSnapshot(
-          confirmation.snapshot,
-          null,
-        ).length > 0
+        hasUnsafeDatabaseHealthEvidence(
+          confirmation,
+          previousConnectionErrorCounterBaseline,
+        )
       ) {
         return buildDatabaseMetricCollection({
           attempts,
           observation: confirmation,
-          parsedObservations,
-        });
-      }
-      if (confirmationCounters === null) {
-        return buildDatabaseMetricCollection({
-          attempts,
-          observation,
           parsedObservations,
         });
       }
@@ -552,15 +548,21 @@ export class DatabaseHealthMonitor {
           parsedObservations,
         });
       }
+      const composedConnectionErrorObservation =
+        composeRecoveredConnectionErrorObservation({
+          confirmation,
+          observation,
+        });
+      if (composedConnectionErrorObservation !== null) {
+        return buildDatabaseMetricCollection({
+          attempts,
+          observation: composedConnectionErrorObservation,
+          parsedObservations,
+        });
+      }
       return buildDatabaseMetricCollection({
         attempts,
-        observation: {
-          missingMetrics: [],
-          snapshot: {
-            ...observation.snapshot,
-            connectionErrorCounters: confirmationCounters,
-          },
-        },
+        observation,
         parsedObservations,
       });
     } catch {
@@ -1544,16 +1546,64 @@ function hasUsableDatabaseHealthMetric(
     < DATABASE_HEALTH_REQUIRED_METRIC_NAMES.length;
 }
 
-function shouldConfirmMissingConnectionErrors(
+function shouldConfirmPartialObservation(
   observation: DatabaseMetricObservation,
+  previousConnectionErrorCounterBaseline:
+    Readonly<Record<string, number>> | null,
 ): boolean {
-  return observation.missingMetrics.length === 1
-    && observation.missingMetrics[0]
-      === DATABASE_CONNECTION_ERROR_METRIC_NAME
-    && evaluateDatabaseMetricSnapshot(
-      observation.snapshot,
+  return observation.missingMetrics.length > 0
+    && hasUsableDatabaseHealthMetric(observation)
+    && !hasUnsafeDatabaseHealthEvidence(
+      observation,
+      previousConnectionErrorCounterBaseline,
+    );
+}
+
+function hasUnsafeDatabaseHealthEvidence(
+  observation: DatabaseMetricObservation,
+  previousConnectionErrorCounterBaseline:
+    Readonly<Record<string, number>> | null,
+): boolean {
+  const connectionErrorCounters =
+    observation.snapshot.connectionErrorCounters;
+  const connectionErrorDeltas = connectionErrorCounters === null
+    ? null
+    : calculateConnectionErrorDeltas(
+      connectionErrorCounters,
+      previousConnectionErrorCounterBaseline,
+    );
+  return evaluateDatabaseMetricSnapshot(
+    observation.snapshot,
+    connectionErrorDeltas,
+  ).length > 0;
+}
+
+function composeRecoveredConnectionErrorObservation(input: {
+  confirmation: DatabaseMetricObservation;
+  observation: DatabaseMetricObservation;
+}): DatabaseMetricObservation | null {
+  const confirmationCounters =
+    input.confirmation.snapshot.connectionErrorCounters;
+  if (
+    input.observation.missingMetrics.length !== 1
+    || input.observation.missingMetrics[0]
+      !== DATABASE_CONNECTION_ERROR_METRIC_NAME
+    || input.confirmation.missingMetrics.length === 0
+    || confirmationCounters === null
+    || evaluateDatabaseMetricSnapshot(
+      input.confirmation.snapshot,
       null,
-    ).length === 0;
+    ).length > 0
+  ) {
+    return null;
+  }
+  return {
+    missingMetrics: [],
+    snapshot: {
+      ...input.observation.snapshot,
+      connectionErrorCounters: confirmationCounters,
+    },
+  };
 }
 
 async function readBoundedResponseText(

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -235,6 +235,8 @@ type DatabaseHealthCollectedSample =
 
 interface DatabaseMetricCollection {
   attempts: number;
+  connectionErrorCounterBaseline: Record<string, number>;
+  connectionErrorDeltas: DatabaseConnectionErrorDeltas | null;
   connectionErrorEvidence: DatabaseConnectionErrorCollectionEvidence;
   observation: DatabaseMetricObservation;
 }
@@ -341,19 +343,13 @@ export class DatabaseHealthMonitor {
     try {
       const {
         attempts,
+        connectionErrorCounterBaseline,
+        connectionErrorDeltas,
         connectionErrorEvidence,
         observation,
       } = await this.collectMetricObservation(
         previousConnectionErrorCounterBaseline,
       );
-      const observedConnectionErrorCounters =
-        observation.snapshot.connectionErrorCounters;
-      const connectionErrorCounterBaseline = observedConnectionErrorCounters
-        ? advanceConnectionErrorCounterBaseline(
-          observedConnectionErrorCounters,
-          previousConnectionErrorCounterBaseline,
-        )
-        : (previousConnectionErrorCounterBaseline ?? {});
       if (observation.missingMetrics.length > 0) {
         const monitoringMissingMetrics = [...observation.missingMetrics];
         const durableConnectionErrorEvidence =
@@ -361,13 +357,6 @@ export class DatabaseHealthMonitor {
             connectionErrorEvidence,
             missingMetrics: monitoringMissingMetrics,
           });
-        const connectionErrorDeltas =
-          observedConnectionErrorCounters === null
-            ? null
-            : calculateConnectionErrorDeltas(
-              observedConnectionErrorCounters,
-              previousConnectionErrorCounterBaseline,
-            );
         const conditions = evaluateDatabaseMetricSnapshot(
           observation.snapshot,
           connectionErrorDeltas,
@@ -407,10 +396,6 @@ export class DatabaseHealthMonitor {
         };
       }
       const snapshot = requireCompleteDatabaseMetricSnapshot(observation);
-      const connectionErrorDeltas = calculateConnectionErrorDeltas(
-        snapshot.connectionErrorCounters,
-        previousConnectionErrorCounterBaseline,
-      );
       const conditions = evaluateDatabaseMetricSnapshot(
         snapshot,
         connectionErrorDeltas,
@@ -490,6 +475,7 @@ export class DatabaseHealthMonitor {
         attempts,
         observation: retryObservation,
         parsedObservations: [retryObservation],
+        previousConnectionErrorCounterBaseline,
       });
     }
     if (!hasUsableDatabaseHealthMetric(observation)) {
@@ -502,12 +488,14 @@ export class DatabaseHealthMonitor {
           attempts,
           observation: retryObservation,
           parsedObservations,
+          previousConnectionErrorCounterBaseline,
         });
       } catch {
         return buildDatabaseMetricCollection({
           attempts,
           observation,
           parsedObservations,
+          previousConnectionErrorCounterBaseline,
         });
       }
     }
@@ -521,9 +509,15 @@ export class DatabaseHealthMonitor {
         attempts,
         observation,
         parsedObservations,
+        previousConnectionErrorCounterBaseline,
       });
     }
 
+    const confirmationConnectionErrorCounterBaseline =
+      advanceObservationConnectionErrorCounterBaseline(
+        observation,
+        previousConnectionErrorCounterBaseline,
+      );
     await this.waitImplementation(DATABASE_HEALTH_COLLECTION_RETRY_DELAY_MS);
     attempts += 1;
     try {
@@ -532,13 +526,14 @@ export class DatabaseHealthMonitor {
       if (
         hasUnsafeDatabaseHealthEvidence(
           confirmation,
-          previousConnectionErrorCounterBaseline,
+          confirmationConnectionErrorCounterBaseline,
         )
       ) {
         return buildDatabaseMetricCollection({
           attempts,
           observation: confirmation,
           parsedObservations,
+          previousConnectionErrorCounterBaseline,
         });
       }
       if (confirmation.missingMetrics.length === 0) {
@@ -546,6 +541,7 @@ export class DatabaseHealthMonitor {
           attempts,
           observation: confirmation,
           parsedObservations,
+          previousConnectionErrorCounterBaseline,
         });
       }
       const composedConnectionErrorObservation =
@@ -558,18 +554,21 @@ export class DatabaseHealthMonitor {
           attempts,
           observation: composedConnectionErrorObservation,
           parsedObservations,
+          previousConnectionErrorCounterBaseline,
         });
       }
       return buildDatabaseMetricCollection({
         attempts,
         observation,
         parsedObservations,
+        previousConnectionErrorCounterBaseline,
       });
     } catch {
       return buildDatabaseMetricCollection({
         attempts,
         observation,
         parsedObservations,
+        previousConnectionErrorCounterBaseline,
       });
     }
   }
@@ -1495,6 +1494,8 @@ function buildDatabaseMetricCollection(input: {
   attempts: number;
   observation: DatabaseMetricObservation;
   parsedObservations: readonly DatabaseMetricObservation[];
+  previousConnectionErrorCounterBaseline:
+    Readonly<Record<string, number>> | null;
 }): DatabaseMetricCollection {
   const missingPortAttempts: Record<
     (typeof DATABASE_CONNECTION_ERROR_PORTS)[number],
@@ -1509,13 +1510,58 @@ function buildDatabaseMetricCollection(input: {
       missingPortAttempts[port] += 1;
     }
   }
+  const connectionErrorState = collectConnectionErrorSequence({
+    observations: input.parsedObservations,
+    previousConnectionErrorCounterBaseline:
+      input.previousConnectionErrorCounterBaseline,
+  });
   return {
     attempts: input.attempts,
+    connectionErrorCounterBaseline: connectionErrorState.baseline,
+    connectionErrorDeltas: connectionErrorState.deltas,
     connectionErrorEvidence: {
       missingPortAttempts,
       parsedAttempts: input.parsedObservations.length,
     },
     observation: input.observation,
+  };
+}
+
+function collectConnectionErrorSequence(input: {
+  observations: readonly DatabaseMetricObservation[];
+  previousConnectionErrorCounterBaseline:
+    Readonly<Record<string, number>> | null;
+}): {
+  baseline: Record<string, number>;
+  deltas: DatabaseConnectionErrorDeltas | null;
+} {
+  let baseline = { ...(input.previousConnectionErrorCounterBaseline ?? {}) };
+  const deltas: Record<
+    (typeof DATABASE_CONNECTION_ERROR_PORTS)[number],
+    number | null
+  > = { "5432": null, "6432": null };
+  let observedCounters = false;
+  for (const observation of input.observations) {
+    const counters = observation.snapshot.connectionErrorCounters;
+    if (counters === null) {
+      continue;
+    }
+    observedCounters = true;
+    const observationDeltas = calculateConnectionErrorDeltas(
+      counters,
+      baseline,
+    );
+    for (const port of DATABASE_CONNECTION_ERROR_PORTS) {
+      const delta = observationDeltas[port];
+      if (delta !== null) {
+        deltas[port] = (deltas[port] ?? 0) + delta;
+      }
+    }
+    baseline = advanceConnectionErrorCounterBaseline(counters, baseline);
+  }
+  return {
+    baseline,
+    deltas: observedCounters ? deltas : null,
   };
 }
 
@@ -1576,6 +1622,20 @@ function hasUnsafeDatabaseHealthEvidence(
     observation.snapshot,
     connectionErrorDeltas,
   ).length > 0;
+}
+
+function advanceObservationConnectionErrorCounterBaseline(
+  observation: DatabaseMetricObservation,
+  previousConnectionErrorCounterBaseline:
+    Readonly<Record<string, number>> | null,
+): Readonly<Record<string, number>> | null {
+  const counters = observation.snapshot.connectionErrorCounters;
+  return counters === null
+    ? previousConnectionErrorCounterBaseline
+    : advanceConnectionErrorCounterBaseline(
+      counters,
+      previousConnectionErrorCounterBaseline,
+    );
 }
 
 function composeRecoveredConnectionErrorObservation(input: {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1301,6 +1301,184 @@ describe("database health monitor", () => {
     expect(harness.retryWaits).toEqual([]);
   });
 
+  it("pages an unsafe counter delta from an incomplete confirmation", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+    });
+    const safePartialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+    }).replace(
+      /^planetscale_postgres_settings_max_connections.*$/mu,
+      "",
+    );
+    const unsafeConfirmationMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 6,
+    }).replace(
+      /^planetscale_pgbouncer_pools_server.*$/gmu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1) {
+          return baselineMetricsBody;
+        }
+        return scrapeAttempt === 2
+          ? safePartialMetricsBody
+          : unsafeConfirmationMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(6);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      connectionErrorDelta: 2,
+      failureCode: "required_metrics_missing",
+      scrapeStatus: "failed",
+    });
+  });
+
+  it("pages a counter increment between a reset partial and its confirmation", async () => {
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 10,
+    });
+    const resetPartialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 1,
+    }).replace(
+      /^planetscale_postgres_connection_state.*$/gmu,
+      "",
+    );
+    const incrementedMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 2,
+    });
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1) {
+          return baselineMetricsBody;
+        }
+        if (scrapeAttempt === 2) {
+          return resetPartialMetricsBody;
+        }
+        return incrementedMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 1, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+    expect(harness.monitor.readRecentSamples()[0]).toMatchObject({
+      connectionErrorDelta: 1,
+      scrapeStatus: "ok",
+    });
+
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+    ).resolves.toMatchObject({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(8);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+    expect(
+      harness.monitor
+        .readRecentSamples(3)
+        .map((sample) => sample.connectionErrorDelta),
+    ).toEqual([0, 1, 0]);
+  });
+
+  it("retains a new sparse series observed only by the first partial", async () => {
+    const pooledOnlyMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_edge_postgres_connection_errors_total\{[^\n]*planetscale_port="5432".*$/mu,
+      "",
+    );
+    const newDirectPartialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 1,
+    }).replace(
+      /^planetscale_postgres_connection_state.*$/gmu,
+      "",
+    );
+    const incrementedMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 2,
+    });
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        if (scrapeAttempt === 1 || scrapeAttempt === 3) {
+          return pooledOnlyMetricsBody;
+        }
+        return scrapeAttempt === 2
+          ? newDirectPartialMetricsBody
+          : incrementedMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 3),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 1, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(8);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.primaryLinqRequests).toHaveLength(1);
+    expect(
+      harness.monitor
+        .readRecentSamples(3)
+        .map((sample) => sample.connectionErrorDelta),
+    ).toEqual([1, 0, 0]);
+  });
+
   it("pages after two checks when the connection-error family stays absent", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const missingConnectionErrorsBody = buildMetricsBody({

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1025,10 +1025,10 @@ describe("database health monitor", () => {
     expect(warning).toHaveBeenCalledWith(
       "Database health metrics collection failed.",
       {
-        attempts: 1,
+        attempts: 2,
         connectionErrorEvidence: {
           missingPortAttempts: { "5432": 0, "6432": 0 },
-          parsedAttempts: 1,
+          parsedAttempts: 2,
         },
         failureCode: "required_metrics_missing",
         failures: 1,
@@ -1048,7 +1048,7 @@ describe("database health monitor", () => {
         kind: "monitoring_unavailable",
         connectionErrorEvidence: {
           missingPortAttempts: { "5432": 0, "6432": 0 },
-          parsedAttempts: 2,
+          parsedAttempts: 4,
         },
         missingMetrics: [
           "planetscale_postgres_settings_max_connections",
@@ -1196,6 +1196,109 @@ describe("database health monitor", () => {
       }),
     ]);
     expect(harness.primaryLinqRequests).toEqual([]);
+  });
+
+  it("confirms a safe missing Postgres-state family before counting the check", async () => {
+    const completeMetricsBody = buildMetricsBody({ branchId: BRANCH_ID });
+    const partialMetricsBody = completeMetricsBody.replace(
+      /^planetscale_postgres_connection_state.*$/gmu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return scrapeAttempt === 1
+          ? partialMetricsBody
+          : completeMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      consecutiveScrapeFailures: 0,
+      incidentOpen: false,
+    });
+  });
+
+  it("keeps a persistently missing Postgres-state family incomplete after confirmation", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const partialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      /^planetscale_postgres_connection_state.*$/gmu,
+      "",
+    );
+    const harness = createMonitorHarness({ metricsBody: partialMetricsBody });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "failed",
+    });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [{
+        failures: 2,
+        kind: "monitoring_unavailable",
+        missingMetrics: ["planetscale_postgres_connection_state"],
+      }],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(8);
+    expect(harness.retryWaits).toEqual([1_000, 1_000]);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      consecutiveScrapeFailures: 2,
+    });
+  });
+
+  it("pages an unsafe connection-error delta from a partial scrape without confirmation", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const baselineMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 4,
+    });
+    const unsafePartialMetricsBody = buildMetricsBody({
+      branchId: BRANCH_ID,
+      directErrors: 6,
+    }).replace(
+      /^planetscale_postgres_connection_state.*$/gmu,
+      "",
+    );
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return scrapeAttempt === 1
+          ? baselineMetricsBody
+          : unsafePartialMetricsBody;
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
+      .toMatchObject({ outcome: "healthy", sampleStatus: "ok" });
+    await expect(
+      harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
+    ).resolves.toMatchObject({
+      conditions: [
+        { count: 2, kind: "direct_migration_admission_failures" },
+      ],
+      outcome: "alert_sent",
+      sampleStatus: "failed",
+    });
+
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([]);
   });
 
   it("pages after two checks when the connection-error family stays absent", async () => {
@@ -1378,7 +1481,7 @@ describe("database health monitor", () => {
     ).toEqual([1, 2, 0, 0]);
   });
 
-  it("keeps multi-family omissions single-pass when the connection-error family is also missing", async () => {
+  it("confirms safe multi-family omissions once", async () => {
     const partialMetricsBody = buildMetricsBody({
       branchId: BRANCH_ID,
     }).replace(
@@ -1396,8 +1499,8 @@ describe("database health monitor", () => {
       sampleStatus: "failed",
     });
 
-    expect(harness.planetScaleRequests).toHaveLength(2);
-    expect(harness.retryWaits).toEqual([]);
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.retryWaits).toEqual([1_000]);
     expect(harness.monitor.readRecentSamples()).toEqual([
       expect.objectContaining({
         failureCode: "required_metrics_missing",
@@ -1472,7 +1575,7 @@ describe("database health monitor", () => {
       ],
       readMetricsBody() {
         scrapeAttempt += 1;
-        return scrapeAttempt === 1
+        return scrapeAttempt <= 2
           ? missingMaxConnectionsMetricsBody
           : unsafeSparseMetricsBody;
       },
@@ -1501,7 +1604,7 @@ describe("database health monitor", () => {
       checkedAtMs: FIVE_MINUTES_MS * 2,
       connectionErrorEvidence: {
         missingPortAttempts: { "5432": 0, "6432": 0 },
-        parsedAttempts: 2,
+        parsedAttempts: 3,
       },
       failures: 2,
       incompleteChecks: 2,
@@ -1538,7 +1641,7 @@ describe("database health monitor", () => {
       monitoringAlertObligation: {
         connectionErrorEvidence: {
           missingPortAttempts: { "5432": 0, "6432": 0 },
-          parsedAttempts: 2,
+          parsedAttempts: 3,
         },
       },
       pendingAlertIdempotencyKey: idempotencyKey,
@@ -1596,8 +1699,8 @@ describe("database health monitor", () => {
     expect(bodies[0]?.message.parts[0]?.value).not.toContain(
       "connection errors",
     );
-    expect(harness.planetScaleRequests).toHaveLength(6);
-    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.planetScaleRequests).toHaveLength(8);
+    expect(harness.retryWaits).toEqual([1_000, 1_000]);
   });
 
   it("retains an unusable parsed observation when its retry transport fails", async () => {
@@ -1615,12 +1718,13 @@ describe("database health monitor", () => {
       ],
       readMetricsBody() {
         scrapeAttempt += 1;
-        if (scrapeAttempt === 1) {
+        if (scrapeAttempt <= 2) {
           return missingMaxConnectionsMetricsBody;
         }
-        return scrapeAttempt === 2 ? "" : completeMetricsBody;
+        return scrapeAttempt === 3 ? "" : completeMetricsBody;
       },
       serviceDiscoveryResponses: [
+        createServiceDiscoveryResponse,
         createServiceDiscoveryResponse,
         createServiceDiscoveryResponse,
         () => new Response(null, { status: 503 }),
@@ -1633,8 +1737,8 @@ describe("database health monitor", () => {
       harness.runScheduledCheck(FIVE_MINUTES_MS * 2),
     ).resolves.toMatchObject({ outcome: "alert_failed", sampleStatus: "failed" });
 
-    expect(harness.planetScaleRequests).toHaveLength(5);
-    expect(harness.retryWaits).toEqual([1_000]);
+    expect(harness.planetScaleRequests).toHaveLength(7);
+    expect(harness.retryWaits).toEqual([1_000, 1_000]);
     const pendingState = harness.monitor.readAlertState();
     const idempotencyKey = pendingState.pendingAlertIdempotencyKey;
     const pendingMessage = pendingState.pendingAlertMessage;
@@ -1644,13 +1748,13 @@ describe("database health monitor", () => {
     expect(pendingState.monitoringAlertObligation).toMatchObject({
       connectionErrorEvidence: {
         missingPortAttempts: { "5432": 1, "6432": 1 },
-        parsedAttempts: 2,
+        parsedAttempts: 3,
       },
       failures: 2,
       incompleteChecks: 2,
       unavailableChecks: 0,
     });
-    expect(pendingMessage).toContain("5432 in 1/2; 6432 in 1/2");
+    expect(pendingMessage).toContain("5432 in 1/3; 6432 in 1/3");
 
     const originalBodies = await Promise.all(
       harness.allLinqRequests.map(readLinqRequestBody),
@@ -1660,7 +1764,7 @@ describe("database health monitor", () => {
       monitoringAlertObligation: {
         connectionErrorEvidence: {
           missingPortAttempts: { "5432": 1, "6432": 1 },
-          parsedAttempts: 2,
+          parsedAttempts: 3,
         },
       },
       pendingAlertIdempotencyKey: idempotencyKey,
@@ -2129,6 +2233,7 @@ describe("database health monitor", () => {
       ],
       metricsBody: partialMetricsBody,
       serviceDiscoveryResponses: [
+        createServiceDiscoveryResponse,
         createServiceDiscoveryResponse,
         () => new Response(null, { status: 503 }),
         () => new Response(null, { status: 503 }),


### PR DESCRIPTION
A single safe PlanetScale scrape that omitted a required metric family could immediately count as an incomplete database-health check. The monitor now gives every usable safe partial observation one bounded confirmation, so a recovered second scrape stays healthy while persistent omissions still reach the existing two-check warning.

Unsafe evidence from either observation still returns immediately. Connection-error counters are evaluated sequentially within the run, so a reset/new series can initialize on the first scrape without hiding an increment on confirmation or losing a sparse series before the next check. The two-observation/four-request ceiling, one-second delay, Durable Object state owner, and warning threshold are unchanged.

## Product UX

- Effort: Patch
- Result: Ready
- Affected person: The on-call operator receiving background database-health pages.
- Walkthrough: A transient safe omission recovers without a page; concrete unsafe evidence on either scrape pages immediately; persistent incompleteness still pages after two checks; reset/new counter evidence remains non-replayable and cannot be consumed by confirmation.
- Material exclusions: No member-facing interface, conversation, or product journey changes.

## Evidence

- `apps/cloudflare/test/database-health-monitor.test.ts`: 99 tests passed, including transient recovery, persistent Postgres-state omission, unsafe initial and incomplete-confirmation counter evidence, reset-series increments between scrapes, first-scrape-only sparse-series retention, unsafe gauge confirmation, and request bounds.
- Database-health supporting node suites: 24 tests passed.
- Database-health Workers boundary suite: 5 tests passed.
- `pnpm --dir apps/cloudflare typecheck` passed.
- `git diff --check` passed.

## Non-obvious affected surfaces

- Durable database-health evidence counts now include the bounded confirmation observation; monitor tests lock the resulting `parsedAttempts` and per-port omission ratios.
- Connection-error baselines and deltas now derive from every parsed observation in scrape order, preserving reset/new and sparse-port series even when the selected gauge snapshot comes from a different scrape.
- Scheduled Cloudflare execution may spend one extra second and one extra discovery/scrape pair only when the first usable partial has no unsafe evidence; tests prove the existing four-request maximum.
- Reliability, architecture, operator, and test-map documentation now describe the generalized safe-partial and sequential-counter contract.

## Architecture and reuse

- **Existing systems reused:** The existing database-health monitor, PlanetScale discovery/scrape functions, counter delta/baseline helpers, Durable Object store, condition evaluator, retry delay, and alert admission threshold remain the owners.
- **New logic:** The existing confirmation branch now admits any usable partial whose available evidence is safe, advances a run-local counter baseline between parsed observations, evaluates confirmation safety against that baseline, and accepts a complete confirmation without discarding earlier counter evidence.
- **New abstractions:** No dependency, service, queue, persisted state, or cross-package abstraction was added; narrow internal helpers keep sequential counter collection, safety evaluation, and the legacy connection-error merge explicit.
- **Complexity intentionally avoided:** The change adds no polling loop, longer provider wait, background retry owner, metric-specific durable state, or warning suppression; one bounded confirmation and one in-memory baseline are sufficient.

## Hot reply path impact

Not applicable. The scheduled database-health Durable Object is outside the Foreground Reply Critical Path and adds no member-message database, network, or provider wait.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request assembly changed.
- Codex runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request assembly changed.

## Change-shape breakdown

Classification rule: authored TypeScript under `src` is source; Vitest files are tests/fixtures; Markdown and the execution plan are docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 154 | 44 |
| Tests/fixtures | 301 | 18 |
| Docs | 149 | 62 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **604** | **124** |

## Risks

- Warning sensitivity is preserved: unsafe evidence from the initial or confirmation observation pages immediately, and two consecutive incomplete scheduled checks still open the monitoring condition.
- Provider fanout remains bounded to two sequential observations, each with discovery plus scrape: four external requests maximum, one one-second delay, and no database transaction.
- Persistent or failed confirmation retains the original omission rather than converting unknown telemetry to zero.
- Sequential counter tests prove reset/new series initialization cannot hide an increment or discard first-scrape-only sparse evidence.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Workers use the same Durable Object state and stored sample schema; mixed rollout only changes whether a safe partial check receives confirmation and how its in-run counters are evaluated.
- Safe order: Deploy the Cloudflare Worker normally; no Web, container, database, or private-runtime tandem deploy is required.
- Rollback floor: None. No state schema or binding changes ship, so the prior Worker remains compatible at every point.
- Expected exposure: Checks routed to the prior version during rollout may retain the old single-scrape false-positive behavior for that check only.
- Reversibility: Roll back the Worker version directly; no migration or state repair is required.
- Convergence proof: Confirm Cloudflare reports the new Worker version active and the scheduled Durable Object continues completing checks within its existing lease.
- Post-deploy checks: Inspect bounded database-health warning aggregates for required-metric omissions and confirm unsafe condition alerts and scheduled completion remain normal without exposing raw metric payloads.

## Changelog

- Changelog: not applicable
- Reason: This is an internal operator-monitoring correction with no member-visible product behavior.

ReviewGPT context sensitivity: sensitive — this changes bounded retry behavior and external Cloudflare monitor egress.
ReviewGPT first-reviewed head: a94af368aa8d7fd40caace79767819ea1234aa9e

