### PR TITLE
Fix Starter Stripe matrix fixture lifecycle

### DIFF
--- a/.agents/friction-log/20260821235820-reviewgpt-specialist-composer/friction.md
+++ b/.agents/friction-log/20260821235820-reviewgpt-specialist-composer/friction.md
@@ -1,0 +1,28 @@
+---
+title: 'ReviewGPT specialist composer keeps Send disabled after confirmed ZIP'
+severity: 'minor'
+target: 'cobuildwithus/review-gpt'
+---
+
+## Expected Behavior
+
+A waited completion-specialists run with an exact-head ZIP and a prompt below the repository byte cap should confirm the attachment, enable Send, submit once, and begin response capture.
+
+## Current Behavior
+
+Two managed browser lanes confirmed one ready ZIP attachment and prefilled a prompt below the 6,500-byte repository cap, but Auto-send ended with send-button-disabled after the draft timeout. No review was submitted and each invalid attempt consumed roughly ten minutes.
+
+## Possible Solution
+
+Make draft validation expose the concrete reason Send remains disabled after the attachment reports ready. If composer-added wrapper text participates in a separate limit, include that serialized size in preflight and keep the canonical preset below the effective UI threshold.
+
+## Minimal Reproducible Example
+
+1. Run the waited completion-specialists preset against a clean exact pushed PR head.
+2. Let the managed browser confirm the single ZIP attachment as ready.
+3. Observe that the prompt is prefilled but Send remains disabled until draft staging fails.
+4. Retry on another signed-in managed lane and observe the same terminal status.
+
+## Context
+
+This blocks the mandatory preliminary coverage review even though PR packaging, attachment readiness, model selection, local verification, and exact-head checks all pass.

--- a/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
@@ -444,6 +444,7 @@ async function createMember(
     billingStatus,
     environment: requireScenario().runtimeEnv,
     memberId,
+    previouslyActivated: billingStatus === "canceled",
     privyUserId,
     verifiedEmail,
   });
@@ -476,6 +477,7 @@ async function bindDirectFixture(
     billingStatus,
     environment: requireScenario().runtimeEnv,
     memberId,
+    previouslyActivated: true,
   });
 }
 

--- a/apps/web/test/hosted-billing-live-support.test.ts
+++ b/apps/web/test/hosted-billing-live-support.test.ts
@@ -8,7 +8,10 @@ import {
   readStripeSurfaceForTest,
   redactHostedBillingBrowserErrorForTest,
 } from "./support/hosted-billing-browser-driver";
-import { seedHostedBillingMemberForTest } from "./support/hosted-billing-live-testkit";
+import {
+  provisionHostedBillingActivationProofForTest,
+  seedHostedBillingMemberForTest,
+} from "./support/hosted-billing-live-testkit";
 import {
   buildHostedStripeRunCorrelationToken,
   buildStripeFixtureChildEnvironmentForTest,
@@ -273,7 +276,37 @@ describe("hosted billing live browser support", () => {
     await expect(seedHostedBillingMemberForTest({
       billingStatus: "not_started",
       memberId: " ",
+      previouslyActivated: false,
     })).rejects.toThrow(/requires a member id/u);
+  });
+
+  it("leaves a never-activated Starter seed without activation-proof roots", async () => {
+    const provision = vi.fn();
+    await provisionHostedBillingActivationProofForTest({
+      memberId: "member_starter_seed",
+      previouslyActivated: false,
+      provision,
+      tx: { kind: "fixture-transaction" },
+    });
+
+    expect(provision).not.toHaveBeenCalled();
+  });
+
+  it("adds activation-proof roots when the seed has prior activation", async () => {
+    const provision = vi.fn();
+    const tx = { kind: "fixture-transaction" };
+    await provisionHostedBillingActivationProofForTest({
+      memberId: "member_paid_seed",
+      previouslyActivated: true,
+      provision,
+      tx,
+    });
+
+    expect(provision).toHaveBeenCalledWith({
+      reason: "hosted-billing-live.test-seed",
+      tx,
+      userId: "member_paid_seed",
+    });
   });
 });
 

--- a/apps/web/test/support/hosted-billing-live-testkit.ts
+++ b/apps/web/test/support/hosted-billing-live-testkit.ts
@@ -74,6 +74,8 @@ export interface HostedBillingMemberSeedForTest {
   billingStatus: HostedBillingStatusForTest;
   environment?: NodeJS.ProcessEnv;
   memberId: string;
+  /** Seeds the crypto-root marker used to detect an earlier activation. */
+  previouslyActivated: boolean;
   privyUserId?: string | null;
   verifiedEmail?: string | null;
 }
@@ -123,6 +125,26 @@ export interface HostedFamilyProjectionForTest {
   } | null;
   stripeCustomerId: string | null;
   stripeSubscriptionId: string | null;
+}
+
+export async function provisionHostedBillingActivationProofForTest<TTx>(input: {
+  memberId: string;
+  previouslyActivated: boolean;
+  provision: (input: {
+    reason: string;
+    tx: TTx;
+    userId: string;
+  }) => Promise<void>;
+  tx: TTx;
+}): Promise<void> {
+  if (!input.previouslyActivated) {
+    return;
+  }
+  await input.provision({
+    reason: "hosted-billing-live.test-seed",
+    tx: input.tx,
+    userId: input.memberId,
+  });
 }
 
 interface HostedBillingTestReader {
@@ -348,11 +370,6 @@ export async function seedHostedBillingMemberForTest(
           memberId: input.memberId,
           prisma: tx,
         });
-        await modules.provisionHostedCryptoDomainRootsForUserTx({
-          reason: "hosted-billing-live.test-seed",
-          tx,
-          userId: input.memberId,
-        });
         await modules.upsertHostedMemberIdentity({
           maskedPhoneNumberHint: null,
           memberId: input.memberId,
@@ -371,6 +388,13 @@ export async function seedHostedBillingMemberForTest(
           walletProvider: null,
         });
       }
+
+      await provisionHostedBillingActivationProofForTest({
+        memberId: input.memberId,
+        previouslyActivated: input.previouslyActivated,
+        provision: modules.provisionHostedCryptoDomainRootsForUserTx,
+        tx,
+      });
 
       await tx.hostedMember.update({
         data: {


### PR DESCRIPTION
## Why and outcome

Main pushes still run the credentialed hosted Stripe browser matrix. Its Starter-to-Pulse case was creating a never-activated member with crypto roots that production treats as proof of an earlier activation. Starter enrollment therefore skipped activation and the browser looped between Home and Join.

The live test fixture now represents activation history explicitly: new Starter and Family-invitee seeds omit activation proof, while lapsed and paid fixtures provision it. Production billing and activation logic are unchanged.

## Product UX

Not applicable. This is internal test-fixture correction and does not change a member journey, copy, interface, or production behavior.

## Evidence

- Hosted billing hermetic suite: 3 files, 26 tests passed.
- Activation, Starter enrollment, and page-auth suite: 3 files, 70 tests passed.
- Hosted-local billing harness: 2 files, 88 tests passed.
- Hosted Stripe CI contract guard passed.
- Hosted Web and Cloudflare TypeScript checks passed.
- Focused Hosted Web lint passed.
- The credentialed live Stripe matrix remains main-push CI-owned; sandbox credentials are intentionally unavailable to local and pull-request code.

## Non-obvious affected surfaces

- Live hosted-local Stripe matrix fixture state: Starter and Family invitee members now begin without prior-activation proof; lapsed and paid fixtures retain it.
- Developer tooling evidence: a public-safe Frog entry records repeated mandatory ReviewGPT composer failures observed during this task.
- Production surfaces: none. No application source, schema, billing owner, or activation behavior changed.

## Architecture and reuse

- Existing systems reused: The existing billing seed, crypto-root provisioner, production activation proof semantics, live browser matrix, and Frog log remain the owners.
- New logic: One required fixture flag declares whether the seeded member has prior activation history.
- New abstractions: One test-only provisioning helper isolates and hermetically proves the activation-proof decision.
- Complexity intentionally avoided: No production fallback, activation bypass, schema change, compatibility branch, or additional state owner was added.

## Hot reply path impact

Not applicable. Only Stripe test fixtures, their proof, and developer-friction evidence changed; no production conversation path changed.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool, schema, or provider-visible input changed.
- Group runtime: Not applicable; no prompt, tool, schema, or provider-visible input changed.

## Change-shape breakdown

Classification rule: Stripe fixture and regression changes are tests/fixtures; the Frog entry is docs. No generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 65 | 6 |
| Docs | 28 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 93 | 6 |

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only and developer-friction changes do not alter a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal Stripe matrix fixture reliability and developer-friction evidence are not member-visible.