### PR TITLE
Keep Kernel canary reverse tunnel alive

### DIFF
--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -327,7 +327,10 @@ function startKernelTunnel(input: {
     {
       detached: true,
       env: buildKernelCliEnvironment(input.apiKey, process.env),
-      stdio: "ignore",
+      // Kernel's SSH command opens a remote shell in addition to the reverse
+      // forward. Keep its stdin open so EOF does not close that shell and tear
+      // down the tunnel before the browser reaches hosted-local Web.
+      stdio: ["pipe", "ignore", "ignore"],
     },
   );
   if (child.pid === undefined) {

--- a/apps/web/test/fixtures/kernel-tunnel-stdin.sh
+++ b/apps/web/test/fixtures/kernel-tunnel-stdin.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+while IFS= read -r _line; do :; done

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -321,6 +321,20 @@ describe("hosted-local Junction wearable browser authorization", () => {
 
     const session = await openHostedLocalJunctionBrowserSessionForTest(config);
     expect(process.listenerCount("exit")).toBe(parentExitListenersBefore + 1);
+    expect(kernelLifecycleMocks.spawn).toHaveBeenCalledWith(
+      "/opt/kernel-tools/kernel",
+      [
+        "browsers",
+        "ssh",
+        "kernel-session-1",
+        "-R",
+        "43123:localhost:43123",
+      ],
+      expect.objectContaining({
+        detached: true,
+        stdio: ["pipe", "ignore", "ignore"],
+      }),
+    );
 
     await closeHostedLocalJunctionBrowserSessionForTest(session, config);
 

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { fileURLToPath } from "node:url";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -357,6 +358,70 @@ describe("hosted-local Junction wearable browser authorization", () => {
       "kernel-session-1",
     );
     expect(process.listenerCount("exit")).toBe(parentExitListenersBefore);
+  });
+
+  it("keeps the real tunnel child alive until owned cleanup", async () => {
+    const { spawn: actualSpawn } = await vi.importActual<
+      typeof import("node:child_process")
+    >("node:child_process");
+    const browser = {
+      close: vi.fn(async () => undefined),
+      contexts: vi.fn(() => [{ clearCookies: vi.fn(async () => undefined) }]),
+    };
+    const config = createConfig({
+      KERNEL_API_KEY: "kernel-test-key",
+      MURPH_E2E_CONNECT_URL:
+        "http://localhost:43123/connect#deviceConnectIntent=opaque&connectSource=whoop",
+      MURPH_E2E_KERNEL_CLI_PATH: fileURLToPath(
+        new URL("fixtures/kernel-tunnel-stdin.sh", import.meta.url),
+      ),
+      MURPH_E2E_PROVIDER_BROWSER: "kernel",
+      MURPH_E2E_PROVIDER_HEADLESS: "1",
+      MURPH_E2E_WEB_BASE_URL: "http://localhost:43123",
+    });
+    const parentExitListenersBefore = process.listenerCount("exit");
+    let session: Awaited<
+      ReturnType<typeof openHostedLocalJunctionBrowserSessionForTest>
+    > | null = null;
+
+    kernelLifecycleMocks.ensureProfile.mockResolvedValueOnce(undefined);
+    kernelLifecycleMocks.createAutomationBrowser.mockResolvedValueOnce({
+      cdpWsUrl: "wss://cdp.example.test/session/capability-secret",
+      sessionId: "kernel-session-real-child",
+    });
+    kernelLifecycleMocks.spawn.mockImplementationOnce(actualSpawn);
+    kernelLifecycleMocks.connectOverCDP.mockResolvedValueOnce(browser);
+    kernelLifecycleMocks.deleteBrowserByIdOrName.mockResolvedValueOnce(undefined);
+
+    try {
+      session = await openHostedLocalJunctionBrowserSessionForTest(config);
+      const tunnel = session.kernelTunnel;
+      expect(tunnel).not.toBeNull();
+      if (!tunnel) throw new Error("Expected the Kernel tunnel fixture to start.");
+
+      const exitedBeforeCleanup = await Promise.race([
+        new Promise<boolean>((resolve) => {
+          tunnel.child.once("exit", () => resolve(true));
+        }),
+        new Promise<boolean>((resolve) => {
+          setTimeout(() => resolve(false), 200);
+        }),
+      ]);
+      expect(exitedBeforeCleanup).toBe(false);
+      expect(tunnel.child.exitCode).toBeNull();
+      expect(tunnel.child.signalCode).toBeNull();
+
+      await closeHostedLocalJunctionBrowserSessionForTest(session, config);
+      session = null;
+
+      expect(tunnel.child.signalCode).toBe("SIGTERM");
+      expect(process.listenerCount("exit")).toBe(parentExitListenersBefore);
+    } finally {
+      if (session) {
+        await closeHostedLocalJunctionBrowserSessionForTest(session, config)
+          .catch(() => undefined);
+      }
+    }
   });
 
   it("deletes the created Kernel browser when CDP exposes no context", async () => {


### PR DESCRIPTION
## Outcome
Keeps the Kernel CLI SSH session open for the full protected-main WHOOP canary instead of giving its interactive remote shell immediate EOF.

## Product UX result
No member-facing UI changes. This restores the unattended WHOOP connection proof that guards the existing connection experience.

## Direct evidence
- Focused browser-runner test: 26/26 passed, including a real detached child that survives with stdin open and exits through owned cleanup.
- Scoped ESLint and fixture shell syntax passed.
- Web typecheck passed.
- The prior protected-main run failed before provider auth because the reverse tunnel exited; Kernel CLI v0.31.0 forwards stdin into its interactive SSH child, and the runner had configured stdin as ignored.

## Affected surfaces
- Protected-main Junction WHOOP browser canary only.
- Oura/local browser behavior is unchanged.

## Architecture and reuse
- Existing systems reused: the existing Kernel browser client, Kernel CLI reverse forward, exact process ownership, cleanup, and redaction flow.
- New logic: keep the owned Kernel CLI child stdin open for the tunnel lifetime.
- New abstractions: none; the existing owned tunnel child and cleanup path already model this lifetime.
- Complexity intentionally avoided: no replacement tunnel protocol, supervisor, retry loop, or new dependency.

## Hot reply path impact
None.

## Provider-input impact
No credential, Junction payload, or WHOOP form behavior changes.

## Deployment concerns
- Deployment: not applicable
- Reason: Workflow-only behavior; no Vercel or Cloudflare runtime deployment or ordering concern.

## Changelog
- Changelog: not applicable
- Reason: Operational canary correction only; no member-visible behavior changed.

## LOC
- Source: +4 / -1
- Tests/fixtures: +83 / -0
- Docs: +0 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

ReviewGPT context sensitivity: sensitive — changes external Kernel SSH runtime/tunnel behavior.
ReviewGPT first-reviewed head: af37769dd6c39671c2a0884d8e71e0be51a08913