### PR TITLE
Include Apollo in default ReviewGPT lane selection

### DIFF
--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -446,12 +446,11 @@ the current user explicitly asks for it.
    Spotlight or scans unrelated filesystem roots for an app bundle.
 
    `REVIEW_GPT_BROWSER_LANE_COUNT` limits the automatic pool to the first one
-   through six lanes and defaults to four. A value supplied on the current
+   through six lanes and defaults to all six. A value supplied on the current
    command is authoritative; the local config is only a fallback preference and
-   cannot widen or replace that per-run pool cap. A host with provisioned
-   Vonneumann and Apollo profiles opts into all six by setting it in the local
-   `$XDG_CONFIG_HOME/murph/review-gpt.conf`, without committing machine-specific
-   preferences or account details.
+   cannot widen or replace that per-run pool cap. A host can narrow the pool by
+   setting the count in its local `$XDG_CONFIG_HOME/murph/review-gpt.conf`,
+   without committing machine-specific preferences or account details.
 
    A lane is considered usable when its managed profile is unlocked, or when its
    configured CDP endpoint is already alive. The default random path skips a

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1621,7 +1621,7 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
-    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4')
+    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-6')
     expect(reviewGptConfig).toContain('REVIEW_GPT_THREAD_URL')
     expect(reviewGptConfig).toContain('review_gpt_reuses_existing_thread=1')
     expect(reviewGptConfig).toContain(
@@ -1899,7 +1899,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(prReviewGptLoop).toContain('Vonneumann on `9446`')
     expect(prReviewGptLoop).toContain('Apollo on')
     expect(prReviewGptLoop).toContain('`9454`, always with profile `Default`')
-    expect(prReviewGptLoop).toContain('through six lanes and defaults to four')
+    expect(prReviewGptLoop).toContain('through six lanes and defaults to all six')
     expect(prReviewGptLoop).toContain('current installed Brave binary')
     expect(prReviewGptLoop).toContain(
       "passes none of Chromium's background-timer, occluded-window, or renderer",
@@ -2447,8 +2447,8 @@ printf '%s|%s|%s|%s|%s\n' \
         defaultBackgroundMode,
         defaultDisplayMode,
       ] = defaultResult.stdout.trim().split('|')
-      expect(['eragon', 'phlebas', 'hercules', 'mountain']).toContain(defaultLane)
-      expect(defaultLaneCount).toBe('4')
+      expect(['vonneumann', 'apollo']).toContain(defaultLane)
+      expect(defaultLaneCount).toBe('6')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
@@ -2468,7 +2468,7 @@ printf '%s|%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        'main|6|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
       writeHarnessFile(

--- a/scripts/review-gpt-config.test.ts
+++ b/scripts/review-gpt-config.test.ts
@@ -165,6 +165,20 @@ afterEach(() => {
 });
 
 describe("ReviewGPT repository config", () => {
+  it("includes every managed lane in the default automatic pool", () => {
+    const harness = createHarness();
+    const result = runConfig(harness, {
+      REVIEW_GPT_BROWSER_LANE: "auto",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("count=6\n");
+    expect(result.stdout).toContain(
+      "pool=eragon phlebas hercules mountain vonneumann apollo\n",
+    );
+    expect(existsSync(harness.mdfindMarker)).toBe(false);
+  });
+
   it("keeps an explicit per-run lane count above local preferences", () => {
     const harness = createHarness(
       "REVIEW_GPT_BROWSER_LANE_COUNT=6\nMURPH_REVIEW_GPT_BROWSER_LANE_COUNT=5\n",

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -158,7 +158,7 @@ if [[ -n "$review_gpt_direct_browser_lane_count" ]]; then
 elif [[ -n "$review_gpt_direct_compat_browser_lane_count" ]]; then
   review_gpt_browser_lane_count="$review_gpt_direct_compat_browser_lane_count"
 else
-  review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
+  review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-6}}"
 fi
 
 if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then


### PR DESCRIPTION
Normal ReviewGPT runs already support Vonneumann and Apollo, but automatic selection defaults to the first four lanes. This changes the default pool to all six registered managed lanes so Apollo can be selected without a machine-local override; explicit count overrides still narrow the pool.

## Product UX

- Product UX: not applicable. This is internal review tooling with no member-visible product behavior.

## Evidence

- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` — 45 passed, 1 skipped.
- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/review-gpt-config.test.ts` — 5 passed.
- `bash -n scripts/review-gpt.config.sh` — passed.
- `git diff --check` — passed.
- Preliminary specialist: one accepted stale release-contract coverage finding, resolved in the current head; no Product UX, prompt, or frontend finding.

## Non-obvious affected surfaces

- Normal ReviewGPT automatic browser selection expands from four to all six registered managed profiles. The focused config and release-contract tests prove the resulting pool.
- Explicit named-lane selection and per-run or local lane-count narrowing remain unchanged and retain existing coverage.

## Architecture and reuse

- Existing systems reused: The existing six-lane registry, usability probe, randomized selector, and override precedence remain the sole owners.
- New logic: Only the fallback lane count changes from four to six.
- New abstractions: None; the existing count contract is sufficient.
- Complexity intentionally avoided: No second lane list, feature flag, host detection, or profile provisioning logic was added.

## Hot reply path impact

- Not applicable. Internal review tooling does not run on the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request assembly changed.
- Codex: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request assembly changed.

## Change-shape breakdown

Classification uses file role: test files as tests/fixtures, operating guide as docs, shell selector as config/tooling. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 19 | 5 |
| Docs | 4 | 5 |
| Config/tooling | 1 | 1 |
| Generated/other | 0 | 0 |
| Total | 24 | 11 |

ReviewGPT context sensitivity: routine — a narrow internal selector-default change with focused regression coverage.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal review tooling does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal workflow and review tooling only.
