### PR TITLE
Allow alternate Codex home for live assistant journeys

### DIFF
--- a/.agents/friction-log/20260826095235-frog-autofix-fixtures/friction.md
+++ b/.agents/friction-log/20260826095235-frog-autofix-fixtures/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Frog autofix fixtures use a privacy-rejected git email'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Repo-tools tests that create temporary Git repositories should use fixture identities accepted by the repository privacy hook.
+
+## Current Behavior
+
+Several Frog autofix tests configure a synthetic non-noreply email. Their temporary commits are rejected by the privacy hook, so unrelated `pnpm test:diff` runs fail and can remain alive after reporting the failures.
+
+## Possible Solution
+
+Use one approved synthetic noreply fixture identity for temporary Git repositories.
+
+## Minimal Reproducible Example
+
+Run the focused Frog autofix test named `preserves parent-local review ancestry and handoffs after a foreign body edit` through `scripts/vitest.config.ts`.
+
+## Context
+
+This reproduced without the candidate patch on the default branch while verifying an unrelated repo-tool runner change.

--- a/.agents/skills/verify-murph-assistant/SKILL.md
+++ b/.agents/skills/verify-murph-assistant/SKILL.md
@@ -48,7 +48,7 @@ the acceptance result.
    already-authenticated local home:
 
    ```bash
-   pnpm test:assistant:live -- --test "<unique test-name pattern>" --codex-home <ALTERNATE_CODEX_HOME>
+   pnpm test:assistant:live -- --test "<unique test-name pattern>" --codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>
    ```
 
    The explicit home selects existing local auth and config; it does not copy

--- a/.agents/skills/verify-murph-assistant/SKILL.md
+++ b/.agents/skills/verify-murph-assistant/SKILL.md
@@ -42,6 +42,18 @@ the acceptance result.
    `--model <model>` only when the product target differs. Use
    `--auth provider` only for an explicitly configured supported provider-key
    lane. Never print, copy, or persist auth material.
+
+   If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT`
+   before any provider action, rerun the same journey once with another
+   already-authenticated local home:
+
+   ```bash
+   pnpm test:assistant:live -- --test "<unique test-name pattern>" --codex-home <ALTERNATE_CODEX_HOME>
+   ```
+
+   The explicit home selects existing local auth and config; it does not copy
+   credentials. Do not discover profiles automatically or cycle through homes.
+   If the alternate home is also blocked, record `Hold`.
 5. Read every printed member-visible reply and inspect the corresponding tool
    assertions. Mark the journey `Ready` only when all are true:
    - Murph fulfills the user's real purpose correctly and completely.
@@ -65,10 +77,10 @@ the acceptance result.
 
 - Keep live journeys opt-in. Routine CI compiles them but must not call a paid
   provider or depend on a developer's subscription.
-- The local subscription mode intentionally uses the normal local Codex home
-  for auth but does not copy it into a temporary home. It is developer-local
-  evidence, not a hermetic CI lane. Provider-key mode keeps its
-  isolated Codex home and minimal secret allowlist.
+- The local subscription mode uses the normal local Codex home by default and
+  may select one explicit alternate home, but it never copies auth into a
+  temporary home. It is developer-local evidence, not a hermetic CI lane.
+  Provider-key mode keeps its isolated Codex home and minimal secret allowlist.
 - Do not call production databases, delivery providers, device providers, or
   member-facing channels. Inject synthetic ports and fixtures.
 - A stochastic pass is evidence for the tested model and run, not a guarantee

--- a/.agents/skills/verify-murph-assistant/SKILL.md
+++ b/.agents/skills/verify-murph-assistant/SKILL.md
@@ -43,17 +43,11 @@ the acceptance result.
    `--auth provider` only for an explicitly configured supported provider-key
    lane. Never print, copy, or persist auth material.
 
-   If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT`
-   before any provider action, rerun the same journey once with another
-   already-authenticated local home:
-
-   ```bash
-   pnpm test:assistant:live -- --test "<unique test-name pattern>" --codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>
-   ```
-
-   The explicit home selects existing local auth and config; it does not copy
-   credentials. Do not discover profiles automatically or cycle through homes.
-   If the alternate home is also blocked, record `Hold`.
+   If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT`,
+   follow the alternate-home retry contract in
+   `agent-docs/operations/verification-and-runtime.md` § Expensive And
+   Stochastic Proof Order. That section owns its authorization, path, retry,
+   and stopping rules.
 5. Read every printed member-visible reply and inspect the corresponding tool
    assertions. Mark the journey `Ready` only when all are true:
    - Murph fulfills the user's real purpose correctly and completely.

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -259,11 +259,12 @@ count, repetition, clarity, warmth, autonomy, and truthful recovery. Routine CI
 must never depend on local subscription state or make the paid call.
 
 If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT` before
-any provider action, rerun that same focused journey once with
-`--codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>`. Use only another already-authenticated,
-authorized local home; the runner selects its existing auth and config without
-copying credentials. Do not auto-discover profiles or cycle through homes. If
-the alternate home is also blocked, record `Hold`.
+any provider action and an explicitly authorized absolute alternate path is
+already available, rerun that same focused journey once with
+`--codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>`. The runner selects that home's
+existing auth and config without copying credentials. Do not auto-discover
+profiles or cycle through homes. If no authorized alternate path is available,
+or if the supplied alternate is also blocked, record `Hold`.
 
 Assistant Engine's lower-level opt-in live Codex journeys still use
 `MURPH_RUN_REAL_CODEX_E2E=1`; provider-key mode requires a supported provider

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -260,7 +260,7 @@ must never depend on local subscription state or make the paid call.
 
 If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT` before
 any provider action, rerun that same focused journey once with
-`--codex-home <ALTERNATE_CODEX_HOME>`. Use only another already-authenticated,
+`--codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>`. Use only another already-authenticated,
 authorized local home; the runner selects its existing auth and config without
 copying credentials. Do not auto-discover profiles or cycle through homes. If
 the alternate home is also blocked, record `Hold`.

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -258,10 +258,18 @@ reply and record a `Ready` or `Hold` UX verdict covering correctness, action
 count, repetition, clarity, warmth, autonomy, and truthful recovery. Routine CI
 must never depend on local subscription state or make the paid call.
 
+If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT` before
+any provider action, rerun that same focused journey once with
+`--codex-home <ALTERNATE_CODEX_HOME>`. Use only another already-authenticated,
+authorized local home; the runner selects its existing auth and config without
+copying credentials. Do not auto-discover profiles or cycle through homes. If
+the alternate home is also blocked, record `Hold`.
+
 Assistant Engine's lower-level opt-in live Codex journeys still use
 `MURPH_RUN_REAL_CODEX_E2E=1`; provider-key mode requires a supported provider
 credential, while explicit subscription mode uses the normal local Codex home
-for auth and is developer-local rather than hermetic CI evidence. The
+by default and may select one alternate local home for auth. It remains
+developer-local rather than hermetic CI evidence. The
 generated-image avatar journey must exercise the production tool contracts in
 three natural turns: launch with a truthful wait acknowledgement, trusted
 completion media attachment with no group mutation, and a later explicit

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -8744,6 +8744,36 @@ describe('real Codex app-server cache usage e2e harness', () => {
     })
   })
 
+  it('selects one explicit Codex home only in subscription mode', async () => {
+    const config = await resolveRealCodexE2eConfig({
+      sourceEnv: {
+        HOME: '/synthetic-home',
+        MURPH_REAL_CODEX_AUTH: 'subscription',
+        MURPH_REAL_CODEX_HOME: '/alternate-codex-home',
+        PATH: '/usr/bin:/bin',
+      },
+    })
+
+    expect(config).toEqual({
+      codexHome: '/alternate-codex-home',
+      env: {
+        HOME: '/synthetic-home',
+        PATH: '/usr/bin:/bin',
+      },
+      model: DEFAULT_REAL_CODEX_MODEL,
+      modelProvider: OPENAI_SUBSCRIPTION_MODEL_PROVIDER,
+      temporaryPaths: [],
+    })
+    await expect(resolveRealCodexE2eConfig({
+      sourceEnv: {
+        MURPH_REAL_CODEX_AUTH: 'provider',
+        MURPH_REAL_CODEX_HOME: '/alternate-codex-home',
+      },
+    })).rejects.toThrow(
+      'MURPH_REAL_CODEX_HOME is available only with subscription auth.',
+    )
+  })
+
   it('keeps the built-in OpenAI provider out of provider-key mode', async () => {
     await expect(resolveRealCodexE2eConfig({
       sourceEnv: {
@@ -13528,18 +13558,17 @@ async function resolveRealCodexE2eConfig(
   const model =
     normalizeEnvString(sourceEnv.MURPH_REAL_CODEX_MODEL)
     ?? DEFAULT_REAL_CODEX_MODEL
-  const configuredCodexHome = normalizeEnvString(sourceEnv.MURPH_REAL_CODEX_HOME)
-  if (configuredCodexHome) {
-    throw new Error(
-      'MURPH_REAL_CODEX_HOME is not supported; provider mode creates an isolated home and subscription mode uses the normal local Codex home.',
-    )
-  }
-
   const authMode =
     normalizeEnvString(sourceEnv.MURPH_REAL_CODEX_AUTH) ?? 'provider'
   if (authMode !== 'provider' && authMode !== 'subscription') {
     throw new Error(
       'MURPH_REAL_CODEX_AUTH must be provider or subscription.',
+    )
+  }
+  const configuredCodexHome = normalizeEnvString(sourceEnv.MURPH_REAL_CODEX_HOME)
+  if (authMode === 'provider' && configuredCodexHome) {
+    throw new Error(
+      'MURPH_REAL_CODEX_HOME is available only with subscription auth.',
     )
   }
   const explicitModelProvider =
@@ -13554,7 +13583,7 @@ async function resolveRealCodexE2eConfig(
       )
     }
     return {
-      codexHome: null,
+      codexHome: configuredCodexHome,
       env: buildRealCodexSubscriptionE2eEnv(sourceEnv),
       model,
       modelProvider: OPENAI_SUBSCRIPTION_MODEL_PROVIDER,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -39,6 +39,10 @@ import {
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildAssistantRealCodexRunEnv,
+  parseAssistantRealCodexRunArgs,
+} from '../../../scripts/run-assistant-real-codex-e2e.ts'
+import {
   executeCodexAppServerTurn,
   resolveMurphDynamicTools,
   stopWarmCodexAppServer,
@@ -8744,15 +8748,21 @@ describe('real Codex app-server cache usage e2e harness', () => {
     })
   })
 
-  it('selects one explicit Codex home only in subscription mode', async () => {
-    const config = await resolveRealCodexE2eConfig({
+  it('composes one explicit runner Codex home only in subscription mode', async () => {
+    const sourceEnv = buildAssistantRealCodexRunEnv({
+      options: parseAssistantRealCodexRunArgs([
+        'focused journey',
+        '--codex-home',
+        '/alternate-codex-home',
+      ]),
       sourceEnv: {
+        CODEX_HOME: '/ambient-codex-home',
         HOME: '/synthetic-home',
-        MURPH_REAL_CODEX_AUTH: 'subscription',
-        MURPH_REAL_CODEX_HOME: '/alternate-codex-home',
+        MURPH_REAL_CODEX_HOME: '/ambient-real-codex-home',
         PATH: '/usr/bin:/bin',
       },
     })
+    const config = await resolveRealCodexE2eConfig({ sourceEnv })
 
     expect(config).toEqual({
       codexHome: '/alternate-codex-home',

--- a/scripts/run-assistant-real-codex-e2e.test.ts
+++ b/scripts/run-assistant-real-codex-e2e.test.ts
@@ -71,6 +71,7 @@ describe('assistant real Codex local runner', () => {
       sourceEnv: {
         CODEX_HOME: '/alternate-codex-home',
         MURPH_REAL_CODEX_COMMAND: 'legacy-wrapper',
+        MURPH_REAL_CODEX_HOME: '/ambient-real-codex-home',
         MURPH_REAL_CODEX_MODEL_PROVIDER: 'openai-env',
         OPENAI_API_KEY: 'provider-value',
         PATH: '/usr/bin:/bin',
@@ -192,10 +193,14 @@ describe('assistant real Codex local runner', () => {
     expect(requests[0]?.stdio).toBe('capture')
   })
 
-  it('starts exactly one subscription journey after a one-match preflight', () => {
+  it('routes one explicit subscription home through preflight and the live journey', () => {
     const requests: AssistantRealCodexCommandRequest[] = []
     const status = executeAssistantRealCodexRun(
-      parseAssistantRealCodexRunArgs(['adaptive wearable']),
+      parseAssistantRealCodexRunArgs([
+        'adaptive wearable',
+        '--codex-home',
+        '/selected-codex-home',
+      ]),
       {
         runCommand: (request) => {
           requests.push(request)
@@ -209,8 +214,9 @@ describe('assistant real Codex local runner', () => {
             : { status: 0 }
         },
         sourceEnv: {
-          CODEX_HOME: '/alternate-codex-home',
+          CODEX_HOME: '/ambient-codex-home',
           HOME: '/normal-home',
+          MURPH_REAL_CODEX_HOME: '/ambient-real-codex-home',
           PATH: '/usr/bin:/bin',
         },
         writeStderr: () => undefined,
@@ -224,10 +230,21 @@ describe('assistant real Codex local runner', () => {
       { command: 'codex', stdio: 'ignore' },
       { command: 'pnpm', stdio: 'inherit' },
     ])
-    for (const request of requests) {
-      expect(request.env.CODEX_HOME).toBeUndefined()
-      expect(request.env.HOME).toBe('/normal-home')
-    }
+    expect(requests[0]?.env).toMatchObject({
+      HOME: '/normal-home',
+      MURPH_REAL_CODEX_HOME: '/selected-codex-home',
+    })
+    expect(requests[0]?.env.CODEX_HOME).toBeUndefined()
+    expect(requests[1]?.env).toMatchObject({
+      CODEX_HOME: '/selected-codex-home',
+      HOME: '/normal-home',
+    })
+    expect(requests[1]?.env.MURPH_REAL_CODEX_HOME).toBeUndefined()
+    expect(requests[2]?.env).toMatchObject({
+      HOME: '/normal-home',
+      MURPH_REAL_CODEX_HOME: '/selected-codex-home',
+    })
+    expect(requests[2]?.env.CODEX_HOME).toBeUndefined()
     expect(requests[2]?.args).toContain(
       '^real Codex adaptive wearable journey$',
     )

--- a/scripts/run-assistant-real-codex-e2e.test.ts
+++ b/scripts/run-assistant-real-codex-e2e.test.ts
@@ -17,6 +17,7 @@ describe('assistant real Codex local runner', () => {
       'adaptive wearable no-data outreach',
     ])).toEqual({
       authMode: 'subscription',
+      codexHome: null,
       help: false,
       model: null,
       testPattern: 'adaptive wearable no-data outreach',
@@ -35,10 +36,32 @@ describe('assistant real Codex local runner', () => {
       'gpt-5.6-sol',
     ])).toEqual({
       authMode: 'provider',
+      codexHome: null,
       help: false,
       model: 'gpt-5.6-sol',
       testPattern: 'member preference',
     })
+  })
+
+  it('supports one explicit Codex home for subscription auth', () => {
+    expect(parseAssistantRealCodexRunArgs([
+      'member preference',
+      '--codex-home',
+      '/alternate-codex-home',
+    ])).toEqual({
+      authMode: 'subscription',
+      codexHome: '/alternate-codex-home',
+      help: false,
+      model: null,
+      testPattern: 'member preference',
+    })
+    expect(() => parseAssistantRealCodexRunArgs([
+      'member preference',
+      '--auth',
+      'provider',
+      '--codex-home',
+      '/alternate-codex-home',
+    ])).toThrow('--codex-home is available only with subscription auth.')
   })
 
   it('sets only the live-test controls owned by the selected auth mode', () => {
@@ -66,6 +89,32 @@ describe('assistant real Codex local runner', () => {
       HOME: '/normal-home',
       PATH: '/usr/bin:/bin',
     })
+    const selectedRunEnv = buildAssistantRealCodexRunEnv({
+      options: parseAssistantRealCodexRunArgs([
+        'focused journey',
+        '--codex-home',
+        '/selected-codex-home',
+      ]),
+      sourceEnv: {
+        CODEX_HOME: '/ambient-codex-home',
+        HOME: '/normal-home',
+        MURPH_REAL_CODEX_HOME: '/ambient-real-codex-home',
+        PATH: '/usr/bin:/bin',
+      },
+    })
+    expect(selectedRunEnv.CODEX_HOME).toBeUndefined()
+    expect(selectedRunEnv.MURPH_REAL_CODEX_HOME).toBe('/selected-codex-home')
+    const selectedLoginEnv = buildAssistantRealCodexLoginEnv(
+      {
+        CODEX_HOME: '/ambient-codex-home',
+        HOME: '/normal-home',
+        MURPH_REAL_CODEX_HOME: '/ambient-real-codex-home',
+        PATH: '/usr/bin:/bin',
+      },
+      '/selected-codex-home',
+    )
+    expect(selectedLoginEnv.CODEX_HOME).toBe('/selected-codex-home')
+    expect(selectedLoginEnv.MURPH_REAL_CODEX_HOME).toBeUndefined()
   })
 
   it('builds package-relative list and focused run invocations', () => {

--- a/scripts/run-assistant-real-codex-e2e.test.ts
+++ b/scripts/run-assistant-real-codex-e2e.test.ts
@@ -62,6 +62,11 @@ describe('assistant real Codex local runner', () => {
       '--codex-home',
       '/alternate-codex-home',
     ])).toThrow('--codex-home is available only with subscription auth.')
+    expect(() => parseAssistantRealCodexRunArgs([
+      'member preference',
+      '--codex-home',
+      'relative-codex-home',
+    ])).toThrow('--codex-home requires an absolute path.')
   })
 
   it('sets only the live-test controls owned by the selected auth mode', () => {

--- a/scripts/run-assistant-real-codex-e2e.ts
+++ b/scripts/run-assistant-real-codex-e2e.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { isAbsolute } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 export type AssistantRealCodexAuthMode = 'provider' | 'subscription'
@@ -47,7 +48,7 @@ const USAGE = [
   '',
   'Options:',
   '  --auth subscription|provider  Use local ChatGPT auth (default) or provider env.',
-  '  --codex-home <path>            Use an explicit local Codex home for subscription auth.',
+  '  --codex-home <absolute-path>   Use an explicit local Codex home for subscription auth.',
   '  --model <model>               Override the default gpt-5.6-terra model.',
   '  -h, --help                    Show this help.',
 ].join('\n')
@@ -77,7 +78,11 @@ export function parseAssistantRealCodexRunArgs(
       continue
     }
     if (argument === '--codex-home') {
-      options.codexHome = readRequiredValue(argv, index, argument)
+      const codexHome = readRequiredValue(argv, index, argument)
+      if (!isAbsolute(codexHome)) {
+        throw new Error('--codex-home requires an absolute path.')
+      }
+      options.codexHome = codexHome
       index += 1
       continue
     }

--- a/scripts/run-assistant-real-codex-e2e.ts
+++ b/scripts/run-assistant-real-codex-e2e.ts
@@ -5,6 +5,7 @@ export type AssistantRealCodexAuthMode = 'provider' | 'subscription'
 
 export interface AssistantRealCodexRunOptions {
   authMode: AssistantRealCodexAuthMode
+  codexHome: string | null
   help: boolean
   model: string | null
   testPattern: string | null
@@ -34,6 +35,7 @@ export interface AssistantRealCodexRunDependencies {
 
 const DEFAULT_OPTIONS: AssistantRealCodexRunOptions = {
   authMode: 'subscription',
+  codexHome: null,
   help: false,
   model: null,
   testPattern: null,
@@ -45,6 +47,7 @@ const USAGE = [
   '',
   'Options:',
   '  --auth subscription|provider  Use local ChatGPT auth (default) or provider env.',
+  '  --codex-home <path>            Use an explicit local Codex home for subscription auth.',
   '  --model <model>               Override the default gpt-5.6-terra model.',
   '  -h, --help                    Show this help.',
 ].join('\n')
@@ -73,6 +76,11 @@ export function parseAssistantRealCodexRunArgs(
       index += 1
       continue
     }
+    if (argument === '--codex-home') {
+      options.codexHome = readRequiredValue(argv, index, argument)
+      index += 1
+      continue
+    }
     if (argument === '--auth') {
       const authMode = readRequiredValue(argv, index, argument)
       if (authMode !== 'provider' && authMode !== 'subscription') {
@@ -94,6 +102,9 @@ export function parseAssistantRealCodexRunArgs(
   if (!options.help && !options.testPattern) {
     throw new Error('A focused --test name pattern is required.')
   }
+  if (options.authMode === 'provider' && options.codexHome) {
+    throw new Error('--codex-home is available only with subscription auth.')
+  }
 
   return options
 }
@@ -104,7 +115,7 @@ export function buildAssistantRealCodexRunEnv(input: {
 }): NodeJS.ProcessEnv {
   const sourceEnv = input.sourceEnv ?? process.env
   const env = input.options.authMode === 'subscription'
-    ? buildNormalCodexHomeEnv(sourceEnv)
+    ? buildSubscriptionRunEnv(sourceEnv, input.options.codexHome)
     : { ...sourceEnv }
   env.MURPH_RUN_REAL_CODEX_E2E = '1'
 
@@ -115,6 +126,7 @@ export function buildAssistantRealCodexRunEnv(input: {
     delete env.MURPH_REAL_CODEX_PROVIDER_ENV_KEY
   } else {
     delete env.MURPH_REAL_CODEX_AUTH
+    delete env.MURPH_REAL_CODEX_HOME
   }
 
   if (input.options.model) {
@@ -126,8 +138,16 @@ export function buildAssistantRealCodexRunEnv(input: {
 
 export function buildAssistantRealCodexLoginEnv(
   sourceEnv: NodeJS.ProcessEnv,
+  codexHome: string | null = null,
 ): NodeJS.ProcessEnv {
-  return buildNormalCodexHomeEnv(sourceEnv)
+  const env = { ...sourceEnv }
+  delete env.MURPH_REAL_CODEX_HOME
+  if (codexHome) {
+    env.CODEX_HOME = codexHome
+  } else {
+    delete env.CODEX_HOME
+  }
+  return env
 }
 
 export function buildAssistantRealCodexListArgs(
@@ -244,7 +264,10 @@ export function executeAssistantRealCodexRun(
     const loginStatus = dependencies.runCommand({
       args: ['login', 'status'],
       command: 'codex',
-      env: buildAssistantRealCodexLoginEnv(dependencies.sourceEnv),
+      env: buildAssistantRealCodexLoginEnv(
+        dependencies.sourceEnv,
+        options.codexHome,
+      ),
       stdio: 'ignore',
     })
     if (loginStatus.status !== 0) {
@@ -293,11 +316,17 @@ function readRequiredValue(
   return value
 }
 
-function buildNormalCodexHomeEnv(
+function buildSubscriptionRunEnv(
   sourceEnv: NodeJS.ProcessEnv,
+  codexHome: string | null,
 ): NodeJS.ProcessEnv {
   const env = { ...sourceEnv }
   delete env.CODEX_HOME
+  if (codexHome) {
+    env.MURPH_REAL_CODEX_HOME = codexHome
+  } else {
+    delete env.MURPH_REAL_CODEX_HOME
+  }
   return env
 }
 


### PR DESCRIPTION
## Outcome

`test:assistant:live` can select one explicit, already-authenticated Codex home by absolute path when the default subscription home reaches its usage limit. When an explicitly authorized alternate is already available, the workflow allows one bounded retry; otherwise it records `Hold`.

## Product UX

- Effort: Not applicable; this changes developer-only verification tooling and workflow guidance.
- Affected people: Murph contributors running focused synthetic real-Codex journeys.
- Walkthrough verdict: Ready. The default path is unchanged, the alternate path is explicit, and invalid provider-auth composition fails before a paid run.

## Direct evidence

- Runner tests: 9/9 passed, including absolute-path rejection and exact top-level child environments for enumeration, login preflight, and live execution.
- Composed runner-to-real-E2E harness selector test: 1/1 passed with 92 unrelated tests skipped.
- Repo-tools TypeScript and Assistant Engine typechecks passed.
- `pnpm test:assistant:live -- --help` exposes `--codex-home <absolute-path>` without making a paid call.
- `git diff --check` and the privacy scan passed.
- Current-base `git merge-tree --write-tree` completed without conflicts.
- Scoped `pnpm test:diff` passed syntax, repository TypeScript, dependency, logging, provider-boundary, and architecture guards before the unrelated Frog autofix suite failed. The same focused Frog failure reproduces on `main` because its temporary Git fixture uses a privacy-rejected email; a Frog entry records that repository friction.

## Non-obvious affected surfaces

- The selected absolute path reaches both the `codex login status` preflight and the existing app-server `codexHome` option.
- Ambient `CODEX_HOME` and `MURPH_REAL_CODEX_HOME` remain ignored by default.
- Provider-key mode rejects `--codex-home` and continues to own its isolated temporary home.
- The selected path is not printed, copied, persisted, auto-discovered, or forwarded into the model environment.
- The required Frog entry matches `.github/workflows/friction-log.yml` on a merge push to `main`. That existing, environment-scoped reconciliation owner may update linked GitHub issue or pull-request state through `frog/sync`; the entry is included because the unrelated fixture failure reproduced on the base branch and qualified for Developer Friction Logging. The existing Frog workflow guards and Pull Request Evidence check remain the proof owners; this PR adds no reconciliation authority or workflow logic.

## Architecture and reuse

- Existing systems reused: The current focused runner, subscription login preflight, `MURPH_REAL_CODEX_HOME` test seam, and app-server `codexHome` option.
- New logic: One nullable CLI option and subscription-only propagation through the existing seam.
- New abstractions: None; the existing runner option and app-server `codexHome` seam cover the complete path.
- Complexity intentionally avoided: No profile registry, profile discovery, credential copying, fallback manager, retry loop, or production runtime branch.

## Hot reply path impact

- Not applicable. No Murph runtime or member reply path changes.

## Murph initial provider input impact

- Not applicable. No prompt, tool schema, context, model selection, or provider request changes.

## Design proof

- Not applicable. No hosted Web component, layout, interaction, or user-visible copy changes.

## Deployment concerns

- Deployment: not applicable
- Reason: This is local verification tooling, tests, and workflow documentation only; no Vercel, Cloudflare, package runtime, schema, or environment binding changes.

## ReviewGPT

- Preliminary specialist pass: `FINDINGS` on the valid retry. Accepted and resolved all findings: composed runner-to-harness proof, an absolute-path boundary, and one canonical fallback contract with explicit `Hold` behavior when no authorized alternate is available.
- Final round 1: `FINDINGS`; accepted the missing Frog reconciliation disclosure and corrected this PR body without changing production code.
- Final round 2: `PASS` on the prior corrected sensitive full snapshot; both prior findings were verified resolved.
- Final round 3: `PASS` on the current sensitive full snapshot; the requirement-level retrospective was accepted, every prior finding was verified resolved, and no qualifying findings remain.
- Round-3 retrospective decision: continue with the current reduced shape. The original requirement remains one explicit, already-authorized alternate Codex home and one bounded retry before `Hold`. Relative to the first-reviewed implementation, review work added composed runner-to-harness proof, rejected ambiguous relative paths, and consolidated duplicated fallback guidance; it added no production owner, state, discovery, credential copying, or retry manager, and removed one duplicate detailed contract. The findings did not repeat one underlying mechanism. Keep one absolute selector, the existing runner/app-server `codexHome` seam, and one canonical workflow contract; shrinking further would remove required proof or leave the no-alternate outcome ambiguous, while splitting or redesigning would add coordination without a demonstrated need.
- Final cross-cutting gate: required because the local selector touches subscription authentication configuration.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: b08c2fddde8e81d740d1dee18d2a95e44c681c3f

## Changelog

- Changelog: not applicable
- Reason: Developer-only verification tooling has no member-visible release surface.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 38 | 4 |
| Tests/fixtures | 125 | 15 |
| Docs | 44 | 5 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **207** | **24** |


