### PR TITLE
Add stage diagnostics for companion address-book timeouts

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-companion-address-book-timeout-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-companion-address-book-timeout-diagnostics.md
@@ -1,0 +1,73 @@
+# Diagnose companion address-book request stalls
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Reproduce the companion address-book status read against local PostgreSQL.
+- Make a future hosted timeout identify the exact incomplete request stage
+  without logging member, token, contact, or request data.
+- Preserve the existing authentication, privacy, response, and write behavior.
+
+## Scope
+
+- In scope: the companion address-book GET route, privacy-safe stage timing,
+  focused route coverage, and a local PostgreSQL status-query proof.
+- Out of scope: changing route authorization, adding retries, changing the
+  address-book schema, altering client behavior, or claiming a database fix
+  before a production stall identifies the failing stage.
+
+## Constraints
+
+- Emit only fixed event and stage labels plus bounded numeric timing data.
+- Emit a diagnostic before Vercel's 60-second function deadline while leaving
+  the in-flight operation and response behavior unchanged.
+- Avoid steady-state log volume by reporting only requests that cross the slow
+  threshold.
+- Keep the implementation local to the route unless an existing shared owner
+  is demonstrably reusable.
+
+## Tasks
+
+1. Run the exact status query against local PostgreSQL and inspect its plan and
+   operation timing.
+2. Add a small slow-stage observer around authentication and status lookup.
+3. Add focused fake-timer coverage for both stalled stages, normal completion,
+   and privacy-safe log fields.
+4. Run focused tests, Web typecheck, diff/privacy inspection, then commit, push,
+   open the PR, and run the required exact-head review and CI gates.
+
+## Verification
+
+- Focused companion address-book route tests.
+- Real local PostgreSQL status-query timing and `EXPLAIN (ANALYZE, BUFFERS)`
+  using synthetic rows only.
+- Web typecheck.
+- `git diff --check` and identifier/privacy inspection.
+- Exact-head CI and required ReviewGPT passes.
+
+## Product UX
+
+- No user-visible response, authorization, or recovery behavior changes.
+- The operational improvement is an exact fixed-label diagnosis on any future
+  slow GET so the underlying database or authentication stage can be fixed
+  without exposing private address-book data.
+- Identity-token verification, member lookup, and status lookup retain their
+  existing order and error behavior. Normal requests clear every diagnostic
+  timer without emitting a log. Result: ready.
+
+## Local Evidence
+
+- The exact Prisma status read against current local PostgreSQL with the maximum
+  1,000 synthetic contacts completed 20 warm reads at 1.119 ms median and
+  6.067 ms maximum.
+- The exact SQL plan executed in 0.248 ms. This did not reproduce the hosted
+  stall and rules out the bounded status query as intrinsically slow; the
+  remaining evidence points to an intermittent connection/socket wait until a
+  future stage warning identifies the incomplete await.
+- Focused companion route and bearer-auth suites: 22 tests passed.
+- Web typecheck passed after generating the standard ignored Health Commons
+  artifact required by a fresh worktree.
+Completed: 2026-08-25

--- a/apps/web/app/api/device-sync/companion/address-book/route.ts
+++ b/apps/web/app/api/device-sync/companion/address-book/route.ts
@@ -10,6 +10,7 @@ import {
 import { jsonOk, withJsonError } from "@/src/lib/device-sync/settings-http";
 import { readJsonObject } from "@/src/lib/http";
 import {
+  type PrivyBearerMemberAuthStage,
   requireActivePrivyMemberAuthFromBearerToken,
   requirePrivyMemberAuthFromBearerToken,
 } from "@/src/lib/hosted-onboarding/request-auth";
@@ -18,13 +19,41 @@ import { getPrisma } from "@/src/lib/prisma";
 
 export const maxDuration = 60;
 
+const SLOW_GET_STAGE_MS = 5_000;
+
+type AddressBookGetStage = PrivyBearerMemberAuthStage | "status_read";
+
+async function runObservedGetStage<TResult>(
+  stage: AddressBookGetStage,
+  run: () => Promise<TResult>,
+): Promise<TResult> {
+  const startedAtMs = Date.now();
+  const timer = setTimeout(() => {
+    console.warn("Hosted companion address-book GET stage slow.", {
+      elapsedMs: Math.max(0, Date.now() - startedAtMs),
+      stage,
+    });
+  }, SLOW_GET_STAGE_MS);
+
+  try {
+    return await run();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export const GET = withJsonError(async (request: Request) => {
   const prisma = getPrisma();
-  const auth = await requirePrivyMemberAuthFromBearerToken(request, prisma);
-  return jsonOk(await readHostedAddressBookStatus({
-    memberId: auth.member.id,
-    prisma,
-  }));
+  const auth = await requirePrivyMemberAuthFromBearerToken(request, prisma, {
+    runStage: runObservedGetStage,
+  });
+  return jsonOk(await runObservedGetStage(
+    "status_read",
+    () => readHostedAddressBookStatus({
+      memberId: auth.member.id,
+      prisma,
+    }),
+  ));
 });
 
 export const PUT = withJsonError(async (request: Request) => {

--- a/apps/web/src/lib/hosted-onboarding/request-auth.ts
+++ b/apps/web/src/lib/hosted-onboarding/request-auth.ts
@@ -32,6 +32,17 @@ export interface PrivyMemberAuthContext {
 
 export type PrivySessionContext = HostedPrivySession;
 
+export type PrivyBearerMemberAuthStage =
+  | "identity_token_verification"
+  | "member_lookup";
+
+export interface PrivyBearerMemberAuthOptions {
+  runStage?<TResult>(
+    stage: PrivyBearerMemberAuthStage,
+    run: () => Promise<TResult>,
+  ): Promise<TResult>;
+}
+
 export interface AuthenticatedPrivyMemberAuthContext extends Omit<PrivyMemberAuthContext, "member"> {
   member: HostedMemberCoreState;
 }
@@ -184,8 +195,13 @@ export async function requireActivePrivyMemberAuthFromBearerToken(
 export async function requirePrivyMemberAuthFromBearerToken(
   request: Request,
   prisma: PrismaClient = getPrisma(),
+  options: PrivyBearerMemberAuthOptions = {},
 ): Promise<AuthenticatedPrivyMemberAuthContext> {
-  const session = await resolveHostedPrivySessionFromBearerToken(request);
+  const runStage = options.runStage ?? ((_stage, run) => run());
+  const session = await runStage(
+    "identity_token_verification",
+    () => resolveHostedPrivySessionFromBearerToken(request),
+  );
 
   if (!session) {
     throw hostedOnboardingError({
@@ -195,10 +211,13 @@ export async function requirePrivyMemberAuthFromBearerToken(
     });
   }
 
-  const member = await resolvePrivyMemberAuthFromSession({
-    identity: session.identity,
-    prisma,
-  });
+  const member = await runStage(
+    "member_lookup",
+    () => resolvePrivyMemberAuthFromSession({
+      identity: session.identity,
+      prisma,
+    }),
+  );
 
   if (!member) {
     throw hostedOnboardingError({

--- a/apps/web/test/device-sync-companion-address-book-route-composed-auth.test.ts
+++ b/apps/web/test/device-sync-companion-address-book-route-composed-auth.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getPrisma: vi.fn(),
+  lookupHostedMemberForPrivyPrincipal: vi.fn(),
+  prisma: { label: "address-book-composed-auth-prisma" },
+  readHostedAddressBookStatus: vi.fn(),
+  resolveHostedPrivySessionFromBearerToken: vi.fn(),
+}));
+
+vi.mock("@/src/lib/prisma", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-session", () => ({
+  resolveHostedPrivySessionFromBearerToken:
+    mocks.resolveHostedPrivySessionFromBearerToken,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/member-identity-service", () => ({
+  lookupHostedMemberForPrivyPrincipal:
+    mocks.lookupHostedMemberForPrivyPrincipal,
+}));
+
+vi.mock("@/src/lib/hosted-address-book/projection", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/src/lib/hosted-address-book/projection")>()),
+  readHostedAddressBookStatus: mocks.readHostedAddressBookStatus,
+}));
+
+type AddressBookRoute =
+  typeof import("../app/api/device-sync/companion/address-book/route");
+
+const SLOW_GET_STAGE_MS = 5_000;
+const IDENTITY = {
+  phone: null,
+  telegram: null,
+  userId: "did:privy:composed-address-book-auth",
+  wallet: null,
+};
+const MEMBER = { id: "member-composed-address-book-auth" };
+const SESSION = {
+  identity: IDENTITY,
+  linkedAccounts: [],
+  verifiedPrivyUser: { id: IDENTITY.userId },
+};
+const STATUS = {
+  enabled: false,
+  lastReplacedAt: null,
+  revision: 0,
+  schemaVersion: 1 as const,
+  storedContactCount: 0,
+  writeCapability: "disabled" as const,
+};
+
+let route: AddressBookRoute;
+
+describe("device sync companion address-book composed auth diagnostics", () => {
+  beforeAll(async () => {
+    route = await import("../app/api/device-sync/companion/address-book/route");
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPrisma.mockReturnValue(mocks.prisma);
+    mocks.resolveHostedPrivySessionFromBearerToken.mockResolvedValue(SESSION);
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(MEMBER);
+    mocks.readHostedAddressBookStatus.mockResolvedValue(STATUS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("maps pending real identity verification to the identity stage", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveSession!: (value: typeof SESSION) => void;
+    mocks.resolveHostedPrivySessionFromBearerToken.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    const responsePromise = route.GET(request);
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted companion address-book GET stage slow.",
+      {
+        elapsedMs: SLOW_GET_STAGE_MS,
+        stage: "identity_token_verification",
+      },
+    );
+    expect(mocks.lookupHostedMemberForPrivyPrincipal).not.toHaveBeenCalled();
+
+    resolveSession(SESSION);
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("maps pending real member resolution to the member-lookup stage", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveMember!: (value: typeof MEMBER) => void;
+    mocks.lookupHostedMemberForPrivyPrincipal.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMember = resolve;
+      }),
+    );
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    const responsePromise = route.GET(request);
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted companion address-book GET stage slow.",
+      {
+        elapsedMs: SLOW_GET_STAGE_MS,
+        stage: "member_lookup",
+      },
+    );
+    expect(mocks.readHostedAddressBookStatus).not.toHaveBeenCalled();
+
+    resolveMember(MEMBER);
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+});

--- a/apps/web/test/device-sync-companion-address-book-route.test.ts
+++ b/apps/web/test/device-sync-companion-address-book-route.test.ts
@@ -71,6 +71,8 @@ const DELETION = {
   schemaVersion: 1 as const,
 };
 
+const SLOW_GET_STAGE_MS = 5_000;
+
 let route: AddressBookRoute;
 
 describe("device sync companion address-book route", () => {
@@ -100,6 +102,8 @@ describe("device sync companion address-book route", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
 
@@ -115,6 +119,7 @@ describe("device sync companion address-book route", () => {
     expect(mocks.requirePrivyMemberAuthFromBearerToken).toHaveBeenCalledWith(
       request,
       mocks.prisma,
+      { runStage: expect.any(Function) },
     );
     expect(mocks.requireActivePrivyMemberAuthFromBearerToken).not.toHaveBeenCalled();
     expect(mocks.assertHostedLaunchRequiredConsentGranted).not.toHaveBeenCalled();
@@ -123,6 +128,111 @@ describe("device sync companion address-book route", () => {
       prisma: mocks.prisma,
     });
     expect(route.maxDuration).toBe(60);
+  });
+
+  it("reports stalled identity-token verification before the route deadline", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveAuth!: (value: { member: typeof MEMBER }) => void;
+    const pendingAuth = new Promise<{ member: typeof MEMBER }>((resolve) => {
+      resolveAuth = resolve;
+    });
+    mocks.requirePrivyMemberAuthFromBearerToken.mockImplementation(
+      (_request, _prisma, options) => options.runStage(
+        "identity_token_verification",
+        () => pendingAuth,
+      ),
+    );
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    const responsePromise = route.GET(request);
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted companion address-book GET stage slow.",
+      {
+        elapsedMs: SLOW_GET_STAGE_MS,
+        stage: "identity_token_verification",
+      },
+    );
+
+    resolveAuth({ member: MEMBER });
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("reports a stalled member lookup before the route deadline", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveAuth!: (value: { member: typeof MEMBER }) => void;
+    const pendingAuth = new Promise<{ member: typeof MEMBER }>((resolve) => {
+      resolveAuth = resolve;
+    });
+    mocks.requirePrivyMemberAuthFromBearerToken.mockImplementation(
+      (_request, _prisma, options) => options.runStage(
+        "member_lookup",
+        () => pendingAuth,
+      ),
+    );
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    const responsePromise = route.GET(request);
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted companion address-book GET stage slow.",
+      {
+        elapsedMs: SLOW_GET_STAGE_MS,
+        stage: "member_lookup",
+      },
+    );
+
+    resolveAuth({ member: MEMBER });
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("reports a stalled status read without logging member or request data", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveStatus!: (value: typeof STATUS) => void;
+    mocks.readHostedAddressBookStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    const responsePromise = route.GET(request);
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Hosted companion address-book GET stage slow.",
+      {
+        elapsedMs: SLOW_GET_STAGE_MS,
+        stage: "status_read",
+      },
+    );
+
+    resolveStatus(STATUS);
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+
+  it("clears the slow-stage timers after a normal status read", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const request = new Request(
+      "https://app.example.test/api/device-sync/companion/address-book",
+    );
+
+    await expect(route.GET(request)).resolves.toMatchObject({ status: 200 });
+    await vi.advanceTimersByTimeAsync(SLOW_GET_STAGE_MS * 2);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("requires active access and launch consent for bounded replacements", async () => {

--- a/apps/web/test/hosted-onboarding-companion-member-access.test.ts
+++ b/apps/web/test/hosted-onboarding-companion-member-access.test.ts
@@ -72,6 +72,9 @@ import {
   ensureHostedCompanionMemberId,
   requireHostedCompanionMemberIdFromRequest,
 } from "@/src/lib/hosted-onboarding/companion-member-access";
+import {
+  requirePrivyMemberAuthFromBearerToken,
+} from "@/src/lib/hosted-onboarding/request-auth";
 
 type AdmissionRouteModule = typeof import(
   "../app/api/device-sync/companion/admission/route"
@@ -184,6 +187,30 @@ describe("native companion hosted member admission", () => {
     });
 
     expect(mocks.lookupHostedMemberForPrivyPrincipal).not.toHaveBeenCalled();
+  });
+
+  it("exposes identity verification and member lookup as observable bearer stages", async () => {
+    const activeMember = member(HostedBillingStatus.active);
+    const observedStages: string[] = [];
+    mocks.resolveHostedPrivySessionFromBearerToken.mockResolvedValue({ identity });
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(activeMember);
+
+    const result = await requirePrivyMemberAuthFromBearerToken(
+      admissionRequest(),
+      prisma,
+      {
+        runStage: async (stage, run) => {
+          observedStages.push(stage);
+          return run();
+        },
+      },
+    );
+
+    expect(result.member).toBe(activeMember);
+    expect(observedStages).toEqual([
+      "identity_token_verification",
+      "member_lookup",
+    ]);
   });
 
   it("maps an invalid non-empty bearer through the real member owner without device ingress", async () => {


### PR DESCRIPTION
## Why and outcome

Three companion address-book status reads exhausted Vercel's 60-second function limit without identifying the incomplete await. This adds a privacy-safe warning after five seconds that distinguishes identity-token verification, member lookup, and the final address-book status read while preserving the existing request, auth, error, and response behavior.

## Product UX

Internal operational change; Product UX does not apply because no member-visible state, response, authorization requirement, recovery path, or interaction changes.

## Evidence

- Focused companion route and bearer-auth suites, including composed pending-auth proof: 24 tests passed.
- Web typecheck passed.
- Focused ESLint passed for all changed source and test files.
- Exact local PostgreSQL status read with the maximum 1,000 synthetic contacts: 20 warm reads, 1.119 ms median and 6.067 ms maximum.
- Exact SQL `EXPLAIN (ANALYZE, BUFFERS)`: 0.248 ms execution. The query itself did not reproduce the hosted stall.
- `git diff --check` and privacy-path inspection passed.

## Non-obvious affected surfaces

- Shared native bearer authentication accepts an optional stage runner so this route can observe identity verification separately from member resolution. Every existing caller retains the same default behavior; focused bearer-auth coverage proves both ordered stages and the default companion suite remains green.
- Hosted Web runtime logging gains one fixed-label warning only after a GET stage exceeds five seconds. It logs no member, token, contact, URL, request, or response data.

## Architecture and reuse

- **Existing systems reused:** The existing bearer-auth owner, address-book status reader, route error wrapper, and Vercel log stream remain authoritative.
- **New logic:** One route-local slow-stage timer emits a fixed event with elapsed milliseconds and one of three fixed stage names.
- **New abstractions:** A narrow optional bearer-auth stage runner exposes the two already-existing awaits without duplicating authentication policy in the route.
- **Complexity intentionally avoided:** No retry, cancellation, deadline change, persisted diagnostic state, request identifier, queue, or new logging service was added; the diagnostic leaves the in-flight request untouched.

## Hot reply path impact

Not applicable. The companion address-book GET is outside the Foreground Reply Critical Path and adds no database or provider await.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool, schema, generated guidance, or provider-visible input changed.
- Codex runtime: Not applicable; no prompt, instruction, tool, schema, generated guidance, or provider-visible input changed.

ReviewGPT context sensitivity: sensitive — the diff touches native bearer-auth staging and a hosted route, although it does not change authority decisions.

ReviewGPT first-reviewed head: bdae7e60c14c6fbe3093344dc14add6f1d6c0283

## Change-shape breakdown

Classification rule: authored runtime files are source; Vitest files are tests/fixtures; the closed execution plan is docs; no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 58 | 10 |
| Tests/fixtures | 271 | 0 |
| Docs | 73 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **402** | **10** |

No binary files.

## Deployment concerns

- Deployment: not applicable
- Reason: this is a backward-compatible hosted Web-only diagnostic with no database migration, environment binding, Cloudflare change, tandem deploy, or component skew requirement.

## Changelog

- Changelog: not applicable
- Reason: this is internal timeout observability with no member-visible outcome.


