### PR TITLE
fix: validate hosted-local Temporal doctor

### DIFF
--- a/packages/hosted-local-harness/src/cli.ts
+++ b/packages/hosted-local-harness/src/cli.ts
@@ -517,6 +517,12 @@ async function runDoctor(
     profileName: parsed.profileName,
   });
   const config = resolveHostedLocalDevConfig(profiled.env);
+  if (config.temporal.mode !== "disabled") {
+    const { requireHostedLocalTemporalWorkerPackageDir } = await import(
+      "./dev-hosted-local/temporal.ts"
+    );
+    requireHostedLocalTemporalWorkerPackageDir(profiled.env);
+  }
   const commands = [
     runDoctorCommand("node", ["--version"]),
     runDoctorCommand("pnpm", ["--version"]),

--- a/packages/hosted-local-harness/test/cli.test.ts
+++ b/packages/hosted-local-harness/test/cli.test.ts
@@ -265,6 +265,41 @@ describe("hosted-local run CLI", () => {
     expect(startHostedLocalDevStack).not.toHaveBeenCalled();
   });
 
+  test("rejects worktree doctor when Temporal needs a missing worker package", async () => {
+    resolveHostedLocalWorktreeConfig.mockResolvedValueOnce(
+      createHostedLocalWorktreeConfig({ includeTemporalWorkerPackage: false }),
+    );
+
+    await expect(
+      runHostedLocalCli(["worktree", "doctor", "feature-a", "--json"], {
+        env: {},
+        stdout: createBufferedStdout().stdout,
+      }),
+    ).rejects.toThrow("Hosted-local Temporal requires an external worker package.");
+
+    expect(runDoctorCommand).not.toHaveBeenCalled();
+  });
+
+  test("allows doctor without a worker package when Temporal is disabled", async () => {
+    resolveHostedLocalDevConfig.mockReturnValueOnce({
+      ...resolveHostedLocalDevConfig(),
+      temporal: {
+        host: "127.0.0.1",
+        mode: "disabled",
+        namespace: "default",
+        port: 7233,
+        taskQueue: "murph-hosted-runtime",
+      },
+    });
+
+    await runHostedLocalCli(["doctor", "--json"], {
+      env: {},
+      stdout: createBufferedStdout().stdout,
+    });
+
+    expect(runDoctorCommand).toHaveBeenCalledTimes(4);
+  });
+
   test("prepares worktree resources before delegating worktree up to the normal stack", async () => {
     const output = createBufferedStdout();
 
@@ -492,6 +527,8 @@ describe("hosted-local run CLI", () => {
       const environment = {
         ...process.env,
         HOSTED_APP_SESSION_HMAC_KEY: authority,
+        MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR:
+          "../murph-cloud/packages/hosted-orchestrator-temporal",
       };
       await runHostedLocalCli(command, {
         env: environment,
@@ -715,12 +752,20 @@ function createHostedLocalStack(input: {
   };
 }
 
-function createHostedLocalWorktreeConfig() {
+function createHostedLocalWorktreeConfig(
+  input: { includeTemporalWorkerPackage?: boolean } = {},
+) {
   return {
     buildId: "worktree-feature-a",
     databaseName: "murph_dev_feature_a",
     databaseUrl: "postgresql://postgres@127.0.0.1:5432/murph_dev_feature_a",
     env: {
+      ...(input.includeTemporalWorkerPackage === false
+        ? {}
+        : {
+            MURPH_DEV_TEMPORAL_WORKER_PACKAGE_DIR:
+              "../murph-cloud/packages/hosted-orchestrator-temporal",
+          }),
       MURPH_DEV_WORKTREE_SCOPE: "feature-a",
       MURPH_DEV_WEB_PORT: "3101",
       MURPH_HOSTED_LOCAL_PROFILE: "dev",


### PR DESCRIPTION
## Why this PR exists

Hosted-local `doctor` could report a Temporal-enabled profile as ready even
when the private Temporal worker package required by startup was absent.

## User goal / user-visible behavior

A developer running `hosted-local doctor` now gets the existing actionable
missing-worker-package error before generic readiness probes. UI-only work can
still select `MURPH_DEV_TEMPORAL=disabled`, and that doctor path remains green.

## User experience

- Product UX: not applicable; this is an internal developer CLI truthfulness fix.
- Recovery stays explicit through the existing worker-package variable or the
  existing disabled-Temporal mode.

## Invariants

- Enabled hosted-local Temporal still requires the private external worker
  package.
- Disabled Temporal never requires that package.
- Startup remains the canonical runtime owner; doctor reuses its existing
  fail-closed validator and message.

## Non-obvious affected surfaces

- Both top-level and worktree-scoped doctor commands pass through the same
  validation.
- Worker-only profiles continue to default Temporal to disabled.
- Generic Node, pnpm, Docker, and PostgreSQL probes are skipped when the
  mandatory Temporal package prerequisite is already missing.

## Architecture and reuse

- Existing systems reused: `requireHostedLocalTemporalWorkerPackageDir` and the
  current profile/config resolution path.
- New logic: one enabled-mode guard in the doctor owner.
- New abstractions: none; the existing Temporal validator already owns the
  required package-path policy and actionable failure message.
- Complexity intentionally avoided: no duplicated package-path parsing,
  fallback policy, or error copy.

## Hot reply path impact

- Not applicable; this local developer command does not touch member messaging
  or the hosted reply path.

## Provider-input impact

- None; no provider-visible prompt, schema, tool description, or request input
  changes.

## Preliminary specialist lenses

- Product UX: not applicable; internal developer CLI behavior only.
- Prompt: not applicable; no prompt-owned behavior changes.
- Frontend: not applicable; no rendered UI changes.
- Coverage: applicable; focused tests cover enabled Temporal without a package
  and disabled Temporal without a package.

## Verification

- Focused CLI suite: 23/23 passed.
- Hosted-local harness typecheck: passed.
- Hosted-local harness package-boundary verification: 2/2 passed.
- Direct doctor smoke: missing package fails before readiness; disabled
  Temporal succeeds.
- Full package coverage: 442 passed, 1 skipped, 1 unrelated failure in the
  pre-existing MinIO signal integration test, which timed out before creating
  its `minio-ready` fixture and does not import either changed file.

## Change shape

Classification rule: runtime implementation is source; Vitest files are
tests/fixtures; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 0 |
| Tests/fixtures | 46 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 52 | 1 |

ReviewGPT context sensitivity: sensitive

Reason: the change alters a fail-closed Temporal prerequisite, even though the
surface is local developer tooling rather than deployed runtime.

ReviewGPT first-reviewed head: 72fff8059e9d23c187a099be65d27794a5eece7a

Frog autofix issue: #2124

## Changelog

- Changelog: not applicable
- Reason: Internal developer workflow behavior only.

## Deployment concerns

- Deployment: not applicable
- Reason: No deployed application, service, schema, or runtime configuration changes.
