### PR TITLE
Ask when automatic meal nutrition is unclear

### DIFF
--- a/.agents/friction-log/20260824234256-changelog-only-pr/friction.md
+++ b/.agents/friction-log/20260824234256-changelog-only-pr/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Changelog-only PR skips the preview required for current design proof'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A pull request that changes an `apps/web/changelog/entries` fragment should either receive a reviewer-openable Web preview or have a documented proof route that does not require a current preview.
+
+## Current Behavior
+
+The Vercel integration can mark the deployment ignored when the only hosted Web change is a changelog fragment, while the completion workflow still requires a current reviewer-openable design representation for every user-facing hosted Web diff.
+
+## Possible Solution
+
+Treat changelog fragments as preview-relevant inputs, or document a narrow changelog-content proof path that reuses the server-rendered archive study without requiring a branch preview.
+
+## Minimal Reproducible Example
+
+1. Add one valid JSON fragment under `apps/web/changelog/entries/<date>/`.
+2. Push the draft pull request without changing a Web component.
+3. Observe that the Vercel status succeeds as an ignored deployment and supplies no branch preview URL.
+
+## Context
+
+This blocks current-branch visual review of an otherwise valid changelog item and forces agents to choose between starting the full hosted Web environment or reporting a browser-proof gap despite focused archive rendering tests.

--- a/agent-docs/exec-plans/active/2026-08-24-automatic-meal-clarification.md
+++ b/agent-docs/exec-plans/active/2026-08-24-automatic-meal-clarification.md
@@ -62,9 +62,9 @@ behavior.
 
 ## Tasks
 
-1. [ ] Add one unresolved-capture clarification rule to the automatic-capture
+1. [x] Add one unresolved-capture clarification rule to the automatic-capture
    skill and remove the conflicting managed-automation fallback.
-2. [ ] Add focused prompt and automation regression proof, including ordering
+2. [x] Add focused prompt and automation regression proof, including ordering
    and no-duplicate recovery requirements.
 3. [ ] Run focused tests, assistant-engine typecheck, provider-input
    measurement, diff/privacy review, and the required exact-head review gates.
@@ -80,3 +80,34 @@ behavior.
 - Assistant-engine typecheck, provider-input base/head measurement,
   `git diff --check`, privacy inspection, exact-head ReviewGPT specialist pass,
   required CI, and current-base merge-tree proof.
+
+Completed candidate proof:
+
+- The automatic-capture skill contract passed 4 tests; the focused managed
+  closeout seed regression passed 1 test.
+- Assistant-engine typecheck passed.
+- The public changelog fragment passed 57 focused fragment, registry, page, and
+  route tests; Hosted Web typecheck passed.
+- `git diff --check` and the scoped privacy/path scan passed.
+- Vercel ignored the changelog-only preview, the documented `agent-browser`
+  binary was unavailable, and the in-app browser exposed no browser instance.
+  The existing server-rendered archive tests are the available presentation
+  proof; current-branch browser proof remains an explicit review gap.
+- No live-provider model scenario has run. The current direct proof validates
+  prompt ownership, cleanup ordering, the no-duplicate continuation, and the
+  managed automation handoff rather than sampled model output.
+
+## Product UX walkthrough
+
+Result: Ready for exact-head specialist review.
+
+- Clear captures remain on the existing enrichment and card branch because the
+  new gate applies only after inspection cannot support an honest estimate.
+- An unresolved scheduled capture completes photo cleanup, asks one compact
+  clarification, and stops before Goal, totals, or card work. Focused ordering
+  assertions cover that path.
+- A later answer or blocked card request finds and edits the existing device
+  meal, reads it back, and uses fresh canonical totals. Prompt assertions cover
+  tombstoned attachments, narrow questions, and no replacement meal.
+- Existing intuitive-eating, eating-disorder-risk, number-sensitive, duplicate,
+  and nearby-meal safeguards are unchanged.

--- a/agent-docs/exec-plans/active/2026-08-24-automatic-meal-clarification.md
+++ b/agent-docs/exec-plans/active/2026-08-24-automatic-meal-clarification.md
@@ -1,0 +1,82 @@
+# Automatic meal clarification
+
+Status: active
+Created: 2026-08-24
+Updated: 2026-08-24
+
+## Goal
+
+Keep automatic meal capture useful when a retained photo cannot support an
+honest nutrition estimate: remove the image on the existing privacy schedule,
+ask one compact clarification, and use the answer to enrich the existing
+canonical meal before recomputing any requested daily card.
+
+## Evidence
+
+- Automatic import correctly creates one canonical photo-backed device meal
+  without inventing food identity or nutrition.
+- The scheduled closeout inspects each selected photo and always replaces it
+  with a privacy tombstone, but its current fallback rules prohibit questions.
+- A visually ambiguous capture can therefore remain nutrition-empty after the
+  only inspectable image is gone, while a later card request has no explicit
+  recovery contract.
+
+## Product UX plan
+
+Effort: focused conversational recovery.
+
+Irreducible purpose: a member who shared an ambiguous meal photo can provide
+the missing facts and receive truthful nutrition tracking without duplicate
+logging.
+
+- A clear photo follows the current enrichment, cleanup, totals, and card path
+  unchanged.
+- When one or more selected photos cannot support an honest estimate, Murph
+  completes privacy cleanup and sends one compact question, using capture time
+  only when needed to distinguish meals. The question requests only food or
+  drink identity and the approximate amount or ingredients needed to estimate.
+- A later answer or card request reuses the current conversation and canonical
+  capture time to find the existing device meal. Murph asks one narrow question
+  if essential facts are still missing; otherwise it edits and reads back that
+  meal before obtaining fresh totals or attaching a card.
+- Intuitive-eating, eating-disorder-risk, and number-sensitive behavior remains
+  non-numeric. Duplicate and uncertain-nearby-meal safeguards remain unchanged.
+- Several unresolved captures produce one compact, time-labeled clarification
+  rather than several messages. No reply leaves the canonical meals unchanged;
+  a later eligible interactive turn can recover them.
+
+Done means the scheduled path no longer substitutes a generic closeout for an
+unresolved capture, interactive recovery never creates a second meal, and
+focused proof covers prompt ownership, cleanup ordering, and the managed
+automation handoff. No visual artifact is useful for this text-only iMessage
+behavior.
+
+## Architecture
+
+- Keep the canonical meal as the only persisted meal truth.
+- Reuse the existing private conversation as the clarification continuation.
+- Keep retained photos as the existing pre-cleanup work queue and preserve the
+  privacy tombstone boundary.
+- Add no database field, queue, cursor, flag, state machine, dependency, or
+  second automation.
+
+## Tasks
+
+1. [ ] Add one unresolved-capture clarification rule to the automatic-capture
+   skill and remove the conflicting managed-automation fallback.
+2. [ ] Add focused prompt and automation regression proof, including ordering
+   and no-duplicate recovery requirements.
+3. [ ] Run focused tests, assistant-engine typecheck, provider-input
+   measurement, diff/privacy review, and the required exact-head review gates.
+4. [ ] Replay the Product UX journeys, resolve accepted findings, close this
+   plan, and prepare the final PR candidate.
+
+## Verification
+
+- Focused automatic-capture skill and managed-automation tests.
+- Focused production-shaped model scenario when the real-provider lane is
+  available; otherwise retain it as credential-gated evidence and report the
+  skipped lane.
+- Assistant-engine typecheck, provider-input base/head measurement,
+  `git diff --check`, privacy inspection, exact-head ReviewGPT specialist pass,
+  required CI, and current-base merge-tree proof.

--- a/agent-docs/exec-plans/completed/2026-08-24-automatic-meal-clarification.md
+++ b/agent-docs/exec-plans/completed/2026-08-24-automatic-meal-clarification.md
@@ -1,8 +1,8 @@
 # Automatic meal clarification
 
-Status: active
+Status: completed
 Created: 2026-08-24
-Updated: 2026-08-24
+Updated: 2026-08-25
 
 ## Goal
 
@@ -31,16 +31,21 @@ logging.
 
 - A clear photo follows the current enrichment, cleanup, totals, and card path
   unchanged.
-- When one or more selected photos cannot support an honest estimate, Murph
-  completes privacy cleanup and sends one compact question, using capture time
-  only when needed to distinguish meals. The question requests only food or
-  drink identity and the approximate amount or ingredients needed to estimate.
+- Murph estimates conservatively whenever the photo supports a recognizable
+  food or drink category and defensible portion range. Ordinary visual
+  uncertainty does not trigger a question.
+- When one or more selected photos are genuinely too indeterminate for any
+  meaningful bounded estimate, Murph completes privacy cleanup and sends one
+  compact question. It uses time on the occurrence date and date plus time for
+  historical or multi-date captures. The question requests only the food or
+  drink identity and approximate amount needed to estimate.
 - A later answer or card request reuses the current conversation and canonical
   capture time to find the existing device meal. Murph asks one narrow question
   if essential facts are still missing; otherwise it edits and reads back that
   meal before obtaining fresh totals or attaching a card.
 - Intuitive-eating, eating-disorder-risk, and number-sensitive behavior remains
-  non-numeric. Duplicate and uncertain-nearby-meal safeguards remain unchanged.
+  non-numeric and receives no estimate-enabling clarification. Duplicate and
+  uncertain-nearby-meal safeguards remain unchanged.
 - Several unresolved captures produce one compact, time-labeled clarification
   rather than several messages. No reply leaves the canonical meals unchanged;
   a later eligible interactive turn can recover them.
@@ -66,9 +71,9 @@ behavior.
    skill and remove the conflicting managed-automation fallback.
 2. [x] Add focused prompt and automation regression proof, including ordering
    and no-duplicate recovery requirements.
-3. [ ] Run focused tests, assistant-engine typecheck, provider-input
+3. [x] Run focused tests, assistant-engine typecheck, provider-input
    measurement, diff/privacy review, and the required exact-head review gates.
-4. [ ] Replay the Product UX journeys, resolve accepted findings, close this
+4. [x] Replay the Product UX journeys, resolve accepted findings, close this
    plan, and prepare the final PR candidate.
 
 ## Verification
@@ -93,21 +98,49 @@ Completed candidate proof:
   binary was unavailable, and the in-app browser exposed no browser instance.
   The existing server-rendered archive tests are the available presentation
   proof; current-branch browser proof remains an explicit review gap.
-- No live-provider model scenario has run. The current direct proof validates
-  prompt ownership, cleanup ordering, the no-duplicate continuation, and the
-  managed automation handoff rather than sampled model output.
+- The preliminary specialist review returned three accepted findings: inherit
+  protected-context estimation eligibility, disambiguate historical captures
+  by date and time, and add production-shaped two-turn model proof. The prompt
+  and tests now implement all three corrections without new runtime state.
+- The real-Codex test module compiles and now contains the scheduled
+  cleanup/question/stop, reply/edit/readback/fresh-totals journey plus the
+  protected-context suppression branch. No supported provider credential is
+  present locally, so the paid model call remains skipped under the repository's
+  documented opt-in gate.
+- The deferred skill is 4,750 `o200k_harmony` tokens / 21,940 UTF-8 bytes,
+  +383 / +1,864 from `origin/main`. Ordinary private and group provider inputs
+  remain unchanged because this skill is deferred.
 
 ## Product UX walkthrough
 
-Result: Ready for exact-head specialist review.
+Result: Ready for final exact-head CI.
 
 - Clear captures remain on the existing enrichment and card branch because the
-  new gate applies only after inspection cannot support an honest estimate.
+  new gate treats a recognizable category and defensible portion range as
+  enough for a bounded estimate; ordinary uncertainty does not ask a question.
 - An unresolved scheduled capture completes photo cleanup, asks one compact
   clarification, and stops before Goal, totals, or card work. Focused ordering
   assertions cover that path.
 - A later answer or blocked card request finds and edits the existing device
   meal, reads it back, and uses fresh canonical totals. Prompt assertions cover
   tombstoned attachments, narrow questions, and no replacement meal.
-- Existing intuitive-eating, eating-disorder-risk, number-sensitive, duplicate,
+- Intuitive-eating, eating-disorder-risk, and number-sensitive contexts clean
+  the photo and stop without an estimate-enabling question, Goal read, totals,
+  or card. Historical and multi-date questions include date and time. Duplicate
   and nearby-meal safeguards are unchanged.
+
+## Parent final review
+
+- All three accepted specialist findings are resolved at the existing skill and
+  proof owners; the preliminary pass returned no patch artifact and is not
+  rerun under the one-pass rule.
+- The final diff retains one meal owner, one privacy-cleanup boundary, and the
+  existing conversation continuation. It adds no production state, service,
+  queue, dependency, or tool contract.
+- Focused prompt and automation tests pass, assistant-engine typecheck passes,
+  the real-Codex scenario compiles under its documented credential gate, and
+  `git diff --check` plus the scoped privacy scan pass.
+- Remaining proof gap: the opt-in live-provider scenario could not run locally
+  because neither supported provider credential is present. Exact-head CI owns
+  the broad deterministic suite.
+Completed: 2026-08-25

--- a/apps/web/changelog/entries/2026-08-24/automatic-meal-clarification.json
+++ b/apps/web/changelog/entries/2026-08-24/automatic-meal-clarification.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-24",
+  "order": 100,
+  "item": {
+    "id": "automatic-meal-clarification",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Meal photos can ask for missing details",
+    "summary": "When an automatic meal photo is too unclear to estimate, Murph now asks one focused question instead of leaving daily nutrition stuck.",
+    "details": "The retained image still follows its privacy cleanup schedule. A reply updates the existing meal instead of creating a duplicate, then Murph refreshes the nutrition totals and eligible card.",
+    "relevanceTags": ["assistant", "meals", "nutrition"],
+    "sourcePullRequests": [2241]
+  }
+}

--- a/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
+++ b/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
@@ -137,10 +137,12 @@ When enriching a captured meal:
 Do not run `meal add` for a captured photo that already has a meal id. The
 automatic import is the meal log; `meal edit` adds the useful structure. By
 default, save a bounded photo estimate without asking for confirmation on every
-meal, but the estimate must retain provenance and uncertainty. If the photo
-cannot support a meaningful estimate, leave the photo-only meal intact and ask
-one narrow portion or identity question only when the member is present and the
-answer would materially help.
+meal. Retain provenance, uncertainty, and assumptions; a visible food or drink
+category with a defensible portion range is enough even when the exact recipe,
+ingredients, or serving is uncertain. Clarification is a last resort, not a
+confidence check: ask one narrow identity or portion question only when actual
+attachment inspection leaves identity or amount too indeterminate for any
+meaningful bounded estimate and the answer would materially help.
 
 A recent device meal remains unresolved after its attachment becomes a privacy
 tombstone when its saved identity, amount or ingredients, and nutrition cannot
@@ -148,10 +150,12 @@ support the member's current request. When the member answers a capture question
 or asks for totals or a card that meal blocks, match the existing meal from the
 current conversation, device source, capture date, and capture time with bounded
 `meal list` and `meal show` reads; never add a replacement or restore the photo.
-If essential identity or amount details are still missing, ask one narrow
-question instead of refusing or inventing totals. Otherwise edit and read back
-that meal, then use the food-journal workflow with fresh totals and any eligible
-card. Never calculate around it or reuse pre-edit totals.
+Apply the estimation-eligibility rule above before recovery. When estimation is
+skipped, do not ask for identity or amount merely to enable nutrition estimates.
+Otherwise, ask instead of refusing or inventing totals only when the saved facts
+still fail that last-resort threshold. With enough facts, edit and read back the
+existing meal, then use fresh food-journal totals and any eligible card. Never
+calculate around it or reuse pre-edit totals.
 
 Do not surface calorie numbers for intuitive-eating contexts, eating-disorder
 risk, or number-sensitive members.
@@ -186,14 +190,16 @@ On a scheduled run:
    fails the run. On retry, combine photos that remain with same-occurrence
    removal revisions so a provider or partial-cleanup failure loses no meal.
 
-Before step 6, if inspection cannot identify enough food or drink and approximate
-amount or ingredients for an honest estimate, complete photo cleanup and send one
-compact question covering only those unresolved meals. Use local capture times
-only to distinguish them and ask only for the missing identity and amount
-details. This sole scheduled-question exception stops the closeout: run no Goal,
-totals, or card work, expose no meal ids, and do not substitute ordinary
-closeout or a dashboard refusal. The answer uses the existing-meal recovery
-above.
+Before step 6, apply the estimation-eligibility rule above. When estimation is
+skipped, complete photo cleanup and stop with the established non-numeric
+closeout: ask no estimate-enabling question and run no Goal, totals, or card
+work. Otherwise, after cleaning each capture that still fails the last-resort
+threshold, send one compact question for only those meals and stop before Goal,
+totals, or card work. Use local time when all share the occurrence date; include
+date and time for any historical or multi-date set. Ask only for missing identity
+and amount, expose no meal ids, and do not substitute ordinary closeout or a
+dashboard refusal. This is the sole scheduled-question exception; its answer
+uses the existing-meal recovery above.
 
 6. After inspection, enrichment, read-back, and photo cleanup, first prove the
    cheap read-only active Goal discovery is complete. Run `vault-cli goal list --status active

--- a/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
+++ b/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
@@ -142,6 +142,23 @@ cannot support a meaningful estimate, leave the photo-only meal intact and ask
 one narrow portion or identity question only when the member is present and the
 answer would materially help.
 
+Treat a recent device meal as unresolved even after its attachment has become a
+privacy tombstone when its saved food identity, amount or ingredients, and
+nutrition are still too incomplete for the member's current request. If the
+member answers an earlier capture question or asks for totals or a card that the
+unresolved meal blocks:
+
+1. Use the current conversation, source, capture date, and capture time to find
+   the existing meal with bounded `meal list` and `meal show` reads. Never add a
+   replacement meal or restore the photo.
+2. If the member has not supplied enough food or drink identity and approximate
+   amount or ingredients for an honest estimate, ask one narrow clarification
+   question instead of refusing the request or inventing totals.
+3. Otherwise edit that existing meal, read it back, and then follow the
+   food-journal workflow with a fresh canonical totals read and any eligible
+   response card. Do not calculate around the unresolved meal or reuse totals
+   from before the edit.
+
 Do not surface calorie numbers for intuitive-eating contexts, eating-disorder
 risk, or number-sensitive members.
 
@@ -174,6 +191,18 @@ On a scheduled run:
    replaces retained image bytes with a privacy tombstone. Any removal failure
    fails the run. On retry, combine photos that remain with same-occurrence
    removal revisions so a provider or partial-cleanup failure loses no meal.
+
+Before step 6, stop the numeric closeout when inspection could not identify
+enough food or drink and approximate amount or ingredients to save an honest
+estimate for any selected capture. Complete the required photo cleanup, then
+send one compact clarification question covering only those unresolved meals;
+use local capture times only when needed to distinguish them, and ask only for
+the missing identity and approximate amount or ingredients. This is the sole
+scheduled-question exception. Run no Goal reads, totals, or response-card work
+on this path, do not expose meal ids, and do not substitute the ordinary
+closeout or a dashboard refusal. The member's answer continues through the
+existing-meal recovery above.
+
 6. After inspection, enrichment, read-back, and photo cleanup, first prove the
    cheap read-only active Goal discovery is complete. Run `vault-cli goal list --status active
    --limit 200 --format json`. If it returns 200 records, fail closed with the

--- a/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
+++ b/packages/assistant-engine/skills/automatic-meal-capture/SKILL.md
@@ -142,22 +142,16 @@ cannot support a meaningful estimate, leave the photo-only meal intact and ask
 one narrow portion or identity question only when the member is present and the
 answer would materially help.
 
-Treat a recent device meal as unresolved even after its attachment has become a
-privacy tombstone when its saved food identity, amount or ingredients, and
-nutrition are still too incomplete for the member's current request. If the
-member answers an earlier capture question or asks for totals or a card that the
-unresolved meal blocks:
-
-1. Use the current conversation, source, capture date, and capture time to find
-   the existing meal with bounded `meal list` and `meal show` reads. Never add a
-   replacement meal or restore the photo.
-2. If the member has not supplied enough food or drink identity and approximate
-   amount or ingredients for an honest estimate, ask one narrow clarification
-   question instead of refusing the request or inventing totals.
-3. Otherwise edit that existing meal, read it back, and then follow the
-   food-journal workflow with a fresh canonical totals read and any eligible
-   response card. Do not calculate around the unresolved meal or reuse totals
-   from before the edit.
+A recent device meal remains unresolved after its attachment becomes a privacy
+tombstone when its saved identity, amount or ingredients, and nutrition cannot
+support the member's current request. When the member answers a capture question
+or asks for totals or a card that meal blocks, match the existing meal from the
+current conversation, device source, capture date, and capture time with bounded
+`meal list` and `meal show` reads; never add a replacement or restore the photo.
+If essential identity or amount details are still missing, ask one narrow
+question instead of refusing or inventing totals. Otherwise edit and read back
+that meal, then use the food-journal workflow with fresh totals and any eligible
+card. Never calculate around it or reuse pre-edit totals.
 
 Do not surface calorie numbers for intuitive-eating contexts, eating-disorder
 risk, or number-sensitive members.
@@ -192,16 +186,14 @@ On a scheduled run:
    fails the run. On retry, combine photos that remain with same-occurrence
    removal revisions so a provider or partial-cleanup failure loses no meal.
 
-Before step 6, stop the numeric closeout when inspection could not identify
-enough food or drink and approximate amount or ingredients to save an honest
-estimate for any selected capture. Complete the required photo cleanup, then
-send one compact clarification question covering only those unresolved meals;
-use local capture times only when needed to distinguish them, and ask only for
-the missing identity and approximate amount or ingredients. This is the sole
-scheduled-question exception. Run no Goal reads, totals, or response-card work
-on this path, do not expose meal ids, and do not substitute the ordinary
-closeout or a dashboard refusal. The member's answer continues through the
-existing-meal recovery above.
+Before step 6, if inspection cannot identify enough food or drink and approximate
+amount or ingredients for an honest estimate, complete photo cleanup and send one
+compact question covering only those unresolved meals. Use local capture times
+only to distinguish them and ask only for the missing identity and amount
+details. This sole scheduled-question exception stops the closeout: run no Goal,
+totals, or card work, expose no meal ids, and do not substitute ordinary
+closeout or a dashboard refusal. The answer uses the existing-meal recovery
+above.
 
 6. After inspection, enrichment, read-back, and photo cleanup, first prove the
    cheap read-only active Goal discovery is complete. Run `vault-cli goal list --status active

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -224,7 +224,7 @@ export const MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION = {
     '',
     'Use the engine-supplied `Occurrence local date` from the Scheduled occurrence context as the action and search-date anchor, even when the wall-clock `Today\'s date` differs. Use the occurrence instant for bounded same-occurrence retry evidence.',
     '',
-    'If the skill selects neither a retained photo nor a same-occurrence removal revision, return `{"kind":"skip","privateSummary":"No captured meals are awaiting closeout."}`. A removal failure or any selected photo remaining fails the run. After successful cleanup, follow the skill\'s presentation rules. If a response card is attached, return a `send_message` decision whose text contains no nutrition values because the runtime replaces it with deterministic card text. Otherwise return the ordinary compact closeout. Do not expose images, internal paths, or automation details.',
+    'If the skill selects neither a retained photo nor a same-occurrence removal revision, return `{"kind":"skip","privateSummary":"No captured meals are awaiting closeout."}`. A removal failure or any selected photo remaining fails the run. After successful cleanup, follow the skill\'s presentation rules. Return its compact unresolved-capture question when required. If a response card is attached, return a `send_message` decision whose text contains no nutrition values because the runtime replaces it with deterministic card text. Otherwise return the ordinary compact closeout. Do not expose images, internal paths, or automation details.',
   ].join('\n'),
 } satisfies MurphManagedAutomationSeed
 

--- a/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
@@ -101,16 +101,16 @@ describe('assistant automatic meal capture skill', () => {
     )
     expect(skill).toContain('vault-cli meal edit <meal-id>')
     expect(compact(skill)).toContain(
-      'Treat a recent device meal as unresolved even after its attachment has become a privacy tombstone',
+      'A recent device meal remains unresolved after its attachment becomes a privacy tombstone',
     )
     expect(compact(skill)).toContain(
-      'Never add a replacement meal or restore the photo.',
+      'never add a replacement or restore the photo.',
     )
     expect(compact(skill)).toContain(
-      'ask one narrow clarification question instead of refusing the request or inventing totals.',
+      'ask one narrow question instead of refusing or inventing totals.',
     )
     expect(compact(skill)).toContain(
-      'edit that existing meal, read it back, and then follow the food-journal workflow with a fresh canonical totals read and any eligible response card.',
+      'edit and read back that meal, then use the food-journal workflow with fresh totals and any eligible card.',
     )
     expect(skill).toContain('## Run the automatic 9pm closeout')
     expect(skill).toContain(
@@ -275,7 +275,7 @@ describe('assistant automatic meal capture skill', () => {
       skill.indexOf('vault-cli meal totals --from <date> --to'),
     )
     const compactClarification = compactSkill.indexOf(
-      'Before step 6, stop the numeric closeout',
+      'Before step 6, if inspection cannot identify enough',
     )
     expect(compactClarification).toBeGreaterThan(
       compactSkill.indexOf('vault-cli meal remove-photo <meal-id>'),
@@ -284,10 +284,10 @@ describe('assistant automatic meal capture skill', () => {
       compactSkill.indexOf('vault-cli goal list --status active'),
     )
     expect(compactSkill).toContain(
-      'This is the sole scheduled-question exception.',
+      'This sole scheduled-question exception stops the closeout',
     )
     expect(compactSkill).toContain(
-      'Run no Goal reads, totals, or response-card work on this path, do not expose meal ids, and do not substitute the ordinary closeout or a dashboard refusal.',
+      'run no Goal, totals, or card work, expose no meal ids, and do not substitute ordinary closeout or a dashboard refusal.',
     )
     const attachCardIndex = compactSkill.indexOf(
       'call `murph.attach_response_card` with this exact mapping',

--- a/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
@@ -100,6 +100,18 @@ describe('assistant automatic meal capture skill', () => {
       'Suggest resending only after later evidence shows the upload failed.',
     )
     expect(skill).toContain('vault-cli meal edit <meal-id>')
+    expect(compact(skill)).toContain(
+      'Treat a recent device meal as unresolved even after its attachment has become a privacy tombstone',
+    )
+    expect(compact(skill)).toContain(
+      'Never add a replacement meal or restore the photo.',
+    )
+    expect(compact(skill)).toContain(
+      'ask one narrow clarification question instead of refusing the request or inventing totals.',
+    )
+    expect(compact(skill)).toContain(
+      'edit that existing meal, read it back, and then follow the food-journal workflow with a fresh canonical totals read and any eligible response card.',
+    )
     expect(skill).toContain('## Run the automatic 9pm closeout')
     expect(skill).toContain(
       'engine-supplied `Occurrence local date` from the `Scheduled\n   occurrence context` as the action and latest-capture boundary',
@@ -261,6 +273,21 @@ describe('assistant automatic meal capture skill', () => {
     )
     expect(skill.indexOf('vault-cli meal remove-photo <meal-id>')).toBeLessThan(
       skill.indexOf('vault-cli meal totals --from <date> --to'),
+    )
+    const compactClarification = compactSkill.indexOf(
+      'Before step 6, stop the numeric closeout',
+    )
+    expect(compactClarification).toBeGreaterThan(
+      compactSkill.indexOf('vault-cli meal remove-photo <meal-id>'),
+    )
+    expect(compactClarification).toBeLessThan(
+      compactSkill.indexOf('vault-cli goal list --status active'),
+    )
+    expect(compactSkill).toContain(
+      'This is the sole scheduled-question exception.',
+    )
+    expect(compactSkill).toContain(
+      'Run no Goal reads, totals, or response-card work on this path, do not expose meal ids, and do not substitute the ordinary closeout or a dashboard refusal.',
     )
     const attachCardIndex = compactSkill.indexOf(
       'call `murph.attach_response_card` with this exact mapping',

--- a/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-automatic-meal-capture-skill.test.ts
@@ -107,10 +107,19 @@ describe('assistant automatic meal capture skill', () => {
       'never add a replacement or restore the photo.',
     )
     expect(compact(skill)).toContain(
-      'ask one narrow question instead of refusing or inventing totals.',
+      'ask instead of refusing or inventing totals only when the saved facts still fail that last-resort threshold.',
     )
     expect(compact(skill)).toContain(
-      'edit and read back that meal, then use the food-journal workflow with fresh totals and any eligible card.',
+      'With enough facts, edit and read back the existing meal, then use fresh food-journal totals and any eligible card.',
+    )
+    expect(compact(skill)).toContain(
+      'Clarification is a last resort, not a confidence check:',
+    )
+    expect(compact(skill)).toContain(
+      'a visible food or drink category with a defensible portion range is enough',
+    )
+    expect(compact(skill)).toContain(
+      'When estimation is skipped, do not ask for identity or amount merely to enable nutrition estimates.',
     )
     expect(skill).toContain('## Run the automatic 9pm closeout')
     expect(skill).toContain(
@@ -275,7 +284,7 @@ describe('assistant automatic meal capture skill', () => {
       skill.indexOf('vault-cli meal totals --from <date> --to'),
     )
     const compactClarification = compactSkill.indexOf(
-      'Before step 6, if inspection cannot identify enough',
+      'Before step 6, apply the estimation-eligibility rule above.',
     )
     expect(compactClarification).toBeGreaterThan(
       compactSkill.indexOf('vault-cli meal remove-photo <meal-id>'),
@@ -284,10 +293,16 @@ describe('assistant automatic meal capture skill', () => {
       compactSkill.indexOf('vault-cli goal list --status active'),
     )
     expect(compactSkill).toContain(
-      'This sole scheduled-question exception stops the closeout',
+      'This is the sole scheduled-question exception',
     )
     expect(compactSkill).toContain(
-      'run no Goal, totals, or card work, expose no meal ids, and do not substitute ordinary closeout or a dashboard refusal.',
+      'When estimation is skipped, complete photo cleanup and stop with the established non-numeric closeout: ask no estimate-enabling question and run no Goal, totals, or card work.',
+    )
+    expect(compactSkill).toContain(
+      'Use local time when all share the occurrence date; include date and time for any historical or multi-date set.',
+    )
+    expect(compactSkill).toContain(
+      'Ask only for missing identity and amount, expose no meal ids, and do not substitute ordinary closeout or a dashboard refusal.',
     )
     const attachCardIndex = compactSkill.indexOf(
       'call `murph.attach_response_card` with this exact mapping',

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -13,6 +13,7 @@ import {
   workoutSessionSchema,
 } from '@murphai/contracts'
 import {
+  addMeal,
   initializeVault,
   readHabitatAspect,
   upsertHabitatAspect,
@@ -97,6 +98,7 @@ import type {
   AssistantHostedAutomationToolRequest,
 } from '../src/assistant/execution-context.ts'
 import {
+  MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION,
   MURPH_MANAGED_AUTOMATIONS,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
@@ -8093,6 +8095,358 @@ describeRealCodex('real Codex daily nutrition-card authority e2e', () => {
   })
 })
 
+describeRealCodex('real Codex automatic meal clarification e2e', () => {
+  it(
+    'asks only for a genuinely unidentifiable capture and enriches that same meal after the reply',
+    { timeout: 1_800_000 },
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+
+      try {
+        const eligible = await runRealAutomaticMealClarificationScenario({
+          config,
+          protectedContext: false,
+        })
+        expect(eligible.firstMessage).toMatch(/\?/u)
+        expect(eligible.firstMessage).toMatch(/what|food|drink|meal/iu)
+        expect(eligible.firstMessage).toMatch(
+          /amount|how much|portion|roughly|about/iu,
+        )
+        const mealShowCommand =
+          `meal show ${eligible.mealId} --format json`
+        const removePhotoCommand =
+          `meal remove-photo ${eligible.mealId}`
+        const firstShowIndex = eligible.firstCommands.findIndex((command) =>
+          command === mealShowCommand
+        )
+        const removeIndex = eligible.firstCommands.findIndex((command) =>
+          command === removePhotoCommand
+        )
+        expect(firstShowIndex).toBeGreaterThanOrEqual(0)
+        expect(removeIndex).toBeGreaterThan(firstShowIndex)
+        expect(
+          eligible.firstCommands.findIndex(
+            (command, index) =>
+              index > removeIndex
+              && command === mealShowCommand,
+          ),
+        ).toBeGreaterThan(removeIndex)
+        expect(eligible.firstCommands).not.toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/^(?:goal|meal totals)\b/u),
+          ]),
+        )
+        expect(eligible.firstCard).toBeNull()
+        expect(eligible.savedAttachmentCount).toBe(0)
+
+        const editIndex = eligible.followupCommands.findIndex((command) =>
+          command.startsWith(`meal edit ${eligible.mealId} `)
+        )
+        const readbackIndex = eligible.followupCommands.findIndex(
+          (command, index) =>
+            index > editIndex
+            && command === mealShowCommand,
+        )
+        const totalsIndex = eligible.followupCommands.findIndex(
+          (command, index) =>
+            index > readbackIndex
+            && command.startsWith(
+              'meal totals --from 2026-08-24 --to 2026-08-24',
+            ),
+        )
+        expect(editIndex).toBeGreaterThanOrEqual(0)
+        const editCommand = eligible.followupCommands[editIndex] ?? ''
+        for (const requiredFlag of [
+          '--ingredient',
+          '--nutrition-calories',
+          '--nutrition-protein-grams',
+          '--nutrition-carbs-grams',
+          '--nutrition-fat-grams',
+          '--nutrition-source estimated',
+        ]) {
+          expect(editCommand).toContain(requiredFlag)
+        }
+        expect(readbackIndex).toBeGreaterThan(editIndex)
+        expect(totalsIndex).toBeGreaterThan(readbackIndex)
+        expect(eligible.commands).not.toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/^meal add\b/u),
+          ]),
+        )
+        expect(eligible.followupMessage).toMatch(/smoothie/iu)
+        if (eligible.savedCalories === null) {
+          throw new Error('Expected the existing captured meal to be enriched.')
+        }
+        expect(eligible.savedCalories).toBeGreaterThan(0)
+        expect(eligible.followupMessage).toContain(
+          String(eligible.savedCalories),
+        )
+
+        const protectedResult =
+          await runRealAutomaticMealClarificationScenario({
+            config,
+            protectedContext: true,
+          })
+        expect(protectedResult.firstCommands).toContain(
+          `meal remove-photo ${protectedResult.mealId}`,
+        )
+        expect(protectedResult.firstCommands).not.toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/^(?:goal|meal edit|meal totals)\b/u),
+          ]),
+        )
+        expect(protectedResult.firstMessage).not.toMatch(/\?/u)
+        expect(protectedResult.firstMessage).not.toMatch(
+          /calor|macro|protein|carb|fat|fiber|portion|how much/iu,
+        )
+        expect(protectedResult.firstCard).toBeNull()
+        expect(protectedResult.savedAttachmentCount).toBe(0)
+        expect(protectedResult.savedCalories).toBeNull()
+      } finally {
+        await removeRealCodexTemporaryPaths(config.temporaryPaths)
+      }
+    },
+  )
+})
+
+async function runRealAutomaticMealClarificationScenario(input: {
+  config: RealCodexE2eConfig
+  protectedContext: boolean
+}): Promise<{
+  commands: string[]
+  firstCard: unknown
+  firstCommands: string[]
+  firstMessage: string
+  followupCommands: string[]
+  followupMessage: string
+  mealId: string
+  savedAttachmentCount: number | null
+  savedCalories: number | null
+}> {
+  const workingRoot = await mkdtemp(
+    path.join(tmpdir(), 'murph-automatic-meal-clarification-e2e-'),
+  )
+
+  try {
+    const binDirectory = path.join(workingRoot, 'bin')
+    const commandLog = path.join(workingRoot, 'vault-commands.log')
+    const photoPath = path.join(workingRoot, 'ambiguous-meal.jpg')
+    const skillsRoot = path.join(workingRoot, 'skills')
+    const vaultRoot = path.join(workingRoot, 'vault')
+    await initializeVault({ timezone: 'America/New_York', vaultRoot })
+    await Promise.all([
+      mkdir(binDirectory, { recursive: true }),
+      materializeAssistantSkill({
+        skillsRoot,
+        slug: 'automatic-meal-capture',
+      }),
+      materializeAssistantSkill({ skillsRoot, slug: 'food-journal' }),
+      writeFile(commandLog, '', 'utf8'),
+      writeFile(photoPath, 'synthetic undecodable meal image\n', 'utf8'),
+    ])
+    const meal = await addMeal({
+      externalRef: {
+        resourceId: 'capture_automatic_clarification',
+        resourceType: 'photo',
+        system: 'meal-photo-capture',
+        version: '5'.repeat(64),
+      },
+      occurredAt: '2026-08-24T23:37:00.000Z',
+      photoPath,
+      source: 'device',
+      vaultRoot,
+    })
+    await materializeAutomaticMealClarificationVaultCli({ binDirectory })
+
+    const inheritedPath = normalizeEnvString(input.config.env.PATH)
+    const sharedTurn = {
+      approvalPolicy: 'never' as const,
+      baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+      codexCommand:
+        normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND) ?? undefined,
+      codexHome: input.config.codexHome,
+      dynamicTools: [MURPH_ATTACH_RESPONSE_CARD_TOOL],
+      env: {
+        ...input.config.env,
+        AUTOMATIC_MEAL_E2E_CLI_ENTRYPOINT:
+          HABITAT_VOICE_E2E_CLI_ENTRYPOINT,
+        AUTOMATIC_MEAL_E2E_COMMAND_LOG: commandLog,
+        AUTOMATIC_MEAL_E2E_TSX_BIN: HABITAT_VOICE_E2E_TSX_BIN,
+        AUTOMATIC_MEAL_E2E_VAULT: vaultRoot,
+        [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+        PATH: inheritedPath
+          ? `${binDirectory}${path.delimiter}${inheritedPath}`
+          : binDirectory,
+      },
+      excludeResumeTurns: true,
+      model: input.config.model,
+      modelProvider: input.config.modelProvider,
+      reasoningEffort: 'medium' as const,
+      sandbox: 'workspace-write' as const,
+      workingDirectory: vaultRoot,
+    }
+    const first = await executeRealCodexAppServerTurn({
+      ...sharedTurn,
+      developerInstructions:
+        buildAutomaticMealClarificationDeveloperInstructions({
+          protectedContext: input.protectedContext,
+          scheduled: true,
+        }),
+      prompt: [
+        MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION.instructions,
+        'Controlled scenario evidence:',
+        '- The canonical fixture has one device-captured meal at 7:37pm and no nearby manual duplicate.',
+        '- Inspect the retained attachment through the canonical meal before deciding whether it supports an estimate.',
+        '- Complete the normal closeout and return its terminal delivery decision.',
+      ].join('\n\n'),
+    })
+    const firstDecision = parseAssistantNotificationDecision(
+      first.finalMessage,
+    )
+    const firstMessage = firstDecision.kind === 'send_message'
+      ? firstDecision.text
+      : firstDecision.privateSummary
+    const firstCommandText = (await readFile(commandLog, 'utf8')).trim()
+    const firstCommands = firstCommandText === ''
+      ? []
+      : firstCommandText.split('\n')
+    const afterFirst = await readAutomaticMealClarificationState({
+      mealId: meal.mealId,
+      vaultRoot,
+    })
+
+    if (input.protectedContext) {
+      return {
+        commands: firstCommands,
+        firstCard: first.responseCard,
+        firstCommands,
+        firstMessage,
+        followupCommands: [],
+        followupMessage: '',
+        mealId: meal.mealId,
+        ...afterFirst,
+      }
+    }
+
+    const followup = await executeRealCodexAppServerTurn({
+      ...sharedTurn,
+      developerInstructions:
+        buildAutomaticMealClarificationDeveloperInstructions({
+          protectedContext: false,
+          scheduled: false,
+        }),
+      prompt: [
+        'That empty cup was a berry smoothie: about one cup, made with berries, Greek yogurt, and milk.',
+        'Update that captured meal and tell me my refreshed calorie and macro total for August 24.',
+        'Do not add another meal.',
+      ].join(' '),
+      resumeSessionId: first.sessionId,
+    })
+    const allCommandText = (await readFile(commandLog, 'utf8')).trim()
+    const commands = allCommandText === '' ? [] : allCommandText.split('\n')
+    const afterFollowup = await readAutomaticMealClarificationState({
+      mealId: meal.mealId,
+      vaultRoot,
+    })
+
+    return {
+      commands,
+      firstCard: first.responseCard,
+      firstCommands,
+      firstMessage,
+      followupCommands: commands.slice(firstCommands.length),
+      followupMessage: followup.finalMessage,
+      mealId: meal.mealId,
+      ...afterFollowup,
+    }
+  } finally {
+    await removeRealCodexTemporaryPath(workingRoot)
+  }
+}
+
+function buildAutomaticMealClarificationDeveloperInstructions(input: {
+  protectedContext: boolean
+  scheduled: boolean
+}): string {
+  return buildAssistantSystemPrompt({
+    assistantCliContract: 'Use vault-cli for canonical member data.',
+    assistantContextSnapshotPrompt: input.protectedContext
+      ? [
+          'Known member context:',
+          '- The member uses intuitive eating, has eating-disorder-risk context, and is number-sensitive.',
+          '- Do not estimate or surface calories or macros, and minimize food prompts.',
+        ].join('\n')
+      : null,
+    assistantHostedDeviceConnectAvailable: false,
+    assistantHostedDeviceConnectProviders: [],
+    assistantKnowledgeToolsAvailable: false,
+    channel: 'linq',
+    cliAccess: {
+      rawCommand: 'vault-cli',
+      setupCommand: 'murph',
+    },
+    conversationScope: 'direct',
+    currentLocalDate: '2026-08-24',
+    currentTimeZone: 'America/New_York',
+    hostedRuntime: true,
+    modelBehaviorProfile: 'gpt5-agentic',
+    onboardingGuidance: false,
+    ...(input.scheduled
+      ? { scheduledOccurrenceAt: '2026-08-25T01:00:00.000Z' }
+      : { ordinaryInboundTurn: true }),
+    turnTrigger: input.scheduled ? 'automation-cron' : null,
+  })
+}
+
+async function materializeAutomaticMealClarificationVaultCli(input: {
+  binDirectory: string
+}): Promise<void> {
+  await mkdir(input.binDirectory, { recursive: true })
+  const executablePath = path.join(input.binDirectory, 'vault-cli')
+  await writeFile(
+    executablePath,
+    [
+      '#!/bin/sh',
+      'set -eu',
+      'if [ -z "$AUTOMATIC_MEAL_E2E_COMMAND_LOG" ] || [ -z "$AUTOMATIC_MEAL_E2E_CLI_ENTRYPOINT" ] || [ -z "$AUTOMATIC_MEAL_E2E_TSX_BIN" ] || [ -z "$AUTOMATIC_MEAL_E2E_VAULT" ]; then',
+      '  exit 70',
+      'fi',
+      'printf \'%s\\n\' "$*" >> "$AUTOMATIC_MEAL_E2E_COMMAND_LOG"',
+      'exec "$AUTOMATIC_MEAL_E2E_TSX_BIN" "$AUTOMATIC_MEAL_E2E_CLI_ENTRYPOINT" "$@" --vault "$AUTOMATIC_MEAL_E2E_VAULT"',
+      '',
+    ].join('\n'),
+    {
+      encoding: 'utf8',
+      mode: 0o700,
+    },
+  )
+  await chmod(executablePath, 0o700)
+}
+
+async function readAutomaticMealClarificationState(input: {
+  mealId: string
+  vaultRoot: string
+}): Promise<{
+  savedAttachmentCount: number | null
+  savedCalories: number | null
+}> {
+  const vault = await readVaultRawTolerant(input.vaultRoot)
+  const event = [...vault.events]
+    .reverse()
+    .find((candidate) => candidate.entityId === input.mealId)
+  const meal = readRecord(event?.attributes.meal)
+  const nutrition = readRecord(meal?.nutrition)
+  const totals = readRecord(nutrition?.totals)
+
+  return {
+    savedAttachmentCount: Array.isArray(meal?.attachments)
+      ? meal.attachments.length
+      : null,
+    savedCalories: typeof totals?.calories === 'number'
+      ? totals.calories
+      : null,
+  }
+}
 type NutritionConditionRecovery =
   | 'ambiguous'
   | 'complete'

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -1250,6 +1250,9 @@ describe('applyMurphManagedAutomations', () => {
     expect(MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION.instructions).toContain(
       'A removal failure or any selected photo remaining fails the run',
     )
+    expect(MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION.instructions).toContain(
+      'Return its compact unresolved-capture question when required.',
+    )
 
     await expect(ensureAutomaticMealCloseoutAutomation({
       defaultRoute,


### PR DESCRIPTION
## Why and outcome

An automatically captured meal could lose its retained photo at the privacy cleanup boundary while remaining too incomplete for an honest nutrition estimate. Later card requests could then fall back to a refusal instead of recovering the meal.

This change makes the existing automatic-capture skill estimate conservatively whenever the image supports a recognizable food or drink and defensible portion range. Only a genuinely unidentifiable capture asks one compact clarification after cleanup; the answer enriches the existing canonical meal before fresh totals or an eligible card. It adds no new state owner.

## Product UX

- Effort: focused conversational recovery.
- Walkthrough: Ready. Clear or reasonably estimable captures continue without a question. Genuinely unidentifiable captures receive one question, with date plus time only for historical or multi-date work. Later answers edit the existing meal. Intuitive-eating, eating-disorder-risk, and number-sensitive contexts clean up the photo and stop without estimate-enabling questions or numeric work.
- Material exclusion: no frontend meal dashboard is added or invented when nutrition is incomplete.
- Browser gap: the changelog-only Vercel preview was ignored and the available browser controls exposed no browser instance. Server-rendered archive tests cover the authored changelog state.

## Evidence

- Automatic-capture skill contract: 4 tests passed.
- Managed closeout seed regression: 1 focused test passed.
- Assistant-engine typecheck passed.
- Changelog fragment, registry, page, and route coverage: 57 tests passed; Hosted Web typecheck passed.
- Direct contract proof places clarification after photo cleanup and before Goal, totals, or card work, and requires existing-meal edit/readback plus fresh totals.
- The required preliminary specialist pass returned three findings. All were accepted and fixed: protected-context inheritance, historical date/time disambiguation, and production-shaped two-turn proof. No patch artifact was returned.
- A focused real-Codex scenario now uses the production prompt, real vault, and real CLI to cover cleanup/question/stop, reply/edit/readback/fresh totals, no duplicate meal, and protected-context suppression. The module compiles under the documented gate; the paid model call did not run locally because neither supported provider credential is present.

## Non-obvious affected surfaces

- Managed automatic-meal automation seed: its fallback now permits the skill-owned clarification question after successful cleanup. The focused seed test covers this handoff.
- Public changelog: one member-facing improvement fragment documents the recovery and duplicate-avoidance boundary. Focused archive and route tests cover publication.
- Developer workflow: one public-safe Frog entry records that changelog-only PRs can lack the current preview required by the design-proof workflow.

## Architecture and reuse

- Existing systems reused: the canonical device meal, retained-photo cleanup, private conversation, food-journal totals, and response-card workflow remain the only owners.
- New logic: one prompt gate estimates by default, asks only when identity or amount is too indeterminate for any meaningful bounded estimate, and then edits and reads back the existing meal.
- New abstractions: none; the existing skill owns both scheduled and interactive recovery.
- Complexity intentionally avoided: no queue, database field, cursor, flag, state machine, duplicate meal, photo restoration, or second automation.

## Hot reply path impact

Not applicable. This changes model instructions only and adds no database, network, provider, transaction, timeout, retry, or other awaited operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

The latest pinned identical-fixture App Server captures remain byte-identical for ordinary private and group turns because the changed automatic-capture skill is deferred and the managed seed is absent from those requests. Private remains 16,046 `o200k_harmony` tokens / 72,075 UTF-8 bytes at base and head; group remains 14,168 / 61,489. The capture includes all provider-visible request fields and excludes model selection, reasoning, storage, streaming, service tier, cache/client metadata, and transport headers identically.

When loaded, the deferred automatic-capture skill moves from 4,367 tokens / 20,076 bytes to 4,750 / 21,940 (+383 / +1,864). The automatic closeout seed itself moves from 231 / 1,169 to 241 / 1,231 (+10 / +62). Counts use `gpt-tokenizer` 3.4.0 with `o200k_harmony`; no tool schema or generated guidance changed.

## Design proof

- Design page: https://murph.ai/screenshots/ops#changelog-archive
- Evidence: The existing repository-owned archive study renders the real changelog component. The new item changes text content only; 57 server-rendered archive/feed/page tests prove the branch content and publication path. Vercel skipped the branch preview, so the linked production study demonstrates component structure rather than the unmerged item bytes.
- Coverage: Changelog archive content at its existing responsive component boundary; no component, layout, interaction, or responsive behavior changed.

## Change-shape breakdown

Classification is by authored file purpose; the changelog fragment is runtime content, while the execution plan and Frog entry are docs. No binary or generated file is included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 46 | 5 |
| Tests/fixtures | 399 | 0 |
| Docs | 172 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 617 | 5 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new runner processes use their own complete prompt bundle; no shared record shape or cross-version write is introduced.
- Safe order: Deploy through the normal hosted assistant runner release.
- Rollback floor: None; the change persists no new state.
- Expected exposure: During a gradual rollout, an older warm runner can retain the prior generic fallback for one closeout.
- Reversibility: Reverting the prompt bundle restores the prior behavior without data migration.
- Convergence proof: Confirm active runner versions have converged through the existing deployment smoke.
- Post-deploy checks: Exercise a synthetic ambiguous automatic capture and verify one clarification after cleanup plus existing-meal enrichment on reply.

## Changelog

- Changelog: updated
- Items: 2026-08-24 · automatic-meal-clarification

## Risks

- Prompt behavior remains model-dependent. The rule and opt-in production-shaped scenario are explicit, but the current local lane lacked a supported provider credential for the paid sample.
- Numeric-suitability, eating-disorder-risk, intuitive-eating, number-sensitive, duplicate-meal, and photo-privacy rules remain owned by their existing gates; the clarification path now explicitly inherits them.
