### PR TITLE
Retry transient hosted device-sync persistence failures

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1065,11 +1065,14 @@ Last verified: 2026-08-20
   permission/authentication, quota, input, and integrity failures remain
   single-attempt and fail closed; the official SDK's broad default retry budget
   stays disabled.
-- Hosted artifact uploads are content-addressed and replay-safe. Transport failures
-  plus HTTP 408, 429, and 5xx responses carry typed retryability into the existing
-  device-sync job owner, which requeues with its normal bounded backoff. Write-fence
-  and authority failures, other HTTP responses, malformed data, and unclassified
-  errors remain terminal; the runtime must not create a second artifact retry queue.
+- Hosted artifact reads and uploads are content-addressed and replay-safe. Transport
+  failures plus HTTP 408, 429, and 5xx responses carry typed retryability into the
+  existing device-sync job owner, which requeues with its normal bounded backoff.
+  A canonical device-sync checkpoint becomes retryable only after its existing
+  exact-successor reconciliation also fails for a proven timeout or transient
+  transport/status reason. Write-fence, lease, authority, deterministic 4xx,
+  malformed-data, parser, and unclassified failures remain terminal; the runtime
+  must not create a second artifact or checkpoint retry queue.
 - Hosted device-sync provider cadence and local job continuation are separate
   wake domains. Web's canonical `nextReconcileAt` carries only the provider
   schedule consumed by the global due-reconcile sweep. The first durable

--- a/agent-docs/exec-plans/active/2026-08-20-device-sync-transient-read-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-20-device-sync-transient-read-retry.md
@@ -1,0 +1,68 @@
+# Device-sync transient read retry
+
+Status: active
+Created: 2026-08-20
+Updated: 2026-08-20
+
+## Goal
+
+- Preserve the existing device-sync retry budget when hosted artifact reads or
+  canonical checkpoint publication fail for a proven transient transport reason.
+
+## Success criteria
+
+- Typed transient artifact-read failures become retryable device-sync failures
+  instead of terminal `SYNC_JOB_FAILED` results.
+- Proven transient checkpoint transport failures retry after existing
+  reconciliation has ruled out an ambiguous committed result.
+- Authority, lease, parser, integrity, deterministic response, and caller
+  cancellation failures remain terminal or retain their existing semantics.
+- Focused tests and affected package typechecks pass, followed by required
+  ReviewGPT and exact-head CI gates.
+
+## Scope
+
+- In scope: hosted device-sync error translation, focused tests, and durable
+  retry documentation where the existing contract would otherwise be unclear.
+- Out of scope: changing provider fetch windows, retry counts, canonical write
+  authority, checkpoint durability, Junction height conflict behavior, or
+  adding another queue.
+
+## Constraints
+
+- Keep canonical writes atomic and fail closed on ambiguous checkpoint state.
+- Reuse existing typed errors and the existing durable job retry owner.
+- Log and persist only bounded metadata; never expose provider payloads or
+  member identifiers.
+
+## Tasks
+
+1. Prove the current error-translation gap from the hosted artifact and
+   checkpoint boundaries through device-sync job classification.
+2. Add the narrow transient translations and focused regression coverage.
+3. Run focused tests, affected package typechecks, diff/privacy inspection,
+   ReviewGPT, and exact-head CI.
+4. Merge, deploy in the safe compatibility order, and verify bounded runtime
+   evidence.
+
+## Decisions
+
+- Equal-revision Junction height conflicts remain unchanged: they are expected
+  fail-closed provider-data-integrity protection and require the provider to
+  advance or correct its revision.
+- Reuse the current job row and attempt budget; no new retry state owner is
+  introduced.
+
+## Verification
+
+- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/device-sync-service.test.ts`
+  passed with 4 tests.
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-platform.test.ts`
+  passed with 196 tests.
+- `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/service.test.ts -t "keeps per-attempt failure diagnostics after a later job success|exposes safe structured diagnostics for provider failures"`
+  passed with 2 focused retry-policy tests.
+- `pnpm --dir packages/assistant-runtime typecheck` and
+  `pnpm --dir apps/cloudflare typecheck` passed.
+- The full Cloudflare suite passed with 148 files, 2,612 tests, and 2 skipped.
+- `git diff --check` passed; exact-head CI and both required ReviewGPT stages
+  remain pending.

--- a/agent-docs/exec-plans/active/2026-08-20-device-sync-transient-read-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-20-device-sync-transient-read-retry.md
@@ -63,6 +63,8 @@ Updated: 2026-08-20
   passed with 2 focused retry-policy tests.
 - `pnpm --dir packages/assistant-runtime typecheck` and
   `pnpm --dir apps/cloudflare typecheck` passed.
+- `pnpm --dir apps/web test:prepared -- test/changelog-fragments.test.ts`
+  passed with 7 tests, and `pnpm --dir apps/web typecheck` passed.
 - The full Cloudflare suite passed with 148 files, 2,612 tests, and 2 skipped.
 - `git diff --check` passed; exact-head CI and both required ReviewGPT stages
   remain pending.

--- a/agent-docs/exec-plans/completed/2026-08-20-device-sync-transient-read-retry.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-device-sync-transient-read-retry.md
@@ -1,6 +1,6 @@
 # Device-sync transient read retry
 
-Status: active
+Status: completed
 Created: 2026-08-20
 Updated: 2026-08-20
 
@@ -42,8 +42,8 @@ Updated: 2026-08-20
 2. Add the narrow transient translations and focused regression coverage.
 3. Run focused tests, affected package typechecks, diff/privacy inspection,
    ReviewGPT, and exact-head CI.
-4. Merge, deploy in the safe compatibility order, and verify bounded runtime
-   evidence.
+4. Hand off the green, reviewed PR for the separately authorized merge and
+   deployment boundary.
 
 ## Decisions
 
@@ -58,7 +58,8 @@ Updated: 2026-08-20
 - `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/device-sync-service.test.ts`
   passed with 4 tests.
 - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-platform.test.ts`
-  passed with 196 tests.
+  passed with 197 tests after the accepted specialist finding was reproduced
+  and fixed with a real `Response` whose erroring body follows a known `401`.
 - `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/service.test.ts -t "keeps per-attempt failure diagnostics after a later job success|exposes safe structured diagnostics for provider failures"`
   passed with 2 focused retry-policy tests.
 - `pnpm --dir packages/assistant-runtime typecheck` and
@@ -66,5 +67,18 @@ Updated: 2026-08-20
 - `pnpm --dir apps/web test:prepared -- test/changelog-fragments.test.ts`
   passed with 7 tests, and `pnpm --dir apps/web typecheck` passed.
 - The full Cloudflare suite passed with 148 files, 2,612 tests, and 2 skipped.
-- `git diff --check` passed; exact-head CI and both required ReviewGPT stages
-  remain pending.
+- Preliminary specialist ReviewGPT found one medium transport-classification
+  issue: a known non-OK checkpoint status could be lost when its optional body
+  failed. The finding was accepted, reproduced before the fix, and resolved by
+  making the received status authoritative while preserving caller
+  cancellation.
+- Final full ReviewGPT round 2 reviewed exact head
+  `67eeca843bdb2183409b6d49332159cbfaaf6b1a`, confirmed the specialist finding
+  resolved, reported no findings, and returned `ROUND_OUTCOME: PASS` with the
+  required `REVIEW_COMPLETE` marker.
+- All required exact-head GitHub checks passed. The first release
+  build/typecheck attempt reached 679 passing verification-tool tests before
+  an unrelated GitHub Markdown-rendering HTTP 403; its failed-job rerun passed.
+- `git diff --check` passed. PR #2095 is ready for the separately authorized
+  merge/deploy step; neither action was performed in this task.
+Completed: 2026-08-20

--- a/apps/cloudflare/src/runtime-platform/artifact-store.ts
+++ b/apps/cloudflare/src/runtime-platform/artifact-store.ts
@@ -16,11 +16,13 @@ import {
 import type { HostedWorkspaceCheckpointBridgeAuthority } from "./authority-headers.ts";
 import {
   createHostedRuntimeWriteFenceHeaders,
+  isHostedRuntimeInternalAuthorityRejectedError,
   requireHostedRuntimeWriteFenceHeaders,
 } from "./authority-headers.ts";
 import {
   HOSTED_REPLAY_SAFE_READ_RETRY_ATTEMPTS,
   HostedRuntimeControlPlaneFetchError,
+  readHostedRuntimeControlPlaneFetchFailureDiagnostics,
   shouldPreserveHostedRuntimeFetchError,
   shouldRetryHostedRuntimeReplaySafeRead,
   sleepHostedReplaySafeReadRetryDelay,
@@ -307,7 +309,7 @@ export function createCloudflareArtifactStore(input: {
           }
           throw new HostedRuntimeArtifactReadError({
             cause: error,
-            retryable: true,
+            retryable: isRetryableHostedArtifactReadError(error),
           });
         }
         assertHostedArtifactFetchLive(context.signal);
@@ -337,7 +339,7 @@ export function createCloudflareArtifactStore(input: {
         } catch (error) {
           throw new HostedRuntimeArtifactReadError({
             cause: error,
-            retryable: response.status !== 422,
+            retryable: isRetryableHostedArtifactReadStatus(response.status),
           });
         }
         const bodyStartedAt = Date.now();
@@ -426,6 +428,48 @@ export function createCloudflareArtifactStore(input: {
       await putArtifactOnce({ bytes, sha256 });
     },
   };
+}
+
+function isRetryableHostedArtifactReadStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function isRetryableHostedArtifactReadError(error: unknown): boolean {
+  if (isHostedRuntimeInternalAuthorityRejectedError(error)) {
+    return false;
+  }
+
+  const status = readHostedArtifactErrorStatus(error);
+  if (status !== null) {
+    return isRetryableHostedArtifactReadStatus(status);
+  }
+
+  const diagnostics = readHostedRuntimeControlPlaneFetchFailureDiagnostics(error);
+  if (!diagnostics || diagnostics.fetchCallerSignalAborted) {
+    return false;
+  }
+  return diagnostics.fetchCauseKind === "cloudflare_rpc_destroy"
+    || diagnostics.fetchCauseKind === "fetch_failed"
+    || diagnostics.fetchCauseKind === "network"
+    || diagnostics.fetchCauseKind === "timeout";
+}
+
+function readHostedArtifactErrorStatus(error: unknown): number | null {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    for (const key of ["status", "statusCode", "responseStatus"] as const) {
+      const value = (current as Partial<Record<typeof key, unknown>>)[key];
+      if (typeof value === "number" && Number.isSafeInteger(value)) {
+        return value;
+      }
+    }
+    current = "cause" in current
+      ? (current as { cause?: unknown }).cause
+      : null;
+  }
+  return null;
 }
 
 function isRetryableHostedArtifactWriteStatus(status: number): boolean {

--- a/apps/cloudflare/src/runtime-platform/web-control-transport.ts
+++ b/apps/cloudflare/src/runtime-platform/web-control-transport.ts
@@ -381,7 +381,7 @@ async function fetchHostedWebControlPlaneJsonAttempt(
     userId: input.boundUserId,
   });
 
-  const text = await readHostedWebControlPlaneResponseText({
+  const readResponseText = () => readHostedWebControlPlaneResponseText({
     description: input.description,
     maxBytes: input.sensitiveResponseBody?.maxBytes,
     response,
@@ -390,6 +390,16 @@ async function fetchHostedWebControlPlaneJsonAttempt(
   });
   const acceptedStatus = input.acceptedStatuses?.includes(response.status) ?? false;
   if (!response.ok && !acceptedStatus) {
+    let text = "";
+    try {
+      text = await readResponseText();
+    } catch (error) {
+      if (input.signal?.aborted) {
+        throw input.signal.reason ?? error;
+      }
+      // The received status is authoritative even when its optional diagnostic
+      // body is lost at transport.
+    }
     const error = createHostedWebControlPlaneResponseError({
       description: input.description,
       detail: input.sensitiveResponseBody ? "" : text.trim(),
@@ -421,6 +431,7 @@ async function fetchHostedWebControlPlaneJsonAttempt(
     throw error;
   }
 
+  const text = await readResponseText();
   if (!text.trim()) {
     return null;
   }

--- a/apps/cloudflare/src/runtime-platform/workspace-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-port.ts
@@ -1,4 +1,7 @@
-import type { HostedRuntimePlatform } from "@murphai/assistant-runtime/hosted-runtime-contracts";
+import {
+  HostedRuntimeCanonicalCheckpointError,
+  type HostedRuntimePlatform,
+} from "@murphai/assistant-runtime/hosted-runtime-contracts";
 import {
   checkpointHostedRuntimeBridgeWebWorkspace,
   HostedRuntimeBridgeCheckpointLeaseError,
@@ -23,6 +26,7 @@ import {
   isHostedRuntimeInternalAuthorityRejectedError,
   requireHostedRuntimeWriteFenceHeaders,
 } from "./authority-headers.ts";
+import { readHostedRuntimeControlPlaneFetchFailureDiagnostics } from "./control-plane-fetch.ts";
 import {
   fetchHostedWebControlPlaneJson,
   HostedWebControlPlaneResponseError,
@@ -114,7 +118,15 @@ export function createHostedWebWorkspacePort(input: {
         let retried: HostedWorkspaceCheckpointResponse;
         try {
           retried = await checkpointThroughBridge();
-        } catch {
+        } catch (retryError) {
+          if (
+            isTransientHostedWorkspaceCheckpointError(error)
+            && isTransientHostedWorkspaceCheckpointError(retryError)
+          ) {
+            throw new HostedRuntimeCanonicalCheckpointError({
+              cause: error,
+            });
+          }
           throw error;
         }
         if (retried.checkpointed) {
@@ -140,6 +152,46 @@ export function createHostedWebWorkspacePort(input: {
       return response;
     },
   };
+}
+
+function isTransientHostedWorkspaceCheckpointError(error: unknown): boolean {
+  if (
+    error instanceof HostedRuntimeBridgeCheckpointLeaseError
+    || isHostedRuntimeInternalAuthorityRejectedError(error)
+  ) {
+    return false;
+  }
+  if (error instanceof HostedWebControlPlaneResponseError) {
+    return error.status === 408 || error.status >= 500;
+  }
+
+  const diagnostics = readHostedRuntimeControlPlaneFetchFailureDiagnostics(error);
+  if (diagnostics) {
+    if (diagnostics.fetchCallerSignalAborted) {
+      return false;
+    }
+    return diagnostics.fetchCauseKind === "cloudflare_rpc_destroy"
+      || diagnostics.fetchCauseKind === "fetch_failed"
+      || diagnostics.fetchCauseKind === "network"
+      || diagnostics.fetchCauseKind === "timeout";
+  }
+
+  return hasErrorName(error, "TimeoutError");
+}
+
+function hasErrorName(error: unknown, name: string): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error && current.name === name) {
+      return true;
+    }
+    current = "cause" in current
+      ? (current as { cause?: unknown }).cause
+      : null;
+  }
+  return false;
 }
 
 function isAmbiguousHostedWorkspaceCheckpointError(error: unknown): boolean {

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -37,6 +37,7 @@ import {
 import {
   HostedRuntimeArtifactReadError,
   HostedRuntimeArtifactWriteError,
+  HostedRuntimeCanonicalCheckpointError,
 } from "@murphai/assistant-runtime/hosted-runtime-contracts";
 import {
   HOSTED_RUNTIME_EMAIL_EGRESS_RECIPIENT_PATH,
@@ -4735,7 +4736,9 @@ describe("buildHostedExecutionRuntimePlatform", () => {
   });
 
   it.each([
+    { retryable: false, status: 401 },
     { retryable: false, status: 422 },
+    { retryable: true, status: 429 },
     { retryable: true, status: 503 },
   ])("maps artifact HTTP $status to retryable=$retryable", async ({
     retryable,
@@ -8905,6 +8908,89 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(rejected.cause).toBe(firstFailure);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(recordCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("marks canonical checkpoint timeouts retryable only after reconciliation also times out", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new DOMException("Synthetic checkpoint timeout.", "TimeoutError");
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+      },
+    });
+
+    await expect(platform.workspacePort!.checkpoint({
+      attemptId: "attempt_1",
+      expectedWorkspaceVersion: "4",
+      inboxMediaRetentionWakeAt: null,
+      leaseGeneration: "9",
+      nextWakeAt: null,
+      nextWakeReason: null,
+      reason: "canonical_runtime_commit",
+      redactedStatus: {
+        hostedCanonicalWriteReceiptLogByteSize: 512,
+        hostedCanonicalWriteReceiptLogSha256: "2".repeat(64),
+      },
+      snapshotRef: null,
+    })).rejects.toMatchObject({
+      name: "HostedRuntimeCanonicalCheckpointError",
+      retryable: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a deterministic checkpoint rejection terminal after an ambiguous timeout", async () => {
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        throw new DOMException("Synthetic checkpoint timeout.", "TimeoutError");
+      }
+      return new Response("Unauthorized", { status: 401 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+      },
+    });
+
+    let rejected: unknown = null;
+    try {
+      await platform.workspacePort!.checkpoint({
+        attemptId: "attempt_1",
+        expectedWorkspaceVersion: "4",
+        inboxMediaRetentionWakeAt: null,
+        leaseGeneration: "9",
+        nextWakeAt: null,
+        nextWakeReason: null,
+        reason: "canonical_runtime_commit",
+        redactedStatus: {
+          hostedCanonicalWriteReceiptLogByteSize: 512,
+          hostedCanonicalWriteReceiptLogSha256: "3".repeat(64),
+        },
+        snapshotRef: null,
+      });
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toBeInstanceOf(Error);
+    expect(rejected).not.toBeInstanceOf(HostedRuntimeCanonicalCheckpointError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not retry a canonical checkpoint after its active lease changes", async () => {

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -8993,6 +8993,58 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a deterministic checkpoint rejection terminal when its response body is lost", async () => {
+    const firstFailure = new DOMException("Synthetic checkpoint timeout.", "TimeoutError");
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        throw firstFailure;
+      }
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new TypeError("Synthetic response body lost."));
+        },
+      }), { status: 401 });
+    });
+    const platform = buildTestHostedExecutionRuntimePlatform({
+      boundUserId: "member_123",
+      fetchImpl: fetchMock as typeof fetch,
+      workspaceCheckpointBridge: {
+        readCurrentLease: () => ({
+          attemptId: "attempt_1",
+          leaseGeneration: "9",
+          userId: "member_123",
+          workspaceVersion: "4",
+        }),
+      },
+    });
+
+    let rejected: unknown = null;
+    try {
+      await platform.workspacePort!.checkpoint({
+        attemptId: "attempt_1",
+        expectedWorkspaceVersion: "4",
+        inboxMediaRetentionWakeAt: null,
+        leaseGeneration: "9",
+        nextWakeAt: null,
+        nextWakeReason: null,
+        reason: "canonical_runtime_commit",
+        redactedStatus: {
+          hostedCanonicalWriteReceiptLogByteSize: 512,
+          hostedCanonicalWriteReceiptLogSha256: "4".repeat(64),
+        },
+        snapshotRef: null,
+      });
+    } catch (error) {
+      rejected = error;
+    }
+
+    expect(rejected).toMatchObject({
+      hostedRuntimeFetchCauseKind: "timeout",
+    });
+    expect(rejected).not.toBeInstanceOf(HostedRuntimeCanonicalCheckpointError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry a canonical checkpoint after its active lease changes", async () => {
     const fetchMock = vi.fn(async () => {
       throw new Error("Synthetic ambiguous checkpoint failure.");

--- a/apps/web/changelog/entries/2026-08-20/device-sync-recovers-from-short-delays.json
+++ b/apps/web/changelog/entries/2026-08-20/device-sync-recovers-from-short-delays.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-20",
+  "order": 200,
+  "item": {
+    "id": "device-sync-recovers-from-short-delays",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Device sync recovers from short delays",
+    "summary": "Connected health data now keeps its existing retry attempts when a temporary hosted storage interruption affects a sync.",
+    "details": "Only proven temporary read and save failures are retried; permission, malformed-data, and integrity failures still stop immediately.",
+    "relevanceTags": ["device-sync", "reliability", "wearables"],
+    "sourcePullRequests": [2095]
+  }
+}

--- a/packages/assistant-runtime/src/device-sync-service.ts
+++ b/packages/assistant-runtime/src/device-sync-service.ts
@@ -29,7 +29,9 @@ import type {
   ProviderJobConnectionSource,
 } from "@murphai/device-syncd/types";
 import {
+  HostedRuntimeArtifactReadError,
   HostedRuntimeArtifactWriteError,
+  HostedRuntimeCanonicalCheckpointError,
   type HostedRuntimeDeviceSyncPort,
 } from "./hosted-runtime/platform.ts";
 import { hostedSourceStateUnavailable } from "./hosted-device-sync-source-state.ts";
@@ -99,16 +101,34 @@ function createHostedRuntimeDeviceSyncImporter(
 }
 
 function translateHostedRuntimeDeviceSyncImporterError(error: unknown): unknown {
-  if (!(error instanceof HostedRuntimeArtifactWriteError)) {
-    return error;
+  if (error instanceof HostedRuntimeArtifactReadError) {
+    return deviceSyncError({
+      cause: error,
+      code: "HOSTED_DEVICE_SYNC_ARTIFACT_READ_FAILED",
+      httpStatus: error.retryable ? 503 : 500,
+      message: "Hosted device-sync artifact read failed. Retry shortly.",
+      retryable: error.retryable,
+    });
   }
-  return deviceSyncError({
-    cause: error,
-    code: "HOSTED_DEVICE_SYNC_ARTIFACT_WRITE_FAILED",
-    httpStatus: error.retryable ? 503 : 500,
-    message: "Hosted device-sync artifact persistence failed. Retry shortly.",
-    retryable: error.retryable,
-  });
+  if (error instanceof HostedRuntimeArtifactWriteError) {
+    return deviceSyncError({
+      cause: error,
+      code: "HOSTED_DEVICE_SYNC_ARTIFACT_WRITE_FAILED",
+      httpStatus: error.retryable ? 503 : 500,
+      message: "Hosted device-sync artifact persistence failed. Retry shortly.",
+      retryable: error.retryable,
+    });
+  }
+  if (error instanceof HostedRuntimeCanonicalCheckpointError) {
+    return deviceSyncError({
+      cause: error,
+      code: "HOSTED_DEVICE_SYNC_CANONICAL_CHECKPOINT_FAILED",
+      httpStatus: 503,
+      message: "Hosted device-sync canonical checkpoint failed. Retry shortly.",
+      retryable: true,
+    });
+  }
+  return error;
 }
 
 async function listHostedJobConnectionSources(input: {

--- a/packages/assistant-runtime/src/hosted-runtime-contracts.ts
+++ b/packages/assistant-runtime/src/hosted-runtime-contracts.ts
@@ -66,6 +66,7 @@ export {
   HOSTED_RUNTIME_ARTIFACT_READ_PURPOSES,
   HostedRuntimeArtifactReadError,
   HostedRuntimeArtifactWriteError,
+  HostedRuntimeCanonicalCheckpointError,
 } from "./hosted-runtime/platform.ts";
 export {
   HOSTED_SHARED_CHANNEL_PLATFORM_ENV_NAMES,

--- a/packages/assistant-runtime/src/hosted-runtime/platform.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/platform.ts
@@ -188,6 +188,20 @@ export class HostedRuntimeArtifactWriteError extends Error {
   }
 }
 
+export class HostedRuntimeCanonicalCheckpointError extends Error {
+  readonly retryable = true;
+
+  constructor(input: { cause: unknown }) {
+    super(
+      input.cause instanceof Error
+        ? input.cause.message
+        : "Hosted runtime canonical checkpoint failed.",
+      { cause: input.cause },
+    );
+    this.name = "HostedRuntimeCanonicalCheckpointError";
+  }
+}
+
 export interface HostedRuntimeAssistantConfigurationToolPort {
   request(
     request: HostedRuntimeAssistantConfigurationControlRequest,

--- a/packages/assistant-runtime/test/device-sync-service.test.ts
+++ b/packages/assistant-runtime/test/device-sync-service.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 
 import { beforeEach, expect, test, vi } from "vitest";
+import { isDeviceSyncError } from "@murphai/device-syncd/errors";
+import type { CreateDeviceSyncServiceInput } from "@murphai/device-syncd/service";
+import type { DeviceSyncImporterPort } from "@murphai/device-syncd/types";
+import {
+  HostedRuntimeArtifactReadError,
+  HostedRuntimeCanonicalCheckpointError,
+} from "../src/hosted-runtime/platform.ts";
 
 const mocks = vi.hoisted(() => ({
   closeStore: vi.fn(),
@@ -48,3 +55,89 @@ test("hosted runtime device-sync helper closes the store when service creation t
 
   assert.equal(mocks.closeStore.mock.calls.length, 1);
 });
+
+test.each([
+  {
+    code: "HOSTED_DEVICE_SYNC_ARTIFACT_READ_FAILED",
+    error: new HostedRuntimeArtifactReadError({
+      cause: new DOMException("Synthetic artifact timeout.", "TimeoutError"),
+      retryable: true,
+    }),
+    httpStatus: 503,
+    retryable: true,
+  },
+  {
+    code: "HOSTED_DEVICE_SYNC_CANONICAL_CHECKPOINT_FAILED",
+    error: new HostedRuntimeCanonicalCheckpointError({
+      cause: new DOMException("Synthetic checkpoint timeout.", "TimeoutError"),
+    }),
+    httpStatus: 503,
+    retryable: true,
+  },
+  {
+    code: "HOSTED_DEVICE_SYNC_ARTIFACT_READ_FAILED",
+    error: new HostedRuntimeArtifactReadError({
+      cause: new Error("Synthetic artifact integrity failure."),
+      retryable: false,
+    }),
+    httpStatus: 500,
+    retryable: false,
+  },
+])("hosted runtime device-sync translates $code retryable=$retryable into the existing job policy", async ({
+  code,
+  error,
+  httpStatus,
+  retryable,
+}) => {
+  const importer = captureHostedDeviceSyncImporter({
+    async importDeviceProviderSnapshot() {
+      throw error;
+    },
+  });
+
+  let rejected: unknown = null;
+  try {
+    await importer.importDeviceProviderSnapshot({
+      provider: "demo",
+      snapshot: {},
+      vaultRoot: "/tmp/vault-root",
+    });
+  } catch (caught) {
+    rejected = caught;
+  }
+
+  expect(isDeviceSyncError(rejected)).toBe(true);
+  if (!isDeviceSyncError(rejected)) {
+    throw new Error("Expected a device-sync error.");
+  }
+  expect(rejected).toMatchObject({
+    code,
+    httpStatus,
+    retryable,
+  });
+});
+
+function captureHostedDeviceSyncImporter(
+  importer: DeviceSyncImporterPort,
+): DeviceSyncImporterPort {
+  let captured: DeviceSyncImporterPort | null = null;
+  mocks.createDeviceSyncService.mockImplementation((input: CreateDeviceSyncServiceInput) => {
+    captured = input.importer ?? null;
+    return {};
+  });
+
+  createHostedRuntimeDeviceSyncService({
+    secret: "secret-for-tests",
+    config: {
+      publicBaseUrl: "https://sync.example.test/device-sync",
+      vaultRoot: "/tmp/vault-root",
+    },
+    importer,
+    providers: [],
+  });
+
+  if (!captured) {
+    throw new Error("Expected the hosted device-sync importer wrapper.");
+  }
+  return captured;
+}


### PR DESCRIPTION
## Why and outcome

Transient hosted artifact reads and canonical checkpoint transport failures were reaching device-syncd as unknown errors, so the existing job owner marked them terminal on the first attempt. This change preserves the existing bounded retry budget for proven temporary failures while keeping deterministic, authority, lease, parser, integrity, and caller-cancellation failures terminal.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: Members whose connected health-data sync encounters a short hosted storage or control-plane interruption.
- Journey: A proven temporary failure is classified at its runtime boundary, an ambiguous canonical checkpoint is reconciled once, and the existing device-sync job row is requeued with its remaining attempt budget.
- Material exclusions: No provider fetch windows, retry counts, connection status, consent, or visible interaction flow changes. Deterministic and fail-closed failures do not retry.
- Specialist lenses: Product UX and coverage are applicable; prompt and frontend are not applicable because no prompt stack or rendered UI changed.

## Evidence

- Artifact HTTP classification covers terminal 401/422 and retryable 429/503.
- Canonical checkpoint proof covers timeout then timeout as retryable only after two attempts, timeout then readable 401 as terminal, and timeout then a 401 with a lost body as terminal.
- The lost-body regression failed before remediation by producing a retryable checkpoint error; it now preserves the existing ambiguous failure without entering the typed retry path.
- Assistant-runtime translation tests cover retryable artifact reads, retryable canonical checkpoints, and terminal artifact integrity failures.
- Existing device-sync owner tests prove retryable failures are queued with four attempts remaining and non-retryable failures are dead after one attempt.
- `packages/assistant-runtime` focused tests: 4 passed.
- `apps/cloudflare/test/runner-platform.test.ts`: 197 passed.
- Device-sync retry-policy focus: 2 passed.
- Pre-remediation full Cloudflare suite: 148 files passed, 2,612 tests passed, 2 skipped.
- Assistant-runtime, Cloudflare, and Web typechecks passed.
- Changelog fragment registry: 7 passed.
- `git diff --check` passed.
- All required checks passed on final plan-only archive head `fd4e8d03ff2220d13efd55979c9a348b3cf4e8be`; the reviewed code head `67eeca843bdb2183409b6d49332159cbfaaf6b1a` also passed after rerunning one unrelated GitHub Markdown-rendering HTTP 403.
- Preliminary specialist ReviewGPT’s accepted transport-classification finding was reproduced and remediated.
- Final full ReviewGPT round 2 reviewed `67eeca843bdb2183409b6d49332159cbfaaf6b1a`, confirmed the prior finding resolved, reported no findings, and returned `ROUND_OUTCOME: PASS` with `REVIEW_COMPLETE`.

## Non-obvious affected surfaces

- Cloudflare artifact-store reads: narrows retryable HTTP and transport classification so deterministic 4xx, authority failures, caller aborts, and unclassified errors remain terminal.
- Cloudflare web-control transport: keeps a received non-OK status authoritative when its optional diagnostic body is lost, while preserving caller cancellation.
- Cloudflare workspace checkpoint bridge: emits a typed retryable error only after the existing exact-successor reconciliation also fails for a proven transient reason.
- Assistant-runtime device-sync importer: translates the typed runtime failures into the existing device-sync error contract.
- Device-sync job execution: unchanged owner; its existing five-attempt job policy consumes the translated retryability.
- Public changelog: records the member-visible recovery improvement with bounded claims.

## Architecture and reuse

- Existing systems reused: Hosted artifact error types, control-plane diagnostics, exact-successor checkpoint reconciliation, and the existing durable device-sync job retry owner.
- New logic: Strict status/transport classifiers, status-authoritative non-OK response handling, and one retryable checkpoint translation after failed ambiguity reconciliation.
- New abstractions: One narrow `HostedRuntimeCanonicalCheckpointError` marks the already-proven retryable checkpoint boundary.
- Complexity intentionally avoided: No new queue, retry counter, persisted state, repair workflow, or retry of deterministic/fail-closed failures.

## Hot reply path impact

Not applicable. Device-sync importer persistence and background job retry handling do not change the Foreground Reply Critical Path or add awaited work to current-message acceptance, provider start, or durable reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool schema, generated guidance, model selection, or provider-visible request assembly changed.
- Codex runtime: Not applicable; no Codex instruction or provider-visible input surface changed.
- Measurement: Path-level diff inspection; provider-input rendering was unnecessary because no provider-input owner changed.

## Change-shape breakdown

Classification rule: production TypeScript under `src` is source; `*.test.ts` is tests/fixtures; Markdown and the authored changelog fragment are docs/static content; no config/tooling or generated files changed. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 156 | 14 |
| Tests/fixtures | 231 | 0 |
| Docs | 104 | 5 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 491 | 19 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Web has no contract change. Old warm RunnerContainer processes may retain the prior terminal behavior while new runner bundles use the retry translation; both use the same persisted job and checkpoint shapes.
- Safe order: Deploy the Cloudflare Worker/runner bundle normally; no tandem Vercel deployment is required.
- Rollback floor: Rollback is schema-free and returns only to the prior terminal-on-transient behavior.
- Expected exposure: During gradual rollout, jobs handled by an old warm container may still terminate on a transient hosted persistence failure.
- Reversibility: Revert the runner bundle without data migration; existing queued jobs remain valid.
- Convergence proof: Confirm active runner versions converge on the deployed bundle.
- Post-deploy checks: Inspect bounded device-sync failure-code and disposition aggregates for the new artifact-read/checkpoint codes, confirm retryable failures are queued, and verify deterministic failures remain terminal.

## Changelog

- Changelog: updated
- Items: 2026-08-20 · device-sync-recovers-from-short-delays

## Risks

The retry boundary must not reinterpret permission, lease, cancellation, parser, or integrity failures as temporary. Tests exercise transient, deterministic, and lost-diagnostic-body paths; retries stay owned by the existing bounded job row.

ReviewGPT context sensitivity: sensitive
Reason: This changes retry and fail-closed behavior across Cloudflare and shared hosted-runtime owners.

ReviewGPT first-reviewed head: 9a3376d3081cd4f1d3cfe53a3647e764d0ffb80a
