### PR TITLE
test(hosted): preserve mailbox completion contracts

### DIFF
--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -152,6 +152,7 @@ describe("hosted local Temporal orchestration e2e", () => {
     );
     const activationReplicaRef =
       activationStatus.workspace?.browserVaultReplicaRef;
+    expect(activationReplicaRef).toBeDefined();
     const providerRequestBaseline = activeScenario.assistantProviderRequests.length;
     const completedAt = new Date().toISOString();
     const completionId = randomUUID();
@@ -194,6 +195,12 @@ describe("hosted local Temporal orchestration e2e", () => {
       expectedSeq: append.wake.seq,
       userId: environmentInterviewUserId,
     });
+    await expect.poll(async () =>
+      (await activeScenario.harness.readUserStatus(environmentInterviewUserId))
+        .workspace?.browserVaultReplicaRef, {
+      interval: 250,
+      timeout: 120_000,
+    }).not.toEqual(activationReplicaRef);
     const finalStatus = await activeScenario.harness.readUserStatus(
       environmentInterviewUserId,
     );

--- a/apps/web/test/support/hosted-web-testkit.ts
+++ b/apps/web/test/support/hosted-web-testkit.ts
@@ -574,6 +574,20 @@ interface HostedMailboxAppendForTestStoreModule {
       laneSeq: bigint | number | string;
     };
   }>;
+  appendHostedMailboxEnvelopeWithIdentityTx(input: {
+    envelope: HostedExecutionWake;
+    expiresAt: Date | string | null;
+    itemId: string;
+    tx: unknown;
+  }): Promise<{
+    duplicate: boolean;
+    inserted: boolean;
+    item: {
+      dedupeKey: string;
+      id: string;
+      laneSeq: bigint | number | string;
+    };
+  }>;
 }
 
 interface HostedWorkspaceSeedForTestPrismaClient {
@@ -873,10 +887,18 @@ export async function appendHostedExecutionWakeForTest(input: {
   const wake = parseHostedExecutionWake(input.wake);
   return withHostedWebTestkitDeps(input.environment, async (deps) => {
     const append = await deps.prisma.$transaction(async (tx) =>
-      deps.hostedMailboxStore.appendHostedMailboxEnvelopeTx({
-        envelope: wake,
-        tx,
-      }));
+      wake.kind === "assistant.ask.requested"
+        || wake.kind === "assistant.ask.completed"
+        ? deps.hostedMailboxStore.appendHostedMailboxEnvelopeWithIdentityTx({
+            envelope: wake,
+            expiresAt: wake.ask.expiresAt,
+            itemId: wake.eventId,
+            tx,
+          })
+        : deps.hostedMailboxStore.appendHostedMailboxEnvelopeTx({
+            envelope: wake,
+            tx,
+          }));
     return {
       duplicate: append.duplicate,
       inserted: append.inserted,
@@ -2310,6 +2332,8 @@ async function loadHostedMailboxAppendForTestModules(): Promise<HostedMailboxApp
     advanceHostedMailboxConsumedSeqByLane:
       typedHostedMailboxStoreModule.advanceHostedMailboxConsumedSeqByLane,
     appendHostedMailboxEnvelopeTx: typedHostedMailboxStoreModule.appendHostedMailboxEnvelopeTx,
+    appendHostedMailboxEnvelopeWithIdentityTx:
+      typedHostedMailboxStoreModule.appendHostedMailboxEnvelopeWithIdentityTx,
   };
 }
 


### PR DESCRIPTION
## Why and outcome

The Environment interview incident fix was blocked by two stale integration-test assumptions. This aligns the fixtures with production mailbox identity and waits for the asynchronous browser replica refresh.

## Product UX

Not applicable. This changes test support only and does not change product behavior or UI.

## Evidence

- pnpm --filter @murphai/cloudflare-runner typecheck
- pnpm --filter @murphai/hosted-web typecheck
- Focused hosted-local Temporal scenarios are running against the private worker candidate.

## Non-obvious affected surfaces

- Hosted Web testkit: assistant-ask fixtures now use the same mailbox identity rule as production.
- Temporal orchestration E2E: the test waits for eventual browser replica publication after the system checkpoint.

## Architecture and reuse

- Existing systems reused: existing identity-preserving mailbox append owner and Vitest polling.
- New logic: test fixtures select identity-preserving append for assistant-ask events.
- New abstractions: none; existing owners cover both needs.
- Complexity intentionally avoided: no production state, retry, queue, or UI changes.

## Hot reply path impact

Not applicable. No production code changes.

## Murph initial provider input impact

Not applicable for Murph and Codex. No provider-input surface changed.

## Change-shape breakdown

Classification rule: both changed files are tests or direct test support.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 35 | 4 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 35 | 4 |

No binary files.

## Deployment concerns

Deployment: not applicable. This PR changes test code only.