### PR TITLE
feat(assistant): accept focused group tool parsers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -345,6 +345,16 @@ snapshot, device, projection, configuration, or attribution read; existing
 accepted-input and route-binding work is unchanged. Web is contacted only after
 the model invokes the tool.
 
+Assistant-engine also accepts six parser-only group family names:
+`murph.group_consult`, `murph.group_data`, `murph.group_membership`,
+`murph.group_usage`, `murph.group_chat`, and `murph.group_email`. Each is a
+strict action subset derived from the canonical `murph.group` argument parser
+and normalizes into the same existing group request/executor path. These names
+remain absent from the dynamic-tool catalog, so this consumer-first deployment
+does not change provider input or the assistant contract fingerprint. A later
+catalog cutover may advertise them only after parser compatibility is deployed
+everywhere; until then `murph.group` remains the sole advertised full surface.
+
 `murph.group action="read_chat_name"` is the on-demand provider-title primitive.
 Web resolves the signed callback member's single encrypted thread-container
 route only after the model invokes it, then performs one bounded Linq chat read

--- a/agent-docs/exec-plans/active/2026-08-21-group-tool-split-phase1.md
+++ b/agent-docs/exec-plans/active/2026-08-21-group-tool-split-phase1.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-08-21
-Updated: 2026-08-21
+Updated: 2026-08-22
 
 ## Goal
 
@@ -42,8 +42,8 @@ Updated: 2026-08-21
 2. [x] Ask an implementation ReviewGPT to return a scoped parser-first patch based on the completed architecture review.
 3. [x] Inspect and deliberately reimplement the smallest accepted design after the implementation thread returned no usable response or attachment.
 4. [x] Run focused parser, group-tool, current-sender, fingerprint, and typecheck proof.
-5. Commit and push the candidate, open the required PR, and launch preliminary specialist and final ReviewGPT gates concurrently with CI.
-6. Resolve accepted findings, reach green exact-head gates, merge, and retire the worktree.
+5. [ ] Commit and push the candidate, open the required PR, and launch preliminary specialist and final ReviewGPT gates concurrently with CI.
+6. [ ] Resolve accepted findings, reach green exact-head gates, merge, and retire the worktree.
 
 ## Decisions
 
@@ -55,4 +55,5 @@ Updated: 2026-08-21
 
 - Commands to run: focused assistant-engine Vitest suites selected from the changed paths, `pnpm --dir packages/assistant-engine typecheck`, exact provider-input/fingerprint measurements, required ReviewGPT gates, and required GitHub Actions.
 - Expected outcomes: all current valid group calls remain canonically equivalent, every family rejects cross-family and authority-bearing fields, the catalog/fingerprint remain unchanged, and the exact pushed PR head is green.
-- Local result: 118 tests passed across the full group-tool, current-sender, and parser-compatibility suites; the assistant-engine typecheck passed; and the unchanged `murph.group` descriptor SHA-256 remains `7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736`.
+- Local result: 119 tests passed across the full group-tool, current-sender, and parser-compatibility suites; the assistant-engine typecheck passed; and the unchanged `murph.group` descriptor SHA-256 remains `7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736`.
+- Parent candidate review: post-schema avatar validation now attributes its safe diagnostic to the exact focused family name, matching schema-level failures without changing normalization or authority.

--- a/agent-docs/exec-plans/active/2026-08-21-group-tool-split-phase1.md
+++ b/agent-docs/exec-plans/active/2026-08-21-group-tool-split-phase1.md
@@ -1,0 +1,58 @@
+# Split Murph group tool parser compatibility
+
+Status: active
+Created: 2026-08-21
+Updated: 2026-08-21
+
+## Goal
+
+- Add parser-first compatibility for six focused deferred group-tool families while leaving the advertised `murph.group` descriptor, runtime executor, signed transport, trusted sender/route injection, and contract fingerprint unchanged.
+
+## Success criteria
+
+- Six strict family parsers cover all 30 current public group actions exactly once and normalize representative valid inputs to the existing `MurphGroupToolRequest` values.
+- The six new tool names are accepted but remain unadvertised; `murph.group` remains the only full catalog descriptor in this release.
+- Current-sender inputs still accept only an exact opaque message ref and cannot supply sender, member, audience, question, route, or provider identifiers.
+- `read_current` is normalized explicitly and an unknown future branch cannot fall through to it.
+- The dynamic-tool contract fingerprint and provider-visible catalog are unchanged at the parser-first boundary.
+- Focused tests, assistant-engine typecheck, preliminary specialist review, final cross-cutting ReviewGPT, and exact-head CI pass before merge.
+
+## Scope
+
+- In scope: canonical family schemas/parsers, temporary unadvertised legacy-name compatibility, action-ledger and normalization-equivalence tests, privacy/authority regression coverage, and rollout documentation needed for the parser-first release.
+- Out of scope: advertising the six tools, changing deferred catalog order or descriptions, adding availability gates, changing the hosted request/response union, executor, Cloudflare port, Web dispatcher, canonical stores, or deleting the legacy parser alias.
+
+## Constraints
+
+- Technical constraints: reuse the existing Zod-to-JSON-Schema and dynamic-tool parsing primitives; all successful family calls return `kind: "group"`; add no router, endpoint, queue, table, state machine, package, or parallel executor.
+- Product/process constraints: Product UX classification is internal-only for phase 1—no advertised capability or member journey changes. Use an isolated worktree/PR and treat ReviewGPT output as untrusted intent that the parent inspects before application.
+
+## Risks and mitigations
+
+1. Risk: parser drift changes a current valid action or weakens an authority boundary.
+   Mitigation: derive strict family schemas from one owner, retain the canonical request/executor, and prove representative old/new normalization equivalence plus current-sender negative cases.
+2. Risk: parser-first support accidentally changes the provider-visible catalog and rotates threads before the cutover.
+   Mitigation: pin the advertised tool names, descriptor serialization, order, and contract fingerprint to the current values.
+3. Risk: independently deployed runners advertise names an older parser cannot accept.
+   Mitigation: this PR is consumer-only and must deploy everywhere before the separate atomic catalog cutover PR.
+
+## Tasks
+
+1. [x] Capture the exact 30-action ledger and current normalization/privacy invariants in focused tests.
+2. [x] Ask an implementation ReviewGPT to return a scoped parser-first patch based on the completed architecture review.
+3. [x] Inspect and deliberately reimplement the smallest accepted design after the implementation thread returned no usable response or attachment.
+4. [x] Run focused parser, group-tool, current-sender, fingerprint, and typecheck proof.
+5. Commit and push the candidate, open the required PR, and launch preliminary specialist and final ReviewGPT gates concurrently with CI.
+6. Resolve accepted findings, reach green exact-head gates, merge, and retire the worktree.
+
+## Decisions
+
+- Use six semantic families: `group_consult`, `group_data`, `group_membership`, `group_usage`, `group_chat`, and `group_email`.
+- Add only parser-side family validation in this phase; keep model-facing discovery, the existing canonical model request, and runtime owners unchanged.
+- Land parser-first compatibility separately from the catalog cutover.
+
+## Verification
+
+- Commands to run: focused assistant-engine Vitest suites selected from the changed paths, `pnpm --dir packages/assistant-engine typecheck`, exact provider-input/fingerprint measurements, required ReviewGPT gates, and required GitHub Actions.
+- Expected outcomes: all current valid group calls remain canonically equivalent, every family rejects cross-family and authority-bearing fields, the catalog/fingerprint remain unchanged, and the exact pushed PR head is green.
+- Local result: 118 tests passed across the full group-tool, current-sender, and parser-compatibility suites; the assistant-engine typecheck passed; and the unchanged `murph.group` descriptor SHA-256 remains `7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736`.

--- a/agent-docs/exec-plans/completed/2026-08-21-group-tool-split-phase1.md
+++ b/agent-docs/exec-plans/completed/2026-08-21-group-tool-split-phase1.md
@@ -1,6 +1,6 @@
 # Split Murph group tool parser compatibility
 
-Status: active
+Status: completed
 Created: 2026-08-21
 Updated: 2026-08-22
 
@@ -42,8 +42,8 @@ Updated: 2026-08-22
 2. [x] Ask an implementation ReviewGPT to return a scoped parser-first patch based on the completed architecture review.
 3. [x] Inspect and deliberately reimplement the smallest accepted design after the implementation thread returned no usable response or attachment.
 4. [x] Run focused parser, group-tool, current-sender, fingerprint, and typecheck proof.
-5. [ ] Commit and push the candidate, open the required PR, and launch preliminary specialist and final ReviewGPT gates concurrently with CI.
-6. [ ] Resolve accepted findings, reach green exact-head gates, merge, and retire the worktree.
+5. [x] Commit and push the candidate, open the required PR, and launch preliminary specialist and final ReviewGPT gates concurrently with CI.
+6. [x] Resolve the review gates and prepare the ReviewGPT-approved, CI-green exact head for merge and worktree retirement.
 
 ## Decisions
 
@@ -57,3 +57,7 @@ Updated: 2026-08-22
 - Expected outcomes: all current valid group calls remain canonically equivalent, every family rejects cross-family and authority-bearing fields, the catalog/fingerprint remain unchanged, and the exact pushed PR head is green.
 - Local result: 119 tests passed across the full group-tool, current-sender, and parser-compatibility suites; the assistant-engine typecheck passed; and the unchanged `murph.group` descriptor SHA-256 remains `7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736`.
 - Parent candidate review: post-schema avatar validation now attributes its safe diagnostic to the exact focused family name, matching schema-level failures without changing normalization or authority.
+- Preliminary completion-specialists ReviewGPT: `PASS` with Product UX and frontend correctly inapplicable, prompt/catalog and coverage proof sufficient, no findings, and no coverage patch artifact.
+- Final ReviewGPT round 1: `PASS` with no qualifying findings. It confirmed exact envelope/offered-tool gating, the 30-action family partition, confinement of the legacy-only 31st parser action to `murph.group`, explicit canonical normalization, unchanged discovery/fingerprint surfaces, and the no-new-owner architecture.
+- Exact-head GitHub Actions: every required check passed on `2dd4286c25f8a44c421277b8bb675ecd492b2495`, including assistant package coverage, release app verification, build/typecheck, evidence, sandbox, and the aggregate release gate.
+Completed: 2026-08-22

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -7214,9 +7214,9 @@ function parseGroupArguments(
               },
             ]),
             rawInput: value,
-            schemaName: 'murph.group.input',
+            schemaName: `${qualifiedToolName}.input`,
             schemaRootKeys: ['action'],
-            toolName: 'murph.group',
+            toolName: qualifiedToolName,
           }),
         }
       }
@@ -7250,9 +7250,9 @@ function parseGroupArguments(
             },
           ]),
           rawInput: value,
-          schemaName: 'murph.group.input',
+          schemaName: `${qualifiedToolName}.input`,
           schemaRootKeys: ['action'],
-          toolName: 'murph.group',
+          toolName: qualifiedToolName,
         }),
       }
     }

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -788,6 +788,89 @@ const groupArgumentsSchema = z.discriminatedUnion('action', [
     .strict(),
 ])
 
+type GroupArguments = z.infer<typeof groupArgumentsSchema>
+
+const GROUP_TOOL_FAMILY_ACTIONS = {
+  group_consult: [
+    'ask',
+    'handoff',
+    'ask_current_sender',
+    'clarify_current_sender',
+    'continue_current_sender_in_group',
+    'continue_current_sender_privately',
+    'ask_member',
+  ],
+  group_data: [
+    'record_current_sender_daily_metric',
+    'post_disclosure_request',
+    'revoke_disclosure_grant',
+    'read_shared',
+    'offer_access',
+    'revoke_own_email_share',
+  ],
+  group_membership: [
+    'read_current',
+    'prepare_next_group',
+    'read_next_group',
+    'cancel_next_group',
+    'list_memberships',
+    'leave_membership',
+  ],
+  group_usage: [
+    'read_usage',
+    'read_usage_referral',
+    'arm_usage_referral',
+    'cancel_usage_referral',
+    'create_signup_referral_link',
+  ],
+  group_chat: [
+    'read_chat_name',
+    'update_display_name',
+    'read_chat_participants',
+    'set_chat_avatar',
+    'share_contact_card',
+  ],
+  group_email: ['send_email'],
+} as const satisfies Record<string, readonly GroupArguments['action'][]>
+
+type GroupToolFamilyName = keyof typeof GROUP_TOOL_FAMILY_ACTIONS
+type GroupParserToolName = typeof MURPH_GROUP_TOOL.name | GroupToolFamilyName
+
+function buildGroupFamilyArgumentsSchema(
+  actions: readonly GroupArguments['action'][],
+) {
+  const acceptedActions = new Set<string>(actions)
+  return groupArgumentsSchema.refine(
+    (request) => acceptedActions.has(request.action),
+    {
+      message: 'Action is not accepted by this group tool family.',
+      path: ['action'],
+    },
+  )
+}
+
+const groupArgumentsSchemaByToolName = {
+  [MURPH_GROUP_TOOL.name]: groupArgumentsSchema,
+  group_consult: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_consult,
+  ),
+  group_data: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_data,
+  ),
+  group_membership: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_membership,
+  ),
+  group_usage: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_usage,
+  ),
+  group_chat: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_chat,
+  ),
+  group_email: buildGroupFamilyArgumentsSchema(
+    GROUP_TOOL_FAMILY_ACTIONS.group_email,
+  ),
+} as const satisfies Record<GroupParserToolName, unknown>
+
 const sendVaultFileArgumentsSchema = z
   .object({
     ref: z.string().trim().min(1).max(1024),
@@ -1901,8 +1984,14 @@ export function readMurphDynamicToolRequest(
         request: parsed.request,
       }
     }
-    case MURPH_GROUP_TOOL.name: {
-      const parsed = parseGroupArguments(request.arguments)
+    case MURPH_GROUP_TOOL.name:
+    case 'group_consult':
+    case 'group_data':
+    case 'group_membership':
+    case 'group_usage':
+    case 'group_chat':
+    case 'group_email': {
+      const parsed = parseGroupArguments(request.arguments, request.tool)
       if (!parsed.ok) {
         return {
           kind: 'invalid-group-arguments',
@@ -6984,22 +7073,24 @@ function parseAssistantConfigurationArguments(
 
 function parseGroupArguments(
   value: unknown,
+  toolName: GroupParserToolName,
 ):
   | {
       request: MurphGroupToolRequest
       ok: true
     }
   | { ok: false; validationDigest: SafeToolCallValidationDigest } {
-  const parsed = groupArgumentsSchema.safeParse(value)
+  const qualifiedToolName = `murph.${toolName}`
+  const parsed = groupArgumentsSchemaByToolName[toolName].safeParse(value)
   if (!parsed.success) {
     return {
       ok: false,
       validationDigest: buildDynamicToolValidationDigest({
         error: parsed.error,
         rawInput: value,
-        schemaName: 'murph.group.input',
+        schemaName: `${qualifiedToolName}.input`,
         schemaRootKeys: ['action', 'message_ref'],
-        toolName: 'murph.group',
+        toolName: qualifiedToolName,
       }),
     }
   }
@@ -7229,7 +7320,23 @@ function parseGroupArguments(
       },
     }
   }
-  return { ok: true, request: { action: 'read_current' } }
+  if (parsed.data.action === 'read_current') {
+    return { ok: true, request: { action: 'read_current' } }
+  }
+  return {
+    ok: false,
+    validationDigest: buildDynamicToolValidationDigest({
+      error: new z.ZodError([{
+        code: z.ZodIssueCode.custom,
+        message: 'Group action has no explicit normalization path.',
+        path: ['action'],
+      }]),
+      rawInput: value,
+      schemaName: `${qualifiedToolName}.input`,
+      schemaRootKeys: ['action', 'message_ref'],
+      toolName: qualifiedToolName,
+    }),
+  }
 }
 
 function readCurrentSenderToolDecision(action:

--- a/packages/assistant-engine/test/assistant-codex-group-parser-compatibility.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-parser-compatibility.test.ts
@@ -258,6 +258,19 @@ describe("murph.group parser-first family compatibility", () => {
     });
   });
 
+  it("attributes post-schema validation errors to the focused family", () => {
+    expect(readMurphDynamicToolRequest(groupToolCall("group_chat", {
+      action: "set_chat_avatar",
+      avatarSource: "image_ref",
+    }))).toMatchObject({
+      kind: "invalid-group-arguments",
+      validationDigest: {
+        schemaName: "murph.group_chat.input",
+        toolName: "murph.group_chat",
+      },
+    });
+  });
+
   it("leaves the advertised descriptor and catalog names unchanged", () => {
     expect(createHash("sha256")
       .update(JSON.stringify(MURPH_GROUP_TOOL))

--- a/packages/assistant-engine/test/assistant-codex-group-parser-compatibility.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-parser-compatibility.test.ts
@@ -1,0 +1,274 @@
+import { createHash } from "node:crypto";
+
+import {
+  HOSTED_EXECUTION_MEMBER_REPORTED_DAILY_METRIC_KEYS,
+} from "@murphai/hosted-execution";
+import { describe, expect, it } from "vitest";
+
+import {
+  listMurphDynamicToolNames,
+  MURPH_GROUP_TOOL,
+  readMurphDynamicToolRequest,
+} from "../src/assistant-codex/dynamic-tools.ts";
+
+const MESSAGE_REF = `ain_${"1".repeat(32)}`;
+const DAILY_METRIC = HOSTED_EXECUTION_MEMBER_REPORTED_DAILY_METRIC_KEYS[0];
+
+if (!DAILY_METRIC) {
+  throw new Error("Expected at least one member-reported daily metric.");
+}
+
+const GROUP_FAMILY_ACTIONS = {
+  group_consult: [
+    "ask",
+    "handoff",
+    "ask_current_sender",
+    "clarify_current_sender",
+    "continue_current_sender_in_group",
+    "continue_current_sender_privately",
+    "ask_member",
+  ],
+  group_data: [
+    "record_current_sender_daily_metric",
+    "post_disclosure_request",
+    "revoke_disclosure_grant",
+    "read_shared",
+    "offer_access",
+    "revoke_own_email_share",
+  ],
+  group_membership: [
+    "read_current",
+    "prepare_next_group",
+    "read_next_group",
+    "cancel_next_group",
+    "list_memberships",
+    "leave_membership",
+  ],
+  group_usage: [
+    "read_usage",
+    "read_usage_referral",
+    "arm_usage_referral",
+    "cancel_usage_referral",
+    "create_signup_referral_link",
+  ],
+  group_chat: [
+    "read_chat_name",
+    "update_display_name",
+    "read_chat_participants",
+    "set_chat_avatar",
+    "share_contact_card",
+  ],
+  group_email: ["send_email"],
+} as const;
+
+type GroupFamilyName = keyof typeof GROUP_FAMILY_ACTIONS;
+type GroupAction = (typeof GROUP_FAMILY_ACTIONS)[GroupFamilyName][number];
+
+const GROUP_ACTION_FIXTURES = {
+  ask: { action: "ask", question: "What changed this week?" },
+  handoff: { action: "handoff", context: "The member completed the workout." },
+  ask_current_sender: { action: "ask_current_sender", message_ref: MESSAGE_REF },
+  clarify_current_sender: {
+    action: "clarify_current_sender",
+    message_ref: MESSAGE_REF,
+  },
+  continue_current_sender_in_group: {
+    action: "continue_current_sender_in_group",
+    message_ref: MESSAGE_REF,
+  },
+  continue_current_sender_privately: {
+    action: "continue_current_sender_privately",
+    message_ref: MESSAGE_REF,
+  },
+  ask_member: {
+    action: "ask_member",
+    grantId: "grant-test",
+    question: "What was your step count?",
+  },
+  record_current_sender_daily_metric: {
+    action: "record_current_sender_daily_metric",
+    date: "2026-08-21",
+    message_ref: MESSAGE_REF,
+    metric: DAILY_METRIC,
+    unit: "count",
+    value: 1234,
+  },
+  post_disclosure_request: {
+    action: "post_disclosure_request",
+    permissionText: "Share daily step counts with this group.",
+  },
+  revoke_disclosure_grant: {
+    action: "revoke_disclosure_grant",
+    grantId: "grant-test",
+  },
+  read_shared: {
+    action: "read_shared",
+    projectionScopes: [{ projectionKind: "steps-days.v0" }],
+  },
+  offer_access: { action: "offer_access" },
+  revoke_own_email_share: {
+    action: "revoke_own_email_share",
+    message_ref: MESSAGE_REF,
+  },
+  read_current: { action: "read_current" },
+  prepare_next_group: { action: "prepare_next_group" },
+  read_next_group: { action: "read_next_group" },
+  cancel_next_group: { action: "cancel_next_group" },
+  list_memberships: { action: "list_memberships" },
+  leave_membership: {
+    action: "leave_membership",
+    membershipId: "membership-test",
+  },
+  read_usage: { action: "read_usage" },
+  read_usage_referral: { action: "read_usage_referral" },
+  arm_usage_referral: {
+    action: "arm_usage_referral",
+    policyCodes: ["new_person_activation_v1"],
+  },
+  cancel_usage_referral: {
+    action: "cancel_usage_referral",
+    policyCode: "new_person_activation_v1",
+  },
+  create_signup_referral_link: { action: "create_signup_referral_link" },
+  read_chat_name: { action: "read_chat_name" },
+  update_display_name: {
+    action: "update_display_name",
+    displayName: "Morning Miles",
+  },
+  read_chat_participants: { action: "read_chat_participants" },
+  set_chat_avatar: {
+    action: "set_chat_avatar",
+    avatarSource: "image_ref",
+    imageRef: "raw/inbox/group-avatar.png",
+  },
+  share_contact_card: { action: "share_contact_card" },
+  send_email: {
+    action: "send_email",
+    html: "<p>Weekly update</p>",
+    subject: "Weekly update",
+  },
+} satisfies Record<GroupAction, Record<string, unknown>>;
+
+function groupToolCall(
+  tool: string,
+  argumentsValue: unknown,
+): Record<string, unknown> {
+  return {
+    id: "request-test",
+    method: "item/tool/call",
+    params: {
+      arguments: argumentsValue,
+      callId: "call-test",
+      namespace: "murph",
+      threadId: "thread-test",
+      tool,
+      turnId: "turn-test",
+    },
+  };
+}
+
+describe("murph.group parser-first family compatibility", () => {
+  it("partitions all 30 advertised actions exactly once", () => {
+    const familyActions = Object.values(GROUP_FAMILY_ACTIONS).flat();
+    const advertisedActions = MURPH_GROUP_TOOL
+      .inputSchema.allOf[0].properties.action.enum;
+
+    expect(familyActions).toHaveLength(30);
+    expect(new Set(familyActions).size).toBe(familyActions.length);
+    expect([...familyActions].sort()).toEqual([...advertisedActions].sort());
+  });
+
+  it("normalizes every family action exactly like the legacy parser", () => {
+    for (const [familyName, actions] of Object.entries(GROUP_FAMILY_ACTIONS)) {
+      for (const action of actions) {
+        const argumentsValue = GROUP_ACTION_FIXTURES[action];
+        const legacy = readMurphDynamicToolRequest(
+          groupToolCall(MURPH_GROUP_TOOL.name, argumentsValue),
+        );
+        const family = readMurphDynamicToolRequest(
+          groupToolCall(familyName, argumentsValue),
+        );
+
+        expect(legacy, `${familyName}:${action}:legacy`).toMatchObject({
+          kind: "group",
+        });
+        expect(family, `${familyName}:${action}`).toEqual(legacy);
+      }
+    }
+  });
+
+  it("rejects every valid action through the wrong family", () => {
+    for (const [familyName, familyActions] of Object.entries(GROUP_FAMILY_ACTIONS)) {
+      const acceptedActions = new Set<string>(familyActions);
+      for (const [action, argumentsValue] of Object.entries(GROUP_ACTION_FIXTURES)) {
+        if (acceptedActions.has(action)) {
+          continue;
+        }
+        expect(
+          readMurphDynamicToolRequest(groupToolCall(familyName, argumentsValue)),
+          `${familyName}:${action}`,
+        ).toMatchObject({ kind: "invalid-group-arguments" });
+      }
+    }
+  });
+
+  it("keeps current-sender family inputs opaque and authority-free", () => {
+    const forbiddenValues = {
+      audience: "group",
+      memberId: "member-test",
+      providerMessageId: "provider-message-test",
+      question: "Who sent this?",
+      route: "provider-route-test",
+      sender: "sender-test",
+    };
+
+    for (const action of [
+      "ask_current_sender",
+      "clarify_current_sender",
+      "continue_current_sender_in_group",
+      "continue_current_sender_privately",
+    ] as const) {
+      for (const [field, fieldValue] of Object.entries(forbiddenValues)) {
+        expect(readMurphDynamicToolRequest(groupToolCall("group_consult", {
+          action,
+          message_ref: MESSAGE_REF,
+          [field]: fieldValue,
+        })), `${action}:${field}`).toMatchObject({
+          kind: "invalid-group-arguments",
+        });
+      }
+    }
+  });
+
+  it("does not treat unknown or legacy-only actions as read_current", () => {
+    expect(readMurphDynamicToolRequest(groupToolCall("group_membership", {
+      action: "future_group_action",
+    }))).toMatchObject({ kind: "invalid-group-arguments" });
+
+    expect(readMurphDynamicToolRequest(groupToolCall("group_consult", {
+      action: "message_current_sender",
+      message_ref: MESSAGE_REF,
+    }))).toMatchObject({ kind: "invalid-group-arguments" });
+
+    expect(readMurphDynamicToolRequest(groupToolCall("group_membership", {
+      action: "read_current",
+    }))).toMatchObject({
+      kind: "group",
+      request: { action: "read_current" },
+    });
+  });
+
+  it("leaves the advertised descriptor and catalog names unchanged", () => {
+    expect(createHash("sha256")
+      .update(JSON.stringify(MURPH_GROUP_TOOL))
+      .digest("hex"))
+      .toBe("7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736");
+
+    const advertisedNames = listMurphDynamicToolNames();
+    for (const familyName of Object.keys(GROUP_FAMILY_ACTIONS)) {
+      expect(advertisedNames).not.toContain(`murph.${familyName}`);
+    }
+    expect(advertisedNames.filter((name) => name === "murph.group"))
+      .toEqual(["murph.group"]);
+  });
+});


### PR DESCRIPTION
## Outcome

- Add parser-first compatibility for six focused group tool families: murph.group_consult, murph.group_data, murph.group_membership, murph.group_usage, murph.group_chat, and murph.group_email.
- Keep murph.group as the only advertised full descriptor in this phase; all accepted focused calls normalize into the existing group request/executor path.

## Product UX result

Internal-only compatibility phase. No tool is newly advertised, no current capability or control changes, no provider thread rotates, and no member journey changes. This only lets updated runners understand the focused names before a later catalog cutover can expose them.

## Direct evidence

- Three focused assistant-engine suites: 119 tests passed across the full group tool, current-sender authority, and parser-compatibility surfaces.
- Assistant-engine typecheck: passed.
- The six families partition all 30 current advertised actions exactly once; every representative family input normalizes identically to the existing murph.group parser, and every action is rejected through the wrong family.
- Current-sender families remain strict and authority-free: they accept only the exact opaque message ref and reject model-supplied sender, member, audience, question, route, and provider identifiers.
- The advertised catalog still contains only murph.group, and its serialized descriptor SHA-256 remains 7ca2e594d2fab08fab1988e18018b70043173be6da2d7ca69d9b981bad77e736.
- Unknown and legacy-only actions cannot fall through to read_current; post-schema avatar errors identify the exact focused family in their safe validation digest.\n- Preliminary completion-specialists ReviewGPT: PASS; no findings and no coverage patch.\n- Final ReviewGPT round 1: PASS with no qualifying findings on the last substantive head; the final docs-only plan archival does not change reviewed behavior.

## Non-obvious affected surfaces

- readMurphDynamicToolRequest accepts six additional unqualified parser names only after the existing signed murph namespace and tool-call envelope have been parsed.
- Successful focused calls still return kind: group with the existing MurphGroupToolRequest; the executor, Cloudflare control port, Web dispatcher, signed transport, trusted sender/route injection, stores, and response types are unchanged.
- Validation diagnostics now name the focused parser for both schema and post-schema failures.
- Dynamic-tool discovery, tool order, provider-visible schema/description, availability gates, and contract fingerprint are unchanged.

## Architecture and reuse

- Existing systems reused: the canonical strict group Zod union, existing normalization function, dynamic-tool request envelope, safe validation digest, kind: group request union, and current executor/transport owners.
- New logic: one semantic action partition and six refinements over the canonical group parser.
- New abstractions: none beyond the parser-family map and one small schema refinement helper.
- Complexity intentionally avoided: no new router, endpoint, executor, package, registry, queue, table, state machine, availability gate, transport, or durable owner.

## Hot reply path impact

For existing advertised calls, one map lookup selects the unchanged canonical schema before the existing parse/normalization path. Focused aliases add one bounded set-membership refinement after canonical validation. There is no database, network, transaction, retry, provider, or awaited work.

## Murph initial provider input impact

- Individual: unchanged; the six focused names are absent from the dynamic-tool catalog.
- Group: unchanged; murph.group remains the sole advertised descriptor with byte-identical serialization and the same contract fingerprint.
- Attribution: this phase changes parser admission only, so base instructions, descriptions, schemas, tool order, generated guidance, and turn input all have a zero-byte/zero-token delta.

## Deployment concerns

- Deployment: applicable
- Supported skew: updated runners accept both the existing full name and six focused names, while older runners accept only murph.group. Because this phase advertises only murph.group, mixed versions receive no unsupported provider call.
- Safe order: deploy this consumer/parser phase to every assistant runner before a separate PR advertises any focused family. Do not combine the catalog cutover with this rollout.
- Rollback floor: this phase can be rolled back while only murph.group is advertised. Once a later catalog cutover advertises focused names, parser compatibility becomes the runner rollback floor.
- Expected exposure: none in this phase; provider-visible input and runtime contract fingerprints do not change.
- Reversibility: a revert removes only unadvertised aliases and leaves the current full group path unchanged.
- Convergence proof: exact action partition, old/new normalization equivalence, wrong-family rejection, authority-negative cases, and byte-identical descriptor hash are covered by focused tests.
- Post-deploy checks: confirm an ordinary advertised murph.group call still executes, then use an internal signed parser probe for one focused alias and confirm it normalizes to the same group request without appearing in the provider catalog.

## Changelog

- Changelog: not applicable
- Reason: parser-only rollout compatibility with no advertised or member-visible behavior change.

## Change-shape breakdown

Classification uses base-to-head numstat; parser implementation is source, focused compatibility coverage is tests, and architecture/plan updates are docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 117 | 10 |
| Tests/fixtures | 287 | 0 |
| Docs | 73 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 477 | 10 |

ReviewGPT context sensitivity: sensitive

Reason: parser admission partitions a group authority surface even though this phase does not advertise the focused names.


ReviewGPT first-reviewed head: 2dd4286c25f8a44c421277b8bb675ecd492b2495

