### PR TITLE
fix(frog): route autofix reviews to isolated lanes

### DIFF
--- a/.agents/friction-log/20260825203740-frog-autofix-implementation/friction.md
+++ b/.agents/friction-log/20260825203740-frog-autofix-implementation/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Frog autofix implementation review ignores isolated browser lanes'
+severity: 'major'
+---
+
+## Expected Behavior
+
+The local Frog autofix worker should route ReviewGPT implementation authoring through the repository's existing automatic pool of isolated authenticated browser lanes.
+
+## Current Behavior
+
+The generated implementation-review config hardcodes the everyday Brave profile and CDP port 9452. When that profile is already open without remote debugging, ReviewGPT exits before authoring a patch even though isolated managed lanes are healthy.
+
+## Possible Solution
+
+Reuse `scripts/review-gpt.config.sh` for browser-lane selection, then override only the Frog-specific package command and response settings in the private generated config.
+
+## Minimal Reproducible Example
+
+1. Keep the ordinary Brave profile open without a CDP listener.
+2. Confirm at least one isolated ReviewGPT lane is available.
+3. Run one eligible local Frog autofix task.
+4. Observe implementation authoring stop with ReviewGPT status 1 before a candidate is published.
+
+## Context
+
+This prevents the installed local Frog worker from repairing an otherwise admitted, local-agent-only issue and unnecessarily couples unattended automation to the user’s interactive browser.

--- a/scripts/frog-autofix.test.ts
+++ b/scripts/frog-autofix.test.ts
@@ -2300,6 +2300,7 @@ esac
       archiveContents(path.join(implementation.reviewRoot, "codebase.zip"));
       const implementationConfig = readFileSync(implementation.config, "utf8");
       expect(implementationConfig).toContain("/scripts/review-gpt.config.sh'");
+      expect(implementationConfig).toContain('REVIEW_GPT_BROWSER_LANE="auto"');
       expect(implementationConfig).not.toContain("BraveSoftware/Brave-Browser");
       expect(implementationConfig).not.toContain('managed_browser_port="9452"');
 
@@ -2318,6 +2319,16 @@ esac
       writeFileSync(
         path.join(mainBrowserProfile, "SingletonLock"),
         "interactive-browser\n",
+      );
+      mkdirSync(path.join(reviewConfigHome, "murph"), { recursive: true });
+      writeFileSync(
+        path.join(reviewConfigHome, "murph", "review-gpt.conf"),
+        [
+          "REVIEW_GPT_BROWSER_LANE=main",
+          "managed_browser_port=9452",
+          `managed_browser_user_data_dir=${JSON.stringify(mainBrowserProfile)}`,
+          "",
+        ].join("\n"),
       );
       const configProbe = spawnSync(
         "bash",
@@ -2359,6 +2370,14 @@ esac
         path.join(reviewHome, "Library", "Application Support", "MurphReviewGPT"),
       );
       expect(configValues.get("port")).not.toBe("9452");
+      const capturedBrowserEndpoint = readFileSync(
+        implementation.browserEndpointPath,
+        "utf8",
+      ).trim();
+      expect(capturedBrowserEndpoint).toBe(
+        `http://127.0.0.1:${configValues.get("port")}`,
+      );
+      expect(capturedBrowserEndpoint).not.toBe("http://127.0.0.1:9452");
 
       const packageCanonical = (
         kind: "final" | "specialist",
@@ -4442,6 +4461,23 @@ try {
       .toBeLessThan(patchDownloadSource.indexOf("parseSinglePatchArtifact"));
     expect(patchDownloadSource.indexOf("refreshAndRequireCommittedFrictionTask("))
       .toBeGreaterThan(patchDownloadSource.indexOf("const wake = runCommand("));
+    expect(patchDownloadSource).not.toContain("9452");
+    expect(patchDownloadSource).toContain(
+      '"--browser-endpoint",\n      browserEndpoint,',
+    );
+    const implementationFlowSource = implementationSource.slice(
+      implementationSource.indexOf("const implementation = runParentReview({"),
+      implementationSource.indexOf("applyImplementationPatch(worktree"),
+    );
+    expect(implementationFlowSource).toContain(
+      "implementation.browserEndpoint,\n          implementation.chatUrl,",
+    );
+    expect(parentReviewSource).toContain(
+      "readBoundedParentFile(browserEndpointPath, 128)",
+    );
+    expect(parentReviewSource).toContain(
+      "return { browserEndpoint, chatUrl, response };",
+    );
     const reviewedHead = "a".repeat(40);
     expect(extractFirstReviewedHead(
       `Body\n\nReviewGPT first-reviewed head: ${reviewedHead}\n`,

--- a/scripts/frog-autofix.test.ts
+++ b/scripts/frog-autofix.test.ts
@@ -2184,6 +2184,7 @@ describe("Frog autofix guards", () => {
         "package-audit-context-full.sh",
         "repo-tools.config.sh",
         "review-gpt-context-policy.sh",
+        "review-gpt.config.sh",
       ]) {
         copyFileSync(
           path.join(targetReviewControlRoot, "scripts", script),
@@ -2230,6 +2231,9 @@ case "$json" in
 esac
 `);
       chmodSync(gh, 0o700);
+      const curl = path.join(fakeBin, "curl");
+      writeFileSync(curl, "#!/bin/bash\nexit 1\n");
+      chmodSync(curl, 0o700);
       const task = committedFrictionTask(root, 42);
       const body = bodyWithParentMetadata(renderRecoveredPullRequestBody(42), {
         firstHead: head,
@@ -2294,6 +2298,67 @@ esac
         task,
       );
       archiveContents(path.join(implementation.reviewRoot, "codebase.zip"));
+      const implementationConfig = readFileSync(implementation.config, "utf8");
+      expect(implementationConfig).toContain("/scripts/review-gpt.config.sh'");
+      expect(implementationConfig).not.toContain("BraveSoftware/Brave-Browser");
+      expect(implementationConfig).not.toContain('managed_browser_port="9452"');
+
+      const reviewHome = path.join(runRoot, "review-home");
+      const reviewConfigHome = path.join(runRoot, "review-config");
+      mkdirSync(reviewHome, { recursive: true });
+      mkdirSync(reviewConfigHome, { recursive: true });
+      const mainBrowserProfile = path.join(
+        reviewHome,
+        "Library",
+        "Application Support",
+        "BraveSoftware",
+        "Brave-Browser",
+      );
+      mkdirSync(mainBrowserProfile, { recursive: true });
+      writeFileSync(
+        path.join(mainBrowserProfile, "SingletonLock"),
+        "interactive-browser\n",
+      );
+      const configProbe = spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            "review_gpt_register_dir_preset() { :; }",
+            "review_gpt_register_preset_group() { :; }",
+            'source "$FROG_REVIEW_CONFIG"',
+            "printf 'pool-count=%s\\n' \"${#review_gpt_browser_lanes[@]}\"",
+            "printf 'selected=%s\\n' \"$REVIEW_GPT_SELECTED_BROWSER_LANE\"",
+            "printf 'data-dir=%s\\n' \"$managed_browser_user_data_dir\"",
+            "printf 'port=%s\\n' \"$managed_browser_port\"",
+          ].join("\n"),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            FROG_REVIEW_CONFIG: implementation.config,
+            HOME: reviewHome,
+            LANG: "C",
+            LC_ALL: "C",
+            PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+            XDG_CONFIG_HOME: reviewConfigHome,
+          },
+        },
+      );
+      expect(configProbe.status, configProbe.stderr).toBe(0);
+      const configValues = new Map(
+        configProbe.stdout.trim().split("\n").map((line) => {
+          const separator = line.indexOf("=");
+          return [line.slice(0, separator), line.slice(separator + 1)] as const;
+        }),
+      );
+      expect(configValues.get("pool-count")).toBe("6");
+      expect(configValues.get("selected")).not.toBe("main");
+      expect(configValues.get("data-dir")).toContain(
+        path.join(reviewHome, "Library", "Application Support", "MurphReviewGPT"),
+      );
+      expect(configValues.get("port")).not.toBe("9452");
 
       const packageCanonical = (
         kind: "final" | "specialist",

--- a/scripts/frog-autofix.ts
+++ b/scripts/frog-autofix.ts
@@ -1963,12 +1963,17 @@ export function buildParentReviewArchive(
   );
   const config = path.join(reviewRoot, "review-gpt.config.sh");
   const sharedReviewConfig = path.join(primary, "scripts", "review-gpt.config.sh");
+  const implementationConfigHome = path.join(reviewRoot, "implementation-config");
+  const browserEndpointPath = path.join(reviewRoot, "browser-endpoint.txt");
+  rmSync(implementationConfigHome, { force: true, recursive: true });
+  mkdirSync(implementationConfigHome, { mode: 0o700, recursive: true });
+  rmSync(browserEndpointPath, { force: true });
   writePrivateFileAtomically(
     config,
-    `#!/bin/bash\nsource ${safeShellLiteral(sharedReviewConfig)}\nname_prefix="frog-autofix-parent"\nout_dir=""\npackage_script=${safeShellLiteral(emitScript)}\nresponse_timeout_ms="10800000"\nsnapshot_attachment_name="codebase.zip"\n`,
+    `#!/bin/bash\nfrog_review_gpt_xdg_config_home="\${XDG_CONFIG_HOME-}"\nfrog_review_gpt_xdg_config_home_set="\${XDG_CONFIG_HOME+x}"\nXDG_CONFIG_HOME=${safeShellLiteral(implementationConfigHome)}\nREVIEW_GPT_BROWSER_LANE="auto"\nsource ${safeShellLiteral(sharedReviewConfig)}\nif [[ "$frog_review_gpt_xdg_config_home_set" == "x" ]]; then\n  XDG_CONFIG_HOME="$frog_review_gpt_xdg_config_home"\nelse\n  unset XDG_CONFIG_HOME\nfi\nprintf 'http://127.0.0.1:%s\\n' "$managed_browser_port" > ${safeShellLiteral(browserEndpointPath)}\nname_prefix="frog-autofix-parent"\nout_dir=""\npackage_script=${safeShellLiteral(emitScript)}\nresponse_timeout_ms="10800000"\nsnapshot_attachment_name="codebase.zip"\n`,
     0o600,
   );
-  return { config, reviewRoot };
+  return { browserEndpointPath, config, reviewRoot };
 }
 
 export function reviewGptEntry(primary: string): string {
@@ -1986,10 +1991,11 @@ function runParentReview(options: {
   transient: string;
   worktree: string;
 }): {
+  browserEndpoint: string;
   chatUrl: string;
   response: string;
 } {
-  const { config, reviewRoot } = buildParentReviewArchive(
+  const { browserEndpointPath, config, reviewRoot } = buildParentReviewArchive(
     options.primary,
     options.worktree,
     options.transient,
@@ -2045,7 +2051,16 @@ function runParentReview(options: {
   }
   requireImplementationCompletion(response);
   const chatUrl = extractSingleConversationUrl(review.stdout);
-  return { chatUrl, response };
+  let browserEndpoint: string;
+  try {
+    browserEndpoint = readBoundedParentFile(browserEndpointPath, 128).trim();
+  } catch {
+    throw new TerminalPrePullRequestFailure("implementation-output");
+  }
+  if (!/^http:\/\/127\.0\.0\.1:[1-9][0-9]{0,4}$/u.test(browserEndpoint)) {
+    throw new TerminalPrePullRequestFailure("implementation-output");
+  }
+  return { browserEndpoint, chatUrl, response };
 }
 
 export function assertExpectedPullRequestBody(options: {
@@ -2288,6 +2303,7 @@ function downloadImplementationPatch(
   primary: string,
   worktree: string,
   reviewRoot: string,
+  browserEndpoint: string,
   chatUrl: string,
   issueNumber: number,
   task: FrogTaskIdentity,
@@ -2300,7 +2316,7 @@ function downloadImplementationPatch(
       "thread",
       "wake",
       "--browser-endpoint",
-      "http://127.0.0.1:9452",
+      browserEndpoint,
       "--chat-url",
       chatUrl,
       "--delay",
@@ -4544,6 +4560,7 @@ async function runOnce() {
           primary,
           worktree,
           reviewRoot,
+          implementation.browserEndpoint,
           implementation.chatUrl,
           issue.number,
           repairTask,

--- a/scripts/frog-autofix.ts
+++ b/scripts/frog-autofix.ts
@@ -1962,9 +1962,10 @@ export function buildParentReviewArchive(
     0o700,
   );
   const config = path.join(reviewRoot, "review-gpt.config.sh");
+  const sharedReviewConfig = path.join(primary, "scripts", "review-gpt.config.sh");
   writePrivateFileAtomically(
     config,
-    `#!/bin/bash\nname_prefix="frog-autofix-parent"\nout_dir=""\ninclude_tests=0\ninclude_docs=0\nchatgpt_url="https://chatgpt.com"\npackage_script=${safeShellLiteral(emitScript)}\nattach_artifacts=1\nmanaged_browser_user_data_dir="$HOME/Library/Application Support/BraveSoftware/Brave-Browser"\nmanaged_browser_profile="Default"\nmanaged_browser_port="9452"\nmanaged_browser_background_mode="balanced"\nbrowser_binary_path="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"\nmodel="gpt-5.6-sol"\nthinking="current"\napp_connector="current"\nresponse_timeout_ms="10800000"\nsnapshot_attachment_name="codebase.zip"\n`,
+    `#!/bin/bash\nsource ${safeShellLiteral(sharedReviewConfig)}\nname_prefix="frog-autofix-parent"\nout_dir=""\npackage_script=${safeShellLiteral(emitScript)}\nresponse_timeout_ms="10800000"\nsnapshot_attachment_name="codebase.zip"\n`,
     0o600,
   );
   return { config, reviewRoot };


### PR DESCRIPTION
## Why and outcome

Frog autofix implementation authoring hardcoded the interactive Brave profile and port 9452, so an ordinary browser session could stop an admitted unattended repair even when Murph's isolated ReviewGPT lanes were healthy. The private implementation-review config now forces the repository's automatic six-lane selector in a clean private config scope, records the exact selected loopback endpoint, and reuses that same endpoint when downloading the authored patch.

## Product UX

- Effort: Not applicable — local developer automation only.
- Result: Not applicable.
- Walkthrough: No member-facing path changes.

## Evidence

- Direct: The focused harness creates a conflicting local preference for the main browser, locks that profile, disables CDP discovery, and proves Frog still selects one of six isolated lanes.
- Endpoint continuity: The harness proves the selected isolated endpoint is persisted and passed unchanged from implementation authoring to artifact wake; neither path contains port 9452.
- Focused: `scripts/frog-autofix.test.ts` passed 56/56.
- Broad: repo-tools passed 46 files / 711 tests; full workspace typecheck, dependency policy, and boundary checks passed.
- Authorship: ReviewGPT authored the initial implementation and the exact remediation for both accepted review findings; the committed Frog report records the reproduced setup failure.

## Non-obvious affected surfaces

- Only Frog's pre-PR implementation-author ReviewGPT flow changes browser selection and artifact retrieval.
- A user-owned local ReviewGPT preference cannot redirect Frog implementation authoring to the everyday browser.
- Patch retrieval is now bound to the same isolated loopback endpoint that accepted the authoring turn; it cannot silently reselect another lane.
- Existing final/specialist ReviewGPT packaging continues to use the shared lane owner.
- Model, marker, exact-turn, artifact, and fail-closed response checks are unchanged.

## Architecture and reuse

- Existing systems reused: `scripts/review-gpt.config.sh` remains the sole browser-lane map and automatic availability selector.
- New logic: The generated private Frog config isolates user preferences, forces automatic selection, records the selected endpoint, and carries it through the existing implementation result.
- New abstractions: None; the existing generated private config and implementation result remain the only adapters.
- Complexity intentionally avoided: No duplicated port/profile mapping, browser process management, fallback browser, or new dependency.

## Hot reply path impact

- Path status: Not applicable — no conversation runtime changes.
- Database calls: None.
- Network/provider calls: No new calls; ReviewGPT uses the existing managed-browser lane pool.
- Other awaited latency: None beyond existing ReviewGPT execution.
- Before/after proof: A locked interactive profile or local main-lane preference no longer determines implementation-author availability, and artifact wake stays on the selected isolated lane.

## Murph initial provider input impact

- Individual Murph: Not applicable.
- Group Murph: Not applicable.
- Measurement method: Not run — no provider-input path changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Local repository tooling only; the installed agent consumes the fix after its primary checkout advances.

## Changelog

- Changelog: not applicable
- Reason: Internal developer tooling with no member-visible behavior.

## Lines of code

| Area | Added | Deleted |
| --- | ---: | ---: |
| Frog autofix implementation | 23 | 5 |
| Frog autofix regression | 101 | 0 |
| Friction report | 27 | 0 |
| **Total** | **151** | **5** |

## ReviewGPT

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: faccc1e6c770ce6d27a2a9553e5884d1befbc8e4
