### PR TITLE
Preserve replacement starts across delayed container stops

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-20-hosted-rollout-startup-convergence.md
+++ b/agent-docs/exec-plans/completed/2026-08-20-hosted-rollout-startup-convergence.md
@@ -14,11 +14,14 @@ Success criteria:
 - Fatal, stale, stopped, poisoned, architecture-mismatched, and
   previously-ready unhealthy containers retain bounded cleanup.
 - Cleanup captured for an old start cannot invalidate a newer replacement.
-- Focused tests, typecheck, exact-head CI, and ReviewGPT pass.
+- Focused tests, typecheck, and exact-head CI pass. No additional ReviewGPT
+  round runs after the user explicitly stopped the review loop.
 
 ## Constraints
 
-- Do not deploy, mutate production state, merge, or activate remediation.
+- Keep this public follow-up scoped to the container lifecycle owner; the
+  separately authorized private worker deployment resumes only after its PR
+  and exact-head gates pass.
 - Keep retry responses and fail-closed behavior bounded.
 - Add no durable lifecycle state, queue, or second lifecycle owner.
 - Keep production evidence aggregate and free of member identifiers.
@@ -118,22 +121,26 @@ That premise is now invalidated. The corrective decision is:
   without destroy, and then proves a later warm-health failure still recycles
   that same anchored record.
 - A stale never-ready start older than 20 seconds still enters bounded cleanup.
+- A private integration run later reproduced the remaining callback order three
+  times: old-shell cleanup settled, a replacement start was issued, then the
+  old shell's delayed `onStop` cleared the provisional replacement before its
+  `onStart` arrived.
+- The focused regression failed on current `main` with `Hosted runner container
+  changed while cold readiness was recorded`, then passed after `onStop` stopped
+  clearing a provisional replacement. The existing bounded readiness deadline
+  remains the ambiguity fallback; no state owner or persistence was added.
+- The complete `runner-container.test.ts` file passes 210 tests, the Cloudflare
+  typecheck passes, and the formerly failing hosted-local retryable-outbox
+  foreground-restart scenario passes end to end in 132.90 seconds.
 
 ## State
 
-Active. ReviewGPT round 7 returned one material delayed-lifecycle-error finding
-at the hard cap, and its smallest deletion-only production correction is
-implemented with an ordering regression. Current `main` merged cleanly twice
-without manual conflict resolution, including the upstream repair for the
-unrelated Web release-test mock failure and updated native device-sync timeout
-proof. The earlier merge exposed one synthetic preemption fixture that changed
-`lastChange` on every read and omitted the real `onStart` hook; the fixture now
-uses one stable platform timestamp and the existing lifecycle callback, with no
-production-code expansion. Focused verification, parent final review, and
-exact-head CI remain; the merged corrected tree passes 424 focused Cloudflare
-tests, 550 hosted-execution tests, 32 focused Web tests, and the Cloudflare and
-hosted-execution typechecks. The hard cap prohibits an automatic round 8. The
-PR remains draft and no production action is authorized.
+Implementation complete. PR #2090 merged the bounded startup-convergence owner,
+and the follow-up closes the one generation-blind `onStop` order exposed by the
+private integration gate. The correction is one provisional-start guard plus
+one ordering regression. Focused unit, typecheck, and hosted-local E2E proof are
+green. Exact-head GitHub CI remains the merge gate. Per the user's explicit
+instruction, no ReviewGPT round runs after round 7.
 
 ## Working Set
 
@@ -148,3 +155,6 @@ PR remains draft and no production action is authorized.
 - `apps/cloudflare/test/deploy-automation.test.ts`
 - `apps/cloudflare/test/container-image-contract.test.ts`
 - `apps/cloudflare/DEPLOY.md`
+Status: completed
+Updated: 2026-08-22
+Completed: 2026-08-22

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -1743,7 +1743,11 @@ export class RunnerContainer extends Container {
       destroyRequestPresent: this.lastDestroyRequest !== null,
       idleTtlDeltaMs: readNullableNumber(lifecycleDetails.idleTtlDeltaMs),
     });
-    const stopAppliedToCurrentGeneration = !(
+    // onStop has no start identity. Preserve a bounded replacement start until
+    // its onStart hook or readiness deadline resolves which generation owns it.
+    const pendingReplacementStart =
+      this.currentContainerStart?.pendingOnStartObservation === true;
+    const stopAppliedToCurrentGeneration = !pendingReplacementStart && !(
       this.isPlatformContainerDefinitelyRunning()
       && this.currentContainerStart !== null
     )

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3348,6 +3348,34 @@ describe("RunnerContainer", () => {
     }
   });
 
+  it("does not let an old stop clear a replacement before its start hook", async () => {
+    let container: RunnerContainer;
+    const startAndWaitForPorts = vi.fn(async () => {
+      container.onStop({ exitCode: 137, reason: "exit" });
+      container.onStart();
+    });
+    ({ container } = createContainerDouble({
+      initialStatus: "stopped",
+      platformRunning: false,
+      startAndWaitForPorts,
+    }));
+
+    await expect(container.ensureReadyForProcessing({
+      timeoutMs: 7_500,
+      userId: "member_123",
+    })).resolves.toEqual({
+      action: "started",
+      kind: "ready",
+    });
+
+    expect(startAndWaitForPorts).toHaveBeenCalledOnce();
+    expect(Reflect.get(container, "currentContainerStart")).toMatchObject({
+      pendingOnStartObservation: false,
+      pendingUntilMs: null,
+      readyObservedBy: "cold-start-ready",
+    });
+  });
+
   it("falls back to warm health after a container stop invalidates startup readiness proof", async () => {
     const { container, containerFetch, startAndWaitForPorts } = createContainerDouble();
 


### PR DESCRIPTION
## Why and outcome

After #2090, the private integration gate exposed one remaining callback order: cleanup of an old Cloudflare container could settle, a replacement start could be issued, and then the old container's delayed `onStop` could clear that replacement before its `onStart` arrived. The next readiness proof then failed even though the replacement was healthy.

`onStop` now preserves the existing bounded provisional-start record when the callback cannot identify its generation. The replacement's `onStart` adopts that record, while the existing readiness deadline still retires a genuinely stale start.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: A hosted member whose idle runner needs a replacement no longer enters a retry loop solely because the prior shell's stop callback arrives late. Unhealthy and stale starts retain the existing bounded cleanup behavior.

## Evidence

- Direct: The focused ordering regression failed on base with `Hosted runner container changed while cold readiness was recorded`, then passed after the fix. The exact hosted-local `retryable-outbox-foreground-restart` scenario passed end to end in 132.90 seconds.
- Coverage: `runner-container.test.ts` passes all 210 tests, and the Cloudflare package typecheck passes. The unit regression fixes the exact lifecycle callback order; the hosted-local scenario covers container expiry, replacement, Temporal retry, checkpoint, and exactly-once delivery together.

## Non-obvious affected surfaces

Idle-expiry cleanup, explicit container destroy settlement, replacement cold starts, shell prewarm adoption, and runtime-start retry all share the same in-memory start owner. Existing unit coverage plus the hosted-local foreground-restart scenario exercise those boundaries.

## Architecture and reuse

- Existing systems reused: `currentContainerStart.pendingOnStartObservation`, `onStart` record adoption, the lifecycle lock, and the existing 20-second readiness deadline.
- New logic: A generation-blind stop callback cannot clear a provisional replacement start.
- New abstractions: None; the existing start record already owns this ambiguity.
- Complexity intentionally avoided: No generation registry, queue, persisted lifecycle state, callback manager, or new timeout.

## Hot reply path impact

- Path status: Touched; this changes only in-memory container-start ownership before runtime processing begins.
- Database calls: None.
- Network/provider calls: None added or moved.
- Other awaited latency: None; the fix is one synchronous boolean guard.
- Before/after proof: The base regression rejected a healthy replacement after the delayed stop; head resolves it and the full hosted-local restart scenario completes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run; no prompt, provider-input, tool-schema, history, or wrapper surface changed.

## Risks

`onStop` has no process identity. Preserving a provisional start can delay cleanup only until the already-existing bounded readiness deadline; clearing it could destroy ownership of a newer healthy replacement. No additional ReviewGPT round was run, per explicit user direction after round 7 on the parent change.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Cloudflare Workers remain compatible with all current Web and Temporal callers; no protocol, image, environment, credential, database, or stored-data shape changes.
- Safe order: Deploy the Cloudflare Worker normally. The separately planned Render Temporal blue-green rollout can occur before or after because this patch changes no cross-service contract.
- Rollback floor: None; there is no schema or persistent state change. Rolling back restores the prior delayed-stop retry race.
- Expected exposure: During gradual Worker rollout, only requests routed through older Worker instances can retain the prior replacement-start failure.
- Reversibility: Roll back the Worker version; no data migration, runner-image rollback, or cleanup is required.
- Convergence proof: Confirm the deployed Worker version and direct deploy smoke, then exercise one idle-expiry replacement without a `runtime_error` or duplicate delivery.
- Post-deploy checks: Run the hosted deploy smoke and inspect bounded counts for replacement readiness, delayed stops, runtime-start failures, and duplicate-delivery protection.

## Change-shape breakdown

Classification rule: Runtime implementation is source, the ordering regression is tests, and the closed execution plan is docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 1 |
| Tests / fixtures | 28 | 0 |
| Docs | 25 | 15 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **58** | **16** |

## Changelog

- Changelog: not applicable
- Reason: This is an internal hosted-runtime reliability correction with no member-visible feature or interface to announce.
