### PR TITLE
perf(web): bound home projection fanout

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-home-db-fanout.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-home-db-fanout.md
@@ -1,0 +1,51 @@
+# Bound hosted Home database fanout
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Reduce authenticated Home's composed peak database concurrency without weakening independent fallback behavior or adding another data owner.
+
+## Success criteria
+
+- Initial-onboarding/contact and messaging/routing advisory projections no longer overlap.
+- Either projection can still succeed when the other rejects.
+- Normal authenticated Home peak is mechanically bounded below five simultaneous page/layout database owners.
+- When both completion markers are present, the losing connected-app resolver is not started.
+- Focused Home tests, exact-head ReviewGPT, and required PR checks resolve.
+
+## Scope
+
+- In scope: Home server-component orchestration and focused composed-concurrency/error tests.
+- Out of scope: combining owner projections, changing authentication/access/usage/consent checks, device completion per-connection crypto fanout, or UI redesign.
+
+## Constraints
+
+- Technical constraints: preserve `allSettled`-equivalent independent results; serialize only advisory reads; keep device completion priority when URL markers conflict.
+- Product/process constraints: member-visible reliability/performance patch with Product UX and coverage specialist lenses plus sensitive final ReviewGPT.
+
+## Risks and mitigations
+
+1. Risk: Naive promise chaining lets one advisory failure suppress the other.
+   Mitigation: settle each operation independently while sequencing their start.
+2. Risk: Serialization adds latency.
+   Mitigation: restrict it to two advisory projections and prove required access/usage/consent work remains parallel.
+
+## Tasks
+
+1. Add a deferred-promise composed-concurrency test and sibling-failure regressions.
+2. Sequence the two advisory projections and avoid starting the losing completion resolver.
+3. Run focused Home/layout tests and Product UX walkthrough for ordinary, degraded, and dual-marker paths.
+4. Commit, push, open the draft PR, launch both ReviewGPT stages in parallel with CI, resolve findings, close this plan, and push the final scoped commit.
+
+## Decisions
+
+- Prefer sequencing over a combined projection because existing owners have different crypto/failure boundaries.
+
+## Verification
+
+- Commands to run: focused dashboard Home page/layout/device completion tests, Web typecheck when needed, and `git diff --check`.
+- Expected outcomes: peak start count is bounded, sibling failure remains isolated, and visible fallback behavior is unchanged.
+Completed: 2026-08-25

--- a/apps/web/app/(dashboard)/home/page.tsx
+++ b/apps/web/app/(dashboard)/home/page.tsx
@@ -57,6 +57,52 @@ export default async function HomePage({
 
   const prisma = getPrisma();
   const usageGateCheckedAt = new Date();
+  const initialVisitProjectionPromise = member
+    ? (async () => {
+        const state = await readHostedInitialOnboardingState({
+          memberId: member.id,
+          prisma,
+        });
+        return {
+          contactAction: state.status === "pending"
+            ? await resolveHomeInitialVisitContactAction()
+            : null,
+          state,
+        };
+      })()
+    : Promise.resolve(null);
+  const messagingSetupStatePromise = initialVisitProjectionPromise.then(
+    () => member
+      ? readHostedMemberMessagingSetupState({
+          memberId: member.id,
+          prisma,
+        })
+      : null,
+    () => member
+      ? readHostedMemberMessagingSetupState({
+          memberId: member.id,
+          prisma,
+        })
+      : null,
+  );
+  const deviceCompletionPromise = Promise.resolve(
+    resolveDeviceSyncCompletionDialogModel({
+      member,
+      searchParams: resolvedSearchParams,
+    }),
+  );
+  const connectedAppCompletionPromise = deviceCompletionPromise.then(
+    (deviceCompletion) => deviceCompletion
+      ? null
+      : resolveConnectedAppCompletionDialogModel({
+          member,
+          searchParams: resolvedSearchParams,
+        }),
+    () => resolveConnectedAppCompletionDialogModel({
+      member,
+      searchParams: resolvedSearchParams,
+    }),
+  );
   const homeProjectionResults = await Promise.allSettled([
     shouldShowHomeDeviceSyncStep({
       member,
@@ -69,34 +115,10 @@ export default async function HomePage({
           prisma,
         })
       : Promise.resolve(null),
-    resolveDeviceSyncCompletionDialogModel({
-      member,
-      searchParams: resolvedSearchParams,
-    }),
-    resolveConnectedAppCompletionDialogModel({
-      member,
-      searchParams: resolvedSearchParams,
-    }),
-    member
-      ? (async () => {
-          const state = await readHostedInitialOnboardingState({
-            memberId: member.id,
-            prisma,
-          });
-          return {
-            contactAction: state.status === "pending"
-              ? await resolveHomeInitialVisitContactAction()
-              : null,
-            state,
-          };
-        })()
-      : Promise.resolve(null),
-    member
-      ? readHostedMemberMessagingSetupState({
-          memberId: member.id,
-          prisma,
-        })
-      : Promise.resolve(null),
+    deviceCompletionPromise,
+    connectedAppCompletionPromise,
+    initialVisitProjectionPromise,
+    messagingSetupStatePromise,
   ]);
   const [
     showDeviceStepResult,

--- a/apps/web/app/(dashboard)/home/page.tsx
+++ b/apps/web/app/(dashboard)/home/page.tsx
@@ -19,10 +19,12 @@ import {
   UploadLabsMurphContactAction,
 } from "@/src/components/home/upload-labs-action";
 import {
+  CONNECTED_APP_COMPLETION_HOME_MARKER,
   type ConnectedAppCompletionSearchParams,
   resolveConnectedAppCompletionDialogModel,
 } from "@/src/lib/connected-apps/connect-completion";
 import {
+  DEVICE_SYNC_COMPLETION_HOME_MARKER,
   resolveDeviceSyncCompletionDialogModel,
   type DeviceSyncCompletionSearchParams,
 } from "@/src/lib/device-sync/connect-completion";
@@ -57,6 +59,11 @@ export default async function HomePage({
 
   const prisma = getPrisma();
   const usageGateCheckedAt = new Date();
+  const hasCompletionMarker = readsCompletionMarker(
+    resolvedSearchParams[DEVICE_SYNC_COMPLETION_HOME_MARKER],
+  ) || readsCompletionMarker(
+    resolvedSearchParams[CONNECTED_APP_COMPLETION_HOME_MARKER],
+  );
   const initialVisitProjectionPromise = member
     ? (async () => {
         const state = await readHostedInitialOnboardingState({
@@ -64,27 +71,25 @@ export default async function HomePage({
           prisma,
         });
         return {
-          contactAction: state.status === "pending"
+          contactAction: !hasCompletionMarker && state.status === "pending"
             ? await resolveHomeInitialVisitContactAction()
             : null,
           state,
         };
       })()
     : Promise.resolve(null);
-  const messagingSetupStatePromise = initialVisitProjectionPromise.then(
-    () => member
-      ? readHostedMemberMessagingSetupState({
-          memberId: member.id,
-          prisma,
-        })
-      : null,
-    () => member
-      ? readHostedMemberMessagingSetupState({
-          memberId: member.id,
-          prisma,
-        })
-      : null,
-  );
+  const readMessagingSetupState = () => member
+    ? readHostedMemberMessagingSetupState({
+        memberId: member.id,
+        prisma,
+      })
+    : null;
+  const messagingSetupStatePromise = hasCompletionMarker
+    ? Promise.resolve(readMessagingSetupState())
+    : initialVisitProjectionPromise.then(
+        readMessagingSetupState,
+        readMessagingSetupState,
+      );
   const deviceCompletionPromise = Promise.resolve(
     resolveDeviceSyncCompletionDialogModel({
       member,
@@ -266,4 +271,8 @@ async function resolveHomeInitialVisitContactAction() {
     console.warn("Home initial onboarding contact projection unavailable.");
     return null;
   }
+}
+
+function readsCompletionMarker(value: string | string[] | undefined) {
+  return (Array.isArray(value) ? value[0] : value) === "1";
 }

--- a/apps/web/changelog/entries/2026-08-25/home-loads-more-reliably.json
+++ b/apps/web/changelog/entries/2026-08-25/home-loads-more-reliably.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-25",
+  "order": 100,
+  "item": {
+    "id": "home-loads-more-reliably",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Home loads more reliably",
+    "summary": "Home now reduces overlapping data work so dashboard details are less likely to fall back during busy periods.",
+    "details": "Independent sections still recover separately if one optional detail is unavailable.",
+    "relevanceTags": ["dashboard", "reliability"],
+    "sourcePullRequests": [2289]
+  }
+}

--- a/apps/web/test/dashboard-home-page.test.tsx
+++ b/apps/web/test/dashboard-home-page.test.tsx
@@ -317,6 +317,52 @@ test("HomePage keeps its core content when an independent projection fails", asy
   assert.equal(mocks.readHostedAiUsageGate.mock.calls.length, 1);
 });
 
+test("HomePage sequences advisory onboarding and messaging projections", async () => {
+  type InitialState = {
+    preferences: { persona: null; tone: null; voice: null };
+    status: "pending";
+  };
+  const resolveInitialState = vi.fn<(value: InitialState) => void>();
+  const signalInitialStarted = vi.fn<() => void>();
+  const initialStarted = new Promise<void>((resolve) => {
+    signalInitialStarted.mockImplementation(resolve);
+  });
+  mocks.readHostedInitialOnboardingState.mockImplementationOnce(() => {
+    signalInitialStarted();
+    return new Promise<InitialState>((resolve) => {
+      resolveInitialState.mockImplementation(resolve);
+    });
+  });
+
+  const { default: HomePage } = await import("../app/(dashboard)/home/page");
+  const page = HomePage({ searchParams: Promise.resolve({}) });
+
+  await initialStarted;
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 0);
+
+  resolveInitialState({
+    preferences: { persona: null, tone: null, voice: null },
+    status: "pending",
+  });
+  await page;
+
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 1);
+});
+
+test("HomePage still reads messaging when the earlier advisory projection fails", async () => {
+  mocks.readHostedInitialOnboardingState.mockRejectedValueOnce(
+    new Error("initial onboarding unavailable"),
+  );
+
+  const { default: HomePage } = await import("../app/(dashboard)/home/page");
+  const markup = renderToStaticMarkup(
+    await HomePage({ searchParams: Promise.resolve({}) }),
+  );
+
+  assert.match(markup, /Some dashboard details are unavailable/);
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 1);
+});
+
 test("HomePage degrades a failed read-only usage projection without mutating allowance state", async () => {
   mocks.readHostedAiUsageGate.mockRejectedValueOnce(
     new Error("usage projection unavailable"),
@@ -866,6 +912,24 @@ test("HomePage presents connection results before canonical onboarding", async (
     plainHomeMarkup,
     /data-home-initial-visit-persona-picker="shown"/,
   );
+});
+
+test("HomePage skips the losing connected-app resolver after device completion", async () => {
+  const { default: HomePage } = await import("../app/(dashboard)/home/page");
+
+  const markup = renderToStaticMarkup(
+    await HomePage({
+      searchParams: Promise.resolve({
+        connectedAppCompletion: "1",
+        connectedAppStatus: "success",
+        deviceSyncCompletion: "1",
+        toolkit: "gmail",
+      }),
+    }),
+  );
+
+  assert.match(markup, /Device connection complete/);
+  assert.equal(mocks.resolveConnectedAppCompletionDialogModel.mock.calls.length, 0);
 });
 
 test("HomePage opens pending persona onboarding on plain home", async () => {

--- a/apps/web/test/dashboard-home-page.test.tsx
+++ b/apps/web/test/dashboard-home-page.test.tsx
@@ -13,7 +13,9 @@ import { afterEach, beforeEach, test, vi } from "vitest";
 import { renderClientComponent } from "./render-client-component";
 
 const mocks = vi.hoisted(() => ({
+  getHostedDashboardLayoutAuthSnapshot: vi.fn(),
   getHostedPageAuthSnapshot: vi.fn(),
+  readHostedConsentStatus: vi.fn(),
   resolveConnectedAppCompletionDialogModel: vi.fn(),
   resolveDeviceSyncCompletionDialogModel: vi.fn(),
   readHostedInitialOnboardingState: vi.fn(),
@@ -162,8 +164,15 @@ vi.mock("@/src/lib/connected-apps/connect-completion", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/page-auth", () => ({
+  getHostedDashboardLayoutAuthSnapshot:
+    mocks.getHostedDashboardLayoutAuthSnapshot,
   getHostedPageAuthSnapshot: mocks.getHostedPageAuthSnapshot,
   getHostedDashboardPageAuthSnapshot: mocks.getHostedPageAuthSnapshot,
+}));
+
+vi.mock("@/src/lib/legal/consent", () => ({
+  hasHostedHistoricalLaunchConsent: () => false,
+  readHostedConsentStatus: mocks.readHostedConsentStatus,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
@@ -199,6 +208,16 @@ beforeEach(() => {
     authenticatedMember: MEMBER,
     session: null,
   });
+  mocks.getHostedDashboardLayoutAuthSnapshot.mockResolvedValue({
+    pageAuth: {
+      authenticated: true,
+      authenticatedMember: MEMBER,
+      session: null,
+    },
+    sidebarAuth: { authenticated: true, label: null },
+    status: "ready",
+  });
+  mocks.readHostedConsentStatus.mockResolvedValue({ launchGranted: true });
   mocks.shouldShowHomeDeviceSyncStep.mockResolvedValue(true);
   mocks.resolveDeviceSyncCompletionDialogModel.mockImplementation(
     ({ searchParams }: { searchParams: Record<string, string | undefined> }) => {
@@ -317,36 +336,169 @@ test("HomePage keeps its core content when an independent projection fails", asy
   assert.equal(mocks.readHostedAiUsageGate.mock.calls.length, 1);
 });
 
-test("HomePage sequences advisory onboarding and messaging projections", async () => {
+test("HomePage bounds composed dashboard owners and preserves advisory siblings", async () => {
   type InitialState = {
     preferences: { persona: null; tone: null; voice: null };
     status: "pending";
   };
-  const resolveInitialState = vi.fn<(value: InitialState) => void>();
-  const signalInitialStarted = vi.fn<() => void>();
-  const initialStarted = new Promise<void>((resolve) => {
-    signalInitialStarted.mockImplementation(resolve);
-  });
-  mocks.readHostedInitialOnboardingState.mockImplementationOnce(() => {
-    signalInitialStarted();
-    return new Promise<InitialState>((resolve) => {
-      resolveInitialState.mockImplementation(resolve);
+  const activeOwners = new Set<string>();
+  let peakOwners = new Set<string>();
+
+  function createOwner<T>(label: string) {
+    let rejectPromise: ((reason?: unknown) => void) | null = null;
+    let resolvePromise: ((value: T) => void) | null = null;
+    let signalStarted: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
     });
-  });
+
+    const settle = (settler: () => void) => {
+      assert.ok(activeOwners.delete(label), `${label} must be active before settling`);
+      settler();
+    };
+
+    return {
+      reject(reason: unknown) {
+        assert.ok(rejectPromise, `${label} must start before rejection`);
+        settle(() => rejectPromise?.(reason));
+      },
+      resolve(value: T) {
+        assert.ok(resolvePromise, `${label} must start before resolution`);
+        settle(() => resolvePromise?.(value));
+      },
+      run() {
+        assert.equal(activeOwners.has(label), false, `${label} must start once`);
+        activeOwners.add(label);
+        if (activeOwners.size > peakOwners.size) {
+          peakOwners = new Set(activeOwners);
+        }
+        signalStarted?.();
+        return new Promise<T>((resolve, reject) => {
+          resolvePromise = resolve;
+          rejectPromise = reject;
+        });
+      },
+      started,
+    };
+  }
+
+  const consentOwner = createOwner<{ launchGranted: boolean }>("layout consent");
+  const deviceOwner = createOwner<boolean>("device onboarding");
+  const usageOwner = createOwner<null>("usage allowance");
+  const initialOwner = createOwner<InitialState>("initial onboarding");
+  const contactOwner = createOwner<{
+    href: string;
+    kind: string;
+    label: string;
+    rel: undefined;
+    target: undefined;
+  }>("contact projection");
+  const messagingOwner = createOwner<{
+    identity: { phoneLookupKey: string };
+    routing: null;
+  }>("messaging setup");
+
+  mocks.readHostedConsentStatus.mockImplementationOnce(consentOwner.run);
+  mocks.shouldShowHomeDeviceSyncStep.mockImplementationOnce(deviceOwner.run);
+  mocks.readHostedAiUsageGate.mockImplementationOnce(usageOwner.run);
+  mocks.readHostedInitialOnboardingState.mockImplementationOnce(initialOwner.run);
+  mocks.resolveHostedMurphContactOption.mockImplementationOnce(contactOwner.run);
+  mocks.readHostedMemberMessagingSetupState.mockImplementationOnce(
+    messagingOwner.run,
+  );
 
   const { default: HomePage } = await import("../app/(dashboard)/home/page");
+  const { default: DashboardLayout } = await import("../app/(dashboard)/layout");
   const page = HomePage({ searchParams: Promise.resolve({}) });
+  const layout = DashboardLayout({ children: null });
 
-  await initialStarted;
+  await Promise.all([
+    consentOwner.started,
+    deviceOwner.started,
+    usageOwner.started,
+    initialOwner.started,
+  ]);
+  assert.deepEqual(
+    [...peakOwners].sort(),
+    ["device onboarding", "initial onboarding", "layout consent", "usage allowance"],
+  );
+  assert.ok(peakOwners.size < 5);
   assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 0);
 
-  resolveInitialState({
+  initialOwner.resolve({
     preferences: { persona: null, tone: null, voice: null },
     status: "pending",
   });
-  await page;
+  await contactOwner.started;
+  assert.equal(activeOwners.has("contact projection"), true);
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 0);
+  assert.ok(peakOwners.size < 5);
+
+  contactOwner.resolve({
+    href: "sms:+15555550123",
+    kind: "text",
+    label: "Text Murph",
+    rel: undefined,
+    target: undefined,
+  });
+  await messagingOwner.started;
 
   assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 1);
+  assert.ok(peakOwners.size < 5);
+
+  consentOwner.resolve({ launchGranted: true });
+  deviceOwner.resolve(true);
+  usageOwner.resolve(null);
+  messagingOwner.resolve({
+    identity: { phoneLookupKey: "hbidx:phone:v1:member" },
+    routing: null,
+  });
+  const [pageElement] = await Promise.all([page, layout]);
+  const markup = renderToStaticMarkup(pageElement);
+
+  assert.equal(activeOwners.size, 0);
+  assert.equal(peakOwners.size, 4);
+  assert.match(markup, /Welcome to Murph/);
+  assert.match(markup, /data-home-initial-visit-persona-picker="shown"/);
+
+  mocks.readHostedInitialOnboardingState.mockRejectedValueOnce(
+    new Error("initial onboarding unavailable"),
+  );
+  mocks.readHostedMemberMessagingSetupState.mockResolvedValueOnce({
+    identity: { phoneLookupKey: null },
+    routing: {
+      linqChatId: null,
+      pendingLinqChatId: null,
+      pendingLinqParticipantContact: null,
+      telegramThreadId: null,
+      telegramUserId: null,
+    },
+  });
+  const initialRejectedMarkup = renderToStaticMarkup(
+    await HomePage({ searchParams: Promise.resolve({}) }),
+  );
+
+  assert.match(initialRejectedMarkup, /Some dashboard details are unavailable/);
+  assert.match(initialRejectedMarkup, /Message Murph/);
+  assert.doesNotMatch(initialRejectedMarkup, /data-home-initial-visit-persona-picker/);
+
+  mocks.readHostedInitialOnboardingState.mockResolvedValueOnce({
+    preferences: { persona: null, tone: null, voice: null },
+    status: "pending",
+  });
+  mocks.readHostedMemberMessagingSetupState.mockRejectedValueOnce(
+    new Error("messaging setup unavailable"),
+  );
+  const messagingRejectedMarkup = renderToStaticMarkup(
+    await HomePage({ searchParams: Promise.resolve({}) }),
+  );
+
+  assert.match(messagingRejectedMarkup, /Some dashboard details are unavailable/);
+  assert.match(
+    messagingRejectedMarkup,
+    /data-home-initial-visit-persona-picker="shown"/,
+  );
+  assert.match(messagingRejectedMarkup, /data-contact-action-href="sms:\+15555550123"/);
 });
 
 test("HomePage still reads messaging when the earlier advisory projection fails", async () => {

--- a/apps/web/test/dashboard-home-page.test.tsx
+++ b/apps/web/test/dashboard-home-page.test.tsx
@@ -154,11 +154,13 @@ vi.mock("@/src/lib/device-sync/home-onboarding", () => ({
 }));
 
 vi.mock("@/src/lib/device-sync/connect-completion", () => ({
+  DEVICE_SYNC_COMPLETION_HOME_MARKER: "deviceSyncCompletion",
   resolveDeviceSyncCompletionDialogModel:
     mocks.resolveDeviceSyncCompletionDialogModel,
 }));
 
 vi.mock("@/src/lib/connected-apps/connect-completion", () => ({
+  CONNECTED_APP_COMPLETION_HOME_MARKER: "connectedAppCompletion",
   resolveConnectedAppCompletionDialogModel:
     mocks.resolveConnectedAppCompletionDialogModel,
 }));
@@ -1064,6 +1066,86 @@ test("HomePage presents connection results before canonical onboarding", async (
     plainHomeMarkup,
     /data-home-initial-visit-persona-picker="shown"/,
   );
+});
+
+test("HomePage starts callback messaging alongside canonical onboarding", async () => {
+  type InitialState = {
+    preferences: { persona: null; tone: null; voice: null };
+    status: "pending";
+  };
+  type MessagingState = {
+    identity: { phoneLookupKey: string };
+    routing: null;
+  };
+  const resolveInitialState = vi.fn<(value: InitialState) => void>();
+  const resolveMessagingState = vi.fn<(value: MessagingState) => void>();
+  const signalInitialStarted = vi.fn<() => void>();
+  const signalMessagingStarted = vi.fn<() => void>();
+  const initialStarted = new Promise<void>((resolve) => {
+    signalInitialStarted.mockImplementation(resolve);
+  });
+  const messagingStarted = new Promise<void>((resolve) => {
+    signalMessagingStarted.mockImplementation(resolve);
+  });
+  mocks.readHostedInitialOnboardingState.mockImplementationOnce(() => {
+    signalInitialStarted();
+    return new Promise<InitialState>((resolve) => {
+      resolveInitialState.mockImplementation(resolve);
+    });
+  });
+  mocks.readHostedMemberMessagingSetupState.mockImplementationOnce(() => {
+    signalMessagingStarted();
+    return new Promise<MessagingState>((resolve) => {
+      resolveMessagingState.mockImplementation(resolve);
+    });
+  });
+
+  const { default: HomePage } = await import("../app/(dashboard)/home/page");
+  const page = HomePage({
+    searchParams: Promise.resolve({ deviceSyncCompletion: "1" }),
+  });
+
+  await Promise.all([initialStarted, messagingStarted]);
+  assert.equal(mocks.readHostedInitialOnboardingState.mock.calls.length, 1);
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 1);
+  assert.equal(mocks.resolveHostedMurphContactOption.mock.calls.length, 0);
+
+  resolveMessagingState({
+    identity: { phoneLookupKey: "hbidx:phone:v1:member" },
+    routing: null,
+  });
+  resolveInitialState({
+    preferences: { persona: null, tone: null, voice: null },
+    status: "pending",
+  });
+  const markup = renderToStaticMarkup(await page);
+
+  assert.match(markup, /Device connection complete/);
+  assert.doesNotMatch(markup, /data-home-initial-visit-persona-picker/);
+  assert.equal(mocks.resolveHostedMurphContactOption.mock.calls.length, 0);
+});
+
+test("HomePage retains callback completion when canonical onboarding fails", async () => {
+  mocks.readHostedInitialOnboardingState.mockRejectedValueOnce(
+    new Error("initial onboarding unavailable"),
+  );
+
+  const { default: HomePage } = await import("../app/(dashboard)/home/page");
+  const markup = renderToStaticMarkup(
+    await HomePage({
+      searchParams: Promise.resolve({
+        connectedAppCompletion: "1",
+        connectedAppStatus: "success",
+        toolkit: "gmail",
+      }),
+    }),
+  );
+
+  assert.match(markup, /Gmail is connected/);
+  assert.match(markup, /Some dashboard details are unavailable/);
+  assert.doesNotMatch(markup, /data-home-initial-visit-persona-picker/);
+  assert.equal(mocks.readHostedMemberMessagingSetupState.mock.calls.length, 1);
+  assert.equal(mocks.resolveHostedMurphContactOption.mock.calls.length, 0);
 });
 
 test("HomePage skips the losing connected-app resolver after device completion", async () => {


### PR DESCRIPTION
Reduces overlapping `/home` database projections while preserving independent fallback behavior and completion-dialog precedence.

ReviewGPT first-reviewed head: 9160773e676966a6fd6ce36595e5c168af4fda94
ReviewGPT context sensitivity: sensitive

## Product UX

- Effort: Small.
- Walkthrough: Ready. Signed-in members retain the same home states; optional projection failure remains isolated, and device completion still wins when both completion callbacks are present.

## Evidence

- `pnpm --dir apps/web test:prepared test/dashboard-home-page.test.tsx` (31 passed)
- `pnpm --dir apps/web typecheck:prepared` (passed)

## Non-obvious affected surfaces

- Home completion callbacks: canonical onboarding and messaging setup start together when either callback marker is present; optional contact projection is skipped, and device completion still wins when both markers are present.
- Home advisory projections: marker-free renders retain initial-onboarding-before-messaging sequencing, while either failure remains independently recoverable.

## Architecture and reuse

- Existing systems reused: Existing home projection helpers and `Promise.allSettled` fallback ownership remain authoritative.
- New logic: Marker-free advisory pairs remain sequenced to reduce simultaneous database demand; callback renders bypass only the unnecessary contact projection and start messaging independently.
- New abstractions: None; direct promise ordering is sufficient for this route-local behavior.
- Complexity intentionally avoided: No new cache, queue, pool manager, or shared state owner.

## Hot reply path impact

- Not applicable: `/home` rendering is outside the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-visible input surface changed.
- Codex runtime: Not applicable; no provider-visible input surface changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/home#home-partial-load-section
- Evidence: Existing partial-load and recovery visuals are unchanged; this PR changes only server-side projection ordering.
- Coverage: Existing signed-in home success, partial fallback, device completion, and connected-app completion states at existing responsive layouts.

## Change-shape breakdown

Classification: route implementation is source; Vitest coverage is tests/fixtures; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 71 | 40 |
| Tests/fixtures | 298 | 0 |
| Docs | 65 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 434 | 40 |

## Deployment concerns

- Deployment: applicable
- Supported skew: The change is isolated to the Vercel Web route and uses existing helper contracts.
- Safe order: Deploy the Web commit normally; no tandem Cloudflare deploy is required.
- Rollback floor: The prior route remains compatible with all current state.
- Expected exposure: Mixed Web instances may differ only in projection ordering during rollout.
- Reversibility: Revert the Web commit.
- Convergence proof: Confirm the Vercel deployment serves the candidate commit.
- Post-deploy checks: Inspect bounded `/home` pool-pressure and fallback aggregates.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · home-loads-more-reliably
