### PR TITLE
fix(cloudflare): preserve partial Queue metrics

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-20-device-webhook-queue-partial-metrics.md
+++ b/agent-docs/exec-plans/active/2026-08-20-device-webhook-queue-partial-metrics.md
@@ -1,0 +1,84 @@
+# Device webhook Queue partial metrics
+
+Status: active
+Created: 2026-08-20
+Updated: 2026-08-20
+
+## Goal
+
+- Stop valid partial Cloudflare Queue observations from masquerading as total
+  monitoring failures while preserving alerts for real queue API loss, dead
+  letters, and provably stalled main-queue messages.
+
+## Success criteria
+
+- A nonzero backlog with an omitted optional oldest-message timestamp preserves
+  the returned count and byte metrics and does not increment the metric-failure
+  streak or page as "metrics unavailable."
+- Real rejected or invalid Queue metric reads still become typed partial/failed
+  observations and page after the existing consecutive-check threshold.
+- Dead-letter backlog and timestamp-backed main-queue stall alerts remain
+  unchanged and covered.
+- Focused Cloudflare tests and typecheck pass, required ReviewGPT gates pass,
+  and exact-head required CI is green before merge.
+
+## Scope
+
+- In scope: device-webhook Queue metric normalization, monitor tests, and the
+  narrow operator-facing monitoring contract.
+- Out of scope: queue consumer behavior, retry or DLQ configuration, provider
+  ingestion, queue draining, new state/schema owners, or alert transport.
+
+## Constraints
+
+- Technical constraints: Cloudflare documents `oldestMessageTimestamp` as
+  optional; unavailable age must stay unknown rather than becoming zero, while
+  independent count/byte signals remain usable.
+- Product/process constraints: keep the smallest rollback-compatible change,
+  preserve the production-critical webhook path, and deploy only after the
+  protected Worker checks pass.
+
+## Risks and mitigations
+
+1. Risk: accepting an absent timestamp could hide a real stalled queue.
+   Mitigation: retain timestamp-backed stall detection and independent DLQ/API
+   failure alerts; do not infer a healthy age from missing data.
+2. Risk: changing stored observation semantics could require a Durable Object
+   migration or break rollback.
+   Mitigation: retain the existing snapshot schema and represent the optional
+   timestamp with its existing nullable field.
+
+## Tasks
+
+1. Prove the production failure mode against Cloudflare metrics, runtime flow,
+   and the monitor's exact collection path.
+2. Normalize the provider-documented optional timestamp without discarding
+   valid count and byte metrics.
+3. Add regressions for partial timestamps and unchanged real-failure alerts.
+4. Run focused tests/typecheck, inspect the diff, and complete ReviewGPT/CI.
+5. Merge the approved PR and retire the task worktree.
+
+## Decisions
+
+- Rejected treating the REST sentinel as a real epoch timestamp: the Worker
+  binding intentionally exposes that field as optional, and zero would create
+  a false decades-old stall.
+- Rejected adding a second monitoring state machine: the existing nullable
+  timestamp already expresses unknown age while count and byte metrics remain
+  authoritative for the fields Cloudflare returned.
+- Live production proof showed the Queue metrics endpoint succeeding while the
+  optional age was unknown, the dead-letter queue was empty, and webhook traces
+  plus hosted imports continued completing after the alert. The failure was in
+  Murph's observation normalization rather than Queue delivery or credentials.
+
+## Verification
+
+- Commands to run: the focused device-webhook Queue health monitor test, the
+  Cloudflare typecheck, `git diff --check`, required exact-head GitHub checks,
+  and the repository's preliminary/final ReviewGPT gates.
+- Expected outcomes: missing optional age remains a successful observation with
+  preserved backlog metrics and no false page; genuine metric rejection, DLQ
+  backlog, and timestamp-backed stall tests remain green.
+- Current local proof: the focused monitor suite passes 9 tests, the Cloudflare
+  typecheck passes, the full Cloudflare Node suite passes 2,614 tests with two
+  skips, and `git diff --check` is clean.

--- a/agent-docs/exec-plans/active/2026-08-20-device-webhook-queue-partial-metrics.md
+++ b/agent-docs/exec-plans/active/2026-08-20-device-webhook-queue-partial-metrics.md
@@ -38,6 +38,21 @@ Updated: 2026-08-20
   preserve the production-critical webhook path, and deploy only after the
   protected Worker checks pass.
 
+## Product UX
+
+- Effort: Patch.
+- Outcome: on-call operators stop receiving false total-metrics-loss pages
+  without seeing an unknown queue age represented as confirmed health.
+- Reaches: the existing five-minute Queue-health observation and Linq paging
+  journey only.
+- Proof: provider-shaped monitor sequences preserve partial backlog data, reset
+  only the real read-failure streak, keep an existing stall incident open, and
+  recover only after a complete healthy sample.
+- Walkthrough: an unknown-age positive backlog persists as partial without a
+  page; a real read failure still pages after two checks; a timestamp-backed
+  stall retains its incident and one-hour pacing across an unknown-age sample;
+  an empty queue closes the incident. Result: Ready.
+
 ## Risks and mitigations
 
 1. Risk: accepting an absent timestamp could hide a real stalled queue.
@@ -70,6 +85,13 @@ Updated: 2026-08-20
   optional age was unknown, the dead-letter queue was empty, and webhook traces
   plus hosted imports continued completing after the alert. The failure was in
   Murph's observation normalization rather than Queue delivery or credentials.
+- Accepted both preliminary findings and the final round-one finding. Unknown
+  age is now an existing `partial` observation with no alert condition, so it
+  cannot close a real incident; the specialist coverage artifact added the
+  focused failure-streak reset sequence and touched tests only.
+- Refreshed Product UX purpose verdict after remediation: Ready. The smallest
+  complete operator experience distinguishes successful partial telemetry from
+  both confirmed queue health and actual metric-read failure.
 
 ## Verification
 
@@ -79,6 +101,6 @@ Updated: 2026-08-20
 - Expected outcomes: missing optional age remains a successful observation with
   preserved backlog metrics and no false page; genuine metric rejection, DLQ
   backlog, and timestamp-backed stall tests remain green.
-- Current local proof: the focused monitor suite passes 9 tests, the Cloudflare
-  typecheck passes, the full Cloudflare Node suite passes 2,614 tests with two
-  skips, and `git diff --check` is clean.
+- Current local proof: the remediated focused monitor suite passes 11 tests,
+  the Cloudflare typecheck passes, the pre-remediation full Cloudflare Node
+  suite passes 2,614 tests with two skips, and `git diff --check` is clean.

--- a/agent-docs/exec-plans/completed/2026-08-20-device-webhook-queue-partial-metrics.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-device-webhook-queue-partial-metrics.md
@@ -1,6 +1,6 @@
 # Device webhook Queue partial metrics
 
-Status: active
+Status: completed
 Created: 2026-08-20
 Updated: 2026-08-20
 
@@ -92,6 +92,14 @@ Updated: 2026-08-20
 - Refreshed Product UX purpose verdict after remediation: Ready. The smallest
   complete operator experience distinguishes successful partial telemetry from
   both confirmed queue health and actual metric-read failure.
+- Final ReviewGPT round 2 returned `PASS` with no qualifying findings on the
+  corrected head. Its waited browser capture lost debugger access only after
+  ChatGPT completed the response; a read-only export of the same exact thread
+  recovered the marked response without resending the review.
+- Parent final review found no remaining correctness, privacy, architecture,
+  deployment-skew, or proof gap. The production diff remains a net deletion and
+  reuses the existing nullable snapshot, partial status, incident, and pacing
+  owners.
 
 ## Verification
 
@@ -101,6 +109,10 @@ Updated: 2026-08-20
 - Expected outcomes: missing optional age remains a successful observation with
   preserved backlog metrics and no false page; genuine metric rejection, DLQ
   backlog, and timestamp-backed stall tests remain green.
-- Current local proof: the remediated focused monitor suite passes 11 tests,
-  the Cloudflare typecheck passes, the pre-remediation full Cloudflare Node
-  suite passes 2,614 tests with two skips, and `git diff --check` is clean.
+- Current local proof: the remediated focused monitor suite passes 11 tests and
+  the Cloudflare typecheck passes. The remediated full Cloudflare Node suite
+  passed 2,615 tests with two skips and hit one unrelated 60-second Clinical
+  Records timeout under concurrent browser load; the isolated file then passed
+  all 14 tests in 1.75 seconds. Exact-head required CI is green and
+  `git diff --check` is clean.
+Completed: 2026-08-20

--- a/apps/cloudflare/src/device-webhook-queue-health/monitor.ts
+++ b/apps/cloudflare/src/device-webhook-queue-health/monitor.ts
@@ -259,6 +259,9 @@ function buildObservation(input: {
     });
   }
   const oldestMainMessageAtMs = input.main?.oldestMessageAtMs ?? null;
+  const mainQueueHealthIncomplete = input.main !== null
+    && input.main.backlogCount > 0
+    && oldestMainMessageAtMs === null;
   if (oldestMainMessageAtMs !== null) {
     const ageMs = Math.max(0, input.observedAtMs - oldestMainMessageAtMs);
     if (ageMs >= DEVICE_WEBHOOK_QUEUE_STALL_AGE_MS) {
@@ -287,7 +290,7 @@ function buildObservation(input: {
     main: input.main,
     observedAtMs: input.observedAtMs,
     status: input.failedQueues.length === 0
-      ? "ok"
+      ? mainQueueHealthIncomplete ? "partial" : "ok"
       : input.failedQueues.length === 2
       ? "failed"
       : "partial",

--- a/apps/cloudflare/src/device-webhook-queue-health/monitor.ts
+++ b/apps/cloudflare/src/device-webhook-queue-health/monitor.ts
@@ -237,13 +237,6 @@ async function readQueueMetrics(
   ) {
     throw new Error(`Invalid ${queueName} Queue oldest-message timestamp.`);
   }
-  if (
-    queueName === "main"
-    && metrics.backlogCount > 0
-    && oldestMessageAtMs === null
-  ) {
-    throw new Error("Main Queue backlog is missing its oldest-message timestamp.");
-  }
   return {
     backlogBytes: metrics.backlogBytes,
     backlogCount: metrics.backlogCount,

--- a/apps/cloudflare/test/device-webhook-queue-health-monitor.test.ts
+++ b/apps/cloudflare/test/device-webhook-queue-health-monitor.test.ts
@@ -105,6 +105,41 @@ describe("device webhook Queue health monitor", () => {
     );
   });
 
+  it("preserves backlog metrics when Cloudflare cannot determine message age", async () => {
+    const unknownAgeMetrics = metrics({
+      backlogBytes: 1_024,
+      backlogCount: 5,
+    });
+    const harness = createHarness({
+      mainMetrics: [unknownAgeMetrics, unknownAgeMetrics],
+    });
+
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "ok",
+      outcome: "healthy",
+    });
+
+    harness.setNow(FIVE_MINUTES_MS * 2);
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "ok",
+      outcome: "healthy",
+    });
+
+    expect(harness.monitor.readLatestObservation()).toMatchObject({
+      failedQueues: [],
+      main: {
+        backlogBytes: 1_024,
+        backlogCount: 5,
+        oldestMessageAtMs: null,
+      },
+      status: "ok",
+    });
+    expect(harness.monitor.readState().consecutiveMetricsFailures).toBe(0);
+    expect(harness.sent).toEqual([]);
+  });
+
   it("requires two consecutive metric failures before paging monitoring loss", async () => {
     const harness = createHarness({
       mainMetrics: [new Error("synthetic metrics failure")],

--- a/apps/cloudflare/test/device-webhook-queue-health-monitor.test.ts
+++ b/apps/cloudflare/test/device-webhook-queue-health-monitor.test.ts
@@ -116,15 +116,15 @@ describe("device webhook Queue health monitor", () => {
 
     await expect(harness.run()).resolves.toEqual({
       conditions: [],
-      observationStatus: "ok",
-      outcome: "healthy",
+      observationStatus: "partial",
+      outcome: "alert_deferred",
     });
 
     harness.setNow(FIVE_MINUTES_MS * 2);
     await expect(harness.run()).resolves.toEqual({
       conditions: [],
-      observationStatus: "ok",
-      outcome: "healthy",
+      observationStatus: "partial",
+      outcome: "alert_deferred",
     });
 
     expect(harness.monitor.readLatestObservation()).toMatchObject({
@@ -134,9 +134,103 @@ describe("device webhook Queue health monitor", () => {
         backlogCount: 5,
         oldestMessageAtMs: null,
       },
-      status: "ok",
+      status: "partial",
     });
     expect(harness.monitor.readState().consecutiveMetricsFailures).toBe(0);
+    expect(harness.sent).toEqual([]);
+  });
+
+  it("does not close or re-page a stalled incident while backlog age is unknown", async () => {
+    const stalledMetrics = metrics({
+      backlogCount: 1,
+      oldestMessageAtMs: FIVE_MINUTES_MS,
+    });
+    const harness = createHarness({
+      mainMetrics: [
+        stalledMetrics,
+        metrics({ backlogCount: 1 }),
+        stalledMetrics,
+        metrics(),
+      ],
+      nowMs: 20 * 60 * 1_000,
+    });
+
+    await expect(harness.run()).resolves.toMatchObject({
+      outcome: "alert_sent",
+    });
+    expect(harness.sent).toHaveLength(1);
+
+    harness.setNow(25 * 60 * 1_000);
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "partial",
+      outcome: "alert_deferred",
+    });
+    expect(harness.monitor.readState()).toMatchObject({
+      incidentOpen: true,
+      incidentSequence: 1,
+    });
+
+    harness.setNow(30 * 60 * 1_000);
+    await expect(harness.run()).resolves.toMatchObject({
+      conditions: [{ kind: "main_queue_stalled" }],
+      outcome: "alert_deferred",
+    });
+    expect(harness.sent).toHaveLength(1);
+    expect(harness.monitor.readState()).toMatchObject({
+      incidentOpen: true,
+      incidentSequence: 1,
+    });
+
+    harness.setNow(35 * 60 * 1_000);
+    await expect(harness.run()).resolves.toMatchObject({
+      outcome: "healthy",
+    });
+    expect(harness.monitor.readState().incidentOpen).toBe(false);
+  });
+
+  it("resets a real metric failure after a successful unknown-age sample", async () => {
+    const harness = createHarness({
+      mainMetrics: [
+        new Error("synthetic metrics failure"),
+        metrics({
+          backlogBytes: 1_024,
+          backlogCount: 5,
+        }),
+        new Error("synthetic metrics failure"),
+      ],
+    });
+
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "partial",
+      outcome: "alert_deferred",
+    });
+    expect(harness.monitor.readState().consecutiveMetricsFailures).toBe(1);
+
+    harness.setNow(FIVE_MINUTES_MS * 2);
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "partial",
+      outcome: "alert_deferred",
+    });
+    expect(harness.monitor.readLatestObservation()).toMatchObject({
+      failedQueues: [],
+      main: {
+        backlogBytes: 1_024,
+        backlogCount: 5,
+        oldestMessageAtMs: null,
+      },
+    });
+    expect(harness.monitor.readState().consecutiveMetricsFailures).toBe(0);
+
+    harness.setNow(FIVE_MINUTES_MS * 3);
+    await expect(harness.run()).resolves.toEqual({
+      conditions: [],
+      observationStatus: "partial",
+      outcome: "alert_deferred",
+    });
+    expect(harness.monitor.readState().consecutiveMetricsFailures).toBe(1);
     expect(harness.sent).toEqual([]);
   });
 


### PR DESCRIPTION
## Outcome

Cloudflare Queue metrics can legitimately report backlog count and bytes while the oldest-message timestamp is unknown. The monitor previously discarded that successful snapshot and incremented its total metric-failure streak, producing repeated false "metrics unavailable" pages.

This change preserves the usable count and byte metrics, records a positive backlog with unknown age as partial rather than healthy, and keeps the existing behavior for real Queue read failures, dead-letter backlog, and timestamp-backed main-queue stalls.

## Product UX

- Effort: Patch
- Outcome: On-call operators stop receiving false total-metrics-loss pages without seeing unknown queue age represented as confirmed health.
- Reaches: The existing five-minute Queue-health observation and Linq paging journey only.
- Proof: Provider-shaped monitor sequences preserve partial backlog data, reset only the real read-failure streak, retain an existing stall incident and hourly pacing, and recover only after a complete healthy sample.
- Walkthrough: Unknown-age positive backlog is partial with no page; a real read failure still pages after two checks; a timestamp-backed stall remains one incident across an unknown-age sample; an empty queue closes it.
- Result: Ready

## Evidence

- Live, secret-safe production checks showed the Queue metrics request succeeding while age was unknown, the dead-letter queue was empty, and webhook processing plus hosted imports continued after the alert.
- Cloudflare documents the endpoint as best-effort/approximate, returns zero when oldest age is unknown, and exposes the Worker field as optional: https://developers.cloudflare.com/api/resources/queues/methods/get_metrics
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/device-webhook-queue-health-monitor.test.ts --no-coverage` — 11 tests passed on the remediated head.
- `pnpm --dir apps/cloudflare typecheck` — passed on the remediated head.
- `pnpm --dir apps/cloudflare test:node` — 2,615 tests passed, 2 skipped, and one unrelated Clinical Records test hit its 60-second timeout under concurrent browser load; the isolated file then passed all 14 tests in 1.75 seconds.
- `git diff --check` — passed.
- Preliminary specialist result: findings resolved. Product UX now uses the existing partial status; the accepted coverage artifact touched only the focused Vitest file and added the failure → unknown age → failure reset sequence.
- Final ReviewGPT round 1: finding resolved with the same partial-state correction plus stall → unknown age → stall pacing/recovery coverage.
- Final ReviewGPT round 2: PASS with no qualifying findings on `33dacb208447`. The original waited browser capture lost debugger access after ChatGPT completed; a read-only export of that same exact thread recovered the marked `REVIEW_COMPLETE` response without resending the review.
- Parent final review: no remaining correctness, privacy, architecture, deploy-skew, or proof gap.

Preliminary specialist lenses: Product UX applicable (Patch, Ready); prompt not applicable; frontend not applicable; coverage applicable.

## Non-obvious affected surfaces

- Cloudflare Queue-health Durable Object observation semantics: a positive backlog with unknown age is now a successful partial observation, resets the real metric-read failure streak, and cannot close an existing incident. The persisted schema and nullable timestamp representation are unchanged.
- Incident reminder pacing: a known stall, unknown-age sample, and recurring known stall remain one incident, preventing a duplicate page inside the existing one-hour interval.
- Queue delivery, consumer acknowledgements, retries, DLQ routing, provider ingestion, and alert transport are unchanged.

## Architecture and reuse

- Existing systems reused: the existing Queue `metrics()` binding, nullable metric snapshot, partial status, failure streak, Durable Object incident state, and alert admission flow.
- New logic: one derived completeness predicate distinguishes an unknown age from confirmed health.
- New abstractions: none; Cloudflare's optional timestamp maps to the existing nullable field and status vocabulary.
- Complexity intentionally avoided: no fallback API call, timestamp inference, second counter/state machine, storage migration, or queue-consumer change.

## Hot reply path impact

Not applicable. The scheduled Cloudflare monitor is outside foreground message acceptance, provider start, and durable reply handoff.

## Murph initial provider input impact

- Hosted runtime: Not applicable; no prompt, instruction, tool/schema, or provider-visible request assembly changed.
- Local runtime: Not applicable; no prompt, instruction, tool/schema, or provider-visible request assembly changed.

ReviewGPT context sensitivity: sensitive — this changes production Cloudflare monitoring and failure classification.

ReviewGPT first-reviewed head: aa1852eed00f1f3ef836b6acd9f00bf6de1004b8

## Change-shape breakdown

Classification: production TypeScript is source; Vitest is tests/fixtures; the completed execution plan is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 8 |
| Tests/fixtures | 129 | 0 |
| Docs | 118 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 251 | 8 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Worker versions share the same Queue bindings, Durable Object schema, and nullable stored timestamp; only unknown-age classification differs.
- Safe order: Deploy the Cloudflare Worker alone; no Web or container tandem deploy is required.
- Rollback floor: Reverting the Worker is storage-compatible but restores the false metric-failure classification.
- Expected exposure: During gradual rollout, scheduled checks may alternate the old and new classification; webhook Queue delivery is unaffected.
- Reversibility: Roll back only the Worker version; no data repair or migration is required.
- Convergence proof: Confirm the deployed Worker version, then observe a scheduled partial Queue-health snapshot that preserves count/bytes when age is unknown.
- Post-deploy checks: Re-read bounded main/DLQ metrics, verify webhook processing continues, and confirm unknown age no longer produces a `queue_metrics_unavailable` condition while genuine read-failure alerts remain configured.

## Changelog

- Changelog: not applicable
- Reason: This changes internal operator monitoring only; members do not see the alert or monitoring state.
