### PR TITLE
Log successful hosted runtime completion

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-25-runtime-invocation-finished-log.md
+++ b/agent-docs/exec-plans/active/2026-08-25-runtime-invocation-finished-log.md
@@ -1,0 +1,82 @@
+# Hosted runtime normal-completion marker
+
+Status: active
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Make every successfully resolved hosted workspace invocation emit one typed,
+  deidentified terminal runtime event so an empty system-mailbox pass can be
+  distinguished from an invocation that aborted after mailbox import.
+- Preserve runtime results, scheduling, checkpointing, retries, and all other
+  control flow exactly.
+
+## Success criteria
+
+- The exported in-process invocation owner emits exactly one
+  `runtime.invocation_finished` event after its private implementation resolves.
+- The event contains only the existing typed attempt attribution and normalized
+  processing mode; it contains no member data or inferred state/outcome fields.
+- A successful empty system-mailbox import produces both its existing zero-count
+  `mailbox.imported` log and the new terminal event for the same attempt.
+- A thrown or aborted invocation produces no terminal event.
+- Focused runtime-control and assistant-runtime tests and typechecks pass, and
+  required PR review gates resolve on the exact pushed candidate head.
+
+## Scope
+
+- In scope: the hosted-execution typed event-code registry, the assistant-runtime
+  exported invocation boundary, and focused production-path regression coverage.
+- Out of scope: replay, alerts, persistence, schemas, queues, retry behavior,
+  checkpoint behavior, state owners, and inferred no-work classification.
+
+## Constraints
+
+- Technical constraints: use the existing structured-log pipeline; emit only
+  after successful resolution; keep the invocation result byte-for-byte
+  unchanged; retain all legacy runtime phase diagnostics.
+- Product/process constraints: metadata only, one event per normal invocation,
+  no user-visible behavior change, isolated worktree/draft PR, focused proof,
+  preliminary specialists and final ReviewGPT gate before merge authorization.
+
+## Risks and mitigations
+
+1. Risk: adding markers to scattered early returns misses a normal path or
+   duplicates another.
+   Mitigation: wrap the one exported owner around a private implementation and
+   emit once after its awaited result.
+2. Risk: derived `no_work`, checkpoint, or wake fields drift from their real
+   owners.
+   Mitigation: omit them; correlate the terminal event with the existing typed
+   mailbox-import event by attempt id.
+3. Risk: telemetry failure changes invocation behavior.
+   Mitigation: use the existing synchronous best-effort structured logger and
+   return the implementation result unchanged.
+
+## Tasks
+
+1. Prove the empty successful return and thrown/aborted seams in current code
+   and focused tests.
+2. Register `runtime.invocation_finished` and add the one exported-owner wrapper.
+3. Add focused success/no-terminal-on-error coverage and run scoped checks.
+4. Inspect the diff/privacy boundary, commit and open a draft PR, then run the
+   required exact-head specialist/final review gates and CI.
+
+## Decisions
+
+- Keep the event shape to `eventCode`, `attemptId`, and normalized
+  `processingMode`. The event's presence is the success signal; existing
+  `mailbox.imported` counters prove the empty/no-work case without duplicated
+  or inferred terminal fields.
+- Keep the current `runtime.return` phase diagnostics unchanged. They serve
+  phase timing and are not the typed terminal event owner.
+
+## Verification
+
+- Commands to run: focused assistant-runtime entrypoint test, hosted-execution
+  runtime-control test, both affected package typechecks, `git diff --check`,
+  privacy scan, required exact-head ReviewGPT gates, and required GitHub checks.
+- Expected outcomes: exactly one typed terminal event on successful empty system
+  processing, none on thrown/aborted execution, unchanged invocation result and
+  passing affected package contracts.

--- a/agent-docs/exec-plans/completed/2026-08-25-runtime-invocation-finished-log.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-runtime-invocation-finished-log.md
@@ -1,6 +1,6 @@
 # Hosted runtime normal-completion marker
 
-Status: active
+Status: completed
 Created: 2026-08-25
 Updated: 2026-08-25
 
@@ -74,9 +74,12 @@ Updated: 2026-08-25
 
 ## Verification
 
-- Commands to run: focused assistant-runtime entrypoint test, hosted-execution
-  runtime-control test, both affected package typechecks, `git diff --check`,
-  privacy scan, required exact-head ReviewGPT gates, and required GitHub checks.
-- Expected outcomes: exactly one typed terminal event on successful empty system
-  processing, none on thrown/aborted execution, unchanged invocation result and
-  passing affected package contracts.
+- Focused assistant-runtime proof passed for successful empty system processing,
+  default-mode normalization, and no terminal event on abort.
+- The hosted-execution registry test and both affected package typechecks passed.
+- `git diff --check`, the added-line privacy scan, final ReviewGPT round 1, and
+  the required GitHub checks passed on the immutable reviewed candidate.
+- Preliminary specialist review found one isolated default-mode coverage gap;
+  the accepted test-only correction passed its focused test and package
+  typecheck without changing production behavior.
+Completed: 2026-08-25

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -28,6 +28,20 @@ Runner bundle assembly esbuild-bundles two boot-critical surfaces with byte budg
 The device-sync package boundary suite also walks the static source graph from the runner's runtime-config entrypoint and rejects provider runtime modules, importer modules, and the Junction SDK. This focused gate catches boot-closure ownership regressions before the packed-bundle guard validates the final esbuild metafile.
 Hosted assistant delivery recovery now relies on committed side-effect state inside the encrypted workspace and the web-owned hosted workspace checkpoint.
 
+## Hosted Runtime Terminal-Event Rollout
+
+When the runner adds a strict hosted runtime event code, deploy Web's shared
+hosted-execution reader first. Next deploy the Cloudflare runner bundle with
+immediate convergence and let older containers drain. A new runner must not
+write the event to an older Web reader because the older strict registry can
+reject the bounded runtime-log batch.
+
+Roll back the runner writer first and let the newer event drain before rolling
+back Web. After deployment, use a bounded time window to compare aggregate
+empty `mailbox.imported` attempts with `runtime.invocation_finished` attempts
+and confirm the Web ingest-rejection aggregate remains zero. Keep the proof
+deidentified: report only aggregate counts, not attempt IDs or row payloads.
+
 ## Gemini Video Analysis Rollout
 
 Deploy Web's Gemini usage-record acceptance and date-bound Gemini 3.7 Flash

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1207,6 +1207,27 @@ export async function runHostedWorkspaceRuntimeJobInProcess(
   input: HostedAssistantWorkspaceRuntimeJobInput,
   options: HostedWorkspaceRuntimeJobOptions,
 ): Promise<HostedWorkspaceInvocationResult> {
+  const result = await runHostedWorkspaceRuntimeJobInProcessImpl(input, options);
+  void writeHostedRuntimeLogBestEffort({
+    entry: {
+      attemptId: input.request.attemptId,
+      component: "runtime",
+      eventCode: "runtime.invocation_finished",
+      level: "info",
+      phase: "invoke",
+      redactedJson: {
+        processingMode: input.request.processingMode ?? "default",
+      },
+    },
+    platform: options.platform,
+  });
+  return result;
+}
+
+async function runHostedWorkspaceRuntimeJobInProcessImpl(
+  input: HostedAssistantWorkspaceRuntimeJobInput,
+  options: HostedWorkspaceRuntimeJobOptions,
+): Promise<HostedWorkspaceInvocationResult> {
   const runtime = normalizeHostedAssistantRuntimeConfig(input.runtime, options.platform);
   const mailboxPort = runtime.platform.mailboxPort ?? null;
   const workspacePort = runtime.platform.workspacePort ?? null;

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -443,6 +443,9 @@ import {
   readHostedPendingAssistantInputIds,
 } from "../src/hosted-runtime/pending-input-index.ts";
 import {
+  drainHostedRuntimeLogWritesBestEffort,
+} from "../src/hosted-runtime/runtime-logs.ts";
+import {
   markHostedWorkspaceLiveRuntimeStateDirtyForSnapshotRefBestEffort,
   restoreHostedWorkspaceRuntimeJobWorkspace,
   writeHostedWorkspaceCleanCheckpointMarkerBestEffort,
@@ -603,15 +606,91 @@ function readCapturedRuntimePhaseLogs(input: {
 }
 
 describe("hosted workspace runtime entrypoint", () => {
+  test("records one terminal event after an empty system-mailbox invocation", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const attemptId = "attempt_synthetic_empty_system_mailbox_finished";
+
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await writeMailboxImportStateFile(
+        vaultRoot,
+        createEmptyHostedMailboxImportState(),
+      );
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId,
+            leaseGeneration: "7",
+            processingMode: "system_mailbox",
+            userId: TEST_USER_ID,
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "e".repeat(64),
+                key: "users/bundles/member-synthetic/empty-system-mailbox.bundle.json",
+                size: 128,
+              }),
+            };
+          },
+          async importItem() {
+            throw new Error("An empty system-mailbox invocation must not import an item.");
+          },
+          platform: createPlatform({
+            logRequests,
+            mailboxPort: createMailboxPort({ events: [], items: [] }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests: [],
+              events: [],
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          async runAssistantPhase() {
+            throw new Error("An empty system-mailbox invocation must not run the assistant.");
+          },
+          vaultRoot,
+        },
+      );
+      await drainHostedRuntimeLogWritesBestEffort();
+
+      assert.equal(result.status, "idle");
+      const entries = logRequests.flatMap((request) => request.entries);
+      const imported = entries.filter((entry) =>
+        entry.attemptId === attemptId
+        && entry.eventCode === "mailbox.imported"
+      );
+      assert.equal(imported.length, 1);
+      assert.equal(imported[0]?.redactedJson?.fetchedCount, 0);
+      assert.equal(imported[0]?.redactedJson?.importedCount, 0);
+      assert.equal(imported[0]?.redactedJson?.stateChanged, false);
+      assert.deepEqual(
+        entries.filter((entry) =>
+          entry.attemptId === attemptId
+          && entry.eventCode === "runtime.invocation_finished"
+        ).map((entry) => entry.redactedJson),
+        [{ processingMode: "system_mailbox" }],
+      );
+    } finally {
+      await drainHostedRuntimeLogWritesBestEffort();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("rejects a blocked runtime when the host signal aborts", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const hostAbortController = new AbortController();
     const hostAbortReason = new Error("host request aborted");
     const workspaceReadStarted = createDeferred<void>();
     const workspaceReadRelease = createDeferred<HostedWorkspaceReadResponse>();
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const attemptId = "attempt_synthetic_host_abort";
     const resultPromise = runHostedWorkspaceRuntimeJobInProcess(createWorkspaceRuntimeJobInput({
       request: {
-        attemptId: "attempt_synthetic_host_abort",
+        attemptId,
         leaseGeneration: "7",
         userId: TEST_USER_ID,
         workspaceVersion: "0",
@@ -624,6 +703,7 @@ describe("hosted workspace runtime entrypoint", () => {
         throw new Error("Host abort test should not import mailbox items.");
       },
       platform: createPlatform({
+        logRequests,
         mailboxPort: createMailboxPort({ events: [], items: [] }),
         workspacePort: {
           async read() {
@@ -649,12 +729,21 @@ describe("hosted workspace runtime entrypoint", () => {
         new Promise<unknown>((resolve) => setTimeout(() => resolve(timeout), 250)),
       ]);
       assert.equal(outcome, hostAbortReason);
+      await drainHostedRuntimeLogWritesBestEffort();
+      assert.equal(
+        logRequests.flatMap((request) => request.entries).some((entry) =>
+          entry.attemptId === attemptId
+          && entry.eventCode === "runtime.invocation_finished"
+        ),
+        false,
+      );
     } finally {
       workspaceReadRelease.resolve({
         fetchedAt: TEST_NOW,
         workspace: createWorkspaceState({ version: "0" }),
       });
       await resultPromise.catch(() => undefined);
+      await drainHostedRuntimeLogWritesBestEffort();
       await removeTempRoot(vaultRoot);
     }
   });

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.test.ts
@@ -3103,12 +3103,14 @@ describe("hosted workspace runtime entrypoint", () => {
   test("uses invocation workspace state without a startup workspace-port read", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const suppliedWorkspace = createWorkspaceState({ version: "0" });
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const attemptId = "attempt_synthetic_invocation_workspace";
 
     try {
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
-            attemptId: "attempt_synthetic_invocation_workspace",
+            attemptId,
             leaseGeneration: "7",
             userId: TEST_USER_ID,
             workspace: suppliedWorkspace,
@@ -3123,6 +3125,7 @@ describe("hosted workspace runtime entrypoint", () => {
             throw new Error("Invocation workspace state test should not import mailbox items.");
           },
           platform: createPlatform({
+            logRequests,
             mailboxPort: createMailboxPort({ events: [], items: [] }),
             workspacePort: {
               async read() {
@@ -3136,9 +3139,18 @@ describe("hosted workspace runtime entrypoint", () => {
           vaultRoot,
         },
       );
+      await drainHostedRuntimeLogWritesBestEffort();
 
       assert.equal(result.status, "idle");
+      assert.deepEqual(
+        logRequests.flatMap((request) => request.entries).filter((entry) =>
+          entry.attemptId === attemptId
+          && entry.eventCode === "runtime.invocation_finished"
+        ).map((entry) => entry.redactedJson),
+        [{ processingMode: "default" }],
+      );
     } finally {
+      await drainHostedRuntimeLogWritesBestEffort();
       await removeTempRoot(vaultRoot);
     }
   });

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -3402,6 +3402,7 @@ export const HOSTED_RUNTIME_LOG_EVENT_CODES = [
   "runner.lease_superseded",
   "runner.provider_egress_diagnostic",
   "runner.started",
+  "runtime.invocation_finished",
   "workspace.codex_home_snapshot",
 ] as const;
 

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -303,6 +303,7 @@ describe("hosted runtime control contracts", () => {
     expect(HOSTED_RUNTIME_LOG_EVENT_CODES).toContain("checkpoint.snapshot_preempted");
     expect(HOSTED_RUNTIME_LOG_EVENT_CODES).toContain("runner.accepted_attempt_failed");
     expect(HOSTED_RUNTIME_LOG_EVENT_CODES).toContain("runner.provider_egress_diagnostic");
+    expect(HOSTED_RUNTIME_LOG_EVENT_CODES).toContain("runtime.invocation_finished");
     expect(HOSTED_RUNTIME_LOG_EVENT_CODES).toContain("workspace.codex_home_snapshot_failed");
     expect(HOSTED_RUNTIME_LOG_EVENT_CODES).not.toContain("run.acquired");
     expect(HOSTED_WORKSPACE_INVOCATION_STATUSES).toEqual([


### PR DESCRIPTION
## Why and outcome

Successful empty hosted system invocations currently stop after `mailbox.imported`, so operators cannot distinguish a normal no-work return from an abort after import. This adds one typed, deidentified `runtime.invocation_finished` row at the existing invocation owner after successful resolution only.

The event carries the existing attempt attribution and normalized processing mode. It adds no replay, alert, persistence, scheduling, checkpoint, or retry behavior.

## Product UX

Not applicable. This is internal runtime observability with no member-visible behavior or interaction change.

## Evidence

- Production-path empty `system_mailbox` invocation: one `mailbox.imported` entry with fetched/imported `0` and `stateChanged=false`, followed by exactly one terminal event for the same attempt.
- Successful invocation without an explicit processing mode: exactly one terminal event normalized to `processingMode: "default"`.
- Explicit host-abort path: no terminal event.
- `pnpm exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-workspace-entrypoint.test.ts -t "records one terminal event|uses invocation workspace state|rejects a blocked runtime"` — 3 passed.
- `pnpm exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-control.test.ts -t "freezes the mailbox lanes, item kinds, checkpoint reasons, and log codes"` — 1 passed.
- `pnpm --filter @murphai/assistant-runtime typecheck` — passed.
- `pnpm --filter @murphai/hosted-execution typecheck` — passed.
- `pnpm docs:drift`, `git diff --check`, and the added-line privacy scan — passed.

## Non-obvious affected surfaces

- The shared hosted-runtime event-code registry changes so Web's strict log reader accepts the new runner event. The focused runtime-control contract test covers registry admission; `apps/cloudflare/DEPLOY.md` records the required reader-first rollout and runner-first rollback.

## Architecture and reuse

- **Existing systems reused:** The existing invocation owner, typed runtime-log entry, queued best-effort log transport, attempt attribution, and invocation-end bounded drain.
- **New logic:** One informational event is enqueued after the in-process invocation resolves successfully.
- **New abstractions:** None. The existing function body is private only so the exported owner has one completion seam across all early returns.
- **Complexity intentionally avoided:** No outcome inference, duplicate checkpoint/wake/state fields, replay, alerts, storage, queues, state machines, or control-flow branches. Empty work is derived by correlating this event with the existing typed import counters.

## Hot reply path impact

Not applicable. The event is created only after the invocation has resolved, outside durable acceptance through provider start and durable reply handoff. It joins the existing best-effort info-log queue and existing bounded invocation-end drain; no new awaited operation is added to the foreground reply critical path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool, schema, generated guidance, model, or runtime-environment input changes.
- Group runtime: Not applicable for the same reason.

## Change-shape breakdown

Classification: production TypeScript is source; test TypeScript is tests/fixtures; the archived execution plan and deploy contract are docs; no generated files or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 22 | 0 |
| Tests/fixtures | 104 | 2 |
| Docs | 99 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **225** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Internal runtime telemetry only; members cannot see the event.

## Deployment concerns

- Deployment: applicable
- Durable contract: `apps/cloudflare/DEPLOY.md` records the rollout, rollback, and proof requirements.
- Supported skew: New Web readers accept both old runner logs and the new terminal event; old Web readers do not accept the new event code.
- Safe order: Deploy Web's shared reader first, then deploy the Cloudflare runner bundle with immediate convergence and let older containers drain.
- Rollback floor: While the new runner is active, do not roll Web below the event-aware reader; roll the runner back and drain it first.
- Expected exposure: With the safe order there is no rejected-log window; reversing it can reject a bounded runtime-log batch containing the new event.
- Reversibility: Roll Cloudflare back first, confirm new event emission has stopped, then roll Web back if needed.
- Convergence proof: Confirm new runner instances emit `runtime.invocation_finished` and Web persists it with typed attempt attribution.
- Post-deploy checks: Over a bounded window, compare aggregate empty-import attempts with terminal-event attempts and confirm the Web ingest-rejection aggregate remains zero; report no attempt IDs or row payloads.

ReviewGPT context sensitivity: sensitive — this changes hosted execution telemetry and an independently deployed strict reader/writer boundary.
ReviewGPT first-reviewed head: 0e39dd1bb5f0562d52072d827d2ad2556d33df06
