### PR TITLE
Meter exact Codex subagent usage

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
+++ b/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
@@ -65,8 +65,10 @@ existing cumulative fallback.
 ## Verification
 
 - Focused subagent usage tests pass (14 tests).
-- Full assistant Codex runtime tests pass (273 tests).
+- Full assistant Codex runtime tests pass (274 tests), including timeout-only
+  cleanup of unresolved metadata request bookkeeping.
 - Full real Codex scripted-runtime tests pass (99 tests).
 - Focused public CLI Codex lifecycle tests pass (9 tests).
 - Assistant-engine typecheck passes.
-- Pending exact-head ReviewGPT specialist/final gates and required CI.
+- The prior corrected head passed all 19 required CI checks; exact-head
+  ReviewGPT and CI remain pending for the final cleanup candidate.

--- a/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
+++ b/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
@@ -6,8 +6,9 @@ Updated: 2026-08-22
 ## Goal
 
 Record authoritative per-request token usage and effective execution metadata
-for Codex child-agent turns without forking Codex CLI or double-counting the
-existing cumulative fallback.
+for every authorized Codex child-agent provider request, including detached
+MultiAgent V2 work that outlives its root reply, without forking Codex CLI or
+double-counting the existing cumulative fallback.
 
 ## Constraints
 
@@ -38,15 +39,63 @@ existing cumulative fallback.
 
 - People and path: a hosted member whose turn uses an authorized child and
   then completes or fails while optional child metadata is still unresolved.
-- Evidence: the parameterized runtime regression settles both terminal paths
-  without advancing the five-second metadata timeout; the real scripted-runtime
-  child records one exact draft with effective metadata and no duplicate or raw
-  payload event.
-- Difference from plan: the preliminary Product UX review found that the first
-  candidate awaited accounting enrichment after root completion. The terminal
-  drain was removed, preserving best-effort enrichment without delaying reply
-  handoff or failure recovery.
+- Evidence: the real pinned app-server proves direct and group roots return
+  before their detached children, then records one exact draft during idle and
+  carries each child result into a later turn. Mocked runtime proofs cover root
+  failure, duplicate raw responses, checkpoint completion, metadata timeout,
+  requested stop, and unexpected idle process loss.
+- Difference from plan: preliminary review first removed a terminal metadata
+  drain that delayed root settlement. A later review exposed the deeper
+  lifetime mismatch: turn-local accounting still discarded valid V2 work that
+  completed after settlement. The lifecycle owner was therefore moved to the
+  resident process instead of adding another terminal wait.
 - Result: Ready.
+
+## Retrospective
+
+The first implementation treated child usage as turn-local state. That model
+was sufficient for synchronous children, but it repeated a parent/child
+lifetime mismatch: a valid detached MultiAgent V2 child can continue after the
+root reply, while the root turn's buffers are destroyed at settlement. Exact
+usage arriving during process idle was therefore irretrievably discarded.
+
+The corrected design deletes the turn-local lifecycle owner and reuses the
+resident `CodexAppServerProcess`, which already owns detached-child execution
+across root settlement, idle completion, later turns, workspace checkpoints,
+and process shutdown. Canonical parent events still provide the only billing
+authorization. The original root contributes its stable operation identity,
+accepted-input authority, model context, and ordinal allocator. Hosted drafts
+are handed to the existing `recordDetachedUsage` path, which preserves
+assistant-engine as the sole usage-ledger writer. Non-hosted callers retain
+the existing result-based draft buffer only while their root turn is active;
+there is no second process-owned writer, draft queue, scheduler, retry loop, or
+durable state.
+
+Lifecycle semantics are explicit:
+
+- Root success returns without waiting for child metadata or completion. A
+  hosted detached authorization remains with the resident process until its
+  child usage is finalized.
+- Root failure preserves already parsed exact or cumulative evidence. Normal
+  poison/stop cleanup forces metadata fallback before process teardown.
+- During idle and later root turns, the resident process observes child events
+  globally and records each exact provider response against the original root
+  operation and ordinal namespace.
+- A successful workspace checkpoint waits for detached children, forces any
+  remaining metadata fallback, records or returns the resulting drafts, and
+  then clears the bounded process evidence. Interrupted checkpoints preserve
+  the same owner and authorization for a later attempt.
+- Requested shutdown and unexpected process close flush all provider evidence
+  that reached and was parsed from stdout before rejecting optional metadata
+  requests. A process loss before usage evidence reaches stdout cannot be
+  reconstructed and does not mint speculative usage.
+- Duplicate raw responses are suppressed by `responseId`; exact raw usage and
+  cumulative fallback remain mutually exclusive for each child turn.
+
+Proof covers synchronous and detached children, direct and group roots,
+child-before-parent authorization ordering, idle and later-turn completion,
+root failure, duplicate raw responses, checkpoint completion/interruption,
+metadata timeout cleanup, requested stop, and unexpected idle process loss.
 
 ## Plan
 
@@ -64,11 +113,11 @@ existing cumulative fallback.
 
 ## Verification
 
-- Focused subagent usage tests pass (14 tests).
-- Full assistant Codex runtime tests pass (274 tests), including timeout-only
-  cleanup of unresolved metadata request bookkeeping.
+- Focused subagent usage tests pass (15 tests).
+- Full assistant Codex runtime tests pass (276 tests), including root failure,
+  idle process loss, checkpoint, duplicate-response, and timeout cleanup.
 - Full real Codex scripted-runtime tests pass (99 tests).
 - Focused public CLI Codex lifecycle tests pass (9 tests).
 - Assistant-engine typecheck passes.
-- The prior corrected head passed all 19 required CI checks; exact-head
+- The latest pushed head passed all 20 required CI checks; exact-head
   ReviewGPT and CI remain pending for the final cleanup candidate.

--- a/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
+++ b/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
@@ -24,6 +24,30 @@ existing cumulative fallback.
 - Add no Codex fork, protocol schema copy, dependency, database change, or new
   billing owner.
 
+## Product UX Patch
+
+- Outcome: hosted members are charged exactly once for child work without
+  delaying a completed reply for accounting enrichment.
+- Reaches: hosted multi-agent turns that run one or more authorized Codex child
+  threads, including the failure/recovery path.
+- Proof: unresolved child metadata cannot delay successful or failed root
+  settlement, and the real pinned Codex app-server emits one exact child usage
+  draft without cumulative double billing or raw-payload persistence.
+
+## Product UX Walkthrough
+
+- People and path: a hosted member whose turn uses an authorized child and
+  then completes or fails while optional child metadata is still unresolved.
+- Evidence: the parameterized runtime regression settles both terminal paths
+  without advancing the five-second metadata timeout; the real scripted-runtime
+  child records one exact draft with effective metadata and no duplicate or raw
+  payload event.
+- Difference from plan: the preliminary Product UX review found that the first
+  candidate awaited accounting enrichment after root completion. The terminal
+  drain was removed, preserving best-effort enrichment without delaying reply
+  handoff or failure recovery.
+- Result: Ready.
+
 ## Plan
 
 1. Reconstruct ReviewGPT's scoped design against current `origin/main` and
@@ -41,6 +65,8 @@ existing cumulative fallback.
 ## Verification
 
 - Focused subagent usage tests pass (14 tests).
-- Full assistant Codex runtime tests pass (269 tests).
+- Full assistant Codex runtime tests pass (273 tests).
+- Full real Codex scripted-runtime tests pass (99 tests).
+- Focused public CLI Codex lifecycle tests pass (9 tests).
 - Assistant-engine typecheck passes.
 - Pending exact-head ReviewGPT specialist/final gates and required CI.

--- a/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
+++ b/agent-docs/exec-plans/active/2026-08-22-codex-subagent-usage-metering.md
@@ -1,0 +1,46 @@
+# Codex Subagent Usage Metering
+
+Status: active
+Updated: 2026-08-22
+
+## Goal
+
+Record authoritative per-request token usage and effective execution metadata
+for Codex child-agent turns without forking Codex CLI or double-counting the
+existing cumulative fallback.
+
+## Constraints
+
+- Keep assistant-engine as the sole hosted usage-ledger writer.
+- Accept only the pinned Codex app-server protocol shapes and canonical parent
+  evidence for child-thread authorization.
+- Use exact `rawResponse/completed` usage when the child lifecycle supports it;
+  use cumulative `thread/tokenUsage/updated` deltas only for cold or legacy
+  lifecycles that cannot emit raw usage.
+- Select one usage source for each child lifecycle and deduplicate exact raw
+  responses by `responseId`.
+- Persist token and execution metadata only; never persist child prompts,
+  messages, thread identifiers, or reasoning content.
+- Add no Codex fork, protocol schema copy, dependency, database change, or new
+  billing owner.
+
+## Plan
+
+1. Reconstruct ReviewGPT's scoped design against current `origin/main` and
+   inspect the pinned Codex protocol for exact request and notification shapes.
+2. Enable raw response events on fresh thread starts and capture authorized
+   child lifecycle usage plus effective metadata from metadata-only resumes.
+3. Convert each child lifecycle through a deterministic raw-or-cumulative
+   source selector and preserve existing ledger ordinals and pricing rules.
+4. Add focused request-shape, parser, authorization, deduplication, source
+   selection, cold-resume fallback, and privacy regressions.
+5. Run focused tests and assistant-engine typecheck, inspect the candidate diff,
+   then commit, push, open a PR, and run required exact-head review gates with
+   CI.
+
+## Verification
+
+- Focused subagent usage tests pass (14 tests).
+- Full assistant Codex runtime tests pass (269 tests).
+- Assistant-engine typecheck passes.
+- Pending exact-head ReviewGPT specialist/final gates and required CI.

--- a/agent-docs/exec-plans/completed/2026-08-22-codex-subagent-usage-metering.md
+++ b/agent-docs/exec-plans/completed/2026-08-22-codex-subagent-usage-metering.md
@@ -1,6 +1,6 @@
 # Codex Subagent Usage Metering
 
-Status: active
+Status: completed
 Updated: 2026-08-22
 
 ## Goal
@@ -119,5 +119,9 @@ metadata timeout cleanup, requested stop, and unexpected idle process loss.
 - Full real Codex scripted-runtime tests pass (99 tests).
 - Focused public CLI Codex lifecycle tests pass (9 tests).
 - Assistant-engine typecheck passes.
-- The latest pushed head passed all 20 required CI checks; exact-head
-  ReviewGPT and CI remain pending for the final cleanup candidate.
+- The behavior-bearing head passed all required exact-head CI checks.
+- ReviewGPT substantive round 3 returned `ROUND_OUTCOME: PASS` from a fresh
+  full sensitive snapshot and confirmed the retrospective resolves every prior
+  accepted finding without a second writer or lifecycle owner.
+- The behavior-bearing head merges cleanly with the latest `origin/main`.
+Completed: 2026-08-22

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -1327,10 +1327,47 @@ class CodexAppServerProcess {
     params: Record<string, unknown>,
     pendingMethod = method,
   ): Promise<unknown> {
+    return this.beginRequest(method, params, pendingMethod).promise
+  }
+
+  sendRequestWithTimeout(input: {
+    method: string
+    params: Record<string, unknown>
+    pendingMethod?: string
+    timeoutLabel: string
+    timeoutMs: number
+  }): Promise<unknown> {
+    const request = this.beginRequest(
+      input.method,
+      input.params,
+      input.pendingMethod ?? input.method,
+    )
+    return withCodexRpcTimeout(
+      request.promise,
+      input.timeoutMs,
+      input.timeoutLabel,
+      () => {
+        // Ordinary responses remove themselves in
+        // resolvePendingCodexRpcRequest. A timeout has no response to do that
+        // work, so release its process-wide bookkeeping here rather than
+        // leaking one entry per unresponsive child.
+        this.pendingRequests.delete(request.id)
+      },
+    )
+  }
+
+  private beginRequest(
+    method: string,
+    params: Record<string, unknown>,
+    pendingMethod: string,
+  ): {
+    id: CodexRpcId
+    promise: Promise<unknown>
+  } {
     const id = this.nextRequestId
     this.nextRequestId += 1
 
-    return new Promise<unknown>((resolve, reject) => {
+    const promise = new Promise<unknown>((resolve, reject) => {
       this.pendingRequests.set(id, {
         method: pendingMethod,
         reject,
@@ -1346,6 +1383,7 @@ class CodexAppServerProcess {
         reject(failure)
       }
     })
+    return { id, promise }
   }
 
   sendNotification(method: string, params: Record<string, unknown>): void {
@@ -5275,18 +5313,16 @@ async function runCodexAppServerTurnOnProcess(
       return
     }
 
-    const request = withCodexRpcTimeout(
-      codexProcess.sendRequest(
-        'thread/resume',
-        {
-          excludeTurns: true,
-          threadId: sample.threadId,
-        },
-        'subagent/thread/resume',
-      ),
-      CODEX_BACKGROUND_WORK_RPC_TIMEOUT_MS,
-      'subagent thread/resume',
-    )
+    const request = codexProcess.sendRequestWithTimeout({
+      method: 'thread/resume',
+      params: {
+        excludeTurns: true,
+        threadId: sample.threadId,
+      },
+      pendingMethod: 'subagent/thread/resume',
+      timeoutLabel: 'subagent thread/resume',
+      timeoutMs: CODEX_BACKGROUND_WORK_RPC_TIMEOUT_MS,
+    })
       .then((threadResult) => readCodexSubagentExecutionMetadata({
         expectedThreadId: sample.threadId,
         threadResult,

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -142,10 +142,11 @@ import {
 } from './assistant-codex/failures.js'
 import {
   type CodexSubagentExecutionMetadata,
+  type CodexSubagentReceiverEvidence,
   type CodexSubagentTurnTokenUsageSample,
   extractCodexSubagentUsageDrafts,
   isAssistantCodexTokenUsageEventType,
-  readCodexCollabReceiverThreadIds,
+  readCodexCollabReceiverEvidence,
 } from './assistant/providers/helpers.js'
 import {
   materializeCodexImages,
@@ -251,9 +252,31 @@ const CODEX_GENERATED_AUDIO_PHASE_TIMING_TRACE_SCHEMA =
 const CODEX_GENERATED_AUDIO_PHASE_TIMING_TRACE_TYPE =
   'assistant.codex.generated_audio_phase_timing'
 const CODEX_APP_SERVER_STARTUP_STDERR_MAX_LENGTH = 16_384
-// Bound on distinct subagent threads whose token usage is tracked per parent
-// turn. Far above any sane spawn fan-out; threads past the cap are ignored.
+// Bound on distinct subagent threads whose token usage is retained by the
+// resident process between workspace boundaries. Far above hosted fan-out;
+// threads past the cap are ignored.
 const MAX_CODEX_SUBAGENT_USAGE_THREADS = 32
+
+type CodexSubagentDetachedUsageRecorder = NonNullable<
+  AssistantHostedToolContext['recordDetachedUsage']
+>
+
+interface CodexSubagentUsageAuthorization {
+  modelProvider: string | null
+  parentModel: string | null
+  retainAfterRoot: boolean
+  rootThreadId: string
+  requestedModel: string | null
+  serviceTier: AssistantProviderServiceTier | null
+  recordingContext: {
+    effectiveEnv: Readonly<Record<string, string | undefined>>
+    operationId: string
+    originAssistantInputId: string
+    recordDetachedUsage: CodexSubagentDetachedUsageRecorder
+  } | null
+  unhostedUsageDrafts: AssistantProviderUsageDraft[]
+  nextUsageOrdinal(): number
+}
 
 type CodexAppServerProcessState =
   | 'idle'
@@ -563,6 +586,7 @@ export interface CodexAppServerTurnInput {
   environments?: readonly Readonly<Record<string, unknown>>[] | null
   runtimeWorkspaceRoots?: readonly string[] | null
   threadConfig?: Readonly<Record<string, unknown>> | null
+  usageOperationId?: string | null
   // Sent on every turn/start: a value selects the tier, null explicitly
   // resets a sticky thread-level override back to the default tier.
   serviceTier?: AssistantProviderServiceTier | null
@@ -1070,6 +1094,25 @@ class CodexAppServerProcess {
   private readonly detachedCompletedChildThreadIds = new Set<string>()
   private detachedChildViolation: string | null = null
   private readonly detachedRootThreadIds = new Set<string>()
+  // The resident App Server already owns detached-child lifetime across root
+  // settlement, idle completion, later turns, and workspace boundaries. Keep
+  // accounting evidence at that same boundary so a nonblocking root reply
+  // cannot discard the only exact usage signal.
+  private readonly subagentUsageAuthorizationByTurn =
+    new Map<string, CodexSubagentUsageAuthorization>()
+  private readonly subagentUsageAuthorizationByThread =
+    new Map<string, CodexSubagentUsageAuthorization>()
+  private readonly subagentUsageCompletedTurns = new Set<string>()
+  private readonly subagentUsageCumulativeFinalizedTurns = new Set<string>()
+  private subagentUsageBoundaryGeneration = 0
+  private readonly subagentUsageExecutionMetadataByThread =
+    new Map<string, CodexSubagentExecutionMetadata | null>()
+  private readonly subagentUsagePendingMetadataRequests =
+    new Map<string, Promise<void>>()
+  private readonly subagentUsageRawResponseIds = new Set<string>()
+  private readonly subagentUsageSamples =
+    new Map<string, CodexSubagentTurnTokenUsageSample>()
+  private readonly subagentUsageTrackedThreadIds = new Set<string>()
   private stopCompleted = false
   private state: CodexAppServerProcessState = 'idle'
   private stderrBuffer = ''
@@ -1386,6 +1429,359 @@ class CodexAppServerProcess {
     return { id, promise }
   }
 
+  authorizeSubagentUsage(input: {
+    evidence: readonly CodexSubagentReceiverEvidence[]
+    modelProvider: string | null
+    parentModel: string | null
+    recordingContext: CodexSubagentUsageAuthorization['recordingContext']
+    rootThreadId: string
+    serviceTier: AssistantProviderServiceTier | null
+    unhostedUsageDrafts: AssistantProviderUsageDraft[]
+    nextUsageOrdinal(): number
+  }): void {
+    for (const evidence of input.evidence) {
+      if (
+        !this.subagentUsageTrackedThreadIds.has(evidence.threadId) &&
+        !this.subagentUsageAuthorizationByThread.has(evidence.threadId) &&
+        new Set([
+          ...this.subagentUsageTrackedThreadIds,
+          ...this.subagentUsageAuthorizationByThread.keys(),
+        ]).size >= MAX_CODEX_SUBAGENT_USAGE_THREADS
+      ) {
+        const evictableThreadId = [...this.subagentUsageTrackedThreadIds]
+          .find((candidate) =>
+            !this.isSubagentUsageThreadAuthorized(candidate),
+          )
+        if (evictableThreadId === undefined) {
+          continue
+        }
+        this.removeSubagentUsageThread(evictableThreadId)
+      }
+      const authorization: CodexSubagentUsageAuthorization = {
+        modelProvider: input.modelProvider,
+        nextUsageOrdinal: input.nextUsageOrdinal,
+        parentModel: input.parentModel,
+        recordingContext: input.recordingContext,
+        retainAfterRoot:
+          evidence.detached && input.recordingContext !== null,
+        rootThreadId: input.rootThreadId,
+        requestedModel: evidence.requestedModel,
+        serviceTier: input.serviceTier,
+        unhostedUsageDrafts: input.unhostedUsageDrafts,
+      }
+      let assigned = false
+      let alreadyAuthorized = false
+      for (const [usageKey, sample] of this.subagentUsageSamples) {
+        if (sample.threadId !== evidence.threadId) {
+          continue
+        }
+        if (this.subagentUsageAuthorizationByTurn.has(usageKey)) {
+          alreadyAuthorized = true
+          continue
+        }
+        this.subagentUsageAuthorizationByTurn.set(usageKey, authorization)
+        assigned = true
+      }
+      if (assigned) {
+        this.beginSubagentUsageMetadataRequest(evidence.threadId)
+        this.finalizeSubagentUsageForThread(evidence.threadId)
+      } else if (!alreadyAuthorized) {
+        this.subagentUsageAuthorizationByThread.set(
+          evidence.threadId,
+          authorization,
+        )
+      }
+    }
+  }
+
+  finalizeSubagentUsageDraftsWithoutRecorder(): void {
+    for (const [usageKey, authorization] of this.subagentUsageAuthorizationByTurn) {
+      if (authorization.recordingContext === null) {
+        this.finalizeSubagentUsageSample(usageKey, true)
+      }
+    }
+  }
+
+  releaseSubagentUsageAuthorizationsForRoot(rootThreadId: string): void {
+    for (const [usageKey, authorization] of [
+      ...this.subagentUsageAuthorizationByTurn,
+    ]) {
+      if (
+        authorization.rootThreadId !== rootThreadId ||
+        authorization.retainAfterRoot
+      ) {
+        continue
+      }
+      this.finalizeSubagentUsageSample(usageKey, true)
+      if (this.subagentUsageSamples.has(usageKey)) {
+        this.removeSubagentUsageSample(usageKey)
+      }
+    }
+    for (const [threadId, authorization] of this.subagentUsageAuthorizationByThread) {
+      if (
+        authorization.rootThreadId === rootThreadId &&
+        !authorization.retainAfterRoot
+      ) {
+        this.subagentUsageAuthorizationByThread.delete(threadId)
+      }
+    }
+  }
+
+  private beginSubagentUsageMetadataRequest(threadId: string): void {
+    if (this.subagentUsageExecutionMetadataByThread.has(threadId)) {
+      this.finalizeSubagentUsageForThread(threadId)
+      return
+    }
+    if (this.subagentUsagePendingMetadataRequests.has(threadId)) {
+      return
+    }
+
+    const boundaryGeneration = this.subagentUsageBoundaryGeneration
+    const request = this.sendRequestWithTimeout({
+      method: 'thread/resume',
+      params: {
+        excludeTurns: true,
+        threadId,
+      },
+      pendingMethod: 'subagent/thread/resume',
+      timeoutLabel: 'subagent thread/resume',
+      timeoutMs: CODEX_BACKGROUND_WORK_RPC_TIMEOUT_MS,
+    })
+      .then((threadResult) => readCodexSubagentExecutionMetadata({
+        expectedThreadId: threadId,
+        threadResult,
+      }))
+      .catch(() => null)
+      .then((metadata) => {
+        if (boundaryGeneration !== this.subagentUsageBoundaryGeneration) {
+          return
+        }
+        this.subagentUsageExecutionMetadataByThread.set(threadId, metadata)
+        this.finalizeSubagentUsageForThread(threadId)
+      })
+      .finally(() => {
+        this.subagentUsagePendingMetadataRequests.delete(threadId)
+      })
+    this.subagentUsagePendingMetadataRequests.set(threadId, request)
+  }
+
+  private finalizeAllSubagentUsage(forceMetadataFallback: boolean): void {
+    for (const usageKey of [...this.subagentUsageAuthorizationByTurn.keys()]) {
+      this.finalizeSubagentUsageSample(usageKey, forceMetadataFallback)
+    }
+  }
+
+  private finalizeSubagentUsageForThread(threadId: string): void {
+    for (const [usageKey, sample] of this.subagentUsageSamples) {
+      if (sample.threadId === threadId) {
+        this.finalizeSubagentUsageSample(usageKey, false)
+      }
+    }
+  }
+
+  private finalizeSubagentUsageSample(
+    usageKey: string,
+    forceMetadataFallback: boolean,
+  ): void {
+    const sample = this.subagentUsageSamples.get(usageKey)
+    const authorization = this.subagentUsageAuthorizationByTurn.get(usageKey)
+    if (!sample || !authorization) {
+      return
+    }
+    const metadataSettled =
+      this.subagentUsageExecutionMetadataByThread.has(sample.threadId)
+    if (!metadataSettled && !forceMetadataFallback) {
+      return
+    }
+
+    const executionMetadata = metadataSettled
+      ? this.subagentUsageExecutionMetadataByThread.get(sample.threadId) ?? null
+      : null
+    const commonInput = {
+      authorizedRequestedModelByThreadId: new Map([
+        [sample.threadId, authorization.requestedModel],
+      ]),
+      modelProvider: authorization.modelProvider,
+      ordinalStart: 0,
+      parentModel: authorization.parentModel,
+      parentRawEvents: [],
+      seenRawResponseIds: this.subagentUsageRawResponseIds,
+      serviceTier: authorization.serviceTier,
+    }
+    let drafts: AssistantProviderUsageDraft[] = []
+    const rawResponseEvents = sample.rawResponseEvents ?? []
+    if (rawResponseEvents.length > 0) {
+      for (const rawResponseEvent of rawResponseEvents) {
+        drafts.push(...extractCodexSubagentUsageDrafts({
+          ...commonInput,
+          subagentTokenUsageByTurn: new Map([[usageKey, {
+            ...sample,
+            executionMetadata,
+            rawResponseEvents: [rawResponseEvent],
+          }]]),
+        }))
+      }
+    } else if (
+      (
+        this.subagentUsageCompletedTurns.has(usageKey) ||
+        forceMetadataFallback
+      ) &&
+      !this.subagentUsageCumulativeFinalizedTurns.has(usageKey)
+    ) {
+      drafts = extractCodexSubagentUsageDrafts({
+        ...commonInput,
+        subagentTokenUsageByTurn: new Map([[usageKey, {
+          ...sample,
+          executionMetadata,
+        }]]),
+      })
+      this.subagentUsageCumulativeFinalizedTurns.add(usageKey)
+    }
+
+    for (const draft of drafts) {
+      draft.providerRequestOrdinal = authorization.nextUsageOrdinal()
+      const recordingContext = authorization.recordingContext
+      if (recordingContext) {
+        recordingContext.recordDetachedUsage({
+          effectiveEnv: recordingContext.effectiveEnv,
+          operationId: recordingContext.operationId,
+          originAssistantInputId: recordingContext.originAssistantInputId,
+          usageDraft: draft,
+        })
+      } else {
+        authorization.unhostedUsageDrafts.push(draft)
+      }
+    }
+
+    if (
+      this.subagentUsageCompletedTurns.has(usageKey) &&
+      (
+        rawResponseEvents.length > 0 ||
+        this.subagentUsageCumulativeFinalizedTurns.has(usageKey)
+      )
+    ) {
+      this.removeSubagentUsageSample(usageKey)
+    }
+  }
+
+  private isSubagentUsageThreadAuthorized(threadId: string): boolean {
+    if (this.subagentUsageAuthorizationByThread.has(threadId)) {
+      return true
+    }
+    for (const usageKey of this.subagentUsageAuthorizationByTurn.keys()) {
+      if (this.subagentUsageSamples.get(usageKey)?.threadId === threadId) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private observeSubagentUsage(message: CodexRpcMessage): void {
+    const method = readCodexEventMethod(message)
+    const threadId = extractCodexThreadIdFromMessage(message)
+    if (
+      !threadId ||
+      threadId === this.boundThreadId ||
+      this.detachedRootThreadIds.has(threadId)
+    ) {
+      return
+    }
+    const turnId = extractCodexTurnIdFromMessage(message)
+    if (!turnId) {
+      return
+    }
+    const usageKey = createCodexSubagentTurnUsageKey({ threadId, turnId })
+
+    if (isCodexTurnStartedMethod(method)) {
+      if (this.subagentUsageSamples.has(usageKey)) {
+        return
+      }
+      if (
+        !this.subagentUsageTrackedThreadIds.has(threadId) &&
+        this.subagentUsageTrackedThreadIds.size >=
+          MAX_CODEX_SUBAGENT_USAGE_THREADS
+      ) {
+        const evictableThreadId = [...this.subagentUsageTrackedThreadIds]
+          .find((candidate) =>
+            !this.isSubagentUsageThreadAuthorized(candidate),
+          )
+        if (evictableThreadId === undefined) {
+          return
+        }
+        this.removeSubagentUsageThread(evictableThreadId)
+      }
+      this.subagentUsageTrackedThreadIds.add(threadId)
+      const sample: CodexSubagentTurnTokenUsageSample = {
+        firstEvent: null,
+        lastEvent: null,
+        occurredAt: new Date().toISOString(),
+        rawResponseEvents: [],
+        threadId,
+        turnId,
+      }
+      this.subagentUsageSamples.set(usageKey, sample)
+      const authorization = this.subagentUsageAuthorizationByThread.get(threadId)
+      if (authorization) {
+        this.subagentUsageAuthorizationByTurn.set(usageKey, authorization)
+        this.beginSubagentUsageMetadataRequest(threadId)
+      }
+      return
+    }
+
+    const sample = this.subagentUsageSamples.get(usageKey)
+    if (!sample) {
+      return
+    }
+    if (method === 'rawResponse/completed') {
+      sample.rawResponseEvents ??= []
+      sample.rawResponseEvents.push(message)
+      this.finalizeSubagentUsageSample(usageKey, false)
+      return
+    }
+    if (isAssistantCodexTokenUsageEventType(method)) {
+      sample.firstEvent ??= message
+      sample.lastEvent = message
+      return
+    }
+    if (isCodexTurnCompletedMethod(method)) {
+      this.subagentUsageCompletedTurns.add(usageKey)
+      this.finalizeSubagentUsageSample(usageKey, false)
+    }
+  }
+
+  private removeSubagentUsageSample(usageKey: string): void {
+    const threadId = this.subagentUsageSamples.get(usageKey)?.threadId ?? null
+    const authorization = this.subagentUsageAuthorizationByTurn.get(usageKey)
+    this.subagentUsageSamples.delete(usageKey)
+    this.subagentUsageAuthorizationByTurn.delete(usageKey)
+    this.subagentUsageCompletedTurns.delete(usageKey)
+    this.subagentUsageCumulativeFinalizedTurns.delete(usageKey)
+    if (
+      threadId &&
+      authorization?.retainAfterRoot &&
+      this.subagentUsageAuthorizationByThread.get(threadId) === authorization
+    ) {
+      this.subagentUsageAuthorizationByThread.delete(threadId)
+    }
+    if (
+      threadId &&
+      ![...this.subagentUsageSamples.values()]
+        .some((sample) => sample.threadId === threadId)
+    ) {
+      this.subagentUsageTrackedThreadIds.delete(threadId)
+    }
+  }
+
+  private removeSubagentUsageThread(threadId: string): void {
+    this.subagentUsageAuthorizationByThread.delete(threadId)
+    for (const [usageKey, sample] of [...this.subagentUsageSamples]) {
+      if (sample.threadId === threadId) {
+        this.removeSubagentUsageSample(usageKey)
+      }
+    }
+    this.subagentUsageTrackedThreadIds.delete(threadId)
+  }
+
   sendNotification(method: string, params: Record<string, unknown>): void {
     void this.writeRpcMessage({
       method,
@@ -1528,10 +1924,20 @@ class CodexAppServerProcess {
   }
 
   private clearDetachedChildBoundary(): void {
+    this.finalizeAllSubagentUsage(true)
+    this.subagentUsageBoundaryGeneration += 1
     this.detachedChildThreadIds.clear()
     this.detachedCompletedChildThreadIds.clear()
     this.detachedChildViolation = null
     this.detachedRootThreadIds.clear()
+    this.subagentUsageAuthorizationByThread.clear()
+    this.subagentUsageAuthorizationByTurn.clear()
+    this.subagentUsageCompletedTurns.clear()
+    this.subagentUsageCumulativeFinalizedTurns.clear()
+    this.subagentUsageExecutionMetadataByThread.clear()
+    this.subagentUsageRawResponseIds.clear()
+    this.subagentUsageSamples.clear()
+    this.subagentUsageTrackedThreadIds.clear()
   }
 
   private recordDetachedChildViolation(message: string): void {
@@ -1606,6 +2012,10 @@ class CodexAppServerProcess {
     this.endReason ??= resolveCodexAppServerEndReason(reason)
     this.normalShutdown = true
     this.state = 'stopping'
+    // A parsed provider response is already authoritative. Hand it off before
+    // teardown rejects optional metadata enrichment or releases process-owned
+    // detached lifecycle state.
+    this.finalizeAllSubagentUsage(true)
     this.rejectPending(
       new VaultCliError(
         'ASSISTANT_CODEX_APP_SERVER_STOPPED',
@@ -1861,6 +2271,7 @@ class CodexAppServerProcess {
     if (parsed.ok) {
       this.observeDetachedChildLifecycle(parsed.value)
       this.observeThreadTokenUsage(parsed.value)
+      this.observeSubagentUsage(parsed.value)
       if (this.activeTurn) {
         this.activeTurn.onParsedMessage(parsed.value)
       } else {
@@ -1893,6 +2304,11 @@ class CodexAppServerProcess {
       this.handleStdoutLine(this.stdoutBuffer)
     }
     this.stdoutBuffer = ''
+
+    // An unexpected exit while detached work is idle has no active turn to
+    // run the ordinary failure cleanup. Preserve any provider evidence parsed
+    // before close; a response that never reached stdout remains unknowable.
+    this.finalizeAllSubagentUsage(true)
 
     if (!this.normalShutdown) {
       this.poisoned = true
@@ -3270,6 +3686,7 @@ async function runCodexAppServerTurnOnProcess(
   }> = []
   const reservedNoReplyDeliveryContextOrdinals = new Set<number>()
   const additionalUsages: AssistantProviderUsageDraft[] = []
+  const subagentUsageDrafts: AssistantProviderUsageDraft[] = []
   let nextDynamicToolUsageOrdinal = (input.providerRequestOrdinal ?? 0) + 1
   // Trusted turn-scoped provider-call ceilings: one counter per assistant turn,
   // owned here and threaded into the dynamic-tool executor.
@@ -3294,16 +3711,6 @@ async function runCodexAppServerTurnOnProcess(
         policy: input.generateSongPolicy,
       }
     : null
-  const subagentTokenUsageByTurn =
-    new Map<string, CodexSubagentTurnTokenUsageSample>()
-  const subagentExecutionMetadataByThreadId =
-    new Map<string, CodexSubagentExecutionMetadata | null>()
-  const pendingSubagentMetadataRequests = new Map<string, Promise<void>>()
-  const trackedSubagentUsageThreadIds = new Set<string>()
-  // Thread ids named by this turn's collab tool calls (spawn/sendInput/...),
-  // collected live so evidenced subagent threads win buffer slots over
-  // stale/unattributed foreign threads when the cap is reached.
-  const collabReceiverThreadIds = new Set<string>()
   let rolloutRelativePath: string | null = null
   let providerActionCount = 0
   const providerActionItemIds = new Set<string>()
@@ -3403,18 +3810,14 @@ async function runCodexAppServerTurnOnProcess(
     })
   }
 
-  // Subagent usage drafts are derived lazily from the buffered per-thread
-  // samples so both the success result and the failure context can include
-  // whatever child usage was observed before the turn settled.
-  const buildSubagentUsageDrafts = (): AssistantProviderUsageDraft[] =>
-    extractCodexSubagentUsageDrafts({
-      modelProvider: normalizeNullableString(input.modelProvider) ?? null,
-      ordinalStart: nextDynamicToolUsageOrdinal,
-      parentModel: normalizeNullableString(input.model) ?? null,
-      parentRawEvents: jsonEvents,
-      serviceTier: input.serviceTier ?? null,
-      subagentTokenUsageByTurn,
-    })
+  let settledSubagentUsageDrafts: AssistantProviderUsageDraft[] | null = null
+  const buildSubagentUsageDrafts = (): AssistantProviderUsageDraft[] => {
+    if (settledSubagentUsageDrafts === null) {
+      codexProcess.finalizeSubagentUsageDraftsWithoutRecorder()
+      settledSubagentUsageDrafts = [...subagentUsageDrafts]
+    }
+    return settledSubagentUsageDrafts
+  }
 
   const hasNoReplyFinalActionPatch = (): boolean =>
     finalActionPatches.some((entry) => entry.patch.kind === 'none')
@@ -5099,9 +5502,6 @@ async function runCodexAppServerTurnOnProcess(
         )
       }
     }
-    for (const receiverThreadId of readCodexCollabReceiverThreadIds(message)) {
-      collabReceiverThreadIds.add(receiverThreadId)
-    }
     lastEventError = extractCodexErrorMessage(message) ?? lastEventError
     lastEventErrorInfo = extractCodexErrorInfo(message) ?? lastEventErrorInfo
 
@@ -5301,49 +5701,7 @@ async function runCodexAppServerTurnOnProcess(
     completeTurn?.()
   }
 
-  const beginSubagentMetadataRequest = (
-    sample: CodexSubagentTurnTokenUsageSample,
-  ): void => {
-    if (subagentExecutionMetadataByThreadId.has(sample.threadId)) {
-      sample.executionMetadata =
-        subagentExecutionMetadataByThreadId.get(sample.threadId) ?? null
-      return
-    }
-    if (pendingSubagentMetadataRequests.has(sample.threadId)) {
-      return
-    }
-
-    const request = codexProcess.sendRequestWithTimeout({
-      method: 'thread/resume',
-      params: {
-        excludeTurns: true,
-        threadId: sample.threadId,
-      },
-      pendingMethod: 'subagent/thread/resume',
-      timeoutLabel: 'subagent thread/resume',
-      timeoutMs: CODEX_BACKGROUND_WORK_RPC_TIMEOUT_MS,
-    })
-      .then((threadResult) => readCodexSubagentExecutionMetadata({
-        expectedThreadId: sample.threadId,
-        threadResult,
-      }))
-      .catch(() => null)
-      .then((metadata) => {
-        subagentExecutionMetadataByThreadId.set(sample.threadId, metadata)
-        for (const trackedSample of subagentTokenUsageByTurn.values()) {
-          if (trackedSample.threadId === sample.threadId) {
-            trackedSample.executionMetadata = metadata
-          }
-        }
-      })
-      .finally(() => {
-        pendingSubagentMetadataRequests.delete(sample.threadId)
-      })
-    pendingSubagentMetadataRequests.set(sample.threadId, request)
-  }
-
   const handleSubagentThreadMessage = (
-    threadId: string,
     message: CodexRpcMessage,
   ): void => {
     const requestId = readCodexRpcServerRequestId(message)
@@ -5355,81 +5713,7 @@ async function runCodexAppServerTurnOnProcess(
         requestId,
         writeRpcMessage: tryWriteRpcMessage,
       })
-      return
     }
-
-    const eventMethod = readCodexEventMethod(message)
-    const messageTurnId = extractCodexTurnIdFromMessage(message)
-    if (isCodexTurnStartedMethod(eventMethod)) {
-      if (!messageTurnId) {
-        return
-      }
-      const usageKey = createCodexSubagentTurnUsageKey({
-        threadId,
-        turnId: messageTurnId,
-      })
-      if (subagentTokenUsageByTurn.has(usageKey)) {
-        return
-      }
-      if (
-        !trackedSubagentUsageThreadIds.has(threadId)
-        && trackedSubagentUsageThreadIds.size >= MAX_CODEX_SUBAGENT_USAGE_THREADS
-      ) {
-        const evictableThreadId = collabReceiverThreadIds.has(threadId)
-          ? [...trackedSubagentUsageThreadIds].find(
-            (trackedThreadId) => !collabReceiverThreadIds.has(trackedThreadId),
-          )
-          : undefined
-        if (evictableThreadId === undefined) {
-          return
-        }
-        trackedSubagentUsageThreadIds.delete(evictableThreadId)
-        for (const [trackedUsageKey, sample] of subagentTokenUsageByTurn) {
-          if (sample.threadId === evictableThreadId) {
-            subagentTokenUsageByTurn.delete(trackedUsageKey)
-          }
-        }
-      }
-      trackedSubagentUsageThreadIds.add(threadId)
-      const sample: CodexSubagentTurnTokenUsageSample = {
-        firstEvent: null,
-        lastEvent: null,
-        occurredAt: new Date().toISOString(),
-        rawResponseEvents: [],
-        threadId,
-        turnId: messageTurnId,
-      }
-      subagentTokenUsageByTurn.set(usageKey, sample)
-      if (collabReceiverThreadIds.has(threadId)) {
-        beginSubagentMetadataRequest(sample)
-      }
-      return
-    }
-    if (!messageTurnId) {
-      return
-    }
-
-    const usageKey = createCodexSubagentTurnUsageKey({
-      threadId,
-      turnId: messageTurnId,
-    })
-    const sample = subagentTokenUsageByTurn.get(usageKey)
-    if (!sample) {
-      // A child token sample without an observed start has no safe accounting
-      // timestamp. Parent collab evidence authorizes the child but cannot
-      // establish when its provider operation began.
-      return
-    }
-    if (eventMethod === 'rawResponse/completed') {
-      sample.rawResponseEvents ??= []
-      sample.rawResponseEvents.push(message)
-      return
-    }
-    if (!isAssistantCodexTokenUsageEventType(eventMethod)) {
-      return
-    }
-    sample.firstEvent ??= message
-    sample.lastEvent = message
   }
 
   const handleStaleParentTurnMessage = (message: CodexRpcMessage): void => {
@@ -5520,8 +5804,9 @@ async function runCodexAppServerTurnOnProcess(
     }
 
     // Codex owns subagent/thread lifecycle. Murph only keeps foreign thread
-    // traffic away from the active parent turn: token usage is buffered for
-    // billing, server requests are denied, and other child events are dropped.
+    // traffic away from the active parent turn: the resident process has
+    // already observed accounting lifecycle, server requests are denied, and
+    // other child events are dropped.
     // Before a fresh thread/start response produces this turn's thread id, the
     // previous bound thread id is enough to distinguish late child traffic.
     const messageThreadId = extractCodexThreadIdFromMessage(message)
@@ -5532,7 +5817,7 @@ async function runCodexAppServerTurnOnProcess(
       knownParentThreadId !== null &&
       messageThreadId !== knownParentThreadId
     ) {
-      handleSubagentThreadMessage(messageThreadId, message)
+      handleSubagentThreadMessage(message)
       return
     }
 
@@ -5594,18 +5879,41 @@ async function runCodexAppServerTurnOnProcess(
       method === 'rawResponse/completed'
     ) {
       // Raw response items can contain provider payload content. Exact child
-      // usage is captured above in the isolated subagent buffer; neither raw
+      // usage is captured by the resident process observer; neither raw
       // notification belongs in the parent turn's persisted event surface.
       return
     }
 
     handleAcceptedEvent(message, method)
-    for (const receiverThreadId of readCodexCollabReceiverThreadIds(message)) {
-      for (const sample of subagentTokenUsageByTurn.values()) {
-        if (sample.threadId === receiverThreadId) {
-          beginSubagentMetadataRequest(sample)
-        }
-      }
+    const evidence = readCodexCollabReceiverEvidence(message)
+    if (evidence.length > 0 && knownParentThreadId) {
+      const invocationScope =
+        input.hostedToolContext?.currentInvocationScope?.() ?? null
+      const originAssistantInputId =
+        invocationScope?.origin.kind === 'accepted_input'
+          ? invocationScope.origin.assistantInputId
+          : input.hostedToolContext?.currentAssistantInputId?.() ?? null
+      const operationId = normalizeNullableString(input.usageOperationId)
+      const recordDetachedUsage = input.hostedToolContext?.recordDetachedUsage
+      const recordingContext =
+        originAssistantInputId && operationId && recordDetachedUsage
+          ? {
+              effectiveEnv: input.env,
+              operationId,
+              originAssistantInputId,
+              recordDetachedUsage,
+            }
+          : null
+      codexProcess.authorizeSubagentUsage({
+        evidence,
+        modelProvider: normalizeNullableString(input.modelProvider) ?? null,
+        nextUsageOrdinal: () => nextDynamicToolUsageOrdinal++,
+        parentModel: normalizeNullableString(input.model) ?? null,
+        recordingContext,
+        rootThreadId: knownParentThreadId,
+        serviceTier: input.serviceTier ?? null,
+        unhostedUsageDrafts: subagentUsageDrafts,
+      })
     }
   }
 
@@ -5980,6 +6288,10 @@ async function runCodexAppServerTurnOnProcess(
     closeLiveTurn()
     clearInterruptCleanupTimer()
     cleanupAbortListener()
+    if (codexThreadId) {
+      buildSubagentUsageDrafts()
+      codexProcess.releaseSubagentUsageAuthorizationsForRoot(codexThreadId)
+    }
     codexProcess.noteBoundThreadId(codexThreadId)
     codexProcess.releaseTurn(activeTurnBinding)
     codexProcess.releaseReservation()

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -5306,10 +5306,6 @@ async function runCodexAppServerTurnOnProcess(
     pendingSubagentMetadataRequests.set(sample.threadId, request)
   }
 
-  const drainPendingSubagentMetadataRequests = async (): Promise<void> => {
-    await Promise.all([...pendingSubagentMetadataRequests.values()])
-  }
-
   const handleSubagentThreadMessage = (
     threadId: string,
     message: CodexRpcMessage,
@@ -5329,7 +5325,7 @@ async function runCodexAppServerTurnOnProcess(
     const eventMethod = readCodexEventMethod(message)
     const messageTurnId = extractCodexTurnIdFromMessage(message)
     if (isCodexTurnStartedMethod(eventMethod)) {
-      if (!messageTurnId || !collabReceiverThreadIds.has(threadId)) {
+      if (!messageTurnId) {
         return
       }
       const usageKey = createCodexSubagentTurnUsageKey({
@@ -5368,7 +5364,9 @@ async function runCodexAppServerTurnOnProcess(
         turnId: messageTurnId,
       }
       subagentTokenUsageByTurn.set(usageKey, sample)
-      beginSubagentMetadataRequest(sample)
+      if (collabReceiverThreadIds.has(threadId)) {
+        beginSubagentMetadataRequest(sample)
+      }
       return
     }
     if (!messageTurnId) {
@@ -5566,6 +5564,13 @@ async function runCodexAppServerTurnOnProcess(
     }
 
     handleAcceptedEvent(message, method)
+    for (const receiverThreadId of readCodexCollabReceiverThreadIds(message)) {
+      for (const sample of subagentTokenUsageByTurn.values()) {
+        if (sample.threadId === receiverThreadId) {
+          beginSubagentMetadataRequest(sample)
+        }
+      }
+    }
   }
 
   const emitActionDiagnosticsTrace = () => {
@@ -5861,7 +5866,6 @@ async function runCodexAppServerTurnOnProcess(
     lifecycleStage = 'turn_running'
     await turnCompleted
     clearInterruptCleanupTimer()
-    await drainPendingSubagentMetadataRequests()
     await drainPendingDynamicToolRequests()
     await drainPendingDynamicToolExecutions()
     await drainPendingProgressDeliveries()
@@ -5919,7 +5923,6 @@ async function runCodexAppServerTurnOnProcess(
       ? (buildRecordedTerminationError(lastEventError) ?? error)
       : error
     emitActionDiagnosticsTrace()
-    await drainPendingSubagentMetadataRequests()
     await drainPendingDynamicToolRequests()
     dynamicToolAbortController.abort()
     await drainPendingDynamicToolExecutions()

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -141,6 +141,7 @@ import {
   readNodeErrorCode,
 } from './assistant-codex/failures.js'
 import {
+  type CodexSubagentExecutionMetadata,
   type CodexSubagentTurnTokenUsageSample,
   extractCodexSubagentUsageDrafts,
   isAssistantCodexTokenUsageEventType,
@@ -417,6 +418,39 @@ function readCodexThreadTokenUsageUpdate(message: CodexRpcMessage): {
         threadId,
       }
     : null
+}
+
+function readCodexSubagentExecutionMetadata(input: {
+  expectedThreadId: string
+  threadResult: unknown
+}): CodexSubagentExecutionMetadata | null {
+  const result = readCodexRecord(input.threadResult)
+  const thread = readCodexRecord(result?.thread)
+  const threadId = readCodexNonEmptyString(thread?.id)
+  const model = readCodexNonEmptyString(result?.model)
+  const modelProvider = readCodexNonEmptyString(result?.modelProvider)
+  const serviceTier = result?.serviceTier === null
+    ? null
+    : readCodexNonEmptyString(result?.serviceTier)
+  const reasoningEffort = result?.reasoningEffort === null
+    ? null
+    : readCodexNonEmptyString(result?.reasoningEffort)
+  if (
+    threadId !== input.expectedThreadId ||
+    !model ||
+    !modelProvider ||
+    (serviceTier === null && result?.serviceTier !== null) ||
+    (reasoningEffort === null && result?.reasoningEffort !== null)
+  ) {
+    return null
+  }
+
+  return {
+    model,
+    modelProvider,
+    reasoningEffort,
+    serviceTier,
+  }
 }
 
 function buildCodexAppServerNotFoundError(codexCommand: string): VaultCliError {
@@ -1288,13 +1322,17 @@ class CodexAppServerProcess {
     rejectPendingCodexRpcRequests(this.pendingRequests, error)
   }
 
-  sendRequest(method: string, params: Record<string, unknown>): Promise<unknown> {
+  sendRequest(
+    method: string,
+    params: Record<string, unknown>,
+    pendingMethod = method,
+  ): Promise<unknown> {
     const id = this.nextRequestId
     this.nextRequestId += 1
 
     return new Promise<unknown>((resolve, reject) => {
       this.pendingRequests.set(id, {
-        method,
+        method: pendingMethod,
         reject,
         resolve,
       })
@@ -3220,6 +3258,9 @@ async function runCodexAppServerTurnOnProcess(
     : null
   const subagentTokenUsageByTurn =
     new Map<string, CodexSubagentTurnTokenUsageSample>()
+  const subagentExecutionMetadataByThreadId =
+    new Map<string, CodexSubagentExecutionMetadata | null>()
+  const pendingSubagentMetadataRequests = new Map<string, Promise<void>>()
   const trackedSubagentUsageThreadIds = new Set<string>()
   // Thread ids named by this turn's collab tool calls (spawn/sendInput/...),
   // collected live so evidenced subagent threads win buffer slots over
@@ -5222,6 +5263,53 @@ async function runCodexAppServerTurnOnProcess(
     completeTurn?.()
   }
 
+  const beginSubagentMetadataRequest = (
+    sample: CodexSubagentTurnTokenUsageSample,
+  ): void => {
+    if (subagentExecutionMetadataByThreadId.has(sample.threadId)) {
+      sample.executionMetadata =
+        subagentExecutionMetadataByThreadId.get(sample.threadId) ?? null
+      return
+    }
+    if (pendingSubagentMetadataRequests.has(sample.threadId)) {
+      return
+    }
+
+    const request = withCodexRpcTimeout(
+      codexProcess.sendRequest(
+        'thread/resume',
+        {
+          excludeTurns: true,
+          threadId: sample.threadId,
+        },
+        'subagent/thread/resume',
+      ),
+      CODEX_BACKGROUND_WORK_RPC_TIMEOUT_MS,
+      'subagent thread/resume',
+    )
+      .then((threadResult) => readCodexSubagentExecutionMetadata({
+        expectedThreadId: sample.threadId,
+        threadResult,
+      }))
+      .catch(() => null)
+      .then((metadata) => {
+        subagentExecutionMetadataByThreadId.set(sample.threadId, metadata)
+        for (const trackedSample of subagentTokenUsageByTurn.values()) {
+          if (trackedSample.threadId === sample.threadId) {
+            trackedSample.executionMetadata = metadata
+          }
+        }
+      })
+      .finally(() => {
+        pendingSubagentMetadataRequests.delete(sample.threadId)
+      })
+    pendingSubagentMetadataRequests.set(sample.threadId, request)
+  }
+
+  const drainPendingSubagentMetadataRequests = async (): Promise<void> => {
+    await Promise.all([...pendingSubagentMetadataRequests.values()])
+  }
+
   const handleSubagentThreadMessage = (
     threadId: string,
     message: CodexRpcMessage,
@@ -5241,7 +5329,7 @@ async function runCodexAppServerTurnOnProcess(
     const eventMethod = readCodexEventMethod(message)
     const messageTurnId = extractCodexTurnIdFromMessage(message)
     if (isCodexTurnStartedMethod(eventMethod)) {
-      if (!messageTurnId) {
+      if (!messageTurnId || !collabReceiverThreadIds.has(threadId)) {
         return
       }
       const usageKey = createCodexSubagentTurnUsageKey({
@@ -5271,19 +5359,19 @@ async function runCodexAppServerTurnOnProcess(
         }
       }
       trackedSubagentUsageThreadIds.add(threadId)
-      subagentTokenUsageByTurn.set(usageKey, {
+      const sample: CodexSubagentTurnTokenUsageSample = {
         firstEvent: null,
         lastEvent: null,
         occurredAt: new Date().toISOString(),
+        rawResponseEvents: [],
         threadId,
         turnId: messageTurnId,
-      })
+      }
+      subagentTokenUsageByTurn.set(usageKey, sample)
+      beginSubagentMetadataRequest(sample)
       return
     }
-    if (
-      !isAssistantCodexTokenUsageEventType(eventMethod)
-      || !messageTurnId
-    ) {
+    if (!messageTurnId) {
       return
     }
 
@@ -5296,6 +5384,14 @@ async function runCodexAppServerTurnOnProcess(
       // A child token sample without an observed start has no safe accounting
       // timestamp. Parent collab evidence authorizes the child but cannot
       // establish when its provider operation began.
+      return
+    }
+    if (eventMethod === 'rawResponse/completed') {
+      sample.rawResponseEvents ??= []
+      sample.rawResponseEvents.push(message)
+      return
+    }
+    if (!isAssistantCodexTokenUsageEventType(eventMethod)) {
       return
     }
     sample.firstEvent ??= message
@@ -5356,6 +5452,8 @@ async function runCodexAppServerTurnOnProcess(
     const responseId = readCodexRpcResponseId(message)
     if (responseId !== null) {
       const pending = codexProcess.pendingRequests.get(responseId)
+      const isSubagentMetadataResponse =
+        pending?.method === 'subagent/thread/resume'
       const resolveResult = resolvePendingCodexRpcRequest({
         message,
         pendingRequests: codexProcess.pendingRequests,
@@ -5365,7 +5463,9 @@ async function runCodexAppServerTurnOnProcess(
         codexProcess.consumeIgnoredResponseId(responseId)
         return
       }
-      acceptJsonEvent(message)
+      if (!isSubagentMetadataResponse) {
+        acceptJsonEvent(message)
+      }
       if (message.error) {
         return
       }
@@ -5452,6 +5552,16 @@ async function runCodexAppServerTurnOnProcess(
       messageTurnId === null &&
       method !== 'model/rerouted'
     ) {
+      return
+    }
+
+    if (
+      method === 'rawResponseItem/completed' ||
+      method === 'rawResponse/completed'
+    ) {
+      // Raw response items can contain provider payload content. Exact child
+      // usage is captured above in the isolated subagent buffer; neither raw
+      // notification belongs in the parent turn's persisted event surface.
       return
     }
 
@@ -5751,6 +5861,7 @@ async function runCodexAppServerTurnOnProcess(
     lifecycleStage = 'turn_running'
     await turnCompleted
     clearInterruptCleanupTimer()
+    await drainPendingSubagentMetadataRequests()
     await drainPendingDynamicToolRequests()
     await drainPendingDynamicToolExecutions()
     await drainPendingProgressDeliveries()
@@ -5808,6 +5919,7 @@ async function runCodexAppServerTurnOnProcess(
       ? (buildRecordedTerminationError(lastEventError) ?? error)
       : error
     emitActionDiagnosticsTrace()
+    await drainPendingSubagentMetadataRequests()
     await drainPendingDynamicToolRequests()
     dynamicToolAbortController.abort()
     await drainPendingDynamicToolExecutions()

--- a/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
@@ -44,11 +44,14 @@ export function buildCodexThreadStartParams(
     workingDirectory: string
   },
 ): Record<string, unknown> {
-  return buildCodexThreadContextParams({
-    includeInstructions: true,
-    includeServiceName: true,
-    input,
-  })
+  return {
+    ...buildCodexThreadContextParams({
+      includeInstructions: true,
+      includeServiceName: true,
+      input,
+    }),
+    experimentalRawEvents: true,
+  }
 }
 
 export function buildCodexThreadResumeParams(input: {

--- a/packages/assistant-engine/src/assistant-codex/app-server-rpc.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-rpc.ts
@@ -394,6 +394,7 @@ export async function withCodexRpcTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
   method: string,
+  onTimeout?: () => void,
 ): Promise<T> {
   let timeoutId: NodeJS.Timeout | undefined
   try {
@@ -401,6 +402,7 @@ export async function withCodexRpcTimeout<T>(
       promise,
       new Promise<T>((_, reject) => {
         timeoutId = setTimeout(() => {
+          onTimeout?.()
           reject(
             new VaultCliError(
               'ASSISTANT_CODEX_APP_SERVER_TIMEOUT',

--- a/packages/assistant-engine/src/assistant/providers/codex-cli.ts
+++ b/packages/assistant-engine/src/assistant/providers/codex-cli.ts
@@ -266,6 +266,7 @@ export async function executeCodexAssistantTurnAttempt(
       input.onboardingFirstReadCompletionTransitionAvailable ?? false,
     publicInternetFetch: input.publicInternetFetch ?? null,
     threadConfig: input.codexThreadConfig ?? null,
+    usageOperationId: input.activeTurnId ?? null,
     onFirstAssistantResponseCompleted:
       input.activeTurnSteering
         ? () => input.activeTurnSteering?.closeInputAdmission()

--- a/packages/assistant-engine/src/assistant/providers/helpers.ts
+++ b/packages/assistant-engine/src/assistant/providers/helpers.ts
@@ -6,6 +6,7 @@ import {
   readCodexNonEmptyString,
   readCodexRecord,
   readCodexServerNotification,
+  readCodexTokenUsageBreakdown,
   readCodexThreadTokenUsage,
   type CodexThreadTokenUsage,
   type CodexTokenUsageBreakdown,
@@ -1007,20 +1008,30 @@ function subtractCodexTokenUsage(
 }
 
 export interface CodexSubagentTurnTokenUsageSample {
+  executionMetadata?: CodexSubagentExecutionMetadata | null
   firstEvent: unknown
   lastEvent: unknown
   occurredAt: string
+  rawResponseEvents?: unknown[]
   threadId: string
   turnId: string
 }
 
+export interface CodexSubagentExecutionMetadata {
+  model: string
+  modelProvider: string
+  reasoningEffort: string | null
+  serviceTier: string | null
+}
+
 // Codex ships no aggregate usage primitive for spawned subagent threads (no
 // usage RPC, no usage on the protocol Turn, no parent-side aggregation), so
-// the canonical pattern is consuming each child thread's tokenUsage
-// notifications. This converts the buffered first/final tokenUsage samples
-// per child turn into additional usage drafts on the parent turn, using the
-// same total-delta arithmetic as the parent's billed usage. Billing is
-// gated on spawn evidence: only threads named by a parent-thread
+// the canonical pattern is consuming each child thread's usage notifications.
+// Fresh raw-enabled lifecycles produce one exact rawResponse/completed usage
+// record per provider request. Cold or legacy lifecycles retain the existing
+// first/final tokenUsage delta fallback. A lifecycle chooses exactly one
+// source, so cumulative notifications can never double-bill exact raw usage.
+// Billing is gated on spawn evidence: only threads named by a parent-thread
 // collabAgentToolCall item's receiverThreadIds (multi-agent V1: spawnAgent,
 // sendInput, wait, resume — covering freshly spawned and reused children) or
 // by a subAgentActivity item's agentThreadId (multi-agent V2, which emits
@@ -1049,10 +1060,91 @@ export function extractCodexSubagentUsageDrafts(input: {
     input.parentRawEvents,
   )
   const drafts: AssistantProviderUsageDraft[] = []
+  const seenRawResponseIds = new Set<string>()
   let ordinal = input.ordinalStart
 
   for (const sample of input.subagentTokenUsageByTurn.values()) {
     if (!spawnModelByThreadId.has(sample.threadId)) {
+      continue
+    }
+
+    const requestedModel = spawnModelByThreadId.get(sample.threadId)
+      ?? input.parentModel
+      ?? null
+    const servedModel = sample.executionMetadata?.model ?? requestedModel
+    const modelProvider = sample.executionMetadata?.modelProvider
+      ?? input.modelProvider
+    const serviceTier = sample.executionMetadata
+      ? readAssistantProviderServiceTier(sample.executionMetadata.serviceTier)
+      : input.serviceTier ?? null
+    const providerMetadataJson = sample.executionMetadata
+      ? {
+          reasoningEffort: sample.executionMetadata.reasoningEffort,
+          requestedServiceTier: sample.executionMetadata.serviceTier,
+        }
+      : null
+    const appendDraft = (usageInput: {
+      providerRequestId: string | null
+      sourcePath: string
+      usage: CodexTokenUsageBreakdown
+    }): void => {
+      const rawUsageJson = sanitizeCodexUsage(usageInput.usage)
+      drafts.push({
+        occurredAt: sample.occurredAt,
+        provider: 'codex-cli',
+        providerRequestOrdinal: ordinal++,
+        providerRequestOutcome: 'succeeded',
+        usage: {
+          apiKeyEnv: null,
+          baseUrl: null,
+          cacheWriteTokens: usageInput.usage.cacheWriteInputTokens,
+          cachedInputTokens: usageInput.usage.cachedInputTokens,
+          inputTokens: usageInput.usage.inputTokens,
+          outputTokens: usageInput.usage.outputTokens,
+          providerMetadataJson,
+          providerName: resolveAssistantCodexUsageProviderName(modelProvider),
+          providerRequestId: usageInput.providerRequestId,
+          rawUsageJson,
+          rawUsageJsonHash: hashAssistantProviderStableJson(rawUsageJson),
+          reasoningTokens: usageInput.usage.reasoningOutputTokens,
+          requestedModel,
+          servedModel,
+          tokenPricingBasis: resolveCodexAssistantProviderTokenPricingBasis({
+            model: servedModel,
+            modelProvider,
+            serviceTier,
+          }),
+          totalTokens: usageInput.usage.totalTokens,
+          usageExtractionSourcePath: usageInput.sourcePath,
+          usageExtractionVersion: CODEX_USAGE_EXTRACTION_VERSION,
+        },
+      })
+    }
+
+    const rawResponseEvents = sample.rawResponseEvents ?? []
+    const rawResponseSourceSelected = rawResponseEvents.some((event) =>
+      readCodexServerNotification(event)?.method === 'rawResponse/completed'
+    )
+    if (rawResponseSourceSelected) {
+      for (const event of rawResponseEvents) {
+        const response = readAssistantCodexRawResponseUsageFromEvent(event)
+        if (
+          !response ||
+          response.threadId !== sample.threadId ||
+          response.turnId !== sample.turnId ||
+          seenRawResponseIds.has(response.responseId)
+        ) {
+          continue
+        }
+        seenRawResponseIds.add(response.responseId)
+        if (response.usage) {
+          appendDraft({
+            providerRequestId: response.responseId,
+            sourcePath: 'subagent.rawResponse.completed.usage',
+            usage: response.usage,
+          })
+        }
+      }
       continue
     }
 
@@ -1069,47 +1161,57 @@ export function extractCodexSubagentUsageDrafts(input: {
         : []
     })
     const delta = resolveAssistantCodexThreadTokenUsageTotalDelta(pairs)
-    if (!delta) {
-      continue
-    }
-
-    const model = spawnModelByThreadId.get(sample.threadId)
-      ?? input.parentModel
-      ?? null
-    const rawUsageJson = sanitizeCodexUsage(delta)
-    drafts.push({
-      occurredAt: sample.occurredAt,
-      provider: 'codex-cli',
-      providerRequestOrdinal: ordinal++,
-      providerRequestOutcome: 'succeeded',
-      usage: {
-        apiKeyEnv: null,
-        baseUrl: null,
-        cacheWriteTokens: delta.cacheWriteInputTokens,
-        cachedInputTokens: delta.cachedInputTokens,
-        inputTokens: delta.inputTokens,
-        outputTokens: delta.outputTokens,
-        providerMetadataJson: null,
-        providerName: resolveAssistantCodexUsageProviderName(input.modelProvider),
+    if (delta) {
+      appendDraft({
         providerRequestId: null,
-        rawUsageJson,
-        rawUsageJsonHash: hashAssistantProviderStableJson(rawUsageJson),
-        reasoningTokens: delta.reasoningOutputTokens,
-        requestedModel: model,
-        servedModel: model,
-        tokenPricingBasis: resolveCodexAssistantProviderTokenPricingBasis({
-          model,
-          modelProvider: input.modelProvider,
-          serviceTier: input.serviceTier ?? null,
-        }),
-        totalTokens: delta.totalTokens,
-        usageExtractionSourcePath: 'subagent.turn.tokenUsage.total.delta',
-        usageExtractionVersion: CODEX_USAGE_EXTRACTION_VERSION,
-      },
-    })
+        sourcePath: 'subagent.turn.tokenUsage.total.delta',
+        usage: delta,
+      })
+    }
   }
 
   return drafts
+}
+
+function readAssistantCodexRawResponseUsageFromEvent(rawEvent: unknown): {
+  responseId: string
+  threadId: string
+  turnId: string
+  usage: CodexTokenUsageBreakdown | null
+} | null {
+  const notification = readCodexServerNotification(rawEvent)
+  if (notification?.method !== 'rawResponse/completed') {
+    return null
+  }
+
+  const params = notification.params
+  const threadId = readCodexNonEmptyString(params.threadId)
+  const turnId = readCodexNonEmptyString(params.turnId)
+  const responseId = readCodexNonEmptyString(params.responseId)
+  const usage = params.usage === null
+    ? null
+    : readCodexTokenUsageBreakdown(params.usage)
+  if (
+    !threadId ||
+    !turnId ||
+    !responseId ||
+    (usage === null && params.usage !== null)
+  ) {
+    return null
+  }
+
+  return {
+    responseId,
+    threadId,
+    turnId,
+    usage,
+  }
+}
+
+function readAssistantProviderServiceTier(
+  value: string | null,
+): AssistantProviderServiceTier | null {
+  return value === 'flex' ? value : null
 }
 
 export function resolveCodexAssistantProviderTokenPricingBasis(input: {

--- a/packages/assistant-engine/src/assistant/providers/helpers.ts
+++ b/packages/assistant-engine/src/assistant/providers/helpers.ts
@@ -1042,6 +1042,7 @@ export interface CodexSubagentExecutionMetadata {
 // proof of a subagent — a stale flush from a previous thread must never mint a
 // usage row.
 export function extractCodexSubagentUsageDrafts(input: {
+  authorizedRequestedModelByThreadId?: ReadonlyMap<string, string | null>
   modelProvider: string | null
   ordinalStart: number
   parentModel?: string | null
@@ -1051,16 +1052,17 @@ export function extractCodexSubagentUsageDrafts(input: {
     string,
     CodexSubagentTurnTokenUsageSample
   >
+  seenRawResponseIds?: Set<string>
 }): AssistantProviderUsageDraft[] {
   if (input.subagentTokenUsageByTurn.size === 0) {
     return []
   }
 
-  const spawnModelByThreadId = readCodexCollabSpawnModelsByThread(
-    input.parentRawEvents,
-  )
+  const spawnModelByThreadId = input.authorizedRequestedModelByThreadId
+    ? new Map(input.authorizedRequestedModelByThreadId)
+    : readCodexCollabSpawnModelsByThread(input.parentRawEvents)
   const drafts: AssistantProviderUsageDraft[] = []
-  const seenRawResponseIds = new Set<string>()
+  const seenRawResponseIds = input.seenRawResponseIds ?? new Set<string>()
   let ordinal = input.ordinalStart
 
   for (const sample of input.subagentTokenUsageByTurn.values()) {
@@ -1251,17 +1253,27 @@ function readCodexCollabSpawnModelsByThread(
   return modelByThreadId
 }
 
-// Receiver thread ids named by a single parent-thread collab tool call or
-// subagent activity event, if any. Exported so the live turn loop can
-// prioritize evidenced subagent threads when its bounded usage buffer fills
-// up.
-export function readCodexCollabReceiverThreadIds(
+export interface CodexSubagentReceiverEvidence {
+  detached: boolean
+  requestedModel: string | null
+  threadId: string
+}
+
+export function readCodexCollabReceiverEvidence(
   rawEvent: unknown,
-): readonly string[] {
-  return readCodexCollabToolCallFromEvent(rawEvent)?.receiverThreadIds ?? []
+): readonly CodexSubagentReceiverEvidence[] {
+  const collabToolCall = readCodexCollabToolCallFromEvent(rawEvent)
+  return collabToolCall
+    ? collabToolCall.receiverThreadIds.map((threadId) => ({
+        detached: collabToolCall.detached,
+        requestedModel: collabToolCall.spawnModel,
+        threadId,
+      }))
+    : []
 }
 
 function readCodexCollabToolCallFromEvent(rawEvent: unknown): {
+  detached: boolean
   receiverThreadIds: string[]
   spawnModel: string | null
 } | null {
@@ -1279,6 +1291,7 @@ function readCodexCollabToolCallFromEvent(rawEvent: unknown): {
     const agentThreadId = readCodexNonEmptyString(item?.agentThreadId)
     return agentThreadId
       ? {
+          detached: true,
           receiverThreadIds: [agentThreadId],
           spawnModel: null,
         }
@@ -1297,6 +1310,7 @@ function readCodexCollabToolCallFromEvent(rawEvent: unknown): {
   }
 
   return {
+    detached: false,
     receiverThreadIds,
     spawnModel: item.tool === 'spawnAgent'
       ? readCodexNonEmptyString(item.model)

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -86,6 +86,7 @@ import {
 import {
   attachCodexAppServerProcessExitCleanup,
   stopCodexAppServerChild,
+  withCodexRpcTimeout,
 } from '../src/assistant-codex/app-server-rpc.ts'
 import {
   extractCodexAppServerUserMessageImages,
@@ -776,6 +777,37 @@ async function runCodexTelegramVoiceMemoOnlyTurn(input: {
 }
 
 describe('assistant codex runtime', () => {
+  it('runs RPC timeout cleanup only when the timeout wins', async () => {
+    vi.useFakeTimers()
+    try {
+      const timedOutCleanup = vi.fn()
+      const timedOutRequest = withCodexRpcTimeout(
+        new Promise<never>(() => undefined),
+        25,
+        'subagent thread/resume',
+        timedOutCleanup,
+      )
+      const timeoutExpectation = expect(timedOutRequest).rejects.toMatchObject({
+        code: 'ASSISTANT_CODEX_APP_SERVER_TIMEOUT',
+      })
+
+      await vi.advanceTimersByTimeAsync(25)
+      await timeoutExpectation
+      expect(timedOutCleanup).toHaveBeenCalledOnce()
+
+      const completedCleanup = vi.fn()
+      await expect(withCodexRpcTimeout(
+        Promise.resolve('metadata'),
+        25,
+        'subagent thread/resume',
+        completedCleanup,
+      )).resolves.toBe('metadata')
+      expect(completedCleanup).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('builds Codex app-server args for configured turns', () => {
     expect(
       buildCodexAppServerArgs({

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -854,6 +854,7 @@ describe('assistant codex runtime', () => {
       cwd: '/workspace',
       developerInstructions: 'Stable Murph instructions.',
       dynamicTools: MURPH_DYNAMIC_TOOLS_WITHOUT_PROGRESS,
+      experimentalRawEvents: true,
       model: 'gpt-5',
       modelProvider: 'vercel-ai-gateway',
       sandbox: 'workspace-write',
@@ -1052,6 +1053,7 @@ describe('assistant codex runtime', () => {
       developerInstructions: 'Stable Murph instructions.',
       dynamicTools: MURPH_DYNAMIC_TOOLS_WITHOUT_PROGRESS,
       ephemeral: true,
+      experimentalRawEvents: true,
       model: 'gpt-5',
       modelProvider: 'vercel-ai-gateway',
       permissions: 'murph-group-read',
@@ -1212,6 +1214,7 @@ describe('assistant codex runtime', () => {
               approvalPolicy: 'never',
               cwd: expectedWorkingDirectory,
               dynamicTools: MURPH_DYNAMIC_TOOLS_WITHOUT_PROGRESS,
+              experimentalRawEvents: true,
               model,
               modelProvider,
               sandbox: 'workspace-write',
@@ -15056,6 +15059,7 @@ describe('assistant codex runtime', () => {
       expect(asRecord(threadRequests[0]?.params)).toEqual({
         ...expectedFreshThreadContext,
         dynamicTools: MURPH_DYNAMIC_TOOLS_WITHOUT_PROGRESS,
+        experimentalRawEvents: true,
         serviceName: 'murph',
       })
       expect(asRecord(threadRequests[1]?.params)).toEqual(expectedResumeThreadContext)
@@ -18584,6 +18588,192 @@ describe('assistant codex event shaping', () => {
   })
 
   describe('codex subagent thread events', () => {
+    it('buffers exact child usage while resolving metadata and rejects foreign child lifecycles', async () => {
+      const workingDirectory = await createTempDir(
+        'assistant-codex-subagent-raw-work-',
+      )
+      const codexHome = await createTempDir(
+        'assistant-codex-subagent-raw-home-',
+      )
+      const spawnedChildren: MockChildProcess[] = []
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_050 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-subagent-raw-parent',
+              turnId: 'turn-subagent-raw-parent',
+            })
+            child.stdout.write(jsonLine({
+              method: 'rawResponseItem/completed',
+              params: {
+                item: {
+                  content: 'must-not-enter-parent-events-from-raw-item',
+                  type: 'reasoning',
+                },
+                threadId: 'thread-subagent-raw-parent',
+                turnId: 'turn-subagent-raw-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'turn/started',
+              params: {
+                threadId: 'thread-subagent-foreign',
+                turn: { id: 'turn-subagent-foreign' },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'collab-spawn-raw-child',
+                  type: 'collabAgentToolCall',
+                  tool: 'spawnAgent',
+                  status: 'completed',
+                  senderThreadId: 'thread-subagent-raw-parent',
+                  receiverThreadIds: ['thread-subagent-raw-child'],
+                  model: 'gpt-5.6-terra',
+                },
+                threadId: 'thread-subagent-raw-parent',
+                turnId: 'turn-subagent-raw-parent',
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'turn/started',
+              params: {
+                threadId: 'thread-subagent-raw-child',
+                turn: { id: 'turn-subagent-raw-child' },
+              },
+            }))
+            const rawResponse = {
+              method: 'rawResponse/completed',
+              params: {
+                responseId: 'response-subagent-raw-1',
+                threadId: 'thread-subagent-raw-child',
+                turnId: 'turn-subagent-raw-child',
+                usage: {
+                  cacheWriteInputTokens: 0,
+                  cachedInputTokens: 300,
+                  inputTokens: 900,
+                  outputTokens: 300,
+                  reasoningOutputTokens: 40,
+                  totalTokens: 1_200,
+                },
+              },
+            }
+            // Usage may arrive before the metadata-only resume response.
+            child.stdout.write(jsonLine(rawResponse))
+            child.stdout.write(jsonLine(rawResponse))
+            writeTokenUsage({
+              child,
+              last: {
+                cachedInputTokens: 0,
+                inputTokens: 9_000,
+                outputTokens: 999,
+                reasoningOutputTokens: 0,
+                totalTokens: 9_999,
+              },
+              threadId: 'thread-subagent-raw-child',
+              total: {
+                cachedInputTokens: 0,
+                inputTokens: 9_000,
+                outputTokens: 999,
+                reasoningOutputTokens: 0,
+                totalTokens: 9_999,
+              },
+              turnId: 'turn-subagent-raw-child',
+            })
+
+            const metadataResume = await waitForRpcMethod(child, 'thread/resume')
+            child.stdout.write(jsonLine({
+              id: metadataResume.id,
+              result: {
+                model: 'gpt-5.6-sol',
+                modelProvider: 'openai',
+                reasoningEffort: 'high',
+                serviceTier: 'flex',
+                thread: {
+                  id: 'thread-subagent-raw-child',
+                  preview: 'must-not-enter-parent-events',
+                },
+              },
+            }))
+            writeCodexV2AssistantEventTurn({
+              child,
+              finalMessage: 'Exact child usage recorded',
+              threadId: 'thread-subagent-raw-parent',
+              turnId: 'turn-subagent-raw-parent',
+            })
+          })()
+        })
+
+        return child
+      })
+
+      const result = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: { PATH: '/custom/bin' },
+        model: 'gpt-5.6-sol',
+        modelProvider: 'local-test-provider',
+        prompt: 'delegate one exact child operation',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      expect(result.additionalUsages).toMatchObject([
+        {
+          provider: 'codex-cli',
+          providerRequestOrdinal: 1,
+          usage: {
+            cachedInputTokens: 300,
+            inputTokens: 900,
+            outputTokens: 300,
+            providerMetadataJson: {
+              reasoningEffort: 'high',
+              requestedServiceTier: 'flex',
+            },
+            providerName: 'openai',
+            providerRequestId: 'response-subagent-raw-1',
+            reasoningTokens: 40,
+            requestedModel: 'gpt-5.6-terra',
+            servedModel: 'gpt-5.6-sol',
+            tokenPricingBasis: 'openai-flex',
+            totalTokens: 1_200,
+            usageExtractionSourcePath:
+              'subagent.rawResponse.completed.usage',
+          },
+        },
+      ])
+      expect(result.additionalUsages).toHaveLength(1)
+      const written = readWrittenRpcMessages(
+        requireMockChildProcess(spawnedChildren[0] ?? null),
+      )
+      expect(
+        written
+          .filter((message) => message.method === 'thread/resume')
+          .map((message) => message.params),
+      ).toEqual([{
+        excludeTurns: true,
+        threadId: 'thread-subagent-raw-child',
+      }])
+      expect(JSON.stringify(result.jsonEvents)).not.toContain(
+        'must-not-enter-parent-events',
+      )
+      expect(
+        result.additionalUsages.map((draft) => draft.usage.totalTokens),
+      ).toEqual([1_200])
+    })
+
     it('inherits the parent model for activity-only children and uses collab spawn models', async () => {
       const workingDirectory = await createTempDir('assistant-codex-subagent-usage-work-')
       const codexHome = await createTempDir('assistant-codex-subagent-usage-home-')
@@ -18592,6 +18782,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_100 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -18802,8 +18993,19 @@ describe('assistant codex event shaping', () => {
       expect(
         readWrittenRpcMessages(
           requireMockChildProcess(spawnedChildren[0] ?? null),
-        ).filter((message) => message.method === 'thread/resume'),
-      ).toHaveLength(0)
+        )
+          .filter((message) => message.method === 'thread/resume')
+          .map((message) => message.params),
+      ).toEqual([
+        {
+          excludeTurns: true,
+          threadId: 'thread-subagent-child-a',
+        },
+        {
+          excludeTurns: true,
+          threadId: 'thread-subagent-child-b',
+        },
+      ])
     })
 
     it.each(['completed', 'failed'] as const)(
@@ -18825,6 +19027,7 @@ describe('assistant codex event shaping', () => {
         try {
           codexMocks.spawn.mockImplementation(() => {
             const child = new MockChildProcess()
+            respondToSubagentMetadataRequestsWithoutMetadata(child)
             child.pid = 31_150 + spawnedChildren.length
             spawnedChildren.push(child)
 
@@ -19031,6 +19234,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_175 + spawnedChildren.length
         spawnedChildren.push(child)
         queueMicrotask(() => {
@@ -19094,6 +19298,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_200 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19162,6 +19367,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_400 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19290,6 +19496,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_450 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19416,6 +19623,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_550 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19560,6 +19768,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_475 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19665,6 +19874,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_500 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19848,6 +20058,7 @@ describe('assistant codex event shaping', () => {
         }))
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_600 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -19994,6 +20205,7 @@ describe('assistant codex event shaping', () => {
 
       codexMocks.spawn.mockImplementation(() => {
         const child = new MockChildProcess()
+        respondToSubagentMetadataRequestsWithoutMetadata(child)
         child.pid = 31_700 + spawnedChildren.length
         spawnedChildren.push(child)
 
@@ -23354,6 +23566,34 @@ class MockStdin extends EventEmitter {
 
     this.onEnd?.(write)
     this.emit('finish')
+  }
+}
+
+function respondToSubagentMetadataRequestsWithoutMetadata(
+  child: MockChildProcess,
+): void {
+  const precedingOnWrite = child.stdin.onWrite
+  child.stdin.onWrite = (write) => {
+    precedingOnWrite?.(write)
+    for (const line of write.split('\n')) {
+      if (line.trim().length === 0) {
+        continue
+      }
+      const message = asRecord(JSON.parse(line))
+      const params = isTestRecord(message.params)
+        ? asRecord(message.params)
+        : null
+      if (
+        message.method !== 'thread/resume' ||
+        params?.excludeTurns !== true ||
+        typeof params?.threadId !== 'string'
+      ) {
+        continue
+      }
+      queueMicrotask(() => {
+        child.stdout.write(jsonLine({ id: message.id, result: {} }))
+      })
+    }
   }
 }
 

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -66,6 +66,7 @@ import {
 import type {
   CodexAppServerLiveTurn,
   CodexAppServerTurnInput,
+  CodexAppServerTurnResult,
 } from '../src/assistant-codex.ts'
 import type {
   AssistantRuntimeIssueInput,
@@ -18774,6 +18775,337 @@ describe('assistant codex event shaping', () => {
       ).toEqual([1_200])
     })
 
+    it.each(['raw', 'cumulative'] as const)(
+      'captures %s child usage before parent authorization evidence',
+      async (usageSource) => {
+        const workingDirectory = await createTempDir(
+          `assistant-codex-subagent-${usageSource}-before-evidence-work-`,
+        )
+        const codexHome = await createTempDir(
+          `assistant-codex-subagent-${usageSource}-before-evidence-home-`,
+        )
+        const spawnedChildren: MockChildProcess[] = []
+        mockProcessGroupSignalsForChildren(spawnedChildren)
+        let metadataRequestedBeforeEvidence = false
+
+        codexMocks.spawn.mockImplementation(() => {
+          const child = new MockChildProcess()
+          child.pid = 31_060 + spawnedChildren.length
+          spawnedChildren.push(child)
+
+          queueMicrotask(() => {
+            void (async () => {
+              const initialize = await waitForRpcMethod(child, 'initialize')
+              child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+              await writeWarmTurnStarted({
+                child,
+                requestCount: 1,
+                threadId: 'thread-subagent-before-evidence-parent',
+                turnId: 'turn-subagent-before-evidence-parent',
+              })
+              writeStartedTurn(
+                child,
+                'thread-subagent-before-evidence-child',
+                'turn-subagent-before-evidence-child',
+              )
+              if (usageSource === 'raw') {
+                child.stdout.write(jsonLine({
+                  method: 'rawResponse/completed',
+                  params: {
+                    responseId: 'response-subagent-before-evidence',
+                    threadId: 'thread-subagent-before-evidence-child',
+                    turnId: 'turn-subagent-before-evidence-child',
+                    usage: {
+                      cacheWriteInputTokens: 0,
+                      cachedInputTokens: 10,
+                      inputTokens: 80,
+                      outputTokens: 20,
+                      reasoningOutputTokens: 5,
+                      totalTokens: 100,
+                    },
+                  },
+                }))
+              } else {
+                writeTokenUsage({
+                  child,
+                  last: {
+                    cacheWriteInputTokens: 0,
+                    cachedInputTokens: 10,
+                    inputTokens: 80,
+                    outputTokens: 20,
+                    reasoningOutputTokens: 5,
+                    totalTokens: 100,
+                  },
+                  threadId: 'thread-subagent-before-evidence-child',
+                  total: {
+                    cacheWriteInputTokens: 0,
+                    cachedInputTokens: 10,
+                    inputTokens: 80,
+                    outputTokens: 20,
+                    reasoningOutputTokens: 5,
+                    totalTokens: 100,
+                  },
+                  turnId: 'turn-subagent-before-evidence-child',
+                })
+              }
+              metadataRequestedBeforeEvidence = readWrittenRpcMessages(child)
+                .some((message) => message.method === 'thread/resume')
+
+              child.stdout.write(jsonLine({
+                method: 'item/completed',
+                params: {
+                  item: {
+                    id: 'collab-spawn-before-evidence-child',
+                    type: 'collabAgentToolCall',
+                    tool: 'spawnAgent',
+                    status: 'completed',
+                    senderThreadId: 'thread-subagent-before-evidence-parent',
+                    receiverThreadIds: [
+                      'thread-subagent-before-evidence-child',
+                    ],
+                    model: 'gpt-5.6-terra',
+                  },
+                  threadId: 'thread-subagent-before-evidence-parent',
+                  turnId: 'turn-subagent-before-evidence-parent',
+                },
+              }))
+              const metadataResume = await waitForRpcMethod(
+                child,
+                'thread/resume',
+              )
+              child.stdout.write(jsonLine({
+                id: metadataResume.id,
+                result: {
+                  model: 'gpt-5.6-sol',
+                  modelProvider: 'openai',
+                  reasoningEffort: 'high',
+                  serviceTier: 'flex',
+                  thread: {
+                    id: 'thread-subagent-before-evidence-child',
+                  },
+                },
+              }))
+              writeCodexV2AssistantEventTurn({
+                child,
+                finalMessage: 'Captured child usage before evidence',
+                threadId: 'thread-subagent-before-evidence-parent',
+                turnId: 'turn-subagent-before-evidence-parent',
+              })
+            })()
+          })
+
+          return child
+        })
+
+        const result = await executeCodexAppServerTurn({
+          approvalPolicy: 'never',
+          codexHome,
+          env: { PATH: '/custom/bin' },
+          model: 'gpt-5.6-sol',
+          modelProvider: 'local-test-provider',
+          prompt: 'child usage arrives before parent evidence',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+
+        expect(metadataRequestedBeforeEvidence).toBe(false)
+        expect(result.additionalUsages).toMatchObject([{
+          providerRequestOrdinal: 1,
+          usage: {
+            inputTokens: 80,
+            outputTokens: 20,
+            providerMetadataJson: {
+              reasoningEffort: 'high',
+              requestedServiceTier: 'flex',
+            },
+            providerName: 'openai',
+            providerRequestId: usageSource === 'raw'
+              ? 'response-subagent-before-evidence'
+              : null,
+            reasoningTokens: 5,
+            requestedModel: 'gpt-5.6-terra',
+            servedModel: 'gpt-5.6-sol',
+            totalTokens: 100,
+            usageExtractionSourcePath: usageSource === 'raw'
+              ? 'subagent.rawResponse.completed.usage'
+              : 'subagent.turn.tokenUsage.total.delta',
+          },
+        }])
+        expect(result.additionalUsages).toHaveLength(1)
+        expect(
+          readWrittenRpcMessages(
+            requireMockChildProcess(spawnedChildren[0] ?? null),
+          ).filter((message) => message.method === 'thread/resume'),
+        ).toHaveLength(1)
+      },
+    )
+
+    it.each(['completed', 'failed'] as const)(
+      'does not delay a %s parent terminal on unresolved child metadata',
+      async (parentOutcome) => {
+        const workingDirectory = await createTempDir(
+          `assistant-codex-subagent-metadata-${parentOutcome}-work-`,
+        )
+        const codexHome = await createTempDir(
+          `assistant-codex-subagent-metadata-${parentOutcome}-home-`,
+        )
+        const spawnedChildren: MockChildProcess[] = []
+        mockProcessGroupSignalsForChildren(spawnedChildren)
+        let metadataResumeId: unknown = null
+        let parentTerminalAt = 0
+
+        codexMocks.spawn.mockImplementation(() => {
+          const child = new MockChildProcess()
+          child.pid = 31_075 + spawnedChildren.length
+          spawnedChildren.push(child)
+
+          queueMicrotask(() => {
+            void (async () => {
+              const initialize = await waitForRpcMethod(child, 'initialize')
+              child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+              await writeWarmTurnStarted({
+                child,
+                requestCount: 1,
+                threadId: 'thread-subagent-metadata-parent',
+                turnId: 'turn-subagent-metadata-parent',
+              })
+              child.stdout.write(jsonLine({
+                method: 'item/completed',
+                params: {
+                  item: {
+                    id: 'collab-spawn-metadata-child',
+                    type: 'collabAgentToolCall',
+                    tool: 'spawnAgent',
+                    status: 'completed',
+                    senderThreadId: 'thread-subagent-metadata-parent',
+                    receiverThreadIds: ['thread-subagent-metadata-child'],
+                    model: 'gpt-5.6-terra',
+                  },
+                  threadId: 'thread-subagent-metadata-parent',
+                  turnId: 'turn-subagent-metadata-parent',
+                },
+              }))
+              writeStartedTurn(
+                child,
+                'thread-subagent-metadata-child',
+                'turn-subagent-metadata-child',
+              )
+              child.stdout.write(jsonLine({
+                method: 'rawResponse/completed',
+                params: {
+                  responseId: 'response-subagent-metadata-child',
+                  threadId: 'thread-subagent-metadata-child',
+                  turnId: 'turn-subagent-metadata-child',
+                  usage: {
+                    cacheWriteInputTokens: 0,
+                    cachedInputTokens: 12,
+                    inputTokens: 80,
+                    outputTokens: 20,
+                    reasoningOutputTokens: 4,
+                    totalTokens: 100,
+                  },
+                },
+              }))
+              metadataResumeId = (
+                await waitForRpcMethod(child, 'thread/resume')
+              ).id
+              parentTerminalAt = Date.now()
+              if (parentOutcome === 'completed') {
+                writeCodexV2AssistantEventTurn({
+                  child,
+                  finalMessage: 'Parent settled without metadata',
+                  threadId: 'thread-subagent-metadata-parent',
+                  turnId: 'turn-subagent-metadata-parent',
+                })
+              } else {
+                writeCompletedTurn(
+                  child,
+                  'thread-subagent-metadata-parent',
+                  'turn-subagent-metadata-parent',
+                  'failed',
+                )
+              }
+            })()
+          })
+
+          return child
+        })
+
+        let result: CodexAppServerTurnResult | null = null
+        let turnError: unknown = null
+        try {
+          result = await executeCodexAppServerTurn({
+            approvalPolicy: 'never',
+            codexHome,
+            env: { PATH: '/custom/bin' },
+            model: 'gpt-5.6-sol',
+            modelProvider: 'local-test-provider',
+            prompt: 'settle without waiting for child metadata',
+            sandbox: 'workspace-write',
+            workingDirectory,
+          })
+        } catch (error) {
+          turnError = error
+        }
+
+        expect(parentTerminalAt).toBeGreaterThan(0)
+        expect(Date.now() - parentTerminalAt).toBeLessThan(2_000)
+        if (parentOutcome === 'completed') {
+          expect(turnError).toBeNull()
+          expect(result?.finalMessage).toBe('Parent settled without metadata')
+        } else {
+          expect(result).toBeNull()
+          expect(turnError).toBeInstanceOf(Error)
+        }
+        const failureContext = readCodexAppServerTurnFailureContext(turnError)
+        const additionalUsages = result?.additionalUsages
+          ?? failureContext?.additionalUsages
+        const jsonEvents = result?.jsonEvents ?? failureContext?.jsonEvents
+        expect(additionalUsages).toMatchObject([{
+          providerRequestOrdinal: 1,
+          usage: {
+            inputTokens: 80,
+            outputTokens: 20,
+            providerMetadataJson: null,
+            providerName: 'local-test-provider',
+            providerRequestId: 'response-subagent-metadata-child',
+            reasoningTokens: 4,
+            requestedModel: 'gpt-5.6-terra',
+            servedModel: 'gpt-5.6-terra',
+            totalTokens: 100,
+            usageExtractionSourcePath:
+              'subagent.rawResponse.completed.usage',
+          },
+        }])
+        expect(additionalUsages).toHaveLength(1)
+        const usageSnapshot = JSON.stringify(additionalUsages)
+
+        const child = requireMockChildProcess(spawnedChildren[0] ?? null)
+        expect(metadataResumeId).not.toBeNull()
+        child.stdout.write(jsonLine({
+          id: metadataResumeId,
+          result: {
+            model: 'late-model-must-not-mutate-result',
+            modelProvider: 'late-provider-must-not-mutate-result',
+            reasoningEffort: 'high',
+            serviceTier: 'flex',
+            thread: {
+              id: 'thread-subagent-metadata-child',
+              preview: 'late-metadata-must-not-enter-parent-events',
+            },
+          },
+        }))
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve)
+        })
+
+        expect(JSON.stringify(additionalUsages)).toBe(usageSnapshot)
+        expect(JSON.stringify(jsonEvents)).not.toContain(
+          'late-metadata-must-not-enter-parent-events',
+        )
+      },
+    )
+
     it('inherits the parent model for activity-only children and uses collab spawn models', async () => {
       const workingDirectory = await createTempDir('assistant-codex-subagent-usage-work-')
       const codexHome = await createTempDir('assistant-codex-subagent-usage-home-')
@@ -21146,6 +21478,16 @@ describe('assistant codex event shaping', () => {
         reasoningOutputTokens: 0,
         totalTokens: 2_500,
       })
+      expect(
+        readWrittenRpcMessages(
+          requireMockChildProcess(spawnedChildren[0] ?? null),
+        )
+          .filter((message) => message.method === 'thread/resume')
+          .map((message) => message.params),
+      ).toEqual([{
+        excludeTurns: true,
+        threadId: 'thread-subagent-evict-child',
+      }])
     })
   })
 })

--- a/packages/assistant-engine/test/assistant-codex-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.test.ts
@@ -264,8 +264,10 @@ function createProgressDeliveryMock(
 function createHostedToolContext(input: {
   beforeToolExecution?: AssistantHostedToolContext['beforeToolExecution']
   computerToolsAvailable?: boolean
+  currentAssistantInputId?: AssistantHostedToolContext['currentAssistantInputId']
   groupTool?: AssistantHostedToolContext['groupTool']
   imageGenerationLauncher?: AssistantHostedToolContext['imageGenerationLauncher']
+  recordDetachedUsage?: AssistantHostedToolContext['recordDetachedUsage']
   sendVaultFile?: AssistantHostedToolContext['sendVaultFile']
   vaultFileSendAvailable?: boolean
 } = {}): AssistantHostedToolContext {
@@ -274,11 +276,17 @@ function createHostedToolContext(input: {
       ? { beforeToolExecution: input.beforeToolExecution }
       : {}),
     computerToolsAvailable: input.computerToolsAvailable ?? true,
+    ...(input.currentAssistantInputId
+      ? { currentAssistantInputId: input.currentAssistantInputId }
+      : {}),
     currentHostedDeliveryContext: () => null,
     currentHostedMailboxItemIds: () => [],
     groupTool: input.groupTool ?? null,
     imageGenerationLauncher: input.imageGenerationLauncher ?? null,
     persistGeneratedImageCapture: async (write) => await write(),
+    ...(input.recordDetachedUsage
+      ? { recordDetachedUsage: input.recordDetachedUsage }
+      : {}),
     sendVaultFile: input.sendVaultFile ?? vi.fn(async () => {
       throw new Error('Vault-file sending is unavailable for this turn.')
     }),
@@ -19849,6 +19857,119 @@ describe('assistant codex event shaping', () => {
       })
     })
 
+    it('records exact hosted detached usage when the root turn fails', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-hosted-subagent-fail-work-')
+      const codexHome = await createTempDir('assistant-codex-hosted-subagent-fail-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      const originAssistantInputId = `ain_${'b'.repeat(32)}`
+      const recordDetachedUsage = vi.fn()
+      mockProcessGroupSignalsForChildren(spawnedChildren)
+
+      codexMocks.spawn.mockImplementation(() => {
+        const child = new MockChildProcess()
+        child.pid = 31_450 + spawnedChildren.length
+        spawnedChildren.push(child)
+
+        queueMicrotask(() => {
+          void (async () => {
+            const initialize = await waitForRpcMethod(child, 'initialize')
+            child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
+            await writeWarmTurnStarted({
+              child,
+              requestCount: 1,
+              threadId: 'thread-hosted-subagent-fail-parent',
+              turnId: 'turn-hosted-subagent-fail-parent',
+            })
+            writeSubAgentActivity(
+              child,
+              'thread-hosted-subagent-fail-parent',
+              'thread-hosted-subagent-fail-child',
+              'started',
+              { turnId: 'turn-hosted-subagent-fail-parent' },
+            )
+            writeStartedTurn(
+              child,
+              'thread-hosted-subagent-fail-child',
+              'turn-hosted-subagent-fail-child',
+            )
+            child.stdout.write(jsonLine({
+              method: 'rawResponse/completed',
+              params: {
+                responseId: 'response-hosted-subagent-fail-child',
+                threadId: 'thread-hosted-subagent-fail-child',
+                turnId: 'turn-hosted-subagent-fail-child',
+                usage: {
+                  cacheWriteInputTokens: 3,
+                  cachedInputTokens: 11,
+                  inputTokens: 91,
+                  outputTokens: 23,
+                  reasoningOutputTokens: 7,
+                  totalTokens: 114,
+                },
+              },
+            }))
+            writeCompletedTurn(
+              child,
+              'thread-hosted-subagent-fail-child',
+              'turn-hosted-subagent-fail-child',
+            )
+            writeCompletedTurn(
+              child,
+              'thread-hosted-subagent-fail-parent',
+              'turn-hosted-subagent-fail-parent',
+              'failed',
+            )
+          })()
+        })
+
+        return child
+      })
+
+      const error: unknown = await executeCodexAppServerTurn({
+        approvalPolicy: 'never',
+        codexHome,
+        env: { PATH: '/custom/bin' },
+        hostedToolContext: createHostedToolContext({
+          currentAssistantInputId: () => originAssistantInputId,
+          recordDetachedUsage,
+        }),
+        model: 'gpt-5.6-sol',
+        modelProvider: 'openai',
+        prompt: 'fail after exact hosted child usage arrives',
+        sandbox: 'workspace-write',
+        usageOperationId: 'turn-hosted-subagent-failure-usage',
+        workingDirectory,
+      }).then(
+        () => {
+          throw new Error('expected the Codex turn to fail')
+        },
+        (turnError: unknown) => turnError,
+      )
+
+      expect(error).toMatchObject({ code: 'ASSISTANT_CODEX_FAILED' })
+      expect(
+        readCodexAppServerTurnFailureContext(error)?.additionalUsages,
+      ).toEqual([])
+      expect(recordDetachedUsage).toHaveBeenCalledTimes(1)
+      expect(recordDetachedUsage.mock.calls[0]?.[0]).toMatchObject({
+        operationId: 'turn-hosted-subagent-failure-usage',
+        originAssistantInputId,
+        usageDraft: {
+          provider: 'codex-cli',
+          providerRequestOrdinal: 1,
+          usage: {
+            inputTokens: 91,
+            outputTokens: 23,
+            providerRequestId: 'response-hosted-subagent-fail-child',
+            reasoningTokens: 7,
+            totalTokens: 114,
+            usageExtractionSourcePath:
+              'subagent.rawResponse.completed.usage',
+          },
+        },
+      })
+    })
+
     it('includes pending reactions in the failure context when a no-reply turn fails', async () => {
       const workingDirectory = await createTempDir('assistant-codex-reaction-fail-work-')
       const codexHome = await createTempDir('assistant-codex-reaction-fail-home-')
@@ -20691,6 +20812,94 @@ describe('assistant codex event shaping', () => {
       expect(spawnedChildren).toHaveLength(1)
     })
 
+    it('flushes parsed hosted child usage when the idle process exits', async () => {
+      const workingDirectory = await createTempDir('assistant-codex-idle-exit-usage-work-')
+      const codexHome = await createTempDir('assistant-codex-idle-exit-usage-home-')
+      const spawnedChildren: MockChildProcess[] = []
+      const releaseChild = createDeferred<void>()
+      const processClosed = createDeferred<void>()
+      const originAssistantInputId = `ain_${'c'.repeat(32)}`
+      const recordDetachedUsage = vi.fn()
+      mockWarmCodexProcess(spawnedChildren, 31_825, async (child) => {
+        await initializeWarmTurn(
+          child,
+          'thread-idle-exit-usage-parent',
+          'turn-idle-exit-usage-parent',
+        )
+        writeSubAgentActivity(
+          child,
+          'thread-idle-exit-usage-parent',
+          'thread-idle-exit-usage-child',
+          'started',
+          { turnId: 'turn-idle-exit-usage-parent' },
+        )
+        writeCompletedTurn(
+          child,
+          'thread-idle-exit-usage-parent',
+          'turn-idle-exit-usage-parent',
+        )
+        await releaseChild.promise
+        writeStartedTurn(
+          child,
+          'thread-idle-exit-usage-child',
+          'turn-idle-exit-usage-child',
+        )
+        child.stdout.write(jsonLine({
+          method: 'rawResponse/completed',
+          params: {
+            responseId: 'response-idle-exit-usage-child',
+            threadId: 'thread-idle-exit-usage-child',
+            turnId: 'turn-idle-exit-usage-child',
+            usage: {
+              cacheWriteInputTokens: 0,
+              cachedInputTokens: 9,
+              inputTokens: 71,
+              outputTokens: 17,
+              reasoningOutputTokens: 4,
+              totalTokens: 88,
+            },
+          },
+        }))
+        child.emit('exit', 1, null)
+        child.emit('close', 1, null)
+        processClosed.resolve(undefined)
+      })
+
+      const result = await executeBackgroundBoundaryTurn(
+        codexHome,
+        workingDirectory,
+        'reply before the detached child finishes',
+        {
+          hostedToolContext: createHostedToolContext({
+            currentAssistantInputId: () => originAssistantInputId,
+            recordDetachedUsage,
+          }),
+          usageOperationId: 'turn-idle-process-exit-usage',
+        },
+      )
+      expect(result.finalMessage).toBe('')
+      expect(result.additionalUsages).toEqual([])
+      expect(recordDetachedUsage).not.toHaveBeenCalled()
+
+      releaseChild.resolve(undefined)
+      await processClosed.promise
+      expect(recordDetachedUsage).toHaveBeenCalledTimes(1)
+      expect(recordDetachedUsage.mock.calls[0]?.[0]).toMatchObject({
+        operationId: 'turn-idle-process-exit-usage',
+        originAssistantInputId,
+        usageDraft: {
+          providerRequestOrdinal: 1,
+          usage: {
+            inputTokens: 71,
+            outputTokens: 17,
+            providerRequestId: 'response-idle-exit-usage-child',
+            reasoningTokens: 4,
+            totalTokens: 88,
+          },
+        },
+      })
+    })
+
     it('keeps the root reply nonblocking while the workspace boundary waits for descendants', async () => {
       const workingDirectory = await createTempDir('assistant-codex-background-boundary-work-')
       const codexHome = await createTempDir('assistant-codex-background-boundary-home-')
@@ -20699,6 +20908,8 @@ describe('assistant codex event shaping', () => {
       const childStarted = createDeferred<void>()
       const completeChild = createDeferred<void>()
       const terminalScanObserved = createDeferred<void>()
+      const originAssistantInputId = `ain_${'8'.repeat(32)}`
+      const recordDetachedUsage = vi.fn()
       mockWarmCodexProcess(spawnedChildren, 31_850, async (child) => {
         await initializeWarmTurn(
           child,
@@ -20729,6 +20940,24 @@ describe('assistant codex event shaping', () => {
         )
         childStarted.resolve(undefined)
         await completeChild.promise
+        const rawResponse = {
+          method: 'rawResponse/completed',
+          params: {
+            responseId: 'response-background-boundary-child',
+            threadId: 'thread-background-boundary-child',
+            turnId: 'turn-background-boundary-child',
+            usage: {
+              cacheWriteInputTokens: 0,
+              cachedInputTokens: 10,
+              inputTokens: 80,
+              outputTokens: 20,
+              reasoningOutputTokens: 5,
+              totalTokens: 100,
+            },
+          },
+        }
+        child.stdout.write(jsonLine(rawResponse))
+        child.stdout.write(jsonLine(rawResponse))
         writeCompletedTurn(
           child,
           'thread-background-boundary-child',
@@ -20745,8 +20974,16 @@ describe('assistant codex event shaping', () => {
         codexHome,
         workingDirectory,
         'delegate ingestion and reply now',
+        {
+          hostedToolContext: createHostedToolContext({
+            currentAssistantInputId: () => originAssistantInputId,
+            recordDetachedUsage,
+          }),
+          usageOperationId: 'turn-hosted-detached-subagent-usage',
+        },
       )
       expect(result.turnId).toBe('turn-background-boundary-parent')
+      expect(result.additionalUsages).toEqual([])
 
       let boundaryResolved = false
       const boundary = waitForWarmCodexBackgroundWork().then(() => {
@@ -20762,6 +20999,21 @@ describe('assistant codex event shaping', () => {
       await terminalScanObserved.promise
       await expect(boundary).resolves.toBeUndefined()
       expect(boundaryResolved).toBe(true)
+      expect(recordDetachedUsage).toHaveBeenCalledExactlyOnceWith({
+        effectiveEnv: expect.objectContaining({ PATH: '/custom/bin' }),
+        operationId: 'turn-hosted-detached-subagent-usage',
+        originAssistantInputId,
+        usageDraft: expect.objectContaining({
+          provider: 'codex-cli',
+          providerRequestOrdinal: 1,
+          usage: expect.objectContaining({
+            providerRequestId: 'response-background-boundary-child',
+            totalTokens: 100,
+            usageExtractionSourcePath:
+              'subagent.rawResponse.completed.usage',
+          }),
+        }),
+      })
       expect(spawnedChildren).toHaveLength(1)
     })
 
@@ -24604,6 +24856,7 @@ async function executeBackgroundBoundaryTurn(
   codexHome: string,
   workingDirectory: string,
   prompt: string,
+  overrides: Partial<CodexAppServerTurnInput> = {},
 ) {
   return await executeCodexAppServerTurn({
     approvalPolicy: 'never',
@@ -24612,6 +24865,7 @@ async function executeBackgroundBoundaryTurn(
     prompt,
     sandbox: 'workspace-write',
     workingDirectory,
+    ...overrides,
   })
 }
 

--- a/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
@@ -3451,6 +3451,22 @@ text(result.output);
       const childResult = `LATE_CHILD_RESULT_${scopeLabel}`
       const firstPrompt = `SPAWN_LATE_CHILD_${scopeLabel}`
       const laterPrompt = `USE_LATE_CHILD_${scopeLabel}`
+      const originAssistantInputId = conversationScope === 'direct'
+        ? `ain_${'9'.repeat(32)}`
+        : `ain_${'a'.repeat(32)}`
+      const usageOperationId = `turn-meter-delayed-${conversationScope}`
+      const recordDetachedUsage = vi.fn()
+      const hostedToolContext: AssistantHostedToolContext = {
+        computerToolsAvailable: false,
+        currentAssistantInputId: () => originAssistantInputId,
+        currentHostedDeliveryContext: () => null,
+        currentHostedMailboxItemIds: () => [],
+        recordDetachedUsage,
+        sendVaultFile: async () => {
+          throw new Error('Vault-file sending is unavailable for this turn.')
+        },
+        vaultFileSendAvailable: false,
+      }
       scenario.stub.queue(
         {
           functionCall: {
@@ -3472,6 +3488,7 @@ text(result.output);
             `late_child_${conversationScope}`,
           ],
           text: childResult,
+          usageInputTokens: 53,
         },
         {
           requestExcludes: ['Message Type: FINAL_ANSWER'],
@@ -3484,11 +3501,14 @@ text(result.output);
         ...scenario.turnInput,
         baseInstructions: buildScriptedHostedSystemPrompt(conversationScope),
         groupConversation: conversationScope === 'group',
+        hostedToolContext,
         prompt: firstPrompt,
+        usageOperationId,
       })
 
       expect(first.finalMessage).toBe(`ROOT_REPLIED_WITHOUT_WAIT_${scopeLabel}`)
       expect(first.sessionId).toEqual(expect.any(String))
+      expect(first.additionalUsages).toEqual([])
       expect(
         scenario.stub.completedResponseLabelsSinceBaseline(),
       ).not.toContain(childResult)
@@ -3503,7 +3523,40 @@ text(result.output);
       expect(
         scenario.stub.completedResponseLabelsSinceBaseline(),
       ).toContain(childResult)
-      await delay(100)
+      const usageDeadline = Date.now() + 5_000
+      while (
+        recordDetachedUsage.mock.calls.length === 0
+        && Date.now() < usageDeadline
+      ) {
+        await delay(20)
+      }
+      expect(recordDetachedUsage).toHaveBeenCalledTimes(1)
+      const recordedUsage = recordDetachedUsage.mock.calls[0]?.[0]
+      expect(recordedUsage).toMatchObject({
+        operationId: usageOperationId,
+        originAssistantInputId,
+        usageDraft: {
+          provider: 'codex-cli',
+          providerRequestOrdinal: 1,
+          usage: expect.objectContaining({
+            inputTokens: 53,
+            outputTokens: 7,
+            providerMetadataJson: {
+              reasoningEffort: 'low',
+              requestedServiceTier: null,
+            },
+            providerName: SCRIPTED_MODEL_PROVIDER,
+            providerRequestId: expect.stringMatching(/^resp_scripted_/u),
+            reasoningTokens: 0,
+            requestedModel: SCRIPTED_MODEL,
+            servedModel: SCRIPTED_MODEL,
+            totalTokens: 60,
+            usageExtractionSourcePath:
+              'subagent.rawResponse.completed.usage',
+          }),
+        },
+      })
+      expect(recordedUsage?.effectiveEnv).toEqual(expect.any(Object))
 
       scenario.stub.queue({
         requestIncludes: [
@@ -3515,12 +3568,16 @@ text(result.output);
       const later = await executeCodexAppServerTurn({
         ...scenario.turnInput,
         groupConversation: conversationScope === 'group',
+        hostedToolContext,
         prompt: laterPrompt,
         resumeSessionId: first.sessionId,
+        usageOperationId: `turn-later-${conversationScope}`,
       })
 
       expect(later.finalMessage).toBe(`INCORPORATED_${childResult}`)
       expect(later.threadId).toBe(first.threadId)
+      expect(later.additionalUsages).toEqual([])
+      expect(recordDetachedUsage).toHaveBeenCalledTimes(1)
       expect(scenario.stub.requestCountSinceBaseline()).toBe(4)
     },
   )

--- a/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-scripted-runtime.test.ts
@@ -3357,6 +3357,89 @@ text(result.output);
     expect((await readFile(requestLog, 'utf8')).trim().split('\n')).toHaveLength(3)
   })
 
+  it('meters one synchronous child through the real pinned app-server', {
+    timeout: TURN_TIMEOUT_MS,
+  }, async () => {
+    const scenario = await prepareScriptedTurnScenario({
+      multiAgentV2: true,
+    })
+    const rootPrompt = 'METER_ONE_SYNCHRONOUS_CHILD'
+    const childResult = 'SYNCHRONOUS_CHILD_COMPLETE'
+    scenario.stub.queue(
+      {
+        functionCall: {
+          arguments: {
+            fork_turns: 'none',
+            message: `Return exactly ${childResult}.`,
+            task_name: 'exact_usage_child',
+          },
+          name: 'spawn_agent',
+          namespace: 'collaboration',
+        },
+        requestIncludes: [rootPrompt],
+      },
+      {
+        completionLabel: childResult,
+        requestIncludes: [
+          'Message Type: NEW_TASK',
+          'exact_usage_child',
+        ],
+        text: childResult,
+        usageInputTokens: 37,
+      },
+      {
+        functionCall: {
+          arguments: {},
+          name: 'wait_agent',
+          namespace: 'collaboration',
+        },
+        requestExcludes: ['Message Type: NEW_TASK'],
+        requestIncludes: [rootPrompt],
+      },
+      {
+        requestExcludes: ['Message Type: NEW_TASK'],
+        requestIncludes: [rootPrompt],
+        text: 'ROOT_COMPLETED_AFTER_CHILD',
+      },
+    )
+
+    const result = await executeCodexAppServerTurn({
+      ...scenario.turnInput,
+      baseInstructions: 'Use the scripted collaboration tools and return the final result.',
+      prompt: rootPrompt,
+    })
+
+    expect(result.finalMessage).toBe('ROOT_COMPLETED_AFTER_CHILD')
+    expect(result.additionalUsages).toMatchObject([{
+      provider: 'codex-cli',
+      providerRequestOrdinal: 1,
+      usage: {
+        inputTokens: 37,
+        outputTokens: 7,
+        providerMetadataJson: {
+          reasoningEffort: 'low',
+          requestedServiceTier: null,
+        },
+        providerName: SCRIPTED_MODEL_PROVIDER,
+        providerRequestId: expect.stringMatching(/^resp_scripted_/u),
+        reasoningTokens: 0,
+        requestedModel: SCRIPTED_MODEL,
+        servedModel: SCRIPTED_MODEL,
+        totalTokens: 44,
+        usageExtractionSourcePath: 'subagent.rawResponse.completed.usage',
+      },
+    }])
+    expect(result.additionalUsages).toHaveLength(1)
+    expect(
+      result.jsonEvents
+        .map((event) => readString(readRecord(event)?.method))
+        .filter((method): method is string => method !== null),
+    ).not.toEqual(expect.arrayContaining([
+      'rawResponseItem/completed',
+      'rawResponse/completed',
+    ]))
+  })
+
   it.each(['direct', 'group'] as const)(
     'carries a delayed V2 child completion into a later %s root turn without waiting',
     { timeout: TURN_TIMEOUT_MS },

--- a/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
@@ -13,6 +13,7 @@ import {
   type CodexSubagentTurnTokenUsageSample,
   extractCodexSubagentUsageDrafts,
   hashAssistantProviderStableJson,
+  readCodexCollabReceiverEvidence,
 } from '../src/assistant/providers/helpers.ts'
 
 const SUBAGENT_PROVIDER_REQUEST_STARTED_AT = '2026-07-23T11:59:00.000Z'
@@ -117,6 +118,31 @@ function sampleFromEvents(
 }
 
 describe('extractCodexSubagentUsageDrafts', () => {
+  it('classifies V2 activity as detached and V1 collaboration as root-bound', () => {
+    expect(readCodexCollabReceiverEvidence({
+      method: 'item/completed',
+      params: {
+        item: {
+          agentThreadId: 'thread-child-v2',
+          kind: 'started',
+          type: 'subAgentActivity',
+        },
+      },
+    })).toEqual([{
+      detached: true,
+      requestedModel: null,
+      threadId: 'thread-child-v2',
+    }])
+    expect(readCodexCollabReceiverEvidence(spawnEndEvent({
+      model: 'gpt-5.6-terra-mini',
+      receiverThreadIds: ['thread-child-v1'],
+    }))).toEqual([{
+      detached: false,
+      requestedModel: 'gpt-5.6-terra-mini',
+      threadId: 'thread-child-v1',
+    }])
+  })
+
   it('returns no drafts without subagent samples', () => {
     expect(
       extractCodexSubagentUsageDrafts({

--- a/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-subagent-usage.test.ts
@@ -45,6 +45,30 @@ function tokenUsageEvent(input: {
   }
 }
 
+function rawResponseCompletedEvent(input: {
+  responseId: string
+  threadId: string
+  turnId: string
+  usage: Record<string, number> | null
+}): Record<string, unknown> {
+  return {
+    method: 'rawResponse/completed',
+    params: {
+      responseId: input.responseId,
+      threadId: input.threadId,
+      turnId: input.turnId,
+      usage: input.usage === null
+        ? null
+        : {
+            cacheWriteInputTokens: 0,
+            cachedInputTokens: 0,
+            reasoningOutputTokens: 0,
+            ...input.usage,
+          },
+    },
+  }
+}
+
 function spawnEndEvent(input: {
   receiverThreadIds: readonly string[]
   model?: string
@@ -139,6 +163,133 @@ describe('extractCodexSubagentUsageDrafts', () => {
       providerName: 'hosted-openai',
       tokenPricingBasis: 'openai-flex',
     })
+  })
+
+  it('uses exact raw response usage once per response and attributes effective child metadata', () => {
+    const threadId = 'thread-raw-child'
+    const turnId = 'turn-raw-child'
+    const cumulative = tokenUsageEvent({
+      threadId,
+      turnId,
+      total: { inputTokens: 900, outputTokens: 99, totalTokens: 999 },
+      last: { inputTokens: 900, outputTokens: 99, totalTokens: 999 },
+    })
+    const firstRaw = rawResponseCompletedEvent({
+      responseId: 'response-raw-1',
+      threadId,
+      turnId,
+      usage: {
+        cachedInputTokens: 40,
+        inputTokens: 80,
+        outputTokens: 20,
+        reasoningOutputTokens: 5,
+        totalTokens: 100,
+      },
+    })
+    const secondRaw = rawResponseCompletedEvent({
+      responseId: 'response-raw-2',
+      threadId,
+      turnId,
+      usage: {
+        inputTokens: 160,
+        outputTokens: 40,
+        reasoningOutputTokens: 10,
+        totalTokens: 200,
+      },
+    })
+    const sample = sampleFromEvents([cumulative])
+    sample.executionMetadata = {
+      model: 'gpt-5.6-sol',
+      modelProvider: 'openai',
+      reasoningEffort: 'high',
+      serviceTier: 'flex',
+    }
+    sample.rawResponseEvents = [
+      firstRaw,
+      firstRaw,
+      {
+        method: 'rawResponse/completed',
+        params: {
+          responseId: 'response-malformed',
+          threadId,
+          turnId,
+          usage: { input_tokens: 50, output_tokens: 10 },
+        },
+      },
+      secondRaw,
+    ]
+
+    const drafts = extractCodexSubagentUsageDrafts({
+      modelProvider: 'local-test-provider',
+      ordinalStart: 4,
+      parentModel: 'gpt-5.6-sol',
+      parentRawEvents: [spawnEndEvent({
+        model: 'gpt-5.6-terra',
+        receiverThreadIds: [threadId],
+      })],
+      serviceTier: null,
+      subagentTokenUsageByTurn: new Map([[threadId, sample]]),
+    })
+
+    expect(drafts).toHaveLength(2)
+    expect(drafts).toMatchObject([
+      {
+        providerRequestOrdinal: 4,
+        usage: {
+          cachedInputTokens: 40,
+          inputTokens: 80,
+          outputTokens: 20,
+          providerMetadataJson: {
+            reasoningEffort: 'high',
+            requestedServiceTier: 'flex',
+          },
+          providerName: 'openai',
+          providerRequestId: 'response-raw-1',
+          reasoningTokens: 5,
+          requestedModel: 'gpt-5.6-terra',
+          servedModel: 'gpt-5.6-sol',
+          tokenPricingBasis: 'openai-flex',
+          totalTokens: 100,
+          usageExtractionSourcePath: 'subagent.rawResponse.completed.usage',
+        },
+      },
+      {
+        providerRequestOrdinal: 5,
+        usage: {
+          inputTokens: 160,
+          outputTokens: 40,
+          providerRequestId: 'response-raw-2',
+          reasoningTokens: 10,
+          totalTokens: 200,
+        },
+      },
+    ])
+    expect(drafts.map((draft) => draft.usage.totalTokens)).toEqual([100, 200])
+  })
+
+  it('does not fall back to cumulative estimates after an exact raw lifecycle signal', () => {
+    const threadId = 'thread-raw-null-child'
+    const turnId = 'turn-raw-null-child'
+    const cumulative = tokenUsageEvent({
+      threadId,
+      turnId,
+      total: { inputTokens: 80, outputTokens: 20, totalTokens: 100 },
+      last: { inputTokens: 80, outputTokens: 20, totalTokens: 100 },
+    })
+    const sample = sampleFromEvents([cumulative])
+    sample.rawResponseEvents = [rawResponseCompletedEvent({
+      responseId: 'response-without-usage',
+      threadId,
+      turnId,
+      usage: null,
+    })]
+
+    expect(extractCodexSubagentUsageDrafts({
+      modelProvider: 'openai',
+      ordinalStart: 1,
+      parentRawEvents: [spawnEndEvent({ receiverThreadIds: [threadId] })],
+      subagentTokenUsageByTurn: new Map([[threadId, sample]]),
+    })).toEqual([])
   })
 
   it('builds per-turn total deltas with spawn-attributed models', () => {

--- a/packages/cli/test/assistant-codex.test.ts
+++ b/packages/cli/test/assistant-codex.test.ts
@@ -255,6 +255,7 @@ test('executeCodexAppServerTurn runs the JSON-RPC lifecycle and returns streamed
             approvalPolicy: 'never',
             cwd: expectedWorkingDirectory,
             dynamicTools,
+            experimentalRawEvents: true,
             model: 'gpt-5',
             sandbox: 'workspace-write',
             serviceName: 'murph',


### PR DESCRIPTION
## Outcome

Record authoritative per-request usage for every authorized Codex child-agent provider request, including detached MultiAgent V2 work that completes after its root reply. Fresh raw-enabled lifecycles emit one usage draft per exact `rawResponse/completed` response, deduplicated by response ID; cold and legacy lifecycles retain the cumulative delta fallback, and a lifecycle never uses both sources. Effective child model, provider, reasoning effort, and service tier come from best-effort metadata when available.

The resident Codex app-server process now owns child accounting evidence for the same lifetime in which it already owns detached execution. Canonical parent collaboration events remain the only billing authority. The original root supplies its stable turn identity, accepted-input authority, model context, and ordinal allocator; hosted drafts use the existing assistant-engine detached-usage writer even when child usage arrives while idle or during a later root turn.

Raw response payload notifications and metadata-resume responses remain excluded from the persisted parent event surface. Child prompts, messages, thread IDs, and reasoning content are never persisted by this path.

## Product UX

Product UX Patch — `Ready`. A hosted member whose turn delegates to a child receives the root reply or failure recovery without waiting for optional accounting metadata or detached completion, while authorized child work is charged exactly once. There is no user-visible content, action, or presentation change.

## Evidence

- `pnpm --dir packages/assistant-engine exec vitest run test/assistant-codex-subagent-usage.test.ts` — 15 passed.
- `pnpm --dir packages/assistant-engine exec vitest run test/assistant-codex-runtime.test.ts` — 276 passed.
- `pnpm --dir packages/assistant-engine exec vitest run test/assistant-codex-scripted-runtime.test.ts` — 99 passed through the real pinned Codex app-server.
- `pnpm --dir packages/cli exec vitest run test/assistant-codex.test.ts` — 9 passed.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- `pnpm docs:drift`, `git diff --check`, and privacy scans — passed.

The real app-server proof covers direct and group roots that return before their detached children, exact usage recorded once during idle, and child results consumed by a later root. Mocked runtime proofs additionally cover synchronous children, child-before-parent evidence, duplicates, root failure, metadata timeout cleanup, checkpoint completion/interruption, requested stop, and unexpected idle process loss.

## Non-obvious affected surfaces

- Fresh Codex app-server thread starts opt into raw events; exact request-shape tests cover assistant-engine and the public CLI fixture.
- The process observes foreign-thread accounting events before active/idle routing, but billing and metadata lookup remain fail-closed until a canonical parent collaboration event names that thread.
- MultiAgent V2 activity evidence retains hosted authority after root settlement. V1 and non-hosted result authority is released with the root.
- Original-root operation IDs and a retained ordinal allocator keep detached rows in the same idempotency namespace as root and dynamic-tool provider requests.
- Workspace checkpoints force fallback and clear bounded evidence only after detached children and background terminals are quiescent. Interrupted checkpoints preserve the owner for a later attempt.
- Requested shutdown and unexpected close flush evidence already parsed from stdout. Usage that never reached stdout before process loss is unknowable and is never fabricated.
- Metadata responses that arrive after a completed boundary are generation-gated and cannot repopulate cleared accounting state.

## Architecture and reuse

- **Existing systems reused:** `CodexAppServerProcess` as the detached lifecycle owner; canonical collaboration evidence; the existing background RPC timeout; `recordDetachedUsage` and assistant-engine's sole usage-ledger writer; provider drafts, stable usage hashing, normalization, and pricing resolution.
- **New logic:** process-lifetime child authorization and samples, exact-or-cumulative finalization, response-ID deduplication, boundary generation cleanup, and original-root recording context.
- **New abstractions:** one child authorization value and one canonical receiver-evidence value. Non-hosted drafts still use the existing turn result buffer.
- **Complexity intentionally avoided:** no Codex fork, copied protocol schema, dependency, database/schema change, second writer, process-owned draft queue, terminal drain, retry loop, scheduler, durable queue, or payload persistence.

## Hot reply path impact

Applicable. Each canonically evidenced child thread adds at most one best-effort local app-server `thread/resume` JSON-RPC write with `excludeTurns: true`. Root settlement awaits neither that response nor detached completion. Hosted usage handoff calls the existing best-effort recorder off the reply path; unresolved metadata uses deterministic fallback at completion, checkpoint, stop, or process close.

## Murph initial provider input impact

- **Murph assembly:** Not applicable — no prompt, instruction, tool/schema, generated guidance, or other provider-visible request content changed.
- **Codex assembly:** Not applicable — `experimentalRawEvents` and metadata-only `thread/resume` are app-server control-plane fields and do not alter model request input.

## Risks

Billing correctness depends on canonical authorization, preserving original-root idempotency fields, selecting one source per child lifecycle, and deduplicating exact responses. Privacy depends on raw child events remaining process-local and excluded from persisted parent events. The highest-risk detached lifecycle paths have both mocked edge-case coverage and real pinned-protocol direct/group coverage.

## Review findings

- Preliminary specialists: accepted and fixed the terminal metadata delay and missing real-protocol coverage.
- Final round 1: accepted and fixed order-dependent child admission; its duplicate timing finding was already resolved by the same remediation.
- Original-head CI: fixed the stale public CLI request fixture that caused the CLI coverage timeout/cascade.
- Parent final review: fixed stale pending-request bookkeeping after a permanently unresolved metadata RPC without adding a success-path microtask.
- Final round 2: accepted the requirement-level finding that turn-local ownership discarded detached V2 usage after root settlement. The retrospective now defines success, failure, idle/later-turn, checkpoint, shutdown, and loss semantics; the implementation reuses the resident process and existing detached writer rather than adding another queue or owner.$'\n'- Final round 3: `ROUND_OUTCOME: PASS` on the full sensitive snapshot; no qualifying finding remained and every prior accepted finding was confirmed resolved.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new assistant-engine instances may coexist; generic usage rows already accept cumulative and exact extraction paths plus nullable metadata.
- Safe order: Ordinary assistant-engine rollout; no reader/writer or client sequencing is required.
- Rollback floor: There is no schema or incompatible persisted state, so rollback remains safe after exact rows are written.
- Expected exposure: During a mixed rollout, separate turns may use exact raw metering or the existing cumulative fallback; each child lifecycle remains single-owner and single-source.
- Reversibility: Roll back the assistant-engine build; subsequent turns return to cumulative fallback while existing generic usage rows remain valid.
- Convergence proof: Confirm all assistant-engine instances report the deployed version and fresh synchronous plus detached child turns record the exact extraction source once.
- Post-deploy checks: Inspect bounded aggregates for extraction-source mix, duplicate non-null provider request IDs, and Codex runtime/protocol error rates.

## Changelog

- Changelog: not applicable
- Reason: Internal usage-accounting correction with no user-facing content or surface change.

## Change shape

Classification rule: authored engine implementation is source; Vitest files are tests/fixtures; the execution plan is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 739 | 154 |
| Tests/fixtures | 1189 | 3 |
| Docs | 123 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2051** | **157** |

ReviewGPT context sensitivity: sensitive — billing, privacy, hosted runtime ordering, and provider control-plane behavior change.

ReviewGPT first-reviewed head: 6928dc5b4a51e9dd71726abc38cc81221de99e54