### PR TITLE
Restore all 48 Junction resources

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-20-junction-all-48-resources.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-junction-all-48-resources.md
@@ -1,0 +1,140 @@
+# Restore all 48 Junction resources in hosted collection
+
+Status: completed
+Created: 2026-08-20
+Updated: 2026-08-20
+
+Pull request: #2102
+
+## Goal
+
+- Existing hosted Junction connections collect every one of the 48 supported
+  resource families without requiring a reconnect, while preserving the
+  current bounded scheduling, provider-call, import, and recovery behavior.
+
+## Success criteria
+
+- Hosted production serialization retains the code-owned
+  `JUNCTION_PRODUCTION_TIMESERIES_RESOURCES` list through member overlays.
+- The serialized list is exactly the canonical 48-resource registry, with no
+  duplicate or member-controlled additions.
+- Omitted programmatic configuration still resolves the curated default; only
+  the explicit production assembly changes.
+- Focused resolver and policy tests pass, the affected package and Web
+  typechecks pass, and the changelog fragment validates.
+- The PR documents composed maximum fanout, rollout order, direct evidence,
+  Product UX journeys, and residual freshness risk.
+- Required preliminary and final ReviewGPT gates and exact-head CI are green.
+
+## Scope
+
+- In scope:
+  - Restore the code-owned Junction production resource list in hosted runtime
+    provider configuration.
+  - Restore focused coverage that proves member overlays cannot replace it.
+  - Publish a concise connected-health changelog item.
+- Out of scope:
+  - Changing global omitted-config defaults or per-resource importer support.
+  - Adding concurrency, queues, retry state, provider-specific bypasses, or
+    database work.
+  - Changing member consent, connection setup, or device settings UI.
+
+## Constraints
+
+- Technical constraints:
+  - Keep the provider registry as the one resource-policy owner.
+  - Preserve one bounded resource/day (or closed-hour for page-heavy data)
+    continuation unit, serial pagination, timeout/yield, and dense-stream
+    reduction limits.
+  - Preserve the distinction between an omitted list and an explicit list.
+- Product/process constraints:
+  - No member action or reconnect may be required.
+  - Preserve foreground conversation preemption and existing retry/recovery.
+  - Treat production aggregates as private and include only summarized,
+    identifier-free operational evidence in durable artifacts.
+
+## Risks and mitigations
+
+1. Risk: A full sweep admits 17 more resource families than the current curated
+   hosted default, increasing external provider work and catch-up time.
+   Mitigation: Retain the existing serial continuation, timeout, pagination,
+   dense-data reduction, and retry bounds; deploy the hosted runner first and
+   monitor pass duration, timeout yields, failures, rate limits, and queue age.
+2. Risk: A member overlay could accidentally narrow or expand the production
+   policy.
+   Mitigation: Apply the code-owned list last and assert exact equality in a
+   focused resolver test.
+3. Risk: Deploy skew could advertise broader collection before the hosted
+   runner uses it.
+   Mitigation: The change is runtime-only; publish the Web changelog after the
+   Cloudflare runner rollout is healthy.
+
+## Tasks
+
+1. Confirm the current policy owner, hosted serialization boundary, recent PR
+   overlap, and production recovery/freshness evidence.
+2. Restore the explicit all-48 list at the hosted boundary and update focused
+   tests.
+3. Run scoped tests, typechecks, policy/fanout proof, and Product UX replay.
+4. Push an exact candidate, open the PR, add its changelog fragment, and close
+   this plan in the final scoped commit.
+5. Run preliminary specialist and final ReviewGPT gates alongside exact-head
+   CI, resolve findings, and confirm mergeability.
+
+## Decisions
+
+- The code-owned `JUNCTION_PRODUCTION_TIMESERIES_RESOURCES` export remains the
+  production policy owner. The hosted resolver will preserve it instead of
+  changing all registry entries to enabled-by-default.
+- The 17-resource expansion is accepted at the explicit request of the product
+  owner. Existing production evidence shows recovered scheduling and no recent
+  rate limiting, but timeout-yield frequency still makes rollout monitoring
+  necessary.
+- No new database path is introduced. The control-plane query count and open
+  transaction count are unchanged; added work is bounded external collection.
+
+## Verification
+
+- Commands to run:
+  - Focused assistant-runtime resolver test.
+  - Focused device-sync policy/config tests that assert the 48-resource
+    production list and its bounds.
+  - Affected package typecheck and Web typecheck.
+  - Focused changelog fragment/registry tests after the PR-numbered item lands.
+  - Repository diff/privacy/secret checks and required PR exact-head CI.
+- Expected outcomes:
+  - Hosted serialization contains exactly 48 unique canonical resources after
+    member overlays.
+  - Omitted standalone config retains curated defaults.
+  - No provider concurrency, database fanout, retry ownership, or consent
+    behavior changes.
+
+### Results
+
+- Focused resolver regression proof failed before the source change because the
+  hosted result omitted 47 of the 48 explicit production resources, then passed
+  after the correction (3 tests).
+- Device-sync config and manifest policy coverage passed (73 tests), proving
+  exact all-48 activation and curated omitted-config defaults.
+- Assistant-runtime and device-syncd typechecks passed.
+- The changelog fragment generator, registry, archive rendering, and page tests
+  passed (53 tests); the fully prepared Web typecheck passed.
+- The browser-control runtime was unavailable in this session, so responsive
+  screenshot inspection could not run. The existing server-rendered archive
+  and design-study coverage provided the next-best local representation proof;
+  exact-head CI remains the broad gate.
+- Composed fanout remains bounded at 48 configured resources: 6 wide resources
+  and 42 one-day resources. A full-job continuation owns one resource and one
+  closed UTC day; ordinary collection is at most three serial single-attempt
+  pages with an eight-second timeout per page (24 seconds maximum provider
+  wait), and page-heavy features retry one closed hour. Workout streams admit
+  at most 32 workouts, 100,000 points and 8 MiB per workout through serial
+  reads; ECG admits at most 64 recordings and 100,000 samples per window. Both
+  reduce before snapshot retention.
+- The expansion changes explicit hosted external-provider admission from the
+  current 31 curated resources to 48 (+17, about 55%). It does not add provider
+  concurrency, database queries, transactions, pooled connections, retry state,
+  or work identities. Recent aggregate production evidence showed paired
+  device-sync passes and no provider rate limiting, while frequent bounded
+  timeout yields keep rollout monitoring necessary.
+Completed: 2026-08-20

--- a/apps/web/changelog/entries/2026-08-20/broader-connected-health-coverage.json
+++ b/apps/web/changelog/entries/2026-08-20/broader-connected-health-coverage.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-20",
+  "order": 200,
+  "item": {
+    "id": "broader-connected-health-coverage",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Connected health covers more signals",
+    "summary": "Murph now checks all 48 supported connected-health data families, adding signals such as floors climbed, stand time, workout details, and ECG features when a connected source provides them.",
+    "details": "No reconnect is needed. Unavailable fields stay absent, and dense ECG and workout streams are reduced within existing safety limits before entering the health record.",
+    "relevanceTags": ["connected-health", "device-sync", "wearables"],
+    "sourcePullRequests": [2102]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-provider-configs.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-provider-configs.ts
@@ -54,13 +54,9 @@ export function resolveHostedRuntimeDeviceSyncProviderConfigs(
           [provider]: runtimeConfig,
         })[provider]
       : undefined;
-    const codeOwnedConfig = provider === "junction" && runtimeProviderConfigs.junction
-      ? { timeseriesResources: runtimeProviderConfigs.junction.timeseriesResources }
-      : {};
     runtimeProviderConfigs[provider] = {
       ...(serializableRuntimeConfig ?? {}),
       ...memberConfig,
-      ...codeOwnedConfig,
     } as never;
   }
 

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-provider-configs.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-provider-configs.ts
@@ -27,9 +27,6 @@ export function resolveHostedRuntimeDeviceSyncProviderConfigs(
     const junction = readConfiguredJunctionDeviceSyncProviderConfig(platformEnv);
 
     if (junction) {
-      // Hosted config owns no explicit resource list; preserve that omission so
-      // provider normalization applies the contracts-owned curated defaults.
-      delete junction.timeseriesResources;
       runtimeProviderConfigs.junction = junction;
     }
   }
@@ -57,9 +54,13 @@ export function resolveHostedRuntimeDeviceSyncProviderConfigs(
           [provider]: runtimeConfig,
         })[provider]
       : undefined;
+    const codeOwnedConfig = provider === "junction" && runtimeProviderConfigs.junction
+      ? { timeseriesResources: runtimeProviderConfigs.junction.timeseriesResources }
+      : {};
     runtimeProviderConfigs[provider] = {
       ...(serializableRuntimeConfig ?? {}),
       ...memberConfig,
+      ...codeOwnedConfig,
     } as never;
   }
 

--- a/packages/assistant-runtime/test/hosted-runtime-device-sync-provider-configs.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-device-sync-provider-configs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { JUNCTION_PRODUCTION_TIMESERIES_RESOURCES } from "@murphai/device-syncd/config";
 import { resolveHostedRuntimeDeviceSyncProviderConfigs } from "../src/hosted-runtime/device-sync-provider-configs.ts";
 
 const staticProviderConfigs = {
@@ -60,7 +61,7 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
     });
   });
 
-  it("keeps hosted Junction resources omitted until curated defaults are normalized", () => {
+  it("preserves all 48 code-owned Junction production resources through member overlays", () => {
     const resolved = resolveHostedRuntimeDeviceSyncProviderConfigs(
       {
         junction: {
@@ -68,7 +69,12 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
           region: "us",
         },
       },
-      {},
+      {
+        junction: {
+          environment: "sandbox",
+          region: "us",
+        },
+      },
       {
         JUNCTION_API_KEY: "sk_us_test_runtime",
         JUNCTION_CLIENT_USER_ID_SECRET: "runtime-client-user-secret",
@@ -79,12 +85,13 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
     );
 
     expect(resolved.junction).toMatchObject({
-      apiKey: "sk_us_test_runtime",
-      clientUserIdSecret: "runtime-client-user-secret",
       environment: "sandbox",
       pushSourceRecoveryEnabled: true,
       region: "us",
     });
-    expect(resolved.junction).not.toHaveProperty("timeseriesResources");
+    expect(JUNCTION_PRODUCTION_TIMESERIES_RESOURCES).toHaveLength(48);
+    expect(new Set(JUNCTION_PRODUCTION_TIMESERIES_RESOURCES).size).toBe(48);
+    expect(resolved.junction?.timeseriesResources)
+      .toEqual([...JUNCTION_PRODUCTION_TIMESERIES_RESOURCES]);
   });
 });

--- a/packages/assistant-runtime/test/hosted-runtime-device-sync-provider-configs.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-device-sync-provider-configs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { JUNCTION_PRODUCTION_TIMESERIES_RESOURCES } from "@murphai/device-syncd/config";
+import {
+  createConfiguredDeviceSyncProvidersFromConfigs,
+  JUNCTION_PRODUCTION_TIMESERIES_RESOURCES,
+} from "@murphai/device-syncd/config";
 import { resolveHostedRuntimeDeviceSyncProviderConfigs } from "../src/hosted-runtime/device-sync-provider-configs.ts";
 
 const staticProviderConfigs = {
@@ -61,7 +64,7 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
     });
   });
 
-  it("preserves all 48 code-owned Junction production resources through member overlays", () => {
+  it("preserves all 48 code-owned Junction production resources for hosted members", () => {
     const resolved = resolveHostedRuntimeDeviceSyncProviderConfigs(
       {
         junction: {
@@ -69,12 +72,7 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
           region: "us",
         },
       },
-      {
-        junction: {
-          environment: "sandbox",
-          region: "us",
-        },
-      },
+      {},
       {
         JUNCTION_API_KEY: "sk_us_test_runtime",
         JUNCTION_CLIENT_USER_ID_SECRET: "runtime-client-user-secret",
@@ -85,6 +83,8 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
     );
 
     expect(resolved.junction).toMatchObject({
+      apiKey: "sk_us_test_runtime",
+      clientUserIdSecret: "runtime-client-user-secret",
       environment: "sandbox",
       pushSourceRecoveryEnabled: true,
       region: "us",
@@ -93,5 +93,8 @@ describe("resolveHostedRuntimeDeviceSyncProviderConfigs", () => {
     expect(new Set(JUNCTION_PRODUCTION_TIMESERIES_RESOURCES).size).toBe(48);
     expect(resolved.junction?.timeseriesResources)
       .toEqual([...JUNCTION_PRODUCTION_TIMESERIES_RESOURCES]);
+    expect(createConfiguredDeviceSyncProvidersFromConfigs(resolved)
+      .map((provider) => provider.provider))
+      .toEqual(["junction"]);
   });
 });


### PR DESCRIPTION
## Why and outcome

The hosted runtime deleted Junction's explicit production resource list and fell back to the curated 31-resource default. This removes that hosted-only override, so the platform-owned Junction config retains the code-owned list and hosted production collects all 48 supported resources without a reconnect. Omitted programmatic configurations still use the curated default.

## Product UX

- Effort: Product change
- Walkthrough: Ready
- Established member: Each hosted pass reconstructs the platform-owned Junction config from the hosted environment. Removing the override leaves its code-owned 48-resource policy intact. OAuth, consent, connection, and reconnect behavior are unchanged; Junction member overlays are not part of this path.
- Available ordinary resource: Existing availability checks, resource/day continuations, grouped fetches, and the canonical importer are reused. Coverage follows newly admitted `floors_climbed` data to a `floors-climbed` observation with value 8 and unit `count`.
- Unavailable resource: An ordinary reconcile imports an available resource while 404/422 optional resources are skipped and recorded without blocking the pass or fabricating facts.
- Dense resource: ECG samples reduce to O(recordings) neutral events and compact evidence; workout streams use bounded serial reads and retain only reduced features. Raw sample arrays do not enter retained snapshots.
- Recovery and priority: Existing cursors, retries, cold restore, and timeout yields resume the same resource/window. Current conversations still preempt background collection.
- Exclusions: No immediate-freshness promise, consent change, settings control, or expansion beyond connected and authorized sources.

## Evidence

- Regression proof: the focused hosted resolver test failed at base because the explicit list disappeared, then passed at head with exactly 48 unique resources (3 tests).
- Device-sync policy proof: config and manifest coverage passed (73 tests), including exact all-48 production activation and curated omitted-config behavior.
- Established-member journey: focused production-path coverage confirms the real platform-owned config retains required credentials and exactly 48 resources, constructs the Junction provider, imports available data while skipping unavailable resources, turns `floors_climbed` into a canonical fact, and reduces dense ECG/workout inputs before retention.
- Typechecks: assistant-runtime, device-syncd, and fully prepared hosted Web passed.
- Changelog: fragment generation plus registry, archive render, and page coverage passed (53 tests).
- Repository checks: agent-docs drift and git diff checks passed.
- Operational context: A recent six-hour aggregate showed 1,031 paired device-sync pass starts/finishes, p95 50.8 seconds, no provider 429s, and one active device lane with five pending items. About 41% of passes intentionally yielded at the timeout boundary, so rollout monitoring remains required.
- Visual proof: current-head 320x900 and 1280x900 renders show the real changelog card and surrounding archive. No horizontal overflow: 270/270 CSS px on phone and 774/774 on desktop.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Current-head evidence: phone and desktop renders in the specialist packet exercise the real archive component and authored entry, not a mock.
- Coverage: 320x900 and 1280x900; hierarchy, typography, wrapping, archive context, and overflow.

## Non-obvious affected surfaces

- Cloudflare runner bundle: old and new warm containers can temporarily collect 31 and 48 resources respectively.
- Public changelog: the Web artifact publishes the outcome after runner behavior is live.
- Junction policy normalization and canonical health storage are unchanged.

## Architecture and reuse

- Existing systems reused: The contracts-owned Junction registry, production export, hosted resolver, member overlay, resource/day cursor, bounded provider client, canonical importer, and retry/checkpoint owners.
- New logic: None; deleting the hosted-only resource-list removal restores the existing production policy.
- New abstractions: None; the existing production export and resolver boundary are sufficient.
- Complexity intentionally avoided: No registry, database state, queue, concurrency, retry store, feature flag, environment override, or compatibility shim.

## Hot reply path impact

Not applicable. This changes background configuration only and adds no database, provider, or awaited operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph: Not applicable; no prompt, instruction, model tool schema, or first provider-visible AI request changed.
- Codex: Not applicable; no prompt, instruction, model tool schema, or first provider-visible AI request changed.

## Risks

- Admission rises from 31 to 48 resources: +17, about 55%, for a complete configured sweep.
- The maximum is 48: 6 wide and 42 one-day. A continuation owns one resource and one closed UTC day. Ordinary collection allows at most three serial single-attempt pages with an eight-second timeout, or 24 seconds provider wait; page-heavy features retry one closed hour.
- Workout streams admit at most 32 workouts, 100,000 points, and 8 MiB per workout through serial reads. ECG admits at most 64 recordings and 100,000 samples per window. Both reduce before retention.
- Database query count, open transactions, peak pooled connections, provider concurrency, work identities, and retry ownership are unchanged.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 3 |
| Tests/fixtures | 12 | 2 |
| Docs | 154 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 166 | 5 |

## Changelog

- Changelog: updated
- Items: 2026-08-20 · broader-connected-health-coverage

## Deployment concerns

- Deployment: applicable
- Deploy unit: behavior ships in the Cloudflare runner/container; changelog ships in Vercel. Protocol and persisted shapes do not change.
- Supported skew: New containers collect 48 while old warm containers collect 31. Both write identical canonical shapes and use the same resource/window cursor.
- Safe order: Deploy Cloudflare runner, let the container version converge, then publish Vercel changelog.
- Rollback floor: None. Reverting returns future collection to 31; accepted canonical facts remain valid.
- Expected exposure: One rollout window can show different breadths. Each invocation remains bounded and foreground-preemptible.
- Reversibility: Revert runner independently; no Web or database rollback is required for correctness.
- Convergence proof: Confirm active managed-container version matches this head and hosted resolver smoke reports exactly 48.
- Post-deploy checks: Monitor p95/p99 duration, timeout-yield ratio, failures by status class, provider 429s, pending-item age, and foreground latency.

ReviewGPT context sensitivity: sensitive - expands health-data provider collection and hosted rollout surface.

ReviewGPT first-reviewed head: 85c5d9354f1b7d662ef279de17461fc82caacc03