### PR TITLE
fix(web): inspect environment geocoding response shape

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -11,6 +11,8 @@ Every pull request carries one mechanically validated, field-complete
 deployment-concerns disposition. Applicable deploy boundaries record supported skew, safe order,
 rollback floor, expected exposure, reversibility, convergence proof, and
 post-deploy checks; other changes record one concrete not-applicable reason.
+Shared protocols between independently deployed components use a
+consumer-first rollout and prove every supported mixed-version pair.
 Every PR also records non-obvious affected surfaces, a mechanically validated
 architecture/reuse summary, foreground reply-path impact, complete initial
 provider-input impact, and categorized added/deleted LOC. User-facing hosted

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -333,7 +333,11 @@ Every PR includes:
   Select `Deployment: applicable` and complete the deployment contract when the
   change crosses a deploy boundary; otherwise select
   `Deployment: not applicable` with a concrete reason. The pull-request
-  evidence guard validates this section.
+  evidence guard validates this section. For a shared protocol between
+  independently deployed components, identify the producer and consumer, use a
+  consumer-first safe order, and name direct proof for every supported
+  mixed-version pair. Current-head producer/consumer proof alone is
+  insufficient.
 - **Changelog.** Add exactly one `## Changelog` section with
   `Changelog: updated` and its item IDs, or `Changelog: not applicable` with a
   concrete reason. The changelog guard validates this section.

--- a/apps/web/src/lib/environment/conditions.ts
+++ b/apps/web/src/lib/environment/conditions.ts
@@ -44,6 +44,10 @@ export async function loadEnvironmentConditions(input: {
       operation: "execute",
     },
   });
+  console.info(
+    "Environment conditions geocoding response shape.",
+    describeProviderValueShape(geocoding),
+  );
   const place = readGeocodedPlace(geocoding);
   if (!place) {
     throw hostedOnboardingError({
@@ -163,4 +167,35 @@ function readAirQuality(value: unknown): EnvironmentConditions["airQuality"] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeProviderValueShape(
+  value: unknown,
+  depth = 0,
+): unknown {
+  if (Array.isArray(value)) {
+    return {
+      item: depth < 3 && value.length > 0
+        ? describeProviderValueShape(value[0], depth + 1)
+        : null,
+      length: value.length,
+      type: "array",
+    };
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value).sort().slice(0, 20);
+    return {
+      fields: depth < 3
+        ? Object.fromEntries(
+            keys.map((key) => [
+              key,
+              describeProviderValueShape(value[key], depth + 1),
+            ]),
+          )
+        : null,
+      keys,
+      type: "object",
+    };
+  }
+  return { type: value === null ? "null" : typeof value };
 }

--- a/docs/contracts/00-invariants.md
+++ b/docs/contracts/00-invariants.md
@@ -642,6 +642,11 @@ direct-Starter gate is fully exhausted again.
 
 - Cross-plane changes state safe deploy order, warm-old-bundle behavior,
   rollback floor, and whether coordinated deployment is required.
+- A protocol change between independently deployed components is
+  consumer-first. Deploy a consumer that accepts both the current and next
+  shape before any producer emits the next shape. A strict consumer must not
+  receive a new field, value, or message kind until that compatible consumer is
+  live. Remove legacy acceptance only after every old producer has drained.
 - A producer that persists new fail-closed authority becomes a hard rollback
   floor before its first such write when an older producer would ignore that
   authority. A below-floor emergency rollback first disables and drains every
@@ -650,6 +655,9 @@ direct-Starter gate is fully exhausted again.
 - Schema and protocol evolution is additive-first. Compatibility stays
   legacy-facing, includes a removal condition, and is deleted after verified
   production drain.
+- Compatibility proof covers every mixed-version pair that the deployment can
+  create. A current-producer/current-consumer test alone does not prove a safe
+  rolling deployment.
 
 ## Observability And Bounded Growth
 


### PR DESCRIPTION
## Why

The Environment dashboard cannot resolve a valid city in production, so weather and outdoor air remain unavailable. Existing logs stop at the generic location-not-found error and do not expose the provider response contract.

## User-visible goal and UX

Restore reliable live weather and outdoor-air data. This diagnostic candidate does not change the UI. It adds the minimum safe evidence needed to identify the provider contract mismatch.

## Invariants

- Never log the API key, requested location, member identity, coordinates, or weather values.
- Keep the existing OpenWeather-through-Composio integration unchanged.
- Keep current error behavior unchanged.

## Architecture and reuse

The existing Environment conditions owner records a bounded structural summary immediately after geocoding. The summary contains value types, object keys, and array length only. It uses no new dependency, state, service, retry, or fallback.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/environment-conditions.test.ts`
- Result: 4 tests passed.

## Change shape

- Source: +35 / -0
- Tests: +0 / -0
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Changelog

Not applicable. This is internal, temporary diagnostic observability with no member-visible behavior change.

## Product UX

Not applicable. No product behavior or presentation changes.

## Provider input impact

No provider request changes. The production request still uses the server-held OpenWeather key through the existing Composio route.

## Deployment

Deploy the web app normally. Trigger one Environment conditions request, inspect the safe shape log, then replace this diagnostic with the proven parser correction.

ReviewGPT context sensitivity: sensitive