### PR TITLE
perf: bound vault query reads by family

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-21-vault-query-narrow-readers.md
+++ b/agent-docs/exec-plans/active/2026-08-21-vault-query-narrow-readers.md
@@ -122,8 +122,9 @@ Updated: 2026-08-22
   already-landed narrow readers are not reimplemented.
 - 2026-08-21: Classify the task as a standard, multi-package internal
   architecture/performance change with the coverage preliminary lens and the
-  final cross-cutting ReviewGPT gate. Product UX, prompt, and frontend lenses
-  are not currently applicable.
+  final cross-cutting ReviewGPT gate. Product UX and frontend are not
+  applicable. Prompt review applies because this plan and package ownership
+  guidance are part of the change.
 - 2026-08-22: ReviewGPT returned the narrow-reader implementation from the
   original audit thread. Its first artifact expired before download; the same
   thread regenerated the scoped patch from the already-attached current-main
@@ -140,25 +141,34 @@ Updated: 2026-08-22
   that the filtered SQL date predicate does not preserve the existing
   canonical-day selection contract. The command remains on the full read model
   until the aggregate freshness phase can preserve that behavior explicitly.
+- 2026-08-22: Accept all preliminary specialist findings and both final-round
+  findings. Correct the prompt-lens disposition, restore canonical-day
+  precedence in the shared filtered projection predicate, register canonical
+  `vault_` IDs with the core lookup family, and collapse generic-show routing
+  onto the shared lookup registries plus the existing query-family catalog.
+  Projection/read-model parity, every generic-show route, typed misses, an
+  initialized-vault exact read, and a delayed Europe/Berlin meal closeout now
+  protect the corrected behavior.
 
 ## Verification
 
 - Completed local proof:
   - Query suite: 66 files and 696 tests passed.
-  - Vault-usecases focused proof: 8 files and 50 tests passed.
-  - Vault-usecases suite: 43 files and 366 tests passed.
-  - CLI suite: 125 files and 1,185 tests passed; one unrelated assistant-session
-    redaction test timed out at 60 seconds under concurrent typecheck load and
-    passed alone in 19 seconds. The changed canonical-write-lock harness passed
-    its focused 6-test rerun.
-  - `pnpm typecheck` passed, including query, vault-usecases, and CLI.
+  - Corrected-head contracts suite: 40 files and 326 tests passed.
+  - Original vault-usecases focused proof: 8 files and 50 tests passed.
+  - Corrected-head vault-usecases suite: 44 files and 369 tests passed. The
+    corrected routing and exact core-reader focused run passed 2 files and 5
+    tests.
+  - Corrected-head CLI suite: 126 files passed with 1,187 tests passed and 1
+    skipped. The delayed-closeout focused proof passed 1 file and 11 tests.
+  - Corrected-head `pnpm typecheck` passed, including query, vault-usecases,
+    and CLI.
   - `pnpm test:scenario-integrity` passed for 207 scenarios, 12 sample inputs,
     and 29 golden-output directories.
   - `git diff --check`, artifact reverse-check, and privacy scans passed.
 - Remaining exact-head proof:
-  - Required GitHub Actions, preliminary specialist ReviewGPT coverage pass,
-    final ReviewGPT `ROUND_OUTCOME: PASS`, and current-base
-    `git merge-tree --write-tree` proof.
+  - Corrected-head GitHub Actions, final ReviewGPT `ROUND_OUTCOME: PASS`, and
+    current-base `git merge-tree --write-tree` proof.
 - Expected outcomes:
   - Representative exact and family reads do not create or modify the query
     projection and are insensitive to unrelated malformed records.

--- a/agent-docs/exec-plans/active/2026-08-21-vault-query-narrow-readers.md
+++ b/agent-docs/exec-plans/active/2026-08-21-vault-query-narrow-readers.md
@@ -1,0 +1,167 @@
+# Stop exact and family-scoped CLI reads from rebuilding the full vault projection
+
+Status: active
+Created: 2026-08-21
+Updated: 2026-08-22
+
+## Goal
+
+- Make narrow CLI reads scale with the requested record or family instead of
+  walking every canonical source, refreshing the complete SQLite projection,
+  and hydrating the whole vault.
+- Preserve the full projection for commands whose product meaning is genuinely
+  cross-family or aggregate.
+
+## Success criteria
+
+- Every remaining exact-record command identified by the source-backed
+  ReviewGPT audit uses a canonical owner read or an existing bounded manifest
+  read and does not call `query.readVault()`.
+- Every remaining family-scoped command uses a family-owned canonical reader or
+  a family/kind/date-filtered query API; supported aliases never fall back to a
+  full-vault scan.
+- Repeated aggregate commands in scope perform at most one command-scoped
+  freshness check and query only the rows they need where the current query
+  projection can support that without a new index or state owner.
+- Direct and projected reads share existing lookup-family, event display
+  identity, visibility, and lifecycle/revision helpers so their output cannot
+  drift silently.
+- Architecture tests prevent exact and family-scoped handlers from regaining a
+  dependency on the full projection gateway.
+- Behavioral tests prove representative exact reads succeed without creating
+  or modifying `query.sqlite` and without opening unrelated canonical roots.
+- Focused package tests and typecheck pass, exact-head CI is green, the
+  preliminary specialist ReviewGPT coverage lens is resolved, and the final
+  ReviewGPT gate reaches `ROUND_OUTCOME: PASS` with no accepted findings.
+
+## Scope
+
+- In scope:
+  - Reconcile the original ReviewGPT audit with current `main`, retaining the
+    narrow readers already landed by PR #2070 and later work.
+  - Remaining generic show, audit show, manifest, intake, vault, journal,
+    experiment, protocol, capture, blood-test, immunization, measurement-list,
+    Murph Age input, and personal-pattern paths that still hydrate the complete
+    vault for an exact, family-scoped, or duplicate aggregate read.
+  - Small public query/core/vault-usecases seams and tests needed to express
+    exact-record, family-scoped, and aggregate-projection capabilities.
+  - Durable architecture documentation only where the final ownership contract
+    is not already explicit.
+- Out of scope:
+  - Cross-family list/search/timeline, vault statistics, nutrition/wearable/
+    metric analysis, experiment progress/outcomes, automatic experiment
+    matching, export creation, and explicit projection rebuilds that genuinely
+    require aggregate projection state.
+  - A second index, incremental projection writer, source-generation journal,
+    cross-process rebuild lock, or compatibility layer without measured need.
+  - Cleanup unrelated to the audited projection-read call graph.
+
+## Constraints
+
+- Technical constraints:
+  - `packages/core` remains the canonical record owner, `packages/query` remains
+    the read/projection owner, and `packages/vault-usecases` remains a thin
+    command-shaped composition layer.
+  - Query state remains rebuildable and read-only relative to canonical writes.
+  - Prefer extending existing public owner boundaries and shared registries over
+    adding abstractions or persistent state.
+  - Preserve current canonical IDs, aliases, visibility, lifecycle collapse,
+    output shapes, and missing-record errors.
+- Product/process constraints:
+  - ReviewGPT authors the implementation patch from the original audit thread;
+    the parent treats it as untrusted intent, inspects every hunk, and applies
+    only the smallest current-main-safe design.
+  - Use the isolated task worktree and preserve every unrelated checkout.
+  - Keep this internal performance/architecture change free of new user-facing
+    claims unless the final diff proves a meaningful member-visible outcome.
+
+## Risks and mitigations
+
+1. Risk: A direct reader returns a subtly different identity, visibility, or
+   lifecycle result from the projection.
+   Mitigation: Reuse shared lookup-family and event/lifecycle helpers and add
+   direct-versus-projected parity fixtures for every migrated family.
+2. Risk: Alias compatibility turns a bounded family lookup back into a vault
+   scan.
+   Mitigation: Resolve only documented aliases inside their owning family and
+   fail with the existing typed not-found result otherwise.
+3. Risk: Aggregate optimization creates a second freshness or persistence
+   owner.
+   Mitigation: Reuse the query projection's existing freshness owner in one
+   command-scoped session; defer any new index or incremental writer.
+4. Risk: The broad audit invites unrelated refactoring.
+   Mitigation: Require each changed call path to correspond to a current
+   `readVault()` offender and reject changes that do not reduce that bounded
+   cost or protect the architecture mechanically.
+
+## Tasks
+
+1. Give the original ReviewGPT audit thread a current-main source bundle and
+   this plan; have it return a patch that inventories and removes only the
+   remaining exact, family-scoped, and duplicate aggregate full-vault reads.
+2. Inspect every ReviewGPT hunk against current owners, split or delete
+   speculative structure, and apply the accepted patch deliberately.
+3. Add or refine focused regression tests for projection-file independence,
+   unrelated-root isolation, direct/projected parity, bounded family aliases,
+   aggregate freshness reuse, and static call-graph enforcement.
+4. Run focused query, vault-usecases, CLI, scenario-integrity, and TypeScript
+   proof; review the complete diff for privacy, architecture, and scope.
+5. Commit and push the candidate, open a draft PR with complete evidence, and
+   start the preliminary specialist coverage pass plus final ReviewGPT round 1
+   concurrently with exact-head CI. Resolve accepted findings until PASS.
+6. Run the parent final review, close this plan through `scripts/finish-task`,
+   push the final head, and prove current-base mergeability.
+
+## Decisions
+
+- 2026-08-21: No open PR, active plan, active worktree, or live process owns the
+  broader fix. One detached dirty checkout is inactive pre-merge residue from
+  PR #2070 and remains untouched.
+- 2026-08-21: Use the original ReviewGPT conversation so implementation retains
+  the audit's rationale, while attaching a fresh current-main source bundle so
+  already-landed narrow readers are not reimplemented.
+- 2026-08-21: Classify the task as a standard, multi-package internal
+  architecture/performance change with the coverage preliminary lens and the
+  final cross-cutting ReviewGPT gate. Product UX, prompt, and frontend lenses
+  are not currently applicable.
+- 2026-08-22: ReviewGPT returned the narrow-reader implementation from the
+  original audit thread. Its first artifact expired before download; the same
+  thread regenerated the scoped patch from the already-attached current-main
+  snapshot, and the recovered artifact passed a full hunk review, privacy scan,
+  forward apply check, and post-apply reverse check.
+- 2026-08-22: Accept the exact/family-reader phase and its shared identity,
+  visibility, lifecycle, bounded-source, filtered-collection, and architecture
+  guard changes. Keep the three genuinely aggregate follow-ups separate:
+  measurement-entry composition, Murph Age batch inputs, and wearable personal
+  patterns need a command-scoped projection freshness design rather than an
+  exact-reader substitution.
+- 2026-08-22: Reject the attempted filtered projection substitution for the
+  measurement record list. A production-faithful Junction regression proved
+  that the filtered SQL date predicate does not preserve the existing
+  canonical-day selection contract. The command remains on the full read model
+  until the aggregate freshness phase can preserve that behavior explicitly.
+
+## Verification
+
+- Completed local proof:
+  - Query suite: 66 files and 696 tests passed.
+  - Vault-usecases focused proof: 8 files and 50 tests passed.
+  - Vault-usecases suite: 43 files and 366 tests passed.
+  - CLI suite: 125 files and 1,185 tests passed; one unrelated assistant-session
+    redaction test timed out at 60 seconds under concurrent typecheck load and
+    passed alone in 19 seconds. The changed canonical-write-lock harness passed
+    its focused 6-test rerun.
+  - `pnpm typecheck` passed, including query, vault-usecases, and CLI.
+  - `pnpm test:scenario-integrity` passed for 207 scenarios, 12 sample inputs,
+    and 29 golden-output directories.
+  - `git diff --check`, artifact reverse-check, and privacy scans passed.
+- Remaining exact-head proof:
+  - Required GitHub Actions, preliminary specialist ReviewGPT coverage pass,
+    final ReviewGPT `ROUND_OUTCOME: PASS`, and current-base
+    `git merge-tree --write-tree` proof.
+- Expected outcomes:
+  - Representative exact and family reads do not create or modify the query
+    projection and are insensitive to unrelated malformed records.
+  - Output/error compatibility fixtures pass.
+  - No exact/family handler reaches the full projection gateway.
+  - No unresolved accepted ReviewGPT or CI finding remains.

--- a/agent-docs/exec-plans/completed/2026-08-21-vault-query-narrow-readers.md
+++ b/agent-docs/exec-plans/completed/2026-08-21-vault-query-narrow-readers.md
@@ -1,6 +1,6 @@
 # Stop exact and family-scoped CLI reads from rebuilding the full vault projection
 
-Status: active
+Status: completed
 Created: 2026-08-21
 Updated: 2026-08-22
 
@@ -149,6 +149,11 @@ Updated: 2026-08-22
   Projection/read-model parity, every generic-show route, typed misses, an
   initialized-vault exact read, and a delayed Europe/Berlin meal closeout now
   protect the corrected behavior.
+- 2026-08-22: ReviewGPT round 2 re-audited the complete corrected PR snapshot,
+  validated the immutable first-head and previous-head ancestry, confirmed all
+  prior accepted findings resolved, and returned `ROUND_OUTCOME: PASS` with no
+  new original or review-induced issue. The selected Pro-model evidence and
+  elapsed review duration exceeded the final-gate trust floor.
 
 ## Verification
 
@@ -166,12 +171,17 @@ Updated: 2026-08-22
   - `pnpm test:scenario-integrity` passed for 207 scenarios, 12 sample inputs,
     and 29 golden-output directories.
   - `git diff --check`, artifact reverse-check, and privacy scans passed.
+  - Corrected-head required GitHub checks passed.
+  - Preliminary specialists completed with three accepted findings; final
+    round 1 completed with two overlapping accepted findings; full-snapshot
+    final round 2 returned `ROUND_OUTCOME: PASS` after every correction landed.
 - Remaining exact-head proof:
-  - Corrected-head GitHub Actions, final ReviewGPT `ROUND_OUTCOME: PASS`, and
-    current-base `git merge-tree --write-tree` proof.
+  - Close this plan on the final docs-only head, wait for its required GitHub
+    checks, and run current-base `git merge-tree --write-tree` proof.
 - Expected outcomes:
   - Representative exact and family reads do not create or modify the query
     projection and are insensitive to unrelated malformed records.
   - Output/error compatibility fixtures pass.
   - No exact/family handler reaches the full projection gateway.
   - No unresolved accepted ReviewGPT or CI finding remains.
+Completed: 2026-08-22

--- a/packages/cli/src/commands/audit-command-helpers.ts
+++ b/packages/cli/src/commands/audit-command-helpers.ts
@@ -33,10 +33,13 @@ export async function showAudit(
 ): Promise<CommandShowEntity> {
   await assertInitializedVaultRoot(vaultRoot)
   const query = await loadQueryRuntime()
-  const vault = await query.readVault(vaultRoot)
-  const record = query.lookupEntityById(vault, auditId)
+  const record = await query.resolveCanonicalEntityInFamily(
+    vaultRoot,
+    'audit',
+    auditId,
+  )
 
-  if (!record || record.family !== 'audit') {
+  if (!record) {
     throw new VaultCliError('not_found', `No audit record found for "${auditId}".`)
   }
 
@@ -49,8 +52,11 @@ export async function listAudits(
 ): Promise<AuditCommandListItem[]> {
   await assertInitializedVaultRoot(vaultRoot)
   const query = await loadQueryRuntime()
-  const vault = await query.readVault(vaultRoot)
-  const sorted = [...vault.audits]
+  const records = await query.listCanonicalEntities(vaultRoot, {
+    family: 'audit',
+    limit: null,
+  })
+  const sorted = records
     .filter((record) => matchesOptionalString(firstString(record.attributes, ['action']), options.action))
     .filter((record) => matchesOptionalString(firstString(record.attributes, ['actor']), options.actor))
     .filter((record) => matchesOptionalString(record.status ?? null, options.status))

--- a/packages/cli/src/commands/export-intake-read-helpers.ts
+++ b/packages/cli/src/commands/export-intake-read-helpers.ts
@@ -142,10 +142,13 @@ async function loadQueryRuntime() {
 
 async function loadAssessmentRecord(vaultRoot: string, assessmentId: string) {
   const query = await loadQueryRuntime()
-  const readModel = await query.readVault(vaultRoot)
-  const record = query.lookupEntityById(readModel, assessmentId)
+  const record = await query.resolveCanonicalEntityInFamily(
+    vaultRoot,
+    'assessment',
+    assessmentId,
+  )
 
-  if (!record || record.family !== 'assessment') {
+  if (!record) {
     throw new VaultCliError(
       'not_found',
       `No assessment found for "${assessmentId}".`,

--- a/packages/cli/test/canonical-write-lock.test.ts
+++ b/packages/cli/test/canonical-write-lock.test.ts
@@ -474,6 +474,7 @@ test.sequential("provider and event CLI usecases map renamed core error codes to
           queryRuntime: {
             readVault: async () => ({}),
             lookupEntityById: () => eventRecord,
+            resolveCanonicalEntityInFamily: async () => eventRecord,
           },
           run: async ({ records }) => {
             const { editEventRecord } = records;
@@ -558,6 +559,7 @@ test.sequential("editEventRecord strips stored lifecycle metadata before calling
     queryRuntime: {
       readVault: async () => ({}),
       lookupEntityById: () => eventRecord,
+      resolveCanonicalEntityInFamily: async () => eventRecord,
     },
     run: async ({ records }) => {
       const { editEventRecord } = records;
@@ -591,6 +593,10 @@ test.sequential("experiment and journal CLI usecases map renamed core error code
     queryRuntime: {
       readVault: async () => ({}),
       lookupEntityById: () => ({
+        family: "experiment",
+        path: "experiments/focus-sprint.md",
+      }),
+      resolveCanonicalEntityInFamily: async () => ({
         family: "experiment",
         path: "experiments/focus-sprint.md",
       }),

--- a/packages/cli/test/meal-add-typed-parity.test.ts
+++ b/packages/cli/test/meal-add-typed-parity.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { rm, writeFile } from 'node:fs/promises'
+import { rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import {
@@ -353,6 +353,104 @@ test.sequential(
         [retried.mealId, first.mealId],
       )
       assert.deepEqual(work.items[0]?.data.attachments ?? [], [])
+    } finally {
+      await rm(parentRoot, { force: true, recursive: true })
+    }
+  },
+)
+
+test.sequential(
+  'meal closeout-work keeps a next-local-day photo for that day closeout',
+  async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'murph-cli-meal-closeout-local-day-',
+    )
+
+    try {
+      await initializeVault({ vaultRoot, timezone: 'Europe/Berlin' })
+      const day20PhotoPath = path.join(parentRoot, 'august-20-meal.jpg')
+      const day21PhotoPath = path.join(parentRoot, 'august-21-meal.jpg')
+      await Promise.all([
+        writeFile(day20PhotoPath, 'august 20 synthetic image', 'utf8'),
+        writeFile(day21PhotoPath, 'august 21 synthetic image', 'utf8'),
+      ])
+      const day20Meal = await addMeal({
+        externalRef: {
+          resourceId: 'capture_closeout_august_20',
+          resourceType: 'photo',
+          system: 'meal-photo-capture',
+          version: '3'.repeat(64),
+        },
+        occurredAt: '2026-08-20T19:30:00.000Z',
+        photoPath: day20PhotoPath,
+        source: 'device',
+        vaultRoot,
+      })
+      const day21Meal = await addMeal({
+        externalRef: {
+          resourceId: 'capture_closeout_august_21',
+          resourceType: 'photo',
+          system: 'meal-photo-capture',
+          version: '4'.repeat(64),
+        },
+        occurredAt: '2026-08-20T22:15:00.000Z',
+        photoPath: day21PhotoPath,
+        source: 'device',
+        vaultRoot,
+      })
+      assert.equal(day20Meal.event.dayKey, '2026-08-20')
+      assert.equal(day21Meal.event.dayKey, '2026-08-21')
+
+      const day20Result = await runInProcessJsonCli<MealCloseoutWorkResult>(
+        createMealCli(),
+        [
+          'meal',
+          'closeout-work',
+          '--occurrence-at',
+          '2026-08-20T21:00:00.000Z',
+          '--to',
+          '2026-08-20',
+          '--limit',
+          '10',
+          '--vault',
+          vaultRoot,
+        ],
+      )
+      assert.equal(day20Result.exitCode, null)
+      const day20Work = requireData(day20Result.envelope)
+      assert.deepEqual(day20Work.items.map((item) => item.id), [day20Meal.mealId])
+
+      const removed = await runInProcessJsonCli<ShowResult>(createMealCli(), [
+        'meal',
+        'remove-photo',
+        day20Meal.mealId,
+        '--vault',
+        vaultRoot,
+      ])
+      assert.equal(removed.exitCode, null)
+      assert.ok(day21Meal.photo)
+      await stat(path.join(vaultRoot, day21Meal.photo.relativePath))
+
+      const day21Result = await runInProcessJsonCli<MealCloseoutWorkResult>(
+        createMealCli(),
+        [
+          'meal',
+          'closeout-work',
+          '--occurrence-at',
+          '2026-08-21T21:00:00.000Z',
+          '--to',
+          '2026-08-21',
+          '--limit',
+          '10',
+          '--vault',
+          vaultRoot,
+        ],
+      )
+      assert.equal(day21Result.exitCode, null)
+      assert.equal(
+        requireData(day21Result.envelope).items.some((item) => item.id === day21Meal.mealId),
+        true,
+      )
     } finally {
       await rm(parentRoot, { force: true, recursive: true })
     }

--- a/packages/contracts/src/lookup-id-families.ts
+++ b/packages/contracts/src/lookup-id-families.ts
@@ -13,6 +13,7 @@ export const LOOKUP_ID_FAMILY_REGISTRY = Object.freeze<LookupIdFamilyDefinition[
   {
     family: "core",
     entityKind: "core",
+    prefix: `${ID_PREFIXES.vault}_`,
     exactIds: ["core", "current"],
     queryable: true,
   },

--- a/packages/contracts/test/lookup-id-families.test.ts
+++ b/packages/contracts/test/lookup-id-families.test.ts
@@ -11,6 +11,7 @@ describe("lookup ID families", () => {
   it.each([
     ["core", "core", true],
     [" current ", "core", true],
+    ["vault_01JNV40W8VFYQ2H7CMJY5A9R4K", "core", true],
     ["journal:2026-07-15", "journal", true],
     ["hab_sleep-environment", "habitat", true],
     ["xfm_batch_1", "transform", false],

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,11 +1,19 @@
 # `@murphai/query`
 
-Workspace-private read-helper, filter, derived-retrieval, and export-pack surface over canonical vault state. Query code must not mutate canonical vault data. It owns the rebuildable local query projection at `.runtime/projections/query.sqlite`, which backs both canonical read materialization and lexical search.
+Workspace-private read-helper, filter, derived-retrieval, and export-pack surface over canonical vault state. Query code must not mutate canonical vault data. It owns the rebuildable local query projection at `.runtime/projections/query.sqlite`, which backs cross-family, aggregate, derived, and lexical-search reads.
 
-Narrow health reads should query that projection by family/kind/date before
-decoding records. In particular, blood-test list/show must not hydrate the full
-projected vault; blood-specific classification and text matching run over the
-filtered `event`/`test` candidate set.
+Exact and family-local reads must not rebuild or hydrate that shared projection.
+Use core-owned exact readers when the canonical owner exposes one, or use
+`resolveCanonicalEntityInFamily()` / `readCanonicalEntityFamilySource()` for a
+bounded query-shaped family read. Alias resolution stays inside the selected
+family, and exact canonical ids retain precedence over aliases. Collection
+reads that still need projection freshness should use filtered APIs such as
+`listCanonicalEntities()` rather than materializing the complete vault model.
+
+Narrow health collection reads should query that projection by family/kind/date
+before decoding records. Exact blood-test and immunization lookups use the
+bounded event-family source reader so a stale projection cannot turn one-record
+lookup into a whole-vault rebuild.
 
 The first retrieval milestone now lives here too: lexical `searchVault()` over the sparse read model plus `buildTimeline()` for descending journal/event/display-grade sample-summary context.
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -67,6 +67,11 @@
       "import": "./dist/id-families.js",
       "default": "./dist/id-families.js"
     },
+    "./query-visibility": {
+      "types": "./dist/query-visibility.d.ts",
+      "import": "./dist/query-visibility.js",
+      "default": "./dist/query-visibility.js"
+    },
     "./murph-age": {
       "types": "./dist/murph-age.d.ts",
       "import": "./dist/murph-age.js",

--- a/packages/query/src/health/blood-tests.ts
+++ b/packages/query/src/health/blood-tests.ts
@@ -4,6 +4,7 @@ import {
 } from "@murphai/contracts";
 import type { CanonicalEntity } from "../canonical-entities.ts";
 import { listCanonicalEntitiesRuntime } from "../query-projection.ts";
+import { readCanonicalEntityFamilySource } from "../vault-source.ts";
 import {
   applyLimit,
   asObject,
@@ -201,7 +202,9 @@ export async function readBloodTest(
   vaultRoot: string,
   eventId: string,
 ): Promise<BloodTestQueryRecord | null> {
-  const records = await listBloodTests(vaultRoot);
+  const records = selectProjectedBloodTests(
+    await readCanonicalEntityFamilySource(vaultRoot, "event"),
+  );
   return records.find((record) => record.id === eventId) ?? null;
 }
 
@@ -209,7 +212,9 @@ export async function showBloodTest(
   vaultRoot: string,
   lookup: string,
 ): Promise<BloodTestQueryRecord | null> {
-  const records = await listBloodTests(vaultRoot);
+  const records = selectProjectedBloodTests(
+    await readCanonicalEntityFamilySource(vaultRoot, "event"),
+  );
   return (
     records.find((record) =>
       matchesLookup(lookup, record.id, record.title, record.testName, record.labPanelId),

--- a/packages/query/src/health/canonical-collector.ts
+++ b/packages/query/src/health/canonical-collector.ts
@@ -2,6 +2,7 @@ import { VAULT_LAYOUT, type BankEntityKind } from "@murphai/contracts";
 
 import {
   compareCanonicalEntities,
+  type CanonicalEntityFamily,
   type CanonicalEntity,
 } from "../canonical-entities.ts";
 import { projectAssessmentEntity } from "./projectors/assessment.ts";
@@ -207,6 +208,39 @@ const REGISTRY_COLLECTORS = [
     (document) => toRegistryRecord(document, workoutFormatRegistryDefinition),
   ),
 ] as const satisfies readonly RegistryCollectorConfig[];
+
+/**
+ * Read one health-owned canonical family without traversing every registry.
+ *
+ * This is the source-backed counterpart to filtered projection reads. It is
+ * intended for exact and family-local resolution paths where rebuilding the
+ * shared query projection would be disproportionate to the requested read.
+ */
+export async function readCanonicalHealthFamilyEntities(
+  vaultRoot: string,
+  family: CanonicalEntityFamily,
+): Promise<CanonicalEntity[]> {
+  if (family === "assessment") {
+    return readJsonlEntitiesStrict(
+      vaultRoot,
+      VAULT_LAYOUT.assessmentLedgerDirectory,
+      projectAssessmentEntity,
+    );
+  }
+
+  const collector = REGISTRY_COLLECTORS.find((candidate) => candidate.family === family);
+  if (!collector) {
+    return [];
+  }
+
+  const result = await readRegistryEntitiesAsync(
+    vaultRoot,
+    collector,
+    new Map<string, string>(),
+    readMarkdownDocument,
+  );
+  return result.entities;
+}
 
 function createRegistryCollectorConfig(
   key: RegistryCollectionKey,

--- a/packages/query/src/health/immunizations.ts
+++ b/packages/query/src/health/immunizations.ts
@@ -1,5 +1,6 @@
 import type { CanonicalEntity } from "../canonical-entities.ts";
-import { listEntities, readVault, type VaultReadModel } from "../model.ts";
+import { listCanonicalEntitiesRuntime } from "../query-projection.ts";
+import { readCanonicalEntityFamilySource } from "../vault-source.ts";
 import {
   applyLimit,
   asObject,
@@ -148,15 +149,10 @@ function matchesImmunizationOptions(
 }
 
 function selectProjectedImmunizations(
-  vault: VaultReadModel,
+  entities: readonly CanonicalEntity[],
   options: ImmunizationListOptions = {},
 ): ImmunizationQueryRecord[] {
-  const records = listEntities(vault, {
-    families: ["event"],
-    kinds: ["immunization"],
-    from: options.from,
-    to: options.to,
-  })
+  const records = entities
     .map(immunizationRecordFromEventEntity)
     .filter(isImmunizationRecord)
     .filter((record) => matchesImmunizationOptions(record, options))
@@ -169,14 +165,23 @@ export async function listImmunizations(
   vaultRoot: string,
   options: ImmunizationListOptions = {},
 ): Promise<ImmunizationQueryRecord[]> {
-  return selectProjectedImmunizations(await readVault(vaultRoot), options);
+  const entities = await listCanonicalEntitiesRuntime(vaultRoot, {
+    family: "event",
+    from: options.from,
+    kinds: ["immunization"],
+    limit: null,
+    to: options.to,
+  });
+  return selectProjectedImmunizations(entities, options);
 }
 
 export async function readImmunization(
   vaultRoot: string,
   eventId: string,
 ): Promise<ImmunizationQueryRecord | null> {
-  const records = await listImmunizations(vaultRoot);
+  const records = selectProjectedImmunizations(
+    await readCanonicalEntityFamilySource(vaultRoot, "event"),
+  );
   return records.find((record) => record.id === eventId) ?? null;
 }
 
@@ -184,7 +189,9 @@ export async function showImmunization(
   vaultRoot: string,
   lookup: string,
 ): Promise<ImmunizationQueryRecord | null> {
-  const records = await listImmunizations(vaultRoot);
+  const records = selectProjectedImmunizations(
+    await readCanonicalEntityFamilySource(vaultRoot, "event"),
+  );
   return (
     records.find((record) =>
       matchesLookup(

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -36,6 +36,7 @@ export {
   listExperiments,
   listJournalEntries,
   listProtocols,
+  lookupCanonicalEntityById,
   lookupEntityById,
 } from "./model.ts";
 export {
@@ -47,6 +48,9 @@ export {
   hashCanonicalQuerySources,
   isCanonicalQuerySourcePath,
   listCanonicalSourceManifest,
+  readCanonicalEntityFamilySource,
+  readVaultMetadataSource,
+  resolveCanonicalEntityInFamily,
 } from "./vault-source.ts";
 export {
   listCanonicalObservationMetricEntries,
@@ -98,11 +102,18 @@ export type {
   AutomationQueryRecord,
 } from "./automation.ts";
 export {
+  deriveVaultRecordIdentity,
   describeLookupConstraint,
   ID_FAMILY_REGISTRY,
   inferIdEntityKind,
   isQueryableLookupId,
 } from "./id-families.ts";
+export {
+  isDefaultProjectedEventRecord,
+  isDefaultProjectedQueryEntity,
+  isDisplayGradeObservation,
+  isSearchIndexedQueryEntity,
+} from "./query-visibility.ts";
 export {
   buildOverviewMetrics,
   isActiveOverviewExperimentStatus,

--- a/packages/query/src/projection/entity-store.ts
+++ b/packages/query/src/projection/entity-store.ts
@@ -139,12 +139,12 @@ function queryStoredCanonicalEntities(
     parameters.push(...filters.kinds);
   }
   if (filters.from) {
-    whereClauses.push("(date >= ? OR occurred_at >= ?)");
-    parameters.push(filters.from, `${filters.from}T00:00:00.000Z`);
+    whereClauses.push("COALESCE(date, substr(occurred_at, 1, 10)) >= ?");
+    parameters.push(filters.from);
   }
   if (filters.to) {
-    whereClauses.push("(date <= ? OR occurred_at <= ?)");
-    parameters.push(filters.to, `${filters.to}T23:59:59.999Z`);
+    whereClauses.push("COALESCE(date, substr(occurred_at, 1, 10)) <= ?");
+    parameters.push(filters.to);
   }
 
   const limit = filters.limit === null ? null : normalizeCanonicalEntityLimit(filters.limit ?? 1_000);

--- a/packages/query/src/query-visibility.ts
+++ b/packages/query/src/query-visibility.ts
@@ -9,12 +9,28 @@ function normalizedString(value: unknown): string | null {
   return typeof value === "string" ? value.trim().toLowerCase() : null;
 }
 
-function isDisplayGradeObservation(attributes: Record<string, unknown>): boolean {
+export function isDisplayGradeObservation(attributes: Record<string, unknown>): boolean {
   return (
     normalizedString(attributes.visibility) === "display" ||
     normalizedString(attributes.queryVisibility) === "default" ||
     attributes.canonicalFact === true
   );
+}
+
+export function isDefaultProjectedEventRecord(input: {
+  attributes: Record<string, unknown>;
+  kind: string;
+}): boolean {
+  if (input.kind !== "observation") {
+    return true;
+  }
+
+  const isMetricObservation =
+    typeof input.attributes.metric === "string" &&
+    typeof input.attributes.value === "number" &&
+    Number.isFinite(input.attributes.value);
+
+  return !isMetricObservation || isDisplayGradeObservation(input.attributes);
 }
 
 function isDefaultHiddenMetricObservationEntity(entity: CanonicalEntity): boolean {
@@ -23,12 +39,7 @@ function isDefaultHiddenMetricObservationEntity(entity: CanonicalEntity): boolea
   }
 
   const attributes = isRecord(entity.attributes) ? entity.attributes : {};
-  const isMetricObservation =
-    typeof attributes.metric === "string" &&
-    typeof attributes.value === "number" &&
-    Number.isFinite(attributes.value);
-
-  return isMetricObservation && !isDisplayGradeObservation(attributes);
+  return !isDefaultProjectedEventRecord({ attributes, kind: entity.kind });
 }
 
 export function isDefaultProjectedQueryEntity(entity: CanonicalEntity): boolean {

--- a/packages/query/src/read-model.ts
+++ b/packages/query/src/read-model.ts
@@ -305,7 +305,21 @@ export function lookupEntityById(
   vault: VaultReadModel,
   entityId: string,
 ): CanonicalEntity | null {
-  return lookupById(getVaultEntities(vault), entityId, (entity) => entity.entityId);
+  return lookupCanonicalEntityById(getVaultEntities(vault), entityId);
+}
+
+/**
+ * Resolve one canonical entity from an already-bounded source family.
+ *
+ * Exact ids retain precedence over family-local aliases, matching the full
+ * VaultReadModel lookup contract without requiring callers to construct or
+ * hydrate that model.
+ */
+export function lookupCanonicalEntityById(
+  entities: readonly CanonicalEntity[],
+  entityId: string,
+): CanonicalEntity | null {
+  return lookupById(entities, entityId, (entity) => entity.entityId);
 }
 
 export function listEntities(

--- a/packages/query/src/vault-source.ts
+++ b/packages/query/src/vault-source.ts
@@ -23,12 +23,18 @@ import {
   resolveCanonicalRecordClass,
   uniqueStrings,
   type CanonicalEntity,
+  type CanonicalEntityFamily,
 } from "./canonical-entities.ts";
-import { collectCanonicalEntities } from "./health/canonical-collector.ts";
+import {
+  collectCanonicalEntities,
+  readCanonicalHealthFamilyEntities,
+} from "./health/canonical-collector.ts";
 import { walkRelativeFiles } from "./health/loaders.ts";
 import { collapseEventLedgerEntities } from "./health/projectors/history.ts";
 import { deriveVaultRecordIdentity } from "./id-families.ts";
 import { parseMarkdownDocument } from "./markdown.ts";
+import { lookupCanonicalEntityById } from "./read-model.ts";
+import { isDefaultProjectedQueryEntity } from "./query-visibility.ts";
 import {
   PROTOCOL_DIRECTORY,
   PROTOCOL_DOC_TYPE,
@@ -126,6 +132,81 @@ export async function readVaultSourceTolerant(
     metadata,
     entities: [...baseEntities, ...healthEntities.entities].sort(compareCanonicalEntities),
   };
+}
+
+/**
+ * Read one canonical family directly from its source owner without consulting
+ * or rebuilding the shared query projection.
+ */
+export async function readCanonicalEntityFamilySource(
+  vaultRoot: string,
+  family: CanonicalEntityFamily,
+): Promise<CanonicalEntity[]> {
+  let entities: CanonicalEntity[];
+
+  switch (family) {
+    case "core": {
+      const metadata = await readOptionalVaultMetadata(
+        path.join(vaultRoot, VAULT_LAYOUT.metadata),
+      );
+      const entity = await readOptionalCoreEntity(vaultRoot, metadata);
+      entities = entity ? [entity] : [];
+      break;
+    }
+    case "experiment":
+      entities = await readExperimentEntities(vaultRoot);
+      break;
+    case "protocol":
+      entities = await readProtocolEntities(vaultRoot);
+      break;
+    case "journal":
+      entities = await readJournalEntities(vaultRoot);
+      break;
+    case "event":
+      entities = await readJsonlRecordFamily(
+        vaultRoot,
+        VAULT_LAYOUT.eventLedgerDirectory,
+        "event",
+      );
+      break;
+    case "sample":
+      entities = await readMetricSampleEntities(vaultRoot);
+      break;
+    case "audit":
+      entities = await readJsonlRecordFamily(
+        vaultRoot,
+        VAULT_LAYOUT.auditDirectory,
+        "audit",
+      );
+      break;
+    default:
+      entities = await readCanonicalHealthFamilyEntities(vaultRoot, family);
+      break;
+  }
+
+  return entities.filter(isDefaultProjectedQueryEntity);
+}
+
+/**
+ * Resolve an exact id or a documented alias inside one canonical family.
+ * Exact entity ids retain precedence over aliases, matching readVault().
+ */
+export async function resolveCanonicalEntityInFamily(
+  vaultRoot: string,
+  family: CanonicalEntityFamily,
+  lookup: string,
+): Promise<CanonicalEntity | null> {
+  return lookupCanonicalEntityById(
+    await readCanonicalEntityFamilySource(vaultRoot, family),
+    lookup,
+  );
+}
+
+/** Read only vault metadata; no canonical family or projection is traversed. */
+export async function readVaultMetadataSource(
+  vaultRoot: string,
+): Promise<QueryRecordData | null> {
+  return readOptionalVaultMetadata(path.join(vaultRoot, VAULT_LAYOUT.metadata));
 }
 
 export async function listCanonicalSourceManifest(

--- a/packages/query/test/browser-vault-metric-points-labs-measurements.test.ts
+++ b/packages/query/test/browser-vault-metric-points-labs-measurements.test.ts
@@ -20,7 +20,9 @@ import {
 } from "../src/browser.ts";
 import {
   buildMetricProjection,
+  listEntities,
   listCanonicalEntities,
+  readVault,
   rebuildQueryProjection,
 } from "../src/index.ts";
 
@@ -1162,6 +1164,31 @@ test("listCanonicalEntities applies projection-table family, kind, and date filt
       kinds: ["measurement"],
     });
     assert.deepEqual(staleMeasurements, []);
+
+    const readModel = await readVault(vaultRoot);
+    const bounds = [
+      { from: "2026-05-02" },
+      { to: "2026-05-01" },
+      { from: "2026-05-01", to: "2026-05-01" },
+      { from: "2026-05-02", to: "2026-05-02" },
+    ];
+    for (const bound of bounds) {
+      const projected = await listCanonicalEntities(vaultRoot, {
+        family: "event",
+        kinds: ["note"],
+        limit: null,
+        ...bound,
+      });
+      const modeled = listEntities(readModel, {
+        families: ["event"],
+        kinds: ["note"],
+        ...bound,
+      });
+      assert.deepEqual(
+        projected.map((entity) => entity.entityId),
+        modeled.map((entity) => entity.entityId),
+      );
+    }
   } finally {
     await rm(vaultRoot, { recursive: true, force: true });
   }
@@ -1286,6 +1313,26 @@ async function createMetricPointProjectionVault(): Promise<string> {
             value: 87,
           },
         ],
+      }),
+      JSON.stringify({
+        schemaVersion: "murph.event.v1",
+        id: "evt_projection_canonical_may_01",
+        kind: "note",
+        occurredAt: "2026-05-02T00:30:00.000Z",
+        recordedAt: "2026-05-02T00:31:00.000Z",
+        dayKey: "2026-05-01",
+        source: "manual",
+        title: "Late evening May 1 note",
+      }),
+      JSON.stringify({
+        schemaVersion: "murph.event.v1",
+        id: "evt_projection_canonical_may_02",
+        kind: "note",
+        occurredAt: "2026-05-01T23:30:00.000Z",
+        recordedAt: "2026-05-01T23:31:00.000Z",
+        dayKey: "2026-05-02",
+        source: "manual",
+        title: "Early morning May 2 note",
       }),
       "",
     ].join("\n"),

--- a/packages/query/test/narrow-family-readers.test.ts
+++ b/packages/query/test/narrow-family-readers.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { VAULT_LAYOUT } from "@murphai/contracts";
+import { QUERY_DB_RELATIVE_PATH } from "@murphai/runtime-state/node";
+import { test } from "vitest";
+
+import {
+  readCanonicalEntityFamilySource,
+  resolveCanonicalEntityInFamily,
+} from "../src/vault-source.ts";
+
+test("bounded event-family reads preserve lifecycle, display identity, aliases, and visibility without query.sqlite", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-narrow-event-"));
+
+  try {
+    const eventPath = path.posix.join(
+      VAULT_LAYOUT.eventLedgerDirectory,
+      "2026",
+      "2026-08.jsonl",
+    );
+    await writeVaultFile(
+      vaultRoot,
+      eventPath,
+      [
+        {
+          id: "evt_document_1",
+          kind: "document",
+          documentId: "doc_document_1",
+          occurredAt: "2026-08-20T10:00:00.000Z",
+          recordedAt: "2026-08-20T10:01:00.000Z",
+          title: "Original document",
+          lifecycle: { revision: 1 },
+        },
+        {
+          id: "evt_document_1",
+          kind: "document",
+          documentId: "doc_document_1",
+          occurredAt: "2026-08-20T10:00:00.000Z",
+          recordedAt: "2026-08-20T10:02:00.000Z",
+          title: "Revised document",
+          lifecycle: { revision: 2 },
+        },
+        {
+          id: "evt_deleted_1",
+          kind: "note",
+          occurredAt: "2026-08-20T11:00:00.000Z",
+          recordedAt: "2026-08-20T11:01:00.000Z",
+          title: "Deleted note",
+          lifecycle: { revision: 1 },
+        },
+        {
+          id: "evt_deleted_1",
+          kind: "note",
+          occurredAt: "2026-08-20T11:00:00.000Z",
+          recordedAt: "2026-08-20T11:02:00.000Z",
+          title: "Deleted note",
+          lifecycle: { revision: 2, state: "deleted" },
+        },
+        {
+          id: "evt_hidden_metric_1",
+          kind: "observation",
+          occurredAt: "2026-08-20T12:00:00.000Z",
+          recordedAt: "2026-08-20T12:01:00.000Z",
+          title: "Dense metric",
+          metric: "heart-rate",
+          value: 72,
+          unit: "bpm",
+        },
+        {
+          id: "evt_display_metric_1",
+          kind: "observation",
+          occurredAt: "2026-08-20T13:00:00.000Z",
+          recordedAt: "2026-08-20T13:01:00.000Z",
+          title: "Display metric",
+          metric: "resting-heart-rate",
+          value: 58,
+          unit: "bpm",
+          canonicalFact: true,
+        },
+      ].map((record) => JSON.stringify(record)).join("\n") + "\n",
+    );
+    await writeVaultFile(
+      vaultRoot,
+      path.posix.join(
+        VAULT_LAYOUT.assessmentLedgerDirectory,
+        "2099",
+        "2099-01.jsonl",
+      ),
+      "{\n",
+    );
+
+    const queryDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+
+    const entities = await readCanonicalEntityFamilySource(vaultRoot, "event");
+    const byOwner = await resolveCanonicalEntityInFamily(
+      vaultRoot,
+      "event",
+      "doc_document_1",
+    );
+    const byEventId = await resolveCanonicalEntityInFamily(
+      vaultRoot,
+      "event",
+      "evt_document_1",
+    );
+
+    assert.equal(byOwner?.entityId, "doc_document_1");
+    assert.equal(byEventId?.entityId, "doc_document_1");
+    assert.equal(byOwner?.title, "Revised document");
+    assert.equal(
+      (byOwner?.attributes.lifecycle as { revision?: number } | undefined)?.revision,
+      2,
+    );
+    assert.equal(entities.some((entity) => entity.entityId === "evt_deleted_1"), false);
+    assert.equal(entities.some((entity) => entity.entityId === "evt_hidden_metric_1"), false);
+    assert.equal(entities.some((entity) => entity.entityId === "evt_display_metric_1"), true);
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+  } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+});
+
+test("bounded family reads do not open or replace an existing query.sqlite", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-query-narrow-sentinel-"));
+
+  try {
+    await writeVaultFile(
+      vaultRoot,
+      path.posix.join(VAULT_LAYOUT.journalDirectory, "2026", "2026-08-20.md"),
+      [
+        "---",
+        "title: Narrow journal",
+        "date: 2026-08-20",
+        "---",
+        "",
+        "Family-local journal body.",
+      ].join("\n"),
+    );
+    await writeVaultFile(
+      vaultRoot,
+      path.posix.join(VAULT_LAYOUT.eventLedgerDirectory, "2099", "2099-01.jsonl"),
+      "{\n",
+    );
+
+    const queryDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+    await mkdir(path.dirname(queryDatabasePath), { recursive: true });
+    await writeFile(queryDatabasePath, "query-sentinel\n", "utf8");
+    const beforeBytes = await readFile(queryDatabasePath);
+    const beforeStat = await stat(queryDatabasePath);
+
+    const journal = await resolveCanonicalEntityInFamily(
+      vaultRoot,
+      "journal",
+      "2026-08-20",
+    );
+
+    assert.equal(journal?.entityId, "journal:2026-08-20");
+    assert.deepEqual(await readFile(queryDatabasePath), beforeBytes);
+    assert.equal((await stat(queryDatabasePath)).mtimeMs, beforeStat.mtimeMs);
+  } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+});
+
+async function writeVaultFile(
+  vaultRoot: string,
+  relativePath: string,
+  contents: string,
+): Promise<void> {
+  const absolutePath = path.join(vaultRoot, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, contents, "utf8");
+}

--- a/packages/vault-usecases/README.md
+++ b/packages/vault-usecases/README.md
@@ -14,6 +14,15 @@ It does not own canonical record schemas, canonical write behavior, query entity
 
 Keep this package thin. Add a surface here only when multiple CLI/headless callers need the same vault usecase orchestration and importing the lower-level owner internals would create the wrong dependency direction.
 
+Exact command paths compose core-owned canonical readers or query-owned bounded
+family readers; they must not call `query.readVault()`. Family aliases are
+resolved only within their owning family. Family collection commands may use a
+filtered projection API, while genuinely cross-family, aggregate, derived, or
+global-invariant commands may still materialize the shared query projection.
+When an exact read feeds a mutation, carry the observed lifecycle revision or
+source revision into the canonical core writer rather than treating projection
+state as write authority.
+
 ## Clinical FHIR snapshots
 
 `@murphai/vault-usecases/clinical-records` is the explicit execution seam for a

--- a/packages/vault-usecases/src/commands/query-record-command-helpers.ts
+++ b/packages/vault-usecases/src/commands/query-record-command-helpers.ts
@@ -4,6 +4,7 @@ import {
   extractIsoDatePrefix,
   type EventRecord,
 } from '@murphai/contracts'
+import { deriveVaultRecordIdentity } from '@murphai/query/id-families'
 import {
   loadQueryRuntime as loadBaseQueryRuntime,
   type QueryRuntimeModule,
@@ -110,11 +111,12 @@ export function toExactEventQueryRecord(
   event: EventRecord,
   ledgerFile: string,
 ): QueryRecord {
-  const displayId = event.kind === 'document'
-    ? event.documentId
-    : event.kind === 'meal'
-      ? event.mealId
-      : event.id
+  const identity = deriveVaultRecordIdentity(
+    'event',
+    event as unknown as Record<string, unknown>,
+    event.id,
+  )
+  const displayId = identity.displayId
   const relatedIds = [...new Set((event.links ?? []).map((link) => link.targetId))]
   const attributes: JsonObject = structuredClone(event) as JsonObject
   const storedLifecycle = attributes.lifecycle
@@ -134,7 +136,7 @@ export function toExactEventQueryRecord(
 
   return {
     entityId: displayId,
-    primaryLookupId: displayId,
+    primaryLookupId: identity.primaryLookupId,
     lookupIds: [...new Set([displayId, event.id, ...relatedIds])],
     family: 'event',
     recordClass: 'ledger',

--- a/packages/vault-usecases/src/usecases/capture.ts
+++ b/packages/vault-usecases/src/usecases/capture.ts
@@ -697,8 +697,8 @@ async function loadCaptureRecord(vault: string, lookup: string): Promise<QueryRe
   }
 
   const query = await loadQueryRuntime('capture query reads')
-  const readModel = await query.readVault(vault)
-  const record = query.lookupEntityById(readModel, normalizedLookup)
+  const eventRecords = await query.readCanonicalEntityFamilySource(vault, 'event')
+  const record = query.lookupCanonicalEntityById(eventRecords, normalizedLookup)
 
   if (record && isCaptureRecord(record)) {
     return record
@@ -706,11 +706,8 @@ async function loadCaptureRecord(vault: string, lookup: string): Promise<QueryRe
 
   const labelTag = captureSlugOrNull(normalizedLookup)
   if (labelTag) {
-    const latestLabelMatch = query
-      .listEntities(readModel, {
-        families: ['event'],
-        kinds: ['note'],
-      })
+    const latestLabelMatch = eventRecords
+      .filter((candidate: QueryRecord) => candidate.kind === 'note')
       .filter((candidate: QueryRecord) => isCaptureRecord(candidate) && candidate.tags.includes(labelTag))
       .sort(compareByLatest)[0]
 
@@ -742,19 +739,19 @@ export async function listCaptureRecords(input: {
   limit?: number
 }) {
   const query = await loadQueryRuntime('capture query reads')
-  const readModel = await query.readVault(input.vault)
   const limit =
     typeof input.limit === 'number' && Number.isFinite(input.limit)
       ? Math.max(1, Math.min(DEFAULT_LIST_LIMIT * 4, Math.round(input.limit)))
       : DEFAULT_LIST_LIMIT
   const requiredTags = requestedCaptureTags(input)
-  const items = query
-    .listEntities(readModel, {
-      families: ['event'],
-      kinds: ['note'],
-      from: input.from,
-      to: input.to,
-    })
+  const records = await query.listCanonicalEntities(input.vault, {
+    family: 'event',
+    kinds: ['note'],
+    from: input.from,
+    to: input.to,
+    limit: null,
+  })
+  const items = records
     .filter((record: QueryRecord) => isCaptureRecord(record))
     .filter((record: QueryRecord) => recordMatchesAllTags(record, requiredTags))
     .sort(compareByLatest)

--- a/packages/vault-usecases/src/usecases/document-meal-read.ts
+++ b/packages/vault-usecases/src/usecases/document-meal-read.ts
@@ -153,14 +153,14 @@ async function listOwnedRecords(input: {
 }) {
   const limit = input.limit ?? DEFAULT_LIST_LIMIT
   const query = await loadQueryRuntime('document/meal query reads')
-  const readModel = await query.readVault(input.vault)
-  const items = query
-    .listEntities(readModel, {
-      families: ['event'],
-      kinds: [input.expectedKind],
-      from: input.from,
-      to: input.to,
-    })
+  const records = await query.listCanonicalEntities(input.vault, {
+    family: 'event',
+    kinds: [input.expectedKind],
+    from: input.from,
+    to: input.to,
+    limit: null,
+  })
+  const items = records
     .slice(0, limit)
     .map((record: QueryRecord) => {
       const entity = toOwnedEventCommandShowEntity(record, OWNED_EVENT_LINK_KEYS)
@@ -191,13 +191,13 @@ export async function listAutomaticMealPhotoCloseoutWorkRecords(input: {
   }
   const occurrenceTime = occurrenceAt.getTime()
   const query = await loadQueryRuntime('automatic meal photo closeout reads')
-  const readModel = await query.readVault(input.vault)
-  const automaticCaptures = query
-    .listEntities(readModel, {
-      families: ['event'],
-      kinds: ['meal'],
-      to: input.to,
-    })
+  const records = await query.listCanonicalEntities(input.vault, {
+    family: 'event',
+    kinds: ['meal'],
+    to: input.to,
+    limit: null,
+  })
+  const automaticCaptures = records
     .filter(isAutomaticMealCapture)
   const retryEvidence = automaticCaptures.filter(
     (record) => readTimestamp(record.attributes.recordedAt) >= occurrenceTime,

--- a/packages/vault-usecases/src/usecases/event-record-mutations.ts
+++ b/packages/vault-usecases/src/usecases/event-record-mutations.ts
@@ -171,10 +171,13 @@ async function requireEventRecord(
   }
 
   const query = await loadQueryRuntime()
-  const readModel = await query.readVault(input.vault)
-  const record = query.lookupEntityById(readModel, input.lookup)
+  const record = await query.resolveCanonicalEntityInFamily(
+    input.vault,
+    'event',
+    input.lookup,
+  )
 
-  if (!record || record.family !== 'event') {
+  if (!record) {
     throw new VaultCliError(
       'not_found',
       `No ${input.entityLabel} found for "${input.lookup}".`,

--- a/packages/vault-usecases/src/usecases/exact-event-record.ts
+++ b/packages/vault-usecases/src/usecases/exact-event-record.ts
@@ -1,5 +1,6 @@
 import type { EventRecord } from '@murphai/contracts'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
+import { isDefaultProjectedEventRecord } from '@murphai/query/query-visibility'
 
 import { toExactEventQueryRecord } from '../commands/query-record-command-helpers.js'
 import type { QueryCanonicalEntity } from '../query-runtime.js'
@@ -36,35 +37,6 @@ export function isExactEventLookup(lookup: string): boolean {
   return /^evt_[0-9A-Za-z]+$/u.test(lookup.trim())
 }
 
-function normalizedVisibility(value: unknown): string | null {
-  return typeof value === 'string' ? value.trim().toLowerCase() : null
-}
-
-/**
- * Preserve the default query surface's visibility rule without hydrating the
- * query projection. Raw device metric observations stay available to metric
- * projections, but exact public event commands must not expose them unless
- * they were explicitly promoted to display-grade evidence.
- */
-function isDefaultVisibleEvent(event: EventRecord): boolean {
-  if (event.kind !== 'observation') {
-    return true
-  }
-
-  const attributes = event as unknown as Record<string, unknown>
-  const isMetricObservation =
-    typeof attributes.metric === 'string'
-    && typeof attributes.value === 'number'
-    && Number.isFinite(attributes.value)
-  if (!isMetricObservation) {
-    return true
-  }
-
-  return normalizedVisibility(attributes.visibility) === 'display'
-    || normalizedVisibility(attributes.queryVisibility) === 'default'
-    || attributes.canonicalFact === true
-}
-
 export async function readExactEventRecord(input: {
   vault: string
   lookup: string
@@ -80,7 +52,10 @@ export async function readExactEventRecord(input: {
   try {
     const exact = await core.readEvent({ vaultRoot: input.vault, eventId })
     if (
-      !isDefaultVisibleEvent(exact.event)
+      !isDefaultProjectedEventRecord({
+        attributes: exact.event as unknown as Record<string, unknown>,
+        kind: exact.event.kind,
+      })
       || (
         input.expectedKinds
         && input.expectedKinds.length > 0

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -2650,8 +2650,20 @@ export async function listJournalRecords(input: {
 }
 
 export async function showVaultSummary(vault: string) {
-  const readModel = await readExperimentJournalVault(vault)
-  const metadata = readModel.metadata
+  const query = await loadExperimentJournalVaultQueryRuntime()
+  let metadata: Record<string, unknown> | null
+  let coreDocument: QueryCanonicalEntity | null
+
+  try {
+    const [metadataSource, coreEntities] = await Promise.all([
+      query.readVaultMetadataSource(vault),
+      query.readCanonicalEntityFamilySource(vault, 'core'),
+    ])
+    metadata = metadataSource
+    coreDocument = coreEntities[0] ?? null
+  } catch (error) {
+    throw toVaultMetadataCliError(error)
+  }
 
   return {
     vault,
@@ -2660,9 +2672,9 @@ export async function showVaultSummary(vault: string) {
     title: stringOrNull(metadata?.title),
     timezone: stringOrNull(metadata?.timezone),
     createdAt: normalizeIsoTimestamp(stringOrNull(metadata?.createdAt)),
-    corePath: readModel.coreDocument?.path ?? null,
-    coreTitle: readModel.coreDocument?.title ?? null,
-    coreUpdatedAt: normalizeIsoTimestamp(readModel.coreDocument?.occurredAt),
+    corePath: coreDocument?.path ?? null,
+    coreTitle: coreDocument?.title ?? null,
+    coreUpdatedAt: normalizeIsoTimestamp(coreDocument?.occurredAt),
   }
 }
 
@@ -2822,10 +2834,15 @@ async function requireEntityFamily(
   family: EntityFamily,
 ) {
   const query = await loadExperimentJournalVaultQueryRuntime()
-  const readModel = await readExperimentJournalVault(vault)
-  const entity = query.lookupEntityById(readModel, lookup)
+  let entity: QueryCanonicalEntity | null
 
-  if (!entity || entity.family !== family) {
+  try {
+    entity = await query.resolveCanonicalEntityInFamily(vault, family, lookup)
+  } catch (error) {
+    throw toVaultMetadataCliError(error)
+  }
+
+  if (!entity) {
     throw new VaultCliError('not_found', `No ${family} found for "${lookup}".`, {
       family,
       lookup,

--- a/packages/vault-usecases/src/usecases/explicit-health-family-services.ts
+++ b/packages/vault-usecases/src/usecases/explicit-health-family-services.ts
@@ -1384,8 +1384,17 @@ export function createExplicitHealthQueryServices(
     },
     async showPrivateProtocol(input: EntityLookupInput) {
       const { query } = await loadRuntime();
-      const vault = await query.readVault(input.vault);
-      const summary = query.getProtocolSummary(vault, input.id);
+      const entities = await query.readCanonicalEntityFamilySource(
+        input.vault,
+        "protocol",
+      );
+      const summary = query.getProtocolSummary(
+        query.createVaultReadModel({
+          entities,
+          vaultRoot: input.vault,
+        }),
+        input.id,
+      );
       if (!summary) {
         throw new VaultCliError("not_found", `No protocol found for "${input.id}".`);
       }
@@ -1397,7 +1406,14 @@ export function createExplicitHealthQueryServices(
     },
     async listPrivateProtocols(input: PrivateProtocolListInput) {
       const { query } = await loadRuntime();
-      const vault = await query.readVault(input.vault);
+      const entities = await query.readCanonicalEntityFamilySource(
+        input.vault,
+        "protocol",
+      );
+      const vault = query.createVaultReadModel({
+        entities,
+        vaultRoot: input.vault,
+      });
       const summaries = query
         .listProtocolSummaries(vault, {
           statuses: input.status ? [input.status] : undefined,

--- a/packages/vault-usecases/src/usecases/integrated-services.ts
+++ b/packages/vault-usecases/src/usecases/integrated-services.ts
@@ -138,50 +138,12 @@ const COMPACT_WEARABLE_TREND_POINT_LIMIT = 14
 const COMPACT_WEARABLE_STRING_LENGTH = 160
 
 function genericShowFamily(id: string): QueryEntityFamily | null {
-  switch (inferEntityKind(id)) {
-    case "allergy":
-      return "allergy"
-    case "assessment":
-      return "assessment"
-    case "audit":
-      return "audit"
-    case "condition":
-      return "condition"
-    case "core":
-      return "core"
-    case "document":
-    case "event":
-    case "meal":
-      return "event"
-    case "experiment":
-      return "experiment"
-    case "family":
-      return "family"
-    case "food":
-      return "food"
-    case "genetics":
-      return "genetics"
-    case "goal":
-      return "goal"
-    case "habitat":
-      return "habitat"
-    case "journal":
-      return "journal"
-    case "protocol":
-      return "protocol"
-    case "provider":
-      return "provider"
-    case "recipe":
-      return "recipe"
-    case "regimen":
-      return "regimen"
-    case "sample":
-      return "sample"
-    case "workout_format":
-      return "workout_format"
-    default:
-      return null
+  const entityKind = inferEntityKind(id)
+  if (entityKind === "document" || entityKind === "meal") {
+    return "event"
   }
+
+  return ALL_QUERY_ENTITY_FAMILIES.find((family) => family === entityKind) ?? null
 }
 
 type CompactWearableValue = JsonValue | typeof OMIT_COMPACT_WEARABLE_VALUE

--- a/packages/vault-usecases/src/usecases/integrated-services.ts
+++ b/packages/vault-usecases/src/usecases/integrated-services.ts
@@ -15,6 +15,7 @@ import type {
   CommandContext,
   JsonObject,
 } from "../health-cli-method-types.js"
+import type { QueryEntityFamily } from "../query-runtime.js"
 import type {
   CoreWriteServices,
   ImporterServices,
@@ -37,6 +38,7 @@ import {
   asEntityEnvelope,
   asListEnvelope,
   describeLookupConstraint,
+  inferEntityKind,
   materializeExportPack,
   matchesGenericKindFilter,
   normalizeIssues,
@@ -134,6 +136,53 @@ const COMPACT_WEARABLE_ARRAY_LIMIT = 8
 const COMPACT_WEARABLE_DRIFT_SIGNAL_LIMIT = 8
 const COMPACT_WEARABLE_TREND_POINT_LIMIT = 14
 const COMPACT_WEARABLE_STRING_LENGTH = 160
+
+function genericShowFamily(id: string): QueryEntityFamily | null {
+  switch (inferEntityKind(id)) {
+    case "allergy":
+      return "allergy"
+    case "assessment":
+      return "assessment"
+    case "audit":
+      return "audit"
+    case "condition":
+      return "condition"
+    case "core":
+      return "core"
+    case "document":
+    case "event":
+    case "meal":
+      return "event"
+    case "experiment":
+      return "experiment"
+    case "family":
+      return "family"
+    case "food":
+      return "food"
+    case "genetics":
+      return "genetics"
+    case "goal":
+      return "goal"
+    case "habitat":
+      return "habitat"
+    case "journal":
+      return "journal"
+    case "protocol":
+      return "protocol"
+    case "provider":
+      return "provider"
+    case "recipe":
+      return "recipe"
+    case "regimen":
+      return "regimen"
+    case "sample":
+      return "sample"
+    case "workout_format":
+      return "workout_format"
+    default:
+      return null
+  }
+}
 
 type CompactWearableValue = JsonValue | typeof OMIT_COMPACT_WEARABLE_VALUE
 
@@ -1226,8 +1275,10 @@ function createIntegratedQueryServices(): QueryServices {
       }
 
       const query = await loadQueryRuntime()
-      const readModel = await query.readVault(vault)
-      const entity = query.lookupEntityById(readModel, id)
+      const family = genericShowFamily(id)
+      const entity = family
+        ? await query.resolveCanonicalEntityInFamily(vault, family, id)
+        : null
 
       if (!entity) {
         throw new VaultCliError("not_found", `No entity found for "${id}".`)

--- a/packages/vault-usecases/src/usecases/intervention-experiment-link.ts
+++ b/packages/vault-usecases/src/usecases/intervention-experiment-link.ts
@@ -9,9 +9,9 @@ import type { JsonObject } from '../health-cli-method-types.js'
 import {
   loadQueryRuntime,
   type QueryCanonicalEntity,
-  type QueryVaultReadModel,
 } from '../query-runtime.js'
 import { editEventRecord } from './event-record-mutations.js'
+import { readExactEventRecord } from './exact-event-record.js'
 import { showEventRecord } from './provider-event.js'
 import { normalizeOptionalText } from './vault-usecase-helpers.js'
 
@@ -73,12 +73,15 @@ export async function resolveInterventionExperimentLink(
   }
 
   const query = await loadQueryRuntime()
-  const readModel = await query.readVault(input.vault)
-  const localDate = resolveEventLocalDate(readModel, input.occurredAt)
+  const [metadata, experiments] = await Promise.all([
+    query.readVaultMetadataSource(input.vault),
+    query.readCanonicalEntityFamilySource(input.vault, 'experiment'),
+  ])
+  const localDate = resolveEventLocalDate(metadata, input.occurredAt)
 
   if (input.experiment !== undefined) {
     const experiment = requireExperimentCandidateByLookup(
-      readModel,
+      experiments,
       input.experiment,
     )
     assertExperimentCanBeLinked({
@@ -99,7 +102,7 @@ export async function resolveInterventionExperimentLink(
     }
   }
 
-  const candidates = readModel.experiments
+  const candidates = experiments
     .map(toExperimentCandidate)
     .filter((candidate): candidate is ExperimentCandidate => candidate !== null)
     .filter((candidate) => candidate.frontmatter.status === 'active')
@@ -156,10 +159,19 @@ export async function attachInterventionSessionToExperiment(input: {
   allowOutOfWindow?: boolean
 }) {
   const query = await loadQueryRuntime()
-  const readModel = await query.readVault(input.vault)
-  const event = requireInterventionSessionEvent(readModel, input.eventId)
-  const experiment = requireExperimentCandidateByLookup(readModel, input.experiment)
-  const localDate = resolveExistingEventLocalDate(readModel, event)
+  const [exactEvent, metadata, experiments] = await Promise.all([
+    readExactEventRecord({
+      vault: input.vault,
+      lookup: input.eventId,
+      entityLabel: 'intervention',
+      expectedKinds: ['intervention_session'],
+    }),
+    query.readVaultMetadataSource(input.vault),
+    query.readCanonicalEntityFamilySource(input.vault, 'experiment'),
+  ])
+  const event = requireInterventionSessionEvent(exactEvent.record, input.eventId)
+  const experiment = requireExperimentCandidateByLookup(experiments, input.experiment)
+  const localDate = resolveExistingEventLocalDate(metadata, event)
   const interventionType = readInterventionType(event)
 
   assertExperimentCanBeLinked({
@@ -191,6 +203,10 @@ export async function attachInterventionSessionToExperiment(input: {
       `experimentSlug=${JSON.stringify(experiment.experimentSlug)}`,
       `links=${JSON.stringify(links)}`,
     ],
+    validatedEvent: {
+      event: exactEvent.event,
+      ledgerFile: exactEvent.ledgerFile,
+    },
   })
 
   return {
@@ -207,9 +223,13 @@ export async function detachInterventionSessionFromExperiment(input: {
   vault: string
   eventId: string
 }) {
-  const query = await loadQueryRuntime()
-  const readModel = await query.readVault(input.vault)
-  const event = requireInterventionSessionEvent(readModel, input.eventId)
+  const exactEvent = await readExactEventRecord({
+    vault: input.vault,
+    lookup: input.eventId,
+    entityLabel: 'intervention',
+    expectedKinds: ['intervention_session'],
+  })
+  const event = requireInterventionSessionEvent(exactEvent.record, input.eventId)
   const links = replaceExperimentLink(event.links, null)
   const hasExperimentState =
     readCurrentExperimentLink(event) !== null ||
@@ -235,6 +255,10 @@ export async function detachInterventionSessionFromExperiment(input: {
     clear: links.length > 0
       ? ['experimentId', 'experimentSlug']
       : ['experimentId', 'experimentSlug', 'links'],
+    validatedEvent: {
+      event: exactEvent.event,
+      ledgerFile: exactEvent.ledgerFile,
+    },
   })
 
   return {
@@ -265,16 +289,17 @@ export function replaceExperimentLink(
 }
 
 function requireInterventionSessionEvent(
-  readModel: QueryVaultReadModel,
+  event: QueryCanonicalEntity,
   eventId: string,
 ): QueryCanonicalEntity {
-  const event = readModel.events.find((candidate) =>
-    candidate.entityId === eventId ||
-    candidate.primaryLookupId === eventId ||
-    candidate.lookupIds.includes(eventId),
-  )
-
-  if (!event || event.kind !== 'intervention_session') {
+  if (
+    event.kind !== 'intervention_session'
+    || (
+      event.entityId !== eventId
+      && event.primaryLookupId !== eventId
+      && !event.lookupIds.includes(eventId)
+    )
+  ) {
     throw new VaultCliError(
       'not_found',
       `No intervention found for "${eventId}".`,
@@ -297,12 +322,12 @@ function readInterventionType(event: QueryCanonicalEntity): string {
 }
 
 function requireExperimentCandidateByLookup(
-  readModel: QueryVaultReadModel,
+  experiments: readonly QueryCanonicalEntity[],
   lookup: string,
 ): ExperimentCandidate {
   const experiment =
-    readModel.experiments.find((candidate) => candidate.experimentSlug === lookup) ??
-    readModel.experiments.find((candidate) =>
+    experiments.find((candidate) => candidate.experimentSlug === lookup) ??
+    experiments.find((candidate) =>
       candidate.entityId === lookup ||
       candidate.primaryLookupId === lookup ||
       candidate.lookupIds.includes(lookup),
@@ -447,7 +472,7 @@ function slugifyInterventionValue(value: string | null | undefined): string | nu
 }
 
 function resolveExistingEventLocalDate(
-  readModel: QueryVaultReadModel,
+  metadata: Record<string, unknown> | null,
   event: QueryCanonicalEntity,
 ): string {
   const date =
@@ -465,15 +490,15 @@ function resolveExistingEventLocalDate(
     )
   }
 
-  return resolveEventLocalDate(readModel, event.occurredAt)
+  return resolveEventLocalDate(metadata, event.occurredAt)
 }
 
 function resolveEventLocalDate(
-  readModel: QueryVaultReadModel,
+  metadata: Record<string, unknown> | null,
   occurredAt: string,
 ): string {
-  const timeZone = typeof readModel.metadata?.timezone === 'string'
-    ? readModel.metadata.timezone
+  const timeZone = typeof metadata?.timezone === 'string'
+    ? metadata.timezone
     : 'UTC'
 
   return toLocalDayKey(occurredAt, timeZone)

--- a/packages/vault-usecases/src/usecases/measurement-read.ts
+++ b/packages/vault-usecases/src/usecases/measurement-read.ts
@@ -112,23 +112,6 @@ async function resolveManifestFile(
   return resolveRawImportManifestFile(vault, directories[0]!)
 }
 
-async function loadTrackedMeasurementRecord(
-  vault: string,
-  lookup: string,
-  allowedKinds: readonly TrackedMeasurementEventKind[],
-  label: string,
-): Promise<QueryRecord> {
-  const query = await loadQueryRuntime(`${label} query reads`)
-  const readModel = await query.readVault(vault)
-  const record = query.lookupEntityById(readModel, lookup)
-
-  if (!record || record.family !== 'event' || !allowedKinds.includes(record.kind as TrackedMeasurementEventKind)) {
-    throw new VaultCliError('not_found', `No ${label} found for "${lookup}".`)
-  }
-
-  return record
-}
-
 export async function showMeasurementRecord(vault: string, lookup: string) {
   const { record } = await readExactEventRecord({
     vault,
@@ -311,7 +294,12 @@ export async function listMeasurementEntries(input: {
 }
 
 export async function showMeasurementManifest(vault: string, lookup: string) {
-  const record = await loadTrackedMeasurementRecord(vault, lookup, TRACKED_MEASUREMENT_EVENT_KINDS, 'measurement')
+  const { record } = await readExactEventRecord({
+    vault,
+    lookup,
+    entityLabel: 'measurement',
+    expectedKinds: TRACKED_MEASUREMENT_EVENT_KINDS,
+  })
   const manifestFile = await resolveManifestFile(vault, record)
   const manifest = await readRawImportManifest(vault, manifestFile)
 

--- a/packages/vault-usecases/src/usecases/provider-event.ts
+++ b/packages/vault-usecases/src/usecases/provider-event.ts
@@ -688,14 +688,21 @@ export async function listEventRecords(input: {
 }) {
   const tags = normalizeRepeatableFlagOption(input.tag, 'tag')
   const query = await loadProviderEventQueryRuntime()
-  const readModel = await query.readVault(input.vault)
+  const records = await query.listCanonicalEntities(input.vault, {
+    family: 'event',
+    kinds: input.kind ? [input.kind] : undefined,
+    from: input.from,
+    to: input.to,
+    limit: null,
+  })
+  const readModel = query.createVaultReadModel({
+    entities: records,
+    vaultRoot: input.vault,
+  })
   const items = query
     .listEntities(readModel, {
       families: ['event'],
-      kinds: input.kind ? [input.kind] : undefined,
       experimentSlug: input.experiment,
-      from: input.from,
-      to: input.to,
       tags,
     })
     .slice(0, input.limit)

--- a/packages/vault-usecases/src/usecases/workout-read.ts
+++ b/packages/vault-usecases/src/usecases/workout-read.ts
@@ -76,23 +76,6 @@ async function resolveManifestFile(
   return resolveRawImportManifestFile(vault, directories[0]!)
 }
 
-async function loadTrackedWorkoutRecord(
-  vault: string,
-  lookup: string,
-  allowedKinds: readonly TrackedWorkoutEventKind[],
-  label: string,
-): Promise<QueryRecord> {
-  const query = await loadQueryRuntime(`${label} query reads`)
-  const readModel = await query.readVault(vault)
-  const record = query.lookupEntityById(readModel, lookup)
-
-  if (!record || record.family !== 'event' || !allowedKinds.includes(record.kind as TrackedWorkoutEventKind)) {
-    throw new VaultCliError('not_found', `No ${label} found for "${lookup}".`)
-  }
-
-  return record
-}
-
 async function listTrackedWorkoutRecords(input: {
   vault: string
   from?: string
@@ -101,18 +84,18 @@ async function listTrackedWorkoutRecords(input: {
   kinds: readonly TrackedWorkoutEventKind[]
 }) {
   const query = await loadQueryRuntime('workout query reads')
-  const readModel = await query.readVault(input.vault)
   const limit =
     typeof input.limit === 'number' && Number.isFinite(input.limit)
       ? Math.max(1, Math.min(MAX_LIST_LIMIT, Math.round(input.limit)))
       : DEFAULT_LIST_LIMIT
-  const items = query
-    .listEntities(readModel, {
-      families: ['event'],
-      kinds: [...input.kinds],
-      from: input.from,
-      to: input.to,
-    })
+  const records = await query.listCanonicalEntities(input.vault, {
+    family: 'event',
+    kinds: [...input.kinds],
+    from: input.from,
+    to: input.to,
+    limit: null,
+  })
+  const items = records
     .slice(0, limit)
     .map((record: QueryRecord) => {
       const entity = toCommandShowEntity(record)
@@ -133,7 +116,12 @@ async function showTrackedWorkoutManifest(
   allowedKinds: readonly TrackedWorkoutEventKind[],
   label: string,
 ) {
-  const record = await loadTrackedWorkoutRecord(vault, lookup, allowedKinds, label)
+  const { record } = await readExactEventRecord({
+    vault,
+    lookup,
+    entityLabel: label,
+    expectedKinds: allowedKinds,
+  })
   const manifestFile = await resolveManifestFile(vault, record)
   const manifest = await readRawImportManifest(vault, manifestFile)
 

--- a/packages/vault-usecases/test/capture.test.ts
+++ b/packages/vault-usecases/test/capture.test.ts
@@ -93,6 +93,7 @@ afterEach(() => {
   vi.doUnmock('../src/captures.ts')
   vi.doUnmock('../src/commands/query-record-command-helpers.js')
   vi.doUnmock('../src/usecases/shared.js')
+  vi.doUnmock('../src/usecases/exact-event-record.js')
 })
 
 describe('capture usecases', () => {
@@ -304,9 +305,7 @@ describe('capture usecases', () => {
       occurredAt: '2026-04-08T13:00:00Z',
       title: 'Newest capture',
     })
-    const readModel = { kind: 'query-read-model' }
-    const lookupEntityById = vi.fn(() => null)
-    const listEntities = vi.fn(() => [middleCapture, oldestCapture, newestCapture])
+    const listCanonicalEntities = vi.fn(async () => [middleCapture, oldestCapture, newestCapture])
     const readRawImportManifest = vi.fn()
 
     const capturesModule = await importWithMocks<typeof import('../src/captures.ts')>(
@@ -320,9 +319,7 @@ describe('capture usecases', () => {
           return {
             ...actual,
             loadQueryRuntime: vi.fn(async () => ({
-              readVault: vi.fn(async () => readModel),
-              lookupEntityById,
-              listEntities,
+              listCanonicalEntities,
             })),
           }
         },
@@ -344,11 +341,12 @@ describe('capture usecases', () => {
       limit: 2,
     })
 
-    expect(listEntities).toHaveBeenCalledWith(readModel, {
-      families: ['event'],
+    expect(listCanonicalEntities).toHaveBeenCalledWith('/vault', {
+      family: 'event',
       kinds: ['note'],
       from: undefined,
       to: undefined,
+      limit: null,
     })
     expect(result.items.map((item) => item.id)).toEqual([
       'evt_capture_2',
@@ -358,30 +356,20 @@ describe('capture usecases', () => {
 
   it('resolves event ids directly for show lookups', async () => {
     const captureRecord = createCaptureRecord()
-    const readModel = { kind: 'query-read-model' }
-    const lookupEntityById = vi.fn((_, lookup: string) =>
-      lookup === 'evt_capture_1' ? captureRecord : null,
-    )
-    const listEntities = vi.fn(() => [])
+    const readExactEventRecord = vi.fn(async () => ({
+      event: captureRecord.attributes,
+      ledgerFile: captureRecord.path,
+      record: captureRecord,
+    }))
     const readRawImportManifest = vi.fn()
 
     const capturesModule = await importWithMocks<typeof import('../src/captures.ts')>(
       '../src/captures.ts',
       {
-        '../src/commands/query-record-command-helpers.js': async () => {
-          const actual = await vi.importActual<
-            typeof import('../src/commands/query-record-command-helpers.ts')
-          >('../src/commands/query-record-command-helpers.ts')
-
-          return {
-            ...actual,
-            loadQueryRuntime: vi.fn(async () => ({
-              readVault: vi.fn(async () => readModel),
-              lookupEntityById,
-              listEntities,
-            })),
-          }
-        },
+        '../src/usecases/exact-event-record.js': () => ({
+          isExactEventLookup: (lookup: string) => lookup.startsWith('evt_'),
+          readExactEventRecord,
+        }),
         '../src/usecases/shared.js': async () => {
           const actual = await vi.importActual<typeof import('../src/usecases/shared.ts')>(
             '../src/usecases/shared.ts',
@@ -397,8 +385,12 @@ describe('capture usecases', () => {
 
     const result = await capturesModule.showCaptureRecord('/vault', 'evt_capture_1')
 
-    expect(lookupEntityById).toHaveBeenCalledWith(readModel, 'evt_capture_1')
-    expect(listEntities).not.toHaveBeenCalled()
+    expect(readExactEventRecord).toHaveBeenCalledWith({
+      vault: '/vault',
+      lookup: 'evt_capture_1',
+      entityLabel: 'capture',
+      expectedKinds: ['note'],
+    })
     expect(result.entity).toMatchObject({
       id: 'evt_capture_1',
       kind: 'capture',
@@ -413,19 +405,25 @@ describe('capture usecases', () => {
   it('resolves stable labels to the latest capture for show and manifest', async () => {
     const olderCapture = createCaptureRecord({
       entityId: 'evt_capture_0',
+      primaryLookupId: 'evt_capture_0',
+      lookupIds: ['evt_capture_0'],
       occurredAt: '2026-04-08T11:00:00Z',
       title: 'Older capture',
     })
     const latestCapture = createCaptureRecord({
       entityId: 'evt_capture_1',
+      primaryLookupId: 'evt_capture_1',
+      lookupIds: ['evt_capture_1'],
       occurredAt: '2026-04-08T12:00:00Z',
       title: 'Latest capture',
     })
-    const readModel = { kind: 'query-read-model' }
-    const lookupEntityById = vi.fn((_, lookup: string) =>
-      lookup === 'evt_capture_1' ? latestCapture : null,
+    const eventRecords = [olderCapture, latestCapture]
+    const readCanonicalEntityFamilySource = vi.fn(async () => eventRecords)
+    const lookupCanonicalEntityById = vi.fn((records: QueryRecord[], lookup: string) =>
+      records.find((record) =>
+        record.entityId === lookup || record.lookupIds.includes(lookup),
+      ) ?? null,
     )
-    const listEntities = vi.fn(() => [olderCapture, latestCapture])
     const manifest = {
       artifacts: [],
       importId: 'imp_capture_1',
@@ -454,9 +452,8 @@ describe('capture usecases', () => {
           return {
             ...actual,
             loadQueryRuntime: vi.fn(async () => ({
-              readVault: vi.fn(async () => readModel),
-              lookupEntityById,
-              listEntities,
+              readCanonicalEntityFamilySource,
+              lookupCanonicalEntityById,
             })),
           }
         },
@@ -480,11 +477,11 @@ describe('capture usecases', () => {
       'mole-left-forearm-1',
     )
 
-    expect(lookupEntityById).toHaveBeenCalledWith(readModel, 'mole-left-forearm-1')
-    expect(listEntities).toHaveBeenCalledWith(readModel, {
-      families: ['event'],
-      kinds: ['note'],
-    })
+    expect(readCanonicalEntityFamilySource).toHaveBeenCalledWith('/vault', 'event')
+    expect(lookupCanonicalEntityById).toHaveBeenCalledWith(
+      eventRecords,
+      'mole-left-forearm-1',
+    )
     expect(showResult.entity).toMatchObject({
       id: 'evt_capture_1',
       kind: 'capture',

--- a/packages/vault-usecases/test/experiment-onboarding-schedule.test.ts
+++ b/packages/vault-usecases/test/experiment-onboarding-schedule.test.ts
@@ -63,6 +63,7 @@ test("applyExperimentOnboardingRecord writes structured run-plan schedules", asy
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [experimentEntity] })),
     lookupEntityById: vi.fn(() => experimentEntity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => experimentEntity),
   };
   const updateExperiment = vi.fn(
     async (_input: { runPlan?: { schedule?: unknown } }) => ({
@@ -139,6 +140,7 @@ test("applyExperimentOnboardingRecord accepts status-only updates", async () => 
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [experimentEntity] })),
     lookupEntityById: vi.fn(() => experimentEntity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => experimentEntity),
   };
   const updateExperiment = vi.fn(
     async (_input: { runPlan?: unknown; status?: string }) => ({
@@ -215,6 +217,7 @@ test("applyExperimentOnboardingRecord preserves untouched hypothesis fields on p
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [experimentEntity] })),
     lookupEntityById: vi.fn(() => experimentEntity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => experimentEntity),
   };
   const updateExperiment = vi.fn(
     async (_input: { analysisPlan?: Record<string, unknown> }) => ({
@@ -299,6 +302,7 @@ test("applyExperimentOnboardingRecord clears run baseline windows with zero base
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [experimentEntity] })),
     lookupEntityById: vi.fn(() => experimentEntity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => experimentEntity),
   };
   const updateExperiment = vi.fn(
     async (_input: { runPlan?: Record<string, unknown> }) => ({
@@ -373,6 +377,7 @@ test("applyExperimentOnboardingRecord rejects legacy string schedule payloads", 
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [experimentEntity] })),
     lookupEntityById: vi.fn(() => experimentEntity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => experimentEntity),
   };
   const updateExperiment = vi.fn();
 

--- a/packages/vault-usecases/test/experiment-session-intervention-type.test.ts
+++ b/packages/vault-usecases/test/experiment-session-intervention-type.test.ts
@@ -58,6 +58,7 @@ async function loadExperimentJournalModule() {
   const queryRuntime = {
     readVault: vi.fn(async () => ({ entities: [entity], experiments: [entity] })),
     lookupEntityById: vi.fn(() => entity),
+    resolveCanonicalEntityInFamily: vi.fn(async () => entity),
   };
   const upsertEventRecord = vi.fn(async () => ({
     created: true,

--- a/packages/vault-usecases/test/generic-show-routing.test.ts
+++ b/packages/vault-usecases/test/generic-show-routing.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+
+import { afterEach, test, vi } from "vitest";
+
+import type {
+  QueryCanonicalEntity,
+  QueryEntityFamily,
+} from "../src/query-runtime.ts";
+import { importWithMocks, mockActualModule } from "./mock-import.ts";
+
+const QUERY_FAMILY_ROUTES = [
+  ["alg_1", "allergy"],
+  ["asmt_1", "assessment"],
+  ["aud_1", "audit"],
+  ["cond_1", "condition"],
+  ["vault_1", "core"],
+  ["core", "core"],
+  ["current", "core"],
+  ["evt_1", "event"],
+  ["exp_1", "experiment"],
+  ["fam_1", "family"],
+  ["food_1", "food"],
+  ["var_1", "genetics"],
+  ["goal_1", "goal"],
+  ["hab_1", "habitat"],
+  ["journal:2026-08-20", "journal"],
+  ["prot_1", "protocol"],
+  ["prov_1", "provider"],
+  ["reg_1", "regimen"],
+  ["rcp_1", "recipe"],
+  ["smp_1", "sample"],
+  ["wfmt_1", "workout_format"],
+  ["doc_1", "event"],
+  ["meal_1", "event"],
+] as const satisfies ReadonlyArray<readonly [string, QueryEntityFamily]>;
+
+afterEach(() => {
+  vi.doUnmock("../src/usecases/runtime.js");
+  vi.restoreAllMocks();
+});
+
+test("generic show derives every query family from the shared lookup registries", async () => {
+  const resolveCanonicalEntityInFamily = vi.fn(
+    async (_vault: string, family: QueryEntityFamily, lookup: string) =>
+      createQueryEntity(family, lookup),
+  );
+  const integratedServicesModule = await importWithMocks<
+    typeof import("../src/usecases/integrated-services.ts")
+  >("../src/usecases/integrated-services.ts", {
+    "../src/usecases/runtime.js": mockActualModule(
+      "../src/usecases/runtime.ts",
+      (actual) => ({
+        ...actual,
+        loadQueryRuntime: vi.fn(async () => ({ resolveCanonicalEntityInFamily })),
+      }),
+    ),
+  });
+  const services = integratedServicesModule.createIntegratedVaultServices();
+
+  for (const [lookup, family] of QUERY_FAMILY_ROUTES) {
+    resolveCanonicalEntityInFamily.mockClear();
+    const shown = await services.query.show({
+      id: lookup,
+      requestId: null,
+      vault: "/vault",
+    });
+
+    assert.equal(shown.entity.id, lookup);
+    assert.deepEqual(resolveCanonicalEntityInFamily.mock.calls, [
+      ["/vault", family, lookup],
+    ]);
+  }
+});
+
+test("generic show preserves typed errors for unknown, constrained, and missing ids", async () => {
+  const resolveCanonicalEntityInFamily = vi.fn(async () => null);
+  const integratedServicesModule = await importWithMocks<
+    typeof import("../src/usecases/integrated-services.ts")
+  >("../src/usecases/integrated-services.ts", {
+    "../src/usecases/runtime.js": mockActualModule(
+      "../src/usecases/runtime.ts",
+      (actual) => ({
+        ...actual,
+        loadQueryRuntime: vi.fn(async () => ({ resolveCanonicalEntityInFamily })),
+      }),
+    ),
+  });
+  const services = integratedServicesModule.createIntegratedVaultServices();
+
+  await assert.rejects(
+    services.query.show({ id: "unknown_1", requestId: null, vault: "/vault" }),
+    { code: "not_found", name: "VaultCliError" },
+  );
+  assert.equal(resolveCanonicalEntityInFamily.mock.calls.length, 0);
+
+  await assert.rejects(
+    services.query.show({ id: "xfm_1", requestId: null, vault: "/vault" }),
+    { code: "invalid_lookup_id", name: "VaultCliError" },
+  );
+  assert.equal(resolveCanonicalEntityInFamily.mock.calls.length, 0);
+
+  await assert.rejects(
+    services.query.show({ id: "evt_missing", requestId: null, vault: "/vault" }),
+    { code: "not_found", name: "VaultCliError" },
+  );
+  assert.deepEqual(resolveCanonicalEntityInFamily.mock.calls, [
+    ["/vault", "event", "evt_missing"],
+  ]);
+});
+
+function createQueryEntity(
+  family: QueryEntityFamily,
+  lookup: string,
+): QueryCanonicalEntity {
+  const kind = lookup.startsWith("doc_")
+    ? "document"
+    : lookup.startsWith("meal_")
+      ? "meal"
+      : family === "core"
+        ? "core_document"
+        : family;
+
+  return {
+    attributes: {},
+    body: null,
+    date: null,
+    entityId: lookup,
+    experimentSlug: null,
+    family,
+    frontmatter: null,
+    kind,
+    links: [],
+    lookupIds: [lookup],
+    occurredAt: null,
+    path: `${family}/${lookup}`,
+    primaryLookupId: lookup,
+    recordClass: "bank",
+    relatedIds: [],
+    status: null,
+    stream: null,
+    tags: [],
+    title: lookup,
+  };
+}

--- a/packages/vault-usecases/test/narrow-query-readers-real.test.ts
+++ b/packages/vault-usecases/test/narrow-query-readers-real.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { VAULT_LAYOUT } from "@murphai/contracts";
+import { createExperiment, initializeVault, upsertEvent } from "@murphai/core";
+import { QUERY_DB_RELATIVE_PATH } from "@murphai/runtime-state/node";
+import { test } from "vitest";
+
+import { showExperimentRecord } from "../src/usecases/experiment-journal-vault.ts";
+import { showWorkoutRecord } from "../src/usecases/workout-read.ts";
+
+test("exact event reads ignore unrelated canonical roots and do not create query.sqlite", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-narrow-event-read-"));
+
+  try {
+    await initializeVault({
+      vaultRoot,
+      createdAt: "2026-08-20T12:00:00.000Z",
+      timezone: "UTC",
+    });
+    const saved = await upsertEvent({
+      vaultRoot,
+      payload: {
+        kind: "activity_session",
+        occurredAt: "2026-08-20T13:00:00.000Z",
+        title: "Narrow reader workout",
+        activityType: "running",
+        durationMinutes: 30,
+        workout: {
+          exercises: [],
+        },
+      },
+    });
+    await writeVaultFile(
+      vaultRoot,
+      path.posix.join(
+        VAULT_LAYOUT.assessmentLedgerDirectory,
+        "2099",
+        "2099-01.jsonl",
+      ),
+      "{\n",
+    );
+
+    const queryDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+
+    const shown = await showWorkoutRecord(vaultRoot, saved.eventId);
+
+    assert.equal(shown.entity.id, saved.eventId);
+    assert.equal(shown.entity.kind, "activity_session");
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+  } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+});
+
+test("experiment id and slug reads stay inside the experiment family and leave query.sqlite untouched", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-narrow-experiment-read-"));
+
+  try {
+    await initializeVault({
+      vaultRoot,
+      createdAt: "2026-08-20T12:00:00.000Z",
+      timezone: "UTC",
+    });
+    const saved = await createExperiment({
+      vaultRoot,
+      slug: "narrow-reader",
+      title: "Narrow Reader",
+      startedOn: "2026-08-20",
+    });
+    await writeVaultFile(
+      vaultRoot,
+      path.posix.join(VAULT_LAYOUT.eventLedgerDirectory, "2099", "2099-01.jsonl"),
+      "{\n",
+    );
+
+    const queryDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+    await mkdir(path.dirname(queryDatabasePath), { recursive: true });
+    await writeFile(queryDatabasePath, "narrow-reader-sentinel\n", "utf8");
+    const beforeBytes = await readFile(queryDatabasePath);
+    const beforeStat = await stat(queryDatabasePath);
+
+    const byId = await showExperimentRecord(vaultRoot, saved.experiment.id);
+    const bySlug = await showExperimentRecord(vaultRoot, saved.experiment.slug);
+
+    assert.equal(byId.entity.id, saved.experiment.id);
+    assert.equal(bySlug.entity.id, saved.experiment.id);
+    assert.deepEqual(await readFile(queryDatabasePath), beforeBytes);
+    assert.equal((await stat(queryDatabasePath)).mtimeMs, beforeStat.mtimeMs);
+  } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+});
+
+async function writeVaultFile(
+  vaultRoot: string,
+  relativePath: string,
+  contents: string,
+): Promise<void> {
+  const absolutePath = path.join(vaultRoot, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, contents, "utf8");
+}

--- a/packages/vault-usecases/test/narrow-query-readers-real.test.ts
+++ b/packages/vault-usecases/test/narrow-query-readers-real.test.ts
@@ -10,6 +10,7 @@ import { test } from "vitest";
 
 import { showExperimentRecord } from "../src/usecases/experiment-journal-vault.ts";
 import { showWorkoutRecord } from "../src/usecases/workout-read.ts";
+import { createIntegratedVaultServices } from "../src/vault-services.ts";
 
 test("exact event reads ignore unrelated canonical roots and do not create query.sqlite", async () => {
   const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-narrow-event-read-"));
@@ -96,6 +97,38 @@ test("experiment id and slug reads stay inside the experiment family and leave q
     assert.equal(bySlug.entity.id, saved.experiment.id);
     assert.deepEqual(await readFile(queryDatabasePath), beforeBytes);
     assert.equal((await stat(queryDatabasePath)).mtimeMs, beforeStat.mtimeMs);
+  } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+});
+
+test("generic show resolves the initialized vault id without creating query.sqlite", async () => {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-narrow-core-read-"));
+
+  try {
+    const initialized = await initializeVault({
+      vaultRoot,
+      createdAt: "2026-08-20T12:00:00.000Z",
+      timezone: "UTC",
+    });
+    const queryDatabasePath = path.join(vaultRoot, QUERY_DB_RELATIVE_PATH);
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+
+    const shown = await createIntegratedVaultServices().query.show({
+      vault: vaultRoot,
+      id: initialized.metadata.vaultId,
+      requestId: null,
+    });
+
+    assert.equal(shown.entity.id, initialized.metadata.vaultId);
+    assert.equal(shown.entity.kind, "core_document");
+    await assert.rejects(
+      () => stat(queryDatabasePath),
+      (error): boolean => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
   } finally {
     await rm(vaultRoot, { force: true, recursive: true });
   }

--- a/packages/vault-usecases/test/query-read-architecture.test.ts
+++ b/packages/vault-usecases/test/query-read-architecture.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { test } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+const allowedFullVaultReaders = new Map<string, number>([
+  ["packages/cli/src/commands/export-intake-read-helpers.ts", 1],
+  ["packages/cli/src/commands/search.ts", 1],
+  ["packages/vault-usecases/src/usecases/experiment-journal-vault.ts", 1],
+  ["packages/vault-usecases/src/usecases/integrated-services.ts", 1],
+  ["packages/vault-usecases/src/usecases/measurement-read.ts", 2],
+  ["packages/vault-usecases/src/usecases/workout-live-state.ts", 1],
+]);
+
+const narrowReaderContracts = new Map<string, readonly string[]>([
+  [
+    "packages/cli/src/commands/audit-command-helpers.ts",
+    ["resolveCanonicalEntityInFamily", "listCanonicalEntities"],
+  ],
+  [
+    "packages/cli/src/commands/export-intake-read-helpers.ts",
+    ["resolveCanonicalEntityInFamily"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/capture.ts",
+    ["readCanonicalEntityFamilySource", "listCanonicalEntities"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/event-record-mutations.ts",
+    ["resolveCanonicalEntityInFamily"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/experiment-journal-vault.ts",
+    ["resolveCanonicalEntityInFamily", "readVaultMetadataSource"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/integrated-services.ts",
+    ["resolveCanonicalEntityInFamily"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/intervention-experiment-link.ts",
+    ["readCanonicalEntityFamilySource", "readExactEventRecord", "readVaultMetadataSource"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/measurement-read.ts",
+    ["readExactEventRecord"],
+  ],
+  [
+    "packages/vault-usecases/src/usecases/workout-read.ts",
+    ["readExactEventRecord", "listCanonicalEntities"],
+  ],
+]);
+
+const forbiddenExactReaderCalls = [
+  "ensureFreshQueryProjection(",
+  "loadProjectedVaultSource(",
+  "searchVaultRuntime(",
+] as const;
+
+test("full-vault query hydration remains confined to aggregate and derived owners", async () => {
+  const sourceFiles = await Promise.all([
+    walkTypeScriptFiles(path.join(repositoryRoot, "packages", "cli", "src")),
+    walkTypeScriptFiles(path.join(repositoryRoot, "packages", "vault-usecases", "src")),
+  ]).then((groups) => groups.flat());
+  const actual = new Map<string, number>();
+
+  for (const absolutePath of sourceFiles) {
+    const source = await readFile(absolutePath, "utf8");
+    const count = source.match(/\.readVault\s*\(/gu)?.length ?? 0;
+    if (count > 0) {
+      actual.set(toRepositoryPath(absolutePath), count);
+    }
+  }
+
+  assert.deepEqual(
+    [...actual.entries()].sort(([left], [right]) => left.localeCompare(right)),
+    [...allowedFullVaultReaders.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+});
+
+test("exact and family-local command owners depend on narrow query capabilities", async () => {
+  for (const [relativePath, requiredCalls] of narrowReaderContracts) {
+    const source = await readFile(path.join(repositoryRoot, relativePath), "utf8");
+
+    for (const requiredCall of requiredCalls) {
+      assert.ok(
+        source.includes(requiredCall),
+        `${relativePath} must retain the ${requiredCall} narrow-reader boundary`,
+      );
+    }
+    for (const forbiddenCall of forbiddenExactReaderCalls) {
+      assert.equal(
+        source.includes(forbiddenCall),
+        false,
+        `${relativePath} must not call ${forbiddenCall}`,
+      );
+    }
+  }
+});
+
+async function walkTypeScriptFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const absolutePath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      return walkTypeScriptFiles(absolutePath);
+    }
+    return entry.isFile() && entry.name.endsWith(".ts") ? [absolutePath] : [];
+  }));
+  return files.flat();
+}
+
+function toRepositoryPath(absolutePath: string): string {
+  return path.relative(repositoryRoot, absolutePath).split(path.sep).join("/");
+}

--- a/packages/vault-usecases/test/record-service-coverage.test.ts
+++ b/packages/vault-usecases/test/record-service-coverage.test.ts
@@ -7,10 +7,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { VaultCliError } from "@murphai/operator-config/vault-cli-errors";
 import { CURRENT_VAULT_FORMAT_VERSION } from "@murphai/contracts";
-import {
-  createVaultReadModel,
-  type ProtocolSummary,
-} from "@murphai/query";
+import type { ProtocolSummary } from "@murphai/query";
 import * as queryRuntime from "@murphai/query";
 
 import {
@@ -197,6 +194,17 @@ async function loadManifestReadUsecases(queryRuntime: {
   readVault: (vault: string) => Promise<unknown>;
   lookupEntityById: (readModel: unknown, lookup: string) => QueryRecord | null;
 }) {
+  const readExactEventRecord = vi.fn(async (input: {
+    lookup: string
+    expectedKinds?: readonly string[]
+  }) => {
+    const readModel = await queryRuntime.readVault('./vault')
+    const record = queryRuntime.lookupEntityById(readModel, input.lookup)
+    if (!record || (input.expectedKinds && !input.expectedKinds.includes(record.kind))) {
+      throw new VaultCliError('not_found', `No event found for "${input.lookup}".`)
+    }
+    return { event: record.attributes, ledgerFile: record.path, record }
+  })
   const readOwnedEventRecord = vi.fn(async (input: { lookup: string; kind: string }) => {
     const readModel = await queryRuntime.readVault('./vault')
     const record = queryRuntime.lookupEntityById(readModel, input.lookup)
@@ -229,6 +237,9 @@ async function loadManifestReadUsecases(queryRuntime: {
         loadQueryRuntime: vi.fn(async () => queryRuntime),
       }),
     ),
+    "../src/usecases/exact-event-record.ts": () => ({
+      readExactEventRecord,
+    }),
   });
 
   return { documentMeal, workoutRead };
@@ -637,7 +648,7 @@ describe("record service seams", () => {
                 })
             : null,
       ),
-      listEntities: vi.fn(() => [
+      listCanonicalEntities: vi.fn(async () => [
         sampleQueryRecord({
           kind: "document",
           family: "event",
@@ -776,8 +787,7 @@ describe("record service seams", () => {
 
   test("event mutations require the requested id to identify the event directly", async () => {
     const queryRuntime = {
-      readVault: vi.fn(async () => ({ vault: "./vault" })),
-      lookupEntityById: vi.fn((_readModel: unknown, lookup: string) =>
+      resolveCanonicalEntityInFamily: vi.fn((_vault: string, _family: string, lookup: string) =>
         lookup === "media_1"
           ? sampleQueryRecord({
               kind: "activity_session",
@@ -1287,12 +1297,7 @@ describe("record service seams", () => {
   test("private protocol listing filters by Health Commons protocol references", async () => {
     const query = {
       ...queryRuntime,
-      readVault: vi.fn(async () =>
-        createVaultReadModel({
-          vaultRoot: "./vault",
-          entities: [],
-        })
-      ),
+      readCanonicalEntityFamilySource: vi.fn(async () => []),
       listProtocolSummaries: vi.fn((): ProtocolSummary[] => [
         {
           id: "protocol_1",
@@ -1526,6 +1531,34 @@ describe("record service seams", () => {
         family: "experiment",
         kind: "experiment",
       })),
+      resolveCanonicalEntityInFamily: vi.fn(async (
+        _vault: string,
+        family: string,
+      ) => sampleQueryRecord({
+        entityId: family === "journal" ? "journal:2026-04-08" : "exp_1",
+        primaryLookupId: family === "journal" ? "journal:2026-04-08" : "exp_1",
+        family: family === "journal" ? "journal" : "experiment",
+        kind: family === "journal" ? "journal_day" : "experiment",
+      })),
+      readVaultMetadataSource: vi.fn(async () => ({
+        formatVersion: CURRENT_VAULT_FORMAT_VERSION,
+        vaultId: "vault_1",
+        title: "Vault",
+        timezone: "UTC",
+        createdAt: "2026-04-08T12:00:00.000Z",
+      })),
+      readCanonicalEntityFamilySource: vi.fn(async (_vault: string, family: string) =>
+        family === "core"
+          ? [sampleQueryRecord({
+              entityId: "vault_1",
+              primaryLookupId: "vault_1",
+              family: "core",
+              kind: "core_document",
+              path: "core.md",
+              title: "Core",
+              occurredAt: "2026-04-08T11:00:00.000Z",
+            })]
+          : []),
       listEntities: vi.fn(() => [sampleQueryRecord({
         entityId: "exp_1",
         primaryLookupId: "exp_1",
@@ -1689,6 +1722,7 @@ describe("record service seams", () => {
     const anchoredMetricQuery = {
       readVault: vi.fn(async () => journalQuery.readVault()),
       lookupEntityById: vi.fn(() => anchoredExperiment),
+      resolveCanonicalEntityInFamily: vi.fn(async () => anchoredExperiment),
       listMetricPoints: vi.fn(async (_vault: string, filters: unknown) => {
         anchoredMetricPointFilters.push(filters);
         return [];


### PR DESCRIPTION
## Outcome

Exact and family-scoped vault reads now use canonical owner reads or bounded family readers instead of rebuilding and hydrating the complete query projection. Cross-family and genuinely aggregate commands remain projection-backed.

The change preserves existing IDs, aliases, visibility, lifecycle collapse, mutation authority, output shapes, and typed not-found behavior while adding durable architecture and filesystem regression guards.

## Product UX

Not applicable. This is an internal read-path performance and ownership change with no UI, copy, interaction, permission, or member-facing contract change.

## Prompt review

Applicable to the changed execution plan and package ownership guidance, but not to runtime provider prompts. The plan now routes the prompt lens correctly without duplicating the canonical prompt checklist.

## Evidence

- Query suite: 66 files, 696 tests passed; focused canonical-day projection/read-model parity passed 2 files and 114 tests.
- Contracts suite: 40 files, 326 tests passed.
- Vault-usecases suite: 44 files, 369 tests passed; focused exact-core and generic-routing proof passed 2 files and 5 tests.
- CLI suite: 126 files, 1,187 tests passed and 1 skipped; focused delayed-closeout proof passed 1 file and 11 tests.
- Corrected-head repository typecheck passed, including query, vault-usecases, and CLI.
- Scenario integrity passed for 207 scenarios, 12 sample inputs, and 29 golden-output directories.
- Artifact forward/reverse checks, git diff --check, and privacy scans passed.
- Full-snapshot final ReviewGPT round 2 returned `ROUND_OUTCOME: PASS` with no new finding.

## Non-obvious affected surfaces

- Generic query show dispatch now selects one family through the existing lookup-ID registry; architecture coverage proves it cannot fall back to the global projection.
- Intervention attach/detach reads the exact canonical event plus metadata and experiment-family state in parallel, while the existing core writer retains optimistic-concurrency authority.
- Event display identity and default visibility are shared between source-backed and projected readers to prevent semantic drift.
- Query package exports one visibility subpath used by vault-usecases; package typecheck and full suites cover the boundary.
- Measurement record listing deliberately remains on the full read model because it is part of the deferred aggregate-freshness phase. The shared filtered projection predicate now preserves canonical-day precedence for migrated bounded lists.

## Architecture and reuse

- Existing systems reused: core exact event/owner reads, query family collectors, the lookup-ID registry, canonical lifecycle collapse, projection filtering, and existing vault-usecase command seams.
- New logic: one query-owned bounded family source reader, family-local resolution, metadata-only read, and generic-show routing derived from the existing lookup registry and query-family catalog.
- New abstractions: no new persistence or state owner; the added capabilities are thin exports over existing collectors and read-model lookup semantics.
- Complexity intentionally avoided: no second index, incremental projection writer, source-generation journal, cross-process lock, migration, compatibility layer, or repair loop.

## Hot reply path impact

Applicable when an assistant tool invokes one of the changed query commands during a foreground reply. No database, network/provider, timeout, retry, or fallback operation was added. Exact event commands perform the existing single core exact read; generic show performs one bounded family read; intervention linking performs three parallel bounded reads before the unchanged canonical mutation. These replace a source-manifest walk, possible full projection rebuild, and whole-vault hydration. Latency is expected to decrease but was not benchmarked; filesystem tests prove representative exact reads do not create or modify query.sqlite and ignore malformed unrelated roots.

## Murph initial provider input impact

- Murph: Not applicable; no prompt, tool schema, generated guidance, or first provider-visible request assembly changed.
- Codex: Not applicable; no Codex provider-input surface changed.

## ReviewGPT finding ledger

- Preliminary prompt finding accepted: the active plan now marks prompt review applicable to changed execution and ownership guidance.
- Preliminary and round 1 canonical-day finding accepted: the shared SQL predicate now uses canonical date with occurred-at fallback; projection/read-model parity and a real Europe/Berlin delayed meal-closeout journey prove adjacent-day photos are not consumed early.
- Preliminary and round 1 generic-show finding accepted: canonical vault IDs are registered with the core lookup family, the duplicate 21-case switch is deleted, and table-driven routing covers every query family plus typed misses.
- Full-snapshot round 2 verified every correction and returned `ROUND_OUTCOME: PASS` with no original or review-induced issue.
- No ReviewGPT finding was rejected.

## Risks

- Direct/projected semantic drift is mitigated by shared identity and visibility helpers plus lifecycle/alias fixtures.
- Canonical-day drift is guarded at the shared projection owner and through the automatic meal-closeout command path.
- Aggregate freshness work is deliberately deferred for measurement-entry composition, Murph Age batch inputs, and wearable personal patterns; those paths need one coherent command-scoped projection session rather than an exact-reader substitution.

## Change-shape breakdown

Classification rule: production package source is source; test directories and .test files are tests/fixtures; README and execution-plan files are docs; package manifests are config/tooling; generated output is separate.

Immutable first-reviewed baseline:

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 429 | 188 |
| Tests/fixtures | 510 | 54 |
| Docs | 190 | 6 |
| Config/tooling | 5 | 0 |
| Generated/other | 0 | 0 |
| Total | 1134 | 248 |

Current final head:

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 396 | 192 |
| Tests/fixtures | 834 | 55 |
| Docs | 210 | 6 |
| Config/tooling | 5 | 0 |
| Generated/other | 0 | 0 |
| Total | 1445 | 253 |

## Deployment concerns

- Deployment: not applicable
- Reason: Workspace packages compile and ship together; this changes no durable schema, record shape, protocol, environment, or independently deployed compatibility boundary.

## Changelog

- Changelog: not applicable
- Reason: No member-visible capability or contract changes; this is internal read-path performance and architecture enforcement.

ReviewGPT context sensitivity: sensitive — cross-package query/runtime behavior is used by assistant tool calls and exact CLI reads.
ReviewGPT first-reviewed head: ed49c7e03bd04814129bb5c3a75483f0bd03d61c