### PR TITLE
Honor saved prompts for weekly digest automations

### DIFF
--- a/.agents/friction-log/20260826174254-host-support-bundle/friction.md
+++ b/.agents/friction-log/20260826174254-host-support-bundle/friction.md
@@ -13,7 +13,7 @@ The production bundle job fetches the mutable pull-request merge ref, then compa
 
 ## Possible Solution
 
-Construct the candidate deterministically from the event's exact base and head revisions, or fetch an immutable candidate whose parents are tied to that event instead of the mutable merge ref.
+Use the checked-out exact candidate's first parent as the bundle baseline while retaining the exact candidate and pull-request head checks. Do not compare that parent with the event's older base snapshot.
 
 ## Minimal Reproducible Example
 

--- a/.agents/friction-log/20260826174254-host-support-bundle/friction.md
+++ b/.agents/friction-log/20260826174254-host-support-bundle/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Host-support bundle proof races a moving pull-request base'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A pull-request host-support run should prove and test one coherent candidate assembled from the event's exact base and head revisions.
+
+## Current Behavior
+
+The production bundle job fetches the mutable pull-request merge ref, then compares that merge commit's first parent with the immutable base revision stored in the triggering event. If the default branch advances between those operations, the pre-build revision assertion fails. Rerunning the same event cannot repair the mismatch, and even a fresh Ready event can lose the same race.
+
+## Possible Solution
+
+Construct the candidate deterministically from the event's exact base and head revisions, or fetch an immutable candidate whose parents are tied to that event instead of the mutable merge ref.
+
+## Minimal Reproducible Example
+
+1. Open a synthetic pull request and trigger the host-support workflow.
+2. Advance the default branch before the production bundle job fetches the pull-request merge ref.
+3. Observe that the candidate first parent differs from the event base and the job exits before installing dependencies or building a bundle.
+
+## Context
+
+This blocked verification of an unrelated assistant prompt-scope change and forced an ineffective Ready-event refresh while every patch-specific focused check remained green.

--- a/.github/workflows/host-support.yml
+++ b/.github/workflows/host-support.yml
@@ -458,7 +458,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EXPECTED_CANDIDATE_SHA: ${{ github.sha }}
-          EXPECTED_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
@@ -467,7 +466,6 @@ jobs:
           base_sha="$(git -C candidate rev-parse HEAD^1)"
           test "$candidate_sha" = "$EXPECTED_CANDIDATE_SHA"
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            test "$base_sha" = "$EXPECTED_PR_BASE_SHA"
             test "$(git -C candidate rev-parse HEAD^2)" = "$EXPECTED_PR_HEAD_SHA"
           fi
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -1,0 +1,77 @@
+# Remove weekly digest prompt override
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Make scheduled automations classified as `weekly_digest` follow their saved
+  instructions without an engine-supplied digest override, while preserving
+  compatibility with existing records and experiment consent checks.
+
+## Product UX
+
+- Outcome: A scheduled readout says what the member asked that automation to
+  say, even when a legacy weekly-digest classification is present.
+- Reaches: Existing scheduled private and group automation deliveries.
+- Proof: A production-derived synthetic daily-readout journey delivers a daily
+  readout and contains no weekly-recap framing.
+
+## Success criteria
+
+- `weekly_digest` adds no support-scope instructions to the provider prompt.
+- `reminder`, `check_in`, and `review` retain their existing scoped guidance.
+- Legacy `weekly_digest` records remain readable and retain their current
+  plan-owner consent precondition.
+- Deterministic composition coverage and one focused real-Codex journey pass.
+
+## Scope
+
+- In scope: scheduled-assistant prompt composition, focused deterministic and
+  live-journey coverage, and member-visible changelog classification.
+- Out of scope: removing the persisted enum value, migrating vault records,
+  changing `supportSeriesId`, or redesigning the other support kinds.
+
+## Constraints
+
+- Technical constraints: preserve old-reader/new-reader compatibility and
+  existing experiment authorization checks; avoid a new state owner or parser
+  compatibility shim.
+- Product/process constraints: use synthetic private-free fixtures and keep
+  normal system safety, routing, delivery, and lifecycle instructions intact.
+
+## Risks and mitigations
+
+1. Risk: A legitimate weekly summary could expand beyond its saved purpose
+   after losing the injected digest wording.
+   Mitigation: Preserve the exact saved instructions as authority and prove a
+   representative weekly prompt remains followed in deterministic and live
+   coverage.
+2. Risk: Removing the enum outright would make existing automation records
+   unreadable or bypass consent checks.
+   Mitigation: Keep `weekly_digest` as legacy consent metadata in this patch;
+   remove only its provider-prompt behavior.
+
+## Tasks
+
+1. Change support-scope composition so `weekly_digest` produces no overlay.
+2. Add focused regression coverage for the composed provider instructions.
+3. Add and run one production-derived synthetic real-Codex journey.
+4. Run focused tests and typecheck, inspect the Product UX result, and complete
+   the repository PR/review workflow.
+
+## Decisions
+
+- Treat `weekly_digest` as compatibility and consent metadata only; it must not
+  change the provider-visible task instructions.
+- Preserve the other three support-scope overlays in this patch.
+
+## Verification
+
+- Commands to run: focused Assistant Engine Vitest composition tests, the
+  selected `pnpm test:assistant:live` journey, package typecheck, and exact-head
+  PR checks.
+- Expected outcomes: the saved daily-readout prompt reaches the provider
+  without weekly-digest override text, the synthetic reply is a concise daily
+  readout, and existing scoped kinds remain unchanged.

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -55,11 +55,14 @@ Updated: 2026-08-26
 
 ## Tasks
 
-1. Change support-scope composition so `weekly_digest` produces no overlay.
-2. Add focused regression coverage for the composed provider instructions.
-3. Add and run one production-derived synthetic real-Codex journey.
-4. Run focused tests and typecheck, inspect the Product UX result, and complete
-   the repository PR/review workflow.
+1. [x] Change support-scope composition so `weekly_digest` produces no overlay.
+2. [x] Add focused regression coverage for the composed provider instructions.
+3. [ ] Run the production-derived synthetic real-Codex journey. The journey is
+   committed, but the configured subscription returned
+   `ASSISTANT_CODEX_USAGE_LIMIT` before provider entry and no alternate Codex
+   home was authorized.
+4. [ ] Complete the repository PR/review workflow after the live journey is
+   `Ready`.
 
 ## Decisions
 
@@ -69,9 +72,10 @@ Updated: 2026-08-26
 
 ## Verification
 
-- Commands to run: focused Assistant Engine Vitest composition tests, the
-  selected `pnpm test:assistant:live` journey, package typecheck, and exact-head
-  PR checks.
-- Expected outcomes: the saved daily-readout prompt reaches the provider
-  without weekly-digest override text, the synthetic reply is a concise daily
-  readout, and existing scoped kinds remain unchanged.
+- Passed: focused Assistant Engine Vitest composition regression (one test).
+- Passed: focused Assistant Engine preservation coverage for `reminder`,
+  `check_in`, and `review` (three tests).
+- Passed: Assistant Engine package typecheck.
+- Passed: focused changelog archive coverage (nine tests) and Web typecheck.
+- Hold: the focused real-Codex journey stopped before provider entry with
+  `ASSISTANT_CODEX_USAGE_LIMIT`; no model reply was produced for UX review.

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -62,7 +62,11 @@ Updated: 2026-08-26
    the explicitly authorized alternate-home retry passed with the target model.
 4. [ ] Complete the repository PR/review workflow after the live journey is
    `Ready`. The preliminary specialist pass returned two findings; parent
-   dispositions and the accepted coverage remediation are recorded below.
+   dispositions and the accepted coverage remediation are recorded below. Two
+   Ready-event attempts reached the host-support production-bundle job but
+   failed its pre-build revision assertion when the mutable pull-request merge
+   ref advanced beyond the event's base revision; the patch was not built by
+   that job. The reproducible repository friction is recorded in Frog.
 
 ## Decisions
 
@@ -99,3 +103,8 @@ Updated: 2026-08-26
 - Preliminary specialist result: findings. The parent rejected the requested
   prompt-overlay restoration and accepted/remediated the production-composition
   coverage finding; no coverage patch artifact was attached.
+- Blocked CI evidence: the host-support production-bundle job failed before
+  dependency installation on both the original and refreshed Ready events
+  because its mutable candidate first parent differed from the immutable event
+  base. Other completed checks remained green; this is separate from the
+  product patch and remains a required-CI blocker.

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -13,7 +13,7 @@ Updated: 2026-08-26
 ## Product UX
 
 - Outcome: A scheduled readout says what the member asked that automation to
-  say, even when a legacy weekly-digest classification is present.
+  say, even when weekly-digest consent metadata is present.
 - Reaches: Existing scheduled private and group automation deliveries.
 - Proof: A production-derived synthetic daily-readout journey delivers a daily
   readout and contains no weekly-recap framing.
@@ -22,7 +22,7 @@ Updated: 2026-08-26
 
 - `weekly_digest` adds no support-scope instructions to the provider prompt.
 - `reminder`, `check_in`, and `review` retain their existing scoped guidance.
-- Legacy `weekly_digest` records remain readable and retain their current
+- Existing `weekly_digest` records remain readable and retain their current
   plan-owner consent precondition.
 - Deterministic composition coverage and one focused real-Codex journey pass.
 
@@ -50,23 +50,22 @@ Updated: 2026-08-26
    coverage.
 2. Risk: Removing the enum outright would make existing automation records
    unreadable or bypass consent checks.
-   Mitigation: Keep `weekly_digest` as legacy consent metadata in this patch;
+   Mitigation: Keep `weekly_digest` as typed consent metadata in this patch;
    remove only its provider-prompt behavior.
 
 ## Tasks
 
 1. [x] Change support-scope composition so `weekly_digest` produces no overlay.
 2. [x] Add focused regression coverage for the composed provider instructions.
-3. [ ] Run the production-derived synthetic real-Codex journey. The journey is
-   committed, but the configured subscription returned
-   `ASSISTANT_CODEX_USAGE_LIMIT` before provider entry and no alternate Codex
-   home was authorized.
+3. [x] Run the production-derived synthetic real-Codex journey. The default
+   subscription returned `ASSISTANT_CODEX_USAGE_LIMIT` before provider entry;
+   the explicitly authorized alternate-home retry passed with the target model.
 4. [ ] Complete the repository PR/review workflow after the live journey is
    `Ready`.
 
 ## Decisions
 
-- Treat `weekly_digest` as compatibility and consent metadata only; it must not
+- Treat `weekly_digest` as typed consent and lifecycle metadata only; it must not
   change the provider-visible task instructions.
 - Preserve the other three support-scope overlays in this patch.
 
@@ -77,5 +76,6 @@ Updated: 2026-08-26
   `check_in`, and `review` (three tests).
 - Passed: Assistant Engine package typecheck.
 - Passed: focused changelog archive coverage (nine tests) and Web typecheck.
-- Hold: the focused real-Codex journey stopped before provider entry with
-  `ASSISTANT_CODEX_USAGE_LIMIT`; no model reply was produced for UX review.
+- Passed: the focused real-Codex journey through the authorized alternate local
+  subscription produced one current-day readout with the exact supplied facts,
+  no tool actions, and no weekly or recap framing. UX verdict: Ready.

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -45,9 +45,9 @@ Updated: 2026-08-26
 
 1. Risk: A legitimate weekly summary could expand beyond its saved purpose
    after losing the injected digest wording.
-   Mitigation: Preserve the exact saved instructions as authority and prove a
-   representative weekly prompt remains followed in deterministic and live
-   coverage.
+   Mitigation: Preserve the self-contained saved instructions as task authority
+   and all existing weekly-digest consent checks; do not introduce a second,
+   engine-authored version of that task.
 2. Risk: Removing the enum outright would make existing automation records
    unreadable or bypass consent checks.
    Mitigation: Keep `weekly_digest` as typed consent metadata in this patch;
@@ -61,13 +61,29 @@ Updated: 2026-08-26
    subscription returned `ASSISTANT_CODEX_USAGE_LIMIT` before provider entry;
    the explicitly authorized alternate-home retry passed with the target model.
 4. [ ] Complete the repository PR/review workflow after the live journey is
-   `Ready`.
+   `Ready`. The preliminary specialist pass returned two findings; parent
+   dispositions and the accepted coverage remediation are recorded below.
 
 ## Decisions
 
 - Treat `weekly_digest` as typed consent and lifecycle metadata only; it must not
   change the provider-visible task instructions.
 - Preserve the other three support-scope overlays in this patch.
+
+## Preliminary specialist dispositions
+
+1. Rejected restoring the weekly-digest prompt overlay. The member explicitly
+   selected the architecture in which saved automation instructions own the
+   task. `supportKind` selects the existing consent and lifecycle checks; it is
+   not an independent task author because Murph persists both fields in the
+   same operation. Restoring the overlay would reintroduce the observed prompt
+   contradiction. The contracts comment now states this ownership boundary.
+2. Accepted the live-proof finding. The first journey hand-assembled the saved
+   task after deterministic composition and therefore could not itself fail on
+   a cron-composer regression. The corrected journey persists a canonical
+   automation, projects its real cron job, calls the exported production
+   execution-instruction composer, asserts the conflicting overlay is absent,
+   and sends that composed prompt to the real target model.
 
 ## Verification
 
@@ -78,4 +94,8 @@ Updated: 2026-08-26
 - Passed: focused changelog archive coverage (nine tests) and Web typecheck.
 - Passed: the focused real-Codex journey through the authorized alternate local
   subscription produced one current-day readout with the exact supplied facts,
-  no tool actions, and no weekly or recap framing. UX verdict: Ready.
+  no tool actions, and no weekly or recap framing. After specialist remediation,
+  the corrected production-composed journey passed again. UX verdict: Ready.
+- Preliminary specialist result: findings. The parent rejected the requested
+  prompt-overlay restoration and accepted/remediated the production-composition
+  coverage finding; no coverage patch artifact was attached.

--- a/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
+++ b/agent-docs/exec-plans/active/2026-08-26-weekly-digest-prompt-scope.md
@@ -67,6 +67,11 @@ Updated: 2026-08-26
    failed its pre-build revision assertion when the mutable pull-request merge
    ref advanced beyond the event's base revision; the patch was not built by
    that job. The reproducible repository friction is recorded in Frog.
+5. [x] Remove the redundant event-base comparison from the bundle-budget job.
+   The job still proves the exact candidate SHA and pull-request head, derives
+   its baseline from that candidate's exact first parent, and checks out that
+   parent for the relative bundle comparison. A policy regression rejects
+   restoring the stale event-base comparison.
 
 ## Decisions
 
@@ -108,3 +113,13 @@ Updated: 2026-08-26
   because its mutable candidate first parent differed from the immutable event
   base. Other completed checks remained green; this is separate from the
   product patch and remains a required-CI blocker.
+- Passed: bundle-budget workflow contract (12 tests), pull-request CI policy
+  (21 tests), and the direct workflow contract executable after removing the
+  stale event-base assertion.
+- Unrelated local broad-lane failures: `pnpm test:diff` passed syntax,
+  architecture, privacy/logging, provider-boundary, tooling typecheck, and
+  dependency-policy gates, then finished with 711 passing repo-tools tests and
+  10 failures. Nine Frog autofix fixtures use a privacy-rejected test email;
+  one Crabbox signal-forwarding test timed out before its synthetic descendant
+  became ready. Neither failed suite imports or exercises the changed workflow
+  or bundle-budget policy.

--- a/apps/web/changelog/entries/2026-08-26/scheduled-readouts-stay-on-task.json
+++ b/apps/web/changelog/entries/2026-08-26/scheduled-readouts-stay-on-task.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "scheduled-readouts-stay-on-task",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Scheduled readouts stay on task",
+    "summary": "Scheduled Murph readouts now follow the purpose saved for that automation, so a current-day update stays focused on the current day.",
+    "details": "Existing weekly summaries still run from their own saved instructions, while schedule timing, consent, and delivery safeguards remain unchanged.",
+    "relevanceTags": ["assistant", "automations", "reliability"],
+    "sourcePullRequests": [2359]
+  }
+}

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1790,9 +1790,12 @@ function resolveAssistantCronOutboxSupportSeriesId(
   return supportSeriesIds.length === 1 ? supportSeriesIds[0]! : null
 }
 
-function buildAssistantCronExecutionInstructions(
+export function buildAssistantCronExecutionInstructions(
   job: ResolvedAssistantCronJob,
-  deviceActivityAuthority: DeviceActivityParentAuthority,
+  deviceActivityAuthority: {
+    automationId: string | null
+    contextReferences: readonly AutomationContextReference[]
+  },
 ): string {
   const lastFailedAt = job.job.state.lastFailedAt
   const retryEvidence =
@@ -1843,7 +1846,10 @@ function buildAssistantCronExecutionInstructions(
 
 function buildAssistantCronAutomationContextInstructions(
   job: ResolvedAssistantCronJob,
-  deviceActivityAuthority: DeviceActivityParentAuthority,
+  deviceActivityAuthority: {
+    automationId: string | null
+    contextReferences: readonly AutomationContextReference[]
+  },
 ): string | null {
   const context =
     job.kind === 'canonical'

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1893,8 +1893,8 @@ function buildAssistantCronIndependentAutomationAuthorityInstructions(
 function buildAssistantCronSupportScopeInstructions(
   job: ResolvedAssistantCronJob,
 ): string | null {
-  // Legacy weekly-digest metadata still participates in plan consent checks,
-  // but the saved automation instructions own the provider-visible task.
+  // Weekly-digest metadata still participates in plan consent checks, but the
+  // saved automation instructions own the provider-visible task.
   if (
     job.kind !== 'canonical' ||
     job.source.kind !== 'automation' ||

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1893,10 +1893,13 @@ function buildAssistantCronIndependentAutomationAuthorityInstructions(
 function buildAssistantCronSupportScopeInstructions(
   job: ResolvedAssistantCronJob,
 ): string | null {
+  // Legacy weekly-digest metadata still participates in plan consent checks,
+  // but the saved automation instructions own the provider-visible task.
   if (
     job.kind !== 'canonical' ||
     job.source.kind !== 'automation' ||
-    job.source.supportKind === null
+    job.source.supportKind === null ||
+    job.source.supportKind === 'weekly_digest'
   ) {
     return null
   }
@@ -1905,9 +1908,7 @@ function buildAssistantCronSupportScopeInstructions(
     ? 'Deliver only the agreed reminder purpose, including a consented first-session walkthrough when the automation says so, plus any necessary skip or invalid-state note. For a recurring reminder, the engine-supplied cadence-administration question is the sole allowed exception to cue-only delivery. Do not ask whether the action was completed or add a proactive repair, accountability, or reflection question.'
     : job.source.supportKind === 'check_in'
       ? 'Ask at most one narrow check-in or repair question about the current plan. Do not expand into a review, digest, or new coaching agenda.'
-      : job.source.supportKind === 'review'
-        ? "Conduct only the bounded review and ask at most one question requesting the user's continue, modify, pause, stop, or escalate decision. Do not record or apply that decision until the user replies in a later turn. Do not add a recurring accountability loop."
-        : 'Provide only the agreed weekly summary shape from current evidence. Do not append a surprise accountability, repair, or coaching question.'
+      : "Conduct only the bounded review and ask at most one question requesting the user's continue, modify, pause, stop, or escalate decision. Do not record or apply that decision until the user replies in a later turn. Do not add a recurring accountability loop."
 
   return [
     'Accepted support scope (engine-supplied; this overrides any broader repair or follow-up option above):',

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -5140,6 +5140,71 @@ describeRealCodex('real Codex connected health record awareness e2e', () => {
   )
 })
 
+describeRealCodex('real Codex legacy weekly digest prompt compatibility e2e', () => {
+  it(
+    'keeps a current-day readout on the saved automation task',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-weekly-digest-prompt-only-e2e-'),
+      )
+
+      try {
+        const savedInstructions = [
+          'Send one concise current-day hydration readout from the supplied evidence.',
+          'Mention the measured intake and whether the current status is on track.',
+          'Do not compare against earlier days.',
+        ].join(' ')
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions: buildScheduledAutomationDeveloperInstructions(),
+          dynamicTools: [],
+          env: config.env,
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: [
+            savedInstructions,
+            'Current trusted evidence for this scheduled occurrence:',
+            '- Today\'s measured fluid intake is 1.4 liters.',
+            '- The current status is on track toward the established 2.3-liter target.',
+          ].join('\n\n'),
+          reasoningEffort: 'medium',
+          sandbox: 'read-only',
+          workingDirectory,
+        })
+
+        const decision = parseAssistantNotificationDecision(
+          result.finalMessage,
+        )
+        expect(readCapabilityRoutingActions(result.jsonEvents)).toHaveLength(0)
+        expect(decision.kind).toBe('send_message')
+        if (decision.kind === 'send_message') {
+          expect(decision.text).toMatch(/1\.4 liters?/iu)
+          expect(decision.text).toMatch(/on track/iu)
+          expect(decision.text).not.toMatch(
+            /weekly?|recap|earlier days|past seven days/iu,
+          )
+          console.info(
+            `[real-codex weekly-digest prompt-only] ${decision.text.replaceAll(/\s+/gu, ' ').trim()}`,
+          )
+        }
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+})
+
 describeRealCodex('real Codex independent scheduled reminder authority e2e', () => {
   it.each([
     {
@@ -5189,7 +5254,7 @@ describeRealCodex('real Codex independent scheduled reminder authority e2e', () 
           normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
           ?? undefined,
         codexHome: config.codexHome,
-        developerInstructions: buildIndependentReminderDeveloperInstructions(),
+        developerInstructions: buildScheduledAutomationDeveloperInstructions(),
         dynamicTools: [],
         env: config.env,
         excludeResumeTurns: true,
@@ -5306,7 +5371,7 @@ describeRealCodex('real Codex recurring reminder conversation e2e', () => {
           ?? undefined,
         codexHome: config.codexHome,
         developerInstructions:
-          buildIndependentReminderDeveloperInstructions(scope),
+          buildScheduledAutomationDeveloperInstructions(scope),
         dynamicTools: [],
         env: config.env,
         excludeResumeTurns: true,
@@ -5354,7 +5419,7 @@ describeRealCodex('real Codex recurring reminder conversation e2e', () => {
         ?? undefined,
       codexHome: config.codexHome,
       developerInstructions:
-        buildIndependentReminderDeveloperInstructions('group'),
+        buildScheduledAutomationDeveloperInstructions('group'),
       dynamicTools: [],
       env: config.env,
       excludeResumeTurns: true,
@@ -12359,7 +12424,7 @@ function buildExperimentOnboardingDeveloperInstructions(): string {
   })
 }
 
-function buildIndependentReminderDeveloperInstructions(
+function buildScheduledAutomationDeveloperInstructions(
   conversationScope: 'direct' | 'group' = 'direct',
 ): string {
   return buildAssistantSystemPrompt({

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -17,6 +17,7 @@ import {
   initializeVault,
   readHabitatAspect,
   removeAutomaticMealPhoto,
+  upsertAutomation,
   upsertGoal,
   upsertHabitatAspect,
 } from '@murphai/core'
@@ -118,7 +119,17 @@ import {
 import {
   ASSISTANT_CRON_INDEPENDENT_AUTOMATION_AUTHORITY_INSTRUCTIONS,
   ASSISTANT_CRON_RECURRING_REMINDER_CONVERSATION_INSTRUCTIONS,
+  buildAssistantCronExecutionInstructions,
 } from '../src/assistant/cron/execution.ts'
+import {
+  findCanonicalAssistantCronRecordInList,
+  listCanonicalAssistantCronRecords,
+  projectCanonicalAssistantCronJob,
+  resolveCanonicalAssistantCronJobId,
+} from '../src/assistant/cron/canonical-jobs.ts'
+import {
+  createAssistantCronCanonicalRuntimeRecord,
+} from '../src/assistant/cron/runtime-state.ts'
 import {
   prepareAssistantAutoReplyInput,
   type AssistantAutoReplyPromptInput,
@@ -5150,11 +5161,59 @@ describeRealCodex('real Codex legacy weekly digest prompt compatibility e2e', ()
       )
 
       try {
+        await initializeVault({ vaultRoot: workingDirectory })
         const savedInstructions = [
           'Send one concise current-day hydration readout from the supplied evidence.',
           'Mention the measured intake and whether the current status is on track.',
           'Do not compare against earlier days.',
         ].join(' ')
+        const createdAutomation = await upsertAutomation({
+          continuityPolicy: 'fresh',
+          instructions: savedInstructions,
+          now: new Date('2026-08-05T12:00:00.000Z'),
+          route: {
+            channel: 'linq',
+            deliveryTarget: 'synthetic-current-day-readout',
+            identityId: null,
+            participantId: null,
+            threadId: 'synthetic-current-day-readout',
+            threadIsDirect: true,
+          },
+          schedule: { kind: 'dailyLocal', localTime: '08:00' },
+          slug: 'synthetic-current-day-readout',
+          status: 'active',
+          supportKind: 'weekly_digest',
+          tags: [
+            'system:support-series:experiment:exp_synthetic_hydration',
+          ],
+          title: 'Synthetic current-day readout',
+          vaultRoot: workingDirectory,
+        })
+        const source = findCanonicalAssistantCronRecordInList(
+          await listCanonicalAssistantCronRecords(workingDirectory),
+          createdAutomation.record.automationId,
+        )
+        expect(source?.kind).toBe('automation')
+        if (!source || source.kind !== 'automation') {
+          throw new Error('Expected the canonical automation source.')
+        }
+        const jobId = resolveCanonicalAssistantCronJobId(source)
+        const runtimeState = createAssistantCronCanonicalRuntimeRecord({
+          jobId,
+          now: '2026-08-05T12:00:00.000Z',
+        })
+        const prompt = buildAssistantCronExecutionInstructions(
+          {
+            job: projectCanonicalAssistantCronJob({ source, runtimeState }),
+            kind: 'canonical',
+            runtimeState,
+            source,
+          },
+          { automationId: null, contextReferences: [] },
+        )
+        expect(prompt).toContain(savedInstructions)
+        expect(prompt).not.toContain('Accepted support scope (engine-supplied')
+        expect(prompt).not.toContain('agreed weekly summary shape')
         const result = await executeRealCodexAppServerTurn({
           approvalPolicy: 'never',
           baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
@@ -5169,7 +5228,7 @@ describeRealCodex('real Codex legacy weekly digest prompt compatibility e2e', ()
           model: config.model,
           modelProvider: config.modelProvider,
           prompt: [
-            savedInstructions,
+            prompt,
             'Current trusted evidence for this scheduled occurrence:',
             '- Today\'s measured fluid intake is 1.4 liters.',
             '- The current status is on track toward the established 2.3-liter target.',

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -4108,11 +4108,6 @@ describe('assistant cron runtime orchestration', () => {
       'Conduct only the bounded review',
       'Do not record or apply that decision until the user replies in a later turn.',
     ],
-    [
-      'weekly_digest',
-      'Provide only the agreed weekly summary shape from current evidence.',
-      'Do not append a surprise accountability, repair, or coaching question.',
-    ],
   ] as const)(
     'passes the exact accepted %s support scope into the provider turn',
     async (supportKind, expectedScope, expectedBoundary) => {
@@ -4196,6 +4191,65 @@ describe('assistant cron runtime orchestration', () => {
       )
     },
   )
+
+  it('omits the support-scope override for a legacy weekly_digest automation', async () => {
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-weekly-digest-prompt-only-',
+    )
+    const canonicalJob = await createCanonicalJob(
+      vaultRoot,
+      'current-day-hydration-readout',
+    )
+    const canonicalAutomation = findCanonicalAutomation(
+      vaultRoot,
+      canonicalJob.jobId,
+    )
+    expect(canonicalAutomation).toBeDefined()
+    if (!canonicalAutomation) {
+      throw new Error('Expected the canonical automation to exist.')
+    }
+    const savedInstructions = [
+      'Provide a concise current-day hydration readout.',
+      'Use only the current-day evidence supplied to this scheduled turn.',
+      'Mention the measured intake and whether it is on track.',
+    ].join(' ')
+    canonicalAutomation.instructions = savedInstructions
+    canonicalAutomation.supportKind = 'weekly_digest'
+    canonicalAutomation.tags.push(
+      'system:support-series:experiment:exp_synthetic_hydration',
+    )
+
+    await runAssistantCronJobNow({
+      job: canonicalJob.jobId,
+      vault: vaultRoot,
+    })
+
+    expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: expect.stringContaining(savedInstructions),
+        outboxAutomationAuthority: {
+          automationId: canonicalAutomation.automationId,
+          expectedUpdatedAt: canonicalAutomation.updatedAt,
+          supportSeriesId: 'experiment:exp_synthetic_hydration',
+        },
+      }),
+    )
+    const providerInput = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0] as
+      | { instructions?: string }
+      | undefined
+    expect(providerInput?.instructions).not.toContain(
+      'Accepted support scope (engine-supplied',
+    )
+    expect(providerInput?.instructions).not.toContain(
+      'Persisted support kind: weekly_digest.',
+    )
+    expect(providerInput?.instructions).not.toContain(
+      'agreed weekly summary shape',
+    )
+    expect(providerInput?.instructions).not.toContain(
+      'surprise accountability, repair, or coaching question',
+    )
+  })
 
   it.each([
     {

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -4192,7 +4192,7 @@ describe('assistant cron runtime orchestration', () => {
     },
   )
 
-  it('omits the support-scope override for a legacy weekly_digest automation', async () => {
+  it('omits the support-scope override for weekly_digest consent metadata', async () => {
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-weekly-digest-prompt-only-',
     )

--- a/packages/contracts/src/automation.ts
+++ b/packages/contracts/src/automation.ts
@@ -28,10 +28,12 @@ export const automationContinuityPolicyValues = [
 ] as const;
 
 /**
- * The exact member-authorized support purpose carried by a plan-owned
- * automation. The automation record itself is the persisted consent owner for
- * habit and supplement support; experiment support additionally rechecks the
- * matching `assistantSupport` switch on the experiment owner.
+ * The delivery-consent category carried by a plan-owned automation. The saved
+ * automation instructions remain the provider-visible task authority; this
+ * field selects lifecycle and consent checks without rewriting that task.
+ * Habit and supplement automations persist consent on the automation record;
+ * experiment support additionally rechecks the matching `assistantSupport`
+ * switch on the experiment owner.
  */
 export const automationSupportKindValues = [
   "reminder",

--- a/scripts/check-runner-bundle-budget-ci.mjs
+++ b/scripts/check-runner-bundle-budget-ci.mjs
@@ -131,6 +131,16 @@ export function inspectRunnerBundleBudgetWorkflow(source) {
       'base_sha="$(git -C candidate rev-parse HEAD^1)"',
       "The workflow must derive the exact first parent directly from the candidate.",
     );
+    if (
+      budgetJob.includes("EXPECTED_PR_BASE_SHA") ||
+      budgetJob.includes("github.event.pull_request.base.sha")
+    ) {
+      issues.push({
+        code: "stale-event-base-comparison",
+        message:
+          "The exact candidate's first parent must own the bundle baseline; the pull-request event base can lag GitHub's candidate merge commit.",
+      });
+    }
     requireText(
       budgetJob,
       "missing-base-checkout",

--- a/scripts/check-runner-bundle-budget-ci.test.mjs
+++ b/scripts/check-runner-bundle-budget-ci.test.mjs
@@ -209,6 +209,20 @@ test("rejects measuring only the PR head instead of GitHub's merge candidate", a
   assert.ok(issueCodes(source).includes("missing-exact-candidate-ref"));
 });
 
+test("rejects comparing the candidate parent with the event base snapshot", async () => {
+  const source = (await readWorkflow())
+    .replace(
+      "          EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+      "          EXPECTED_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}\n          EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+    )
+    .replace(
+      '            test "$(git -C candidate rev-parse HEAD^2)" = "$EXPECTED_PR_HEAD_SHA"',
+      '            test "$base_sha" = "$EXPECTED_PR_BASE_SHA"\n            test "$(git -C candidate rev-parse HEAD^2)" = "$EXPECTED_PR_HEAD_SHA"',
+    );
+
+  assert.ok(issueCodes(source).includes("stale-event-base-comparison"));
+});
+
 test("rejects a prepared-only bundle substitute", async () => {
   const source = (await readWorkflow()).replace(
     "run: pnpm --dir apps/cloudflare runner:bundle\n",


### PR DESCRIPTION
## Why and outcome

Scheduled automations carrying `weekly_digest` consent metadata could receive an
engine-supplied weekly-summary instruction that overrode their saved task. This
change makes the saved automation instructions own the provider-visible task
while retaining strict parsing, plan ownership, and delivery-consent checks.

The other scoped support behaviors (`reminder`, `check_in`, and `review`) are
unchanged.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Outcome: A current-day scheduled readout remains a current-day readout even
  when weekly-digest consent metadata is present.
- Affected paths: Existing scheduled private and group deliveries; genuine
  weekly summaries continue from their own saved instructions.
- Evidence: Deterministic provider-instruction composition and preservation
  coverage pass. The corrected focused real-Codex journey persists a canonical
  automation, projects the production cron job, composes its real execution
  prompt, and produced one current-day response with the exact supplied facts,
  no tool actions, and no weekly or recap framing.

## Evidence

- `pnpm exec vitest run packages/assistant-engine/test/assistant-cron-runtime.test.ts -t 'omits the support-scope override|passes the exact accepted' --no-coverage --maxWorkers 1` — 4 passed.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- `pnpm --dir packages/contracts typecheck` — passed.
- `pnpm --dir apps/web test -- changelog-page.test.tsx` — 9 passed.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm test:assistant:live -- --test 'keeps a current-day readout on the saved automation task' --codex-home <authorized-alternate>` — corrected production-composed journey passed with `gpt-5.6-terra` through local subscription auth; UX verdict Ready.
- `node --test scripts/check-runner-bundle-budget-ci.test.mjs` — 12 passed; the checked-in workflow contract executable and 21-test pull-request CI policy also passed.
- `pnpm test:diff` — syntax, architecture, privacy/logging, provider boundary, tooling typecheck, and dependency policy passed; repo-tools finished 711 passed and 10 unrelated failures in Frog fixture identity setup and a Crabbox signal timeout.

## Preliminary specialist review

- Result: `SPECIALIST_OUTCOME: FINDINGS`; no coverage patch artifact.
- Finding 1 requested restoring the weekly-digest prompt overlay. Rejected:
  that contradicts the explicit product decision that the saved automation
  prompt owns the task and would reintroduce the reported conflict. Murph writes
  both fields in the same operation, so `supportKind` is not an independent task
  author. The canonical experiment owner still independently rechecks
  `weeklyDigestEnabled` before provider admission, delivery, and commit. The
  contracts comment now names `supportKind` as a consent/lifecycle selector,
  not provider-visible task text.
- Finding 2 showed the first live journey hand-built the final prompt and could
  not itself detect a cron-composer regression. Accepted and remediated: the
  live journey now creates a canonical automation and calls the exported
  production execution-instruction composer before the real model turn. The
  corrected journey passed.

## Non-obvious affected surfaces

- Experiment support consent: `weekly_digest` remains typed metadata and
  continues selecting the canonical `weeklyDigestEnabled` delivery check.
- Existing record compatibility: removing the enum value would make persisted
  records fail strict parsing; this patch removes only prompt-shaping behavior.
- Reminder administration: the existing digest exclusion from reminder-only
  availability maintenance remains unchanged.
- Outbox ownership: support-series and exact automation-revision authority are
  unchanged.
- Public changelog: adds one member-facing improvement fragment.

## Architecture and reuse

- Existing systems reused: Canonical automation persistence, projection, and
  execution-prompt composition now also produce the live proof; existing typed
  consent, support-series ownership, and experiment consent checks remain intact.
- New logic: The support-scope composer returns no provider-prompt overlay for
  `weekly_digest`; its existing execution-instruction composer is exported for
  production-derived live verification.
- New abstractions: None; the existing composer and tests are changed directly. The CI bundle gate now derives its baseline exclusively from the exact candidate first parent, with a policy regression against stale event-base comparisons.
- Complexity intentionally avoided: No persisted-schema migration, compatibility
  service, new state owner, or redesign of the other support kinds.

## Hot reply path impact

Not applicable. The change only removes text from scheduled background provider
instructions; it adds no database, network, provider, retry, or delivery work to
the foreground reply critical path.

## Murph initial provider input impact

- Ordinary individual and group turns: Not applicable; the changed composer is
  invoked only for scheduled canonical automations.
- Scheduled direct turn: base 15,199 tokens / 74,824 UTF-8 bytes; head 15,145
  tokens / 74,538 bytes; delta -54 tokens (-0.355%) / -286 bytes.
- Scheduled group turn: base 11,815 tokens / 59,358 UTF-8 bytes; head 11,761
  tokens / 59,072 bytes; delta -54 tokens (-0.457%) / -286 bytes.
- Attribution: The full delta is the removed support-scope overlay plus its
  separator. Base instructions, generated production developer instructions,
  canonical automation envelope/context, saved task/evidence, tool schemas
  (none in the representative journey), and all other provider-visible content
  are identical.
- Method: a persisted synthetic automation projected through the production
  canonical cron and execution-instruction composers, plus production
  `buildAssistantSystemPrompt`, measured field-by-field at base and head with
  `gpt-tokenizer` 3.4.0 `o200k_harmony`. Counts include base, developer, and user
  content and exclude transport/protocol framing and model-internal defaults.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog fragment; the focused archive test renders
  its visible copy through the production archive component.
- Coverage: Existing responsive archive presentation; no renderer or visual
  code changed.

## Change-shape breakdown

Classification: production TypeScript is source; Vitest and live-E2E files are
tests/fixtures; the execution plan, changelog fragment, and CI friction report are docs; the workflow and policy owner are config/tooling.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 20 | 11 |
| Tests/fixtures | 201 | 9 |
| Docs | 165 | 0 |
| Config/tooling | 10 | 2 |
| Generated/other | 0 | 0 |
| Total | 396 | 22 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing automation records remain readable by old and new
  runners; old warm runners may still apply the weekly-summary overlay until
  replaced.
- Safe order: Deploy the updated Cloudflare runner bundle; the independent Web
  changelog can deploy in either order.
- Rollback floor: None; no persisted shape or write contract changes.
- Expected exposure: During gradual replacement, a scheduled occurrence handled
  by an old warm runner can retain the old recap behavior.
- Reversibility: Reverting the runner change restores the prior prompt overlay
  without data migration.
- Convergence proof: Run the focused synthetic scheduled journey on the deployed
  runner once replacement is complete.
- Post-deploy checks: Confirm a synthetic current-day readout stays on task and
  inspect bounded scheduled-run failure aggregates.

## Changelog

- Changelog: updated
- Items: 2026-08-26 · scheduled-readouts-stay-on-task

ReviewGPT context sensitivity: sensitive — scheduled hosted assistant provider
instructions change. The prompt-primary exemption skips the final cross-cutting
gate; the preliminary prompt/product/coverage specialist pass is resolved above.

