### PR TITLE
Remove the Fitbit Junction note

### DIFF
--- a/apps/web/app/(dashboard)/connect/connect-source-card.tsx
+++ b/apps/web/app/(dashboard)/connect/connect-source-card.tsx
@@ -41,10 +41,6 @@ export function SourceCard({
     || (source.connectionAvailable === false && Boolean(source.unavailableActionUrl));
   const isAvailable = Boolean(source.connectTarget);
   const canStart = authenticated && isAvailable;
-  const showFitbitJunctionDisclosure = source.connectTarget === "fitbit"
-    && canStart
-    && migrationState !== "verifying_successor"
-    && migrationState !== "cutover_ready";
   const canDisconnect = !setupOnly
     && authenticated
     && Boolean(source.disconnectConnectionId);
@@ -209,20 +205,6 @@ export function SourceCard({
             {errorMessage ? (
               <p role="alert" className="text-xs leading-snug text-destructive">
                 {errorMessage}
-              </p>
-            ) : null}
-            {showFitbitJunctionDisclosure ? (
-              <p className="max-w-[22rem] text-xs leading-relaxed text-muted-foreground">
-                Google authorization is handled through{" "}
-                <a
-                  className="underline underline-offset-2 hover:text-foreground"
-                  href="https://www.junction.com"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Junction
-                </a>
-                .
               </p>
             ) : null}
             {!authenticated ? (

--- a/apps/web/changelog/entries/2026-08-25/direct-links-to-device-connections.json
+++ b/apps/web/changelog/entries/2026-08-25/direct-links-to-device-connections.json
@@ -9,6 +9,6 @@
     "summary": "Links can now open a specific connection on Murph's Connect Devices page.",
     "details": "The requested source opens in a focused dialog; sign-in and authorization still require the member's explicit action.",
     "relevanceTags": ["connections", "device-sync"],
-    "sourcePullRequests": [2261, 2283]
+    "sourcePullRequests": [2261, 2283, 2308, 2320]
   }
 }

--- a/apps/web/test/connect-page.test.ts
+++ b/apps/web/test/connect-page.test.ts
@@ -3343,6 +3343,10 @@ test("connect source card design study renders the production action states", as
 
   assert.match(markup, /id="connect-source-card-actions"/u);
   assert.match(markup, /data-design-state="signed-out-source-actions"/u);
+  assert.doesNotMatch(
+    markup,
+    /Google authorization is handled through/u,
+  );
   assert.match(markup, /aria-label="Disconnect Garmin"/u);
   assert.match(markup, /aria-label="Download app for Apple Health"/u);
   assert.match(markup, /aria-label="Connect Fitbit"/u);


### PR DESCRIPTION
## Outcome

Removes the provider implementation note from the Fitbit connection card and focused source dialog while leaving Google Health authorization behavior unchanged.

## Product UX

- Effort: Patch.
- Affected people: signed-in members viewing Fitbit on phone or desktop, including direct /connect#fitbit links.
- Result: the card keeps one clear next action without an unnecessary provider disclosure.

## Evidence

- Focused connect and changelog render suites: 118 tests passed.
- Hosted Web typecheck passed.
- Changed-file ESLint passed.
- Stale disclosure string search passed.

## Design proof

- Design page: [Fitbit focused dialog](https://www.withmurph.ai/screenshots/health?connectSourceDialog=fitbit#connect-source-dialog)
- Evidence: exact-head static rendering of the production SourceCard proves the disclosure is absent while Connect and migration actions remain present. Images add no material proof because the patch only deletes one paragraph and changes no visual primitives.
- Coverage: authenticated Fitbit idle, authorization-required, verifying, switching, and retry states render through the existing card and focused-dialog study. Phone and desktop use unchanged responsive classes, and removing content only reduces vertical height.

## Architecture and reuse

- Existing systems reused: the existing SourceCard owns both card and focused-dialog presentations.
- New logic: none; the patch deletes one derived visibility condition and its rendered paragraph.
- New abstractions: none are needed because SourceCard already owns both rendered surfaces.
- Complexity intentionally avoided: no replacement component, provider flag, dependency, or duplicate copy owner.
- Hot reply path: not applicable; no assistant or messaging path changes.
- Provider input: not applicable; no provider request, authorization, or callback behavior changes.

## Deployment concerns

- Deployment: not applicable
- Reason: This is a render-only deletion with no schema, protocol, environment, skew, ordering, rollback-floor, exposure, or convergence change. Reverting the commit restores the note, and the Fitbit focused-dialog route provides post-merge proof.

## Changelog

- Changelog: updated
- Items: 2026-08-25 · direct-links-to-device-connections

## LOC

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 18 |
| Tests / fixtures | 4 | 0 |
| Docs | 1 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |