### PR TITLE
Fix runner release provenance for private deploy overlays

### DIFF
--- a/.agents/friction-log/20260825160442-runner-provenance-rejects/friction.md
+++ b/.agents/friction-log/20260825160442-runner-provenance-rejects/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Runner provenance rejects intentional private deployment overlays'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A protected cross-repository deployment can identify the exact public commit while intentionally materializing private runtime assets into the checkout before bundle assembly.
+
+## Current Behavior
+
+The bundle provenance resolver treats every dirty checkout as lacking release provenance. The required private asset overlay therefore produces a null release SHA, causing both hosted-local gates and the production deploy artifact validator to fail before rollout.
+
+## Possible Solution
+
+Let the protected workflow pass its already-resolved public commit SHA into bundle assembly, verify that it exactly matches checked-out HEAD, and retain the source and final-bundle fingerprints for assembled-content identity.
+
+## Minimal Reproducible Example
+
+1. Check out an exact public commit.
+2. Materialize an intentional deployment-only asset under a tracked package path.
+3. Assemble the runner bundle.
+4. Observe that the manifest records no release SHA and is rejected by deployment validation.
+
+## Context
+
+This blocks the canonical Cloudflare deployment workflow after release-provenance validation was added.

--- a/apps/cloudflare/scripts/assemble-runner-bundle.ts
+++ b/apps/cloudflare/scripts/assemble-runner-bundle.ts
@@ -53,6 +53,7 @@ const shouldSkipBundleOnlyDependencies = process.argv.includes(
 const shouldSkipPackPreflights =
   process.argv.includes("--skip-pack-preflights") ||
   process.env.MURPH_RUNNER_BUNDLE_SKIP_PACK_PREFLIGHTS === "1";
+const expectedReleaseSha = process.env.MURPH_RUNNER_BUNDLE_EXPECTED_RELEASE_SHA;
 
 rerunUnderWorkspaceArtifactLockIfNeeded();
 
@@ -107,7 +108,7 @@ async function assembleRunnerBundle(): Promise<void> {
     includeBundleOnlyDependencies,
   });
   const packedWorkspacePackageNames = [...hostedRunnerWorkspacePackageNames].sort();
-  const releaseSha = resolvePublicRunnerReleaseSha(repoRoot);
+  const releaseSha = resolvePublicRunnerReleaseSha(repoRoot, expectedReleaseSha);
 
   try {
     if (!shouldSkipBuild) {

--- a/apps/cloudflare/scripts/deploy-artifacts.ts
+++ b/apps/cloudflare/scripts/deploy-artifacts.ts
@@ -313,6 +313,7 @@ async function readRunnerBundleManifest(bundleDir: string): Promise<RunnerBundle
 
 export function resolvePublicRunnerReleaseSha(
   repoRoot: string = defaultRepoRoot,
+  expectedReleaseSha?: string,
 ): string | null {
   const releaseResult = spawnSync(
     "git",
@@ -330,6 +331,17 @@ export function resolvePublicRunnerReleaseSha(
     || !publicReleaseShaPattern.test(releaseSha)
   ) {
     throw new Error("Could not resolve the public Murph release SHA for the runner bundle.");
+  }
+
+  if (expectedReleaseSha !== undefined) {
+    const normalizedExpectedReleaseSha = expectedReleaseSha.trim().toLowerCase();
+    if (!publicReleaseShaPattern.test(normalizedExpectedReleaseSha)) {
+      throw new Error("Expected runner bundle release SHA must be a full public Git commit SHA.");
+    }
+    if (releaseSha !== normalizedExpectedReleaseSha) {
+      throw new Error("Public Murph checkout does not match the expected runner bundle release SHA.");
+    }
+    return releaseSha;
   }
 
   const statusResult = spawnSync(

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -93,6 +93,12 @@ describe("hosted runner container image contract", () => {
     expect(bundleAssemblyScript).toContain("run-with-workspace-artifact-lock.mjs");
     expect(bundleAssemblyScript).toContain('const shouldSkipBuild = process.argv.includes("--skip-build");');
     expect(bundleAssemblyScript).toContain(
+      "const expectedReleaseSha = process.env.MURPH_RUNNER_BUNDLE_EXPECTED_RELEASE_SHA;",
+    );
+    expect(bundleAssemblyScript).toContain(
+      "const releaseSha = resolvePublicRunnerReleaseSha(repoRoot, expectedReleaseSha);",
+    );
+    expect(bundleAssemblyScript).toContain(
       'import { resolveCloudflareDeployPaths } from "./deploy-automation.js";',
     );
     expect(bundleAssemblyScript).toContain(

--- a/apps/cloudflare/test/deploy-artifacts.test.ts
+++ b/apps/cloudflare/test/deploy-artifacts.test.ts
@@ -147,10 +147,15 @@ describe("deploy artifact validation", () => {
         "test release",
       ]);
 
-      expect(resolvePublicRunnerReleaseSha(repoRoot)).toMatch(/^[a-f0-9]{40}$/u);
+      const releaseSha = resolvePublicRunnerReleaseSha(repoRoot);
+      expect(releaseSha).toMatch(/^[a-f0-9]{40}$/u);
 
       await writeFile(path.join(repoRoot, "release-source.txt"), "dirty\n", "utf8");
       expect(resolvePublicRunnerReleaseSha(repoRoot)).toBeNull();
+      expect(resolvePublicRunnerReleaseSha(repoRoot, releaseSha ?? undefined)).toBe(releaseSha);
+      expect(() => resolvePublicRunnerReleaseSha(repoRoot, "f".repeat(40))).toThrow(
+        "Public Murph checkout does not match the expected runner bundle release SHA.",
+      );
     } finally {
       await rm(repoRoot, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why and outcome

The new runner release-provenance check treated the intentional private assistant-asset overlay as an unknown dirty build. That made every canonical Cloudflare predeploy lane and the production deploy reject the bundle before rollout.

This keeps ordinary dirty builds fail-closed, while allowing the protected cross-repository workflow to supply the already-resolved public SHA. Bundle assembly accepts it only when it is a full commit SHA and exactly matches checked-out `HEAD`; the existing source and bundle fingerprints still identify the assembled bytes.

## Product UX

- Effort: Patch
- Outcome: No member-facing behavior changes. The canonical deployment path can ship an exact public release with its required private assets.
- Reaches: Operators running the protected hosted-execution deployment workflow.
- Proof: The focused provenance test covers clean, dirty, explicit-match, and explicit-mismatch paths.

## Evidence

- Focused deploy-artifact and assembly source-contract tests: 57/57 passed.
- Cloudflare typecheck passed.
- Production incident proof: the protected workflow resolved the exact public main SHA, then both predeploy and deploy artifact validation rejected the intentional private overlay before any Worker mutation.

## Non-obvious affected surfaces

- The private workflow must bind `MURPH_RUNNER_BUNDLE_EXPECTED_RELEASE_SHA` to its immutable public-source resolver output.
- Hosted-local and production bundles retain the final source and bundle fingerprints; the explicit SHA identifies the public commit rather than claiming the checkout contains no intentional private overlay.

## Architecture and reuse

- Existing systems reused: Protected public-SHA resolver, Git `HEAD` verification, manifest provenance field, and source/bundle fingerprints.
- New logic: Accept an explicit expected release SHA only after validating its shape and exact equality with checked-out `HEAD`.
- New abstractions: None; no service, state owner, queue, dependency, or persistence.
- Complexity intentionally avoided: Ordinary local bundle assembly keeps the existing clean-checkout requirement; no dirty-path allowlist or synthetic commit.

## Hot reply path impact

None. This changes build-time deployment provenance only.

## Murph initial provider input impact

None. No prompt, model, tool, or provider-input path changes.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 14 | 1 |
| Tests\/fixtures | 12 | 1 |
| Docs | 27 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 53 | 2 |

## Risks

- The explicit SHA path intentionally permits a modified checkout, but only after proving its declared public SHA equals `HEAD`; assembled-content identity remains covered by the existing fingerprints.
- The private workflow mapping must merge after this public contract.

## Deployment concerns

- Deployment: applicable
- Safe order: Merge this public contract first, then the matching `murph-cloud` workflow mapping, then rerun the protected production Cloudflare deploy without skipping predeploy gates.
- Supported skew: The public contract is additive and unused until the private workflow passes the expected SHA.
- Rollback: Revert the private workflow mapping before reverting this public helper.
- Post-deploy proof: Require all predeploy gates, deploy artifact validation, Worker rollout, runner-container smoke, live model turn, and exact release-SHA reporting to pass.

## Changelog

- Changelog: not applicable
- Reason: Internal deployment repair with no member-facing capability change.

ReviewGPT context sensitivity: sensitive — runtime deployment provenance and cross-repository workflow composition.

ReviewGPT first-reviewed head: 449cbe79b6a9477759271f1a5a8694ef2b13f1b6