### PR TITLE
feat(web): link directly to connect source cards

### DIFF
--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -94,7 +94,7 @@ export function SourceCard({
   return (
     <div
       id={source.id}
-      className="relative box-border flex min-w-0 w-full max-w-full scroll-mt-24 flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 target:border-primary/60 target:ring-2 target:ring-primary/20 target:ring-offset-2 target:ring-offset-background sm:p-5"
+      className="relative box-border flex min-w-0 w-full max-w-full scroll-mt-24 flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 target:border-primary/80 target:ring-2 target:ring-primary target:ring-offset-2 target:ring-offset-background sm:p-5"
     >
       {!setupOnly ? (
         <div className="absolute top-3 right-3 sm:top-4 sm:right-4">

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -92,7 +92,10 @@ export function SourceCard({
     || Boolean(errorMessage);
 
   return (
-    <div className="relative box-border flex min-w-0 w-full max-w-full flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 sm:p-5">
+    <div
+      id={source.id}
+      className="relative box-border flex min-w-0 w-full max-w-full scroll-mt-24 flex-col justify-between overflow-hidden rounded-xl border border-border/50 bg-[rgba(255,252,246,0.9)] p-4 target:border-primary/60 target:ring-2 target:ring-primary/20 target:ring-offset-2 target:ring-offset-background sm:p-5"
+    >
       {!setupOnly ? (
         <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
           <SourceStatusDot

--- a/apps/web/changelog/entries/2026-08-25/direct-links-to-device-connections.json
+++ b/apps/web/changelog/entries/2026-08-25/direct-links-to-device-connections.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-25",
+  "order": 100,
+  "item": {
+    "id": "direct-links-to-device-connections",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Direct links to device connections",
+    "summary": "Links can now open a specific connection card on Murph's Connect Devices page.",
+    "details": "The link scrolls to and highlights the requested source; sign-in and authorization still require the member's explicit action.",
+    "relevanceTags": ["connections", "device-sync"],
+    "sourcePullRequests": [2261]
+  }
+}

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -195,6 +195,10 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.match(markup, /aria-label="Search sources"/);
   assert.match(markup, />33 of 33 sources</);
   assert.match(markup, /lg:grid-cols-2 xl:grid-cols-4/);
+  assert.match(markup, /id="fitbit"/u);
+  assert.match(markup, /id="oura"/u);
+  assert.equal(markup.match(/scroll-mt-24/gu)?.length, 33);
+  assert.equal(markup.match(/target:ring-2/gu)?.length, 33);
   assert.doesNotMatch(markup, /data-priority list/);
   assert.doesNotMatch(markup, /Priority/u);
   assert.doesNotMatch(

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -198,7 +198,9 @@ test("ConnectPage renders source search, source names, and logo marks", async ()
   assert.match(markup, /id="fitbit"/u);
   assert.match(markup, /id="oura"/u);
   assert.equal(markup.match(/scroll-mt-24/gu)?.length, 33);
+  assert.equal(markup.match(/target:border-primary\/80/gu)?.length, 33);
   assert.equal(markup.match(/target:ring-2/gu)?.length, 33);
+  assert.equal(markup.match(/target:ring-primary(?=\s)/gu)?.length, 33);
   assert.doesNotMatch(markup, /data-priority list/);
   assert.doesNotMatch(markup, /Priority/u);
   assert.doesNotMatch(


### PR DESCRIPTION
## Why and outcome

Operators need a shareable URL that opens a specific connection on `/connect`. Each existing source card now owns a stable fragment anchor, so links such as `/connect#fitbit` scroll to and visually emphasize the requested card while leaving sign-in and authorization as explicit member actions.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: the person sharing a connection link; a signed-out recipient who must sign in; and a signed-in recipient who sees the source's existing connect, migration, recovery, or disconnect state.
- Recovery and exclusions: an unknown fragment leaves the ordinary Connect Devices page intact. The link never starts OAuth, signs a member in, changes connection state, or changes the existing callback/intention contracts.

## Evidence

- Direct Playwright journey proof on the real `/connect#fitbit` route at 1440×1000 and 390×844: HTTP 200, Fitbit is `:target`, the whole card is visible, the target ring is rendered, the normal sign-in action remains, no Next error overlay appears, and no OAuth begins.
- The accepted preliminary ReviewGPT finding was remediated with a full-primary target ring and stronger border. The final light-mode ring is 4.99:1 against the page and the border is 3.38:1; refreshed phone and desktop renders confirm the target remains clear without obscuring card content.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts apps/web/test/connect-page.test.ts` — 103 tests passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm --dir apps/web exec eslint 'app/(dashboard)/connect/connect-source-card.tsx' test/connect-page.test.ts` — passed.
- Changelog generation plus focused archive tests — 47 tests passed.
- Repository-owned guarded Vercel preview build and deployment — ready. Vercel SSO protects the preview, so the exact phone and desktop captures are attached to the specialist review packet.

## Non-obvious affected surfaces

- All 33 source cards receive anchors, not only Fitbit, so the URL contract stays catalog-driven and reusable. Focused server-render coverage proves every card receives the anchor and target styling.
- Existing device-connect intent fragments remain unchanged. A plain source fragment contains no intent payload, so the existing parser ignores it.
- Provider and OAuth behavior are unchanged; native browser fragment navigation owns scrolling and `:target` owns the visual state.

## Architecture and reuse

- **Existing systems reused:** `ConnectSource.id`, the existing `SourceCard`, native URL fragments, and Tailwind's `target:` variant.
- **New logic:** each card exposes its existing catalog ID as its DOM anchor and applies restrained target-only border/ring styles with a sticky-header scroll offset.
- **New abstractions:** none; the source catalog already provides the stable identifier and the browser already owns fragment navigation.
- **Complexity intentionally avoided:** no query parser, client effect, new state, redirect, API route, provider branch, or automatic authorization behavior.

## Hot reply path impact

Not applicable — this changes only Connect Devices page presentation and does not touch message acceptance, provider start, or reply handoff.

## Murph initial provider input impact

- Individual runtime: Not applicable — no prompt, tool, schema, or provider-visible request assembly changed.
- Group runtime: Not applicable — no prompt, tool, schema, or provider-visible request assembly changed.

## Design proof

- Design page: [Targeted Fitbit source card](https://murph-ce6fu2m53-cobuildwithus.vercel.app/screenshots/health#fitbit)
- Evidence: the repository's health screenshot study renders the real production `SourceCard` as the fragment target, showing the target border/ring without changing its existing action. The separate real-page journey proof covers `/connect#fitbit` scrolling and action safety. Vercel SSO protects the exact preview; selected redacted renders are attached to the specialist packet.
- Coverage: targeted signed-in study state plus signed-out real-page Fitbit state at desktop 1440×1000 and phone 390×844; structural coverage also proves the anchor contract across all 33 cards.

## Change shape

Classification rule: production TSX is source, regression assertions are tests/fixtures, and the public changelog fragment is docs. No binary or generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 1 |
| Tests/fixtures | 6 | 0 |
| Docs | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **24** | **1** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old Web deployments ignore the fragment and show the normal page; new Web deployments scroll to and highlight the card. Both preserve the existing explicit member action.
- Safe order: deploy Web only; no tandem service, schema, provider, or configuration rollout is required.
- Rollback floor: rollback is safe at any point because shared links still resolve to `/connect`, only without card targeting on the old version.
- Expected exposure: during rollout, some requests may briefly receive the ordinary unhighlighted Connect Devices page; no request can start an unintended connection.
- Reversibility: revert the component-only anchor/style change and redeploy Web.
- Convergence proof: after rollout, `/connect#fitbit` resolves Fitbit as `:target` and keeps the whole card visible at phone and desktop widths.
- Post-deploy checks: open `/connect#fitbit` signed out, confirm the target ring and sign-in action, then confirm a generic unknown fragment leaves the ordinary page usable.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · direct-links-to-device-connections

## Review routing

- Preliminary lenses: Product UX, frontend, and coverage applicable; prompt not applicable.
- Preliminary result: one medium contrast finding accepted and fixed on the final head; parent revalidation includes computed contrast and refreshed desktop/phone journey proof.
- Final ReviewGPT gate: not applicable because the production diff is a low-risk frontend-only fragment/styling change with no auth, persistence, API, provider, runtime, or trust-boundary behavior.
