### PR TITLE
Correlate workspace snapshot start diagnostics

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-26-snapshot-start-attempt-correlation.md
+++ b/agent-docs/exec-plans/active/2026-08-26-snapshot-start-attempt-correlation.md
@@ -1,0 +1,39 @@
+# Snapshot Start Attempt Correlation
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Correlate the existing slow or failed workspace-snapshot start diagnostics
+  with the existing runtime checkpoint attempt identifier.
+- Preserve the current metadata-only logging, timing thresholds, checkpoint
+  behavior, and privacy boundary.
+
+## Constraints
+
+- Reuse the existing Cloudflare structured-log path and canonical
+  `workspaceAttemptId` vocabulary.
+- Add no logging service, database write, metric pipeline, retry, timeout,
+  queue, scheduler, or persisted state.
+- Keep unauthorized requests uncorrelated because they have no validated write
+  fence.
+
+## Plan
+
+1. Carry the validated write-fence attempt identifier into the existing route
+   diagnostic and the parsed session attempt identifier into the existing
+   session-owner diagnostic.
+2. Add focused route and Durable Object tests proving both diagnostic scopes
+   carry the same attempt identifier without exposing snapshot or user data.
+3. Run focused Cloudflare tests and typecheck, inspect the final diff and
+   privacy boundary, then complete the repository PR review and CI workflow.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts
+  --no-coverage apps/cloudflare/test/runner-outbound.test.ts
+  apps/cloudflare/test/user-runner-alarm.test.ts` — passed (372 tests).
+- `pnpm --dir apps/cloudflare typecheck` — passed.
+- `git diff --check` — passed.

--- a/agent-docs/exec-plans/completed/2026-08-26-snapshot-start-attempt-correlation.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-snapshot-start-attempt-correlation.md
@@ -1,6 +1,6 @@
 # Snapshot Start Attempt Correlation
 
-Status: active
+Status: completed
 Created: 2026-08-26
 Updated: 2026-08-26
 
@@ -34,6 +34,12 @@ Updated: 2026-08-26
 
 - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts
   --no-coverage apps/cloudflare/test/runner-outbound.test.ts
-  apps/cloudflare/test/user-runner-alarm.test.ts` — passed (372 tests).
+  apps/cloudflare/test/user-runner-alarm.test.ts` — passed (374 tests),
+  including route and session-owner failures plus the unauthorized omission
+  boundary.
 - `pnpm --dir apps/cloudflare typecheck` — passed.
 - `git diff --check` — passed.
+- Preliminary completion-specialists review — one accepted test-coverage
+  finding, resolved with focused failure and authorization-boundary proof.
+- Final cross-cutting ReviewGPT round 1 — passed with no findings.
+Completed: 2026-08-26

--- a/apps/cloudflare/src/runner-outbound.ts
+++ b/apps/cloudflare/src/runner-outbound.ts
@@ -553,6 +553,7 @@ interface HostedWorkspaceSnapshotStartRouteDiagnostics {
   durationsCapped: boolean;
   sessionCreateStorageDurationMs: number;
   startedAt: number;
+  workspaceAttemptId: string | null;
   writeFenceOwnerValidationDurationMs: number;
 }
 
@@ -594,6 +595,7 @@ async function handleRunnerWorkspaceSnapshotStartRequest(input: {
             response: unauthorized(),
           };
         }
+        diagnostics.workspaceAttemptId = writeFence.attemptId;
 
         const body = await readJsonObject(input.request, {
           limitBytes: 16 * 1024,
@@ -752,6 +754,7 @@ function createHostedWorkspaceSnapshotStartRouteDiagnostics(): HostedWorkspaceSn
     durationsCapped: false,
     sessionCreateStorageDurationMs: 0,
     startedAt: Date.now(),
+    workspaceAttemptId: null,
     writeFenceOwnerValidationDurationMs: 0,
   };
 }
@@ -825,6 +828,9 @@ function emitHostedWorkspaceSnapshotStartRouteDiagnostics(input: {
       snapshotStartWriteFenceOwnerValidationDurationMs:
         input.diagnostics.writeFenceOwnerValidationDurationMs,
       userIdPresent: input.userIdPresent,
+      ...(input.diagnostics.workspaceAttemptId
+        ? { workspaceAttemptId: input.diagnostics.workspaceAttemptId }
+        : {}),
     },
     level: input.outcome === "failed" ? "warn" : "info",
     message: "Hosted runner workspace snapshot start diagnostic.",

--- a/apps/cloudflare/src/user-runner/workspace-snapshot-sessions.ts
+++ b/apps/cloudflare/src/user-runner/workspace-snapshot-sessions.ts
@@ -325,6 +325,7 @@ export function createWorkspaceSnapshotSessionService(input: {
           newWorkspaceCandidateCount,
           outcome,
           recordedCandidateCount,
+          workspaceAttemptId: sessionInput.attemptId,
         });
         return session;
       };
@@ -457,6 +458,7 @@ export function createWorkspaceSnapshotSessionService(input: {
           newWorkspaceCandidateCount,
           outcome: "failed",
           recordedCandidateCount,
+          workspaceAttemptId: sessionInput.attemptId,
         });
         throw error;
       }
@@ -846,6 +848,7 @@ function emitHostedWorkspaceSnapshotSessionStartDiagnostics(input: {
   newWorkspaceCandidateCount: number;
   outcome: HostedWorkspaceSnapshotSessionStartOutcome;
   recordedCandidateCount: number;
+  workspaceAttemptId: string;
 }): void {
   const totalDurationMs = input.diagnostics.alarmCandidateWorkDurationMs
     + input.diagnostics.ownerValidationDurationMs
@@ -883,6 +886,7 @@ function emitHostedWorkspaceSnapshotSessionStartDiagnostics(input: {
         : input.diagnostics.currentSubstage,
       snapshotStartWriteFenceOwnerValidationDurationMs:
         input.diagnostics.ownerValidationDurationMs,
+      workspaceAttemptId: input.workspaceAttemptId,
     },
     level: input.outcome === "failed" ? "warn" : "info",
     message: "Hosted runner workspace snapshot session start diagnostic.",

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -4480,6 +4480,54 @@ describe("handleRunnerOutboundRequest", () => {
     ));
   });
 
+  it("correlates failed workspace snapshot start route diagnostics", async () => {
+    const fixture = await createHostedRuntimeCryptoContextFixture();
+    const runner = createWorkspaceVersionAwareUserRunner();
+    const runnerStub = runner.getByName();
+    const failedStub: WorkerUserRunnerStubLike = {
+      ...runnerStub,
+      async createHostedWorkspaceSnapshotUploadSession() {
+        throw new Error("workspace snapshot session create failed");
+      },
+    };
+    const env = createRunnerOutboundEnv({
+      ...fixture.env,
+      USER_RUNNER: { getByName: () => failedStub },
+    });
+    vi.stubGlobal("fetch", fixture.fetchMock);
+    hostedExecutionMocks.emitHostedExecutionStructuredLog.mockClear();
+
+    await expect(handleRunnerOutboundRequest(
+      createWorkspaceSnapshotStartRequest({
+        expectedWorkspaceVersion: "4",
+        workspaceVersion: "4",
+      }),
+      env,
+      "member_123",
+    )).rejects.toThrow("workspace snapshot session create failed");
+    const diagnosticLog =
+      hostedExecutionMocks.emitHostedExecutionStructuredLog.mock.calls
+        .map(([entry]) => entry)
+        .find(
+          (entry: { details?: unknown; level?: string; message?: string }) =>
+            entry.message
+              === "Hosted runner workspace snapshot start diagnostic.",
+        );
+    expect(diagnosticLog).toMatchObject({
+      level: "warn",
+      userId: null,
+    });
+    expect(requireTestObject(
+      diagnosticLog?.details,
+      "failed workspace snapshot start route diagnostic details",
+    )).toMatchObject({
+      snapshotStartDiagnosticScopeKind: "route",
+      snapshotStartOutcomeKind: "failed",
+      snapshotStartSubstageKind: "session_create_storage",
+      workspaceAttemptId: "attempt_1",
+    });
+  });
+
   it.each([
     {
       durationKey: "snapshotStartWriteFenceOwnerValidationDurationMs",
@@ -5895,6 +5943,23 @@ describe("handleRunnerOutboundRequest", () => {
     expect(runner.validateRuntimeWriteFence).not.toHaveBeenCalled();
     expect(runner.createHostedWorkspaceSnapshotUploadSession).not.toHaveBeenCalled();
     expect(runner.workspaceSnapshotUploadSessions.size).toBe(0);
+    const diagnosticLog =
+      hostedExecutionMocks.emitHostedExecutionStructuredLog.mock.calls
+        .map(([entry]) => entry)
+        .find(
+          (entry: { details?: unknown; message?: string }) =>
+            entry.message
+              === "Hosted runner workspace snapshot start diagnostic.",
+        );
+    const details = requireTestObject(
+      diagnosticLog?.details,
+      "unauthorized workspace snapshot start route diagnostic details",
+    );
+    expect(details).toMatchObject({
+      snapshotStartDiagnosticScopeKind: "route",
+      snapshotStartOutcomeKind: "unauthorized",
+    });
+    expect(details).not.toHaveProperty("workspaceAttemptId");
   });
 
   it("does not expose a test-gated Worker body upload route for workspace snapshots", async () => {

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -4422,6 +4422,7 @@ describe("handleRunnerOutboundRequest", () => {
       snapshotStartSubstageKind: "completed",
       snapshotStartTotalDurationMs: 60_000,
       userIdPresent: true,
+      workspaceAttemptId: "attempt_1",
     });
     const durationKeys = [
       "snapshotStartAlarmCandidateWorkDurationMs",
@@ -4458,6 +4459,7 @@ describe("handleRunnerOutboundRequest", () => {
       "snapshotStartTotalDurationMs",
       "snapshotStartWriteFenceOwnerValidationDurationMs",
       "userIdPresent",
+      "workspaceAttemptId",
     ]);
     const serializedDetails = JSON.stringify(details);
     expect(serializedDetails).not.toContain(requireTestString(

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -7202,6 +7202,48 @@ describe("HostedUserRunner execution coordination", () => {
     )).toBe(false);
   });
 
+  it("correlates failed snapshot session-owner starts", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const { runner, sql } = createRunnerHarness({
+      onStoragePut: ({ key }) => {
+        if (key === workspaceSnapshotUploadSessionCurrentStorageKey()) {
+          throw new Error("workspace snapshot session storage failed");
+        }
+      },
+    });
+    await activateWorkspaceSnapshotSessionOwner({ runner, sql });
+    const workspacePrefix = await hostedWorkspaceSnapshotUserPrefix({
+      userId: TEST_USER_ID,
+    });
+    mocks.emitHostedExecutionStructuredLog.mockClear();
+
+    await expect(runner.createHostedWorkspaceSnapshotUploadSession(
+      createWorkspaceSnapshotUploadSessionForTest({
+        objectKey:
+          `${workspacePrefix}snapshot_failed_session_owner.snapshot.enc`,
+        snapshotId: "snapshot_failed_session_owner",
+      }),
+    )).rejects.toThrow("workspace snapshot session storage failed");
+
+    const diagnosticLog = mocks.emitHostedExecutionStructuredLog.mock.calls
+      .map(([entry]) => entry)
+      .find(
+        (entry) => entry.message
+          === "Hosted runner workspace snapshot session start diagnostic.",
+      );
+    expect(diagnosticLog).toMatchObject({
+      level: "warn",
+      userId: null,
+    });
+    expect(diagnosticLog?.details).toMatchObject({
+      snapshotStartDiagnosticScopeKind: "session_owner",
+      snapshotStartOutcomeKind: "failed",
+      snapshotStartSubstageKind: "session_create_storage",
+      workspaceAttemptId: "attempt_1",
+    });
+  });
+
   it("attributes previous-session candidate persistence to alarm work", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -7271,6 +7271,7 @@ describe("HostedUserRunner execution coordination", () => {
       snapshotStartSessionCreateStorageDurationMs: 0,
       snapshotStartSubstageKind: "completed",
       snapshotStartWriteFenceOwnerValidationDurationMs: 0,
+      workspaceAttemptId: "attempt_1",
     });
   });
 
@@ -7364,6 +7365,7 @@ describe("HostedUserRunner execution coordination", () => {
       snapshotStartOutcomeKind: "created",
       snapshotStartRecordedCandidateCount: 0,
       snapshotStartSubstageKind: "completed",
+      workspaceAttemptId: "attempt_1",
     });
     for (const key of [
       "snapshotStartAlarmCandidateWorkDurationMs",
@@ -7395,6 +7397,7 @@ describe("HostedUserRunner execution coordination", () => {
       "snapshotStartSessionCreateStorageDurationMs",
       "snapshotStartSubstageKind",
       "snapshotStartWriteFenceOwnerValidationDurationMs",
+      "workspaceAttemptId",
     ]);
     expect(JSON.stringify(details)).not.toContain("snapshot_create_no_scan_current");
     expect(JSON.stringify(details)).not.toContain(workspacePrefix);


### PR DESCRIPTION
## Why and outcome

Slow and failed idle-shutdown snapshot starts already report bounded substage timings, but those diagnostics could not be joined to the checkpoint attempt that triggered them. This adds the existing validated `workspaceAttemptId` to both the route and session-owner diagnostic scopes so one checkpoint attempt can be traced end to end.

## Product UX

Not applicable. This changes internal operator telemetry only; checkpoint behavior, timing thresholds, retries, and member-visible behavior are unchanged.

## Evidence

- Focused Cloudflare Vitest: 374 tests passed across `runner-outbound.test.ts` and `user-runner-alarm.test.ts`.
- Cloudflare package typecheck passed.
- Route and session-owner failure tests prove both warn/failed diagnostics carry `workspaceAttemptId`; an authorization-boundary test proves an unvalidated request does not.
- Existing bounded-key and privacy assertions exclude snapshot identifiers, object keys, encryption material, and user IDs.
- Fast successful starts remain silent.
- Preliminary specialist review: one accepted coverage finding, resolved by the focused failure and authorization-boundary tests.
- Final cross-cutting ReviewGPT round 1: passed with no findings.

## Non-obvious affected surfaces

- Cloudflare runner outbound snapshot-start route: records the already-validated write-fence attempt ID only after authorization succeeds.
- HostedUserRunner Durable Object snapshot-session owner: records the attempt ID already present in the parsed session input.
- No checkpoint protocol, storage schema, upload behavior, alarm scheduling, retry, timeout, or persisted state changes.

## Architecture and reuse

- **Existing systems reused:** The existing structured-log emitter, snapshot-start diagnostics, validated write fence, session input, and canonical `workspaceAttemptId` vocabulary.
- **New logic:** Copy one existing attempt ID into each existing diagnostic detail object.
- **New abstractions:** None; the current diagnostic owners already have the correlation value at the correct boundary.
- **Complexity intentionally avoided:** No logging service, database write, metrics pipeline, hash, cache, retry, queue, scheduler, or compatibility layer.

## Hot reply path impact

Not applicable. The change is limited to idle-shutdown workspace snapshot diagnostics and does not touch foreground message acceptance, provider start, or reply handoff.

## Murph initial provider input impact

- Assistant runtime: Not applicable; no provider-input surface changed.
- Codex runtime: Not applicable; no provider-input surface changed.

## Change-shape breakdown

Classification: authored runtime TypeScript is source; Vitest files are tests; the completed execution plan is docs; no binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 0 |
| Tests/fixtures | 112 | 0 |
| Docs | 45 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **167** | **0** |

## Risks

The added value is an existing internal attempt identifier, not member, snapshot, object, or encryption data. Unauthorized requests remain uncorrelated because they have no validated write fence.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Worker versions differ only by an optional structured-log detail; checkpoint and container protocols are unchanged.
- Safe order: One Cloudflare deployment is sufficient; no Web or runner-container tandem deploy is required.
- Rollback floor: Reverting safely removes the optional correlation field without changing runtime state or records.
- Expected exposure: A gradual rollout can produce a mix of correlated and uncorrelated diagnostics for one rollout window.
- Reversibility: Revert the Cloudflare Worker version; no data migration or cleanup is required.
- Convergence proof: Deployment version converges and new slow or failed snapshot-start diagnostics contain `workspaceAttemptId` in both scopes.
- Post-deploy checks: Confirm the deployed version, inspect bounded snapshot-start diagnostic aggregates, and verify new slow or failed rows carry the attempt ID.

## Changelog

- Changelog: not applicable
- Reason: Internal telemetry correlation only; no member-visible behavior changes.

ReviewGPT context sensitivity: sensitive — the patch changes production Cloudflare runtime diagnostics at a deploy boundary.
ReviewGPT first-reviewed head: bbba6c976288ac3363f2c16a9029e17c98872ce9
