### PR TITLE
docs: require verification steps in final handoffs

### DIFF
--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -1,6 +1,6 @@
 # Completion Workflow
 
-Last verified: 2026-08-24
+Last verified: 2026-08-25
 
 This workflow applies to repo code/docs/test/config changes after implementation is materially complete.
 Use `agent-docs/operations/agent-workflow-routing.md` to classify the task, choose the commit path, and decide whether plan mechanics apply.
@@ -259,6 +259,15 @@ product-decision owners.
     default completion bar; if a required check failed for a credibly unrelated
     pre-existing reason, name the command, failing target, and why the current
     diff did not cause it.
+    For every completed feature or bug fix, the final message to the developer
+    or user must also include a concise `How to verify` section for testing the
+    landed change. Name any prerequisite or environment, give the shortest
+    concrete action sequence, and state the observable expected result. For a
+    feature, cover its shortest end-to-end path. For a bug fix, start from the
+    original reproduction when practical and name the behavior that proves the
+    regression is gone. Automated check names may supplement these instructions
+    but do not replace them. If practical human verification is unavailable,
+    say why and point to the closest direct proof.
     If the completed task could break or degrade production when deployed components are temporarily out of sync, include a final-response section labeled `DEPLOYMENT CONCERNS:` with the recommended safe deployment order, required tandem deploy or compatibility window, expected skew behavior, and post-deploy checks. For Cloudflare hosted execution changes, explicitly consider both web/Worker skew and Worker/container skew: a new Worker version can receive traffic while active warm `RunnerContainer` processes still run the previous runner bundle, process env, or provider-credential shape during gradual rollout.
 
 ## PR Description


### PR DESCRIPTION
## Why and outcome

Feature and bug-fix handoffs should tell the developer or user how to test the landed result. This updates the completion workflow so final messages include concise prerequisites, concrete test actions, and observable expected results, with feature and regression-specific guidance.

## Product UX

Not applicable. This changes internal agent workflow documentation and does not alter member-facing product behavior.

## Evidence

- Read back the updated final-handoff step and confirmed it covers features, bug reproductions, expected results, and unavailable human-verification cases.
- `git diff --check origin/main...HEAD`
- Confirmed the base-to-head diff contains only `agent-docs/operations/completion-workflow.md`.

## Non-obvious affected surfaces

Agent final-response expectations are intentionally affected because this is the owning completion-workflow contract. No production, runtime, state, deployment, or user-data surface changes.

## Architecture and reuse

- Existing systems reused: The existing final-handoff step remains the single owner for completion-message requirements.
- New logic: One documentation rule requires a concise post-landing verification section for completed features and bug fixes.
- New abstractions: None; the existing completion workflow is sufficient.
- Complexity intentionally avoided: No new template, script, checker, or enforcement mechanism was added for a prose-only requirement.

## Hot reply path impact

Not applicable. Internal workflow documentation does not change the Foreground Reply Critical Path.

## Murph initial provider input impact

- Local runtime: Not applicable; no Murph provider-input assembly surface changed.
- Hosted runtime: Not applicable; no Murph provider-input assembly surface changed.

## Change-shape breakdown

Classification rule: authored Markdown is docs; no binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 10 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 10 | 1 |

## Deployment concerns

- Deployment: not applicable
- Reason: Internal workflow documentation does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal workflow documentation is not member-visible.
