### PR TITLE
Stop duplicate scheduled reconcile signals

### DIFF
--- a/.agents/friction-log/20260820042201-vercel-ready-deployment/friction.md
+++ b/.agents/friction-log/20260820042201-vercel-ready-deployment/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Vercel Ready deployment can leave production domains on previous build'
+severity: 'major'
+---
+
+## Expected Behavior
+
+After the protected Web deployment reports production Ready, every configured production custom domain should resolve to that exact deployment, or the deploy workflow should fail before reporting completion.
+
+## Current Behavior
+
+A merged Web deployment reached Ready and received the project production aliases, but the primary custom domain remained pinned to the prior deployment. Scheduled production callbacks therefore continued executing old code until an explicit Vercel promotion moved the production domain set.
+
+## Possible Solution
+
+Make the deploy workflow perform and verify an exact deployment promotion. Assert the deployment id behind every production custom domain, including the callback host, before the workflow reports success.
+
+## Minimal Reproducible Example
+
+1. Merge a Web change and wait for its production deployment to report Ready.
+2. Inspect the new deployment aliases and the deployment serving the primary custom domain.
+3. Observe the project aliases on the new deployment while the custom domain still serves the prior deployment.
+4. Promote the exact new deployment and observe the custom domain move.
+
+## Context
+
+This masked an urgent runtime correction: build and project-alias checks were green while minute-scheduled production traffic continued hitting old code. No environment variables or secret values were involved.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1042,13 +1042,15 @@ Last verified: 2026-08-20
   errors remain terminal; the runtime must not create a second artifact retry queue.
 - Hosted device-sync provider cadence and local job continuation are separate
   wake domains. Web's canonical `nextReconcileAt` carries only the provider
-  schedule consumed by the global due-reconcile sweep. The selector suppresses
-  an unchanged due tuple only within the current five-minute recovery bucket;
-  if checkpoint recovery leaves that tuple stale, a later bucket may re-signal
-  the same durable mailbox item. The bounded identities are one canonical
-  schedule event and one durable mailbox item, not one Temporal signal or one
-  provider execution for the tuple's entire lifetime. The canonical mailbox
-  item/event already exists in the committed input workspace. Its read-only
+  schedule consumed by the global due-reconcile sweep. The first durable
+  mailbox append owns the direct Temporal signal. A later recovery bucket may
+  record the same still-due tuple for bounded sweep suppression, but a duplicate
+  append does not re-signal it: the shared mailbox-handoff sweep recovers a
+  never-imported first signal, and the imported runtime work keeps its persisted
+  retry timestamp. The bounded identities are one canonical schedule event and
+  one durable mailbox item, not a new Temporal signal or provider execution in
+  every recovery bucket. The canonical mailbox item/event already exists in the
+  committed input workspace. Its read-only
   provider request classes run before checkpoint 1, which then durably captures
   the replayable post-pull/intermediate state. If checkpoint 2 fails to persist
   record/completion, a cold restore from checkpoint 1 may execute the same HTTP

--- a/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
+++ b/agent-docs/exec-plans/active/2026-08-19-runtime-wake-retirement.md
@@ -57,6 +57,13 @@ All evidence is aggregate and contains no production identifiers.
 - Imported-but-unhandled items remain durable in runtime state with their own
   retry timestamp. Re-signaling them from Web bypassed that owner and recreated
   the minute-level no-op loop.
+- After the imported-frontier correction reached the exact production domain,
+  the handoff sweep fell from roughly twenty candidates per minute to one. A
+  second bounded source remained: about twenty long-running Junction schedules
+  retained the same canonical due tuple, and every five-minute recovery bucket
+  re-signaled their duplicate mailbox items. Those signals produced another
+  delayed wave of successful zero-fetch, zero-import invocations even though
+  the runtime already owned the imported work.
 
 ## Product UX Patch
 
@@ -97,6 +104,10 @@ All evidence is aggregate and contains no production identifiers.
 8. Retire the Web recovery sweep's ownership at the persisted system imported
    frontier, preserve recovery for never-imported items, and verify production
    quiescence after the follow-up Web deployment.
+9. Keep the direct Temporal signal on the first scheduled device-sync mailbox
+   append, but do not signal a duplicate append from a later recovery bucket.
+   Let the imported-frontier handoff sweep recover a missed first signal and the
+   runtime's persisted retry timestamp own imported continuation work.
 
 ## Verification
 
@@ -106,5 +117,8 @@ All evidence is aggregate and contains no production identifiers.
   logs.
 - Follow-up focused regressions, real-PostgreSQL imported-frontier proof, Web
   typecheck, and focused lint: passed.
-- Follow-up exact-head ReviewGPT gates, CI, deploy, and production convergence:
-  pending.
+- Imported-frontier PR, exact-head ReviewGPT gates, required CI, merge, and Web
+  deployment: passed. The production handoff candidate count converged from
+  roughly twenty per minute to one with no warning/error shift.
+- Duplicate due-reconcile signal retirement, exact-head gates, deploy, and final
+  production convergence: pending.

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1592,16 +1592,18 @@ workflow-side direct-wake flags, derived-floor SQL, or lag netting merely to
 avoid harmless post-delivery no-op ensures. There is no direct
 Web-to-Cloudflare message path and no second durable wake authority. Temporal
 remains the sole durable retry and reconciliation owner. The existing
-Temporal scheduled-reconcile
-command also runs one bounded preference-handoff sweep. Web selects live
-`member.preferences.updated` rows above the authoritative system-lane
-`consumed_seq` for active person runtimes or synthetic room runtimes with an
-active owner or current participant, then rechecks canonical runtime access and
-reissues their pointer-only `signalWithStart`; the mailbox row remains the only
-work record and repeated sweeps are idempotent. This is a narrow backstop for
-already-committed hosted style writes from personal Settings or runtime-bound
-conversation controls, not a second queue or a generic mailbox-lag scheduler.
-Other missed post-commit signals still have no web cron backstop.
+Temporal scheduled-reconcile command also runs one bounded preference-handoff
+sweep. Web selects supported system-lane handoff rows above the workspace's
+authoritative imported frontier for active person runtimes or synthetic room
+runtimes with an active owner or current participant, then rechecks canonical
+runtime access and reissues their pointer-only `signalWithStart`. The supported
+rows include preferences, due device-sync work, daily metrics, browser-vault
+refresh, maintenance, and queued Clinical Records retrieval. Import transfers
+retry ownership to the runtime, so the sweep never uses the later
+handled-through frontier as signal authority. The mailbox row remains the only
+work record and repeated sweeps are idempotent. This is a narrow backstop for a
+missed first post-commit handoff, not a second queue or a generic mailbox-lag
+scheduler. Other missed post-commit signals still have no Web cron backstop.
 
 Hosted reply-latency telemetry records only boundaries observed by their owning
 process. Its ingress `acceptedAt` value copies the mailbox row's PostgreSQL

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -2484,6 +2484,12 @@ export async function appendHostedDeviceSyncScheduledReconcileWake(input: {
     healthDataConnectionId: input.connectionId,
     healthDataUserId: input.userId,
     signalFailureMode: "throw",
+    // The first append owns the direct Temporal handoff. A later recovery
+    // bucket can encounter the same durable schedule tuple while its imported
+    // runtime work is still pending; the shared mailbox-handoff sweep recovers
+    // only a never-imported first signal, while imported work keeps its own
+    // persisted retry owner.
+    startWorkflowOnDuplicate: false,
     wake,
     store,
     persist: async () => {},

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -1848,7 +1848,7 @@ describe("hosted device-sync wakes", () => {
     }
   });
 
-  it("re-signals one unchanged due tuple in the next recovery bucket without appending another mailbox item", async () => {
+  it("leaves an unchanged imported due tuple with its runtime retry owner", async () => {
     mocks.appendHostedMailboxEnvelopeTx
       .mockResolvedValueOnce({
         dedupeConflict: false,
@@ -1903,7 +1903,6 @@ describe("hosted device-sync wakes", () => {
       ),
     ).toEqual([canonicalWake.eventId, canonicalWake.eventId]);
     expect(mocks.signalHostedDeviceSyncMailboxRuntime.mock.calls).toEqual([
-      [{ mailboxItemId: "mailbox_existing" }],
       [{ mailboxItemId: "mailbox_existing" }],
     ]);
     expect(mocks.createSignal.mock.calls.map(([request]) => ({


### PR DESCRIPTION
## Outcome

Stops later recovery buckets from sending another Temporal signal for an unchanged scheduled device-sync mailbox item. The first append still signals directly; the imported-frontier handoff sweep remains the recovery owner for a missed first signal.

## Product UX result

Long-running wearable sync work keeps its existing runtime retry owner without repeated empty hosted-runtime starts. Fresh due work and never-imported recovery remain prompt.

## Architecture and reuse

- Existing systems reused: The durable mailbox insertion result, imported-frontier handoff sweep, runtime retry owner, and current-bucket device-sync signal suppression remain the existing owners.
- New logic: Scheduled reconciliation suppresses a direct Temporal signal only when the durable mailbox append reports an unchanged duplicate.
- New abstractions: No new abstraction was added because the existing wake-service option already expresses duplicate signaling policy.
- Complexity intentionally avoided: No new queue, retry loop, scheduler, state owner, or deployment dependency was introduced.

## Direct evidence

- Production: roughly twenty unchanged Junction due tuples were re-signaled every five minutes and produced delayed zero-fetch/zero-import invocations.
- Focused wake-service regression: 185 tests passed.
- Due-sweep and handoff coverage: 17 tests passed; combined post-rebase focused suite: 202 tests passed.
- Web typecheck and focused ESLint passed.
- Local diff verification reached unrelated pre-existing workspace-boundary violations outside this patch.

## Changelog

- Changelog: not applicable
- Reason: This is an internal scheduling reliability correction with no new member-visible feature or workflow.

## Deployment concerns

- Deployment: applicable
- Supported skew: The Web change is compatible with the current Temporal runtime because it only removes redundant duplicate signals while preserving the first signal and durable mailbox item.
- Safe order: Merge the Web change, wait for the exact Vercel build, then promote that build to the production custom domain; no Cloudflare, Render, or Temporal deploy is required.
- Rollback floor: The preceding production Web build remains deployable, but rolling back would restore the duplicate scheduled-signal churn.
- Expected exposure: Before custom-domain promotion and while already-accepted signals drain, production can continue to show the old no-op waves.
- Reversibility: Vercel can promote the preceding production build without a data migration or protocol rollback.
- Convergence proof: Confirm the exact new deployment serves the production custom domain and observe multiple complete five-minute scheduler windows without the roughly twenty-item no-op wave.
- Post-deploy checks: Inspect exact-deployment scheduler logs, bounded runtime-log aggregates, and warning or error counts while confirming fresh device-sync work still runs.

## Risk

Duplicate append recovery now routes through the existing imported-frontier handoff sweep instead of direct re-signal. The inserted first append and durable mailbox identity are unchanged.

ReviewGPT context sensitivity: sensitive — changes hosted retry and Temporal signal ownership.

ReviewGPT first-reviewed head: 1689b29101b35d88c149508dc6dfbe4f36d27e3a