### PR TITLE
fix(cloudflare): align hosted tool expectation

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -241,6 +241,7 @@ export function expectAdvertisedMurphDynamicTools(
     imessageContactAvailable?: boolean;
     messageTargetingAvailable?: boolean;
     pendingVaultFilesAvailable?: boolean;
+    physicalNoteRecoveryAvailable?: boolean;
     physicalNotesAvailable?: boolean;
     phoneCallsAvailable?: boolean;
     progressUpdatesAvailable?: boolean;
@@ -296,6 +297,13 @@ export function expectAdvertisedMurphDynamicTools(
       if (
         options.imessageContactAvailable !== true
         && name === "murph.imessage_contact"
+      ) {
+        return false;
+      }
+
+      if (
+        options.physicalNoteRecoveryAvailable !== true
+        && name === "murph.resolve_physical_note"
       ) {
         return false;
       }

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -598,6 +598,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
       && name !== "murph.select_reply_target"
       && name !== "murph.create_phone_call"
       && name !== "murph.pending_vault_files"
+      && name !== "murph.resolve_physical_note"
       && name !== "murph.send_physical_note"
       && name !== "murph.send_vault_file"
       && name !== "murph.ask_grok"
@@ -616,6 +617,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     expect(allToolNames).toContain("murph.create_phone_call");
     expect(allToolNames).toContain("murph.group_room_model");
     expect(allToolNames).toContain("murph.imessage_contact");
+    expect(allToolNames).toContain("murph.resolve_physical_note");
     expect(allToolNames).toContain("murph.send_physical_note");
     expect(allToolNames).toContain("murph.send_progress_update");
     expect(allToolNames).toContain("murph.ask_grok");
@@ -675,6 +677,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
         imessageContactAvailable: true,
         messageTargetingAvailable: true,
         pendingVaultFilesAvailable: true,
+        physicalNoteRecoveryAvailable: true,
         physicalNotesAvailable: true,
         phoneCallsAvailable: true,
         progressUpdatesAvailable: true,


### PR DESCRIPTION
## Why and outcome

The production Cloudflare deploy gate expected murph.resolve_physical_note on a Linq turn where runtime availability correctly omitted it. The helper now models physical-note recovery independently from physical-note sending, matching the runtime catalog introduced by #2099 and unblocking the deploy gate without changing production behavior.

## Product UX

Not applicable. This is an internal test-contract correction; member-visible behavior is unchanged.

## Evidence

- pnpm --dir apps/cloudflare exec vitest run test/hosted-local-e2e-support.test.ts --config vitest.node.workspace.ts --no-coverage - 24 passed.
- pnpm --dir apps/cloudflare typecheck - passed.
- git diff --check - passed.
- The failed production gate received no resolve_physical_note; the corrected default expectation excludes it unless physicalNoteRecoveryAvailable is explicitly true.

## Non-obvious affected surfaces

- Cloudflare hosted-local Linq delivery deploy gate: its dynamic-tool advertisement assertion now mirrors the production catalog's independent recovery availability predicate.
- Other hosted-local scenarios using the shared helper: recovery is default-off in expectations and can be enabled explicitly when the scenario supplies current-input recovery authority.

## Architecture and reuse

- Existing systems reused: the shared expectAdvertisedMurphDynamicTools availability-option pattern and the runtime's existing physicalNoteRecoveryAvailable concept.
- New logic: one exact-name filter for murph.resolve_physical_note.
- New abstractions: none; the existing options object is sufficient.
- Complexity intentionally avoided: no runtime change, compatibility layer, new fixture owner, or deploy exception.

## Hot reply path impact

Not applicable. The PR changes assertions only and adds no database, network, provider, or awaited production work.

## Murph initial provider input impact

- Individual Murph: Not applicable; no provider-visible production input changes.
- Group Murph: Not applicable; no provider-visible production input changes.
- Measurement: omitted because the diff is test-only and does not change request assembly.

## Change-shape breakdown

Classification rule: both files are test assertion/support code, so all authored lines are tests/fixtures. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 11 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **11** | **0** |

## Deployment concerns

- Deployment: not applicable
- Reason: The patch changes only predeploy test expectations; it does not alter a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal test-contract correction with no member-visible change.