### PR TITLE
Fix hosted web prebuilt workflow triggers

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-prebuilt-workflow-trigger-boundary.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-prebuilt-workflow-trigger-boundary.md
@@ -1,0 +1,55 @@
+Goal (incl. success criteria):
+- Fix Frog issue #2149 by making the supported local hosted-web prebuilt deployment preserve the Workflow SDK's exact queue-consumer triggers in the final Vercel Build Output function metadata.
+- Success means linked or deduplicated Step and Flow routes resolve to valid final function configs containing their SDK-generated triggers, invalid evidence blocks upload, focused proof and exact-head review gates pass, and the PR lands cleanly.
+
+Constraints/Assumptions:
+- Keep managed Vercel builds and application Workflow semantics unchanged.
+- Derive trigger values from the generated Workflow SDK config; do not duplicate SDK-owned topic or retry constants in production code.
+- Treat generated config, symlinks, and Build Output metadata as untrusted local build evidence and fail closed before upload when the proof is missing, malformed, escaping, ambiguous, or conflicting.
+- Preserve unrelated existing function triggers and support both distinct and shared final functions.
+- Keep secrets, deployment credentials, network behavior, and production state out of the change.
+
+Key decisions:
+- Repair the repository-owned local `vercel build` / `vercel deploy --prebuilt` boundary instead of changing managed builds or Workflow application routes.
+- Capture the exact generated SDK config just before the existing cleanup removes generated source artifacts, then remove the capture before upload.
+- Resolve final function targets through the Build Output route links and merge exact triggers idempotently into each owning `.vc-config.json`.
+- Validate every target before the first write and revalidate the finished artifact before starting the upload.
+
+State:
+- Completed; implementation, focused and broad local proof, scoped candidate commit, and final candidate/privacy review are complete.
+
+Done:
+- Proved the root cause at the final Build Output packaging seam: both generated Workflow routes can link to one shared function whose final metadata omits the SDK-generated queue triggers.
+- Confirmed the SDK generates the exact Step and Flow `queue/v2beta` trigger definitions before cleanup.
+- Recovered and applied the exact single ReviewGPT implementation artifact after validating its response marker, artifact identity, paths, privacy, scope, and clean applicability.
+- Added the prebuilt deployment wrapper, SDK-config capture boundary, focused synthetic coverage, package entrypoint, and hosted-web documentation.
+- Passed the focused Vitest suite: 2 files and 11 tests.
+- Passed the repository TypeScript tools check.
+- Passed package JSON parsing, patch parity, privacy/scope scans, and `git diff --check`.
+- Passed the diff-aware verifier, including 45 repository-tools files and 695 tests; all hosted, dependency, workspace-boundary, and cycle guards; the hosted-web TypeScript check; 850 hosted-web test files and 11,609 tests; lint with zero errors; dev smoke; and the production Next build.
+- Confirmed the final candidate contains exactly the six ReviewGPT-authored implementation files, uses the approved no-reply Git identity, and contains no private identifiers or unrelated tracked output.
+- Created and pushed the scoped implementation candidate commit.
+
+Now:
+- Archive this plan through the required scoped completion helper.
+
+Next:
+- Open the Draft PR, start preliminary and final exact-head ReviewGPT gates concurrently with CI after lane assignment, remediate accepted findings, complete the parent final review, and merge only after stable green exact-head proof.
+
+Open questions (UNCONFIRMED if needed):
+- None.
+
+Working set (files/ids/commands):
+- `apps/web/README.md`
+- `apps/web/package.json`
+- `scripts/clean-hosted-web-workflow-artifacts.ts`
+- `scripts/clean-hosted-web-workflow-artifacts.test.ts`
+- `scripts/deploy-hosted-web-vercel-prebuilt.ts`
+- `scripts/deploy-hosted-web-vercel-prebuilt.test.ts`
+- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/clean-hosted-web-workflow-artifacts.test.ts scripts/deploy-hosted-web-vercel-prebuilt.test.ts`
+- `node scripts/run-typescript.mjs package -p tsconfig.tools.json --pretty false`
+- `pnpm test:diff apps/web/README.md apps/web/package.json scripts/clean-hosted-web-workflow-artifacts.ts scripts/clean-hosted-web-workflow-artifacts.test.ts scripts/deploy-hosted-web-vercel-prebuilt.ts scripts/deploy-hosted-web-vercel-prebuilt.test.ts`
+Status: completed
+Updated: 2026-08-25
+Completed: 2026-08-25
+Completed: 2026-08-25

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1870,6 +1870,25 @@ This branch is a greenfield hosted-runtime cutover. If you have an older local
 database from the superseded run/ingress/cursor chain, reset it before
 reapplying migrations.
 
+## Local Vercel prebuilt deployment
+
+Use the repository-owned local prebuilt boundary instead of running a bare
+`vercel build` followed by `vercel deploy --prebuilt`:
+
+```bash
+pnpm --dir apps/web vercel:deploy:prebuilt -- --prod
+```
+
+Omit `--prod` for a preview deployment. The command runs `vercel build`,
+captures the SDK-generated Workflow function config in an ephemeral local file
+before the normal generated-source cleanup, and applies every exact generated
+trigger to the resolved final function bundle. It handles distinct functions
+and Next.js-deduplicated route links, revalidates the finished Build Output
+artifact, removes the captured evidence, and starts `vercel deploy --prebuilt`
+only after that proof succeeds. Missing, malformed, escaping, or conflicting
+evidence stops before upload. Managed Vercel builds continue to use the
+checked-in `vercel.json` build command and do not use this local boundary.
+
 ## Local dev aids
 
 Dev-only helpers for iterating on UI. All guarded by `process.env.NODE_ENV !== "production"` and removed from the production bundle.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "dev:prepared-local-env": "bash -c 'pnpm changelog:generate && pnpm --dir ../.. exec tsx apps/web/scripts/dev-local.ts \"$@\"' --",
     "prebuild": "pnpm --dir ../../packages/runtime-state build",
     "build": "pnpm public-routes:waf-check && pnpm product-labels:env-check && pnpm hosted-crypto:env-check && pnpm legal:pdf && pnpm changelog:generate && pnpm health-commons:generate && pnpm prisma:generate:build && pnpm typecheck:prepared && bash scripts/run-production-next-build.sh && pnpm --dir ../.. workflow:clean-web-artifacts -- --quiet && pnpm health-commons:trace-check && pnpm og-assets:trace-check && pnpm og-assets:runtime-check",
+    "vercel:deploy:prebuilt": "pnpm --dir ../.. exec tsx --tsconfig tsconfig.base.json scripts/deploy-hosted-web-vercel-prebuilt.ts",
     "changelog:generate": "pnpm --dir ../.. exec tsx apps/web/scripts/generate-changelog-fragments.ts",
     "health-commons:generate": "pnpm --dir ../.. health-commons:generate",
     "health-commons:trace-check": "pnpm --dir ../.. exec tsx apps/web/scripts/check-health-commons-traces.ts",

--- a/scripts/clean-hosted-web-workflow-artifacts.test.ts
+++ b/scripts/clean-hosted-web-workflow-artifacts.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   cleanHostedWebWorkflowGeneratedArtifacts,
-  HOSTED_WEB_WORKFLOW_GENERATED_CACHE_PATHS,
   HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR,
+  HOSTED_WEB_WORKFLOW_GENERATED_CACHE_PATHS,
+  HOSTED_WEB_WORKFLOW_GENERATED_CONFIG_PATH,
+  HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
 } from "./clean-hosted-web-workflow-artifacts.js";
 
 describe("cleanHostedWebWorkflowGeneratedArtifacts", () => {
@@ -66,6 +68,47 @@ describe("cleanHostedWebWorkflowGeneratedArtifacts", () => {
       await expect(readFile(unrelatedMap, "utf8")).resolves.toContain("src/index.ts");
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("captures the exact SDK config before removing generated Workflow source", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "hosted-web-workflow-prebuilt-source-"),
+    );
+    const captureRoot = await mkdtemp(
+      path.join(os.tmpdir(), "hosted-web-workflow-prebuilt-capture-"),
+    );
+    const generatedConfigPath = path.join(
+      tempRoot,
+      HOSTED_WEB_WORKFLOW_GENERATED_CONFIG_PATH,
+    );
+    const capturePath = path.join(
+      captureRoot,
+      HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+    );
+    const generatedConfig = `${JSON.stringify({
+      steps: { experimentalTriggers: [{ type: "queue/v2beta" }] },
+      version: "0",
+      workflows: { experimentalTriggers: [{ type: "queue/v2beta" }] },
+    }, null, 2)}\n`;
+
+    try {
+      await mkdir(path.dirname(generatedConfigPath), { recursive: true });
+      await writeFile(generatedConfigPath, generatedConfig, "utf8");
+
+      const removedPaths = await cleanHostedWebWorkflowGeneratedArtifacts({
+        prebuiltConfigCapturePath: capturePath,
+        repoRoot: tempRoot,
+      });
+
+      expect(removedPaths).toContain(HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR);
+      await expect(readFile(capturePath, "utf8")).resolves.toBe(generatedConfig);
+      await expect(readFile(generatedConfigPath, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+      await rm(captureRoot, { force: true, recursive: true });
     }
   });
 });

--- a/scripts/clean-hosted-web-workflow-artifacts.ts
+++ b/scripts/clean-hosted-web-workflow-artifacts.ts
@@ -1,4 +1,6 @@
-import { lstat, readdir, readFile, rm } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { copyFile, lstat, readdir, readFile, realpath, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,6 +8,12 @@ const defaultRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)
 
 export const HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR =
   "apps/web/app/.well-known/workflow";
+export const HOSTED_WEB_WORKFLOW_GENERATED_CONFIG_PATH =
+  `${HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR}/v1/config.json`;
+export const HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV =
+  "MURPH_HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_PATH";
+export const HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME =
+  "workflow-config.json";
 export const HOSTED_WEB_WORKFLOW_GENERATED_CACHE_PATHS = [
   "apps/web/.next/cache/workflow-generated-manifest",
   "apps/web/.next/cache/workflow-socket.json",
@@ -19,12 +27,24 @@ const workflowGeneratedSourceMarkers = [
 ] as const;
 
 export async function cleanHostedWebWorkflowGeneratedArtifacts(input: {
+  prebuiltConfigCapturePath?: string;
   repoRoot?: string;
 } = {}): Promise<string[]> {
   const repoRoot = input.repoRoot ?? defaultRepoRoot;
   const removedPaths: string[] = [];
 
-  await removeIfPresent(repoRoot, HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR, removedPaths);
+  if (input.prebuiltConfigCapturePath) {
+    await capturePrebuiltWorkflowConfig(
+      repoRoot,
+      input.prebuiltConfigCapturePath,
+    );
+  }
+
+  await removeIfPresent(
+    repoRoot,
+    HOSTED_WEB_WORKFLOW_GENERATED_ARTIFACT_DIR,
+    removedPaths,
+  );
 
   for (const relativePath of HOSTED_WEB_WORKFLOW_GENERATED_CACHE_PATHS) {
     await removeIfPresent(repoRoot, relativePath, removedPaths);
@@ -33,6 +53,96 @@ export async function cleanHostedWebWorkflowGeneratedArtifacts(input: {
   await removeWorkflowGeneratedSourceMaps(repoRoot, removedPaths);
 
   return removedPaths.sort();
+}
+
+async function capturePrebuiltWorkflowConfig(
+  repoRoot: string,
+  capturePath: string,
+): Promise<void> {
+  if (
+    !path.isAbsolute(capturePath) ||
+    path.basename(capturePath) !==
+      HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME
+  ) {
+    throw new Error(
+      "Workflow SDK config capture must use the local prebuilt temporary file.",
+    );
+  }
+
+  const sourcePath = path.join(
+    repoRoot,
+    HOSTED_WEB_WORKFLOW_GENERATED_CONFIG_PATH,
+  );
+  let sourceStats;
+  try {
+    sourceStats = await lstat(sourcePath);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      throw new Error(
+        "Workflow SDK config is missing at the local prebuilt capture boundary.",
+      );
+    }
+    throw new Error(
+      "Unable to inspect the Workflow SDK config at the local prebuilt capture boundary.",
+    );
+  }
+  if (!sourceStats.isFile()) {
+    throw new Error(
+      "Workflow SDK config must be a regular file at the local prebuilt capture boundary.",
+    );
+  }
+
+  const resolvedRepoRoot = await realpath(repoRoot);
+  const resolvedSourcePath = await realpath(sourcePath);
+  assertPathWithin(
+    resolvedRepoRoot,
+    resolvedSourcePath,
+    "Workflow SDK config",
+  );
+
+  const captureDirectory = path.dirname(capturePath);
+  let captureDirectoryStats;
+  try {
+    captureDirectoryStats = await lstat(captureDirectory);
+  } catch {
+    throw new Error(
+      "Local prebuilt Workflow config capture directory is unavailable.",
+    );
+  }
+  if (!captureDirectoryStats.isDirectory()) {
+    throw new Error(
+      "Local prebuilt Workflow config capture directory must be a regular directory.",
+    );
+  }
+
+  const resolvedTemporaryRoot = await realpath(os.tmpdir());
+  const resolvedCaptureDirectory = await realpath(captureDirectory);
+  assertPathWithin(
+    resolvedTemporaryRoot,
+    resolvedCaptureDirectory,
+    "Local prebuilt Workflow config capture directory",
+  );
+  const resolvedCapturePath = path.join(
+    resolvedCaptureDirectory,
+    HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+  );
+
+  try {
+    await copyFile(
+      resolvedSourcePath,
+      resolvedCapturePath,
+      fsConstants.COPYFILE_EXCL,
+    );
+  } catch (error) {
+    if (isFileExistsError(error)) {
+      throw new Error(
+        "A stale Workflow SDK config capture blocks the local prebuilt build.",
+      );
+    }
+    throw new Error(
+      "Unable to capture the Workflow SDK config for the local prebuilt build.",
+    );
+  }
 }
 
 async function removeIfPresent(
@@ -112,6 +222,30 @@ async function listFiles(root: string): Promise<string[]> {
   return files.flat();
 }
 
+function assertPathWithin(
+  rootPath: string,
+  candidatePath: string,
+  label: string,
+): void {
+  const relativePath = path.relative(rootPath, candidatePath);
+  if (
+    relativePath === "" ||
+    (!path.isAbsolute(relativePath) &&
+      relativePath !== ".." &&
+      !relativePath.startsWith(`..${path.sep}`))
+  ) {
+    return;
+  }
+  throw new Error(`${label} resolves outside its allowed boundary.`);
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EEXIST";
+}
+
 function isMissingFileError(error: unknown): boolean {
   return typeof error === "object" &&
     error !== null &&
@@ -121,7 +255,10 @@ function isMissingFileError(error: unknown): boolean {
 
 export async function main(): Promise<void> {
   const quiet = process.argv.includes("--quiet");
-  const removedPaths = await cleanHostedWebWorkflowGeneratedArtifacts();
+  const removedPaths = await cleanHostedWebWorkflowGeneratedArtifacts({
+    prebuiltConfigCapturePath:
+      process.env[HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV],
+  });
 
   if (quiet) {
     return;

--- a/scripts/deploy-hosted-web-vercel-prebuilt.test.ts
+++ b/scripts/deploy-hosted-web-vercel-prebuilt.test.ts
@@ -1,0 +1,441 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV,
+  HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+} from "./clean-hosted-web-workflow-artifacts.js";
+import {
+  deployHostedWebVercelPrebuilt,
+  ensureHostedWebVercelPrebuiltWorkflowTriggers,
+} from "./deploy-hosted-web-vercel-prebuilt.js";
+
+const STEP_TRIGGER = {
+  consumer: "default",
+  initialDelaySeconds: 0,
+  retryAfterSeconds: 5,
+  topic: "__wkf_step_*",
+  type: "queue/v2beta",
+};
+const FLOW_TRIGGER = {
+  consumer: "default",
+  initialDelaySeconds: 0,
+  retryAfterSeconds: 5,
+  topic: "__wkf_workflow_*",
+  type: "queue/v2beta",
+};
+const SDK_CONFIG = {
+  steps: {
+    experimentalTriggers: [STEP_TRIGGER],
+    maxDuration: "max",
+  },
+  version: "0",
+  workflows: {
+    experimentalTriggers: [FLOW_TRIGGER],
+    maxDuration: "max",
+  },
+};
+
+type Fixture = {
+  functionsDir: string;
+  outputDir: string;
+  root: string;
+  sdkConfigPath: string;
+};
+
+describe("ensureHostedWebVercelPrebuiltWorkflowTriggers", () => {
+  it("repairs one shared final function with every exact SDK-generated trigger", async () => {
+    await withFixture(async (fixture) => {
+      const sharedFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_shared.func",
+        { runtime: "nodejs22.x" },
+      );
+      await linkWorkflowRoute(fixture, "step", sharedFunctionDir);
+      await linkWorkflowRoute(fixture, "flow", sharedFunctionDir);
+
+      await ensureHostedWebVercelPrebuiltWorkflowTriggers({
+        outputDir: fixture.outputDir,
+        sdkConfigPath: fixture.sdkConfigPath,
+      });
+
+      await expect(readFunctionConfig(sharedFunctionDir)).resolves.toEqual({
+        experimentalTriggers: [STEP_TRIGGER, FLOW_TRIGGER],
+        runtime: "nodejs22.x",
+      });
+    });
+  });
+
+  it("repairs distinct final functions without assigning a second route's trigger", async () => {
+    await withFixture(async (fixture) => {
+      const unrelatedTrigger = {
+        consumer: "other",
+        topic: "unrelated",
+        type: "queue/v2beta",
+      };
+      const stepFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_step.func",
+        { experimentalTriggers: [unrelatedTrigger] },
+      );
+      const flowFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_flow.func",
+        {},
+      );
+      await linkWorkflowRoute(fixture, "step", stepFunctionDir);
+      await linkWorkflowRoute(fixture, "flow", flowFunctionDir);
+
+      await ensureHostedWebVercelPrebuiltWorkflowTriggers({
+        outputDir: fixture.outputDir,
+        sdkConfigPath: fixture.sdkConfigPath,
+      });
+
+      await expect(readFunctionConfig(stepFunctionDir)).resolves.toEqual({
+        experimentalTriggers: [unrelatedTrigger, STEP_TRIGGER],
+      });
+      await expect(readFunctionConfig(flowFunctionDir)).resolves.toEqual({
+        experimentalTriggers: [FLOW_TRIGGER],
+      });
+    });
+  });
+
+  it("is byte-for-byte idempotent after the artifact is valid", async () => {
+    await withFixture(async (fixture) => {
+      const sharedFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_shared.func",
+        {},
+      );
+      await linkWorkflowRoute(fixture, "step", sharedFunctionDir);
+      await linkWorkflowRoute(fixture, "flow", sharedFunctionDir);
+
+      await ensureHostedWebVercelPrebuiltWorkflowTriggers({
+        outputDir: fixture.outputDir,
+        sdkConfigPath: fixture.sdkConfigPath,
+      });
+      const configPath = path.join(sharedFunctionDir, ".vc-config.json");
+      const firstContents = await readFile(configPath, "utf8");
+
+      await ensureHostedWebVercelPrebuiltWorkflowTriggers({
+        outputDir: fixture.outputDir,
+        sdkConfigPath: fixture.sdkConfigPath,
+      });
+
+      await expect(readFile(configPath, "utf8")).resolves.toBe(firstContents);
+    });
+  });
+
+  it("rejects missing or malformed SDK trigger evidence", async () => {
+    await withFixture(async (fixture) => {
+      const sharedFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_shared.func",
+        {},
+      );
+      await linkWorkflowRoute(fixture, "step", sharedFunctionDir);
+      await linkWorkflowRoute(fixture, "flow", sharedFunctionDir);
+
+      await rm(fixture.sdkConfigPath, { force: true });
+      await expect(
+        ensureHostedWebVercelPrebuiltWorkflowTriggers({
+          outputDir: fixture.outputDir,
+          sdkConfigPath: fixture.sdkConfigPath,
+        }),
+      ).rejects.toThrow("captured Workflow SDK config is missing");
+
+      await writeJson(fixture.sdkConfigPath, {
+        ...SDK_CONFIG,
+        workflows: {
+          experimentalTriggers: [
+            { ...FLOW_TRIGGER, type: "queue/v1" },
+          ],
+        },
+      });
+      await expect(
+        ensureHostedWebVercelPrebuiltWorkflowTriggers({
+          outputDir: fixture.outputDir,
+          sdkConfigPath: fixture.sdkConfigPath,
+        }),
+      ).rejects.toThrow("is not a valid queue/v2beta trigger");
+    });
+  });
+
+  it("validates every distinct final function before writing any of them", async () => {
+    await withFixture(async (fixture) => {
+      const stepFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_step.func",
+        { runtime: "nodejs22.x" },
+      );
+      const flowFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_flow.func",
+        {},
+      );
+      await writeFile(
+        path.join(flowFunctionDir, ".vc-config.json"),
+        "not-json",
+        "utf8",
+      );
+      await linkWorkflowRoute(fixture, "step", stepFunctionDir);
+      await linkWorkflowRoute(fixture, "flow", flowFunctionDir);
+      const stepConfigPath = path.join(stepFunctionDir, ".vc-config.json");
+      const originalStepConfig = await readFile(stepConfigPath, "utf8");
+
+      await expect(
+        ensureHostedWebVercelPrebuiltWorkflowTriggers({
+          outputDir: fixture.outputDir,
+          sdkConfigPath: fixture.sdkConfigPath,
+        }),
+      ).rejects.toThrow("is not valid JSON");
+      await expect(readFile(stepConfigPath, "utf8")).resolves.toBe(
+        originalStepConfig,
+      );
+    });
+  });
+
+  it("rejects route links that escape the Vercel functions boundary", async () => {
+    await withFixture(async (fixture) => {
+      const outsideFunctionDir = path.join(fixture.root, "outside.func");
+      await mkdir(outsideFunctionDir, { recursive: true });
+      await writeJson(path.join(outsideFunctionDir, ".vc-config.json"), {});
+      await linkWorkflowRoute(fixture, "step", outsideFunctionDir);
+      const flowFunctionDir = await createFunctionTarget(
+        fixture,
+        "__next_flow.func",
+        {},
+      );
+      await linkWorkflowRoute(fixture, "flow", flowFunctionDir);
+
+      await expect(
+        ensureHostedWebVercelPrebuiltWorkflowTriggers({
+          outputDir: fixture.outputDir,
+          sdkConfigPath: fixture.sdkConfigPath,
+        }),
+      ).rejects.toThrow("resolves outside its allowed local build boundary");
+    });
+  });
+
+  it(
+    "rejects an existing trigger with the same queue identity but different SDK fields",
+    async () => {
+      await withFixture(async (fixture) => {
+        const sharedFunctionDir = await createFunctionTarget(
+          fixture,
+          "__next_shared.func",
+          {
+            experimentalTriggers: [
+              STEP_TRIGGER,
+              { ...STEP_TRIGGER, retryAfterSeconds: 60 },
+            ],
+          },
+        );
+        await linkWorkflowRoute(fixture, "step", sharedFunctionDir);
+        await linkWorkflowRoute(fixture, "flow", sharedFunctionDir);
+
+        await expect(
+          ensureHostedWebVercelPrebuiltWorkflowTriggers({
+            outputDir: fixture.outputDir,
+            sdkConfigPath: fixture.sdkConfigPath,
+          }),
+        ).rejects.toThrow("conflicting Workflow queue trigger");
+      });
+    },
+  );
+});
+
+describe("deployHostedWebVercelPrebuilt", () => {
+  it("repairs and verifies the artifact before starting the prebuilt upload", async () => {
+    const repoRoot = await mkdtemp(
+      path.join(os.tmpdir(), "hosted-web-vercel-prebuilt-command-"),
+    );
+    const invocations: string[][] = [];
+    let capturePath = "";
+    let sharedFunctionDir = "";
+
+    try {
+      await mkdir(path.join(repoRoot, "apps/web"), { recursive: true });
+
+      await deployHostedWebVercelPrebuilt({
+        commandRunner: async (invocation) => {
+          invocations.push(invocation.args);
+          if (invocation.args[0] === "build") {
+            capturePath = getPrebuiltCapturePath(invocation.env);
+            const outputDir = path.join(repoRoot, "apps/web/.vercel/output");
+            const functionsDir = path.join(outputDir, "functions");
+            sharedFunctionDir = path.join(functionsDir, "__next_shared.func");
+            await writeJson(capturePath, SDK_CONFIG);
+            await writeJson(path.join(outputDir, "config.json"), { version: 3 });
+            await writeJson(
+              path.join(sharedFunctionDir, ".vc-config.json"),
+              { runtime: "nodejs22.x" },
+            );
+            await linkRoutePath(
+              path.join(functionsDir, ".well-known/workflow/v1/step.func"),
+              sharedFunctionDir,
+            );
+            await linkRoutePath(
+              path.join(functionsDir, ".well-known/workflow/v1/flow.func"),
+              sharedFunctionDir,
+            );
+            return;
+          }
+
+          expect(
+            invocation.env[HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV],
+          ).toBe(undefined);
+          await expect(readFile(capturePath, "utf8")).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+          await expect(readFunctionConfig(sharedFunctionDir)).resolves.toEqual({
+            experimentalTriggers: [STEP_TRIGGER, FLOW_TRIGGER],
+            runtime: "nodejs22.x",
+          });
+        },
+        repoRoot,
+        vercelArgs: ["--prod"],
+      });
+
+      expect(invocations).toEqual([
+        ["build", "--prod"],
+        ["deploy", "--prebuilt", "--prod"],
+      ]);
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not start a prebuilt upload when artifact proof fails", async () => {
+    const repoRoot = await mkdtemp(
+      path.join(os.tmpdir(), "hosted-web-vercel-prebuilt-command-"),
+    );
+    const invocations: string[][] = [];
+    let capturePath = "";
+
+    try {
+      await mkdir(path.join(repoRoot, "apps/web"), { recursive: true });
+
+      await expect(
+        deployHostedWebVercelPrebuilt({
+          commandRunner: async (invocation) => {
+            invocations.push(invocation.args);
+            if (invocation.args[0] !== "build") {
+              return;
+            }
+
+            capturePath = getPrebuiltCapturePath(invocation.env);
+            const outputDir = path.join(repoRoot, "apps/web/.vercel/output");
+            const functionsDir = path.join(outputDir, "functions");
+            await writeJson(capturePath, SDK_CONFIG);
+            await writeJson(path.join(outputDir, "config.json"), { version: 3 });
+            const stepFunctionDir = path.join(functionsDir, "__next_step.func");
+            await writeJson(
+              path.join(stepFunctionDir, ".vc-config.json"),
+              {},
+            );
+            await linkRoutePath(
+              path.join(
+                functionsDir,
+                ".well-known/workflow/v1/step.func",
+              ),
+              stepFunctionDir,
+            );
+          },
+          repoRoot,
+        }),
+      ).rejects.toThrow("Workflow flow route function is missing");
+
+      expect(invocations).toEqual([["build"]]);
+      await expect(readFile(capturePath, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+function getPrebuiltCapturePath(env: NodeJS.ProcessEnv): string {
+  const capturePath =
+    env[HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV];
+  expect(typeof capturePath).toBe("string");
+  if (typeof capturePath !== "string") {
+    throw new Error("Expected the local prebuilt capture path.");
+  }
+  expect(path.basename(capturePath)).toBe(
+    HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+  );
+  return capturePath;
+}
+
+async function withFixture(run: (fixture: Fixture) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "hosted-web-vercel-prebuilt-"));
+  const outputDir = path.join(root, ".vercel/output");
+  const functionsDir = path.join(outputDir, "functions");
+  const sdkConfigPath = path.join(root, "workflow-config.json");
+
+  try {
+    await mkdir(functionsDir, { recursive: true });
+    await writeJson(path.join(outputDir, "config.json"), { version: 3 });
+    await writeJson(sdkConfigPath, SDK_CONFIG);
+    await run({ functionsDir, outputDir, root, sdkConfigPath });
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+async function createFunctionTarget(
+  fixture: Fixture,
+  name: string,
+  config: object,
+): Promise<string> {
+  const functionDir = path.join(fixture.functionsDir, name);
+  await writeJson(path.join(functionDir, ".vc-config.json"), config);
+  return functionDir;
+}
+
+async function linkWorkflowRoute(
+  fixture: Fixture,
+  routeSegment: "flow" | "step",
+  targetDirectory: string,
+): Promise<void> {
+  await linkRoutePath(
+    path.join(
+      fixture.functionsDir,
+      ".well-known/workflow/v1",
+      `${routeSegment}.func`,
+    ),
+    targetDirectory,
+  );
+}
+
+async function linkRoutePath(
+  routePath: string,
+  targetDirectory: string,
+): Promise<void> {
+  await mkdir(path.dirname(routePath), { recursive: true });
+  const relativeTarget = path.relative(path.dirname(routePath), targetDirectory);
+  await symlink(relativeTarget, routePath, "dir");
+}
+
+async function writeJson(filePath: string, value: object): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readFunctionConfig(functionDir: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(path.join(functionDir, ".vc-config.json"), "utf8"),
+  );
+}

--- a/scripts/deploy-hosted-web-vercel-prebuilt.ts
+++ b/scripts/deploy-hosted-web-vercel-prebuilt.ts
@@ -1,0 +1,571 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  lstat,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV,
+  HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+} from "./clean-hosted-web-workflow-artifacts.js";
+
+const defaultRepoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const HOSTED_WEB_APP_DIR = "apps/web";
+const MAX_JSON_FILE_BYTES = 1024 * 1024;
+const WORKFLOW_FUNCTIONS = [
+  { configKey: "steps", routeSegment: "step" },
+  { configKey: "workflows", routeSegment: "flow" },
+] as const;
+
+type JsonObject = Record<string, unknown>;
+type WorkflowTrigger = JsonObject & {
+  consumer: string;
+  initialDelaySeconds: number;
+  retryAfterSeconds: number;
+  topic: string;
+  type: "queue/v2beta";
+};
+type ExpectedRouteTriggers = {
+  routeSegment: string;
+  triggers: WorkflowTrigger[];
+};
+type FunctionGroup = {
+  expectedTriggers: WorkflowTrigger[];
+  functionConfigPath: string;
+};
+type FunctionConfigPlan = {
+  functionConfigPath: string;
+  updatedConfig: JsonObject | null;
+};
+type CommandInvocation = {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  label: string;
+};
+type CommandRunner = (invocation: CommandInvocation) => Promise<void>;
+
+export async function ensureHostedWebVercelPrebuiltWorkflowTriggers(input: {
+  outputDir: string;
+  sdkConfigPath: string;
+}): Promise<void> {
+  const sdkConfig = await readJsonObject(
+    input.sdkConfigPath,
+    "captured Workflow SDK config",
+  );
+  const expectedRoutes = parseExpectedRouteTriggers(sdkConfig);
+
+  const outputConfig = await readJsonObject(
+    path.join(input.outputDir, "config.json"),
+    "Vercel Build Output config",
+  );
+  if (outputConfig.version !== 3) {
+    throw new Error("Vercel Build Output config must declare version 3.");
+  }
+
+  const outputRoot = await resolveDirectory(
+    input.outputDir,
+    "Vercel Build Output directory",
+  );
+  const functionsRoot = await resolveDirectory(
+    path.join(input.outputDir, "functions"),
+    "Vercel functions directory",
+  );
+  assertPathWithin(outputRoot, functionsRoot, "Vercel functions directory");
+
+  const plans = await createFunctionConfigPlans({
+    expectedRoutes,
+    functionsRoot,
+  });
+  for (const plan of plans) {
+    if (plan.updatedConfig !== null) {
+      await writeJsonAtomically(plan.functionConfigPath, plan.updatedConfig);
+    }
+  }
+
+  const verificationPlans = await createFunctionConfigPlans({
+    expectedRoutes,
+    functionsRoot,
+  });
+  if (verificationPlans.some((plan) => plan.updatedConfig !== null)) {
+    throw new Error(
+      "Vercel prebuilt Workflow trigger validation failed after repairing the artifact.",
+    );
+  }
+}
+
+export async function deployHostedWebVercelPrebuilt(input: {
+  commandRunner?: CommandRunner;
+  repoRoot?: string;
+  vercelArgs?: string[];
+} = {}): Promise<void> {
+  const repoRoot = await resolveDirectory(
+    input.repoRoot ?? defaultRepoRoot,
+    "repository root",
+  );
+  const appDir = await resolveDirectory(
+    path.join(repoRoot, HOSTED_WEB_APP_DIR),
+    "Hosted Web application directory",
+  );
+  assertPathWithin(repoRoot, appDir, "Hosted Web application directory");
+
+  const outputDir = path.join(appDir, ".vercel/output");
+  const captureDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "hosted-web-workflow-prebuilt-"),
+  );
+  const sdkConfigPath = path.join(
+    captureDirectory,
+    HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_FILE_NAME,
+  );
+  const commandRunner = input.commandRunner ?? runCommand;
+  const vercelArgs = input.vercelArgs ?? [];
+
+  const buildEnv = {
+    ...process.env,
+    [HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV]: sdkConfigPath,
+  };
+  const deployEnv = { ...process.env };
+  delete deployEnv[HOSTED_WEB_WORKFLOW_PREBUILT_CONFIG_CAPTURE_ENV];
+
+  try {
+    await commandRunner({
+      args: ["build", ...vercelArgs],
+      command: "vercel",
+      cwd: appDir,
+      env: buildEnv,
+      label: "local Vercel prebuilt build",
+    });
+
+    const resolvedOutputDir = await resolveDirectory(
+      outputDir,
+      "Vercel Build Output directory",
+    );
+    assertPathWithin(appDir, resolvedOutputDir, "Vercel Build Output directory");
+    await ensureHostedWebVercelPrebuiltWorkflowTriggers({
+      outputDir: resolvedOutputDir,
+      sdkConfigPath,
+    });
+
+    // The SDK evidence is outside .vercel/output and must not outlive this proof.
+    // A cleanup failure blocks the upload rather than leaving ambiguous state.
+    await rm(sdkConfigPath, { force: true });
+
+    await commandRunner({
+      args: ["deploy", "--prebuilt", ...vercelArgs],
+      command: "vercel",
+      cwd: appDir,
+      env: deployEnv,
+      label: "Vercel prebuilt upload",
+    });
+  } finally {
+    await rm(captureDirectory, { force: true, recursive: true });
+  }
+}
+
+async function createFunctionConfigPlans(input: {
+  expectedRoutes: ExpectedRouteTriggers[];
+  functionsRoot: string;
+}): Promise<FunctionConfigPlan[]> {
+  const groups = await resolveFunctionGroups(input.functionsRoot, input.expectedRoutes);
+  const plans = await Promise.all(
+    [...groups.values()].map(async (group): Promise<FunctionConfigPlan> => {
+      const currentConfig = await readJsonObject(
+        group.functionConfigPath,
+        "resolved Vercel function .vc-config.json",
+      );
+      const currentTriggers = parseExistingTriggers(currentConfig);
+      const mergedTriggers = mergeRequiredWorkflowTriggers(
+        currentTriggers,
+        group.expectedTriggers,
+        "Resolved Vercel function contains a conflicting Workflow queue trigger.",
+      );
+
+      return {
+        functionConfigPath: group.functionConfigPath,
+        updatedConfig: mergedTriggers.length === currentTriggers.length
+          ? null
+          : {
+              ...currentConfig,
+              experimentalTriggers: mergedTriggers,
+            },
+      };
+    }),
+  );
+
+  return plans.sort((left, right) =>
+    left.functionConfigPath.localeCompare(right.functionConfigPath)
+  );
+}
+
+async function resolveFunctionGroups(
+  functionsRoot: string,
+  expectedRoutes: ExpectedRouteTriggers[],
+): Promise<Map<string, FunctionGroup>> {
+  const resolvedRoutes = await Promise.all(
+    expectedRoutes.map(async (route) => ({
+      route,
+      functionConfigPath: await resolveRouteFunctionConfig(
+        functionsRoot,
+        route.routeSegment,
+      ),
+    })),
+  );
+  const groups = new Map<string, FunctionGroup>();
+
+  for (const resolvedRoute of resolvedRoutes) {
+    const existingGroup = groups.get(resolvedRoute.functionConfigPath);
+    if (!existingGroup) {
+      groups.set(resolvedRoute.functionConfigPath, {
+        expectedTriggers: [...resolvedRoute.route.triggers],
+        functionConfigPath: resolvedRoute.functionConfigPath,
+      });
+      continue;
+    }
+
+    existingGroup.expectedTriggers = mergeRequiredWorkflowTriggers(
+      existingGroup.expectedTriggers,
+      resolvedRoute.route.triggers,
+      "Captured Workflow SDK config contains conflicting queue triggers " +
+        "for one final function.",
+    );
+  }
+
+  return groups;
+}
+
+async function resolveRouteFunctionConfig(
+  functionsRoot: string,
+  routeSegment: string,
+): Promise<string> {
+  const routeFunctionDir = await resolveDirectory(
+    path.join(
+      functionsRoot,
+      ".well-known",
+      "workflow",
+      "v1",
+      `${routeSegment}.func`,
+    ),
+    `Workflow ${routeSegment} route function`,
+  );
+  assertPathWithin(
+    functionsRoot,
+    routeFunctionDir,
+    `Workflow ${routeSegment} route function`,
+  );
+
+  return path.join(routeFunctionDir, ".vc-config.json");
+}
+
+function parseExpectedRouteTriggers(config: JsonObject): ExpectedRouteTriggers[] {
+  if (config.version !== "0") {
+    throw new Error("Captured Workflow SDK config must declare version \"0\".");
+  }
+
+  return WORKFLOW_FUNCTIONS.map(({ configKey, routeSegment }) => {
+    const functionConfig = config[configKey];
+    if (!isJsonObject(functionConfig)) {
+      throw new Error(`Captured Workflow SDK config is missing ${configKey}.`);
+    }
+
+    const triggerValues = functionConfig.experimentalTriggers;
+    if (!Array.isArray(triggerValues) || triggerValues.length === 0) {
+      throw new Error(
+        `Captured Workflow SDK config ${configKey}.experimentalTriggers ` +
+          "must be a non-empty array.",
+      );
+    }
+
+    const triggers = triggerValues.map((value, index) => {
+      if (!isWorkflowTrigger(value)) {
+        throw new Error(
+          `Captured Workflow SDK config ${configKey}.experimentalTriggers[${index}] ` +
+            "is not a valid queue/v2beta trigger.",
+        );
+      }
+      return value;
+    });
+    assertUnambiguousTriggerSet(
+      triggers,
+      `Captured Workflow SDK config ${configKey}.experimentalTriggers`,
+    );
+
+    return { routeSegment, triggers };
+  });
+}
+
+function parseExistingTriggers(config: JsonObject): JsonObject[] {
+  if (!Object.hasOwn(config, "experimentalTriggers")) {
+    return [];
+  }
+
+  const triggerValues = config.experimentalTriggers;
+  if (!Array.isArray(triggerValues)) {
+    throw new Error(
+      "Resolved Vercel function experimentalTriggers must be an array when present.",
+    );
+  }
+
+  const triggers = triggerValues.map((value, index) => {
+    if (!isJsonObject(value)) {
+      throw new Error(
+        `Resolved Vercel function experimentalTriggers[${index}] must be a JSON object.`,
+      );
+    }
+    return value;
+  });
+  return triggers;
+}
+
+function mergeRequiredWorkflowTriggers<T extends JsonObject>(
+  currentTriggers: T[],
+  requiredTriggers: WorkflowTrigger[],
+  conflictMessage: string,
+): Array<T | WorkflowTrigger> {
+  const merged: Array<T | WorkflowTrigger> = [...currentTriggers];
+
+  for (const requiredTrigger of requiredTriggers) {
+    const identity = workflowTriggerIdentity(requiredTrigger);
+    const matching = merged.filter(
+      (trigger) => queueTriggerIdentity(trigger) === identity,
+    );
+
+    if (matching.length === 0) {
+      merged.push(requiredTrigger);
+      continue;
+    }
+    if (
+      matching.length === 1 &&
+      isDeepStrictEqual(matching[0], requiredTrigger)
+    ) {
+      continue;
+    }
+    throw new Error(conflictMessage);
+  }
+
+  return merged;
+}
+
+function assertUnambiguousTriggerSet(
+  triggers: WorkflowTrigger[],
+  label: string,
+): void {
+  for (let index = 0; index < triggers.length; index += 1) {
+    for (
+      let comparisonIndex = index + 1;
+      comparisonIndex < triggers.length;
+      comparisonIndex += 1
+    ) {
+      if (isDeepStrictEqual(triggers[index], triggers[comparisonIndex])) {
+        throw new Error(`${label} contains a duplicate trigger.`);
+      }
+      if (
+        workflowTriggerIdentity(triggers[index]) ===
+        workflowTriggerIdentity(triggers[comparisonIndex])
+      ) {
+        throw new Error(`${label} contains conflicting queue trigger identities.`);
+      }
+    }
+  }
+}
+
+function workflowTriggerIdentity(trigger: WorkflowTrigger): string {
+  return JSON.stringify([trigger.type, trigger.topic, trigger.consumer]);
+}
+
+function queueTriggerIdentity(trigger: JsonObject): string | null {
+  if (
+    typeof trigger.type !== "string" ||
+    typeof trigger.topic !== "string" ||
+    typeof trigger.consumer !== "string"
+  ) {
+    return null;
+  }
+  return JSON.stringify([trigger.type, trigger.topic, trigger.consumer]);
+}
+
+function isWorkflowTrigger(value: unknown): value is WorkflowTrigger {
+  return isJsonObject(value) &&
+    value.type === "queue/v2beta" &&
+    typeof value.topic === "string" &&
+    value.topic.trim().length > 0 &&
+    typeof value.consumer === "string" &&
+    value.consumer.trim().length > 0 &&
+    typeof value.retryAfterSeconds === "number" &&
+    Number.isInteger(value.retryAfterSeconds) &&
+    value.retryAfterSeconds >= 0 &&
+    typeof value.initialDelaySeconds === "number" &&
+    Number.isInteger(value.initialDelaySeconds) &&
+    value.initialDelaySeconds >= 0;
+}
+
+async function readJsonObject(filePath: string, label: string): Promise<JsonObject> {
+  const fileStats = await assertRegularFile(filePath, label);
+  if (fileStats.size > MAX_JSON_FILE_BYTES) {
+    throw new Error(`${label} exceeds the supported size limit.`);
+  }
+
+  let contents: string;
+  try {
+    contents = await readFile(filePath, "utf8");
+  } catch {
+    throw new Error(`Unable to read ${label}.`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new Error(`${label} is not valid JSON.`);
+  }
+  if (!isJsonObject(parsed)) {
+    throw new Error(`${label} must contain one JSON object.`);
+  }
+
+  return parsed;
+}
+
+async function assertRegularFile(
+  filePath: string,
+  label: string,
+): Promise<import("node:fs").Stats> {
+  let fileStats;
+  try {
+    fileStats = await lstat(filePath);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      throw new Error(`${label} is missing.`);
+    }
+    throw new Error(`Unable to inspect ${label}.`);
+  }
+  if (!fileStats.isFile()) {
+    throw new Error(`${label} must be a regular file.`);
+  }
+
+  return fileStats;
+}
+
+async function resolveDirectory(directoryPath: string, label: string): Promise<string> {
+  let resolvedPath: string;
+  try {
+    resolvedPath = await realpath(directoryPath);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      throw new Error(`${label} is missing.`);
+    }
+    throw new Error(`Unable to resolve ${label}.`);
+  }
+
+  let directoryStats;
+  try {
+    directoryStats = await stat(resolvedPath);
+  } catch {
+    throw new Error(`Unable to inspect ${label}.`);
+  }
+  if (!directoryStats.isDirectory()) {
+    throw new Error(`${label} must resolve to a directory.`);
+  }
+
+  return resolvedPath;
+}
+
+function assertPathWithin(rootPath: string, candidatePath: string, label: string): void {
+  const relativePath = path.relative(rootPath, candidatePath);
+  if (
+    relativePath === "" ||
+    (!path.isAbsolute(relativePath) &&
+      relativePath !== ".." &&
+      !relativePath.startsWith(`..${path.sep}`))
+  ) {
+    return;
+  }
+  throw new Error(`${label} resolves outside its allowed local build boundary.`);
+}
+
+async function writeJsonAtomically(
+  filePath: string,
+  value: JsonObject,
+): Promise<void> {
+  const fileStats = await stat(filePath);
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: fileStats.mode & 0o777,
+    });
+    await rename(tempPath, filePath);
+  } finally {
+    await rm(tempPath, { force: true });
+  }
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value);
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT";
+}
+
+async function runCommand(invocation: CommandInvocation): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(invocation.command, invocation.args, {
+      cwd: invocation.cwd,
+      env: invocation.env,
+      shell: false,
+      stdio: "inherit",
+    });
+
+    child.once("error", () => {
+      reject(new Error(`Unable to start ${invocation.label}.`));
+    });
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const outcome = signal
+        ? `signal ${signal}`
+        : `exit code ${code ?? "unknown"}`;
+      reject(new Error(`${invocation.label} failed with ${outcome}.`));
+    });
+  });
+}
+
+export async function main(): Promise<void> {
+  await deployHostedWebVercelPrebuilt({
+    vercelArgs: process.argv.slice(2),
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error
+      ? error.message
+      : "Hosted Web Vercel prebuilt deployment failed.";
+    console.error(message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Why and outcome
The supported local hosted-web prebuilt Vercel path needed to preserve the Workflow SDK's exact queue-consumer trigger metadata after generated-source cleanup. This adds a repository-owned prebuilt deploy command that captures the SDK config before cleanup, repairs the resolved final Vercel Build Output function configs, revalidates before upload, and fails closed on missing, malformed, escaping, ambiguous, or conflicting evidence.

Managed Vercel builds continue to use the checked-in build command and are unchanged.

## Product UX
Product UX does not apply. This is internal deployment tooling and documentation; it changes no user-facing app journey, UI, copy, or rendered state.

## Evidence
- `jq -e . apps/web/package.json`
- `git diff --check`
- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/clean-hosted-web-workflow-artifacts.test.ts scripts/deploy-hosted-web-vercel-prebuilt.test.ts`
- `pnpm typecheck`
- `pnpm test:diff apps/web/README.md apps/web/package.json scripts/clean-hosted-web-workflow-artifacts.ts scripts/clean-hosted-web-workflow-artifacts.test.ts scripts/deploy-hosted-web-vercel-prebuilt.ts scripts/deploy-hosted-web-vercel-prebuilt.test.ts`

## Non-obvious affected surfaces
- Local hosted-web Vercel prebuilt deployment boundary: the new package script owns `vercel build` plus `vercel deploy --prebuilt` so trigger repair happens before upload. Covered by wrapper ordering and no-upload-on-proof-failure tests.
- Workflow generated artifact cleanup: the existing cleaner now optionally captures the generated SDK config before deleting generated source. Covered by the capture-before-cleanup test.
- Vercel Build Output function metadata: local `.vercel/output/functions/**/.vc-config.json` files may be amended to include SDK-generated queue triggers, including when Step and Flow routes dedupe to one final function. Covered by shared-function, distinct-function, idempotence, malformed-evidence, conflict, and symlink-escape tests.

## Architecture and reuse
- Existing systems reused: existing Workflow SDK generated config, Vercel Build Output layout, generated-artifact cleaner, package-script entrypoint, and repo verification tooling.
- New logic: a local deploy wrapper captures evidence, resolves route links to final function configs, merges exact `queue/v2beta` triggers idempotently, validates every target before writing, and removes capture evidence before upload.
- New abstractions: no application abstraction was added; the reusable surface is one script-level repair function and one env/capture constant shared with the cleaner.
- Complexity intentionally avoided: no duplicated SDK topic constants, no app route/runtime behavior change, no managed Vercel build change, and no broad deployment state machine.

## Hot reply path impact
Not applicable. The foreground reply critical path is unchanged because this only affects local deployment packaging before a Vercel prebuilt upload.

## Murph initial provider input impact
Not applicable for both Murph and Codex runtimes. No prompt, tool schema, provider request assembly, or model-visible input surface changed.

## Design proof
Not applicable. No user-facing hosted Web UI, component, route, state, viewport, or rendered interaction changed.

## Change-shape breakdown
Classification rule: authored deployment scripts and package-script changes are config/tooling; focused Vitest files are tests/fixtures; README and completed execution-plan guidance are docs/process; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 485 | 1 |
| Docs | 74 | 0 |
| Config/tooling | 712 | 3 |
| Generated/other | 0 | 0 |
| Total | 1271 | 4 |

## Deployment concerns
- Deployment: applicable
- Supported skew: Existing managed Vercel builds and deployed functions are unchanged; local prebuilt deploys using the new command either upload repaired Build Output metadata or fail before upload.
- Safe order: Land this helper first, then use `pnpm --dir apps/web vercel:deploy:prebuilt -- --prod` for local production prebuilt deploys. No Cloudflare tandem deploy is required.
- Rollback floor: No persisted data, schema, or runtime protocol changes are introduced. Rolling back to an older Vercel deployment is safe, but rolling back to an unrepaired prebuilt artifact can remove the restored Workflow queue triggers.
- Expected exposure: Only local prebuilt deployment operators are affected; invalid evidence blocks before production upload.
- Reversibility: Stop using the helper, redeploy through the managed Vercel build path, or roll back to a known deployment.
- Convergence proof: Focused synthetic tests cover shared and distinct final functions, idempotence, malformed evidence, symlink escape, conflict handling, and upload ordering.
- Post-deploy checks: After any production prebuilt deploy, verify the deployment came from this command and confirm Step and Flow Workflow queue triggers/consumers are present or run a bounded Workflow trigger smoke.

## Changelog
- Changelog: not applicable
- Reason: This is internal deployment tooling with no member-visible product change.

ReviewGPT context sensitivity: sensitive - changes a deployment boundary and local Vercel Build Output metadata repair.
ReviewGPT first-reviewed head: b3357c9afb6b24d905f395c9b5168dc30f5b4b62
