### PR TITLE
docs: require consumer-first protocol rollouts

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -11,6 +11,8 @@ Every pull request carries one mechanically validated, field-complete
 deployment-concerns disposition. Applicable deploy boundaries record supported skew, safe order,
 rollback floor, expected exposure, reversibility, convergence proof, and
 post-deploy checks; other changes record one concrete not-applicable reason.
+Shared protocols between independently deployed components use a
+consumer-first rollout and prove every supported mixed-version pair.
 Every PR also records non-obvious affected surfaces, a mechanically validated
 architecture/reuse summary, foreground reply-path impact, complete initial
 provider-input impact, and categorized added/deleted LOC. User-facing hosted

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -333,7 +333,11 @@ Every PR includes:
   Select `Deployment: applicable` and complete the deployment contract when the
   change crosses a deploy boundary; otherwise select
   `Deployment: not applicable` with a concrete reason. The pull-request
-  evidence guard validates this section.
+  evidence guard validates this section. For a shared protocol between
+  independently deployed components, identify the producer and consumer, use a
+  consumer-first safe order, and name direct proof for every supported
+  mixed-version pair. Current-head producer/consumer proof alone is
+  insufficient.
 - **Changelog.** Add exactly one `## Changelog` section with
   `Changelog: updated` and its item IDs, or `Changelog: not applicable` with a
   concrete reason. The changelog guard validates this section.

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -642,6 +642,11 @@ direct-Starter gate is fully exhausted again.
 
 - Cross-plane changes state safe deploy order, warm-old-bundle behavior,
   rollback floor, and whether coordinated deployment is required.
+- A protocol change between independently deployed components is
+  consumer-first. Deploy a consumer that accepts both the current and next
+  shape before any producer emits the next shape. A strict consumer must not
+  receive a new field, value, or message kind until that compatible consumer is
+  live. Remove legacy acceptance only after every old producer has drained.
 - A producer that persists new fail-closed authority becomes a hard rollback
   floor before its first such write when an older producer would ignore that
   authority. A below-floor emergency rollback first disables and drains every
@@ -650,6 +655,9 @@ direct-Starter gate is fully exhausted again.
 - Schema and protocol evolution is additive-first. Compatibility stays
   legacy-facing, includes a removal condition, and is deleted after verified
   production drain.
+- Compatibility proof covers every mixed-version pair that the deployment can
+  create. A current-producer/current-consumer test alone does not prove a safe
+  rolling deployment.
 
 ## Observability And Bounded Growth
 


### PR DESCRIPTION
## Why and outcome

A production incident showed that current-version tests can pass while independently deployed protocol peers remain incompatible during rollout.

This change makes consumer-first rollout order and mixed-version proof explicit in the baseline contract and PR workflow.

## Product UX

Not applicable. This PR changes internal engineering policy only and has no member-visible behavior.

## Evidence

- `pnpm docs:drift`
- `git diff --check origin/main...HEAD`
- Manual diff review confirms a documentation-only change.

## Non-obvious affected surfaces

- PR deployment-concerns evidence: shared protocol changes must now identify producer, consumer, safe order, and mixed-version proof.
- Baseline deployment contract: independently deployed protocols now require consumer-first evolution.

## Architecture and reuse

- Existing systems reused: The existing baseline invariants, completion workflow, and docs index own this policy.
- New logic: None. The PR adds documentation requirements only.
- New abstractions: None. The existing deployment-compatibility section remains the single contract owner.
- Complexity intentionally avoided: No new document, CI job, tool, state, or runtime compatibility layer was added.

## Hot reply path impact

Not applicable. The PR does not change runtime code or the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable. No provider-visible input changes.
- Codex runtime: Not applicable. No provider-visible input changes.

## Design proof

Not applicable. The PR does not change hosted Web UI.

## Change-shape breakdown

Classification uses the base-to-head authored diff. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 15 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 15 | 1 |

## Deployment concerns

- Deployment: not applicable
- Reason: This PR changes engineering documentation only and does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Members cannot see this internal engineering-policy change.