### PR TITLE
Fix Environment realtime commands

### DIFF
--- a/apps/cloudflare/src/worker/route-handlers/environment-realtime.ts
+++ b/apps/cloudflare/src/worker/route-handlers/environment-realtime.ts
@@ -2,6 +2,7 @@ import {
   CLOUDFLARE_HOSTED_CONTROL_USER_ROUTE_SPECS,
   matchCloudflareHostedControlUserRoutePath,
 } from "@murphai/cloudflare-hosted-control/routes";
+import { ENVIRONMENT_REALTIME_TOOL_NAMES } from "@murphai/contracts";
 import { emitHostedExecutionStructuredLog } from "@murphai/hosted-execution";
 import OpenAI from "openai";
 
@@ -135,10 +136,9 @@ function buildEnvironmentRealtimeSession() {
       "Translate meaning into the exact canonical allowed values without translating those stored values.",
       "Never return user-visible text or audio. Never ask a question. Choose exactly one tool for every response.",
       "For every turn with explicit current-topic facts, call a tool before returning.",
-      "When the member asks to change language, call set_environment_language.",
+      `When the member asks to change language, call ${ENVIRONMENT_REALTIME_TOOL_NAMES.setLanguage}.`,
       "A clear request to end, stop, finish, save and end, or conclude the conversation is a finish command in any language.",
-      "Navigation commands take priority over every other tool. Call control_environment_interview and include explicit current-topic facts spoken with the command.",
-      "When the current topic has enough clear answers, call save_environment_topics.",
+      `Save facts and navigation together with ${ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview}.`,
       "A topic can also be completed when the member explicitly declines its remaining fields.",
       "Uncertainty or lack of knowledge leaves the field unresolved and writes nothing. Use the string declined only for an explicit skip, refusal, or preference not to answer.",
       "If the member clearly answers the next visible topic early, include that topic too.",
@@ -153,7 +153,7 @@ function buildEnvironmentRealtimeSession() {
       {
         description:
           "Change the visible interview language when the member asks for a specific language.",
-        name: "set_environment_language",
+        name: ENVIRONMENT_REALTIME_TOOL_NAMES.setLanguage,
         parameters: {
           additionalProperties: false,
           properties: {
@@ -169,91 +169,8 @@ function buildEnvironmentRealtimeSession() {
       },
       {
         description:
-          "Save explicit current-topic facts immediately when other important details are still missing. When one field remains, use this for every concise answer that is semantically valid for that field. Normalize equivalent wording to the canonical allowed value.",
-        name: "mark_environment_fields",
-        parameters: {
-          additionalProperties: false,
-          properties: {
-            fields: {
-              items: {
-                additionalProperties: false,
-                properties: {
-                  aspectId: { type: "string" },
-                  indicatorId: { type: "string" },
-                  note: {
-                    anyOf: [
-                      { maxLength: 400, minLength: 1, type: "string" },
-                      { type: "null" },
-                    ],
-                  },
-                  value: {
-                    anyOf: [
-                      { type: "string" },
-                      { type: "number" },
-                      { type: "boolean" },
-                    ],
-                  },
-                },
-                required: ["aspectId", "indicatorId", "value"],
-                type: "object",
-              },
-              maxItems: 16,
-              minItems: 1,
-              type: "array",
-            },
-          },
-          required: ["fields"],
-          type: "object",
-        },
-        type: "function",
-      },
-      {
-        description:
-          "Move through or finish the interview when the member gives a clear navigation command. Include any explicit current-topic facts spoken with the command.",
-        name: "control_environment_interview",
-        parameters: {
-          additionalProperties: false,
-          properties: {
-            action: {
-              enum: ["back", "next", "skip", "finish"],
-              type: "string",
-            },
-            fields: {
-              items: {
-                additionalProperties: false,
-                properties: {
-                  aspectId: { type: "string" },
-                  indicatorId: { type: "string" },
-                  note: {
-                    anyOf: [
-                      { maxLength: 400, minLength: 1, type: "string" },
-                      { type: "null" },
-                    ],
-                  },
-                  value: {
-                    anyOf: [
-                      { type: "string" },
-                      { type: "number" },
-                      { type: "boolean" },
-                    ],
-                  },
-                },
-                required: ["aspectId", "indicatorId", "value"],
-                type: "object",
-              },
-              maxItems: 16,
-              type: "array",
-            },
-          },
-          required: ["action"],
-          type: "object",
-        },
-        type: "function",
-      },
-      {
-        description:
           "Continue only when the latest turn is unrelated, unintelligible, or contains no explicit new fact or interview command. Do not use this for a concise answer that is semantically valid for the visible field.",
-        name: "continue_environment_interview",
+        name: ENVIRONMENT_REALTIME_TOOL_NAMES.continueInterview,
         parameters: {
           additionalProperties: false,
           properties: {},
@@ -263,11 +180,15 @@ function buildEnvironmentRealtimeSession() {
       },
       {
         description:
-          "Save one or more completed Environment topics using only explicit member answers.",
-        name: "save_environment_topics",
+          "Save every explicit fact for the visible topic, then optionally navigate. Facts are saved before navigation.",
+        name: ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
         parameters: {
           additionalProperties: false,
           properties: {
+            action: {
+              enum: ["back", "next", "skip", "finish"],
+              type: "string",
+            },
             languageCode: {
               description:
                 "ISO 639-1 code of the language spoken in the member's latest answer.",
@@ -314,7 +235,7 @@ function buildEnvironmentRealtimeSession() {
               type: "array",
             },
           },
-          required: ["languageCode", "topics"],
+          anyOf: [{ required: ["topics"] }, { required: ["action"] }],
           type: "object",
         },
         type: "function",

--- a/apps/cloudflare/test/worker-environment-realtime-route.test.ts
+++ b/apps/cloudflare/test/worker-environment-realtime-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ENVIRONMENT_REALTIME_TOOL_NAMES } from "@murphai/contracts";
 
 import { readHostedExecutionEnvironment } from "../src/env.ts";
 import type {
@@ -70,9 +71,15 @@ describe("worker Environment Realtime route", () => {
     expect(session.instructions).toContain(
       "Uncertainty or lack of knowledge leaves the field unresolved",
     );
+    expect(session.tools.map((tool) => tool.name)).toEqual([
+      ENVIRONMENT_REALTIME_TOOL_NAMES.setLanguage,
+      ENVIRONMENT_REALTIME_TOOL_NAMES.continueInterview,
+      ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
+    ]);
     expect(
-      session.tools.find((tool) =>
-        tool.name === "control_environment_interview"
+      session.tools.find(
+        (tool) =>
+          tool.name === ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
       )?.parameters.properties?.action?.enum,
     ).toEqual(["back", "next", "skip", "finish"]);
   });

--- a/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ENVIRONMENT_INTERVIEW_NOTE_MAX_LENGTH,
+  ENVIRONMENT_REALTIME_TOOL_NAMES,
   HABITAT_DECLINED_VALUE,
 } from "@murphai/contracts";
 import {
@@ -928,7 +929,7 @@ export function EnvironmentVoiceCapture({
         handledCallIdsRef.current.add(callId);
         toolCallPendingRef.current = true;
         const channel = dataChannelRef.current;
-        if (payload.name === "set_environment_language") {
+        if (payload.name === ENVIRONMENT_REALTIME_TOOL_NAMES.setLanguage) {
           const language = parseToolLanguage(payload.arguments);
           if (!language) {
             toolCallPendingRef.current = false;
@@ -957,7 +958,9 @@ export function EnvironmentVoiceCapture({
           requestQueuedResponse();
           return;
         }
-        if (payload.name === "continue_environment_interview") {
+        if (
+          payload.name === ENVIRONMENT_REALTIME_TOOL_NAMES.continueInterview
+        ) {
           toolCallPendingRef.current = false;
           responsePendingRef.current = false;
           sendFunctionResult(
@@ -975,7 +978,7 @@ export function EnvironmentVoiceCapture({
           requestQueuedResponse();
           return;
         }
-        if (payload.name !== "update_environment_interview") {
+        if (payload.name !== ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview) {
           toolCallPendingRef.current = false;
           responsePendingRef.current = false;
           prepareForNextTurn();
@@ -2060,7 +2063,7 @@ function buildRealtimeTools(
     {
       description:
         "Change the visible interview language when the member asks for a specific language.",
-      name: "set_environment_language",
+      name: ENVIRONMENT_REALTIME_TOOL_NAMES.setLanguage,
       parameters: {
         additionalProperties: false,
         properties: {
@@ -2077,7 +2080,7 @@ function buildRealtimeTools(
     {
       description:
         "Continue only when the latest turn is unrelated, unintelligible, or contains no explicit new fact or interview command. Do not use this for a concise answer that is semantically valid for the visible field.",
-      name: "continue_environment_interview",
+      name: ENVIRONMENT_REALTIME_TOOL_NAMES.continueInterview,
       parameters: {
         additionalProperties: false,
         properties: {},
@@ -2088,7 +2091,7 @@ function buildRealtimeTools(
     {
       description:
         "Save every explicit fact for the current or next visible topic, then optionally navigate. Facts are always saved before navigation. Next leaves unresolved fields unchanged. Skip declines every other unresolved current field.",
-      name: "update_environment_interview",
+      name: ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
       parameters: {
         additionalProperties: false,
         properties: {

--- a/packages/contracts/src/environment-interview.ts
+++ b/packages/contracts/src/environment-interview.ts
@@ -76,6 +76,12 @@ export interface EnvironmentInterviewAnswer {
 
 export const ENVIRONMENT_INTERVIEW_NOTE_MAX_LENGTH = 400;
 
+export const ENVIRONMENT_REALTIME_TOOL_NAMES = {
+  continueInterview: "continue_environment_interview",
+  setLanguage: "set_environment_language",
+  updateInterview: "update_environment_interview",
+} as const;
+
 export function getEnvironmentInterviewTopicGroup(
   topicId: string,
 ): (typeof ENVIRONMENT_INTERVIEW_TOPIC_GROUPS)[number]


### PR DESCRIPTION
## Why and outcome

Production Environment voice sessions transcribed speech but ignored facts and voice navigation. The Worker and browser now use one shared tool-name contract, so checklist updates, Next, Skip, Back, and Finish reach the existing browser handler.

## Product UX

- Effort: patch
- Walkthrough: existing presentation is unchanged.
- The fix restores the shipped interaction. It adds no controls, copy, or layout changes.

## Evidence

- Environment voice component: 12 tests passed.
- Cloudflare Environment Realtime route: 3 tests passed.
- Web, Cloudflare, and contracts typechecks passed.
- Scoped Web ESLint passed.

## Non-obvious affected surfaces

- The authenticated Worker creates the Realtime session.
- The browser replaces the generic session schema with the visible topic schema.
- Both owners now import the same three tool names from the Environment contract.

## Architecture and reuse

The existing Environment interview, Worker route, and Habitat save path remain unchanged. One lower-level contract constant removes duplicate protocol names. The Worker deletes obsolete tool definitions instead of adding compatibility machinery.

## Hot reply path impact

Not applicable. This fixes the separate Environment voice session and does not change conversation replies.

## Murph initial provider input impact

No change to normal assistant provider input. The Environment Realtime session now exposes the same consolidated tool contract already used by the browser.

## Design proof

- Design page: https://withmurph.ai/screenshots/health#environment-progressive-capture
- Evidence: no visual change; the existing real component study remains accurate.
- Coverage: active transcript, checklist updates, and navigation use the existing presentation.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 23 | 97 |
| Tests/fixtures | 11 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 34 | 97 |

No binary files changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: current Web already expects the consolidated tool; the new Worker restores compatibility.
- Safe order: deploy the Cloudflare Worker first. The following Web deploy is behavior-neutral.
- Rollback floor: do not roll the Worker back while this Web version is active.
- Expected exposure: voice transcripts continue, but facts and commands fail until the Worker deploy completes.
- Reversibility: restore both Worker and Web to the earlier matching multi-tool version together.
- Convergence proof: confirm the deployed Worker smoke, then speak one fact and say Next in one production session.
- Post-deploy checks: verify one checklist mark, voice Next, and voice Finish.

## Changelog

- Changelog: not applicable
- Reason: this restores the behavior already announced by the 2026-08-20 realtime-environment-interview entry; it adds no new member outcome.

## Risks

The initial Worker schema is broad because the browser supplies the exact visible-topic schema immediately after connection. The browser still validates every returned topic and field before saving.

ReviewGPT context sensitivity: sensitive