### PR TITLE
Recover stalled usage-limit links after overlapping receipts

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-23-usage-limit-delivery-overlap-recovery.md
+++ b/agent-docs/exec-plans/active/2026-08-23-usage-limit-delivery-overlap-recovery.md
@@ -1,0 +1,37 @@
+# Usage-limit Delivery Overlap Recovery
+
+Status: active
+Created: 2026-08-23
+Updated: 2026-08-23
+
+## Goal
+
+Preserve the due recovery-link continuation when an accepted rich-link send,
+a delayed idempotent replay, a delivery receipt, and new over-limit
+conversation work overlap.
+
+## Evidence
+
+- The exact PR 46 integration passed this scenario on public commit
+  `a7b10093b1`, then failed twice on current public `main`.
+- Both failures observed the accepted primary text, two lost-acknowledgment link
+  attempts, and a delayed primary replay, but no third link attempt.
+- The final runtime projection retained blocked conversation work while moving
+  `nextWakeAt` to the next ordinary assistant wake, so the incomplete recovery
+  delivery lost its earlier continuation.
+
+## Approach
+
+- Trace the existing delivery claim, wake-candidate, and reconciliation owners
+  through the exact overlap before changing code.
+- Fix the smallest owning transition so a completing or released in-flight
+  delivery cannot erase the earlier incomplete-delivery timer.
+- Keep the managed-AI denial fence, stable provider idempotency keys, and
+  blocked conversation semantics unchanged.
+
+## Verification
+
+- Add or strengthen a focused failing owner-level regression first.
+- Run focused tests and relevant typechecks.
+- Prove the production-shaped ambiguity scenario against PR 46.
+- Complete the required completion and ReviewGPT gates before merge.

--- a/agent-docs/exec-plans/completed/2026-08-23-usage-limit-delivery-overlap-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-08-23-usage-limit-delivery-overlap-recovery.md
@@ -1,6 +1,6 @@
 # Usage-limit Delivery Overlap Recovery
 
-Status: active
+Status: completed
 Created: 2026-08-23
 Updated: 2026-08-23
 
@@ -35,3 +35,4 @@ conversation work overlap.
 - Run focused tests and relevant typechecks.
 - Prove the production-shaped ambiguity scenario against PR 46.
 - Complete the required completion and ReviewGPT gates before merge.
+Completed: 2026-08-23

--- a/apps/web/changelog/entries/2026-08-23/usage-limit-links-recover-after-short-delays.json
+++ b/apps/web/changelog/entries/2026-08-23/usage-limit-links-recover-after-short-delays.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-23",
+  "order": 100,
+  "item": {
+    "id": "usage-limit-links-recover-after-short-delays",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Usage-limit links recover after short delays",
+    "summary": "Account recovery links now resume promptly when a delivery receipt arrives during a delayed message retry.",
+    "details": "Murph waits for an active delivery to finish before retrying the link, while ordinary messages remain blocked until account access is restored.",
+    "relevanceTags": ["assistant", "billing", "reliability"],
+    "sourcePullRequests": [2185]
+  }
+}

--- a/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
@@ -1,6 +1,11 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
 
 import {
+  acquireHostedLinqChatOwnershipLockTx,
+} from "../hosted-routing/linq-chat-ownership-lock";
+import { LINQ_API_DEFAULT_TIMEOUT_MS } from "../linq/api";
+import { generateHostedRandomPrefixedId, sha256Hex } from "../primitives";
+import {
   createHostedLinqChatLookupKey,
   createHostedLinqChatLookupKeyReadCandidates,
   createHostedLinqMessageLookupKey,
@@ -42,10 +47,6 @@ import type { ParsedHostedLinqProviderEvent } from "./linq-provider-events";
 import { toHostedOnboardingLogIdSuffix } from "./logging";
 import { normalizePhoneNumber } from "./phone";
 import { lockHostedMemberRow } from "./shared";
-import { generateHostedRandomPrefixedId, sha256Hex } from "../primitives";
-import {
-  acquireHostedLinqChatOwnershipLockTx,
-} from "../hosted-routing/linq-chat-ownership-lock";
 
 type HostedLinqDeliveryClient = PrismaClient | Prisma.TransactionClient;
 const HOSTED_LINQ_DELIVERY_PROVIDER_DISPATCH_STARTED_STATUS =
@@ -74,6 +75,13 @@ type HostedLinqDeliveryProviderDispatchData = {
   template: string | null;
 };
 export const HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS = 15 * 60 * 1000;
+// A rich-link replay is a bounded primary request plus two bounded link
+// attempts. Once that provider window and a small completion margin pass, the
+// partial-delivery fence cannot still own useful work. Reusing the general
+// fifteen-minute pre-provider fence here would strand a receipt-triggered
+// recovery when the first replay times out concurrently.
+const HOSTED_AI_USAGE_LIMIT_RICH_LINK_REPLAY_CLAIM_STALE_MS =
+  LINQ_API_DEFAULT_TIMEOUT_MS + 5_000;
 const HOSTED_AI_USAGE_LINQ_NOTICE_DELIVERY_SOURCE =
   "hosted_webhook_side_effect";
 const HOSTED_AI_USAGE_TELEGRAM_NOTICE_DELIVERY_SOURCE =
@@ -2845,7 +2853,7 @@ async function claimExistingHostedLinqDeliveryProviderDispatchTx(input: {
   if (replayableUsageLimitRichLinkPartial) {
     const retryAt = new Date(
       input.delivery.attemptedAt.getTime()
-        + HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_STALE_MS,
+        + HOSTED_AI_USAGE_LIMIT_RICH_LINK_REPLAY_CLAIM_STALE_MS,
     );
     if (
       input.delivery.status

--- a/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-observability-store.test.ts
@@ -2343,7 +2343,7 @@ describe("hosted Linq observability stores", () => {
     });
   });
 
-  it("keeps a fresh usage-limit rich-link replay fence in flight", async () => {
+  it("keeps a bounded usage-limit rich-link replay fence in flight", async () => {
     const fixture = createObservabilityPrismaFixture();
     const previousAttemptedAt = new Date("2026-03-26T12:04:00.000Z");
     const lastReceiptAt = new Date("2026-03-26T12:03:59.000Z");
@@ -2375,7 +2375,7 @@ describe("hosted Linq observability stores", () => {
     });
 
     await expect(startHostedAiUsageLimitNoticeDispatchTx({
-      attemptedAt: new Date("2026-03-26T12:05:00.000Z"),
+      attemptedAt: new Date("2026-03-26T12:04:10.000Z"),
       linqChatId: "chat_123",
       memberId: "member_123",
       periodStart: AI_USAGE_NOTICE_PERIOD_START,
@@ -2385,11 +2385,87 @@ describe("hosted Linq observability stores", () => {
       targetKind: "thread",
       usageCreditLedgerVersion: 0n,
     })).resolves.toEqual({
-      retryAt: new Date("2026-03-26T12:19:00.000Z"),
+      retryAt: new Date("2026-03-26T12:04:15.000Z"),
       status: "in_flight",
     });
 
     expect(fixture.hostedLinqDeliveryUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("reclaims a usage-limit rich-link replay after its provider window", async () => {
+    const fixture = createObservabilityPrismaFixture();
+    const attemptedAt = new Date("2026-03-26T12:04:15.001Z");
+    const previousAttemptedAt = new Date("2026-03-26T12:04:00.000Z");
+    const failedAt = new Date("2026-03-26T12:00:30.000Z");
+    const lastReceiptAt = new Date("2026-03-26T12:03:59.000Z");
+    const updatedAt = new Date("2026-03-26T12:04:01.000Z");
+    const linqChatLookupKey = createHostedLinqChatLookupKey("chat_123");
+    const messageLookupKey = createHostedLinqMessageLookupKey(
+      "linq_text_accepted",
+    );
+    const sourceRef = createHostedLinqDeliverySourceRefLookupKey(
+      "linq-message:event-123",
+    );
+    fixture.hostedLinqDeliveryFindUnique.mockResolvedValueOnce({
+      acceptedAt: null,
+      attemptedAt: previousAttemptedAt,
+      deliveredAt: null,
+      failedAt,
+      failureCode: "ASSISTANT_LINQ_RICH_LINK_PARTIAL_DELIVERY",
+      groupJoinOutreachId: null,
+      groupJoinReplyOccurredAt: null,
+      id: "hld_replaying_usage_notice",
+      lastReceiptAt,
+      linqChatLookupKey,
+      messageLookupKey,
+      phoneNumberLookupKey: null,
+      retryAfterAt: null,
+      skippedAt: null,
+      source: "hosted_webhook_side_effect",
+      sourceRef,
+      status: "provider_dispatch_started",
+      targetKind: "thread",
+      template: "ai_usage_quota",
+      updatedAt,
+    });
+    fixture.hostedLinqDeliveryUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+    await expect(startHostedAiUsageLimitNoticeDispatchTx({
+      attemptedAt,
+      linqChatId: "chat_123",
+      memberId: "member_123",
+      periodStart: AI_USAGE_NOTICE_PERIOD_START,
+      prisma: fixture.prisma as never,
+      source: "hosted_webhook_side_effect",
+      sourceRef: "linq-message:event-123",
+      targetKind: "thread",
+      usageCreditLedgerVersion: 0n,
+    })).resolves.toEqual({
+      idempotencyKey: buildCurrentAiUsageNoticeKey(),
+      providerIdempotencyKey: "ai-usage-attempt:hld_replaying_usage_notice",
+      replayingRichLinkPartial: true,
+      status: "claimed",
+    });
+
+    expect(fixture.hostedLinqDeliveryUpdateMany).toHaveBeenCalledWith({
+      data: {
+        attemptedAt,
+        status: "provider_dispatch_started",
+        updatedAt: attemptedAt,
+      },
+      where: expect.objectContaining({
+        attemptedAt: previousAttemptedAt,
+        failedAt,
+        failureCode: "ASSISTANT_LINQ_RICH_LINK_PARTIAL_DELIVERY",
+        id: "hld_replaying_usage_notice",
+        lastReceiptAt,
+        linqChatLookupKey,
+        messageLookupKey,
+        sourceRef,
+        status: "provider_dispatch_started",
+        updatedAt,
+      }),
+    });
   });
 
   it("keeps a fresh current AI usage notice claim in flight", async () => {


### PR DESCRIPTION
## Outcome

- Reclaims a stalled usage-limit rich-link replay after its bounded provider window instead of leaving recovery dormant behind the general pre-provider claim fence.
- Preserves stable provider idempotency, managed-AI blocking, and the existing general and Telegram claim windows.

## Product UX

A member whose usage-limit recovery link overlaps a delivery receipt and a timed-out retry receives the pending link on the next recovery attempt instead of waiting for unrelated future work. The initiating and receiving actor is the same member in the hosted Linq thread; the persisted delivery row remains the continuation and recovery owner, and ordinary assistant work remains blocked until access is restored.

## Evidence

- 273 focused delivery, transport, claim, and reconciliation tests passed.
- 49 focused changelog registry, archive, and route tests passed.
- `pnpm --dir apps/web typecheck` passed.
- Paired private run [32666537450](https://github.com/cobuildwithus/murph-cloud/actions/runs/32666537450) passed the exact Delivery ambiguity + restart E2E and Group email newsletter E2E on this candidate with private PR 46. The observed failures were the assertions addressed by PR 2184, which this branch does not yet contain, and unrelated hosted-local startup lanes; the final composed run follows both public merges.

## Affected surfaces

- Hosted Linq usage-limit denial delivery and receipt-triggered reconciliation.
- Hot reply path: no change; the existing denial fence remains authoritative.
- Provider input: no payload, credential, destination, or idempotency-key change.
- Deployment: no schema, dependency, environment, or cross-repository contract change.

## Architecture and reuse

- Existing systems reused: The persisted delivery row remains the sole claim, idempotency, continuation, and recovery owner.
- New logic: Only an identifiable usage-limit rich-link replay derives its reclaim deadline from the existing bounded provider timeout.
- New abstractions: None; the change is one deadline constant and the existing claim transition.
- Complexity intentionally avoided: No new queue, state owner, retry loop, provider key, schema, or compatibility path; general pre-provider and Telegram claims retain their existing 15-minute window.

## Changelog

- Changelog: updated
- Items: 2026-08-23 · usage-limit-links-recover-after-short-delays

## ReviewGPT

ReviewGPT context sensitivity: sensitive
Reason: this changes retry and concurrency timing on an external delivery path.
ReviewGPT first-reviewed head: d37d99bed441c1ac225fd9ce1d0b52deac861495

## LOC

- Source: +13 / -5
- Tests/fixtures: +79 / -3
- Docs: +52 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0

## Deployment concerns

- Deployment: not applicable
- Reason: No coordinated deployment, schema migration, environment change, compatibility window, or post-deploy binding check is required. The change is backward-compatible with the existing hosted Web and Cloudflare runtime deployment order.

## Final composed proof

- Final paired run [32677228642](https://github.com/cobuildwithus/murph-cloud/actions/runs/32677228642): all 14 jobs passed on public `b56ceaa9b1526bdf9acca6f1f174963a3fcc8cfb` and private `3812b076fbc0afcd8ad559e97e39ae41f2f295cc`, including Telegram, foreground priority, delivery ambiguity, group newsletter, and the Temporal aggregate.