### PR TITLE
perf(web): remove redundant reconciliation reads

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-reconciliation-db-reads.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-reconciliation-db-reads.md
@@ -1,0 +1,51 @@
+# Remove redundant reconciliation database reads
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Remove database reads whose results cannot affect the deployed Temporal reconciliation response while preserving live access and existence authority.
+
+## Success criteria
+
+- Inactive reconciliation avoids the redundant core member existence read while retaining the canonical active-access decision.
+- Workflow reconciliation does not read pending Environment interview state that the wire deliberately omits.
+- Status/UI consumers continue receiving Environment interview state.
+- Maximum query counts are asserted for inactive and active workflow paths.
+- Focused proof, exact-head ReviewGPT, and required PR checks resolve.
+
+## Scope
+
+- In scope: runtime reconciliation-facts orchestration and focused Web tests.
+- Out of scope: Temporal workflow cadence/coalescing, mailbox semantics, status/UI response shape, and new caching or persistence.
+
+## Constraints
+
+- Technical constraints: remove only reads proved redundant by an existing owner or stripped wire field; preserve missing-member, suspension, access, and workspace authority.
+- Product/process constraints: internal performance change with coverage specialist review and sensitive final ReviewGPT because it touches hosted orchestration behavior.
+
+## Risks and mitigations
+
+1. Risk: Removing an existence read changes missing-member versus inactive behavior.
+   Mitigation: trace and test the canonical access resolver's exact dispositions before deleting the sibling read.
+2. Risk: A non-workflow consumer still needs Environment interview state.
+   Mitigation: branch at the existing decision-source boundary and retain status/UI coverage.
+
+## Tasks
+
+1. Add failing call-count and response regressions for inactive workflow, active workflow, and status/UI paths.
+2. Delete the redundant reads at their current orchestration owner without copying predicates.
+3. Run focused reconciliation-facts and route tests; inspect maximum-cardinality query counts.
+4. Commit, push, open the draft PR, launch both ReviewGPT stages in parallel with CI, resolve findings, close this plan, and push the final scoped commit.
+
+## Decisions
+
+- Delete unused work instead of adding a cache, batch owner, or workflow state.
+
+## Verification
+
+- Commands to run: focused hosted-orchestration reconciliation-facts tests, Web typecheck if required, and `git diff --check`.
+- Expected outcomes: response semantics are unchanged, call-count assertions fall by one inactive read and two workflow interview queries, and UI/status paths retain their data.
+Completed: 2026-08-25

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -51,9 +51,6 @@ import {
 import { projectHostedAiUsageLimitNoticeForDelivery } from "../hosted-execution/usage-limit-notice-message";
 import { readActiveHostedMemberAccess } from "../hosted-onboarding/member-access";
 import {
-  readHostedMemberCoreState,
-} from "../hosted-onboarding/hosted-member-store";
-import {
   hasHostedMemberEstablishedLinqHomeRoute,
 } from "../hosted-onboarding/hosted-member-routing-store";
 import {
@@ -142,8 +139,8 @@ export async function readHostedRuntimeReconciliationFacts(
 ): Promise<HostedRuntimeReconciliationFacts> {
   const prisma = getPrisma();
   const now = normalizeHostedRuntimeReconciliationDate(input.now);
-  const [member, workspace] = await Promise.all([
-    readHostedMemberCoreState({
+  const [hasActiveAccess, workspace] = await Promise.all([
+    readActiveHostedMemberAccess({
       memberId: input.userId,
       prisma,
     }),
@@ -151,10 +148,7 @@ export async function readHostedRuntimeReconciliationFacts(
   ]);
   const projectedWorkspace = projectHostedRuntimeReconciliationWorkspace(workspace);
 
-  if (!member || !(await readActiveHostedMemberAccess({
-    memberId: input.userId,
-    prisma,
-  }))) {
+  if (!hasActiveAccess) {
     const facts = buildHostedRuntimeBlockedFacts({
       mailboxLag: [],
       reason: "user_not_active",
@@ -207,10 +201,12 @@ export async function readHostedRuntimeReconciliationFacts(
       prisma,
       userId: input.userId,
     }),
-    readPendingHostedEnvironmentInterviewMailboxItem({
-      prisma,
-      userId: input.userId,
-    }),
+    input.decisionSource === "status"
+      ? readPendingHostedEnvironmentInterviewMailboxItem({
+          prisma,
+          userId: input.userId,
+        })
+      : null,
   ]);
   const environmentInterviewPending = pendingEnvironmentInterview !== null;
   const redactedStatus = readHostedMailboxRedactedStatusRecord(

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -1276,6 +1276,24 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(mocks.sendClaimedHostedAiUsageLimitNoticeToTelegramThread).not.toHaveBeenCalled();
   });
 
+  it("retains Environment interview state for read-only status checks", async () => {
+    mocks.readPendingHostedEnvironmentInterviewMailboxItem.mockResolvedValue({
+      id: "mailbox_environment_interview_1",
+    });
+
+    const {
+      readHostedRuntimeReconciliationFacts,
+    } = await import("../src/lib/hosted-orchestration/runtime-reconciliation-facts");
+    const facts = await readHostedRuntimeReconciliationFacts({
+      decisionSource: "status",
+      usageGateMode: "read_only",
+      userId: MEMBER_ID,
+    });
+
+    expect(facts.environmentInterviewPending).toBe(true);
+    expect(mocks.readPendingHostedEnvironmentInterviewMailboxItem).toHaveBeenCalledTimes(1);
+  });
+
   it("does not gate future model-capable workspace wakes", async () => {
     mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
       nextWakeAt: "2026-05-20T12:05:00.000Z",
@@ -1653,6 +1671,7 @@ describe("hosted orchestration reconciliation facts", () => {
     const facts = await response.json();
 
     expect(facts).not.toHaveProperty("environmentInterviewPending");
+    expect(mocks.readPendingHostedEnvironmentInterviewMailboxItem).not.toHaveBeenCalled();
   });
 
   it("blocks inactive members while preserving workspace facts", async () => {
@@ -1685,6 +1704,7 @@ describe("hosted orchestration reconciliation facts", () => {
       },
     });
     expect(mocks.readHostedMailboxMaxSeqByLane).not.toHaveBeenCalled();
+    expect(mocks.hostedMemberFindUnique).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -1671,6 +1671,7 @@ describe("hosted orchestration reconciliation facts", () => {
     const facts = await response.json();
 
     expect(facts).not.toHaveProperty("environmentInterviewPending");
+    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
     expect(mocks.readPendingHostedEnvironmentInterviewMailboxItem).not.toHaveBeenCalled();
   });
 
@@ -1703,6 +1704,7 @@ describe("hosted orchestration reconciliation facts", () => {
         version: "4",
       },
     });
+    expect(mocks.readHostedMemberCoreState).not.toHaveBeenCalled();
     expect(mocks.readHostedMailboxMaxSeqByLane).not.toHaveBeenCalled();
     expect(mocks.hostedMemberFindUnique).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Removes two redundant database reads from hosted runtime reconciliation: active access is now the sole member gate, and the Environment interview lookup runs only for the status response that consumes it.

ReviewGPT first-reviewed head: ff45e9286cf9c6741024ab7296e2fb89338f2fc5
ReviewGPT context sensitivity: sensitive

## Product UX

- Not applicable: this is a behavior-preserving background reconciliation optimization with no UI or copy change.

## Evidence

- `pnpm --dir apps/web test:prepared test/hosted-orchestration-reconciliation-facts.test.ts` (50 passed)
- `pnpm --dir apps/web typecheck:prepared` (passed)

## Non-obvious affected surfaces

- Inactive-member reconciliation still returns the same blocked facts while using one canonical active-access read.
- Read-only status checks retain Environment interview state; workflow decisions no longer fetch unused interview state.

## Architecture and reuse

- Existing systems reused: `readActiveHostedMemberAccess` remains the canonical active-member owner and the existing decision-source contract selects status-only facts.
- New logic: The interview query is gated by the consumer that serializes it.
- New abstractions: None; direct deletion and one conditional are sufficient.
- Complexity intentionally avoided: No cache, batched facade, alternate member projection, or persisted reconciliation state.

## Hot reply path impact

- Not applicable: hosted reconciliation status/workflow decisions are outside durable current-message acceptance through reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-visible input surface changed.
- Codex runtime: Not applicable; no provider-visible input surface changed.

## Change-shape breakdown

Classification: reconciliation implementation is source; focused Vitest coverage is tests/fixtures; completed execution plan is docs; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 13 |
| Tests/fixtures | 22 | 0 |
| Docs | 51 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 82 | 13 |

## Deployment concerns

- Deployment: applicable
- Supported skew: The change uses existing database rows and response shapes.
- Safe order: Deploy Web normally; no tandem Cloudflare or schema deploy is required.
- Rollback floor: The previous redundant reads remain compatible with all state.
- Expected exposure: Mixed Web instances differ only in query count during rollout.
- Reversibility: Revert the Web commit.
- Convergence proof: Confirm the Vercel deployment serves the candidate commit.
- Post-deploy checks: Inspect reconciliation errors and bounded database-read latency aggregates.

## Changelog

- Changelog: not applicable
- Reason: Internal query-count reduction with intentionally unchanged member behavior.
