### PR TITLE
test(hosted): keep foreground storm on generic owner

### DIFF
--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -30,7 +30,6 @@ import {
   buildHostedExecutionCodexAuthRequestedWake,
   buildHostedExecutionDailyMetricReportedWake,
   buildHostedExecutionDeviceSyncWake,
-  buildHostedExecutionEnvironmentInterviewCompletedWake,
   buildHostedExecutionEnvironmentVoiceCapturedWake,
   buildHostedExecutionMealPhotoCapturedWake,
   buildHostedExecutionMemberActionCompletedWake,
@@ -203,7 +202,7 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     linqStub = null;
   }, 120_000);
 
-  it("replies promptly while model-free work owns every durable system wake", async () => {
+  it("replies promptly while generic model-free system work owns the runner", async () => {
     await seedProbe(systemMailboxProbe);
     const stagedMealPhoto = await stageMealPhotoForProbe(systemMailboxProbe);
     const stagedEnvironmentVoice = await stageEnvironmentVoiceForProbe(
@@ -216,7 +215,10 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     );
     expect(systemWakes.map((wake) => wake.kind).sort()).toEqual(
       HOSTED_EXECUTION_WAKE_KINDS
-        .filter((kind) => kind !== "conversation.message")
+        .filter((kind) =>
+          kind !== "conversation.message"
+          && kind !== "environment-interview.completed"
+        )
         .sort(),
     );
 
@@ -2278,21 +2280,6 @@ function buildEverySystemWake(
   ] as const;
 
   return [
-    buildHostedExecutionEnvironmentInterviewCompletedWake({
-      completedAt,
-      completionId: randomUUID(),
-      eventId: `environment-interview.completed:priority:${runId}`,
-      memberId: identity.userId,
-      occurredAt: completedAt,
-      topics: [{
-        answers: [{
-          aspectId: "sleep-environment",
-          indicatorId: "night_temp_c",
-          value: 19,
-        }],
-        topicId: "sleep:0",
-      }],
-    }),
     buildHostedExecutionDeviceSyncWake({
       eventId: `device-sync.wake:priority:${runId}`,
       occurredAt: requestedAt,


### PR DESCRIPTION
## Why and outcome

The generic system-owner priority test included the Environment interview event, which has its own dedicated processing owner. That event correctly preempted the generic owner and made the test wait for an impossible state.

This keeps the generic-owner storm on its intended scope. The dedicated Environment interview Temporal test still proves interview handling and completion.

## Product UX

Not applicable. This changes one integration fixture only.

## Evidence

- pnpm --filter @murphai/cloudflare-runner typecheck
- The latest private matrix proved the Environment interview Temporal scenario passes. Its only remaining failure was this mismatched generic-owner fixture.

## Non-obvious affected surfaces

- Foreground reply priority E2E fixture only. Production routing is unchanged.

## Architecture and reuse

- Existing systems reused: dedicated Environment interview Temporal coverage and existing generic system-owner priority coverage.
- New logic: the generic-owner fixture excludes the event owned by the dedicated interview mode.
- New abstractions: none; the existing owner split is sufficient.
- Complexity intentionally avoided: no production routing, state, retry, queue, or UI changes.

## Hot reply path impact

Not applicable. No production code changes.

## Murph initial provider input impact

Not applicable for Murph and Codex. No provider-input surface changed.

## Change-shape breakdown

Classification rule: the changed file is an integration test fixture.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 5 | 18 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 5 | 18 |

No binary files.

## Deployment concerns

Deployment: not applicable. This PR changes test code only.