### PR TITLE
Complete Environment voice report coverage

### DIFF
--- a/.agents/friction-log/20260826131502-graft-rebuilds-a/friction.md
+++ b/.agents/friction-log/20260826131502-graft-rebuilds-a/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Graft rebuilds a large untracked index in fresh task worktrees'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A Graft query should use the repository index without adding task files or hundreds of megabytes to the worktree.
+
+## Current Behavior
+
+The first Graft query in a fresh sanctioned worktree refreshed the graph and created an untracked graft directory of about 656 MB. This blocks a clean scoped task handoff until the generated directory is removed.
+
+## Possible Solution
+
+Use a shared cache outside the worktree, or ensure generated graph state is ignored and cleaned automatically.
+
+## Minimal Reproducible Example
+
+1. Create a sanctioned task worktree.
+2. Run `graft grep "a known UI string"`.
+3. Run `git status --short` and `du -sh graft`.
+
+## Context
+
+This happened during a small Environment UI and coverage fix. The generated index was much larger than the product diff and required cleanup before commit.

--- a/agent-docs/exec-plans/active/2026-08-26-environment-report-coverage.md
+++ b/agent-docs/exec-plans/active/2026-08-26-environment-report-coverage.md
@@ -1,0 +1,82 @@
+# Complete Environment report coverage and clarify first-run copy
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Make the main Environment voice interview cover every condition counted by
+  the report, so complete answers can reach 100% coverage.
+- Make the first-run page state plainly explain what the member fills in and
+  what useful report they receive.
+
+## Success criteria
+
+- Missing gradeable low-priority conditions appear in the main voice script.
+- A complete main voice interview and report coverage use the same gradeable
+  condition set.
+- The first-run page removes the Habitat eyebrow, repeated page description,
+  and redundant privacy label.
+- The first-run headline, body, and CTA clearly promise an Environment report
+  about sleep, air quality, and focus.
+- Focused tests, TypeScript checks, desktop and phone browser proof, required
+  specialist review, and exact-head CI pass.
+
+## Scope
+
+- In scope: Environment voice-script selection, regression tests, first-run
+  Environment page copy and hierarchy, existing design representation.
+- Out of scope: report scoring changes, catalog priority changes, new fields,
+  assistant persistence changes, and visual redesign outside this first-run
+  state.
+
+## Constraints
+
+- Technical constraints: reuse the catalog and existing interview field list;
+  do not add another coverage owner or dependency.
+- Product/process constraints: Product UX Patch. Preserve decline behavior,
+  category-specific capture, accessibility, responsive layout, and existing
+  report behavior for members with data.
+
+## Risks and mitigations
+
+1. Risk: The main interview starts asking optional or informational questions
+   that do not affect the promised report coverage.
+   Mitigation: include every gradeable condition regardless of priority, while
+   keeping informational low-priority fields optional and outside the main
+   completion set.
+2. Risk: Copy promises more insight than the report provides.
+   Mitigation: name only the existing grade, report, and practical checks.
+
+## Tasks
+
+1. Completed: align the main voice script with gradeable report coverage.
+2. Completed: add regression tests for the two low-priority gradeable conditions and the
+   complete-to-100% invariant.
+3. Completed: remove redundant first-run labels and replace the headline, body, and CTA.
+4. Completed: verify focused behavior, types, desktop and phone rendering, and the final
+   diff.
+5. In progress: run the required specialist ReviewGPT pass and exact-head CI.
+
+## Decisions
+
+- Keep the existing five topic groups and realtime interview. Change only field
+  selection and copy.
+- Use `Fill in my report` as the action. It states the task without repeating
+  the result promised by the headline.
+- Treat stored `null` values as missing, so an unanswered condition is asked
+  again instead of appearing covered.
+- Use one dynamic `Fill the remaining N gaps` line for partial reports and
+  rename the recommendation strip to `What you can improve`.
+
+## Verification
+
+- Focused Environment voice/page tests: 38 passed.
+- Hosted Web TypeScript check: passed.
+- Browser proof: empty report checked at 1440×1000 and 390×844; partial and
+  populated report copy checked at 1200×500.
+- Product UX Patch walkthrough: Ready. The zero-data and partial-report member
+  journeys now state the task and outcome directly. No material exclusions or
+  changes from the approved scope.
+- Remaining proof: preliminary specialist ReviewGPT and exact-head PR checks.

--- a/agent-docs/exec-plans/active/2026-08-26-environment-report-coverage.md
+++ b/agent-docs/exec-plans/active/2026-08-26-environment-report-coverage.md
@@ -35,7 +35,7 @@ Updated: 2026-08-26
 
 - Technical constraints: reuse the catalog and existing interview field list;
   do not add another coverage owner or dependency.
-- Product/process constraints: Product UX Patch. Preserve decline behavior,
+- Product/process constraints: Product UX Product change. Preserve decline behavior,
   category-specific capture, accessibility, responsive layout, and existing
   report behavior for members with data.
 
@@ -67,8 +67,11 @@ Updated: 2026-08-26
   the result promised by the headline.
 - Treat stored `null` values as missing, so an unanswered condition is asked
   again instead of appearing covered.
-- Use one dynamic `Fill the remaining N gaps` line for partial reports and
-  rename the recommendation strip to `What you can improve`.
+- Use one dynamic `Fill in the remaining N details` line for partial reports
+  and rename the recommendation strip to the neutral `What to review next`.
+- The member-started main voice walkthrough is the bounded exception to the
+  normal context-only rule for low-priority gradeable conditions. Update the
+  Habitat product spec in the same change.
 
 ## Verification
 
@@ -76,7 +79,7 @@ Updated: 2026-08-26
 - Hosted Web TypeScript check: passed.
 - Browser proof: empty report checked at 1440×1000 and 390×844; partial and
   populated report copy checked at 1200×500.
-- Product UX Patch walkthrough: Ready. The zero-data and partial-report member
+- Product UX Product change walkthrough: Ready. The zero-data and partial-report member
   journeys now state the task and outcome directly. No material exclusions or
   changes from the approved scope.
 - Remaining proof: preliminary specialist ReviewGPT and exact-head PR checks.

--- a/agent-docs/exec-plans/completed/2026-08-26-environment-report-coverage.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-environment-report-coverage.md
@@ -1,6 +1,6 @@
 # Complete Environment report coverage and clarify first-run copy
 
-Status: active
+Status: completed
 Created: 2026-08-26
 Updated: 2026-08-26
 
@@ -35,9 +35,9 @@ Updated: 2026-08-26
 
 - Technical constraints: reuse the catalog and existing interview field list;
   do not add another coverage owner or dependency.
-- Product/process constraints: Product UX Product change. Preserve decline behavior,
-  category-specific capture, accessibility, responsive layout, and existing
-  report behavior for members with data.
+- Product/process constraints: Product UX Product change. Preserve decline
+  behavior, category-specific capture, accessibility, responsive layout, and
+  existing report behavior for members with data.
 
 ## Risks and mitigations
 
@@ -57,7 +57,7 @@ Updated: 2026-08-26
 3. Completed: remove redundant first-run labels and replace the headline, body, and CTA.
 4. Completed: verify focused behavior, types, desktop and phone rendering, and the final
    diff.
-5. In progress: run the required specialist ReviewGPT pass and exact-head CI.
+5. Completed: run the required specialist ReviewGPT pass and exact-head CI.
 
 ## Decisions
 
@@ -69,17 +69,25 @@ Updated: 2026-08-26
   again instead of appearing covered.
 - Use one dynamic `Fill in the remaining N details` line for partial reports
   and rename the recommendation strip to the neutral `What to review next`.
+- Keep the remaining-detail count in the partial-report action. The specialist
+  review warned that a large count can look like a completion quota, but the
+  member explicitly requested this single-line count. The card remains an
+  optional continuation action outside onboarding.
 - The member-started main voice walkthrough is the bounded exception to the
   normal context-only rule for low-priority gradeable conditions. Update the
   Habitat product spec in the same change.
 
 ## Verification
 
-- Focused Environment voice/page tests: 38 passed.
+- Focused Environment voice/page tests: 118 passed across 8 files.
 - Hosted Web TypeScript check: passed.
-- Browser proof: empty report checked at 1440×1000 and 390×844; partial and
-  populated report copy checked at 1200×500.
-- Product UX Product change walkthrough: Ready. The zero-data and partial-report member
-  journeys now state the task and outcome directly. No material exclusions or
-  changes from the approved scope.
-- Remaining proof: preliminary specialist ReviewGPT and exact-head PR checks.
+- Browser proof: empty, partial, and populated report states checked at desktop
+  and 390×844 phone widths.
+- Product UX Product change walkthrough: Ready. The zero-data and partial-report
+  member journeys now state the task and outcome directly. No material
+  exclusions or changes from the approved scope.
+- Preliminary specialist ReviewGPT: completed on `5f279a90d9a0`. Prompt,
+  frontend, and coverage lenses reported no findings. One Product UX finding
+  about the explicit remaining-detail count was rejected for the reason above.
+- Pull request evidence check: passed on `5f279a90d9a0`.
+Completed: 2026-08-26

--- a/agent-docs/product-specs/habitat.md
+++ b/agent-docs/product-specs/habitat.md
@@ -1,6 +1,6 @@
 # Habitat: Progressive Member Life-Context
 
-Last verified: 2026-08-20
+Last verified: 2026-08-26
 
 ## Current State
 
@@ -61,7 +61,7 @@ updated: 2026-07-07
 
 ## Domain Catalog
 
-A typed, versioned catalog in `packages/contracts` (product spec, not per-member state) defines: domains → aspects → indicators, and per indicator: id, value type/enum, priority (`high | medium | low`), an example conversational question, and an optional evidence target (e.g. `co2 < 1000 ppm`). Low priority means: never proactively asked; filled only when context surfaces it.
+A typed, versioned catalog in `packages/contracts` (product spec, not per-member state) defines: domains → aspects → indicators, and per indicator: id, value type/enum, priority (`high | medium | low`), an example conversational question, and an optional evidence target (e.g. `co2 < 1000 ppm`). Low priority means context-only in normal conversation. The member-started Environment voice walkthrough may ask a low-priority condition when that condition contributes to report coverage; low-priority informational facts remain outside the main walkthrough.
 
 Questions in the catalog are conversation starters, not form fields. One natural question ("do you sleep with the window open?") routinely fills several indicators at once; the agent extracts every indicator the answer contains.
 
@@ -98,9 +98,11 @@ Ordered by importance:
 4. **Realtime voice walkthrough.** The authenticated Environment page streams
    microphone audio through a short-lived Realtime session while showing one
    topic at a time. With no resolved facts, the script covers all five
-   categories. A partial profile asks only for unresolved high- and
-   medium-priority facts. Once those facts are resolved, the script becomes one
-   free-form update prompt. The extractor saves explicit catalog values and an
+   categories. A partial profile asks for unresolved high- and medium-priority
+   facts plus every unresolved condition that contributes to report coverage,
+   regardless of catalog priority. Low-priority informational facts stay
+   optional. Once those facts are resolved, the script becomes one free-form
+   update prompt. The extractor saves explicit catalog values and an
    optional concise note for useful detail that the value cannot express. It
    receives the prior note during updates, preserves details that remain true,
    and removes contradicted details. Raw audio and the live transcript are not
@@ -117,7 +119,7 @@ Ordered by importance:
 
 ## Environment v1 — Aspects and Indicators
 
-Priorities: **H** = proactively collectable, **M** = ask when nearby topic arises, **L** = context-only, never proactively asked.
+Priorities: **H** = proactively collectable, **M** = ask when a nearby topic arises, **L** = context-only outside a member-started Environment voice walkthrough. The main walkthrough asks an L field only when it contributes to report coverage; a category walkthrough can include all unresolved fields in that category.
 
 ### `home-location` — location and climate
 
@@ -229,7 +231,7 @@ Zone/aspect grades (A–F or `unknown`) render on the home visualization — spe
 ## Environment UI
 
 - `/environment` reads the private Browser Vault replica. Production UI never substitutes fixtures for missing member data.
-- Zero-data members see a benefit-led empty state with voice and chat entry points. Sparse records keep the report visible and offer a voice script derived from unknown, non-declined high- and medium-priority facts, including useful informational context such as city, ventilation, and work mode. Once those collection-eligible facts are resolved, the fill-gaps action becomes a free-form voice or chat update. Each category also offers one voice action that covers all its unresolved fields, including optional context. There are no edit forms. The open page waits for a newer Browser Vault replica after accepted voice writes and updates the visible report without a full reload.
+- Zero-data members see a benefit-led empty state with voice and chat entry points. Sparse records keep the report visible and offer a voice script derived from unknown, non-declined high- and medium-priority facts plus every gradeable condition. This includes useful informational context such as city, ventilation, and work mode, while low-priority informational facts stay optional. Once those collection-eligible facts are resolved, the fill-gaps action becomes a free-form voice or chat update. Each category also offers one voice action that covers all its unresolved fields, including optional context. There are no edit forms. The open page waits for a newer Browser Vault replica after accepted voice writes and updates the visible report without a full reload.
 - The page shows derived A–F grades only after at least 50% of gradeable conditions are known. Missing and declined data never lower the grade. The overall score shows its condition base and positive capability bonus separately. Optional access can improve the score, but its absence is neutral.
 - Assessment coverage always names its known gradeable conditions. It remains
   distinct from the larger set of optional and conversational details that a
@@ -266,6 +268,7 @@ Zone/aspect grades (A–F or `unknown`) render on the home visualization — spe
 - 2026-08-25 — Environment letter grades use the A–F scale with 90/80/70/60 cutoffs, and a red flag caps a sufficiently covered audit at F. The earlier A–E scale with 90/75/55/35 cutoffs read as one letter too generous to anyone who knows the A–F scale. Percentages stay visible beside the letter, and every surface that carries a letter — hero, grade dialog, print report, and the share-card route validator — accepts the same set.
 - 2026-07-30 — The voice walkthrough uploads privately to the authenticated Murph path. Audio is staged application-encrypted, processed by a silent Habitat-only turn, deleted after the canonical checkpoint, and covered by a 24-hour R2 lifecycle backstop; no iMessage, Telegram, or browser share sheet is part of the primary flow.
 - 2026-07-30 — Voice guidance has three modes: five-category first walkthrough, catalog-derived gap filling for unknown high- and medium-priority facts that excludes declined facts, and one free-form update prompt once those collection-eligible facts are resolved. Grade coverage does not select the script.
+- 2026-08-26 — A member-started main Environment voice walkthrough includes every gradeable condition, regardless of catalog priority, so a complete set of answers can reach 100% report coverage. Low-priority informational facts remain outside the main walkthrough. This supersedes the 2026-07-30 selection rule for the authenticated Environment voice flow only.
 - 2026-07-30 — Every ordinary Habitat write and live-conditions egress may retain or send only a member-stated city or approximate region; precise addresses are rejected and unsafe legacy values fail closed before provider egress.
 - 2026-07-30 — First-seen Environment voice uploads use the existing AI-usage gate, one unconsumed recording per member, and a server-enforced three-minute media cap. Exact retries remain idempotent, and the open page polls Browser Vault long enough to show the processing result.
 - 2026-07-31 — `/environment/print` is authenticated and derives its printable

--- a/apps/web/app/(dashboard)/environment/environment-components.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-components.tsx
@@ -1157,9 +1157,9 @@ export function NextChecksStrip({
     if (next) open(next);
   };
   return (
-    <section aria-label="What you can improve">
+    <section aria-label="What to review next">
       <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-        What you can improve
+        What to review next
       </p>
       <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {shown.map((item) => (

--- a/apps/web/app/(dashboard)/environment/environment-components.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-components.tsx
@@ -1157,9 +1157,9 @@ export function NextChecksStrip({
     if (next) open(next);
   };
   return (
-    <section aria-label="What to check next">
+    <section aria-label="What you can improve">
       <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-        What to check next
+        What you can improve
       </p>
       <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {shown.map((item) => (

--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -528,8 +528,8 @@ export function EnvironmentEmptyState({
             id="environment-empty-title"
             className="max-w-[19ch] text-balance font-serif text-4xl font-semibold leading-[1.04] tracking-[-0.03em] text-foreground"
           >
-            Fill in your report to see how your home affects your sleep, air
-            quality and focus.
+            Fill in your report to review your setup for sleep, air quality and
+            focus.
           </h2>
           <p className="mt-5 max-w-[58ch] text-pretty text-base leading-relaxed text-muted-foreground">
             Answer one short topic at a time. Murph turns your answers into a
@@ -782,8 +782,8 @@ export function EnvironmentCaptureCard({
             : known === 0
             ? "Build your environment report in one take"
             : missing === 1
-            ? "Fill the remaining gap"
-            : `Fill the remaining ${missing} gaps`}
+            ? "Fill in the remaining detail"
+            : `Fill in the remaining ${missing} details`}
         </h2>
         {updating || known === 0 ? (
           <p className="mt-1 max-w-[68ch] text-pretty text-base text-muted-foreground sm:text-sm">
@@ -896,7 +896,7 @@ function environmentUpdateSummary(
       ? `Added ${state.factsAdded} details.`
       : "Murph saved your changes.";
   if (state.remainingDetails === 0) {
-    return `${added} Your current report has no remaining gaps.`;
+    return `${added} Your current report has no remaining details.`;
   }
   return `${added} ${state.remainingDetails} ${
     state.remainingDetails === 1 ? "detail is" : "details are"

--- a/apps/web/app/(dashboard)/environment/environment-page-client.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-page-client.tsx
@@ -13,7 +13,7 @@ import {
   normalizeHabitatCityOrRegion,
 } from "@murphai/contracts";
 import Image from "next/image";
-import { LoaderCircle, ShieldCheck } from "lucide-react";
+import { LoaderCircle } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
@@ -494,11 +494,7 @@ export function EnvironmentShell({
   return (
     <div className="flex w-full flex-col gap-10">
       <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <PageHeader
-          eyebrow="Habitat"
-          title="Your environment"
-          description="What Murph knows about your home, and what to check next."
-        />
+        <PageHeader title="Your environment" />
         {actions ? (
           <div className="flex shrink-0 items-center gap-5 sm:pb-1">
             {actions}
@@ -528,22 +524,16 @@ export function EnvironmentEmptyState({
     >
       <div className="grid lg:grid-cols-[6fr_5fr]">
         <div className="flex flex-col px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
-          <p className="flex items-center gap-2 text-base font-medium text-primary sm:text-sm">
-            <ShieldCheck
-              className="size-5 shrink-0 sm:size-4"
-              aria-hidden="true"
-            />
-            Private to you
-          </p>
           <h2
             id="environment-empty-title"
-            className="mt-7 max-w-[19ch] text-balance font-serif text-4xl font-semibold leading-[1.04] tracking-[-0.03em] text-foreground"
+            className="max-w-[19ch] text-balance font-serif text-4xl font-semibold leading-[1.04] tracking-[-0.03em] text-foreground"
           >
-            See how your home supports your sleep, air and focus.
+            Fill in your report to see how your home affects your sleep, air
+            quality and focus.
           </h2>
           <p className="mt-5 max-w-[58ch] text-pretty text-base leading-relaxed text-muted-foreground">
-            Talk through one short topic at a time. Murph saves each clear
-            answer before moving on.
+            Answer one short topic at a time. Murph turns your answers into a
+            grade and practical next checks.
           </p>
 
           <div className="mt-8 flex flex-col items-start gap-4">
@@ -556,7 +546,7 @@ export function EnvironmentEmptyState({
                 processing
                   ? "Saving report…"
                   : script.flow === "walkthrough"
-                  ? "Start report"
+                  ? "Fill in my report"
                   : script.flow === "fill-gaps"
                   ? "Continue report"
                   : "Update by voice"
@@ -766,7 +756,6 @@ export function EnvironmentReport({
 
 export function EnvironmentCaptureCard({
   contactOptions,
-  coverage,
   known,
   script,
   onVoiceAccepted,
@@ -784,8 +773,6 @@ export function EnvironmentCaptureCard({
     (sum, topic) => sum + (topic.focus?.length ?? 0),
     0,
   );
-  const topicCount = script.topics.length;
-
   return (
     <section className="flex flex-col gap-5 rounded-xl border border-border bg-card px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6">
       <div className="min-w-0">
@@ -794,21 +781,17 @@ export function EnvironmentCaptureCard({
             ? "All current details covered"
             : known === 0
             ? "Build your environment report in one take"
-            : coverage < 50
-            ? "Complete the picture"
-            : "Fill the remaining gaps"}
+            : missing === 1
+            ? "Fill the remaining gap"
+            : `Fill the remaining ${missing} gaps`}
         </h2>
-        <p className="mt-1 max-w-[68ch] text-pretty text-base text-muted-foreground sm:text-sm">
-          {updating
-            ? "Tell Murph if something changes at home or in your workspace."
-            : known === 0
-            ? "Talk through sleep, air, light, recovery and work. Murph saves each topic as you go."
-            : `${missing} ${
-                missing === 1 ? "detail" : "details"
-              } missing · ${topicCount} short ${
-                topicCount === 1 ? "topic" : "topics"
-              }`}
-        </p>
+        {updating || known === 0 ? (
+          <p className="mt-1 max-w-[68ch] text-pretty text-base text-muted-foreground sm:text-sm">
+            {updating
+              ? "Tell Murph if something changes at home or in your workspace."
+              : "Talk through sleep, air, light, recovery and work. Murph saves each topic as you go."}
+          </p>
+        ) : null}
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-3">
         <EnvironmentVoiceCapture
@@ -823,7 +806,7 @@ export function EnvironmentCaptureCard({
               : updating
               ? "Update by voice"
               : known === 0
-              ? "Start report"
+              ? "Fill in my report"
               : "Continue report"
           }
           triggerVariant={updating ? "outline" : "default"}

--- a/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
+++ b/apps/web/app/(dashboard)/environment/environment-voice-capture.tsx
@@ -2346,7 +2346,10 @@ function describeFields(fields: readonly EnvironmentVoiceField[]): string {
                 field.existingNote,
               )}.`
             : "";
-          return `- ${field.aspectId}.${field.indicatorId}: ${field.label}.${meaning} Allowed: ${allowed}.${existingNote}`;
+          const extractionGuidance = field.extractionGuidance
+            ? ` Extraction rule: ${field.extractionGuidance}`
+            : "";
+          return `- ${field.aspectId}.${field.indicatorId}: ${field.label}.${meaning} Allowed: ${allowed}.${existingNote}${extractionGuidance}`;
         })
         .join("\n");
 }

--- a/apps/web/app/(dashboard)/environment/environment-voice-script.ts
+++ b/apps/web/app/(dashboard)/environment/environment-voice-script.ts
@@ -46,6 +46,8 @@ const VOICE_FIELD_LABELS: Readonly<Record<string, string>> = {
   "home-air.air_purifier": "Whether you use an air purifier and what kind",
   "home-air.air_quality_meter": "What indoor air quality you measure",
   "home-air.damp_or_mold": "Whether you have damp or mold at home",
+  "home-air.smoke_sources":
+    "Whether anyone smokes indoors or you often use a fireplace or candles",
   "home-air.stove": "What kind of stove you cook on",
   "home-air.ventilation": "How fresh air enters your home",
   "home-location.area_type":
@@ -73,6 +75,7 @@ const VOICE_FIELD_LABELS: Readonly<Record<string, string>> = {
     "How you block noise while sleeping",
   "sleep-environment.phone_by_bed": "Where your phone stays at night",
   "sleep-environment.temp_control": "How you control bedroom temperature",
+  "sleep-environment.tv_in_bedroom": "Whether there is a TV in your bedroom",
   "sleep-environment.window_at_night":
     "Whether your window is open or closed at night",
   "workspace.breaks": "How often you take breaks from sitting",
@@ -126,7 +129,7 @@ function buildUpdateScript(notes: HabitatIndicatorNotes): EnvironmentVoiceScript
   topics: [
     {
       fields: listEnvironmentInterviewFields("update")
-        .filter(({ indicator }) => indicator.priority !== "low")
+        .filter(isMainEnvironmentInterviewField)
         .map((field) => toVoiceField(field, notes)),
       id: "update",
       title: "What changed?",
@@ -204,7 +207,8 @@ export function buildEnvironmentVoiceScriptForGroup(
   const allFields = listEnvironmentInterviewFields(group.id);
   const missingFields = allFields.filter(
     ({ aspectId, indicator }) =>
-      values[aspectId]?.[indicator.id] === undefined,
+      values[aspectId]?.[indicator.id] === undefined ||
+      values[aspectId]?.[indicator.id] === null,
   );
   const selectedFields = missingFields.length > 0 ? missingFields : allFields;
   const topics = chunk(
@@ -274,22 +278,27 @@ function buildMissingScript(
 ): EnvironmentVoiceScript {
   const interviewFields = ENVIRONMENT_INTERVIEW_TOPIC_GROUPS.flatMap((group) =>
     listEnvironmentInterviewFields(group.id).filter(
-      ({ indicator }) => indicator.priority !== "low",
+      isMainEnvironmentInterviewField,
     ),
   );
   const totalDetails = interviewFields.length;
   const initialCoveredDetails = interviewFields.filter(
     ({ aspectId, indicator }) => {
       const value = values[aspectId]?.[indicator.id];
-      return value !== undefined && value !== HABITAT_DECLINED_VALUE;
+      return (
+        value !== undefined &&
+        value !== null &&
+        value !== HABITAT_DECLINED_VALUE
+      );
     },
   ).length;
   const topics = ENVIRONMENT_INTERVIEW_TOPIC_GROUPS.flatMap((group) => {
     const missingFields = listEnvironmentInterviewFields(group.id)
       .filter(
-        ({ aspectId, indicator }) =>
-          indicator.priority !== "low" &&
-          values[aspectId]?.[indicator.id] === undefined,
+        (field) =>
+          isMainEnvironmentInterviewField(field) &&
+          (values[field.aspectId]?.[field.indicator.id] === undefined ||
+            values[field.aspectId]?.[field.indicator.id] === null),
       )
       .map((field) => toVoiceField(field, notes));
     return chunk(missingFields, MAX_TOPIC_FIELDS).map(
@@ -335,6 +344,12 @@ function buildMissingScript(
     totalDetails,
     topics: typedTopics,
   };
+}
+
+function isMainEnvironmentInterviewField({
+  indicator,
+}: ReturnType<typeof listEnvironmentInterviewFields>[number]): boolean {
+  return indicator.priority !== "low" || indicator.informational !== true;
 }
 
 function toVoiceField({

--- a/apps/web/app/(dashboard)/environment/environment-voice-script.ts
+++ b/apps/web/app/(dashboard)/environment/environment-voice-script.ts
@@ -12,6 +12,7 @@ export type EnvironmentVoiceFlow = "walkthrough" | "fill-gaps" | "update";
 
 export type EnvironmentVoiceField = {
   aspectId: string;
+  extractionGuidance?: string;
   indicatorId: string;
   label: string;
   existingNote?: string;
@@ -38,6 +39,9 @@ export type EnvironmentVoiceScript = {
 };
 
 const MAX_TOPIC_FIELDS = 4;
+
+const SMOKE_SOURCES_EXTRACTION_GUIDANCE =
+  "If several sources are explicit, store smoking before fireplace before frequent_candles. Keep every additional source in the note.";
 
 const VOICE_FIELD_LABELS: Readonly<Record<string, string>> = {
   "allergens-home.pets_at_home": "Whether you have pets and what kind",
@@ -360,6 +364,9 @@ function toVoiceField({
 >[number], notes: HabitatIndicatorNotes): EnvironmentVoiceField {
   return {
     aspectId,
+    ...(aspectId === "home-air" && indicator.id === "smoke_sources"
+      ? { extractionGuidance: SMOKE_SOURCES_EXTRACTION_GUIDANCE }
+      : {}),
     indicatorId: indicator.id,
     label: VOICE_FIELD_LABELS[`${aspectId}.${indicator.id}`] ?? indicator.label,
     ...(notes[aspectId]?.[indicator.id]

--- a/apps/web/app/design/environment-progress-study.tsx
+++ b/apps/web/app/design/environment-progress-study.tsx
@@ -274,7 +274,7 @@ export function EnvironmentProgressStudy() {
           script={GAP_SCRIPTS[30]}
         />
       </StudyState>
-      <StudyState label="70% · Ask only for remaining gaps">
+      <StudyState label="70% · Ask only for remaining details">
         <EnvironmentCaptureCard
           contactOptions={DESIGN_CONTACT_OPTIONS}
           coverage={70}

--- a/apps/web/changelog/entries/2026-08-26/environment-report-full-coverage.json
+++ b/apps/web/changelog/entries/2026-08-26/environment-report-full-coverage.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "environment-report-full-coverage",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Environment reports can reach full coverage",
+    "summary": "The main Environment voice interview now asks every condition used in report coverage.",
+    "details": "A complete set of answers can now reach 100%. You can still skip a question or update an answer later.",
+    "relevanceTags": ["environment", "voice", "reports"],
+    "sourcePullRequests": [2335]
+  }
+}

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -348,7 +348,7 @@ test("EnvironmentPage renders private habitat facts from Browser Vault", async (
   assert.match(markup, /href="\/environment\/print"/);
   assert.match(markup, /Print report/);
   assert.match(markup, /group\/category/);
-  assert.match(markup, /What you can improve/);
+  assert.match(markup, /What to review next/);
   assert.doesNotMatch(markup, /What to check next/);
   assert.doesNotMatch(markup, /fixture data|mock/i);
   assert.doesNotMatch(markup, /Overall picture/);
@@ -434,7 +434,7 @@ test("EnvironmentPage gives zero-data members one clear start and previews the r
 
   assert.match(
     markup,
-    /Fill in your report to see how your home affects your sleep, air quality and focus/,
+    /Fill in your report to review your setup for sleep, air quality and focus/,
   );
   assert.match(markup, /Fill in my report/);
   assert.match(markup, /Prefer typing\? Use chat/);

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -348,6 +348,8 @@ test("EnvironmentPage renders private habitat facts from Browser Vault", async (
   assert.match(markup, /href="\/environment\/print"/);
   assert.match(markup, /Print report/);
   assert.match(markup, /group\/category/);
+  assert.match(markup, /What you can improve/);
+  assert.doesNotMatch(markup, /What to check next/);
   assert.doesNotMatch(markup, /fixture data|mock/i);
   assert.doesNotMatch(markup, /Overall picture/);
   assert.doesNotMatch(markup, /Target score/);
@@ -430,10 +432,18 @@ test("EnvironmentPage gives zero-data members one clear start and previews the r
 
   const markup = renderToStaticMarkup(await EnvironmentPage());
 
-  assert.match(markup, /See how your home supports your sleep, air and focus/);
-  assert.match(markup, /Start report/);
+  assert.match(
+    markup,
+    /Fill in your report to see how your home affects your sleep, air quality and focus/,
+  );
+  assert.match(markup, /Fill in my report/);
   assert.match(markup, /Prefer typing\? Use chat/);
-  assert.match(markup, /Murph saves each clear answer before moving on/);
+  assert.match(
+    markup,
+    /Murph turns your answers into a grade and practical next checks/,
+  );
+  assert.doesNotMatch(markup, /Habitat/);
+  assert.doesNotMatch(markup, /Private to you/);
   assert.match(markup, /Your report will cover/);
   assert.match(markup, /class="flex w-full flex-col gap-10"/);
   assert.doesNotMatch(

--- a/apps/web/test/environment-capture-card.test.tsx
+++ b/apps/web/test/environment-capture-card.test.tsx
@@ -17,7 +17,13 @@ const GAP_SCRIPT: EnvironmentVoiceScript = {
   topics: [
     {
       eyebrow: "Sleep",
-      focus: ["Night temperature"],
+      focus: [
+        "Night temperature",
+        "Bedroom darkness",
+        "Bedroom noise",
+        "Indoor smoke",
+        "Bedroom TV",
+      ],
       id: "sleep",
       prompt: "Cover only what is missing.",
       title: "Your sleep setup",
@@ -51,9 +57,9 @@ test("partial reports offer to fill only what is missing", async () => {
 
   try {
     const bodyText = rendered.window.document.body.textContent ?? "";
-    assert.match(bodyText, /Complete the picture/);
+    assert.match(bodyText, /Fill the remaining 5 gaps/);
     assert.match(bodyText, /Continue report/);
-    assert.match(bodyText, /1 detail missing · 1 short topic/);
+    assert.doesNotMatch(bodyText, /detail missing|short topic/);
     assert.doesNotMatch(bodyText, /Update by voice/);
   } finally {
     await rendered.cleanup();

--- a/apps/web/test/environment-capture-card.test.tsx
+++ b/apps/web/test/environment-capture-card.test.tsx
@@ -57,7 +57,7 @@ test("partial reports offer to fill only what is missing", async () => {
 
   try {
     const bodyText = rendered.window.document.body.textContent ?? "";
-    assert.match(bodyText, /Fill the remaining 5 gaps/);
+    assert.match(bodyText, /Fill in the remaining 5 details/);
     assert.match(bodyText, /Continue report/);
     assert.doesNotMatch(bodyText, /detail missing|short topic/);
     assert.doesNotMatch(bodyText, /Update by voice/);

--- a/apps/web/test/environment-voice-capture.test.tsx
+++ b/apps/web/test/environment-voice-capture.test.tsx
@@ -81,7 +81,10 @@ import {
   summarizeEnvironmentInterviewCompletion,
   withoutSavedFields,
 } from "../app/(dashboard)/environment/environment-voice-capture";
-import type { EnvironmentVoiceScript } from "../app/(dashboard)/environment/environment-voice-script";
+import {
+  buildEnvironmentVoiceScript,
+  type EnvironmentVoiceScript,
+} from "../app/(dashboard)/environment/environment-voice-script";
 import { renderClientComponent } from "./render-client-component";
 
 const SCRIPT: EnvironmentVoiceScript = {
@@ -838,6 +841,22 @@ test("tells the extractor how to read a checklist topic, a range, and imperial u
   assert.match(instructions, /an approximate single number/i);
   assert.match(instructions, /leaves the field unresolved and writes nothing/);
   assert.match(instructions, /Fahrenheit to Celsius/);
+});
+
+test("gives the extractor a deterministic precedence for multiple indoor smoke sources", () => {
+  const script = buildEnvironmentVoiceScript({});
+  const smokeTopic = script.topics.find((topic) =>
+    topic.fields?.some((field) => field.indicatorId === "smoke_sources"),
+  );
+  assert.ok(smokeTopic);
+
+  const instructions = buildTopicInstructions(smokeTopic, null, "en");
+
+  assert.match(
+    instructions,
+    /store smoking before fireplace before frequent_candles/,
+  );
+  assert.match(instructions, /Keep every additional source in the note/);
 });
 
 test("reports nothing left to ask when this session answered every field", () => {

--- a/apps/web/test/environment-voice-refresh.test.tsx
+++ b/apps/web/test/environment-voice-refresh.test.tsx
@@ -127,7 +127,7 @@ test("waits for changed Environment values after realtime topic processing", asy
     });
     const trigger = Array.from(
       rendered.window.document.querySelectorAll("button"),
-    ).find((button) => button.textContent?.includes("Start report"));
+    ).find((button) => button.textContent?.includes("Fill in my report"));
     assert.ok(trigger instanceof rendered.window.HTMLButtonElement);
     await act(async () => {
       trigger.click();

--- a/apps/web/test/environment-voice-script.test.ts
+++ b/apps/web/test/environment-voice-script.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ENVIRONMENT_INTERVIEW_TOPIC_GROUPS,
   HABITAT_CATALOG,
   HABITAT_DECLINED_VALUE,
+  listEnvironmentInterviewFields,
 } from "@murphai/contracts";
 
 import {
@@ -34,7 +36,7 @@ describe("environment voice script", () => {
     expect(location?.label).toMatch(/not your address/i);
   });
 
-  it("asks about unknown high and medium context without mixing it into grade coverage", () => {
+  it("asks every gradeable condition plus unknown high and medium context", () => {
     const script = buildEnvironmentVoiceScript({
       "sleep-environment": {
         night_temp_c: 19,
@@ -49,10 +51,52 @@ describe("environment voice script", () => {
     expect(focus).toContain("How fresh air enters your home");
     expect(focus).toContain("Whether you work at home, an office, or both");
     expect(focus).toContain("Whether you use a laptop or external monitor");
+    expect(focus).toContain("Whether there is a TV in your bedroom");
+    expect(focus).toContain(
+      "Whether anyone smokes indoors or you often use a fireplace or candles",
+    );
     expect(focus).not.toContain("Where your phone stays at night");
     expect(focus).not.toContain("Whether your home has been tested for radon");
     expect(focus).not.toContain("Your drinking water source or filter");
     expect(script.topics[0]?.prompt).toBeUndefined();
+  });
+
+  it("includes every gradeable report condition in the main interview", () => {
+    const script = buildEnvironmentVoiceScript({});
+    const includedFields = new Set(
+      script.topics.flatMap((topic) =>
+        (topic.fields ?? []).map(
+          (field) => `${field.aspectId}.${field.indicatorId}`,
+        ),
+      ),
+    );
+    const gradeableFields = ENVIRONMENT_INTERVIEW_TOPIC_GROUPS.flatMap(
+      (group) => listEnvironmentInterviewFields(group.id),
+    )
+      .filter(({ indicator }) => indicator.informational !== true)
+      .map(({ aspectId, indicator }) => `${aspectId}.${indicator.id}`);
+
+    expect([...includedFields]).toEqual(
+      expect.arrayContaining(gradeableFields),
+    );
+  });
+
+  it("asks again when a report condition is stored without a value", () => {
+    const script = buildEnvironmentVoiceScript({
+      "sleep-environment": { night_temp_c: null },
+    });
+    const fields = script.topics.flatMap((topic) => topic.fields ?? []);
+
+    expect(script.flow).toBe("walkthrough");
+    expect(script.initialCoveredDetails).toBe(0);
+    expect(fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          aspectId: "sleep-environment",
+          indicatorId: "night_temp_c",
+        }),
+      ]),
+    );
   });
 
   it("omits declined gaps and switches to an open update only when collection gaps are resolved", () => {
@@ -85,7 +129,7 @@ function resolvedCollectionValues(): HabitatValues {
     }
     const indicators: Record<string, typeof HABITAT_DECLINED_VALUE> = {};
     for (const indicator of aspect.indicators) {
-      if (indicator.priority !== "low") {
+      if (indicator.priority !== "low" || indicator.informational !== true) {
         indicators[indicator.id] = HABITAT_DECLINED_VALUE;
       }
     }

--- a/apps/web/test/environment-voice-script.test.ts
+++ b/apps/web/test/environment-voice-script.test.ts
@@ -5,13 +5,19 @@ import {
   HABITAT_CATALOG,
   HABITAT_DECLINED_VALUE,
   listEnvironmentInterviewFields,
+  type HabitatIndicatorValue,
 } from "@murphai/contracts";
 
 import {
   buildEnvironmentVoiceScript,
   buildEnvironmentVoiceScriptForGroup,
+  type EnvironmentVoiceField,
 } from "../app/(dashboard)/environment/environment-voice-script";
-import type { HabitatValues } from "../app/(dashboard)/environment/home-model";
+import {
+  resolveEnvironmentCoverage,
+  resolveHabitatScene,
+  type HabitatValues,
+} from "../app/(dashboard)/environment/home-model";
 
 describe("environment voice script", () => {
   it("uses focused topics at zero coverage and asks only for city-level location", () => {
@@ -79,6 +85,22 @@ describe("environment voice script", () => {
     expect([...includedFields]).toEqual(
       expect.arrayContaining(gradeableFields),
     );
+
+    const gradeableFieldKeys = new Set(gradeableFields);
+    const completeValues: HabitatValues = {};
+    for (const field of script.topics.flatMap((topic) => topic.fields ?? [])) {
+      const key = `${field.aspectId}.${field.indicatorId}`;
+      if (!gradeableFieldKeys.has(key)) {
+        continue;
+      }
+      const aspectValues = completeValues[field.aspectId] ?? {};
+      aspectValues[field.indicatorId] = exampleValue(field.valueType);
+      completeValues[field.aspectId] = aspectValues;
+    }
+
+    expect(
+      resolveEnvironmentCoverage(resolveHabitatScene(completeValues)).coverage,
+    ).toBe(100);
   });
 
   it("asks again when a report condition is stored without a value", () => {
@@ -97,6 +119,20 @@ describe("environment voice script", () => {
         }),
       ]),
     );
+
+    const groupScript = buildEnvironmentVoiceScriptForGroup("sleep", {
+      "sleep-environment": { night_temp_c: null },
+    });
+    expect(
+      groupScript?.topics.flatMap((topic) => topic.fields ?? []),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          aspectId: "sleep-environment",
+          indicatorId: "night_temp_c",
+        }),
+      ]),
+    );
   });
 
   it("omits declined gaps and switches to an open update only when collection gaps are resolved", () => {
@@ -108,6 +144,12 @@ describe("environment voice script", () => {
     expect(script.dialogTitle).toBe("Update your environment");
     expect(script.topics).toHaveLength(1);
     expect(script.topics[0].id).toBe("update");
+    expect(script.topics[0].fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ indicatorId: "smoke_sources" }),
+        expect.objectContaining({ indicatorId: "tv_in_bedroom" }),
+      ]),
+    );
   });
 
   it("uses canonical accepted topic ids for category interviews", () => {
@@ -120,6 +162,25 @@ describe("environment voice script", () => {
     );
   });
 });
+
+function exampleValue(
+  valueType: EnvironmentVoiceField["valueType"],
+): HabitatIndicatorValue {
+  if (valueType.kind === "enum") {
+    const value = valueType.values[0];
+    if (value === undefined) {
+      throw new TypeError("Environment enum field has no allowed value");
+    }
+    return value;
+  }
+  if (valueType.kind === "number") {
+    return valueType.min ?? 1;
+  }
+  if (valueType.kind === "boolean") {
+    return false;
+  }
+  return "known";
+}
 
 function resolvedCollectionValues(): HabitatValues {
   const values: HabitatValues = {};


### PR DESCRIPTION
## Why and outcome

The main Environment voice interview skipped two graded conditions. A member could answer every shown question and still stop below 100% coverage.

The interview now includes every graded condition, treats stored null values as missing, and keeps declined answers optional. The Environment page also uses clearer report and review copy.

## Product UX

- Effort: Product UX Product change
- Walkthrough: Ready
- Affected people: members starting an empty report and members returning with remaining details
- Material exclusions: category-specific manual edits and report scoring rules are unchanged
- Plan difference: none

## Evidence

- Focused Vitest suite: 8 files and 118 tests passed
- Web TypeScript check passed
- Local browser walkthrough passed for the empty report, remaining-details card, and mixed next-review state at desktop and 390×844 phone widths

## Non-obvious affected surfaces

- The free-form Environment update script now exposes every graded field to extraction, matching the initial walkthrough.
- Category interviews treat stored null values as unanswered. Focused voice-script tests cover this behavior.

## Architecture and reuse

- Existing systems reused: the Environment catalog, interview topic groups, voice field extraction, and existing screenshot study.
- New logic: one field predicate aligns voice inclusion with graded report conditions, and one field-specific extraction rule resolves compound smoke answers.
- New abstractions: none beyond the local predicate. The existing catalog remains the source of truth.
- Complexity intentionally avoided: no new coverage state, questionnaire, service, or scoring path.

## Hot reply path impact

Not applicable. This changes the hosted Environment page and its voice-script metadata, not message acceptance or reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable to representative individual or group turns. Their initial provider request is unchanged. The separate Environment Realtime extractor adds one field-specific precedence rule, covered by a focused prompt test.
- Codex runtime: Not applicable. No Codex prompt, tool schema, or generated guidance changed.

## Design proof

- Design page: https://murph-git-codex-environment-report-coverage-cobuildwithus.vercel.app/screenshots/health#environment-empty-dashboard-shell
- Evidence: the production Environment empty state and report study show the new headline, CTA, single-line detail count, and next-review heading.
- Coverage: empty, partial, and populated report states at desktop and phone widths.

## Change-shape breakdown

UI and voice-script files are source. Vitest files are tests. The plan, product spec, changelog, and Frog entry are docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 56 | 48 |
| Tests/fixtures | 151 | 11 |
| Docs | 143 | 7 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 350 | 66 |

No binary files.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-only behavior and copy change with no cross-service rollout order or compatibility window.

## Changelog

- Changelog: updated
- Items: 2026-08-26 · environment-report-full-coverage
