### PR TITLE
Answer every rapid group request in one reply

### DIFF
--- a/apps/web/changelog/entries/2026-08-20/group-replies-follow-current-beat.json
+++ b/apps/web/changelog/entries/2026-08-20/group-replies-follow-current-beat.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 4,
     "title": "Group replies follow the current beat",
-    "summary": "In active iMessage and Telegram groups, Murph now briefly holds an answer and reconsiders it when another message arrives before send.",
-    "details": "Murph sends only the final response for that moment, or stays quiet when the room has moved on. Completed actions are not repeated.",
+    "summary": "In active iMessage and Telegram groups, Murph now combines rapid still-relevant requests into one complete reply.",
+    "details": "A clear correction replaces only what it changes; if the room has moved on, Murph can stay quiet. Completed actions are not repeated.",
     "relevanceTags": ["assistant", "groups", "messaging"],
-    "sourcePullRequests": [2107]
+    "sourcePullRequests": [2107, 2232]
   }
 }

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -190,9 +190,9 @@ export { buildResolveAssistantSessionInput } from './session-resolution.js'
 const DEFAULT_INITIAL_ACCEPTED_TURN_INPUT_ID = 'initial'
 const PHONE_CALL_MANUAL_ACCEPTED_TURN_INPUT_ID_PREFIX = 'manual-phone-call:'
 const ASSISTANT_GROUP_REPLY_RECONSIDERATION_INSTRUCTION = [
-  'Your previous response was held and was not sent. New messages arrived before delivery.',
-  'Reconsider the current group beat. Return the one final response to send now, or finish without a reply if Murph should no longer speak.',
-  'You may return the prior response unchanged. Do not mention this review or repeat completed effects.',
+  'New messages arrived before delivery.',
+  'Re-evaluate all accepted messages under the group turn rules and return one final result.',
+  'Do not mention this review or repeat completed effects.',
 ].join(' ')
 
 function shouldHoldAssistantGroupReplyDraft(input: {
@@ -1307,7 +1307,14 @@ export async function sendAssistantMessageLocal(
             acceptedInput: acceptanceInput.activeTurnInput,
             input: previousInput,
           })
-          currentInput = nextInput
+          currentInput =
+            holdGroupReplyDraft &&
+            acceptanceInput.providerRequestOrdinal === 0
+              ? {
+                  ...nextInput,
+                  prompt: `${previousInput.prompt}\n\n${nextInput.prompt}`,
+                }
+              : nextInput
           acceptedInputIdsForProviderRequest = acceptedInputJournal.inputIds
           acceptedInputItemsForProviderRequest = acceptedInputJournal.inputs
           return {

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -1313,6 +1313,10 @@ export async function sendAssistantMessageLocal(
               ? {
                   ...nextInput,
                   prompt: `${previousInput.prompt}\n\n${nextInput.prompt}`,
+                  userMessageContent: [
+                    ...(previousInput.userMessageContent ?? []),
+                    ...(acceptanceInput.activeTurnInput.userMessageContent ?? []),
+                  ],
                 }
               : nextInput
           acceptedInputIdsForProviderRequest = acceptedInputJournal.inputIds

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1215,7 +1215,7 @@ Classify the request by its purpose, not by whether it needs research or produce
 Social role:
 The humans are the protagonists, and Murph is an active, low-ego participant—not a passive help desk. Create openings, join clearly open room beats, and yield when one or more humans own the exchange. Optimize for more and better human-to-human conversation, not for Murph's share of messages; neither a funny line nor a blanket preference for silence overrides the actual conversational floor.
 
-Human ownership can be collective. A fresh relationship-bearing bid to the room's humans—such as "y'all remember...?", "look who I ran into", or a personal artifact offered for shared recognition or story continuation—gets first refusal even when no individual is named: send no reply or reaction unless Murph is addressed, a Murph-owned bit or challenge continues, immediate safety requires it, or a later message clearly reopens the floor. Read immediate same-purpose same-sender elaborations as one beat. A later bubble that introduces a new factual or task request or directly addresses Murph is a new decision unit even inside the same accepted provider turn; answer only that new ask under the ordinary rule.
+Human ownership can be collective. A fresh relationship-bearing bid to the room's humans—such as "y'all remember...?", "look who I ran into", or a personal artifact offered for shared recognition or story continuation—gets first refusal even when no individual is named: send no reply or reaction unless Murph is addressed, a Murph-owned bit or challenge continues, immediate safety requires it, or a later message clearly reopens the floor. Read immediate same-purpose same-sender elaborations as one beat. A later factual or task request or direct Murph address reopens the floor under the ordinary rule, even inside the same accepted provider turn.
 
 Floor follows authority, not punctuation. After safety, answer a direct Murph ask; answer an unaddressed room-wide question briefly when its exact answer is established by public or general knowledge, the visible conversation, server-approved group evidence, or an available task tool; otherwise, if answering would require the humans' private relationships, personal conduct, shared social history, recognition, or recollection, finish without text or reaction. A yes/no question, tag question, or "does anyone know?" does not create authority. Never use a joke, ruling, or mock refusal to imply knowledge of an unverified private fact about a person. If Murph is directly asked without such evidence, say plainly that you do not know; do not speculate or turn the limit into a bit.
 
@@ -1318,9 +1318,9 @@ function buildAssistantTurnPriorityText(
 4. Ask one narrow question only when missing detail materially changes safety, attribution, the group-owned write target, or the answer.
 5. Complete only public reads and authorized group-owned actions. Move personal operations to the requester's private Murph conversation without sending a personal settings URL unless an owning group workflow explicitly permits a clearly labeled per-person enrollment link.
 6. Use \`finish_without_reply\` only when no accepted message in the turn still merits a text reply.
-7. Incorporate every still-relevant accepted message, reason over the whole current beat, and do not repeat completed effects.
+7. Answer all still-relevant, unanswered requests that these rules assign to Murph across the accepted messages in one reply. A clear correction or replacement supersedes only what it changes; do not repeat completed effects.
 8. Lead each reply with the result, state uncertainty or blockers plainly, and claim an action only when a real runtime result proves it happened.
-9. Take one terminal action for the room's current beat: one text reply, one reaction, or silence. Do not answer each accepted message separately or recap the burst point by point.`;
+9. Take one terminal action for the room's current beat: one text reply, one reaction, or silence.`;
   }
   return `Turn priority order:
 1. Safety, privacy, and explicit user instructions override ordinary task preferences.

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -971,7 +971,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         const actions = readCapabilityRoutingActions(result.jsonEvents)
 
         expect(result.finalMessage.trim()).toBe(
-          '14:B 15:A 18:B 19:A 20:B 21:A 22:A 23:D 24:A 25:D 26:A 27:A 28:A 29:A 30:A 31:B 32:A 33:A 34:A 35:A 36:A 37:D 38:A 39:D 40:D 41:A 42:B 43:D 44:A 45:A 46:A 47:B 48:B 49:A 50:B 51:A 52:B 53:A 54:A 55:B 56:A 57:B 58:A 59:B 60:A 61:B 62:A 63:A 64:A 65:A 66:B 67:B 68:B 69:B',
+          '14:B 15:A 18:B 19:A 20:B 21:A 22:A 23:D 24:A 25:D 26:A 27:A 28:A 29:A 30:A 31:B 32:A 33:A 34:A 35:A 36:A 37:D 38:A 39:D 40:D 41:A 42:B 43:D 44:A 45:A 46:A 47:B 48:B 49:A 50:B 51:A 52:B 53:A 54:A 55:B 56:A 57:B 58:A 59:B 60:A 61:B 62:A 63:A 64:A 65:A 66:B 67:B 68:B 69:B 70:A 71:A',
         )
         expect(
           actions.some((action) =>
@@ -10587,8 +10587,8 @@ function buildGroupPointOfViewCandidateProbe(): string {
     'This is a playful group-chat candidate-choice evaluation.',
     'For each numbered transcript, choose the action Murph should take.',
     'Each candidate describes the complete action for that transcript.',
-    'For transcripts 14-22, 30-35, and 46-69, choose A or B. For transcripts 23-29 and 36-45, choose A, B, C, or D.',
-    'Reply exactly in the form `14:<A-or-B> 15:<A-or-B> 18:<A-or-B> 19:<A-or-B> 20:<A-or-B> 21:<A-or-B> 22:<A-or-B> 23:<A-B-C-or-D> 24:<A-B-C-or-D> 25:<A-B-C-or-D> 26:<A-B-C-or-D> 27:<A-B-C-or-D> 28:<A-B-C-or-D> 29:<A-B-C-or-D> 30:<A-or-B> 31:<A-or-B> 32:<A-or-B> 33:<A-or-B> 34:<A-or-B> 35:<A-or-B> 36:<A-B-C-or-D> 37:<A-B-C-or-D> 38:<A-B-C-or-D> 39:<A-B-C-or-D> 40:<A-B-C-or-D> 41:<A-B-C-or-D> 42:<A-B-C-or-D> 43:<A-B-C-or-D> 44:<A-B-C-or-D> 45:<A-B-C-or-D> 46:<A-or-B> 47:<A-or-B> 48:<A-or-B> 49:<A-or-B> 50:<A-or-B> 51:<A-or-B> 52:<A-or-B> 53:<A-or-B> 54:<A-or-B> 55:<A-or-B> 56:<A-or-B> 57:<A-or-B> 58:<A-or-B> 59:<A-or-B> 60:<A-or-B> 61:<A-or-B> 62:<A-or-B> 63:<A-or-B> 64:<A-or-B> 65:<A-or-B> 66:<A-or-B> 67:<A-or-B> 68:<A-or-B> 69:<A-or-B>` with no explanation.',
+    'For transcripts 14-22, 30-35, and 46-71, choose A or B. For transcripts 23-29 and 36-45, choose A, B, C, or D.',
+    'Reply exactly in the form `14:<A-or-B> 15:<A-or-B> 18:<A-or-B> 19:<A-or-B> 20:<A-or-B> 21:<A-or-B> 22:<A-or-B> 23:<A-B-C-or-D> 24:<A-B-C-or-D> 25:<A-B-C-or-D> 26:<A-B-C-or-D> 27:<A-B-C-or-D> 28:<A-B-C-or-D> 29:<A-B-C-or-D> 30:<A-or-B> 31:<A-or-B> 32:<A-or-B> 33:<A-or-B> 34:<A-or-B> 35:<A-or-B> 36:<A-B-C-or-D> 37:<A-B-C-or-D> 38:<A-B-C-or-D> 39:<A-B-C-or-D> 40:<A-B-C-or-D> 41:<A-B-C-or-D> 42:<A-B-C-or-D> 43:<A-B-C-or-D> 44:<A-B-C-or-D> 45:<A-B-C-or-D> 46:<A-or-B> 47:<A-or-B> 48:<A-or-B> 49:<A-or-B> 50:<A-or-B> 51:<A-or-B> 52:<A-or-B> 53:<A-or-B> 54:<A-or-B> 55:<A-or-B> 56:<A-or-B> 57:<A-or-B> 58:<A-or-B> 59:<A-or-B> 60:<A-or-B> 61:<A-or-B> 62:<A-or-B> 63:<A-or-B> 64:<A-or-B> 65:<A-or-B> 66:<A-or-B> 67:<A-or-B> 68:<A-or-B> 69:<A-or-B> 70:<A-or-B> 71:<A-or-B>` with no explanation.',
     '',
     '14. Nate: "Correct, the lid-free society has begun."',
     'A: "Correct, the lid-free society has begun."',
@@ -10767,15 +10767,15 @@ function buildGroupPointOfViewCandidateProbe(): string {
     'A: Return one text reply in one bubble; the host owns any pre-send cadence.',
     'B: Run a shell sleep, then split the answer across two short bubbles.',
     '',
-    '50. Murph is told its previous response was held and not sent because another ordinary human message arrived. The refreshed beat still calls for a text reply.',
+    '50. New messages arrive before delivery, and the refreshed beat still calls for a text reply.',
     'A: Return the old response and then a separate response to the new message.',
     'B: Reconsider the whole current beat and return one final response.',
     '',
-    '51. Murph is told its previous response was held and not sent. The new message introduces genuinely urgent safety information.',
+    '51. New messages arrive before delivery, including genuinely urgent safety information.',
     'A: Reconsider the current beat and answer the urgent information once.',
     'B: Preserve the old response and defer the urgent information to another turn.',
     '',
-    '52. Murph is told its previous response was held and not sent. Another human has now fully answered the room question and taken the floor.',
+    '52. New messages arrive before delivery. Another human has now fully answered the room question and taken the floor.',
     'A: Send Murph\'s held answer too so the original asker gets two answers.',
     'B: Re-evaluate the floor and finish without the stale text reply.',
     '',
@@ -10846,6 +10846,14 @@ function buildGroupPointOfViewCandidateProbe(): string {
     '69. A participant grants the exact scoring scope inside the recorded 24-hour window, but the room materially changed the challenge stakes after the offer.',
     'A: Record the participant as `in` under the changed terms.',
     'B: Keep the grant valid but ask for one ordinary confirmation of the changed challenge.',
+    '',
+    '70. Two accepted messages in one group turn each make a separate direct request to Murph. Both remain relevant and unanswered.',
+    'A: Return one reply that answers both requests.',
+    'B: Answer only the later request.',
+    '',
+    '71. A participant asks Murph to recommend a vegetarian restaurant. A later accepted message corrects only the diet requirement to vegan.',
+    'A: Return one vegan recommendation without a separate vegetarian answer.',
+    'B: Answer both the superseded vegetarian request and the vegan correction.',
   ].join('\n')
 }
 

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -929,6 +929,65 @@ describeRealCodex('real Codex live workout prescription e2e', () => {
 
 describeRealCodex('real Codex group-chat behavior e2e', () => {
   it(
+    'answers every still-relevant request after same-thread reconsideration',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-group-reconsideration-e2e-'),
+      )
+
+      try {
+        const commonInput = {
+          approvalPolicy: 'never' as const,
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions:
+            buildGroupPointOfViewDeveloperInstructions(),
+          env: config.env,
+          excludeResumeTurns: true,
+          model: 'gpt-5.6-sol',
+          modelProvider: config.modelProvider,
+          reasoningEffort: 'low' as const,
+          sandbox: 'workspace-write' as const,
+          workingDirectory,
+        }
+        const first = await executeRealCodexAppServerTurn({
+          ...commonInput,
+          prompt: 'Murph, what is 13 plus 8?',
+        })
+        expect(first.finalMessage).toMatch(/\b21\b/u)
+
+        const reconsiderationInstruction = [
+          'New messages arrived before delivery.',
+          'Re-evaluate all accepted messages under the group turn rules and return one final result.',
+          'Do not mention this review or repeat completed effects.',
+        ].join(' ')
+        const second = await executeRealCodexAppServerTurn({
+          ...commonInput,
+          prompt: `${reconsiderationInstruction}\n\nMurph, what is 7 times 6?`,
+          resumeSessionId: first.sessionId,
+        })
+
+        expect(second.sessionId).toBe(first.sessionId)
+        expect(second.finalMessage).toMatch(/\b21\b/u)
+        expect(second.finalMessage).toMatch(/\b42\b/u)
+        expect(second.finalMessage).not.toMatch(
+          /held|not sent|previous response|re-?evaluat|review/iu,
+        )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    480_000,
+  )
+
+  it(
     'prefers grounded group-chat actions while respecting collective human ownership',
     async () => {
       const config = await resolveRealCodexE2eConfig()

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -4488,7 +4488,7 @@ test('sendAssistantMessageLocal attributes required progress after real live ste
   providerRelease.resolve()
 
   await expect(resultPromise).resolves.toMatchObject({
-    prompt: 'Event-backed follow up',
+    prompt: 'Initial prompt\n\nEvent-backed follow up',
     response: 'final after event input',
   })
   assert.equal(mocks.executeCodexTurnWithRecovery.mock.calls.length, 1)

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -6986,6 +6986,7 @@ test('sendAssistantMessageLocal probes active-turn input once before provider st
 })
 
 test('sendAssistantMessageLocal keeps every group prompt accepted before provider start', async () => {
+  const initialImage = Buffer.from('synthetic-image-input')
   const session = createAssistantSession({
     binding: {
       actorId: null,
@@ -7066,6 +7067,17 @@ test('sendAssistantMessageLocal keeps every group prompt accepted before provide
     deliverResponse: true,
     prompt: 'What time does the venue open?',
     turnTrigger: 'automation-auto-reply',
+    userMessageContent: [
+      {
+        image: initialImage,
+        mediaType: 'image/png',
+        type: 'image',
+      },
+      {
+        text: 'What time does the venue open?',
+        type: 'text',
+      },
+    ],
     vault: '/vaults/test',
   })
   await firstDraftReady.promise
@@ -7075,6 +7087,24 @@ test('sendAssistantMessageLocal keeps every group prompt accepted before provide
   ).toBe(
     'What time does the venue open?\n\nAlso share the walking time.',
   )
+  expect(
+    mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.input
+      .userMessageContent,
+  ).toEqual([
+    {
+      image: initialImage,
+      mediaType: 'image/png',
+      type: 'image',
+    },
+    {
+      text: 'What time does the venue open?',
+      type: 'text',
+    },
+    {
+      text: 'Also share the walking time.',
+      type: 'text',
+    },
+  ])
   await vi.advanceTimersByTimeAsync(4_000)
   await expect(resultPromise).resolves.toMatchObject({
     response: 'The venue opens at nine, and the walk takes ten minutes.',

--- a/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-runtime.test.ts
@@ -6361,9 +6361,12 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
     ).toMatchObject({
       prompt: 'Actually, plans changed.',
       turnContext: expect.stringContaining(
-        'Your previous response was held and was not sent.',
+        'Re-evaluate all accepted messages under the group turn rules and return one final result.',
       ),
     })
+    expect(
+      mocks.executeCodexTurnWithRecovery.mock.calls[1]?.[0]?.input.turnContext,
+    ).not.toContain('previous response was held')
     expect(
       mocks.executeCodexTurnWithRecovery.mock.calls[1]?.[0]?.resolvedSession
         ?.resumeState,
@@ -6980,6 +6983,104 @@ test('sendAssistantMessageLocal probes active-turn input once before provider st
       source: 'manual',
     }),
   ])
+})
+
+test('sendAssistantMessageLocal keeps every group prompt accepted before provider start', async () => {
+  const session = createAssistantSession({
+    binding: {
+      actorId: null,
+      channel: 'telegram',
+      conversationKey: 'channel:telegram|identity:identity-1|thread:thread-1',
+      delivery: { kind: 'thread', target: 'thread-1' },
+      identityId: 'identity-1',
+      threadId: 'thread-1',
+      threadIsDirect: false,
+    },
+  })
+  const sharedPlan = createSharedPlan()
+  sharedPlan.conversationPolicy.audience.channel = 'telegram'
+  sharedPlan.conversationPolicy.audience.threadIsDirect = false
+  let admissionCount = 0
+  const activeTurnInput = vi.fn<AssistantActiveTurnInputAdmissionHook>(
+    async () => {
+      admissionCount += 1
+      if (admissionCount > 1) {
+        return { kind: 'no-new-input' }
+      }
+      return {
+        acceptedInputs: [
+          {
+            id: 'hook-1',
+            promptFallbackReason: 'manual-input',
+            promptFallbackText: 'Also share the walking time.',
+            source: 'manual',
+          },
+        ],
+        kind: 'accepted' as const,
+        prompt: 'Also share the walking time.',
+        transcriptText: 'Also share the walking time.',
+        userMessageContent: [
+          {
+            text: 'Also share the walking time.',
+            type: 'text' as const,
+          },
+        ],
+      }
+    },
+  )
+  const firstDraftReady = createDeferred<void>()
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    plan: { ...sharedPlan, persistUserPromptOnFailure: false },
+    session,
+  })
+  mocks.executeCodexTurnWithRecovery.mockImplementationOnce(
+    async (providerInput) => {
+      providerInput.activeTurnSteering?.onFirstAssistantResponseCompleted()
+      firstDraftReady.resolve()
+      return {
+        kind: 'succeeded',
+        providerTurn: {
+          onboardingGuidanceInjected: true,
+          codexContinuation: { kind: 'explicit-structured-history' },
+          codexThreadId: 'provider-thread-group-pre-provider',
+          response: 'The venue opens at nine, and the walk takes ten minutes.',
+          responseDeliveryContextOrdinal: 0,
+          route: { routeId: 'route-group-pre-provider' },
+          session,
+          transcriptResponse:
+            'The venue opens at nine, and the walk takes ten minutes.',
+        },
+      }
+    },
+  )
+
+  vi.useFakeTimers()
+  const resultPromise = sendAssistantMessageLocal({
+    activeTurnInput,
+    conversation: {
+      channel: 'telegram',
+      directness: 'group',
+      identityId: 'identity-1',
+      threadId: 'thread-1',
+    },
+    deliverResponse: true,
+    prompt: 'What time does the venue open?',
+    turnTrigger: 'automation-auto-reply',
+    vault: '/vaults/test',
+  })
+  await firstDraftReady.promise
+
+  expect(
+    mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]?.input.prompt,
+  ).toBe(
+    'What time does the venue open?\n\nAlso share the walking time.',
+  )
+  await vi.advanceTimersByTimeAsync(4_000)
+  await expect(resultPromise).resolves.toMatchObject({
+    response: 'The venue opens at nine, and the walk takes ten minutes.',
+  })
+  expect(mocks.executeCodexTurnWithRecovery).toHaveBeenCalledOnce()
+  expect(mocks.dispatchAssistantReply).toHaveBeenCalledOnce()
 })
 
 test('sendAssistantMessageLocal exposes hosted current-input authority to dynamic tools', async () => {

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -138,20 +138,24 @@ describe('assistant execution prompt contract', () => {
     expect(directPrompt).toContain(sharedIdentity)
     expect(groupPrompt).toContain(sharedStyleOwner)
     expect(directPrompt).toContain(sharedStyleOwner)
-    expect(groupPrompt).toContain('reason over the whole current beat')
+    const completeGroupReplyRule =
+      'Answer all still-relevant, unanswered requests that these rules assign to Murph across the accepted messages in one reply.'
+    expect(groupPrompt.split(completeGroupReplyRule)).toHaveLength(2)
+    expect(groupPrompt).toContain(
+      'A clear correction or replacement supersedes only what it changes',
+    )
     expect(groupPrompt).toContain('do not repeat completed effects')
     expect(groupPrompt).toContain(scopedSafety)
     expect(directPrompt).toContain(scopedSafety)
     expect(groupPrompt).not.toContain('replaces the earlier answer')
     expect(groupPrompt).not.toContain('carry forward anything still worth saying')
+    expect(groupPrompt).not.toContain('answer only that new ask')
     expect(groupPrompt).not.toContain('Use light humor when it fits')
     expect(groupPrompt).not.toContain('plainspoken, and casual')
     expect(groupPrompt).toContain(
       'Take one terminal action for the room\'s current beat: one text reply, one reaction, or silence.',
     )
-    expect(groupPrompt).toContain(
-      'Do not answer each accepted message separately or recap the burst point by point.',
-    )
+    expect(groupPrompt).not.toContain('Do not answer each accepted message separately')
     expect(groupPrompt).not.toContain('sleep 8')
     expect(groupPrompt).not.toContain('sleep 6')
     expect(directPrompt).not.toContain('Group texting rhythm:')
@@ -242,7 +246,7 @@ describe('assistant execution prompt contract', () => {
       'Read immediate same-purpose same-sender elaborations as one beat.',
     )
     expect(groupLayers.staticCacheableCorePrompt).toContain(
-      'A later bubble that introduces a new factual or task request or directly addresses Murph is a new decision unit even inside the same accepted provider turn',
+      'A later factual or task request or direct Murph address reopens the floor under the ordinary rule, even inside the same accepted provider turn.',
     )
     expect(groupLayers.staticCacheableCorePrompt).toContain(
       'Floor follows authority, not punctuation.',


### PR DESCRIPTION
## Why and outcome

Rapid accepted group messages now produce one complete reply for every still-relevant unanswered request. A correction supersedes only the detail it changes.

This also removes internal held-draft wording from reconsideration and preserves an earlier accepted message when a later message arrives before the first provider request starts.

## Product UX

- Effort: Patch.
- Linq/iMessage and Telegram group members get one concise answer covering the current burst instead of an answer to only the last request.
- A correction replaces the affected request rather than causing both old and corrected answers.
- Image-bearing first requests retain their image when a later text message joins the same pre-provider turn.
- Direct, email, scheduled, and non-group behavior are unchanged.
- No visual surface changed; design proof is not applicable.

## Direct evidence

- Prompt contract: 74/74 tests passed on the remediated head.
- Rich-input pre-provider regression: 1/1 focused test passed, proving the combined provider input retains both text prompts and the original synthetic image.
- Assistant engine typecheck passed on the remediated head.
- The two-turn same-thread GPT-5.6 Sol E2E is added and transforms under the normal suite. Its opt-in provider execution is locally blocked before provider start because the required `OPENAI_API_KEY` is unavailable.
- Changelog validation: 49/49 focused tests passed.
- A pinned real Codex app-server measurement against a hermetic scripted Responses provider captured the complete first GPT-5.6 Sol request.
- Diff whitespace and privacy scans passed.

## Non-obvious affected surfaces

- Applies only to eligible, delivered, unscheduled group auto-replies.
- Existing same-thread reconsideration, one-terminal-action selection, and four-second hold behavior remain in place.
- Persistence, transcript, outbox, routing, and provider schemas are unchanged.
- Regression fixtures are synthetic and contain no production transcript or member data.

## Architecture and reuse

- Existing systems reused: the current accepted-input checkpoint, held-group reply selection, and same-thread reconsideration path.
- New logic: concatenate two already-materialized accepted group prompts and their ordered rich-content parts when both exist before provider request zero, then tell the model once to answer all still-relevant requests.
- New abstractions: none; the existing local-service owner already has both accepted inputs and is the narrowest correct boundary.
- Complexity intentionally avoided: no new queue, state owner, retry path, provider call, or special-case response merger.

## Hot reply path impact

- The foreground group path changes after the existing accepted-input checkpoint and before the existing first provider start.
- Added awaited, database, network, or provider operations: zero.
- Maximum added work: one in-memory concatenation of two already-materialized strings at request ordinal zero.
- The existing four-second hold, request-one reconsideration, timeout, retry, fallback, and terminal-action ordering are unchanged.
- Before: a later accepted prompt could replace the earlier prompt before provider start. After: both are visible to the one existing provider turn.
- Expected latency effect: negligible.

## Murph initial provider input impact

Measurement used the pinned real Codex app server with a hermetic local scripted Responses provider, model `gpt-5.6-sol`, low reasoning, production code mode, identical direct/group fixtures, and locked `gpt-tokenizer@3.4.0` `o200k_harmony`.

The full normalized provider-visible JSON request was counted. Temporary home/workdir paths, request identifiers, timestamps, and the local port were normalized; no provider-visible field was excluded, and raw bodies remained in memory only.

| Scope | Base bytes | Head bytes | Delta | Base tokens | Head tokens | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Direct | 115,539 | 115,539 | 0 (0.0000%) | 25,105 | 25,105 | 0 (0.0000%) |
| Group | 98,105 | 98,059 | -46 (-0.0469%) | 21,234 | 21,226 | -8 (-0.0377%) |

The first-request group delta is entirely the simplified assembled group instructions. Tools, schema, generated context, and all other provider-visible fields are unchanged. Pre-provider prompt and rich-content composition only add the second accepted input when one exists; the single-message fixture isolates the system-prompt delta. The later reconsideration instruction does not appear in request zero.

## Change shape

Classification: small prompt-primary behavior correction with narrow mechanical prompt assembly and focused regression coverage.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 7 |
| Tests / fixtures | 215 | 13 |
| Docs / content | 3 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 236 | 23 |

No binary assets changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: persisted shapes and APIs are unchanged; warm old runners may finish with the old behavior while new runners use the corrected behavior.
- Safe order: deploy the Cloudflare assistant runner; the Web changelog may deploy independently because runtime behavior does not depend on it.
- Rollback floor: revert the prompt and local-service source change; no data or schema rollback is required.
- Expected exposure: one runner rollout window may contain a mix of old and corrected group reply behavior.
- Reversibility: the change is code-only and can be reverted without migrating persisted state or provider contracts.
- Convergence proof: confirm every active assistant runner build targets the merged commit after the rollout window.
- Post-deploy checks: two rapid independent group requests yield one reply covering both; an image-bearing first request retains the image; a rapid correction yields only the corrected result; inspect group reply failures and latency.


## Changelog

- Changelog: updated
- Items: 2026-08-20 · group-replies-follow-current-beat

ReviewGPT context sensitivity: routine - prompt-primary group reply correction with no persistence, trust-boundary, retry, scheduling, schema, or API change.
