### PR TITLE
perf(web): bound static generation concurrency

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-25-vercel-static-generation-concurrency.md
+++ b/agent-docs/exec-plans/completed/2026-08-25-vercel-static-generation-concurrency.md
@@ -1,0 +1,72 @@
+# Vercel Static Generation Concurrency
+
+Status: completed
+
+Date: 2026-08-25
+
+## Goal
+
+Keep hosted Web production builds within the existing two-CPU build budget by
+preventing each Next static-generation export worker from silently using its
+default eight-page concurrency.
+
+The protected invariant is that build-resource fanout stays explicit and
+bounded without weakening route generation, type validation, or static output.
+
+## Evidence And Ownership
+
+- `apps/web/next.config.ts` is the current owner of the hosted Web production
+  build shape and already sets `experimental.cpus` to `2`.
+- The pinned Next 16.3 implementation defaults
+  `experimental.staticGenerationMaxConcurrency` to `8` when it is unset and
+  uses that value to batch concurrent export-page work.
+- `apps/web/README.md` is the single prose owner for the hosted production-build
+  memory contract.
+
+No new state, queue, dependency, telemetry path, retry policy, or route-specific
+behavior is needed. The smallest correction is to derive the static-generation
+cap from the existing CPU-budget constant.
+
+## Plan
+
+1. Configure static-generation concurrency from the existing hosted Web
+   production-build CPU constant.
+2. Extend the focused Next-config contract test so the two settings cannot
+   drift apart.
+3. Record the bounded static-generation contract in the current production
+   build owner documentation.
+4. Run the focused config suite, hosted Web typecheck and lint, documentation
+   drift/reference checks, diff checks, and privacy review.
+
+## Failure, Rollback, And Deploy Skew
+
+- The change affects build scheduling only; generated routes and runtime
+  behavior remain unchanged.
+- A lower concurrency can increase static-generation duration, so exact-head
+  Vercel preview/deploy evidence remains the external acceptance boundary.
+- Rollback is the ordinary removal of this config field. There is no persisted
+  state, cross-plane skew, or migration.
+
+## Verification
+
+- Focused `apps/web/test/next-config.test.ts` proof for the exact config value
+  and coupling to the existing CPU budget.
+- Hosted Web typecheck and lint for the touched app configuration.
+- Documentation drift/reference validation and `git diff --check`.
+- Final diff review confirms no secret, identifier, generated artifact, or
+  unrelated change entered the patch.
+
+## Verification Log
+
+- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/next-config.test.ts`
+  passed: 46 tests.
+- `pnpm --dir apps/web typecheck` passed.
+- `pnpm --dir apps/web lint` passed with warnings only in unchanged files.
+- `pnpm docs:drift` passed.
+- A direct `tsx` config assertion confirmed both `experimental.cpus` and
+  `experimental.staticGenerationMaxConcurrency` resolve to `2` for the
+  production-build phase.
+- `git diff --check` passed, and targeted privacy/domain scans found no new
+  private identifier or noncanonical-domain text.
+Updated: 2026-08-25
+Completed: 2026-08-25

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1743,12 +1743,13 @@ used by the Vercel package build and the CI memory-observation lane. Forced-cold
 Standard previews remain the direct acceptance evidence, and a Next upgrade
 must revalidate the heap boundary.
 
-Next's static-generation export loop defaults to eight concurrent pages per
-export worker even when the configured build CPU budget is lower. Hosted Web
-therefore derives `staticGenerationMaxConcurrency` from the existing two-CPU
-production build constant. This keeps per-worker page-render fanout explicit
-without skipping any static output; exact-head Vercel builds remain the duration
-and capacity proof.
+Next's static-generation export loop defaults to eight concurrent pages in each
+of the two configured export workers, allowing up to sixteen page renders at
+once. Hosted Web derives `staticGenerationMaxConcurrency` from the existing
+two-CPU production build constant, capping each worker at two concurrent pages
+and the composed build at four. This keeps page-render fanout explicit without
+skipping any static output; exact-head Vercel builds remain the duration and
+capacity proof.
 
 Production builds use Next 16.3's supported Webpack fallback. The production
 script passes `--webpack` and enables `webpackMemoryOptimizations`. The Workflow

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1743,6 +1743,13 @@ used by the Vercel package build and the CI memory-observation lane. Forced-cold
 Standard previews remain the direct acceptance evidence, and a Next upgrade
 must revalidate the heap boundary.
 
+Next's static-generation export loop defaults to eight concurrent pages per
+export worker even when the configured build CPU budget is lower. Hosted Web
+therefore derives `staticGenerationMaxConcurrency` from the existing two-CPU
+production build constant. This keeps per-worker page-render fanout explicit
+without skipping any static output; exact-head Vercel builds remain the duration
+and capacity proof.
+
 Production builds use Next 16.3's supported Webpack fallback. The production
 script passes `--webpack` and enables `webpackMemoryOptimizations`. The Workflow
 integration contributes custom Webpack configuration, so Next's canonical

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -306,6 +306,9 @@ export function buildHostedWebNextConfig(
     env: buildHostedWebClientEnv(environment),
     experimental: {
       cpus: HOSTED_WEB_PRODUCTION_BUILD_CPUS,
+      // Next otherwise renders up to eight static pages per export worker.
+      // Keep per-worker fanout aligned with the production-build CPU budget.
+      staticGenerationMaxConcurrency: HOSTED_WEB_PRODUCTION_BUILD_CPUS,
       // Next 16.3 enables persistent production-build caching by default.
       // Keep builds independent until that new state owner is evaluated
       // separately.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -306,8 +306,8 @@ export function buildHostedWebNextConfig(
     env: buildHostedWebClientEnv(environment),
     experimental: {
       cpus: HOSTED_WEB_PRODUCTION_BUILD_CPUS,
-      // Next otherwise renders up to eight static pages per export worker.
-      // Keep per-worker fanout aligned with the production-build CPU budget.
+      // Next otherwise renders up to eight static pages in each of two export
+      // workers. Cap each worker at two pages, for four composed renders.
       staticGenerationMaxConcurrency: HOSTED_WEB_PRODUCTION_BUILD_CPUS,
       // Next 16.3 enables persistent production-build caching by default.
       // Keep builds independent until that new state owner is evaluated

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -368,12 +368,15 @@ test("next.config keeps Turbopack focused on the repo root without custom worksp
   assert.equal(productionNextConfig.experimental?.cpus, HOSTED_WEB_PRODUCTION_BUILD_CPUS);
 });
 
-test("production static generation stays within the configured build CPU budget", () => {
+test("production static generation composes to at most four concurrent renders", () => {
+  const exportWorkers = productionNextConfig.experimental?.cpus;
+  const rendersPerWorker =
+    productionNextConfig.experimental?.staticGenerationMaxConcurrency;
+
   assert.equal(HOSTED_WEB_PRODUCTION_BUILD_CPUS, 2);
-  assert.equal(
-    productionNextConfig.experimental?.staticGenerationMaxConcurrency,
-    HOSTED_WEB_PRODUCTION_BUILD_CPUS,
-  );
+  assert.equal(exportWorkers, HOSTED_WEB_PRODUCTION_BUILD_CPUS);
+  assert.equal(rendersPerWorker, 2);
+  assert.equal(exportWorkers * rendersPerWorker, 4);
 });
 
 test("production build skips only the duplicate typecheck after the runner proves it", () => {

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -368,6 +368,14 @@ test("next.config keeps Turbopack focused on the repo root without custom worksp
   assert.equal(productionNextConfig.experimental?.cpus, HOSTED_WEB_PRODUCTION_BUILD_CPUS);
 });
 
+test("production static generation stays within the configured build CPU budget", () => {
+  assert.equal(HOSTED_WEB_PRODUCTION_BUILD_CPUS, 2);
+  assert.equal(
+    productionNextConfig.experimental?.staticGenerationMaxConcurrency,
+    HOSTED_WEB_PRODUCTION_BUILD_CPUS,
+  );
+});
+
 test("production build skips only the duplicate typecheck after the runner proves it", () => {
   const preparedConfig = buildHostedWebNextConfig(
     PHASE_PRODUCTION_BUILD,


### PR DESCRIPTION
## Why and outcome

Next can render eight static pages in each of two hosted Web export workers, allowing roughly sixteen concurrent page renders despite the two-worker build budget. This caps each worker at two pages, reducing the composed ceiling to four without skipping routes or weakening validation.

## Product UX

- Effort: Not applicable - build scheduling only.
- Result: Not applicable.
- Walkthrough: Runtime UI and member journeys are unchanged; the affected operator journey is a production deployment completing predictably.

## Evidence

- Direct: The focused Next configuration suite passed 46 tests and asserts two export workers times two renders per worker equals a composed ceiling of four.
- Coverage: Hosted Web typecheck, lint, documentation drift, and diff checks passed.
- Specialist disposition: Accepted the preliminary truthfulness finding; comments, docs, tests, and outcome now state the composed four-render bound instead of implying a total of two.
- External: The forced exact-head preview remained queued behind a verified-stalled pre-fix production build, so it cannot prove the scheduling correction. The merge commit production deployment must complete static generation without delayed route timeouts or worker starvation before closure.

## Non-obvious affected surfaces

- Hosted Web production build scheduling changes from an implicit maximum of sixteen concurrent static renders across two workers to an explicit maximum of four.
- Generated routes, runtime request handling, database access, persisted state, and Cloudflare are unchanged.

## Architecture and reuse

- Existing systems reused: The existing hosted Web production CPU-budget constant remains the single owner of export-worker count and supplies the per-worker render cap.
- New logic: Each of two export workers is limited to two concurrent page renders, producing a composed ceiling of four.
- New abstractions: None; the supported Next configuration field and existing config builder are sufficient.
- Complexity intentionally avoided: No route-specific scheduling, queue, worker manager, telemetry service, dependency, or persisted state was added.

## Hot reply path impact

- Path status: Not applicable - this changes build scheduling only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None at runtime.
- Before/after proof: The focused configuration test locks the composed fanout at two workers times two renders.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run - no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: Production build scheduling is a reliability-sensitive configuration surface.
ReviewGPT first-reviewed head: 9774130fb707b816bfb1dff146dfc1bc92a81629

## Deployment concerns

- Deployment: applicable
- Supported skew: Generated routes and runtime behavior are identical before and after the build-scheduling change.
- Safe order: Deploy hosted Web normally; no tandem Cloudflare or database deployment is required.
- Rollback floor: The prior Web deployment remains compatible with all current runtime contracts.
- Expected exposure: Only Vercel build scheduling changes, from up to sixteen to up to four composed static renders.
- Reversibility: Revert this PR and redeploy hosted Web.
- Convergence proof: Confirm a production Vercel deployment containing the merge commit reaches Ready and is promoted.
- Post-deploy checks: Verify static generation completes without delayed route timeouts or worker starvation.

## Change-shape breakdown

Classification rule: Next configuration is config/tooling, its focused test is tests, and the README plus completed execution plan are docs; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 11 | 0 |
| Docs | 80 | 0 |
| Config / tooling | 3 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **94** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal build reliability only; no intended member-facing behavior or copy changes.

