### PR TITLE
Preserve exact context for direct native replies

### DIFF
--- a/apps/web/changelog/entries/2026-08-25/replies-to-earlier-messages.json
+++ b/apps/web/changelog/entries/2026-08-25/replies-to-earlier-messages.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-25",
+  "order": 100,
+  "item": {
+    "id": "replies-to-earlier-messages",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Clearer replies to earlier messages",
+    "summary": "When you reply to an earlier Murph message in a direct conversation, Murph now uses that exact message to understand what you mean.",
+    "details": "The selected message is treated as the reply target without changing ordinary conversation context or tapback handling.",
+    "relevanceTags": ["messaging", "reliability"],
+    "sourcePullRequests": [2279]
+  }
+}

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -1531,6 +1531,9 @@ async function evaluateAssistantAutoReplyGroup(input: {
   }
   const crossSessionReplyContext =
     readPromptInputsCrossSessionReplyContext(promptInputs)
+  const affirmativeReaction =
+    primaryReplyInput.sourceMetadata?.kind === 'linq' &&
+    primaryReplyInput.sourceMetadata.affirmativeReaction === true
   const outboxContext =
     await resolveAssistantAutoReplyCrossSessionDeliveryContext({
       deliveryTarget: conversationDeliveryTarget,
@@ -1538,6 +1541,7 @@ async function evaluateAssistantAutoReplyGroup(input: {
         crossSessionReplyContext.hasNativeReplyReference,
       historyReader: input.historyReader,
       input: primaryReplyInput,
+      preserveSameSessionReplyTarget: !affirmativeReaction,
       replyToMessageId: crossSessionReplyContext.replyToMessageId,
       session: existingSession,
       vault: input.vault,
@@ -1546,9 +1550,6 @@ async function evaluateAssistantAutoReplyGroup(input: {
     providerStartCriticalPath,
     'automationCrossSessionContextDoneAtMonotonicMs',
   )
-  const affirmativeReaction =
-    primaryReplyInput.sourceMetadata?.kind === 'linq' &&
-    primaryReplyInput.sourceMetadata.affirmativeReaction === true
   if (
     affirmativeReaction &&
     (outboxContext.replyTargetDelivery === null ||
@@ -4672,6 +4673,7 @@ async function resolveAssistantAutoReplyCrossSessionDeliveryContext(input: {
   hasNativeReplyReference: boolean
   historyReader: AssistantAutoReplyHistoryReader
   input: AssistantAutoReplyPrimaryInput
+  preserveSameSessionReplyTarget: boolean
   replyToMessageId: string | null
   session: AssistantSession | null
   vault: string
@@ -4714,6 +4716,24 @@ async function resolveAssistantAutoReplyCrossSessionDeliveryContext(input: {
         matchingDeliveries,
         replyToMessageId,
       )
+  // Generic same-session history is already present in the transcript. An
+  // explicit native reply still needs its one selected assistant message
+  // preserved so the model can distinguish it from newer transcript turns.
+  if (
+    input.preserveSameSessionReplyTarget &&
+    replyTargetDelivery !== null &&
+    input.session !== null &&
+    replyTargetDelivery.sessionId === input.session.sessionId
+  ) {
+    return {
+      claim: null,
+      deliveries: buildAssistantAutoReplyPriorDeliveryContexts({
+        deliveries: [replyTargetDelivery],
+        exactReplyTargetIntentId: replyTargetDelivery.intentId,
+      }),
+      replyTargetDelivery,
+    }
+  }
   const orderedMatchingDeliveries = [...matchingDeliveries]
     .sort((left, right) =>
       compareAssistantAutoReplyDeliveryOrders(left.order, right.order),

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -1541,7 +1541,9 @@ async function evaluateAssistantAutoReplyGroup(input: {
         crossSessionReplyContext.hasNativeReplyReference,
       historyReader: input.historyReader,
       input: primaryReplyInput,
-      preserveSameSessionReplyTarget: !affirmativeReaction,
+      preserveSameSessionReplyTarget:
+        primaryReplyInput.conversation.threadIsDirect === true &&
+        !affirmativeReaction,
       replyToMessageId: crossSessionReplyContext.replyToMessageId,
       session: existingSession,
       vault: input.vault,

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -420,6 +420,13 @@ describe('assistant auto-reply event-first path', () => {
 
   it('loads every exact Murph anchor in a compound native-reply group', async () => {
     const vault = await createTempVault()
+    replyEventPathMocks.resolveAssistantSession.mockResolvedValue({
+      created: false,
+      session: {
+        lastTurnAt: '2026-08-07T21:09:30.000Z',
+        sessionId: 'session-chat',
+      },
+    })
     const deliveries = [
       createOutboxMessage({
         channel: 'linq',
@@ -427,7 +434,7 @@ describe('assistant auto-reply event-first path', () => {
         message: 'First prior Murph message.',
         providerMessageId: 'linq-msg-compound-murph-target-first',
         sentAt: '2026-08-07T21:08:00.000Z',
-        sessionId: 'session-automation-first',
+        sessionId: 'session-chat',
         target: 'thread-1',
       }),
       createOutboxMessage({
@@ -436,7 +443,7 @@ describe('assistant auto-reply event-first path', () => {
         message: 'Second prior Murph message.',
         providerMessageId: 'linq-msg-compound-murph-target-second',
         sentAt: '2026-08-07T21:09:00.000Z',
-        sessionId: 'session-automation-second',
+        sessionId: 'session-chat',
         target: 'thread-1',
       }),
     ]
@@ -476,6 +483,9 @@ describe('assistant auto-reply event-first path', () => {
     const prompt = readSentPrompt()
     expect(prompt).toContain('First prior Murph message.')
     expect(prompt).toContain('Second prior Murph message.')
+    expect(readSentInput().turnContext ?? '').not.toContain(
+      'Prior message 1 (native reply target):',
+    )
     expect(replyEventPathMocks.listAssistantOutboxIntents).toHaveBeenCalledWith(
       expect.objectContaining({
         providerMessageIds: [

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -3453,10 +3453,14 @@ describe('assistant auto-reply event-first path', () => {
 
       const sendInput = readSentInput()
       const turnContext = sendInput.turnContext ?? ''
+      const exactSameSessionReply = sessionScope === 'same-session' &&
+        replyMode === 'native'
       const textProjected = presentation === 'text' &&
-        sessionScope === 'cross-session'
-      const contextExpected = hasReferences || textProjected
-      const claimExpected = contextExpected || replyMode === 'ordinary'
+        (sessionScope === 'cross-session' || exactSameSessionReply)
+      const contextExpected = hasReferences || textProjected ||
+        (exactSameSessionReply && presentation === 'media-only')
+      const claimExpected = !exactSameSessionReply &&
+        (contextExpected || replyMode === 'ordinary')
       expect(turnContext.includes(deliveryText)).toBe(textProjected)
       expect(turnContext.includes(referenceId)).toBe(hasReferences)
       expect(sendInput.trustedContextReferences).toEqual(
@@ -4855,6 +4859,74 @@ describe('assistant auto-reply event-first path', () => {
     }))
     expect(replyEventPathMocks.listAssistantTurnReceipts).not.toHaveBeenCalled()
     expect(result.terminalLinqCleanup).toBeUndefined()
+  })
+
+  it('anchors a direct Linq native reply to an exact same-session message', async () => {
+    const vault = await createTempVault()
+    replyEventPathMocks.resolveAssistantSession.mockResolvedValue({
+      created: false,
+      session: {
+        lastTurnAt: '2026-04-08T00:06:00.000Z',
+        sessionId: 'session-chat',
+      },
+    })
+    replyEventPathMocks.listAssistantOutboxIntents.mockResolvedValue([
+      createOutboxMessage({
+        channel: 'linq',
+        intentId: 'intent-same-session-target',
+        message: 'The exact earlier answer.',
+        providerMessageId: 'linq-msg-same-session-target',
+        sentAt: '2026-04-08T00:05:00.000Z',
+        sessionId: 'session-chat',
+      }),
+      createOutboxMessage({
+        channel: 'linq',
+        intentId: 'intent-newer-same-session-message',
+        message: 'A newer unrelated answer.',
+        providerMessageId: 'linq-msg-newer-same-session',
+        sentAt: '2026-04-08T00:06:00.000Z',
+        sessionId: 'session-chat',
+      }),
+    ])
+    const candidate = createAssistantInputCandidate({
+      occurredAt: '2026-04-08T00:10:00.000Z',
+      optionalInboxCaptureId: null,
+      replyTarget: {
+        channel: 'linq',
+        messageId: 'linq-inbound-native-reply',
+        threadId: 'thread-1',
+      },
+      source: 'linq',
+      sourceMetadata: {
+        kind: 'linq',
+        partCount: 1,
+        reactionEligible: false,
+        replyToMessageId: 'linq-msg-same-session-target',
+        service: 'iMessage',
+      },
+      text: 'Can you clarify this?',
+      threadIsDirect: true,
+    })
+
+    await processAssistantAutoReplyGroup({
+      allowSelfAuthored: false,
+      context: createReplyContext(candidate),
+      enabledChannels: ['linq'],
+      inboxServices: createInboxServices(),
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault,
+    })
+
+    const sendInput = readSentInput()
+    expect(sendInput.turnContext).toContain(
+      'Prior message 1 (native reply target):',
+    )
+    expect(sendInput.turnContext).toContain('The exact earlier answer.')
+    expect(sendInput.turnContext).not.toContain('A newer unrelated answer.')
+    expect(sendInput.receiptMetadata).not.toHaveProperty(
+      AUTO_REPLY_RECEIPT_CROSS_SESSION_CONTEXT_INTENT_ID_KEY,
+    )
   })
 
   it('binds an attested same-session affirmative Linq reaction to the exact older target', async () => {


### PR DESCRIPTION
## Why and outcome

Direct native replies could lose their exact same-session assistant-message anchor because generic same-session history is intentionally suppressed as transcript-duplicate context. Preserve the uniquely attested selected message as the direct turn's native reply target while keeping ordinary same-session history suppressed.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: members replying to an earlier assistant bubble in a direct Linq/iMessage conversation.
- Non-regression journeys: ordinary direct replies, same-session tapback reactions, cross-session native replies, and compound group native replies retain their existing behavior.
- Real-model replay: a synthetic direct reply selected the older of two distinct same-session assistant messages; the presented answer addressed only that selected message and ignored the newer unrelated topic.

## Evidence

- Before fix: the focused regression reached provider start with no `turnContext` despite a unique exact provider-message match.
- After fix: the focused regression passes and marks only the selected earlier message as `native reply target`.
- `pnpm --dir packages/assistant-engine typecheck`
- Full reply event-path file: 107 tests passed.
- Focused direct exact-anchor, tapback boundary, and compound group boundary: 3 tests passed.
- A temporary production-prompt/App Server harness exercised normal direct reply selection and routing through an actual model and the delivery presentation boundary; its synthetic answer identified the selected older topic and excluded the newer topic. The proof-only harness was removed afterward.

## Non-obvious affected surfaces

- Same-session tapback reactions keep their existing dedicated reaction context and do not gain reminder/automation metadata; covered by the existing affirmative-reaction regression.
- Compound authenticated groups keep one exact anchor per accepted input and do not gain a competing singular turn-level target, including when both target deliveries belong to the active session.
- Cross-session reply selection is unchanged; covered by the full reply event-path suite.

## Architecture and reuse

- **Existing systems reused:** The existing exact outbox provider-ID matcher and prior-delivery context formatter remain the single owners.
- **New logic:** One early resolver branch preserves only a uniquely matched same-session native reply target for an explicitly direct conversation and creates no cross-session claim.
- **New abstractions:** None; the existing resolver contract is sufficient.
- **Complexity intentionally avoided:** No transcript reconstruction, provider lookup, new state, compatibility layer, or group-specific path was added.

## Hot reply path impact

- This changes the Foreground Reply Critical Path between durable inbound acceptance and provider start.
- Added or moved awaited database/network/provider operations: 0. The existing outbox-history read remains one awaited operation in the same serial position with unchanged timeout, retry, and fallback behavior.
- Added work is one in-memory identity comparison and existing bounded context formatting for a uniquely matched delivery.
- Before/after proof is the focused regression; no external call counts changed.

## Murph initial provider input impact

- Pinned Codex App Server capture used a local scripted Responses endpoint, `gpt-5.6-terra`, low reasoning, production code mode, and `gpt-tokenizer` 3.4.0 `o200k_harmony`.
- Direct changes from 28,156 tokens / 130,352 UTF-8 bytes to 28,301 / 131,061: +145 tokens (+0.5150%) and +709 bytes.
- The representative group request remains byte- and token-identical at 24,501 tokens / 113,945 bytes. A same-session compound-group regression additionally proves that this direct-only context is absent while both existing per-input anchors remain.
- Captured fields were `include`, `input`, `instructions`, `parallel_tool_calls`, `text`, `tool_choice`, and `tools`. Temporary paths and generated input IDs were normalized. The direct base was reconstructed by omitting only the newly proven exact-reply context from the same complete request; two normalized group captures were identical.
- The direct delta is entirely the selected prior-message annotation in `input`; assembled instructions, tool/schema/generated guidance, and every other provider-visible field are unchanged.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: The only hosted Web change is a content-only changelog fragment rendered by the existing production archive component.
- Coverage: Existing archive presentation at mobile and desktop; no renderer, style, state, or interaction changes.

## Change-shape breakdown

Classification uses `git diff --numstat` and assigns production TypeScript to source and Vitest code to tests/fixtures.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 25 | 3 |
| Tests/fixtures | 87 | 5 |
| Docs | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **126** | **8** |

No binary files.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new runner processes share the same inputs and stored formats; they differ only in same-session reply interpretation.
- Safe order: Deploy through the ordinary Cloudflare runner release; no Web tandem deploy is required.
- Rollback floor: Safe at any point because this adds no persisted state or protocol field.
- Expected exposure: Warm old runner processes may retain the old interpretation until ordinary rollout convergence.
- Reversibility: Reverting the runner code restores prior behavior without data repair.
- Convergence proof: Confirm the released runner version reaches active hosted executions.
- Post-deploy checks: Exercise one synthetic direct native reply and inspect bounded reply-path error aggregates.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · replies-to-earlier-messages
