### PR TITLE
Fail fast when Prisma concurrency pause hooks drift

### DIFF
--- a/apps/web/test/device-sync-dirty-account-deletion-concurrency.test.ts
+++ b/apps/web/test/device-sync-dirty-account-deletion-concurrency.test.ts
@@ -146,6 +146,18 @@ async function waitForBlockedBackend(input: {
   throw new Error("Expected the transaction to wait on a PostgreSQL lock.");
 }
 
+const PAUSEABLE_DIRTY_MARKER_MUTATION_METHODS = new Set<PropertyKey>([
+  "updateMany",
+  "updateManyAndReturn",
+]);
+
+function isPrismaDelegateMutationMethod(
+  property: PropertyKey,
+): property is string {
+  return typeof property === "string"
+    && /^(?:create|delete|update|upsert)/u.test(property);
+}
+
 function pauseBeforeDirtyMarkerUpdate(input: {
   allowUpdate: Deferred<void>;
   beforeUpdate: Deferred<void>;
@@ -153,15 +165,28 @@ function pauseBeforeDirtyMarkerUpdate(input: {
 }): Prisma.TransactionClient {
   const deviceSyncDirtyConnection = new Proxy(input.tx.deviceSyncDirtyConnection, {
     get(target, property) {
-      if (property === "updateMany") {
-        return async (args: Prisma.DeviceSyncDirtyConnectionUpdateManyArgs) => {
+      if (PAUSEABLE_DIRTY_MARKER_MUTATION_METHODS.has(property)) {
+        const mutation = Reflect.get(target, property, target);
+        if (typeof mutation !== "function") {
+          throw new TypeError(
+            `Prisma dirty-marker mutation method "${String(property)}" is unavailable.`,
+          );
+        }
+        return async (...args: unknown[]) => {
           input.beforeUpdate.resolve();
           await input.allowUpdate.promise;
-          return target.updateMany(args);
+          return Reflect.apply(mutation, target, args);
         };
       }
+      if (isPrismaDelegateMutationMethod(property)) {
+        // Keep the lock-order fixture fail-closed: a production CAS method
+        // change must fail immediately instead of timing out on beforeUpdate.
+        throw new TypeError(
+          `Dirty-marker concurrency pause hook does not support Prisma mutation method "${property}".`,
+        );
+      }
 
-      const value = Reflect.get(target, property, target);
+      const value: unknown = Reflect.get(target, property, target);
       return typeof value === "function" ? value.bind(target) : value;
     },
   });
@@ -171,7 +196,7 @@ function pauseBeforeDirtyMarkerUpdate(input: {
       if (property === "deviceSyncDirtyConnection") {
         return deviceSyncDirtyConnection;
       }
-      const value = Reflect.get(target, property, target);
+      const value: unknown = Reflect.get(target, property, target);
       return typeof value === "function" ? value.bind(target) : value;
     },
   });
@@ -216,6 +241,75 @@ function buildCompanionHrvResource() {
     windowStart: null,
   };
 }
+
+describe("device-sync dirty-marker concurrency pause hook", () => {
+  it.each([
+    "updateMany",
+    "updateManyAndReturn",
+  ] as const)("pauses %s before delegating", async (method) => {
+    const allowUpdate = createDeferred();
+    const beforeUpdate = createDeferred();
+    const delegatedMethods: string[] = [];
+    const tx = {
+      deviceSyncDirtyConnection: {
+        updateMany: async () => {
+          delegatedMethods.push("updateMany");
+          return { count: 1 };
+        },
+        updateManyAndReturn: async () => {
+          delegatedMethods.push("updateManyAndReturn");
+          return [];
+        },
+      },
+    } as unknown as Prisma.TransactionClient;
+    const pausedTx = pauseBeforeDirtyMarkerUpdate({
+      allowUpdate,
+      beforeUpdate,
+      tx,
+    });
+    const delegate = Reflect.get(
+      pausedTx,
+      "deviceSyncDirtyConnection",
+    ) as object;
+    const mutation = Reflect.get(delegate, method);
+    if (typeof mutation !== "function") {
+      throw new TypeError(`Expected ${method} to be callable.`);
+    }
+
+    const operation = Reflect.apply(
+      mutation,
+      delegate,
+      [{}],
+    ) as Promise<unknown>;
+    await beforeUpdate.promise;
+    try {
+      expect(delegatedMethods).toEqual([]);
+    } finally {
+      allowUpdate.resolve();
+    }
+
+    await operation;
+    expect(delegatedMethods).toEqual([method]);
+  });
+
+  it("fails fast when the dirty-marker CAS drifts to another Prisma mutation method", () => {
+    const pausedTx = pauseBeforeDirtyMarkerUpdate({
+      allowUpdate: createDeferred(),
+      beforeUpdate: createDeferred(),
+      tx: {
+        deviceSyncDirtyConnection: {},
+      } as unknown as Prisma.TransactionClient,
+    });
+    const delegate = Reflect.get(
+      pausedTx,
+      "deviceSyncDirtyConnection",
+    ) as object;
+
+    expect(() => Reflect.get(delegate, "update")).toThrowError(
+      "Dirty-marker concurrency pause hook does not support Prisma mutation method \"update\".",
+    );
+  });
+});
 
 describe.skipIf(!runPostgresConcurrencyProof)(
   "device-sync dirty-state PostgreSQL account-deletion ordering",


### PR DESCRIPTION
## Why and outcome

A Prisma mutation-method change could bypass the concurrency fixture pause and make the test silently stale. The proxy now supports both current bulk-update variants and rejects every other mutation method immediately.

Fixes #2033

## Product UX

- Effort: Not applicable — internal tooling, CI, documentation, or test infrastructure only.
- Result: Not applicable
- Walkthrough: No member-facing product journey changes.

## Evidence

- Direct: The focused dirty-account concurrency suite passed 3 tests with 14 database-dependent cases intentionally skipped.
- Coverage: Unit proof covers both supported delegates and an unsupported mutation; the full workspace typecheck passed.

## Architecture and reuse

- Existing systems reused: The existing repository-owned script, workflow, package, or test harness remains the behavior owner.
- New logic: This PR adds only the bounded validation or lifecycle rule described above at that existing owner.
- New abstractions: Any new helper is local to its owner; no cross-cutting runtime abstraction is introduced.
- Complexity intentionally avoided: No new service, dependency, persistence layer, or speculative compatibility path is added.

## Risks

Correctness: this is test-harness-only and deliberately fails before a timeout when production CAS ownership changes.

ReviewGPT context sensitivity: routine — concurrency test harness only.

## Changelog

- Changelog: not applicable
- Reason: Internal engineering workflow and verification behavior only.