### PR TITLE
fix(web): bound migration guard patterns to SQL statements

### DIFF
--- a/apps/web/scripts/run-prisma-migrate-deploy.ts
+++ b/apps/web/scripts/run-prisma-migrate-deploy.ts
@@ -516,9 +516,21 @@ function findQuotedSqlTokenEnd(
   start: number,
   quote: "'" | '"',
 ): number {
+  const prefix = sql[start - 1];
+  const characterBeforePrefix = sql[start - 2];
+  const usesBackslashEscapes =
+    quote === "'"
+    && (prefix === "E" || prefix === "e")
+    && (characterBeforePrefix === undefined
+      || !/[A-Za-z0-9_$]/u.test(characterBeforePrefix));
   let index = start + 1;
 
   while (index < sql.length) {
+    if (usesBackslashEscapes && sql[index] === "\\") {
+      index += 2;
+      continue;
+    }
+
     if (sql[index] !== quote) {
       index += 1;
       continue;

--- a/apps/web/scripts/run-prisma-migrate-deploy.ts
+++ b/apps/web/scripts/run-prisma-migrate-deploy.ts
@@ -377,12 +377,13 @@ export async function findHostedWebPrismaPredeployDestructiveMigrations(
     }
 
     const sqlPath = path.join(migrationsDir, entry.name, "migration.sql");
-    const sql = stripSqlComments(await readFile(sqlPath, "utf8"));
+    const sqlStatements = splitSqlStatements(await readFile(sqlPath, "utf8"));
     const compatibleReasons =
       hostedWebPrismaPredeployCompatibleMigrationReasons.get(entry.name);
     const destructivePattern = incompatiblePredeploySqlPatterns.find(
       ({ label, pattern }) =>
-        pattern.test(sql) && !compatibleReasons?.has(label),
+        !compatibleReasons?.has(label)
+        && sqlStatements.some((statement) => pattern.test(statement)),
     );
 
     if (destructivePattern !== undefined) {
@@ -424,8 +425,123 @@ function nonEmptyEnv(value: string | undefined): string | undefined {
   return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed;
 }
 
-function stripSqlComments(sql: string): string {
-  return sql.replace(/--.*$/gmu, "").replace(/\/\*[\s\S]*?\*\//gu, "");
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let statement = "";
+  let index = 0;
+
+  while (index < sql.length) {
+    const character = sql[index];
+    const nextCharacter = sql[index + 1];
+
+    if (character === "-" && nextCharacter === "-") {
+      statement += " ";
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (character === "/" && nextCharacter === "*") {
+      statement += " ";
+      index = skipSqlBlockComment(sql, index + 2);
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      const end = findQuotedSqlTokenEnd(sql, index, character);
+      statement += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    if (character === "$") {
+      const delimiter = readDollarQuoteDelimiter(sql, index);
+      if (delimiter !== undefined) {
+        const bodyStart = index + delimiter.length;
+        const bodyEnd = sql.indexOf(delimiter, bodyStart);
+        const end = bodyEnd === -1 ? sql.length : bodyEnd + delimiter.length;
+        statement += sql.slice(index, end);
+        index = end;
+        continue;
+      }
+    }
+
+    if (character === ";") {
+      if (statement.trim().length > 0) {
+        statements.push(statement);
+      }
+      statement = "";
+      index += 1;
+      continue;
+    }
+
+    statement += character;
+    index += 1;
+  }
+
+  if (statement.trim().length > 0) {
+    statements.push(statement);
+  }
+
+  return statements;
+}
+
+function skipSqlBlockComment(sql: string, start: number): number {
+  let depth = 1;
+  let index = start;
+
+  while (index < sql.length && depth > 0) {
+    if (sql[index] === "/" && sql[index + 1] === "*") {
+      depth += 1;
+      index += 2;
+      continue;
+    }
+
+    if (sql[index] === "*" && sql[index + 1] === "/") {
+      depth -= 1;
+      index += 2;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return index;
+}
+
+function findQuotedSqlTokenEnd(
+  sql: string,
+  start: number,
+  quote: "'" | '"',
+): number {
+  let index = start + 1;
+
+  while (index < sql.length) {
+    if (sql[index] !== quote) {
+      index += 1;
+      continue;
+    }
+
+    if (sql[index + 1] === quote) {
+      index += 2;
+      continue;
+    }
+
+    return index + 1;
+  }
+
+  return sql.length;
+}
+
+function readDollarQuoteDelimiter(sql: string, start: number): string | undefined {
+  const previousCharacter = sql[start - 1];
+  if (previousCharacter !== undefined && /[A-Za-z0-9_$]/u.test(previousCharacter)) {
+    return undefined;
+  }
+
+  return /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/u.exec(sql.slice(start))?.[0];
 }
 
 function runCommandInherited(

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -335,6 +335,79 @@ describe("hosted web production migration guard", () => {
     }
   });
 
+  test("keeps nullable ADD COLUMN independent from a later trigger function body", async () => {
+    const migrationsDir = await mkdtemp(
+      path.join(tmpdir(), "hosted-web-prisma-migrations-"),
+    );
+
+    try {
+      await writeMigrationSql(
+        migrationsDir,
+        "20260825000000_nullable_column_then_trigger",
+        [
+          'ALTER TABLE "hosted_member" ADD COLUMN "note" TEXT;',
+          "CREATE FUNCTION preserve_note() RETURNS trigger LANGUAGE plpgsql AS $$",
+          "BEGIN",
+          '  IF NEW."note" IS NOT NULL THEN',
+          "    RETURN NEW;",
+          "  END IF;",
+          "END;",
+          "$$;",
+        ].join("\n"),
+      );
+
+      assert.deepEqual(
+        await findHostedWebPrismaPredeployDestructiveMigrations(migrationsDir),
+        [],
+      );
+    } finally {
+      await rm(migrationsDir, { force: true, recursive: true });
+    }
+  });
+
+  test.each([
+    [
+      "single-quoted values",
+      "ALTER TABLE \"hosted_member\" ADD COLUMN \"required_value\" TEXT DEFAULT 'still;one statement' NOT NULL;",
+    ],
+    [
+      "quoted identifiers",
+      'ALTER TABLE "hosted;member" ADD COLUMN "required;value" TEXT NOT NULL;',
+    ],
+    [
+      "line comments",
+      'ALTER TABLE "hosted_member" ADD COLUMN "required_value" TEXT -- comment;\nNOT NULL;',
+    ],
+    [
+      "block comments",
+      'ALTER TABLE "hosted_member" ADD COLUMN "required_value" TEXT /* comment; */ NOT NULL;',
+    ],
+    [
+      "dollar-quoted values",
+      'ALTER TABLE "hosted_member" ADD COLUMN "required_value" TEXT DEFAULT $value$still;one statement$value$ NOT NULL;',
+    ],
+  ])("preserves semicolons inside %s when classifying one statement", async (
+    _context,
+    sql,
+  ) => {
+    const migrationsDir = await mkdtemp(
+      path.join(tmpdir(), "hosted-web-prisma-migrations-"),
+    );
+    const migrationId = "20260825000001_required_column";
+
+    try {
+      await writeMigrationSql(migrationsDir, migrationId, sql);
+
+      assert.deepEqual(
+        (await findHostedWebPrismaPredeployDestructiveMigrations(migrationsDir))
+          .map(({ migrationId: id, reason }) => ({ migrationId: id, reason })),
+        [{ migrationId, reason: "ADD COLUMN NOT NULL" }],
+      );
+    } finally {
+      await rm(migrationsDir, { force: true, recursive: true });
+    }
+  });
+
   test("keeps existing hosted web Prisma migration history exempt", async () => {
     await assert.doesNotReject(() =>
       assertHostedWebPrismaPredeployMigrationsAreExpandOnly(

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -371,6 +371,10 @@ describe("hosted web production migration guard", () => {
       "ALTER TABLE \"hosted_member\" ADD COLUMN \"required_value\" TEXT DEFAULT 'still;one statement' NOT NULL;",
     ],
     [
+      "escape-string values",
+      "ALTER TABLE \"hosted_member\" ADD COLUMN \"required_value\" TEXT DEFAULT E'escaped\\';still one statement' NOT NULL;",
+    ],
+    [
       "quoted identifiers",
       'ALTER TABLE "hosted;member" ADD COLUMN "required;value" TEXT NOT NULL;',
     ],


### PR DESCRIPTION
## Why this PR exists

The hosted-web predeploy migration guard evaluated bounded destructive-pattern
regexes across an entire migration file. A nullable `ADD COLUMN` could therefore
inherit `NOT NULL` text from a later trigger function and block a safe release.

## User goal / user-visible behavior

Safe additive migrations pass predeploy verification while destructive SQL
continues to fail closed.

## User experience

Internal release tooling only; no member-facing behavior changes.

## Invariants

- Destructive migration patterns remain blocked after the frozen baseline.
- SQL statement boundaries ignore semicolons inside quoted values, identifiers,
  comments, dollar-quoted bodies, and PostgreSQL escape strings.
- Historical migration exemptions and explicit compatible-reason ownership are
  unchanged.

## Non-obvious affected surfaces

Only the hosted-web Prisma predeploy guard and its focused test suite change.
Migration execution, Prisma schema state, and contract-migration ownership are
unchanged.

## Architecture and reuse

- Existing systems reused: the hosted-web Prisma predeploy guard and its existing
  incompatible-pattern registry remain the sole owners.
- New logic: a local PostgreSQL-aware statement splitter scopes each existing
  pattern to one statement.
- New abstractions: none outside the guard module.
- Complexity intentionally avoided: no parser dependency, service, state owner,
  compatibility layer, or public API was added.

## Changelog

- Changelog: not applicable
- Reason: This changes internal release verification only and has no member-visible behavior.

## Hot reply path impact

Not applicable; this does not affect foreground reply acceptance or provider
handoff.

## Murph initial provider input impact

Not applicable; no assistant/provider request assembly changes.

## Deployment concerns

- Deployment: not applicable
- Reason: This only corrects predeploy verification and introduces no runtime or cross-deploy skew.

## Preliminary specialist lenses

Coverage applies. The preliminary specialist found that PostgreSQL escape
strings could split a destructive statement at a semicolon after a
backslash-escaped quote. The scanner now handles that token form explicitly,
and the focused regression proves the guard remains fail-closed.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/production-migration-guard.test.ts` — 65 passed.
- `pnpm --dir apps/web typecheck` — passed, including fresh Prisma generation.
- `git diff --check` — passed.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 132 | 4 |
| Tests / fixtures | 77 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

ReviewGPT context sensitivity: sensitive

ReviewGPT first-reviewed head: f75e10d729b0112918d0c4bf4fcbf427b8b14ff4

Frog autofix issue: #2116

Closes #2116
