### PR TITLE
test: align live Starter settings check

### DIFF
--- a/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
@@ -134,7 +134,7 @@ async function proveStarterUsageStartsPaidPulseThroughCheckout(): Promise<void> 
   const actor = await createActor(member.session);
   try {
     await requireDriver().activateStarterUsage(actor, invite.inviteCode);
-    await requireDriver().assertSettingsUsageLabel(actor, "Starter AI usage");
+    await requireDriver().assertSettingsAvailableUsage(actor, "Starter AI usage");
 
     const checkout = await requireDriver().beginDirectPlanCheckout(actor, "Pulse");
     await requireDriver().assertStripeCheckoutReady(actor);

--- a/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
@@ -134,10 +134,7 @@ async function proveStarterUsageStartsPaidPulseThroughCheckout(): Promise<void> 
   const actor = await createActor(member.session);
   try {
     await requireDriver().activateStarterUsage(actor, invite.inviteCode);
-    await requireDriver().assertSettingsText(
-      actor,
-      /non-expiring starter usage is active/iu,
-    );
+    await requireDriver().assertSettingsUsageLabel(actor, "Starter AI usage");
 
     const checkout = await requireDriver().beginDirectPlanCheckout(actor, "Pulse");
     await requireDriver().assertStripeCheckoutReady(actor);

--- a/apps/web/test/support/hosted-billing-browser-driver.ts
+++ b/apps/web/test/support/hosted-billing-browser-driver.ts
@@ -396,13 +396,17 @@ export class HostedBillingBrowserDriver {
     });
   }
 
-  async assertSettingsUsageLabel(
+  async assertSettingsAvailableUsage(
     actor: HostedBillingBrowserActor,
     label: string,
   ): Promise<void> {
     await this.runStep("settings-projection", "murph-settings", async () => {
       await this.openSettings(actor);
-      await actor.page.getByLabel(label, { exact: true }).waitFor();
+      const usage = actor.page.getByLabel(label, { exact: true });
+      await usage.waitFor();
+      await usage.getByRole("progressbar", {
+        name: /\b(?:[1-9]\d?|100)% remaining$/u,
+      }).waitFor();
     });
   }
 

--- a/apps/web/test/support/hosted-billing-browser-driver.ts
+++ b/apps/web/test/support/hosted-billing-browser-driver.ts
@@ -396,6 +396,16 @@ export class HostedBillingBrowserDriver {
     });
   }
 
+  async assertSettingsUsageLabel(
+    actor: HostedBillingBrowserActor,
+    label: string,
+  ): Promise<void> {
+    await this.runStep("settings-projection", "murph-settings", async () => {
+      await this.openSettings(actor);
+      await actor.page.getByLabel(label, { exact: true }).waitFor();
+    });
+  }
+
   async assertSettingsPlanState(
     actor: HostedBillingBrowserActor,
     input: {


### PR DESCRIPTION
## Outcome

The production-shaped Stripe browser matrix now verifies that activated Starter usage is both visible and still available, instead of waiting for prose intentionally removed from Settings.

## Product UX result

No production UI or billing behavior changes. The check follows the existing accessible Starter usage card and its remaining-usage progress indicator.

## Direct evidence

- Hosted Billing Settings: 69 tests passed.
- Hosted Stripe CI contract: 21 tests passed.
- The live browser test module compiled with all five provider-gated cases skipped locally.
- Hosted Web typecheck passed.
- Two consecutive main runs reproduced the deleted-copy timeout; the other four live Stripe journeys passed.
- Preliminary coverage review found that the label alone also covered exhausted usage; the accepted correction now requires a nonzero remaining percentage within the labeled card.

## Affected surfaces

Only the production-shaped Stripe E2E assertion and its browser-driver helper change.

## Architecture and reuse

- Existing systems reused: the Settings accessible usage card, its progressbar label, HostedBillingBrowserDriver navigation, and the existing settings-projection diagnostic step.
- New logic: one focused helper waits for the exact usage card and a nested progressbar reporting 1–100% remaining.
- New abstractions: none are needed because the browser driver already owns Settings navigation and diagnostic recording.
- Complexity intentionally avoided: no duplicated UI copy, production branch, retry machinery, dependency, or state.

## Hot reply path impact

None.

## Provider input impact

None.

## Deployment concerns

- Deployment: not applicable
- Reason: This changes only internal test assertions, so it has no runtime skew, rollout, or rollback concerns.

## Changelog

- Changelog: not applicable
- Reason: This only corrects an internal billing verification assertion and does not change member-visible behavior.

## Design proof

Not applicable. No production UI change.

## Change shape

- Source: +0 / -0
- Tests and direct proof: +15 / -4
- Docs: +0 / -0
- Config and tooling: +0 / -0
- Generated and other: +0 / -0
- Total: +15 / -4

ReviewGPT context sensitivity: routine
Reason: test-only semantic selector correction with no production behavior change.