### PR TITLE
Delete obsolete device-sync dirty retention

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-20-companion-import-freshness.md
+++ b/agent-docs/exec-plans/active/2026-08-20-companion-import-freshness.md
@@ -114,5 +114,13 @@ artifacts.
   after deletion. The full device-syncd suite passed 1,255 tests, including the
   exact-identity and scheduled-child regression, and both production-shaped
   Junction late-sleep recovery paths passed. Device-syncd typecheck passed.
-  ReviewGPT round 3, required CI, and final deployment compatibility proof:
-  pending.
+- Final ReviewGPT round three found review-induced dirty-payload retention
+  plumbing whose only producer had already been deleted by the exact-receipt
+  redesign. That unreachable cross-fetch channel was deleted instead of
+  retained as speculative complexity. The production pass now has one explicit
+  authoritative dirty-state fetch owner, while a cold retry refetches the Web
+  source of truth.
+- The focused runtime and production-pass tests passed 205 tests. The full
+  assistant-runtime suite again passed 2,422 tests with five skipped, and
+  assistant-runtime typecheck passed. ReviewGPT round four, required CI, and
+  final deployment compatibility proof: pending.

--- a/agent-docs/exec-plans/completed/2026-08-20-companion-import-freshness.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-companion-import-freshness.md
@@ -1,6 +1,6 @@
 # Project Canonical Imports Into Companion Freshness
 
-Status: active
+Status: completed
 Updated: 2026-08-20
 
 ## Goal
@@ -120,7 +120,12 @@ artifacts.
   retained as speculative complexity. The production pass now has one explicit
   authoritative dirty-state fetch owner, while a cold retry refetches the Web
   source of truth.
-- The focused runtime and production-pass tests passed 205 tests. The full
-  assistant-runtime suite again passed 2,422 tests with five skipped, and
-  assistant-runtime typecheck passed. ReviewGPT round four, required CI, and
-  final deployment compatibility proof: pending.
+- The focused runtime and production-pass tests passed 212 tests on current
+  main. The full assistant-runtime suite passed 2,422 tests with five skipped,
+  and assistant-runtime typecheck passed.
+- The clean follow-up PR full-snapshot ReviewGPT audit returned PASS with no
+  findings. It independently confirmed the single authoritative fetch, cold
+  refetch and relinking, exact receipt gate, staged acknowledgements, retries,
+  and checkpoint promotion. Required CI and production rollout remain release
+  gates outside this completed implementation plan.
+Completed: 2026-08-20

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -150,11 +150,6 @@ interface HostedDirtyDeviceSyncAdmissionResult {
   pendingDirtyPayloadJobs: HostedDeviceSyncRuntimeDirtyPayloadJob[];
 }
 
-interface HostedDeviceSyncWakeHintApplyResult {
-  pendingDirtyPayloadJobs: HostedDeviceSyncRuntimeDirtyPayloadJob[];
-  superseded: boolean;
-}
-
 type HostedRuntimeDeviceSyncStore = ReturnType<typeof requireHostedRuntimeDeviceSyncStore>;
 type HostedAccountHydrationInput = Parameters<HostedRuntimeDeviceSyncStore["hydrateHostedAccount"]>[0];
 type HostedDeviceSyncRuntimeClient = HostedRuntimeDeviceSyncPort | null;
@@ -406,20 +401,15 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
   }
 
   if (input.wake.kind === "device-sync.wake") {
-    const wakeHintResult = await applyHostedDeviceSyncWakeHint({
+    const superseded = await applyHostedDeviceSyncWakeHint({
       wake: input.wake,
       hostedToLocalAccountIds: state.hostedToLocalAccountIds,
       service: input.service,
     });
-    if (wakeHintResult.superseded) {
+    if (superseded) {
       state.wakeSuperseded = true;
       return state;
     }
-    state.pendingDirtyPayloadJobs = wakeHintResult.pendingDirtyPayloadJobs;
-    state.pendingDirtyAcks = buildHostedRetainedDirtyPayloadAcks(
-      wakeHintResult.pendingDirtyPayloadJobs,
-      null,
-    );
   }
   if (
     input.skipDirtyPendingFetch !== true
@@ -431,7 +421,6 @@ export async function syncHostedDeviceSyncControlPlaneState(input: {
       signal: input.signal ?? null,
       service: input.service,
       stagedDirtyAcks: input.stagedDirtyAcks ?? null,
-      retainedDirtyPayloadJobs: state.pendingDirtyPayloadJobs,
       wake: input.wake,
     });
     state.pendingDirtyAcks = dirtyState.acks;
@@ -459,7 +448,6 @@ export async function applyHostedPendingDirtyDeviceSyncStateForWake(input: {
     signal: input.signal ?? null,
     service: input.service,
     stagedDirtyAcks: input.stagedDirtyAcks ?? null,
-    retainedDirtyPayloadJobs: input.state.pendingDirtyPayloadJobs,
     wake: input.wake,
   });
   input.state.pendingDirtyAcks = dirtyState.acks;
@@ -767,9 +755,9 @@ async function applyHostedDeviceSyncWakeHint(input: {
   wake: HostedRuntimeEvent;
   hostedToLocalAccountIds: Map<string, string>;
   service: DeviceSyncService;
-}): Promise<HostedDeviceSyncWakeHintApplyResult> {
+}): Promise<boolean> {
   if (input.wake.kind !== "device-sync.wake") {
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   const wake = resolveHostedDeviceSyncWakeContext(input.wake);
@@ -777,13 +765,13 @@ async function applyHostedDeviceSyncWakeHint(input: {
   const store = requireHostedRuntimeDeviceSyncStore(input.service);
 
   if (!localAccountId) {
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   const account = store.getAccountById(localAccountId);
 
   if (!account) {
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   // Missing epochs remain readable during deploy skew, but have no authority.
@@ -791,7 +779,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
     wake.expectedConnectedAt === null
     || wake.expectedConnectedAt !== account.connectedAt
   ) {
-    return { pendingDirtyPayloadJobs: [], superseded: true };
+    return true;
   }
 
   const terminalStatus = readHostedTerminalDeviceSyncStatus(account);
@@ -802,7 +790,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
       status: terminalStatus,
       store,
     });
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   if (input.wake.reason === "disconnected") {
@@ -813,7 +801,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
       "HOSTED_DEVICE_SYNC_DISCONNECTED",
       "Hosted device-sync wake marked the connection as disconnected.",
     );
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   if (input.wake.reason === "reauthorization_required") {
@@ -827,7 +815,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
       "HOSTED_DEVICE_SYNC_REAUTHORIZATION_REQUIRED",
       "Hosted device-sync wake marked the connection as requiring reconnection.",
     );
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   const jobHints = normalizeHostedDeviceSyncJobHints(wake.hint);
@@ -840,7 +828,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
     && jobHints.length === 0
   ) {
     input.service.queueManualReconcile(localAccountId);
-    return { pendingDirtyPayloadJobs: [], superseded: false };
+    return false;
   }
 
   for (const [index, hint] of jobHints.entries()) {
@@ -872,7 +860,7 @@ async function applyHostedDeviceSyncWakeHint(input: {
     store.patchAccount(localAccountId, wakePatch);
   }
 
-  return { pendingDirtyPayloadJobs: [], superseded: false };
+  return false;
 }
 
 export function resolveHostedDeviceSyncWakeLocalAccountId(input: {
@@ -1041,7 +1029,6 @@ async function applyHostedPendingDirtyDeviceSyncState(input: {
   signal?: AbortSignal | null;
   service: DeviceSyncService;
   stagedDirtyAcks?: readonly HostedExecutionDeviceSyncStagedDirtyAck[] | null;
-  retainedDirtyPayloadJobs?: readonly HostedDeviceSyncRuntimeDirtyPayloadJob[];
   wake: HostedRuntimeEvent;
 }): Promise<{
   acks: HostedDeviceSyncRuntimeDirtyAck[];
@@ -1062,58 +1049,16 @@ async function applyHostedPendingDirtyDeviceSyncState(input: {
       ? { stagedDirtyAcks: [...input.stagedDirtyAcks] }
       : {}),
   });
-  const retainedDirtyPayloadJobs = (input.retainedDirtyPayloadJobs ?? []).map((pendingJob) => ({
-    ...pendingJob,
-  }));
-  const retainedDirtyPayloadIds = new Set(
-    retainedDirtyPayloadJobs.flatMap((pendingJob) =>
-      pendingJob.dirtyPayloadId ? [pendingJob.dirtyPayloadId] : []
-    ),
-  );
   const acks: HostedDeviceSyncRuntimeDirtyAck[] = [];
-  const pendingDirtyPayloadJobs: HostedDeviceSyncRuntimeDirtyPayloadJob[] = [
-    ...retainedDirtyPayloadJobs,
-  ];
-  const unmatchedRetainedJobIndexes = new Set(
-    retainedDirtyPayloadJobs.map((_pendingJob, index) => index),
-  );
+  const pendingDirtyPayloadJobs: HostedDeviceSyncRuntimeDirtyPayloadJob[] = [];
   let hasMoreForWake = pending.hasMore;
 
   for (const dirtyState of pending.items) {
     if (!wakeConnectionId || dirtyState.connectionId !== wakeConnectionId) {
       continue;
     }
-    const unretainedDirtyResources = dirtyState.dirtyResources.filter((resource) =>
-      !resource.dirtyPayloadId || !retainedDirtyPayloadIds.has(resource.dirtyPayloadId)
-    );
-    const matchedRetainedJobIndexes = retainedDirtyPayloadJobs.flatMap((pendingJob, index) =>
-      pendingJob.dirtyPayloadId
-        && dirtyState.dirtyResources.some(
-          (resource) => resource.dirtyPayloadId === pendingJob.dirtyPayloadId,
-        )
-        ? [index]
-        : []
-    );
-    if (unretainedDirtyResources.length === 0 && dirtyState.dirtyResources.length > 0) {
-      for (const index of matchedRetainedJobIndexes) {
-        const retained = retainedDirtyPayloadJobs[index];
-        if (!retained) {
-          continue;
-        }
-        retained.processedRevision = dirtyState.dirtyRevision;
-        unmatchedRetainedJobIndexes.delete(index);
-        mergeHostedDeviceSyncRuntimeDirtyAck(acks, {
-          connectionId: retained.connectionId,
-          nextWakeAt: pending.nextWakeAt,
-          processedRevision: retained.processedRevision,
-        });
-      }
-      continue;
-    }
     const applied = applyHostedDirtyDeviceSyncState({
-      dirtyState: unretainedDirtyResources.length === dirtyState.dirtyResources.length
-        ? dirtyState
-        : { ...dirtyState, dirtyResources: unretainedDirtyResources },
+      dirtyState,
       hostedToLocalAccountIds: input.hostedToLocalAccountIds,
       nextWakeAt: pending.nextWakeAt,
       service: input.service,
@@ -1121,71 +1066,13 @@ async function applyHostedPendingDirtyDeviceSyncState(input: {
     });
 
     if (applied) {
-      for (const index of matchedRetainedJobIndexes) {
-        const retained = retainedDirtyPayloadJobs[index];
-        if (!retained) {
-          continue;
-        }
-        retained.processedRevision = applied.ack.processedRevision;
-        unmatchedRetainedJobIndexes.delete(index);
-      }
-      mergeHostedDeviceSyncRuntimeDirtyAck(acks, applied.ack);
+      acks.push(applied.ack);
       pendingDirtyPayloadJobs.push(...applied.pendingDirtyPayloadJobs);
       hasMoreForWake = hasMoreForWake || applied.deferredJobCount > 0;
     }
   }
 
-  for (const index of unmatchedRetainedJobIndexes) {
-    const retained = retainedDirtyPayloadJobs[index];
-    if (!retained) {
-      continue;
-    }
-    mergeHostedDeviceSyncRuntimeDirtyAck(acks, {
-      connectionId: retained.connectionId,
-      nextWakeAt: pending.nextWakeAt,
-      processedRevision: retained.processedRevision,
-    });
-  }
-
   return { acks, hasMoreForWake, pendingDirtyPayloadJobs };
-}
-
-function buildHostedRetainedDirtyPayloadAcks(
-  pendingJobs: readonly HostedDeviceSyncRuntimeDirtyPayloadJob[],
-  nextWakeAt: string | null,
-): HostedDeviceSyncRuntimeDirtyAck[] {
-  const acks: HostedDeviceSyncRuntimeDirtyAck[] = [];
-  for (const pending of pendingJobs) {
-    mergeHostedDeviceSyncRuntimeDirtyAck(acks, {
-      connectionId: pending.connectionId,
-      nextWakeAt,
-      processedRevision: pending.processedRevision,
-    });
-  }
-  return acks;
-}
-
-function mergeHostedDeviceSyncRuntimeDirtyAck(
-  acks: HostedDeviceSyncRuntimeDirtyAck[],
-  incoming: HostedDeviceSyncRuntimeDirtyAck,
-): void {
-  const existing = acks.find((ack) =>
-    ack.connectionId === incoming.connectionId
-    && ack.processedRevision === incoming.processedRevision
-  );
-  if (!existing) {
-    acks.push(incoming);
-    return;
-  }
-  existing.nextWakeAt = minOptionalIso(existing.nextWakeAt, incoming.nextWakeAt);
-  if (incoming.processedDirtyPayloadIds) {
-    existing.processedDirtyPayloadIds = [
-      ...new Set([
-        ...(existing.processedDirtyPayloadIds ?? []),
-        ...incoming.processedDirtyPayloadIds,
-      ]),
-    ];
-  }
 }
 
 function applyHostedDirtyDeviceSyncState(input: {

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -1739,8 +1739,9 @@ describe("runHostedDeviceSyncPass", () => {
     expect(mocks.createHostedRuntimeDeviceSyncService).not.toHaveBeenCalled();
   });
 
-  it("passes staged dirty ack overlays into control-plane sync", async () => {
+  it("fetches authoritative dirty state once after hydration and preserves staged acks", async () => {
     const close = vi.fn();
+    const deviceSyncPort = createMaintenanceDeviceSyncPortStub();
     const service = {
       close,
       drainWorker: vi.fn(async () => 0),
@@ -1762,7 +1763,7 @@ describe("runHostedDeviceSyncPass", () => {
       },
       "/tmp/vault-root",
       DEVICE_SYNC_CONFIG,
-      createMaintenanceDeviceSyncPortStub(),
+      deviceSyncPort,
       45_000,
       {
         stagedDirtyAcks: [
@@ -1778,6 +1779,20 @@ describe("runHostedDeviceSyncPass", () => {
     expect(mocks.syncHostedDeviceSyncControlPlaneState).toHaveBeenCalledWith(
       expect.objectContaining({
         skipDirtyPendingFetch: true,
+        stagedDirtyAcks: [
+          {
+            connectionId: "dsc_123",
+            processedDirtyPayloadIds: ["dsp_1"],
+            processedRevision: "7",
+          },
+        ],
+      }),
+    );
+    expect(mocks.syncHostedDeviceSyncControlPlaneState).toHaveBeenCalledTimes(1);
+    expect(mocks.applyHostedPendingDirtyDeviceSyncStateForWake).toHaveBeenCalledTimes(1);
+    expect(mocks.applyHostedPendingDirtyDeviceSyncStateForWake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceSyncPort,
         stagedDirtyAcks: [
           {
             connectionId: "dsc_123",


### PR DESCRIPTION
## Outcome

Deletes the now-unreachable cross-fetch dirty-payload retention channel left behind by the exact canonical-import receipt redesign in #2079. The live flow remains explicit: hydrate without fetching dirty state, run the scheduler, fetch authoritative Web dirty state once, then advance freshness only from an exact durable import receipt.

ReviewGPT context sensitivity: sensitive

ReviewGPT sensitivity reason: This is final-review remediation for a health-data freshness path crossing hosted runtime checkpoint behavior.

ReviewGPT first-reviewed head: 7ad944ccb60dd60c4f5bc1cb5fa7830f60561d3f

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: No user-visible behavior changes from #2079. Successful exact Apple Health imports still advance matching freshness; empty, failed, unrelated, or scheduled-only work does not.
- Recovery: A cold runtime retry refetches the Web source of truth instead of carrying process-local dirty payload state.

## Evidence

- Static call-graph proof shows the removed channel had no producer after #2079 deleted dirty-payload wake hints.
- Focused runtime and production-pass suite on current main: 212 tests passed.
- Assistant-runtime typecheck passed.
- The same patch on the original candidate passed the full assistant-runtime suite: 2,422 tests passed with five expected skips.
- ReviewGPT returned PASS with no findings at source head 7ad944c; the current head adds only the completed implementation-plan archive.
- `git diff --check` and private-identifier scans passed.

## Non-obvious affected surfaces

- Removes only review-induced wake-result state, retained payload threading, ack merging, filtering, and revision-rewrite code.
- Keeps ordinary in-pass `pendingDirtyPayloadJobs`, exact canonical import receipt matching, checkpoint promotion, retries, and acknowledgements unchanged.

## Architecture and reuse

- Existing systems reused: The Web dirty-state endpoint remains the single authoritative fetch owner; the existing in-pass pending jobs, exact canonical receipts, checkpoint promotion, and acknowledgement path remain unchanged.
- New logic: None. This change deletes unreachable retention logic and adds one production-pass call-count assertion.
- New abstractions: None. No replacement state owner, queue, dependency, compatibility layer, or helper is added.
- Complexity intentionally avoided: The runtime refetches authoritative Web state on cold retry instead of carrying duplicate process-local state across fetches; 128 source lines are deleted.

## Hot reply path impact

Not applicable. This remains background device-sync work.

## Murph initial provider input impact

- Murph runtime: Not applicable.
- Codex runtime: Not applicable.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 15 | 128 |
| Tests/fixtures | 17 | 2 |
| Docs | 16 | 3 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 48 | 133 |

## Deployment concerns

- Deployment: applicable
- Supported skew: The deleted channel is unreachable, so Web and Cloudflare versions before or after this cleanup keep the same exact-receipt contract.
- Safe order: Keep the already-started backward-compatible Web deployment before the Cloudflare runtime deployment.
- Rollback floor: The SQLite v11 floor from #2079 remains; recover Cloudflare with a forward v11-capable deployment instead of a binary downgrade.
- Expected exposure: No new user-visible exposure is expected because this follow-up removes only dead state plumbing.
- Reversibility: The cleanup can be reverted independently without changing the signed contract or Postgres state, although restoring unreachable code is unnecessary.
- Convergence proof: The merged Web head must contain #2079 and this deletion before the Cloudflare workflow resolves and deploys that public main commit.
- Post-deploy checks: Verify the exact merged Web commit, then require Cloudflare endpoint, container, direct-R2, and live-model smoke checks.

## Changelog

- Changelog: not applicable
- Reason: The member-visible freshness correction and its announcement shipped in #2079; this follow-up only deletes unreachable internal state plumbing.



