### PR TITLE
Prepare Codex auth mailbox crypto before transaction

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-26-db-codex-auth-mailbox-crypto.md
+++ b/agent-docs/exec-plans/active/2026-08-26-db-codex-auth-mailbox-crypto.md
@@ -12,7 +12,8 @@ Updated: 2026-08-26
 
 ## Success criteria
 
-- Codex auth prepares mailbox crypto before opening its transaction.
+- Codex auth prepares mailbox crypto before opening the transaction that
+  commits a new auth attempt and mailbox wake.
 - The transaction uses only the existing prepared-crypto append surface.
 - Attempt, event, and dedupe identity remain stable across the supported single
   prepared-root retry.
@@ -57,21 +58,38 @@ Updated: 2026-08-26
   Codex-auth-specific crypto owner.
 - Preserve one attempt ID across prepared-root re-entry rather than creating a
   second logical auth attempt.
+- Preserve provider-independent terminal no-op and existing-wake reuse paths:
+  those short locked decisions return without invoking mailbox crypto
+  preparation.
 
 ## Verification
 
 - Commands to run: focused Codex auth/mailbox Vitest files; scoped ESLint;
   hosted Web typecheck; `git diff --check`; exact static call-path searches.
-- Expected outcomes: all checks pass, preparation occurs before any transaction
-  or member lock, unrelated members are not blocked by preparation, and the
-  Codex auth path contains no legacy provider-capable transaction append.
+- Expected outcomes: all checks pass, preparation occurs before the transaction
+  that commits a new wake, terminal no-op and existing-wake reuse paths stay
+  provider-independent, unrelated members are not blocked by preparation, and
+  the Codex auth path contains no legacy provider-capable transaction append.
 - Completed local proof:
   - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-codex-auth-store.test.ts`
     passed.
+  - After accepting the preliminary specialist finding, `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-codex-auth-store.test.ts apps/web/test/settings-chatgpt-route.test.ts`
+    passed.
   - `pnpm --dir apps/web typecheck` passed.
   - `pnpm --dir apps/web exec eslint src/lib/codex-auth/store.ts test/hosted-codex-auth-store.test.ts`
+    passed.
+  - After accepting the preliminary specialist finding,
+    `pnpm --dir apps/web exec eslint src/lib/codex-auth/store.ts test/hosted-codex-auth-store.test.ts test/settings-chatgpt-route.test.ts`
     passed.
   - `git diff --check` passed.
   - Static diff searches found no credential/direct-identifier shapes, no
     remaining Codex-auth legacy mailbox append import, and no new `as any` or
     `as unknown` casts.
+
+## ReviewGPT disposition
+
+- Preliminary `completion-specialists` returned one finding: unconditional
+  mailbox crypto preparation wrapped terminal no-op and existing-wake reuse
+  outcomes. Accepted. Remediation keeps those paths provider-independent,
+  prepares crypto only for a new wake commit, and revalidates under the member
+  lock before appending.

--- a/agent-docs/exec-plans/active/2026-08-26-db-codex-auth-mailbox-crypto.md
+++ b/agent-docs/exec-plans/active/2026-08-26-db-codex-auth-mailbox-crypto.md
@@ -1,0 +1,77 @@
+# Prepare Codex auth mailbox crypto before its transaction
+
+Status: active - local proof complete, PR gates pending
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Keep provider-capable mailbox crypto work outside the Codex auth database
+  transaction so a slow KMS/provider call cannot hold a pooled connection or
+  the hosted-member row lock.
+
+## Success criteria
+
+- Codex auth prepares mailbox crypto before opening its transaction.
+- The transaction uses only the existing prepared-crypto append surface.
+- Attempt, event, and dedupe identity remain stable across the supported single
+  prepared-root retry.
+- Focused tests and the hosted Web typecheck pass.
+- A separate draft PR is opened and exact-head ReviewGPT gates are started.
+
+## Scope
+
+- In scope: `beginHostedCodexAuthAttempt` and its focused store tests.
+- Out of scope: device credentials, identity crypto, Linq lock ordering,
+  account deletion, member actions, and other legacy mailbox callers.
+
+## Constraints
+
+- Technical constraints: reuse the existing prepared mailbox crypto owner and
+  transaction adapter; add no new state, queue, manager, or abstraction.
+- Product/process constraints: preserve connect/disconnect behavior and
+  idempotency; keep the PR draft; do not merge or mark Ready.
+
+## Risks and mitigations
+
+1. Risk: preparing crypto outside the transaction could change retry identity.
+   Mitigation: allocate the next attempt ID once before the existing one-retry
+   owner and prove stable attempt, event, and dedupe identity in a focused test.
+2. Risk: a provider-capable fallback remains reachable under the lock.
+   Mitigation: replace the legacy transaction append with the prepared-only
+   adapter and assert preparation ordering plus root-client isolation.
+
+## Tasks
+
+1. Validate the ReviewGPT disposition, artifact hash, scope, and architecture.
+2. Apply the agreed two-file patch and inspect it as untrusted intent.
+3. Run focused behavioral, lint, type, and diff checks.
+4. Commit and push the exact candidate, then open a separate draft PR.
+5. Start preliminary specialist and final ReviewGPT against the exact PR head
+   concurrently with required CI.
+
+## Decisions
+
+- Reuse `runWithPreparedHostedMailboxItemAppendCrypto` and
+  `appendHostedMailboxEnvelopeWithPreparedCryptoTx`; do not introduce a new
+  Codex-auth-specific crypto owner.
+- Preserve one attempt ID across prepared-root re-entry rather than creating a
+  second logical auth attempt.
+
+## Verification
+
+- Commands to run: focused Codex auth/mailbox Vitest files; scoped ESLint;
+  hosted Web typecheck; `git diff --check`; exact static call-path searches.
+- Expected outcomes: all checks pass, preparation occurs before any transaction
+  or member lock, unrelated members are not blocked by preparation, and the
+  Codex auth path contains no legacy provider-capable transaction append.
+- Completed local proof:
+  - `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-codex-auth-store.test.ts`
+    passed.
+  - `pnpm --dir apps/web typecheck` passed.
+  - `pnpm --dir apps/web exec eslint src/lib/codex-auth/store.ts test/hosted-codex-auth-store.test.ts`
+    passed.
+  - `git diff --check` passed.
+  - Static diff searches found no credential/direct-identifier shapes, no
+    remaining Codex-auth legacy mailbox append import, and no new `as any` or
+    `as unknown` casts.

--- a/agent-docs/exec-plans/completed/2026-08-26-db-codex-auth-mailbox-crypto.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-db-codex-auth-mailbox-crypto.md
@@ -1,6 +1,6 @@
 # Prepare Codex auth mailbox crypto before its transaction
 
-Status: active - local proof complete, PR gates pending
+Status: completed
 Created: 2026-08-26
 Updated: 2026-08-26
 
@@ -18,7 +18,8 @@ Updated: 2026-08-26
 - Attempt, event, and dedupe identity remain stable across the supported single
   prepared-root retry.
 - Focused tests and the hosted Web typecheck pass.
-- A separate draft PR is opened and exact-head ReviewGPT gates are started.
+- A separate draft PR is opened and exact-head ReviewGPT gates pass after
+  accepted remediation.
 
 ## Scope
 
@@ -50,6 +51,8 @@ Updated: 2026-08-26
 4. Commit and push the exact candidate, then open a separate draft PR.
 5. Start preliminary specialist and final ReviewGPT against the exact PR head
    concurrently with required CI.
+6. Apply accepted preliminary remediation and complete the final ReviewGPT
+   follow-up round.
 
 ## Decisions
 
@@ -93,3 +96,8 @@ Updated: 2026-08-26
   outcomes. Accepted. Remediation keeps those paths provider-independent,
   prepares crypto only for a new wake commit, and revalidates under the member
   lock before appending.
+- Final PR ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` on the initial
+  candidate head.
+- Final PR ReviewGPT round 2 returned `ROUND_OUTCOME: PASS` on the remediated
+  head and confirmed the accepted preliminary finding was resolved.
+Completed: 2026-08-26

--- a/agent-docs/exec-plans/completed/2026-08-26-db-codex-auth-mailbox-crypto.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-db-codex-auth-mailbox-crypto.md
@@ -32,7 +32,8 @@ Updated: 2026-08-26
 - Technical constraints: reuse the existing prepared mailbox crypto owner and
   transaction adapter; add no new state, queue, manager, or abstraction.
 - Product/process constraints: preserve connect/disconnect behavior and
-  idempotency; keep the PR draft; do not merge or mark Ready.
+  idempotency; keep the PR draft through ordinary pushes and remediation, then
+  admit the exact final head to required CI; do not merge.
 
 ## Risks and mitigations
 

--- a/apps/web/src/lib/codex-auth/store.ts
+++ b/apps/web/src/lib/codex-auth/store.ts
@@ -14,8 +14,9 @@ import type {
 } from "@murphai/hosted-execution/runtime-control";
 
 import {
-  appendHostedMailboxEnvelopeTx,
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx,
   readHostedMailboxItemByDedupeKey,
+  runWithPreparedHostedMailboxItemAppendCrypto,
 } from "../hosted-mailbox/store";
 import {
   HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
@@ -85,101 +86,109 @@ export async function beginHostedCodexAuthAttempt(input: {
 }): Promise<HostedCodexAuthAttemptResult> {
   const prisma = input.prisma ?? getPrisma();
   const now = input.now ?? new Date();
+  const nextAttemptId = createHostedCodexAuthAttemptId();
 
-  return await prisma.$transaction(async (tx) => {
-    await lockHostedMemberRow(tx, input.memberId);
-    const current = await tx.hostedCodexAuthConnection.findUnique({
-      where: { memberId: input.memberId },
-    });
+  return await runWithPreparedHostedMailboxItemAppendCrypto({
+    append: (prepared) => prisma.$transaction(async (tx) => {
+      await lockHostedMemberRow(tx, input.memberId);
+      const current = await tx.hostedCodexAuthConnection.findUnique({
+        where: { memberId: input.memberId },
+      });
 
-    if (input.action === "connect") {
-      if (current?.state === "connected") {
-        return {
-          attemptId: null,
-          mailboxItemId: null,
-          view: { state: "connected" },
-        };
-      }
-      if (
-        current?.state === "connecting"
-        && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
-      ) {
-        return {
-          attemptId: current.attemptId,
-          mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
-            action: input.action,
+      if (input.action === "connect") {
+        if (current?.state === "connected") {
+          return {
+            attemptId: null,
+            mailboxItemId: null,
+            view: { state: "connected" },
+          };
+        }
+        if (
+          current?.state === "connecting"
+          && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
+        ) {
+          return {
             attemptId: current.attemptId,
-            memberId: input.memberId,
-            prisma: tx,
-          }),
-          view: projectHostedCodexAuthConnection(current, now),
-        };
-      }
-    } else {
-      if (!current || current.state === "disconnected") {
-        return {
-          attemptId: null,
-          mailboxItemId: null,
-          view: { state: "disconnected" },
-        };
-      }
-      if (
-        current.state === "disconnecting"
-        && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
-      ) {
-        return {
-          attemptId: current.attemptId,
-          mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
-            action: input.action,
+            mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
+              action: input.action,
+              attemptId: current.attemptId,
+              memberId: input.memberId,
+              prisma: tx,
+            }),
+            view: projectHostedCodexAuthConnection(current, now),
+          };
+        }
+      } else {
+        if (!current || current.state === "disconnected") {
+          return {
+            attemptId: null,
+            mailboxItemId: null,
+            view: { state: "disconnected" },
+          };
+        }
+        if (
+          current.state === "disconnecting"
+          && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
+        ) {
+          return {
             attemptId: current.attemptId,
-            memberId: input.memberId,
-            prisma: tx,
-          }),
-          view: { state: "disconnecting" },
-        };
+            mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
+              action: input.action,
+              attemptId: current.attemptId,
+              memberId: input.memberId,
+              prisma: tx,
+            }),
+            view: { state: "disconnecting" },
+          };
+        }
       }
-    }
 
-    const attemptId = createHostedCodexAuthAttemptId();
-    const state = input.action === "connect" ? "connecting" : "disconnecting";
-    await tx.hostedCodexAuthConnection.upsert({
-      create: {
-        attemptId,
-        memberId: input.memberId,
-        state,
-        updatedAt: now,
-        userCode: null,
-        verificationUrl: null,
-      },
-      update: {
-        attemptId,
-        state,
-        updatedAt: now,
-        userCode: null,
-        verificationUrl: null,
-      },
-      where: { memberId: input.memberId },
-    });
+      const state = input.action === "connect" ? "connecting" : "disconnecting";
+      await tx.hostedCodexAuthConnection.upsert({
+        create: {
+          attemptId: nextAttemptId,
+          memberId: input.memberId,
+          state,
+          updatedAt: now,
+          userCode: null,
+          verificationUrl: null,
+        },
+        update: {
+          attemptId: nextAttemptId,
+          state,
+          updatedAt: now,
+          userCode: null,
+          verificationUrl: null,
+        },
+        where: { memberId: input.memberId },
+      });
 
-    const mailbox = await appendHostedMailboxEnvelopeTx({
-      envelope: buildHostedExecutionCodexAuthRequestedWake({
-        action: input.action,
-        attemptId,
-        eventId: buildHostedCodexAuthAttemptEventId(input.action, attemptId),
-        occurredAt: now.toISOString(),
-        userId: input.memberId,
-      }),
-      tx,
-    });
+      const mailbox = await appendHostedMailboxEnvelopeWithPreparedCryptoTx({
+        envelope: buildHostedExecutionCodexAuthRequestedWake({
+          action: input.action,
+          attemptId: nextAttemptId,
+          eventId: buildHostedCodexAuthAttemptEventId(
+            input.action,
+            nextAttemptId,
+          ),
+          occurredAt: now.toISOString(),
+          userId: input.memberId,
+        }),
+        prepared,
+        tx,
+      });
 
-    return {
-      attemptId,
-      mailboxItemId: mailbox.item.id,
-      view: state === "connecting"
-        ? { state, userCode: null, verificationUrl: null }
-        : { state },
-    };
-  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+      return {
+        attemptId: nextAttemptId,
+        mailboxItemId: mailbox.item.id,
+        view: state === "connecting"
+          ? { state, userCode: null, verificationUrl: null }
+          : { state },
+      };
+    }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS),
+    prisma,
+    userId: input.memberId,
+  });
 }
 
 export async function markHostedCodexAuthAttemptError(input: {

--- a/apps/web/src/lib/codex-auth/store.ts
+++ b/apps/web/src/lib/codex-auth/store.ts
@@ -88,59 +88,28 @@ export async function beginHostedCodexAuthAttempt(input: {
   const now = input.now ?? new Date();
   const nextAttemptId = createHostedCodexAuthAttemptId();
 
+  const existing = await prisma.$transaction((tx) =>
+    readLockedHostedCodexAuthAttemptExistingResultTx({
+      action: input.action,
+      memberId: input.memberId,
+      now,
+      tx,
+    }), HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+  if (existing) {
+    return existing;
+  }
+
   return await runWithPreparedHostedMailboxItemAppendCrypto({
     append: (prepared) => prisma.$transaction(async (tx) => {
-      await lockHostedMemberRow(tx, input.memberId);
-      const current = await tx.hostedCodexAuthConnection.findUnique({
-        where: { memberId: input.memberId },
-      });
-
-      if (input.action === "connect") {
-        if (current?.state === "connected") {
-          return {
-            attemptId: null,
-            mailboxItemId: null,
-            view: { state: "connected" },
-          };
-        }
-        if (
-          current?.state === "connecting"
-          && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
-        ) {
-          return {
-            attemptId: current.attemptId,
-            mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
-              action: input.action,
-              attemptId: current.attemptId,
-              memberId: input.memberId,
-              prisma: tx,
-            }),
-            view: projectHostedCodexAuthConnection(current, now),
-          };
-        }
-      } else {
-        if (!current || current.state === "disconnected") {
-          return {
-            attemptId: null,
-            mailboxItemId: null,
-            view: { state: "disconnected" },
-          };
-        }
-        if (
-          current.state === "disconnecting"
-          && !hostedCodexAuthAttemptIsStale(current.updatedAt, now)
-        ) {
-          return {
-            attemptId: current.attemptId,
-            mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
-              action: input.action,
-              attemptId: current.attemptId,
-              memberId: input.memberId,
-              prisma: tx,
-            }),
-            view: { state: "disconnecting" },
-          };
-        }
+      const revalidatedExisting =
+        await readLockedHostedCodexAuthAttemptExistingResultTx({
+          action: input.action,
+          memberId: input.memberId,
+          now,
+          tx,
+        });
+      if (revalidatedExisting) {
+        return revalidatedExisting;
       }
 
       const state = input.action === "connect" ? "connecting" : "disconnecting";
@@ -189,6 +158,69 @@ export async function beginHostedCodexAuthAttempt(input: {
     prisma,
     userId: input.memberId,
   });
+}
+
+async function readLockedHostedCodexAuthAttemptExistingResultTx(input: {
+  action: HostedCodexAuthAction;
+  memberId: string;
+  now: Date;
+  tx: Prisma.TransactionClient;
+}): Promise<HostedCodexAuthAttemptResult | null> {
+  await lockHostedMemberRow(input.tx, input.memberId);
+  const current = await input.tx.hostedCodexAuthConnection.findUnique({
+    where: { memberId: input.memberId },
+  });
+
+  if (input.action === "connect") {
+    if (current?.state === "connected") {
+      return {
+        attemptId: null,
+        mailboxItemId: null,
+        view: { state: "connected" },
+      };
+    }
+    if (
+      current?.state === "connecting"
+      && !hostedCodexAuthAttemptIsStale(current.updatedAt, input.now)
+    ) {
+      return {
+        attemptId: current.attemptId,
+        mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
+          action: input.action,
+          attemptId: current.attemptId,
+          memberId: input.memberId,
+          prisma: input.tx,
+        }),
+        view: projectHostedCodexAuthConnection(current, input.now),
+      };
+    }
+    return null;
+  }
+
+  if (!current || current.state === "disconnected") {
+    return {
+      attemptId: null,
+      mailboxItemId: null,
+      view: { state: "disconnected" },
+    };
+  }
+  if (
+    current.state === "disconnecting"
+    && !hostedCodexAuthAttemptIsStale(current.updatedAt, input.now)
+  ) {
+    return {
+      attemptId: current.attemptId,
+      mailboxItemId: await readHostedCodexAuthAttemptMailboxItemId({
+        action: input.action,
+        attemptId: current.attemptId,
+        memberId: input.memberId,
+        prisma: input.tx,
+      }),
+      view: { state: "disconnecting" },
+    };
+  }
+
+  return null;
 }
 
 export async function markHostedCodexAuthAttemptError(input: {

--- a/apps/web/test/hosted-codex-auth-store.test.ts
+++ b/apps/web/test/hosted-codex-auth-store.test.ts
@@ -145,6 +145,9 @@ describe("hosted Codex auth store", () => {
     expect(
       mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
     ).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.runWithPreparedHostedMailboxItemAppendCrypto,
+    ).toHaveBeenCalledTimes(1);
     expect(mocks.readHostedMailboxItemByDedupeKey).toHaveBeenCalledWith({
       dedupeKey: `codex-auth:connect:${first.attemptId}`,
       prisma: prisma.tx,
@@ -176,6 +179,74 @@ describe("hosted Codex auth store", () => {
     expect(
       mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
     ).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.runWithPreparedHostedMailboxItemAppendCrypto,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns terminal no-op states without mailbox crypto preparation", async () => {
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementation(
+      async () => {
+        throw new Error("Terminal no-op states must not prepare mailbox crypto.");
+      },
+    );
+
+    const connectedPrisma = createCodexAuthPrismaHarness({
+      attemptId: "hca_connectedattempt",
+      memberId: "member_123",
+      state: "connected",
+      updatedAt: new Date("2026-06-23T12:00:00.000Z"),
+      userCode: null,
+      verificationUrl: null,
+    });
+    await expect(beginHostedCodexAuthAttempt({
+      action: "connect",
+      memberId: "member_123",
+      now: new Date("2026-06-23T12:01:00.000Z"),
+      prisma: connectedPrisma.client,
+    })).resolves.toEqual({
+      attemptId: null,
+      mailboxItemId: null,
+      view: { state: "connected" },
+    });
+
+    const absentPrisma = createCodexAuthPrismaHarness();
+    await expect(beginHostedCodexAuthAttempt({
+      action: "disconnect",
+      memberId: "member_123",
+      now: new Date("2026-06-23T12:01:00.000Z"),
+      prisma: absentPrisma.client,
+    })).resolves.toEqual({
+      attemptId: null,
+      mailboxItemId: null,
+      view: { state: "disconnected" },
+    });
+
+    const disconnectedPrisma = createCodexAuthPrismaHarness({
+      attemptId: "hca_disconnectedattempt",
+      memberId: "member_123",
+      state: "disconnected",
+      updatedAt: new Date("2026-06-23T12:00:00.000Z"),
+      userCode: null,
+      verificationUrl: null,
+    });
+    await expect(beginHostedCodexAuthAttempt({
+      action: "disconnect",
+      memberId: "member_123",
+      now: new Date("2026-06-23T12:01:00.000Z"),
+      prisma: disconnectedPrisma.client,
+    })).resolves.toEqual({
+      attemptId: null,
+      mailboxItemId: null,
+      view: { state: "disconnected" },
+    });
+
+    expect(
+      mocks.runWithPreparedHostedMailboxItemAppendCrypto,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).not.toHaveBeenCalled();
   });
 
   it("reuses a fresh disconnect wake so route retries can re-signal runtime", async () => {
@@ -203,6 +274,9 @@ describe("hosted Codex auth store", () => {
     expect(
       mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
     ).not.toHaveBeenCalled();
+    expect(
+      mocks.runWithPreparedHostedMailboxItemAppendCrypto,
+    ).not.toHaveBeenCalled();
     expect(mocks.readHostedMailboxItemByDedupeKey).toHaveBeenCalledWith({
       dedupeKey: "codex-auth:disconnect:hca_disconnectattempt",
       prisma: prisma.tx,
@@ -210,7 +284,7 @@ describe("hosted Codex auth store", () => {
     });
   });
 
-  it("finishes mailbox crypto preparation before the Codex transaction opens", async () => {
+  it("finishes mailbox crypto preparation before the Codex append transaction opens", async () => {
     const events: string[] = [];
     const preparation = createDeferred<void>();
     const prisma = createCodexAuthPrismaHarness(null, { events });
@@ -229,7 +303,7 @@ describe("hosted Codex auth store", () => {
         return input.append(buildPreparedMailboxCrypto(input.userId));
       },
     );
-    mocks.lockHostedMemberRow.mockImplementationOnce(async () => {
+    mocks.lockHostedMemberRow.mockImplementation(async () => {
       events.push("member-lock");
     });
     mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mockImplementationOnce(
@@ -250,8 +324,11 @@ describe("hosted Codex auth store", () => {
     await vi.waitFor(() => {
       expect(events).toContain("provider-start");
     });
-    expect(prisma.transaction).not.toHaveBeenCalled();
-    expect(mocks.lockHostedMemberRow).not.toHaveBeenCalled();
+    expect(prisma.transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.getActiveTransactionDepth()).toBe(0);
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).not.toHaveBeenCalled();
 
     preparation.resolve();
     await expect(pending).resolves.toMatchObject({
@@ -259,15 +336,13 @@ describe("hosted Codex auth store", () => {
       view: { state: "connecting" },
     });
 
+    const appendTransactionStart = events.lastIndexOf("transaction-start");
+    const appendMemberLock = events.lastIndexOf("member-lock");
     expect(events.indexOf("provider-finished")).toBeLessThan(
-      events.indexOf("transaction-start"),
+      appendTransactionStart,
     );
-    expect(events.indexOf("transaction-start")).toBeLessThan(
-      events.indexOf("member-lock"),
-    );
-    expect(events.indexOf("member-lock")).toBeLessThan(
-      events.indexOf("mailbox-append"),
-    );
+    expect(appendTransactionStart).toBeLessThan(appendMemberLock);
+    expect(appendMemberLock).toBeLessThan(events.indexOf("mailbox-append"));
     expect(prisma.getRootAccessesDuringTransaction()).toEqual([]);
   });
 
@@ -297,7 +372,8 @@ describe("hosted Codex auth store", () => {
       prisma: prisma.client,
     });
     await blockedPreparationStarted.promise;
-    expect(prisma.transaction).not.toHaveBeenCalled();
+    expect(prisma.transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.getActiveTransactionDepth()).toBe(0);
 
     await expect(beginHostedCodexAuthAttempt({
       action: "connect",
@@ -308,7 +384,7 @@ describe("hosted Codex auth store", () => {
       mailboxItemId: "mailbox_item_codex_auth",
       view: { state: "connecting" },
     });
-    expect(prisma.transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.transaction).toHaveBeenCalledTimes(3);
     expect(prisma.getRecord("member_unrelated")).toMatchObject({
       memberId: "member_unrelated",
       state: "connecting",
@@ -319,7 +395,7 @@ describe("hosted Codex auth store", () => {
       mailboxItemId: "mailbox_item_codex_auth",
       view: { state: "connecting" },
     });
-    expect(prisma.transaction).toHaveBeenCalledTimes(2);
+    expect(prisma.transaction).toHaveBeenCalledTimes(4);
     expect(prisma.getRootAccessesDuringTransaction()).toEqual([]);
   });
 
@@ -358,7 +434,7 @@ describe("hosted Codex auth store", () => {
       prisma: prisma.client,
     });
 
-    expect(prisma.transaction).toHaveBeenCalledTimes(2);
+    expect(prisma.transaction).toHaveBeenCalledTimes(3);
     expect(
       mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
     ).toHaveBeenCalledTimes(2);
@@ -666,6 +742,7 @@ function createCodexAuthPrismaHarness(
   options: { events?: string[] } = {},
 ): {
   client: CodexAuthPrismaForTest;
+  getActiveTransactionDepth: () => number;
   getRecord: (memberId?: string) => StoredCodexAuthConnection | null;
   getRootAccessesDuringTransaction: () => string[];
   setRecord: (record: StoredCodexAuthConnection | null) => void;
@@ -759,6 +836,7 @@ function createCodexAuthPrismaHarness(
   // Narrow test double: the store touches only this delegate plus $transaction.
   return {
     client: codexAuthPrismaClientForTest(client),
+    getActiveTransactionDepth: () => transactionDepth,
     getRecord: (memberId = defaultMemberId) => {
       const record = records.get(memberId);
       return record ? { ...record } : null;

--- a/apps/web/test/hosted-codex-auth-store.test.ts
+++ b/apps/web/test/hosted-codex-auth-store.test.ts
@@ -5,16 +5,23 @@ import {
   beginHostedCodexAuthAttempt,
   readHostedCodexAuthConnectionView,
 } from "@/src/lib/codex-auth/store";
+import type {
+  PreparedHostedMailboxItemAppendCrypto,
+} from "@/src/lib/hosted-mailbox/store";
 
 const mocks = vi.hoisted(() => ({
-  appendHostedMailboxEnvelopeTx: vi.fn(),
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx: vi.fn(),
   lockHostedMemberRow: vi.fn(),
   readHostedMailboxItemByDedupeKey: vi.fn(),
+  runWithPreparedHostedMailboxItemAppendCrypto: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-mailbox/store", () => ({
-  appendHostedMailboxEnvelopeTx: mocks.appendHostedMailboxEnvelopeTx,
+  appendHostedMailboxEnvelopeWithPreparedCryptoTx:
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
   readHostedMailboxItemByDedupeKey: mocks.readHostedMailboxItemByDedupeKey,
+  runWithPreparedHostedMailboxItemAppendCrypto:
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/shared", async (importOriginal) => {
@@ -56,15 +63,25 @@ interface CodexAuthWhere {
 describe("hosted Codex auth store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.appendHostedMailboxEnvelopeTx.mockImplementation(async () => ({
-      item: {
-        id: "mailbox_item_codex_auth",
-      },
-    }));
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mockImplementation(
+      async () => ({
+        item: {
+          id: "mailbox_item_codex_auth",
+        },
+      }),
+    );
     mocks.lockHostedMemberRow.mockResolvedValue(undefined);
     mocks.readHostedMailboxItemByDedupeKey.mockImplementation(async () => ({
       id: "mailbox_item_codex_auth",
     }));
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementation(
+      async (input: {
+        append: (
+          prepared: PreparedHostedMailboxItemAppendCrypto,
+        ) => Promise<unknown>;
+        userId: string;
+      }) => input.append(buildPreparedMailboxCrypto(input.userId)),
+    );
   });
 
   it("dedupes fresh connect attempts and replaces stale ones with a new runtime wake", async () => {
@@ -86,8 +103,17 @@ describe("hosted Codex auth store", () => {
       verificationUrl: null,
     });
     expect(mocks.lockHostedMemberRow).toHaveBeenCalledWith(prisma.tx, "member_123");
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+    expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).toHaveBeenCalledWith({
+      append: expect.any(Function),
+      prisma: prisma.client,
+      userId: "member_123",
+    });
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).toHaveBeenCalledWith({
       envelope: expect.objectContaining({
         action: "connect",
         attemptId: first.attemptId,
@@ -96,6 +122,7 @@ describe("hosted Codex auth store", () => {
         occurredAt: "2026-06-23T12:00:00.000Z",
         userId: "member_123",
       }),
+      prepared: buildPreparedMailboxCrypto("member_123"),
       tx: prisma.tx,
     });
 
@@ -115,7 +142,9 @@ describe("hosted Codex auth store", () => {
         verificationUrl: null,
       },
     });
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).toHaveBeenCalledTimes(1);
     expect(mocks.readHostedMailboxItemByDedupeKey).toHaveBeenCalledWith({
       dedupeKey: `codex-auth:connect:${first.attemptId}`,
       prisma: prisma.tx,
@@ -144,7 +173,9 @@ describe("hosted Codex auth store", () => {
       userCode: null,
       verificationUrl: null,
     });
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).toHaveBeenCalledTimes(2);
   });
 
   it("reuses a fresh disconnect wake so route retries can re-signal runtime", async () => {
@@ -169,11 +200,191 @@ describe("hosted Codex auth store", () => {
       mailboxItemId: "mailbox_item_codex_auth",
       view: { state: "disconnecting" },
     });
-    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).not.toHaveBeenCalled();
     expect(mocks.readHostedMailboxItemByDedupeKey).toHaveBeenCalledWith({
       dedupeKey: "codex-auth:disconnect:hca_disconnectattempt",
       prisma: prisma.tx,
       userId: "member_123",
+    });
+  });
+
+  it("finishes mailbox crypto preparation before the Codex transaction opens", async () => {
+    const events: string[] = [];
+    const preparation = createDeferred<void>();
+    const prisma = createCodexAuthPrismaHarness(null, { events });
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementationOnce(
+      async (input: {
+        append: (
+          prepared: PreparedHostedMailboxItemAppendCrypto,
+        ) => Promise<unknown>;
+        prisma: CodexAuthPrismaForTest;
+        userId: string;
+      }) => {
+        events.push("provider-start");
+        expect(input.prisma).toBe(prisma.client);
+        await preparation.promise;
+        events.push("provider-finished");
+        return input.append(buildPreparedMailboxCrypto(input.userId));
+      },
+    );
+    mocks.lockHostedMemberRow.mockImplementationOnce(async () => {
+      events.push("member-lock");
+    });
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mockImplementationOnce(
+      async (input: { tx: object }) => {
+        events.push("mailbox-append");
+        expect(input.tx).toBe(prisma.tx);
+        return { item: { id: "mailbox_item_codex_auth" } };
+      },
+    );
+
+    const pending = beginHostedCodexAuthAttempt({
+      action: "connect",
+      memberId: "member_123",
+      now: new Date("2026-06-23T12:00:00.000Z"),
+      prisma: prisma.client,
+    });
+
+    await vi.waitFor(() => {
+      expect(events).toContain("provider-start");
+    });
+    expect(prisma.transaction).not.toHaveBeenCalled();
+    expect(mocks.lockHostedMemberRow).not.toHaveBeenCalled();
+
+    preparation.resolve();
+    await expect(pending).resolves.toMatchObject({
+      mailboxItemId: "mailbox_item_codex_auth",
+      view: { state: "connecting" },
+    });
+
+    expect(events.indexOf("provider-finished")).toBeLessThan(
+      events.indexOf("transaction-start"),
+    );
+    expect(events.indexOf("transaction-start")).toBeLessThan(
+      events.indexOf("member-lock"),
+    );
+    expect(events.indexOf("member-lock")).toBeLessThan(
+      events.indexOf("mailbox-append"),
+    );
+    expect(prisma.getRootAccessesDuringTransaction()).toEqual([]);
+  });
+
+  it("lets an unrelated member begin while another member's crypto preparation waits", async () => {
+    const blockedPreparation = createDeferred<void>();
+    const blockedPreparationStarted = createDeferred<void>();
+    const prisma = createCodexAuthPrismaHarness();
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementation(
+      async (input: {
+        append: (
+          prepared: PreparedHostedMailboxItemAppendCrypto,
+        ) => Promise<unknown>;
+        userId: string;
+      }) => {
+        if (input.userId === "member_blocked") {
+          blockedPreparationStarted.resolve();
+          await blockedPreparation.promise;
+        }
+        return input.append(buildPreparedMailboxCrypto(input.userId));
+      },
+    );
+
+    const blocked = beginHostedCodexAuthAttempt({
+      action: "connect",
+      memberId: "member_blocked",
+      now: new Date("2026-06-23T12:00:00.000Z"),
+      prisma: prisma.client,
+    });
+    await blockedPreparationStarted.promise;
+    expect(prisma.transaction).not.toHaveBeenCalled();
+
+    await expect(beginHostedCodexAuthAttempt({
+      action: "connect",
+      memberId: "member_unrelated",
+      now: new Date("2026-06-23T12:00:00.000Z"),
+      prisma: prisma.client,
+    })).resolves.toMatchObject({
+      mailboxItemId: "mailbox_item_codex_auth",
+      view: { state: "connecting" },
+    });
+    expect(prisma.transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.getRecord("member_unrelated")).toMatchObject({
+      memberId: "member_unrelated",
+      state: "connecting",
+    });
+
+    blockedPreparation.resolve();
+    await expect(blocked).resolves.toMatchObject({
+      mailboxItemId: "mailbox_item_codex_auth",
+      view: { state: "connecting" },
+    });
+    expect(prisma.transaction).toHaveBeenCalledTimes(2);
+    expect(prisma.getRootAccessesDuringTransaction()).toEqual([]);
+  });
+
+  it("keeps one attempt and dedupe identity across prepared-root re-entry", async () => {
+    const prisma = createCodexAuthPrismaHarness();
+    const firstRootDrift = new Error("prepared root changed");
+    mocks.runWithPreparedHostedMailboxItemAppendCrypto.mockImplementationOnce(
+      async (input: {
+        append: (
+          prepared: PreparedHostedMailboxItemAppendCrypto,
+        ) => Promise<unknown>;
+        userId: string;
+      }) => {
+        try {
+          return await input.append(buildPreparedMailboxCrypto(
+            input.userId,
+            "root_before_rotation",
+          ));
+        } catch (error) {
+          expect(error).toBe(firstRootDrift);
+          return input.append(buildPreparedMailboxCrypto(
+            input.userId,
+            "root_after_rotation",
+          ));
+        }
+      },
+    );
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx
+      .mockRejectedValueOnce(firstRootDrift)
+      .mockResolvedValueOnce({ item: { id: "mailbox_item_codex_auth" } });
+
+    const result = await beginHostedCodexAuthAttempt({
+      action: "connect",
+      memberId: "member_123",
+      now: new Date("2026-06-23T12:00:00.000Z"),
+      prisma: prisma.client,
+    });
+
+    expect(prisma.transaction).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx,
+    ).toHaveBeenCalledTimes(2);
+    type PreparedAppendInput = {
+      envelope: { attemptId: string; eventId: string };
+      prepared: PreparedHostedMailboxItemAppendCrypto;
+    };
+    const firstAppend = (
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[0]?.[0]
+    ) as PreparedAppendInput | undefined;
+    const secondAppend = (
+      mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[1]?.[0]
+    ) as PreparedAppendInput | undefined;
+    if (!firstAppend || !secondAppend) {
+      throw new Error("Expected both prepared Codex mailbox append attempts.");
+    }
+    expect(firstAppend.envelope).toEqual(secondAppend.envelope);
+    expect(firstAppend.envelope.attemptId).toBe(result.attemptId);
+    expect(firstAppend.envelope.eventId).toBe(
+      `codex-auth:connect:${result.attemptId}`,
+    );
+    expect(firstAppend.prepared.rootKeyId).toBe("root_before_rotation");
+    expect(secondAppend.prepared.rootKeyId).toBe("root_after_rotation");
+    expect(prisma.getRecord()).toMatchObject({
+      attemptId: result.attemptId,
+      state: "connecting",
     });
   });
 
@@ -450,32 +661,47 @@ describe("hosted Codex auth store", () => {
   });
 });
 
-function createCodexAuthPrismaHarness(initial: StoredCodexAuthConnection | null = null): {
+function createCodexAuthPrismaHarness(
+  initial: StoredCodexAuthConnection | null = null,
+  options: { events?: string[] } = {},
+): {
   client: CodexAuthPrismaForTest;
-  getRecord: () => StoredCodexAuthConnection | null;
+  getRecord: (memberId?: string) => StoredCodexAuthConnection | null;
+  getRootAccessesDuringTransaction: () => string[];
   setRecord: (record: StoredCodexAuthConnection | null) => void;
+  transaction: ReturnType<typeof vi.fn>;
   tx: object;
 } {
-  let record: StoredCodexAuthConnection | null = initial;
+  const defaultMemberId = initial?.memberId ?? "member_123";
+  const records = new Map<string, StoredCodexAuthConnection>();
+  if (initial) {
+    records.set(initial.memberId, { ...initial });
+  }
   const delegate = {
     deleteMany: vi.fn(async (args: { where: CodexAuthWhere }) => {
-      if (matchesRecordWhere(record, args.where)) {
-        record = null;
+      const current = records.get(args.where.memberId) ?? null;
+      if (matchesRecordWhere(current, args.where)) {
+        records.delete(args.where.memberId);
         return { count: 1 };
       }
       return { count: 0 };
     }),
-    findUnique: vi.fn(async (args: { where: { memberId: string } }) =>
-      record?.memberId === args.where.memberId ? { ...record } : null),
+    findUnique: vi.fn(async (args: { where: { memberId: string } }) => {
+      const record = records.get(args.where.memberId);
+      return record ? { ...record } : null;
+    }),
     updateMany: vi.fn(async (args: {
       data: StoredCodexAuthConnectionUpdate;
       where: CodexAuthWhere;
     }) => {
-      const current = record;
+      const current = records.get(args.where.memberId) ?? null;
       if (!current || !matchesRecordWhere(current, args.where)) {
         return { count: 0 };
       }
-      record = applyRecordUpdate(current, args.data);
+      records.set(
+        args.where.memberId,
+        applyRecordUpdate(current, args.data),
+      );
       return { count: 1 };
     }),
     upsert: vi.fn(async (args: {
@@ -483,31 +709,69 @@ function createCodexAuthPrismaHarness(initial: StoredCodexAuthConnection | null 
       update: StoredCodexAuthConnectionUpdate;
       where: { memberId: string };
     }) => {
-      if (record?.memberId === args.where.memberId) {
-        record = applyRecordUpdate(record, args.update);
-      } else {
-        record = { ...args.create };
-      }
+      const current = records.get(args.where.memberId);
+      const record = current
+        ? applyRecordUpdate(current, args.update)
+        : { ...args.create };
+      records.set(args.where.memberId, record);
       return { ...record };
     }),
   };
   const tx = {
     hostedCodexAuthConnection: delegate,
   };
-  const client = {
-    $transaction: vi.fn(async (
-      callback: (transactionClient: typeof tx) => Promise<unknown>,
-    ) => callback(tx)),
+  let transactionDepth = 0;
+  const rootAccessesDuringTransaction: string[] = [];
+  const transaction = vi.fn(async (
+    callback: (transactionClient: typeof tx) => Promise<unknown>,
+  ) => {
+    const snapshot = new Map(records);
+    options.events?.push("transaction-start");
+    transactionDepth += 1;
+    try {
+      const result = await callback(tx);
+      options.events?.push("transaction-commit");
+      return result;
+    } catch (error) {
+      records.clear();
+      for (const [memberId, record] of snapshot) {
+        records.set(memberId, record);
+      }
+      options.events?.push("transaction-rollback");
+      throw error;
+    } finally {
+      transactionDepth -= 1;
+    }
+  });
+  const rawClient = {
+    $transaction: transaction,
     hostedCodexAuthConnection: delegate,
   };
+  const client = new Proxy(rawClient, {
+    get(target, property, receiver) {
+      if (transactionDepth > 0) {
+        rootAccessesDuringTransaction.push(String(property));
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
 
   // Narrow test double: the store touches only this delegate plus $transaction.
   return {
     client: codexAuthPrismaClientForTest(client),
-    getRecord: () => record,
-    setRecord: (next) => {
-      record = next;
+    getRecord: (memberId = defaultMemberId) => {
+      const record = records.get(memberId);
+      return record ? { ...record } : null;
     },
+    getRootAccessesDuringTransaction: () => [...rootAccessesDuringTransaction],
+    setRecord: (next) => {
+      if (next) {
+        records.set(next.memberId, { ...next });
+      } else {
+        records.delete(defaultMemberId);
+      }
+    },
+    transaction,
     tx,
   };
 }
@@ -560,4 +824,26 @@ function matchesRecordWhere(
     return record.state === where.state;
   }
   return where.state.in.includes(record.state);
+}
+
+function buildPreparedMailboxCrypto(
+  userId: string,
+  rootKeyId = `root_prepared_${userId}`,
+): PreparedHostedMailboxItemAppendCrypto {
+  return {
+    domain: "ingress",
+    rootKeyId,
+    userId,
+  };
+}
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
 }


### PR DESCRIPTION
## Why and outcome

`beginHostedCodexAuthAttempt` held the hosted-member transaction while appending a mailbox wake through the legacy transaction encryption path. This moves provider-capable mailbox root preparation to the existing prepared-mailbox owner before the transaction that commits a new auth attempt and mailbox wake, then commits the wake with the prepared-crypto append adapter.

Provider-independent terminal no-op and existing-wake reuse outcomes now return from a short locked DB decision without mailbox crypto preparation. If a new wake is still needed, the store prepares crypto outside the committing transaction, reacquires the member lock, revalidates the decision, and uses the same preallocated attempt/event/dedupe identity across the existing prepared-root retry.

## Product UX

- Effort: Not applicable - internal Settings ChatGPT reliability hardening with no visible copy, UI state, action count, or journey contract change.
- Result: Not applicable.
- Walkthrough: POST and DELETE `/api/settings/chatgpt` still return the same connection views and still signal the runtime only when a mailbox item is returned. Retry/no-op paths remain provider-independent.

## Evidence

- Direct: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-codex-auth-store.test.ts apps/web/test/settings-chatgpt-route.test.ts` passed.
- Direct: `pnpm --dir apps/web exec eslint src/lib/codex-auth/store.ts test/hosted-codex-auth-store.test.ts test/settings-chatgpt-route.test.ts` passed.
- Direct: `pnpm --dir apps/web typecheck` passed.
- Direct: `git diff --check` passed.
- Direct: Final PR ReviewGPT round 1 returned `ROUND_OUTCOME: PASS`; final round 2 returned `ROUND_OUTCOME: PASS` on the remediated head.
- Direct: Static searches found no remaining Codex-auth legacy mailbox append import, no new `as any` or `as unknown` casts, and no credential/direct-identifier shapes in the diff.
- Coverage: The store tests prove preparation finishes before the new-wake append transaction, terminal no-op and existing-wake reuse paths fail if crypto preparation is invoked, unrelated members can proceed while another member's preparation waits, stable identity across prepared-root retry, fresh retry dedupe, and existing callback state handling. Route tests prove Settings still signals runtime only for returned mailbox items.

## Non-obvious affected surfaces

- Settings ChatGPT POST/DELETE route: unchanged route contract; store still returns a mailbox item only for attempts that need a runtime wake, and existing wake reuse remains provider-independent.
- Hosted mailbox append crypto: reuses the existing prepared-root lifecycle and transaction adapter instead of adding a Codex-auth-specific owner.
- Hosted-member row lock: terminal/reuse decisions stay short and DB-only; provider-capable root preparation is outside the committing critical section for new wakes.

## Architecture and reuse

- Existing systems reused: `runWithPreparedHostedMailboxItemAppendCrypto`, `appendHostedMailboxEnvelopeWithPreparedCryptoTx`, existing hosted-member lock, existing Codex auth attempt state, existing mailbox dedupe/event identities.
- New logic: `beginHostedCodexAuthAttempt` first performs a locked provider-independent decision, prepares crypto only when a new wake is needed, then revalidates under the lock before committing with the same preallocated attempt ID.
- New abstractions: None; the added helper is local to the Codex auth store and reuses existing owners.
- Complexity intentionally avoided: No new queue, manager, state machine, persisted state, dependency, compatibility path, or Codex-auth-specific crypto owner.

## Hot reply path impact

- Path status: Not applicable - this is a signed-in Settings ChatGPT route, not the foreground conversation reply path.
- Database calls: None added to the hot reply path.
- Network/provider calls: None added to the hot reply path.
- Other awaited latency: None added to the hot reply path.
- Before/after proof: Focused store tests prove provider-capable preparation occurs before the new-wake append transaction and is skipped for provider-independent no-op/reuse outcomes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run - no assistant/provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 1733da7fccc8e37e0bb15a52644829453bfe6d71
Classification reason: Touches auth-adjacent hosted Settings behavior, database transaction ordering, mailbox encryption preparation, and runtime wake append identity.

- Preliminary specialist finding accepted and remediated: unconditional crypto preparation wrapped terminal no-op and existing-wake reuse outcomes. The corrected head keeps those outcomes provider-independent and revalidates before a prepared new-wake commit.
- Final PR ReviewGPT rounds 1 and 2 returned PASS.

## Deployment concerns

- Deployment: not applicable
- Reason: Single Web code change using existing committed mailbox prepared-crypto APIs; no schema, configuration, Cloudflare/runtime protocol, or cross-deploy compatibility boundary changed.

## Change-shape breakdown

Classification rule: `apps/web/src/lib/codex-auth/store.ts` is Source; `apps/web/test/hosted-codex-auth-store.test.ts` is Tests / fixtures; the completed execution plan is Docs. No binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 129 | 88 |
| Tests / fixtures | 396 | 32 |
| Docs | 104 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **629** | **120** |

## Changelog

- Changelog: not applicable
- Reason: Internal transaction/crypto hardening for the Settings ChatGPT store; no safe public member-facing outcome, UI, copy, or capability changed.


