### PR TITLE
Restore group-to-private handoff continuation

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
+++ b/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
@@ -59,3 +59,31 @@ Updated: 2026-08-24
 - Provider-visible description byte and route-wide budget comparison.
 - `git diff --check` and privacy-sensitive diff inspection.
 - Exact-head CI and preliminary specialist ReviewGPT pass.
+
+## Product UX Walkthrough
+
+- Fresh complete handoff: the current Message selects the existing new private
+  request action, while the host still owns sender identity, route checks, and
+  delivery. Contract coverage passed.
+- Missing-detail path: Murph persists the existing clarification before asking
+  the participant, so a later answer has a continuation owner. Contract coverage
+  passed alongside the existing mutual-exclusion tests.
+- Later clarification answer: only a later Message may select group or private
+  continuation; a fresh request cannot use continuation. Existing mapping and
+  authority tests passed.
+- Failure and recovery: unavailable routing and rejected authority remain
+  truthful server results, and accepted work remains described as queued rather
+  than sent. No fallback or retry behavior changed.
+- Result: Ready. The existing journey is restored for each changed path without
+  a new state, action, or user-visible step.
+
+## Local Evidence
+
+- Assistant Engine focused suites: 41 tests passed.
+- Assistant Engine typecheck: passed.
+- Changelog registry: 38 focused tests passed; Web typecheck passed.
+- Normalized real Codex App Server capture with `gpt-tokenizer` 3.4.0
+  `o200k_harmony`: the initial deferred-tool request is unchanged at 13,843
+  tokens / 58,845 UTF-8 bytes. The first request after `group_consult` discovery
+  changes from 16,973 tokens / 72,448 bytes to 17,038 / 72,803, a delta of 65
+  tokens / 355 bytes entirely from the tool description.

--- a/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
+++ b/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
@@ -1,0 +1,61 @@
+# Restore group-to-private handoff continuation
+
+Status: active
+Created: 2026-08-24
+Updated: 2026-08-24
+
+## Goal
+
+- Make the existing group consultation tool select the correct current-sender
+  action for fresh private handoffs, missing-detail questions, and later
+  clarification answers.
+- Preserve the current Web-owned authority, persistence, routing, and delivery
+  boundaries without adding state or fallback behavior.
+
+## Product UX Patch
+
+- Outcome: a group participant can complete an existing private-Murph handoff
+  after Murph asks for one missing detail, without receiving a false failure.
+- Reaches: the existing group conversation path that either has a complete
+  private handoff now or needs one user answer before choosing its destination.
+- Proof: the provider-visible tool contract distinguishes fresh requests from
+  persisted clarification continuations, focused tests lock that contract, and
+  existing execution tests continue to prove server-side authority and mutual
+  exclusion.
+
+## Scope
+
+- In scope: the `group_consult` tool description, focused prompt-contract
+  coverage, provider-input measurement, and a public changelog item.
+- Out of scope: new actions, new persisted state, retries, server authority,
+  private-route selection, delivery transport, and changes to group notices.
+
+## Constraints
+
+- A fresh complete private handoff uses the existing new-request action.
+- A follow-up question that must survive into the next message first persists
+  the existing clarification request.
+- Continuation actions are reserved for a later message answering a successfully
+  persisted clarification.
+- Accepted handoff remains queued rather than claimed as sent.
+- Keep the provider-visible instruction concise and within the existing tool
+  description budget.
+- Preserve unrelated worktree state and use the task worktree/PR lane.
+
+## Tasks
+
+1. Tighten the existing `group_consult` description at its current owner.
+2. Add focused contract coverage for fresh, clarification, and continuation
+   selection semantics.
+3. Run focused tests and typecheck, measure provider-input impact, complete the
+   Product UX walkthrough, and inspect the final diff.
+4. Commit and push the candidate, open the PR, and run the required preliminary
+   Product UX, prompt, and coverage ReviewGPT lenses concurrently with CI.
+
+## Verification
+
+- Focused assistant tool-description and current-sender tests.
+- Assistant Engine typecheck.
+- Provider-visible description byte and route-wide budget comparison.
+- `git diff --check` and privacy-sensitive diff inspection.
+- Exact-head CI and preliminary specialist ReviewGPT pass.

--- a/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
+++ b/agent-docs/exec-plans/active/2026-08-24-group-private-handoff-contract.md
@@ -83,7 +83,7 @@ Updated: 2026-08-24
 - Assistant Engine typecheck: passed.
 - Changelog registry: 38 focused tests passed; Web typecheck passed.
 - Normalized real Codex App Server capture with `gpt-tokenizer` 3.4.0
-  `o200k_harmony`: the initial deferred-tool request is unchanged at 13,843
+  `o200k_harmony`: the initial deferred-tool request is unchanged at 13,887
   tokens / 58,845 UTF-8 bytes. The first request after `group_consult` discovery
-  changes from 16,973 tokens / 72,448 bytes to 17,038 / 72,803, a delta of 65
-  tokens / 355 bytes entirely from the tool description.
+  changes from 17,021 tokens / 72,448 bytes to 17,083 / 72,790, a delta of 62
+  tokens / 342 bytes entirely from the tool description.

--- a/apps/web/changelog/entries/2026-08-24/group-private-handoff-continuation.json
+++ b/apps/web/changelog/entries/2026-08-24/group-private-handoff-continuation.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-24",
+  "order": 100,
+  "item": {
+    "id": "group-private-handoff-continuation",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Group-to-private handoffs keep moving",
+    "summary": "When a group-to-private handoff needs one more detail, Murph can now ask and continue after the participant replies.",
+    "details": "Fresh private requests and follow-up answers use their existing separate paths; queued work is still not described as sent.",
+    "relevanceTags": ["assistant", "groups", "reliability"],
+    "sourcePullRequests": [2224]
+  }
+}

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
@@ -1254,7 +1254,7 @@ function buildMurphGroupFamilyTool<
 export const MURPH_GROUP_CONSULT_TOOL = buildMurphGroupFamilyTool({
   name: 'group_consult',
   description:
-    'Ask or hand off to a group, member, or sender; host binds authority. For the current sender, message_current_sender starts a fresh, complete private handoff now. Before asking a follow-up to choose group or private delivery, call clarify_current_sender. Use continue_current_sender_privately or continue_current_sender_in_group only on a later Message answering that persisted clarification; never for a fresh request. Accepted handoff is queued, not sent.',
+    'Ask or hand off to a group/member/sender; host binds authority. For a complete current-sender private request, use message_current_sender. Before asking any follow-up needed to complete a current-sender handoff, call clarify_current_sender. Use continue_current_sender_privately or continue_current_sender_in_group only on a later Message answering that persisted clarification; never for a fresh request. Accepted handoff is queued, not sent.',
 })
 
 export const MURPH_GROUP_DATA_TOOL = buildMurphGroupFamilyTool({

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
@@ -1254,7 +1254,7 @@ function buildMurphGroupFamilyTool<
 export const MURPH_GROUP_CONSULT_TOOL = buildMurphGroupFamilyTool({
   name: 'group_consult',
   description:
-    'Ask or hand off to a group/member/sender; host binds authority. Accepted handoff is queued, not sent.',
+    'Ask or hand off to a group, member, or sender; host binds authority. For the current sender, message_current_sender starts a fresh, complete private handoff now. Before asking a follow-up to choose group or private delivery, call clarify_current_sender. Use continue_current_sender_privately or continue_current_sender_in_group only on a later Message answering that persisted clarification; never for a fresh request. Accepted handoff is queued, not sent.',
 })
 
 export const MURPH_GROUP_DATA_TOOL = buildMurphGroupFamilyTool({

--- a/packages/assistant-engine/test/assistant-tool-description-contracts.test.ts
+++ b/packages/assistant-engine/test/assistant-tool-description-contracts.test.ts
@@ -88,4 +88,19 @@ describe("assistant tool description call contracts", () => {
     expect(MURPH_GROUP_CONSULT_TOOL.description).toContain("hand off");
     expect(MURPH_GROUP_CONSULT_TOOL.description).toContain("queued, not sent");
   });
+
+  it("distinguishes fresh current-sender handoffs from clarification continuations", () => {
+    expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
+      "message_current_sender starts a fresh, complete private handoff now",
+    );
+    expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
+      "Before asking a follow-up to choose group or private delivery, call clarify_current_sender",
+    );
+    expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
+      "continue_current_sender_privately or continue_current_sender_in_group only on a later Message",
+    );
+    expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
+      "never for a fresh request",
+    );
+  });
 });

--- a/packages/assistant-engine/test/assistant-tool-description-contracts.test.ts
+++ b/packages/assistant-engine/test/assistant-tool-description-contracts.test.ts
@@ -91,10 +91,10 @@ describe("assistant tool description call contracts", () => {
 
   it("distinguishes fresh current-sender handoffs from clarification continuations", () => {
     expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
-      "message_current_sender starts a fresh, complete private handoff now",
+      "For a complete current-sender private request, use message_current_sender",
     );
     expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
-      "Before asking a follow-up to choose group or private delivery, call clarify_current_sender",
+      "Before asking any follow-up needed to complete a current-sender handoff, call clarify_current_sender",
     );
     expect(MURPH_GROUP_CONSULT_TOOL.description).toContain(
       "continue_current_sender_privately or continue_current_sender_in_group only on a later Message",


### PR DESCRIPTION
## Why and outcome

Group-to-private handoffs could fail after Murph asked for a missing detail because the provider-visible tool contract did not distinguish a fresh request from a later answer to persisted clarification. This tightens the existing `group_consult` contract so complete requests, clarification questions, and later continuations select their existing actions correctly.

The server-owned authority, routing, persistence, and delivery boundaries are unchanged.

## Product UX

- Effort: Product UX Patch
- Walkthrough: Ready
- Affected people: group participants making a complete private handoff, answering a missing-detail question, or receiving a truthful unavailable/rejected result.
- Material exclusions: no new state, action, user-visible step, retry, transport behavior, or group notice.
- Plan difference: none.

## Direct evidence

- Focused Assistant Engine suites: 41 tests passed, including the tool-description contract and existing current-sender authority/mutual-exclusion coverage.
- Assistant Engine typecheck: passed.
- Changelog registry: 38 focused tests passed; Web typecheck passed.
- Product walkthrough covered fresh complete requests, missing-detail clarification, later continuation, unavailable/rejected authority, and queued-not-sent wording.
- Visual evidence: not applicable; no hosted Web UI or visual state changed.

## Non-obvious affected surfaces

- Assistant provider thread compatibility: dynamic tools participate in the existing assistant contract fingerprint, so the description change starts a compatible fresh provider thread for affected routes. Existing fingerprint/session behavior is reused; no new invalidation mechanism is added.
- Initial provider input: the discovered `group_consult` descriptor grows by 342 UTF-8 bytes / 62 `o200k_harmony` tokens. Paired normalized request capture is reported below.
- Hosted runner rollout: old and new runners use the same action schema and persisted clarification state. Deployment details are below.

## Architecture and reuse

- Existing systems reused: the current `group_consult` action schema, Web-owned sender authority, clarification persistence, route checks, queue handoff, and contract fingerprint.
- New logic: one concise provider-visible selection rule distinguishes fresh, clarification, and continuation actions.
- New abstractions: none; the existing tool description is the narrow owning contract.
- Complexity intentionally avoided: no classifier, fallback retry, state machine, queue, action, or duplicate server-side policy was introduced because existing host enforcement is already correct.

## Hot reply path impact

This changes model selection on the Foreground Reply Critical Path but adds or moves no code-level database, network/provider, or other awaited operation. A complete request still uses one existing `message_current_sender` action. An incomplete request may now make one existing `clarify_current_sender` callback before Murph asks its follow-up; a later Message uses one existing continuation callback. These calls are serial and occur on separate turns. No automatic retry, fallback, timeout, or concurrency behavior changed, and rejected authority still fails closed. The focused execution suites prove the unchanged host boundary; no new code-path latency was introduced to measure.

## Murph initial provider input impact

Method: paired normalized captures from the pinned real Codex App Server against the scripted Responses provider, using identical fixtures, low reasoning, code mode, and `gpt-tokenizer` 3.4.0 with `o200k_harmony`. Counts cover the complete provider-visible request; only the discovered dynamic-tool description differs. Runtime paths and random temporary paths were normalized. Provider output is excluded.

- Representative individual/direct turn: `group_consult` is not available, so the changed field is absent. Base and head remain byte-for-byte identical by catalog selection; no provider-input surface changes on this route.
- Representative group turn, initial deferred-tool request: base 13,887 tokens / 58,845 UTF-8 bytes; head 13,887 / 58,845; delta 0 tokens (0.0000%) / 0 bytes. The changed tool has not been discovered yet.
- Representative group turn, first request after `group_consult` discovery: base 17,021 tokens / 72,448 bytes; head 17,083 / 72,790; delta +62 tokens (+0.3643%) / +342 bytes (+0.4721%). The entire delta is the tool description; instructions and other tool/schema/generated guidance are unchanged.

## Change shape

Classification is by file role in `origin/main...HEAD`; all files are authored text and there are no binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests/fixtures | 15 | 0 |
| Docs | 103 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **119** | **1** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new hosted runners accept the same action schema and persisted clarification rows; mixed versions are safe.
- Safe order: use the ordinary runner rollout; no coordinated Web, schema, or data migration is required.
- Rollback floor: the previous runner remains compatible with all state written by the new runner.
- Expected exposure: during rollout, instances can differ only in provider action-selection guidance; affected new turns rotate through the existing contract fingerprint.
- Reversibility: revert the description and its coverage; no data rollback is needed.
- Convergence proof: confirm all runner instances report the target build.
- Post-deploy checks: inspect bounded aggregates for clarification-unavailable/conflict outcomes and accepted current-sender handoffs without reading message content.

## Changelog

- Changelog: updated
- Items: 2026-08-24 · group-private-handoff-continuation
