### PR TITLE
Compact broad group consent offers

### DIFF
--- a/apps/web/changelog/entries/2026-08-25/shorter-group-sharing-consent.json
+++ b/apps/web/changelog/entries/2026-08-25/shorter-group-sharing-consent.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-25",
+  "order": 100,
+  "item": {
+    "id": "shorter-group-sharing-consent",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Shorter group sharing consent",
+    "summary": "When a group requests many health permissions, Murph now summarizes them in seven clear categories instead of sending a long item-by-item list.",
+    "details": "The reaction still applies the exact permission set. Narrow offers remain specific, and the review link lets each person inspect or customize every permission before sharing.",
+    "relevanceTags": ["groups", "messaging", "privacy"],
+    "sourcePullRequests": [2298]
+  }
+}

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -23,6 +23,7 @@ import {
   type HostedRuntimeGroupToolSelfOptOutContext,
 } from "@murphai/hosted-execution/runtime-control";
 import type {
+  HostedVaultShareProjectionKind,
   HostedVaultShareProjectionScope,
 } from "@murphai/hosted-execution/vault-share";
 import {
@@ -154,6 +155,74 @@ export const HOSTED_THREAD_CONTAINER_PARTICIPANT_RECONCILE_MAX =
 
 const HOSTED_GROUP_JOIN_OFFER_IDEMPOTENCY_PREFIX = "group-join-offer:v3:";
 const HOSTED_GROUP_JOIN_OFFER_IDEMPOTENCY_DIGEST_LENGTH = 40;
+const HOSTED_GROUP_JOIN_OFFER_EXACT_SCOPE_MAX = 7;
+
+type HostedGroupJoinOfferScopeCategory =
+  | "activity"
+  | "connections"
+  | "heart-and-fitness"
+  | "nutrition"
+  | "profile"
+  | "sleep"
+  | "workouts";
+
+const HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_BY_PROJECTION_KIND = {
+  "active-calories-days.v0": "activity",
+  "activity-days.v0": "activity",
+  "activity-distance-days.v1": "activity",
+  "activity-minutes-days.v1": "activity",
+  "activity-score-days.v0": "activity",
+  "activity-session-count-days.v1": "activity",
+  "calories-days.v0": "nutrition",
+  "carbs-days.v0": "nutrition",
+  "day-strain-days.v0": "activity",
+  "deep-sleep-days.v0": "sleep",
+  "deep-sleep-sources-days.v1": "sleep",
+  "device-sync-status.v0": "connections",
+  "distance-days.v0": "activity",
+  "elevation-gain-days.v0": "activity",
+  "fat-days.v0": "nutrition",
+  "fiber-days.v0": "nutrition",
+  "floors-climbed-days.v0": "activity",
+  "group-email.v0": "profile",
+  "heart-rate-zones-days.v0": "heart-and-fitness",
+  "hrv-days.v0": "heart-and-fitness",
+  "max-heart-rate-days.v0": "heart-and-fitness",
+  "profile-name.v0": "profile",
+  "protein-days.v0": "nutrition",
+  "rem-sleep-days.v0": "sleep",
+  "rem-sleep-sources-days.v1": "sleep",
+  "resting-heart-rate-days.v0": "heart-and-fitness",
+  "sleep-duration-days.v0": "sleep",
+  "sleep-times.v0": "sleep",
+  "steps-days.v0": "activity",
+  "time-zone.v0": "profile",
+  "vo2-max-days.v0": "heart-and-fitness",
+  "workout-days.v0": "workouts",
+  "workout-strain-days.v0": "workouts",
+  "workouts.v0": "workouts",
+} as const satisfies Record<HostedVaultShareProjectionKind, HostedGroupJoinOfferScopeCategory>;
+
+const HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_ORDER = [
+  "sleep",
+  "activity",
+  "workouts",
+  "heart-and-fitness",
+  "nutrition",
+  "connections",
+] as const satisfies readonly Exclude<HostedGroupJoinOfferScopeCategory, "profile">[];
+
+const HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_LABEL = {
+  activity: "activity",
+  connections: "health source connections",
+  "heart-and-fitness": "heart and fitness",
+  nutrition: "nutrition",
+  sleep: "sleep",
+  workouts: "workouts",
+} as const satisfies Record<
+  Exclude<HostedGroupJoinOfferScopeCategory, "profile">,
+  string
+>;
 
 export function buildHostedGroupJoinOfferProviderIdempotencyKey(input: {
   groupId: string;
@@ -1753,9 +1822,20 @@ async function readHostedLinqExplicitGroupDisplayName(
 function renderHostedGroupJoinOfferScopeSentence(
   projectionScopes: readonly HostedVaultShareProjectionScope[],
 ): string {
-  const labels = projectHostedVaultShareProjectionDisplays(projectionScopes)
-    .map((display) => formatHostedGroupJoinOfferShareScopeLabel(display.label));
-  const sentence = `your ${formatHumanList(["Murph profile name", ...labels])}`;
+  const displays = projectHostedVaultShareProjectionDisplays(projectionScopes);
+  const useCategories = displays.length > HOSTED_GROUP_JOIN_OFFER_EXACT_SCOPE_MAX;
+  const shareScopeLabels = useCategories
+    ? renderHostedGroupJoinOfferScopeCategories(projectionScopes)
+    : [
+        "Murph profile name",
+        ...displays.map((display) =>
+          formatHostedGroupJoinOfferShareScopeLabel(display.label)
+        ),
+      ];
+  const sentence = `your ${formatHumanList(shareScopeLabels)}`;
+  if (useCategories) {
+    return `${sentence} (${renderHostedGroupJoinOfferCompactDisclosure(projectionScopes)})`;
+  }
   const disclosures: string[] = [];
   if (projectionScopes.some((scope) =>
     isHostedVaultShareRecentDateProjectionKind(scope.projectionKind)
@@ -1808,6 +1888,59 @@ function renderHostedGroupJoinOfferScopeSentence(
   return disclosures.length > 0
     ? `${sentence} (${disclosures.join("; ")})`
     : sentence;
+}
+
+function renderHostedGroupJoinOfferScopeCategories(
+  projectionScopes: readonly HostedVaultShareProjectionScope[],
+): string[] {
+  const categories = new Set(
+    projectionScopes.map(
+      (scope) => HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_BY_PROJECTION_KIND[
+        scope.projectionKind
+      ],
+    ),
+  );
+  const hasEmail = projectionScopes.some(
+    (scope) => scope.projectionKind === "group-email.v0",
+  );
+  const hasTimeZone = projectionScopes.some(
+    (scope) => scope.projectionKind === "time-zone.v0",
+  );
+  const profileDetails = [
+    "name",
+    ...(hasEmail ? ["email"] : []),
+    ...(hasTimeZone ? ["time zone"] : []),
+  ];
+  return [
+    profileDetails.length === 1
+      ? "Murph profile name"
+      : `Murph profile (${formatHumanList(profileDetails)})`,
+    ...HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_ORDER.flatMap((category) =>
+      categories.has(category)
+        ? [HOSTED_GROUP_JOIN_OFFER_SCOPE_CATEGORY_LABEL[category]]
+        : []
+    ),
+  ];
+}
+
+function renderHostedGroupJoinOfferCompactDisclosure(
+  projectionScopes: readonly HostedVaultShareProjectionScope[],
+): string {
+  const includedDetails = [
+    ...(projectionScopes.some((scope) =>
+      isHostedVaultShareRecentDateProjectionKind(scope.projectionKind)
+    ) ? ["source details"] : []),
+    ...(projectionScopes.some(isHostedGroupSleepStageProjectionScope)
+      ? ["sleep-stage times"]
+      : []),
+    ...(projectionScopes.some(isHostedGroupMealNutritionProjectionScope)
+      ? ["connected-app meals"]
+      : []),
+  ];
+  return [
+    "recent data covers the last 7 days",
+    `${formatHumanList(includedDetails)} ${includedDetails.length === 1 ? "is" : "are"} included`,
+  ].join("; ");
 }
 
 function isHostedGroupMealNutritionProjectionScope(

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -1826,15 +1826,15 @@ function renderHostedGroupJoinOfferScopeSentence(
   const useCategories = displays.length > HOSTED_GROUP_JOIN_OFFER_EXACT_SCOPE_MAX;
   const shareScopeLabels = useCategories
     ? renderHostedGroupJoinOfferScopeCategories(projectionScopes)
-    : [
-        "Murph profile name",
-        ...displays.map((display) =>
-          formatHostedGroupJoinOfferShareScopeLabel(display.label)
-        ),
-      ];
+      : [
+          "Murph profile name",
+          ...displays.map((display) =>
+            formatHostedGroupJoinOfferShareScopeLabel(display.label)
+          ),
+        ];
   const sentence = `your ${formatHumanList(shareScopeLabels)}`;
   if (useCategories) {
-    return `${sentence} (${renderHostedGroupJoinOfferCompactDisclosure(projectionScopes)})`;
+    return sentence;
   }
   const disclosures: string[] = [];
   if (projectionScopes.some((scope) =>
@@ -1921,26 +1921,6 @@ function renderHostedGroupJoinOfferScopeCategories(
         : []
     ),
   ];
-}
-
-function renderHostedGroupJoinOfferCompactDisclosure(
-  projectionScopes: readonly HostedVaultShareProjectionScope[],
-): string {
-  const includedDetails = [
-    ...(projectionScopes.some((scope) =>
-      isHostedVaultShareRecentDateProjectionKind(scope.projectionKind)
-    ) ? ["source details"] : []),
-    ...(projectionScopes.some(isHostedGroupSleepStageProjectionScope)
-      ? ["sleep-stage times"]
-      : []),
-    ...(projectionScopes.some(isHostedGroupMealNutritionProjectionScope)
-      ? ["connected-app meals"]
-      : []),
-  ];
-  return [
-    "recent data covers the last 7 days",
-    `${formatHumanList(includedDetails)} ${includedDetails.length === 1 ? "is" : "are"} included`,
-  ].join("; ");
 }
 
 function isHostedGroupMealNutritionProjectionScope(

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -329,6 +329,7 @@ import {
   filterHostedRuntimeGroupToolResponseProjectionScopes,
 } from "@/src/lib/hosted-groups/group-tool-scope-filter";
 import {
+  HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_KINDS,
   HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_SCOPES,
   buildHostedVaultShareActivityDistanceProjectionScope,
   buildHostedVaultShareActivityMinutesProjectionScope,
@@ -383,6 +384,12 @@ const RUNNING_SESSION_COUNT_SCOPE = buildHostedVaultShareActivitySessionCountPro
 });
 const COMPLETE_ACCESS_OFFER_SCOPES =
   resolveHostedGroupAccessOfferProjectionScopes(undefined);
+const EXPLICIT_COMPREHENSIVE_ACCESS_OFFER_SCOPES =
+  HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_KINDS.map((projectionKind) => ({
+    projectionKind,
+  }));
+const COMPLETE_ACCESS_OFFER_MESSAGE =
+  "Sounds good. Like or heart this message to share your Murph profile (name, email, and time zone), sleep, activity, workouts, heart and fitness, nutrition, and health source connections (recent data covers the last 7 days; source details, sleep-stage times, and connected-app meals are included) with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.";
 const GROUP_RUNTIME_LINQ_THREAD = {
   authority: {
     accountLookupKey: "hplk_group_runtime",
@@ -4108,7 +4115,7 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: "chat_group_1",
-        message: expect.stringContaining("workout details"),
+        message: COMPLETE_ACCESS_OFFER_MESSAGE,
       }),
     );
     expect(mocks.recordHostedGroupJoinOfferTx).toHaveBeenCalledWith({
@@ -4456,7 +4463,7 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       }));
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("workout details"),
+        message: COMPLETE_ACCESS_OFFER_MESSAGE,
       }),
     );
   });
@@ -4609,10 +4616,16 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     );
   });
 
-  it("posts the comprehensive canonical offer when the legacy template is missing", async () => {
+  it("compacts an explicit comprehensive offer without changing its permission snapshot", async () => {
     await expect(handleHostedRuntimeGroupTool({
       memberId: "member_container",
-      request: { action: "post_join_offer", linqThread: LINQ_THREAD },
+      request: {
+        action: "post_join_offer",
+        joinOffer: {
+          projectionKinds: [...HOSTED_VAULT_SHARE_SELECTABLE_PROJECTION_KINDS],
+        },
+        linqThread: LINQ_THREAD,
+      },
     })).resolves.toMatchObject({
       action: "post_join_offer",
       result: { status: "sent" },
@@ -4620,7 +4633,7 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
 
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("workout details"),
+        message: COMPLETE_ACCESS_OFFER_MESSAGE,
       }),
     );
     expect(mocks.recordHostedGroupJoinOfferTx).toHaveBeenCalledWith({
@@ -4628,7 +4641,7 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       groupId: GROUP_SUMMARY.id,
       message: { channel: "linq", messageId: "msg_offer_1" },
       postedAt: expect.any(Date),
-      projectionScopes: COMPLETE_ACCESS_OFFER_SCOPES,
+      projectionScopes: EXPLICIT_COMPREHENSIVE_ACCESS_OFFER_SCOPES,
       tx: fakeTx,
     });
   });

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -389,7 +389,7 @@ const EXPLICIT_COMPREHENSIVE_ACCESS_OFFER_SCOPES =
     projectionKind,
   }));
 const COMPLETE_ACCESS_OFFER_MESSAGE =
-  "Sounds good. Like or heart this message to share your Murph profile (name, email, and time zone), sleep, activity, workouts, heart and fitness, nutrition, and health source connections (recent data covers the last 7 days; source details, sleep-stage times, and connected-app meals are included) with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.";
+  "Sounds good. Like or heart this message to share your Murph profile (name, email, and time zone), sleep, activity, workouts, heart and fitness, nutrition, and health source connections with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.";
 const GROUP_RUNTIME_LINQ_THREAD = {
   authority: {
     accountLookupKey: "hplk_group_runtime",
@@ -4614,6 +4614,77 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
           "Sounds good. Like or heart this message to share your Murph profile name and recent running session count (health values include their source names; running session count covers the last 7 days) with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.",
       }),
     );
+  });
+
+  it("keeps seven optional scopes exact instead of collapsing them to categories", async () => {
+    const projectionKinds = [
+      "sleep-times.v0",
+      "sleep-duration-days.v0",
+      "activity-days.v0",
+      "workout-days.v0",
+      "heart-rate-zones-days.v0",
+      "resting-heart-rate-days.v0",
+      "protein-days.v0",
+    ] as const;
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        joinOffer: { projectionKinds: [...projectionKinds] },
+        linqThread: LINQ_THREAD,
+      },
+    })).resolves.toMatchObject({
+      action: "post_join_offer",
+      result: { status: "sent" },
+    });
+
+    expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Sounds good. Like or heart this message to share your Murph profile name, sleep timing, sleep duration, activity minutes, workout summaries, heart-rate zones, resting heart rate, and daily protein (health values include their source names; nutrition totals come from your meals in Murph, including meals imported from connected apps; sleep timing and sleep duration cover the last 7 days) with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.",
+      }),
+    );
+  });
+
+  it("compacts eight scopes without claiming absent categories or disclosure details", async () => {
+    const projectionKinds = [
+      "sleep-times.v0",
+      "sleep-duration-days.v0",
+      "activity-days.v0",
+      "workout-days.v0",
+      "heart-rate-zones-days.v0",
+      "steps-days.v0",
+      "resting-heart-rate-days.v0",
+      "hrv-days.v0",
+    ] as const;
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        joinOffer: { projectionKinds: [...projectionKinds] },
+        linqThread: LINQ_THREAD,
+      },
+    })).resolves.toMatchObject({
+      action: "post_join_offer",
+      result: { status: "sent" },
+    });
+
+    expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Sounds good. Like or heart this message to share your Murph profile name, sleep, activity, workouts, and heart and fitness with the group, or use https://www.withmurph.ai/groups/join/abc123 to customize what you share.",
+      }),
+    );
+    expect(mocks.recordHostedGroupJoinOfferTx).toHaveBeenCalledWith({
+      expectedOfferGeneration: OFFER_GENERATION_A,
+      groupId: GROUP_SUMMARY.id,
+      message: { channel: "linq", messageId: "msg_offer_1" },
+      postedAt: expect.any(Date),
+      projectionScopes: projectionKinds.map((projectionKind) => ({ projectionKind })),
+      tx: fakeTx,
+    });
   });
 
   it("compacts an explicit comprehensive offer without changing its permission snapshot", async () => {


### PR DESCRIPTION
## Outcome

Broad group join consent offers now collapse long permission inventories into seven recognizable categories while keeping narrow offers exact.

## Product UX

- Broad offers show profile, sleep, activity, workouts, heart and fitness, nutrition, and health source connections.
- No secondary caveat or detailed inventory is appended to broad offers.
- Reaction consent remains bound to the unchanged exact permission snapshot, and the first-party link still exposes every permission for review or customization.

## Evidence

- `pnpm --dir apps/web test:prepared -- hosted-group-tool.test.ts` (163 passed)
- `pnpm --dir apps/web test:prepared -- changelog-page.test.tsx` (9 passed)
- `pnpm --dir apps/web typecheck:prepared`
- `pnpm --dir apps/web exec eslint src/lib/hosted-groups/group-tool.ts test/hosted-group-tool.test.ts`

## Affected surfaces

- Native iMessage group join-offer copy only.
- Narrow offers with seven or fewer optional scopes retain their exact labels and disclosures.

## Architecture and reuse

- Existing systems reused: the Web-owned join-offer renderer, exact saved permission snapshots, reaction consent, and first-party customization link.
- New logic: broad offers group permission labels into seven fixed categories.
- New abstractions: none; category rendering stays inside the existing consent-message owner.
- Complexity intentionally avoided: no permission migration, new state owner, provider contract, queue, runtime branch, or alternate consent path.

## Hot reply path

String rendering only; no added I/O, model work, database work, retry, or queue behavior.

## Provider input

No provider request shape or target changed. Only the rendered message body is shorter for broad offers.

## Deployment concerns

Web-only compatible change. No Cloudflare coordination or deployment ordering is required.

- Deployment: not applicable
- Reason: This changes Web-owned message rendering only and does not alter runtime contracts or cross-service compatibility.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · shorter-group-sharing-consent

## Review disposition

- Final consent-copy finding rejected by explicit product-owner direction: broad reaction consent is intentionally category-level, with the exact frozen scopes available through the first-party review and customization link.
- Accepted the coverage finding and added exact seven-scope and compact eight-scope boundary tests, including proof that the saved permission snapshot is unchanged.
- Rejected the proposed longer compact caveat after explicit product direction to keep broad consent category-only; exact details remain available through the review link.

## ReviewGPT

ReviewGPT context sensitivity: sensitive

Reason: The patch changes consent presentation for health-data sharing while preserving the underlying authorization snapshot.

ReviewGPT first-reviewed head: c0a3baf1378a65f6ba7ad7a4918e99578835e45f

## LOC

- Source: +116 / -3
- Tests and fixtures: +90 / -6
- Docs: +14 / -0
- Config and tooling: +0 / -0
- Generated and other: +0 / -0