### PR TITLE
test(hosted): wait for interview mailbox consumption

### DIFF
--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -190,7 +190,18 @@ describe("hosted local Temporal orchestration e2e", () => {
     expect(workflowState.lastExecutionErrorCode).toBeNull();
     expect(workflowState.lastExecutionKind).toMatch(/runtime_/u);
 
-    const finalStatus = await activeScenario.waitForHostedCompletion(
+    await expect.poll(async () => {
+      const mailboxItem = await readHostedMailboxItemForTest({
+        dedupeKey: eventId,
+        environment: activeScenario.runtimeEnv,
+        userId: environmentInterviewUserId,
+      });
+      return mailboxItem.consumedAt;
+    }, {
+      interval: 250,
+      timeout: 120_000,
+    }).toEqual(expect.any(String));
+    const finalStatus = await activeScenario.harness.readUserStatus(
       environmentInterviewUserId,
     );
     expect(finalStatus.lastErrorCode ?? null).toBeNull();


### PR DESCRIPTION
## Why and outcome

The Environment interview integration test waited for the whole hosted workspace to become idle. The interview mailbox item was already consumed, but an unrelated due assistant wake kept that broad idle check open until timeout. Wait for the exact interview mailbox item instead, which is the user-visible completion boundary this test must prove.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: No member-visible change. This unblocks the production Temporal worker repair without weakening runtime checks.

## Evidence

- Direct: The failed run showed system mailbox lag at zero, the interview sequence handled, and no execution error. The remaining due assistant wake alone prevented the broad idle helper from returning.
- Coverage: Cloudflare package typecheck passes. The private cross-repository E2E will exercise the exact mailbox-consumption boundary.

## Non-obvious affected surfaces

The private `murph-cloud` integration workflow checks out public `murph` main. Its required gate uses this test.

## Architecture and reuse

- Existing systems reused: Existing mailbox read helper, Vitest polling, and hosted status read.
- New logic: None.
- New abstractions: None.
- Complexity intentionally avoided: No runtime, protocol, persistence, or product changes.

## Hot reply path impact

- Path status: Not applicable — test-only change.
- Database calls: None in production.
- Network/provider calls: None in production.
- Other awaited latency: None in production.
- Before/after proof: The test now waits for the exact durable item it asserts, instead of unrelated workspace idleness.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — test-only change.

## Risks

Low. The test still proves the exact interview item was consumed, the worker had no error, the workspace snapshot changed, and no model request ran.

ReviewGPT context sensitivity: routine
Classification reason: One test wait boundary with no runtime change. Per incident direction, no ReviewGPT rerun.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only change; no runtime artifact changes.

## Design proof

No visual change. No design catalog update is needed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 12 | 2 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **12** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Test-only incident repair.
