### PR TITLE
Fix signup notification ownership

### DIFF
--- a/.agents/friction-log/20260820095405-reviewgpt-replayable-wake/friction.md
+++ b/.agents/friction-log/20260820095405-reviewgpt-replayable-wake/friction.md
@@ -1,0 +1,28 @@
+---
+title: 'ReviewGPT replayable wake command points to missing global binary'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The replayable wake command printed after a response-capture failure should invoke a ReviewGPT binary that exists in the repository environment, so the accepted thread can be recovered without resending.
+
+## Current Behavior
+
+The printed command resolved to a stale global pnpm shim whose package binary no longer existed. Running it failed immediately with a missing-file error. Recovery required replacing the printed executable with the repository-local `pnpm exec cobuild-review-gpt` command before the tool could perform its exact-target check.
+
+## Possible Solution
+
+Emit a repository-local wake command, or persist and print the exact executable path used by the successful ReviewGPT invocation instead of resolving a global shim at recovery time.
+
+## Minimal Reproducible Example
+
+1. Run a waited ReviewGPT audit until prompt submission succeeds but response capture cannot finish.
+2. Copy the emitted replayable `cobuild-review-gpt thread wake` command.
+3. Run it from the same task worktree.
+4. Observe the command fail before recovery because its global package binary is missing.
+5. Prefix the same arguments with `pnpm exec` and observe the repository-local binary run the recovery check.
+
+## Context
+
+The invalid recovery command delayed a mandatory exact-head audit and risked turning a recoverable accepted thread into a duplicate-send retry. The recovery itself still failed closed for a separate already-recorded missing-target condition.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1578,9 +1578,12 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   delivery, but never for account lookup, direct-public sender authorization,
   or email-linked channel state until Privy verifies it. Welcome, internal
   signup, and cancellation-feedback mail retain their existing bounded,
-  idempotent Resend ownership; later successful payments must not repeat
-  activation side effects, and email paths must not persist provider payloads
-  or expose recipients in logs.
+  idempotent Resend ownership. The internal signup email follows a committed
+  member activation across Starter enrollment, Checkout success, and Stripe
+  reconciliation; a welcome-only or later paid-billing event is not signup
+  evidence. Later successful payments must not repeat activation side effects,
+  and email paths must not persist provider payloads or expose recipients in
+  logs.
 
   Reserved support escalation uses the existing product-feedback callback as a
   one-turn explicit action. A verified-private request for Murph human support

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1579,13 +1579,14 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   or email-linked channel state until Privy verifies it. Welcome, internal
   signup, and cancellation-feedback mail retain their existing bounded,
   idempotent Resend ownership. The internal signup email follows a committed
-  member activation across Starter enrollment, Checkout success, and Stripe
-  reconciliation; its one post-response task is registered at the first
-  post-commit boundary, and both its read and attempt claim use canonical hosted
-  access, including Family sponsorship. A welcome-only or later paid-billing
-  event is not signup evidence. Later successful payments must not repeat
-  activation side effects, and email paths must not persist provider payloads
-  or expose recipients in logs.
+  member activation across Starter enrollment, Checkout success, Stripe
+  reconciliation, and Family invite acceptance from the browser, Linq, or
+  Telegram; its one post-response task is registered at the first post-commit
+  boundary, and both its read and attempt claim use canonical hosted access,
+  including Family sponsorship. A welcome-only or later paid-billing event is
+  not signup evidence. Later successful payments and accepted-invite replays
+  must not repeat activation side effects, and email paths must not persist
+  provider payloads or expose recipients in logs.
 
   Reserved support escalation uses the existing product-feedback callback as a
   one-turn explicit action. A verified-private request for Murph human support

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1580,10 +1580,12 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   signup, and cancellation-feedback mail retain their existing bounded,
   idempotent Resend ownership. The internal signup email follows a committed
   member activation across Starter enrollment, Checkout success, and Stripe
-  reconciliation; a welcome-only or later paid-billing event is not signup
-  evidence. Later successful payments must not repeat activation side effects,
-  and email paths must not persist provider payloads or expose recipients in
-  logs.
+  reconciliation; its one post-response task is registered at the first
+  post-commit boundary, and both its read and attempt claim use canonical hosted
+  access, including Family sponsorship. A welcome-only or later paid-billing
+  event is not signup evidence. Later successful payments must not repeat
+  activation side effects, and email paths must not persist provider payloads
+  or expose recipients in logs.
 
   Reserved support escalation uses the existing product-feedback callback as a
   one-turn explicit action. A verified-private request for Murph human support

--- a/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
+++ b/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
@@ -4,7 +4,8 @@
 
 Send the existing internal signup email exactly once from a real hosted member
 activation, regardless of whether Starter enrollment, the Checkout success
-return, or Stripe webhook reconciliation completes that activation first.
+return, Stripe webhook reconciliation, or Family invite acceptance completes
+that activation first.
 
 ## Evidence
 
@@ -16,6 +17,8 @@ return, or Stripe webhook reconciliation completes that activation first.
   member, allowing an existing active member to be mislabeled as a new signup.
 - Stripe's existing `activatedMemberId` also owns pending runtime-wake replay;
   a distinct transient outcome is required to prove activation happened now.
+- Browser, Linq, and Telegram Family invite acceptance can activate a member
+  immediately under an active Family plan without any later Stripe event.
 - The notification sender already owns a durable per-member attempt claim and
   a stable provider idempotency key.
 
@@ -37,8 +40,9 @@ return, or Stripe webhook reconciliation completes that activation first.
 ## Plan
 
 1. Route the notification from the existing post-commit activation outcomes in
-   Starter enrollment, Checkout success, and Stripe reconciliation, registering
-   one post-response task before other fallible effects.
+   Starter enrollment, Checkout success, Stripe reconciliation, and Family
+   invite acceptance, registering one post-response task before other fallible
+   effects.
 2. Stop using `welcomeEmailMemberId` as notification eligibility; include every
    distinct activated member reported by a Family Stripe outcome.
 3. Add focused regression coverage for true activation, replay/idempotent
@@ -53,8 +57,9 @@ Effort: Patch.
 
 - Outcome: operators receive one internal email for a genuine hosted signup,
   without later payments or activation-wake replays being mislabeled.
-- Reaches: existing Starter, Checkout-success, and Stripe-reconciliation
-  activation journeys; member-facing welcome behavior remains unchanged.
+- Reaches: existing Starter, Checkout-success, Stripe-reconciliation, and
+  browser/Linq/Telegram Family-acceptance activation journeys; member-facing
+  welcome behavior remains unchanged.
 - Proof: focused owner tests distinguish newly committed activation from
   welcome-only billing and pending-wake replay, including Family activation.
 
@@ -68,6 +73,10 @@ Effort: Patch.
 - Walked webhook-only and Family activation: one task serially processes each
   distinct newly activated member, canonical Family access is accepted, and the
   existing durable per-member claim deduplicates competing owners and replays.
+- Walked browser, Linq, and Telegram Family invite acceptance under an already
+  active Family plan: only the callback result that says activation committed
+  carries the member id to the first post-commit boundary; accepted-invite
+  replays carry no notification work.
 - Walked provider failure and historical members: delivery remains best-effort
   with the existing provider idempotency key, and no backfill is introduced.
 - Difference from plan: the implementation added an explicit transient
@@ -76,13 +85,17 @@ Effort: Patch.
   the candidate had to be registered before other post-commit effects and use
   canonical access rather than direct billing status; the remediation reuses
   native `after()` and the existing access owner without new persisted state.
+  The next full audit found Family invite acceptance as a separate activation
+  owner; remediation carries the same transient activation proof through the
+  three existing acceptance paths without adding another sender or state owner.
 
 Result: Ready.
 
 ## Verification
 
 - Focused notification, member-store, Starter, Checkout-success, Family,
-  Stripe billing-event, and Stripe reconciliation tests passed (594 tests).
+  browser/Linq/Telegram Family acceptance, Stripe billing-event, and Stripe
+  reconciliation tests passed (854 tests across 10 files).
 - Hosted-web typecheck passed.
 - Focused ESLint and `git diff --check` passed.
 - Stripe billing-event and Checkout-completion owner tests prove the transient
@@ -91,6 +104,9 @@ Result: Ready.
   scheduler coverage proves one deduplicated task with provider concurrency one.
 - Checkout cleanup and Stripe runtime-recheck recovery tests prove registration
   happens before later failure and is not repeated by activation replay.
+- Browser Family acceptance plus Linq and Telegram dispatch coverage proves
+  first-activation registration, replay suppression, and registration before
+  fallible wake or confirmation work.
 
 ## State
 

--- a/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
+++ b/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
@@ -21,8 +21,13 @@ return, or Stripe webhook reconciliation completes that activation first.
 
 ## Constraints
 
-- Add no schema, queue, scheduler, retry owner, or compatibility layer.
+- Add no schema, queue, durable scheduler service, retry owner, or compatibility
+  layer.
 - Keep the internal email best-effort and outside database transactions.
+- Register one native post-response task at the first post-commit boundary so
+  provider latency and later post-commit failures cannot delay or erase it.
+- Reuse canonical hosted access for both live eligibility and the atomic claim;
+  do not add a Family-specific branch.
 - Preserve customer welcome-email behavior and the existing per-member
   notification idempotency contract.
 - Do not backfill or email historical members as part of this change.
@@ -32,7 +37,8 @@ return, or Stripe webhook reconciliation completes that activation first.
 ## Plan
 
 1. Route the notification from the existing post-commit activation outcomes in
-   Starter enrollment, Checkout success, and Stripe reconciliation.
+   Starter enrollment, Checkout success, and Stripe reconciliation, registering
+   one post-response task before other fallible effects.
 2. Stop using `welcomeEmailMemberId` as notification eligibility; include every
    distinct activated member reported by a Family Stripe outcome.
 3. Add focused regression coverage for true activation, replay/idempotent
@@ -55,28 +61,36 @@ Effort: Patch.
 ## Product UX Walkthrough
 
 - Walked Starter activation with and without a member welcome email: the
-  internal email remains tied to activation and runs after commit.
+  internal email remains tied to activation, registers after commit, and does
+  not hold the enrollment or current-inbound path open on Resend.
 - Walked Checkout success for a new activation, a welcome-only standard
   payment, and a reused pending wake: only the new activation is eligible.
-- Walked webhook-only and Family activation: each newly activated member is
-  eligible once, while the existing durable per-member claim deduplicates
-  competing owners and replays.
+- Walked webhook-only and Family activation: one task serially processes each
+  distinct newly activated member, canonical Family access is accepted, and the
+  existing durable per-member claim deduplicates competing owners and replays.
 - Walked provider failure and historical members: delivery remains best-effort
   with the existing provider idempotency key, and no backfill is introduced.
 - Difference from plan: the implementation added an explicit transient
   `newlyActivatedMemberIds` outcome after review proved the existing runtime
-  wake target was broader than a new activation.
+  wake target was broader than a new activation. Exact-head review then proved
+  the candidate had to be registered before other post-commit effects and use
+  canonical access rather than direct billing status; the remediation reuses
+  native `after()` and the existing access owner without new persisted state.
 
 Result: Ready.
 
 ## Verification
 
-- Focused notification, Starter, Checkout-success, Stripe billing-event, and
-  Stripe reconciliation tests passed (253 tests).
+- Focused notification, member-store, Starter, Checkout-success, Family,
+  Stripe billing-event, and Stripe reconciliation tests passed (594 tests).
 - Hosted-web typecheck passed.
 - Focused ESLint and `git diff --check` passed.
 - Stripe billing-event and Checkout-completion owner tests prove the transient
   new-activation outcome stays empty for later payments and pending-wake replay.
+- Sender/claim tests prove canonical Family access and one atomic attempt gate;
+  scheduler coverage proves one deduplicated task with provider concurrency one.
+- Checkout cleanup and Stripe runtime-recheck recovery tests prove registration
+  happens before later failure and is not repeated by activation replay.
 
 ## State
 

--- a/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
+++ b/agent-docs/exec-plans/active/2026-08-20-signup-notification-ownership.md
@@ -1,0 +1,84 @@
+# Signup Notification Ownership
+
+## Goal
+
+Send the existing internal signup email exactly once from a real hosted member
+activation, regardless of whether Starter enrollment, the Checkout success
+return, or Stripe webhook reconciliation completes that activation first.
+
+## Evidence
+
+- The notification currently follows `welcomeEmailMemberId`, which is a
+  member-facing email decision rather than activation proof.
+- Starter enrollment and the Checkout success return can complete activation
+  without invoking the internal notification.
+- Standard paid Checkout can nominate a welcome email without activating a
+  member, allowing an existing active member to be mislabeled as a new signup.
+- Stripe's existing `activatedMemberId` also owns pending runtime-wake replay;
+  a distinct transient outcome is required to prove activation happened now.
+- The notification sender already owns a durable per-member attempt claim and
+  a stable provider idempotency key.
+
+## Constraints
+
+- Add no schema, queue, scheduler, retry owner, or compatibility layer.
+- Keep the internal email best-effort and outside database transactions.
+- Preserve customer welcome-email behavior and the existing per-member
+  notification idempotency contract.
+- Do not backfill or email historical members as part of this change.
+- Keep production evidence and member/provider identifiers out of repository
+  artifacts.
+
+## Plan
+
+1. Route the notification from the existing post-commit activation outcomes in
+   Starter enrollment, Checkout success, and Stripe reconciliation.
+2. Stop using `welcomeEmailMemberId` as notification eligibility; include every
+   distinct activated member reported by a Family Stripe outcome.
+3. Add focused regression coverage for true activation, replay/idempotent
+   ownership, suppressed or absent welcome email, Family activation, and the
+   non-activating standard Checkout case.
+4. Run focused hosted-web tests, typecheck, privacy/scope review, exact-head
+   ReviewGPT gates, and required PR CI.
+
+## Product UX
+
+Effort: Patch.
+
+- Outcome: operators receive one internal email for a genuine hosted signup,
+  without later payments or activation-wake replays being mislabeled.
+- Reaches: existing Starter, Checkout-success, and Stripe-reconciliation
+  activation journeys; member-facing welcome behavior remains unchanged.
+- Proof: focused owner tests distinguish newly committed activation from
+  welcome-only billing and pending-wake replay, including Family activation.
+
+## Product UX Walkthrough
+
+- Walked Starter activation with and without a member welcome email: the
+  internal email remains tied to activation and runs after commit.
+- Walked Checkout success for a new activation, a welcome-only standard
+  payment, and a reused pending wake: only the new activation is eligible.
+- Walked webhook-only and Family activation: each newly activated member is
+  eligible once, while the existing durable per-member claim deduplicates
+  competing owners and replays.
+- Walked provider failure and historical members: delivery remains best-effort
+  with the existing provider idempotency key, and no backfill is introduced.
+- Difference from plan: the implementation added an explicit transient
+  `newlyActivatedMemberIds` outcome after review proved the existing runtime
+  wake target was broader than a new activation.
+
+Result: Ready.
+
+## Verification
+
+- Focused notification, Starter, Checkout-success, Stripe billing-event, and
+  Stripe reconciliation tests passed (253 tests).
+- Hosted-web typecheck passed.
+- Focused ESLint and `git diff --check` passed.
+- Stripe billing-event and Checkout-completion owner tests prove the transient
+  new-activation outcome stays empty for later payments and pending-wake replay.
+
+## State
+
+Status: active
+Updated: 2026-08-20

--- a/agent-docs/exec-plans/completed/2026-08-20-signup-notification-ownership.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-signup-notification-ownership.md
@@ -107,8 +107,12 @@ Result: Ready.
 - Browser Family acceptance plus Linq and Telegram dispatch coverage proves
   first-activation registration, replay suppression, and registration before
   fallible wake or confirmation work.
+- Final ReviewGPT round 3 returned `ROUND_OUTCOME: PASS` on the complete exact
+  head after verifying every current activation owner and all prior fixes.
+- Every required PR check passed on the reviewed implementation head.
 
 ## State
 
-Status: active
+Status: completed
 Updated: 2026-08-20
+Completed: 2026-08-20

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -815,7 +815,7 @@ Hosted onboarding extras:
 - `HOSTED_MAILBOX_FINGERPRINT_KEY`
 - `HOSTED_ONBOARDING_SIGNUP_PHONE_NUMBER`
 - `RESEND_API_KEY`, `HOSTED_SIGNUP_WELCOME_EMAIL_FROM`, and `HOSTED_SIGNUP_WELCOME_EMAIL_FOUNDER_NAME` enable the plain-text post-activation signup welcome email to the member's verified email address, or to the Stripe checkout email when no verified email is linked yet. Leave any of them unset to disable the send path.
-- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients when Stripe reconciliation accepts a hosted signup or trial activation. Leave it unset to disable the internal notification path.
+- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients after hosted onboarding commits a member activation. Starter enrollment, the Checkout success return, and Stripe reconciliation share the same durable per-member notification gate. Leave it unset to disable the internal notification path.
 - `HOSTED_SIGNUP_WELCOME_EMAIL_TIMEOUT_MS` optionally bounds the Resend request timeout; the default is 10 seconds.
 - `HOSTED_LINQ_ALERT_EMAIL_FROM` and `HOSTED_LINQ_ALERT_EMAILS`, together with
   `RESEND_API_KEY`, enable the shared plain-text operational channel. Stripe

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -815,7 +815,7 @@ Hosted onboarding extras:
 - `HOSTED_MAILBOX_FINGERPRINT_KEY`
 - `HOSTED_ONBOARDING_SIGNUP_PHONE_NUMBER`
 - `RESEND_API_KEY`, `HOSTED_SIGNUP_WELCOME_EMAIL_FROM`, and `HOSTED_SIGNUP_WELCOME_EMAIL_FOUNDER_NAME` enable the plain-text post-activation signup welcome email to the member's verified email address, or to the Stripe checkout email when no verified email is linked yet. Leave any of them unset to disable the send path.
-- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients after hosted onboarding commits a member activation. Starter enrollment, the Checkout success return, and Stripe reconciliation register one post-response task at their first post-commit boundary and share the same canonical-access, durable per-member notification gate. Leave it unset to disable the internal notification path.
+- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients after hosted onboarding commits a member activation. Starter enrollment, the Checkout success return, Stripe reconciliation, and Family invite acceptance from the browser, Linq, or Telegram register one post-response task at their first post-commit boundary and share the same canonical-access, durable per-member notification gate. Leave it unset to disable the internal notification path.
 - `HOSTED_SIGNUP_WELCOME_EMAIL_TIMEOUT_MS` optionally bounds the Resend request timeout; the default is 10 seconds.
 - `HOSTED_LINQ_ALERT_EMAIL_FROM` and `HOSTED_LINQ_ALERT_EMAILS`, together with
   `RESEND_API_KEY`, enable the shared plain-text operational channel. Stripe

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -815,7 +815,7 @@ Hosted onboarding extras:
 - `HOSTED_MAILBOX_FINGERPRINT_KEY`
 - `HOSTED_ONBOARDING_SIGNUP_PHONE_NUMBER`
 - `RESEND_API_KEY`, `HOSTED_SIGNUP_WELCOME_EMAIL_FROM`, and `HOSTED_SIGNUP_WELCOME_EMAIL_FOUNDER_NAME` enable the plain-text post-activation signup welcome email to the member's verified email address, or to the Stripe checkout email when no verified email is linked yet. Leave any of them unset to disable the send path.
-- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients after hosted onboarding commits a member activation. Starter enrollment, the Checkout success return, and Stripe reconciliation share the same durable per-member notification gate. Leave it unset to disable the internal notification path.
+- `HOSTED_SIGNUP_NOTIFICATION_EMAILS` optionally enables a plain-text internal notification to comma-separated recipients after hosted onboarding commits a member activation. Starter enrollment, the Checkout success return, and Stripe reconciliation register one post-response task at their first post-commit boundary and share the same canonical-access, durable per-member notification gate. Leave it unset to disable the internal notification path.
 - `HOSTED_SIGNUP_WELCOME_EMAIL_TIMEOUT_MS` optionally bounds the Resend request timeout; the default is 10 seconds.
 - `HOSTED_LINQ_ALERT_EMAIL_FROM` and `HOSTED_LINQ_ALERT_EMAILS`, together with
   `RESEND_API_KEY`, enable the shared plain-text operational channel. Stripe

--- a/apps/web/src/lib/hosted-onboarding/billing-success-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-success-service.ts
@@ -20,6 +20,9 @@ import {
   withHostedMemberStripeMutationLock,
 } from "./hosted-member-billing-store";
 import {
+  sendHostedSignupNotificationEmailForMemberBestEffort,
+} from "./signup-notification-email";
+import {
   sendHostedSignupWelcomeEmailForMemberBestEffort,
 } from "./signup-welcome-email";
 import {
@@ -120,6 +123,12 @@ export async function reconcileHostedBillingCheckoutSuccess(input: {
     memberId: activationOutcome.welcomeEmailMemberId,
     prisma,
   });
+  for (const memberId of activationOutcome.newlyActivatedMemberIds) {
+    await sendHostedSignupNotificationEmailForMemberBestEffort({
+      memberId,
+      prisma,
+    });
+  }
 
   return getHostedInviteStatus({
     authenticatedMember: input.member,
@@ -141,6 +150,7 @@ type HostedCheckoutSessionSuccessOutcome = {
   cleanupFamilySponsoredStripeSubscriptionId?: string | null;
   cleanupStandardCheckout?: HostedStripeCheckoutCleanup | null;
   hostedExecutionEventId: string | null;
+  newlyActivatedMemberIds: string[];
   welcomeEmailMemberId: string | null;
 };
 
@@ -171,6 +181,7 @@ async function applyHostedCheckoutSessionSuccessWithinUnwrapCache(
   let activationOutcome: HostedCheckoutSessionSuccessOutcome = {
     activatedMemberId: null,
     hostedExecutionEventId: null,
+    newlyActivatedMemberIds: [],
     welcomeEmailMemberId: null,
   };
 

--- a/apps/web/src/lib/hosted-onboarding/billing-success-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-success-service.ts
@@ -20,7 +20,7 @@ import {
   withHostedMemberStripeMutationLock,
 } from "./hosted-member-billing-store";
 import {
-  sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails,
 } from "./signup-notification-email";
 import {
   sendHostedSignupWelcomeEmailForMemberBestEffort,
@@ -77,6 +77,12 @@ export async function reconcileHostedBillingCheckoutSuccess(input: {
     prisma,
     session,
   });
+  if (activationOutcome.newlyActivatedMemberIds.length > 0) {
+    scheduleHostedSignupNotificationEmails({
+      memberIds: activationOutcome.newlyActivatedMemberIds,
+      prisma,
+    });
+  }
   if (activationOutcome.cleanupFamilySponsoredStripeSubscriptionId) {
     await cleanupHostedFamilySponsoredDirectSubscription({
       memberId: invite.memberId,
@@ -123,13 +129,6 @@ export async function reconcileHostedBillingCheckoutSuccess(input: {
     memberId: activationOutcome.welcomeEmailMemberId,
     prisma,
   });
-  for (const memberId of activationOutcome.newlyActivatedMemberIds) {
-    await sendHostedSignupNotificationEmailForMemberBestEffort({
-      memberId,
-      prisma,
-    });
-  }
-
   return getHostedInviteStatus({
     authenticatedMember: input.member,
     inviteCode: input.inviteCode,

--- a/apps/web/src/lib/hosted-onboarding/family-plan.ts
+++ b/apps/web/src/lib/hosted-onboarding/family-plan.ts
@@ -103,6 +103,9 @@ import {
   signalHostedMemberActivationRuntimeWakeBestEffortResult,
 } from "./member-activation-runtime-wake";
 import {
+  scheduleHostedSignupNotificationEmails,
+} from "./signup-notification-email";
+import {
   createHostedMember,
   readHostedMemberCoreState,
   type HostedMemberCoreState,
@@ -4941,6 +4944,12 @@ export async function acceptHostedFamilyInvite(input: {
   }), HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
   const activation = activationHolder.value;
 
+  if (activation?.activated) {
+    scheduleHostedSignupNotificationEmails({
+      memberIds: [activation.memberId],
+      prisma,
+    });
+  }
   if (activation?.hostedExecutionEventId) {
     await signalHostedMemberActivationRuntimeWakeBestEffortResult({
       hostedExecutionEventId: activation.hostedExecutionEventId,

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-store.ts
@@ -15,6 +15,7 @@ import {
   createHostedEmailLookupKeyReadCandidates,
 } from "./contact-privacy";
 import { hostedOnboardingError } from "./errors";
+import { activeHostedMemberAccessWhere } from "./member-access";
 import {
   decryptHostedWebNullableString,
   decryptHostedWebNullableStrings,
@@ -377,10 +378,9 @@ export async function claimHostedMemberSignupNotificationEmailAttempt(input: {
       signupNotificationEmailAttemptedAt: input.attemptedAt,
     },
     where: {
-      billingStatus: HostedBillingStatus.active,
+      ...activeHostedMemberAccessWhere(),
       id: input.memberId,
       signupNotificationEmailAttemptedAt: null,
-      suspendedAt: null,
     },
   });
 

--- a/apps/web/src/lib/hosted-onboarding/signup-notification-email.ts
+++ b/apps/web/src/lib/hosted-onboarding/signup-notification-email.ts
@@ -1,4 +1,7 @@
-import { HostedBillingStatus, type PrismaClient } from "@prisma/client";
+import "server-only";
+
+import { type PrismaClient } from "@prisma/client";
+import { after } from "next/server";
 
 import { getPrisma } from "../prisma";
 import { parseCommaSeparatedList } from "../primitives";
@@ -7,6 +10,7 @@ import {
   readHostedMemberCoreState,
   readHostedMemberEmailAuthorization,
 } from "./hosted-member-store";
+import { readActiveHostedMemberAccess } from "./member-access";
 import {
   HostedResendPlainTextEmailError,
   readHostedResendPlainTextEmailConfig,
@@ -34,6 +38,35 @@ export type HostedSignupNotificationEmailResult =
 
 export const HostedSignupNotificationEmailError = HostedResendPlainTextEmailError;
 export type HostedSignupNotificationEmailError = HostedResendPlainTextEmailError;
+
+export function scheduleHostedSignupNotificationEmails(input: {
+  memberIds: readonly string[];
+  prisma: PrismaClient;
+  sourceEventId?: string | null;
+  sourceEventType?: string | null;
+}): void {
+  const memberIds = [...new Set(input.memberIds)];
+  if (memberIds.length === 0) {
+    return;
+  }
+
+  const task = async () => {
+    for (const memberId of memberIds) {
+      await sendHostedSignupNotificationEmailForMemberBestEffort({
+        memberId,
+        prisma: input.prisma,
+        sourceEventId: input.sourceEventId,
+        sourceEventType: input.sourceEventType,
+      });
+    }
+  };
+
+  try {
+    after(task);
+  } catch {
+    void task();
+  }
+}
 
 export async function sendHostedSignupNotificationEmailForMemberBestEffort(input: {
   env?: HostedSignupNotificationEmailEnv;
@@ -79,21 +112,18 @@ export async function sendHostedSignupNotificationEmailForMember(input: {
   }
 
   const prisma = input.prisma ?? getPrisma();
-  const member = await readHostedMemberCoreState({
+  const hasActiveAccess = await readActiveHostedMemberAccess({
     memberId: input.memberId,
     prisma,
   });
 
-  if (!member) {
+  if (!hasActiveAccess) {
+    const member = await readHostedMemberCoreState({
+      memberId: input.memberId,
+      prisma,
+    });
     return {
-      reason: "member_not_found",
-      status: "skipped",
-    };
-  }
-
-  if (member.billingStatus !== HostedBillingStatus.active || member.suspendedAt) {
-    return {
-      reason: "member_not_active",
+      reason: member ? "member_not_active" : "member_not_found",
       status: "skipped",
     };
   }
@@ -125,7 +155,6 @@ export async function sendHostedSignupNotificationEmailForMember(input: {
     idempotencyKey: buildHostedSignupNotificationEmailIdempotencyKey(input.memberId),
     subject: HOSTED_SIGNUP_NOTIFICATION_EMAIL_SUBJECT,
     text: buildHostedSignupNotificationEmailText({
-      billingStatus: member.billingStatus,
       customerEmail,
       memberId: input.memberId,
       sourceEventId: input.sourceEventId,
@@ -182,7 +211,6 @@ function readHostedSignupNotificationEmailRecipients(value: string | undefined):
 }
 
 function buildHostedSignupNotificationEmailText(input: {
-  billingStatus: string;
   customerEmail?: string | null;
   memberId: string;
   sourceEventId?: string | null;
@@ -193,7 +221,6 @@ function buildHostedSignupNotificationEmailText(input: {
     "",
     `Member ID: ${input.memberId}`,
     input.customerEmail ? `Email: ${input.customerEmail}` : null,
-    `Billing status: ${input.billingStatus}`,
     input.sourceEventType ? `Stripe event: ${input.sourceEventType}` : null,
     input.sourceEventId ? `Stripe event ID: ${input.sourceEventId}` : null,
   ].filter((line): line is string => line !== null).join("\n");

--- a/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
@@ -36,6 +36,9 @@ import {
 } from "./member-activation-runtime-wake";
 import { readActiveHostedFamilySponsorship } from "./member-access";
 import {
+  sendHostedSignupNotificationEmailForMemberBestEffort,
+} from "./signup-notification-email";
+import {
   sendHostedSignupWelcomeEmailForMemberBestEffort,
 } from "./signup-welcome-email";
 import {
@@ -112,6 +115,7 @@ type HostedStarterUsagePostCommitEffects = {
   activatedMemberId: string | null;
   hostedExecutionEventId: string | null;
   hostedExecutionMailboxItemId: string | null;
+  signupNotificationEmailMemberId: string | null;
   welcomeEmailMemberId: string | null;
 };
 
@@ -433,6 +437,8 @@ async function ensureHostedStarterUsageEnrollmentWithPolicy(
           hostedExecutionMailboxItemId: shouldWakeActivationRuntime
             ? activation?.hostedExecutionMailboxItemId ?? null
             : null,
+          signupNotificationEmailMemberId:
+            activation?.activated ? invite.member.id : null,
           welcomeEmailMemberId:
             activation?.activated && !policy.suppressSignupWelcomeEmail
               ? invite.member.id
@@ -722,6 +728,12 @@ async function runHostedStarterUsagePostCommitEffects(
   if (input.welcomeEmailMemberId) {
     await sendHostedSignupWelcomeEmailForMemberBestEffort({
       memberId: input.welcomeEmailMemberId,
+      prisma: input.prisma,
+    });
+  }
+  if (input.signupNotificationEmailMemberId) {
+    await sendHostedSignupNotificationEmailForMemberBestEffort({
+      memberId: input.signupNotificationEmailMemberId,
       prisma: input.prisma,
     });
   }

--- a/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
@@ -36,7 +36,7 @@ import {
 } from "./member-activation-runtime-wake";
 import { readActiveHostedFamilySponsorship } from "./member-access";
 import {
-  sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails,
 } from "./signup-notification-email";
 import {
   sendHostedSignupWelcomeEmailForMemberBestEffort,
@@ -486,6 +486,13 @@ async function ensureHostedStarterUsageEnrollmentWithPolicy(
     );
   })();
 
+  if (outcome.effects.signupNotificationEmailMemberId) {
+    scheduleHostedSignupNotificationEmails({
+      memberIds: [outcome.effects.signupNotificationEmailMemberId],
+      prisma,
+    });
+  }
+
   const deferredActivationWake = policy.instantStartAdmission
     ? buildHostedLinqInstantStartDeferredActivationWake(outcome.effects)
     : null;
@@ -728,12 +735,6 @@ async function runHostedStarterUsagePostCommitEffects(
   if (input.welcomeEmailMemberId) {
     await sendHostedSignupWelcomeEmailForMemberBestEffort({
       memberId: input.welcomeEmailMemberId,
-      prisma: input.prisma,
-    });
-  }
-  if (input.signupNotificationEmailMemberId) {
-    await sendHostedSignupNotificationEmailForMemberBestEffort({
-      memberId: input.signupNotificationEmailMemberId,
       prisma: input.prisma,
     });
   }

--- a/apps/web/src/lib/hosted-onboarding/stripe-billing-events.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-billing-events.ts
@@ -135,6 +135,7 @@ type HostedStripeActivationOutcome = HostedStripeActivatedMemberOutcome & {
   cleanupFamilySponsoredStripeSubscriptionId?: string | null;
   cleanupPulseTrialStripeSubscriptionId?: string | null;
   cleanupStandardCheckout?: HostedStripeCheckoutCleanup | null;
+  newlyActivatedMemberIds: string[];
   runtimeRecheckMemberIds?: string[];
   welcomeEmailMemberId: string | null;
 };
@@ -307,6 +308,7 @@ export async function applyStripeCheckoutCompleted(
     return {
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     };
   }
@@ -350,6 +352,7 @@ export async function applyStripeCheckoutCompleted(
     return {
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     };
   }
@@ -475,6 +478,7 @@ export async function applyStripeCheckoutCompleted(
   return {
     activatedMemberId: null,
     hostedExecutionEventId: null,
+    newlyActivatedMemberIds: [],
     welcomeEmailMemberId: memberSnapshot.core.id,
   };
 }
@@ -879,6 +883,7 @@ async function convertHostedLegacyPulseTrialToStarterTx(input: {
     cleanupPulseTrialStripeSubscriptionId,
     hostedExecutionEventId: activation.hostedExecutionEventId,
     hostedExecutionMailboxItemId: activation.hostedExecutionMailboxItemId ?? null,
+    newlyActivatedMemberIds: activation.activated ? [input.member.id] : [],
     runtimeRecheckMemberIds: [input.member.id],
     welcomeEmailMemberId: isHostedStripeActivationWelcomeCandidate(activation)
       ? input.member.id
@@ -1353,6 +1358,7 @@ export async function applyStripeInvoicePaid(
     return {
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     };
   }
@@ -1386,6 +1392,7 @@ export async function applyStripeInvoicePaid(
     return {
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     };
   }
@@ -1401,6 +1408,7 @@ export async function applyStripeInvoicePaid(
     return {
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     };
   }
@@ -1485,6 +1493,7 @@ export async function applyStripeInvoicePaid(
       : null,
     hostedExecutionEventId: activation.hostedExecutionEventId,
     hostedExecutionMailboxItemId: activation.hostedExecutionMailboxItemId ?? null,
+    newlyActivatedMemberIds: activation.activated ? [updatedMember.core.id] : [],
     runtimeRecheckMemberIds: runtimeRecheckMemberId
       ? [runtimeRecheckMemberId]
       : [],
@@ -1586,6 +1595,9 @@ function buildHostedStripeActivationOutcomeFromFamilySubscription(
     activatedMemberId: firstActivation?.activatedMemberId ?? null,
     activatedMembers,
     hostedExecutionEventId: firstActivation?.hostedExecutionEventId ?? null,
+    newlyActivatedMemberIds: familySubscription.activations
+      .filter((activation) => activation.activated)
+      .map((activation) => activation.memberId),
     runtimeRecheckMemberIds: familySubscription.runtimeRecheckMemberIds ?? [],
     welcomeEmailMemberId: null,
   };
@@ -1614,6 +1626,7 @@ function buildEmptyHostedStripeActivationOutcome(): HostedStripeActivationOutcom
     activatedMemberId: null,
     activatedMembers: [],
     hostedExecutionEventId: null,
+    newlyActivatedMemberIds: [],
     runtimeRecheckMemberIds: [],
     welcomeEmailMemberId: null,
   };

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -108,7 +108,7 @@ import {
   sendHostedSignupWelcomeEmailForMemberBestEffort,
 } from "./signup-welcome-email";
 import {
-  sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails,
 } from "./signup-notification-email";
 import {
   sendHostedSubscriptionCancellationEmailForMember,
@@ -932,6 +932,14 @@ async function processClaimedHostedStripeEvent(
           preflightProcessingContext,
         );
     const { memberId: processingMemberId, result } = processing;
+    if (result.newlyActivatedMemberIds.length > 0) {
+      scheduleHostedSignupNotificationEmails({
+        memberIds: result.newlyActivatedMemberIds,
+        prisma,
+        sourceEventId: claimed.eventId,
+        sourceEventType: claimed.type,
+      });
+    }
     if (result.cleanupPulseTrialStripeSubscriptionId && !processingMemberId) {
       throw new Error("Pulse Trial cleanup requires a direct billing member.");
     }
@@ -1019,14 +1027,6 @@ async function processClaimedHostedStripeEvent(
       await sendHostedSignupWelcomeEmailForMemberBestEffort({
         memberId: result.welcomeEmailMemberId,
         prisma,
-      });
-    }
-    for (const memberId of new Set(result.newlyActivatedMemberIds)) {
-      await sendHostedSignupNotificationEmailForMemberBestEffort({
-        memberId,
-        prisma,
-        sourceEventId: claimed.eventId,
-        sourceEventType: claimed.type,
       });
     }
     if (result.subscriptionCancellationEmail) {

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -405,6 +405,7 @@ async function processHostedStripeEventRecord(
   cleanupStandardCheckout: HostedStripeCheckoutCleanup | null;
   hostedExecutionEventId: string | null;
   hostedExecutionMailboxItemId: string | null;
+  newlyActivatedMemberIds: string[];
   runtimeRecheckMemberIds: string[];
   subscriptionCancellationEmail: HostedSubscriptionCancellationEmailCandidate | null;
   welcomeEmailMemberId: string | null;
@@ -1019,8 +1020,10 @@ async function processClaimedHostedStripeEvent(
         memberId: result.welcomeEmailMemberId,
         prisma,
       });
+    }
+    for (const memberId of new Set(result.newlyActivatedMemberIds)) {
       await sendHostedSignupNotificationEmailForMemberBestEffort({
-        memberId: result.welcomeEmailMemberId,
+        memberId,
         prisma,
         sourceEventId: claimed.eventId,
         sourceEventType: claimed.type,
@@ -1763,6 +1766,7 @@ function mapHostedStripeActivationOutcome(
     cleanupStandardCheckout?: HostedStripeCheckoutCleanup | null;
     hostedExecutionEventId: string | null;
     hostedExecutionMailboxItemId?: string | null;
+    newlyActivatedMemberIds: string[];
     runtimeRecheckMemberIds?: string[];
     welcomeEmailMemberId?: string | null;
   },
@@ -1775,6 +1779,7 @@ function mapHostedStripeActivationOutcome(
   cleanupStandardCheckout: HostedStripeCheckoutCleanup | null;
   hostedExecutionEventId: string | null;
   hostedExecutionMailboxItemId: string | null;
+  newlyActivatedMemberIds: string[];
   runtimeRecheckMemberIds: string[];
   subscriptionCancellationEmail: HostedSubscriptionCancellationEmailCandidate | null;
   welcomeEmailMemberId: string | null;
@@ -1792,6 +1797,7 @@ function mapHostedStripeActivationOutcome(
     hostedExecutionEventId: outcome.hostedExecutionEventId,
     hostedExecutionMailboxItemId:
       outcome.hostedExecutionMailboxItemId ?? null,
+    newlyActivatedMemberIds: outcome.newlyActivatedMemberIds,
     runtimeRecheckMemberIds: outcome.runtimeRecheckMemberIds ?? [],
     subscriptionCancellationEmail: null,
     welcomeEmailMemberId: outcome.welcomeEmailMemberId ?? null,
@@ -1850,6 +1856,7 @@ function mapHostedStripeSubscriptionUpdateOutcome(
     cleanupStandardCheckout?: HostedStripeCheckoutCleanup | null;
     hostedExecutionEventId?: string | null;
     hostedExecutionMailboxItemId?: string | null;
+    newlyActivatedMemberIds?: string[];
     runtimeRecheckMemberIds?: string[];
     subscriptionCancellationEmail?: HostedSubscriptionCancellationEmailCandidate | null;
     welcomeEmailMemberId?: string | null;
@@ -1863,6 +1870,7 @@ function mapHostedStripeSubscriptionUpdateOutcome(
   cleanupStandardCheckout: HostedStripeCheckoutCleanup | null;
   hostedExecutionEventId: string | null;
   hostedExecutionMailboxItemId: string | null;
+  newlyActivatedMemberIds: string[];
   runtimeRecheckMemberIds: string[];
   subscriptionCancellationEmail: HostedSubscriptionCancellationEmailCandidate | null;
   welcomeEmailMemberId: string | null;
@@ -1880,6 +1888,7 @@ function mapHostedStripeSubscriptionUpdateOutcome(
     hostedExecutionEventId: outcome?.hostedExecutionEventId ?? null,
     hostedExecutionMailboxItemId:
       outcome?.hostedExecutionMailboxItemId ?? null,
+    newlyActivatedMemberIds: outcome?.newlyActivatedMemberIds ?? [],
     runtimeRecheckMemberIds: outcome?.runtimeRecheckMemberIds ?? [],
     subscriptionCancellationEmail:
       outcome?.subscriptionCancellationEmail ?? null,
@@ -1896,6 +1905,7 @@ function buildEmptyHostedStripeEventProcessingResult(): {
   cleanupStandardCheckout: HostedStripeCheckoutCleanup | null;
   hostedExecutionEventId: string | null;
   hostedExecutionMailboxItemId: string | null;
+  newlyActivatedMemberIds: string[];
   runtimeRecheckMemberIds: string[];
   subscriptionCancellationEmail: HostedSubscriptionCancellationEmailCandidate | null;
   welcomeEmailMemberId: string | null;
@@ -1909,6 +1919,7 @@ function buildEmptyHostedStripeEventProcessingResult(): {
     cleanupStandardCheckout: null,
     hostedExecutionEventId: null,
     hostedExecutionMailboxItemId: null,
+    newlyActivatedMemberIds: [],
     runtimeRecheckMemberIds: [],
     subscriptionCancellationEmail: null,
     welcomeEmailMemberId: null,

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-shared.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq-shared.ts
@@ -329,6 +329,7 @@ export function buildFamilyInviteAcceptedResponse(input: {
   message: string;
   messageId: string;
   occurredAt: string;
+  signupNotificationMemberId?: string;
   sourceEventId: string;
   wakeHandoff?: HostedWebhookWakeHandoff;
 }): HostedOnboardingLinqDirectPlan {
@@ -349,6 +350,13 @@ export function buildFamilyInviteAcceptedResponse(input: {
       reason: "family-invite-accepted",
     },
     postCommitGroupJoinConfirmationMemberIds: [input.memberId],
+    ...(input.signupNotificationMemberId
+      ? {
+          postCommitSignupNotificationMemberIds: [
+            input.signupNotificationMemberId,
+          ],
+        }
+      : {}),
     ...(input.wakeHandoff ? { wakeHandoffs: [input.wakeHandoff] } : {}),
   });
 }

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1859,6 +1859,7 @@ export async function planHostedOnboardingLinqWebhook(input: {
       : undefined;
   let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromPhoneTx>> = null;
   let familyActivationWake: HostedWebhookWakeHandoff | null = null;
+  let familySignupNotificationMemberId: string | null = null;
   let familyDraftCheckoutConflict = false;
   let familyStripeEffectPending = false;
   let familyRouteBlockedPlan: HostedOnboardingLinqDirectPlan | null = null;
@@ -1924,6 +1925,9 @@ export async function planHostedOnboardingLinqWebhook(input: {
           });
         },
         onAcceptedMemberActivated: (activation) => {
+          if (activation.activated) {
+            familySignupNotificationMemberId = activation.memberId;
+          }
           if (activation.hostedExecutionEventId && activation.hostedExecutionMailboxItemId) {
             familyActivationWake = {
               eventId: activation.hostedExecutionEventId,
@@ -1995,6 +1999,12 @@ export async function planHostedOnboardingLinqWebhook(input: {
         }),
         messageId: summary.messageId,
         occurredAt,
+        ...(familySignupNotificationMemberId
+          ? {
+              signupNotificationMemberId:
+                familySignupNotificationMemberId,
+            }
+          : {}),
         sourceEventId: input.event.event_id,
         ...(familyActivationWake ? { wakeHandoff: familyActivationWake } : {}),
       }),

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-telegram.ts
@@ -148,11 +148,15 @@ export async function planHostedOnboardingTelegramWebhook(input: {
     let familyStripeEffectPending = false;
     let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromTelegramTx>> = null;
     let familyActivationWake: HostedWebhookWakeHandoff | null = null;
+    let familySignupNotificationMemberId: string | null = null;
     let familyTelegramBindingMemberId: string | null = null;
     try {
       familyAcceptance = await acceptHostedFamilyInviteFromTelegramTx({
         now: new Date(summary.occurredAt),
         onAcceptedMemberActivated: (activation) => {
+          if (activation.activated) {
+            familySignupNotificationMemberId = activation.memberId;
+          }
           if (activation.hostedExecutionEventId && activation.hostedExecutionMailboxItemId) {
             familyActivationWake = {
               eventId: activation.hostedExecutionEventId,
@@ -217,6 +221,13 @@ export async function planHostedOnboardingTelegramWebhook(input: {
         desiredSideEffects: [],
         postCommitGroupJoinConfirmationMemberIds: [familyAcceptance.memberId],
         postCommitPhoneCallResultRecoveryMemberIds: [familyAcceptance.memberId],
+        ...(familySignupNotificationMemberId
+          ? {
+              postCommitSignupNotificationMemberIds: [
+                familySignupNotificationMemberId,
+              ],
+            }
+          : {}),
         response: {
           ok: true,
           reason: "family-invite-accepted",

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
@@ -18,6 +18,7 @@ export type HostedWebhookPlan<TResult, TSideEffect = never> = {
   linqReadReceiptRouteAuthority?: HostedLinqThreadRouteEgressAuthority;
   postCommitGroupJoinConfirmationMemberIds?: readonly string[];
   postCommitPhoneCallResultRecoveryMemberIds?: readonly string[];
+  postCommitSignupNotificationMemberIds?: readonly string[];
   postCommitUsageReferralIds?: readonly string[];
   response: TResult;
   wakeHandoffs?: readonly HostedWebhookWakeHandoff[];

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -64,6 +64,9 @@ import {
   sendPendingHostedLinqAlertsBestEffort,
 } from "./linq-alert-email";
 import {
+  scheduleHostedSignupNotificationEmails,
+} from "./signup-notification-email";
+import {
   ingestHostedLinqProviderEventTx,
 } from "./linq-provider-event-store";
 import {
@@ -707,6 +710,12 @@ export async function handleHostedOnboardingLinqWebhook(input: {
           },
           prisma,
         });
+        if (planned.postCommitSignupNotificationMemberIds?.length) {
+          scheduleHostedSignupNotificationEmails({
+            memberIds: planned.postCommitSignupNotificationMemberIds,
+            prisma,
+          });
+        }
         if (
           planned.nextRequiredPendingGroupSetupCandidateId !== undefined
         ) {
@@ -1981,6 +1990,12 @@ export async function handleHostedOnboardingTelegramWebhook(input: {
     },
     prisma,
   });
+  if (plan.postCommitSignupNotificationMemberIds?.length) {
+    scheduleHostedSignupNotificationEmails({
+      memberIds: plan.postCommitSignupNotificationMemberIds,
+      prisma,
+    });
+  }
 
   if (plan.desiredSideEffects.length > 0) {
     throw new Error(

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -51,6 +51,9 @@ const activationWakeMocks = vi.hoisted(() => ({
 const groupJoinConfirmationMocks = vi.hoisted(() => ({
   materializePendingHostedGroupJoinConfirmationsBestEffort: vi.fn(),
 }));
+const signupNotificationMocks = vi.hoisted(() => ({
+  scheduleHostedSignupNotificationEmails: vi.fn(),
+}));
 
 vi.mock("@/src/lib/hosted-web/encryption", () => ({
   decryptHostedWebNullableFields: encryptionMocks.decryptHostedWebNullableFields,
@@ -96,6 +99,10 @@ vi.mock("@/src/lib/hosted-mailbox/store", () => ({
 vi.mock("@/src/lib/hosted-groups/group-join-confirmation", () => ({
   materializePendingHostedGroupJoinConfirmationsBestEffort:
     groupJoinConfirmationMocks.materializePendingHostedGroupJoinConfirmationsBestEffort,
+}));
+vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
+  scheduleHostedSignupNotificationEmails:
+    signupNotificationMocks.scheduleHostedSignupNotificationEmails,
 }));
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
   requireHostedOnboardingPublicBaseUrl: runtimeMocks.requireHostedOnboardingPublicBaseUrl,
@@ -4123,6 +4130,18 @@ describe("hosted Family plan", () => {
         source: "family-invite-web-accept",
         timeoutMs: 5_000,
       });
+    expect(signupNotificationMocks.scheduleHostedSignupNotificationEmails)
+      .toHaveBeenCalledWith({
+        memberIds: ["member_mom"],
+        prisma,
+      });
+    expect(
+      signupNotificationMocks.scheduleHostedSignupNotificationEmails.mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      activationWakeMocks.signalHostedMemberActivationRuntimeWakeBestEffortResult
+        .mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(cryptoRootMocks.prepareHostedCryptoDomainRootCandidates).toHaveBeenCalledWith({
       prisma,
       userId: "member_mom",
@@ -4262,6 +4281,9 @@ describe("hosted Family plan", () => {
     expect(tx.hostedAccountGroupInvite.updateMany).not.toHaveBeenCalled();
     expect(tx.hostedAccountGroupMembership.upsert).not.toHaveBeenCalled();
     expect(cryptoRootMocks.prepareHostedCryptoDomainRootCandidates).not.toHaveBeenCalled();
+    expect(
+      signupNotificationMocks.scheduleHostedSignupNotificationEmails,
+    ).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -9470,6 +9470,7 @@ describe("hosted Family plan", () => {
     )).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -9510,6 +9511,7 @@ describe("hosted Family plan", () => {
     )).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 

--- a/apps/web/test/hosted-onboarding-billing-success-service.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-success-service.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     prepareHostedStripeCheckoutCompletion: vi.fn(),
     preparedCryptoDomainRoots: new Map(),
     signalHostedMemberActivationRuntimeWakeBestEffortResult: vi.fn(),
+    sendHostedSignupNotificationEmailForMemberBestEffort: vi.fn(),
     sendHostedSignupWelcomeEmailForMemberBestEffort: vi.fn(),
     readHostedMemberCoreState: vi.fn(),
     requireHostedInviteForAuthentication: vi.fn(),
@@ -83,6 +84,11 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
 vi.mock("@/src/lib/hosted-onboarding/signup-welcome-email", () => ({
   sendHostedSignupWelcomeEmailForMemberBestEffort:
     mocks.sendHostedSignupWelcomeEmailForMemberBestEffort,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
+  sendHostedSignupNotificationEmailForMemberBestEffort:
+    mocks.sendHostedSignupNotificationEmailForMemberBestEffort,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/stripe-billing-lookup", async () => {
@@ -162,12 +168,14 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     mocks.applyStripeCheckoutCompleted.mockResolvedValue({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cleanupHostedFamilySponsoredDirectSubscription.mockResolvedValue(undefined);
     mocks.cancelHostedPulseTrialCheckoutLoserSubscription.mockResolvedValue(undefined);
     mocks.cleanupHostedStandardCheckoutLoser.mockResolvedValue(undefined);
     mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mockResolvedValue(undefined);
+    mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mockResolvedValue(undefined);
     mocks.getHostedInviteStatus.mockResolvedValue(createStatus({
       stage: "activating",
     }));
@@ -427,6 +435,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     );
     expect(mocks.activateHostedMemberForPositiveSourceTx).not.toHaveBeenCalled();
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).not.toHaveBeenCalled();
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort).not.toHaveBeenCalled();
   });
 
@@ -444,6 +453,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       activatedMemberId: null,
       cleanupPulseTrialStripeSubscriptionId: "sub_delayed_trial",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cancelHostedPulseTrialCheckoutLoserSubscription
@@ -502,6 +512,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
         subscriptionId: "sub_superseded",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -540,6 +551,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
         subscriptionId: "sub_loser",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -625,6 +637,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     mocks.applyStripeCheckoutCompleted.mockResolvedValueOnce({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -641,6 +654,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       memberId: "member_123",
       prisma,
     });
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).not.toHaveBeenCalled();
   });
 
@@ -655,6 +669,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     mocks.applyStripeCheckoutCompleted.mockResolvedValueOnce({
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_123",
+      newlyActivatedMemberIds: ["member_123"],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -671,6 +686,10 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       memberId: "member_123",
       prisma,
     });
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).toHaveBeenCalledWith({
+      memberId: "member_123",
+      prisma,
+    });
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).toHaveBeenCalledWith({
       hostedExecutionEventId: "wake_123",
       memberId: "member_123",
@@ -682,6 +701,43 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     ).toBeLessThan(
       mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mock.invocationCallOrder[0],
     );
+    expect(
+      mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not send a signup notification when Checkout only reuses a pending activation wake", async () => {
+    const tx = {
+      __tag: "tx",
+      $queryRaw: vi.fn(async () => []),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (innerTx: typeof tx) => Promise<unknown>) => callback(tx)),
+    };
+    mocks.applyStripeCheckoutCompleted.mockResolvedValueOnce({
+      activatedMemberId: "member_123",
+      hostedExecutionEventId: "wake_123",
+      newlyActivatedMemberIds: [],
+      welcomeEmailMemberId: "member_123",
+    });
+
+    await expect(reconcileHostedBillingCheckoutSuccess({
+      inviteCode: "invite-code",
+      member: createAuthenticatedMember(),
+      prisma: prisma as never,
+      sessionId: "cs_123",
+    })).resolves.toEqual(createStatus({
+      stage: "activating",
+    }));
+
+    expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult)
+      .toHaveBeenCalledOnce();
+    expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
+      .toHaveBeenCalledOnce();
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+      .not.toHaveBeenCalled();
   });
 
   it("only writes the durable billing reference when the checkout session has no subscription object", async () => {

--- a/apps/web/test/hosted-onboarding-billing-success-service.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-success-service.test.ts
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => {
     prepareHostedStripeCheckoutCompletion: vi.fn(),
     preparedCryptoDomainRoots: new Map(),
     signalHostedMemberActivationRuntimeWakeBestEffortResult: vi.fn(),
-    sendHostedSignupNotificationEmailForMemberBestEffort: vi.fn(),
+    scheduleHostedSignupNotificationEmails: vi.fn(),
     sendHostedSignupWelcomeEmailForMemberBestEffort: vi.fn(),
     readHostedMemberCoreState: vi.fn(),
     requireHostedInviteForAuthentication: vi.fn(),
@@ -87,8 +87,8 @@ vi.mock("@/src/lib/hosted-onboarding/signup-welcome-email", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
-  sendHostedSignupNotificationEmailForMemberBestEffort:
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails:
+    mocks.scheduleHostedSignupNotificationEmails,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/stripe-billing-lookup", async () => {
@@ -175,7 +175,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     mocks.cancelHostedPulseTrialCheckoutLoserSubscription.mockResolvedValue(undefined);
     mocks.cleanupHostedStandardCheckoutLoser.mockResolvedValue(undefined);
     mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mockResolvedValue(undefined);
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mockResolvedValue(undefined);
+    mocks.scheduleHostedSignupNotificationEmails.mockReturnValue(undefined);
     mocks.getHostedInviteStatus.mockResolvedValue(createStatus({
       stage: "activating",
     }));
@@ -435,7 +435,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
     );
     expect(mocks.activateHostedMemberForPositiveSourceTx).not.toHaveBeenCalled();
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort).not.toHaveBeenCalled();
   });
 
@@ -654,7 +654,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       memberId: "member_123",
       prisma,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).not.toHaveBeenCalled();
   });
 
@@ -686,8 +686,8 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       memberId: "member_123",
       prisma,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).toHaveBeenCalledWith({
-      memberId: "member_123",
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_123"],
       prisma,
     });
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult).toHaveBeenCalledWith({
@@ -697,15 +697,59 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       source: "checkout-success.activation",
     });
     expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult.mock.invocationCallOrder[0],
+    );
+    expect(
       mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult.mock.invocationCallOrder[0],
     ).toBeLessThan(
       mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mock.invocationCallOrder[0],
     );
-    expect(
-      mocks.sendHostedSignupWelcomeEmailForMemberBestEffort.mock.invocationCallOrder[0],
-    ).toBeLessThan(
-      mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mock.invocationCallOrder[0],
+  });
+
+  it("registers a fresh activation notification before fallible Checkout cleanup", async () => {
+    const tx = {
+      __tag: "tx",
+      $queryRaw: vi.fn(async () => []),
+    };
+    const prisma = {
+      $transaction: vi.fn(
+        async (callback: (innerTx: typeof tx) => Promise<unknown>) => callback(tx),
+      ),
+    };
+    mocks.applyStripeCheckoutCompleted.mockResolvedValueOnce({
+      activatedMemberId: "member_123",
+      cleanupPulseTrialStripeSubscriptionId: "sub_cleanup_123",
+      hostedExecutionEventId: "wake_123",
+      newlyActivatedMemberIds: ["member_123"],
+      welcomeEmailMemberId: "member_123",
+    });
+    mocks.cancelHostedPulseTrialCheckoutLoserSubscription.mockRejectedValueOnce(
+      new Error("cleanup unavailable"),
     );
+
+    await expect(reconcileHostedBillingCheckoutSuccess({
+      inviteCode: "invite-code",
+      member: createAuthenticatedMember(),
+      prisma: prisma as never,
+      sessionId: "cs_123",
+    })).rejects.toThrow("cleanup unavailable");
+
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_123"],
+      prisma,
+    });
+    expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.cancelHostedPulseTrialCheckoutLoserSubscription.mock
+        .invocationCallOrder[0],
+    );
+    expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult)
+      .not.toHaveBeenCalled();
+    expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
+      .not.toHaveBeenCalled();
   });
 
   it("does not send a signup notification when Checkout only reuses a pending activation wake", async () => {
@@ -736,7 +780,7 @@ describe("reconcileHostedBillingCheckoutSuccess", () => {
       .toHaveBeenCalledOnce();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
       .toHaveBeenCalledOnce();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+    expect(mocks.scheduleHostedSignupNotificationEmails)
       .not.toHaveBeenCalled();
   });
 

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -194,6 +194,7 @@ const mocks = vi.hoisted(() => {
     appendHostedMailboxEnvelopeWithSourceMessageTx: vi.fn(),
     appendHostedMailboxEnvelopeWithPreparedCryptoTx: vi.fn(),
     materializePendingHostedGroupJoinConfirmationsBestEffort: vi.fn(),
+    scheduleHostedSignupNotificationEmails: vi.fn(),
     acceptHostedFamilyInviteFromPhoneTx: vi.fn(),
     prepareHostedFamilyOwnerNotification: vi.fn(),
     buildHostedFamilyInviteAcceptedReplyText: vi.fn(() => "Welcome to Murph Family."),
@@ -292,6 +293,11 @@ vi.mock("@/src/lib/hosted-onboarding/webhook-provider-linq", async (importOrigin
 vi.mock("@/src/lib/hosted-groups/group-join-confirmation", () => ({
   materializePendingHostedGroupJoinConfirmationsBestEffort:
     mocks.materializePendingHostedGroupJoinConfirmationsBestEffort,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
+  scheduleHostedSignupNotificationEmails:
+    mocks.scheduleHostedSignupNotificationEmails,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/linq-daily-state", async () => {
@@ -6572,8 +6578,18 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       prisma,
       timeoutMs: expect.any(Number),
     });
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_family"],
+      prisma,
+    });
     expect(hostedMemberRoutingUpsert.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.signalHostedMailboxAppendRuntime.mock.invocationCallOrder[0],
+    );
+    expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.signalHostedMailboxAppendRuntime.mock.invocationCallOrder[0]
+      ?? Number.POSITIVE_INFINITY,
     );
     expect(mocks.signalHostedMailboxAppendRuntime.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.materializePendingHostedGroupJoinConfirmationsBestEffort.mock.invocationCallOrder[0],
@@ -6712,6 +6728,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       occurredAt: "2026-03-26T12:00:00.000Z",
       prisma,
     });
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(expect.objectContaining({
       chatId: "chat_home",
       idempotencyKey: "linq-message:evt_family_sparse_saved_home",

--- a/apps/web/test/hosted-onboarding-member-store.test.ts
+++ b/apps/web/test/hosted-onboarding-member-store.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@/src/lib/hosted-onboarding/member-private-codecs";
 
 import {
+  claimHostedMemberSignupNotificationEmailAttempt,
   composeHostedMemberSnapshot,
   createHostedMember as createHostedMemberStore,
   lookupHostedMemberByVerifiedEmailAddress,
@@ -30,6 +31,9 @@ import {
   readHostedMemberVerifiedEmailSnapshots,
   type HostedMemberCoreState,
 } from "@/src/lib/hosted-onboarding/hosted-member-store";
+import {
+  activeHostedMemberAccessWhere,
+} from "@/src/lib/hosted-onboarding/member-access";
 import {
   bindHostedMemberStripeCustomerIdIfMissingTx,
   lookupHostedMemberStripeBillingRefByStripeCustomerId,
@@ -99,6 +103,30 @@ describe("hosted-member-store", () => {
       },
     });
     vi.clearAllMocks();
+  });
+
+  it("claims signup notification attempts through canonical active access", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const attemptedAt = new Date("2026-08-20T12:00:00.000Z");
+
+    await expect(claimHostedMemberSignupNotificationEmailAttempt({
+      attemptedAt,
+      memberId: "member_123",
+      prisma: {
+        hostedMember: { updateMany },
+      } as never,
+    })).resolves.toBe(true);
+
+    expect(updateMany).toHaveBeenCalledWith({
+      data: {
+        signupNotificationEmailAttemptedAt: attemptedAt,
+      },
+      where: {
+        ...activeHostedMemberAccessWhere(),
+        id: "member_123",
+        signupNotificationEmailAttemptedAt: null,
+      },
+    });
   });
 
   afterEach(() => {

--- a/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
+++ b/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => {
     readHostedStarterUsageGrantTx: vi.fn(),
     requireHostedInviteForBillingCheckout: vi.fn(),
     runWithHostedDomainRootUnwrapCache: vi.fn(),
-    sendHostedSignupNotificationEmailForMemberBestEffort: vi.fn(),
+    scheduleHostedSignupNotificationEmails: vi.fn(),
     sendHostedSignupWelcomeEmailForMemberBestEffort: vi.fn(),
     signalHostedMemberActivationRuntimeWakeBestEffortResult: vi.fn(),
     unwrapHostedDomainRootForWeb: vi.fn(),
@@ -101,8 +101,8 @@ vi.mock("@/src/lib/hosted-onboarding/signup-welcome-email", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
-  sendHostedSignupNotificationEmailForMemberBestEffort:
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails:
+    mocks.scheduleHostedSignupNotificationEmails,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/starter-usage-grant", () => ({
@@ -146,7 +146,6 @@ type ProviderWork = {
     | "kms-sign"
     | "kms-unwrap"
     | "messaging"
-    | "notification-email"
     | "runtime-wake"
     | "welcome-email";
   rootKeyId?: string;
@@ -397,10 +396,7 @@ describe("Starter usage enrollment owner", () => {
       .mockImplementation(async () => {
         await runProviderWork({ kind: "welcome-email" });
       });
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort
-      .mockImplementation(async () => {
-        await runProviderWork({ kind: "notification-email" });
-      });
+    mocks.scheduleHostedSignupNotificationEmails.mockReturnValue(undefined);
   });
 
   it("enrolls once across supported channels and emits activation effects once", async () => {
@@ -440,8 +436,16 @@ describe("Starter usage enrollment owner", () => {
       .toHaveBeenCalledOnce();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
       .not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-      .toHaveBeenCalledOnce();
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: [memberState.id],
+      prisma,
+    });
+    expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult.mock
+        .invocationCallOrder[0],
+    );
   });
 
   it("keeps the Web signup email separate from companion conversation welcome", async () => {
@@ -463,8 +467,10 @@ describe("Starter usage enrollment owner", () => {
     );
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
       .toHaveBeenCalledOnce();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-      .toHaveBeenCalledOnce();
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: [memberState.id],
+      prisma,
+    });
   });
 
   it("re-signals a still-pending activation on repeated companion enrollment", async () => {
@@ -771,8 +777,10 @@ describe("Starter usage enrollment owner", () => {
         .not.toHaveBeenCalled();
       expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
         .not.toHaveBeenCalled();
-      expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-        .toHaveBeenCalledOnce();
+      expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+        memberIds: [memberState.id],
+        prisma,
+      });
 
       if (!result.deferredActivationWake) {
         throw new Error("Expected one deferred activation wake.");

--- a/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
+++ b/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     readHostedStarterUsageGrantTx: vi.fn(),
     requireHostedInviteForBillingCheckout: vi.fn(),
     runWithHostedDomainRootUnwrapCache: vi.fn(),
+    sendHostedSignupNotificationEmailForMemberBestEffort: vi.fn(),
     sendHostedSignupWelcomeEmailForMemberBestEffort: vi.fn(),
     signalHostedMemberActivationRuntimeWakeBestEffortResult: vi.fn(),
     unwrapHostedDomainRootForWeb: vi.fn(),
@@ -99,6 +100,11 @@ vi.mock("@/src/lib/hosted-onboarding/signup-welcome-email", () => ({
     mocks.sendHostedSignupWelcomeEmailForMemberBestEffort,
 }));
 
+vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
+  sendHostedSignupNotificationEmailForMemberBestEffort:
+    mocks.sendHostedSignupNotificationEmailForMemberBestEffort,
+}));
+
 vi.mock("@/src/lib/hosted-onboarding/starter-usage-grant", () => ({
   ensureHostedStarterUsageGrantTx: mocks.ensureHostedStarterUsageGrantTx,
   readHostedStarterUsageGrantTx: mocks.readHostedStarterUsageGrantTx,
@@ -140,6 +146,7 @@ type ProviderWork = {
     | "kms-sign"
     | "kms-unwrap"
     | "messaging"
+    | "notification-email"
     | "runtime-wake"
     | "welcome-email";
   rootKeyId?: string;
@@ -390,6 +397,10 @@ describe("Starter usage enrollment owner", () => {
       .mockImplementation(async () => {
         await runProviderWork({ kind: "welcome-email" });
       });
+    mocks.sendHostedSignupNotificationEmailForMemberBestEffort
+      .mockImplementation(async () => {
+        await runProviderWork({ kind: "notification-email" });
+      });
   });
 
   it("enrolls once across supported channels and emits activation effects once", async () => {
@@ -429,6 +440,8 @@ describe("Starter usage enrollment owner", () => {
       .toHaveBeenCalledOnce();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
       .not.toHaveBeenCalled();
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+      .toHaveBeenCalledOnce();
   });
 
   it("keeps the Web signup email separate from companion conversation welcome", async () => {
@@ -449,6 +462,8 @@ describe("Starter usage enrollment owner", () => {
       }),
     );
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
+      .toHaveBeenCalledOnce();
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
       .toHaveBeenCalledOnce();
   });
 
@@ -756,6 +771,8 @@ describe("Starter usage enrollment owner", () => {
         .not.toHaveBeenCalled();
       expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
         .not.toHaveBeenCalled();
+      expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+        .toHaveBeenCalledOnce();
 
       if (!result.deferredActivationWake) {
         throw new Error("Expected one deferred activation wake.");

--- a/apps/web/test/hosted-onboarding-stripe-billing-events.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-billing-events.test.ts
@@ -299,6 +299,7 @@ describe("hosted onboarding stripe billing events", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -350,6 +351,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -541,6 +543,7 @@ describe("hosted onboarding stripe billing events", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -571,6 +574,7 @@ describe("hosted onboarding stripe billing events", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -606,6 +610,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_123",
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: ["member_123"],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
@@ -626,6 +631,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_123",
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: ["member_123"],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
@@ -862,6 +868,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_123",
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: ["member_123"],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
@@ -910,6 +917,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       hostedExecutionEventId: null,
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -966,6 +974,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       hostedExecutionEventId: null,
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1015,6 +1024,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_existing",
       hostedExecutionMailboxItemId: "mailbox_wake_existing",
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
@@ -1041,6 +1051,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "wake_123",
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: ["member_123"],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
@@ -1076,6 +1087,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1188,6 +1200,7 @@ describe("hosted onboarding stripe billing events", () => {
         hostedExecutionMailboxItemId: "mailbox_family_existing",
       }],
       hostedExecutionEventId: "wake_family_existing",
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
@@ -1347,6 +1360,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: {
         memberId: "member_123",
@@ -1390,6 +1404,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: {
         memberId: "member_123",
@@ -1424,6 +1439,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
@@ -1451,6 +1467,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
@@ -1619,6 +1636,7 @@ describe("hosted onboarding stripe billing events", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
@@ -1878,6 +1896,7 @@ describe("hosted onboarding stripe billing events", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -1994,6 +2013,7 @@ describe("hosted onboarding stripe billing events", () => {
     )).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -2177,6 +2197,7 @@ describe("hosted onboarding stripe billing events", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 

--- a/apps/web/test/hosted-onboarding-stripe-checkout-completed.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-checkout-completed.test.ts
@@ -399,6 +399,7 @@ describe("applyStripeCheckoutCompleted", () => {
     ).resolves.toEqual({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -642,6 +643,7 @@ describe("applyStripeCheckoutCompleted", () => {
         activatedMemberId: null,
         activatedMembers: [],
         hostedExecutionEventId: null,
+        newlyActivatedMemberIds: [],
         runtimeRecheckMemberIds: [],
         welcomeEmailMemberId: null,
       });
@@ -738,6 +740,7 @@ describe("applyStripeCheckoutCompleted", () => {
           activatedMemberId: null,
           activatedMembers: [],
           hostedExecutionEventId: null,
+          newlyActivatedMemberIds: [],
           runtimeRecheckMemberIds: [],
           welcomeEmailMemberId: null,
         });
@@ -1422,6 +1425,7 @@ describe("applyStripeCheckoutCompleted", () => {
         subscriptionId: "sub_old",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -1448,6 +1452,7 @@ describe("applyStripeCheckoutCompleted", () => {
       cleanupPulseTrialStripeSubscriptionId: "sub_123",
       hostedExecutionEventId: "wake_123",
       hostedExecutionMailboxItemId: null,
+      newlyActivatedMemberIds: ["member_123"],
       runtimeRecheckMemberIds: ["member_123"],
       welcomeEmailMemberId: "member_123",
     });
@@ -1520,6 +1525,7 @@ describe("applyStripeCheckoutCompleted", () => {
         activatedMembers: [],
         cleanupPulseTrialStripeSubscriptionId: "sub_123",
         hostedExecutionEventId: null,
+        newlyActivatedMemberIds: [],
         runtimeRecheckMemberIds: [],
         welcomeEmailMemberId: null,
       });
@@ -1551,6 +1557,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1688,6 +1695,7 @@ describe("applyStripeCheckoutCompleted", () => {
         activatedMemberId: null,
         activatedMembers: [],
         hostedExecutionEventId: null,
+        newlyActivatedMemberIds: [],
         runtimeRecheckMemberIds: [],
         welcomeEmailMemberId: null,
       });
@@ -1717,6 +1725,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1743,6 +1752,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1783,6 +1793,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMembers: [],
       cleanupPulseTrialStripeSubscriptionId: "sub_delayed_checkout",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1829,6 +1840,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMembers: [],
       cleanupPulseTrialStripeSubscriptionId: "sub_delayed_checkout",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -2175,6 +2187,7 @@ describe("applyStripeCheckoutCompleted", () => {
       activatedMembers: [],
       cleanupPulseTrialStripeSubscriptionId: "sub_delayed_checkout",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -377,6 +377,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.applyStripeCheckoutCompleted.mockResolvedValue({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.applyStripeCheckoutExpired.mockResolvedValue(undefined);
@@ -385,6 +386,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMemberId: "member_123",
       hostedExecutionEventId: "dispatch_123",
       hostedExecutionMailboxItemId: "mailbox_dispatch_123",
+      newlyActivatedMemberIds: ["member_123"],
       welcomeEmailMemberId: "member_123",
     });
     mocks.applyStripeInvoicePaymentFailed.mockResolvedValue(undefined);
@@ -393,6 +395,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMemberId: null,
       activatedMembers: [],
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.activateHostedMemberForPositiveSourceTx.mockResolvedValue({
@@ -2194,12 +2197,7 @@ describe("hosted Stripe event reconciliation", () => {
       memberId: "member_123",
       prisma: prisma.client,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: prisma.client,
-      sourceEventId: event.id,
-      sourceEventType: event.type,
-    });
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
   });
 
   it("defers Pulse Trial provider authority to the locked checkout owner", async () => {
@@ -2750,6 +2748,10 @@ describe("hosted Stripe event reconciliation", () => {
         },
       ],
       hostedExecutionEventId: "member.activated:family:owner",
+      newlyActivatedMemberIds: [
+        "member_family_owner",
+        "member_family_child",
+      ],
       welcomeEmailMemberId: null,
     });
 
@@ -2818,6 +2820,23 @@ describe("hosted Stripe event reconciliation", () => {
       },
       status: HostedStripeEventStatus.completed,
     }));
+    expect(mocks.sendHostedSignupWelcomeEmailForMember).not.toHaveBeenCalled();
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+      .toHaveBeenCalledTimes(2);
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+      .toHaveBeenNthCalledWith(1, {
+        memberId: "member_family_owner",
+        prisma: prisma.client,
+        sourceEventId: event.id,
+        sourceEventType: event.type,
+      });
+    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
+      .toHaveBeenNthCalledWith(2, {
+        memberId: "member_family_child",
+        prisma: prisma.client,
+        sourceEventId: event.id,
+        sourceEventType: event.type,
+      });
   });
 
   it("prepares Family candidates when a reused subscription still resolves its direct owner", async () => {

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -58,7 +58,7 @@ const mocks = vi.hoisted(() => ({
   reconcileHostedAiUsageGateForBillingModeChangeTx: vi.fn(),
   refreshHostedBillingPlanSwitchToPulsePendingFieldsFromScheduleTx: vi.fn(),
   resolveStripeCustomerContext: vi.fn(),
-  sendHostedSignupNotificationEmailForMemberBestEffort: vi.fn(),
+  scheduleHostedSignupNotificationEmails: vi.fn(),
   sendHostedSignupWelcomeEmailForMember: vi.fn(),
   sendHostedSubscriptionCancellationEmailForMember: vi.fn(),
   signalHostedRuntimeRecheckRuntime: vi.fn(),
@@ -274,8 +274,8 @@ vi.mock("@/src/lib/hosted-onboarding/signup-welcome-email", async () => {
 });
 
 vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
-  sendHostedSignupNotificationEmailForMemberBestEffort:
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort,
+  scheduleHostedSignupNotificationEmails:
+    mocks.scheduleHostedSignupNotificationEmails,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/subscription-cancellation-email", () => ({
@@ -454,7 +454,7 @@ describe("hosted Stripe event reconciliation", () => {
       providerMessageId: "resend_email_123",
       status: "sent",
     });
-    mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mockResolvedValue(undefined);
+    mocks.scheduleHostedSignupNotificationEmails.mockReturnValue(undefined);
     mocks.sendHostedSubscriptionCancellationEmailForMember.mockResolvedValue({
       status: "sent",
     });
@@ -592,19 +592,19 @@ describe("hosted Stripe event reconciliation", () => {
       memberId: "member_123",
       prisma: prisma.client,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).toHaveBeenCalledWith({
-      memberId: "member_123",
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_123"],
       prisma: prisma.client,
       sourceEventId: "evt_invoice_paid_123",
       sourceEventType: "invoice.paid",
     });
     expect(
-      mocks.sendHostedSignupWelcomeEmailForMember.mock.invocationCallOrder[0],
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
     ).toBeLessThan(
-      mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mock.invocationCallOrder[0],
+      mocks.sendHostedSignupWelcomeEmailForMember.mock.invocationCallOrder[0],
     );
     expect(
-      mocks.sendHostedSignupNotificationEmailForMemberBestEffort.mock.invocationCallOrder[0],
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
     ).toBeLessThan(
       vi.mocked(prisma.client.hostedStripeEvent.updateMany).mock.invocationCallOrder.at(-1) ?? 0,
     );
@@ -697,7 +697,7 @@ describe("hosted Stripe event reconciliation", () => {
       }),
     );
     expect(mocks.sendHostedSignupWelcomeEmailForMember).not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
     expect(mocks.sendHostedSubscriptionCancellationEmailForMember).not.toHaveBeenCalled();
     expect(
       mocks.prepareHostedStripeDirectMemberActivationCrypto,
@@ -715,6 +715,7 @@ describe("hosted Stripe event reconciliation", () => {
         subscriptionId: "sub_loser",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -754,6 +755,7 @@ describe("hosted Stripe event reconciliation", () => {
         subscriptionId: "sub_loser",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cleanupHostedStandardCheckoutLoser.mockRejectedValueOnce(
@@ -789,6 +791,7 @@ describe("hosted Stripe event reconciliation", () => {
         subscriptionId: "sub_loser",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cleanupHostedStandardCheckoutLoser.mockRejectedValue(
@@ -1217,6 +1220,7 @@ describe("hosted Stripe event reconciliation", () => {
         activatedMemberId: "member_123",
         hostedExecutionEventId: "dispatch_retry",
         hostedExecutionMailboxItemId: "mailbox_dispatch_retry",
+        newlyActivatedMemberIds: ["member_123"],
         runtimeRecheckMemberIds: ["member_123"],
         welcomeEmailMemberId: null,
       })
@@ -1224,6 +1228,7 @@ describe("hosted Stripe event reconciliation", () => {
         activatedMemberId: "member_123",
         hostedExecutionEventId: "dispatch_retry",
         hostedExecutionMailboxItemId: "mailbox_dispatch_retry",
+        newlyActivatedMemberIds: [],
         runtimeRecheckMemberIds: [],
         welcomeEmailMemberId: null,
       });
@@ -1255,7 +1260,19 @@ describe("hosted Stripe event reconciliation", () => {
     })).resolves.toMatchObject({ status: "completed" });
 
     expect(mocks.applyStripeInvoicePaid).toHaveBeenCalledTimes(2);
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledOnce();
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_123"],
+      prisma: prisma.client,
+      sourceEventId: event.id,
+      sourceEventType: event.type,
+    });
     expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.signalHostedRuntimeRecheckRuntime.mock.invocationCallOrder[0],
+    );
     expect(prisma.rows[0]).toEqual(expect.objectContaining({
       activationResultJson: {
         activationMailboxItemIds: ["mailbox_dispatch_retry"],
@@ -1277,6 +1294,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.applyStripeInvoicePaid.mockResolvedValueOnce({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       runtimeRecheckMemberIds: [],
       welcomeEmailMemberId: null,
     });
@@ -1393,6 +1411,7 @@ describe("hosted Stripe event reconciliation", () => {
       expect(mocks.reconcileHostedAiUsageGateForBillingModeChangeTx)
         .toHaveBeenCalledOnce();
       expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(2);
+      expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
       expect(prisma.rows[0]).toEqual(expect.objectContaining({
         lastErrorCode: null,
         processedAt: expect.any(Date),
@@ -1916,6 +1935,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.applyStripeInvoicePaid.mockResolvedValue({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -2142,6 +2162,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.applyStripeInvoicePaid.mockResolvedValueOnce({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -2163,7 +2184,7 @@ describe("hosted Stripe event reconciliation", () => {
     });
 
     expect(mocks.sendHostedSignupWelcomeEmailForMember).not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
   });
 
   it("uses checkout completion as a welcome candidate so invoice-before-checkout email ordering can recover", async () => {
@@ -2173,6 +2194,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.applyStripeCheckoutCompleted.mockResolvedValueOnce({
       activatedMemberId: null,
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: "member_123",
     });
 
@@ -2197,7 +2219,7 @@ describe("hosted Stripe event reconciliation", () => {
       memberId: "member_123",
       prisma: prisma.client,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
   });
 
   it("defers Pulse Trial provider authority to the locked checkout owner", async () => {
@@ -2268,6 +2290,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMemberId: null,
       cleanupPulseTrialStripeSubscriptionId: "sub_checkout_123",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cancelHostedPulseTrialCheckoutLoserSubscription
@@ -2314,6 +2337,7 @@ describe("hosted Stripe event reconciliation", () => {
         subscriptionId: "sub_checkout_123",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cleanupHostedFamilySponsoredDirectSubscription
@@ -2355,6 +2379,7 @@ describe("hosted Stripe event reconciliation", () => {
         subscriptionId: "sub_checkout_123",
       },
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
     mocks.cleanupHostedFamilySponsoredDirectSubscription.mockRejectedValueOnce(
@@ -2395,6 +2420,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMembers: [],
       cleanupFamilySponsoredStripeSubscriptionId: "sub_123",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
     });
@@ -2444,6 +2470,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMemberId: null,
       cleanupFamilySponsoredStripeSubscriptionId: "sub_123",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       welcomeEmailMemberId: null,
     });
 
@@ -2487,6 +2514,7 @@ describe("hosted Stripe event reconciliation", () => {
       activatedMemberId: null,
       cleanupPulseTrialStripeSubscriptionId: "sub_123",
       hostedExecutionEventId: null,
+      newlyActivatedMemberIds: [],
       subscriptionCancellationEmail: null,
       welcomeEmailMemberId: null,
     });
@@ -2702,8 +2730,8 @@ describe("hosted Stripe event reconciliation", () => {
       memberId: "member_123",
       prisma: prisma.client,
     });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).toHaveBeenCalledWith({
-      memberId: "member_123",
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: ["member_123"],
       prisma: prisma.client,
       sourceEventId: "evt_invoice_paid_123",
       sourceEventType: "invoice.paid",
@@ -2821,22 +2849,16 @@ describe("hosted Stripe event reconciliation", () => {
       status: HostedStripeEventStatus.completed,
     }));
     expect(mocks.sendHostedSignupWelcomeEmailForMember).not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-      .toHaveBeenCalledTimes(2);
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-      .toHaveBeenNthCalledWith(1, {
-        memberId: "member_family_owner",
-        prisma: prisma.client,
-        sourceEventId: event.id,
-        sourceEventType: event.type,
-      });
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort)
-      .toHaveBeenNthCalledWith(2, {
-        memberId: "member_family_child",
-        prisma: prisma.client,
-        sourceEventId: event.id,
-        sourceEventType: event.type,
-      });
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledOnce();
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: [
+        "member_family_owner",
+        "member_family_child",
+      ],
+      prisma: prisma.client,
+      sourceEventId: event.id,
+      sourceEventType: event.type,
+    });
   });
 
   it("prepares Family candidates when a reused subscription still resolves its direct owner", async () => {
@@ -3504,6 +3526,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.stripe.events.retrieve.mockResolvedValue(event);
     mocks.stripe.subscriptions.retrieve.mockResolvedValue(canonicalSubscription);
     mocks.applyStripeSubscriptionUpdated.mockResolvedValueOnce({
+      newlyActivatedMemberIds: [],
       subscriptionCancellationEmail: {
         memberId: "member_123",
         stripeSubscriptionId: "sub_123",
@@ -3541,7 +3564,7 @@ describe("hosted Stripe event reconciliation", () => {
       subscriptionCancellationEmailSentAt: expect.any(Date),
     }));
     expect(mocks.sendHostedSignupWelcomeEmailForMember).not.toHaveBeenCalled();
-    expect(mocks.sendHostedSignupNotificationEmailForMemberBestEffort).not.toHaveBeenCalled();
+    expect(mocks.scheduleHostedSignupNotificationEmails).not.toHaveBeenCalled();
   });
 
   it("retries cancellation feedback email provider failures before completing the receipt", async () => {
@@ -3559,6 +3582,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.stripe.events.retrieve.mockResolvedValue(event);
     mocks.stripe.subscriptions.retrieve.mockResolvedValue(canonicalSubscription);
     mocks.applyStripeSubscriptionUpdated.mockResolvedValue({
+      newlyActivatedMemberIds: [],
       subscriptionCancellationEmail: {
         memberId: "member_123",
         stripeSubscriptionId: "sub_123",
@@ -3631,6 +3655,7 @@ describe("hosted Stripe event reconciliation", () => {
     mocks.stripe.events.retrieve.mockResolvedValue(event);
     mocks.stripe.subscriptions.retrieve.mockResolvedValue(canonicalSubscription);
     mocks.applyStripeSubscriptionUpdated.mockResolvedValue({
+      newlyActivatedMemberIds: [],
       subscriptionCancellationEmail: {
         memberId: "member_123",
         stripeSubscriptionId: "sub_123",

--- a/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-telegram-dispatch.test.ts
@@ -137,6 +137,7 @@ const mocks = vi.hoisted(() => {
       workflowId: "hosted-user-runtime:member_123",
     })),
     materializePendingHostedGroupJoinConfirmationsBestEffort: vi.fn(async () => {}),
+    scheduleHostedSignupNotificationEmails: vi.fn(),
     provisionActiveHostedDomainRootEnvelopeForUserOnly: vi.fn(async () => ({})),
     observeHostedUsageReferralInboundTx: vi.fn(async (): Promise<{
       isBoundReferralTarget: boolean;
@@ -293,6 +294,11 @@ vi.mock("@/src/lib/hosted-growth/usage-referral", () => ({
 vi.mock("@/src/lib/hosted-groups/group-join-confirmation", () => ({
   materializePendingHostedGroupJoinConfirmationsBestEffort:
     mocks.materializePendingHostedGroupJoinConfirmationsBestEffort,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/signup-notification-email", () => ({
+  scheduleHostedSignupNotificationEmails:
+    mocks.scheduleHostedSignupNotificationEmails,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", async () => {
@@ -2886,9 +2892,31 @@ describe("handleHostedOnboardingTelegramWebhook", () => {
     );
   });
 
-  it("sends the accepted family invite reply seeded by the accepted Telegram member id", async () => {
+  it("registers a newly activated Telegram Family member before postcommit work", async () => {
     mocks.runtimeEnv.telegramWebhookSecret = "telegram-secret";
     const acceptedMemberId = "member_telegram_family";
+    mocks.acceptHostedFamilyInviteFromTelegramTx.mockImplementationOnce(async (input: {
+      onAcceptedMemberActivated: (result: {
+        activated: boolean;
+        hostedExecutionEventId: string;
+        hostedExecutionMailboxItemId: string;
+        memberId: string;
+      }) => Promise<void> | void;
+    }) => {
+      await input.onAcceptedMemberActivated({
+        activated: true,
+        hostedExecutionEventId: "member.activated:family:member_telegram_family",
+        hostedExecutionMailboxItemId: "mailbox_member_telegram_family_activation",
+        memberId: acceptedMemberId,
+      });
+      return {
+        groupId: "hbag_telegram",
+        memberId: acceptedMemberId,
+        planCode: "pulse",
+        role: "member",
+        status: "active",
+      };
+    });
     const invite = {
       acceptedAt: null,
       acceptedByMemberId: null,
@@ -2916,6 +2944,12 @@ describe("handleHostedOnboardingTelegramWebhook", () => {
       targetTelegramUsernameLookupKey: createHostedTelegramUsernameLookupKey("@alice_user"),
       updatedAt: new Date("2026-06-18T12:00:00.000Z"),
     };
+    mocks.readHostedMailboxItemOwnerById.mockImplementation(async (input: {
+      mailboxItemId: string;
+    }) => ({
+      id: input.mailboxItemId,
+      userId: acceptedMemberId,
+    }));
     const hostedAccountGroupInviteFindUnique = vi.fn(async () => invite);
     const hostedAccountGroupMembershipFindFirst = vi.fn().mockResolvedValue(null);
     const prisma = withPrismaTransaction({
@@ -3033,12 +3067,16 @@ describe("handleHostedOnboardingTelegramWebhook", () => {
       reason: "family-invite-accepted",
     });
 
-    expect(mocks.provisionActiveHostedDomainRootEnvelopeForUserOnly).toHaveBeenCalledWith({
-      domain: "control",
+    expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
+      memberIds: [acceptedMemberId],
       prisma,
-      reason: "hosted-family.telegram-routing",
-      userId: acceptedMemberId,
     });
+    expect(
+      mocks.scheduleHostedSignupNotificationEmails.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.signalHostedMailboxAppendRuntime.mock.invocationCallOrder[0]
+      ?? Number.POSITIVE_INFINITY,
+    );
     expect(mocks.enqueueHostedExecutionOutbox).toHaveBeenCalledWith(
       expect.objectContaining({
         envelope: expect.objectContaining({

--- a/apps/web/test/hosted-signup-notification-email.test.ts
+++ b/apps/web/test/hosted-signup-notification-email.test.ts
@@ -1,15 +1,26 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  scheduleHostedSignupNotificationEmails,
   sendHostedSignupNotificationEmailForMember,
   sendHostedSignupNotificationEmailForMemberBestEffort,
 } from "@/src/lib/hosted-onboarding/signup-notification-email";
+
+const nextServerMocks = vi.hoisted(() => ({
+  after: vi.fn<(task: () => Promise<void>) => void>(),
+}));
+
+vi.mock("next/server", () => ({
+  after: nextServerMocks.after,
+}));
 
 const mocks = vi.hoisted(() => ({
   claimHostedMemberSignupNotificationEmailAttempt: vi.fn(),
   getPrisma: vi.fn(),
   prisma: {
-    readonly: true,
+    hostedMember: {
+      findUnique: vi.fn(),
+    },
   },
   readHostedMemberCoreState: vi.fn(),
   readHostedMemberEmailAuthorization: vi.fn(),
@@ -45,6 +56,12 @@ describe("hosted signup notification email", () => {
     vi.clearAllMocks();
     mocks.claimHostedMemberSignupNotificationEmailAttempt.mockResolvedValue(true);
     mocks.getPrisma.mockReturnValue(mocks.prisma);
+    mocks.prisma.hostedMember.findUnique.mockResolvedValue({
+      accountGroupMemberships: [],
+      billingStatus: "active",
+      suspendedAt: null,
+      threadContainer: null,
+    });
     mocks.readHostedMemberCoreState.mockResolvedValue({
       billingStatus: "active",
       createdAt: new Date("2026-05-01T00:00:00.000Z"),
@@ -58,6 +75,11 @@ describe("hosted signup notification email", () => {
       stripeCheckoutEmail: null,
       verifiedEmail: null,
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("skips when HOSTED_SIGNUP_NOTIFICATION_EMAILS is unset", async () => {
@@ -78,6 +100,7 @@ describe("hosted signup notification email", () => {
     });
 
     expect(mocks.getPrisma).not.toHaveBeenCalled();
+    expect(mocks.prisma.hostedMember.findUnique).not.toHaveBeenCalled();
     expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
   });
 
@@ -99,7 +122,6 @@ describe("hosted signup notification email", () => {
           "New Murph signup.",
           "",
           "Member ID: member_123",
-          "Billing status: active",
           "Stripe event: invoice.paid",
           "Stripe event ID: evt_123",
         ].join("\n"),
@@ -160,24 +182,29 @@ describe("hosted signup notification email", () => {
 
   it.each([
     {
+      accountGroupMemberships: [],
       billingStatus: "past_due",
       suspendedAt: null,
+      threadContainer: null,
     },
     {
+      accountGroupMemberships: [],
       billingStatus: "active",
       suspendedAt: new Date("2026-05-03T00:00:00.000Z"),
+      threadContainer: null,
     },
   ])(
-    "skips members without active unsuspended billing access (%s)",
-    async ({ billingStatus, suspendedAt }) => {
+    "skips members without canonical active access (%s)",
+    async (memberAccess) => {
       const fetchMock: typeof fetch = async () => {
         throw new Error("fetch should not be called");
       };
+      mocks.prisma.hostedMember.findUnique.mockResolvedValue(memberAccess);
       mocks.readHostedMemberCoreState.mockResolvedValue({
-        billingStatus,
+        billingStatus: memberAccess.billingStatus,
         createdAt: new Date("2026-05-01T00:00:00.000Z"),
         id: "member_123",
-        suspendedAt,
+        suspendedAt: memberAccess.suspendedAt,
         updatedAt: new Date("2026-05-01T00:00:00.000Z"),
       });
 
@@ -198,6 +225,42 @@ describe("hosted signup notification email", () => {
       expect(mocks.claimHostedMemberSignupNotificationEmailAttempt).not.toHaveBeenCalled();
     },
   );
+
+  it("sends for active Family access without presenting direct billing as access state", async () => {
+    mocks.prisma.hostedMember.findUnique.mockResolvedValue({
+      accountGroupMemberships: [{
+        group: {
+          billingStatus: "active",
+          suspendedAt: null,
+        },
+        status: "active",
+      }],
+      billingStatus: "canceled",
+      suspendedAt: null,
+      threadContainer: null,
+    });
+    const fetchMock: typeof fetch = async (_input, init) => {
+      const payload = JSON.parse(String(init?.body));
+      expect(payload.text).toContain("Member ID: member_123");
+      expect(payload.text).not.toContain("Billing status:");
+
+      return new Response(JSON.stringify({ id: "resend_email_123" }), {
+        status: 200,
+      });
+    };
+
+    await expect(sendHostedSignupNotificationEmailForMember({
+      env: {
+        HOSTED_SIGNUP_NOTIFICATION_EMAILS: "founder@example.com",
+        HOSTED_SIGNUP_WELCOME_EMAIL_FROM: "Murph <welcome@example.com>",
+        RESEND_API_KEY: "re_test",
+      },
+      fetchImpl: fetchMock,
+      memberId: "member_123",
+    })).resolves.toMatchObject({ status: "sent" });
+
+    expect(mocks.claimHostedMemberSignupNotificationEmailAttempt).toHaveBeenCalledOnce();
+  });
 
   it("skips when the notification attempt was already claimed", async () => {
     const fetchMock: typeof fetch = async () => {
@@ -344,5 +407,51 @@ describe("hosted signup notification email", () => {
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("founder@example.com");
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("re_sensitive_test");
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("delivery failed");
+  });
+
+  it("registers one post-response task and sends distinct members serially", async () => {
+    vi.stubEnv("HOSTED_SIGNUP_NOTIFICATION_EMAILS", "founder@example.com");
+    vi.stubEnv(
+      "HOSTED_SIGNUP_WELCOME_EMAIL_FROM",
+      "Murph <welcome@example.com>",
+    );
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    let requestsInFlight = 0;
+    let peakRequestsInFlight = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      requestsInFlight += 1;
+      peakRequestsInFlight = Math.max(
+        peakRequestsInFlight,
+        requestsInFlight,
+      );
+      await Promise.resolve();
+      requestsInFlight -= 1;
+      return new Response(JSON.stringify({ id: "resend_email_123" }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    scheduleHostedSignupNotificationEmails({
+      memberIds: ["member_1", "member_2", "member_1"],
+      prisma: mocks.prisma as never,
+      sourceEventId: "evt_123",
+      sourceEventType: "invoice.paid",
+    });
+
+    expect(nextServerMocks.after).toHaveBeenCalledOnce();
+    expect(fetchMock).not.toHaveBeenCalled();
+    const task = nextServerMocks.after.mock.calls[0]?.[0];
+    if (!task) {
+      throw new Error("Expected one scheduled signup-notification task.");
+    }
+    await task();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(peakRequestsInFlight).toBe(1);
+    expect(mocks.claimHostedMemberSignupNotificationEmailAttempt)
+      .toHaveBeenNthCalledWith(1, expect.objectContaining({ memberId: "member_1" }));
+    expect(mocks.claimHostedMemberSignupNotificationEmailAttempt)
+      .toHaveBeenNthCalledWith(2, expect.objectContaining({ memberId: "member_2" }));
   });
 });


### PR DESCRIPTION
## Why and outcome

The internal signup email was coupled to the member welcome-email candidate inside Stripe reconciliation. That missed activations completed by Starter enrollment, the Checkout success return, or Family invite acceptance, while a later standard Checkout could emit a false signup alert without activating anyone.

This change makes newly committed member activation the sole eligibility fact across every current activation owner: Starter, Checkout success, Stripe reconciliation, and Family invite acceptance from the browser, Linq, or Telegram. Each owner registers one native post-response task at its first post-commit boundary; the existing canonical hosted-access predicate, durable per-member claim, and provider idempotency key still guarantee one best-effort attempt. There is no historical backfill.

## Product UX

- Effort: Patch
- Result: Ready
- Affected people: operators receive one alert for a genuine hosted activation; members keep existing welcome and onboarding behavior.
- Walkthrough: verified Starter activation with and without welcome mail; Checkout activation versus welcome-only payment and pending-wake replay; webhook-only activation; browser, Linq, and Telegram Family activation versus accepted-invite replay; later post-commit failure; provider failure; and historical-member exclusion.
- Difference from plan: candidate review proved the runtime wake target was broader than new activation, exact-head round 1 proved registration had to precede other fallible effects and use canonical Family access, and round 2 identified Family invite acceptance as a separate activation owner. The final patch carries the existing activation result to each first post-commit boundary and reuses one scheduler and claim.

## Evidence

- 854 focused Vitest cases passed across 10 files covering notification delivery, member store, Starter enrollment, Checkout success/completion, browser/Linq/Telegram Family acceptance, Stripe billing events, and Stripe reconciliation.
- Hosted-web `typecheck:prepared` passed.
- Focused ESLint passed for every changed TypeScript file.
- `git diff --check` passed.
- Browser, Linq, and Telegram tests prove only a newly committed Family activation is registered, accepted-invite replay is excluded, and registration precedes fallible wake/confirmation work.
- Checkout-cleanup and Stripe runtime-recheck recovery tests prove notification registration occurs before later post-commit failure and is not repeated on activation replay.
- Sender/claim tests prove canonical Family access, one atomic attempt gate, deduplication, and provider concurrency one.

## Non-obvious affected surfaces

- Stripe billing outcomes distinguish newly committed activation from a reusable pending runtime wake.
- Linq instant-start retains deferred runtime-wake behavior; notification registration is synchronous and provider work runs after the response.
- Family reconciliation passes every newly activated member to one serial post-response task.
- Browser, Linq, and Telegram invite acceptance carry only the existing transient activation result to their post-commit owners.
- Later paid-billing, welcome-only events, and accepted-invite replays remain ineligible.

## Architecture and reuse

- Existing systems reused: canonical activation results, each activation owner's first post-commit boundary, native Next `after()`, canonical hosted access, the durable per-member attempt claim, and the Resend idempotency key.
- New logic: transient activation member ids separate activation-now from wake or invite replay.
- New abstractions: one small `scheduleHostedSignupNotificationEmails` helper centralizes candidate deduplication, serial processing, and native post-response registration without owning state.
- State shape: unchanged.
- Complexity intentionally avoided: no schema, queue, worker, durable scheduler, retry service, compatibility layer, historical backfill, or duplicate notification state.

## Hot reply path impact

- Linq instant-start and Family invite acceptance can enter the current-inbound path. The only added critical-path work is synchronous native post-response registration after the owning transaction.
- No notification database read, claim, or Resend request is awaited on that path; the callback processes candidates serially after the response.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool schema, or provider-visible input changed.
- Codex runtime: Not applicable; no prompt, instruction, tool schema, or provider-visible input changed.

## Risks

- Notification work remains outside database transactions. Family fanout is bounded by the existing Family seat cap and processed serially.
- Delivery remains best-effort under the existing claim-before-provider contract. A provider failure does not block activation.
- Outside a Next request context, the helper starts the same best-effort task immediately without awaiting it.
- The change intentionally does not notify historical members or replay completed historical events.

## Review evidence

- Final audit round 1 returned two accepted findings: Family access was checked through direct billing state, and awaited notification work was registered after other fallible post-commit effects. Both were fixed by reusing canonical access and registering one native post-response task at the first post-commit boundary.
- The preliminary specialist pass independently returned the same two findings and no additional findings; both dispositions are covered by the current implementation and tests.
- Final audit round 2 returned one accepted finding: active-plan Family invite acceptance can be the activation owner without a later Stripe event. The current head carries the existing `activated` result through browser, Linq, and Telegram post-commit paths and proves replay suppression.
- Final audit round 3 returned `ROUND_OUTCOME: PASS` on the exact pushed
  remediation head with zero accepted findings.
- The later plan-archive commit changes no production behavior, runtime
  configuration, schema, tests, or implemented contract. GitHub's strict
  up-to-date rule then required the one allowed conflict-free base rebase;
  `git range-diff` proved all five PR commits patch-identical, and the rebased
  head again passed 854 focused tests plus hosted-web typecheck. Neither step
  creates another substantive review round.
- Tooling retries are separate from substantive rounds: one specialist response was an invalid provider rate limit, and one round-2 capture lost its owned target after the valid response completed. The exact thread response was recovered and the duplicated-response recovery friction already has a repository record.

## Anomaly retrospective

- Original requirement: send exactly one internal email for a real new hosted activation across all ways activation can commit, without delaying onboarding or backfilling historical members.
- Shape comparison: the first-reviewed head changed 48 added/1 deleted source lines; the current head changes 152 added/24 deleted source lines. Review remediation added 104 source lines and removed 23 relative to that baseline, below the repository's growth threshold.
- Attribution: round 1 added canonical-access and first-postcommit registration corrections; round 2 exposed that the original owner inventory was too narrowly centered on Starter/Checkout/Stripe and missed callers that activate during Family invite acceptance.
- Decision: continue this PR. The corrected shape still has one sender, one existing durable claim, one scheduler, and no new durable owner, queue, state machine, migration, replay pass, or compatibility path. Splitting the Family owners would divide the same exactly-once activation invariant and make completeness harder to judge.

## Change-shape breakdown

Classification rule: `apps/web/src/**` is source, `apps/web/test/**` is tests/fixtures, architecture/README/execution-plan and Frog files are docs, and no config/tooling or generated files changed. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 152 | 24 |
| Tests/fixtures | 451 | 32 |
| Docs | 156 | 4 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 759 | 60 |

## Deployment concerns

- Deployment: not applicable
- Reason: This is a single hosted-web deploy with no schema, configuration, cross-runtime protocol, or coordinated rollout requirement.

## Changelog

- Changelog: not applicable
- Reason: This corrects an internal operations email only; members receive no new or changed product behavior.

ReviewGPT context sensitivity: sensitive
Reason: the patch changes billing-adjacent external email egress, ordering, and idempotency eligibility.

ReviewGPT first-reviewed head: db296c05d4c207c67838ce2f343ec5685dbe670f
