### PR TITLE
Fix unauthenticated ReviewGPT lane selection

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-21-restore-reviewgpt-auth-lane-opt-in.md
+++ b/agent-docs/exec-plans/active/2026-08-21-restore-reviewgpt-auth-lane-opt-in.md
@@ -1,0 +1,70 @@
+# Restore authenticated ReviewGPT lane default
+
+Status: active
+Created: 2026-08-21
+Updated: 2026-08-21
+
+## Goal
+
+- Keep automatic ReviewGPT submissions on the four portable, provisioned
+  browser lanes unless a host explicitly opts into the additional lanes.
+
+## Success criteria
+
+- The default automatic pool contains Eragon, Phlebas, Hercules, and Mountain.
+- Vonneumann and Apollo remain available through an explicit lane selection or
+  `REVIEW_GPT_BROWSER_LANE_COUNT=5|6`.
+- Focused configuration tests and the CLI release-coverage assertion agree with
+  the restored default.
+- Current operating guidance again describes the extra lanes as host opt-ins.
+
+## Scope
+
+- In scope: Murph's ReviewGPT lane-count default, its focused tests, and current
+  operator documentation.
+- Out of scope: browser profile contents, ChatGPT account state, ReviewGPT
+  package automation, or changes to the six supported lane definitions.
+
+## Constraints
+
+- Technical constraints: preserve per-invocation and local-config precedence,
+  lane ordering, explicit Apollo support, and the accepted count range of 1-6.
+- Product/process constraints: keep machine-local authentication and account
+  state out of committed evidence; use synthetic fixtures only.
+
+## Risks and mitigations
+
+1. Risk: restoring the portable default could accidentally remove explicit
+   access to the fifth and sixth lanes.
+   Mitigation: keep the six-lane map and bounds unchanged and cover explicit
+   five- and six-lane opt-in behavior.
+
+## Tasks
+
+1. Restore the four-lane default and align focused assertions and docs.
+2. Run the focused ReviewGPT configuration and release-coverage tests plus
+   shell syntax and typecheck.
+3. Inspect the complete diff, commit and push the exact candidate, run the
+   required preliminary coverage review with CI, resolve findings, and close
+   the plan through the scoped finish helper.
+
+## Decisions
+
+- Revert the default expansion rather than inspect browser cookies in the lane
+  selector. Authentication remains machine-local profile state, and the
+  existing explicit count is already the intended provisioning boundary.
+- Treat the change as internal operator tooling: Product UX, prompt, and
+  frontend review are not applicable; the preliminary coverage lens applies.
+
+## Verification
+
+- Commands to run: focused Vitest files for ReviewGPT configuration and CLI
+  release coverage, `bash -n scripts/review-gpt.config.sh`, package typecheck,
+  `git diff --check`, exact-head CI, and current-base merge-tree proof.
+- Expected outcomes: default count/pool assertions report four lanes; explicit
+  counts five and six still select the additional lanes; all checks pass.
+- Local results: focused ReviewGPT config tests (5 passed), focused CLI release
+  coverage (45 passed, 1 skipped), shell syntax, CLI package typecheck, and the
+  isolated storage-guard retry all passed. The broader diff lane found two
+  unchanged workspace-boundary violations and one unrelated storage-guard
+  timeout; the timed-out test passed alone in 3 seconds.

--- a/agent-docs/exec-plans/completed/2026-08-21-restore-reviewgpt-auth-lane-opt-in.md
+++ b/agent-docs/exec-plans/completed/2026-08-21-restore-reviewgpt-auth-lane-opt-in.md
@@ -1,6 +1,6 @@
 # Restore authenticated ReviewGPT lane default
 
-Status: active
+Status: completed
 Created: 2026-08-21
 Updated: 2026-08-21
 
@@ -68,3 +68,16 @@ Updated: 2026-08-21
   isolated storage-guard retry all passed. The broader diff lane found two
   unchanged workspace-boundary violations and one unrelated storage-guard
   timeout; the timed-out test passed alone in 3 seconds.
+
+## Completion review
+
+- The exact-head preliminary completion-specialists review applied the coverage
+  lens and returned `PASS` with zero findings and no patch artifact. Product UX,
+  prompt, and frontend lenses were correctly not applicable.
+- Parent diff review confirmed the implementation only restores the fallback
+  count. The six-lane map, explicit lane selection, count precedence, validation
+  bounds, and five- and six-lane opt-in coverage remain unchanged.
+- The preliminary pushed head passed its available repository checks while the
+  remaining hosted checks were still running. The plan-closure commit requires
+  a fresh exact-head CI read and current-base merge-tree proof before handoff.
+Completed: 2026-08-21

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -446,11 +446,12 @@ the current user explicitly asks for it.
    Spotlight or scans unrelated filesystem roots for an app bundle.
 
    `REVIEW_GPT_BROWSER_LANE_COUNT` limits the automatic pool to the first one
-   through six lanes and defaults to all six. A value supplied on the current
+   through six lanes and defaults to four. A value supplied on the current
    command is authoritative; the local config is only a fallback preference and
-   cannot widen or replace that per-run pool cap. A host can narrow the pool by
-   setting the count in its local `$XDG_CONFIG_HOME/murph/review-gpt.conf`,
-   without committing machine-specific preferences or account details.
+   cannot widen or replace that per-run pool cap. A host with provisioned
+   Vonneumann or Apollo profiles can opt into five or six lanes in its local
+   `$XDG_CONFIG_HOME/murph/review-gpt.conf`, without committing machine-specific
+   preferences or account details.
 
    A lane is considered usable when its managed profile is unlocked, or when its
    configured CDP endpoint is already alive. The default random path skips a

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1621,7 +1621,7 @@ describe('monorepo release flow coverage audit', () => {
     )
     expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_PROFILE_SLUG:-auto')
     expect(reviewGptConfig).toContain('REVIEW_GPT_BROWSER_LANE_COUNT')
-    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-6')
+    expect(reviewGptConfig).toContain('MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4')
     expect(reviewGptConfig).toContain('REVIEW_GPT_THREAD_URL')
     expect(reviewGptConfig).toContain('review_gpt_reuses_existing_thread=1')
     expect(reviewGptConfig).toContain(
@@ -1899,7 +1899,7 @@ describe('monorepo release flow coverage audit', () => {
     expect(prReviewGptLoop).toContain('Vonneumann on `9446`')
     expect(prReviewGptLoop).toContain('Apollo on')
     expect(prReviewGptLoop).toContain('`9454`, always with profile `Default`')
-    expect(prReviewGptLoop).toContain('through six lanes and defaults to all six')
+    expect(prReviewGptLoop).toContain('through six lanes and defaults to four')
     expect(prReviewGptLoop).toContain('current installed Brave binary')
     expect(prReviewGptLoop).toContain(
       "passes none of Chromium's background-timer, occluded-window, or renderer",
@@ -2447,8 +2447,8 @@ printf '%s|%s|%s|%s|%s\n' \
         defaultBackgroundMode,
         defaultDisplayMode,
       ] = defaultResult.stdout.trim().split('|')
-      expect(['vonneumann', 'apollo']).toContain(defaultLane)
-      expect(defaultLaneCount).toBe('6')
+      expect(['eragon', 'phlebas', 'hercules', 'mountain']).toContain(defaultLane)
+      expect(defaultLaneCount).toBe('4')
       expect(defaultBrowser).toBe(
         '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
       )
@@ -2468,7 +2468,7 @@ printf '%s|%s|%s|%s|%s\n' \
       })
       expect(mainResult.status, mainResult.stderr).toBe(0)
       expect(mainResult.stdout.trim()).toBe(
-        'main|6|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
+        'main|4|/Applications/Brave Browser.app/Contents/MacOS/Brave Browser|balanced|headful',
       )
 
       writeHarnessFile(

--- a/scripts/review-gpt-config.test.ts
+++ b/scripts/review-gpt-config.test.ts
@@ -165,16 +165,16 @@ afterEach(() => {
 });
 
 describe("ReviewGPT repository config", () => {
-  it("includes every managed lane in the default automatic pool", () => {
+  it("keeps unprovisioned extra lanes out of the default automatic pool", () => {
     const harness = createHarness();
     const result = runConfig(harness, {
       REVIEW_GPT_BROWSER_LANE: "auto",
     });
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("count=6\n");
+    expect(result.stdout).toContain("count=4\n");
     expect(result.stdout).toContain(
-      "pool=eragon phlebas hercules mountain vonneumann apollo\n",
+      "pool=eragon phlebas hercules mountain\n",
     );
     expect(existsSync(harness.mdfindMarker)).toBe(false);
   });

--- a/scripts/review-gpt.config.sh
+++ b/scripts/review-gpt.config.sh
@@ -158,7 +158,7 @@ if [[ -n "$review_gpt_direct_browser_lane_count" ]]; then
 elif [[ -n "$review_gpt_direct_compat_browser_lane_count" ]]; then
   review_gpt_browser_lane_count="$review_gpt_direct_compat_browser_lane_count"
 else
-  review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-6}}"
+  review_gpt_browser_lane_count="${REVIEW_GPT_BROWSER_LANE_COUNT:-${MURPH_REVIEW_GPT_BROWSER_LANE_COUNT:-4}}"
 fi
 
 if [[ "$review_gpt_reuses_existing_thread" == "1" ]]; then


### PR DESCRIPTION
## Why and outcome

ReviewGPT's sixth browser lane is host-provisioned and keeps independent ChatGPT session state. A recent default expansion admitted every lane automatically, so a fresh or unauthenticated extra profile could receive a new submission.

This restores the portable automatic pool to the first four lanes. Vonneumann and Apollo remain available through explicit selection or an explicit lane count of five or six.

## Product UX

- Not applicable: this changes internal review tooling only and does not alter a member-facing Murph journey.

## Evidence

- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/review-gpt-config.test.ts` — 5 passed.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts` — 45 passed, 1 skipped.
- `bash -n scripts/review-gpt.config.sh` — passed.
- `pnpm --filter @murphai/murph typecheck` — passed.
- Isolated retry of the unrelated storage-guard timeout — passed in 3 seconds.
- `git diff --check` — passed.
- Exact-head completion-specialists review — PASS, zero findings, no patch artifact.
- The broader diff lane also reported two existing workspace-boundary violations in untouched test files.

## Non-obvious affected surfaces

- ReviewGPT automatic browser-lane selection: the default pool is four again, while the full six-lane map, ordering, explicit pins, and 1-6 validation remain unchanged.
- Review workflow documentation and release-coverage assertions: updated so the executable default and operator guidance cannot drift.

## Architecture and reuse

- **Existing systems reused:** The existing ordered lane pool and `REVIEW_GPT_BROWSER_LANE_COUNT` opt-in remain the sole provisioning boundary.
- **New logic:** No new logic; one fallback value returns from six to four.
- **New abstractions:** None; the existing configuration owner is sufficient.
- **Complexity intentionally avoided:** No cookie inspection, auth probe, profile cloning, or second lane-health state was added.

## Hot reply path impact

- Not applicable: ReviewGPT developer tooling is outside the foreground member reply path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no provider-input assembly surface changed.
- Group runtime: Not applicable; no provider-input assembly surface changed.

## Change-shape breakdown

Classification rule: test files are tests/fixtures, Markdown is docs, the shell config is config/tooling, and no generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 8 | 8 |
| Docs | 88 | 4 |
| Config/tooling | 1 | 1 |
| Generated/other | 0 | 0 |
| **Total** | **97** | **13** |

## Deployment concerns

- Deployment: not applicable
- Reason: Internal ReviewGPT workflow configuration does not change a product runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal review tooling only.