### PR TITLE
Fix physical-note recovery lookup

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-26-physical-note-recovery-resolution.md
+++ b/agent-docs/exec-plans/active/2026-08-26-physical-note-recovery-resolution.md
@@ -1,0 +1,54 @@
+# Physical-Note Recovery Resolution
+
+## Goal
+
+Restore the existing physical-note recovery promise so an explicit recovery
+request can reconcile an aged unresolved send through Lob instead of remaining
+permanently pending because the provider lookup request is malformed.
+
+## Evidence
+
+- Production control data shows one aged unresolved legacy note, later requests
+  blocked behind it, and repeated explicit recovery results that stayed pending
+  without a retry time.
+- The Web recovery service is already designed to clear an aged proven absence
+  atomically with its blockers and stored recovery result.
+- Murph hand-builds a bracket-style metadata query in Axios request options,
+  while the pinned Lob SDK exposes metadata as the list operation's typed
+  metadata argument and serializes that object for the documented `metadata`
+  query parameter. Provider failures are deliberately mapped to indeterminate,
+  so the malformed request becomes an endless safe-pending result.
+
+## Constraints
+
+- Recovery must never create or recall a provider effect.
+- Recent or genuinely indeterminate evidence remains pending; only accepted or
+  aged proven-absence evidence may terminalize the guard.
+- Keep the Web-owned member lock, atomic note/blocker/recovery settlement, and
+  accepted-message authority unchanged.
+- Keep private member, feedback, provider, and row identifiers out of repository
+  artifacts and review evidence.
+
+## Product UX
+
+- Effort: Patch.
+- Outcome: A member asking to resolve an older uncertain physical note receives
+  an accepted or clear outcome when Lob has conclusive evidence, instead of a
+  permanent pending loop caused by Murph's request shape.
+- Reaches: Existing private-direct and authenticated-group recovery journeys
+  with an aged unresolved note and a later blocked send.
+- Proof: A provider-faithful request-shape regression plus the existing aged-
+  absence service and PostgreSQL atomicity scenarios.
+
+## Plan
+
+1. Route Lob metadata lookup through the pinned SDK's typed metadata argument.
+2. Update the provider request-shape regression to the SDK/API-owned encoding.
+3. Run the focused Lob runtime, physical-note service, and applicable
+   PostgreSQL/typecheck proof.
+4. Replay the affected Product UX journeys, complete required review gates,
+   and ship the scoped PR candidate.
+
+## Verification
+
+- Pending implementation.

--- a/agent-docs/exec-plans/active/2026-08-26-physical-note-recovery-resolution.md
+++ b/agent-docs/exec-plans/active/2026-08-26-physical-note-recovery-resolution.md
@@ -51,4 +51,8 @@ permanently pending because the provider lookup request is malformed.
 
 ## Verification
 
-- Pending implementation.
+- Lob runtime and physical-note service: 109 focused tests pass.
+- PostgreSQL recovery atomicity: the focused aged-absence scenario passes.
+- Web typecheck passes.
+- Changelog generation and the 9-test archive rendering suite pass.
+- ReviewGPT specialist/final gates and exact-head CI remain pending.

--- a/agent-docs/exec-plans/completed/2026-08-26-physical-note-recovery-resolution.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-physical-note-recovery-resolution.md
@@ -55,4 +55,13 @@ permanently pending because the provider lookup request is malformed.
 - PostgreSQL recovery atomicity: the focused aged-absence scenario passes.
 - Web typecheck passes.
 - Changelog generation and the 9-test archive rendering suite pass.
-- ReviewGPT specialist/final gates and exact-head CI remain pending.
+- ReviewGPT Product UX/coverage specialists pass with no findings and no patch
+  artifact; the Product UX verdict is Ready.
+- ReviewGPT final round 1 passes with no findings.
+- Candidate CI reached 17 passing checks. One unchanged Cloudflare timeout test
+  failed only under full-suite load and passed three consecutive focused local
+  reproductions; its narrow rerun was requested. Final exact-head CI follows
+  the documentation-only plan-closure commit.
+Status: completed
+Updated: 2026-08-26
+Completed: 2026-08-26

--- a/apps/web/changelog/entries/2026-08-26/physical-note-recovery-unblocks.json
+++ b/apps/web/changelog/entries/2026-08-26/physical-note-recovery-unblocks.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "physical-note-recovery-unblocks",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Physical-note recovery can finish",
+    "summary": "When an older physical-note attempt never reached the printer, Murph can now confirm that and clear the old submission so a separate future note request is no longer blocked.",
+    "details": "Recovery still never sends or retries a note. Accepted notes stay protected, and uncertain printer outcomes remain pending until Murph has conclusive evidence.",
+    "relevanceTags": ["assistant", "physical-notes", "reliability"],
+    "sourcePullRequests": [2327]
+  }
+}

--- a/apps/web/src/lib/physical-notes/lob-runtime.ts
+++ b/apps/web/src/lib/physical-notes/lob-runtime.ts
@@ -134,10 +134,9 @@ export function createLobPhysicalNoteRuntime(input: {
         fetchImpl,
         signal,
       });
-      const query: Record<string, string> = {};
-      query[`metadata[${PHYSICAL_NOTE_METADATA_KEY}]`] = request.noteId;
-      const requestOptions: LobSdkRequestOptions = {};
-      requestOptions.params = query;
+      const metadata = {
+        [PHYSICAL_NOTE_METADATA_KEY]: request.noteId,
+      };
 
       try {
         const response = await letters.list(
@@ -146,13 +145,12 @@ export function createLobPhysicalNoteRuntime(input: {
           undefined,
           undefined,
           undefined,
+          metadata,
           undefined,
           undefined,
           undefined,
           undefined,
           undefined,
-          undefined,
-          requestOptions,
         );
         return readLobLetterLookup(response) ?? { kind: "indeterminate" };
       } catch {

--- a/apps/web/test/physical-notes-lob-runtime.test.ts
+++ b/apps/web/test/physical-notes-lob-runtime.test.ts
@@ -363,7 +363,7 @@ describe("Lob physical-note runtime", () => {
     const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const request = new Request(input, init);
       expect(request.url).toBe(
-        "https://api.lob.com/v1/letters?limit=2&metadata%5Bmurph_physical_note_id%5D=hpn_lookup",
+        "https://api.lob.com/v1/letters?limit=2&metadata=%7B%22murph_physical_note_id%22%3A%22hpn_lookup%22%7D",
       );
       expect(request.method).toBe("GET");
       expect(request.headers.get("authorization")).toMatch(/^Basic /u);


### PR DESCRIPTION
## Why and outcome

An explicit physical-note recovery could remain permanently pending even after the unresolved submission aged past the safety window. Murph sent Lob a hand-built metadata query shape that bypassed the pinned SDK contract, so a conclusive lookup could not reach the existing atomic recovery path.

This routes the lookup through the SDK metadata argument. Accepted notes remain protected, recent or indeterminate results remain pending, and an aged proven absence can clear the old guard and its later blocker without creating or retrying mail.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Replayed the private-direct and authenticated-group recovery journeys for an aged unresolved note plus a later blocked request. Both regain the existing accepted-or-clear resolution; recent and genuinely indeterminate evidence remain deliberately excluded from clearing. No difference from the approved patch plan.

## Evidence

- Direct: Production-safe control-data inspection established an aged unresolved note, later blockers, and repeated pending recovery results. The provider-shaped regression now proves the Lob SDK emits the documented JSON metadata query, and the PostgreSQL scenario proves aged absence, blocker cleanup, and replay settlement commit atomically.
- Coverage: 109 focused Lob runtime and physical-note service tests pass; the focused PostgreSQL atomicity scenario passes; the 9-test changelog archive suite passes; Web typecheck passes.

## Non-obvious affected surfaces

- Lob Letters list lookup: request serialization changes from a custom Axios query override to the SDK-owned typed metadata parameter. The provider-request regression proves the exact emitted URL.
- Stored recovery settlement is intentionally unchanged. Its focused service and PostgreSQL scenarios prove accepted, pending, and aged-absence outcomes retain their existing safety boundaries.

## Architecture and reuse

- Existing systems reused: The pinned Lob SDK list contract, the Web-owned recovery service, the member advisory lock, and the existing atomic note/blocker/recovery settlement.
- New logic: None; this corrects the provider request shape so existing recovery logic can receive conclusive evidence.
- New abstractions: None; the SDK metadata argument is the sufficient owner boundary.
- Complexity intentionally avoided: No retry queue, state manager, provider wrapper, schema change, compatibility layer, or additional effect path.

## Hot reply path impact

- Path status: Touched only when an explicit physical-note recovery tool runs inside a reply turn; no operation is added or reordered.
- Database calls: None added or moved.
- Network/provider calls: The existing single serial Lob lookup remains one call with the existing five-second timeout and fail-closed indeterminate fallback; only its query serialization changes.
- Other awaited latency: None added or moved.
- Before/after proof: The focused runtime regression changes the observed request from the rejected custom bracket encoding to the SDK-owned JSON metadata encoding; service and PostgreSQL proofs preserve call count and settlement semantics.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no prompt, message builder, history, or instruction source changed.
- Tool/schema/generated guidance: Unchanged; no tool definition, schema, or generated guidance changed.
- Other provider-visible input: Unchanged; the patch is confined to server-side Lob request serialization and its regression proof.
- Measurement method: Not run because no provider-input surface changed.

## Design proof

- Design page: [Changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Direct copy review plus the focused server-rendered changelog archive test. A new screenshot adds no proof because this PR changes authored content, not the production renderer, layout, or interaction.
- Coverage: The production archive component renders the new item, details, tags, permalink, and existing try-it affordance; presentation behavior and responsive states are unchanged.

## Risks

- The provider lookup is an external egress surface and intentionally fails closed to pending on timeout, transport failure, malformed response, or ambiguous multiplicity.

ReviewGPT context sensitivity: sensitive
Classification reason: The patch changes a third-party provider lookup used to reconcile an uncertain physical-mail effect.
ReviewGPT first-reviewed head: 611802d345f968148930c1ebedd725b4d74d9597

## Deployment concerns

- Deployment: applicable
- Supported skew: Cloudflare and hosted-runner versions are unaffected; either can coexist with the changed Web lookup.
- Safe order: Deploy Web only; no tandem deployment is required.
- Rollback floor: The prior Web version remains schema- and protocol-compatible but restores the broken pending behavior.
- Expected exposure: Only explicit recovery requests for unresolved physical notes use the changed lookup.
- Reversibility: A Web rollback restores the previous request shape without data migration.
- Convergence proof: Focused SDK-shaped lookup, service, and PostgreSQL settlement tests pass.
- Post-deploy checks: Submit a fresh explicit recovery request for a synthetic aged provider-absent note and confirm it clears without sending mail; confirm an indeterminate lookup remains pending.

## Change-shape breakdown

Classification rule: Authored runtime code is source, Vitest code is tests/fixtures, and the execution plan plus authored changelog fragment are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 6 |
| Tests / fixtures | 1 | 1 |
| Docs | 81 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **86** | **7** |

## Changelog

- Changelog: updated
- Items: 2026-08-26 · physical-note-recovery-unblocks
