### PR TITLE
Compact iMessage workout comparison cards

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2239,13 +2239,13 @@ recovery retains the complete status meaning outside the bitmap.
 Null, incomplete, and unavailable goal states retain a neutral ring, and a
 short subcaption appears only when some totals are partial. Compact-table
 images retain the table grid or workout progress and exercise rows without a
-large empty icon gutter. Stacked generic fields place each measured header
-above its full-width measured value so contract-valid tokens remain contained.
-Their provider
-chrome stays bounded to the title plus an optional generic subtitle or derived
-workout progress rather than repeating the raster's rows and sets. Complete
-semantic text remains available through the deterministic text renderer and
-value-free recovery fallback.
+large empty icon gutter. Their compact grid typography keeps short comparisons
+under one shared header, while stacked generic fields place each measured
+header above its full-width measured value so contract-valid tokens remain
+contained. Generic provider chrome keeps only the title; structured-workout
+chrome adds derived progress. Neither repeats the raster's rows or sets.
+Complete semantic text remains available through the deterministic text
+renderer and value-free recovery fallback.
 The nutrition image derives a quantitative calorie arc only from a complete
 total and an assessed non-null goal; V1, partial, null-goal, and
 unavailable-status snapshots retain only the neutral ring track. The extension
@@ -3805,15 +3805,15 @@ the opaque workout-revision binding plus a bounded typed editable-set projection
 derived from values already visible in that private-direct workout card. None may
 contain a member identity, canonical record reference, credential, tracking
 reference, or other authority.
-Generic V3 tables choose their one shared-header grid solely from the exact
-intrinsic width of every admitted header and cell track plus its gutters. Only
-genuinely overwide content uses repeated full-width field labels; column count
-does not create a second layout authority.
+Generic V3 tables use compact grid typography and choose their one shared-header
+grid solely from the exact intrinsic width of every admitted header and cell
+track plus its gutters. Only genuinely overwide content uses repeated
+full-width field labels; column count does not create a second layout authority.
 The provider request rejects encoded URLs at 2,048 characters, while the
 contract applies the tighter of the fragment and image-path bounds before
-delivery. Compact-table provider chrome uses only bounded title, optional
-generic subtitle, and derived workout-progress fields; complete detail remains
-owned by the semantic text renderer. V4 workout authoring and native decoding
+delivery. Generic compact-table provider chrome uses only the bounded title;
+structured workouts add derived progress. Complete detail remains owned by the
+semantic text renderer. V4 workout authoring and native decoding
 admit up to 16 exercises and 16 sets per exercise, but those logical bounds do
 not replace the measured fragment and image-path gates. A complete snapshot is
 attempted first; a real encoded-envelope rejection recovers through complete

--- a/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
+++ b/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
@@ -100,12 +100,19 @@ Updated: 2026-08-25
   current-branch preview remains the reviewer-openable browser proof.
 - Candidate: draft PR #2285 is open with the implementation commit and
   member-visible changelog item.
-- Remaining gates: preliminary ReviewGPT, final ReviewGPT, exact-head CI, final
-  parent review, plan closure, and current-base merge-tree.
+- Review gates: final ReviewGPT passed with no code findings. Preliminary
+  ReviewGPT found one accepted external evidence gap and returned no patch:
+  only a physical no-extension iPhone/macOS send can prove Linq's final
+  provider-owned balloon composition.
+- CI: every required check on the reviewed candidate head passed.
+- Remaining gate: perform the privacy-safe synthetic send through the normal
+  Linq path on physical app-absent clients, including the existing
+  image-unavailable recovery, before rollout. Then complete final parent review,
+  plan closure, and current-base merge-tree.
 
 ## Product UX walkthrough
 
-- Result: Ready.
+- Result: Hold pending physical provider/device proof.
 - Person and entry point: a private-direct member receives a generic response
   card in an app-absent iMessage client after asking for a small workout
   comparison.
@@ -118,3 +125,7 @@ Updated: 2026-08-25
 - Difference from plan: none. The patch reuses the existing grid/stacked owner
   and removes duplicated provider chrome without adding a card kind, heuristic,
   or state owner.
+- Hold reason: source-level raster, provider-payload, recovery, and responsive
+  proof are green, but those separate seams cannot establish Linq rehosting and
+  Apple's final no-extension balloon composition. Do not replace the required
+  physical check with a simulator or another fallback owner.

--- a/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
+++ b/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
@@ -92,13 +92,16 @@ Updated: 2026-08-25
   response-card image suite passed (24 tests), and the affected operator-config
   suites passed (29 tests).
 - Static proof: Web and operator-config typechecks passed; affected Web ESLint
-  paths and `git diff --check` passed.
+  paths and `git diff --check` passed. Changelog generation and its nine-test
+  page suite also passed after adding the member-visible entry.
 - Browser-catalog capture: the existing design study now includes the synthetic
   comparison at desktop and mobile scales. Two local Playwright launches were
   unable to reach the repo health endpoint after Next reported ready, so the
   current-branch preview remains the reviewer-openable browser proof.
-- Remaining gates: candidate commit, changelog, preliminary ReviewGPT, final
-  ReviewGPT, exact-head CI, final parent review, and current-base merge-tree.
+- Candidate: draft PR #2285 is open with the implementation commit and
+  member-visible changelog item.
+- Remaining gates: preliminary ReviewGPT, final ReviewGPT, exact-head CI, final
+  parent review, plan closure, and current-base merge-tree.
 
 ## Product UX walkthrough
 

--- a/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
+++ b/agent-docs/exec-plans/active/2026-08-25-compact-multi-workout-card.md
@@ -1,0 +1,117 @@
+# Compact multi-workout response cards
+
+Status: active
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Make a small multi-workout comparison legible at a glance in the existing
+  app-absent iMessage response-card presentation, without adding a new card
+  kind or changing workout data ownership.
+
+## Product UX
+
+- Effort: Patch.
+- Outcome: a short comparison uses one compact shared-header grid and does not
+  repeat every row in Linq's outer caption.
+- Reaches: a private-direct member viewing a generic response card without the
+  Messages extension, including Messages on macOS; native-extension and plain
+  semantic-text paths keep their existing behavior.
+- Proof: render a synthetic two-row, three-set comparison through the real
+  image route and inspect the raster at transcript width; verify a genuinely
+  wide table still uses the full-width stacked fallback.
+
+## Success criteria
+
+- The production renderer reproduces the tall stacked layout for a synthetic
+  two-workout comparison before the change.
+- The same card renders as a shared-header grid after the change, with every
+  row and set visible in a materially shorter raster.
+- Generic Linq chrome stops duplicating table rows already present in the
+  bitmap; deterministic complete semantic text remains unchanged.
+- Dense and overwide contract-valid tables remain complete and legible through
+  the existing stacked fallback.
+- Focused tests, Web typecheck, visual inspection, exact-head CI, and the
+  required Product UX/frontend/coverage ReviewGPT lenses pass.
+
+## Scope
+
+- In scope: compact generic-grid typography and gutters, generic Linq card
+  chrome, focused response-card tests, one member-visible changelog item, and
+  current response-card documentation.
+- Out of scope: workout identity/state, native Messages-extension rendering,
+  card schemas, provider delivery ownership, or a new comparison-specific UI.
+
+## Constraints
+
+- Technical constraints: reuse V3 generic cards, the existing grid/stacked
+  layout owner, the existing stateless image route, and the existing semantic
+  text fallback. Preserve measured wrapping and image-path bounds.
+- Product/process constraints: keep private feedback and the supplied
+  screenshot out of committed fixtures and review artifacts; use only
+  synthetic data. Keep the complete answer available when image rendering is
+  unavailable.
+
+## Risks and mitigations
+
+1. Risk: compacting every generic table could make genuinely wide content too
+   dense.
+   Mitigation: change only the grid's density; retain the existing exact-width
+   test and stacked fallback for content that still does not fit.
+2. Risk: removing duplicated provider detail could weaken recovery.
+   Mitigation: leave the deterministic semantic text and value-free text
+   recovery unchanged; only remove rows duplicated under a successfully
+   rendered image.
+
+## Tasks
+
+1. Reproduce the tall two-row, three-column layout through the real image owner.
+2. Add a focused synthetic regression test that proves the compact boundary.
+3. Compact the existing grid and remove redundant generic provider detail.
+4. Render and inspect the corrected raster plus a deliberately overwide case.
+5. Run focused tests/typecheck, complete the Product UX walkthrough, commit,
+   push, and run the required PR review and CI gates.
+
+## Decisions
+
+- Do not add presentation selection heuristics or another card kind. The current
+  generic grid already owns this layout; its density is the defect.
+- Keep stacked fields as the overflow layout rather than truncating or shrinking
+  arbitrary content.
+
+## Verification
+
+- Exact local reproduction: the supplied comparison rendered through the real
+  image route at 1,200 × 1,446 before the change and 1,200 × 528 after it. The
+  supplied private content remains only in ignored local artifacts.
+- Safe visual proof: a synthetic comparison rendered through the same route at
+  1,200 × 488 and was inspected at native resolution; all row and set values
+  are visible in one shared-header grid.
+- Regression proof: the full real-font raster suite passed (12 tests), the full
+  response-card image suite passed (24 tests), and the affected operator-config
+  suites passed (29 tests).
+- Static proof: Web and operator-config typechecks passed; affected Web ESLint
+  paths and `git diff --check` passed.
+- Browser-catalog capture: the existing design study now includes the synthetic
+  comparison at desktop and mobile scales. Two local Playwright launches were
+  unable to reach the repo health endpoint after Next reported ready, so the
+  current-branch preview remains the reviewer-openable browser proof.
+- Remaining gates: candidate commit, changelog, preliminary ReviewGPT, final
+  ReviewGPT, exact-head CI, final parent review, and current-base merge-tree.
+
+## Product UX walkthrough
+
+- Result: Ready.
+- Person and entry point: a private-direct member receives a generic response
+  card in an app-absent iMessage client after asking for a small workout
+  comparison.
+- Feedback and continuation: the first balloon contains the complete compact
+  comparison; no extra action or session state is introduced.
+- Exclusions: native Messages-extension cards and structured workout cards keep
+  their existing renderers and progress chrome.
+- Recovery: complete deterministic semantic text remains unchanged when the
+  image cannot be delivered or the member requests the text version.
+- Difference from plan: none. The patch reuses the existing grid/stacked owner
+  and removes duplicated provider chrome without adding a card kind, heuristic,
+  or state owner.

--- a/agent-docs/exec-plans/completed/2026-08-25-compact-multi-workout-card.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-compact-multi-workout-card.md
@@ -1,6 +1,6 @@
 # Compact multi-workout response cards
 
-Status: active
+Status: completed
 Created: 2026-08-25
 Updated: 2026-08-25
 
@@ -98,21 +98,23 @@ Updated: 2026-08-25
   comparison at desktop and mobile scales. Two local Playwright launches were
   unable to reach the repo health endpoint after Next reported ready, so the
   current-branch preview remains the reviewer-openable browser proof.
-- Candidate: draft PR #2285 is open with the implementation commit and
+- Candidate: PR #2285 is open with the implementation commit and
   member-visible changelog item.
 - Review gates: final ReviewGPT passed with no code findings. Preliminary
   ReviewGPT found one accepted external evidence gap and returned no patch:
   only a physical no-extension iPhone/macOS send can prove Linq's final
   provider-owned balloon composition.
 - CI: every required check on the reviewed candidate head passed.
-- Remaining gate: perform the privacy-safe synthetic send through the normal
-  Linq path on physical app-absent clients, including the existing
-  image-unavailable recovery, before rollout. Then complete final parent review,
-  plan closure, and current-base merge-tree.
+- Release decision: the user explicitly authorized rollout after reviewing the
+  corrected raster. The physical app-absent composition check remains a
+  post-deploy smoke because Linq rehosting and Apple's final balloon are outside
+  the repository-owned renderer; it does not justify another state or fallback
+  owner. Final parent review and the current-base merge-tree are complete.
 
 ## Product UX walkthrough
 
-- Result: Hold pending physical provider/device proof.
+- Result: Ready for the user-authorized Web-first rollout; physical
+  provider/device composition remains a post-deploy smoke.
 - Person and entry point: a private-direct member receives a generic response
   card in an app-absent iMessage client after asking for a small workout
   comparison.
@@ -125,7 +127,9 @@ Updated: 2026-08-25
 - Difference from plan: none. The patch reuses the existing grid/stacked owner
   and removes duplicated provider chrome without adding a card kind, heuristic,
   or state owner.
-- Hold reason: source-level raster, provider-payload, recovery, and responsive
+- Residual proof: source-level raster, provider-payload, recovery, and responsive
   proof are green, but those separate seams cannot establish Linq rehosting and
-  Apple's final no-extension balloon composition. Do not replace the required
-  physical check with a simulator or another fallback owner.
+  Apple's final no-extension balloon composition. Verify that boundary after
+  rollout on a consented physical client; do not replace it with a simulator or
+  another fallback owner.
+Completed: 2026-08-25

--- a/agent-docs/operations/imessage-deliverability.md
+++ b/agent-docs/operations/imessage-deliverability.md
@@ -112,18 +112,20 @@ Generic compact tables use V3. Workout static images use the compact V4 tuple
 wire, while an editable native workout uses V6 with its opaque action binding.
 V3 and V4 reuse their authority-free presentation envelope in the same bounded
 queryless image path. The static renderer mirrors the native table or
-workout summary. Generic Linq provider chrome retains its title, optional
-subtitle, rows, and footer. Structured-workout provider chrome stays bounded to
-the title plus derived progress instead of repeating every rendered set.
+workout summary. Generic Linq provider chrome retains only its title instead of
+repeating the image's subtitle, rows, or footer. Structured-workout provider
+chrome stays bounded to the title plus derived progress instead of repeating
+every rendered set.
 Workout authoring and native decoding admit up to 16 exercises and 16 sets per
 exercise, but the measured 2,048-character URL and image-path checks remain the
 final authority for each complete snapshot. The assistant must attempt the
 complete verified card instead of estimating capacity from counts or asking the
 member to simplify saved workout data; only an actual envelope rejection uses
 the complete deterministic text recovery.
-Generic static tables keep one shared header whenever exact intrinsic header and
-cell tracks plus gutters fit the raster, regardless of column count; only
-genuinely overwide content uses repeated full-width field labels.
+Generic static tables use compact grid typography and keep one shared header
+whenever exact intrinsic header and cell tracks plus gutters fit the raster,
+regardless of column count; only genuinely overwide content uses repeated
+full-width field labels.
 Complete workout semantics remain available through the deterministic text
 renderer and value-free text-recovery fallback. V3 tracking stays only in
 the semantic transcript and is stripped before both encodings; V4 contains no

--- a/agent-docs/product-specs/imessage-workout-tracking.md
+++ b/agent-docs/product-specs/imessage-workout-tracking.md
@@ -93,11 +93,11 @@ Recipients without the Messages extension, including Messages on macOS,
 receive a generated static image that mirrors the compact native workout or
 generic-table balloon. Provider chrome is intentionally bounded to the title
 plus derived progress for structured workouts; it does not repeat the image's
-sets below the balloon. Generic-table provider chrome retains its existing
-title, optional subtitle, rows, and footer. The complete semantic text renderer
-remains the workout recovery owner, and the value-free fallback identifies the
-message as the member's workout before telling them how to request that complete
-text without exposing its values outside the card.
+sets below the balloon. Generic-table provider chrome likewise retains only the
+title instead of repeating the image's subtitle, rows, or footer. The complete
+semantic text renderer remains the recovery owner, and the value-free fallback
+identifies the message as the member's workout or summary before telling them
+how to request that complete text without exposing its values outside the card.
 
 The bitmap remains rectangular because Messages owns the outer mask and
 caption. Because the provider request omits an App Store id, the app-absent

--- a/apps/web/app/design/imessage-compact-table-card-study.tsx
+++ b/apps/web/app/design/imessage-compact-table-card-study.tsx
@@ -114,6 +114,20 @@ const SYNTHETIC_FITTING_FOUR_COLUMN_CARD: CompactTablePresentationCardV1 = {
   footer: "Short fields stay in one compact table.",
 };
 
+const SYNTHETIC_WORKOUT_COMPARISON_CARD: CompactTablePresentationCardV1 = {
+  kind: "compact_table",
+  version: 1,
+  title: "Workout set comparison",
+  subtitle: null,
+  rowHeader: "Workout",
+  columns: ["Set 1", "Set 2", "Set 3"],
+  rows: [
+    { label: "Previous Workout", values: ["–", "20 lb × 8", "–"] },
+    { label: "Current Workout", values: ["25 lb × 8", "25 lb × 8", "–"] },
+  ],
+  footer: null,
+};
+
 export function ImessageCompactTableCardStudy() {
   return (
     <div className="rounded-2xl border border-border bg-card p-4 sm:p-8" inert>
@@ -126,9 +140,10 @@ export function ImessageCompactTableCardStudy() {
         </h3>
         <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
           The image fallback keeps a targetless first pending set honest and
-          keeps a fitting four-column card in one shared-header table. Genuinely
-          overwide rows use stacked fields with each measured header above its
-          full-width value so contract-limit text cannot collide or clip.
+          keeps short workout comparisons and fitting four-column cards in one
+          shared-header table. Genuinely overwide rows use stacked fields with
+          each measured header above its full-width value so contract-limit text
+          cannot collide or clip.
           The rectangular raster keeps its title and optional supporting text
           beside the canonical Murph badge, while Messages supplies the outer
           corner mask.
@@ -145,6 +160,10 @@ export function ImessageCompactTableCardStudy() {
           card={SYNTHETIC_FITTING_FOUR_COLUMN_CARD}
           scale={0.72}
         />
+        <ScaledCompactTableCard
+          card={SYNTHETIC_WORKOUT_COMPARISON_CARD}
+          scale={0.72}
+        />
         <ScaledCompactTableCard card={SYNTHETIC_DENSE_TABLE_CARD} scale={0.62} />
       </div>
       <div className="flex flex-col gap-5 sm:hidden">
@@ -154,6 +173,10 @@ export function ImessageCompactTableCardStudy() {
         />
         <ScaledCompactTableCard
           card={SYNTHETIC_FITTING_FOUR_COLUMN_CARD}
+          scale={0.25}
+        />
+        <ScaledCompactTableCard
+          card={SYNTHETIC_WORKOUT_COMPARISON_CARD}
           scale={0.25}
         />
         <ScaledCompactTableCard card={SYNTHETIC_DENSE_TABLE_CARD} scale={0.25} />

--- a/apps/web/changelog/entries/2026-08-25/compact-imessage-workout-tables.json
+++ b/apps/web/changelog/entries/2026-08-25/compact-imessage-workout-tables.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-25",
+  "order": 100,
+  "item": {
+    "id": "compact-imessage-workout-tables",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "More compact iMessage workout tables",
+    "summary": "Short workout comparisons now fit into one shared-header table instead of repeating every field vertically.",
+    "details": "Wider content still uses the full-width layout, and the complete text version remains available when an image cannot be delivered.",
+    "relevanceTags": ["imessage", "workouts"],
+    "sourcePullRequests": [2285]
+  }
+}

--- a/apps/web/src/components/imessage/compact-table-card-image.tsx
+++ b/apps/web/src/components/imessage/compact-table-card-image.tsx
@@ -32,6 +32,8 @@ const FOOTER_FONT_SIZE = 49;
 const CAPTION_2_FONT_SIZE = 41;
 const CAPTION_FONT_SIZE = 45;
 const SUBHEADLINE_FONT_SIZE = 56;
+const GENERIC_GRID_FONT_SIZE = 48;
+const GENERIC_GRID_GAP = 24;
 const GENERIC_ROW_LABEL_WIDTH = CARD_CONTENT_WIDTH * 0.38;
 const GENERIC_VALUES_WIDTH = CARD_CONTENT_WIDTH * 0.62;
 const INTRINSIC_TRACK_SAFETY_PADDING = 4;
@@ -391,8 +393,6 @@ function GenericTableSnapshot({
     return <GenericStackedRows card={card} header={header} rows={rows} />;
   }
 
-  const valueFontSize = SUBHEADLINE_FONT_SIZE;
-
   return (
     <div
       data-compact-table-layout="grid"
@@ -407,7 +407,7 @@ function GenericTableSnapshot({
           display: "flex",
           height: header?.height ?? 66,
           alignItems: "center",
-          gap: 38,
+          gap: GENERIC_GRID_GAP,
           color: IMESSAGE_CARD_COLOR.secondary,
           fontSize: CAPTION_2_FONT_SIZE,
           fontWeight: 600,
@@ -452,7 +452,7 @@ function GenericTableSnapshot({
             display: "flex",
             height: rows[rowIndex]?.height ?? 93,
             alignItems: "center",
-            gap: 38,
+            gap: GENERIC_GRID_GAP,
             borderTop: `2px solid ${IMESSAGE_CARD_COLOR.divider}`,
           }}
         >
@@ -461,7 +461,7 @@ function GenericTableSnapshot({
               display: "flex",
               width: header?.rowHeaderWidth ?? GENERIC_ROW_LABEL_WIDTH,
               flexShrink: 0,
-              fontSize: SUBHEADLINE_FONT_SIZE,
+              fontSize: GENERIC_GRID_FONT_SIZE,
               fontWeight: 600,
               lineHeight: 1.15,
               whiteSpace: "pre-wrap",
@@ -479,7 +479,7 @@ function GenericTableSnapshot({
                   / card.columns.length,
                 flexShrink: 0,
                 justifyContent: "flex-end",
-                fontSize: valueFontSize,
+                fontSize: GENERIC_GRID_FONT_SIZE,
                 fontVariantNumeric: "tabular-nums",
                 lineHeight: 1.15,
                 textAlign: "right",
@@ -678,7 +678,9 @@ function getCompactTableCardImageLayout(
       genericMode === "grid"
         ? gridWidths.rowHeaderWidth
         : CARD_CONTENT_WIDTH,
-      SUBHEADLINE_FONT_SIZE,
+      genericMode === "grid"
+        ? GENERIC_GRID_FONT_SIZE
+        : SUBHEADLINE_FONT_SIZE,
       600,
     );
     const values = row.values.map((value, index) =>
@@ -687,14 +689,16 @@ function getCompactTableCardImageLayout(
         genericMode === "grid"
           ? gridWidths.columnWidths[index] ?? valueWidth
           : CARD_CONTENT_WIDTH,
-        SUBHEADLINE_FONT_SIZE,
+        genericMode === "grid"
+          ? GENERIC_GRID_FONT_SIZE
+          : SUBHEADLINE_FONT_SIZE,
       )
     );
     const textHeight = genericMode === "grid"
       ? Math.max(
-        label.lineCount * SUBHEADLINE_FONT_SIZE * 1.15,
+        label.lineCount * GENERIC_GRID_FONT_SIZE * 1.15,
         ...values.map((value) =>
-          value.lineCount * SUBHEADLINE_FONT_SIZE * 1.15
+          value.lineCount * GENERIC_GRID_FONT_SIZE * 1.15
         ),
       )
       : label.lineCount * SUBHEADLINE_FONT_SIZE * 1.15
@@ -790,7 +794,7 @@ function getCompactTableGridWidths(
         0.07,
       ),
       ...card.rows.map((row) =>
-        measureDmSans600Text(row.label, SUBHEADLINE_FONT_SIZE)
+        measureDmSans600Text(row.label, GENERIC_GRID_FONT_SIZE)
       ),
     ),
   ) + INTRINSIC_TRACK_SAFETY_PADDING;
@@ -805,13 +809,13 @@ function getCompactTableGridWidths(
         ...card.rows.map((row) =>
           measureDmSans400Text(
             row.values[index] ?? "",
-            SUBHEADLINE_FONT_SIZE,
+            GENERIC_GRID_FONT_SIZE,
           )
         ),
       ),
     ) + INTRINSIC_TRACK_SAFETY_PADDING
   );
-  const horizontalSpacing = card.columns.length * 38;
+  const horizontalSpacing = card.columns.length * GENERIC_GRID_GAP;
   return {
     columnWidths,
     rowHeaderWidth,

--- a/apps/web/test/imessage-compact-table-card-raster.test.tsx
+++ b/apps/web/test/imessage-compact-table-card-raster.test.tsx
@@ -131,6 +131,20 @@ const NARROW_FOUR_COLUMN_CARD: CompactTablePresentationCardV1 = {
   footer: null,
 };
 
+const WORKOUT_COMPARISON_CARD: CompactTablePresentationCardV1 = {
+  kind: "compact_table",
+  version: 1,
+  title: "Workout set comparison",
+  subtitle: null,
+  rowHeader: "Workout",
+  columns: ["Set 1", "Set 2", "Set 3"],
+  rows: [
+    { label: "Previous Workout", values: ["–", "20 lb × 8", "–"] },
+    { label: "Current Workout", values: ["25 lb × 8", "25 lb × 8", "–"] },
+  ],
+  footer: null,
+};
+
 function getMaximumStackedCard(
   columnCount: number,
 ): CompactTablePresentationCardV1 {
@@ -221,6 +235,20 @@ test("real-font route keeps a fitting four-column eight-row table compact", asyn
     card: NARROW_FOUR_COLUMN_CARD,
   });
   assert.deepEqual([image.width, image.height], [1_200, 1_046]);
+
+  const bounds = findNonBackgroundBounds(image);
+  assert.ok(bounds !== null);
+  assert.ok(bounds.left >= 20);
+  assert.ok(bounds.right <= 1_155);
+  assert.ok(bounds.bottom <= image.height - 40);
+});
+
+test("real-font route keeps a short workout comparison compact", async () => {
+  const image = await renderCard({
+    schemaVersion: 3,
+    card: WORKOUT_COMPARISON_CARD,
+  });
+  assert.deepEqual([image.width, image.height], [1_200, 488]);
 
   const bounds = findNonBackgroundBounds(image);
   assert.ok(bounds !== null);

--- a/apps/web/test/imessage-nutrition-card-image.test.tsx
+++ b/apps/web/test/imessage-nutrition-card-image.test.tsx
@@ -135,6 +135,20 @@ const TABLE_CARD: CompactTablePresentationCardV1 = {
   footer: "Adjust load when form slows down.",
 };
 
+const COMPACT_COMPARISON_TABLE_CARD: CompactTablePresentationCardV1 = {
+  kind: "compact_table",
+  version: 1,
+  title: "Workout set comparison",
+  subtitle: null,
+  rowHeader: "Workout",
+  columns: ["Set 1", "Set 2", "Set 3"],
+  rows: [
+    { label: "Previous Workout", values: ["–", "20 lb × 8", "–"] },
+    { label: "Current Workout", values: ["25 lb × 8", "25 lb × 8", "–"] },
+  ],
+  footer: null,
+};
+
 const DENSE_TABLE_CARD: CompactTablePresentationCardV1 = {
   kind: "compact_table",
   version: 1,
@@ -520,6 +534,27 @@ test("response-card image route renders the exact V3 generic table snapshot", as
   assert.doesNotMatch(serialized, /margin-top:171px/u);
   assert.match(serialized, /<h1/u);
   assert.match(serialized, /data-compact-table-layout="grid"/u);
+});
+
+test("short workout comparisons stay in one compact shared-header grid", async () => {
+  const { GET } = await import("../app/imessage/card/v1/[payload]/route");
+  const payload = encodePayload({
+    schemaVersion: 3,
+    card: COMPACT_COMPARISON_TABLE_CARD,
+  });
+  const response = await GET(
+    new Request(`https://www.withmurph.ai/imessage/card/v1/${payload}`),
+    { params: Promise.resolve({ payload }) },
+  );
+
+  assert.equal(response.status, 200);
+  const [imageTree, init] = getImageResponseCall();
+  const serialized = renderToStaticMarkup(imageTree);
+  assert.ok((init.height ?? Number.POSITIVE_INFINITY) < 800);
+  assert.match(serialized, /data-compact-table-layout="grid"/u);
+  assert.doesNotMatch(serialized, /data-compact-table-layout="stacked"/u);
+  assert.equal(serialized.match(/>SET 1<\/div>/gu)?.length, 1);
+  assert.equal(serialized.match(/>25 lb × 8<\/div>/gu)?.length, 2);
 });
 
 test("response-card image route restores and renders the exact compact V4 workout snapshot", async () => {

--- a/packages/operator-config/src/assistant-response-cards.ts
+++ b/packages/operator-config/src/assistant-response-cards.ts
@@ -338,14 +338,9 @@ export function buildLinqIMessageAppLayout(
         subcaption: `${progress.completed}/${progress.total} sets complete`,
       }
     }
-    const semantic = renderCompactTableSemanticPresentation(parsed)
     return {
-      caption: semantic.heading,
+      caption: parsed.title,
       image_url: imageUrl,
-      subcaption: semantic.detailLines.join('\n'),
-      ...(semantic.footer === null
-        ? {}
-        : { trailing_caption: semantic.footer }),
     }
   }
   if (parsed.kind === 'challenge_standings') {

--- a/packages/operator-config/test/linq-compact-table-app-card.test.ts
+++ b/packages/operator-config/test/linq-compact-table-app-card.test.ts
@@ -93,12 +93,9 @@ describe('Linq compact-table app cards', () => {
       }
     ).message.parts[0]?.layout
     expect(layout).toBeDefined()
-    expect(layout?.subcaption).toContain(
-      'Exercise 8 movement pattern: Set 1:',
-    )
-    expect(layout?.trailing_caption).toBe(
-      'Assists and spotted reps remain on the exact set note.',
-    )
+    expect(layout).toEqual(expectedLayout)
+    expect(layout).not.toHaveProperty('subcaption')
+    expect(layout).not.toHaveProperty('trailing_caption')
   })
 
   it('sends a generic table with its exact descriptive recovery fallback', async () => {

--- a/packages/operator-config/test/response-card-static-layout.test.ts
+++ b/packages/operator-config/test/response-card-static-layout.test.ts
@@ -47,27 +47,25 @@ describe('response-card static Linq layouts', () => {
     }
   })
 
-  it('preserves generic provider details without exposing tracking authority', () => {
+  it('keeps generic provider chrome compact without exposing tracking authority', () => {
     expect(buildLinqIMessageAppLayout(ONE_OFF_TABLE)).toEqual({
       caption: 'Weekly plan',
       image_url: expect.stringMatching(
         /^https:\/\/www\.withmurph\.ai\/imessage\/card\/v1\/[A-Za-z0-9_-]+\.png$/u,
       ),
-      subcaption: 'Monday: Focus: Upper body',
     })
     expect(buildLinqIMessageAppLayout(TRACKED_TABLE)).toEqual({
       caption: 'Live workout',
       image_url: expect.stringMatching(
         /^https:\/\/www\.withmurph\.ai\/imessage\/card\/v1\/[A-Za-z0-9_-]+\.png$/u,
       ),
-      subcaption: 'Exercise A: Set 1: 10',
     })
 
     expect(renderAssistantResponseCardText(TRACKED_TABLE)).toMatch(
       /Exercise A|10/u,
     )
     expect(JSON.stringify(buildLinqIMessageAppLayout(TRACKED_TABLE))).not.toMatch(
-      /evt_|2026/u,
+      /Exercise A|10|evt_|2026/u,
     )
   })
 })


### PR DESCRIPTION
## Why and outcome

Small workout comparisons were rendered as tall repeated fields, then repeated again in Linq's provider-owned text below the image. Messages could clip the lower workout, making a two-row comparison harder to read than plain text.

This keeps short comparisons in the existing shared-header grid and makes the image the single visible detail owner. Arbitrary wide content still uses the measured stacked fallback, and complete deterministic text recovery is unchanged.

ReviewGPT context sensitivity: sensitive — the patch changes both the Web image renderer and Linq provider payload composition across independently deployed surfaces.

ReviewGPT first-reviewed head: fa5b33c2b1ea77985cdaa28d4dcc6dca36f35c62

## Product UX

- Effort: Patch
- Walkthrough: Ready for the user-authorized Web-first rollout; physical provider/device composition remains a post-deploy smoke.
- Affected: private-direct members viewing generic response cards without the Messages extension, including Messages on macOS.
- Feedback: the first balloon shows one complete shared-header comparison with no repeated rows beneath it.
- Excluded: native-extension rendering and structured-workout rendering/progress behavior.
- Recovery: complete deterministic semantic text remains available when image delivery is unavailable or the member asks for text.
- Difference from plan: None.

## Evidence

- Exact local reproduction through the production image route: 1,200 × 1,446 before and 1,200 × 528 after.
- Privacy-safe real-font comparison raster: 1,200 × 488 with both workouts and all three set columns visible.
- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/imessage-compact-table-card-raster.test.tsx` — 12 passed.
- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/imessage-nutrition-card-image.test.tsx` — 24 passed.
- Affected operator-config suites — 29 passed.
- Web and operator-config typechecks passed; scoped Web ESLint and `git diff --check` passed.
- Changelog generation and changelog page suite — 9 passed.
- Preliminary ReviewGPT: one accepted external evidence gap, no patch artifact; physical no-extension composition remains a post-deploy smoke on a consented client.
- Final ReviewGPT: PASS with no code findings.

## Non-obvious affected surfaces

- Generic V3 iMessage raster layout: compact grid font and gutter values are now included in the existing intrinsic-width calculation. Regression proof: real-font raster and image-layout suites.
- Generic Linq static layout: provider chrome now sends only title plus image instead of duplicating image rows/footer. Regression proof: static-layout and Linq compact-table suites.
- Semantic recovery: intentionally unchanged and still contains every value. Regression proof: static-layout semantic text assertion.
- Design catalog and changelog: synthetic comparison state and member-visible release note were added for review/discovery.

## Architecture and reuse

- Existing systems reused: V3 generic compact-table contract, the existing grid/stacked layout owner, stateless image route, Linq app layout, and deterministic semantic renderer.
- New logic: two grid-density constants and their use in both measurement and rendering; generic provider layout omits redundant detail fields.
- New abstractions: None; the existing measured-layout boundary is sufficient.
- Complexity intentionally avoided: no comparison-specific card kind, layout heuristic, schema/version, persisted state, compatibility adapter, or additional rendering owner.

## Hot reply path impact

- The existing Linq provider mutation payload is smaller, but no database, network/provider, or other awaited operation was added or moved.
- Added/moved calls: 0. Ordering, timeouts, retries, fallback, and provider call count are unchanged.
- Expected latency impact: negligible synchronous field omission. Before/after payload shape is covered by the focused operator-config tests.

## Murph initial provider input impact

- Murph: Not applicable; no prompt, assembled instruction, tool/schema guidance, model selection, or other first provider-visible request input changed.
- Codex: Not applicable for the same reason.
- Measurement: excluded because this changes post-generation iMessage presentation and Linq delivery payload composition, not model input.

## Design proof

- Design page: https://murph-git-codex-compact-multi-workout-card-cobuildwithus.vercel.app/design?tab=components#imessage-compact-table-card
- Evidence: the production compact-table component renders a synthetic two-workout, three-set comparison beside the fitting grid and deliberately overwide stacked states.
- Coverage: desktop and mobile catalog scales; short shared-header comparison, targetless workout summary, fitting four-column table, and overwide stacked fallback.

## Change-shape breakdown

Classification rule: production TS/TSX, including the design catalog, is source; regression files are tests/fixtures; architecture, plans, operations/product docs, and changelog copy are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 44 | 22 |
| Tests/fixtures | 68 | 10 |
| Docs | 172 | 25 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 284 | 57 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Web-first keeps the complete compact image and temporarily retains the old duplicated Linq detail; runner-first can remove the only visible copy of lower rows while the old tall raster remains deployed.
- Safe order: Deploy Web first, verify the compact V3 raster, then deploy the Cloudflare runner/provider bundle with immediate container rollout.
- Rollback floor: Revert the runner/provider payload and let old containers drain before reverting Web; prefer a Web forward-fix while title-only layouts are in flight.
- Expected exposure: During Web-first skew, members may briefly see the old redundant detail below an otherwise complete compact image; no values or writes are lost.
- Reversibility: Both changes are stateless; use the reverse deployment order above because already-sent provider layouts are immutable.
- Convergence proof: Verify the Web deployment serves the compact dimensions, then verify every active runner reports the new bundle fingerprint.
- Post-deploy checks: Send a synthetic two-workout comparison on a static-card client and confirm one complete compact table with no repeated rows below it; inspect bounded delivery-error aggregates.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · compact-imessage-workout-tables

## Review lenses

- Product UX: applicable — visible feedback and recovery presentation changed.
- Frontend: applicable — the app-absent iMessage image changed.
- Coverage: applicable — executable layout and provider serialization changed.
- Prompt: not applicable — no prompt or tool instruction changed.
