### PR TITLE
Fix stuck physical-note recovery

### DIFF
--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -574,7 +574,10 @@ Last verified: 2026-08-23
   `fetch`, Node HTTP/HTTPS, Undici, and common fetch aliases at registered
   provider boundaries. It uses Babel's parser and scope bindings; it does not
   reimplement TypeScript, validate provider payloads, or duplicate runtime
-  request/response contracts.
+  request/response contracts. The Lob physical-note owner additionally rejects
+  authored low-level SDK `params` overrides; its transport adapter may only
+  narrow the SDK-generated metadata filter to Lob's documented one-key wire
+  shape.
 
   Raw transport is allowed only in an exact path-and-function owner registered
   by the guard: an official SDK fetch hook or override, an opaque presigned byte

--- a/agent-docs/product-specs/physical-notes.md
+++ b/agent-docs/product-specs/physical-notes.md
@@ -271,6 +271,14 @@ idempotency key equal to the physical-note id. The generated artwork is wrapped
 only in deterministic letter-sized transport HTML with the required print-safe
 margin; visual expression remains model-owned.
 
+Recovery calls the official Lob TypeScript SDK with its typed metadata filter.
+The Web-owned SDK transport adapter narrows the generated client's serialized
+metadata query to Lob's documented `metadata[key]=value` wire shape for the one
+physical-note key. Low-level SDK request-parameter overrides are forbidden by
+the provider-request guard. An indeterminate lookup logs only a bounded category
+and optional HTTP status; it never logs the note id, member id, address, provider
+message, or response body, and it never turns an error into evidence of absence.
+
 USPS Secure Destruction is an account-level Lob setting rather than a per-letter
 API field. Operators enable it in the Lob account before live sending so eligible
 undeliverable First Class notes are destroyed instead of returned to Murph's

--- a/apps/web/changelog/entries/2026-08-26/physical-note-recovery-unblocks.json
+++ b/apps/web/changelog/entries/2026-08-26/physical-note-recovery-unblocks.json
@@ -9,6 +9,6 @@
     "summary": "When an older physical-note attempt never reached the printer, Murph can now confirm that and clear the old submission so a separate future note request is no longer blocked.",
     "details": "Recovery still never sends or retries a note. Accepted notes stay protected, and uncertain printer outcomes remain pending until Murph has conclusive evidence.",
     "relevanceTags": ["assistant", "physical-notes", "reliability"],
-    "sourcePullRequests": [2327]
+    "sourcePullRequests": [2327, 2343]
   }
 }

--- a/apps/web/src/lib/physical-notes/lob-runtime.ts
+++ b/apps/web/src/lib/physical-notes/lob-runtime.ts
@@ -60,6 +60,19 @@ export type LobPhysicalNoteLookupResult =
       kind: "indeterminate";
     };
 
+type LobPhysicalNoteLookupDiagnostic =
+  | {
+      category:
+        | "aborted"
+        | "malformed_response"
+        | "multiple_matches"
+        | "transport_error";
+    }
+  | {
+      category: "http_error";
+      status: number;
+    };
+
 export interface LobPhysicalNoteRuntime {
   create(input: {
     artworkUrl: string;
@@ -152,8 +165,16 @@ export function createLobPhysicalNoteRuntime(input: {
           undefined,
           undefined,
         );
-        return readLobLetterLookup(response) ?? { kind: "indeterminate" };
-      } catch {
+        const result = readLobLetterLookup(response);
+        if (result !== null) {
+          return result;
+        }
+        logLobLookupIndeterminate(readLobLetterLookupDiagnostic(response));
+        return { kind: "indeterminate" };
+      } catch (error) {
+        logLobLookupIndeterminate(
+          readLobLookupErrorDiagnostic(error, signal),
+        );
         return { kind: "indeterminate" };
       }
     },
@@ -296,6 +317,7 @@ function createLobFetchAdapter(
 function readLobRequestUrl(config: LobAxiosRequestConfig): URL {
   const url = new URL(requireValue(config.url ?? "", "Lob request URL"));
   appendLobRequestParams(url, config.params);
+  rewriteLobPhysicalNoteMetadataFilter(url);
   return url;
 }
 
@@ -312,6 +334,38 @@ function appendLobRequestParams(url: URL, value: unknown): void {
     }
     url.searchParams.append(key, entry);
   }
+}
+
+function rewriteLobPhysicalNoteMetadataFilter(url: URL): void {
+  const values = url.searchParams.getAll("metadata");
+  if (values.length === 0) {
+    return;
+  }
+  if (values.length !== 1) {
+    throw new TypeError("Lob metadata filter must be unique.");
+  }
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(values[0] ?? "");
+  } catch {
+    throw new TypeError("Lob metadata filter must be serialized JSON.");
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new TypeError("Lob metadata filter must be an object.");
+  }
+  const entries = Object.entries(metadata);
+  if (
+    entries.length !== 1
+    || entries[0]?.[0] !== PHYSICAL_NOTE_METADATA_KEY
+    || typeof entries[0][1] !== "string"
+  ) {
+    throw new TypeError("Lob metadata filter must select one physical note.");
+  }
+  url.searchParams.delete("metadata");
+  url.searchParams.append(
+    `metadata[${PHYSICAL_NOTE_METADATA_KEY}]`,
+    requireValue(entries[0][1], "Lob physical-note metadata value"),
+  );
 }
 
 function readLobRequestHeaders(config: LobAxiosRequestConfig): Headers {
@@ -502,6 +556,40 @@ function readLobLetterLookup(value: unknown): LobPhysicalNoteLookupResult | null
   return providerLetterId
     ? { kind: "accepted", providerLetterId }
     : null;
+}
+
+function readLobLetterLookupDiagnostic(
+  value: unknown,
+): LobPhysicalNoteLookupDiagnostic {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const data = Reflect.get(value, "data");
+    if (Array.isArray(data) && data.length > 1) {
+      return { category: "multiple_matches" };
+    }
+  }
+  return { category: "malformed_response" };
+}
+
+function readLobLookupErrorDiagnostic(
+  error: unknown,
+  signal: AbortSignal,
+): LobPhysicalNoteLookupDiagnostic {
+  const status = readLobHttpStatus(error);
+  if (status !== null) {
+    return { category: "http_error", status };
+  }
+  return signal.aborted
+    ? { category: "aborted" }
+    : { category: "transport_error" };
+}
+
+function logLobLookupIndeterminate(
+  diagnostic: LobPhysicalNoteLookupDiagnostic,
+): void {
+  console.warn(
+    "Lob physical-note metadata lookup was indeterminate.",
+    diagnostic,
+  );
 }
 
 function escapeHtmlAttribute(value: string): string {

--- a/apps/web/test/physical-notes-lob-runtime.test.ts
+++ b/apps/web/test/physical-notes-lob-runtime.test.ts
@@ -360,16 +360,7 @@ describe("Lob physical-note runtime", () => {
   });
 
   it("finds an accepted letter through Lob's exact metadata filter", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
-      const request = new Request(input, init);
-      expect(request.url).toBe(
-        "https://api.lob.com/v1/letters?limit=2&metadata=%7B%22murph_physical_note_id%22%3A%22hpn_lookup%22%7D",
-      );
-      expect(request.method).toBe("GET");
-      expect(request.headers.get("authorization")).toMatch(/^Basic /u);
-      expect(request.headers.get("Lob-Version")).toBe("2024-01-01");
-      expect(init?.body).toBeUndefined();
-      expect(init?.redirect).toBe("error");
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
       return Response.json({
         data: [{ id: "ltr_lookup" }],
       });
@@ -387,6 +378,16 @@ describe("Lob physical-note runtime", () => {
       providerLetterId: "ltr_lookup",
     });
     expect(fetchImpl).toHaveBeenCalledOnce();
+    const [input, init] = fetchImpl.mock.calls[0] ?? [];
+    const request = new Request(input, init);
+    expect(request.url).toBe(
+      "https://api.lob.com/v1/letters?limit=2&metadata%5Bmurph_physical_note_id%5D=hpn_lookup",
+    );
+    expect(request.method).toBe("GET");
+    expect(request.headers.get("authorization")).toMatch(/^Basic /u);
+    expect(request.headers.get("Lob-Version")).toBe("2024-01-01");
+    expect(init?.body).toBeUndefined();
+    expect(init?.redirect).toBe("error");
   });
 
   it("treats a valid empty Lob metadata result as definitively absent", async () => {
@@ -402,6 +403,9 @@ describe("Lob physical-note runtime", () => {
   });
 
   it("keeps multiple Lob metadata matches indeterminate", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(
+      () => undefined,
+    );
     const runtime = createLobPhysicalNoteRuntime({
       apiKey: "test_key",
       fetchImpl: vi.fn<typeof fetch>(async () => Response.json({
@@ -410,9 +414,17 @@ describe("Lob physical-note runtime", () => {
       fromAddressId: "adr_from",
     });
 
-    await expect(runtime.findLetterByNoteId({
-      noteId: "hpn_multiple",
-    })).resolves.toEqual({ kind: "indeterminate" });
+    try {
+      await expect(runtime.findLetterByNoteId({
+        noteId: "hpn_multiple",
+      })).resolves.toEqual({ kind: "indeterminate" });
+      expect(warning).toHaveBeenCalledWith(
+        "Lob physical-note metadata lookup was indeterminate.",
+        { category: "multiple_matches" },
+      );
+    } finally {
+      warning.mockRestore();
+    }
   });
 
   it("uses the short lookup-only provider deadline", async () => {
@@ -452,21 +464,41 @@ describe("Lob physical-note runtime", () => {
       async () => Response.json({ data: [{ object: "letter" }] }),
     ];
 
-    for (const response of responses) {
+    const expectedDiagnostics = [
+      { category: "transport_error" },
+      { category: "http_error", status: 503 },
+      { category: "malformed_response" },
+    ] as const;
+
+    for (const [index, response] of responses.entries()) {
+      const warning = vi.spyOn(console, "warn").mockImplementation(
+        () => undefined,
+      );
       const fetchImpl = vi.fn<typeof fetch>(response);
       const runtime = createLobPhysicalNoteRuntime({
         apiKey: "test_key",
         fetchImpl,
         fromAddressId: "adr_from",
       });
-      await expect(runtime.findLetterByNoteId({
-        noteId: "hpn_indeterminate",
-      })).resolves.toEqual({ kind: "indeterminate" });
-      expect(fetchImpl).toHaveBeenCalledOnce();
+      try {
+        await expect(runtime.findLetterByNoteId({
+          noteId: "hpn_indeterminate",
+        })).resolves.toEqual({ kind: "indeterminate" });
+        expect(fetchImpl).toHaveBeenCalledOnce();
+        expect(warning).toHaveBeenCalledWith(
+          "Lob physical-note metadata lookup was indeterminate.",
+          expectedDiagnostics[index],
+        );
+      } finally {
+        warning.mockRestore();
+      }
     }
   });
 
   it("keeps a timed-out Lob metadata lookup indeterminate", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(
+      () => undefined,
+    );
     const fetchImpl = vi.fn<typeof fetch>(async (_input, init) =>
       await new Promise<Response>((_resolve, reject) => {
         init?.signal?.addEventListener("abort", () => {
@@ -480,10 +512,18 @@ describe("Lob physical-note runtime", () => {
       fromAddressId: "adr_from",
     });
 
-    await expect(runtime.findLetterByNoteId({
-      noteId: "hpn_timeout",
-      signal: AbortSignal.timeout(1),
-    })).resolves.toEqual({ kind: "indeterminate" });
+    try {
+      await expect(runtime.findLetterByNoteId({
+        noteId: "hpn_timeout",
+        signal: AbortSignal.timeout(1),
+      })).resolves.toEqual({ kind: "indeterminate" });
+      expect(warning).toHaveBeenCalledWith(
+        "Lob physical-note metadata lookup was indeterminate.",
+        { category: "aborted" },
+      );
+    } finally {
+      warning.mockRestore();
+    }
   });
 
   it("renders only transport layout around the model-owned artwork", () => {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -7559,6 +7559,10 @@ describeRealCodex('real Codex physical-note stuck recovery e2e', () => {
           action.kind === 'dynamic'
           && action.tool === MURPH_RESOLVE_PHYSICAL_NOTE_TOOL.name
         )
+        const imageCalls = actions.filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_GENERATE_IMAGE_TOOL.name
+        )
         const sendCalls = actions.filter((action) =>
           action.kind === 'dynamic'
           && action.tool === MURPH_SEND_PHYSICAL_NOTE_TOOL.name
@@ -7571,6 +7575,7 @@ describeRealCodex('real Codex physical-note stuck recovery e2e', () => {
           })}\n`,
         )
         expect(recoveryCalls).toHaveLength(1)
+        expect(imageCalls).toHaveLength(0)
         expect(sendCalls).toHaveLength(0)
         expect(resolveRequests).toEqual([{
           originAssistantInputId: messageRef,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -73,6 +73,7 @@ import {
   MURPH_GROUP_CONSULT_TOOL,
 } from '../src/assistant-codex/dynamic-tool-catalog.ts'
 import {
+  MURPH_RESOLVE_PHYSICAL_NOTE_TOOL,
   MURPH_SEND_PHYSICAL_NOTE_TOOL,
 } from '../src/assistant-codex/dynamic-tools/physical-notes.ts'
 import {
@@ -7460,6 +7461,134 @@ describeRealCodex('real Codex physical-note rejection recovery e2e', () => {
       }
     },
     720_000,
+  )
+})
+
+describeRealCodex('real Codex physical-note stuck recovery e2e', () => {
+  it(
+    'checks and clears one stuck physical note without generating or sending another',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-physical-note-stuck-recovery-e2e-'),
+      )
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      const messageRef = `ain_${'6'.repeat(32)}`
+      const targetMessageRef = `ain_${'7'.repeat(32)}`
+      const resolveRequests: unknown[] = []
+      let sendCount = 0
+
+      try {
+        await materializePhysicalNoteSkill({ skillsRoot })
+        const hostedToolContext = {
+          computerToolsAvailable: false,
+          currentHostedDeliveryContext: () => null,
+          currentHostedMailboxItemIds: () => [],
+          currentUserActionScope: () => ({
+            acceptedInputIds: [messageRef],
+            conversationId: 'conversation-physical-note-stuck-recovery',
+            conversationScope: 'direct' as const,
+            inboundMailboxItemIds: ['mailbox-physical-note-stuck-recovery'],
+            originSessionId: 'session-physical-note-stuck-recovery',
+            recipientKey: 'recipient-physical-note-stuck-recovery',
+          }),
+          physicalNotes: {
+            async resolve(request: unknown) {
+              resolveRequests.push(request)
+              return {
+                remainingUnresolved: false,
+                retryAfter: null,
+                settledUsageCostUsdMicros: null,
+                status: 'clear' as const,
+              }
+            },
+            async send() {
+              sendCount += 1
+              return {
+                complimentary: false,
+                costUsdMicros: '250000',
+                failureReason: 'unknown' as const,
+                physicalNoteId: 'hpn_unexpected_send',
+                status: 'failed' as const,
+              }
+            },
+          },
+          privateImageUrlPublisher: {
+            async publishPrivateImageUrl() {
+              throw new Error('Recovery must not publish artwork.')
+            },
+          },
+          sendVaultFile: async () => ({
+            filename: 'unused',
+            status: 'denied' as const,
+          }),
+          vaultFileSendAvailable: false,
+        } satisfies AssistantHostedToolContext
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          authorizeAcceptedMessageTarget: async ({ messageRef: requested }) =>
+            requested === messageRef ? { targetInputId: messageRef } : null,
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions: buildDirectConversationDeveloperInstructions(),
+          dynamicTools: resolveMurphDynamicTools({
+            physicalNotesAvailable: true,
+          }),
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          },
+          excludeResumeTurns: true,
+          hostedToolContext,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: [
+            `Message ref: ${messageRef}`,
+            `Earlier physical-note send Message ref: ${targetMessageRef}`,
+            'That earlier physical note is stuck. Please check it and safely clear the blocker if the provider record allows. Do not create or send a new note.',
+          ].join('\n\n'),
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+        const recoveryCalls = actions.filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_RESOLVE_PHYSICAL_NOTE_TOOL.name
+        )
+        const sendCalls = actions.filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_SEND_PHYSICAL_NOTE_TOOL.name
+        )
+
+        process.stdout.write(
+          `[physical-note-stuck-recovery-e2e] ${JSON.stringify({
+            finalMessage: result.finalMessage,
+            scenario: 'clears one provider-absent blocker without a new send',
+          })}\n`,
+        )
+        expect(recoveryCalls).toHaveLength(1)
+        expect(sendCalls).toHaveLength(0)
+        expect(resolveRequests).toEqual([{
+          originAssistantInputId: messageRef,
+          targetKind: 'send',
+          targetOriginAssistantInputId: targetMessageRef,
+        }])
+        expect(sendCount).toBe(0)
+        expect(result.finalMessage).toMatch(/clear|no longer block/iu)
+        expect(result.finalMessage).toMatch(/no unresolved|nothing (?:new )?was sent/iu)
+        expect(result.finalMessage).not.toMatch(/generat|new artwork|sent a new note/iu)
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
   )
 })
 

--- a/scripts/check-provider-request-boundaries.test.ts
+++ b/scripts/check-provider-request-boundaries.test.ts
@@ -185,6 +185,21 @@ describe("check-provider-request-boundaries", () => {
     ]);
   });
 
+  it("rejects object-literal Lob request params around an official SDK call", () => {
+    expect(violations(`
+      import { LettersApi } from "@lob/lob-typescript-sdk";
+      async function findLetter(letters: LettersApi, query: Record<string, string>) {
+        return letters.list(2, undefined, undefined, undefined, undefined, undefined,
+          undefined, undefined, undefined, undefined, undefined, { params: query });
+      }
+      function createLobFetchAdapter(fetchImpl: typeof fetch) {
+        return (url: string) => fetchImpl(url);
+      }
+    `, "apps/web/src/lib/physical-notes/lob-runtime.ts")).toEqual([
+      "official-sdk-request-override",
+    ]);
+  });
+
   it("keeps providers without a verified TypeScript SDK outside the ban", () => {
     expect(violations(`
       fetch("https://api.telegram.org/bot/example/sendMessage");

--- a/scripts/check-provider-request-boundaries.test.ts
+++ b/scripts/check-provider-request-boundaries.test.ts
@@ -168,6 +168,23 @@ describe("check-provider-request-boundaries", () => {
     `)).toEqual([]);
   });
 
+  it("rejects low-level Lob request params around an official SDK call", () => {
+    expect(violations(`
+      import { LettersApi } from "@lob/lob-typescript-sdk";
+      async function findLetter(letters: LettersApi, query: Record<string, string>) {
+        const requestOptions = {};
+        requestOptions.params = query;
+        return letters.list(2, undefined, undefined, undefined, undefined, undefined,
+          undefined, undefined, undefined, undefined, undefined, requestOptions);
+      }
+      function createLobFetchAdapter(fetchImpl: typeof fetch) {
+        return (url: string) => fetchImpl(url);
+      }
+    `, "apps/web/src/lib/physical-notes/lob-runtime.ts")).toEqual([
+      "official-sdk-request-override",
+    ]);
+  });
+
   it("keeps providers without a verified TypeScript SDK outside the ban", () => {
     expect(violations(`
       fetch("https://api.telegram.org/bot/example/sendMessage");

--- a/scripts/check-provider-request-boundaries.ts
+++ b/scripts/check-provider-request-boundaries.ts
@@ -459,6 +459,7 @@ export const approvedProviderRawHttpOwners = Object.freeze([
 type ProviderRequestBoundaryViolationKind =
   | "approved-owner-overflow"
   | "invalid-approved-owner"
+  | "official-sdk-request-override"
   | "raw-provider-http";
 
 export interface ProviderRequestBoundaryViolation {
@@ -537,8 +538,28 @@ export function findProviderRequestBoundaryViolations(
   const violations = new Map<string, ProviderRequestBoundaryViolation>();
 
   traverse(sourceFile, {
+    AssignmentExpression(assignmentPath) {
+      inspectOfficialSdkRequestOverride(
+        assignmentPath,
+        readStaticMemberName(assignmentPath.node.left),
+      );
+    },
     CallExpression(callPath) {
       inspectCall(callPath);
+    },
+    ObjectProperty(propertyPath) {
+      if (!propertyPath.parentPath.isObjectExpression()) {
+        return;
+      }
+      const key = propertyPath.node.key;
+      inspectOfficialSdkRequestOverride(
+        propertyPath,
+        !propertyPath.node.computed && key.type === "Identifier"
+          ? key.name
+          : key.type === "StringLiteral"
+            ? key.value
+            : null,
+      );
     },
     OptionalCallExpression(callPath) {
       inspectCall(callPath);
@@ -611,6 +632,24 @@ export function findProviderRequestBoundaryViolations(
       boundary: `Direct ${labels.join(" / ")} provider HTTP in ${ownerName}`,
       kind: "raw-provider-http",
       node: callPath.node,
+    });
+  }
+
+  function inspectOfficialSdkRequestOverride(
+    nodePath: NodePath<Node>,
+    optionName: string | null,
+  ): void {
+    if (
+      normalizedPath !== "apps/web/src/lib/physical-notes/lob-runtime.ts"
+      || !hasRuntimeModule(runtimeModules, "@lob/lob-typescript-sdk")
+      || optionName !== "params"
+    ) {
+      return;
+    }
+    recordViolation({
+      boundary: "Lob official SDK low-level request params",
+      kind: "official-sdk-request-override",
+      node: nodePath.node,
     });
   }
 
@@ -1376,6 +1415,8 @@ function formatViolationKind(kind: ProviderRequestBoundaryViolationKind): string
       return "contains more raw transport calls than its approval permits";
     case "invalid-approved-owner":
       return "lost its required runtime SDK import";
+    case "official-sdk-request-override":
+      return "overrides low-level official SDK request options";
     case "raw-provider-http":
       return "uses raw provider HTTP";
   }


### PR DESCRIPTION
## Why and outcome

A physical-note recovery could stay pending forever because the installed Lob SDK serialized its typed metadata filter differently from Lob's documented wire contract. This keeps the official SDK call, corrects only that generated filter in the Web-owned adapter, and adds bounded diagnostics so an old provider-absent attempt can clear without ever treating uncertainty as absence.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: provider-absent old attempts clear; provider-accepted attempts remain protected; timeouts, provider errors, malformed results, and multiple matches remain pending with bounded operational diagnostics.
- Deliberate exclusion: this does not automatically retry or send a note, and it does not add a pre-artwork unresolved-note preflight.

## Evidence

- 111 focused Web physical-note runtime/service/replay tests passed.
- 28 provider-request guard tests passed; the production guard passed.
- 33 deterministic assistant physical-note tests passed.
- 16 focused changelog page/fragment tests passed.
- Web and assistant-engine typechecks passed.
- Focused Web lint and diff/privacy checks passed.
- The preliminary specialist findings were accepted and remediated with zero-image-action and object-literal-guard assertions.
- Final ReviewGPT round 1 passed with no qualifying findings; the later specialist remediation changed tests only.
- The focused real-Codex journey reached the live runner but was blocked before tool execution by `ASSISTANT_CODEX_USAGE_LIMIT`; no production/provider/member action occurred.

## Non-obvious affected surfaces

- Provider-request boundary guard: now rejects low-level Lob SDK `params` overrides that the raw-fetch ownership check did not catch; covered by assignment-form and object-literal regressions.
- Assistant verification scaffolding: adds a synthetic recovery journey asserting one resolve action, zero image-generation actions, and zero send actions; production assistant prompts and tool schemas are unchanged.
- Operational logging: indeterminate Lob lookups emit only a fixed category and optional HTTP status; no identifiers, URLs, bodies, or provider messages.

## Architecture and reuse

- Existing systems reused: Lob official TypeScript SDK, the existing Web-owned fetch adapter, physical-note recovery state machine, and provider-request guard.
- New logic: one strict adapter rewrite from the SDK-generated JSON metadata query to Lob's documented one-key bracket query, plus bounded lookup classification.
- New abstractions: no cross-owner or persisted abstraction; one local diagnostic union and local adapter helper are sufficient.
- Complexity intentionally avoided: no retry queue, manual database clear, alternate provider client, new state owner, or automatic resend path.

## Hot reply path impact

The existing explicit recovery turn still performs at most one serial Lob list request with the existing 5-second timeout and no retry. No database, provider, or other awaited operation was added or moved; only the generated request query is corrected. Errors and ambiguous responses continue to return pending rather than clear.

## Murph initial provider input impact

- Individual runtime: Not applicable; no production prompt, instruction, tool schema, or generated provider-visible guidance changed.
- Group runtime: Not applicable; no production prompt, instruction, tool schema, or generated provider-visible guidance changed.
- Measurement exclusion: the added synthetic live journey is test-only and is never assembled into a production provider request.

## Change-shape breakdown

Classification rule: runtime implementation is source, test files are tests/fixtures, durable Markdown and authored changelog content are docs, guard implementation is config/tooling, and no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 90 | 2 |
| Tests/fixtures | 228 | 22 |
| Docs | 13 | 2 |
| Config/tooling | 41 | 0 |
| Generated/other | 0 | 0 |
| Total | 372 | 26 |

## Changelog

- Changelog: updated
- Items: 2026-08-26 · physical-note-recovery-unblocks

## Deployment concerns

- Deployment: applicable
- Supported skew: This is a Web-only runtime correction with no record, schema, prompt, or cross-deploy contract change.
- Safe order: Deploy the updated Web runtime normally; Cloudflare requires no tandem change.
- Rollback floor: The prior Web version remains schema-compatible but restores the stuck lookup behavior.
- Expected exposure: During rollout, an instance on the old version can still return pending for a recovery check.
- Reversibility: A normal Web rollback is safe because no data shape or irreversible action changes.
- Convergence proof: Confirm the production Web deployment SHA before exercising recovery.
- Post-deploy checks: Run one explicit recovery and inspect only bounded lookup status/category evidence if it remains pending.

ReviewGPT context sensitivity: sensitive — changes an external provider egress and fail-closed recovery boundary.

ReviewGPT first-reviewed head: 9ce40f5171e69768d4397eff20eec1f1631f0f8c