### PR TITLE
Text members when Garmin delivery stalls

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-23-wearable-stall-notices.md
+++ b/agent-docs/exec-plans/active/2026-08-23-wearable-stall-notices.md
@@ -43,13 +43,14 @@ future evidence-backed additions.
 ## Product UX journeys
 
 - Eligible Garmin member: receives one short message saying recent Garmin data
-  has not come through, suggesting Garmin Connect and watch charge/sync checks,
+  has not come through, suggesting Garmin Connect and device charge/sync checks,
   with one low-pressure question and no link.
 - Quiet but ineligible member: receives nothing when access is inactive, no
   recent inbound exists, no established direct thread exists, or egress blocks.
 - Repeated stale passes: preserve one frozen message and one delivery identity.
 - Recovered source: receives no success message; a later distinct stall may
-  create one new episode notice.
+  create one new episode notice. A queued check is revalidated and suppressed
+  at provider entry if data resumes before delivery.
 - Other wearable provider: unchanged until its transport semantics and observed
   false-positive rate justify an explicit policy entry and copy.
 

--- a/agent-docs/exec-plans/active/2026-08-23-wearable-stall-notices.md
+++ b/agent-docs/exec-plans/active/2026-08-23-wearable-stall-notices.md
@@ -1,0 +1,78 @@
+# Wearable delivery-stall notices
+
+Status: active
+Created: 2026-08-23
+Updated: 2026-08-23
+
+## Goal
+
+Text recently engaged members once when a connected push-primary wearable
+source has stopped delivering data long enough to warrant a simple recovery
+prompt, starting with Garmin while preserving a small provider-policy seam for
+future evidence-backed additions.
+
+## Success criteria
+
+- Canonical `DeviceConnectionSource` freshness remains the only stall truth.
+- Garmin members receive at most one direct Linq exact-text notice per silence
+  episode after 72 hours, with no recovery notice or escalation.
+- The notice reuses active-access, recent-inbound, direct-route, mailbox,
+  idempotency, runtime-signal, and provider-entry egress owners.
+- Copy has at least 20 deterministic variants and gives the provider-specific
+  companion-app recovery step without claiming the source disconnected.
+- The design adds no scheduler, database model or migration, provider callback,
+  delivery service, recovery state machine, dependency, or environment flag.
+- Focused tests prove eligibility, episode identity, suppression, replay, copy,
+  and the exact existing delivery contract.
+
+## Constraints
+
+- Keep detection provider-aware. Do not infer that webhook silence means stale
+  data for polled or phone-mediated providers.
+- Reuse sources already loaded by the bounded runtime-apply owner; do not add a
+  fleet scan or per-source database fanout.
+- Keep database transactions short and database-only. Materialize and signal
+  after the connection mutation transaction, with a final canonical recheck.
+- Require active access, a recent inbound within the existing engagement
+  window, and an established direct Linq thread. Never open a cold conversation.
+- Exact-text notices must remain model-free while preserving producer-owned
+  engagement admission and existing provider-entry line-health checks.
+- Do not copy production identifiers, logs, or distinctive member scenarios
+  into code, tests, docs, changelog, prompts, or PR text.
+
+## Product UX journeys
+
+- Eligible Garmin member: receives one short message saying recent Garmin data
+  has not come through, suggesting Garmin Connect and watch charge/sync checks,
+  with one low-pressure question and no link.
+- Quiet but ineligible member: receives nothing when access is inactive, no
+  recent inbound exists, no established direct thread exists, or egress blocks.
+- Repeated stale passes: preserve one frozen message and one delivery identity.
+- Recovered source: receives no success message; a later distinct stall may
+  create one new episode notice.
+- Other wearable provider: unchanged until its transport semantics and observed
+  false-positive rate justify an explicit policy entry and copy.
+
+## Tasks
+
+1. [x] Ask ReviewGPT Pro for a complete scoped implementation patch. Three
+   source-backed attempts failed to return readable repository output or a
+   usable artifact, so implementation continued locally instead of accepting
+   unverified output.
+2. [x] Implement the smallest scoped design in this task worktree using the
+   provider policy, runtime apply, mailbox, engagement, and route owners.
+3. [x] Run focused tests, typecheck, lint, diff/privacy checks, and direct
+   episode replay proof.
+4. [ ] Add the member-facing changelog entry and complete the required
+   preliminary specialist and final ReviewGPT gates on the exact PR head.
+5. [ ] Resolve accepted findings, run the parent final review, close this plan,
+   commit, push, open the PR, and require green exact-head CI.
+
+## Verification
+
+- Focused `packages/device-syncd` staleness-policy tests.
+- Focused Hosted Web runtime-apply/materializer, copy-bank, mailbox ownership,
+  and route/engagement tests.
+- Affected package and Hosted Web typechecks plus scoped lint.
+- `git diff --check`, repository privacy/path inspection, exact-head ReviewGPT
+  gates, current-base merge-tree proof, and required GitHub checks.

--- a/agent-docs/exec-plans/completed/2026-08-23-wearable-stall-notices.md
+++ b/agent-docs/exec-plans/completed/2026-08-23-wearable-stall-notices.md
@@ -1,8 +1,8 @@
 # Wearable delivery-stall notices
 
-Status: active
+Status: completed
 Created: 2026-08-23
-Updated: 2026-08-23
+Updated: 2026-08-24
 
 ## Goal
 
@@ -64,10 +64,11 @@ future evidence-backed additions.
    provider policy, runtime apply, mailbox, engagement, and route owners.
 3. [x] Run focused tests, typecheck, lint, diff/privacy checks, and direct
    episode replay proof.
-4. [ ] Add the member-facing changelog entry and complete the required
+4. [x] Add the member-facing changelog entry and complete the required
    preliminary specialist and final ReviewGPT gates on the exact PR head.
-5. [ ] Resolve accepted findings, run the parent final review, close this plan,
-   commit, push, open the PR, and require green exact-head CI.
+5. [x] Resolve accepted findings, run the parent final review, close this plan,
+   and prepare the final PR candidate. Exact-head CI and merge remain the
+   post-archive delivery gates.
 
 ## Verification
 
@@ -77,3 +78,12 @@ future evidence-backed additions.
 - Affected package and Hosted Web typechecks plus scoped lint.
 - `git diff --check`, repository privacy/path inspection, exact-head ReviewGPT
   gates, current-base merge-tree proof, and required GitHub checks.
+
+Completed local proof: 9 focused device-sync policy tests and package build; 2
+hosted-execution identity tests; 4 assistant-runtime frontier tests; 170 focused
+Web tests; Web typecheck, scoped lint, clean-source Web typecheck with generated
+device-sync output removed, and diff/privacy checks. Preliminary ReviewGPT
+findings were resolved. Final ReviewGPT round 2 passed on the immutable
+remediation head with no remaining qualifying issue. The archived commit is the
+candidate for the final exact-head ReviewGPT, CI, merge-tree, and merge gates.
+Completed: 2026-08-24

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
@@ -26,6 +26,9 @@ import { getPrisma } from "@/src/lib/prisma";
 import {
   acquireHostedLinqChatOwnershipLockTx,
 } from "@/src/lib/hosted-routing/linq-chat-ownership-lock";
+import {
+  isHostedSourceDeliveryStallEpisodeCurrentTx,
+} from "@/src/lib/device-sync/source-delivery-stall-episode";
 import type {
   HostedExecutionResolvedLinqDeliveryRoute,
 } from "@murphai/hosted-execution/contracts";
@@ -133,6 +136,21 @@ export const POST = withJsonError(async (request: Request) => {
         code: "HOSTED_LINQ_EGRESS_RESOLVED_ROUTE_MISMATCH",
         httpStatus: 403,
         message: "Hosted Linq send-time route authority changed before provider entry.",
+        retryable: false,
+      });
+    }
+
+    const sourceEpisode = await isHostedSourceDeliveryStallEpisodeCurrentTx({
+      deliveryIdempotencyKey: idempotencyKey,
+      memberId: userId,
+      now: new Date().toISOString(),
+      tx,
+    });
+    if (sourceEpisode === "superseded") {
+      throw hostedOnboardingError({
+        code: "HOSTED_DEVICE_DELIVERY_STALL_EPISODE_SUPERSEDED",
+        httpStatus: 409,
+        message: "The queued wearable recovery check is no longer current.",
         retryable: false,
       });
     }

--- a/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
+++ b/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
@@ -9,6 +9,6 @@
     "summary": "Murph can now text you when an established Garmin connection stops providing new data, with a quick check that often restores syncing.",
     "details": "The check is limited to recently active direct conversations and appears at most once for each extended quiet period. Murph does not send a follow-up when data resumes.",
     "relevanceTags": ["wearables", "garmin", "reliability"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [2189]
   }
 }

--- a/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
+++ b/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-23",
+  "order": 100,
+  "item": {
+    "id": "garmin-sync-recovery-check",
+    "kind": "feature",
+    "priority": 4,
+    "title": "A helpful check when Garmin goes quiet",
+    "summary": "Murph can now text you when an established Garmin connection stops providing new data, with a quick check that often restores syncing.",
+    "details": "The check is limited to recently active direct conversations and appears at most once for each extended quiet period. Murph does not send a follow-up when data resumes.",
+    "relevanceTags": ["wearables", "garmin", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
+++ b/apps/web/changelog/entries/2026-08-23/garmin-sync-recovery-check.json
@@ -6,7 +6,7 @@
     "kind": "feature",
     "priority": 4,
     "title": "A helpful check when Garmin goes quiet",
-    "summary": "Murph can now text you when an established Garmin connection stops providing new data, with a quick check that often restores syncing.",
+    "summary": "Murph can now text you when an established Garmin connection stops providing new data, with a quick check of Garmin Connect and your Garmin device.",
     "details": "The check is limited to recently active direct conversations and appears at most once for each extended quiet period. Murph does not send a follow-up when data resumes.",
     "relevanceTags": ["wearables", "garmin", "reliability"],
     "sourcePullRequests": [2189]

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -768,6 +768,7 @@ function resolveHostedRuntimeSourceDeliveryStallNoticeCandidates(input: {
         : current?.lastDataAt ?? null,
       lifecycleEpoch: update?.lifecycleEpoch ?? current?.lifecycleEpoch ?? null,
       now: input.now,
+      sourceId: current?.id ?? "",
       sourceInstanceKey,
       sourceProviderSlug: update?.sourceProviderSlug ?? current?.sourceProviderSlug ?? "",
       status: update?.status ?? current?.status ?? "disconnected",

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -66,6 +66,11 @@ import {
 } from "./internal-runtime";
 import { buildStoredTokenBundle } from "./agent-session-token-bundle";
 import {
+  resolveHostedSourceDeliveryStallNoticeCandidate,
+  scheduleHostedSourceDeliveryStallNotices,
+  type HostedSourceDeliveryStallNoticeCandidate,
+} from "./source-delivery-stall-notice";
+import {
   hostedConnectionRecordArgs,
   hostedRuntimeRedactedConnectionRecordArgs,
   expandCanonicalHostedSourceProviderSlugFilter,
@@ -373,7 +378,7 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
   // applies only the resulting canonical connection state.
   for (const update of parsed.updates) {
     const preparedConnection = preparedConnections.get(update.connectionId) ?? null;
-    const applied = await controlPlane.store.withConnectionMutationLock(
+    const appliedResult = await controlPlane.store.withConnectionMutationLock(
       update.connectionId,
       async (tx) => {
         const record = await tx.deviceConnection.findFirst({
@@ -386,12 +391,15 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
 
         if (!record || !preparedConnection) {
           return {
-            connection: null,
-            connectionId: update.connectionId,
-            status: "missing",
-            tokenUpdate: "missing",
-            writeUpdate: "missing",
-          } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry;
+            applied: {
+              connection: null,
+              connectionId: update.connectionId,
+              status: "missing",
+              tokenUpdate: "missing",
+              writeUpdate: "missing",
+            } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry,
+            noticeCandidates: [] as HostedSourceDeliveryStallNoticeCandidate[],
+          };
         }
 
         const secretAuthorityCurrent = isHostedRuntimeApplySecretAuthorityCurrent(
@@ -687,25 +695,38 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
         }
 
         return {
-          connection: buildHostedRuntimeConnectionSnapshot(
-            writtenRecord ?? record,
-            null,
-            durableExternalAccountId,
-            [],
-            {
-              forceReauthorizationRequired:
-                !providerApplicationBindingCurrent,
-              includeCredentialMaterial: false,
-            },
-          ).connection,
-          connectionId: update.connectionId,
-          status: "updated",
-          tokenUpdate,
-          writeUpdate,
-        } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry;
+          applied: {
+            connection: buildHostedRuntimeConnectionSnapshot(
+              writtenRecord ?? record,
+              null,
+              durableExternalAccountId,
+              [],
+              {
+                forceReauthorizationRequired:
+                  !providerApplicationBindingCurrent,
+                includeCredentialMaterial: false,
+              },
+            ).connection,
+            connectionId: update.connectionId,
+            status: "updated",
+            tokenUpdate,
+            writeUpdate,
+          } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry,
+          noticeCandidates: resolveHostedRuntimeSourceDeliveryStallNoticeCandidates({
+            connectionId: update.connectionId,
+            currentSources: sources,
+            now: appliedAt,
+            sourceUpdates: sourceUpdates.toApply,
+          }),
+        };
       },
     );
-    updates.push(applied);
+    updates.push(appliedResult.applied);
+    scheduleHostedSourceDeliveryStallNotices({
+      candidates: appliedResult.noticeCandidates,
+      now: appliedAt,
+      userId: input.trustedUserId,
+    });
   }
 
   return {
@@ -713,6 +734,47 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
     updates,
     userId: input.trustedUserId,
   };
+}
+
+function resolveHostedRuntimeSourceDeliveryStallNoticeCandidates(input: {
+  connectionId: string;
+  currentSources: readonly HostedDeviceConnectionSource[];
+  now: string;
+  sourceUpdates: readonly HostedRuntimeConnectionSourceWrite[];
+}): HostedSourceDeliveryStallNoticeCandidate[] {
+  const updatesByKey = new Map(
+    input.sourceUpdates.map((source) => [source.sourceInstanceKey, source]),
+  );
+  const sourceKeys = new Set([
+    ...input.currentSources.map((source) => source.sourceInstanceKey),
+    ...input.sourceUpdates.map((source) => source.sourceInstanceKey),
+  ]);
+  const currentByKey = new Map(
+    input.currentSources.map((source) => [source.sourceInstanceKey, source]),
+  );
+  const candidates: HostedSourceDeliveryStallNoticeCandidate[] = [];
+  for (const sourceInstanceKey of sourceKeys) {
+    const current = currentByKey.get(sourceInstanceKey);
+    const update = updatesByKey.get(sourceInstanceKey);
+    if (!current && !update) {
+      continue;
+    }
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate({
+      connectionId: input.connectionId,
+      lastDataAt: update && Object.prototype.hasOwnProperty.call(update, "lastDataAt")
+        ? update.lastDataAt ?? null
+        : current?.lastDataAt ?? null,
+      lifecycleEpoch: update?.lifecycleEpoch ?? current?.lifecycleEpoch ?? null,
+      now: input.now,
+      sourceInstanceKey,
+      sourceProviderSlug: update?.sourceProviderSlug ?? current?.sourceProviderSlug ?? "",
+      status: update?.status ?? current?.status ?? "disconnected",
+    });
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
 }
 
 async function prepareHostedRuntimeApplyConnections(input: {

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -373,6 +373,7 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
     userId: input.trustedUserId,
   });
   const updates: HostedExecutionDeviceSyncRuntimeApplyEntry[] = [];
+  const noticeCandidates: HostedSourceDeliveryStallNoticeCandidate[] = [];
 
   // Assistant-runtime maintenance owns per-attempt job failure telemetry. Web
   // applies only the resulting canonical connection state.
@@ -722,12 +723,13 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
       },
     );
     updates.push(appliedResult.applied);
-    scheduleHostedSourceDeliveryStallNotices({
-      candidates: appliedResult.noticeCandidates,
-      now: appliedAt,
-      userId: input.trustedUserId,
-    });
+    noticeCandidates.push(...appliedResult.noticeCandidates);
   }
+  scheduleHostedSourceDeliveryStallNotices({
+    candidates: noticeCandidates,
+    now: appliedAt,
+    userId: input.trustedUserId,
+  });
 
   return {
     appliedAt,

--- a/apps/web/src/lib/device-sync/source-delivery-stall-episode.ts
+++ b/apps/web/src/lib/device-sync/source-delivery-stall-episode.ts
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+import type { Prisma } from "@prisma/client";
+import {
+  isPushPrimarySourceRecoveryNoticeEligible,
+} from "@murphai/device-syncd/source-staleness";
+
+const NOTICE_IDENTITY_PREFIX = "device-delivery-stalled:v1:";
+const SOURCE_ID_PATTERN = /^dcs_[A-Za-z0-9_-]{1,120}$/u;
+const EPISODE_DIGEST_PATTERN = /^[a-f0-9]{32}$/u;
+
+export interface HostedSourceDeliveryStallNoticeCandidate {
+  connectionId: string;
+  lastDataAt: string;
+  lifecycleEpoch: number | null;
+  sourceId: string;
+  sourceInstanceKey: string;
+  sourceProviderSlug: string;
+}
+
+export function resolveHostedSourceDeliveryStallNoticeCandidate(input: {
+  connectionId: string;
+  lastDataAt: string | null;
+  lifecycleEpoch: number | null;
+  now: string;
+  sourceId: string;
+  sourceInstanceKey: string;
+  sourceProviderSlug: string;
+  status: "connected" | "disconnected" | "error" | "unavailable";
+}): HostedSourceDeliveryStallNoticeCandidate | null {
+  if (
+    !SOURCE_ID_PATTERN.test(input.sourceId)
+    || !isPushPrimarySourceRecoveryNoticeEligible(input)
+    || input.lastDataAt === null
+  ) {
+    return null;
+  }
+  return {
+    connectionId: input.connectionId,
+    lastDataAt: input.lastDataAt,
+    lifecycleEpoch: input.lifecycleEpoch,
+    sourceId: input.sourceId,
+    sourceInstanceKey: input.sourceInstanceKey,
+    sourceProviderSlug: input.sourceProviderSlug,
+  };
+}
+
+export function buildHostedSourceDeliveryStallNoticeKey(
+  candidate: HostedSourceDeliveryStallNoticeCandidate,
+): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({
+      connectionId: candidate.connectionId,
+      lastDataAt: candidate.lastDataAt,
+      lifecycleEpoch: candidate.lifecycleEpoch,
+      sourceId: candidate.sourceId,
+      sourceInstanceKey: candidate.sourceInstanceKey,
+      sourceProviderSlug: candidate.sourceProviderSlug,
+      version: "v1",
+    }))
+    .digest("hex")
+    .slice(0, 32);
+  return `${NOTICE_IDENTITY_PREFIX}${candidate.sourceId}:${digest}`;
+}
+
+/**
+ * Revalidates this one queued silence episode while holding its canonical
+ * source row through the provider-dispatch claim transaction.
+ */
+export async function isHostedSourceDeliveryStallEpisodeCurrentTx(input: {
+  deliveryIdempotencyKey: string | null;
+  memberId: string;
+  now: string;
+  tx: Prisma.TransactionClient;
+}): Promise<"current" | "not-applicable" | "superseded"> {
+  const key = input.deliveryIdempotencyKey?.trim() ?? "";
+  if (!key.startsWith(NOTICE_IDENTITY_PREFIX)) {
+    return "not-applicable";
+  }
+  const identity = parseHostedSourceDeliveryStallNoticeKey(key);
+  if (!identity) {
+    return "superseded";
+  }
+
+  const locked = await input.tx.$queryRaw<Array<{ id: string }>>`
+    SELECT id
+    FROM device_connection_source
+    WHERE id = ${identity.sourceId}
+    FOR UPDATE
+  `;
+  if (locked.length !== 1) {
+    return "superseded";
+  }
+
+  const source = await input.tx.deviceConnectionSource.findUnique({
+    select: {
+      connection: { select: { status: true, userId: true } },
+      connectionId: true,
+      id: true,
+      lastDataAt: true,
+      lifecycleEpoch: true,
+      sourceInstanceKey: true,
+      sourceProviderSlug: true,
+      status: true,
+    },
+    where: { id: identity.sourceId },
+  });
+  if (
+    !source
+    || source.connection.userId !== input.memberId
+    || source.connection.status !== "active"
+    || source.status !== "connected"
+    || source.lastDataAt === null
+    || !isPushPrimarySourceRecoveryNoticeEligible({
+      lastDataAt: source.lastDataAt.toISOString(),
+      now: input.now,
+      sourceProviderSlug: source.sourceProviderSlug,
+      status: source.status,
+    })
+  ) {
+    return "superseded";
+  }
+
+  return buildHostedSourceDeliveryStallNoticeKey({
+    connectionId: source.connectionId,
+    lastDataAt: source.lastDataAt.toISOString(),
+    lifecycleEpoch: source.lifecycleEpoch,
+    sourceId: source.id,
+    sourceInstanceKey: source.sourceInstanceKey,
+    sourceProviderSlug: source.sourceProviderSlug,
+  }) === key
+    ? "current"
+    : "superseded";
+}
+
+function parseHostedSourceDeliveryStallNoticeKey(
+  key: string,
+): { sourceId: string } | null {
+  const parts = key.slice(NOTICE_IDENTITY_PREFIX.length).split(":");
+  if (
+    parts.length !== 2
+    || !SOURCE_ID_PATTERN.test(parts[0] ?? "")
+    || !EPISODE_DIGEST_PATTERN.test(parts[1] ?? "")
+  ) {
+    return null;
+  }
+  return { sourceId: parts[0] as string };
+}

--- a/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
+++ b/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
 import { after } from "next/server";
 import type { PrismaClient } from "@prisma/client";
 import {
@@ -24,54 +23,16 @@ import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shar
 import { signalHostedMailboxAppendRuntime } from "../hosted-orchestration/signal-runtime";
 import { resolveHostedAssistantNotificationDestination } from "../hosted-routing/assistant-notification-destination";
 import { getPrisma } from "../prisma";
+import {
+  buildHostedSourceDeliveryStallNoticeKey,
+  type HostedSourceDeliveryStallNoticeCandidate,
+} from "./source-delivery-stall-episode";
 
-const NOTICE_IDENTITY_VERSION = "v1";
-
-export interface HostedSourceDeliveryStallNoticeCandidate {
-  connectionId: string;
-  lastDataAt: string;
-  lifecycleEpoch: number | null;
-  sourceInstanceKey: string;
-  sourceProviderSlug: string;
-}
-
-export function resolveHostedSourceDeliveryStallNoticeCandidate(input: {
-  connectionId: string;
-  lastDataAt: string | null;
-  lifecycleEpoch: number | null;
-  now: string;
-  sourceInstanceKey: string;
-  sourceProviderSlug: string;
-  status: "connected" | "disconnected" | "error" | "unavailable";
-}): HostedSourceDeliveryStallNoticeCandidate | null {
-  if (!isPushPrimarySourceRecoveryNoticeEligible(input) || input.lastDataAt === null) {
-    return null;
-  }
-  return {
-    connectionId: input.connectionId,
-    lastDataAt: input.lastDataAt,
-    lifecycleEpoch: input.lifecycleEpoch,
-    sourceInstanceKey: input.sourceInstanceKey,
-    sourceProviderSlug: input.sourceProviderSlug,
-  };
-}
-
-export function buildHostedSourceDeliveryStallNoticeKey(
-  candidate: HostedSourceDeliveryStallNoticeCandidate,
-): string {
-  const digest = createHash("sha256")
-    .update(JSON.stringify({
-      connectionId: candidate.connectionId,
-      lastDataAt: candidate.lastDataAt,
-      lifecycleEpoch: candidate.lifecycleEpoch,
-      sourceInstanceKey: candidate.sourceInstanceKey,
-      sourceProviderSlug: candidate.sourceProviderSlug,
-      version: NOTICE_IDENTITY_VERSION,
-    }))
-    .digest("hex")
-    .slice(0, 32);
-  return `device-delivery-stalled:${NOTICE_IDENTITY_VERSION}:${digest}`;
-}
+export {
+  buildHostedSourceDeliveryStallNoticeKey,
+  resolveHostedSourceDeliveryStallNoticeCandidate,
+  type HostedSourceDeliveryStallNoticeCandidate,
+} from "./source-delivery-stall-episode";
 
 export function scheduleHostedSourceDeliveryStallNotices(input: {
   candidates: readonly HostedSourceDeliveryStallNoticeCandidate[];
@@ -119,8 +80,7 @@ export async function materializeHostedSourceDeliveryStallNotice(input: {
     prisma,
     userId: input.userId,
   });
-  if (existing) {
-    await signalHostedSourceDeliveryStallNoticeBestEffort({ item: existing, prisma });
+  if (existing && existing.consumedAt !== null) {
     return;
   }
   const appended = await runWithPreparedHostedMailboxItemAppendCrypto({

--- a/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
+++ b/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+import { after } from "next/server";
+import type { PrismaClient } from "@prisma/client";
+import {
+  buildHostedExecutionAssistantNotificationRequestedWake,
+} from "@murphai/hosted-execution";
+import {
+  isPushPrimarySourceRecoveryNoticeEligible,
+  readPushPrimarySourceRecoveryNoticePolicy,
+} from "@murphai/device-syncd/source-staleness";
+
+import {
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+  readHostedMailboxItemByDedupeKey,
+  runWithPreparedHostedMailboxItemAppendCrypto,
+  type HostedMailboxItemRecord,
+} from "../hosted-mailbox/store";
+import { hasHostedRuntimeActiveAccess } from "../hosted-mailbox/runtime-access";
+import { renderUserFacingMessage } from "../hosted-messages/user-facing-messages";
+import { hasHostedLinqInboundWithinDays } from "../hosted-onboarding/linq-daily-state";
+import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from "../hosted-onboarding/shared";
+import { signalHostedMailboxAppendRuntime } from "../hosted-orchestration/signal-runtime";
+import { resolveHostedAssistantNotificationDestination } from "../hosted-routing/assistant-notification-destination";
+import { getPrisma } from "../prisma";
+
+const NOTICE_IDENTITY_VERSION = "v1";
+
+export interface HostedSourceDeliveryStallNoticeCandidate {
+  connectionId: string;
+  lastDataAt: string;
+  lifecycleEpoch: number | null;
+  sourceInstanceKey: string;
+  sourceProviderSlug: string;
+}
+
+export function resolveHostedSourceDeliveryStallNoticeCandidate(input: {
+  connectionId: string;
+  lastDataAt: string | null;
+  lifecycleEpoch: number | null;
+  now: string;
+  sourceInstanceKey: string;
+  sourceProviderSlug: string;
+  status: "connected" | "disconnected" | "error" | "unavailable";
+}): HostedSourceDeliveryStallNoticeCandidate | null {
+  if (!isPushPrimarySourceRecoveryNoticeEligible(input) || input.lastDataAt === null) {
+    return null;
+  }
+  return {
+    connectionId: input.connectionId,
+    lastDataAt: input.lastDataAt,
+    lifecycleEpoch: input.lifecycleEpoch,
+    sourceInstanceKey: input.sourceInstanceKey,
+    sourceProviderSlug: input.sourceProviderSlug,
+  };
+}
+
+export function buildHostedSourceDeliveryStallNoticeKey(
+  candidate: HostedSourceDeliveryStallNoticeCandidate,
+): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({
+      connectionId: candidate.connectionId,
+      lastDataAt: candidate.lastDataAt,
+      lifecycleEpoch: candidate.lifecycleEpoch,
+      sourceInstanceKey: candidate.sourceInstanceKey,
+      sourceProviderSlug: candidate.sourceProviderSlug,
+      version: NOTICE_IDENTITY_VERSION,
+    }))
+    .digest("hex")
+    .slice(0, 32);
+  return `device-delivery-stalled:${NOTICE_IDENTITY_VERSION}:${digest}`;
+}
+
+export function scheduleHostedSourceDeliveryStallNotices(input: {
+  candidates: readonly HostedSourceDeliveryStallNoticeCandidate[];
+  now: string;
+  userId: string;
+}): void {
+  if (input.candidates.length === 0) {
+    return;
+  }
+  const task = async () => {
+    for (const candidate of input.candidates) {
+      try {
+        await materializeHostedSourceDeliveryStallNotice({
+          candidate,
+          now: input.now,
+          userId: input.userId,
+        });
+      } catch {
+        // One source must not prevent later candidates or fail runtime apply.
+      }
+    }
+  };
+  try {
+    after(task);
+  } catch {
+    void task();
+  }
+}
+
+export async function materializeHostedSourceDeliveryStallNotice(input: {
+  candidate: HostedSourceDeliveryStallNoticeCandidate;
+  now: string;
+  prisma?: PrismaClient;
+  userId: string;
+}): Promise<void> {
+  const prisma = input.prisma ?? getPrisma();
+  const now = new Date(input.now);
+  if (!Number.isFinite(now.getTime())) {
+    return;
+  }
+  const notificationKey = buildHostedSourceDeliveryStallNoticeKey(input.candidate);
+  const dedupeKey = `assistant.notification.requested:${notificationKey}`;
+  const existing = await readHostedMailboxItemByDedupeKey({
+    dedupeKey,
+    prisma,
+    userId: input.userId,
+  });
+  if (existing) {
+    await signalHostedSourceDeliveryStallNoticeBestEffort({ item: existing, prisma });
+    return;
+  }
+  const appended = await runWithPreparedHostedMailboxItemAppendCrypto({
+    append: (prepared) => prisma.$transaction(async (tx) => {
+      const source = await tx.deviceConnectionSource.findUnique({
+        select: {
+          connection: { select: { status: true, userId: true } },
+          lastDataAt: true,
+          lifecycleEpoch: true,
+          sourceProviderSlug: true,
+          status: true,
+        },
+        where: {
+          connectionId_sourceInstanceKey: {
+            connectionId: input.candidate.connectionId,
+            sourceInstanceKey: input.candidate.sourceInstanceKey,
+          },
+        },
+      });
+      if (
+        !source
+        || source.connection.userId !== input.userId
+        || source.connection.status !== "active"
+        || source.lifecycleEpoch !== input.candidate.lifecycleEpoch
+        || source.lastDataAt?.toISOString() !== input.candidate.lastDataAt
+        || source.sourceProviderSlug !== input.candidate.sourceProviderSlug
+        || !isPushPrimarySourceRecoveryNoticeEligible({
+          lastDataAt: source.lastDataAt?.toISOString() ?? null,
+          now: input.now,
+          sourceProviderSlug: source.sourceProviderSlug,
+          status: source.status,
+        })
+        || !(await hasHostedRuntimeActiveAccess(input.userId, { prisma: tx }))
+        || !(await hasHostedLinqInboundWithinDays({
+          memberId: input.userId,
+          now,
+          prisma: tx,
+        }))
+      ) {
+        return null;
+      }
+      const destination = await resolveHostedAssistantNotificationDestination({
+        directChannel: "linq",
+        memberId: input.userId,
+        prisma: tx,
+      });
+      if (
+        destination?.conversationShape !== "direct-member"
+        || destination.externalThreadRouteAuthority !== null
+        || destination.route.channel !== "linq"
+        || destination.route.threadIsDirect !== true
+        || destination.route.delivery.kind !== "thread"
+      ) {
+        return null;
+      }
+      const policy = readPushPrimarySourceRecoveryNoticePolicy(source.sourceProviderSlug);
+      if (!policy) {
+        return null;
+      }
+      const text = renderUserFacingMessage({
+        context: {
+          companionAppName: policy.companionAppName,
+          deviceDisplayName: policy.deviceDisplayName,
+          providerDisplayName: policy.providerDisplayName,
+        },
+        key: "linq.device_delivery_stalled",
+        seed: notificationKey,
+      }).text;
+      return appendHostedMailboxEnvelopeWithPreparedCryptoTx({
+        envelope: buildHostedExecutionAssistantNotificationRequestedWake({
+          eventId: dedupeKey,
+          memberId: input.userId,
+          notification: {
+            deliveryDedupeToken: notificationKey,
+            deliveryDispatchMode: "queue-only",
+            deliveryIdempotencyKey: notificationKey,
+            instructions: "Wearable recovery check; exact user-facing text is in responsePolicy.",
+            responsePolicy: { kind: "require_send_exact_text", text },
+            route: destination.route,
+          },
+          occurredAt: now.toISOString(),
+        }),
+        prepared,
+        tx,
+      });
+    }, {
+      ...HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+      timeout: 10_000,
+    }),
+    prisma,
+    userId: input.userId,
+  });
+  if (appended) {
+    await signalHostedSourceDeliveryStallNoticeBestEffort({
+      item: appended.item,
+      prisma,
+    });
+  }
+}
+
+async function signalHostedSourceDeliveryStallNoticeBestEffort(input: {
+  item: HostedMailboxItemRecord;
+  prisma: PrismaClient;
+}): Promise<void> {
+  if (input.item.consumedAt !== null) {
+    return;
+  }
+  try {
+    await signalHostedMailboxAppendRuntime({
+      expectedUserId: input.item.userId,
+      knownCheckpoint: {
+        lane: input.item.lane,
+        laneSeq: input.item.laneSeq,
+        userId: input.item.userId,
+      },
+      mailboxItemId: input.item.id,
+      prisma: input.prisma,
+    });
+  } catch {
+    // The durable live item will be imported by a later runtime wake.
+  }
+}

--- a/apps/web/src/lib/hosted-messages/user-facing-messages.ts
+++ b/apps/web/src/lib/hosted-messages/user-facing-messages.ts
@@ -25,6 +25,7 @@ const USER_FACING_MESSAGE_TEMPLATE_KEYS = [
   "linq.invite_signup",
   "linq.daily_quota",
   "linq.home_redirect",
+  "linq.device_delivery_stalled",
   "linq.ai_usage.billing_inactive",
   "linq.ai_usage.starter_limit_reached",
   "linq.ai_usage.edge_limit_reached",
@@ -49,6 +50,11 @@ export interface UserFacingMessageContextByKey {
   }
   "linq.home_redirect": {
     homeRecipientPhone: string
+  }
+  "linq.device_delivery_stalled": {
+    companionAppName: string
+    deviceDisplayName: string
+    providerDisplayName: string
   }
   "linq.ai_usage.billing_inactive": {
     homeUrl: string
@@ -584,6 +590,28 @@ Sound good?`,
 {homeRecipientPhone}`,
     `Resend your last message on the number where I answer you:
 {homeRecipientPhone}`,
+  ],
+  "linq.device_delivery_stalled": [
+    `I haven't seen recent {providerDisplayName} data come through. Opening {companionAppName} and checking that your {deviceDisplayName} is charged and syncing usually gets it moving again. Want to give that a try?`,
+    `Recent {providerDisplayName} data hasn't reached me. Could you open {companionAppName} and make sure your {deviceDisplayName} is charged and syncing?`,
+    `It looks like {providerDisplayName} data has been quiet for a while. When you have a moment, can you open {companionAppName} and check the {deviceDisplayName} is charged and syncing?`,
+    `I haven't received new {providerDisplayName} data lately. Would you mind opening {companionAppName} and checking your {deviceDisplayName}'s charge and sync?`,
+    `Your recent {providerDisplayName} data isn't coming through. Can you open {companionAppName} and confirm the {deviceDisplayName} is charged and syncing?`,
+    `I may be missing your latest {providerDisplayName} data. Could you check {companionAppName} and make sure the {deviceDisplayName} has charge and is syncing?`,
+    `No recent {providerDisplayName} data has come through on my side. Want to open {companionAppName} and check the {deviceDisplayName}'s charge and sync?`,
+    `Your {providerDisplayName} data has been unusually quiet. Could you open {companionAppName} and check that the {deviceDisplayName} is charged and syncing?`,
+    `I haven't picked up fresh {providerDisplayName} data recently. Can you take a quick look in {companionAppName} and make sure the {deviceDisplayName} is charged and syncing?`,
+    `Recent data from {providerDisplayName} seems to have stopped coming through. Would you check {companionAppName} and confirm the {deviceDisplayName} is charged and syncing?`,
+    `I'm not seeing your latest {providerDisplayName} data. Could you open {companionAppName} and see whether the {deviceDisplayName} is charged and syncing?`,
+    `It has been a while since new {providerDisplayName} data reached me. Want to check {companionAppName} and make sure the {deviceDisplayName} is charged and syncing?`,
+    `Fresh {providerDisplayName} data hasn't come through lately. Can you open {companionAppName} and check the {deviceDisplayName}'s battery and sync?`,
+    `I haven't seen an update from {providerDisplayName} in a bit. Could you open {companionAppName} and make sure your {deviceDisplayName} is charged and syncing?`,
+    `Your latest {providerDisplayName} data may not be making it through. Would you check {companionAppName} and the {deviceDisplayName}'s charge and sync?`,
+    `I seem to be missing recent {providerDisplayName} data. Can you take a look in {companionAppName} and confirm the {deviceDisplayName} is charged and syncing?`,
+    `New {providerDisplayName} data has been quiet on my end. Could you open {companionAppName} and check that your {deviceDisplayName} has charge and is syncing?`,
+    `I haven't received a recent update from {providerDisplayName}. Want to check {companionAppName} and make sure the {deviceDisplayName} is charged and syncing?`,
+    `Your recent {providerDisplayName} readings aren't reaching me right now. Could you open {companionAppName} and check the {deviceDisplayName}'s charge and sync?`,
+    `It looks like I may be missing new {providerDisplayName} data. Can you open {companionAppName} and make sure your {deviceDisplayName} is charged and syncing?`,
   ],
   "linq.ai_usage.billing_inactive": [
     `Your Murph plan isn't active right now. You can sort that out here:

--- a/apps/web/src/lib/hosted-messages/user-facing-messages.ts
+++ b/apps/web/src/lib/hosted-messages/user-facing-messages.ts
@@ -592,7 +592,7 @@ Sound good?`,
 {homeRecipientPhone}`,
   ],
   "linq.device_delivery_stalled": [
-    `I haven't seen recent {providerDisplayName} data come through. Opening {companionAppName} and checking that your {deviceDisplayName} is charged and syncing usually gets it moving again. Want to give that a try?`,
+    `I haven't seen recent {providerDisplayName} data come through. Want to open {companionAppName} and check that your {deviceDisplayName} is charged and syncing?`,
     `Recent {providerDisplayName} data hasn't reached me. Could you open {companionAppName} and make sure your {deviceDisplayName} is charged and syncing?`,
     `It looks like {providerDisplayName} data has been quiet for a while. When you have a moment, can you open {companionAppName} and check the {deviceDisplayName} is charged and syncing?`,
     `I haven't received new {providerDisplayName} data lately. Would you mind opening {companionAppName} and checking your {deviceDisplayName}'s charge and sync?`,

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -281,6 +281,7 @@ function buildConnectionSource(
     lastErrorMessage: string | null;
     lastSeenAt: string | null;
     resourceAvailabilitySummary: Record<string, unknown>;
+    id: string;
     sourceInstanceKey: string;
     sourceProviderSlug: string;
     status: "connected" | "disconnected" | "error" | "unavailable";
@@ -290,6 +291,7 @@ function buildConnectionSource(
     connectionId: "conn_123",
     displayName: "WHOOP",
     firstSeenAt: "2026-04-06T09:00:00.000Z",
+    id: "dcs_abcdefghijklmnop",
     lifecycleEpoch: 1,
     lastDataAt: null,
     lastErrorCode: null,
@@ -1120,6 +1122,77 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
       "conn_first",
       "conn_second",
     ]);
+  });
+
+  it("hands an established eligible source to the existing notice scheduler", async () => {
+    createAuthorityHarness({
+      connectionSources: [{
+        displayName: "Garmin",
+        id: "dcs_abcdefghijklmnop",
+        lastDataAt: "2026-08-01T00:00:00.000Z",
+        sourceInstanceKey: "junction:garmin",
+        sourceProviderSlug: "garmin",
+      }],
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [{ connectionId: "conn_123" }],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(mocks.scheduleHostedSourceDeliveryStallNotices).toHaveBeenCalledWith({
+      candidates: [{
+        connectionId: "conn_123",
+        lastDataAt: "2026-08-01T00:00:00.000Z",
+        lifecycleEpoch: 1,
+        sourceId: "dcs_abcdefghijklmnop",
+        sourceInstanceKey: "junction:garmin",
+        sourceProviderSlug: "garmin",
+      }],
+      now: expect.any(String),
+      userId: "user_123",
+    });
+  });
+
+  it("hands no candidate to the scheduler after source delivery resumes", async () => {
+    createAuthorityHarness({
+      connectionSources: [{
+        displayName: "Garmin",
+        id: "dcs_abcdefghijklmnop",
+        lastDataAt: new Date().toISOString(),
+        sourceInstanceKey: "junction:garmin",
+        sourceProviderSlug: "garmin",
+      }],
+    });
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+
+    await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        body: JSON.stringify({
+          updates: [{ connectionId: "conn_123" }],
+          userId: "user_123",
+        }),
+        method: "POST",
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(mocks.scheduleHostedSourceDeliveryStallNotices).toHaveBeenCalledWith({
+      candidates: [],
+      now: expect.any(String),
+      userId: "user_123",
+    });
   });
 
   it("bounds an N=100 no-op apply to one set read and 100 serial transactions", async () => {
@@ -3986,6 +4059,7 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
       connectionId: record.id,
       displayName: `Source ${index + 1}`,
       firstSeenAt: "2026-04-06T09:00:00.000Z",
+      id: `dcs_source_${index + 1}`,
       lifecycleEpoch: 1,
       lastDataAt: null,
       lastErrorCode: null,

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -61,6 +61,7 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   resolveDeviceProviderApplication: vi.fn(),
+  scheduleHostedSourceDeliveryStallNotices: vi.fn(),
   writeHostedRuntimeLogs: vi.fn(),
 }));
 
@@ -108,6 +109,14 @@ vi.mock("@/src/lib/device-sync/provider-applications", () => ({
   isMemberOwnedDeviceProviderApplicationProvider: (value: unknown) =>
     value === "strava",
   resolveDeviceProviderApplication: mocks.resolveDeviceProviderApplication,
+}));
+
+vi.mock("@/src/lib/device-sync/source-delivery-stall-notice", async (importOriginal) => ({
+  ...(await importOriginal<typeof import(
+    "@/src/lib/device-sync/source-delivery-stall-notice"
+  )>()),
+  scheduleHostedSourceDeliveryStallNotices:
+    mocks.scheduleHostedSourceDeliveryStallNotices,
 }));
 
 function buildHostedRecord(

--- a/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
+++ b/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   hasHostedLinqInboundWithinDays: vi.fn(),
   hasHostedRuntimeActiveAccess: vi.fn(),
+  findDeviceConnectionSource: vi.fn(),
   readHostedMailboxItemByDedupeKey: vi.fn(),
   resolveHostedAssistantNotificationDestination: vi.fn(),
   runWithPreparedHostedMailboxItemAppendCrypto: vi.fn(),
@@ -44,6 +45,7 @@ const BASE_INPUT = {
   lastDataAt: "2026-08-20T00:00:00.000Z",
   lifecycleEpoch: 4,
   now: "2026-08-23T00:00:00.000Z",
+  sourceId: "dcs_abcdefghijklmnop",
   sourceInstanceKey: "source-1",
   sourceProviderSlug: "garmin",
   status: "connected" as const,
@@ -75,6 +77,7 @@ beforeEach(() => {
   const tx = {
     deviceConnectionSource: {
       findUnique: vi.fn().mockResolvedValue({
+        id: BASE_INPUT.sourceId,
         connection: { status: "active", userId: "member-1" },
         lastDataAt: new Date(BASE_INPUT.lastDataAt),
         lifecycleEpoch: BASE_INPUT.lifecycleEpoch,
@@ -83,10 +86,19 @@ beforeEach(() => {
       }),
     },
   };
+  tx.deviceConnectionSource.findUnique = mocks.findDeviceConnectionSource;
   mocks.getPrisma.mockReturnValue({
     $transaction: vi.fn((run: (client: typeof tx) => Promise<unknown>) => run(tx)),
   });
   mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(null);
+  mocks.findDeviceConnectionSource.mockResolvedValue({
+    connection: { status: "active", userId: "member-1" },
+    id: BASE_INPUT.sourceId,
+    lastDataAt: new Date(BASE_INPUT.lastDataAt),
+    lifecycleEpoch: BASE_INPUT.lifecycleEpoch,
+    sourceProviderSlug: BASE_INPUT.sourceProviderSlug,
+    status: BASE_INPUT.status,
+  });
   mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
   mocks.hasHostedLinqInboundWithinDays.mockResolvedValue(true);
   mocks.resolveHostedAssistantNotificationDestination.mockResolvedValue(
@@ -108,6 +120,7 @@ describe("hosted source delivery-stall notice identity", () => {
       connectionId: "connection-1",
       lastDataAt: "2026-08-20T00:00:00.000Z",
       lifecycleEpoch: 4,
+      sourceId: "dcs_abcdefghijklmnop",
       sourceInstanceKey: "source-1",
       sourceProviderSlug: "garmin",
     });
@@ -160,10 +173,14 @@ describe("hosted source delivery-stall notice materialization", () => {
 
     expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
     const appendInput = mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[0]?.[0];
+    const notificationKey = buildHostedSourceDeliveryStallNoticeKey(candidate);
     expect(appendInput?.envelope).toMatchObject({
+      eventId: `assistant.notification.requested:${notificationKey}`,
       kind: "assistant.notification.requested",
       notification: {
+        deliveryDedupeToken: notificationKey,
         deliveryDispatchMode: "queue-only",
+        deliveryIdempotencyKey: notificationKey,
         responsePolicy: {
           kind: "require_send_exact_text",
           text: expect.stringMatching(/Garmin Connect/u),
@@ -184,7 +201,7 @@ describe("hosted source delivery-stall notice materialization", () => {
     });
   });
 
-  it("re-signals an existing live episode without appending another notice", async () => {
+  it("revalidates and re-signals an existing live episode without inserting another notice", async () => {
     const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
     expect(candidate).not.toBeNull();
     if (!candidate) {
@@ -198,8 +215,8 @@ describe("hosted source delivery-stall notice materialization", () => {
       userId: "member-1",
     });
 
-    expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).not.toHaveBeenCalled();
-    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).toHaveBeenCalledOnce();
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledOnce();
   });
 
@@ -210,6 +227,47 @@ describe("hosted source delivery-stall notice materialization", () => {
       return;
     }
     mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(false);
+
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate,
+      now: BASE_INPUT.now,
+      userId: "member-1",
+    });
+
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "recent Linq activity is absent",
+      prepare: () => mocks.hasHostedLinqInboundWithinDays.mockResolvedValue(false),
+    },
+    {
+      name: "the current route is not a direct member thread",
+      prepare: () => mocks.resolveHostedAssistantNotificationDestination.mockResolvedValue({
+        ...DIRECT_LINQ_DESTINATION,
+        conversationShape: "group",
+      }),
+    },
+    {
+      name: "the source received data after candidate selection",
+      prepare: () => mocks.findDeviceConnectionSource.mockResolvedValue({
+        connection: { status: "active", userId: "member-1" },
+        id: BASE_INPUT.sourceId,
+        lastDataAt: new Date("2026-08-22T23:00:00.000Z"),
+        lifecycleEpoch: BASE_INPUT.lifecycleEpoch,
+        sourceProviderSlug: BASE_INPUT.sourceProviderSlug,
+        status: BASE_INPUT.status,
+      }),
+    },
+  ])("suppresses the notice when $name", async ({ prepare }) => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    expect(candidate).not.toBeNull();
+    if (!candidate) {
+      return;
+    }
+    prepare();
 
     await materializeHostedSourceDeliveryStallNotice({
       candidate,

--- a/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
+++ b/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx: vi.fn(),
+  getPrisma: vi.fn(),
+  hasHostedLinqInboundWithinDays: vi.fn(),
+  hasHostedRuntimeActiveAccess: vi.fn(),
+  readHostedMailboxItemByDedupeKey: vi.fn(),
+  resolveHostedAssistantNotificationDestination: vi.fn(),
+  runWithPreparedHostedMailboxItemAppendCrypto: vi.fn(),
+  signalHostedMailboxAppendRuntime: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx:
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+  readHostedMailboxItemByDedupeKey: mocks.readHostedMailboxItemByDedupeKey,
+  runWithPreparedHostedMailboxItemAppendCrypto:
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto,
+}));
+vi.mock("@/src/lib/hosted-mailbox/runtime-access", () => ({
+  hasHostedRuntimeActiveAccess: mocks.hasHostedRuntimeActiveAccess,
+}));
+vi.mock("@/src/lib/hosted-onboarding/linq-daily-state", () => ({
+  hasHostedLinqInboundWithinDays: mocks.hasHostedLinqInboundWithinDays,
+}));
+vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
+  signalHostedMailboxAppendRuntime: mocks.signalHostedMailboxAppendRuntime,
+}));
+vi.mock("@/src/lib/hosted-routing/assistant-notification-destination", () => ({
+  resolveHostedAssistantNotificationDestination:
+    mocks.resolveHostedAssistantNotificationDestination,
+}));
+vi.mock("@/src/lib/prisma", () => ({ getPrisma: mocks.getPrisma }));
+
+import {
+  buildHostedSourceDeliveryStallNoticeKey,
+  materializeHostedSourceDeliveryStallNotice,
+  resolveHostedSourceDeliveryStallNoticeCandidate,
+} from "@/src/lib/device-sync/source-delivery-stall-notice";
+
+const BASE_INPUT = {
+  connectionId: "connection-1",
+  lastDataAt: "2026-08-20T00:00:00.000Z",
+  lifecycleEpoch: 4,
+  now: "2026-08-23T00:00:00.000Z",
+  sourceInstanceKey: "source-1",
+  sourceProviderSlug: "garmin",
+  status: "connected" as const,
+};
+
+const MAILBOX_ITEM = {
+  consumedAt: null,
+  id: "mailbox-1",
+  lane: "system",
+  laneSeq: "7",
+  userId: "member-1",
+};
+
+const DIRECT_LINQ_DESTINATION = {
+  conversationShape: "direct-member",
+  externalThreadRouteAuthority: null,
+  route: {
+    actorId: null,
+    channel: "linq",
+    delivery: { kind: "thread", target: "direct-thread" },
+    identityId: "identity-1",
+    threadId: "thread-1",
+    threadIsDirect: true,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const tx = {
+    deviceConnectionSource: {
+      findUnique: vi.fn().mockResolvedValue({
+        connection: { status: "active", userId: "member-1" },
+        lastDataAt: new Date(BASE_INPUT.lastDataAt),
+        lifecycleEpoch: BASE_INPUT.lifecycleEpoch,
+        sourceProviderSlug: BASE_INPUT.sourceProviderSlug,
+        status: BASE_INPUT.status,
+      }),
+    },
+  };
+  mocks.getPrisma.mockReturnValue({
+    $transaction: vi.fn((run: (client: typeof tx) => Promise<unknown>) => run(tx)),
+  });
+  mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(null);
+  mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(true);
+  mocks.hasHostedLinqInboundWithinDays.mockResolvedValue(true);
+  mocks.resolveHostedAssistantNotificationDestination.mockResolvedValue(
+    DIRECT_LINQ_DESTINATION,
+  );
+  mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mockResolvedValue({
+    item: MAILBOX_ITEM,
+  });
+  mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementation(
+    (input: { append: (prepared: Record<string, never>) => Promise<unknown> }) =>
+      input.append({}),
+  );
+  mocks.signalHostedMailboxAppendRuntime.mockResolvedValue(undefined);
+});
+
+describe("hosted source delivery-stall notice identity", () => {
+  it("derives a candidate only for an eligible provider silence episode", () => {
+    expect(resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT)).toEqual({
+      connectionId: "connection-1",
+      lastDataAt: "2026-08-20T00:00:00.000Z",
+      lifecycleEpoch: 4,
+      sourceInstanceKey: "source-1",
+      sourceProviderSlug: "garmin",
+    });
+    expect(resolveHostedSourceDeliveryStallNoticeCandidate({
+      ...BASE_INPUT,
+      now: "2026-08-22T23:59:59.999Z",
+    })).toBeNull();
+    expect(resolveHostedSourceDeliveryStallNoticeCandidate({
+      ...BASE_INPUT,
+      sourceProviderSlug: "oura",
+    })).toBeNull();
+    expect(resolveHostedSourceDeliveryStallNoticeCandidate({
+      ...BASE_INPUT,
+      status: "disconnected",
+    })).toBeNull();
+  });
+
+  it("keeps one key per silence episode and rotates it for a new delivery or lifecycle", () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    expect(candidate).not.toBeNull();
+    if (!candidate) {
+      return;
+    }
+    const key = buildHostedSourceDeliveryStallNoticeKey(candidate);
+    expect(buildHostedSourceDeliveryStallNoticeKey(candidate)).toBe(key);
+    expect(buildHostedSourceDeliveryStallNoticeKey({
+      ...candidate,
+      lastDataAt: "2026-08-20T01:00:00.000Z",
+    })).not.toBe(key);
+    expect(buildHostedSourceDeliveryStallNoticeKey({
+      ...candidate,
+      lifecycleEpoch: 5,
+    })).not.toBe(key);
+  });
+});
+
+describe("hosted source delivery-stall notice materialization", () => {
+  it("queues exact direct-thread copy through the existing durable mailbox", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    expect(candidate).not.toBeNull();
+    if (!candidate) {
+      return;
+    }
+
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate,
+      now: BASE_INPUT.now,
+      userId: "member-1",
+    });
+
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
+    const appendInput = mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[0]?.[0];
+    expect(appendInput?.envelope).toMatchObject({
+      kind: "assistant.notification.requested",
+      notification: {
+        deliveryDispatchMode: "queue-only",
+        responsePolicy: {
+          kind: "require_send_exact_text",
+          text: expect.stringMatching(/Garmin Connect/u),
+        },
+        route: DIRECT_LINQ_DESTINATION.route,
+      },
+      userId: "member-1",
+    });
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
+      expectedUserId: "member-1",
+      knownCheckpoint: {
+        lane: "system",
+        laneSeq: "7",
+        userId: "member-1",
+      },
+      mailboxItemId: "mailbox-1",
+      prisma: expect.any(Object),
+    });
+  });
+
+  it("re-signals an existing live episode without appending another notice", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    expect(candidate).not.toBeNull();
+    if (!candidate) {
+      return;
+    }
+    mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(MAILBOX_ITEM);
+
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate,
+      now: BASE_INPUT.now,
+      userId: "member-1",
+    });
+
+    expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses members without active access before appending", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    expect(candidate).not.toBeNull();
+    if (!candidate) {
+      return;
+    }
+    mocks.hasHostedRuntimeActiveAccess.mockResolvedValue(false);
+
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate,
+      now: BASE_INPUT.now,
+      userId: "member-1",
+    });
+
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -78,6 +78,9 @@ import {
   createHostedLinqDeliveryIdempotencyLookupKey,
   createHostedLinqDeliverySourceRefLookupKey,
 } from "@/src/lib/hosted-onboarding/linq-observability-identifiers";
+import {
+  buildHostedSourceDeliveryStallNoticeKey,
+} from "@/src/lib/device-sync/source-delivery-stall-episode";
 import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import { POST as postHostedLinqEgressEngagement } from "../app/api/internal/hosted-runtime/linq-egress/engagement/route";
 
@@ -1703,6 +1706,79 @@ describe("hosted Linq egress authority", () => {
       .not.toHaveBeenCalled();
   });
 
+  it.each([
+    { expectedStatus: 200, recovered: false },
+    { expectedStatus: 409, recovered: true },
+  ])(
+    "revalidates a queued wearable silence episode at provider entry (recovered=$recovered)",
+    async ({ expectedStatus, recovered }) => {
+      const sourceId = "dcs_abcdefghijklmnop";
+      const originalLastDataAt = "2026-08-01T00:00:00.000Z";
+      const notificationKey = buildHostedSourceDeliveryStallNoticeKey({
+        connectionId: "connection-1",
+        lastDataAt: originalLastDataAt,
+        lifecycleEpoch: 1,
+        sourceId,
+        sourceInstanceKey: "junction:garmin",
+        sourceProviderSlug: "garmin",
+      });
+      const prisma = createPrismaStub({ homeChatId: "chat-home" });
+      prisma.$queryRaw.mockResolvedValue([{ id: sourceId }]);
+      prisma.deviceConnectionSource.findUnique.mockResolvedValue({
+        connection: { status: "active", userId: "member-1" },
+        connectionId: "connection-1",
+        id: sourceId,
+        lastDataAt: new Date(
+          recovered ? new Date().toISOString() : originalLastDataAt,
+        ),
+        lifecycleEpoch: 1,
+        sourceInstanceKey: "junction:garmin",
+        sourceProviderSlug: "garmin",
+        status: "connected",
+      });
+      mockPersistedLinqInbound({
+        chatId: "chat-home",
+        dedupeKey: "linq-event-wearable-recovery",
+        mailboxItemId: "mailbox-wearable-recovery",
+        messageId: "linq-message-wearable-recovery",
+        occurredAt: new Date().toISOString(),
+        prisma,
+        threadIsDirect: true,
+      });
+      mocks.getPrisma.mockReturnValue(prisma);
+
+      const response = await postHostedLinqEgressEngagement(
+        new Request("https://internal.example.test/engagement", {
+          body: JSON.stringify({
+            authorityCheckOnly: false,
+            idempotencyKey: notificationKey,
+            target: "chat-home",
+            targetKind: "thread",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(expectedStatus);
+      if (recovered) {
+        await expect(response.json()).resolves.toMatchObject({
+          error: {
+            code: "HOSTED_DEVICE_DELIVERY_STALL_EPISODE_SUPERSEDED",
+            retryable: false,
+          },
+        });
+        expect(prisma.hostedLinqDelivery.createMany).not.toHaveBeenCalled();
+      } else {
+        await expect(response.json()).resolves.toMatchObject({
+          ok: true,
+          providerDispatchClaimed: true,
+        });
+        expect(prisma.hostedLinqDelivery.createMany).toHaveBeenCalledOnce();
+      }
+    },
+  );
+
   it("uses the persisted direct-route line when chat attribution and sender are absent", async () => {
     const homeLinePhone = "+15550100009";
     const homeLineLookupKey = createRequiredPhoneLookupKey(homeLinePhone);
@@ -1891,6 +1967,10 @@ function createPrismaStub(input: {
   const defaultLineLookupKey = createRequiredPhoneLookupKey(defaultLinePhone);
   const prisma = {
     $executeRaw: vi.fn().mockResolvedValue(1),
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    deviceConnectionSource: {
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
     hostedMember: {
       findUnique: vi.fn().mockResolvedValue(input.activeMemberAccess === false
         ? null

--- a/apps/web/test/user-facing-messages.test.ts
+++ b/apps/web/test/user-facing-messages.test.ts
@@ -24,6 +24,7 @@ const TEST_TEMPLATE_KEYS = [
   "linq.invite_signup",
   "linq.daily_quota",
   "linq.home_redirect",
+  "linq.device_delivery_stalled",
   "linq.ai_usage.starter_limit_reached",
   "linq.ai_usage.edge_limit_reached",
   "linq.ai_usage.family_limit_reached",
@@ -61,6 +62,11 @@ const TEST_CONTEXT_BY_KEY = {
   },
   "linq.home_redirect": {
     homeRecipientPhone: "+15555550123",
+  },
+  "linq.device_delivery_stalled": {
+    companionAppName: "Garmin Connect",
+    deviceDisplayName: "watch",
+    providerDisplayName: "Garmin",
   },
   "linq.ai_usage.starter_limit_reached": {
     settingsUrl: "https://withmurph.ai/settings?usageRecovery=true#subscription",
@@ -155,6 +161,17 @@ describe("user-facing message variants", () => {
 
   it("identifies Murph in every phone signup invite", () => {
     expectEveryVariantMatches("linq.invite_signup", /Murph/u);
+  });
+
+  it("keeps wearable recovery checks practical, conversational, and link-free", () => {
+    for (const text of collectRenderedTexts("linq.device_delivery_stalled")) {
+      expect(text).toMatch(/Garmin/u);
+      expect(text).toMatch(/Garmin Connect/u);
+      expect(text).toMatch(/charg|battery/iu);
+      expect(text).toMatch(/sync/iu);
+      expect(text).toMatch(/\?$/u);
+      expect(text).not.toMatch(/https?:\/\//iu);
+    }
   });
 
   it("keeps thread allowance copy neutral while explaining the pause", () => {

--- a/apps/web/test/user-facing-messages.test.ts
+++ b/apps/web/test/user-facing-messages.test.ts
@@ -65,7 +65,7 @@ const TEST_CONTEXT_BY_KEY = {
   },
   "linq.device_delivery_stalled": {
     companionAppName: "Garmin Connect",
-    deviceDisplayName: "watch",
+    deviceDisplayName: "Garmin device",
     providerDisplayName: "Garmin",
   },
   "linq.ai_usage.starter_limit_reached": {
@@ -171,6 +171,7 @@ describe("user-facing message variants", () => {
       expect(text).toMatch(/sync/iu);
       expect(text).toMatch(/\?$/u);
       expect(text).not.toMatch(/https?:\/\//iu);
+      expect(text).not.toMatch(/\b(?:watch|usually|often)\b/iu);
     }
   });
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -336,6 +336,9 @@
       "@murphai/device-syncd/public-provider-descriptors": [
         "../../packages/device-syncd/src/public-provider-descriptors.ts"
       ],
+      "@murphai/device-syncd/source-staleness": [
+        "../../packages/device-syncd/src/source-staleness.ts"
+      ],
       "@murphai/device-syncd/types": [
         "../../packages/device-syncd/src/types.ts"
       ]

--- a/docs/device-provider-compatibility-matrix.md
+++ b/docs/device-provider-compatibility-matrix.md
@@ -102,8 +102,11 @@ direct thread. The existing mailbox dedupe key is scoped to source lifecycle
 and `last_data_at`, so repeated stale passes preserve one message per silence
 episode; a later delivery naturally creates a new episode. Materialization
 rechecks canonical source, connection, access, engagement, and route state
-after the sync transaction. No recovery message is sent. Providers without an
-explicit recovery-check policy remain unchanged.
+after the sync transaction. The same episode key carries its opaque source-row
+locator to the existing Linq provider-entry transaction, which locks and
+rebuilds the current episode before claiming dispatch; a resumed, replaced, or
+disconnected source therefore ends as a terminal no-send. No recovery message
+is sent. Providers without an explicit recovery-check policy remain unchanged.
 
 Recovering a dead push carrier cannot be done by pulling, because there is
 nothing to pull and a data refresh cannot make the provider push again. The only

--- a/docs/device-provider-compatibility-matrix.md
+++ b/docs/device-provider-compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Device Provider Compatibility Matrix
 
-Last verified: 2026-08-18
+Last verified: 2026-08-23
 
 ## Purpose
 
@@ -94,6 +94,16 @@ only: it never changes source status, gates ingestion, or triggers
 recovery, and a failure to evaluate or report must not fail the sync pass. A
 source that has never delivered is measured from `first_seen_at`, so a connect
 that emits its opening burst and then goes quiet is caught by the same rule.
+
+Member recovery checks are a separate, opt-in field on that same provider
+policy. Garmin currently admits one direct Linq check after 72 hours without a
+delivery, only for an active member with a recent inbound and an established
+direct thread. The existing mailbox dedupe key is scoped to source lifecycle
+and `last_data_at`, so repeated stale passes preserve one message per silence
+episode; a later delivery naturally creates a new episode. Materialization
+rechecks canonical source, connection, access, engagement, and route state
+after the sync transaction. No recovery message is sent. Providers without an
+explicit recovery-check policy remain unchanged.
 
 Recovering a dead push carrier cannot be done by pulling, because there is
 nothing to pull and a data refresh cannot make the provider push again. The only

--- a/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
+++ b/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
@@ -9,6 +9,7 @@ type PendingItem = Parameters<typeof isHostedSystemMailboxModelFreeExactNotifica
 function exactNotification(input: {
   dedupeKey?: string;
   deliveryDedupeToken?: string;
+  deliveryIdempotencyKey?: string;
   laneSeq: string;
 }): PendingItem {
   const deliveryDedupeToken = input.deliveryDedupeToken ?? "group-join:membership";
@@ -24,7 +25,8 @@ function exactNotification(input: {
       notification: {
         deliveryDedupeToken,
         deliveryDispatchMode: "queue-only",
-        deliveryIdempotencyKey: deliveryDedupeToken,
+        deliveryIdempotencyKey:
+          input.deliveryIdempotencyKey ?? deliveryDedupeToken,
         responsePolicy: { kind: "require_send_exact_text", text: "Confirmation" },
       },
     },
@@ -59,10 +61,16 @@ describe("blocked model-free exact notification frontier", () => {
   });
 
   it("admits a canonical exact wearable delivery-stall notice", () => {
-    expect(isHostedSystemMailboxModelFreeExactNotificationItem(exactNotification({
+    const notification = exactNotification({
       deliveryDedupeToken: "device-delivery-stalled:v1:abc123",
       laneSeq: "1",
-    }))).toBe(true);
+    });
+    expect(isHostedSystemMailboxModelFreeExactNotificationItem(notification)).toBe(true);
+    expect(isHostedSystemMailboxModelFreeExactNotificationItem(exactNotification({
+      deliveryDedupeToken: "device-delivery-stalled:v1:abc123",
+      deliveryIdempotencyKey: "device-delivery-stalled:v1:different",
+      laneSeq: "1",
+    }))).toBe(false);
   });
 
   it("does not overtake a generic notification at the durable frontier", () => {

--- a/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
+++ b/packages/assistant-runtime/test/system-mailbox-state-model-free-notification.test.ts
@@ -6,8 +6,12 @@ import {
 
 type PendingItem = Parameters<typeof isHostedSystemMailboxModelFreeExactNotificationItem>[0];
 
-function exactNotification(input: { dedupeKey?: string; laneSeq: string }): PendingItem {
-  const deliveryDedupeToken = "group-join:membership";
+function exactNotification(input: {
+  dedupeKey?: string;
+  deliveryDedupeToken?: string;
+  laneSeq: string;
+}): PendingItem {
+  const deliveryDedupeToken = input.deliveryDedupeToken ?? "group-join:membership";
   const mailboxDedupeKey = input.dedupeKey
     ?? `assistant.notification.requested:${deliveryDedupeToken}`;
   return {
@@ -52,6 +56,13 @@ describe("blocked model-free exact notification frontier", () => {
     expect(isHostedSystemMailboxModelFreeExactNotificationItem(notification)).toBe(true);
     expect(projectHostedSystemMailboxModelFreeNotificationFrontier({ pending: [later, notification] }).pending).toEqual([notification]);
     expect(projectHostedSystemMailboxModelFreeNotificationFrontier({ pending: [later] }).pending).toEqual([later]);
+  });
+
+  it("admits a canonical exact wearable delivery-stall notice", () => {
+    expect(isHostedSystemMailboxModelFreeExactNotificationItem(exactNotification({
+      deliveryDedupeToken: "device-delivery-stalled:v1:abc123",
+      laneSeq: "1",
+    }))).toBe(true);
   });
 
   it("does not overtake a generic notification at the durable frontier", () => {

--- a/packages/device-syncd/src/source-staleness.ts
+++ b/packages/device-syncd/src/source-staleness.ts
@@ -59,7 +59,7 @@ const PUSH_PRIMARY_SOURCE_POLICIES: ReadonlyMap<string, PushPrimarySourcePolicy>
     neverDeliveredHours: 6,
     recoveryNotice: {
       companionAppName: "Garmin Connect",
-      deviceDisplayName: "watch",
+      deviceDisplayName: "Garmin device",
       providerDisplayName: "Garmin",
       silentHours: 72,
     },

--- a/packages/device-syncd/src/source-staleness.ts
+++ b/packages/device-syncd/src/source-staleness.ts
@@ -37,6 +37,13 @@ export interface PushPrimarySourcePolicy {
    * threshold: a connect that never streams is a total outage for that member.
    */
   neverDeliveredHours: number;
+  /** Optional member-facing recovery prompt for evidence-backed providers. */
+  recoveryNotice?: {
+    companionAppName: string;
+    deviceDisplayName: string;
+    providerDisplayName: string;
+    silentHours: number;
+  };
 }
 
 const HOUR_MS = 60 * 60_000;
@@ -47,7 +54,16 @@ const HOUR_MS = 60 * 60_000;
  * send it, and that service silently stops for individual users.
  */
 const PUSH_PRIMARY_SOURCE_POLICIES: ReadonlyMap<string, PushPrimarySourcePolicy> = new Map([
-  ["garmin", { silentHours: 36, neverDeliveredHours: 6 }],
+  ["garmin", {
+    silentHours: 36,
+    neverDeliveredHours: 6,
+    recoveryNotice: {
+      companionAppName: "Garmin Connect",
+      deviceDisplayName: "watch",
+      providerDisplayName: "Garmin",
+      silentHours: 72,
+    },
+  }],
 ]);
 
 export type PushPrimarySourceStalenessReason = "never_delivered" | "stopped_delivering";
@@ -82,6 +98,30 @@ export function readPushPrimarySourcePolicy(
 
 export function isPushPrimarySourceProvider(sourceProviderSlug: string): boolean {
   return readPushPrimarySourcePolicy(sourceProviderSlug) !== null;
+}
+
+export function readPushPrimarySourceRecoveryNoticePolicy(
+  sourceProviderSlug: string,
+): NonNullable<PushPrimarySourcePolicy["recoveryNotice"]> | null {
+  return readPushPrimarySourcePolicy(sourceProviderSlug)?.recoveryNotice ?? null;
+}
+
+export function isPushPrimarySourceRecoveryNoticeEligible(input: {
+  lastDataAt: string | null;
+  now: string;
+  sourceProviderSlug: string;
+  status: string;
+}): boolean {
+  if (input.status !== "connected" || input.lastDataAt === null) {
+    return false;
+  }
+  const policy = readPushPrimarySourceRecoveryNoticePolicy(input.sourceProviderSlug);
+  const now = parseTimestamp(input.now);
+  const lastDataAt = parseTimestamp(input.lastDataAt);
+  return policy !== null
+    && now !== null
+    && lastDataAt !== null
+    && now - lastDataAt >= policy.silentHours * HOUR_MS;
 }
 
 function parseTimestamp(value: string): number | null {

--- a/packages/device-syncd/test/source-staleness.test.ts
+++ b/packages/device-syncd/test/source-staleness.test.ts
@@ -8,6 +8,8 @@ import { SqliteDeviceSyncStore } from "../src/store.ts";
 import {
   evaluatePushPrimarySourceStaleness,
   isPushPrimarySourceProvider,
+  isPushPrimarySourceRecoveryNoticeEligible,
+  readPushPrimarySourceRecoveryNoticePolicy,
 } from "../src/source-staleness.ts";
 import { makeTempDirectory } from "./helpers.ts";
 
@@ -96,6 +98,48 @@ test("push-primary staleness ignores pull-capable sources and non-connected rows
     }),
     [],
   );
+});
+
+test("Garmin recovery notices start after 72 hours of established delivery silence", () => {
+  assert.deepEqual(readPushPrimarySourceRecoveryNoticePolicy("GARMIN"), {
+    companionAppName: "Garmin Connect",
+    deviceDisplayName: "watch",
+    providerDisplayName: "Garmin",
+    silentHours: 72,
+  });
+  assert.equal(isPushPrimarySourceRecoveryNoticeEligible({
+    lastDataAt: "2026-07-21T00:00:00.001Z",
+    now: "2026-07-24T00:00:00.000Z",
+    sourceProviderSlug: "garmin",
+    status: CONNECTED,
+  }), false);
+  assert.equal(isPushPrimarySourceRecoveryNoticeEligible({
+    lastDataAt: "2026-07-21T00:00:00.000Z",
+    now: "2026-07-24T00:00:00.000Z",
+    sourceProviderSlug: "garmin",
+    status: CONNECTED,
+  }), true);
+});
+
+test("recovery notices require prior delivery, a connected source, and explicit provider policy", () => {
+  for (const input of [
+    { lastDataAt: null, sourceProviderSlug: "garmin", status: CONNECTED },
+    {
+      lastDataAt: "2026-07-01T00:00:00.000Z",
+      sourceProviderSlug: "garmin",
+      status: "disconnected",
+    },
+    {
+      lastDataAt: "2026-07-01T00:00:00.000Z",
+      sourceProviderSlug: "oura",
+      status: CONNECTED,
+    },
+  ] as const) {
+    assert.equal(isPushPrimarySourceRecoveryNoticeEligible({
+      ...input,
+      now: "2026-07-24T00:00:00.000Z",
+    }), false);
+  }
 });
 
 test("device sync store records source data arrival without letting reconcile move it", async () => {

--- a/packages/device-syncd/test/source-staleness.test.ts
+++ b/packages/device-syncd/test/source-staleness.test.ts
@@ -103,7 +103,7 @@ test("push-primary staleness ignores pull-capable sources and non-connected rows
 test("Garmin recovery notices start after 72 hours of established delivery silence", () => {
   assert.deepEqual(readPushPrimarySourceRecoveryNoticePolicy("GARMIN"), {
     companionAppName: "Garmin Connect",
-    deviceDisplayName: "watch",
+    deviceDisplayName: "Garmin device",
     providerDisplayName: "Garmin",
     silentHours: 72,
   });

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -80,7 +80,10 @@ export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
 ] as const satisfies readonly HostedMailboxKind[];
 
 export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_NOTIFICATION_DEDUPE_KEY_PREFIXES =
-  ["assistant.notification.requested:group-join:"] as const;
+  [
+    "assistant.notification.requested:device-delivery-stalled:v1:",
+    "assistant.notification.requested:group-join:",
+  ] as const;
 
 export function isHostedSystemMailboxModelFreeNotification(input: {
   dedupeKey: string | null | undefined;

--- a/packages/hosted-execution/test/orchestration-control-model-free-notification.test.ts
+++ b/packages/hosted-execution/test/orchestration-control-model-free-notification.test.ts
@@ -20,4 +20,15 @@ describe("model-free system mailbox notification identity", () => {
       kind: "runtime.maintenance-requested",
     })).toBe(false);
   });
+
+  it("admits only a versioned wearable delivery-stall notification identity", () => {
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:device-delivery-stalled:v1:abc123",
+      kind: "assistant.notification.requested",
+    })).toBe(true);
+    expect(isHostedSystemMailboxModelFreeNotification({
+      dedupeKey: "assistant.notification.requested:device-delivery-stalled:v1:",
+      kind: "assistant.notification.requested",
+    })).toBe(false);
+  });
 });


### PR DESCRIPTION
## Why and outcome

Some Garmin sources remain reported as connected even after delivery silently stops. Murph now sends one direct, low-pressure recovery check after 72 hours of established Garmin data silence. A queued check is suppressed if current source state shows delivery resumed before provider dispatch.

## Product UX result

- Product purpose verdict: appropriate. The check gives a recently engaged member the smallest useful recovery step without claiming a disconnect, opening a cold conversation, escalating, or adding app UI.
- Eligible journey: an active member with a recent inbound and established direct Linq thread gets one deterministic exact-text variant suggesting Garmin Connect plus a Garmin-device charge/sync check.
- Ineligible journeys: never-delivered, non-connected, unsupported-provider, inactive-access, stale-engagement, non-direct-route, and recovered-before-dispatch cases remain silent.
- Replay/recovery: the durable identity is stable for one source silence episode; a later delivery creates a new possible episode, and recovery itself sends no message.

## Direct evidence

- `packages/device-syncd`: focused staleness test, 9 passed; package build passed.
- `packages/hosted-execution`: focused model-free identity test, 2 passed.
- `packages/assistant-runtime`: focused exact-notification frontier test, 4 passed.
- `apps/web`: focused runtime apply, materializer, provider-entry, 20-variant copy, and changelog tests, 170 passed.
- `apps/web`: `pnpm typecheck:prepared` passed.
- `apps/web`: clean-source `pnpm typecheck:prepared` passed with generated `device-syncd` output removed.
- Scoped Web ESLint and `git diff --check` passed.
- Exact-head CI remains the broad-suite owner.

## Non-obvious affected surfaces

- Hosted runtime reconciliation and assistant-runtime system-mailbox ownership recognize the versioned notice identity as model-free only when the existing exact-text, queue-only, matching-dedupe contract also holds.
- The existing Linq provider-entry transaction now recognizes this one episode-key family, locks its canonical source row, and rejects a superseded episode before the provider-dispatch fence.
- The public changelog documents the member-visible recovery check.

## Architecture and reuse

- Existing systems reused: canonical `DeviceConnectionSource.lastDataAt`, the bounded runtime-apply source read, active-access and recent-inbound gates, direct-route resolution, prepared mailbox crypto, durable dedupe, runtime signaling, provider-entry route/access/line-health checks, and the provider-dispatch fence.
- New logic: one provider-policy field owns the 72-hour threshold and provider-specific copy context, while runtime apply hands eligible observations to one post-response sequential drain. Provider entry rebuilds the same episode key from current source state.
- New abstractions: one small source-episode identity/validity primitive and one candidate/materializer module. Adding another wearable later still requires explicit evidence and one policy entry.
- Complexity intentionally avoided: no scheduler, table, migration, service, provider callback, cancellation worker, recovery state machine, dependency, environment flag, app UI, escalation, or recovery message.

## Database and operational bounds

- The existing apply contract admits at most 100 connections with 64 sources each. Candidate derivation is in-memory over those already-loaded rows.
- Post-response materialization is serial across the complete apply batch, so peak added pooled connections and transactions are one. A consumed episode stops after one indexed mailbox-dedupe read; a live replay revalidates before re-signaling; a first episode uses existing bounded admission/route reads and one transaction capped at 10 seconds.
- The rare provider-entry path adds one indexed source-row lock and one exact source read inside the existing short dispatch-claim transaction. Unrelated messages do neither.
- Mailbox crypto preparation occurs before the transaction. Runtime signaling occurs after commit and is best-effort.
- A notice failure cannot fail or delay the device-sync apply response.

## Hot reply path impact

Not applicable. This changes post-response device-sync apply follow-up work, not durable acceptance of a current conversation message through provider start and reply handoff.

## Murph initial provider input impact

Not applicable. No prompt, tool schema, or first provider-visible request changes. The new notification is admitted only through the existing model-free exact-text contract, so the feature creates no model request.

## Change-shape breakdown

Classification: authored runtime modules are source; Vitest files are tests/fixtures; the execution plan, provider matrix, and changelog fragment are docs; generated and binary files are excluded.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 532 | 26 |
| Tests/fixtures | 539 | 3 |
| Docs | 117 | 1 |
| Config/tooling | 3 | 0 |
| Generated/other | 0 | 0 |
| Total | 1191 | 30 |

## Round-3 architecture retrospective

- Requirement retained: one direct Garmin recovery check after 72 hours of
  established silence, suppressed terminally when canonical delivery resumes
  before provider dispatch; no UI, recovery message, or escalation.
- Shape: the first-reviewed head changed 14 files with 826 additions, 29
  deletions, and 432 authored-source churn. The current head changes 18 files
  with 1,191 additions, 30 deletions, and 558 authored-source churn. The
  base-to-head source shape therefore grew by 126 lines of churn.
- Growth attribution: accepted review remediation changed 178/52 production
  lines, including deleting 50 lines from the original materializer while
  extracting the shared episode identity and composing canonical revalidation
  into the existing provider-entry boundary. It added 228/7 test lines for the
  provider fence, suppression paths, scheduler propagation, and identity
  equations; 24/10 documentation lines; and the final 3-line clean-source Web
  alias.
- Concepts and owners: the only new domain concept is a pure, stateless silence
  episode identity/validity primitive. Scheduling remains owned by bounded
  runtime reconciliation, persistence and replay by the existing mailbox,
  model-free admission by the existing runtime contract, and irreversible
  egress by the existing Linq provider-entry transaction and dispatch fence.
  The alias stays in Web's existing source-resolution configuration. No new
  durable owner, lifecycle, queue, scheduler, service, callback, or repair path
  exists.
- Deletion/reversion decision: do not delete or revert provider-entry source
  locking and episode revalidation; doing so reopens the reproduced
  recovery-before-dispatch bug. Keep live-replay revalidation because replay is
  another path to the same irreversible boundary. Do not fold the pure episode
  primitive back into the stateful materializer: both producer and provider
  consumer need one exact identity equation, while importing the materializer
  would couple the provider route to mailbox, crypto, and runtime-signal work.
- Shrink/split/redesign decision: no additional mechanism can be removed
  without duplicating identity logic or weakening the accepted suppression
  invariant. The 3-line alias cannot be split because the feature otherwise
  fails a clean Web build. Tests, provider documentation, and member-facing
  changelog are proof/disclosure for this same behavior, not independent
  product scope. Persisted episode state or another delivery owner would add
  complexity without solving a demonstrated need.
- Decision: justified continuation as one indivisible change. The remediation
  adds one shared pure primitive and tightens existing owner boundaries; it
  does not broaden the product or architecture.

## Changelog

- Changelog: updated
- Items: 2026-08-23 · garmin-sync-recovery-check

## Deployment concerns

- Deployment: applicable
- Supported skew: The new hosted runtime safely coexists with old Web, which emits no new notice. New Web with an old runtime is not the intended window because the notice would not have the new model-free ownership classification.
- Safe order: Deploy the Cloudflare Worker and hosted runner bundle first with immediate container rollout, verify the runner fingerprint, then deploy Web.
- Rollback floor: Revert Web first to stop producing notices; the runtime classification can remain safely until Web rollback converges.
- Expected exposure: With the safe order, none. Reversed skew can delay a notice or route it through default assistant ownership.
- Reversibility: Web rollback removes production of new notices without persisted-state conversion; the additive runtime prefix can then be reverted.
- Convergence proof: Require the managed-container smoke to report the new runner-bundle fingerprint before Web release.
- Post-deploy checks: Run one synthetic eligible delivery check and inspect bounded counts for queued, consumed, suppressed, and failed notice events without reading private payloads.

ReviewGPT context sensitivity: sensitive — proactive member messaging crosses source freshness, access, routing, durable mailbox, provider-entry validity, and hosted-runtime ownership boundaries.

ReviewGPT first-reviewed head: c1bf75e767ae809103af2efc0d2d51c96d9322b6
