### PR TITLE
Classify wrapped Prisma pool failures accurately

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-26-prisma-pool-error-classifier.md
+++ b/agent-docs/exec-plans/active/2026-08-26-prisma-pool-error-classifier.md
@@ -1,0 +1,84 @@
+# Classify wrapped Prisma pool errors accurately
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Keep hosted Web database-pool telemetry accurate when Prisma adapter errors
+  wrap their driver cause, without treating an ordinary operation timeout as
+  proof of connection exhaustion.
+
+## Success criteria
+
+- ReviewGPT agrees with the narrow classifier correction and returns a valid,
+  apply-ready patch before production code changes.
+- The existing Prisma owner recognizes supported signals inside bounded,
+  cycle-safe adapter wrapper traversal.
+- Prisma `P1008` and unrelated timeout errors remain unclassified, while
+  `P1001`, `P1002`, `P2024`, supported driver codes, and explicit provider
+  markers retain their proven categories.
+- Focused tests cover nested adapter causes, cycles/depth bounds, positive and
+  negative timeout cases, and secret-safe telemetry.
+- Focused tests, hosted Web typecheck, lint, docs drift, exact-head ReviewGPT,
+  and required draft-PR checks pass or have an explicit proof boundary.
+
+## Scope
+
+- In scope: `apps/web/src/lib/prisma.ts`, its focused tests, and process evidence.
+- Out of scope: a telemetry framework, dependency, generic error normalizer,
+  unrelated Prisma consumers, broad retry changes, merge, Ready, or deployment.
+
+## Constraints
+
+- Technical constraints: retain one pure bounded traversal in the existing
+  classifier owner; never log or serialize inspected error contents.
+- Product/process constraints: real-browser ReviewGPT owns the initial
+  implementation proposal; inspect downloaded artifacts as untrusted input;
+  keep the resulting pull request Draft.
+
+## Risks and mitigations
+
+1. Risk: broad traversal could classify an unrelated nested error or loop on a
+   cyclic wrapper.
+   Mitigation: follow only the existing `cause` edge plus Prisma's specific
+   `meta.driverAdapterError.cause` edge, with identity-based cycle detection and
+   a small global node budget.
+2. Risk: error inspection could expose secrets.
+   Mitigation: return only an allowlisted category and preserve structured,
+   allowlisted telemetry tests that assert raw codes/messages are absent.
+
+## Tasks
+
+1. Prove current ownership and existing classifier behavior on `origin/main`.
+2. Ask ReviewGPT to agree or reject the narrow design and implement a patch.
+3. Inspect and deliberately apply a valid artifact only if ReviewGPT agrees.
+4. Run focused verification and review the full diff locally.
+5. Commit, push, open a separate draft PR, and run exact-head specialist/final
+   ReviewGPT concurrently with CI.
+6. Resolve accepted findings without widening the architecture and hand off at
+   the intentional draft boundary.
+
+## Decisions
+
+- Reuse the current classifier owner and its allowlisted logging boundary.
+- Remove `P1008` from pool-failure categories; Prisma documents it as an
+  operation timeout, which is not evidence that checkout or connection setup
+  failed.
+- Real-browser ReviewGPT agreed with the narrow design and returned an exact
+  source-and-test patch with content SHA-256
+  `14b8222196cb70b18a239513e5394c21c970e19af0ce9101d5a38311622d304a`.
+- Preserve the former root-plus-four-cause reach, add an eight-node global
+  budget, and inspect only `cause` plus `meta.driverAdapterError.cause`.
+
+## Verification
+
+- Commands to run: focused `prisma-store-client` Vitest, hosted Web typecheck,
+  focused ESLint, docs drift, `git diff --check`, exact-head PR checks and
+  ReviewGPT passes.
+- Expected outcomes: supported wrapped connection failures classify once,
+  bounded/cyclic/unrelated/P1008 inputs do not emit pool-failure telemetry, and
+  all allowlisted log assertions remain secret-safe.
+- Completed local proof: 55 focused tests passed; focused ESLint, canonical
+  hosted Web typecheck, docs drift, and `git diff --check` passed.

--- a/agent-docs/exec-plans/completed/2026-08-26-prisma-pool-error-classifier.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-prisma-pool-error-classifier.md
@@ -1,6 +1,6 @@
 # Classify wrapped Prisma pool errors accurately
 
-Status: active
+Status: completed
 Created: 2026-08-26
 Updated: 2026-08-26
 
@@ -51,13 +51,13 @@ Updated: 2026-08-26
 
 ## Tasks
 
-1. Prove current ownership and existing classifier behavior on `origin/main`.
-2. Ask ReviewGPT to agree or reject the narrow design and implement a patch.
-3. Inspect and deliberately apply a valid artifact only if ReviewGPT agrees.
-4. Run focused verification and review the full diff locally.
-5. Commit, push, open a separate draft PR, and run exact-head specialist/final
+1. [x] Prove current ownership and existing classifier behavior on `origin/main`.
+2. [x] Ask ReviewGPT to agree or reject the narrow design and implement a patch.
+3. [x] Inspect and deliberately apply a valid artifact only if ReviewGPT agrees.
+4. [x] Run focused verification and review the full diff locally.
+5. [x] Commit, push, open a separate draft PR, and run exact-head specialist/final
    ReviewGPT concurrently with CI.
-6. Resolve accepted findings without widening the architecture and hand off at
+6. [x] Resolve accepted findings without widening the architecture and hand off at
    the intentional draft boundary.
 
 ## Decisions
@@ -82,3 +82,8 @@ Updated: 2026-08-26
   all allowlisted log assertions remain secret-safe.
 - Completed local proof: 55 focused tests passed; focused ESLint, canonical
   hosted Web typecheck, docs drift, and `git diff --check` passed.
+- Exact-head preliminary specialists passed with no findings or patch at
+  `46a477ece090fbc2c5dd78eaeac40f7ffff1bc2a`.
+- Exact-head final ReviewGPT round one passed with no findings at the same head.
+- Draft PR Evidence and the Vercel ignored-build check passed.
+Completed: 2026-08-26

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -70,7 +70,7 @@ const DATABASE_POOL_FAILURE_BY_PRISMA_CODE = new Map<
   DatabasePoolFailureCategory
 >([
   ["P1001", "unreachable"],
-  ["P1008", "connection_timeout"],
+  ["P1002", "connection_timeout"],
   ["P1011", "tls_error"],
   ["P1017", "connection_closed"],
   ["P2024", "pool_checkout_timeout"],
@@ -114,6 +114,10 @@ const DATABASE_POOL_FAILURE_BY_SQLSTATE = new Map<
 const PGBOUNCER_MAX_CLIENT_CONN_SQLSTATE = "08P01";
 const PGBOUNCER_MAX_CLIENT_CONN_MESSAGE =
   "no more connections allowed (max_client_conn)";
+// Preserve the prior root-plus-four-cause reach while bounding the adapter
+// branch that Prisma can add at each node.
+const DATABASE_POOL_FAILURE_TRAVERSAL_MAX_DEPTH = 4;
+const DATABASE_POOL_FAILURE_TRAVERSAL_MAX_NODES = 8;
 
 installHostedWebWarningFilters();
 
@@ -502,12 +506,23 @@ function resolveDatabasePoolMax(poolMax?: number): number {
 function resolveDatabasePoolFailureCategory(
   error: unknown,
 ): DatabasePoolFailureCategory | null {
-  let current: unknown = error;
+  const pending: { depth: number; value: unknown }[] = [
+    { depth: 0, value: error },
+  ];
   const seen = new Set<unknown>();
 
-  for (let depth = 0; current !== undefined && current !== null && depth < 5; depth += 1) {
-    if (seen.has(current)) {
+  for (
+    let index = 0;
+    index < pending.length && seen.size < DATABASE_POOL_FAILURE_TRAVERSAL_MAX_NODES;
+    index += 1
+  ) {
+    const candidate = pending[index];
+    if (!candidate) {
       break;
+    }
+    const current = candidate.value;
+    if (current === undefined || current === null || seen.has(current)) {
+      continue;
     }
     seen.add(current);
 
@@ -559,7 +574,20 @@ function resolveDatabasePoolFailureCategory(
       return "connection_limit";
     }
 
-    current = readUnknownProperty(current, "cause");
+    if (candidate.depth >= DATABASE_POOL_FAILURE_TRAVERSAL_MAX_DEPTH) {
+      continue;
+    }
+    const nextDepth = candidate.depth + 1;
+    const cause = readUnknownProperty(current, "cause");
+    if (cause !== undefined && cause !== null) {
+      pending.push({ depth: nextDepth, value: cause });
+    }
+    const meta = readUnknownProperty(current, "meta");
+    const driverAdapterError = readUnknownProperty(meta, "driverAdapterError");
+    const driverAdapterCause = readUnknownProperty(driverAdapterError, "cause");
+    if (driverAdapterCause !== undefined && driverAdapterCause !== null) {
+      pending.push({ depth: nextDepth, value: driverAdapterCause });
+    }
   }
 
   return null;

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -456,11 +456,10 @@ describe("prisma module", () => {
   });
 
   it.each([
-    { nested: false },
-    { nested: true },
-  ])("classifies SQLSTATE 53300 codes without logging them (nested: $nested)", async ({
-    nested,
-  }) => {
+    "top-level",
+    "cause",
+    "adapter",
+  ] as const)("classifies SQLSTATE 53300 codes without logging them (%s)", async (nesting) => {
     process.env = {
       ...process.env,
       NODE_ENV: "production",
@@ -475,13 +474,24 @@ describe("prisma module", () => {
       throw new Error("Expected the Prisma query extension to be captured.");
     }
     // The message avoids every fallback phrasing so only the code classifies.
+    const secret = "private-adapter-secret";
     const driverFailure = Object.assign(
-      new Error("connection rejected; private-password"),
-      { code: "53300" },
+      new Error(`connection rejected; ${secret}`),
+      nesting === "adapter"
+        ? { originalCode: "53300", privateDetail: secret }
+        : { code: "53300" },
     );
-    const operationFailure = nested
+    const operationFailure = nesting === "cause"
       ? Object.assign(new Error("adapter failure"), { cause: driverFailure })
-      : driverFailure;
+      : nesting === "adapter"
+        ? Object.assign(new Error(`adapter failure; ${secret}`), {
+          code: "P2010",
+          meta: {
+            driverAdapterError: { cause: driverFailure, privateToken: secret },
+            privateMetadata: secret,
+          },
+        })
+        : driverFailure;
 
     await expect(extension.query.$allOperations({
       args: {},
@@ -495,8 +505,10 @@ describe("prisma module", () => {
       totalConnections: 0,
       waitingRequests: 0,
     }));
-    expect(JSON.stringify(warn.mock.calls)).not.toContain("private-password");
-    expect(JSON.stringify(warn.mock.calls)).not.toContain("53300");
+    const serializedLogs = JSON.stringify(warn.mock.calls);
+    expect(serializedLogs).not.toContain(secret);
+    expect(serializedLogs).not.toContain("53300");
+    expect(serializedLogs).not.toContain("P2010");
   });
 
   it.each([
@@ -589,6 +601,123 @@ describe("prisma module", () => {
     expect(serializedLogs).not.toContain("private-password");
   });
 
+  it.each([
+    {
+      code: "P1008",
+      expectedCategory: null,
+      message: "Operations timed out after 5000ms; private-password",
+      scenario: "P1008 operation timeout",
+    },
+    {
+      code: "P1002",
+      expectedCategory: "connection_timeout",
+      message: "Database server was reached but timed out; private-password",
+      scenario: "P1002 connection timeout",
+    },
+    {
+      code: null,
+      expectedCategory: null,
+      message: "Unrelated application timeout; private-password",
+      scenario: "unrelated timeout",
+    },
+  ])("handles $scenario without widening operation retries", async ({
+    code,
+    expectedCategory,
+    message,
+  }) => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { getPrisma } = await import("@/src/lib/prisma");
+
+    getPrisma();
+    const extension = mocks.extensions[0];
+    if (!extension) {
+      throw new Error("Expected the Prisma query extension to be captured.");
+    }
+    const failure = code === null
+      ? new Error(message)
+      : Object.assign(new Error(message), { code });
+    const query = vi.fn().mockRejectedValue(failure);
+
+    await expect(extension.query.$allOperations({
+      args: {},
+      operation: "queryRaw",
+      query,
+    })).rejects.toBe(failure);
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(failureCategories(warn)).toEqual(
+      expectedCategory === null ? [] : [expectedCategory],
+    );
+    expect(failureDispositions(warn)).toEqual(
+      expectedCategory === null ? [] : ["terminal"],
+    );
+    const serializedLogs = JSON.stringify(warn.mock.calls);
+    expect(serializedLogs).not.toContain(message);
+    expect(serializedLogs).not.toContain("private-password");
+    if (code) {
+      expect(serializedLogs).not.toContain(code);
+    }
+  });
+
+  it("keeps pool-failure traversal cycle-safe and within its depth and node budgets", async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { getPrisma } = await import("@/src/lib/prisma");
+
+    getPrisma();
+    const extension = mocks.extensions[0];
+    if (!extension) {
+      throw new Error("Expected the Prisma query extension to be captured.");
+    }
+
+    const cycle: Record<string, unknown> = {};
+    cycle.cause = cycle;
+    cycle.meta = { driverAdapterError: { cause: cycle } };
+
+    let outsideDepthBudget: unknown = { code: "53300" };
+    for (let depth = 0; depth < 5; depth += 1) {
+      outsideDepthBudget = { cause: outsideDepthBudget };
+    }
+
+    // The valid SQLSTATE is the ninth breadth-first node while remaining only
+    // three edges deep, so the global node budget must exclude it.
+    const withEdges = (cause: unknown, driverAdapterCause: unknown) => ({
+      cause,
+      meta: { driverAdapterError: { cause: driverAdapterCause } },
+    });
+    const outsideNodeBudget = withEdges(
+      withEdges(withEdges({}, { code: "53300" }), {}),
+      withEdges({}, {}),
+    );
+
+    for (const { failure, scenario } of [
+      { failure: cycle, scenario: "cycle" },
+      { failure: outsideDepthBudget, scenario: "depth-budget" },
+      { failure: outsideNodeBudget, scenario: "node-budget" },
+    ]) {
+      const query = vi.fn().mockRejectedValue(failure);
+
+      await expect(extension.query.$allOperations({
+        args: {},
+        operation: `queryRaw.${scenario}`,
+        query,
+      })).rejects.toBe(failure);
+
+      expect(query).toHaveBeenCalledOnce();
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockClear();
+    }
+  });
+
   it("classifies recognized operation failures without logging unknown errors", async () => {
     process.env = {
       ...process.env,
@@ -608,12 +737,14 @@ describe("prisma module", () => {
       { code: "P2024" },
     );
 
+    const query = vi.fn().mockRejectedValue(poolFailure);
     await expect(extension.query.$allOperations({
       args: {},
       model: "HostedMember",
       operation: "findUnique",
-      query: async () => Promise.reject(poolFailure),
+      query,
     })).rejects.toBe(poolFailure);
+    expect(query).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith("Hosted web database pool failure.", expect.objectContaining({
       attempt: 2,
       category: "pool_checkout_timeout",


### PR DESCRIPTION
## Why and outcome

Hosted Web database-pool telemetry missed supported driver failures when Prisma wrapped the driver cause under `meta.driverAdapterError.cause`, while Prisma `P1008` operation timeouts were incorrectly counted as connection failures. The existing classifier now follows only the ordinary cause edge and Prisma's specific adapter-cause edge within explicit depth/node bounds, recognizes `P1002`, and leaves `P1008` unclassified.

## Product UX

Product UX does not apply: this is internal error classification and secret-safe database telemetry with no member-visible UI or flow change.

## Evidence

- Real-browser ReviewGPT implementation disposition: AGREE ([thread](https://chatgpt.com/c/6a8f25d7-d338-83ea-a7e4-ffcdd25a81af)); downloaded patch SHA-256 `14b8222196cb70b18a239513e5394c21c970e19af0ce9101d5a38311622d304a` matched capture metadata and applied byte-for-byte.
- Focused hosted Web Prisma classifier suite: 55 tests passed.
- Focused ESLint for the source and test files passed.
- Canonical hosted Web typecheck and agent-docs drift passed.
- `git diff --check` passed.
- Preliminary specialists passed with no findings or patch on `46a477ece090fbc2c5dd78eaeac40f7ffff1bc2a` ([thread](https://chatgpt.com/c/6a8f2fbf-52ec-83ea-9db3-ac24a502353c)).
- Final ReviewGPT round one passed with no findings on the same production head ([thread](https://chatgpt.com/c/6a8f2fa1-93c0-83ea-bcfc-994718644974)). Current head `420412ef6705e6d11653a23c0e3ff1431bcc8353` changes only the reviewed execution plan from active to completed; source and tests are unchanged from the PASS head.

## Non-obvious affected surfaces

- Adapter `onConnectionError`, Prisma operation-extension failures, and interactive transaction failures share this classifier; their retry allowlists and retry counts are unchanged.
- `P1002` emits terminal `connection_timeout` telemetry but is not retried. `P2024` retains its existing one-retry checkout behavior. `P1008` and unrelated operation timeouts emit no pool-failure telemetry.
- Traversal follows only `cause` and `meta.driverAdapterError.cause`, with identity-based cycle detection, four-edge depth, and eight-node global bounds.
- Telemetry continues to emit only allowlisted categories and pool counts; raw codes, messages, metadata, and nested secret-bearing fields are never logged.

## Architecture and reuse

- Existing systems reused: the single `resolveDatabasePoolFailureCategory` owner, existing safe property readers, category maps, retry allowlists, and structured allowlisted logging.
- New logic: one bounded queue inside the existing pure classifier and one corrected Prisma-code mapping.
- New abstractions: None were added because the existing classifier already owns every affected adapter, operation, and transaction error path.
- Complexity intentionally avoided: no dependency, generic error normalizer, telemetry framework, retry policy, wrapper subsystem, queue, schema, or provider-specific service was added.

## Hot reply path impact

Not applicable: classification runs only after a database operation has already failed. This change adds no awaited work, checkout, transaction, provider call, or success-path operation.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool, schema, or provider-visible input changes.
- Codex runtime: Not applicable; no prompt, tool, schema, or provider-visible input changes.

## Change-shape breakdown

Classification is by base-to-head path. There are no binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 33 | 5 |
| Tests/fixtures | 143 | 12 |
| Docs | 89 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 265 | 17 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new hosted Web instances share the same schema and telemetry shape; they may classify these rare failures differently during rollout without affecting database operations.
- Safe order: Deploy hosted Web normally; no Cloudflare, database migration, or tandem rollout is required.
- Rollback floor: The previous hosted Web build can run immediately because no schema, state, or response contract changed.
- Expected exposure: During one Vercel rollout window, older instances may continue missing wrapped adapter signals or counting `P1008` as a connection timeout.
- Reversibility: Revert the hosted Web commit directly; no data repair or migration rollback is required.
- Convergence proof: Confirm the exact commit is the active Vercel production deployment and all hosted Web instances converge.
- Post-deploy checks: Inspect bounded database-pool failure category aggregates and confirm ordinary hosted reply/database health remains stable.

## Changelog

- Changelog: not applicable
- Reason: This corrects internal database telemetry classification without changing member-visible behavior.

ReviewGPT context sensitivity: sensitive — database failure classification and retry-adjacent control flow are affected, although retry policy is unchanged.
ReviewGPT first-reviewed head: 46a477ece090fbc2c5dd78eaeac40f7ffff1bc2a



