### PR TITLE
fix(web): prepare invite identity before transactions

### DIFF
--- a/.agents/friction-log/20260826133951-reviewgpt-preflight-cannot/friction.md
+++ b/.agents/friction-log/20260826133951-reviewgpt-preflight-cannot/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'ReviewGPT preflight cannot package a fresh task worktree'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A task worktree created by the repository helper can run the repository ReviewGPT entrypoint with the reviewed workspace toolchain.
+
+## Current Behavior
+
+A fresh task worktree has no dependency links, so the ReviewGPT preflight reaches the repository no-JavaScript guard and fails because the TypeScript runner is unavailable. Completing the review then requires either coupling the command to another checkout installation or installing the full workspace dependency graph.
+
+## Possible Solution
+
+Have the sanctioned worktree helper expose the primary checkout reviewed dependency installation safely, or make the ReviewGPT wrapper resolve its required repository tools through an explicit supported owner.
+
+## Minimal Reproducible Example
+
+1. Create a task worktree with scripts/create-worktree from a current branch.
+2. Enter the new worktree without installing dependencies.
+3. Run pnpm review:gpt --zip --dry-run.
+4. Observe the preflight fail before packaging because the TypeScript runner cannot be found.
+
+## Context
+
+This blocks the required exact-head ReviewGPT workflow in isolated task branches and makes a repository-wide frozen install the smallest independent recovery.

--- a/agent-docs/exec-plans/active/2026-08-26-identity-kms-before-locks.md
+++ b/agent-docs/exec-plans/active/2026-08-26-identity-kms-before-locks.md
@@ -1,0 +1,65 @@
+# Move public invite identity KMS outside database locks
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Preserve public invite phone-code verification while ensuring saved-phone decryption completes before any database transaction or row lock begins.
+- Keep authorization and concurrency decisions inside their existing owners by revalidating exact prepared row fingerprints under the existing lock order.
+
+## Success criteria
+
+- Invite verification prepares any private identity outside the transaction; confirm and abort paths remain scalar-only under the lock.
+- Confirm and abort read only the plaintext attempt scalar under the lock and never project private identity.
+- Focused tests prove delayed KMS completes before transaction entry, transaction-local provider calls are disabled, stale preparations fail closed, and replay/cooldown behavior remains valid.
+- Hosted Web focused tests and typecheck pass; exact pushed PR head receives the required ReviewGPT gates and required CI.
+- A separate draft PR is opened for this owner and is not merged or marked Ready.
+
+## Scope
+
+- In scope: public invite send-code, confirm, and abort identity handling; directly required hosted identity helpers; focused tests; and current transaction-catalog documentation when its owner row changes.
+- Out of scope: phone-transfer retirement, mailbox append migration, device credentials, billing provider effects, account-deletion lock ordering, provider or schema changes, caches, managers, queues, new services, or new durable state.
+
+## Constraints
+
+- Technical constraints: prepare/decrypt before checkout; revalidate exact raw-row fingerprints under existing locks; preserve sorted lock order, privacy, authorization, provider-disabled behavior, and product-critical flows.
+- Product/process constraints: ReviewGPT must independently agree before any implementation patch is applied; supplied patches are behavioral intent; prefer deletion and existing prepared-root/raw-fingerprint patterns; keep the PR draft and do not merge.
+
+## Risks and mitigations
+
+1. Risk: a preparation becomes stale before the locked commit.
+   Mitigation: compare the exact raw database row fingerprint under the existing lock and fail closed on drift.
+2. Risk: moving projection work changes authorization or callback semantics.
+   Mitigation: keep scalar authority decisions and mutations in the current transaction owner and add focused provider-disabled and drift tests.
+3. Risk: a broad helper introduces another state owner.
+   Mitigation: reuse current preparation/projection helpers and pass immutable prepared values directly; add no cache, manager, service, queue, or persisted state.
+
+## Tasks
+
+1. Capture the fresh ReviewGPT implementation disposition and attachment metadata for the exact current-main bundle.
+2. Trace invite transaction boundaries, current fingerprints, and test seams; verify the returned patch against those owners.
+3. Apply only an agreed, scoped patch and simplify it to the smallest explicit data flow.
+4. Run focused delayed-KMS, disabled-provider, drift, lock-ordering, and typecheck proof; inspect the final diff and privacy boundary.
+5. Commit and push an intermediate exact-head candidate, open a separate draft PR, and start required exact-head ReviewGPT gates concurrently with CI.
+6. Resolve all accepted review findings, complete the parent final review, then close the plan with `scripts/finish-task` and push the final scoped commit.
+
+## Decisions
+
+- Use the existing identity and billing projection owners; this change introduces no new runtime owner or durable state.
+- Treat the ReviewGPT patch as a proposal requiring local code-path and test verification before application.
+- Fresh ReviewGPT implementation review agreed with the invite-only finding (`IMPLEMENTATION_DISPOSITION: AGREE_PATCHED`) against main `a56b39f829767108cd3d842c0590eda46a96b28a`; its returned artifact had SHA-256 `5133bbc4dd5db28aaa15c1778cb8895703a8830594793cc20b111c4d5b7145db`.
+- Apply only the invite send-code/confirm/abort artifact: three production owners and two focused test files. The worktree copies were verified byte-for-byte against a clean temporary-index application of that exact artifact.
+- Keep the scoped unwrap cache around confirm and abort. `runWithHostedDomainRootProviderCallsDisabled` fails closed only while an unwrap cache is present; removing that scope would make a cache miss call the provider directly.
+- No transaction-catalog row changes: the existing identity/authentication owner entries remain broader than this narrow invite correction.
+
+## Verification
+
+- `pnpm --dir apps/web exec tsx scripts/run-hosted-web-vitest.mts test/hosted-onboarding-invite-send-code.test.ts` — passed, 9 tests.
+- `pnpm --dir apps/web exec tsx scripts/run-hosted-web-vitest.mts test/hosted-onboarding-member-service.test.ts` — passed, 17 tests.
+- `pnpm --dir apps/web typecheck` — passed, including generation and TypeScript lanes.
+- Targeted ESLint over the three production files and two focused tests — passed.
+- `git diff --check` and the task-path privacy scan — passed.
+- The fresh task worktree lacked its reviewed toolchain links, so an offline frozen install was required before focused proof; the public-safe repository friction is captured in `.agents/friction-log/20260826133951-reviewgpt-preflight-cannot/friction.md`.
+- Remaining: exact-head preliminary specialist review, final cross-cutting ReviewGPT round, GitHub required checks, current-base merge-tree proof, and final plan closure.

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-identity-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-identity-store.ts
@@ -16,6 +16,7 @@ import {
 import { hostedOnboardingError } from "./errors";
 import {
   buildHostedMemberIdentityPrivateColumns,
+  readHostedMemberIdentityPhoneNumbers,
   readHostedMemberIdentityPrivateState,
 } from "./member-private-codecs";
 import {
@@ -322,7 +323,7 @@ export async function readHostedMemberIdentity(input: {
 
 /**
  * Reads the exact encrypted identity row without projecting private fields.
- * Prepared webhook paths use this to bind an outside-transaction projection
+ * Prepared transaction paths use this to bind an outside-transaction projection
  * to the row re-read while the member lock is held.
  */
 export async function readHostedMemberIdentityRecord(input: {
@@ -334,6 +335,50 @@ export async function readHostedMemberIdentityRecord(input: {
       memberId: input.memberId,
     },
   });
+}
+
+export async function prepareHostedMemberInvitePhoneIdentity(input: {
+  memberId: string;
+  prisma: HostedOnboardingReadClient;
+}) {
+  const identityRecord = await readHostedMemberIdentityRecord(input);
+  if (!identityRecord) {
+    return null;
+  }
+  const phoneNumbers = await readHostedMemberIdentityPhoneNumbers(
+    identityRecord,
+    input.prisma,
+  );
+
+  return {
+    identityRecord,
+    identityState: {
+      maskedPhoneNumberHint: identityRecord.maskedPhoneNumberHint,
+      ...phoneNumbers,
+    },
+  } as const;
+}
+
+export async function readHostedMemberSignupPhoneCodeAttempt(input: {
+  memberId: string;
+  prisma: HostedOnboardingReadClient;
+}): Promise<{ signupPhoneCodeSendAttemptId: string | null } | null> {
+  const identity = await input.prisma.hostedMemberIdentity.findUnique({
+    where: {
+      memberId: input.memberId,
+    },
+    select: {
+      signupPhoneCodeSendAttemptId: true,
+    },
+  });
+
+  return identity
+    ? {
+        signupPhoneCodeSendAttemptId: normalizeNullableString(
+          identity.signupPhoneCodeSendAttemptId,
+        ),
+      }
+    : null;
 }
 
 export async function lockHostedMemberIdentityStateTx(input: {

--- a/apps/web/src/lib/hosted-onboarding/invite-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/invite-service.ts
@@ -12,6 +12,12 @@ import type {
   HostedInviteStatusPayload,
 } from "./types";
 
+import {
+  runWithFreshHostedDomainRootUnwrapCache,
+  runWithHostedDomainRootProviderCallsDisabled,
+  runWithHostedDomainRootUnwrapCache,
+} from "../hosted-crypto/domain-root-unwrap-cache";
+import { HostedDomainRootPreparationMismatchError } from "../hosted-crypto/domain-root-store";
 import { getPrisma } from "../prisma";
 import { isHostedMemberActivationPending } from "./activation-progress";
 import {
@@ -36,9 +42,12 @@ import {
 import { deriveHostedOnboardingStage } from "./lifecycle";
 import { readActiveHostedMemberAccess } from "./member-access";
 import {
+  hostedMemberIdentityRecordsEqual,
+  prepareHostedMemberInvitePhoneIdentity,
   projectHostedMemberIdentityState,
   type HostedMemberIdentityState,
-  readHostedMemberIdentity,
+  readHostedMemberIdentityRecord,
+  readHostedMemberSignupPhoneCodeAttempt,
   writeHostedMemberSignupPhoneState,
 } from "./hosted-member-identity-store";
 import { ensureHostedMemberForPhoneTx } from "./member-identity-service";
@@ -421,55 +430,107 @@ export async function prepareHostedInvitePhoneCode(input: {
   const now = input.now ?? new Date();
   const prisma = input.prisma ?? getPrisma();
 
-  return prisma.$transaction(async (tx) => {
-    const invite = await requireHostedInviteForAuthentication(input.inviteCode, tx, now);
-    await lockHostedMemberRow(tx, invite.memberId);
-
-    const identity = await readHostedInviteIdentityStateOrThrow(invite.memberId, tx);
-    const phoneAuthTarget = resolveHostedInvitePhoneAuthTarget(identity);
-
-    if (phoneAuthTarget.kind === "manual") {
-      throw hostedOnboardingError({
-        code: "SIGNUP_PHONE_UNAVAILABLE",
-        message: "Enter the number that messaged Murph to continue.",
-        httpStatus: 409,
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const runAttempt = async () => {
+      const preparedInvite = await requireHostedInvitePhoneCodeAuthority(
+        input.inviteCode,
+        prisma,
+        now,
+      );
+      const preparedIdentity = await prepareHostedMemberInvitePhoneIdentity({
+        memberId: preparedInvite.memberId,
+        prisma,
       });
-    }
+      if (!preparedIdentity) {
+        throw hostedInviteIdentityMissingError();
+      }
+      const phoneAuthTarget = resolveHostedInvitePhoneAuthTarget(
+        preparedIdentity.identityState,
+      );
 
-    const retryAfterMs = readPhoneCodeRetryAfterMs({
-      lastAttemptAt: maxDate(
-        identity.signupPhoneCodeSentAt,
-        identity.signupPhoneCodeSendAttemptStartedAt,
-      ),
-      now,
-    });
+      return prisma.$transaction(
+        (tx) => runWithHostedDomainRootProviderCallsDisabled(async () => {
+          const invite = await requireHostedInvitePhoneCodeAuthority(
+            input.inviteCode,
+            tx,
+            now,
+          );
+          await lockHostedMemberRow(tx, invite.memberId);
 
-    if (retryAfterMs > 0) {
-      throw hostedOnboardingError({
-        code: "PHONE_CODE_COOLDOWN",
-        message: "Wait a moment before requesting another code.",
-        httpStatus: 429,
-        retryable: true,
-        details: {
-          retryAfterMs,
-        },
-      });
-    }
+          const identityRecord = await readHostedMemberIdentityRecord({
+            memberId: invite.memberId,
+            prisma: tx,
+          });
+          if (
+            invite.memberId !== preparedIdentity.identityRecord.memberId
+            || !identityRecord
+            || !hostedMemberIdentityRecordsEqual(
+              identityRecord,
+              preparedIdentity.identityRecord,
+            )
+          ) {
+            throw new HostedDomainRootPreparationMismatchError();
+          }
 
-    const sendAttemptId = generateHostedPhoneCodeAttemptId();
-    await writeHostedMemberSignupPhoneState({
-      memberId: invite.memberId,
-      prisma: tx,
-      signupPhoneCodeSendAttemptId: sendAttemptId,
-      signupPhoneCodeSendAttemptStartedAt: now,
-    });
+          if (phoneAuthTarget.kind === "manual") {
+            throw hostedOnboardingError({
+              code: "SIGNUP_PHONE_UNAVAILABLE",
+              message: "Enter the number that messaged Murph to continue.",
+              httpStatus: 409,
+            });
+          }
 
-    return {
-      phoneHint: phoneAuthTarget.phoneHint,
-      phoneNumber: phoneAuthTarget.phoneNumber,
-      sendAttemptId,
+          const retryAfterMs = readPhoneCodeRetryAfterMs({
+            lastAttemptAt: maxDate(
+              identityRecord.signupPhoneCodeSentAt,
+              identityRecord.signupPhoneCodeSendAttemptStartedAt,
+            ),
+            now,
+          });
+
+          if (retryAfterMs > 0) {
+            throw hostedOnboardingError({
+              code: "PHONE_CODE_COOLDOWN",
+              message: "Wait a moment before requesting another code.",
+              httpStatus: 429,
+              retryable: true,
+              details: {
+                retryAfterMs,
+              },
+            });
+          }
+
+          const sendAttemptId = generateHostedPhoneCodeAttemptId();
+          await writeHostedMemberSignupPhoneState({
+            memberId: invite.memberId,
+            prisma: tx,
+            signupPhoneCodeSendAttemptId: sendAttemptId,
+            signupPhoneCodeSendAttemptStartedAt: now,
+          });
+
+          return {
+            phoneHint: phoneAuthTarget.phoneHint,
+            phoneNumber: phoneAuthTarget.phoneNumber,
+            sendAttemptId,
+          };
+        }),
+        HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+      );
     };
-  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+
+    try {
+      return await (attempt === 0
+        ? runWithHostedDomainRootUnwrapCache(runAttempt)
+        : runWithFreshHostedDomainRootUnwrapCache(runAttempt));
+    } catch (error) {
+      if (error instanceof HostedDomainRootPreparationMismatchError && attempt === 0) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new HostedDomainRootPreparationMismatchError();
 }
 
 export async function confirmHostedInvitePhoneCode(input: {
@@ -481,32 +542,47 @@ export async function confirmHostedInvitePhoneCode(input: {
   const now = input.now ?? new Date();
   const prisma = input.prisma ?? getPrisma();
 
-  return prisma.$transaction(async (tx) => {
-    const invite = await requireHostedInviteForAuthentication(input.inviteCode, tx, now);
-    await lockHostedMemberRow(tx, invite.memberId);
+  return runWithHostedDomainRootUnwrapCache(() =>
+    prisma.$transaction(
+      (tx) => runWithHostedDomainRootProviderCallsDisabled(async () => {
+        const invite = await requireHostedInvitePhoneCodeAuthority(
+          input.inviteCode,
+          tx,
+          now,
+        );
+        await lockHostedMemberRow(tx, invite.memberId);
 
-    const identity = await readHostedInviteIdentityStateOrThrow(invite.memberId, tx);
-    if (identity.signupPhoneCodeSendAttemptId !== input.sendAttemptId) {
-      throw hostedOnboardingError({
-        code: "PHONE_CODE_ATTEMPT_INVALID",
-        message: "Request a fresh verification code to continue.",
-        httpStatus: 409,
-        retryable: true,
-      });
-    }
+        const identity = await readHostedMemberSignupPhoneCodeAttempt({
+          memberId: invite.memberId,
+          prisma: tx,
+        });
+        if (!identity) {
+          throw hostedInviteIdentityMissingError();
+        }
+        if (identity.signupPhoneCodeSendAttemptId !== input.sendAttemptId) {
+          throw hostedOnboardingError({
+            code: "PHONE_CODE_ATTEMPT_INVALID",
+            message: "Request a fresh verification code to continue.",
+            httpStatus: 409,
+            retryable: true,
+          });
+        }
 
-    await writeHostedMemberSignupPhoneState({
-      memberId: invite.memberId,
-      prisma: tx,
-      signupPhoneCodeSendAttemptId: null,
-      signupPhoneCodeSendAttemptStartedAt: null,
-      signupPhoneCodeSentAt: now,
-    });
+        await writeHostedMemberSignupPhoneState({
+          memberId: invite.memberId,
+          prisma: tx,
+          signupPhoneCodeSendAttemptId: null,
+          signupPhoneCodeSendAttemptStartedAt: null,
+          signupPhoneCodeSentAt: now,
+        });
 
-    return {
-      ok: true,
-    };
-  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+        return {
+          ok: true,
+        };
+      }),
+      HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+    ),
+  );
 }
 
 export async function abortHostedInvitePhoneCode(input: {
@@ -518,25 +594,40 @@ export async function abortHostedInvitePhoneCode(input: {
   const now = input.now ?? new Date();
   const prisma = input.prisma ?? getPrisma();
 
-  return prisma.$transaction(async (tx) => {
-    const invite = await requireHostedInviteForAuthentication(input.inviteCode, tx, now);
-    await lockHostedMemberRow(tx, invite.memberId);
+  return runWithHostedDomainRootUnwrapCache(() =>
+    prisma.$transaction(
+      (tx) => runWithHostedDomainRootProviderCallsDisabled(async () => {
+        const invite = await requireHostedInvitePhoneCodeAuthority(
+          input.inviteCode,
+          tx,
+          now,
+        );
+        await lockHostedMemberRow(tx, invite.memberId);
 
-    const identity = await readHostedInviteIdentityStateOrThrow(invite.memberId, tx);
-    if (identity.signupPhoneCodeSendAttemptId === input.sendAttemptId) {
-      await writeHostedMemberSignupPhoneState({
-        memberId: invite.memberId,
-        prisma: tx,
-        signupPhoneCodeSendAttemptId: null,
-        signupPhoneCodeSendAttemptStartedAt: null,
-        signupPhoneCodeSentAt: now,
-      });
-    }
+        const identity = await readHostedMemberSignupPhoneCodeAttempt({
+          memberId: invite.memberId,
+          prisma: tx,
+        });
+        if (!identity) {
+          throw hostedInviteIdentityMissingError();
+        }
+        if (identity.signupPhoneCodeSendAttemptId === input.sendAttemptId) {
+          await writeHostedMemberSignupPhoneState({
+            memberId: invite.memberId,
+            prisma: tx,
+            signupPhoneCodeSendAttemptId: null,
+            signupPhoneCodeSendAttemptStartedAt: null,
+            signupPhoneCodeSentAt: now,
+          });
+        }
 
-    return {
-      ok: true,
-    };
-  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+        return {
+          ok: true,
+        };
+      }),
+      HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+    ),
+  );
 }
 
 export function requireHostedInviteMemberIdentity(
@@ -562,7 +653,10 @@ export function requireHostedInviteMemberIdentity(
 }
 
 function resolveHostedInvitePhoneAuthTarget(
-  identity: HostedMemberIdentityState,
+  identity: Pick<
+    HostedMemberIdentityState,
+    "maskedPhoneNumberHint" | "phoneNumber" | "signupPhoneNumber"
+  >,
 ): HostedInvitePhoneAuthTargetWithNumber {
   const phoneNumber = identity.phoneNumber ?? identity.signupPhoneNumber;
 
@@ -673,24 +767,46 @@ async function findHostedInviteByCode(
   });
 }
 
-async function readHostedInviteIdentityStateOrThrow(
-  memberId: string,
+async function requireHostedInvitePhoneCodeAuthority(
+  inviteCode: string,
   prisma: HostedOnboardingReadClient,
+  now: Date,
 ) {
-  const identity = await readHostedMemberIdentity({
-    memberId,
-    prisma,
+  const invite = await prisma.hostedInvite.findUnique({
+    where: {
+      inviteCode,
+    },
+    select: {
+      expiresAt: true,
+      memberId: true,
+    },
   });
 
-  if (!identity) {
+  if (!invite) {
     throw hostedOnboardingError({
-      code: "HOSTED_MEMBER_IDENTITY_MISSING",
-      message: "Hosted invite identity state is missing.",
-      httpStatus: 500,
+      code: "INVITE_NOT_FOUND",
+      message: "That Murph invite link is no longer valid.",
+      httpStatus: 404,
     });
   }
 
-  return identity;
+  if (invite.expiresAt <= now) {
+    throw hostedOnboardingError({
+      code: "INVITE_EXPIRED",
+      message: "That Murph invite link has expired. Text the number again for a fresh link.",
+      httpStatus: 410,
+    });
+  }
+
+  return invite;
+}
+
+function hostedInviteIdentityMissingError(): Error {
+  return hostedOnboardingError({
+    code: "HOSTED_MEMBER_IDENTITY_MISSING",
+    message: "Hosted invite identity state is missing.",
+    httpStatus: 500,
+  });
 }
 
 function readPhoneCodeRetryAfterMs(input: {

--- a/apps/web/src/lib/hosted-onboarding/member-private-codecs.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-private-codecs.ts
@@ -185,6 +185,35 @@ export async function readHostedMemberIdentityPhoneNumber(
   });
 }
 
+export async function readHostedMemberIdentityPhoneNumbers(
+  identity: Pick<
+    HostedMemberIdentity,
+    "memberId" | "phoneNumberEncrypted" | "signupPhoneNumberEncrypted"
+  >,
+  prisma?: HostedWebEncryptionPrismaClient,
+): Promise<{
+  phoneNumber: string | null;
+  signupPhoneNumber: string | null;
+}> {
+  const [phoneNumber, signupPhoneNumber] = await decryptHostedWebNullableFields({
+    entries: [{
+      field: HOSTED_MEMBER_IDENTITY_PHONE_NUMBER_FIELD,
+      memberId: identity.memberId,
+      value: identity.phoneNumberEncrypted,
+    }, {
+      field: HOSTED_MEMBER_IDENTITY_SIGNUP_PHONE_FIELD,
+      memberId: identity.memberId,
+      value: identity.signupPhoneNumberEncrypted,
+    }],
+    prisma,
+  });
+
+  return {
+    phoneNumber: phoneNumber ?? null,
+    signupPhoneNumber: signupPhoneNumber ?? null,
+  };
+}
+
 export async function buildHostedMemberRoutingPrivateColumns(input: {
   linqChatId: string | null;
   linqRecipientPhone: string | null;

--- a/apps/web/test/hosted-onboarding-invite-send-code.test.ts
+++ b/apps/web/test/hosted-onboarding-invite-send-code.test.ts
@@ -1,8 +1,8 @@
+import type { HostedMemberIdentity } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const storeMocks = vi.hoisted(() => ({
-  readHostedMemberIdentity: vi.fn(),
-  writeHostedMemberSignupPhoneState: vi.fn(),
+const codecMocks = vi.hoisted(() => ({
+  readHostedMemberIdentityPhoneNumbers: vi.fn(),
 }));
 
 vi.mock("../src/lib/hosted-onboarding/runtime", async () => {
@@ -26,216 +26,467 @@ vi.mock("../src/lib/hosted-onboarding/runtime", async () => {
   };
 });
 
-vi.mock("../src/lib/hosted-onboarding/hosted-member-identity-store", async () => {
-  const actual = await vi.importActual<typeof import("../src/lib/hosted-onboarding/hosted-member-identity-store")>(
-    "../src/lib/hosted-onboarding/hosted-member-identity-store",
-  );
+vi.mock("../src/lib/hosted-onboarding/member-private-codecs", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/hosted-onboarding/member-private-codecs")
+  >("../src/lib/hosted-onboarding/member-private-codecs");
 
   return {
     ...actual,
-    readHostedMemberIdentity: storeMocks.readHostedMemberIdentity,
-    writeHostedMemberSignupPhoneState: storeMocks.writeHostedMemberSignupPhoneState,
+    readHostedMemberIdentityPhoneNumbers:
+      codecMocks.readHostedMemberIdentityPhoneNumbers,
   };
 });
 
+import {
+  areHostedDomainRootProviderCallsDisabled,
+  getHostedDomainRootUnwrapCache,
+} from "../src/lib/hosted-crypto/domain-root-unwrap-cache";
 import {
   abortHostedInvitePhoneCode,
   confirmHostedInvitePhoneCode,
   prepareHostedInvitePhoneCode,
 } from "../src/lib/hosted-onboarding/invite-service";
 
+const NOW = new Date("2026-04-07T01:00:00.000Z");
+
 describe("invite send-code lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    storeMocks.writeHostedMemberSignupPhoneState.mockResolvedValue({
-      memberId: "member_123",
+    codecMocks.readHostedMemberIdentityPhoneNumbers.mockReset();
+    codecMocks.readHostedMemberIdentityPhoneNumbers.mockResolvedValue({
+      phoneNumber: null,
+      signupPhoneNumber: "+15551234567",
     });
   });
 
-  it("records the transient attempt id before returning the phone for the Privy client send", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity());
+  it("finishes delayed phone decryption before transaction entry and disables providers inside the transaction", async () => {
+    const identity = makeIdentityRecord();
+    const harness = makeInvitePrisma({ identity });
+    const decryptStarted = deferred<void>();
+    const releaseDecrypt = deferred<void>();
 
-    const result = await prepareHostedInvitePhoneCode({
-      inviteCode: "invite-code",
-      now: new Date("2026-04-07T01:00:00.000Z"),
-      prisma: makeInvitePrisma(),
+    codecMocks.readHostedMemberIdentityPhoneNumbers.mockImplementationOnce(async () => {
+      expect(harness.isTransactionOpen()).toBe(false);
+      decryptStarted.resolve(undefined);
+      await releaseDecrypt.promise;
+      expect(harness.isTransactionOpen()).toBe(false);
+      return {
+        phoneNumber: null,
+        signupPhoneNumber: "+15551234567",
+      };
     });
 
-    expect(result).toEqual({
+    const resultPromise = prepareHostedInvitePhoneCode({
+      inviteCode: "invite-code",
+      now: NOW,
+      prisma: harness.prisma,
+    });
+
+    await decryptStarted.promise;
+    expect(harness.transaction).not.toHaveBeenCalled();
+    releaseDecrypt.resolve(undefined);
+
+    await expect(resultPromise).resolves.toEqual({
       phoneHint: "*** 4567",
       phoneNumber: "+15551234567",
-      sendAttemptId: expect.stringMatching(/^hbpc_/),
+      sendAttemptId: expect.stringMatching(/^hbpc_/u),
     });
-
-    expect(storeMocks.writeHostedMemberSignupPhoneState).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: expect.any(Object),
-      signupPhoneCodeSendAttemptId: expect.stringMatching(/^hbpc_/),
-      signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:00.000Z"),
+    expect(codecMocks.readHostedMemberIdentityPhoneNumbers).toHaveBeenCalledWith(
+      identity,
+      harness.prisma,
+    );
+    expect(harness.transactionProviderCallFences.length).toBeGreaterThan(0);
+    expect(harness.transactionProviderCallFences.every(Boolean)).toBe(true);
+    expect(harness.transactionUnwrapCacheScopes.every(Boolean)).toBe(true);
+    expect(harness.rootInviteFindUnique).toHaveBeenCalledWith(inviteAuthorityQuery());
+    expect(harness.txInviteFindUnique).toHaveBeenCalledWith(inviteAuthorityQuery());
+    expect(harness.identityUpdate).toHaveBeenCalledWith({
+      where: {
+        memberId: "member_123",
+      },
+      data: {
+        signupPhoneCodeSendAttemptId: expect.stringMatching(/^hbpc_/u),
+        signupPhoneCodeSendAttemptStartedAt: NOW,
+      },
     });
   });
 
   it("falls back to the canonical stored phone after signup-only state has been cleared", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity({
+    const harness = makeInvitePrisma();
+    codecMocks.readHostedMemberIdentityPhoneNumbers.mockResolvedValue({
       phoneNumber: "+15557654321",
       signupPhoneNumber: null,
-    }));
-
-    const result = await prepareHostedInvitePhoneCode({
-      inviteCode: "invite-code",
-      now: new Date("2026-04-07T01:00:00.000Z"),
-      prisma: makeInvitePrisma(),
     });
 
-    expect(result).toEqual({
+    await expect(
+      prepareHostedInvitePhoneCode({
+        inviteCode: "invite-code",
+        now: NOW,
+        prisma: harness.prisma,
+      }),
+    ).resolves.toEqual({
       phoneHint: "*** 4567",
       phoneNumber: "+15557654321",
-      sendAttemptId: expect.stringMatching(/^hbpc_/),
+      sendAttemptId: expect.stringMatching(/^hbpc_/u),
     });
   });
 
+  it("preserves the manual-entry error after exact raw identity revalidation", async () => {
+    const harness = makeInvitePrisma();
+    codecMocks.readHostedMemberIdentityPhoneNumbers.mockResolvedValue({
+      phoneNumber: null,
+      signupPhoneNumber: null,
+    });
+
+    await expect(
+      prepareHostedInvitePhoneCode({
+        inviteCode: "invite-code",
+        now: NOW,
+        prisma: harness.prisma,
+      }),
+    ).rejects.toMatchObject({
+      code: "SIGNUP_PHONE_UNAVAILABLE",
+      httpStatus: 409,
+    });
+    expect(harness.identityUpdate).not.toHaveBeenCalled();
+  });
+
   it("rate limits repeated invite send-code requests while an attempt is in flight", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity({
+    const identity = makeIdentityRecord({
       signupPhoneCodeSendAttemptId: "hbpc_in_flight",
       signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:30.000Z"),
-      signupPhoneCodeSentAt: null,
-    }));
+    });
+    const harness = makeInvitePrisma({ identity });
 
     await expect(
       prepareHostedInvitePhoneCode({
         inviteCode: "invite-code",
         now: new Date("2026-04-07T01:00:45.000Z"),
-        prisma: makeInvitePrisma(),
+        prisma: harness.prisma,
       }),
     ).rejects.toMatchObject({
       code: "PHONE_CODE_COOLDOWN",
       httpStatus: 429,
     });
-
-    expect(storeMocks.writeHostedMemberSignupPhoneState).not.toHaveBeenCalled();
+    expect(harness.identityUpdate).not.toHaveBeenCalled();
   });
 
-  it("starts the durable cooldown on confirm and clears the temporary attempt markers", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity({
-      signupPhoneCodeSendAttemptId: "hbpc_confirm",
-      signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:00.000Z"),
-      signupPhoneCodeSentAt: null,
-    }));
+  it("rejects persistent exact raw-row drift after one fresh preparation", async () => {
+    const preparedFirst = makeIdentityRecord();
+    const currentFirst = makeIdentityRecord({
+      updatedAt: new Date("2026-04-07T01:00:01.000Z"),
+      walletAddressEncrypted: "ciphertext-wallet-v2",
+    });
+    const currentSecond = makeIdentityRecord({
+      updatedAt: new Date("2026-04-07T01:00:02.000Z"),
+      walletAddressEncrypted: "ciphertext-wallet-v3",
+    });
+    const harness = makeInvitePrisma({
+      preparedIdentityRecords: [preparedFirst, currentFirst],
+      transactionIdentityRecords: [currentFirst, currentSecond],
+    });
+
+    await expect(
+      prepareHostedInvitePhoneCode({
+        inviteCode: "invite-code",
+        now: NOW,
+        prisma: harness.prisma,
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_DOMAIN_ROOT_PREPARATION_MISMATCH",
+    });
+    expect(harness.transaction).toHaveBeenCalledTimes(2);
+    expect(codecMocks.readHostedMemberIdentityPhoneNumbers).toHaveBeenCalledTimes(2);
+    expect(harness.identityUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a concurrent send replay through the existing cooldown after fresh preparation", async () => {
+    const prepared = makeIdentityRecord();
+    const replayWinner = makeIdentityRecord({
+      signupPhoneCodeSendAttemptId: "hbpc_replay_winner",
+      signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:30.000Z"),
+      updatedAt: new Date("2026-04-07T01:00:30.000Z"),
+    });
+    const harness = makeInvitePrisma({
+      preparedIdentityRecords: [prepared, replayWinner],
+      transactionIdentityRecords: [replayWinner, replayWinner],
+    });
+
+    await expect(
+      prepareHostedInvitePhoneCode({
+        inviteCode: "invite-code",
+        now: new Date("2026-04-07T01:00:45.000Z"),
+        prisma: harness.prisma,
+      }),
+    ).rejects.toMatchObject({
+      code: "PHONE_CODE_COOLDOWN",
+      httpStatus: 429,
+    });
+    expect(harness.transaction).toHaveBeenCalledTimes(2);
+    expect(harness.identityUpdate).not.toHaveBeenCalled();
+  });
+
+  it("confirms through a scalar-only attempt read with providers disabled", async () => {
+    const harness = makeInvitePrisma({
+      signupPhoneCodeSendAttemptIds: ["hbpc_confirm"],
+    });
 
     await expect(
       confirmHostedInvitePhoneCode({
         inviteCode: "invite-code",
         now: new Date("2026-04-07T01:00:02.000Z"),
-        prisma: makeInvitePrisma(),
+        prisma: harness.prisma,
         sendAttemptId: "hbpc_confirm",
       }),
     ).resolves.toEqual({
       ok: true,
     });
 
-    expect(storeMocks.writeHostedMemberSignupPhoneState).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: expect.any(Object),
-      signupPhoneCodeSendAttemptId: null,
-      signupPhoneCodeSendAttemptStartedAt: null,
-      signupPhoneCodeSentAt: new Date("2026-04-07T01:00:02.000Z"),
+    expect(harness.rootIdentityFindUnique).not.toHaveBeenCalled();
+    expect(codecMocks.readHostedMemberIdentityPhoneNumbers).not.toHaveBeenCalled();
+    expect(harness.txInviteFindUnique).toHaveBeenCalledWith(inviteAuthorityQuery());
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledTimes(1);
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledWith(attemptIdQuery());
+    expect(harness.transactionProviderCallFences.every(Boolean)).toBe(true);
+    expect(harness.transactionUnwrapCacheScopes.every(Boolean)).toBe(true);
+    expect(harness.identityUpdate).toHaveBeenCalledWith({
+      where: {
+        memberId: "member_123",
+      },
+      data: {
+        signupPhoneCodeSendAttemptId: null,
+        signupPhoneCodeSendAttemptStartedAt: null,
+        signupPhoneCodeSentAt: new Date("2026-04-07T01:00:02.000Z"),
+      },
     });
   });
 
-  it("clears only the transient attempt after a failed Privy send while the attempt is still current", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity({
-      signupPhoneCodeSendAttemptId: "hbpc_abort",
-      signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:00.000Z"),
-      signupPhoneCodeSentAt: null,
-    }));
+  it("aborts the current attempt through the same scalar-only provider-disabled boundary", async () => {
+    const harness = makeInvitePrisma({
+      signupPhoneCodeSendAttemptIds: ["hbpc_abort"],
+    });
 
     await expect(
       abortHostedInvitePhoneCode({
         inviteCode: "invite-code",
         now: new Date("2026-04-07T01:00:05.000Z"),
-        prisma: makeInvitePrisma(),
+        prisma: harness.prisma,
         sendAttemptId: "hbpc_abort",
       }),
     ).resolves.toEqual({
       ok: true,
     });
 
-    expect(storeMocks.writeHostedMemberSignupPhoneState).toHaveBeenCalledWith({
-      memberId: "member_123",
-      prisma: expect.any(Object),
-      signupPhoneCodeSendAttemptId: null,
-      signupPhoneCodeSendAttemptStartedAt: null,
-      signupPhoneCodeSentAt: new Date("2026-04-07T01:00:05.000Z"),
+    expect(harness.rootIdentityFindUnique).not.toHaveBeenCalled();
+    expect(codecMocks.readHostedMemberIdentityPhoneNumbers).not.toHaveBeenCalled();
+    expect(harness.txInviteFindUnique).toHaveBeenCalledWith(inviteAuthorityQuery());
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledTimes(1);
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledWith(attemptIdQuery());
+    expect(harness.transactionProviderCallFences.every(Boolean)).toBe(true);
+    expect(harness.transactionUnwrapCacheScopes.every(Boolean)).toBe(true);
+    expect(harness.identityUpdate).toHaveBeenCalledWith({
+      where: {
+        memberId: "member_123",
+      },
+      data: {
+        signupPhoneCodeSendAttemptId: null,
+        signupPhoneCodeSendAttemptStartedAt: null,
+        signupPhoneCodeSentAt: new Date("2026-04-07T01:00:05.000Z"),
+      },
     });
   });
 
-  it("does not clear the cooldown for stale or mismatched abort requests", async () => {
-    storeMocks.readHostedMemberIdentity.mockResolvedValue(makeIdentity({
-      signupPhoneCodeSendAttemptId: "hbpc_current",
-      signupPhoneCodeSendAttemptStartedAt: new Date("2026-04-07T01:00:00.000Z"),
-      signupPhoneCodeSentAt: null,
-    }));
+  it("aborts through a scalar-only attempt read without clearing a later attempt", async () => {
+    const harness = makeInvitePrisma({
+      signupPhoneCodeSendAttemptIds: ["hbpc_current"],
+    });
 
     await expect(
       abortHostedInvitePhoneCode({
         inviteCode: "invite-code",
         now: new Date("2026-04-07T01:01:00.000Z"),
-        prisma: makeInvitePrisma(),
+        prisma: harness.prisma,
         sendAttemptId: "hbpc_old",
       }),
     ).resolves.toEqual({
       ok: true,
     });
 
-    expect(storeMocks.writeHostedMemberSignupPhoneState).not.toHaveBeenCalled();
+    expect(harness.rootIdentityFindUnique).not.toHaveBeenCalled();
+    expect(codecMocks.readHostedMemberIdentityPhoneNumbers).not.toHaveBeenCalled();
+    expect(harness.txInviteFindUnique).toHaveBeenCalledWith(inviteAuthorityQuery());
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledTimes(1);
+    expect(harness.txIdentityFindUnique).toHaveBeenCalledWith(attemptIdQuery());
+    expect(harness.transactionProviderCallFences.every(Boolean)).toBe(true);
+    expect(harness.transactionUnwrapCacheScopes.every(Boolean)).toBe(true);
+    expect(harness.identityUpdate).not.toHaveBeenCalled();
   });
 });
 
-function makeInvitePrisma() {
+function makeInvitePrisma(input: {
+  identity?: HostedMemberIdentity;
+  preparedIdentityRecords?: readonly HostedMemberIdentity[];
+  signupPhoneCodeSendAttemptIds?: readonly (string | null)[];
+  transactionIdentityRecords?: readonly HostedMemberIdentity[];
+} = {}) {
+  const identity = input.identity ?? makeIdentityRecord();
+  const preparedIdentityRecords = [...(input.preparedIdentityRecords ?? [identity])];
+  const transactionIdentityRecords = [
+    ...(input.transactionIdentityRecords ?? [identity]),
+  ];
+  const signupPhoneCodeSendAttemptIds = [
+    ...(input.signupPhoneCodeSendAttemptIds
+      ?? [identity.signupPhoneCodeSendAttemptId]),
+  ];
+  let transactionOpen = false;
+  const transactionProviderCallFences: boolean[] = [];
+  const transactionUnwrapCacheScopes: boolean[] = [];
+  const recordTransactionCryptoBoundary = () => {
+    transactionProviderCallFences.push(areHostedDomainRootProviderCallsDisabled());
+    transactionUnwrapCacheScopes.push(Boolean(getHostedDomainRootUnwrapCache()));
+  };
+  const rootInviteFindUnique = vi.fn().mockResolvedValue(inviteAuthority());
+  const txInviteFindUnique = vi.fn().mockImplementation(async () => {
+    recordTransactionCryptoBoundary();
+    return inviteAuthority();
+  });
+  const rootIdentityFindUnique = vi.fn().mockImplementation(async () =>
+    readSequence(preparedIdentityRecords)
+  );
+  const txIdentityFindUnique = vi.fn().mockImplementation(async (query: {
+    select?: { signupPhoneCodeSendAttemptId?: boolean };
+  }) => {
+    recordTransactionCryptoBoundary();
+    if (query.select?.signupPhoneCodeSendAttemptId) {
+      return {
+        signupPhoneCodeSendAttemptId: readSequence(signupPhoneCodeSendAttemptIds),
+      };
+    }
+    return readSequence(transactionIdentityRecords);
+  });
+  const identityUpdate = vi.fn().mockImplementation(async () => {
+    recordTransactionCryptoBoundary();
+    return {};
+  });
   const tx = {
-    $queryRaw: vi.fn().mockResolvedValue([]),
+    $queryRaw: vi.fn().mockImplementation(async () => {
+      recordTransactionCryptoBoundary();
+      return [];
+    }),
     hostedInvite: {
-      findUnique: vi.fn().mockResolvedValue({
-        expiresAt: new Date("2026-04-08T00:00:00.000Z"),
-        inviteCode: "invite-code",
-        member: {
-          id: "member_123",
-          identity: {
-            maskedPhoneNumberHint: "*** 4567",
-          },
-        },
-        memberId: "member_123",
-      }),
+      findUnique: txInviteFindUnique,
+    },
+    hostedMemberIdentity: {
+      findUnique: txIdentityFindUnique,
+      update: identityUpdate,
     },
   };
+  const transaction = vi.fn(async (
+    callback: (innerTx: typeof tx) => Promise<unknown>,
+  ) => {
+    transactionOpen = true;
+    try {
+      return await callback(tx);
+    } finally {
+      transactionOpen = false;
+    }
+  });
+  const prisma = {
+    $transaction: transaction,
+    hostedInvite: {
+      findUnique: rootInviteFindUnique,
+    },
+    hostedMemberIdentity: {
+      findUnique: rootIdentityFindUnique,
+    },
+  } as never;
 
   return {
-    ...tx,
-    $transaction: vi.fn(async (callback: (innerTx: typeof tx) => Promise<unknown>) => callback(tx)),
-  } as never;
+    identityUpdate,
+    isTransactionOpen: () => transactionOpen,
+    prisma,
+    rootIdentityFindUnique,
+    rootInviteFindUnique,
+    transaction,
+    transactionProviderCallFences,
+    transactionUnwrapCacheScopes,
+    txIdentityFindUnique,
+    txInviteFindUnique,
+  };
 }
 
-function makeIdentity(input?: {
-  phoneNumber?: string | null;
-  signupPhoneCodeSendAttemptId?: string | null;
-  signupPhoneCodeSendAttemptStartedAt?: Date | null;
-  signupPhoneCodeSentAt?: Date | null;
-  signupPhoneNumber?: string | null;
-}) {
+function readSequence<T>(values: T[]): T {
+  const value = values.length > 1 ? values.shift() : values[0];
+  if (value === undefined) {
+    throw new Error("Test sequence is empty.");
+  }
+  return value;
+}
+
+function makeIdentityRecord(
+  overrides: Partial<HostedMemberIdentity> = {},
+): HostedMemberIdentity {
   return {
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
     maskedPhoneNumberHint: "*** 4567",
     memberId: "member_123",
-    phoneNumber: input?.phoneNumber ?? null,
     phoneLookupKey: "hbidx:phone:v1:abc123",
+    phoneNumberEncrypted: null,
     phoneNumberVerifiedAt: null,
-    privyUserId: null,
-    signupPhoneCodeSendAttemptId: input?.signupPhoneCodeSendAttemptId ?? null,
-    signupPhoneCodeSendAttemptStartedAt: input?.signupPhoneCodeSendAttemptStartedAt ?? null,
-    signupPhoneCodeSentAt: input?.signupPhoneCodeSentAt ?? null,
-    signupPhoneNumber: input?.signupPhoneNumber ?? "+15551234567",
-    walletAddress: null,
+    privyUserIdEncrypted: null,
+    privyUserLookupKey: null,
+    signupPhoneCodeSendAttemptId: null,
+    signupPhoneCodeSendAttemptStartedAt: null,
+    signupPhoneCodeSentAt: null,
+    signupPhoneNumberEncrypted: "ciphertext-signup-phone",
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    walletAddressEncrypted: null,
+    walletAddressLookupKey: null,
     walletChainType: null,
     walletCreatedAt: null,
     walletProvider: null,
+    ...overrides,
+  };
+}
+
+function inviteAuthority() {
+  return {
+    expiresAt: new Date("2026-04-08T00:00:00.000Z"),
+    memberId: "member_123",
+  };
+}
+
+function inviteAuthorityQuery() {
+  return {
+    where: {
+      inviteCode: "invite-code",
+    },
+    select: {
+      expiresAt: true,
+      memberId: true,
+    },
+  };
+}
+
+function attemptIdQuery() {
+  return {
+    where: {
+      memberId: "member_123",
+    },
+    select: {
+      signupPhoneCodeSendAttemptId: true,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return {
+    promise,
+    resolve,
   };
 }

--- a/apps/web/test/hosted-onboarding-member-service.test.ts
+++ b/apps/web/test/hosted-onboarding-member-service.test.ts
@@ -352,6 +352,47 @@ describe("ensureHostedMemberForPhone", () => {
 });
 
 describe("prepareHostedInvitePhoneCode", () => {
+  it.each([
+    ["missing", null, "INVITE_NOT_FOUND", 404],
+    [
+      "expired",
+      {
+        ...makeInviteRecord(),
+        expiresAt: NOW,
+      },
+      "INVITE_EXPIRED",
+      410,
+    ],
+  ] as const)(
+    "rejects %s invites before private identity reads or transaction entry",
+    async (_label, invite, code, httpStatus) => {
+      const identityFindUnique = vi.fn();
+      const prisma = asRootPrisma({
+        hostedInvite: {
+          findUnique: vi.fn().mockResolvedValue(invite),
+        },
+        hostedMemberIdentity: {
+          findUnique: identityFindUnique,
+          update: vi.fn(),
+        },
+      });
+
+      await expect(
+        prepareHostedInvitePhoneCode({
+          inviteCode: "invite-code",
+          now: NOW,
+          prisma: prisma as never,
+        }),
+      ).rejects.toMatchObject({
+        code,
+        httpStatus,
+      });
+
+      expect(identityFindUnique).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    },
+  );
+
   it("returns a stored phone for the Privy client send and records the transient send attempt", async () => {
     const hostedMemberIdentity = {
       findUnique: vi.fn().mockResolvedValue(await makeIdentityRecord({

--- a/apps/web/test/hosted-onboarding-member-service.test.ts
+++ b/apps/web/test/hosted-onboarding-member-service.test.ts
@@ -45,9 +45,16 @@ vi.mock("@/src/lib/hosted-onboarding/runtime", async () => {
   };
 });
 
-vi.mock("@/src/lib/hosted-crypto/domain-root-store", () => ({
-  provisionActiveHostedDomainRootEnvelopeForUserOnly: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@/src/lib/hosted-crypto/domain-root-store", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/lib/hosted-crypto/domain-root-store")
+  >();
+
+  return {
+    ...actual,
+    provisionActiveHostedDomainRootEnvelopeForUserOnly: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 const NOW = new Date("2026-04-07T01:00:00.000Z");
 


### PR DESCRIPTION
## Why and outcome

Public invite send-code handling decrypted a member's saved phone identity while a database transaction and member row lock were open. A slow KMS/provider call could therefore pin a pooled connection and serialize member work.

This change prepares only the required phone fields before checkout, binds that preparation to the exact encrypted identity row, and revalidates the raw row under the existing member lock. Confirm and abort now select only the plaintext attempt scalar.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Invite recipients keep the same send-code, cooldown, confirmation, abort, expired-link, and missing-identity outcomes. The correction changes transaction timing and recovery only; phone-transfer and other onboarding paths are deliberately excluded.

## Evidence

- Direct: Focused invite lifecycle tests delay identity decryption and prove the transaction has not opened, reject raw-row drift, exercise the one fresh-preparation retry, preserve concurrent-winner cooldown/replay behavior, and assert scalar-only confirm/abort reads with provider calls disabled.
- Coverage: The invite send-code suite passed 9 tests; the shared member-service suite passed 19 tests; hosted Web typecheck, targeted ESLint, and `git diff --check` passed.

## Non-obvious affected surfaces

- Hosted identity storage: adds a phone-only projection helper and reuses the exact raw encrypted-record comparator so the locked write cannot consume a stale preparation. The drift and delayed-decryption tests cover this boundary.
- Hosted crypto unwrap scope: send-code uses the existing ordinary/fresh two-attempt cache pattern; confirm and abort retain an unwrap scope so transaction-local provider disabling fails closed. Provider-disabled tests cover this boundary.

## Architecture and reuse

- Existing systems reused: Existing hosted identity codecs, exact raw-record equality, member lock order, transaction options, provider-call guard, and fresh unwrap-cache retry pattern.
- New logic: Phone-only pre-transaction preparation, exact locked fingerprint validation, and scalar-only attempt reads for confirm and abort.
- New abstractions: One narrow identity-store preparation helper, one phone-pair codec helper, and one scalar attempt reader; each remains in its existing owner module.
- Complexity intentionally avoided: No cache owner, service, manager, queue, schema, compatibility layer, background reconciliation, or new durable state.

## Hot reply path impact

- Path status: Not applicable — public hosted invite verification is outside the foreground assistant reply critical path.
- Database calls: None added or moved onto the hot reply path.
- Network/provider calls: None added or moved onto the hot reply path.
- Other awaited latency: None added or moved onto the hot reply path.
- Before/after proof: Focused invite tests prove KMS work finishes before database transaction entry.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; this patch does not touch assistant prompt assembly.
- Tool/schema/generated guidance: Unchanged; this patch does not touch provider-visible tools or generated guidance.
- Other provider-visible input: Unchanged; this patch changes only public invite database/KMS ordering.
- Measurement method: Not run — no provider-input surface changed.

## Risks

- Privacy and concurrency: the prepared phone is accepted only when the exact encrypted identity row still matches under the existing member lock; one fresh-cache retry handles ordinary key/row drift and persistent drift fails closed.
- Database load: the path keeps one bounded transaction per attempt and removes KMS/provider latency from it. It adds no per-member fanout or concurrent collection work.

ReviewGPT context sensitivity: sensitive
Classification reason: The patch changes private contact-identity handling, database transaction ordering, and concurrency validation.

ReviewGPT first-reviewed head: 5fd2b7a92ada740af9d16858542bb14c15d10e5e

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new hosted Web instances use the same schema and encrypted identity record; mixed instances remain compatible during rollout.
- Safe order: Deploy the hosted Web change normally; no Cloudflare, worker, schema, or provider deployment is coupled to it.
- Rollback floor: The unchanged database shape and persisted values allow rollback to the prior Web version at any point.
- Expected exposure: During the Vercel rollout, an invite request may reach either implementation; both preserve the same public outcomes, while only the old version may still hold a transaction during decryption.
- Reversibility: Revert or roll back the Web deployment; no data repair or migration is required.
- Convergence proof: Confirm the Vercel production deployment serves the final commit and run the public invite send-code/confirm/abort smoke path.
- Post-deploy checks: Inspect bounded invite error, KMS failure, pool checkout-timeout, and pool-pressure aggregates after the rollout.

## Change-shape breakdown

Classification rule: `apps/web/src/**` is authored source, `apps/web/test/**` is tests/fixtures, the execution plan and Frog entry are docs, and no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 293 | 103 |
| Tests / fixtures | 404 | 105 |
| Docs | 92 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **789** | **208** |

## Changelog

- Changelog: not applicable
- Reason: Internal reliability and privacy-boundary correction; member-visible invite behavior and copy are unchanged.

