### PR TITLE
Use a valid Environment interview ID in the system-wake E2E

### DIFF
--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -2280,7 +2280,7 @@ function buildEverySystemWake(
   return [
     buildHostedExecutionEnvironmentInterviewCompletedWake({
       completedAt,
-      completionId: `environment_interview_priority_${runId}`,
+      completionId: randomUUID(),
       eventId: `environment-interview.completed:priority:${runId}`,
       memberId: identity.userId,
       occurredAt: completedAt,


### PR DESCRIPTION
## Why and outcome

The exhaustive system-wake E2E now builds the Environment interview wake, but its fixture uses a label where the production parser requires a UUID v4. Use the existing UUID generator so the required private worker integration test can exercise the intended runtime path.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: No member-visible change. This unblocks the production Temporal worker repair.

## Evidence

- Direct: The generated value comes from Node's existing `randomUUID()` and enters the production wake parser.
- Coverage: The required cross-repository E2E reached this parser and reported the exact invalid fixture value.

## Non-obvious affected surfaces

The private `murph-cloud` integration workflow checks out public `murph` main. Its required gate uses this fixture.

## Architecture and reuse

- Existing systems reused: Existing UUID generator, production wake builder, and exhaustive system-wake E2E.
- New logic: None.
- New abstractions: None.
- Complexity intentionally avoided: No runtime, protocol, persistence, or product changes.

## Hot reply path impact

- Path status: Not applicable — test-only change.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The fixture now satisfies the production parser's UUID v4 contract.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — test-only change.

## Risks

Low. One test fixture value changes to the format already required by production parsing.

ReviewGPT context sensitivity: routine
Classification reason: One test fixture value with no runtime change.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only change; no runtime artifact changes.

## Design proof

No visual change. No design catalog update is needed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 1 | 1 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Test-only incident repair.
