### PR TITLE
Ratchet hosted runner bundle budget for device sync

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-cli.ts
@@ -159,7 +159,13 @@ const VAULT_CLI_IMPORT_SURFACE_HOOK_SOURCE = [
 // CLI graph. Entry and static-startup limits remain unchanged.
 // Scheduled-log recovery adds 14,891 B to that same lazy CLI graph. Compose the
 // measured deltas; no change alters entry or static-startup topology.
-const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_534_346;
+// Pass-local device-sync event-index reuse and phase telemetry extend the
+// existing lazy Core, Importers, Device Sync, and Assistant Runtime graph
+// without adding a package or changing entry/static-startup topology. The
+// production Linux assembly measured 9,539,530 B on 2026-08-26; ratchet from
+// that exact baseline while retaining the 32 KiB graph allowance and 8 KiB
+// production-overlay reserve.
+const VAULT_CLI_BUNDLE_TOTAL_BYTES_BUDGET = 9_580_490;
 const VAULT_CLI_BUNDLE_ENTRY_BYTES_BUDGET = 20_000;
 const VAULT_CLI_BUNDLE_STATIC_CLOSURE_BYTES_BUDGET = 33_200;
 

--- a/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-cli-bundle.test.ts
@@ -487,15 +487,15 @@ describe("runner bundle vault-cli esbuild step", () => {
     });
 
     expect(
-      assertVaultCliBundleWithinBudgets(createMetafile(9_524_346)),
+      assertVaultCliBundleWithinBudgets(createMetafile(9_570_490)),
     ).toEqual({
       entryBytes: 10_000,
       staticClosureBytes: 10_000,
-      totalBytes: 9_534_346,
+      totalBytes: 9_580_490,
     });
     expect(() =>
-      assertVaultCliBundleWithinBudgets(createMetafile(9_524_347)),
-    ).toThrow(/total output 9534347B exceeds budget 9534346B/u);
+      assertVaultCliBundleWithinBudgets(createMetafile(9_570_491)),
+    ).toThrow(/total output 9580491B exceeds budget 9580490B/u);
   });
 
   it("rejects dynamic-to-static graph drift without relying on total size growth", () => {


### PR DESCRIPTION
## Why and outcome

The production Cloudflare deploy gate correctly stopped because the intended device-sync cache and phase telemetry increased the lazy vault-cli graph by 46,144 bytes over its prior composed baseline. No new package or startup import entered the graph.

This change ratchets the measured total-only baseline and preserves the existing 32 KiB graph allowance plus 8 KiB production-overlay reserve. Entry and static-startup budgets remain unchanged.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected person: a connected-health member waiting for a stalled device-sync backlog to catch up.
- Existing journey: scheduled device sync and later use of fresh health context.
- Exclusions: no UI, copy, permission, reply, provider, or stored-health behavior changes.
- Recovery: the unchanged predeploy gate still blocks any unexpected package or startup-graph growth.

## Evidence

- Production deploy measurement: 9,539,530 B total versus the former 9,534,346 B cap; entry and static-startup budgets did not fail.
- Canonical local assembly: 9,532,641 B total, 805 B entry, and 25,155 B static startup; full parity probes passed.
- Exact boundary test: 14 tests passed.
- Cloudflare package typecheck passed.
- git diff --check and privacy scan passed.

## Non-obvious affected surfaces

- Hosted runner packaging guard only. The ratchet is required for the already-reviewed device-sync runtime patch to pass the protected production deployment workflow.

## Architecture and reuse

- Existing systems reused: the existing byte-budget and parity gates.
- New logic: one measured total-byte baseline and its exact boundary fixture.
- New abstractions: none; the existing constant and assertion remain the single build-time owner for this limit.
- Complexity intentionally avoided: no dependency, package, import edge, state owner, queue, schema, or runtime behavior.

## Hot reply path impact

- Not applicable; this changes only a build-time budget constant and its unit test.

## Murph initial provider input impact

- Murph runtime: Not applicable.
- Codex runtime: Not applicable.

## Design proof

- Not applicable; no user-facing UI changed.

## Change-shape breakdown

- Source/config: 7 added, 1 deleted.
- Tests: 4 added, 4 deleted.
- Total: 11 added, 5 deleted.

## Risks

- An overly loose budget could hide future graph creep. The cap is derived from the exact production measurement and retains the repository's existing fixed 32 KiB allowance plus 8 KiB overlay reserve; entry and startup caps are unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: production Web already accepts both old and expanded timing summaries while the old Cloudflare runtime remains live.
- Safe order: merge this guard correction, then rerun the already-authorized protected Cloudflare production workflow.
- Rollback floor: roll back the Cloudflare worker and runner before reverting the forward-compatible Web parser or this guard ratchet.
- Expected exposure: no runtime change until the protected workflow deploys; afterward only the already-reviewed device-sync optimization and bounded telemetry change.
- Reversibility: revert the ratchet if the device-sync feature is rolled back.
- Convergence proof: require runner bundle assembly, exact deployed fingerprint smoke, live model smoke, new timing fields, and backlog advancement.
- Post-deploy checks: verify cache miss/hit timing, nonnegative unattributed time, pass outcomes, queue depth, and stalled-work aggregates.

## Changelog

- Changelog: not applicable
- Reason: build-time deployment guard correction only; the connected-health improvement already has a changelog item.

ReviewGPT context sensitivity: routine — this is a two-file build-budget ratchet with no production behavior change.




