### PR TITLE
Fix connect dialog handoff ownership

### DIFF
--- a/apps/web/app/(dashboard)/connect/connect-page-client.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-client.tsx
@@ -67,6 +67,7 @@ interface HostedDeviceSyncDisconnectResponse {
 type ConnectStartOptions = {
   vitalDisclosureConfirmed?: boolean;
   intentClaim?: string;
+  onHandoff?: () => void;
 };
 
 type VitalConnectionRequest = {
@@ -349,6 +350,7 @@ export function ConnectSourcesGrid({
           ...(options.intentClaim ? { intentClaim: options.intentClaim } : {}),
           source,
         });
+        options.onHandoff?.();
         return;
       }
 
@@ -367,6 +369,7 @@ export function ConnectSourcesGrid({
               : {}),
           },
         );
+        options.onHandoff?.();
         window.location.assign(authorizationUrl);
       } catch (error) {
         if (options.intentClaim) {
@@ -382,12 +385,14 @@ export function ConnectSourcesGrid({
             sourceName: source.name,
           });
           setPendingSourceId(null);
+          options.onHandoff?.();
           return;
         }
 
         if (isHostedWhoopDirectConnectCapReachedError(error)) {
           setShowWhoopAppleHealthSetupDialog(true);
           setPendingSourceId(null);
+          options.onHandoff?.();
           return;
         }
 
@@ -497,7 +502,10 @@ export function ConnectSourcesGrid({
     };
   }, [activeConnectIntent, authenticated, displaySources]);
 
-  const disconnectConnection = useCallback(async (source: ConnectSource) => {
+  const disconnectConnection = useCallback(async (
+    source: ConnectSource,
+    onHandoff?: () => void,
+  ) => {
     const connectionId = source.disconnectConnectionId?.trim();
     if (
       !connectionId ||
@@ -532,6 +540,7 @@ export function ConnectSourcesGrid({
             "Fitbit is still syncing while Murph retries the switch. You can leave this page.",
         });
         router.refresh();
+        onHandoff?.();
         return;
       }
       if (
@@ -569,6 +578,7 @@ export function ConnectSourcesGrid({
           ? `${resolveDisconnectSuccessMessage(source)} ${resolveDisconnectWarningDetail(result.warning)}`
           : resolveDisconnectSuccessMessage(source),
       });
+      onHandoff?.();
     } catch (error) {
       const message =
         error instanceof Error
@@ -587,6 +597,11 @@ export function ConnectSourcesGrid({
     setDeepLinkedSourceId(null);
     stripConnectSourceHash();
   }, []);
+
+  const handoffDeepLinkedSourceToAuth = useCallback(() => {
+    setDeepLinkedSourceId(null);
+    openAuthDialog();
+  }, [openAuthDialog]);
 
   return (
     <section className="flex min-w-0 flex-col gap-4">
@@ -693,21 +708,21 @@ export function ConnectSourcesGrid({
             presentation="dialog"
             source={deepLinkedSource}
             onDisconnectTargetChange={(source) => {
-              closeDeepLinkedSourceDialog();
               setDisconnectSource(source);
+              closeDeepLinkedSourceDialog();
             }}
             onMigrationRetry={(source) => {
-              closeDeepLinkedSourceDialog();
-              void disconnectConnection(source);
+              void disconnectConnection(source, closeDeepLinkedSourceDialog);
             }}
-            onSignIn={closeDeepLinkedSourceDialog}
+            onSignIn={handoffDeepLinkedSourceToAuth}
             onSetupGuideOpen={(setupGuideId) => {
-              closeDeepLinkedSourceDialog();
               setActiveSetupGuideId(setupGuideId);
+              closeDeepLinkedSourceDialog();
             }}
             onStartConnection={async (source) => {
-              closeDeepLinkedSourceDialog();
-              await startConnection(source);
+              await startConnection(source, {
+                onHandoff: closeDeepLinkedSourceDialog,
+              });
             }}
           />
         ) : null}

--- a/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-page-dialogs.tsx
@@ -27,10 +27,12 @@ const DEFAULT_GARMIN_HISTORICAL_DATA_VOICE_MEMO_SRC = `/audio/garmin-historical-
 
 export function ConnectSourceDialog({
   children,
+  inert = false,
   onOpenChange,
   source,
 }: {
-  children: ReactNode;
+  children?: ReactNode;
+  inert?: boolean;
   onOpenChange: (open: boolean) => void;
   source: Pick<ConnectSource, "name"> | null;
 }) {
@@ -38,7 +40,10 @@ export function ConnectSourceDialog({
 
   return (
     <Dialog open={Boolean(source)} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-md gap-0 overflow-y-auto p-6 md:p-7">
+      <DialogContent
+        className="max-h-[calc(100dvh-2rem)] max-w-md gap-0 overflow-y-auto p-6 md:p-7"
+        inert={inert || undefined}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>{sourceName} connection</DialogTitle>
           <DialogDescription>

--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -229,7 +229,7 @@ export function SourceCard({
               <AuthButton
                 aria-label="Sign in to Murph"
                 className="self-end"
-                onConnect={onSignIn}
+                onAuthRequired={onSignIn}
               >
                 Sign in
               </AuthButton>

--- a/apps/web/app/design/connect-source-card-study.tsx
+++ b/apps/web/app/design/connect-source-card-study.tsx
@@ -411,7 +411,11 @@ export function ConnectSourceCardStudy({
         onOpenChange={() => {}}
       />
 
-      <ConnectSourceDialog source={sourceDialogSource} onOpenChange={() => {}}>
+      <ConnectSourceDialog
+        inert
+        source={sourceDialogSource}
+        onOpenChange={() => {}}
+      >
         {sourceDialogSource ? (
           <div id="connect-source-dialog">
             <SourceCard

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/src/components/ui/dialog", () => {
     DialogContent: ({
       children,
       className,
+      inert,
       showCloseButton = true,
     }: HTMLAttributes<HTMLDivElement> & { showCloseButton?: boolean }) =>
       createElement(
@@ -57,6 +58,7 @@ vi.mock("@/src/components/ui/dialog", () => {
         {
           className,
           "data-dialog-content": "true",
+          "data-dialog-inert": inert ? "true" : "false",
         },
         children,
         showCloseButton
@@ -108,6 +110,7 @@ const mocks = vi.hoisted(() => ({
   resolveHostedMurphContactOption: vi.fn(),
   resolveHostedMurphContactOptions: vi.fn(),
   routerRefresh: vi.fn(),
+  searchParams: null as URLSearchParams | null,
 }));
 
 vi.mock("next/navigation", async (importOriginal) => {
@@ -116,6 +119,7 @@ vi.mock("next/navigation", async (importOriginal) => {
   return {
     ...actual,
     useRouter: () => ({ refresh: mocks.routerRefresh }),
+    useSearchParams: () => mocks.searchParams,
   };
 });
 
@@ -146,6 +150,7 @@ vi.mock("@/src/components/murph/hosted-murph-contact-action", () => ({
 }));
 
 beforeEach(() => {
+  mocks.searchParams = null;
   mocks.buildHostedDeviceSyncSettingsResponse.mockResolvedValue({
     generatedAt: "2026-05-01T00:00:00.000Z",
     ok: true,
@@ -848,6 +853,297 @@ test("ConnectSourcesGrid opens source hashes in a dialog and clears them on clos
   assert.doesNotMatch(reopenedDialog.textContent ?? "", /Fitbit/u);
   assert.ok(reopenedDialog.querySelector('[data-connect-source="oura"]'));
   await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid hands a signed-out source dialog to auth without losing its continuation hash", async () => {
+  const fetch = vi.fn();
+  vi.stubGlobal("fetch", fetch);
+
+  const { AuthProvider } = await import(
+    "@/src/components/hosted-onboarding/auth-dialog-provider"
+  );
+  const { ConnectSourcesGrid } = await import(
+    "../app/(dashboard)/connect/connect-page-client"
+  );
+  const rendered = await renderClientComponent(
+    createElement(
+      AuthProvider,
+      { authenticated: false },
+      createElement(ConnectSourcesGrid, {
+        authenticated: false,
+        sources: [
+          {
+            connectTarget: "fitbit",
+            description: "Sleep, activity, heart rate, and workouts.",
+            id: "fitbit",
+            logo: {
+              className: "size-11 object-contain",
+              height: 44,
+              src: "/fitbit.svg",
+              width: 44,
+            },
+            name: "Fitbit",
+          },
+        ],
+      }),
+    ),
+    {
+      location: {
+        hash: "#fitbit",
+        href: "https://example.test/connect#fitbit",
+        origin: "https://example.test",
+        pathname: "/connect",
+        search: "",
+      },
+      requireButton: false,
+    },
+  );
+
+  const sourceDialog = rendered.container.querySelector("[data-dialog-open]");
+  assert.ok(sourceDialog);
+  const signInButton = sourceDialog.querySelector(
+    'button[aria-label="Sign in to Murph"]',
+  );
+  assert.ok(signInButton instanceof rendered.window.HTMLButtonElement);
+
+  await act(async () => {
+    signInButton.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  await vi.waitFor(() => {
+    assert.equal(mocks.authDialogProps?.open, true);
+    assert.match(rendered.container.textContent ?? "", /Auth dialog/u);
+  });
+  assert.equal(rendered.container.querySelector("[data-dialog-open]"), null);
+  assert.equal(rendered.window.location.hash, "#fitbit");
+  assert.equal(rendered.replaceState.mock.calls.length, 0);
+  assert.equal(fetch.mock.calls.length, 0);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid keeps source-dialog errors visible until authorization owns the handoff", async () => {
+  const fetch = vi.fn()
+    .mockResolvedValueOnce(Response.json(
+      {
+        error: {
+          code: "DEVICE_SYNC_CONNECT_FAILED",
+          message: "Oura could not open. Please try again.",
+        },
+      },
+      { status: 502 },
+    ))
+    .mockResolvedValueOnce(Response.json({
+      authorizationUrl: "https://oura.example.test/oauth/start",
+    }));
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import(
+    "../app/(dashboard)/connect/connect-page-client"
+  );
+  const rendered = await renderClientComponent(
+    createElement(ConnectSourcesGrid, {
+      sources: [
+        {
+          connectTarget: "oura",
+          description: "Sleep and recovery.",
+          id: "oura",
+          logo: {
+            className: "size-11 object-contain",
+            height: 44,
+            src: "/oura.png",
+            width: 44,
+          },
+          name: "Oura",
+        },
+      ],
+    }),
+    {
+      location: {
+        hash: "#oura",
+        href: "https://example.test/connect#oura",
+        origin: "https://example.test",
+        pathname: "/connect",
+        search: "",
+      },
+      requireButton: false,
+    },
+  );
+
+  const connectButton = rendered.container.querySelector(
+    '[data-dialog-open] button[aria-label="Connect Oura"]',
+  );
+  assert.ok(connectButton instanceof rendered.window.HTMLButtonElement);
+  await act(async () => {
+    connectButton.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  await vi.waitFor(() => {
+    const sourceDialog = rendered.container.querySelector("[data-dialog-open]");
+    assert.ok(sourceDialog);
+    assert.match(
+      sourceDialog.querySelector("[role='alert']")?.textContent ?? "",
+      /Oura could not open\. Please try again\./u,
+    );
+  });
+  assert.equal(rendered.window.location.hash, "#oura");
+  assert.equal(rendered.replaceState.mock.calls.length, 0);
+  assert.equal(rendered.assign.mock.calls.length, 0);
+  assert.equal(connectButton.disabled, false);
+
+  await act(async () => {
+    connectButton.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  await vi.waitFor(() => {
+    assert.equal(
+      rendered.assign.mock.calls[0]?.[0],
+      "https://oura.example.test/oauth/start",
+    );
+  });
+  assert.equal(rendered.container.querySelector("[data-dialog-open]"), null);
+  assert.equal(rendered.window.location.hash, "");
+  assert.equal(rendered.replaceState.mock.calls.length, 1);
+  assert.equal(fetch.mock.calls.length, 2);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid replaces a focused source dialog with its connection preflight", async () => {
+  const fetch = vi.fn();
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import(
+    "../app/(dashboard)/connect/connect-page-client"
+  );
+  const rendered = await renderClientComponent(
+    createElement(ConnectSourcesGrid, {
+      sources: [
+        {
+          connectTarget: "garmin",
+          description: "Workouts, sleep, stress, and heart rate.",
+          id: "garmin",
+          logo: {
+            className: "size-11 object-contain",
+            height: 44,
+            src: "/garmin.png",
+            width: 44,
+          },
+          name: "Garmin",
+          requiresVitalDisclosure: true,
+        },
+      ],
+    }),
+    {
+      location: {
+        hash: "#garmin",
+        href: "https://example.test/connect#garmin",
+        origin: "https://example.test",
+        pathname: "/connect",
+        search: "",
+      },
+      requireButton: false,
+    },
+  );
+
+  const connectButton = rendered.container.querySelector(
+    '[data-dialog-open] button[aria-label="Connect Garmin"]',
+  );
+  assert.ok(connectButton instanceof rendered.window.HTMLButtonElement);
+  await act(async () => {
+    connectButton.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  const successorDialog = rendered.container.querySelector("[data-dialog-open]");
+  assert.ok(successorDialog);
+  assert.match(successorDialog.textContent ?? "", /Turn on Historical Data/u);
+  assert.equal(
+    successorDialog.querySelector('[data-connect-source="garmin"]'),
+    null,
+  );
+  assert.equal(rendered.window.location.hash, "");
+  assert.equal(rendered.replaceState.mock.calls.length, 1);
+  assert.equal(fetch.mock.calls.length, 0);
+
+  await rendered.cleanup();
+});
+
+test("ConnectSourcesGrid keeps a failed focused Fitbit migration retry in its dialog", async () => {
+  const fetch = vi.fn(async () => Response.json(
+    {
+      error: {
+        code: "DEVICE_SYNC_DISCONNECT_FAILED",
+        message: "Fitbit migration could not be retried right now.",
+      },
+    },
+    { status: 502 },
+  ));
+  vi.stubGlobal("fetch", fetch);
+
+  const { ConnectSourcesGrid } = await import(
+    "../app/(dashboard)/connect/connect-page-client"
+  );
+  const rendered = await renderClientComponent(
+    createElement(ConnectSourcesGrid, {
+      sources: [createFitbitMigrationSource({
+        migrationRetryRequired: true,
+        migrationState: "cutover_ready",
+      })],
+    }),
+    {
+      location: {
+        hash: "#fitbit",
+        href: "https://example.test/connect#fitbit",
+        origin: "https://example.test",
+        pathname: "/connect",
+        search: "",
+      },
+      requireButton: false,
+    },
+  );
+
+  const retryButton = rendered.container.querySelector(
+    '[data-dialog-open] button[aria-label="Retry Fitbit migration now"]',
+  );
+  assert.ok(retryButton instanceof rendered.window.HTMLButtonElement);
+  await act(async () => {
+    retryButton.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
+  });
+
+  await vi.waitFor(() => {
+    const sourceDialog = rendered.container.querySelector("[data-dialog-open]");
+    assert.ok(sourceDialog);
+    assert.match(
+      sourceDialog.querySelector("[role='alert']")?.textContent ?? "",
+      /Fitbit migration could not be retried right now\./u,
+    );
+  });
+  assert.equal(rendered.window.location.hash, "#fitbit");
+  assert.equal(rendered.replaceState.mock.calls.length, 0);
+  assert.equal(retryButton.disabled, false);
+
+  await rendered.cleanup();
+});
+
+test("connect source card screenshot study makes its focused dialog inert", async () => {
+  mocks.searchParams = new URLSearchParams("connectSourceDialog=fitbit");
+  const { ConnectSourceCardStudy } = await import(
+    "../app/design/connect-source-card-study"
+  );
+  const markup = renderToStaticMarkup(createElement(ConnectSourceCardStudy));
+
+  assert.match(markup, /id="connect-source-dialog"/u);
+  assert.match(markup, /data-dialog-inert="true"/u);
 });
 
 test("sortConnectSourcesByConnectionState keeps connected sources first, then popularity order", async () => {


### PR DESCRIPTION
## Why and outcome

PR #2283 shipped the focused `/connect#source` dialog, but it merged automatically while its required specialist review was still running. That review found two ordinary handoff problems: request failures could disappear with the closed dialog, and signed-out auth could overlap it. This follow-up contains only the accepted remediation.

The focused source dialog now remains the feedback owner while connection or migration work is pending or fails. It closes only when auth, provider navigation, setup, retry success, or another connection dialog accepts control. The screenshot-study dialog is inert.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: signed-out and signed-in members using a direct connection link on phone or desktop.
- Material exclusions: this does not change ordinary `/connect`, source selection, provider APIs, migration rules, or the member-visible dialog layout.
- Refreshed purpose verdict: Ready. A direct-link member reaches the intended source with one explicit next action, truthful in-context failure and retry, and exactly one active continuation owner.

## Evidence

- Preliminary specialist review on PR #2283: FINDINGS. Accepted and resolved the material action-handoff finding and the low screenshot-study inertness finding; no patch artifact was returned and no accepted finding remains unresolved. Per repository policy, the substantive preliminary pass is not rerun after remediation.
- Signed-out proof: auth becomes the only modal owner, no provider request starts, and `#fitbit` remains the post-auth continuation target.
- Failure proof: failed Oura authorization and failed Fitbit migration retry remain visible and retryable in the focused dialog with their source hash intact.
- Success proof: provider navigation and the Vital preflight each replace the focused dialog with exactly one successor owner.
- Focused test: `pnpm --dir apps/web test:prepared -- connect-page.test.ts` — 109 passed.
- Typecheck: `pnpm --dir apps/web typecheck` — passed.
- Focused ESLint on the five changed files — passed.
- Diff hygiene: `git diff --check origin/main...HEAD` — passed.

## Non-obvious affected surfaces

- Auth continuation: the source dialog closes through `AuthButton.onAuthRequired`, opens auth explicitly, and retains the fragment so successful sign-in resumes the same `/connect#source` URL.
- Async ownership: connect and migration callbacks receive a local handoff hook; ordinary errors do not invoke it, while navigation or a successor dialog does.
- Screenshot study: the production dialog composition accepts an optional inert boundary used only by the design-study route.

## Architecture and reuse

- Existing systems reused: `SourceCard`, `AuthButton.onAuthRequired`, current pending/error state, existing dialogs, `window.location.assign`, and the fragment contract remain the owners.
- New logic: a local optional handoff callback marks the exact point where another surface or navigation accepts control.
- New abstractions: none beyond the existing `ConnectSourceDialog` composition; its optional inert prop mirrors `ConnectDisconnectDialog`.
- Complexity intentionally avoided: no toast, modal manager, scroll retry, timer, persistence, provider change, or new dependency.

## Hot reply path impact

Not applicable: this changes only the client-rendered Connect Devices page and its screenshot study.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changes.
- Codex runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changes.

## Design proof

- Design page: [Focused Fitbit connection dialog](https://murph-mlvuccjyj-cobuildwithus.vercel.app/screenshots/health?connectSourceDialog=fitbit#connect-source-dialog)
- Evidence: PR #2283's redacted 1440×1000 desktop and 390×844 phone captures remain visually authoritative because this follow-up changes lifecycle ownership and inertness only, not layout or copy. The composed study test proves the corrected inert boundary.
- Coverage: signed-out source dialog on desktop and phone; focused tests cover auth, failure, retry, provider navigation, and preflight ownership.

## Change shape

Classification rule: member-route and reusable component files are source; the design study and focused Vitest file are tests/fixtures; no docs, config, binary, or generated files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 31 | 11 |
| Tests/fixtures | 301 | 1 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 332 | 12 |

## Deployment concerns

- Deployment: applicable
- Supported skew: the original dialog remains functional until this follow-up deploys; only its action handoff timing differs.
- Safe order: deploy the hosted Web app only; no coordinated backend or provider rollout is required.
- Rollback floor: restore the PR #2283 Web deployment; no data migration or persisted-state repair is required.
- Expected exposure: during rollout, separate page loads may briefly use either handoff behavior.
- Reversibility: promote the prior Web deployment; no state cleanup is needed.
- Convergence proof: confirm the production alias resolves to this merge, then exercise signed-out auth and one failed focused connection.
- Post-deploy checks: verify one active modal owner, retained hash through auth, in-dialog error/retry, and successful provider handoff.

## Changelog

- Changelog: not applicable
- Reason: The existing 2026-08-25 direct-links-to-device-connections item already covers this member flow; this follow-up corrects its dialog handoff without adding a separate announceable capability.

