### PR TITLE
Fix Environment realtime session errors

### DIFF
--- a/apps/cloudflare/src/worker/route-handlers/environment-realtime.ts
+++ b/apps/cloudflare/src/worker/route-handlers/environment-realtime.ts
@@ -235,7 +235,6 @@ function buildEnvironmentRealtimeSession() {
               type: "array",
             },
           },
-          anyOf: [{ required: ["topics"] }, { required: ["action"] }],
           type: "object",
         },
         type: "function",

--- a/apps/cloudflare/test/worker-environment-realtime-route.test.ts
+++ b/apps/cloudflare/test/worker-environment-realtime-route.test.ts
@@ -60,7 +60,10 @@ describe("worker Environment Realtime route", () => {
       tool_choice: string;
       tools: Array<{
         name: string;
-        parameters: { properties?: { action?: { enum?: string[] } } };
+        parameters: {
+          anyOf?: unknown;
+          properties?: { action?: { enum?: string[] } };
+        };
       }>;
     };
     expect(session).toMatchObject({
@@ -82,6 +85,12 @@ describe("worker Environment Realtime route", () => {
           tool.name === ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
       )?.parameters.properties?.action?.enum,
     ).toEqual(["back", "next", "skip", "finish"]);
+    expect(
+      session.tools.find(
+        (tool) =>
+          tool.name === ENVIRONMENT_REALTIME_TOOL_NAMES.updateInterview,
+      )?.parameters.anyOf,
+    ).toBeUndefined();
   });
 
   it("fails closed when the provider key is unavailable", async () => {

--- a/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
@@ -2113,7 +2113,6 @@ function buildRealtimeTools(
             type: "array",
           },
         },
-        anyOf: [{ required: ["topics"] }, { required: ["action"] }],
         type: "object",
       },
       type: "function",

--- a/apps/web/test/environment-voice-capture.test.tsx
+++ b/apps/web/test/environment-voice-capture.test.tsx
@@ -337,6 +337,12 @@ test("saves current and next-topic facts before navigation", async () => {
         tool.name === "update_environment_interview",
     );
     assert.ok(updateTool);
+    assert.ok("parameters" in updateTool);
+    assert.ok(
+      typeof updateTool.parameters === "object" &&
+        updateTool.parameters !== null,
+    );
+    assert.equal("anyOf" in updateTool.parameters, false);
     assert.match(JSON.stringify(updateTool), /sleep:0/);
     assert.match(JSON.stringify(updateTool), /workspace:0/);
     assert.match(JSON.stringify(updateTool), /"next"/);


### PR DESCRIPTION
## Why

The Environment voice interview can connect and then stop with an internal error when the model processes an answer.

## User-visible goal

Keep the live interview connected so spoken facts can mark fields and voice navigation can move between topics.

## Invariants

- The browser still validates every returned topic, field, value, and action before saving.
- The Worker and browser expose the same realtime tool names and schema shape.
- No authentication, persistence, or scoring behavior changes.

## Architecture and reuse

The consolidated update tool had a root-level `anyOf` condition. The Realtime model does not need this schema condition because the browser already rejects empty or invalid updates. This removes the unsupported condition from both session definitions and keeps the existing validation owner.

## Change breakdown

- Source: 2 deletions
- Tests: 16 additions, 1 deletion
- Docs/config/generated: none

## Verification

- Cloudflare Environment Realtime route: 3 tests passed
- Web Environment voice capture: 12 tests passed
- Cloudflare typecheck passed
- Web typecheck passed

## Design proof

No visual change. The existing Environment interview design catalog study remains valid.

## Deployment concerns

Deploy the Cloudflare Worker and Vercel web app from the same merged commit. Both sides remove the same schema condition. Confirm a new production session accepts an answer, marks a field, and handles `next`.