### PR TITLE
test(assistant): add live Luna subagent smoke

### DIFF
--- a/.agents/friction-log/20260825142601-pr-head-draft/friction.md
+++ b/.agents/friction-log/20260825142601-pr-head-draft/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'PR head draft reset lacks pull-request write authority'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+After a ready pull request receives a new commit, the trusted head-change workflow returns that exact head to draft so an authenticated operator can mark it ready and start exact-head CI.
+
+## Current Behavior
+
+The head-change receipt succeeds, but the workflow-run controller's GraphQL draft-conversion call fails with `Resource not accessible by integration`. The pull request remains ready and the new head does not receive the normal exact-head CI set.
+
+## Possible Solution
+
+Give the narrowly scoped reset job pull-request write authority through the existing trusted workflow boundary, then retain its exact repository, branch, pull request, and head-SHA revalidation before conversion.
+
+## Minimal Reproducible Example
+
+1. Open a draft pull request from a same-repository branch.
+2. Mark it ready and let exact-head CI start.
+3. Push one additional commit to the same branch.
+4. Observe the head-change receipt succeed and the draft-reset workflow fail at draft conversion.
+
+## Context
+
+This blocks the intended ready-state reset and requires a manual draft-to-ready cycle before the corrected head receives exact-head CI.

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -321,7 +321,7 @@ describeRealCodex('real Codex child model selection e2e', () => {
           codexHome: config.codexHome,
           env: config.env,
           excludeResumeTurns: true,
-          model: config.model,
+          model: DEFAULT_REAL_CODEX_MODEL,
           modelProvider: config.modelProvider,
           onAdditionalUsage: async (usage) => {
             childUsages.push(usage)
@@ -337,6 +337,17 @@ describeRealCodex('real Codex child model selection e2e', () => {
         })
 
         expect(result.finalMessage.trim()).not.toBe('')
+        const parentUsage = extractCodexAssistantProviderUsage({
+          providerConfig: normalizeAssistantProviderConfig({
+            provider: 'codex-cli',
+            model: DEFAULT_REAL_CODEX_MODEL,
+            modelProvider: config.modelProvider,
+            oss: false,
+          }),
+          rawEvents: result.jsonEvents,
+        })
+        expect(parentUsage.servedModel).not.toBeNull()
+        expect(parentUsage.servedModel).not.toBe('gpt-5.6-luna')
         await waitForWarmCodexBackgroundWork()
         expect(childUsages).toHaveLength(1)
         expect(childUsages[0]).toMatchObject({

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -8383,6 +8383,9 @@ describe('real Codex app-server cache usage e2e harness', () => {
     expect(multiAgentConfigToml).toContain('[features.multi_agent_v2]')
     expect(multiAgentConfigToml).toContain('enabled = true')
     expect(multiAgentConfigToml).toContain(
+      'expose_spawn_agent_model_overrides = true',
+    )
+    expect(multiAgentConfigToml).toContain(
       'max_concurrent_threads_per_session = 4',
     )
   })
@@ -12978,6 +12981,7 @@ function buildRealCodexConfigToml(input: {
       ? [
           '[features.multi_agent_v2]',
           'enabled = true',
+          'expose_spawn_agent_model_overrides = true',
           'max_concurrent_threads_per_session = 4',
           '',
         ]

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -39,7 +39,9 @@ import { describe, expect, it } from 'vitest'
 import {
   executeCodexAppServerTurn,
   resolveMurphDynamicTools,
+  stopWarmCodexAppServer,
   type CodexAppServerTurnInput,
+  waitForWarmCodexBackgroundWork,
 } from '../src/assistant-codex.ts'
 import {
   executeReadOnlyAssistantAsk,
@@ -139,6 +141,7 @@ import type {
 import { extractCodexAssistantProviderUsage } from '../src/assistant/providers/helpers.ts'
 import type {
   AssistantProviderDynamicTool,
+  AssistantProviderUsageDraft,
 } from '../src/assistant/providers/types.ts'
 
 const RUN_REAL_CODEX_E2E = process.env.MURPH_RUN_REAL_CODEX_E2E === '1'
@@ -295,6 +298,66 @@ const HABITAT_VOICE_E2E_CLI_ENTRYPOINT = fileURLToPath(
 const HABITAT_VOICE_E2E_TSX_BIN = fileURLToPath(
   new URL('../../../node_modules/.bin/tsx', import.meta.url),
 )
+
+describeRealCodex('real Codex child model selection e2e', () => {
+  it(
+    'runs a Luna child through native collaboration',
+    async () => {
+      const config = await resolveRealCodexE2eConfig({
+        multiAgentV2: true,
+      })
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-codex-luna-child-e2e-'),
+      )
+      const childUsages: AssistantProviderUsageDraft[] = []
+
+      try {
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          env: config.env,
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          onAdditionalUsage: async (usage) => {
+            childUsages.push(usage)
+          },
+          prompt: [
+            'Run one native collaboration child for this synthetic smoke check.',
+            'Call spawn_agent once with model gpt-5.6-luna and a small task that needs no tools.',
+            'Do not wait for the child; finish the parent response after launching it.',
+          ].join(' '),
+          reasoningEffort: 'low',
+          sandbox: 'read-only',
+          workingDirectory,
+        })
+
+        expect(result.finalMessage.trim()).not.toBe('')
+        await waitForWarmCodexBackgroundWork()
+        expect(childUsages).toHaveLength(1)
+        expect(childUsages[0]).toMatchObject({
+          provider: 'codex-cli',
+          providerRequestOutcome: 'succeeded',
+          usage: {
+            requestedModel: 'gpt-5.6-luna',
+            servedModel: 'gpt-5.6-luna',
+          },
+        })
+      } finally {
+        await stopWarmCodexAppServer('real-codex-luna-child-e2e-complete')
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+})
 
 describeRealCodex('real Codex onboarding progressive disclosure e2e', () => {
   it(
@@ -8309,6 +8372,19 @@ describe('real Codex app-server cache usage e2e harness', () => {
     expect(configToml).toContain('[model_providers.openai-env]')
     expect(configToml).toContain('env_key = "PROVIDER_KEY"')
     expect(configToml).not.toContain('provider-value')
+    expect(configToml).not.toContain('[features.multi_agent_v2]')
+
+    const multiAgentConfigToml = buildRealCodexConfigToml({
+      apiKeyEnv: 'PROVIDER_KEY',
+      model: 'gpt-5.6-terra',
+      modelProvider: OPENAI_ENV_MODEL_PROVIDER,
+      multiAgentV2: true,
+    })
+    expect(multiAgentConfigToml).toContain('[features.multi_agent_v2]')
+    expect(multiAgentConfigToml).toContain('enabled = true')
+    expect(multiAgentConfigToml).toContain(
+      'max_concurrent_threads_per_session = 4',
+    )
   })
 
   it('sanitizes live provider failures before Vitest prints them', () => {
@@ -12766,7 +12842,9 @@ function summarizeCodexEventSequence(
   })
 }
 
-async function resolveRealCodexE2eConfig(): Promise<RealCodexE2eConfig> {
+async function resolveRealCodexE2eConfig(
+  input: { multiAgentV2?: boolean } = {},
+): Promise<RealCodexE2eConfig> {
   const model =
     normalizeEnvString(process.env.MURPH_REAL_CODEX_MODEL)
     ?? DEFAULT_REAL_CODEX_MODEL
@@ -12826,6 +12904,7 @@ async function resolveRealCodexE2eConfig(): Promise<RealCodexE2eConfig> {
       apiKeyEnv,
       model,
       modelProvider,
+      multiAgentV2: input.multiAgentV2,
     }),
     {
       encoding: 'utf8',
@@ -12860,6 +12939,7 @@ function buildRealCodexConfigToml(input: {
   apiKeyEnv: string
   model: string
   modelProvider: string
+  multiAgentV2?: boolean
 }): string {
   const baseUrl =
     input.modelProvider === VERCEL_AI_GATEWAY_MODEL_PROVIDER
@@ -12894,6 +12974,14 @@ function buildRealCodexConfigToml(input: {
     'stream_max_retries = 5',
     'supports_websockets = false',
     '',
+    ...(input.multiAgentV2
+      ? [
+          '[features.multi_agent_v2]',
+          'enabled = true',
+          'max_concurrent_threads_per_session = 4',
+          '',
+        ]
+      : []),
   ].join('\n')
 }
 


### PR DESCRIPTION
## Why and outcome

Add one opt-in live-provider smoke that exercises the merged child-model selection path end to end through Murph's pinned Codex App Server. The root uses Murph's base instructions, calls native `spawn_agent` with `model: gpt-5.6-luna`, crosses the existing background-work boundary, and proves the completed child usage is attributed to Luna.

## Product UX

- Effort: Not applicable; this PR changes test coverage only.
- Result: No member-visible behavior, interaction, copy, timing, delivery, permission, or recovery contract changes.

## Evidence

- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-codex-scripted-runtime.test.ts -t 'carries a delayed V2 child completion|rejects a non-product child model'` — 3 passed, 102 skipped.
- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-codex-real-e2e.test.ts -t 'writes provider-key config without embedding the provider key value'` — 1 passed, 86 skipped.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- The paid-provider smoke is intentionally opt-in. This shell has neither supported provider credential, so the exact live call remains pending rather than being simulated or claimed as run.

## Non-obvious affected surfaces

- The real Codex E2E harness now enables the MultiAgent V2 model-override field only for this smoke; existing live probes keep their prior configuration.
- Cleanup waits for detached work, verifies background terminals through the production boundary, stops the exact test-owned warm App Server, and removes only test-created temporary paths.

## Architecture and reuse

- Existing systems reused: the real-provider harness, pinned Codex App Server path, native `spawn_agent.model`, child usage reporting, and workspace-boundary lifecycle.
- New logic: one opt-in harness flag plus one live smoke assertion over the existing usage record.
- New abstractions: none; the optional argument extends the existing test helper directly.
- Complexity intentionally avoided: no production source, router, validator, state owner, dependency, service, provider proxy, or copied Codex auth state.

## Hot reply path impact

Not applicable. The diff is test-only and adds no production database, filesystem, network/provider, retry, timeout, or awaited work.

## Murph initial provider input impact

Not applicable to production. The only new provider input is the synthetic, opt-in live-smoke prompt; normal individual and group turns are byte-for-byte unchanged because no production prompt or tool surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only coverage does not change a runtime artifact, configuration, schema, or deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal test coverage only; members observe no product change.

## Change shape

Classification rule: the Vitest file is tests/fixtures; the Frog entry is docs. No source, config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 104 | 1 |
| Docs | 27 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 131 | 1 |


