### PR TITLE
fix(web): generate Prisma before focused Vitest

### DIFF
--- a/apps/web/test/run-hosted-web-vitest.test.ts
+++ b/apps/web/test/run-hosted-web-vitest.test.ts
@@ -7,11 +7,46 @@ import {
   buildHostedWebVitestArgs,
   resolveHostedWebVitestProject,
 } from "../scripts/run-hosted-web-vitest.mjs";
+import {
+  createHostedWebVitestConfig,
+  hostedWebVitestProjects,
+} from "../vitest.workspace";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const webTestFile = "imessage-nutrition-card-image.test.tsx";
 
 describe("hosted Web Vitest entrypoint", () => {
+  it("generates a missing Prisma client before returning Web test projects", () => {
+    const events: string[] = [];
+
+    const config = createHostedWebVitestConfig(
+      () => {
+        events.push("probe");
+        return false;
+      },
+      () => {
+        events.push("generate");
+      },
+    );
+    events.push("config-returned");
+
+    expect(events).toEqual(["probe", "generate", "config-returned"]);
+    expect(config.test.projects).toBe(hostedWebVitestProjects);
+  });
+
+  it("reuses an already resolvable Prisma client", () => {
+    let generated = false;
+
+    createHostedWebVitestConfig(
+      () => true,
+      () => {
+        generated = true;
+      },
+    );
+
+    expect(generated).toBe(false);
+  });
+
   it.each([
     webTestFile,
     `test/${webTestFile}`,

--- a/apps/web/vitest.workspace.ts
+++ b/apps/web/vitest.workspace.ts
@@ -1,4 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import path from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { defineConfig, defineProject } from "vitest/config";
@@ -18,6 +21,7 @@ import { hostedWebVitestProjectSpecs } from "./vitest-project-specs.mjs";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appDir, "../..");
+const requireFromHere = createRequire(import.meta.url);
 const hostedWebVitestConcurrency = resolveMurphVitestConcurrency();
 const hostedWebVitestMaxWorkers = resolveMurphAppVitestMaxWorkers();
 const hostedWebAliases = [
@@ -55,10 +59,51 @@ export const hostedWebVitestProjects = hostedWebVitestProjectSpecs.map(
   ({ fileNames, name }) => createHostedWebProject(name, fileNames),
 );
 
-export default defineConfig({
-  test: {
-    ...murphVitestNoTimeouts,
-    maxWorkers: hostedWebVitestMaxWorkers,
-    projects: hostedWebVitestProjects,
-  },
-});
+function isHostedWebPrismaClientGenerated(): boolean {
+  try {
+    const prismaClientPackageJsonPath = requireFromHere.resolve(
+      "@prisma/client/package.json",
+      { paths: [appDir] },
+    );
+    requireFromHere.resolve(".prisma/client/default", {
+      paths: [path.dirname(prismaClientPackageJsonPath)],
+    });
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "MODULE_NOT_FOUND") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function generateHostedWebPrismaClient(): void {
+  execFileSync(
+    process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    ["--dir", "apps/web", "prisma:generate"],
+    {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+}
+
+export function createHostedWebVitestConfig(
+  isPrismaClientGenerated: () => boolean = isHostedWebPrismaClientGenerated,
+  generatePrismaClient: () => void = generateHostedWebPrismaClient,
+) {
+  if (!isPrismaClientGenerated()) {
+    generatePrismaClient();
+  }
+
+  return {
+    test: {
+      ...murphVitestNoTimeouts,
+      maxWorkers: hostedWebVitestMaxWorkers,
+      projects: hostedWebVitestProjects,
+    },
+  };
+}
+
+export default defineConfig(() => createHostedWebVitestConfig());


### PR DESCRIPTION
## Why this PR exists

Focused hosted-Web Vitest runs in a newly created worktree failed before test collection because the generated Prisma client was an undeclared prerequisite. This change makes the hosted-Web Vitest configuration ensure that client exists before it returns projects, so the documented focused command works immediately after a frozen install.

Frog autofix issue: #2167

## User goal / user-visible behavior

Developers can run a focused hosted-Web Vitest file in a fresh sanctioned worktree without first discovering and running Web typecheck as an unrelated setup step.

## Product UX

Product UX does not apply because this changes developer verification configuration and its regression tests only; no member-facing journey, copy, state, or interaction changes.

## User experience

The focused test entrypoint now generates Prisma only when Node cannot resolve the generated client. Existing generated clients are reused without extra work.

## Invariants

- The generated-client probe uses Node's normal module-resolution contract from the installed `@prisma/client` package.
- Generation delegates to the existing `apps/web` `prisma:generate` script.
- Any probe error other than an absent module still fails closed.
- Production Web runtime behavior is unchanged.

## Evidence

- A fresh-worktree focused run began with no generated Prisma client, generated it through the configuration hook, and passed all 51 tests in `hosted-ops-growth.test.ts`.
- The focused configuration regression suite passed all 12 tests, including generation-before-return and reuse-without-generation cases.
- Web typecheck passed.
- `git diff --check`, touched-file ESLint, and the prepared app-level focused wrapper passed.

## Non-obvious affected surfaces

- Hosted-Web Vitest configuration initialization now has one conditional synchronous setup effect before project discovery. The missing-client path is covered by the focused regression test and the real fresh-worktree run; the already-generated path is covered by the reuse regression test.
- No production behavior, state owner, provider, database schema, dependency manifest, or deployment surface changes.

## Architecture and reuse

- **Existing systems reused:** the existing `apps/web prisma:generate` package script, pnpm workspace invocation, and Node module resolution.
- **New logic:** a narrow resolvability probe runs generation only for `MODULE_NOT_FOUND`, before hosted-Web projects are returned.
- **New abstractions:** one exported config factory accepts probe and generation functions so ordering and the no-op path can be tested without spawning Prisma in unit tests.
- **Complexity intentionally avoided:** no new dependency, generated artifact, lockfile change, global setup layer, or second Prisma command owner was added.

## Hot reply path impact

Not applicable. The change affects only the hosted-Web Vitest configuration and tests, not the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool schema, generated guidance, or provider-input assembly surface changed.
- Codex runtime: Not applicable; no prompt, instruction, tool schema, generated guidance, or provider-input assembly surface changed.

## Preliminary specialist lenses

- Product UX: not applicable — no product-owned journey or visible behavior changes.
- Prompt: not applicable — no prompt or instruction surface changes.
- Frontend: not applicable — no rendered UI changes.
- Coverage: applicable — executable test configuration and direct-proof scaffolding change.

## Verification

- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-ops-growth.test.ts` — 51 passed from a missing-client start.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/run-hosted-web-vitest.test.ts` — 12 passed.
- `pnpm --dir apps/web typecheck` — passed.
- Repository-wide `pnpm typecheck` — queued behind the shared host-verification slot.

## Change shape

Classification is by file purpose in the base-to-head authored diff; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 35 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 52 | 7 |
| Generated/other | 0 | 0 |
| **Total** | **87** | **7** |

## Deployment concerns

- Deployment: not applicable
- Reason: the diff affects local Vitest setup and regression coverage only; it does not change a deployed artifact or runtime contract.

## Changelog

- Changelog: not applicable
- Reason: this is an internal developer-verification reliability fix with no member-visible behavior.

ReviewGPT context sensitivity: routine

ReviewGPT first-reviewed head: b6ef443e20622877f7faf5e80df184d19e98810b
