### PR TITLE
Document changelog-only review proof

### DIFF
--- a/agent-docs/FRONTEND.md
+++ b/agent-docs/FRONTEND.md
@@ -93,6 +93,7 @@ cd apps/web && pnpm typecheck
   change.
 - Reuse [localhost:3000/design?tab=components](http://localhost:3000/design?tab=components) before creating a near-duplicate. Every user-facing hosted Web UI diff needs a repository-owned, reviewer-openable representation: the real production component or consent surface on the matching `/design` tab, or the composed section under `/screenshots/<category>`. Add or update a catalog/study state only when no existing route and anchor render the changed state.
 - Add a `/screenshots` study only when a difficult or reusable state benefits from stable presentation proof. Render the real production component with synthetic props, no live data, no live requests, and all interactive controls `inert`. A screenshot study proves presentation only, not the complete product journey.
+- For content-only authored changelog entries and edition metadata, use the narrow no-preview proof route in `apps/web/changelog/README.md`. Any changelog renderer, component, style, visual, or interaction change uses the normal current-branch proof rule.
 - Treat the unlinked and noindex route as a discovery control, not security. Never put private member data or credentials there.
 - Match rendered evidence to the changed visual, state, interaction, and
   responsive risk. A change can need no screenshots, one screenshot, or many.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -15,7 +15,10 @@ Every PR also records non-obvious affected surfaces, a mechanically validated
 architecture/reuse summary, foreground reply-path impact, complete initial
 provider-input impact, and categorized added/deleted LOC. User-facing hosted
 Web UI changes additionally carry mechanically validated design-proof fields
-and dedicated risk-matched catalog/study evidence.
+and dedicated risk-matched catalog/study evidence. Content-only authored
+changelog entries plus optional edition metadata use the narrow changelog-owned
+no-preview proof route; renderer, component, style, visual, or interaction
+changes keep the normal current-branch proof rule.
 The contract and its proof are specified by
 `agent-docs/operations/completion-workflow.md` and
 `agent-docs/references/testing-ci-map.md`.

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -311,9 +311,16 @@ Every PR includes:
   production component on `/design?tab=components`, consent surface on
   `/design?tab=consent`, or composed page section/flow under
   `/screenshots/<category>`. Refresh an expired or inaccessible preview; use a
-  production link only when it already renders the changed state. Add or update
-  the catalog/study state only when no existing route and anchor render the
-  changed state. In a dedicated `## Design proof` section, include that
+  production link only when it already renders the changed state. The only
+  content-only exception is an authored changelog diff under
+  `apps/web/changelog/entries/**` plus optional
+  `apps/web/changelog/editions/**`: follow the review-proof route in
+  `apps/web/changelog/README.md` and do not create or refresh a branch preview
+  solely for design proof. Any changelog renderer, component, style, visual, or
+  interaction change still needs the normal current-branch representation. Add
+  or update the catalog/study state only when no existing route and anchor
+  render the changed state. In a
+  dedicated `## Design proof` section, include that
   `Design page:` link, `Evidence:` matched to the changed visual, state,
   interaction, and responsive risks, and `Coverage:` naming the states and
   viewports checked. A reasoned walkthrough is valid when an image adds no

--- a/apps/web/changelog/README.md
+++ b/apps/web/changelog/README.md
@@ -44,3 +44,19 @@ builds generate an ignored TypeScript module from the fragments, avoiding both
 a committed merge hotspot and runtime filesystem reads. The loader and focused
 tests validate fragments and publish them through the existing archive, feed,
 permalink, and share-card contracts.
+
+## Review proof for content-only entries
+
+A PR whose only user-facing hosted Web changes are authored files under
+`entries/**` plus optional `editions/**` does not need a branch preview solely
+for design proof. Review the changed JSON copy directly, run
+`pnpm --dir apps/web test -- changelog-page.test.tsx`, and use
+`https://www.withmurph.ai/screenshots/ops#changelog-archive` as the
+repository-owned production presentation reference. The focused test loads every
+authored fragment and proves its visible copy and try-it affordance server-render
+through the production archive component; the synthetic archive study renders
+that same production component and therefore covers unchanged presentation.
+
+This exception is content-only. A change to changelog rendering, components,
+styles, visuals, or interaction still requires the normal current-branch design
+proof.

--- a/apps/web/test/changelog-page.test.tsx
+++ b/apps/web/test/changelog-page.test.tsx
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,6 +30,7 @@ vi.mock("@/src/components/murph/hosted-murph-contact-action", () => ({
 
 import ChangelogPage, { generateMetadata } from "../app/changelog/page";
 import { ChangelogArchiveStudy } from "../app/design/changelog-archive-study";
+import { loadChangelogFragmentEditions } from "../src/lib/changelog-fragments";
 import {
   buildAbsoluteChangelogUrl,
   buildChangelogCardPath,
@@ -88,6 +90,71 @@ describe("ChangelogPage", () => {
     expect(markup).toContain(`href="${buildChangelogPagePath(2)}"`);
     expect(markup).toContain("Older");
     expect(markup).not.toContain(">Newer<");
+  });
+
+  it("server-renders every authored fragment through the production archive", async () => {
+    const fragmentEditions = loadChangelogFragmentEditions(
+      fileURLToPath(new URL("../changelog/", import.meta.url)),
+    );
+    const pageMarkupByNumber = new Map<number, string>();
+
+    for (const edition of fragmentEditions) {
+      const pageNumber = resolveChangelogEditionPage(edition.id);
+      expect(pageNumber).not.toBeNull();
+      if (pageNumber === null) {
+        throw new TypeError(`Missing changelog archive page for ${edition.id}`);
+      }
+
+      let markup = pageMarkupByNumber.get(pageNumber);
+      if (!markup) {
+        markup = renderToStaticMarkup(
+          await ChangelogPage({
+            searchParams: Promise.resolve({ edition: edition.id }),
+          }),
+        );
+        pageMarkupByNumber.set(pageNumber, markup);
+      }
+
+      expect(markup).toContain(`id="edition-${edition.id}"`);
+      expect(markup).toContain(renderToStaticMarkup(<>{edition.title}</>));
+      expect(markup).toContain(renderToStaticMarkup(<>{edition.summary}</>));
+
+      for (const item of edition.items) {
+        const itemMarkup = extractChangelogItemMarkup(markup, item.id);
+        expect(itemMarkup).toContain(
+          item.kind === "feature" ? "Feature" : "Improvement",
+        );
+        expect(itemMarkup).toContain(renderToStaticMarkup(<>{item.title}</>));
+        expect(itemMarkup).toContain(renderToStaticMarkup(<>{item.summary}</>));
+        if (item.details) {
+          expect(itemMarkup).toContain(
+            renderToStaticMarkup(<>{item.details}</>),
+          );
+        }
+        if (item.tryIt) {
+          expect(itemMarkup).toContain(
+            renderToStaticMarkup(<>{item.tryIt.label}</>),
+          );
+          if (item.tryIt.href) {
+            expect(itemMarkup).toContain(`href="${item.tryIt.href}"`);
+          }
+        }
+      }
+    }
+
+    const promptRequests = mocks.resolveHostedMurphContactOptions.mock.calls.map(
+      ([input]) => input.message,
+    );
+    const expectedPromptRequests = fragmentEditions.flatMap((edition) =>
+      edition.items.flatMap((item) =>
+        item.tryIt?.prompt
+          ? [{ body: item.tryIt.prompt, subject: `Try it: ${item.title}` }]
+          : [],
+      ),
+    );
+    expect(promptRequests).toEqual(
+      expect.arrayContaining(expectedPromptRequests),
+    );
   });
 
   it("renders the new try-it controls with their exact prompts", async () => {


### PR DESCRIPTION
## Why and outcome

Vercel intentionally ignores non-production hosted-Web deployments, but the completion workflow previously required current-branch design proof even when a PR's only user-facing Web delta was authored changelog JSON. That left no truthful preview URL for content-only changelog work.

This change documents a narrow no-preview route for content-only changelog entries and optional edition metadata. It reuses the production archive study for unchanged presentation and adds production-component server-render coverage for every authored fragment's visible copy and try-it affordance. Changelog renderer, component, style, visual, and interaction changes still require normal current-branch proof.

Closes #2252

## Product UX

Not applicable. This changes developer review workflow and regression proof only; it does not change member-facing product behavior or presentation.

## Evidence

- `pnpm --dir apps/web test -- changelog-page.test.tsx` — 9 tests passed, including every authored fragment through the production archive.
- `pnpm test:frontend-design-proof` — 12 tests passed.
- `pnpm docs:drift` — passed.
- `pnpm --dir apps/web typecheck` — passed after Health Commons and Prisma generation.
- `git diff --check` and the public-data/privacy scan passed.
- The documented production archive study returned HTTP 200.

## Non-obvious affected surfaces

- Completion workflow design-proof policy: gains one content-only changelog exception, while renderer and UI changes remain on the existing current-branch route.
- Changelog regression proof: the focused page suite now renders every authored fragment through the production archive component and checks visible copy and try-it affordances.
- Vercel project policy: unchanged; non-production deployments remain intentionally ignored.

## Architecture and reuse

- Existing systems reused: the fragment loader, production `ChangelogPage`, production `ChangelogEditionSection`, synthetic archive study, and current design-proof guard remain the owners.
- New logic: one focused test enumerates authored fragment editions and verifies their production-rendered content and try-it affordances.
- New abstractions: none; the proof uses existing loaders, route resolution, and render helpers.
- Complexity intentionally avoided: no Vercel policy change, selective preview script, new deployment path, duplicate study, or parallel changelog authority.

## Hot reply path impact

Not applicable. The diff does not change the Foreground Reply Critical Path or add any runtime database, network, provider, or awaited operation.

## Murph initial provider input impact

Not applicable for both individual and group Murph runtimes. No prompt, instruction assembly, tool schema, generated guidance, or other provider-visible input changes.

## Preliminary specialist lenses

- Product UX: not applicable; no product-owned journey or member-visible behavior changes.
- Prompt: not applicable; no prompt or instruction stack consumed by Murph changes.
- Frontend: not applicable; no production UI source, styling, interaction, or responsive behavior changes.
- Coverage: applicable; the PR adds direct production-component proof for content-only changelog entries.

ReviewGPT context sensitivity: routine
Classification reason: The diff is limited to developer workflow documentation and focused test coverage; it changes no production runtime or deploy configuration.
ReviewGPT first-reviewed head: a2763992a34c6045fc1f47d491933321fb3d27a7

## Deployment concerns

- Deployment: not applicable
- Reason: Documentation and regression-test changes do not alter a runtime deployment boundary or Vercel project configuration.

## Change-shape breakdown

Classification is by primary purpose: the four Markdown files are docs and the TSX Vitest file is tests/fixtures. No source, config/tooling, generated, binary, or dependency changes are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 67 | 0 |
| Docs | 31 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **98** | **4** |

## Changelog

- Changelog: not applicable
- Reason: This is an internal developer review workflow and test-proof correction with no new member-visible outcome.
