### PR TITLE
Fix production runner bundle budget for workout continuity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-workout-delivery-bundle-ratchet.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-workout-delivery-bundle-ratchet.md
@@ -1,0 +1,55 @@
+# Ratchet the workout-delivery runner bundle budget
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Unblock the production runner deploy after the reviewed workout-delivery
+  context extended the existing lazy Assistant Engine graph.
+- Preserve the existing bundle guard policy: an exact measured public Linux
+  baseline, 32 KiB of reviewed graph allowance, and 8 KiB reserved for the
+  managed production overlay.
+
+## Evidence
+
+- The exact merged public Linux bundle measured 9,456,843 bytes.
+- The production predeploy bundle measured 9,465,635 bytes and stopped before
+  any production mutation because the existing 9,464,796-byte ceiling was 839
+  bytes too low.
+- Entry and static-startup closure measurements remained within their existing
+  limits, and the largest inputs remained in already-bundled packages.
+
+## Scope
+
+- In scope: the vault CLI total byte budget, its measurement comment, and the
+  locked boundary test.
+- Out of scope: changing bundle contents, dependencies, runtime behavior,
+  entry/static-startup limits, Worker behavior, or deployment workflow logic.
+
+## Tasks
+
+1. Ratchet the total ceiling from the exact public Linux measurement while
+   preserving the existing allowances.
+2. Run the focused budget-policy test, Cloudflare typecheck, and fresh bundle
+   assembly.
+3. Complete ReviewGPT and exact-head CI, merge, then rerun the protected
+   production deploy with immediate container rollout and live smoke.
+
+## Verification
+
+- Focused `runner-bundle-cli-bundle` test.
+- Cloudflare typecheck.
+- Fresh runner bundle assembly with CLI parity probes.
+- Exact-head required CI and protected production deploy smoke.
+
+## Results
+
+- The focused bundle-policy test passed all 14 tests.
+- Cloudflare typecheck passed.
+- Fresh local runner assembly passed at 9,458,746 total bytes, 671 entry
+  bytes, and 24,950 static-startup bytes; all CLI parity probes passed.
+- The protected PR and deployment workflows remain the exact-Linux and
+  production-overlay proof owners after this implementation commit.
+Completed: 2026-08-25

--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -137,11 +137,15 @@ const VAULT_CLI_IMPORT_SURFACE_HOOK_SOURCE = [
 // static-startup topology. The combined cap composes its reviewed 41,089 B
 // lazy-graph delta with the current public Linux baseline and retains the same
 // 32 KiB graph allowance plus 8 KiB production-overlay reserve.
+// Exact workout delivery context extends the existing lazy Assistant Engine
+// graph without adding a package or changing the entry or static-startup
+// topology. The merged public Linux graph measured 9,456,843 B on 2026-08-25;
+// ratchet from that exact baseline while retaining the same allowances.
 // Keep total output inside a narrow 32 KiB allowance and static startup inside
 // an 8 KiB allowance. If a violation fires, investigate the listed largest
 // inputs first; only raise the budget deliberately for understood, intended
 // growth.
-const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_464_796;
+const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_497_803;
 const VAULT_CLI_BUNDLE_ENTRY_BYTES_BUDGET = 20_000;
 const VAULT_CLI_BUNDLE_STATIC_CLOSURE_BYTES_BUDGET = 33_200;
 

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -487,15 +487,15 @@ describe("runner bundle vault-cli esbuild step", () => {
     });
 
     expect(
-      assertVaultCliBundleWithinBudgets(createMetafile(9_454_796)),
+      assertVaultCliBundleWithinBudgets(createMetafile(9_487_803)),
     ).toEqual({
       entryBytes: 10_000,
       staticClosureBytes: 10_000,
-      totalBytes: 9_464_796,
+      totalBytes: 9_497_803,
     });
     expect(() =>
-      assertVaultCliBundleWithinBudgets(createMetafile(9_454_797)),
-    ).toThrow(/total output 9464797B exceeds budget 9464796B/u);
+      assertVaultCliBundleWithinBudgets(createMetafile(9_487_804)),
+    ).toThrow(/total output 9497804B exceeds budget 9497803B/u);
   });
 
   it("rejects dynamic-to-static graph drift without relying on total size growth", () => {


### PR DESCRIPTION
## Why and outcome

The merged workout-delivery continuity patch intentionally extended the existing lazy Assistant Engine graph. Public CI passed, but the managed production overlay put the assembled CLI bundle 839 bytes over its total ceiling, so the protected deploy stopped before any production mutation.

Ratchet the total budget from the exact 9,456,843-byte public Linux measurement while preserving the existing 32 KiB graph allowance and 8 KiB production-overlay reserve. Runtime code, dependencies, entry limits, and static-startup limits are unchanged.

## Product UX

Not applicable. This is an internal build/deploy guard correction with no member-visible behavior change; it only allows the already-reviewed workout continuity release to be assembled and deployed.

## Evidence

- Protected production predeploy measured 9,465,635 bytes against the old 9,464,796-byte ceiling and stopped before deployment.
- Focused bundle-policy test: 14/14 passed, including acceptance at the new exact boundary and rejection one byte over.
- Cloudflare typecheck passed.
- Fresh local runner assembly passed at 9,458,746 total bytes, 671 entry bytes, and 24,950 static-startup bytes; all CLI parity probes passed.

## Non-obvious affected surfaces

- The private production assembly adds its managed runtime overlay to this public bundle and consumes the reserved overlay allowance. The protected production workflow is the final proof of the composed measurement.
- No runtime protocol, Worker behavior, container behavior, dependency graph, or state owner changes.

## Architecture and reuse

- Existing systems reused: the existing fixed bundle byte ratchet and its exact boundary test remain the only owners.
- New logic: none; the total ceiling is recalculated from the measured Linux baseline plus the established allowances.
- New abstractions: none; the current bundle guard is sufficient.
- Complexity intentionally avoided: no code-size contortions, dependency changes, private/public budget split, or deploy bypass for 839 bytes of understood intended lazy-graph growth.

## Hot reply path impact

Not applicable. The diff changes only build-time bundle-budget enforcement and its unit test; it adds no runtime work or awaited operation.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-visible input assembly changes.
- Codex runtime: Not applicable; no prompt, tool schema, generated guidance, or provider request changes.

## Change-shape breakdown

Classification: authored bundle-guard policy is config/tooling; the boundary assertion is tests; the closed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 4 | 4 |
| Docs | 55 | 0 |
| Config/tooling | 5 | 1 |
| Generated/other | 0 | 0 |
| Total | 64 | 5 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Runtime behavior is identical; the budget is evaluated only while assembling a new runner bundle.
- Safe order: Merge this guard correction, then deploy the Cloudflare Worker and runner bundle together with immediate container rollout.
- Rollback floor: This patch creates no new floor; the already-merged workout continuity runner remains the forward-fix target once published.
- Expected exposure: None before rollout because the failed workflow never reached production mutation; immediate rollout replaces old warm runners during the successful deploy.
- Reversibility: Reverting this budget-only patch does not change a built runner, but would block rebuilding the intended graph under the stale ceiling.
- Convergence proof: Protected smoke must report the exact runner fingerprint and validate the assistant CLI surface.
- Post-deploy checks: Require protected managed-container smoke, direct R2 proof, and the live model turn to pass.

## Changelog

- Changelog: not applicable
- Reason: Internal runner assembly policy only; the member-visible workout continuity changelog shipped in the owning PR.

ReviewGPT context sensitivity: sensitive — this controls admission to the hosted Cloudflare production deploy.

ReviewGPT first-reviewed head: e62e361be611c1781b1e2ab922f94faf2ebcf81d
