### PR TITLE
test(hosted): verify system mailbox checkpoint

### DIFF
--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -190,17 +190,10 @@ describe("hosted local Temporal orchestration e2e", () => {
     expect(workflowState.lastExecutionErrorCode).toBeNull();
     expect(workflowState.lastExecutionKind).toMatch(/runtime_/u);
 
-    await expect.poll(async () => {
-      const mailboxItem = await readHostedMailboxItemForTest({
-        dedupeKey: eventId,
-        environment: activeScenario.runtimeEnv,
-        userId: environmentInterviewUserId,
-      });
-      return mailboxItem.consumedAt;
-    }, {
-      interval: 250,
-      timeout: 120_000,
-    }).toEqual(expect.any(String));
+    await waitForSystemMailboxHandledThrough({
+      expectedSeq: append.wake.seq,
+      userId: environmentInterviewUserId,
+    });
     const finalStatus = await activeScenario.harness.readUserStatus(
       environmentInterviewUserId,
     );
@@ -214,7 +207,6 @@ describe("hosted local Temporal orchestration e2e", () => {
       environment: activeScenario.runtimeEnv,
       userId: environmentInterviewUserId,
     })).resolves.toMatchObject({
-      consumedAt: expect.any(String),
       kind: "environment-interview.completed",
       lane: "system",
     });


### PR DESCRIPTION
## Why

The Environment interview Temporal E2E checked `consumedAt` for a system mailbox item. System mailbox completion is committed through the durable handled-through checkpoint, so that assertion never represented the production completion contract and blocked the worker compatibility deploy.

## User-visible goal

Unblock the production worker deploy that clears pending Environment interview saves. This PR changes no product behavior or UI.

## Invariants

- The test still waits for the exact Environment interview system sequence.
- The workspace replica must refresh.
- No assistant provider request may run.
- The stored mailbox item must keep the expected kind and lane.

## Architecture and reuse

Reuse the existing `waitForSystemMailboxHandledThrough` helper in the same E2E file. No new state, service, or dependency.

## Change size

- Source: +0 / -0
- Tests: +4 / -12
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Verification

- `pnpm --filter @murphai/cloudflare-runner typecheck`
- `git diff --check`

## Design proof

Not applicable. Test-only change.
