### PR TITLE
Restore Temporal reconciliation compatibility

### DIFF
--- a/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
+++ b/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
@@ -38,9 +38,17 @@ export const GET = withJsonError(async (
     userId: routeUserId,
   });
 
-  return jsonOk(
-    await readHostedRuntimeReconciliationFactsWithVisibleAccess(factsRequest),
+  const facts = await readHostedRuntimeReconciliationFactsWithVisibleAccess(
+    factsRequest,
   );
+
+  // Keep the wire response compatible with the deployed Temporal worker.
+  // Additive facts must reach that consumer before Web begins emitting them.
+  return jsonOk({
+    blocked: facts.blocked,
+    mailboxLag: facts.mailboxLag,
+    workspace: facts.workspace,
+  });
 });
 
 function assertHostedOrchestrationUserMatches(input: {

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -1640,7 +1640,7 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(facts.blocked).toBeNull();
   });
 
-  it("exposes pending Environment interviews to the orchestration owner", async () => {
+  it("keeps pending Environment interviews off the deployed orchestration wire", async () => {
     mocks.readPendingHostedEnvironmentInterviewMailboxItem.mockResolvedValue({
       id: "mailbox_environment_interview_1",
     });
@@ -1649,9 +1649,9 @@ describe("hosted orchestration reconciliation facts", () => {
       requestForFacts(),
       routeContext(),
     );
-    const facts = parseHostedRuntimeReconciliationFacts(await response.json());
+    const facts = await response.json();
 
-    expect(facts.environmentInterviewPending).toBe(true);
+    expect(facts).not.toHaveProperty("environmentInterviewPending");
   });
 
   it("blocks inactive members while preserving workspace facts", async () => {


### PR DESCRIPTION
## Why and outcome

A newer Web reconciliation response began emitting an additive field before the separately deployed Temporal consumer could parse it. This restores the deployed three-field wire schema at the route boundary so hosted workflow reconciliation can resume without changing mailbox, runtime, or billing behavior.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Hosted members with pending background work regain normal orchestration; no visible UI or copy changes.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared -- test/hosted-orchestration-reconciliation-facts.test.ts` (49 passed); `pnpm --dir apps/web typecheck` passed; focused ESLint completed with one unrelated pre-existing warning.
- Coverage: The route-level regression proves pending Environment interview state is not serialized onto the deployed orchestration wire, while the full reconciliation suite covers active, blocked, mailbox, and wake cases.

## Non-obvious affected surfaces

The private Temporal worker consumes this response through the published strict reconciliation parser. The regression locks the response to the schema that deployed worker accepts.

## Architecture and reuse

- Existing systems reused: Existing Web reconciliation owner, visible-access adapter, JSON response helper, and strict hosted-execution contracts.
- New logic: Explicit route-boundary projection to the currently deployed wire fields.
- New abstractions: None; one existing route owns the compatibility projection.
- Complexity intentionally avoided: No new protocol version, compatibility service, queue, scheduler, persisted state, or fallback execution path.

## Hot reply path impact

- Path status: Not applicable — this changes Temporal reconciliation reads, not durable current-message acceptance through reply handoff.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None.
- Before/after proof: Focused reconciliation route suite passes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no provider-input surface changed.

## Risks

The response is an external runtime boundary. The mitigation deliberately defers the new Environment-interview orchestration signal until the private consumer is versioned and deployed first.

ReviewGPT context sensitivity: sensitive
Classification reason: Active production incident at a strict cross-repository runtime protocol boundary.

## Deployment concerns

- Deployment: applicable
- Supported skew: Current and newer Web internals may compute the additive fact while the route emits only the three fields accepted by the deployed Temporal worker; future consumers also accept the older payload.
- Safe order: Deploy this Web change immediately. Reintroduce the additive field only after publishing the contract and deploying the tolerant private Temporal consumer first.
- Rollback floor: No persisted-state floor; rolling Web back to the incompatible producer revision reopens the incident.
- Expected exposure: One Vercel Web deployment; no Cloudflare or Temporal deployment is required for containment.
- Reversibility: Fully reversible code-only projection with no data mutation.
- Convergence proof: Protocol-rejection logs fall to zero and hosted workspace checkpoints resume after Vercel promotion.
- Post-deploy checks: Watch Temporal reconciliation failures, latest workspace checkpoint time, due workspace count, mailbox no-op passes, and Vercel request rate.

## Change-shape breakdown

Classification rule: The route is source; its focused regression is test code. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 2 |
| Tests / fixtures | 3 | 3 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **13** | **5** |

## Changelog

- Changelog: not applicable
- Reason: Internal incident containment restores existing hosted orchestration behavior without a member-visible feature change.

ReviewGPT first-reviewed head: 650fa2b8acb7807cd890115f00dd5eba51128394