### PR TITLE
Complete device webhooks for unregistered sources

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-21-unregistered-source-webhook-terminal.md
+++ b/agent-docs/exec-plans/completed/2026-08-21-unregistered-source-webhook-terminal.md
@@ -1,0 +1,55 @@
+# Stop dead-lettering webhooks for sources Murph never registered
+
+Status: completed
+Created: 2026-08-21
+Updated: 2026-08-21
+
+## Goal
+
+- Let hosted webhook admission finish, instead of retrying forever, when a
+  confirmed device connection receives a source-attributed event for a source
+  that was never registered on our side.
+
+## Success criteria
+
+- A focused regression test reproduces the current infinite
+  `WEBHOOK_SOURCE_NOT_READY` loop for a confirmed connection with no
+  `device_connection_source` row for the event's source slug.
+- The same event completes its webhook trace and admits no data.
+- A connection still in setup keeps the retryable behavior, so the existing
+  connect race stays recoverable.
+- An existing registered source that is disconnected, fenced, or mid-admission
+  keeps its current retry and terminal behavior.
+- Focused hosted Web tests pass on the final file state.
+
+## Scope
+
+- In scope: the durable admission decision in
+  `apps/web/src/lib/device-sync/wake-service.ts` and its focused coverage.
+- Out of scope: registering unknown sources from provider listings, Queue retry
+  policy, dead-letter retention, monitor thresholds, and the DLQ redrive itself.
+
+## Constraints
+
+- Keep the consent boundary: an unregistered source still admits no data.
+- Keep provider I/O outside database transactions.
+- Smallest durable correction; no new state, queue, or abstraction.
+
+## Risks and mitigations
+
+1. Risk: a real source registration that is still in flight gets dropped.
+   Mitigation: source rows are created when Murph starts a source connect, so
+   only a confirmed connection with no row is treated as terminal; pending setup
+   keeps retrying.
+2. Risk: silently losing health data.
+   Mitigation: the event carries no admissible data for an unregistered source,
+   and scheduled reconcile keeps pulling for registered sources.
+
+## Steps
+
+1. Reproduce the loop in a focused test.
+2. Make the confirmed-connection, unregistered-source case complete the trace.
+3. Prove pending setup and registered-source paths are unchanged.
+4. Open the PR, run the routed review gates, then redrive the dead-letter queue
+   after the Web deploy is live.
+Completed: 2026-08-21

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -3342,12 +3342,11 @@ async function inspectHostedDeviceSyncWebhookAdmissionTx(
       currentSource = source;
     } else {
       if (!source) {
-        throw deviceSyncError({
-          code: "WEBHOOK_SOURCE_NOT_READY",
-          message: "Device source setup is not visible yet. Retry shortly.",
-          retryable: true,
-          httpStatus: 503,
-        });
+        // Pending setup already left above, and starting a source connect
+        // writes its row first, so this connection never admitted this source.
+        // Retrying cannot change that, and the event carries no admissible data.
+        await completeHostedWebhookTraceTx(input, tx);
+        return { kind: "completed" };
       }
 
       if (source.status !== "connected" || isHostedSourceDisconnectFenced(source)) {
@@ -3433,9 +3432,16 @@ async function inspectHostedDeviceSyncWebhookAdmissionTx(
         tx,
       });
   if (!dataSource) {
-    throw webhookSourceNotReadyError(
-      "Device data source setup is not visible yet. Retry shortly.",
-    );
+    if (setupPending) {
+      throw webhookSourceNotReadyError(
+        "Device data source setup is not visible yet. Retry shortly.",
+      );
+    }
+    // Same rule as the event source above: a confirmed connection with no row
+    // never admitted this data source, and an admitted row that is merely
+    // unusable already completes below.
+    await completeHostedWebhookTraceTx(input, tx);
+    return { kind: "completed" };
   }
   const observedSourceWillBeAdmitted = Boolean(
     input.sourceObservation?.sourceAccessActive

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -1995,12 +1995,17 @@ async function prepareHostedWebhookSourceObservation(input: {
           tx,
         });
         if (!source) {
-          if (
-            !sourceInstanceKey
-            || resolveJunctionDeviceConnectRouteByProviderSlug(
-              sourceProviderSlug,
-            ) === null
-          ) {
+          const connectRoute = resolveJunctionDeviceConnectRouteByProviderSlug(
+            sourceProviderSlug,
+          );
+          if (connectRoute === null && !setupPending) {
+            // No connect route can register this slug, so no later delivery can
+            // admit the event. Settle the trace instead of retaining it until
+            // the Queue dead-letters it.
+            await completeHostedWebhookTraceTx(input, tx);
+            return { kind: "terminal" };
+          }
+          if (!sourceInstanceKey || connectRoute === null) {
             throw webhookSourceNotReadyError(
               "Device source setup is not visible yet. Retry shortly.",
             );
@@ -3342,11 +3347,12 @@ async function inspectHostedDeviceSyncWebhookAdmissionTx(
       currentSource = source;
     } else {
       if (!source) {
-        // Pending setup already left above, and starting a source connect
-        // writes its row first, so this connection never admitted this source.
-        // Retrying cannot change that, and the event carries no admissible data.
-        await completeHostedWebhookTraceTx(input, tx);
-        return { kind: "completed" };
+        throw deviceSyncError({
+          code: "WEBHOOK_SOURCE_NOT_READY",
+          message: "Device source setup is not visible yet. Retry shortly.",
+          retryable: true,
+          httpStatus: 503,
+        });
       }
 
       if (source.status !== "connected" || isHostedSourceDisconnectFenced(source)) {
@@ -3432,16 +3438,9 @@ async function inspectHostedDeviceSyncWebhookAdmissionTx(
         tx,
       });
   if (!dataSource) {
-    if (setupPending) {
-      throw webhookSourceNotReadyError(
-        "Device data source setup is not visible yet. Retry shortly.",
-      );
-    }
-    // Same rule as the event source above: a confirmed connection with no row
-    // never admitted this data source, and an admitted row that is merely
-    // unusable already completes below.
-    await completeHostedWebhookTraceTx(input, tx);
-    return { kind: "completed" };
+    throw webhookSourceNotReadyError(
+      "Device data source setup is not visible yet. Retry shortly.",
+    );
   }
   const observedSourceWillBeAdmitted = Boolean(
     input.sourceObservation?.sourceAccessActive

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -9756,13 +9756,13 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.upsertDirtyConnection).toHaveBeenCalledOnce();
   });
 
-  it("completes a Junction event for a source the confirmed connection never registered", async () => {
-    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(
-      buildWebhookAdmissionRecord({
-        provider: "junction",
-        setupPhase: "source_confirmed",
-      }),
-    );
+  it("completes a Junction event for a source with no connect route", async () => {
+    const admissionRecord = buildWebhookAdmissionRecord({
+      provider: "junction",
+      setupPhase: "source_confirmed",
+    });
+    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(admissionRecord);
+    mocks.getConnectionRecordForUser.mockResolvedValue(admissionRecord);
     const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
 
     await expect(handleHostedDeviceSyncWebhookAccepted({
@@ -9775,64 +9775,27 @@ describe("hosted device-sync wakes", () => {
       now: "2026-03-26T12:00:00.000Z",
       ownerId: "user-123",
       processingAttemptedAt: "2026-03-26T12:00:00.000Z",
+      registry: { get: mocks.registryGet, list: mocks.registryList, register: vi.fn() },
+      sourceAdmissionDeferred: true,
       store,
       traceId: "trace_123",
       webhook: {
         acceptanceMode: "durable_webhook_work",
-        eventType: "daily.data.activity.created",
-        jobs: [{
-          kind: "resource",
-          payload: { resource: "activity" },
-        }],
-        sourceProviderSlug: "oura",
-      },
-    })).resolves.toBeUndefined();
-
-    expect(mocks.completeWebhookTrace).toHaveBeenCalledOnce();
-    expect(mocks.markConnectionSourceDataReceived).not.toHaveBeenCalled();
-    expect(mocks.markWebhookReceived).not.toHaveBeenCalled();
-    expect(mocks.upsertConnectionSource).not.toHaveBeenCalled();
-    expect(mocks.prepareDirtyConnectionUpsert).not.toHaveBeenCalled();
-    expect(mocks.upsertDirtyConnection).not.toHaveBeenCalled();
-    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
-  });
-
-  it("completes Junction data for a data source the confirmed connection never registered", async () => {
-    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(
-      buildWebhookAdmissionRecord({
-        provider: "junction",
-        setupPhase: "source_confirmed",
-      }),
-    );
-    const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
-
-    await expect(handleHostedDeviceSyncWebhookAccepted({
-      account: {
-        connectedAt: "2026-03-26T12:00:00.000Z",
-        id: "dsc_123",
-        provider: "junction",
-      },
-      claimToken: "claim-token",
-      now: "2026-03-26T12:00:00.000Z",
-      ownerId: "user-123",
-      processingAttemptedAt: "2026-03-26T12:00:00.000Z",
-      store,
-      traceId: "trace_123",
-      webhook: {
-        acceptanceMode: "durable_webhook_work",
-        dataSourceProviderSlug: "oura",
+        dataSourceProviderSlug: "future_sensor",
         eventType: "historical.data.workout_distance.created",
         jobs: [{
           kind: "resource",
           payload: {
             resource: "workout_distance",
-            sourceProviderSlug: "oura",
+            sourceProviderSlug: "future_sensor",
           },
         }],
+        sourceProviderSlug: "future_sensor",
       },
     })).resolves.toBeUndefined();
 
     expect(mocks.completeWebhookTrace).toHaveBeenCalledOnce();
+    expect(mocks.upsertConnectionSource).not.toHaveBeenCalled();
     expect(mocks.markConnectionSourceDataReceived).not.toHaveBeenCalled();
     expect(mocks.markWebhookReceived).not.toHaveBeenCalled();
     expect(mocks.prepareDirtyConnectionUpsert).not.toHaveBeenCalled();
@@ -9840,11 +9803,7 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
   });
 
-  it("keeps unregistered Junction data retryable while a pending setup admits its source", async () => {
-    const observedSource = buildHostedConnectionSource("dsc_123", "oura", {
-      lastSeenAt: "2026-03-26T11:00:00.000Z",
-      status: "disconnected",
-    });
+  it("keeps a Junction source with no connect route retryable while setup is pending", async () => {
     const admissionRecord = buildWebhookAdmissionRecord({
       provider: "junction",
       setupExpiresAt: "2026-03-26T12:15:00.000Z",
@@ -9852,21 +9811,6 @@ describe("hosted device-sync wakes", () => {
     });
     mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(admissionRecord);
     mocks.getConnectionRecordForUser.mockResolvedValue(admissionRecord);
-    mocks.registryGet.mockReturnValue({
-      connectionHandler: {
-        buildSourceConnectionWork: vi.fn(() => ({
-          initialJobs: [],
-          nextReconcileAt: "2026-03-26T13:00:00.000Z",
-        })),
-        isSourceAccessActive: vi.fn(async () => true),
-      },
-    });
-    mocks.resolveConnectionSourceAdmissionCandidate.mockImplementation(
-      async (request: { sourceProviderSlug: string }) =>
-        request.sourceProviderSlug === "oura"
-          ? buildHostedConnectionSourceAdmissionCandidate(observedSource)
-          : null,
-    );
     const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
 
     await expect(handleHostedDeviceSyncWebhookAccepted({
@@ -9885,16 +9829,12 @@ describe("hosted device-sync wakes", () => {
       traceId: "trace_123",
       webhook: {
         acceptanceMode: "durable_webhook_work",
-        dataSourceProviderSlug: "whoop_v2",
-        eventType: "historical.data.workout_distance.created",
+        eventType: "daily.data.activity.created",
         jobs: [{
           kind: "resource",
-          payload: {
-            resource: "workout_distance",
-            sourceProviderSlug: "whoop_v2",
-          },
+          payload: { resource: "activity" },
         }],
-        sourceProviderSlug: "oura",
+        sourceProviderSlug: "future_sensor",
       },
     })).rejects.toMatchObject({
       code: "WEBHOOK_SOURCE_NOT_READY",
@@ -9903,6 +9843,7 @@ describe("hosted device-sync wakes", () => {
     });
 
     expect(mocks.completeWebhookTrace).not.toHaveBeenCalled();
+    expect(mocks.upsertConnectionSource).not.toHaveBeenCalled();
     expect(mocks.upsertDirtyConnection).not.toHaveBeenCalled();
     expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
   });

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -9756,4 +9756,154 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.upsertDirtyConnection).toHaveBeenCalledOnce();
   });
 
+  it("completes a Junction event for a source the confirmed connection never registered", async () => {
+    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(
+      buildWebhookAdmissionRecord({
+        provider: "junction",
+        setupPhase: "source_confirmed",
+      }),
+    );
+    const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
+
+    await expect(handleHostedDeviceSyncWebhookAccepted({
+      account: {
+        connectedAt: "2026-03-26T12:00:00.000Z",
+        id: "dsc_123",
+        provider: "junction",
+      },
+      claimToken: "claim-token",
+      now: "2026-03-26T12:00:00.000Z",
+      ownerId: "user-123",
+      processingAttemptedAt: "2026-03-26T12:00:00.000Z",
+      store,
+      traceId: "trace_123",
+      webhook: {
+        acceptanceMode: "durable_webhook_work",
+        eventType: "daily.data.activity.created",
+        jobs: [{
+          kind: "resource",
+          payload: { resource: "activity" },
+        }],
+        sourceProviderSlug: "oura",
+      },
+    })).resolves.toBeUndefined();
+
+    expect(mocks.completeWebhookTrace).toHaveBeenCalledOnce();
+    expect(mocks.markConnectionSourceDataReceived).not.toHaveBeenCalled();
+    expect(mocks.markWebhookReceived).not.toHaveBeenCalled();
+    expect(mocks.upsertConnectionSource).not.toHaveBeenCalled();
+    expect(mocks.prepareDirtyConnectionUpsert).not.toHaveBeenCalled();
+    expect(mocks.upsertDirtyConnection).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("completes Junction data for a data source the confirmed connection never registered", async () => {
+    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(
+      buildWebhookAdmissionRecord({
+        provider: "junction",
+        setupPhase: "source_confirmed",
+      }),
+    );
+    const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
+
+    await expect(handleHostedDeviceSyncWebhookAccepted({
+      account: {
+        connectedAt: "2026-03-26T12:00:00.000Z",
+        id: "dsc_123",
+        provider: "junction",
+      },
+      claimToken: "claim-token",
+      now: "2026-03-26T12:00:00.000Z",
+      ownerId: "user-123",
+      processingAttemptedAt: "2026-03-26T12:00:00.000Z",
+      store,
+      traceId: "trace_123",
+      webhook: {
+        acceptanceMode: "durable_webhook_work",
+        dataSourceProviderSlug: "oura",
+        eventType: "historical.data.workout_distance.created",
+        jobs: [{
+          kind: "resource",
+          payload: {
+            resource: "workout_distance",
+            sourceProviderSlug: "oura",
+          },
+        }],
+      },
+    })).resolves.toBeUndefined();
+
+    expect(mocks.completeWebhookTrace).toHaveBeenCalledOnce();
+    expect(mocks.markConnectionSourceDataReceived).not.toHaveBeenCalled();
+    expect(mocks.markWebhookReceived).not.toHaveBeenCalled();
+    expect(mocks.prepareDirtyConnectionUpsert).not.toHaveBeenCalled();
+    expect(mocks.upsertDirtyConnection).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("keeps unregistered Junction data retryable while a pending setup admits its source", async () => {
+    const observedSource = buildHostedConnectionSource("dsc_123", "oura", {
+      lastSeenAt: "2026-03-26T11:00:00.000Z",
+      status: "disconnected",
+    });
+    const admissionRecord = buildWebhookAdmissionRecord({
+      provider: "junction",
+      setupExpiresAt: "2026-03-26T12:15:00.000Z",
+      setupPhase: "pending_link",
+    });
+    mocks.prismaTx.deviceConnection.findUnique.mockResolvedValue(admissionRecord);
+    mocks.getConnectionRecordForUser.mockResolvedValue(admissionRecord);
+    mocks.registryGet.mockReturnValue({
+      connectionHandler: {
+        buildSourceConnectionWork: vi.fn(() => ({
+          initialJobs: [],
+          nextReconcileAt: "2026-03-26T13:00:00.000Z",
+        })),
+        isSourceAccessActive: vi.fn(async () => true),
+      },
+    });
+    mocks.resolveConnectionSourceAdmissionCandidate.mockImplementation(
+      async (request: { sourceProviderSlug: string }) =>
+        request.sourceProviderSlug === "oura"
+          ? buildHostedConnectionSourceAdmissionCandidate(observedSource)
+          : null,
+    );
+    const store = new PrismaDeviceSyncControlPlaneStore({ prisma: getPrisma() });
+
+    await expect(handleHostedDeviceSyncWebhookAccepted({
+      account: {
+        connectedAt: "2026-03-26T12:00:00.000Z",
+        id: "dsc_123",
+        provider: "junction",
+      },
+      claimToken: "claim-token",
+      now: "2026-03-26T12:00:00.000Z",
+      ownerId: "user-123",
+      processingAttemptedAt: "2026-03-26T12:14:59.999Z",
+      registry: { get: mocks.registryGet, list: mocks.registryList, register: vi.fn() },
+      sourceAdmissionDeferred: true,
+      store,
+      traceId: "trace_123",
+      webhook: {
+        acceptanceMode: "durable_webhook_work",
+        dataSourceProviderSlug: "whoop_v2",
+        eventType: "historical.data.workout_distance.created",
+        jobs: [{
+          kind: "resource",
+          payload: {
+            resource: "workout_distance",
+            sourceProviderSlug: "whoop_v2",
+          },
+        }],
+        sourceProviderSlug: "oura",
+      },
+    })).rejects.toMatchObject({
+      code: "WEBHOOK_SOURCE_NOT_READY",
+      httpStatus: 503,
+      retryable: true,
+    });
+
+    expect(mocks.completeWebhookTrace).not.toHaveBeenCalled();
+    expect(mocks.upsertDirtyConnection).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/test/device-sync-prepared-webhook-authority-postgres.test.ts
+++ b/apps/web/test/device-sync-prepared-webhook-authority-postgres.test.ts
@@ -1067,7 +1067,7 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("keeps an unsupported missing Junction source retryable without creating state", async () => {
+    it("settles an unsupported missing Junction source without creating state", async () => {
       const sourceProviderSlug = "future_sensor";
       const fixture = await createFixture({ sourceLastErrorCode: null });
       const providerFetch = vi.fn(async () => new Response(JSON.stringify({
@@ -1093,23 +1093,27 @@ describe.skipIf(!runPostgresProof)(
           store: fixture.store,
         });
 
-        await expect(consumeService.handlePreparedWebhook(prepared)).rejects.toMatchObject({
-          code: "WEBHOOK_SOURCE_NOT_READY",
-          retryable: true,
+        await expect(consumeService.handlePreparedWebhook(prepared)).resolves.toMatchObject({
+          accepted: true,
+          duplicate: false,
         });
 
         expect(providerFetch).not.toHaveBeenCalled();
         await expect(fixture.prisma.deviceConnectionSource.count({
           where: { connectionId: fixture.connectionId },
         })).resolves.toBe(0);
-        await expect(fixture.prisma.deviceWebhookTrace.findUnique({
+        await expect(fixture.prisma.deviceWebhookTrace.findUniqueOrThrow({
+          select: { claimToken: true, status: true },
           where: {
             provider_traceId: {
               provider: "junction",
               traceId: prepared.traceId,
             },
           },
-        })).resolves.toBeNull();
+        })).resolves.toMatchObject({
+          claimToken: null,
+          status: "processed",
+        });
         await expect(fixture.prisma.deviceSyncDirtyConnection.count({
           where: { connectionId: fixture.connectionId },
         })).resolves.toBe(0);


### PR DESCRIPTION
## Why and outcome

A Junction event can name a source slug that has no Murph connect route — for
example a workout whose inline provenance points at a vendor Murph does not
offer. Hosted admission refuses that event, correctly, because Murph never
registered the source. It refused it as retryable, so the event burned all ten
Queue attempts and dead-lettered. Three of them did that this morning and now
page the operator chat every hour until the 14-day retention expires.

This change settles that case where the decision already lives: when a
confirmed connection sees a source slug with no connect route and no source
row, `prepareHostedWebhookSourceObservation` completes the webhook trace instead
of throwing. A slug that does have a connect route keeps its existing
reconstruct-and-verify recovery, and a connection still in setup keeps retrying.

Direct production evidence for the loop: the same three messages were read from
`murph-hosted-device-webhooks-dlq` at 2026-08-21T11:52:45Z during a runbook
redrive and returned `acceptedCount: 0, batchSize: 3, retryCount: 3`; hosted Web
logged `failureCounts: { WEBHOOK_SOURCE_NOT_READY: n }` on every attempt.

## Product UX result

No user-facing surface changes. The affected person is a member whose provider
sends data attributed to a vendor Murph cannot connect: before, that event
retried until it dead-lettered; now it is refused once and the Queue stays
clean. Members with a connectable source are untouched — a missing row there
still reconstructs a disconnected candidate and waits for live provider proof.

## Direct evidence

- `pnpm test:prepared test/device-sync-hosted-wake.test.ts` — 190 passed.
- `DATABASE_URL=<local> MURPH_TEST_POSTGRES_CONCURRENCY=1 pnpm exec vitest run
  --config apps/web/vitest.workspace.ts --no-coverage
  apps/web/test/device-sync-prepared-webhook-authority-postgres.test.ts` — 16
  passed. That file composes the real prepared-webhook route.
- The production-composed scenario fails on the pre-change source file
  (1 failed | 15 passed) and passes after it, so it reproduces the loop through
  `handlePreparedWebhook`, not through an inner branch.
- `pnpm typecheck` (apps/web) and `eslint` on all three changed files pass.

## Non-obvious affected surfaces

`packages/device-syncd/src/public-ingress.ts` defers Junction source admission
whenever the row is missing, not connected, or fenced, so the missing-row
decision belongs to `prepareHostedWebhookSourceObservation`. That is why the
new terminal branch sits beside the existing candidate reconstruction rather
than in `inspectHostedDeviceSyncWebhookAdmissionTx`, which the deferred route
never reaches for this case.

## Architecture and reuse

- Existing systems reused: `resolveJunctionDeviceConnectRouteByProviderSlug`,
  which the same branch already calls to decide whether a candidate can be
  reconstructed, and `completeHostedWebhookTraceTx`, the terminal path this
  function already uses for other settled cases.
- New logic: one branch that completes the trace when a confirmed connection
  has no source row and the slug resolves to no Junction connect route.
- New abstractions: none; no new helper, type, state, or module, and the source
  diff is +11/-6.
- Complexity intentionally avoided: no Queue-side retry budget, no quarantine
  table, no provider lookup to register an unknown vendor, and no second
  missing-row policy below the admission owner.

## Hot reply path impact

None. This path runs in queued webhook admission, not in the inbound reply path.

## Provider-input impact

Provider-authored event content is still only interpretation, never authority.
The decision reads Murph's own connect-route table and source rows.

## Deployment concerns

- Deployment: applicable
- Supported skew: the Queue envelope and admission-callback contracts are
  unchanged, so any deployed Cloudflare Worker version works with either Web
  version; no tandem deploy is required.
- Safe order: deploy Web; `apps/cloudflare` needs no release for this change.
- Rollback floor: the previous Web deployment. Nothing here migrates schema or
  writes state the previous build cannot read.
- Expected exposure: Junction webhook admission for events attributed to a slug
  with no connect route; every connectable source keeps its current path.
- Reversibility: full. Redeploying the previous Web build restores the prior
  retry behavior.
- Convergence proof: after the Web deploy is live, redrive
  `murph-hosted-device-webhooks-dlq` with the runbook in
  `apps/cloudflare/DEPLOY.md` and confirm its backlog reaches zero while the
  main Queue drains to zero.
- Post-deploy checks: watch hosted Web logs on
  `/api/internal/device-sync/webhooks/admit-batch` for `WEBHOOK_SOURCE_NOT_READY`
  counts and confirm no new dead-letter writes appear in Queue analytics.

## Changelog

- Changelog: not applicable
- Reason: no member-visible behavior changes. An event for a source Murph cannot
  connect admitted no data before or after this change; only the internal retry
  disposition for that refusal changes.

## LOC

- source: +11 / -6
- tests/fixtures: +101 / -6
- docs: +55 / -0
- config/tooling: 0
- generated/other: 0

ReviewGPT first-reviewed head: f89dce8be719e375feb50c308487c0f2c97167e0
