### PR TITLE
Fix Codex 0.149.1 auth deploy guard

### DIFF
--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -1088,7 +1088,7 @@ testHostedCodexAuthE2e(
       const currentTimeReminderCounts = promptRequests.map(
         (request) =>
           request.match(
-            /"role":"developer","content":\[\{"type":"input_text","text":"It is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\."\}\]/gu,
+            /It is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\./gu,
           )?.length ?? 0,
       );
       assert.ok(currentTimeReminderCounts.every((count) => count === 1));

--- a/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-codex-config.test.ts
@@ -74,6 +74,8 @@ const HOSTED_CODEX_EXPECTED_AUTO_COMPACT_TOKEN_LIMIT = 132_000;
 const HOSTED_CODEX_AUTO_COMPACT_TOKEN_LIMIT_CEILING = 250_000;
 const HOSTED_CODEX_AUTOCOMPACTION_E2E_INPUT_TOKENS =
   HOSTED_CODEX_EXPECTED_AUTO_COMPACT_TOKEN_LIMIT + 1_000;
+const CURRENT_TIME_REMINDER_PATTERN =
+  /It is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\./gu;
 const HOSTED_CODEX_AUTOCOMPACTION_SUMMARY_SENTINEL =
   "HOSTED_CODEX_AUTOCOMPACTION_SUMMARY_SENTINEL";
 const EXPECTED_MULTI_AGENT_USAGE_HINT = [
@@ -956,6 +958,37 @@ test("hosted Codex runtime config rejects relative command overrides", async () 
   );
 });
 
+test("hosted Codex current-time proof ignores non-authoritative request content", () => {
+  const reminder = "It is 2026-08-26 01:23:45 UTC.";
+  const userInput = {
+    role: "user",
+    content: [{ type: "input_text", text: reminder }],
+  };
+
+  assert.equal(
+    countAuthoritativeCurrentTimeReminders(JSON.stringify({ input: [userInput] })),
+    0,
+  );
+  assert.equal(
+    countAuthoritativeCurrentTimeReminders(
+      JSON.stringify({ input: [userInput], instructions: reminder }),
+    ),
+    1,
+  );
+  assert.equal(
+    countAuthoritativeCurrentTimeReminders(JSON.stringify({
+      input: [
+        userInput,
+        {
+          role: "developer",
+          content: [{ type: "input_text", text: reminder }],
+        },
+      ],
+    })),
+    1,
+  );
+});
+
 testHostedCodexAuthE2e(
   "hosted Codex runtime authenticates, excludes native memory, and rejects legacy OpenAI config",
   async () => {
@@ -1086,10 +1119,7 @@ testHostedCodexAuthE2e(
             request.includes(individualPrompt) || request.includes(groupPrompt),
         );
       const currentTimeReminderCounts = promptRequests.map(
-        (request) =>
-          request.match(
-            /It is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\./gu,
-          )?.length ?? 0,
+        countAuthoritativeCurrentTimeReminders,
       );
       assert.ok(currentTimeReminderCounts.every((count) => count === 1));
 
@@ -2426,12 +2456,47 @@ async function prepareLegacyBuiltInOpenAiCodexHome(input: {
 function parseJsonObject(value: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(value) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : null;
+    return isJsonObject(parsed) ? parsed : null;
   } catch {
     return null;
   }
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function countAuthoritativeCurrentTimeReminders(requestBody: string): number {
+  const parsed = parseJsonObject(requestBody);
+  if (!parsed) {
+    return 0;
+  }
+
+  const inputReminderCount = Array.isArray(parsed.input)
+    ? parsed.input.reduce((count, item) => {
+        if (!isJsonObject(item) || item.role !== "developer") {
+          return count;
+        }
+        return count + countCurrentTimeReminders(item.content);
+      }, 0)
+    : 0;
+  return countCurrentTimeReminders(parsed.instructions) + inputReminderCount;
+}
+
+function countCurrentTimeReminders(value: unknown): number {
+  if (typeof value === "string") {
+    return value.match(CURRENT_TIME_REMINDER_PATTERN)?.length ?? 0;
+  }
+  if (!Array.isArray(value)) {
+    return 0;
+  }
+  return value.reduce(
+    (count, item) =>
+      count + (isJsonObject(item)
+        ? countCurrentTimeReminders(item.text)
+        : countCurrentTimeReminders(item)),
+    0,
+  );
 }
 
 function isNativeMemoryRequestMarker(input: {


### PR DESCRIPTION
## Why and outcome

Unblock the guarded Cloudflare production deploy for Codex CLI 0.149.1. The real CLI still authenticates and sends Murph's current-time reminder exactly once, but 0.149.1 changed the surrounding provider request JSON shape. The guard now verifies that reminder only in authoritative instruction surfaces without coupling to one serialization.

ReviewGPT context sensitivity: routine — one test-only request assertion changes; production runtime, auth, provider configuration, and deploy code are unchanged.

## Product UX

- Effort: Patch — no user-facing behavior or UI changes.
- Result: Ready. The deploy remains fail-closed until this guard passes and the production workflow is rerun.
- Walkthrough: Not applicable; this is a test-only deploy-guard correction.

## Evidence

- Direct: codex --version reports codex-cli 0.149.1.
- Focused guard: 48 passed, 2 skipped in hosted-runtime-codex-config.test.ts with MURPH_RUN_HOSTED_CODEX_AUTH_E2E=1.
- Static: Assistant Runtime typecheck and git diff --check passed.

## Non-obvious affected surfaces

- The protected Cloudflare deployment workflow runs this exact real-binary auth guard before production mutation.
- The assertion parses each request and requires exactly one current-time reminder across top-level instructions and developer-role content.
- A focused negative case proves an identical timestamp in user-role content does not satisfy the authority check.

## Review disposition

- Accepted the preliminary coverage finding. Text presence anywhere in the raw body was insufficient proof of developer authority.
- Remediation parses the request through the existing JSON helper, supports top-level instruction strings and developer content arrays, ignores user content, and retains the per-request exact-count invariant.
- No patch artifact was supplied; the focused real-binary guard and negative authority regression both pass.

## Architecture and reuse

- Existing systems reused: The existing JSON parser, auth request capture, and real-Codex harness remain the owners of this proof.
- New logic: A test-local counter recognizes timestamps only in authoritative Responses instruction surfaces.
- New abstractions: One test-local type guard and two narrow counting helpers; no production abstraction.
- Complexity intentionally avoided: No dependency, runtime parser, compatibility shim, or deploy exception is added for a test assertion.

## Hot reply path impact

- Path status: Not applicable; production code is unchanged.
- Database calls: None.
- Network/provider calls: None added or changed.
- Other awaited latency: None.

## Murph initial provider input impact

- None. The test observes the same provider-visible timestamp reminder without changing its assembly or content.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 72 | 7 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **72** | **7** |

## Deployment concerns

- Deployment: applicable
- Deployment scope: This PR has no deployable runtime change; it only unblocks the guarded rollout.
- Supported skew: The test-only head is compatible with the already-deployed Web and the not-yet-deployed Cloudflare runtime.
- Safe order: Merge after exact-head checks, then rerun the protected Cloudflare production workflow for the already-published 0.149.1 image and merged runtime upgrade.
- Rollback floor: Keep the prior Web, Worker, and 0.147.0 runner image available as the original upgrade rollback set; this test-only PR adds no artifact.
- Expected exposure: No member-facing change; Cloudflare production remains on the prior runtime until the guarded workflow succeeds.
- Reversibility: Reverting this test-only commit restores the prior assertion but would block the 0.149.1 deploy guard again.
- Convergence proof: The rerun must resolve public main, pass the real 0.149.1 auth guard and runner smoke, deploy immediately, and pass its live-model and endpoint smokes.
- Post-deploy checks: Require the workflow's runner smoke, live-model turn, and deployed endpoint smoke to pass.

## Changelog

- Changelog: not applicable
- Reason: Test-only deploy-guard correction with no member-facing change.