### PR TITLE
Enforce production food-search index contract

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-food-search-index-contract.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-food-search-index-contract.md
@@ -1,0 +1,87 @@
+# Enforce the private food-search index contract
+
+Status: completed
+Created: 2026-08-25
+Updated: 2026-08-25
+
+## Goal
+
+- Stop private food-name searches from reaching PostgreSQL's eight-second
+  statement timeout because a production labels database is missing the three
+  indexes required by the deployed bounded query.
+- Make future production builds fail closed on missing, invalid, unready, or
+  wrongly defined search indexes, and add query-free failure context that makes
+  a remaining timeout diagnosable without exposing member search text.
+
+## Success criteria
+
+- The production preflight validates the exact three private-food search index
+  contracts as well as the existing column contract.
+- A dedicated concurrent-index SQL entrypoint gives operators a live-safe path
+  for installing the missing indexes before deployment.
+- GET and batch POST failures identify lookup shape, bounded cardinality, and
+  elapsed time without logging query values.
+- Focused Web tests and typecheck pass; the PR receives required ReviewGPT and
+  exact-head CI proof.
+
+## Scope
+
+- In scope: product-label schema preflight, focused schema tests, the concurrent
+  foods-index rollout SQL, product-label route error diagnostics, and operator
+  documentation.
+- Out of scope: changing the eight-second timeout, storing search terms,
+  automatically mutating the external labels database during a Web build, or
+  changing public/supplement search ranking.
+
+## Constraints
+
+- Technical constraints: runtime credentials remain read-only; index creation
+  is concurrent and outside a transaction; exact index semantics and live
+  validity/readiness must be checked rather than trusting names alone.
+- Product/process constraints: preserve deterministic private-food ranking,
+  fail closed before a deploy when prerequisites are absent, and keep all
+  production evidence aggregate and privacy-safe.
+
+## Risks and mitigations
+
+1. Risk: a same-named but incorrect or interrupted concurrent index could pass
+   a shallow existence check.
+   Mitigation: validate the normalized `pg_get_indexdef` suffix plus
+   `indisvalid`, `indisready`, and `indislive`.
+2. Risk: richer failure logs could expose food queries.
+   Mitigation: record only operation type, booleans, bounded counts/lengths,
+   limit, and elapsed milliseconds.
+
+## Tasks
+
+1. Add focused failing tests for missing, invalid, and wrong-definition index
+   states and privacy-safe GET/POST diagnostics.
+2. Extend the build-time product-label preflight and add the concurrent index
+   rollout entrypoint.
+3. Update the live operator contract, run focused tests/typecheck, and inspect
+   the final diff.
+4. Commit, push, open the PR, then run preliminary and final ReviewGPT alongside
+   required exact-head CI.
+
+## Decisions
+
+- Production read-only proof on 2026-08-25 found a 2.04M-row foods table and
+  none of the three required indexes. Exact application calls reproduced
+  statement timeouts for several ordinary broad private searches, while the
+  generic-only path stayed well below one second.
+- The correction enforces the already-documented index-backed architecture
+  rather than raising the timeout or weakening deterministic ranking.
+
+## Verification
+
+- Commands: focused product-label runtime-env and route tests, Web typecheck,
+  SQL contract readback, `git diff --check`, ReviewGPT, and required PR checks.
+- Expected outcomes: all focused tests and typecheck pass; no diagnostic
+  contains a query value; production deployment remains blocked until the
+  concurrent index rollout has completed and the preflight sees live indexes.
+- Local evidence: 91 focused Web tests passed across the preflight, food route,
+  supplement route, and food-query suites; `pnpm typecheck` passed in
+  `apps/web`; the updated preflight ran through the production Vercel
+  environment and rejected the live labels database for exactly the three
+  missing search indexes without printing credentials or row data.
+Completed: 2026-08-25

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -758,9 +758,12 @@ window sorting. Ranking is deterministic within that admitted set; it is
 intentionally not an exhaustive whole-catalog ranking. Exact IDs and UPCs
 continue to use direct lookup paths.
 
-For an existing labels database, create the foods exact-name-rank, GiST
-name-rank, and canonical-rank indexes concurrently before deploying web code
-that uses this query shape.
+For an existing labels database, run
+`psql -f sql/foods/private-search-indexes.sql` with the labels schema owner to
+create the foods exact-name-rank, GiST name-rank, and canonical-rank indexes
+concurrently before deploying web code that uses this query shape. The
+production build preflight validates all three exact definitions plus their
+live/ready/valid state and fails closed if the rollout is missing or incomplete.
 
 The supplement payload constraint is additive for existing databases:
 `sql/supplements/schema.sql` adds it `NOT VALID`, so it immediately rejects new

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -764,6 +764,20 @@ create the foods exact-name-rank, GiST name-rank, and canonical-rank indexes
 concurrently before deploying web code that uses this query shape. The
 production build preflight validates all three exact definitions plus their
 live/ready/valid state and fails closed if the rollout is missing or incomplete.
+`IF NOT EXISTS` cannot repair a same-named interrupted or wrong-definition
+index. When the preflight reports `not_live` or `wrong_definition`, inspect the
+reported fixed name, drop only that index without blocking table writes, and
+rerun the rollout:
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS public.foods_name_rank_idx;
+DROP INDEX CONCURRENTLY IF EXISTS public.foods_name_exact_rank_idx;
+DROP INDEX CONCURRENTLY IF EXISTS public.foods_canonical_rank_idx;
+```
+
+Run only the statement for each reported nonconforming index. Do not drop an
+exact live/ready/valid index. Like the create script, concurrent drops must run
+outside a transaction.
 
 The supplement payload constraint is additive for existing databases:
 `sql/supplements/schema.sql` adds it `NOT VALID`, so it immediately rejects new

--- a/apps/web/scripts/check-product-label-runtime-env.ts
+++ b/apps/web/scripts/check-product-label-runtime-env.ts
@@ -9,7 +9,7 @@ const { Pool } = pg;
 export const PRODUCT_LABEL_RUNTIME_ENV_REQUIRED_MESSAGE =
   "MURPH_LABELS_DB_URL is required for /api/foods and /api/supplements; MURPH_SUPPLEMENT_DB_URL is not a runtime fallback.";
 export const PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE =
-  "MURPH_LABELS_DB_URL must point at a labels database with the product contaminant schema applied; run apps/web/sql/product-tests/schema.sql before deploying.";
+  "MURPH_LABELS_DB_URL must point at a labels database with the product contaminant schema and private-food search indexes applied; run apps/web/sql/product-tests/schema.sql and apps/web/sql/foods/private-search-indexes.sql before deploying.";
 export const PRODUCT_LABEL_RUNTIME_SCHEMA_VERIFY_FAILED_MESSAGE =
   "Could not verify the product contaminant schema on MURPH_LABELS_DB_URL.";
 
@@ -66,15 +66,50 @@ type ProductLabelSchemaColumn = {
   tableName: string;
   columnName: string;
 };
+type ProductLabelSchemaProblem =
+  | {
+      kind: "column";
+      name: string;
+      reason: "missing";
+    }
+  | {
+      kind: "index";
+      name: string;
+      reason: "missing" | "not_live" | "wrong_definition";
+    };
 type ProductLabelSchemaColumnRow = {
   tableName: string;
   columnName: string;
 };
-type ProductLabelRuntimeEnvDependencies = {
-  readMissingRequiredSchemaColumns?: (
-    connectionString: string,
-  ) => Promise<ProductLabelSchemaColumn[]>;
+type ProductLabelSchemaIndexRow = {
+  definition: string | null;
+  indexName: string;
+  isLive: boolean | null;
+  isReady: boolean | null;
+  isValid: boolean | null;
 };
+type ProductLabelRuntimeEnvDependencies = {
+  readRequiredSchemaProblems?: (
+    connectionString: string,
+  ) => Promise<ProductLabelSchemaProblem[]>;
+};
+
+const REQUIRED_PRODUCT_LABEL_SEARCH_INDEXES = [
+  {
+    definitionSuffix: "USING gist (name gist_trgm_ops)",
+    indexName: "foods_name_rank_idx",
+  },
+  {
+    definitionSuffix:
+      "USING btree (lower(name), data_origin_priority, id)",
+    indexName: "foods_name_exact_rank_idx",
+  },
+  {
+    definitionSuffix:
+      "USING btree (canonical_key, data_origin_priority, id)",
+    indexName: "foods_canonical_rank_idx",
+  },
+] as const;
 
 export async function listProductLabelRuntimeEnvErrors(
   source: EnvSource = process.env,
@@ -91,23 +126,23 @@ export async function listProductLabelRuntimeEnvErrors(
   const labelsDatabaseConnectionString =
     normalizeProductLabelsConnectionString(labelsDatabaseUrl);
 
-  let missingColumns: ProductLabelSchemaColumn[];
+  let schemaProblems: ProductLabelSchemaProblem[];
   try {
-    missingColumns = await (
-      dependencies.readMissingRequiredSchemaColumns ??
-      readMissingRequiredProductLabelSchemaColumns
+    schemaProblems = await (
+      dependencies.readRequiredSchemaProblems ??
+      readRequiredProductLabelSchemaProblems
     )(labelsDatabaseConnectionString);
   } catch {
     return [PRODUCT_LABEL_RUNTIME_SCHEMA_VERIFY_FAILED_MESSAGE];
   }
 
-  if (missingColumns.length === 0) {
+  if (schemaProblems.length === 0) {
     return [];
   }
 
   return [
-    `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing columns: ${
-      missingColumns.map(formatProductLabelSchemaColumn).join(", ")
+    `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing or invalid objects: ${
+      schemaProblems.map(formatProductLabelSchemaProblem).join(", ")
     }.`,
   ];
 }
@@ -133,9 +168,9 @@ function normalizeOptionalString(value: string | undefined): string | null {
   return normalized ? normalized : null;
 }
 
-async function readMissingRequiredProductLabelSchemaColumns(
+async function readRequiredProductLabelSchemaProblems(
   connectionString: string,
-): Promise<ProductLabelSchemaColumn[]> {
+): Promise<ProductLabelSchemaProblem[]> {
   const pool = new Pool({
     connectionString,
     connectionTimeoutMillis: 5_000,
@@ -150,7 +185,7 @@ async function readMissingRequiredProductLabelSchemaColumns(
     const columnNames = REQUIRED_PRODUCT_LABEL_SCHEMA_COLUMNS.map(
       ([, columnName]) => columnName,
     );
-    const result = await pool.query<ProductLabelSchemaColumnRow>(
+    const missingColumns = await pool.query<ProductLabelSchemaColumnRow>(
       `
         WITH required(table_name, column_name) AS (
           SELECT * FROM unnest($1::text[], $2::text[])
@@ -169,16 +204,105 @@ async function readMissingRequiredProductLabelSchemaColumns(
       [tableNames, columnNames],
     );
 
-    return result.rows;
+    const requiredIndexNames = REQUIRED_PRODUCT_LABEL_SEARCH_INDEXES.map(
+      ({ indexName }) => indexName,
+    );
+    const indexes = await pool.query<ProductLabelSchemaIndexRow>(
+      `
+        WITH required(index_name) AS (
+          SELECT unnest($1::text[])
+        )
+        SELECT
+          required.index_name AS "indexName",
+          index_state.indisvalid AS "isValid",
+          index_state.indisready AS "isReady",
+          index_state.indislive AS "isLive",
+          pg_get_indexdef(index_state.indexrelid) AS definition
+        FROM required
+        LEFT JOIN LATERAL (
+          SELECT indexes.*
+          FROM pg_class AS index_class
+          JOIN pg_namespace AS index_namespace
+            ON index_namespace.oid = index_class.relnamespace
+          JOIN pg_index AS indexes
+            ON indexes.indexrelid = index_class.oid
+          JOIN pg_class AS table_class
+            ON table_class.oid = indexes.indrelid
+          JOIN pg_namespace AS table_namespace
+            ON table_namespace.oid = table_class.relnamespace
+          WHERE
+            index_namespace.nspname = 'public'
+            AND index_class.relname = required.index_name
+            AND table_namespace.nspname = 'public'
+            AND table_class.relname = 'foods'
+          LIMIT 1
+        ) AS index_state ON true
+        ORDER BY required.index_name ASC
+      `,
+      [requiredIndexNames],
+    );
+
+    return [
+      ...missingColumns.rows.map(({ tableName, columnName }) => ({
+        kind: "column" as const,
+        name: formatProductLabelSchemaColumn({ tableName, columnName }),
+        reason: "missing" as const,
+      })),
+      ...findProductLabelSearchIndexProblems(indexes.rows),
+    ];
   } finally {
     await pool.end();
   }
+}
+
+function findProductLabelSearchIndexProblems(
+  rows: readonly ProductLabelSchemaIndexRow[],
+): ProductLabelSchemaProblem[] {
+  const rowsByName = new Map(rows.map((row) => [row.indexName, row]));
+  const problems: ProductLabelSchemaProblem[] = [];
+
+  for (const required of REQUIRED_PRODUCT_LABEL_SEARCH_INDEXES) {
+    const row = rowsByName.get(required.indexName);
+    if (!row || !row.definition) {
+      problems.push({
+        kind: "index",
+        name: required.indexName,
+        reason: "missing",
+      });
+      continue;
+    }
+    if (!row.isValid || !row.isReady || !row.isLive) {
+      problems.push({
+        kind: "index",
+        name: required.indexName,
+        reason: "not_live",
+      });
+      continue;
+    }
+
+    const normalizedDefinition = row.definition.replace(/\s+/gu, " ").trim();
+    if (!normalizedDefinition.endsWith(required.definitionSuffix)) {
+      problems.push({
+        kind: "index",
+        name: required.indexName,
+        reason: "wrong_definition",
+      });
+    }
+  }
+
+  return problems;
 }
 
 function formatProductLabelSchemaColumn(
   column: ProductLabelSchemaColumn,
 ): string {
   return `${column.tableName}.${column.columnName}`;
+}
+
+function formatProductLabelSchemaProblem(
+  problem: ProductLabelSchemaProblem,
+): string {
+  return `${problem.name} (${problem.reason})`;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/apps/web/scripts/check-product-label-runtime-env.ts
+++ b/apps/web/scripts/check-product-label-runtime-env.ts
@@ -81,7 +81,7 @@ type ProductLabelSchemaColumnRow = {
   tableName: string;
   columnName: string;
 };
-type ProductLabelSchemaIndexRow = {
+export type ProductLabelSchemaIndexRow = {
   definition: string | null;
   indexName: string;
   isLive: boolean | null;
@@ -255,7 +255,7 @@ async function readRequiredProductLabelSchemaProblems(
   }
 }
 
-function findProductLabelSearchIndexProblems(
+export function findProductLabelSearchIndexProblems(
   rows: readonly ProductLabelSchemaIndexRow[],
 ): ProductLabelSchemaProblem[] {
   const rowsByName = new Map(rows.map((row) => [row.indexName, row]));

--- a/apps/web/sql/foods/private-search-indexes.sql
+++ b/apps/web/sql/foods/private-search-indexes.sql
@@ -3,6 +3,10 @@
 -- Run this file directly with psql. CREATE INDEX CONCURRENTLY cannot run
 -- inside a transaction, so deployment must complete these statements before
 -- the Web build-time product-label preflight is allowed to pass.
+-- IF NOT EXISTS deliberately preserves an already-correct live index. If the
+-- preflight reports `not_live` or `wrong_definition`, follow the fixed-name
+-- concurrent drop procedure in apps/web/README.md for only the reported index,
+-- then rerun this file.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_name_rank_idx
   ON foods
   USING GIST (name gist_trgm_ops);

--- a/apps/web/sql/foods/private-search-indexes.sql
+++ b/apps/web/sql/foods/private-search-indexes.sql
@@ -1,0 +1,14 @@
+\set ON_ERROR_STOP on
+
+-- Run this file directly with psql. CREATE INDEX CONCURRENTLY cannot run
+-- inside a transaction, so deployment must complete these statements before
+-- the Web build-time product-label preflight is allowed to pass.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_name_rank_idx
+  ON foods
+  USING GIST (name gist_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_name_exact_rank_idx
+  ON foods (lower(name), data_origin_priority, id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_canonical_rank_idx
+  ON foods (canonical_key, data_origin_priority, id);

--- a/apps/web/src/lib/product-labels-route.ts
+++ b/apps/web/src/lib/product-labels-route.ts
@@ -15,6 +15,11 @@ const MAX_SEARCH_QUERY_LENGTH = 256;
 const MAX_BATCH_BODY_BYTES = 32 * 1024;
 const GTIN_LENGTHS = new Set([8, 12, 13, 14]);
 
+type ProductLabelsFailureContext = Readonly<Record<
+  string,
+  boolean | number | string
+>>;
+
 type ProductLabelsLookupParam =
   | { key: "id"; value: string }
   | { key: "q"; value: string }
@@ -63,7 +68,10 @@ export function createProductLabelsRouteHandlers<TItem>(
     }
   }
 
-  function apiFailed(error: unknown): Response {
+  function apiFailed(
+    error: unknown,
+    context: ProductLabelsFailureContext,
+  ): Response {
     if (config.isUnconfiguredError?.(error)) {
       console.error(config.errorCodes.unconfigured, {
         errorName: error instanceof Error ? error.name : typeof error,
@@ -72,9 +80,8 @@ export function createProductLabelsRouteHandlers<TItem>(
     }
 
     console.error(config.errorCodes.failed, {
-      ...formatHostedExecutionSafeLogErrorDetails(error, {
-        code: config.errorCodes.failed,
-      }),
+      ...formatProductLabelsSafeLogErrorDetails(error, config.errorCodes.failed),
+      ...context,
     });
     return json({ error: config.errorCodes.failed }, { status: 500 });
   }
@@ -98,6 +105,7 @@ export function createProductLabelsRouteHandlers<TItem>(
     const nutritionOnly =
       config.projectNutritionItem !== undefined &&
       params.get("nutritionOnly") === "true";
+    const startedAt = performance.now();
 
     try {
       if (id) {
@@ -150,7 +158,16 @@ export function createProductLabelsRouteHandlers<TItem>(
           projectProductLabelItem(config, item, nutritionOnly)),
       });
     } catch (error) {
-      return apiFailed(error);
+      return apiFailed(error, {
+        durationMs: roundedDurationMs(startedAt),
+        genericOnly,
+        includeOffMarket,
+        limit,
+        method: "GET",
+        nutritionOnly,
+        operation: id ? "id" : upc ? "upc" : "search",
+        ...(q ? { queryLength: q.length } : {}),
+      });
     }
   }
 
@@ -194,9 +211,10 @@ export function createProductLabelsRouteHandlers<TItem>(
     const nutritionOnly =
       config.projectNutritionItem !== undefined &&
       payload.nutritionOnly === true;
+    const uniqueQueries = dedupeBatchQueries(queries);
+    const startedAt = performance.now();
 
     try {
-      const uniqueQueries = dedupeBatchQueries(queries);
       const uniqueResults = await mapLimit(
         uniqueQueries,
         BATCH_SEARCH_CONCURRENCY,
@@ -235,11 +253,59 @@ export function createProductLabelsRouteHandlers<TItem>(
         results,
       });
     } catch (error) {
-      return apiFailed(error);
+      return apiFailed(error, {
+        batchConcurrency: BATCH_SEARCH_CONCURRENCY,
+        durationMs: roundedDurationMs(startedAt),
+        genericOnly,
+        includeOffMarket,
+        limit,
+        maxQueryLength: Math.max(...uniqueQueries.map((query) => query.length)),
+        method: "POST",
+        nutritionOnly,
+        operation: "batch_search",
+        queryCount: queries.length,
+        uniqueQueryCount: uniqueQueries.length,
+      });
     }
   }
 
   return { GET, POST };
+}
+
+function formatProductLabelsSafeLogErrorDetails(
+  error: unknown,
+  errorCode: string,
+): Record<string, string> {
+  const details = formatHostedExecutionSafeLogErrorDetails(error, {
+    code: errorCode,
+  });
+  const databaseErrorCode = readSafeDatabaseErrorCode(error);
+  const cause = error instanceof Error ? error.cause : undefined;
+  const causeDatabaseErrorCode = readSafeDatabaseErrorCode(cause);
+
+  return {
+    errorCode: details.errorCode,
+    errorType: details.errorType,
+    ...(databaseErrorCode ? { databaseErrorCode } : {}),
+    ...(details.errorCauseType
+      ? { errorCauseType: details.errorCauseType }
+      : {}),
+    ...(causeDatabaseErrorCode ? { causeDatabaseErrorCode } : {}),
+  };
+}
+
+function readSafeDatabaseErrorCode(error: unknown): string | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+  const code = error.code;
+  return typeof code === "string" && /^[A-Za-z0-9._:-]{1,64}$/u.test(code)
+    ? code
+    : null;
+}
+
+function roundedDurationMs(startedAt: number): number {
+  return Math.max(0, Math.round(performance.now() - startedAt));
 }
 
 async function lookupProductLabels<TItem>(

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -50,6 +50,16 @@ describe("foods query helpers", () => {
     expect(schemaSql).toContain(
       "ON foods (canonical_key, data_origin_priority, id)",
     );
+
+    const liveRolloutSql = await readFile(
+      new URL("../sql/foods/private-search-indexes.sql", import.meta.url),
+      "utf8",
+    );
+    expect(liveRolloutSql.match(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/gu))
+      .toHaveLength(3);
+    expect(liveRolloutSql).toContain("foods_name_rank_idx");
+    expect(liveRolloutSql).toContain("foods_name_exact_rank_idx");
+    expect(liveRolloutSql).toContain("foods_canonical_rank_idx");
   });
 
   it("projects meal nutrition and bounded contaminant evidence without unrelated payloads", () => {

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -57,9 +57,15 @@ describe("foods query helpers", () => {
     );
     expect(liveRolloutSql.match(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/gu))
       .toHaveLength(3);
-    expect(liveRolloutSql).toContain("foods_name_rank_idx");
-    expect(liveRolloutSql).toContain("foods_name_exact_rank_idx");
-    expect(liveRolloutSql).toContain("foods_canonical_rank_idx");
+    expect(liveRolloutSql).toMatch(
+      /CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_name_rank_idx\s+ON foods\s+USING GIST \(name gist_trgm_ops\);/u,
+    );
+    expect(liveRolloutSql).toMatch(
+      /CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_name_exact_rank_idx\s+ON foods \(lower\(name\), data_origin_priority, id\);/u,
+    );
+    expect(liveRolloutSql).toMatch(
+      /CREATE INDEX CONCURRENTLY IF NOT EXISTS foods_canonical_rank_idx\s+ON foods \(canonical_key, data_origin_priority, id\);/u,
+    );
   });
 
   it("projects meal nutrition and bounded contaminant evidence without unrelated payloads", () => {

--- a/apps/web/test/foods-route.test.ts
+++ b/apps/web/test/foods-route.test.ts
@@ -663,7 +663,10 @@ describe("foods API route", () => {
 
   it("returns a safe failure payload when the query layer throws", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    mocks.searchFoods.mockRejectedValue(new Error("database unavailable"));
+    mocks.searchFoods.mockRejectedValue(Object.assign(
+      new Error("private query must not be logged"),
+      { code: "57014" },
+    ));
 
     const response = await foodsRoute.GET(
       new Request("https://web.example.test/api/foods?q=yogurt", {
@@ -678,10 +681,20 @@ describe("foods API route", () => {
       error: "foods_api_failed",
     });
     expect(consoleError).toHaveBeenCalledWith("foods_api_failed", {
+      databaseErrorCode: "57014",
+      durationMs: expect.any(Number),
       errorCode: "foods_api_failed",
-      errorMessage: "database unavailable",
       errorType: "Error",
+      genericOnly: false,
+      includeOffMarket: false,
+      limit: 1,
+      method: "GET",
+      nutritionOnly: false,
+      operation: "search",
+      queryLength: 6,
     });
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("private query");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("yogurt");
   });
 
   it("returns an unconfigured error when contaminant schema is missing", async () => {
@@ -1519,9 +1532,19 @@ describe("foods API route", () => {
       error: "foods_api_failed",
     });
     expect(consoleError).toHaveBeenCalledWith("foods_api_failed", {
+      batchConcurrency: 3,
+      durationMs: expect.any(Number),
       errorCode: "foods_api_failed",
-      errorMessage: "database unavailable",
       errorType: "Error",
+      genericOnly: false,
+      includeOffMarket: false,
+      limit: 1,
+      maxQueryLength: 6,
+      method: "POST",
+      nutritionOnly: false,
+      operation: "batch_search",
+      queryCount: 1,
+      uniqueQueryCount: 1,
     });
   });
 });

--- a/apps/web/test/product-label-runtime-env.test.ts
+++ b/apps/web/test/product-label-runtime-env.test.ts
@@ -25,7 +25,7 @@ describe("product label runtime env preflight", () => {
           MURPH_SUPPLEMENT_DB_URL: "postgres://legacy.example.test/supplements",
         },
         {
-          async readMissingRequiredSchemaColumns() {
+          async readRequiredSchemaProblems() {
             throw new Error("local builds should not query labels schema");
           },
         },
@@ -42,7 +42,7 @@ describe("product label runtime env preflight", () => {
           MURPH_SUPPLEMENT_DB_URL: "postgres://legacy.example.test/supplements",
         },
         {
-          async readMissingRequiredSchemaColumns(connectionString) {
+          async readRequiredSchemaProblems(connectionString) {
             expect(connectionString).toBe("postgres://labels.example.test/labels");
             return [];
           },
@@ -60,7 +60,7 @@ describe("product label runtime env preflight", () => {
             "postgres://labels.example.test/labels?sslrootcert=system&sslcert=system&sslkey=system&connect_timeout=10",
         },
         {
-          async readMissingRequiredSchemaColumns(connectionString) {
+          async readRequiredSchemaProblems(connectionString) {
             expect(connectionString).toBe(
               "postgres://labels.example.test/labels?connect_timeout=10",
             );
@@ -79,30 +79,68 @@ describe("product label runtime env preflight", () => {
           MURPH_LABELS_DB_URL: "postgres://labels.example.test/labels",
         },
         {
-          async readMissingRequiredSchemaColumns() {
+          async readRequiredSchemaProblems() {
             return [
               {
-                tableName: "foods",
-                columnName: "serving_grams",
+                kind: "column",
+                name: "foods.serving_grams",
+                reason: "missing",
               },
               {
-                tableName: "contaminant_thresholds",
-                columnName: "threshold_name",
+                kind: "column",
+                name: "contaminant_thresholds.threshold_name",
+                reason: "missing",
               },
               {
-                tableName: "contaminant_thresholds",
-                columnName: "threshold_value",
+                kind: "column",
+                name: "contaminant_thresholds.threshold_value",
+                reason: "missing",
               },
               {
-                tableName: "product_tests",
-                columnName: "source_key",
+                kind: "column",
+                name: "product_tests.source_key",
+                reason: "missing",
               },
             ];
           },
         },
       ),
     ).rejects.toThrow(
-      `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing columns: foods.serving_grams, contaminant_thresholds.threshold_name, contaminant_thresholds.threshold_value, product_tests.source_key.`,
+      `${PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE} Missing or invalid objects: foods.serving_grams (missing), contaminant_thresholds.threshold_name (missing), contaminant_thresholds.threshold_value (missing), product_tests.source_key (missing).`,
+    );
+  });
+
+  it("fails production builds for missing, interrupted, or wrong food-search indexes", async () => {
+    await expect(
+      assertProductLabelRuntimeEnv(
+        {
+          VERCEL_ENV: "production",
+          MURPH_LABELS_DB_URL: "postgres://labels.example.test/labels",
+        },
+        {
+          async readRequiredSchemaProblems() {
+            return [
+              {
+                kind: "index",
+                name: "foods_name_rank_idx",
+                reason: "missing",
+              },
+              {
+                kind: "index",
+                name: "foods_name_exact_rank_idx",
+                reason: "not_live",
+              },
+              {
+                kind: "index",
+                name: "foods_canonical_rank_idx",
+                reason: "wrong_definition",
+              },
+            ];
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      "foods_name_rank_idx (missing), foods_name_exact_rank_idx (not_live), foods_canonical_rank_idx (wrong_definition)",
     );
   });
 
@@ -114,7 +152,7 @@ describe("product label runtime env preflight", () => {
           MURPH_LABELS_DB_URL: "postgres://labels.example.test/labels",
         },
         {
-          async readMissingRequiredSchemaColumns() {
+          async readRequiredSchemaProblems() {
             throw new Error("network unavailable");
           },
         },

--- a/apps/web/test/product-label-runtime-env.test.ts
+++ b/apps/web/test/product-label-runtime-env.test.ts
@@ -2,13 +2,95 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertProductLabelRuntimeEnv,
+  findProductLabelSearchIndexProblems,
   listProductLabelRuntimeEnvErrors,
   PRODUCT_LABEL_RUNTIME_ENV_REQUIRED_MESSAGE,
   PRODUCT_LABEL_RUNTIME_SCHEMA_REQUIRED_MESSAGE,
   PRODUCT_LABEL_RUNTIME_SCHEMA_VERIFY_FAILED_MESSAGE,
 } from "../scripts/check-product-label-runtime-env";
 
+const liveFoodSearchIndexes = [
+  {
+    definition:
+      "CREATE INDEX foods_name_rank_idx ON public.foods USING gist (name gist_trgm_ops)",
+    indexName: "foods_name_rank_idx",
+    isLive: true,
+    isReady: true,
+    isValid: true,
+  },
+  {
+    definition:
+      "CREATE INDEX foods_name_exact_rank_idx ON public.foods USING btree (lower(name), data_origin_priority, id)",
+    indexName: "foods_name_exact_rank_idx",
+    isLive: true,
+    isReady: true,
+    isValid: true,
+  },
+  {
+    definition:
+      "CREATE INDEX foods_canonical_rank_idx ON public.foods USING btree (canonical_key, data_origin_priority, id)",
+    indexName: "foods_canonical_rank_idx",
+    isLive: true,
+    isReady: true,
+    isValid: true,
+  },
+] as const;
+
 describe("product label runtime env preflight", () => {
+  it("classifies the exact food-search catalog contract", () => {
+    expect(findProductLabelSearchIndexProblems(liveFoodSearchIndexes)).toEqual([]);
+
+    for (const state of ["isLive", "isReady", "isValid"] as const) {
+      expect(findProductLabelSearchIndexProblems([
+        { ...liveFoodSearchIndexes[0], [state]: false },
+        ...liveFoodSearchIndexes.slice(1),
+      ])).toEqual([{
+        kind: "index",
+        name: "foods_name_rank_idx",
+        reason: "not_live",
+      }]);
+    }
+
+    expect(findProductLabelSearchIndexProblems([
+      ...liveFoodSearchIndexes.slice(0, 1),
+      { ...liveFoodSearchIndexes[1], isReady: false },
+      {
+        ...liveFoodSearchIndexes[2],
+        definition:
+          "CREATE INDEX foods_canonical_rank_idx ON public.foods USING btree (canonical_key, id)",
+      },
+    ])).toEqual([
+      {
+        kind: "index",
+        name: "foods_name_exact_rank_idx",
+        reason: "not_live",
+      },
+      {
+        kind: "index",
+        name: "foods_canonical_rank_idx",
+        reason: "wrong_definition",
+      },
+    ]);
+
+    expect(findProductLabelSearchIndexProblems([])).toEqual([
+      {
+        kind: "index",
+        name: "foods_name_rank_idx",
+        reason: "missing",
+      },
+      {
+        kind: "index",
+        name: "foods_name_exact_rank_idx",
+        reason: "missing",
+      },
+      {
+        kind: "index",
+        name: "foods_canonical_rank_idx",
+        reason: "missing",
+      },
+    ]);
+  });
+
   it("fails production builds without the shared labels database URL", async () => {
     await expect(
       assertProductLabelRuntimeEnv({

--- a/apps/web/test/supplements-route.test.ts
+++ b/apps/web/test/supplements-route.test.ts
@@ -367,9 +367,16 @@ describe("supplements API route", () => {
       error: "supplements_api_failed",
     });
     expect(consoleError).toHaveBeenCalledWith("supplements_api_failed", {
+      durationMs: expect.any(Number),
       errorCode: "supplements_api_failed",
-      errorMessage: "database unavailable",
       errorType: "Error",
+      genericOnly: false,
+      includeOffMarket: false,
+      limit: 1,
+      method: "GET",
+      nutritionOnly: false,
+      operation: "search",
+      queryLength: 8,
     });
   });
 
@@ -942,9 +949,19 @@ describe("supplements API route", () => {
       error: "supplements_api_failed",
     });
     expect(consoleError).toHaveBeenCalledWith("supplements_api_failed", {
+      batchConcurrency: 3,
+      durationMs: expect.any(Number),
       errorCode: "supplements_api_failed",
-      errorMessage: "database unavailable",
       errorType: "Error",
+      genericOnly: false,
+      includeOffMarket: false,
+      limit: 1,
+      maxQueryLength: 8,
+      method: "POST",
+      nutritionOnly: false,
+      operation: "batch_search",
+      queryCount: 1,
+      uniqueQueryCount: 1,
     });
   });
 });


### PR DESCRIPTION
## Why and outcome

Production food search repeatedly reached the eight-second PostgreSQL statement timeout. Read-only proof against the live labels database found roughly 2.04 million foods and none of the three indexes required by the deployed bounded private-search query. Multiple common synthetic broad searches reproduced the timeout; generic-only searches remained fast.

This adds a concurrent, operator-run index rollout; makes the production preflight validate each index's exact definition and live/ready/valid state; and adds query-free GET/POST failure context so any remaining timeout identifies the request shape and database error code without logging food text.

## Product UX

Internal reliability and observability change. Product UX does not apply because successful food/supplement responses, ranking, limits, auth, and member-visible states do not change.

## Evidence

- Production read-only proof: approximately 2.04M foods; all three required indexes absent; broad private-search calls reproduced PostgreSQL `57014`; generic-only calls stayed below one second.
- Updated production preflight rejected the live database for exactly the three missing index contracts without printing credentials or row data.
- Focused preflight, food-route, supplement-route, and food-query suites: 92 tests passed.
- Direct classifier coverage proves missing, wrong-definition, invalid, not-ready, and not-live index handling; SQL readback coverage asserts every full index definition.
- Web typecheck passed.
- `git diff --check` passed.

## Non-obvious affected surfaces

- The shared product-label route handler also serves supplements, so supplement failures gain the same privacy-safe operation/duration context. Successful behavior is unchanged.
- Production Web builds now fail closed until the external labels database has all three exact, valid, ready, live indexes.
- The SQL entrypoint uses `CREATE INDEX CONCURRENTLY` and therefore must be run directly, outside a transaction, by the labels-schema owner.
- The runbook includes explicit fixed-name concurrent drop/recreate recovery when preflight identifies a nonconforming same-name index; a conforming index must never be dropped.

## Architecture and reuse

- **Existing systems reused:** The existing SQL ranking/index contracts, Web build preflight, shared product-label route handler, and PostgreSQL safe driver code remain authoritative.
- **New logic:** One operator SQL entrypoint and one preflight index-state query enforce the deployment prerequisite that was previously documentation-only.
- **New abstractions:** None beyond the preflight's existing schema-problem representation.
- **Complexity intentionally avoided:** No timeout increase, query rewrite, retry, background index manager, stored search text, or automatic build-time DDL.

## Hot reply path impact

Not applicable. Product-label APIs are outside the Foreground Reply Critical Path and add no successful-request await.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool, schema, generated guidance, or provider-visible input changed.
- Codex runtime: Not applicable; no prompt, instruction, tool, schema, generated guidance, or provider-visible input changed.

ReviewGPT context sensitivity: sensitive — this changes a production build gate, external database rollout contract, and hosted failure diagnostics.

ReviewGPT first-reviewed head: 659d832d285688fc9ef3dd53c66caaf0b3bdbe47

## Change-shape breakdown

Classification rule: runtime TypeScript is source; Vitest files are tests/fixtures; README plus the closed execution plan are docs; the operator SQL entrypoint is config/tooling; no generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 211 | 21 |
| Tests/fixtures | 195 | 19 |
| Docs | 107 | 3 |
| Config/tooling | 18 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **531** | **43** |

No binary files.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web instances remain compatible while the indexes build; the new Web build is intentionally blocked until all three exact index contracts are live.
- Safe order: Run the operator SQL against the external labels database as its schema owner, wait for all three concurrent builds, confirm the preflight, then deploy Web.
- Rollback floor: Keep the indexes in place when rolling Web back; older Web versions use the same query and benefit from them.
- Expected exposure: Search can continue timing out until the indexes finish, but concurrent creation avoids blocking ordinary reads and writes.
- Reversibility: Web code can be rolled back independently; index removal is unnecessary and should only be considered later as a separate measured operation.
- Convergence proof: The production preflight must report all three indexes exact, valid, ready, and live before the Web deployment proceeds.
- Post-deploy checks: Run a privacy-safe synthetic common-term smoke and monitor `foods_api_failed` for database error code `57014`.
- No Cloudflare tandem deploy or compatibility window is required.

## Changelog

- Changelog: not applicable
- Reason: this restores expected internal search reliability and adds operational diagnostics without a new member-visible feature.
