### PR TITLE
fix(assistant): classify runtime command failures

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-26-command-family-runtime-issues.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-command-family-runtime-issues.md
@@ -1,0 +1,68 @@
+# Classify command failures in runtime issues
+
+Status: completed
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Make failed Codex command issues attributable to the same finite, privacy-safe
+  command families already used by hosted turn profiles, without persisting
+  command text, arguments, paths, or output.
+
+## Success criteria
+
+- Failed direct Vault CLI commands retain their bounded command family in the
+  runtime issue detail.
+- Search recovery behavior remains unchanged.
+- Ambiguous or executable shell shapes still fail closed to the generic
+  `command` family.
+- Focused tests, package typecheck, diff checks, exact-head CI, and required
+  review gates pass.
+
+## Scope
+
+- In scope: reuse the existing command-family classifier in the runtime issue
+  tracker and update focused regression coverage.
+- Out of scope: raw command capture, argv or output persistence, new database
+  fields, new telemetry services, and Vault CLI behavior changes.
+
+## Constraints
+
+- Technical constraints: one finite classifier remains the source of truth;
+  search-specific recovery metadata must stay search-only.
+- Product/process constraints: production evidence stays summarized and no
+  private row, identifier, command, path, or output enters repository artifacts.
+
+## Risks and mitigations
+
+1. Risk: broader classification could accidentally retain command content.
+   Mitigation: store only the existing closed union returned by
+   `resolveCodexCommandFamily` and assert shell-control inputs remain generic.
+2. Risk: changing the diagnostic family could alter tolerated search failures.
+   Mitigation: keep the recovery branch explicitly keyed to `search` and retain
+   its focused tests.
+
+## Tasks
+
+1. [x] Replace the local `search | unknown` classifier with the existing finite
+   command-family type and resolver.
+2. [x] Add focused command-failure and fail-closed tests.
+3. [x] Run scoped local verification and package the exact candidate for its
+   draft PR and review gates.
+
+## Decisions
+
+- Reuse the existing transient classifier; do not add schema or storage.
+
+## Verification
+
+- Commands to run: focused assistant-engine Vitest slices, assistant-engine
+  typecheck, `git diff --check`, and the routed PR checks/reviews.
+- Expected outcomes: Vault families are visible as bounded labels, unsafe
+  display commands remain `command`, search recovery behavior is unchanged,
+  and all checks pass.
+- Result: assistant runtime-turn slice passed 44/44; assistant-engine typecheck
+  and `git diff --check` passed. Exact-head CI and managed review remain PR
+  gates.
+Completed: 2026-08-26

--- a/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
+++ b/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
@@ -610,10 +610,22 @@ function resolveDiagnosticCommandFamily(
     return 'command'
   }
 
-  return resolveCodexCommandFamily({
+  const directFamily = resolveCodexCommandFamily({
     commandLabel: normalizedEvent.commandLabel,
     source: 'display',
   })
+  if (directFamily !== 'command') {
+    return directFamily
+  }
+
+  const wrappedFamily = resolveCodexCommandFamily({
+    allowKnownShellWrapper: true,
+    commandLabel: normalizedEvent.commandLabel,
+    source: 'display',
+  })
+  // Only a bare direct search owns no-match suppression and recovery. The
+  // bounded wrapper pass exists to attribute non-search command failures.
+  return wrappedFamily === 'search' ? 'command' : wrappedFamily
 }
 
 function readCommandExitCode(input: {

--- a/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
+++ b/packages/assistant-engine/src/assistant-codex/action-diagnostics.ts
@@ -4,6 +4,9 @@ import type { CodexNormalizedEvent } from '../assistant-codex-events.js'
 import type {
   AssistantRuntimeIssueInput,
 } from '../assistant/issue-reporting.js'
+import type {
+  CodexCommandFamily,
+} from './command-family.js'
 import {
   resolveCodexCommandFamily,
 } from './command-family.js'
@@ -50,11 +53,9 @@ type BytesBucket =
   | '10_100kb'
   | 'gt_100kb'
 
-type CommandDiagnosticFamily = 'search' | 'unknown'
-
 type TrackedCommandDiagnostic = {
   commandOrdinal: number
-  commandFamily: CommandDiagnosticFamily
+  commandFamily: CodexCommandFamily
 }
 
 type TokenUsageSample = {
@@ -138,7 +139,7 @@ export function createCodexActionRuntimeIssueTracker(): CodexActionRuntimeIssueT
     normalizedEvent: CodexNormalizedEvent,
   ): TrackedCommandDiagnostic => ({
     commandOrdinal: nextCommandOrdinal(),
-    commandFamily: resolveDirectSearchCommandFamily(normalizedEvent),
+    commandFamily: resolveDiagnosticCommandFamily(normalizedEvent),
   })
 
   return {
@@ -195,7 +196,7 @@ export function createCodexActionRuntimeIssueTracker(): CodexActionRuntimeIssueT
         ? {
             commandOrdinal:
               startedDiagnostic?.commandOrdinal ?? nextCommandOrdinal(),
-            commandFamily: resolveDirectSearchCommandFamily(
+            commandFamily: resolveDiagnosticCommandFamily(
               input.normalizedEvent,
             ),
           }
@@ -599,23 +600,20 @@ function buildRuntimeIssueInputForFailedCodexAction(input: {
   }
 }
 
-function resolveDirectSearchCommandFamily(
+function resolveDiagnosticCommandFamily(
   normalizedEvent: CodexNormalizedEvent,
-): CommandDiagnosticFamily {
+): CodexCommandFamily {
   if (
     normalizedEvent.kind !== 'status_item'
     || normalizedEvent.commandLabel === null
   ) {
-    return 'unknown'
+    return 'command'
   }
 
-  const command = normalizedEvent.commandLabel.trim()
   return resolveCodexCommandFamily({
-    commandLabel: command,
+    commandLabel: normalizedEvent.commandLabel,
     source: 'display',
-  }) === 'search'
-    ? 'search'
-    : 'unknown'
+  })
 }
 
 function readCommandExitCode(input: {

--- a/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
@@ -2755,7 +2755,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
       summary: 'Codex command execution failed during provider turn.',
       details: {
         actionKind: 'command.execution',
-        commandFamily: 'unknown',
+        commandFamily: 'cat',
         commandOrdinal: 1,
         durationMsBucket: '5_30s',
         exitCode: 2,
@@ -2965,22 +2965,32 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
       {
         command: 'cat /tmp/private-record',
         exitCode: 126,
+        expectedFamily: 'cat',
       },
       {
         command: 'cat /tmp/private-record',
         exitCode: 127,
+        expectedFamily: 'cat',
       },
       {
         command: 'cat /tmp/private-record',
         exitCode: 124,
+        expectedFamily: 'cat',
       },
       {
         command: 'bash -lc "rg private-query /tmp/private-record"',
         exitCode: 1,
+        expectedFamily: 'command',
       },
       {
         command: 'rg private-query /tmp/private-record | head',
         exitCode: 1,
+        expectedFamily: 'command',
+      },
+      {
+        command: 'vault-cli knowledge show page_test --format json',
+        exitCode: 2,
+        expectedFamily: 'vault-cli knowledge',
       },
     ] as const
     const operationalIssues: AssistantRuntimeIssueInput[] = []
@@ -2996,7 +3006,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
       const issue = record(event)
       expect(issue).toMatchObject({
         details: {
-          commandFamily: 'unknown',
+          commandFamily: example.expectedFamily,
           commandOrdinal: index + 5,
           exitCode: example.exitCode,
         },
@@ -3114,7 +3124,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
         const issue = recordCommand({ command, exitCode: 1 })
         expect(issue).toMatchObject({
           details: {
-            commandFamily: 'unknown',
+            commandFamily: 'command',
             commandOrdinal: index + 7,
             exitCode: 1,
           },
@@ -3180,7 +3190,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
     })
     expect(boundaryIssue).toMatchObject({
       details: {
-        commandFamily: 'unknown',
+        commandFamily: 'cat',
         commandOrdinal: 10_000,
         exitCode: 127,
       },

--- a/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
@@ -3105,7 +3105,22 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
       },
     })
 
+    const wrappedVaultIssue = recordCommand({
+      command:
+        'bash -lc "vault-cli knowledge show private-page --format json"',
+      exitCode: 2,
+      output: 'private vault output',
+    })
+    expect(wrappedVaultIssue).toMatchObject({
+      details: {
+        commandFamily: 'vault-cli knowledge',
+        commandOrdinal: 7,
+        exitCode: 2,
+      },
+    })
+
     const commandsWithExecutableShellSyntax = [
+      'bash -lc "rg private-query /tmp/private-record"',
       'rg private-query /tmp/private-record | head',
       'rg private-query /tmp/private-record; head /tmp/private-record',
       'rg private-query /tmp/private-record && head /tmp/private-record',
@@ -3125,7 +3140,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
         expect(issue).toMatchObject({
           details: {
             commandFamily: 'command',
-            commandOrdinal: index + 7,
+            commandOrdinal: index + 8,
             exitCode: 1,
           },
         })
@@ -3135,6 +3150,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
 
     const encodedIssues = JSON.stringify([
       searchIssue,
+      wrappedVaultIssue,
       ...executableShellIssues,
     ])
     expect(encodedIssues).not.toContain('private(foo|bar)')
@@ -3143,6 +3159,8 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
     expect(encodedIssues).not.toContain('/tmp/private-record')
     expect(encodedIssues).not.toContain('private search output')
     expect(encodedIssues).not.toContain('private regex error')
+    expect(encodedIssues).not.toContain('private vault output')
+    expect(encodedIssues).not.toContain('private-page')
     expect(encodedIssues).not.toContain('item-sensitive')
     expect(encodedIssues).not.toContain('turn-current')
   })


### PR DESCRIPTION
## Outcome

Failed Codex commands now reuse the existing finite command-family classifier in assistant runtime issues. Vault CLI failures become attributable by bounded family while command text, arguments, paths, and output remain excluded.

## Product UX

- Not applicable: this is internal operational telemetry and does not change member-visible behavior.

## Direct evidence

- Assistant runtime-turn and command-family tests: 98/98 passed.
- Assistant-engine typecheck passed.
- `git diff --check` passed.
- Privacy assertions and a patch scan found no command arguments, output, local identifiers, or paths in persisted diagnostics or the patch.

## Non-obvious affected surfaces

- Search exit code 1 remains the existing tolerated no-match path; focused runtime coverage exercises it.
- Search recovery metadata remains limited to bare direct search commands; wrapped search remains generic.
- Provider-shaped known shell wrappers can expose a finite non-search family without retaining the wrapped command.
- Ambiguous commands and executable shell-control shapes fail closed to `command`; focused cases cover both.

## Architecture and reuse

- Existing systems reused: `resolveCodexCommandFamily`, its closed hosted-usage union, and the existing runtime issue tracker.
- New logic: Failed command issues retain the finite classifier result instead of collapsing every non-search command to `unknown`; a bounded wrapper pass handles provider-shaped commands while preserving search semantics.
- New abstractions: None; the existing classifier and issue detail object are sufficient.
- Complexity intentionally avoided: No raw argv or output capture, database field, service, queue, compatibility layer, or parallel taxonomy was added.

## Hot reply path impact

- Not applicable: this replaces an existing synchronous diagnostic classification after Codex action events. It adds zero database calls, zero network calls, and zero awaited operations.

## Murph initial provider input impact

| Runtime | Base | Head | Reason |
| --- | --- | --- | --- |
| Individual Murph | Not applicable | Not applicable | Prompts, tools, schemas, generated guidance, and context assembly are unchanged. |
| Group Murph | Not applicable | Not applicable | Prompts, tools, schemas, generated guidance, and context assembly are unchanged. |

- Measurement method: not run because no provider-visible input surface changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old runners emit `unknown`; new runners emit the existing finite family union. The schemaless bounded detail object accepts both during rollout.
- Safe order: Deploy through the normal packaged-runner workflow; no Web or database coordination is required.
- Rollback floor: The runner can roll back at any point because no persisted contract or reader requirement changed.
- Expected exposure: One runner rollout window may contain both coarse and specific family values in aggregate diagnostics.
- Reversibility: Roll back the packaged runner; no data rollback or cleanup is required.
- Convergence proof: Confirm active runner release convergence and observe bounded command-family aggregates without raw values.
- Post-deploy checks: Compare failed-command counts by finite family and exit code, and confirm search no-match suppression remains stable.

## ReviewGPT

- Preliminary coverage lens: completed against candidate `7983cfb120ad4d5e12e084194fe4b4199c329e79` with one medium finding: provider-shaped known shell wrappers remained generic.
- Disposition: accepted and fixed in current head `81783583837a0f1c291815d18a9baa82d20b2f6c`; wrapped Vault commands now retain a finite family, wrapped search stays generic, and the 98-test focused slice passes.
- Prompt, Product UX, and frontend lenses: not applicable.
- Final cross-cutting gate: not applicable; this is a narrow single-owner telemetry reuse with focused deterministic proof.

## Changelog

- Changelog: not applicable
- Reason: Internal telemetry classification only; no member-visible behavior changed.

## Change-shape breakdown

Classification: runtime `.ts` is source, focused `.test.ts` is tests, and the execution plan is docs. No binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 24 | 14 |
| Tests/fixtures | 33 | 5 |
| Docs | 68 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **125** | **19** |
