### PR TITLE
Route group backfill through protected production workflow

### DIFF
--- a/.agents/friction-log/20260826002019-vercel-env-run/friction.md
+++ b/.agents/friction-log/20260826002019-vercel-env-run/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Vercel env run supplies empty protected production database variables'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Repository operator instructions that use `vercel env run --environment=production` should provide the required database binding to the child command, or route the command through the existing protected production workflow.
+
+## Current Behavior
+
+The Vercel project lists `DATABASE_URL` and `DIRECT_DATABASE_URL`, but an authenticated `vercel env run` child receives both names with empty values. Database-backed maintenance scripts therefore fail before even a dry-run, while their repository documentation presents the local command as executable.
+
+## Possible Solution
+
+Use the existing GitHub `production` environment as the database-backed operator boundary, or provide one reusable protected maintenance entrypoint and make the docs name that owner.
+
+## Minimal Reproducible Example
+
+From an authenticated checkout linked to a synthetic Vercel project with protected database variables, run a child process through `vercel env run -e production` that reports only whether each required value is non-empty. Both report false even though the variable names are listed for Production.
+
+## Context
+
+This blocked a bounded, aggregate-only production backfill after the replacement application build and deployment gate were already green. No credentials or row data are needed to reproduce the command-path mismatch.

--- a/.github/workflows/hosted-web-contract-migrations.yml
+++ b/.github/workflows/hosted-web-contract-migrations.yml
@@ -12,6 +12,11 @@ on:
         description: Exact ready Vercel production deployment URL to prove.
         required: true
         type: string
+      run_group_materialization_backfill:
+        description: Temporarily run the bounded routed-group materialization repair after contract migrations.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -175,6 +180,7 @@ jobs:
           DIRECT_DATABASE_URL: ${{ secrets.HOSTED_WEB_DIRECT_DATABASE_URL }}
           MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1"
           MURPH_RUN_HOSTED_WEB_CONTRACT_MIGRATIONS: "1"
+          RUN_GROUP_MATERIALIZATION_BACKFILL: ${{ inputs.run_group_materialization_backfill || 'false' }}
         run: |
           set -euo pipefail
 
@@ -213,3 +219,41 @@ jobs:
           fi
 
           pnpm --dir apps/web release:production:contract-migrate
+
+          if [ "${RUN_GROUP_MATERIALIZATION_BACKFILL}" != "true" ]; then
+            exit 0
+          fi
+
+          current_sha="$(
+            env \
+              -u DIRECT_DATABASE_URL \
+              -u MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS \
+              -u MURPH_RUN_HOSTED_WEB_CONTRACT_MIGRATIONS \
+              pnpm --dir apps/web exec tsx scripts/resolve-vercel-production-alias-sha.ts
+          )"
+          if [ "${current_sha}" != "${DEPLOYED_SHA}" ]; then
+            echo "::error::Vercel production changed before the hosted group materialization backfill."
+            exit 1
+          fi
+
+          verified_sha="$(
+            env \
+              -u DIRECT_DATABASE_URL \
+              -u MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS \
+              -u MURPH_RUN_HOSTED_WEB_CONTRACT_MIGRATIONS \
+              pnpm --dir apps/web exec tsx scripts/verify-vercel-production-deployment.ts
+          )"
+          if [ "${verified_sha}" != "${DEPLOYED_SHA}" ]; then
+            echo "::error::Exact Vercel production verification failed before the hosted group materialization backfill."
+            exit 1
+          fi
+
+          DATABASE_URL="${DIRECT_DATABASE_URL}" \
+            NODE_OPTIONS=--conditions=react-server \
+            pnpm --dir apps/web groups:backfill-materialization --batch-size 50
+          DATABASE_URL="${DIRECT_DATABASE_URL}" \
+            NODE_OPTIONS=--conditions=react-server \
+            pnpm --dir apps/web groups:backfill-materialization --apply --batch-size 50
+          DATABASE_URL="${DIRECT_DATABASE_URL}" \
+            NODE_OPTIONS=--conditions=react-server \
+            pnpm --dir apps/web groups:backfill-materialization --check

--- a/.github/workflows/hosted-web-contract-migrations.yml
+++ b/.github/workflows/hosted-web-contract-migrations.yml
@@ -224,6 +224,8 @@ jobs:
             exit 0
           fi
 
+          pnpm --dir apps/web prisma:generate
+
           current_sha="$(
             env \
               -u DIRECT_DATABASE_URL \

--- a/agent-docs/exec-plans/active/2026-08-25-organic-group-membership-backfill.md
+++ b/agent-docs/exec-plans/active/2026-08-25-organic-group-membership-backfill.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-08-25
-Updated: 2026-08-25
+Updated: 2026-08-26
 
 ## Goal
 
@@ -101,6 +101,16 @@ Updated: 2026-08-25
 5. Resolve accepted findings, merge and deploy, run dry-run/apply/check until
    production reports zero missing groups, then remove the temporary backfill
    command and its operator-only documentation in a cleanup PR.
+
+## Rollout note
+
+- PR #2303 merged and its replacement Web build passed the exact production
+  alias proof and prior-function drain.
+- The documented local Vercel operator path exposed protected production
+  database variable names with empty values, so it could not execute even the
+  dry-run. The repair now reuses the existing protected contract-migration
+  workflow and production environment for one bounded dispatch; that temporary
+  input is removed with the backfill command after convergence.
 
 ## Verification
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1516,21 +1516,17 @@ New routed Linq and Telegram groups materialize their ordinary unnamed hosted
 group and route-owner membership inside the canonical route transaction. For
 the one-time repair of routed containers created before that invariant, deploy
 the replacement Web build first, prove the production alias, wait the configured
-prior-function drain, and prove the alias again. Then run the aggregate-only
-dry run, bounded apply, and zero-pending readiness check:
+prior-function drain, and prove the alias again. Production database variables
+are write-only in Vercel's local CLI path, so run the temporary repair through
+the existing protected production workflow. It performs the aggregate-only dry
+run, one bounded apply batch, and the zero-pending readiness check:
 
 ```bash
-NODE_OPTIONS=--conditions=react-server \
-  vercel env run --environment=production -- \
-  pnpm --dir apps/web groups:backfill-materialization --batch-size 50
-
-NODE_OPTIONS=--conditions=react-server \
-  vercel env run --environment=production -- \
-  pnpm --dir apps/web groups:backfill-materialization --apply --batch-size 50
-
-NODE_OPTIONS=--conditions=react-server \
-  vercel env run --environment=production -- \
-  pnpm --dir apps/web groups:backfill-materialization --check
+gh workflow run hosted-web-contract-migrations.yml \
+  --ref main \
+  -f deployed_sha=<CURRENT_PRODUCTION_SHA> \
+  -f deployment_url=<CURRENT_PRODUCTION_DEPLOYMENT_URL> \
+  -f run_group_materialization_backfill=true
 ```
 
 Each candidate runs serially in its own short database-only transaction and
@@ -1542,9 +1538,9 @@ explicit join flows retain their sharing behavior. The ordinary owner
 membership also satisfies existing current-participant gates for group actions
 such as outbound calls and physical notes; those effects retain exact-message,
 activation, usage, explicit-request, and final pre-provider checks. Repeat bounded
-apply batches until `remainingRows` is zero, then require `--check` to pass. Do
-not install a recurring job; remove the temporary command after production
-convergence is verified.
+workflow runs if more than 50 rows remain, and require the final `--check` to
+pass. Do not install a recurring job; remove the temporary workflow input and
+command after production convergence is verified.
 
 The exact
 `20260727040000_relax_hosted_usage_credit_detached_direct_proof` migration is a

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -2118,6 +2118,7 @@ describe("hosted web production migration guard", () => {
       contractMigrationStep,
       /if \[ "\$\{RUN_GROUP_MATERIALIZATION_BACKFILL\}" != "true" \]; then/u,
     );
+    assert.match(contractMigrationStep, /pnpm --dir apps\/web prisma:generate/u);
     assert.match(
       contractMigrationStep,
       /groups:backfill-materialization --batch-size 50/u,
@@ -2176,6 +2177,9 @@ describe("hosted web production migration guard", () => {
     const backfillGateIndex = contractMigrationStep.indexOf(
       'if [ "${RUN_GROUP_MATERIALIZATION_BACKFILL}" != "true" ]; then',
     );
+    const prismaGenerateIndex = contractMigrationStep.indexOf(
+      "pnpm --dir apps/web prisma:generate",
+    );
     const backfillCurrentProofIndex = contractMigrationStep.indexOf(
       'current_sha="$(',
       contractMigrationIndex + 1,
@@ -2195,7 +2199,8 @@ describe("hosted web production migration guard", () => {
     );
     assert.ok(
       contractMigrationIndex < backfillGateIndex
-        && backfillGateIndex < backfillCurrentProofIndex
+        && backfillGateIndex < prismaGenerateIndex
+        && prismaGenerateIndex < backfillCurrentProofIndex
         && backfillCurrentProofIndex < backfillExactProofIndex
         && backfillExactProofIndex < backfillDryRunIndex
         && backfillDryRunIndex < backfillApplyIndex
@@ -2235,6 +2240,8 @@ elif [[ "$*" == *"exec tsx scripts/verify-vercel-production-deployment.ts"* ]]; 
   printf '%s\\n' "\${DEPLOYED_SHA}"
 elif [[ "$*" == *"release:production:contract-migrate"* ]]; then
   printf 'migrate\\n' >> "\${STUB_CALLS_FILE}"
+elif [[ "$*" == *"prisma:generate"* ]]; then
+  printf 'prisma-generate\\n' >> "\${STUB_CALLS_FILE}"
 elif [[ "$*" == *"groups:backfill-materialization"* ]]; then
   if [[ "\${DATABASE_URL:-}" != "\${DIRECT_DATABASE_URL:-}" ]]; then
     printf 'backfill did not receive the direct database URL\\n' >&2
@@ -2356,7 +2363,7 @@ fi
       assert.equal(backfillExactMatch.status, 0, backfillExactMatch.stderr);
       assert.equal(
         await readFile(callsFile, "utf8"),
-        "verify\nmigrate\nverify\nbackfill-dry\nbackfill-apply\nbackfill-check\n",
+        "verify\nmigrate\nprisma-generate\nverify\nbackfill-dry\nbackfill-apply\nbackfill-check\n",
       );
     } finally {
       await rm(shellFixture, { force: true, recursive: true });

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1989,6 +1989,11 @@ describe("hosted web production migration guard", () => {
     assert.match(workflow, /deployment_status/u);
     assert.match(workflow, /workflow_dispatch/u);
     assert.match(workflow, /deployed_sha/u);
+    assert.match(workflow, /run_group_materialization_backfill:/u);
+    assert.match(
+      workflow,
+      /RUN_GROUP_MATERIALIZATION_BACKFILL: \$\{\{ inputs\.run_group_materialization_backfill \|\| 'false' \}\}/u,
+    );
     assert.match(workflow, /deployment_url/u);
     assert.match(workflow, /github\.event_name == 'workflow_dispatch'/u);
     assert.match(workflow, /github\.event\.deployment_status\.state == 'success'/u);
@@ -2044,7 +2049,7 @@ describe("hosted web production migration guard", () => {
       workflow.match(
         /pnpm --dir apps\/web exec tsx scripts\/verify-vercel-production-deployment\.ts/gu,
       )?.length,
-      3,
+      4,
       "captured deployment proofs must bypass pnpm 10 lifecycle stdout",
     );
 
@@ -2109,6 +2114,19 @@ describe("hosted web production migration guard", () => {
       /MURPH_RUN_HOSTED_WEB_CONTRACT_MIGRATIONS: "1"/u,
     );
     assert.match(contractMigrationStep, /release:production:contract-migrate/u);
+    assert.match(
+      contractMigrationStep,
+      /if \[ "\$\{RUN_GROUP_MATERIALIZATION_BACKFILL\}" != "true" \]; then/u,
+    );
+    assert.match(
+      contractMigrationStep,
+      /groups:backfill-materialization --batch-size 50/u,
+    );
+    assert.match(
+      contractMigrationStep,
+      /groups:backfill-materialization --apply --batch-size 50/u,
+    );
+    assert.match(contractMigrationStep, /groups:backfill-materialization --check/u);
     const initialCurrentProof = productionProofStep.indexOf('current_sha="$(');
     const initialExactProof = productionProofStep.indexOf(
       "verify-vercel-production-deployment.ts",
@@ -2152,6 +2170,38 @@ describe("hosted web production migration guard", () => {
         < workflow.indexOf("release:production:contract-migrate"),
       "contract migrations must expose the database secret only after the alias proof output is set",
     );
+    const contractMigrationIndex = contractMigrationStep.indexOf(
+      "release:production:contract-migrate",
+    );
+    const backfillGateIndex = contractMigrationStep.indexOf(
+      'if [ "${RUN_GROUP_MATERIALIZATION_BACKFILL}" != "true" ]; then',
+    );
+    const backfillCurrentProofIndex = contractMigrationStep.indexOf(
+      'current_sha="$(',
+      contractMigrationIndex + 1,
+    );
+    const backfillExactProofIndex = contractMigrationStep.indexOf(
+      "verify-vercel-production-deployment.ts",
+      contractMigrationIndex + 1,
+    );
+    const backfillDryRunIndex = contractMigrationStep.indexOf(
+      "groups:backfill-materialization --batch-size 50",
+    );
+    const backfillApplyIndex = contractMigrationStep.indexOf(
+      "groups:backfill-materialization --apply --batch-size 50",
+    );
+    const backfillCheckIndex = contractMigrationStep.indexOf(
+      "groups:backfill-materialization --check",
+    );
+    assert.ok(
+      contractMigrationIndex < backfillGateIndex
+        && backfillGateIndex < backfillCurrentProofIndex
+        && backfillCurrentProofIndex < backfillExactProofIndex
+        && backfillExactProofIndex < backfillDryRunIndex
+        && backfillDryRunIndex < backfillApplyIndex
+        && backfillApplyIndex < backfillCheckIndex,
+      "the opt-in group backfill must re-prove production and run dry-run, apply, then check",
+    );
 
     const productionProofRun = extractWorkflowRunScript(productionProofStep);
     const contractMigrationRun = extractWorkflowRunScript(contractMigrationStep);
@@ -2185,6 +2235,25 @@ elif [[ "$*" == *"exec tsx scripts/verify-vercel-production-deployment.ts"* ]]; 
   printf '%s\\n' "\${DEPLOYED_SHA}"
 elif [[ "$*" == *"release:production:contract-migrate"* ]]; then
   printf 'migrate\\n' >> "\${STUB_CALLS_FILE}"
+elif [[ "$*" == *"groups:backfill-materialization"* ]]; then
+  if [[ "\${DATABASE_URL:-}" != "\${DIRECT_DATABASE_URL:-}" ]]; then
+    printf 'backfill did not receive the direct database URL\\n' >&2
+    exit 95
+  fi
+  if [[ "\${NODE_OPTIONS:-}" != "--conditions=react-server" ]]; then
+    printf 'backfill did not receive the react-server condition\\n' >&2
+    exit 94
+  fi
+  if [[ "$*" == *"--apply --batch-size 50"* ]]; then
+    printf 'backfill-apply\\n' >> "\${STUB_CALLS_FILE}"
+  elif [[ "$*" == *"--check"* ]]; then
+    printf 'backfill-check\\n' >> "\${STUB_CALLS_FILE}"
+  elif [[ "$*" == *"--batch-size 50"* ]]; then
+    printf 'backfill-dry\\n' >> "\${STUB_CALLS_FILE}"
+  else
+    printf 'unexpected backfill invocation: %s\\n' "$*" >&2
+    exit 93
+  fi
 else
   printf 'unexpected pnpm invocation: %s\\n' "$*" >&2
   exit 97
@@ -2237,6 +2306,7 @@ fi
       const runWorkflowBody = (options: {
         currentSha: string;
         requireCurrent: boolean;
+        runBackfill?: boolean;
       }) => spawnSync("bash", ["-c", contractMigrationRun], {
         encoding: "utf8",
         env: {
@@ -2246,6 +2316,7 @@ fi
           MURPH_REQUIRE_DIRECT_DATABASE_URL_FOR_MIGRATIONS: "1",
           MURPH_RUN_HOSTED_WEB_CONTRACT_MIGRATIONS: "1",
           PATH: `${shellFixture}:${process.env.PATH ?? ""}`,
+          RUN_GROUP_MATERIALIZATION_BACKFILL: options.runBackfill ? "true" : "false",
           SHOULD_REQUIRE_CURRENT: options.requireCurrent ? "true" : "false",
           STUB_CALLS_FILE: callsFile,
           STUB_CURRENT_SHA: options.currentSha,
@@ -2275,6 +2346,18 @@ fi
       });
       assert.equal(exactMatch.status, 0, exactMatch.stderr);
       assert.equal(await readFile(callsFile, "utf8"), "verify\nmigrate\n");
+      await rm(callsFile, { force: true });
+
+      const backfillExactMatch = runWorkflowBody({
+        currentSha: deployedSha,
+        requireCurrent: true,
+        runBackfill: true,
+      });
+      assert.equal(backfillExactMatch.status, 0, backfillExactMatch.stderr);
+      assert.equal(
+        await readFile(callsFile, "utf8"),
+        "verify\nmigrate\nverify\nbackfill-dry\nbackfill-apply\nbackfill-check\n",
+      );
     } finally {
       await rm(shellFixture, { force: true, recursive: true });
     }


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive — changes a protected production workflow and database mutation entrypoint.

ReviewGPT first-reviewed head: a4b4a32bca2e65f9c8f308019ccdd81b36519aa4

## Outcome

Adds one temporary opt-in dispatch input to the existing hosted Web contract-migration workflow so the already-reviewed routed-group repair can use the existing protected production database secret. Normal deployment-triggered runs remain unchanged.

## Product UX result

No user-facing copy or interaction changes. This only unblocks repair of historical organic groups after the future-write fix is already live.

## Direct evidence

- actionlint passed for the changed workflow.
- Existing production migration guard passed all 66 tests after composing default-off and opt-in workflow behavior.
- The existing Prisma generation owner succeeds before the opt-in backfill path.
- Agent docs drift passed.
- Docs gardening passed with zero issues.
- git diff --check passed.
- The failed local dry-run was proven to receive empty protected database values and made no writes.
- Preliminary ReviewGPT found one stale workflow fixture; its accepted coverage-only patch is applied and focused proof is green.

## Architecture and reuse

- Existing systems reused: the production GitHub Environment, exact Vercel alias verifier, prior-function drain, contract-migration job, Prisma generation owner, and bounded aggregate-only backfill command.
- New logic: one temporary opt-in boolean runs Prisma generation, dry-run, one at-most-50-row apply batch, and the zero-pending check after a fresh deployment proof.
- New abstractions: none are needed because the existing production workflow owns protected execution and the existing bounded command owns the repair.
- Complexity intentionally avoided: no new workflow, secret, endpoint, queue, scheduler, schema, state owner, or recurring repair job; the temporary input and command are deleted after convergence.

## Non-obvious affected surfaces

The optional run performs Prisma generation, dry-run, one serial batch of at most 50 rows, and the zero-pending check. It re-verifies the exact production deployment immediately before database work. A remaining set above 50 fails the check and requires another explicit dispatch.

## Hot reply path impact

None. GitHub operator workflow only.

## Provider-input impact

None.

## Deployment concerns

- Deployment: applicable
- Supported skew: The new input defaults false, so ordinary deployment-triggered runs remain unchanged before and after this bridge lands.
- Safe order: Merge the bridge, wait for exact production deployment and alias/drain proof, manually dispatch one bounded batch, verify convergence, then remove the temporary path.
- Rollback floor: Keep the durable routed-group materialization fix deployed until the historical repair reaches zero pending rows.
- Expected exposure: One explicit operator run performs at most 50 serial database-only repairs with no user-facing interruption.
- Reversibility: The workflow input and repair command are temporary and removable; created canonical group and owner rows are intentional durable product state.
- Convergence proof: The protected command must report zero pending repairs, followed by a read-only aggregate showing zero missing groups and owner memberships.
- Post-deploy checks: Confirm the exact deployment verifier and drain gate, workflow dry-run/apply/check success, and final aggregate-only production state.

## Changelog

- Changelog: not applicable
- Reason: This temporary operator-only rollout path changes no member-visible behavior.

## Change shape

- Source: +0 / -0
- Tests and fixtures: +91 / -1
- Docs: +47 / -17
- Config and tooling: +46 / -0
- Generated and other: +0 / -0