### PR TITLE
Fix hosted runtime mailbox frontier stalls

### DIFF
--- a/.agents/friction-log/20260818004504-reviewgpt-direct-artifact/friction.md
+++ b/.agents/friction-log/20260818004504-reviewgpt-direct-artifact/friction.md
@@ -9,11 +9,11 @@ Downloading a captured assistant artifact from its exact review thread and manag
 
 ## Current Behavior
 
-After a waited review captures the completed response and closes its owned tab, the documented direct artifact-download command can exit successfully while creating an empty output directory. Adding the exact capture metadata then fails because the captured target no longer exists. Recovery requires using the broader thread-wake export path to reopen the same thread and download the artifact.
+After a waited review captures the completed response and closes its owned tab, the documented direct artifact-download command can exit successfully while creating an empty output directory. Adding the exact capture metadata then fails because the captured target no longer exists. A second reproducible variant occurs while the exact target is still alive: two assistant-owned artifact buttons are visible and capture-bound download exits successfully, but the requested patch is written as a zero-byte file and the checksum artifact is not written. Recovery requires using the broader thread-wake export path to reopen the same thread or asking the owning thread to regenerate the artifact.
 
 ## Possible Solution
 
-Make direct download reopen the exact supplied thread URL in the selected managed lane when the captured target was intentionally closed, or fail nonzero and direct callers to the thread-wake recovery command. Verify that success always means at least one requested file was written.
+Make direct download reopen the exact supplied thread URL in the selected managed lane when the captured target was intentionally closed, or fail nonzero and direct callers to the thread-wake recovery command. Verify that success means the requested artifact exists, has a nonzero size, and matches any captured or companion checksum.
 
 ## Minimal Reproducible Example
 
@@ -22,6 +22,7 @@ Make direct download reopen the exact supplied thread URL in the selected manage
 3. Run direct artifact download with the exact thread, lane endpoint, output directory, and artifact index.
 4. Observe exit status zero and an empty output directory.
 5. Retry with exact capture metadata and observe a missing-target error.
+6. In a live-target variant, return visible patch and checksum buttons from the assistant, run the same capture-bound downloads, and observe exit status zero with a zero-byte patch and no checksum file.
 
 ## Context
 

--- a/agent-docs/exec-plans/active/2026-08-20-runtime-frontier-convergence.md
+++ b/agent-docs/exec-plans/active/2026-08-20-runtime-frontier-convergence.md
@@ -1,0 +1,53 @@
+# Hosted Runtime Frontier Convergence
+
+Status: active
+Updated: 2026-08-20
+
+## Goal
+
+Make three proven hosted-runtime failure boundaries converge without weakening
+foreground priority, mailbox ordering, replay safety, or Web-owned durable
+truth:
+
+1. a deterministic system notification must not permanently block eligible
+   model-free system work behind it when assistant automation is policy-blocked;
+2. a device-sync pass that starts must leave durable completion or exact
+   interruption/retry evidence before ownership is released; and
+3. a foreground-progress checkpoint with still-due device work must receive a
+   bounded orchestration re-dispatch.
+
+## Constraints
+
+- Preserve FIFO completion and handled-through fences; do not delete, skip, or
+  manually consume durable mailbox rows.
+- Preserve foreground conversation and accepted assistant work ahead of device
+  maintenance.
+- Keep Web as the product/control truth owner, Temporal pointer-only, and
+  Cloudflare as the execution adapter.
+- Add no scheduler, queue, polling owner, broad resync, or persisted duplicate
+  domain state.
+- Keep production evidence aggregate and anonymous in repository artifacts.
+- Maintain replay-safe Temporal deployment and migration requirements.
+
+## Plan
+
+1. Give ReviewGPT the aggregate production evidence, exact current source, the
+   relevant merged and pending changes in both repositories, and require a
+   scoped implementation patch with focused regressions.
+2. Inspect the returned implementation against mailbox ownership, foreground
+   priority, device-pass durability, Temporal replay, and deployment ordering.
+3. Apply only evidence-backed changes; reject speculative fallbacks or manual
+   data repair.
+4. Run focused public and private runtime, mailbox, Cloudflare, Temporal, replay,
+   and typecheck proof selected from the touched paths.
+5. Commit and open the required PR or coordinated PRs, then run preliminary and
+   final exact-head ReviewGPT gates with required CI.
+6. Deploy in compatibility order and verify the corrected production frontiers
+   converge before resolving the incident.
+
+## Verification
+
+- Pending ReviewGPT implementation result.
+- Pending focused local proof.
+- Pending exact-head CI and ReviewGPT gates.
+- Pending safe deployment and production convergence proof.

--- a/agent-docs/exec-plans/active/2026-08-20-runtime-frontier-convergence.md
+++ b/agent-docs/exec-plans/active/2026-08-20-runtime-frontier-convergence.md
@@ -1,7 +1,7 @@
 # Hosted Runtime Frontier Convergence
 
 Status: active
-Updated: 2026-08-20
+Updated: 2026-08-21
 
 ## Goal
 
@@ -47,7 +47,53 @@ truth:
 
 ## Verification
 
-- Pending ReviewGPT implementation result.
-- Pending focused local proof.
-- Pending exact-head CI and ReviewGPT gates.
+- ReviewGPT reproduced both exact-delivery checkpoint gaps. The public runtime
+  corrections are implemented with focused red-before/green-after regressions.
+- Public package build, typecheck, and full runtime tests pass. Private Temporal
+  PR #40 is merged with its replay-safe bounded redispatch proof.
+- Pending final exact-head CI and ReviewGPT gate.
 - Pending safe deployment and production convergence proof.
+
+## Review Anomaly Retrospective
+
+Substantive round 3 triggered the required direction-level retrospective. Both
+accepted findings occurred where an exact notification crosses a checkpoint
+while the runtime can restart or yield to foreground work.
+
+The first-reviewed patch had 402 authored-source lines of churn. The current
+patch has 658. Review remediation added 356 source lines of commit churn and
+631 test lines of commit churn across two rounds:
+
+- round 1 added stable-key outbox re-resolution, terminal/retry-state reading,
+  mailbox wake projection, and restart recovery coverage;
+- round 2 added token-checked release of a prepared pre-provider dispatch,
+  a checkpoint for that release, and preemption/restore coverage.
+
+The authority decision is explicit: the outbox intent wholly owns delivery
+state, including due time, prepared/sending state, retry, ambiguity fences, and
+terminal disposition. The system mailbox owns FIFO membership and
+handled-through advancement only. Its `nextAttemptAt` is a derived scheduler
+projection of the outbox wake, not an independent delivery decision; every
+resume re-derives it from the stable outbox identity.
+
+The provider-entry contract is:
+
+1. Before provider entry, the outbox is pending/retryable. A prepared claim is
+   durably checkpointed only to fence provider dispatch.
+2. If foreground work wins before provider entry, the existing prepared token
+   restores the captured prior outbox state and that release is checkpointed.
+3. After provider entry, the existing outbox idempotency and non-idempotent
+   ambiguity rules own recovery.
+4. Retryable outbox state projects its wake to the recording mailbox item;
+   terminal outbox state retires that item and advances FIFO handled-through.
+
+Decision: continue the current joined PR without another architectural owner.
+Deletion or reverting either correction would reopen a reproduced infinite
+restart loop, duplicate-send window, or ten-minute unsent-confirmation delay.
+Moving preparation after the foreground checkpoint would require a second
+checkpoint on every normal send to preserve the pre-provider fence; the current
+extra checkpoint occurs only on the rare preemption path. Splitting the already
+complete device retry change would not reduce the exact-delivery lifecycle or
+its deploy contract. The current direction adds no queue, scheduler, state
+field, lifecycle enum, migration, compatibility path, or reconciliation loop;
+it tightens existing mailbox, outbox, and checkpoint boundaries.

--- a/apps/web/changelog/entries/2026-08-20/background-work-keeps-moving.json
+++ b/apps/web/changelog/entries/2026-08-20/background-work-keeps-moving.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-20",
+  "order": 210,
+  "item": {
+    "id": "background-work-keeps-moving",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Background work keeps moving",
+    "summary": "Group-join confirmations and connected-health follow-ups now recover when hosted background work is paused or interrupted.",
+    "details": "Current conversations and approved actions still run first. Other paused automatic messages stay paused, and interrupted connected-health work keeps one bounded retry instead of starting a second recovery loop.",
+    "relevanceTags": ["device-sync", "groups", "reliability"],
+    "sourcePullRequests": [2106]
+  }
+}

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -1773,7 +1773,11 @@ export async function readHostedMailboxFirstLiveSystemItemAfterSeq(input: {
   at: Date;
   prisma?: HostedMailboxStoreClient;
   userId: string;
-}): Promise<{ kind: HostedMailboxKind; laneSeq: string } | null> {
+}): Promise<{
+  dedupeKey: string;
+  kind: HostedMailboxKind;
+  laneSeq: string;
+} | null> {
   const prisma = input.prisma ?? getPrisma();
   const userId = requireNonEmptyString(input.userId, "Hosted mailbox userId");
   const afterSeq = normalizeHostedMailboxSeq(
@@ -1785,6 +1789,7 @@ export async function readHostedMailboxFirstLiveSystemItemAfterSeq(input: {
       laneSeq: "asc",
     },
     select: {
+      dedupeKey: true,
       kind: true,
       laneSeq: true,
     },
@@ -1800,6 +1805,7 @@ export async function readHostedMailboxFirstLiveSystemItemAfterSeq(input: {
 
   return row
     ? {
+        dedupeKey: row.dedupeKey,
         kind: requireHostedMailboxKind(row.kind),
         laneSeq: row.laneSeq.toString(),
       }

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -11,6 +11,7 @@ import {
 import {
   HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON,
   HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS,
+  isHostedSystemMailboxModelFreeNotification,
   type HostedRuntimeReconciliationBlockedReason,
   type HostedRuntimeReconciliationFacts,
   type HostedRuntimeReconciliationFactsRequest,
@@ -810,8 +811,24 @@ async function readHostedRuntimeSystemMailboxFrontier(input: {
     return null;
   }
 
-  return HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS.some(
-    (kind) => kind === frontier.kind,
+  return classifyHostedFirstLiveSystemItemOwnership(frontier);
+}
+
+export function classifyHostedFirstLiveSystemItemOwnership(input: {
+  dedupeKey: string | null | undefined;
+  kind: string;
+}): HostedRuntimeSystemMailboxFrontierClass {
+  if (
+    isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: input.dedupeKey,
+      kind: input.kind,
+    })
+  ) {
+    return "model_free";
+  }
+
+  return HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS.some((kind) =>
+    kind === input.kind && kind !== "assistant.notification.requested"
   )
     ? "model_free"
     : "default_owned";

--- a/apps/web/test/hosted-mailbox-store.test.ts
+++ b/apps/web/test/hosted-mailbox-store.test.ts
@@ -2640,6 +2640,7 @@ describe("fetchHostedMailboxItemsAfterLaneCursors", () => {
       prisma,
       userId: "member_mailbox_1",
     })).resolves.toEqual({
+      dedupeKey: "dedupe_1",
       kind: "assistant.ask.completed",
       laneSeq: "5",
     });
@@ -2648,6 +2649,7 @@ describe("fetchHostedMailboxItemsAfterLaneCursors", () => {
         laneSeq: "asc",
       },
       select: {
+        dedupeKey: true,
         kind: true,
         laneSeq: true,
       },

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -613,11 +613,21 @@ describe("hosted orchestration reconciliation facts", () => {
   });
 
   it.each([
-    ["device-sync.wake", "model_free"],
-    ["assistant.ask.completed", "default_owned"],
+    ["device-sync.wake", "device-sync.wake:item", "model_free"],
+    [
+      "assistant.notification.requested",
+      "assistant.notification.requested:group-join:membership",
+      "model_free",
+    ],
+    [
+      "assistant.notification.requested",
+      "assistant.notification.requested:generic",
+      "default_owned",
+    ],
+    ["assistant.ask.completed", "assistant.ask.completed:item", "default_owned"],
   ] as const)(
-    "classifies the first live system mailbox item %s as %s",
-    async (kind, expectedFrontier) => {
+    "classifies the first live system mailbox item %s with dedupe %s as %s",
+    async (kind, dedupeKey, expectedFrontier) => {
       mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
         redactedStatusJson: {
           conversationImportedSeq: "0",
@@ -630,6 +640,7 @@ describe("hosted orchestration reconciliation facts", () => {
         { lane: "system", maxSeq: "7" },
       ]);
       mocks.readHostedMailboxFirstLiveSystemItemAfterSeq.mockResolvedValue({
+        dedupeKey,
         kind,
         laneSeq: "5",
       });
@@ -657,6 +668,7 @@ describe("hosted orchestration reconciliation facts", () => {
       { lane: "system", maxSeq: "1" },
     ]);
     mocks.readHostedMailboxFirstLiveSystemItemAfterSeq.mockResolvedValue({
+      dedupeKey: "runtime.maintenance-requested:item",
       kind: "runtime.maintenance-requested",
       laneSeq: "1",
     });
@@ -1356,6 +1368,7 @@ describe("hosted orchestration reconciliation facts", () => {
       { lane: "system", maxSeq: "5" },
     ]);
     mocks.readHostedMailboxFirstLiveSystemItemAfterSeq.mockResolvedValue({
+      dedupeKey: "assistant.ask.completed:item",
       kind: "assistant.ask.completed",
       laneSeq: "5",
     });

--- a/apps/web/test/runtime-reconciliation-facts-model-free-notification.test.ts
+++ b/apps/web/test/runtime-reconciliation-facts-model-free-notification.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { classifyHostedFirstLiveSystemItemOwnership } from "@/src/lib/hosted-orchestration/runtime-reconciliation-facts";
+
+describe("first live system mailbox ownership", () => {
+  it("keeps generic notifications default-owned while admitting canonical group joins", () => {
+    expect(classifyHostedFirstLiveSystemItemOwnership({
+      dedupeKey: "assistant.notification.requested:group-join:membership",
+      kind: "assistant.notification.requested",
+    })).toBe("model_free");
+    expect(classifyHostedFirstLiveSystemItemOwnership({
+      dedupeKey: "assistant.notification.requested:generic",
+      kind: "assistant.notification.requested",
+    })).toBe("default_owned");
+    expect(classifyHostedFirstLiveSystemItemOwnership({
+      dedupeKey: "runtime.maintenance-requested:item",
+      kind: "runtime.maintenance-requested",
+    })).toBe("model_free");
+  });
+});

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -256,6 +256,7 @@ import {
   collectHostedAssistantDeliverySideEffects,
   drainHostedPreparedAssistantDeliveries,
   prepareHostedAssistantDeliveryEffectsForDispatch,
+  resetHostedPreparedAssistantDeliveryEffects,
   resolveHostedAssistantDeliveryIntentState,
   resolveHostedAssistantOutboxNextWakeAt,
 } from "./hosted-runtime/callbacks.ts";
@@ -2914,10 +2915,25 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               preparationWake ? [preparationWake] : [],
             );
           }
-          if (!assistantExecutionBlocked && projectedWake.assistantCronDueNow) {
-            return { preempted: true, prepared: preparation !== null };
-          }
-          if (hostAbortObserved || consumeForegroundWake()) {
+          const preemptBeforeExactDelivery =
+            (!assistantExecutionBlocked && projectedWake.assistantCronDueNow)
+            || hostAbortObserved
+            || consumeForegroundWake();
+          if (preemptBeforeExactDelivery) {
+            if (
+              exactDeliveryEffects.length > 0
+              && (exactDeliveryPreparation?.preparedDispatches.length ?? 0) > 0
+            ) {
+              await resetHostedPreparedAssistantDeliveryEffects({
+                effects: exactDeliveryEffects,
+                preparedDispatches:
+                  exactDeliveryPreparation?.preparedDispatches ?? null,
+                vaultRoot: restored.vaultRoot,
+              });
+              await checkpointSystemMailboxMode(
+                `${inputItem.stagePrefix}.checkpoint.release_prepared_delivery`,
+              );
+            }
             return { preempted: true, prepared: preparation !== null };
           }
           const recordItem = exactDeliveryRecordItem

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -2857,6 +2857,11 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               const exactDeliveryPreparation = exactDeliveryEffects.length > 0
                 ? await prepareHostedAssistantDeliveryEffectsForDispatch({
                     assistantDeliveryEffects: exactDeliveryEffects,
+                    selectedNonIdempotentEffectIds: exactDeliveryEffects
+                      .filter((effect) =>
+                        effect.payload.transportIdempotent !== true
+                      )
+                      .map((effect) => effect.effectId),
                     vaultRoot: restored.vaultRoot,
                   })
                 : null;

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3070,13 +3070,15 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                     deliveryIdempotencyKey,
                     vaultRoot: restored.vaultRoot,
                   });
+                const nonterminalDeliveryWakeAt =
+                  refreshedIntentState && !refreshedIntentState.terminal
+                    ? refreshedIntentState.nextWakeAt
+                    : null;
                 const refreshedRecordItem =
-                  refreshedIntentState
-                  && !refreshedIntentState.terminal
-                  && refreshedIntentState.nextWakeAt
+                  nonterminalDeliveryWakeAt
                     ? await retainHostedSystemMailboxItemUntilDeliveryWake({
                         item: recordItem,
-                        nextWakeAt: refreshedIntentState.nextWakeAt,
+                        nextWakeAt: nonterminalDeliveryWakeAt,
                         vaultRoot: restored.vaultRoot,
                       })
                     : recordItem;
@@ -3094,6 +3096,16 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 ?? currentRedactedStatus;
             }
             if (!persistedDelivery.result.intentState?.terminal) {
+              const nextWakeAt = persistedDelivery.result.intentState?.nextWakeAt;
+              if (nextWakeAt) {
+                await checkpointSystemMailboxMode(
+                  `${inputItem.stagePrefix}.checkpoint.delivery_retry`,
+                  [createHostedRuntimeWakeCandidate(
+                    nextWakeAt,
+                    HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON,
+                  )],
+                );
+              }
               return { preempted: true, prepared: true };
             }
             return await recordSystemMailboxItem({

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -412,6 +412,7 @@ const HOSTED_INITIAL_BOOTSTRAP_MAILBOX_IMPORT_LANES = ["system", "conversation"]
 const HOSTED_FOREGROUND_MAILBOX_PREFETCH_LANES = ["conversation", "system"] as const;
 const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS = [
   "apply-runtime-control-request",
+  "dispatch-assistant-notification",
   "run-device-sync-wake",
 ] as const;
 const HOSTED_INITIAL_BOOTSTRAP_PENDING_REASON_CODE = "bootstrap.pending";

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -209,6 +209,7 @@ import {
   enqueueHostedSystemMailboxItem,
   prepareHostedSystemMailboxItemForCheckpoint,
   recordHostedSystemMailboxItemAfterCheckpoint,
+  retainHostedSystemMailboxItemUntilDeliveryWake,
   resolveHostedSystemMailboxNextWakeCandidate,
   type HostedSystemMailboxCheckpointPreparation,
 } from "./hosted-runtime/system-mailbox.ts";
@@ -255,6 +256,7 @@ import {
   collectHostedAssistantDeliverySideEffects,
   drainHostedPreparedAssistantDeliveries,
   prepareHostedAssistantDeliveryEffectsForDispatch,
+  resolveHostedAssistantDeliveryIntentState,
   resolveHostedAssistantOutboxNextWakeAt,
 } from "./hosted-runtime/callbacks.ts";
 import {
@@ -2805,21 +2807,40 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 signal: runtimeAbortController.signal,
                 vaultRoot: restored.vaultRoot,
               });
+              const preparationRecordItem =
+                readHostedSystemMailboxCheckpointPreparationRecordItem(
+                  preparation,
+                );
               if (
-                preparation?.status !== "processed"
+                !preparationRecordItem
                 || !isHostedSystemMailboxModelFreeExactNotificationItem(
-                  preparation.item,
+                  preparationRecordItem,
                 )
               ) {
                 return {
+                  exactDeliveryIntentState: null,
                   exactDeliveryEffects: [],
                   exactDeliveryPreparation: null,
+                  exactDeliveryRecordItem: null,
                   preparation,
                 };
               }
 
+              const deliveryIdempotencyKey =
+                preparationRecordItem.wake.kind ===
+                    "assistant.notification.requested"
+                  ? preparationRecordItem.wake.notification
+                    .deliveryIdempotencyKey ?? ""
+                  : "";
+              const exactDeliveryIntentState =
+                await resolveHostedAssistantDeliveryIntentState({
+                  deliveryIdempotencyKey,
+                  vaultRoot: restored.vaultRoot,
+                });
               const preferredIntentIds =
-                preparation.metrics.deliveryIntentIds ?? [];
+                exactDeliveryIntentState && !exactDeliveryIntentState.terminal
+                  ? [exactDeliveryIntentState.intentId]
+                  : [];
               const preferredIntentIdSet = new Set(preferredIntentIds);
               const exactDeliveryEffects =
                 (await collectHostedAssistantDeliverySideEffects({
@@ -2838,16 +2859,31 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                     vaultRoot: restored.vaultRoot,
                   })
                 : null;
+              const exactDeliveryRecordItem =
+                exactDeliveryEffects.length === 0
+                  && exactDeliveryIntentState
+                  && !exactDeliveryIntentState.terminal
+                  && exactDeliveryIntentState.nextWakeAt
+                  ? await retainHostedSystemMailboxItemUntilDeliveryWake({
+                      item: preparationRecordItem,
+                      nextWakeAt: exactDeliveryIntentState.nextWakeAt,
+                      vaultRoot: restored.vaultRoot,
+                    })
+                  : preparationRecordItem;
               return {
+                exactDeliveryIntentState,
                 exactDeliveryEffects,
                 exactDeliveryPreparation,
+                exactDeliveryRecordItem,
                 preparation,
               };
             },
           });
           const {
+            exactDeliveryIntentState,
             exactDeliveryEffects,
             exactDeliveryPreparation,
+            exactDeliveryRecordItem,
             preparation,
           } = persistedPreparation.result;
           if (persistedPreparation.canonicalWritePersisted) {
@@ -2884,13 +2920,91 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           if (hostAbortObserved || consumeForegroundWake()) {
             return { preempted: true, prepared: preparation !== null };
           }
-          const recordItem = readHostedSystemMailboxCheckpointPreparationRecordItem(preparation);
+          const recordItem = exactDeliveryRecordItem
+            ?? readHostedSystemMailboxCheckpointPreparationRecordItem(preparation);
           if (!recordItem) {
             return { preempted: false, prepared: preparation !== null };
           }
           const ownsExactModelFreeDelivery =
             isHostedSystemMailboxModelFreeExactNotificationItem(recordItem);
-          let exactModelFreeDeliveryCompleted = false;
+          const recordSystemMailboxItem = async (recordInput: {
+            exactDeliveryCompleted: boolean;
+            item: HostedSystemMailboxCheckpointPreparationRecordItem;
+            vaultShareProjectionResult?: HostedVaultShareProjectionOfferResult;
+          }): Promise<{
+            preempted: boolean;
+            prepared: boolean;
+          }> => {
+            const recordWakeInterruption = createHostedRuntimeCheckpointWakeInterruption({
+              enabled: true,
+              runtimeWakeSignal: options.runtimeWakeSignal ?? null,
+            });
+            const recordSignal = recordWakeInterruption.signal
+              ? AbortSignal.any([
+                  runtimeAbortController.signal,
+                  recordWakeInterruption.signal,
+                ])
+              : runtimeAbortController.signal;
+            try {
+              const recordResult = await recordHostedSystemMailboxItemAfterCheckpoint({
+                item: recordInput.item,
+                operatorHomeRoot: restored.operatorHomeRoot,
+                runtime: foregroundRuntime,
+                signal: recordSignal,
+                ...(recordInput.vaultShareProjectionResult
+                  ? {
+                      vaultShareProjectionResult:
+                        recordInput.vaultShareProjectionResult,
+                    }
+                  : {}),
+                vaultRoot: restored.vaultRoot,
+              });
+              const recordWake = selectHostedRuntimeWakeCandidate([
+                createHostedRuntimeWakeCandidate(
+                  recordInput.exactDeliveryCompleted
+                    ? null
+                    : recordResult.nextWakeAt,
+                  isHostedSystemMailboxModelFreeExactNotificationItem(
+                      recordInput.item,
+                    )
+                    && recordResult.nextWakeAt
+                    ? HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON
+                    : recordResult.nextWakeReason ?? null,
+                ),
+                recordInput.exactDeliveryCompleted
+                  || recordInput.item.postCheckpointRecord
+                  ? null
+                  : preparationWake,
+              ]);
+              rememberSystemMailboxPostRecordWake(recordWake);
+              await checkpointSystemMailboxMode(
+                `${inputItem.stagePrefix}.checkpoint.record`,
+                recordWake.at ? [recordWake] : [],
+                recordWakeInterruption.signal,
+              );
+            } catch (error) {
+              await recordWakeInterruption.dispose();
+              if (recordWakeInterruption.takeNotification()) {
+                foregroundWakeObserved = true;
+                return { preempted: true, prepared: true };
+              }
+              throw error;
+            }
+            await recordWakeInterruption.dispose();
+            if (recordWakeInterruption.takeNotification()) {
+              foregroundWakeObserved = true;
+            }
+            return {
+              preempted: shouldYieldSystemMailboxWork(),
+              prepared: true,
+            };
+          };
+          if (ownsExactModelFreeDelivery && exactDeliveryIntentState?.terminal) {
+            return await recordSystemMailboxItem({
+              exactDeliveryCompleted: true,
+              item: recordItem,
+            });
+          }
           if (ownsExactModelFreeDelivery && exactDeliveryEffects.length === 0) {
             return { preempted: true, prepared: true };
           }
@@ -2901,30 +3015,55 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 ...baseRunnerInput,
                 workspace: activeWorkspace,
               },
-              write: async () => await drainHostedPreparedAssistantDeliveries({
-                actionApprovalPort:
-                  foregroundRuntime.platform.actionApprovalPort ?? null,
-                allowPreparedSending: true,
-                assertLiveness: async () => {
-                  assertRuntimeNotAborted();
-                },
-                assistantDeliveryEffects: exactDeliveryEffects,
-                effectsPort: foregroundRuntime.platform.effectsPort,
-                forwardedEnv: foregroundRuntime.forwardedEnv,
-                platform: foregroundRuntime.platform,
-                platformEnv: foregroundRuntime.platformEnv,
-                preparedDispatches:
-                  exactDeliveryPreparation?.preparedDispatches ?? null,
-                providerFetch:
-                  foregroundRuntime.platform.providerFetch ?? null,
-                publicInternetFetch:
-                  foregroundRuntime.platform.publicInternetFetch ?? null,
-                shouldYieldBackgroundDelivery: shouldYieldSystemMailboxWork,
-                signal: runtimeAbortController.signal,
-                userEnv: foregroundRuntime.userEnv,
-                vaultRoot: restored.vaultRoot,
-                wake: recordItem.wake,
-              }),
+              write: async () => {
+                await drainHostedPreparedAssistantDeliveries({
+                  actionApprovalPort:
+                    foregroundRuntime.platform.actionApprovalPort ?? null,
+                  allowPreparedSending: true,
+                  assertLiveness: async () => {
+                    assertRuntimeNotAborted();
+                  },
+                  assistantDeliveryEffects: exactDeliveryEffects,
+                  effectsPort: foregroundRuntime.platform.effectsPort,
+                  forwardedEnv: foregroundRuntime.forwardedEnv,
+                  platform: foregroundRuntime.platform,
+                  platformEnv: foregroundRuntime.platformEnv,
+                  preparedDispatches:
+                    exactDeliveryPreparation?.preparedDispatches ?? null,
+                  providerFetch:
+                    foregroundRuntime.platform.providerFetch ?? null,
+                  publicInternetFetch:
+                    foregroundRuntime.platform.publicInternetFetch ?? null,
+                  shouldYieldBackgroundDelivery: shouldYieldSystemMailboxWork,
+                  signal: runtimeAbortController.signal,
+                  userEnv: foregroundRuntime.userEnv,
+                  vaultRoot: restored.vaultRoot,
+                  wake: recordItem.wake,
+                });
+                const deliveryIdempotencyKey =
+                  recordItem.wake.kind === "assistant.notification.requested"
+                    ? recordItem.wake.notification.deliveryIdempotencyKey ?? ""
+                    : "";
+                const refreshedIntentState =
+                  await resolveHostedAssistantDeliveryIntentState({
+                    deliveryIdempotencyKey,
+                    vaultRoot: restored.vaultRoot,
+                  });
+                const refreshedRecordItem =
+                  refreshedIntentState
+                  && !refreshedIntentState.terminal
+                  && refreshedIntentState.nextWakeAt
+                    ? await retainHostedSystemMailboxItemUntilDeliveryWake({
+                        item: recordItem,
+                        nextWakeAt: refreshedIntentState.nextWakeAt,
+                        vaultRoot: restored.vaultRoot,
+                      })
+                    : recordItem;
+                return {
+                  intentState: refreshedIntentState,
+                  recordItem: refreshedRecordItem,
+                };
+              },
             });
             if (persistedDelivery.canonicalWritePersisted) {
               activeWorkspace = persistedDelivery.workspace;
@@ -2933,21 +3072,13 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
                 ?? persistedDelivery.workspace?.redactedStatus
                 ?? currentRedactedStatus;
             }
-            const deliveryOutcomes = persistedDelivery.result;
-            const deliveryNeedsRetry =
-              deliveryOutcomes.length !== exactDeliveryEffects.length
-              || deliveryOutcomes.some((outcome) =>
-                outcome.retryable
-                || outcome.deliveryStatus === "missing-result"
-                || outcome.deliveryStatus === "pending"
-                || outcome.deliveryStatus === "retryable"
-                || outcome.deliveryStatus === "sending"
-                || outcome.deliveryStatus === "threw"
-              );
-            if (deliveryNeedsRetry) {
+            if (!persistedDelivery.result.intentState?.terminal) {
               return { preempted: true, prepared: true };
             }
-            exactModelFreeDeliveryCompleted = true;
+            return await recordSystemMailboxItem({
+              exactDeliveryCompleted: true,
+              item: persistedDelivery.result.recordItem,
+            });
           }
           const isVaultShareProjectionRecord =
             recordItem.postCheckpointRecord?.kind === "vault-share.projection";
@@ -3030,64 +3161,13 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           if (shouldYieldSystemMailboxWork()) {
             return { preempted: true, prepared: true };
           }
-          const recordWakeInterruption = createHostedRuntimeCheckpointWakeInterruption({
-            enabled: true,
-            runtimeWakeSignal: options.runtimeWakeSignal ?? null,
+          return await recordSystemMailboxItem({
+            exactDeliveryCompleted: false,
+            item: recordItem,
+            ...(isVaultShareProjectionRecord
+              ? { vaultShareProjectionResult: projectionOpportunity.result }
+              : {}),
           });
-          const recordSignal = recordWakeInterruption.signal
-            ? AbortSignal.any([
-                runtimeAbortController.signal,
-                recordWakeInterruption.signal,
-              ])
-            : runtimeAbortController.signal;
-          try {
-            const recordResult = await recordHostedSystemMailboxItemAfterCheckpoint({
-              item: recordItem,
-              operatorHomeRoot: restored.operatorHomeRoot,
-              runtime: foregroundRuntime,
-              signal: recordSignal,
-              ...(isVaultShareProjectionRecord
-                ? { vaultShareProjectionResult: projectionOpportunity.result }
-                : {}),
-              vaultRoot: restored.vaultRoot,
-            });
-            const recordWake = selectHostedRuntimeWakeCandidate([
-              createHostedRuntimeWakeCandidate(
-                exactModelFreeDeliveryCompleted
-                  ? null
-                  : recordResult.nextWakeAt,
-                isHostedSystemMailboxModelFreeExactNotificationItem(recordItem)
-                  && recordResult.nextWakeAt
-                  ? HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON
-                  : recordResult.nextWakeReason ?? null,
-              ),
-              exactModelFreeDeliveryCompleted
-                || recordItem.postCheckpointRecord
-                ? null
-                : preparationWake,
-            ]);
-            rememberSystemMailboxPostRecordWake(recordWake);
-            await checkpointSystemMailboxMode(
-              `${inputItem.stagePrefix}.checkpoint.record`,
-              recordWake.at ? [recordWake] : [],
-              recordWakeInterruption.signal,
-            );
-          } catch (error) {
-            await recordWakeInterruption.dispose();
-            if (recordWakeInterruption.takeNotification()) {
-              foregroundWakeObserved = true;
-              return { preempted: true, prepared: true };
-            }
-            throw error;
-          }
-          await recordWakeInterruption.dispose();
-          if (recordWakeInterruption.takeNotification()) {
-            foregroundWakeObserved = true;
-          }
-          return {
-            preempted: shouldYieldSystemMailboxWork(),
-            prepared: true,
-          };
         });
       };
 

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -222,6 +222,7 @@ import type {
 import {
   findNextHostedSystemMailboxQueueItem,
   isHostedApprovedContinuationSystemMailboxItem,
+  isHostedSystemMailboxModelFreeExactNotificationItem,
   readHostedSystemMailboxState,
   readHostedSystemMailboxHandledThroughSeq,
 } from "./hosted-runtime/system-mailbox-state.ts";
@@ -251,6 +252,9 @@ import {
   consumePendingRuntimeWakeUnlessShuttingDown,
 } from "./hosted-runtime/runtime-wake.ts";
 import {
+  collectHostedAssistantDeliverySideEffects,
+  drainHostedPreparedAssistantDeliveries,
+  prepareHostedAssistantDeliveryEffectsForDispatch,
   resolveHostedAssistantOutboxNextWakeAt,
 } from "./hosted-runtime/callbacks.ts";
 import {
@@ -1080,7 +1084,10 @@ function resolveHostedSystemMailboxCheckpointPreparationWake(
   if (preparation?.status === "processed") {
     return createHostedRuntimeWakeCandidate(
       preparation.metrics.nextWakeAt ?? null,
-      preparation.metrics.nextWakeReason ?? null,
+      isHostedSystemMailboxModelFreeExactNotificationItem(preparation.item)
+        && (preparation.metrics.deliveryIntentIds?.length ?? 0) > 0
+        ? HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON
+        : preparation.metrics.nextWakeReason ?? null,
     );
   }
   if (preparation?.status !== "retryable_failed") {
@@ -2785,20 +2792,64 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
               ...baseRunnerInput,
               workspace: activeWorkspace,
             },
-            write: async () => await prepareHostedSystemMailboxItemForCheckpoint({
-              allowedRouteActions: inputItem.allowedRouteActions,
-              allowedWakeKinds: inputItem.allowedWakeKinds,
-              operatorHomeRoot: restored.operatorHomeRoot,
-              retainProcessedItemUntilRecorded: true,
-              runtime: foregroundRuntime,
-              runtimeLogContext,
-              runtimeEnv: invocationRuntimeEnv,
-              shouldYieldBackgroundMaintenance: shouldYieldSystemMailboxWork,
-              signal: runtimeAbortController.signal,
-              vaultRoot: restored.vaultRoot,
-            }),
+            write: async () => {
+              const preparation = await prepareHostedSystemMailboxItemForCheckpoint({
+                allowedRouteActions: inputItem.allowedRouteActions,
+                allowedWakeKinds: inputItem.allowedWakeKinds,
+                operatorHomeRoot: restored.operatorHomeRoot,
+                retainProcessedItemUntilRecorded: true,
+                runtime: foregroundRuntime,
+                runtimeLogContext,
+                runtimeEnv: invocationRuntimeEnv,
+                shouldYieldBackgroundMaintenance: shouldYieldSystemMailboxWork,
+                signal: runtimeAbortController.signal,
+                vaultRoot: restored.vaultRoot,
+              });
+              if (
+                preparation?.status !== "processed"
+                || !isHostedSystemMailboxModelFreeExactNotificationItem(
+                  preparation.item,
+                )
+              ) {
+                return {
+                  exactDeliveryEffects: [],
+                  exactDeliveryPreparation: null,
+                  preparation,
+                };
+              }
+
+              const preferredIntentIds =
+                preparation.metrics.deliveryIntentIds ?? [];
+              const preferredIntentIdSet = new Set(preferredIntentIds);
+              const exactDeliveryEffects =
+                (await collectHostedAssistantDeliverySideEffects({
+                  actionApprovalPort:
+                    foregroundRuntime.platform.actionApprovalPort ?? null,
+                  includeBackgroundDueIntents: false,
+                  messageVolumeReceiptPort: foregroundRuntime.platform.effectsPort,
+                  preferredIntentIds,
+                  vaultRoot: restored.vaultRoot,
+                })).filter((effect) =>
+                  preferredIntentIdSet.has(effect.effectId)
+                );
+              const exactDeliveryPreparation = exactDeliveryEffects.length > 0
+                ? await prepareHostedAssistantDeliveryEffectsForDispatch({
+                    assistantDeliveryEffects: exactDeliveryEffects,
+                    vaultRoot: restored.vaultRoot,
+                  })
+                : null;
+              return {
+                exactDeliveryEffects,
+                exactDeliveryPreparation,
+                preparation,
+              };
+            },
           });
-          const preparation = persistedPreparation.result;
+          const {
+            exactDeliveryEffects,
+            exactDeliveryPreparation,
+            preparation,
+          } = persistedPreparation.result;
           if (persistedPreparation.canonicalWritePersisted) {
             activeWorkspace = persistedPreparation.workspace;
             currentRedactedStatus =
@@ -2836,6 +2887,67 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
           const recordItem = readHostedSystemMailboxCheckpointPreparationRecordItem(preparation);
           if (!recordItem) {
             return { preempted: false, prepared: preparation !== null };
+          }
+          const ownsExactModelFreeDelivery =
+            isHostedSystemMailboxModelFreeExactNotificationItem(recordItem);
+          let exactModelFreeDeliveryCompleted = false;
+          if (ownsExactModelFreeDelivery && exactDeliveryEffects.length === 0) {
+            return { preempted: true, prepared: true };
+          }
+          if (ownsExactModelFreeDelivery) {
+            const persistedDelivery = await runHostedWorkspaceCanonicalWriteAtBoundary({
+              previousRedactedStatus: currentRedactedStatus,
+              runnerInput: {
+                ...baseRunnerInput,
+                workspace: activeWorkspace,
+              },
+              write: async () => await drainHostedPreparedAssistantDeliveries({
+                actionApprovalPort:
+                  foregroundRuntime.platform.actionApprovalPort ?? null,
+                allowPreparedSending: true,
+                assertLiveness: async () => {
+                  assertRuntimeNotAborted();
+                },
+                assistantDeliveryEffects: exactDeliveryEffects,
+                effectsPort: foregroundRuntime.platform.effectsPort,
+                forwardedEnv: foregroundRuntime.forwardedEnv,
+                platform: foregroundRuntime.platform,
+                platformEnv: foregroundRuntime.platformEnv,
+                preparedDispatches:
+                  exactDeliveryPreparation?.preparedDispatches ?? null,
+                providerFetch:
+                  foregroundRuntime.platform.providerFetch ?? null,
+                publicInternetFetch:
+                  foregroundRuntime.platform.publicInternetFetch ?? null,
+                shouldYieldBackgroundDelivery: shouldYieldSystemMailboxWork,
+                signal: runtimeAbortController.signal,
+                userEnv: foregroundRuntime.userEnv,
+                vaultRoot: restored.vaultRoot,
+                wake: recordItem.wake,
+              }),
+            });
+            if (persistedDelivery.canonicalWritePersisted) {
+              activeWorkspace = persistedDelivery.workspace;
+              currentRedactedStatus =
+                persistedDelivery.redactedStatus
+                ?? persistedDelivery.workspace?.redactedStatus
+                ?? currentRedactedStatus;
+            }
+            const deliveryOutcomes = persistedDelivery.result;
+            const deliveryNeedsRetry =
+              deliveryOutcomes.length !== exactDeliveryEffects.length
+              || deliveryOutcomes.some((outcome) =>
+                outcome.retryable
+                || outcome.deliveryStatus === "missing-result"
+                || outcome.deliveryStatus === "pending"
+                || outcome.deliveryStatus === "retryable"
+                || outcome.deliveryStatus === "sending"
+                || outcome.deliveryStatus === "threw"
+              );
+            if (deliveryNeedsRetry) {
+              return { preempted: true, prepared: true };
+            }
+            exactModelFreeDeliveryCompleted = true;
           }
           const isVaultShareProjectionRecord =
             recordItem.postCheckpointRecord?.kind === "vault-share.projection";
@@ -2941,10 +3053,16 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
             });
             const recordWake = selectHostedRuntimeWakeCandidate([
               createHostedRuntimeWakeCandidate(
-                recordResult.nextWakeAt,
-                recordResult.nextWakeReason ?? null,
+                exactModelFreeDeliveryCompleted
+                  ? null
+                  : recordResult.nextWakeAt,
+                isHostedSystemMailboxModelFreeExactNotificationItem(recordItem)
+                  && recordResult.nextWakeAt
+                  ? HOSTED_RUNTIME_ASSISTANT_DELIVERY_WAKE_REASON
+                  : recordResult.nextWakeReason ?? null,
               ),
-              recordItem.postCheckpointRecord
+              exactModelFreeDeliveryCompleted
+                || recordItem.postCheckpointRecord
                 ? null
                 : preparationWake,
             ]);

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -1726,6 +1726,43 @@ export async function resolveHostedAssistantOutboxNextWakeAt(input: {
   return wakeAt;
 }
 
+export interface HostedAssistantDeliveryIntentState {
+  intentId: string;
+  nextWakeAt: string | null;
+  terminal: boolean;
+}
+
+export async function resolveHostedAssistantDeliveryIntentState(input: {
+  deliveryIdempotencyKey: string;
+  now?: Date;
+  vaultRoot: string;
+}): Promise<HostedAssistantDeliveryIntentState | null> {
+  const matches = (await listAssistantOutboxIntents(input.vaultRoot)).filter(
+    (intent) =>
+      intent.deliveryIdempotencyKey === input.deliveryIdempotencyKey,
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length > 1) {
+    throw new TypeError(
+      "An exact hosted delivery identity matched multiple outbox intents.",
+    );
+  }
+  const intent = matches[0]!;
+  return {
+    intentId: intent.intentId,
+    nextWakeAt: resolveHostedAssistantOutboxIntentWakeAt(
+      intent,
+      input.now ?? new Date(),
+    ),
+    terminal:
+      intent.status === "sent"
+      || intent.status === "failed"
+      || intent.status === "abandoned",
+  };
+}
+
 function resolveHostedAssistantDeliveryBoundaryWakeAt(
   intents: readonly AssistantOutboxIntent[],
   now: Date,

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
@@ -231,6 +231,7 @@ export async function runHostedDeviceSyncPass(
     options.onStage?.("retry_fence");
     await setHostedDeviceSyncDenseRawRetentionMailboxWakeAt({
       nextWakeAt: resolveHostedDeviceSyncYieldRetryAt(),
+      persistAtCanonicalBoundary: true,
       userId: wake.userId,
       vaultRoot,
     });

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -4,12 +4,18 @@ import {
   type HostedExecutionSystemWake,
 } from "@murphai/hosted-execution/contracts";
 import {
+  isHostedSystemMailboxModelFreeNotification,
+} from "@murphai/hosted-execution/orchestration-control";
+import {
   parseHostedExecutionWake,
 } from "@murphai/hosted-execution/parsers";
 import { parseMemberActionOutcomeV1 } from "@murphai/contracts";
 import {
   parseHostedClinicalRecordsRecordOutcomeRequest,
 } from "@murphai/hosted-execution/clinical-records-boundary";
+import {
+  persistHostedRuntimeStateAtCanonicalBoundary,
+} from "@murphai/core";
 import {
   withAssistantRuntimeWriteLock,
 } from "@murphai/assistant-engine/assistant-state";
@@ -233,11 +239,15 @@ export async function removeHostedSystemMailboxPendingItems(input: {
 export async function setHostedDeviceSyncDenseRawRetentionMailboxWakeAt(input: {
   nextWakeAt: string | null;
   now?: () => string;
+  persistAtCanonicalBoundary?: boolean;
   userId: string;
   vaultRoot: string;
 }): Promise<void> {
   if (!input.nextWakeAt) {
     await removePendingHostedDeviceSyncDenseRawRetentionMailboxSuccessors(input.vaultRoot);
+    if (input.persistAtCanonicalBoundary === true) {
+      await persistHostedRuntimeStateAtCanonicalBoundary();
+    }
     return;
   }
 
@@ -275,6 +285,9 @@ export async function setHostedDeviceSyncDenseRawRetentionMailboxWakeAt(input: {
       nextItem,
     ],
   }));
+  if (input.persistAtCanonicalBoundary === true) {
+    await persistHostedRuntimeStateAtCanonicalBoundary();
+  }
 }
 
 async function removePendingHostedDeviceSyncDenseRawRetentionMailboxSuccessors(
@@ -324,10 +337,16 @@ export async function resolveHostedSystemMailboxNextWakeCandidate(input: {
 }): Promise<HostedRuntimeWakeCandidate> {
   const now = (input.now ?? (() => new Date().toISOString()))();
   const state = await readHostedSystemMailboxState(input.vaultRoot);
+  const notificationProjectedState = shouldProjectHostedSystemMailboxModelFreeNotifications({
+    allowedRouteActions: input.allowedRouteActions ?? null,
+    allowedWakeKinds: input.allowedWakeKinds ?? null,
+  })
+    ? projectHostedSystemMailboxModelFreeNotificationFrontier(state)
+    : state;
   const selectionState = input.allowedWakeKinds == null
-    ? state
+    ? notificationProjectedState
     : {
-        pending: state.pending.filter((item) =>
+        pending: notificationProjectedState.pending.filter((item) =>
           input.allowedWakeKinds?.includes(item.wake.kind)
         ),
       };
@@ -399,6 +418,57 @@ export function isHostedApprovedContinuationSystemMailboxItem(
 ): boolean {
   return item.routeAction === "apply-runtime-control-request"
     && item.wake.kind === "runtime.pending-effects-reconcile-requested";
+}
+
+export function isHostedSystemMailboxModelFreeExactNotificationItem(
+  item: HostedSystemMailboxPendingItem,
+): boolean {
+  if (
+    item.routeAction !== "dispatch-assistant-notification"
+    || item.wake.kind !== "assistant.notification.requested"
+  ) {
+    return false;
+  }
+
+  const notification = item.wake.notification;
+  const deliveryDedupeToken = notification.deliveryDedupeToken ?? "";
+  const deliveryIdempotencyKey = notification.deliveryIdempotencyKey ?? "";
+  const expectedDedupeKey =
+    `assistant.notification.requested:${deliveryDedupeToken}`;
+
+  return deliveryDedupeToken.length > 0
+    && deliveryDedupeToken === deliveryIdempotencyKey
+    && item.mailboxDedupeKey === expectedDedupeKey
+    && item.wake.eventId === expectedDedupeKey
+    && notification.deliveryDispatchMode === "queue-only"
+    && notification.responsePolicy?.kind === "require_send_exact_text"
+    && notification.responsePolicy.text.length > 0
+    && isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: item.mailboxDedupeKey,
+      kind: item.wake.kind,
+    });
+}
+
+export function projectHostedSystemMailboxModelFreeNotificationFrontier(
+  state: HostedSystemMailboxState,
+): HostedSystemMailboxState {
+  const durableFrontier = findHostedSystemMailboxDurableFrontierItem(state.pending);
+  if (
+    !durableFrontier
+    || durableFrontier.wake.kind !== "assistant.notification.requested"
+  ) {
+    return {
+      pending: state.pending.filter((item) =>
+        item.wake.kind !== "assistant.notification.requested"
+      ),
+    };
+  }
+
+  return {
+    pending: isHostedSystemMailboxModelFreeExactNotificationItem(durableFrontier)
+      ? [durableFrontier]
+      : [],
+  };
 }
 
 export function mergeHostedSystemMailboxRollbackItems(input: {
@@ -826,6 +896,41 @@ function findNextHostedSystemMailboxQueueItemsForWake(input: {
     items.push(item);
   }
   return items;
+}
+
+function shouldProjectHostedSystemMailboxModelFreeNotifications(input: {
+  allowedRouteActions: readonly HostedSystemMailboxRouteAction[] | null;
+  allowedWakeKinds: readonly HostedExecutionSystemWake["kind"][] | null;
+}): boolean {
+  const includesModelFreeMaintenanceAction =
+    input.allowedRouteActions?.includes("apply-runtime-control-request") === true
+    || input.allowedRouteActions?.includes("run-device-sync-wake") === true;
+  return input.allowedRouteActions?.includes(
+    "dispatch-assistant-notification",
+  ) === true
+    && includesModelFreeMaintenanceAction
+    && input.allowedWakeKinds?.includes(
+      "assistant.notification.requested",
+    ) === true;
+}
+
+function findHostedSystemMailboxDurableFrontierItem(
+  pending: readonly HostedSystemMailboxPendingItem[],
+): HostedSystemMailboxPendingItem | null {
+  let frontier: HostedSystemMailboxPendingItem | null = null;
+  let frontierSeq: bigint | null = null;
+  for (const item of pending) {
+    if (item.mailboxLaneSeq === null) {
+      continue;
+    }
+
+    const seq = BigInt(item.mailboxLaneSeq);
+    if (frontierSeq === null || seq < frontierSeq) {
+      frontier = item;
+      frontierSeq = seq;
+    }
+  }
+  return frontier;
 }
 
 function systemMailboxItemRouteActionAllowed(

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -857,6 +857,23 @@ export async function deferHostedSystemMailboxItemAfterVaultShareProjectionFailu
   );
 }
 
+export async function retainHostedSystemMailboxItemUntilDeliveryWake(input: {
+  item: HostedSystemMailboxPendingItem;
+  nextWakeAt: string;
+  vaultRoot: string;
+}): Promise<HostedSystemMailboxPendingItem> {
+  const retainedItem: HostedSystemMailboxPendingItem = {
+    ...input.item,
+    nextAttemptAt: input.nextWakeAt,
+    status: "recording",
+  };
+  await updateHostedSystemMailboxPendingItem({
+    item: retainedItem,
+    vaultRoot: input.vaultRoot,
+  });
+  return retainedItem;
+}
+
 function isHostedDeviceSyncDirtyPostCheckpointRecord(
   record: HostedSystemMailboxPostCheckpointRecord,
 ): boolean {

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -42,6 +42,7 @@ import type {
 import {
   findNextHostedSystemMailboxQueueItem,
   mergeHostedSystemMailboxRollbackItems,
+  projectHostedSystemMailboxModelFreeNotificationFrontier,
   readHostedSystemMailboxState,
   removeHostedSystemMailboxPendingItemIfCurrent,
   resolveHostedSystemMailboxNextWakeAt,
@@ -308,8 +309,21 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
   const prepared = await updateHostedSystemMailboxState(
     input.vaultRoot,
     (state) => {
+      const notificationProjectedState =
+        input.allowedRouteActions?.includes(
+          "dispatch-assistant-notification",
+        ) === true
+        && (
+          input.allowedRouteActions?.includes("apply-runtime-control-request") === true
+          || input.allowedRouteActions?.includes("run-device-sync-wake") === true
+        )
+        && input.allowedWakeKinds?.includes(
+          "assistant.notification.requested",
+        ) === true
+          ? projectHostedSystemMailboxModelFreeNotificationFrontier(state)
+          : state;
       const selectionState = {
-        pending: state.pending.filter((item) =>
+        pending: notificationProjectedState.pending.filter((item) =>
           (
             input.allowedRouteActions != null
             || item.routeAction !== "run-assistant-ask"

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -1330,6 +1330,13 @@ export async function runHostedWorkspaceCanonicalWriteAtBoundary<TResult>(input:
       await canonicalWritePort.persistCanonicalWrite(writeInput);
       canonicalWritePersisted = true;
     },
+    async persistRuntimeState() {
+      if (!canonicalWritePort.persistRuntimeState) {
+        throw new TypeError("Hosted runtime state checkpoint requires canonical write port support.");
+      }
+      await canonicalWritePort.persistRuntimeState();
+      canonicalWritePersisted = true;
+    },
   };
 
   const result = await withHostedCanonicalWritePort(port, input.write);
@@ -2730,6 +2737,60 @@ function createHostedWorkspaceCanonicalWritePort(input: {
         if (assistantAutomationScheduleChanged) {
           input.onAssistantAutomationScheduleChanged?.();
         }
+      };
+      const withPersistence = input.input.withCanonicalWritePersistence;
+      if (withPersistence) {
+        await withPersistence(persist);
+        return;
+      }
+
+      await persist();
+    },
+    async persistRuntimeState() {
+      const persist = async () => {
+        if (!input.input.checkpointRuntimeRedactedStatus) {
+          throw new TypeError("Hosted runtime state checkpoint requires runtime status checkpoint support.");
+        }
+        const workspace =
+          input.checkpointRequestBuilder.latestWorkspace()
+          ?? input.input.workspace;
+        const now = resolveHostedWorkspaceRunnerNowIso(input.input.now);
+        const systemMailboxWake = await resolveHostedSystemMailboxNextWakeCandidate({
+          now: () => now,
+          vaultRoot: input.input.vaultRoot,
+        });
+        const nextWake = selectHostedRuntimeWakeCandidate([
+          createHostedRuntimeWakeCandidate(
+            workspace?.nextWakeAt,
+            workspace?.nextWakeReason ?? null,
+          ),
+          systemMailboxWake,
+        ]);
+        const checkpoint = await input.input.checkpointRuntimeRedactedStatus({
+          nextWakeAt: nextWake.at,
+          nextWakeReason: nextWake.reason,
+          reason: "canonical_runtime_commit",
+          redactedStatus: input.readPreviousRedactedStatus(),
+          workspace,
+        });
+        if (checkpoint.workspace.userId !== input.input.expectedUserId) {
+          throw new HostedMailboxImportCheckpointUserMismatchError({
+            actualUserId: checkpoint.workspace.userId,
+            expectedUserId: input.input.expectedUserId,
+          });
+        }
+        if (!checkpoint.checkpointed) {
+          throw new HostedMailboxImportCheckpointConflictError(checkpoint);
+        }
+        input.checkpointRequestBuilder.recordStatusCheckpoint(checkpoint);
+        input.checkpointRequestBuilder.markRuntimeStateDirty();
+        await writeHostedForegroundCheckpointDeferredLog({
+          checkpointPhase: "canonical_write",
+          now: input.input.now,
+          platform: input.input.platform,
+          reason: "canonical_runtime_commit",
+          runtimeLogContext: input.input.runtimeLogContext,
+        });
       };
       const withPersistence = input.input.withCanonicalWritePersistence;
       if (withPersistence) {

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -232,6 +232,7 @@ import {
   drainHostedPreparedAssistantDeliveries,
   prepareHostedAssistantDeliveryEffectsForDispatch,
   queueHostedAssistantPendingMessageVolumeReceiptsForVault,
+  resolveHostedAssistantDeliveryIntentState,
   resolveHostedAssistantOutboxNextWakeAt,
 } from "../src/hosted-runtime/callbacks.ts";
 import {
@@ -609,6 +610,72 @@ beforeEach(() => {
 });
 
 describe("hosted runtime callbacks", () => {
+  it("resolves an exact durable delivery identity and preserves its retry wake", async () => {
+    mocks.listAssistantOutboxIntents.mockResolvedValue([
+      createPendingHostedDeliveryIntent({
+        deliveryIdempotencyKey: "unrelated-delivery",
+        intentId: "intent_unrelated",
+      }),
+      createPendingHostedDeliveryIntent({
+        deliveryIdempotencyKey: "exact-delivery",
+        intentId: "intent_exact",
+        nextAttemptAt: "2026-04-08T00:05:00.000Z",
+        status: "retryable",
+      }),
+    ]);
+
+    await expect(resolveHostedAssistantDeliveryIntentState({
+      deliveryIdempotencyKey: "exact-delivery",
+      now: new Date("2026-04-08T00:00:00.000Z"),
+      vaultRoot: "/tmp/vault",
+    })).resolves.toEqual({
+      intentId: "intent_exact",
+      nextWakeAt: "2026-04-08T00:05:00.000Z",
+      terminal: false,
+    });
+  });
+
+  it("recognizes an exact durable delivery that already reached a terminal state", async () => {
+    mocks.listAssistantOutboxIntents.mockResolvedValue([
+      createPendingHostedDeliveryIntent({
+        delivery: createDelivery(),
+        deliveryIdempotencyKey: "exact-delivery",
+        intentId: "intent_exact",
+        status: "sent",
+      }),
+    ]);
+
+    await expect(resolveHostedAssistantDeliveryIntentState({
+      deliveryIdempotencyKey: "exact-delivery",
+      now: new Date("2026-04-08T00:00:00.000Z"),
+      vaultRoot: "/tmp/vault",
+    })).resolves.toEqual({
+      intentId: "intent_exact",
+      nextWakeAt: null,
+      terminal: true,
+    });
+  });
+
+  it("fails closed when one durable delivery identity matches multiple intents", async () => {
+    mocks.listAssistantOutboxIntents.mockResolvedValue([
+      createPendingHostedDeliveryIntent({
+        deliveryIdempotencyKey: "duplicate-delivery",
+        intentId: "intent_one",
+      }),
+      createPendingHostedDeliveryIntent({
+        deliveryIdempotencyKey: "duplicate-delivery",
+        intentId: "intent_two",
+      }),
+    ]);
+
+    await expect(resolveHostedAssistantDeliveryIntentState({
+      deliveryIdempotencyKey: "duplicate-delivery",
+      vaultRoot: "/tmp/vault",
+    })).rejects.toThrow(
+      "An exact hosted delivery identity matched multiple outbox intents.",
+    );
+  });
+
   it("does not pre-claim arbitrary non-idempotent delivery effects before provider dispatch", async () => {
     const preparation = await prepareHostedAssistantDeliveryEffectsForDispatch({
       assistantDeliveryEffects: [createEffect({ transportIdempotent: false })],

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   fetchCompleteHostedDeviceSyncRuntimeSnapshot: vi.fn(),
   applyHostedPendingDirtyDeviceSyncStateForWake: vi.fn(),
   initInboxRuntime: vi.fn(),
+  persistHostedRuntimeStateAtCanonicalBoundary: vi.fn(),
   readConfiguredJunctionDeviceSyncProviderConfig: vi.fn(),
   readHostedAssistantRuntimeState: vi.fn(),
   requireHostedRuntimeDeviceSyncStore: vi.fn(),
@@ -90,6 +91,8 @@ vi.mock("@murphai/vault-usecases/vault-services", () => ({
 vi.mock("@murphai/core", () => ({
   detectWearableStorageMigrationCandidates:
     mocks.detectWearableStorageMigrationCandidates,
+  persistHostedRuntimeStateAtCanonicalBoundary:
+    mocks.persistHostedRuntimeStateAtCanonicalBoundary,
   pruneWearableDenseRawTimeseries: mocks.pruneWearableDenseRawTimeseries,
 }));
 
@@ -1776,6 +1779,12 @@ describe("runHostedDeviceSyncPass", () => {
       },
     );
 
+    expect(mocks.persistHostedRuntimeStateAtCanonicalBoundary).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.persistHostedRuntimeStateAtCanonicalBoundary.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.syncHostedDeviceSyncControlPlaneState.mock.invocationCallOrder[0],
+    );
     expect(mocks.syncHostedDeviceSyncControlPlaneState).toHaveBeenCalledWith(
       expect.objectContaining({
         skipDirtyPendingFetch: true,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -10775,53 +10775,79 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointConversationInputAhead: false,
       expectedProviderSends: 1,
       initialOutboxState: "pending" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "linq" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "pending" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "linq" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "due_retryable" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "linq" as const,
       checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "retryable" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "linq" as const,
       checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "sent" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "telegram" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "pending" as const,
+      providerOutcome: "success" as const,
     },
     {
       channel: "telegram" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "due_retryable" as const,
+      providerOutcome: "success" as const,
     },
-  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($channel, $initialOutboxState outbox, foreground checkpoint: $checkpointConversationInputAhead)", async ({
+    {
+      channel: "linq" as const,
+      checkpointConversationInputAhead: false,
+      expectedProviderSends: 3,
+      initialOutboxState: "pending" as const,
+      providerOutcome: "retryable_failure" as const,
+    },
+    {
+      channel: "linq" as const,
+      checkpointConversationInputAhead: false,
+      expectedProviderSends: 3,
+      initialOutboxState: "pending" as const,
+      providerOutcome: "retryable_failure_with_host_abort" as const,
+    },
+  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($channel, $initialOutboxState outbox, provider: $providerOutcome, foreground checkpoint: $checkpointConversationInputAhead)", async ({
     channel,
     checkpointConversationInputAhead,
     expectedProviderSends,
     initialOutboxState,
+    providerOutcome,
   }) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
     const deliveryBodies: unknown[] = [];
+    const retryCheckpointAbortController = new AbortController();
+    const retryCheckpointAbortReason = new Error(
+      "Synthetic host abort during exact delivery retry checkpoint.",
+    );
     const exactText = "You are now part of the synthetic group.";
     const exactDeliveryKey = "group-join:membership_restored_exact";
     const exactTarget = channel === "telegram"
@@ -10835,6 +10861,9 @@ describe("hosted workspace runtime entrypoint", () => {
       : "hbidx:thread:v1:group-join-restored-test";
     const exactDedupeKey =
       `assistant.notification.requested:${exactDeliveryKey}`;
+    let providerFailuresRemaining =
+      providerOutcome === "success" ? 0 : 3;
+    const providerRetries = providerOutcome !== "success";
     const retryWakeAt = new Date(
       Date.parse(TEST_NOW) + 5 * 60_000,
     ).toISOString();
@@ -10884,6 +10913,15 @@ describe("hosted workspace runtime entrypoint", () => {
         )
       ) {
         deliveryBodies.push(JSON.parse(String(init?.body)));
+        if (providerFailuresRemaining > 0) {
+          providerFailuresRemaining -= 1;
+          return new Response(JSON.stringify({
+            error: { message: "Synthetic retryable provider failure." },
+          }), {
+            headers: { "content-type": "application/json" },
+            status: 503,
+          });
+        }
         return new Response(JSON.stringify(
           channel === "telegram"
             ? {
@@ -11033,7 +11071,7 @@ describe("hosted workspace runtime entrypoint", () => {
         ReturnType<typeof createVaultSnapshotBundle>
       >> = [];
 
-      const result = await runHostedWorkspaceRuntimeJobInProcess(
+      const resultPromise = runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           platformEnv: {
             TELEGRAM_BOT_TOKEN:
@@ -11073,6 +11111,14 @@ describe("hosted workspace runtime entrypoint", () => {
               vaultRoot,
             });
             checkpointBundles.push(checkpointBundle);
+            if (
+              providerOutcome === "retryable_failure_with_host_abort"
+              && checkpointRequests.length === 1
+            ) {
+              retryCheckpointAbortController.abort(
+                retryCheckpointAbortReason,
+              );
+            }
             return {
               snapshotRef: checkpointBundle.snapshotRef,
             };
@@ -11122,9 +11168,69 @@ describe("hosted workspace runtime entrypoint", () => {
           async runAssistantPhase() {
             throw new Error("Restored exact notification must not enter assistant execution.");
           },
+          signal: retryCheckpointAbortController.signal,
           vaultRoot,
         },
       );
+
+      if (providerOutcome === "retryable_failure_with_host_abort") {
+        await assert.rejects(resultPromise, retryCheckpointAbortReason);
+        assert.equal(deliveryBodies.length, expectedProviderSends);
+        const abortedOutbox = await listAssistantOutboxIntents(vaultRoot);
+        const abortedRetryWakeAt = abortedOutbox.at(0)?.nextAttemptAt ?? null;
+        assert.ok(abortedRetryWakeAt);
+        assert.deepEqual(
+          abortedOutbox.map((intent) => ({
+            nextAttemptAt: intent.nextAttemptAt,
+            status: intent.status,
+          })),
+          [{
+            nextAttemptAt: abortedRetryWakeAt,
+            status: "retryable",
+          }],
+        );
+        const durableRetryWorkspace = checkpointBundles.at(-1);
+        assert.ok(durableRetryWorkspace);
+        const durableRetryRoot = await mkdtemp(
+          path.join(tmpdir(), "murph-workspace-entrypoint-aborted-retry-"),
+        );
+        try {
+          await restoreHostedBundleRoots({
+            bytes: durableRetryWorkspace.bytes,
+            expectedKind: "vault",
+            roots: { vault: durableRetryRoot },
+          });
+          assert.deepEqual(
+            (await listAssistantOutboxIntents(durableRetryRoot)).map(
+              (intent) => ({
+                nextAttemptAt: intent.nextAttemptAt,
+                status: intent.status,
+              }),
+            ),
+            [{
+              nextAttemptAt: abortedRetryWakeAt,
+              status: "retryable",
+            }],
+          );
+          assert.deepEqual(
+            (await readHostedSystemMailboxState(durableRetryRoot)).pending.map(
+              (item) => ({
+                nextAttemptAt: item.nextAttemptAt,
+                status: item.status,
+              }),
+            ),
+            [{
+              nextAttemptAt: abortedRetryWakeAt,
+              status: "recording",
+            }],
+          );
+        } finally {
+          await removeTempRoot(durableRetryRoot);
+        }
+        return;
+      }
+
+      const result = await resultPromise;
 
       if (channel === "telegram" && checkpointConversationInputAhead) {
         const preparedWorkspace = checkpointBundles.at(0);
@@ -11170,6 +11276,22 @@ describe("hosted workspace runtime entrypoint", () => {
         expect(JSON.stringify(deliveryBodies[0])).toContain(exactText);
       }
       const outboxAfter = await listAssistantOutboxIntents(vaultRoot);
+      const providerRetryWakeAt = providerRetries
+        ? outboxAfter.at(0)?.nextAttemptAt ?? null
+        : null;
+      if (providerRetries) {
+        assert.ok(providerRetryWakeAt);
+        assert.deepEqual(
+          outboxAfter.map((intent) => ({
+            nextAttemptAt: intent.nextAttemptAt,
+            status: intent.status,
+          })),
+          [{
+            nextAttemptAt: providerRetryWakeAt,
+            status: "retryable",
+          }],
+        );
+      }
       if (checkpointConversationInputAhead) {
         assert.deepEqual(
           outboxAfter.map((intent) => ({
@@ -11184,7 +11306,23 @@ describe("hosted workspace runtime entrypoint", () => {
         );
       }
       const pendingAfter = (await readHostedSystemMailboxState(vaultRoot)).pending;
-      if (initialOutboxState === "retryable") {
+      if (providerRetries) {
+        assert.deepEqual(
+          pendingAfter.map((item) => ({
+            nextAttemptAt: item.nextAttemptAt,
+            status: item.status,
+          })),
+          [{
+            nextAttemptAt: providerRetryWakeAt,
+            status: "recording",
+          }],
+        );
+        assert.notEqual(
+          checkpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+      } else if (initialOutboxState === "retryable") {
         assert.deepEqual(
           pendingAfter.map((item) => ({
             nextAttemptAt: item.nextAttemptAt,
@@ -11227,7 +11365,11 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
       assert.equal(mocks.prepareHostedCodexRuntimeEnvironment.mock.calls.length, 0);
       assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
-      if (initialOutboxState === "retryable") {
+      if (providerRetries) {
+        assert.equal(result.status, "scheduled");
+        assert.equal(result.nextWakeAt, providerRetryWakeAt);
+        assert.equal(result.nextWakeReason, "assistant");
+      } else if (initialOutboxState === "retryable") {
         assert.equal(result.status, "scheduled");
         assert.equal(result.nextWakeAt, retryWakeAt);
         assert.equal(result.nextWakeReason, "assistant");
@@ -11239,6 +11381,196 @@ describe("hosted workspace runtime entrypoint", () => {
       } else {
         assert.equal(result.status, "idle");
         assert.equal(result.nextWakeAt, null);
+      }
+      if (providerRetries) {
+        const durableRetryWorkspace = checkpointBundles.at(-1);
+        assert.ok(durableRetryWorkspace);
+        const durableRetryRoot = await mkdtemp(
+          path.join(tmpdir(), "murph-workspace-entrypoint-durable-retry-"),
+        );
+        try {
+          await restoreHostedBundleRoots({
+            bytes: durableRetryWorkspace.bytes,
+            expectedKind: "vault",
+            roots: { vault: durableRetryRoot },
+          });
+          assert.deepEqual(
+            (await listAssistantOutboxIntents(durableRetryRoot)).map(
+              (intent) => ({
+                nextAttemptAt: intent.nextAttemptAt,
+                status: intent.status,
+              }),
+            ),
+            [{
+              nextAttemptAt: providerRetryWakeAt,
+              status: "retryable",
+            }],
+          );
+          assert.deepEqual(
+            (await readHostedSystemMailboxState(durableRetryRoot)).pending.map(
+              (item) => ({
+                nextAttemptAt: item.nextAttemptAt,
+                status: item.status,
+              }),
+            ),
+            [{
+              nextAttemptAt: providerRetryWakeAt,
+              status: "recording",
+            }],
+          );
+        } finally {
+          await removeTempRoot(durableRetryRoot);
+        }
+
+        const durableRetryWorkspaceVersion = String(
+          BigInt(
+            checkpointRequests.at(-1)?.expectedWorkspaceVersion ?? "0",
+          ) + 1n,
+        );
+        const runColdRetryWorkspace = async (input: {
+          attemptId: string;
+          workspace: Awaited<ReturnType<typeof createVaultSnapshotBundle>>;
+          workspaceVersion: string;
+        }) => {
+          const coldCheckpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+          const coldCheckpointBundles: Array<Awaited<
+            ReturnType<typeof createVaultSnapshotBundle>
+          >> = [];
+          const coldResult = await runHostedWorkspaceRuntimeJobInProcess(
+            createWorkspaceRuntimeJobInput({
+              platformEnv: { TELEGRAM_BOT_TOKEN: "" },
+              forwardedEnv: { LINQ_API_TOKEN: "synthetic-linq-token" },
+              request: {
+                assistantExecutionBlocked: true,
+                attemptId: input.attemptId,
+                processingMode: "system_mailbox",
+                workspaceVersion: input.workspaceVersion,
+              },
+              resolvedConfig: {
+                channelCapabilities: {
+                  emailSendReady: false,
+                  telegramBotConfigured: false,
+                },
+                deviceSync: null,
+                managedAutoReplyChannels: [{
+                  capabilityReady: true,
+                  channel: "linq",
+                  memberChannel: "linq",
+                }],
+              },
+            }),
+            {
+              async createCheckpointSnapshot() {
+                const checkpointBundle = await createVaultSnapshotBundle({
+                  key:
+                    "users/bundles/member-synthetic/"
+                    + `${input.attemptId}-${coldCheckpointRequests.length + 1}.bundle.json`,
+                  vaultRoot,
+                });
+                coldCheckpointBundles.push(checkpointBundle);
+                return { snapshotRef: checkpointBundle.snapshotRef };
+              },
+              async importItem() {
+                throw new Error(
+                  "Cold-restored retry notification must not import a new row.",
+                );
+              },
+              platform: {
+                ...createPlatform({
+                  artifactBytesByHash: new Map([
+                    [input.workspace.hash, input.workspace.bytes],
+                  ]),
+                  mailboxPort: createMailboxPort({ events, items: [] }),
+                  workspacePort: createWorkspacePort({
+                    checkpointRequests: coldCheckpointRequests,
+                    events,
+                    workspace: createWorkspaceState({
+                      snapshotRef: input.workspace.snapshotRef,
+                      version: input.workspaceVersion,
+                    }),
+                  }),
+                }),
+                effectsPort,
+                providerFetch,
+              },
+              async runAssistantPhase() {
+                throw new Error(
+                  "Cold-restored retry notification must not enter assistant execution.",
+                );
+              },
+              vaultRoot,
+            },
+          );
+          return {
+            checkpointBundles: coldCheckpointBundles,
+            checkpointRequests: coldCheckpointRequests,
+            result: coldResult,
+          };
+        };
+
+        const sendsAfterProviderFailure = deliveryBodies.length;
+        const beforeRetry = await runColdRetryWorkspace({
+          attemptId: "attempt_synthetic_group_join_cold_before_retry",
+          workspace: durableRetryWorkspace,
+          workspaceVersion: durableRetryWorkspaceVersion,
+        });
+        assert.equal(deliveryBodies.length, sendsAfterProviderFailure);
+        assert.equal(beforeRetry.checkpointRequests.length, 1);
+        assert.equal(
+          beforeRetry.checkpointRequests[0]?.nextWakeAt,
+          providerRetryWakeAt,
+        );
+        assert.equal(
+          beforeRetry.checkpointRequests[0]?.nextWakeReason,
+          "assistant",
+        );
+        assert.equal(beforeRetry.result.status, "scheduled");
+        assert.equal(beforeRetry.result.nextWakeAt, providerRetryWakeAt);
+        assert.deepEqual(
+          (await listAssistantOutboxIntents(vaultRoot)).map((intent) => ({
+            nextAttemptAt: intent.nextAttemptAt,
+            status: intent.status,
+          })),
+          [{
+            nextAttemptAt: providerRetryWakeAt,
+            status: "retryable",
+          }],
+        );
+
+        if (!providerRetryWakeAt) {
+          throw new Error("Provider retry wake must be available after failure.");
+        }
+        vi.setSystemTime(new Date(providerRetryWakeAt));
+        const beforeRetryWorkspace = beforeRetry.checkpointBundles.at(-1);
+        assert.ok(beforeRetryWorkspace);
+        const beforeRetryWorkspaceVersion = String(
+          BigInt(
+            beforeRetry.checkpointRequests.at(-1)
+              ?.expectedWorkspaceVersion ?? durableRetryWorkspaceVersion,
+          ) + 1n,
+        );
+        const atRetry = await runColdRetryWorkspace({
+          attemptId: "attempt_synthetic_group_join_cold_at_retry",
+          workspace: beforeRetryWorkspace,
+          workspaceVersion: beforeRetryWorkspaceVersion,
+        });
+        assert.equal(deliveryBodies.length, sendsAfterProviderFailure + 1);
+        assert.deepEqual(
+          (await listAssistantOutboxIntents(vaultRoot)).map((intent) =>
+            intent.status
+          ),
+          ["sent"],
+        );
+        assert.deepEqual(
+          (await readHostedSystemMailboxState(vaultRoot)).pending,
+          [],
+        );
+        assert.equal(
+          atRetry.checkpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+        assert.equal(atRetry.result.status, "idle");
       }
       if (checkpointConversationInputAhead) {
         assert.deepEqual(

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -11448,7 +11448,11 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointAttempt += 1;
       checkpointRequests.push(request);
       events.push(`checkpoint.attempt:${activeAttemptId}:${checkpointAttempt}`);
-      if (failRecordCheckpoint && checkpointAttempt === 2) {
+      if (
+        failRecordCheckpoint
+        && activeAttemptId === "attempt_device_sync_closed_loop_initial"
+        && request.reason === "idle_shutdown"
+      ) {
         events.push(`checkpoint.fail:${activeAttemptId}:${checkpointAttempt}`);
         throw new Error("synthetic checkpoint transport fault");
       }
@@ -11792,18 +11796,22 @@ describe("hosted workspace runtime entrypoint", () => {
         /synthetic checkpoint transport fault/u,
       );
 
-      assert.equal(checkpointAttempt, 2);
-      assert.equal(checkpointRequests.length, 2);
+      assert.equal(checkpointAttempt, 3);
+      assert.equal(checkpointRequests.length, 3);
       assert.deepEqual(
         checkpointRequests.map((request) => request.reason),
-        ["canonical_runtime_commit", "idle_shutdown"],
+        [
+          "canonical_runtime_commit",
+          "canonical_runtime_commit",
+          "idle_shutdown",
+        ],
       );
       assert.deepEqual(
         checkpointRequests.map((request) => request.expectedWorkspaceVersion),
-        ["1", "2"],
+        ["1", "2", "3"],
       );
       assert.ok(currentWorkspace);
-      assert.equal(currentWorkspace.version, "2");
+      assert.equal(currentWorkspace.version, "3");
       const initialProviderRequestClasses = providerRequestClasses.slice();
       assert.deepEqual(initialProviderRequestClasses, expectedWhoopRequestClasses);
       assert.deepEqual(cadencePublications, []);
@@ -11812,7 +11820,7 @@ describe("hosted workspace runtime entrypoint", () => {
         "checkpoint.attempt:attempt_device_sync_closed_loop_initial:1",
       );
       const lostRecordCheckpointIndex = events.indexOf(
-        "checkpoint.fail:attempt_device_sync_closed_loop_initial:2",
+        "checkpoint.fail:attempt_device_sync_closed_loop_initial:3",
       );
       assert.notEqual(firstCheckpointAttemptIndex, -1);
       assert.notEqual(lostRecordCheckpointIndex, -1);
@@ -11821,23 +11829,23 @@ describe("hosted workspace runtime entrypoint", () => {
         events.slice(0, firstCheckpointAttemptIndex).filter((event) =>
           event.startsWith("provider.request:")
         ).length,
-        4,
+        0,
       );
       assert.equal(
         events.slice(0, firstCheckpointAttemptIndex).filter((event) =>
           event.startsWith("artifact.put:")
         ).length,
-        4,
+        0,
       );
       assert.equal(
-        events.indexOf("checkpoint.commit:attempt_device_sync_closed_loop_initial:3"),
+        events.indexOf("checkpoint.commit:attempt_device_sync_closed_loop_initial:4"),
         -1,
       );
-      const durablePostPullCheckpoint = checkpointRequests[0];
+      const durablePostPullCheckpoint = checkpointRequests[1];
       assert.ok(durablePostPullCheckpoint);
       assert.deepEqual(currentWorkspace.snapshotRef, durablePostPullCheckpoint.snapshotRef);
       assert.deepEqual(currentWorkspace.snapshotRef, committedInputSnapshotRef);
-      const failedPostPullCheckpoint = checkpointRequests[1];
+      const failedPostPullCheckpoint = checkpointRequests[2];
       assert.ok(failedPostPullCheckpoint);
       const failedPostPullSnapshotRef = failedPostPullCheckpoint.snapshotRef;
       assert.ok(isHostedWorkspaceSnapshotV2Ref(failedPostPullSnapshotRef));
@@ -11896,19 +11904,19 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(canonicalNextReconcileAt, dueAt);
       assert.equal(recovered.nextWakeReason, "device-sync.reconcile");
       assert.ok(currentWorkspace);
-      assert.equal(currentWorkspace.version, "5");
-      assert.equal(checkpointAttempt, 5);
-      assert.equal(checkpointRequests.length, 5);
+      assert.equal(currentWorkspace.version, "7");
+      assert.equal(checkpointAttempt, 7);
+      assert.equal(checkpointRequests.length, 7);
       assert.deepEqual(
-        checkpointRequests.slice(2, 5).map((request) =>
+        checkpointRequests.slice(3, 7).map((request) =>
           request.expectedWorkspaceVersion
         ),
-        ["2", "3", "4"],
+        ["3", "4", "5", "6"],
       );
       const recoveryCheckpointCommitIndexes = events.flatMap((event, index) =>
         event.startsWith(`checkpoint.commit:${recoveryAttemptId}:`) ? [index] : []
       );
-      assert.equal(recoveryCheckpointCommitIndexes.length, 3);
+      assert.equal(recoveryCheckpointCommitIndexes.length, 4);
       const durableRecoveryCompletionCheckpointIndex =
         recoveryCheckpointCommitIndexes[recoveryCheckpointCommitIndexes.length - 1];
       assert.notEqual(durableRecoveryCompletionCheckpointIndex, undefined);
@@ -11959,17 +11967,17 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(settled.nextWakeAt, "2026-04-27T06:05:00.000Z");
       assert.equal(settled.nextWakeReason, "device-sync.reconcile");
       assert.deepEqual(
-        checkpointRequests.slice(5, 7).map((request) =>
+        checkpointRequests.slice(7, 10).map((request) =>
           request.expectedWorkspaceVersion
         ),
-        ["5", "6"],
+        ["7", "8", "9"],
       );
       assert.ok(currentWorkspace);
-      assert.equal(currentWorkspace.version, "7");
+      assert.equal(currentWorkspace.version, "10");
 
       const checkpointAttemptsAfterSettlement = checkpointAttempt;
-      assert.equal(checkpointAttemptsAfterSettlement, 7);
-      assert.equal(checkpointRequests.length, 7);
+      assert.equal(checkpointAttemptsAfterSettlement, 10);
+      assert.equal(checkpointRequests.length, 10);
       assert.equal(
         events.filter((event) => event.startsWith("checkpoint.fail:")).length,
         1,
@@ -11991,9 +11999,9 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(converged.nextWakeReason, undefined);
       assert.equal(providerRequestClasses.length, providerRequestsBeforeConvergence);
       assert.equal(checkpointAttempt, checkpointAttemptsBeforeConvergence + 1);
-      assert.equal(checkpointRequests.at(-1)?.expectedWorkspaceVersion, "7");
+      assert.equal(checkpointRequests.at(-1)?.expectedWorkspaceVersion, "10");
       assert.ok(currentWorkspace);
-      assert.equal(currentWorkspace.version, "8");
+      assert.equal(currentWorkspace.version, "11");
 
       const quiescentBucketAt = "2026-04-27T00:15:00.000Z";
       const quiescentAttemptId =
@@ -12011,17 +12019,17 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(providerRequestClasses.length, providerRequestsBeforeQuiescence);
       assert.equal(checkpointAttempt, checkpointAttemptsBeforeQuiescence);
       assert.ok(currentWorkspace);
-      assert.equal(currentWorkspace.version, "8");
+      assert.equal(currentWorkspace.version, "11");
       assert.equal(
         providerRequestClasses.length,
         providerRequestClassesAfterSettlement,
       );
       assert.equal(checkpointAttempt, checkpointAttemptsAfterSettlement + 1);
-      assert.equal(checkpointAttempt, 8);
+      assert.equal(checkpointAttempt, 11);
       assert.equal(checkpointAttempt, checkpointRequests.length);
       assert.equal(
         events.filter((event) => event.startsWith("checkpoint.commit:")).length,
-        7,
+        10,
       );
       assert.deepEqual([...observedScheduleEventIds], [scheduleEventId]);
       assert.deepEqual([...observedMailboxItemIds], [mailboxItemId]);
@@ -13219,23 +13227,26 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.equal(browserPublishCalls, 0);
       assert.deepEqual(checkpointRequests.map((request) => request.reason), [
         "canonical_runtime_commit",
+        "canonical_runtime_commit",
         "idle_shutdown",
       ]);
       assert.equal(checkpointRequests[0]?.expectedWorkspaceVersion, "0");
       assert.equal(checkpointRequests[1]?.expectedWorkspaceVersion, "1");
+      assert.equal(checkpointRequests[2]?.expectedWorkspaceVersion, "2");
+      assert.equal(checkpointRequests[0]?.nextWakeReason, "device-sync.reconcile");
       assert.equal(
-        typeof checkpointRequests[0]?.redactedStatus?.hostedCanonicalWriteReceiptLogSha256,
+        typeof checkpointRequests[1]?.redactedStatus?.hostedCanonicalWriteReceiptLogSha256,
         "string",
       );
       assert.equal(
-        checkpointRequests[1]?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        checkpointRequests[2]?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
         "0",
       );
-      assert.equal(typeof checkpointRequests[1]?.nextWakeAt, "string");
+      assert.equal(typeof checkpointRequests[2]?.nextWakeAt, "string");
       // The canonical write may make an immediate assistant snapshot refresh
       // earlier than the device continuation; either wake must be checkpointed.
       assert.match(
-        checkpointRequests[1]?.nextWakeReason ?? "",
+        checkpointRequests[2]?.nextWakeReason ?? "",
         /^(assistant|device-sync\.reconcile)$/u,
       );
       const retainedState = await readHostedSystemMailboxState(vaultRoot);
@@ -39127,20 +39138,30 @@ describe("hosted workspace runtime entrypoint", () => {
         },
       );
 
-      assert.deepEqual(events, [
+      const expectedEvents = [
         "workspace.read",
         "mailbox.fetch",
         "mailbox.fetch",
+        ...(input.nextWakeReason === "device-sync.reconcile"
+          ? ["workspace.checkpoint"]
+          : []),
         "snapshot:idle_shutdown",
         "workspace.checkpoint",
-      ]);
+      ];
+      assert.deepEqual(events, expectedEvents);
       const shouldRunDeviceSync = input.nextWakeReason === "device-sync.reconcile";
       assert.equal(deviceSyncPort.fetchSnapshotCalls, shouldRunDeviceSync ? 1 : 0);
       assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
-      assert.equal(checkpointRequests.length, 1);
-      assert.equal(checkpointRequests[0]?.reason, "idle_shutdown");
-      assert.equal(checkpointRequests[0]?.nextWakeAt, null);
-      assert.equal(checkpointRequests[0]?.nextWakeReason, null);
+      assert.equal(checkpointRequests.length, shouldRunDeviceSync ? 2 : 1);
+      const terminalCheckpoint = checkpointRequests.at(-1);
+      assert.equal(terminalCheckpoint?.reason, "idle_shutdown");
+      assert.equal(terminalCheckpoint?.nextWakeAt, null);
+      assert.equal(terminalCheckpoint?.nextWakeReason, null);
+      if (shouldRunDeviceSync) {
+        assert.equal(checkpointRequests[0]?.reason, "canonical_runtime_commit");
+        assert.equal(checkpointRequests[0]?.nextWakeReason, "device-sync.reconcile");
+        assert.equal(typeof checkpointRequests[0]?.nextWakeAt, "string");
+      }
       assert.equal(result.status, "idle");
       assert.equal(result.nextWakeAt, null);
       assert.equal(result.redactedStatus?.hostedMailboxFetchedCount, 0);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -90,6 +90,7 @@ import {
   sha256HostedBundleHex,
   createHostedPortableWorkspaceManifestFromBundle,
   listPendingAssistantRuntimeIssueRecords,
+  restoreHostedBundleRoots,
   restoreHostedExecutionContext,
   snapshotHostedPortableWorkspaceDelta,
   snapshotHostedAssistantRuntimeHotState,
@@ -10770,31 +10771,49 @@ describe("hosted workspace runtime entrypoint", () => {
 
   test.each([
     {
+      channel: "linq" as const,
       checkpointConversationInputAhead: false,
       expectedProviderSends: 1,
       initialOutboxState: "pending" as const,
     },
     {
+      channel: "linq" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "pending" as const,
     },
     {
+      channel: "linq" as const,
       checkpointConversationInputAhead: true,
       expectedProviderSends: 0,
       initialOutboxState: "due_retryable" as const,
     },
     {
+      channel: "linq" as const,
       checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "retryable" as const,
     },
     {
+      channel: "linq" as const,
       checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "sent" as const,
     },
-  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($initialOutboxState outbox, foreground checkpoint: $checkpointConversationInputAhead)", async ({
+    {
+      channel: "telegram" as const,
+      checkpointConversationInputAhead: true,
+      expectedProviderSends: 0,
+      initialOutboxState: "pending" as const,
+    },
+    {
+      channel: "telegram" as const,
+      checkpointConversationInputAhead: true,
+      expectedProviderSends: 0,
+      initialOutboxState: "due_retryable" as const,
+    },
+  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($channel, $initialOutboxState outbox, foreground checkpoint: $checkpointConversationInputAhead)", async ({
+    channel,
     checkpointConversationInputAhead,
     expectedProviderSends,
     initialOutboxState,
@@ -10805,6 +10824,15 @@ describe("hosted workspace runtime entrypoint", () => {
     const deliveryBodies: unknown[] = [];
     const exactText = "You are now part of the synthetic group.";
     const exactDeliveryKey = "group-join:membership_restored_exact";
+    const exactTarget = channel === "telegram"
+      ? "123456789"
+      : "linq_private_group_join_thread";
+    const exactIdentityId = channel === "telegram"
+      ? "telegram-bot"
+      : "hbidx:phone:v1:group-join-restored-test";
+    const exactThreadId = channel === "telegram"
+      ? exactTarget
+      : "hbidx:thread:v1:group-join-restored-test";
     const exactDedupeKey =
       `assistant.notification.requested:${exactDeliveryKey}`;
     const retryWakeAt = new Date(
@@ -10831,13 +10859,13 @@ describe("hosted workspace runtime entrypoint", () => {
         },
         route: {
           actorId: null,
-          channel: "linq",
+          channel,
           delivery: {
             kind: "thread",
-            target: "linq_private_group_join_thread",
+            target: exactTarget,
           },
-          identityId: "hbidx:phone:v1:group-join-restored-test",
-          threadId: "hbidx:thread:v1:group-join-restored-test",
+          identityId: exactIdentityId,
+          threadId: exactThreadId,
           threadIsDirect: true,
         },
       },
@@ -10848,11 +10876,24 @@ describe("hosted workspace runtime entrypoint", () => {
         init?.method
         ?? (request instanceof Request ? request.method : "GET");
       const url = request instanceof Request ? request.url : String(request);
-      if (method === "POST" && url.includes("/messages")) {
+      if (
+        method === "POST"
+        && (
+          (channel === "linq" && url.includes("/messages"))
+          || (channel === "telegram" && url.endsWith("/sendMessage"))
+        )
+      ) {
         deliveryBodies.push(JSON.parse(String(init?.body)));
-        return new Response(JSON.stringify({
-          message: { id: "provider_group_join_restored_confirmation" },
-        }), {
+        return new Response(JSON.stringify(
+          channel === "telegram"
+            ? {
+                ok: true,
+                result: { message_id: 123 },
+              }
+            : {
+                message: { id: "provider_group_join_restored_confirmation" },
+              },
+        ), {
           headers: { "content-type": "application/json" },
           status: 200,
         });
@@ -10861,13 +10902,14 @@ describe("hosted workspace runtime entrypoint", () => {
     });
     const effectsPort = {
       async assertLinqRecentInboundEngagement() {
+        assert.equal(channel, "linq");
         return {
           providerDispatchClaimed: true,
           resolvedRoute: {
             conversationThreadId: null,
             directRecipientPhoneNumber: null,
             fromPhoneNumber: null,
-            target: "linq_private_group_join_thread",
+            target: exactTarget,
             targetKind: "thread" as const,
             threadIsDirect: true,
           },
@@ -10931,16 +10973,16 @@ describe("hosted workspace runtime entrypoint", () => {
         ),
       }));
       const exactIntent = await createAssistantOutboxIntent({
-        channel: "linq",
+        channel,
         createdAt: TEST_NOW,
         dedupeToken: exactDeliveryKey,
         deliveryIdempotencyKey: exactDeliveryKey,
-        deliveryTransportIdempotent: true,
-        explicitTarget: "linq_private_group_join_thread",
-        identityId: "hbidx:phone:v1:group-join-restored-test",
+        deliveryTransportIdempotent: channel === "linq",
+        explicitTarget: exactTarget,
+        identityId: exactIdentityId,
         message: exactText,
         sessionId: "session_group_join_restored_exact",
-        threadId: "hbidx:thread:v1:group-join-restored-test",
+        threadId: exactThreadId,
         threadIsDirect: true,
         turnId: "turn_group_join_restored_exact",
         vault: vaultRoot,
@@ -10966,13 +11008,13 @@ describe("hosted workspace runtime entrypoint", () => {
       if (initialOutboxState === "sent") {
         const sentIntent = await markAssistantOutboxIntentSentById({
           delivery: {
-            channel: "linq",
+            channel,
             idempotencyKey: exactDeliveryKey,
             messageLength: exactText.length,
             providerMessageId: "provider_group_join_already_sent",
-            providerThreadId: "linq_private_group_join_thread",
+            providerThreadId: exactTarget,
             sentAt: TEST_NOW,
-            target: "linq_private_group_join_thread",
+            target: exactTarget,
             targetKind: "explicit",
           },
           intentId: exactIntent.intentId,
@@ -10993,8 +11035,14 @@ describe("hosted workspace runtime entrypoint", () => {
 
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
-          platformEnv: { TELEGRAM_BOT_TOKEN: "" },
-          forwardedEnv: { LINQ_API_TOKEN: "synthetic-linq-token" },
+          platformEnv: {
+            TELEGRAM_BOT_TOKEN:
+              channel === "telegram" ? "synthetic-telegram-token" : "",
+          },
+          forwardedEnv: {
+            LINQ_API_TOKEN:
+              channel === "linq" ? "synthetic-linq-token" : "",
+          },
           request: {
             assistantExecutionBlocked: true,
             attemptId: "attempt_synthetic_blocked_group_join_restored_exact",
@@ -11004,13 +11052,13 @@ describe("hosted workspace runtime entrypoint", () => {
           resolvedConfig: {
             channelCapabilities: {
               emailSendReady: false,
-              telegramBotConfigured: false,
+              telegramBotConfigured: channel === "telegram",
             },
             deviceSync: null,
             managedAutoReplyChannels: [{
               capabilityReady: true,
-              channel: "linq",
-              memberChannel: "linq",
+              channel,
+              memberChannel: channel,
             }],
           },
         }),
@@ -11077,6 +11125,36 @@ describe("hosted workspace runtime entrypoint", () => {
           vaultRoot,
         },
       );
+
+      if (channel === "telegram" && checkpointConversationInputAhead) {
+        const preparedWorkspace = checkpointBundles.at(0);
+        assert.ok(preparedWorkspace);
+        const preparedCheckpointRoot = await mkdtemp(
+          path.join(tmpdir(), "murph-workspace-entrypoint-prepared-checkpoint-"),
+        );
+        try {
+          await restoreHostedBundleRoots({
+            bytes: preparedWorkspace.bytes,
+            expectedKind: "vault",
+            roots: { vault: preparedCheckpointRoot },
+          });
+          assert.deepEqual(
+            (await listAssistantOutboxIntents(preparedCheckpointRoot)).map(
+              (intent) => ({
+                preparedDispatchTokenPresent:
+                  intent.preparedDispatchToken !== null,
+                status: intent.status,
+              }),
+            ),
+            [{
+              preparedDispatchTokenPresent: true,
+              status: "sending",
+            }],
+          );
+        } finally {
+          await removeTempRoot(preparedCheckpointRoot);
+        }
+      }
 
       assert.equal(deliveryBodies.length, expectedProviderSends, JSON.stringify({
         outbox: (await listAssistantOutboxIntents(vaultRoot)).map((intent) => ({
@@ -11167,6 +11245,96 @@ describe("hosted workspace runtime entrypoint", () => {
           checkpointRequests.map((request) => request.expectedWorkspaceVersion),
           ["0", "1"],
         );
+        if (channel === "telegram") {
+          const ambiguousWorkspace = checkpointBundles.at(0);
+          assert.ok(ambiguousWorkspace);
+          const ambiguousCheckpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+          const ambiguousResult = await runHostedWorkspaceRuntimeJobInProcess(
+            createWorkspaceRuntimeJobInput({
+              platformEnv: {
+                TELEGRAM_BOT_TOKEN: "synthetic-telegram-token",
+              },
+              forwardedEnv: { LINQ_API_TOKEN: "" },
+              request: {
+                assistantExecutionBlocked: true,
+                attemptId:
+                  "attempt_synthetic_blocked_group_join_restored_telegram_ambiguous",
+                processingMode: "system_mailbox",
+                workspaceVersion: "1",
+              },
+              resolvedConfig: {
+                channelCapabilities: {
+                  emailSendReady: false,
+                  telegramBotConfigured: true,
+                },
+                deviceSync: null,
+                managedAutoReplyChannels: [{
+                  capabilityReady: true,
+                  channel: "telegram",
+                  memberChannel: "telegram",
+                }],
+              },
+            }),
+            {
+              async createCheckpointSnapshot() {
+                return {
+                  snapshotRef: createBundleRef({
+                    hash: "f".repeat(64),
+                    key:
+                      "users/bundles/member-synthetic/"
+                      + "blocked-group-join-restored-telegram-ambiguous.bundle.json",
+                    size: 512,
+                  }),
+                };
+              },
+              async importItem() {
+                throw new Error(
+                  "Ambiguous Telegram notification must not import a new row.",
+                );
+              },
+              platform: {
+                ...createPlatform({
+                  artifactBytesByHash: new Map([
+                    [ambiguousWorkspace.hash, ambiguousWorkspace.bytes],
+                  ]),
+                  mailboxPort: createMailboxPort({ events, items: [] }),
+                  workspacePort: createWorkspacePort({
+                    checkpointRequests: ambiguousCheckpointRequests,
+                    events,
+                    workspace: createWorkspaceState({
+                      snapshotRef: ambiguousWorkspace.snapshotRef,
+                      version: "1",
+                    }),
+                  }),
+                }),
+                effectsPort,
+                providerFetch,
+              },
+              async runAssistantPhase() {
+                throw new Error(
+                  "Ambiguous Telegram notification must not enter assistant execution.",
+                );
+              },
+              vaultRoot,
+            },
+          );
+
+          assert.equal(deliveryBodies.length, 0);
+          assert.deepEqual(
+            (await listAssistantOutboxIntents(vaultRoot)).map((intent) => ({
+              preparedDispatchTokenPresent:
+                intent.preparedDispatchToken !== null,
+              status: intent.status,
+            })),
+            [{
+              preparedDispatchTokenPresent: true,
+              status: "sending",
+            }],
+          );
+          assert.equal(ambiguousResult.status, "scheduled");
+          assert.ok(ambiguousResult.nextWakeAt);
+          assert.ok(ambiguousResult.nextWakeAt > TEST_NOW);
+        }
         const resumedWorkspaceVersion = String(
           BigInt(
             checkpointRequests.at(-1)?.expectedWorkspaceVersion ?? "0",
@@ -11177,8 +11345,14 @@ describe("hosted workspace runtime entrypoint", () => {
         const resumedCheckpointRequests: HostedWorkspaceCheckpointRequest[] = [];
         const resumedResult = await runHostedWorkspaceRuntimeJobInProcess(
           createWorkspaceRuntimeJobInput({
-            platformEnv: { TELEGRAM_BOT_TOKEN: "" },
-            forwardedEnv: { LINQ_API_TOKEN: "synthetic-linq-token" },
+            platformEnv: {
+              TELEGRAM_BOT_TOKEN:
+                channel === "telegram" ? "synthetic-telegram-token" : "",
+            },
+            forwardedEnv: {
+              LINQ_API_TOKEN:
+                channel === "linq" ? "synthetic-linq-token" : "",
+            },
             request: {
               assistantExecutionBlocked: true,
               attemptId:
@@ -11189,13 +11363,13 @@ describe("hosted workspace runtime entrypoint", () => {
             resolvedConfig: {
               channelCapabilities: {
                 emailSendReady: false,
-                telegramBotConfigured: false,
+                telegramBotConfigured: channel === "telegram",
               },
               deviceSync: null,
               managedAutoReplyChannels: [{
                 capabilityReady: true,
-                channel: "linq",
-                memberChannel: "linq",
+                channel,
+                memberChannel: channel,
               }],
             },
           }),

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -10770,18 +10770,32 @@ describe("hosted workspace runtime entrypoint", () => {
 
   test.each([
     {
+      checkpointConversationInputAhead: false,
       expectedProviderSends: 1,
       initialOutboxState: "pending" as const,
     },
     {
+      checkpointConversationInputAhead: true,
+      expectedProviderSends: 0,
+      initialOutboxState: "pending" as const,
+    },
+    {
+      checkpointConversationInputAhead: true,
+      expectedProviderSends: 0,
+      initialOutboxState: "due_retryable" as const,
+    },
+    {
+      checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "retryable" as const,
     },
     {
+      checkpointConversationInputAhead: false,
       expectedProviderSends: 0,
       initialOutboxState: "sent" as const,
     },
-  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($initialOutboxState outbox)", async ({
+  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($initialOutboxState outbox, foreground checkpoint: $checkpointConversationInputAhead)", async ({
+    checkpointConversationInputAhead,
     expectedProviderSends,
     initialOutboxState,
   }) => {
@@ -10845,6 +10859,32 @@ describe("hosted workspace runtime entrypoint", () => {
       }
       return new Response(null, { status: 204 });
     });
+    const effectsPort = {
+      async assertLinqRecentInboundEngagement() {
+        return {
+          providerDispatchClaimed: true,
+          resolvedRoute: {
+            conversationThreadId: null,
+            directRecipientPhoneNumber: null,
+            fromPhoneNumber: null,
+            target: "linq_private_group_join_thread",
+            targetKind: "thread" as const,
+            threadIsDirect: true,
+          },
+        };
+      },
+      async readRawEmailMessage() {
+        return null;
+      },
+      async recordLinqDeliveryOutcome(request: {
+        providerMessageId?: string | null;
+      }) {
+        events.push(
+          `provider.record:${request.providerMessageId ?? "missing"}`,
+        );
+      },
+      async sendEmail() {},
+    };
 
     try {
       vi.useFakeTimers({ toFake: ["Date"] });
@@ -10905,7 +10945,10 @@ describe("hosted workspace runtime entrypoint", () => {
         turnId: "turn_group_join_restored_exact",
         vault: vaultRoot,
       });
-      if (initialOutboxState === "retryable") {
+      if (
+        initialOutboxState === "retryable"
+        || initialOutboxState === "due_retryable"
+      ) {
         await saveAssistantOutboxIntent(vaultRoot, {
           ...exactIntent,
           attemptCount: 1,
@@ -10914,7 +10957,8 @@ describe("hosted workspace runtime entrypoint", () => {
             code: "ASSISTANT_DELIVERY_RETRYABLE",
             message: "Synthetic retry window.",
           },
-          nextAttemptAt: retryWakeAt,
+          nextAttemptAt:
+            initialOutboxState === "due_retryable" ? TEST_NOW : retryWakeAt,
           status: "retryable",
           updatedAt: TEST_NOW,
         });
@@ -10943,6 +10987,9 @@ describe("hosted workspace runtime entrypoint", () => {
         key: "users/bundles/member-synthetic/blocked-group-join-restored-before.bundle.json",
         vaultRoot,
       });
+      const checkpointBundles: Array<Awaited<
+        ReturnType<typeof createVaultSnapshotBundle>
+      >> = [];
 
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
@@ -10969,12 +11016,17 @@ describe("hosted workspace runtime entrypoint", () => {
         }),
         {
           async createCheckpointSnapshot() {
+            const checkpointBundle = await createVaultSnapshotBundle({
+              key:
+                "users/bundles/member-synthetic/"
+                + `blocked-group-join-restored-checkpoint-${
+                  checkpointRequests.length + 1
+                }.bundle.json`,
+              vaultRoot,
+            });
+            checkpointBundles.push(checkpointBundle);
             return {
-              snapshotRef: createBundleRef({
-                hash: "d".repeat(64),
-                key: "users/bundles/member-synthetic/blocked-group-join-restored.bundle.json",
-                size: 512,
-              }),
+              snapshotRef: checkpointBundle.snapshotRef,
             };
           },
           async importItem() {
@@ -10988,6 +11040,27 @@ describe("hosted workspace runtime entrypoint", () => {
               mailboxPort: createMailboxPort({ events, items: [] }),
               workspacePort: createWorkspacePort({
                 checkpointRequests,
+                ...(checkpointConversationInputAhead
+                  ? {
+                      checkpointResponse(request) {
+                        return {
+                          checkpointed: true,
+                          conversationInputAhead: checkpointRequests.length === 1,
+                          workspace: createWorkspaceState({
+                            inboxMediaRetentionWakeAt:
+                              request.inboxMediaRetentionWakeAt ?? null,
+                            nextWakeAt: request.nextWakeAt ?? null,
+                            nextWakeReason: request.nextWakeReason ?? null,
+                            redactedStatus: request.redactedStatus ?? null,
+                            snapshotRef: request.snapshotRef,
+                            version: String(
+                              BigInt(request.expectedWorkspaceVersion) + 1n,
+                            ),
+                          }),
+                        };
+                      },
+                    }
+                  : {}),
                 events,
                 workspace: createWorkspaceState({
                   snapshotRef: restoredWorkspace.snapshotRef,
@@ -10995,30 +11068,7 @@ describe("hosted workspace runtime entrypoint", () => {
                 }),
               }),
             }),
-            effectsPort: {
-              async assertLinqRecentInboundEngagement() {
-                return {
-                  providerDispatchClaimed: true,
-                  resolvedRoute: {
-                    conversationThreadId: null,
-                    directRecipientPhoneNumber: null,
-                    fromPhoneNumber: null,
-                    target: "linq_private_group_join_thread",
-                    targetKind: "thread",
-                    threadIsDirect: true,
-                  },
-                };
-              },
-              async readRawEmailMessage() {
-                return null;
-              },
-              async recordLinqDeliveryOutcome(request) {
-                events.push(
-                  `provider.record:${request.providerMessageId ?? "missing"}`,
-                );
-              },
-              async sendEmail() {},
-            },
+            effectsPort,
             providerFetch,
           },
           async runAssistantPhase() {
@@ -11041,6 +11091,20 @@ describe("hosted workspace runtime entrypoint", () => {
       if (expectedProviderSends === 1) {
         expect(JSON.stringify(deliveryBodies[0])).toContain(exactText);
       }
+      const outboxAfter = await listAssistantOutboxIntents(vaultRoot);
+      if (checkpointConversationInputAhead) {
+        assert.deepEqual(
+          outboxAfter.map((intent) => ({
+            nextAttemptAt: intent.nextAttemptAt,
+            status: intent.status,
+          })),
+          [{
+            nextAttemptAt: TEST_NOW,
+            status:
+              initialOutboxState === "due_retryable" ? "retryable" : "pending",
+          }],
+        );
+      }
       const pendingAfter = (await readHostedSystemMailboxState(vaultRoot)).pending;
       if (initialOutboxState === "retryable") {
         assert.deepEqual(
@@ -11050,6 +11114,22 @@ describe("hosted workspace runtime entrypoint", () => {
           })),
           [{
             nextAttemptAt: retryWakeAt,
+            status: "recording",
+          }],
+        );
+        assert.notEqual(
+          checkpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+      } else if (checkpointConversationInputAhead) {
+        assert.deepEqual(
+          pendingAfter.map((item) => ({
+            nextAttemptAt: item.nextAttemptAt,
+            status: item.status,
+          })),
+          [{
+            nextAttemptAt: null,
             status: "recording",
           }],
         );
@@ -11073,9 +11153,114 @@ describe("hosted workspace runtime entrypoint", () => {
         assert.equal(result.status, "scheduled");
         assert.equal(result.nextWakeAt, retryWakeAt);
         assert.equal(result.nextWakeReason, "assistant");
+      } else if (checkpointConversationInputAhead) {
+        assert.equal(result.immediateRecheckRequested, true);
+        assert.equal(result.status, "scheduled");
+        assert.equal(result.nextWakeAt, TEST_NOW);
+        assert.equal(result.nextWakeReason, "assistant");
       } else {
         assert.equal(result.status, "idle");
         assert.equal(result.nextWakeAt, null);
+      }
+      if (checkpointConversationInputAhead) {
+        assert.deepEqual(
+          checkpointRequests.map((request) => request.expectedWorkspaceVersion),
+          ["0", "1"],
+        );
+        const resumedWorkspaceVersion = String(
+          BigInt(
+            checkpointRequests.at(-1)?.expectedWorkspaceVersion ?? "0",
+          ) + 1n,
+        );
+        const resumedWorkspace = checkpointBundles.at(-1);
+        assert.ok(resumedWorkspace);
+        const resumedCheckpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+        const resumedResult = await runHostedWorkspaceRuntimeJobInProcess(
+          createWorkspaceRuntimeJobInput({
+            platformEnv: { TELEGRAM_BOT_TOKEN: "" },
+            forwardedEnv: { LINQ_API_TOKEN: "synthetic-linq-token" },
+            request: {
+              assistantExecutionBlocked: true,
+              attemptId:
+                "attempt_synthetic_blocked_group_join_restored_after_foreground",
+              processingMode: "system_mailbox",
+              workspaceVersion: resumedWorkspaceVersion,
+            },
+            resolvedConfig: {
+              channelCapabilities: {
+                emailSendReady: false,
+                telegramBotConfigured: false,
+              },
+              deviceSync: null,
+              managedAutoReplyChannels: [{
+                capabilityReady: true,
+                channel: "linq",
+                memberChannel: "linq",
+              }],
+            },
+          }),
+          {
+            async createCheckpointSnapshot() {
+              return {
+                snapshotRef: createBundleRef({
+                  hash: "e".repeat(64),
+                  key:
+                    "users/bundles/member-synthetic/"
+                    + "blocked-group-join-restored-after-foreground-done.bundle.json",
+                  size: 512,
+                }),
+              };
+            },
+            async importItem() {
+              throw new Error(
+                "Foreground-preempted notification must not import a new row.",
+              );
+            },
+            platform: {
+              ...createPlatform({
+                artifactBytesByHash: new Map([
+                  [resumedWorkspace.hash, resumedWorkspace.bytes],
+                ]),
+                mailboxPort: createMailboxPort({ events, items: [] }),
+                workspacePort: createWorkspacePort({
+                  checkpointRequests: resumedCheckpointRequests,
+                  events,
+                  workspace: createWorkspaceState({
+                    snapshotRef: resumedWorkspace.snapshotRef,
+                    version: resumedWorkspaceVersion,
+                  }),
+                }),
+              }),
+              effectsPort,
+              providerFetch,
+            },
+            async runAssistantPhase() {
+              throw new Error(
+                "Resumed exact notification must not enter assistant execution.",
+              );
+            },
+            vaultRoot,
+          },
+        );
+
+        assert.equal(deliveryBodies.length, 1);
+        expect(JSON.stringify(deliveryBodies[0])).toContain(exactText);
+        assert.deepEqual(
+          (await listAssistantOutboxIntents(vaultRoot)).map((intent) =>
+            intent.status
+          ),
+          ["sent"],
+        );
+        assert.deepEqual(
+          (await readHostedSystemMailboxState(vaultRoot)).pending,
+          [],
+        );
+        assert.equal(
+          resumedCheckpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+        assert.equal(resumedResult.status, "idle");
       }
     } finally {
       vi.useRealTimers();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -10768,6 +10768,321 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
+  test.each([
+    {
+      expectedProviderSends: 1,
+      initialOutboxState: "pending" as const,
+    },
+    {
+      expectedProviderSends: 0,
+      initialOutboxState: "retryable" as const,
+    },
+    {
+      expectedProviderSends: 0,
+      initialOutboxState: "sent" as const,
+    },
+  ])("system mailbox mode resumes a restored exact group-join delivery from its durable identity ($initialOutboxState outbox)", async ({
+    expectedProviderSends,
+    initialOutboxState,
+  }) => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const deliveryBodies: unknown[] = [];
+    const exactText = "You are now part of the synthetic group.";
+    const exactDeliveryKey = "group-join:membership_restored_exact";
+    const exactDedupeKey =
+      `assistant.notification.requested:${exactDeliveryKey}`;
+    const retryWakeAt = new Date(
+      Date.parse(TEST_NOW) + 5 * 60_000,
+    ).toISOString();
+    const exactItem = createMailboxItem({
+      dedupeKey: exactDedupeKey,
+      id: "mailbox_item_group_join_restored_exact",
+      kind: "assistant.notification.requested",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const exactWake = buildHostedExecutionAssistantNotificationRequestedWake({
+      eventId: exactDedupeKey,
+      memberId: TEST_USER_ID,
+      notification: {
+        deliveryDispatchMode: "queue-only",
+        deliveryDedupeToken: exactDeliveryKey,
+        deliveryIdempotencyKey: exactDeliveryKey,
+        instructions: "Send the exact private confirmation text.",
+        responsePolicy: {
+          kind: "require_send_exact_text",
+          text: exactText,
+        },
+        route: {
+          actorId: null,
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "linq_private_group_join_thread",
+          },
+          identityId: "hbidx:phone:v1:group-join-restored-test",
+          threadId: "hbidx:thread:v1:group-join-restored-test",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: TEST_NOW,
+    });
+    const providerFetch = vi.fn<typeof fetch>(async (request, init) => {
+      const method =
+        init?.method
+        ?? (request instanceof Request ? request.method : "GET");
+      const url = request instanceof Request ? request.url : String(request);
+      if (method === "POST" && url.includes("/messages")) {
+        deliveryBodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({
+          message: { id: "provider_group_join_restored_confirmation" },
+        }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    try {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      mocks.prepareHostedCodexRuntimeEnvironment.mockClear();
+      mocks.runAssistantAutomationPass.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await enqueueHostedSystemMailboxItem({
+        item: {
+          item: exactItem,
+          payload: {
+            payloadCiphertext: "ciphertext",
+            payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+            requestId: `request_${exactItem.id}`,
+            source: "inline",
+            status: "resolved",
+          },
+          route: {
+            action: "dispatch-assistant-notification",
+            advanceProgress: true,
+            itemRef: {
+              id: exactItem.id,
+              kind: exactItem.kind,
+              lane: exactItem.lane,
+              laneSeq: exactItem.laneSeq,
+            },
+            state: "route",
+          },
+        },
+        vaultRoot,
+        wake: exactWake,
+      });
+      await updateHostedSystemMailboxState(vaultRoot, (state) => ({
+        pending: state.pending.map((item) =>
+          item.itemId === exactItem.id
+            ? {
+                ...item,
+                attemptCount: 1,
+                lastAttemptAt: TEST_NOW,
+                status: "recording",
+              }
+            : item
+        ),
+      }));
+      const exactIntent = await createAssistantOutboxIntent({
+        channel: "linq",
+        createdAt: TEST_NOW,
+        dedupeToken: exactDeliveryKey,
+        deliveryIdempotencyKey: exactDeliveryKey,
+        deliveryTransportIdempotent: true,
+        explicitTarget: "linq_private_group_join_thread",
+        identityId: "hbidx:phone:v1:group-join-restored-test",
+        message: exactText,
+        sessionId: "session_group_join_restored_exact",
+        threadId: "hbidx:thread:v1:group-join-restored-test",
+        threadIsDirect: true,
+        turnId: "turn_group_join_restored_exact",
+        vault: vaultRoot,
+      });
+      if (initialOutboxState === "retryable") {
+        await saveAssistantOutboxIntent(vaultRoot, {
+          ...exactIntent,
+          attemptCount: 1,
+          lastAttemptAt: TEST_NOW,
+          lastError: {
+            code: "ASSISTANT_DELIVERY_RETRYABLE",
+            message: "Synthetic retry window.",
+          },
+          nextAttemptAt: retryWakeAt,
+          status: "retryable",
+          updatedAt: TEST_NOW,
+        });
+      }
+      if (initialOutboxState === "sent") {
+        const sentIntent = await markAssistantOutboxIntentSentById({
+          delivery: {
+            channel: "linq",
+            idempotencyKey: exactDeliveryKey,
+            messageLength: exactText.length,
+            providerMessageId: "provider_group_join_already_sent",
+            providerThreadId: "linq_private_group_join_thread",
+            sentAt: TEST_NOW,
+            target: "linq_private_group_join_thread",
+            targetKind: "explicit",
+          },
+          intentId: exactIntent.intentId,
+          vault: vaultRoot,
+        });
+        assert.equal(sentIntent?.status, "sent");
+      }
+      const importState = createEmptyHostedMailboxImportState();
+      importState.watermarks.system = "1";
+      await writeMailboxImportStateFile(vaultRoot, importState);
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/blocked-group-join-restored-before.bundle.json",
+        vaultRoot,
+      });
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          platformEnv: { TELEGRAM_BOT_TOKEN: "" },
+          forwardedEnv: { LINQ_API_TOKEN: "synthetic-linq-token" },
+          request: {
+            assistantExecutionBlocked: true,
+            attemptId: "attempt_synthetic_blocked_group_join_restored_exact",
+            processingMode: "system_mailbox",
+            workspaceVersion: "0",
+          },
+          resolvedConfig: {
+            channelCapabilities: {
+              emailSendReady: false,
+              telegramBotConfigured: false,
+            },
+            deviceSync: null,
+            managedAutoReplyChannels: [{
+              capabilityReady: true,
+              channel: "linq",
+              memberChannel: "linq",
+            }],
+          },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "d".repeat(64),
+                key: "users/bundles/member-synthetic/blocked-group-join-restored.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            throw new Error("Restored notification must not import a new row.");
+          },
+          platform: {
+            ...createPlatform({
+              artifactBytesByHash: new Map([
+                [restoredWorkspace.hash, restoredWorkspace.bytes],
+              ]),
+              mailboxPort: createMailboxPort({ events, items: [] }),
+              workspacePort: createWorkspacePort({
+                checkpointRequests,
+                events,
+                workspace: createWorkspaceState({
+                  snapshotRef: restoredWorkspace.snapshotRef,
+                  version: "0",
+                }),
+              }),
+            }),
+            effectsPort: {
+              async assertLinqRecentInboundEngagement() {
+                return {
+                  providerDispatchClaimed: true,
+                  resolvedRoute: {
+                    conversationThreadId: null,
+                    directRecipientPhoneNumber: null,
+                    fromPhoneNumber: null,
+                    target: "linq_private_group_join_thread",
+                    targetKind: "thread",
+                    threadIsDirect: true,
+                  },
+                };
+              },
+              async readRawEmailMessage() {
+                return null;
+              },
+              async recordLinqDeliveryOutcome(request) {
+                events.push(
+                  `provider.record:${request.providerMessageId ?? "missing"}`,
+                );
+              },
+              async sendEmail() {},
+            },
+            providerFetch,
+          },
+          async runAssistantPhase() {
+            throw new Error("Restored exact notification must not enter assistant execution.");
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.equal(deliveryBodies.length, expectedProviderSends, JSON.stringify({
+        outbox: (await listAssistantOutboxIntents(vaultRoot)).map((intent) => ({
+          deliveryIdempotencyKey: intent.deliveryIdempotencyKey,
+          status: intent.status,
+        })),
+        pending: (await readHostedSystemMailboxState(vaultRoot)).pending.map(
+          (item) => ({ itemId: item.itemId, status: item.status }),
+        ),
+        result,
+      }));
+      if (expectedProviderSends === 1) {
+        expect(JSON.stringify(deliveryBodies[0])).toContain(exactText);
+      }
+      const pendingAfter = (await readHostedSystemMailboxState(vaultRoot)).pending;
+      if (initialOutboxState === "retryable") {
+        assert.deepEqual(
+          pendingAfter.map((item) => ({
+            nextAttemptAt: item.nextAttemptAt,
+            status: item.status,
+          })),
+          [{
+            nextAttemptAt: retryWakeAt,
+            status: "recording",
+          }],
+        );
+        assert.notEqual(
+          checkpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+      } else {
+        assert.deepEqual(pendingAfter, []);
+        assert.equal(
+          checkpointRequests.at(-1)?.redactedStatus
+            ?.hostedMailboxSystemHandledThroughSeq,
+          "1",
+        );
+      }
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexRuntimeEnvironment.mock.calls.length, 0);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      if (initialOutboxState === "retryable") {
+        assert.equal(result.status, "scheduled");
+        assert.equal(result.nextWakeAt, retryWakeAt);
+        assert.equal(result.nextWakeReason, "assistant");
+      } else {
+        assert.equal(result.status, "idle");
+        assert.equal(result.nextWakeAt, null);
+      }
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("system mailbox mode hands ready approvals to the foreground owner before device-sync", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -10495,6 +10495,279 @@ describe("hosted workspace runtime entrypoint", () => {
     }
   });
 
+  test("blocked system mailbox mode delivers one exact group-join confirmation without draining a generic notification", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const exactText = "You are now part of the synthetic group.";
+    const deliveryBodies: unknown[] = [];
+    const exactDeliveryKey = "group-join:membership_blocked_exact";
+    const exactDedupeKey =
+      `assistant.notification.requested:${exactDeliveryKey}`;
+    const genericDeliveryKey = "generic:blocked_after_group_join";
+    const genericDedupeKey =
+      `assistant.notification.requested:${genericDeliveryKey}`;
+    const exactItem = createMailboxItem({
+      dedupeKey: exactDedupeKey,
+      id: "mailbox_item_group_join_blocked_exact",
+      kind: "assistant.notification.requested",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const genericItem = createMailboxItem({
+      dedupeKey: genericDedupeKey,
+      id: "mailbox_item_group_join_later_generic",
+      kind: "assistant.notification.requested",
+      lane: "system",
+      laneSeq: "2",
+    });
+    const buildResolvedNotificationItem = (
+      item: HostedMailboxItem,
+    ): HostedMailboxResolvedImportItem => ({
+      item,
+      payload: {
+        payloadCiphertext: "ciphertext",
+        payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+        requestId: `request_${item.id}`,
+        source: "inline",
+        status: "resolved",
+      },
+      route: {
+        action: "dispatch-assistant-notification",
+        advanceProgress: true,
+        itemRef: {
+          id: item.id,
+          kind: item.kind,
+          lane: item.lane,
+          laneSeq: item.laneSeq,
+        },
+        state: "route",
+      },
+    });
+    const buildNotificationWake = (input: {
+      deliveryKey: string;
+      eventId: string;
+      text: string;
+    }) =>
+      buildHostedExecutionAssistantNotificationRequestedWake({
+        eventId: input.eventId,
+        memberId: TEST_USER_ID,
+        notification: {
+          deliveryDispatchMode: "queue-only",
+          deliveryDedupeToken: input.deliveryKey,
+          deliveryIdempotencyKey: input.deliveryKey,
+          instructions: "Send the exact private confirmation text.",
+          responsePolicy: {
+            kind: "require_send_exact_text",
+            text: input.text,
+          },
+          route: {
+            actorId: null,
+            channel: "linq",
+            delivery: {
+              kind: "thread",
+              target: "linq_private_group_join_thread",
+            },
+            identityId: "hbidx:phone:v1:group-join-test",
+            threadId: "hbidx:thread:v1:group-join-test",
+            threadIsDirect: true,
+          },
+        },
+        occurredAt: TEST_NOW,
+      });
+    const providerFetch = vi.fn<typeof fetch>(async (request, init) => {
+      const method =
+        init?.method
+        ?? (request instanceof Request ? request.method : "GET");
+      const url = request instanceof Request ? request.url : String(request);
+      if (method === "POST" && url.includes("/messages")) {
+        deliveryBodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({
+          message: { id: "provider_group_join_confirmation" },
+        }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    try {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      mocks.prepareHostedCodexRuntimeEnvironment.mockClear();
+      mocks.runAssistantAutomationPass.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await enqueueHostedSystemMailboxItem({
+        item: buildResolvedNotificationItem(exactItem),
+        vaultRoot,
+        wake: buildNotificationWake({
+          deliveryKey: exactDeliveryKey,
+          eventId: exactDedupeKey,
+          text: exactText,
+        }),
+      });
+      await enqueueHostedSystemMailboxItem({
+        item: buildResolvedNotificationItem(genericItem),
+        vaultRoot,
+        wake: buildNotificationWake({
+          deliveryKey: genericDeliveryKey,
+          eventId: genericDedupeKey,
+          text: "Generic automatic message.",
+        }),
+      });
+      const importState = createEmptyHostedMailboxImportState();
+      importState.watermarks.system = "2";
+      await writeMailboxImportStateFile(vaultRoot, importState);
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/blocked-group-join-before.bundle.json",
+        vaultRoot,
+      });
+      const completedResult = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          platformEnv: {
+            TELEGRAM_BOT_TOKEN: "",
+          },
+          forwardedEnv: {
+            LINQ_API_TOKEN: "synthetic-linq-token",
+          },
+          request: {
+            assistantExecutionBlocked: true,
+            attemptId: "attempt_synthetic_blocked_group_join_exact",
+            processingMode: "system_mailbox",
+            workspaceVersion: "0",
+          },
+          resolvedConfig: {
+            channelCapabilities: {
+              emailSendReady: false,
+              telegramBotConfigured: false,
+            },
+            deviceSync: null,
+            managedAutoReplyChannels: [{
+              capabilityReady: true,
+              channel: "linq",
+              memberChannel: "linq",
+            }],
+          },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "c".repeat(64),
+                key: "users/bundles/member-synthetic/blocked-group-join.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            throw new Error("Already-imported notifications must not import a new row.");
+          },
+          platform: {
+            ...createPlatform({
+              artifactBytesByHash: new Map([
+                [restoredWorkspace.hash, restoredWorkspace.bytes],
+              ]),
+              mailboxPort: createMailboxPort({ events, items: [] }),
+              workspacePort: createWorkspacePort({
+                checkpointRequests,
+                events,
+                workspace: createWorkspaceState({
+                  snapshotRef: restoredWorkspace.snapshotRef,
+                  version: "0",
+                }),
+              }),
+            }),
+            effectsPort: {
+              async assertLinqRecentInboundEngagement(request) {
+                assert.equal(request.target, "linq_private_group_join_thread");
+                return {
+                  providerDispatchClaimed: true,
+                  resolvedRoute: {
+                    conversationThreadId: null,
+                    directRecipientPhoneNumber: null,
+                    fromPhoneNumber: null,
+                    target: "linq_private_group_join_thread",
+                    targetKind: "thread",
+                    threadIsDirect: true,
+                  },
+                };
+              },
+              async readRawEmailMessage() {
+                return null;
+              },
+              async recordLinqDeliveryOutcome(request) {
+                events.push(
+                  `provider.record:${request.providerMessageId ?? "missing"}`,
+                );
+              },
+              async sendEmail() {},
+            },
+            providerFetch,
+          },
+          async runAssistantPhase() {
+            throw new Error("Blocked exact notification must not enter assistant execution.");
+          },
+          vaultRoot,
+        },
+      );
+
+      const pendingAfter = await readHostedSystemMailboxState(vaultRoot);
+      const outboxAfter = await listAssistantOutboxIntents(vaultRoot);
+      assert.equal(deliveryBodies.length, 1, JSON.stringify({
+        events,
+        outbox: outboxAfter.map((intent) => ({
+          deliveryIdempotencyKey: intent.deliveryIdempotencyKey,
+          status: intent.status,
+        })),
+        pending: pendingAfter.pending.map((item) => ({
+          itemId: item.itemId,
+          mailboxDedupeKey: item.mailboxDedupeKey,
+          status: item.status,
+        })),
+        result: completedResult,
+      }));
+      expect(JSON.stringify(deliveryBodies[0])).toContain(exactText);
+      assert.deepEqual(
+        outboxAfter.map((intent) => ({
+          deliveryIdempotencyKey: intent.deliveryIdempotencyKey,
+          status: intent.status,
+        })),
+        [{
+          deliveryIdempotencyKey: exactDeliveryKey,
+          status: "sent",
+        }],
+      );
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexRuntimeEnvironment.mock.calls.length, 0);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      assert.equal(
+        checkpointRequests.at(-1)?.redactedStatus
+          ?.hostedMailboxSystemHandledThroughSeq,
+        "1",
+      );
+      assert.deepEqual(
+        pendingAfter.pending.map((item) => ({
+          itemId: item.itemId,
+          mailboxDedupeKey: item.mailboxDedupeKey,
+          mailboxLaneSeq: item.mailboxLaneSeq,
+        })),
+        [{
+          itemId: genericItem.id,
+          mailboxDedupeKey: genericDedupeKey,
+          mailboxLaneSeq: "2",
+        }],
+      );
+      assert.equal(completedResult.status, "idle", JSON.stringify(completedResult));
+      assert.equal(completedResult.nextWakeAt, null);
+      assert.equal(completedResult.nextWakeReason ?? null, null);
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("system mailbox mode hands ready approvals to the foreground owner before device-sync", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -11362,6 +11635,7 @@ describe("hosted workspace runtime entrypoint", () => {
     let snapshotOrdinal = 0;
     let activeAttemptId = "unassigned";
     let failRecordCheckpoint = true;
+    let failRetryFenceCheckpoint = false;
     const refreshImplementation =
       mocks.refreshHostedBrowserVaultReplicaFromRuntime.getMockImplementation();
 
@@ -11448,6 +11722,13 @@ describe("hosted workspace runtime entrypoint", () => {
       checkpointAttempt += 1;
       checkpointRequests.push(request);
       events.push(`checkpoint.attempt:${activeAttemptId}:${checkpointAttempt}`);
+      if (
+        failRetryFenceCheckpoint
+        && request.reason === "canonical_runtime_commit"
+      ) {
+        events.push(`checkpoint.fail:${activeAttemptId}:${checkpointAttempt}`);
+        throw new Error("synthetic retry-fence checkpoint transport fault");
+      }
       if (
         failRecordCheckpoint
         && activeAttemptId === "attempt_device_sync_closed_loop_initial"
@@ -11787,6 +12068,52 @@ describe("hosted workspace runtime entrypoint", () => {
       }
       assert.equal(committedInputItem.wake.eventId, scheduleEventId);
       observedScheduleEventIds.add(committedInputItem.wake.eventId);
+      const committedInputWorkspace = currentWorkspace;
+      assert.ok(committedInputWorkspace);
+
+      failRetryFenceCheckpoint = true;
+      const rejectedRetryFenceResult = await runSystemPass({
+        attemptId:
+          "attempt_device_sync_closed_loop_retry_fence_rejected",
+        vaultRoot: warmVaultRoot,
+      });
+      assert.equal(checkpointAttempt, 2);
+      assert.equal(checkpointRequests.length, 2);
+      assert.deepEqual(
+        checkpointRequests.map((request) => request.reason),
+        ["canonical_runtime_commit", "idle_shutdown"],
+      );
+      assert.equal(providerRequestClasses.length, 0);
+      assert.equal(cadencePublications.length, 0);
+      assert.equal(
+        events.filter((event) => event.startsWith("provider.request:")).length,
+        0,
+      );
+      assert.equal(
+        events.filter((event) => event.startsWith("artifact.put:")).length,
+        0,
+      );
+      assert.ok(currentWorkspace);
+      assert.equal(currentWorkspace.version, "2");
+      assert.equal(currentWorkspace.nextWakeReason, "device-sync.reconcile");
+      assert.ok(currentWorkspace.nextWakeAt);
+      assert.equal(
+        currentWorkspace.redactedStatus
+          ?.hostedMailboxSystemHandledThroughSeq
+          ?? "0",
+        "0",
+      );
+      assert.equal(rejectedRetryFenceResult.status, "scheduled");
+      assert.equal(
+        rejectedRetryFenceResult.nextWakeReason,
+        "device-sync.reconcile",
+      );
+      assert.ok(rejectedRetryFenceResult.nextWakeAt);
+      currentWorkspace = committedInputWorkspace;
+      failRetryFenceCheckpoint = false;
+      checkpointAttempt = 0;
+      checkpointRequests.length = 0;
+      events.length = 0;
 
       await assert.rejects(
         runSystemPass({

--- a/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
+++ b/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  isHostedSystemMailboxModelFreeExactNotificationItem,
+  projectHostedSystemMailboxModelFreeNotificationFrontier,
+} from "../src/hosted-runtime/system-mailbox-state.ts";
+
+type PendingItem = Parameters<typeof isHostedSystemMailboxModelFreeExactNotificationItem>[0];
+
+function exactNotification(input: { dedupeKey?: string; laneSeq: string }): PendingItem {
+  const deliveryDedupeToken = "group-join:membership";
+  const mailboxDedupeKey = input.dedupeKey
+    ?? `assistant.notification.requested:${deliveryDedupeToken}`;
+  return {
+    mailboxDedupeKey,
+    mailboxLaneSeq: input.laneSeq,
+    routeAction: "dispatch-assistant-notification",
+    wake: {
+      eventId: mailboxDedupeKey,
+      kind: "assistant.notification.requested",
+      notification: {
+        deliveryDedupeToken,
+        deliveryDispatchMode: "queue-only",
+        deliveryIdempotencyKey: deliveryDedupeToken,
+        responsePolicy: { kind: "require_send_exact_text", text: "Confirmation" },
+      },
+    },
+  } as PendingItem;
+}
+
+function maintenance(laneSeq: string): PendingItem {
+  return {
+    mailboxDedupeKey: `runtime.maintenance-requested:${laneSeq}`,
+    mailboxLaneSeq: laneSeq,
+    routeAction: "apply-runtime-control-request",
+    wake: { kind: "runtime.maintenance-requested" },
+  } as PendingItem;
+}
+
+function assistantAsk(laneSeq: string): PendingItem {
+  return {
+    mailboxDedupeKey: `assistant.ask.completed:${laneSeq}`,
+    mailboxLaneSeq: laneSeq,
+    routeAction: "run-assistant-ask",
+    wake: { kind: "assistant.ask.completed" },
+  } as PendingItem;
+}
+
+describe("blocked model-free exact notification frontier", () => {
+  it("admits a canonical exact group join at the durable frontier before later work", () => {
+    const notification = exactNotification({ laneSeq: "1" });
+    const later = maintenance("2");
+    expect(isHostedSystemMailboxModelFreeExactNotificationItem(notification)).toBe(true);
+    expect(projectHostedSystemMailboxModelFreeNotificationFrontier({ pending: [later, notification] }).pending).toEqual([notification]);
+    expect(projectHostedSystemMailboxModelFreeNotificationFrontier({ pending: [later] }).pending).toEqual([later]);
+  });
+
+  it("does not overtake a generic notification at the durable frontier", () => {
+    const generic = exactNotification({
+      dedupeKey: "assistant.notification.requested:generic",
+      laneSeq: "1",
+    });
+    const later = maintenance("2");
+    expect(isHostedSystemMailboxModelFreeExactNotificationItem(generic)).toBe(false);
+    expect(projectHostedSystemMailboxModelFreeNotificationFrontier({ pending: [later, generic] }).pending).toEqual([]);
+  });
+
+  it("does not admit an exact notification behind an earlier durable item", () => {
+    const earlier = assistantAsk("1");
+    const notification = exactNotification({ laneSeq: "2" });
+    expect(projectHostedSystemMailboxModelFreeNotificationFrontier({
+      pending: [notification, earlier],
+    }).pending).toEqual([earlier]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -244,6 +244,7 @@ export {
   listProtectedCanonicalPaths,
   listWriteOperationMetadataPaths,
   listWriteOperationMetadataPathsWithStageDirectories,
+  persistHostedRuntimeStateAtCanonicalBoundary,
   pruneTerminalWriteOperationRecords,
   readRecoverableStoredWriteOperation,
   readStoredWriteOperation,

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -38,6 +38,7 @@ export {
   listWriteOperationMetadataPaths,
   listWriteOperationMetadataPathsWithStageDirectories,
   applyHostedCanonicalWriteReceipt,
+  persistHostedRuntimeStateAtCanonicalBoundary,
   readStoredWriteOperation,
   readStoredWriteOperationJsonlAppendPayload,
   resolveHostedCanonicalWritePayloadFilePath,

--- a/packages/core/src/operations/write-batch.ts
+++ b/packages/core/src/operations/write-batch.ts
@@ -153,6 +153,7 @@ export interface HostedCanonicalWritePersistenceInput {
 
 export interface HostedCanonicalWritePort {
   persistCanonicalWrite(input: HostedCanonicalWritePersistenceInput): Promise<void>;
+  persistRuntimeState?(): Promise<void>;
 }
 
 const hostedCanonicalWritePortStorage = new AsyncLocalStorage<HostedCanonicalWritePort | null>();
@@ -536,6 +537,18 @@ function resolveAmbientHostedCanonicalWritePort(): HostedCanonicalWritePort | nu
 
 export function readHostedCanonicalWritePort(): HostedCanonicalWritePort | null {
   return resolveAmbientHostedCanonicalWritePort();
+}
+
+export async function persistHostedRuntimeStateAtCanonicalBoundary(): Promise<void> {
+  const port = resolveAmbientHostedCanonicalWritePort();
+  if (!port?.persistRuntimeState) {
+    throw new VaultError(
+      "HOSTED_CANONICAL_WRITE_BOUNDARY_REQUIRED",
+      "Hosted runtime state persistence requires a canonical write boundary.",
+    );
+  }
+
+  await port.persistRuntimeState();
 }
 
 export async function withHostedCanonicalWritePort<TResult>(

--- a/packages/core/test/write-batch-hosted-runtime-state.test.ts
+++ b/packages/core/test/write-batch-hosted-runtime-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  persistHostedRuntimeStateAtCanonicalBoundary,
+  withHostedCanonicalWritePort,
+} from "../src/operations/write-batch.ts";
+
+describe("hosted runtime-state canonical persistence", () => {
+  it("uses exactly one ambient checkpoint owner", async () => {
+    let calls = 0;
+    await withHostedCanonicalWritePort(
+      {
+        persistCanonicalWrite: async () => undefined,
+        persistRuntimeState: async () => { calls += 1; },
+      },
+      async () => persistHostedRuntimeStateAtCanonicalBoundary(),
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("fails closed outside the canonical workspace boundary", async () => {
+    await expect(persistHostedRuntimeStateAtCanonicalBoundary()).rejects.toThrow(/canonical write boundary/);
+  });
+});

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -70,10 +70,28 @@ export const HOSTED_RUNTIME_PROCESSING_MODES =
 export type HostedRuntimeProcessingMode = HostedWorkspaceInvocationProcessingMode;
 
 export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
+  "assistant.notification.requested",
   "device-sync.wake",
   "runtime.browser-vault-refresh-requested",
   "runtime.maintenance-requested",
 ] as const satisfies readonly HostedMailboxKind[];
+
+export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_NOTIFICATION_DEDUPE_KEY_PREFIXES =
+  ["assistant.notification.requested:group-join:"] as const;
+
+export function isHostedSystemMailboxModelFreeNotification(input: {
+  dedupeKey: string | null | undefined;
+  kind: string;
+}): boolean {
+  if (input.kind !== "assistant.notification.requested") {
+    return false;
+  }
+
+  const dedupeKey = input.dedupeKey?.trim() ?? "";
+  return HOSTED_SYSTEM_MAILBOX_MODEL_FREE_NOTIFICATION_DEDUPE_KEY_PREFIXES.some(
+    (prefix) => dedupeKey.length > prefix.length && dedupeKey.startsWith(prefix),
+  );
+}
 
 export const HOSTED_RUNTIME_SYSTEM_MAILBOX_FRONTIER_CLASSES = [
   "default_owned",

--- a/packages/hosted-execution/test/orchestration-control-model-free-notification.test.ts
+++ b/packages/hosted-execution/test/orchestration-control-model-free-notification.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isHostedSystemMailboxModelFreeNotification } from "../src/orchestration-control.ts";
+
+describe("model-free system mailbox notification identity", () => {
+  it("admits only a nonempty canonical group-join notification identity", () => {
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:group-join:membership",
+      kind: "assistant.notification.requested",
+    })).toBe(true);
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:group-join:",
+      kind: "assistant.notification.requested",
+    })).toBe(false);
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:other",
+      kind: "assistant.notification.requested",
+    })).toBe(false);
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:group-join:membership",
+      kind: "runtime.maintenance-requested",
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why and outcome

Three durable hosted-runtime frontiers could remain live without an owner that guaranteed another attempt: an exact group-join confirmation blocked by paused assistant automation, an interrupted device pass with no durable retry schedule, and due device work after foreground progress.

This PR fixes the two public-runtime owners. Exact group-join confirmations can drain without model execution while generic notifications remain blocked, and device passes persist the existing bounded retry wake before external work. The replay-safe Temporal redispatch owner is implemented by private PR #40.

ReviewGPT first-reviewed head: 99d3619c15dda94801a10da3236c9c275df05136

ReviewGPT context sensitivity: sensitive

Reason: This changes hosted runtime recovery, FIFO mailbox ownership, and durable retry checkpoint semantics.

## Product UX

- Effort: Small reliability recovery with no visual UI change.
- Walkthrough: Ready.
- Affected people: members waiting for a group-join confirmation and members whose connected-health work is interrupted mid-pass.
- Boundaries: current conversations and approved actions still run first; unrelated automatic notifications remain paused; no new scheduler or polling owner was added.

## Evidence

- Production evidence was reduced to anonymous lane counts and frontier classes before implementation.
- ReviewGPT independently reproduced the three ownership gaps, implemented and apply-verified the public R1/R2 correction, and confirmed private PR #40 as the R3 owner.
- Final ReviewGPT round 1 then found a restart-only delivery reconciliation hole: a recording mailbox item could lose its invocation-local intent ID. The revised head re-derives the existing outbox intent from its stable delivery identity, preserves its durable retry time, and retires already-terminal work without sending again.
- Final ReviewGPT round 2 found that a foreground checkpoint could leave an unsent idempotent Linq confirmation durably claimed as `sending`. The revised head releases that exact prepared token to its prior pending/retryable state and checkpoints the release before yielding.
- Final ReviewGPT round 3 triggered the mandatory anomaly retrospective; the authority, provider-entry contract, shape growth, alternatives, and continuation decision are recorded below and in the active execution plan.
- Final ReviewGPT round 4 found that exact Telegram confirmations were omitted from the existing non-idempotent prepared-dispatch fence. The revised head durably checkpoints the tokenized `sending` claim before provider entry, releases it if foreground work wins, and preserves ambiguous restart state without a blind resend.
- Final ReviewGPT round 5 found that a provider-generated 30-second retry and its mailbox projection were only warm-local, so a cold restore could fall back to the older ten-minute `sending` recovery window. The revised head creates one full existing-owner checkpoint after both retry writes; cold-restore and host-abort regressions prove the exact retry survives and sends once when due.
- Final ReviewGPT round 6 returned `PASS` for exact head `4a6a2f1b1f50`; it marked rounds 1, 2, 4, and 5 resolved and the round 3 retrospective satisfied, with no remaining qualifying finding.
- `@murphai/assistant-runtime`: release-mode build passed; 2,456 tests passed, 5 skipped.
- `@murphai/core`: 812 passed.
- `@murphai/hosted-execution`: 544 passed.
- Focused Web ownership and mailbox regressions: 123 passed.
- Focused Web group-join route regressions: 23 passed.
- Focused changelog registry and archive coverage: 38 passed.
- Typechecks: Web, assistant-runtime, core, and hosted-execution passed.

## Non-obvious affected surfaces

- Web reconciliation reads the first live system item's dedupe key so only the reserved group-join identity becomes model-free. Covered by the Web ownership regression.
- Hosted-execution exports the shared group-join identity predicate. Covered by its contract test.
- Assistant-runtime projects only the durable notification frontier, sends that exact private Linq or Telegram confirmation through the existing outbox without model execution, and preserves FIFO ordering. On restart it rejoins mailbox work to that outbox intent by the stable delivery key, waits for the outbox retry time, or retires an already-terminal intent without another provider send. Prepared claims are checkpointed before provider entry for both idempotent Linq and non-idempotent Telegram delivery, then released before a foreground yield to preserve the prior pending or due-retryable state. Restored checkpoint tests prove an ambiguous Telegram restart does not blindly resend, the released checkpoint's next pass sends exactly once, and a provider-generated retry remains identical across cold restore and host interruption before sending once when due. Covered by pending, future-retry, provider-created retry, retry-checkpoint abort, due-retry preemption, already-sent, exact-identity, duplicate-identity, model-free frontier, and full runtime tests.
- Core exposes the existing ambient canonical checkpoint owner for runtime-state-only persistence. Covered by fail-closed boundary tests.
- Device maintenance persists a retry schedule before control-plane/provider work. Existing crash, replay, abort, quiescence, and duplicate-suppression tests now assert the added checkpoint order.
- Private Temporal PR #40 owns one bounded due-work redispatch after foreground progress; this PR does not duplicate that owner.

## Architecture and reuse

- Existing systems reused: exact-notification delivery/idempotency, system-mailbox FIFO and handled-through fences, the existing bounded device retry wake, the canonical workspace checkpoint, and Temporal's persisted wake.
- New logic: a narrow group-join notification identity check, durable mailbox/outbox reconciliation by the existing delivery key, selection of exact non-idempotent effects for the existing prepared-dispatch fence, exact prepared-claim release before a foreground yield, one post-provider retry snapshot through the existing system-mailbox checkpoint owner, and one pre-provider device retry checkpoint.
- New abstractions: one shared predicate and one small ambient checkpoint helper, both on existing package ownership boundaries.
- Complexity intentionally avoided: no watchdog, scheduler, polling loop, timer table, migration, manual mailbox repair, or second retry mechanism.

## Hot reply path impact

- Not applicable. The changed work is limited to model-free system mailbox processing and background device maintenance; durable acceptance and provider start for a current conversation message are unchanged.

## Murph initial provider input impact

- Murph runtime: Not applicable. No authored prompt, tool schema, generated guidance, or first provider-visible request changed; eligible confirmations bypass model execution.
- Codex runtime: Not applicable. No Codex prompt or provider-input assembly changed.

## Change-shape breakdown

Classification rule: runtime `.ts` files are source; `test/**` and `*.test.ts` are tests; the execution plan, changelog fragment, and Frog friction entry are docs; no config, generated, moved, or binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 599 | 76 |
| Tests/fixtures | 1,626 | 42 |
| Docs | 116 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2,341** | **120** |

## Review anomaly retrospective

- Trigger: substantive round 3 and four accepted findings at the same exact-delivery checkpoint seam. First-reviewed authored-source churn was 402 lines; current churn is 675. Review remediation added 381 source lines of commit churn and 1,201 test lines of commit churn across four correction rounds.
- Canonical authority: the outbox wholly owns due, prepared/sending, retry, ambiguity, and terminal delivery state. The system mailbox owns FIFO membership and handled-through only; its retry time is a derived scheduling projection re-read from the outbox on resume.
- Provider-entry contract: pending/retryable before entry; token-checked prepared claim checkpointed as the provider fence; foreground preemption restores and checkpoints the prior state; existing outbox idempotency/ambiguity rules own post-entry recovery; a provider-created retry and its mailbox projection receive one full snapshot before the wake is returned; terminal outbox state retires the mailbox item.
- Decision: continue the current direction. Deleting any correction reopens a reproduced indefinite stall, duplicate-send window, or ten-minute unsent delay. Moving preparation later requires an extra checkpoint on every normal send, while selecting Telegram through the existing prepared-dispatch mechanism adds no new state and the release checkpoint exists only on rare preemption. Returning a provider retry without the new full snapshot would make the wake a droppable hint; the existing system-mailbox checkpoint is the smallest durable owner. Splitting the independent, already-complete device retry does not simplify exact delivery. No new queue, scheduler, state field, lifecycle enum, migration, compatibility path, or reconciliation loop was added.

## Deployment concerns

- Deployment: applicable
- Supported skew: the new runner is compatible with the old Web classifier; the reverse order would let Web dispatch work an old runner cannot drain.
- Safe order: deploy private Temporal PR #40 and this public head's runner bundle first, drain or replace warm old RunnerContainers, then deploy the Web reconciliation classifier.
- Rollback floor: revert Web classification before reverting the runner bundle; Temporal's bounded redispatch is compatible with both runner versions.
- Expected exposure: mixed warm-container versions can delay recovery for one rollout window but must not skip or duplicate durable mailbox completion.
- Reversibility: stop the Web model-free classification first, then roll back runner and Temporal workers if needed.
- Convergence proof: verify the exact deployed bundle and worker versions, then confirm anonymous stalled-frontier counts and pending live-item counts decrease.
- Post-deploy checks: inspect bounded runtime event aggregates for exact notification delivery, canonical retry checkpoints, redispatch, retries, and handled-through advancement.

## Changelog

- Changelog: updated
- Items: 2026-08-20 · background-work-keeps-moving
