### PR TITLE
fix(cloudflare): preserve database health provenance

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -603,7 +603,10 @@ Last verified: 2026-08-23
   or classified failure in Durable Object SQLite and prunes history after 30
   days. A two-minute persisted run lease coalesces overlapping cron delivery.
   Concrete unhealthy gauges page immediately. Metric families are normalized
-  independently: an absent or structurally unusable family remains unknown,
+  independently: primary-only Postgres and PgBouncer families require an
+  explicit `planetscale_role="primary"` label, while the edge connection-error
+  family remains role-less by provider contract. An absent or structurally
+  unusable family remains unknown,
   its canonical allowlisted name is retained with the failed sample and warning,
   and every available signal is still evaluated. No unknown value becomes zero.
   A collection that fails before producing a usable observation, including a

--- a/agent-docs/exec-plans/completed/2026-08-25-database-health-samples.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-database-health-samples.md
@@ -1,0 +1,51 @@
+# Make database health samples temporally and structurally truthful
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Make database-health history distinguish scheduled Cron time from actual collection time and fail incomplete primary-only metric families closed.
+
+## Success criteria
+
+- Primary-only metric families require an explicit primary role.
+- Samples retain scheduled and actual collection time for direct Durable Object history reads.
+- Alert copy distinguishes PlanetScale PgBouncer server-pool capacity from Web's local pool.
+- Focused Cloudflare tests, exact-head ReviewGPT, and required PR checks resolve.
+
+## Scope
+
+- In scope: database-health Durable Object store/monitor/metric normalization, an additive collection-time field, alert wording, tests, and current owner docs.
+- Out of scope: a public endpoint, raw metric/label exposure, a new storage owner, Web-local pool monitoring, and alert-provider changes.
+
+## Constraints
+
+- Technical constraints: keep schema changes rollback-compatible and history bounded; do not change alert or baseline ownership.
+- Product/process constraints: Cloudflare reliability/trust-boundary PR with sensitive final ReviewGPT and an explicit deployment/rollback contract.
+
+## Risks and mitigations
+
+1. Risk: A missing role label could be a provider contract change rather than malformed telemetry.
+   Mitigation: follow the documented primary-only family contract and route missing families through existing bounded incomplete-telemetry handling.
+2. Risk: Additive schema deployment can overlap old Worker versions.
+   Mitigation: make new fields nullable/additive, preserve legacy reads, and document the compatibility window.
+
+## Tasks
+
+1. Add tests for explicit-primary labels, actual check time, legacy nullable reads, and unambiguous alert wording.
+2. Add the nullable collection timestamp and strict role selection without changing persistence ownership.
+3. Keep history access on the existing direct Durable Object RPC; do not add a public route in this PR.
+4. Run focused Cloudflare tests/typecheck and inspect retention and rollback behavior.
+5. Commit, push, open the draft PR, launch both ReviewGPT stages in parallel with CI, resolve findings, close this plan, and push the final scoped commit.
+
+## Decisions
+
+- Keep the Durable Object as the only database-health state owner and keep provider labels or URLs out of history.
+
+## Verification
+
+- Commands to run: focused database-health metric/store/monitor/Durable Object tests, Cloudflare typecheck, and `git diff --check`.
+- Expected outcomes: role-less primary-only series are incomplete, scheduled and collection time remain distinguishable, legacy rows remain readable, and no private provider material enters history output.
+Completed: 2026-08-25

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -218,6 +218,13 @@ to retain 30 days of:
 - per-region connection-error counters and positive deltas for direct port 5432
   and pooled application port 6432.
 
+Each retained sample stores both the scheduled Cron slot and the actual
+post-collection check time. Legacy rows expose a null check time rather than
+pretending the scheduled slot was the collection instant. Primary-only
+Postgres and PgBouncer families require the provider's explicit
+`planetscale_role="primary"` label; missing role metadata makes that family
+incomplete instead of treating mixed or replica data as primary.
+
 Discovery selects exactly one target by organization, database name, and branch
 name. The configured branch ID then filters the selected Prometheus payload's
 metric series. Both selectors are required because one organization can have

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -630,8 +630,7 @@ function parsePrometheusLabels(value: string): Readonly<Record<string, string>> 
 }
 
 function isPrimaryMetricPoint(point: PrometheusMetricPoint): boolean {
-  const role = point.labels[ROLE_LABEL];
-  return role === undefined || role === "primary";
+  return point.labels[ROLE_LABEL] === "primary";
 }
 
 function sumByLabel(

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -781,6 +781,7 @@ export class DatabaseHealthMonitor {
 
     if (sample.status === "ok") {
       this.store.recordSuccessfulSample({
+        checkedAtMs: input.checkedAtMs,
         connectionErrorCounterBaseline:
           sample.connectionErrorCounterBaseline,
         connectionErrorDelta: sample.connectionErrorDelta,
@@ -790,6 +791,7 @@ export class DatabaseHealthMonitor {
       });
     } else {
       this.store.recordFailedSample({
+        checkedAtMs: input.checkedAtMs,
         connectionErrorCounterBaseline:
           sample.connectionErrorCounterBaseline,
         connectionErrorDelta: sample.connectionErrorDelta,
@@ -1224,7 +1226,7 @@ function formatDatabaseHealthCondition(
     case "client_wait":
       return `PgBouncer wait ${formatSeconds(condition.seconds)}`;
     case "server_pool_saturation":
-      return `local server pool ${formatPercent(condition.ratio)} (${formatCount(
+      return `PlanetScale PgBouncer server pool ${formatPercent(condition.ratio)} (${formatCount(
         condition.connections,
       )}/${formatCount(condition.limit)})`;
     case "postgres_connection_saturation":

--- a/apps/cloudflare/src/database-health/store.ts
+++ b/apps/cloudflare/src/database-health/store.ts
@@ -48,6 +48,7 @@ export interface DatabaseHealthAlertState {
 }
 
 export interface DatabaseHealthStoredSample {
+  checkedAtMs: number | null;
   clientWaitSeconds: number | null;
   connectionErrorDelta: number | null;
   conditions: DatabaseHealthCondition[];
@@ -85,6 +86,7 @@ interface DatabaseHealthCounterRow extends Record<string, DurableObjectSqlValue>
 }
 
 interface DatabaseHealthSampleRow extends Record<string, DurableObjectSqlValue> {
+  checked_at_ms: number | null;
   client_wait_seconds: number | null;
   conditions_json: string;
   direct_connection_error_delta: number | null;
@@ -293,6 +295,7 @@ export class DatabaseHealthStore {
   }
 
   recordSuccessfulSample(input: {
+    checkedAtMs: number;
     connectionErrorCounterBaseline: Readonly<Record<string, number>>;
     connectionErrorDelta: number;
     conditions: readonly DatabaseHealthCondition[];
@@ -302,6 +305,7 @@ export class DatabaseHealthStore {
     this.sql.exec(
       `INSERT INTO database_health_samples (
          observed_at_ms,
+         checked_at_ms,
          scrape_status,
          failure_code,
          client_wait_seconds,
@@ -317,8 +321,9 @@ export class DatabaseHealthStore {
          direct_connection_error_counters_json,
          monitoring_evidence_json,
          conditions_json
-       ) VALUES (?, 'ok', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+       ) VALUES (?, ?, 'ok', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
        ON CONFLICT(observed_at_ms) DO UPDATE SET
+         checked_at_ms = excluded.checked_at_ms,
          scrape_status = excluded.scrape_status,
          failure_code = excluded.failure_code,
          client_wait_seconds = excluded.client_wait_seconds,
@@ -336,6 +341,7 @@ export class DatabaseHealthStore {
          monitoring_evidence_json = excluded.monitoring_evidence_json,
          conditions_json = excluded.conditions_json`,
       input.observedAtMs,
+      input.checkedAtMs,
       input.snapshot.clientWaitSeconds,
       input.snapshot.clientWaitingConnections,
       input.snapshot.serverConnections,
@@ -352,6 +358,7 @@ export class DatabaseHealthStore {
   }
 
   recordFailedSample(input: {
+    checkedAtMs: number;
     connectionErrorCounterBaseline: Readonly<Record<string, number>>;
     connectionErrorDelta: number | null;
     conditions: readonly DatabaseHealthCondition[];
@@ -364,6 +371,7 @@ export class DatabaseHealthStore {
     this.sql.exec(
       `INSERT INTO database_health_samples (
          observed_at_ms,
+         checked_at_ms,
          scrape_status,
          failure_code,
          client_wait_seconds,
@@ -379,8 +387,9 @@ export class DatabaseHealthStore {
          direct_connection_error_counters_json,
          monitoring_evidence_json,
          conditions_json
-       ) VALUES (?, 'failed', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ) VALUES (?, ?, 'failed', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(observed_at_ms) DO UPDATE SET
+         checked_at_ms = excluded.checked_at_ms,
          scrape_status = excluded.scrape_status,
          failure_code = excluded.failure_code,
          client_wait_seconds = excluded.client_wait_seconds,
@@ -400,6 +409,7 @@ export class DatabaseHealthStore {
          monitoring_evidence_json = excluded.monitoring_evidence_json,
          conditions_json = excluded.conditions_json`,
       input.observedAtMs,
+      input.checkedAtMs,
       input.failureCode,
       snapshot?.clientWaitSeconds ?? null,
       snapshot?.clientWaitingConnections ?? null,
@@ -455,6 +465,7 @@ export class DatabaseHealthStore {
     return this.sql.exec<DatabaseHealthSampleRow>(
       `SELECT
          observed_at_ms,
+         checked_at_ms,
          scrape_status,
          failure_code,
          client_wait_seconds,
@@ -470,6 +481,7 @@ export class DatabaseHealthStore {
        LIMIT ?`,
       safeLimit,
     ).toArray().map((row) => ({
+      checkedAtMs: row.checked_at_ms,
       clientWaitSeconds: row.client_wait_seconds,
       connectionErrorDelta: row.direct_connection_error_delta,
       conditions: parseConditions(row.conditions_json),
@@ -560,6 +572,7 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
   sql.exec(`
     CREATE TABLE IF NOT EXISTS database_health_samples (
       observed_at_ms INTEGER PRIMARY KEY,
+      checked_at_ms INTEGER,
       scrape_status TEXT NOT NULL CHECK (scrape_status IN ('ok', 'failed')),
       failure_code TEXT,
       client_wait_seconds REAL,
@@ -622,6 +635,12 @@ function ensureDatabaseHealthSchema(sql: DurableObjectSqlStorageLike): void {
     "database_health_meta",
     "monitoring_alert_owed_json",
     "TEXT",
+  );
+  ensureDatabaseHealthTableColumn(
+    sql,
+    "database_health_samples",
+    "checked_at_ms",
+    "INTEGER",
   );
   ensureDatabaseHealthTableColumn(
     sql,

--- a/apps/cloudflare/test/database-health-metrics.test.ts
+++ b/apps/cloudflare/test/database-health-metrics.test.ts
@@ -309,6 +309,42 @@ describe("PlanetScale database health metrics", () => {
     }
   });
 
+  it("treats role-less primary-only metrics as incomplete telemetry", () => {
+    const roleLessMaxConnections = buildMetricsBody({
+      branchId: BRANCH_ID,
+    }).replace(
+      `planetscale_postgres_settings_max_connections{planetscale_database_branch_id="${BRANCH_ID}",planetscale_pod="pod-primary",planetscale_role="primary"} 50`,
+      `planetscale_postgres_settings_max_connections{planetscale_database_branch_id="${BRANCH_ID}",planetscale_pod="pod-primary"} 50`,
+    );
+
+    const observation = parsePlanetScaleDatabaseMetricObservation(
+      roleLessMaxConnections,
+      BRANCH_ID,
+    );
+
+    expect(observation.missingMetrics).toContain(
+      "planetscale_postgres_settings_max_connections",
+    );
+  });
+
+  it("ignores replica series when explicit primary series are present", () => {
+    const replicaLabels =
+      `planetscale_database_branch_id="${BRANCH_ID}",`
+      + 'planetscale_pod="pod-replica",planetscale_role="replica"';
+    const snapshot = parsePlanetScaleDatabaseMetrics(
+      [
+        buildMetricsBody({ branchId: BRANCH_ID }),
+        `planetscale_postgres_settings_max_connections{${replicaLabels}} 500`,
+        `planetscale_postgres_connection_state{${replicaLabels},state="active"} 400`,
+        "",
+      ].join("\n"),
+      BRANCH_ID,
+    );
+
+    expect(snapshot.postgresConnections).toBe(10);
+    expect(snapshot.postgresMaxConnections).toBe(50);
+  });
+
   it("fails closed when a selected label set is malformed", () => {
 
     const malformedLabels = buildMetricsBody({

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -67,7 +67,10 @@ describe("database health monitor", () => {
   it("persists samples and sends no Linq page for healthy database metrics", async () => {
     const harness = createMonitorHarness();
 
-    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toEqual({
+    await expect(harness.runScheduledCheck(
+      FIVE_MINUTES_MS,
+      FIVE_MINUTES_MS + 15_000,
+    )).resolves.toEqual({
       conditions: [],
       outcome: "healthy",
       sampleStatus: "ok",
@@ -75,6 +78,7 @@ describe("database health monitor", () => {
 
     expect(harness.monitor.readRecentSamples()).toEqual([
       expect.objectContaining({
+        checkedAtMs: FIVE_MINUTES_MS + 15_000,
         clientWaitSeconds: 0,
         connectionErrorDelta: 0,
         observedAtMs: FIVE_MINUTES_MS,
@@ -947,6 +951,8 @@ describe("database health monitor", () => {
     await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves
       .toMatchObject({ outcome: "alert_failed" });
     const pendingAlert = harness.monitor.readAlertState();
+    expect(pendingAlert.pendingAlertMessage)
+      .toContain("PlanetScale PgBouncer server pool");
     harness.restartMonitor();
     expect(harness.monitor.readAlertState()).toMatchObject({
       pendingAlertIdempotencyKey: pendingAlert.pendingAlertIdempotencyKey,
@@ -4647,7 +4653,7 @@ function createMonitorHarness(input: {
         && query.trimStart().startsWith(
           "INSERT INTO database_health_samples",
         )
-        && query.includes("VALUES (?, 'ok'")
+        && query.includes("VALUES (?, ?, 'ok'")
       ) {
         failBeforeSuccessfulSamplePersist = false;
         throw new Error("Injected successful sample persistence failure.");

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -191,8 +191,18 @@ describe("database health store", () => {
     });
     expect(sql.exec<{ name: string }>(
       "PRAGMA table_info(database_health_samples)",
-    ).toArray().map((column) => column.name))
-      .toContain("monitoring_evidence_json");
+    ).toArray().map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "checked_at_ms",
+        "monitoring_evidence_json",
+      ]),
+    );
+    expect(store.readRecentSamples()).toEqual([
+      expect.objectContaining({
+        checkedAtMs: null,
+        observedAtMs: 300_000,
+      }),
+    ]);
     expect(sql.exec<{ value: number }>(
       `SELECT value
        FROM database_health_schema_meta

--- a/apps/cloudflare/test/database-health-store.test.ts
+++ b/apps/cloudflare/test/database-health-store.test.ts
@@ -83,6 +83,7 @@ describe("database health store", () => {
     };
 
     store.recordFailedSample({
+      checkedAtMs: 301_000,
       connectionErrorCounterBaseline,
       connectionErrorDelta: 2,
       conditions: [
@@ -131,6 +132,7 @@ describe("database health store", () => {
     });
     expect(store.readRecentSamples()).toEqual([
       expect.objectContaining({
+        checkedAtMs: 301_000,
         connectionErrorDelta: 2,
         failureCode: "required_metrics_missing",
       }),


### PR DESCRIPTION
Hardens database-health evidence after the PlanetScale tier change: primary-only metrics now require explicit primary provenance, retained samples preserve actual check time, and saturation alerts name the PlanetScale PgBouncer pool precisely.

ReviewGPT first-reviewed head: ccdbf3a4d7ae62e412da8b21a2ff3c6bdc72c66b
ReviewGPT context sensitivity: sensitive

## Product UX

- Not applicable: this changes internal monitoring evidence and operator alert accuracy only.

## Evidence

- `pnpm --dir apps/cloudflare test:node test/database-health-metrics.test.ts test/database-health-monitor.test.ts test/database-health-store.test.ts` (123 passed)
- `pnpm --dir apps/cloudflare typecheck` (passed)

## Non-obvious affected surfaces

- Durable Object SQLite adds a nullable `checked_at_ms` column; legacy samples intentionally read as null.
- PlanetScale edge connection-error metrics remain role-less by provider contract; only primary Postgres/PgBouncer families require `planetscale_role="primary"`.
- Operator alert copy now distinguishes the provider server pool from the local Web client pool.

## Architecture and reuse

- Existing systems reused: The current database-health monitor, metric-family normalization, additive SQLite migration helper, and retained-sample reader remain authoritative.
- New logic: Strict primary selection and actual check-time persistence at the existing collection boundary.
- New abstractions: None; one nullable column and existing parser/store contracts are sufficient.
- Complexity intentionally avoided: No second history service, source epoch, queue, or new monitoring dependency.

## Hot reply path impact

- Not applicable: scheduled database-health collection is outside the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-visible input surface changed.
- Codex runtime: Not applicable; no provider-visible input surface changed.

## Change-shape breakdown

Classification: monitor/parser/store changes are source; database-health Vitest files are tests/fixtures; README, reliability contract, and completed plan are docs; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 25 | 5 |
| Tests/fixtures | 58 | 4 |
| Docs | 62 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 145 | 10 |

## Deployment concerns

- Deployment: applicable
- Supported skew: The new SQLite column is nullable and additive; old code ignores it and new code treats legacy rows as null.
- Safe order: Deploy the Cloudflare Worker normally; no Vercel tandem deploy is required.
- Rollback floor: Rollback remains safe because the prior Worker ignores the additive column.
- Expected exposure: Existing Durable Objects migrate on access; legacy retained samples continue to report a null actual-check time.
- Reversibility: Revert the Worker commit; the unused column can remain.
- Convergence proof: Confirm the active Worker version and read a bounded current sample through existing monitor tests/probes.
- Post-deploy checks: Verify collection succeeds, explicit-primary families are complete, and current samples carry `checkedAtMs`.

## Changelog

- Changelog: not applicable
- Reason: Internal monitoring provenance and operator alert terminology only.
