### PR TITLE
Return canonical workout cards after direct saves

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -2409,6 +2409,20 @@ card. This action never writes the workout. Missing, duplicate, structurally
 changed, oversized, or cross-member targets fail closed as `workout_changed`,
 leaving the embedded snapshot in place. The result reuses the existing strict
 card decoder rather than defining a parallel workout wire.
+An apply request may opt into the same response path by carrying one optional,
+strictly bounded workout-card presentation. That presentation is rendering
+context only: mutation targeting, optimistic comparison, completion, and every
+canonical value still come from the existing action and locked workout owner.
+On `applied` or `unchanged`, including exact replay, runtime reconciles the
+presentation against the canonical record already returned by the write or
+replay lookup and may attach one `workout.live.apply` V1 result containing the
+ordinary authoritative V6 URL, or the ordinary V4 URL when editing is
+unavailable or V6 exceeds the existing limit. A structural mismatch,
+unsupported projection, or oversized V4 simply omits that optional result
+without changing the successful mutation outcome. Requests that omit
+presentation also omit the result, so deployed readers retain their existing
+apply receipt. This path adds no second snapshot action, canonical reread,
+persisted projection, queue, or receipt owner.
 Admission also rejects any destructive set batch whose final visible projection
 equals its prestate because that request has no observable structural effect.
 The canonical workout write atomically records the action id with the mutation;

--- a/agent-docs/exec-plans/completed/2026-08-26-workout-card-optimistic-state.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-workout-card-optimistic-state.md
@@ -1,0 +1,142 @@
+# workout-card-optimistic-state
+
+Status: completed
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Make a direct workout-card submission update the selected expanded Messages
+  card immediately while Murph confirms the canonical mutation in the
+  background.
+- Return the authoritative post-write card in the same terminal member-action
+  outcome so a normal save never depends on a second snapshot action.
+
+## Success criteria
+
+- Tapping Send to Murph immediately projects the exact submitted draft into the
+  selected in-memory card and clearly labels it as still saving.
+- The one existing idempotent member-action request remains the only retry
+  identity and the editor remains locked until its terminal outcome.
+- A successful apply outcome may carry one ordinary V4/V6 card URL; the native
+  reader replaces its optimistic projection with that strictly decoded
+  authoritative card.
+- A definitive conflict restores the embedded authoritative card while keeping
+  the member's draft visible for review. Transient or ambiguous failures keep
+  the optimistic projection and exact retry request.
+- An older backend result without a card remains a compatible success; the
+  projected card stays visible and the existing snapshot read reconciles the
+  next pristine open.
+- No local database, persisted workout cache, second canonical state owner,
+  queue, new dependency, model turn, or extra backend refresh is added.
+
+## Product UX plan
+
+### Requirement boundary
+
+- Entry: an active V6 workout card is selected in expanded Messages and the
+  member taps Send to Murph after entering direct set or structural changes.
+- Promise: the expanded editor reflects those exact entries immediately while
+  truthfully showing that Murph is still saving them.
+- Non-goals: mutating an already delivered transcript bubble, offline-first
+  workout authoring, general workout storage, concurrent batches, or replacing
+  the canonical vault workout.
+
+### Affected people and recovery
+
+1. Warm or cold successful save: see instant local progress, then a canonical
+   Saved to Murph result without a second read.
+2. Slow or temporarily unavailable runtime: keep the projected entries and the
+   exact retry identity, see honest pending/retry copy, and retry the same
+   action.
+3. Stale or forwarded card: restore the embedded baseline, preserve the typed
+   draft, and require review before creating a fresh request.
+4. Older backend during rollout or rollback: accept terminal success without a
+   result card and reconcile through the existing snapshot path on a later
+   pristine open.
+5. Messages terminates the extension: no local health/workout values are newly
+   persisted; reopening starts from the immutable transcript and canonical
+   snapshot read.
+
+### Proof path
+
+- Focused contract tests cover apply results on applied/unchanged outcomes and
+  reject illegal result/status combinations.
+- Vault-usecase and hosted-runtime tests prove the returned card is built from
+  the post-write canonical workout and recorded in the terminal receipt.
+- Native unit tests cover projection, immediate session replacement, canonical
+  replacement, rollback, missing-result compatibility, and draft preservation.
+- Swift formatting, generated-project validation, simulator tests/build, and
+  backend package tests/typechecks pass before the pushed candidates.
+- Physical Messages proof remains required because Simulator cannot prove
+  Apple's transcript/expanded extension lifecycle.
+
+## Architecture
+
+- Extend the existing `workout.live.apply` action with an optional bounded
+  presentation used only to render the caller's post-write response card. Old
+  clients remain valid.
+- Extend the existing member-action result union with a typed apply result and
+  permit it only for successful apply outcomes. Old native decoders ignore the
+  additional outcome field.
+- Build the result while the canonical post-write workout is already available;
+  do not issue a second member action or create another persisted projection.
+- In native code, keep one mutable selected-message session card. Stage a pure
+  projection from the draft before starting network work, then replace it with
+  the decoded authoritative result when available.
+- Keep `workout.live.snapshot` as best-effort reconciliation for external
+  changes and process relaunch, not the critical path for this save.
+
+## Tasks
+
+1. [x] Obtain a ReviewGPT implementation patch against the clean exact
+   backend and native baselines; inspect and adapt it rather than applying it
+   blindly.
+2. [x] Implement and test the backward-compatible backend apply-result
+   contract and post-write card construction.
+3. [x] Implement and test the native pure card projection and authoritative
+   result replacement with no new persistence owner.
+4. [x] Update durable backend/native architecture and product contracts.
+5. [x] Run focused verification, inspect privacy and deploy skew, and prepare
+   both PR candidates.
+6. [ ] Complete each repo's required ReviewGPT/CI gates, merge in backend-first
+   order, deploy the backend, and leave native release gated on current main CI
+   plus physical Messages proof.
+
+## Decisions
+
+- "Local" means the already-owned selected-message in-memory session. Persisting
+  workout values would violate the companion's health-data minimization rule
+  and add recovery/expiry/account-partition machinery that the requested
+  latency improvement does not need.
+- One pending batch remains the concurrency ceiling. Faster UI feedback does
+  not grant authority for pipelined writes against an unconfirmed binding.
+- Server confirmation stays visually distinct from the optimistic projection;
+  only a terminal successful outcome may render Saved to Murph.
+
+## Verification
+
+- Backend contracts: 330 tests passed, generated schema artifacts verified,
+  and typecheck passed.
+- Backend vault use cases: 385 tests passed and typecheck passed after
+  generating the repository-owned Health Commons test artifact.
+- Backend assistant runtime: 2,513 tests passed, 5 intentional skips, and
+  typecheck passed.
+- Backend docs drift, dependency policy, and whitespace checks passed.
+- Native SwiftFormat, Xcode project generation, pure Foundation typecheck,
+  changed-source parse validation, export-plist validation, app-store asset
+  validation, native-hosted contract tests, and review-workflow verification
+  passed.
+- Native simulator tests remain delegated to required GitHub CI because this
+  machine has Command Line Tools but not the full Xcode application.
+- Physical Messages proof remains a release gate for Apple's transcript and
+  expanded-extension lifecycle.
+
+## Review disposition
+
+- ReviewGPT implementation handoffs completed against both exact clean
+  baselines. Their patch artifacts were digest-verified, read in full, and
+  parent-inspected before integration.
+- Normal preliminary-specialist and final exact-head ReviewGPT gates remain
+  pending on the pushed PR candidates.
+Completed: 2026-08-26

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -75,6 +75,12 @@ attestation failure remains fail-closed. This boundary and its focused proof
 are specified by `agent-docs/RELIABILITY.md` and
 `agent-docs/references/testing-ci-map.md`.
 
+Direct iMessage workout apply may carry bounded rendering context and return an
+optional authoritative post-write V4/V6 card in the existing terminal receipt.
+Mutation authority remains with the locked canonical workout, and response-card
+construction adds no reread, queue, or persisted projection. This contract is
+specified by `agent-docs/RELIABILITY.md`.
+
 Direct and authenticated-group Telegram model-authored rich-content admission,
 optional semantic-card selection, closed HTML, disabled automatic Telegram
 entities, trusted text fallback derivation, and the group-audience runner

--- a/packages/assistant-runtime/src/hosted-runtime/events/member-action.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/member-action.ts
@@ -32,6 +32,9 @@ export async function executeHostedMemberActionWake(input: {
             actionId: input.wake.request.actionId,
             completedAt: new Date().toISOString(),
             reason: result.status === "rejected" ? result.reason : null,
+            ...(result.status !== "rejected" && result.result !== undefined
+              ? { result: result.result }
+              : {}),
             schemaVersion: 1,
             status: result.status,
           },

--- a/packages/assistant-runtime/test/hosted-runtime-member-action.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-member-action.test.ts
@@ -79,6 +79,10 @@ describe("hosted member action runtime", () => {
         ? outcome.postCheckpointRecord.outcome.completedAt
         : "",
     )).not.toBeNaN();
+    if (outcome.postCheckpointRecord?.kind !== "member-action.outcome-recorded") {
+      throw new TypeError("Expected one member-action outcome record.");
+    }
+    expect(outcome.postCheckpointRecord.outcome).not.toHaveProperty("result");
     expect(mocks.applyLiveWorkoutMemberAction).toHaveBeenCalledWith({
       acceptedAt: "2026-08-12T15:00:00.000Z",
       action,
@@ -86,6 +90,75 @@ describe("hosted member action runtime", () => {
       vault: "/vault",
     });
   });
+
+  it.each(["applied", "unchanged"] as const)(
+    "records the optional direct-save card result on %s",
+    async (status) => {
+      const result = {
+        cardUrl: "https://www.withmurph.ai/#murph-card=apply-card",
+        kind: "workout.live.apply" as const,
+        version: 1 as const,
+      };
+      mocks.applyLiveWorkoutMemberAction.mockResolvedValueOnce({
+        result,
+        status,
+      });
+      const action = {
+        expectedWorkout: {
+          actionBinding: "a".repeat(64),
+          exercises: [{ name: "Leg press", sets: [{ logged: false }] }],
+        },
+        kind: "workout.live.apply" as const,
+        mutations: [{
+          exerciseName: "Leg press",
+          exercisePosition: 1,
+          expectedResult: null,
+          kind: "set.put" as const,
+          result: { kind: "reps" as const, reps: 8 },
+          setPosition: 1,
+        }],
+        presentation: {
+          footer: null,
+          subtitle: null,
+          title: "Strength",
+          workout: {
+            exercises: [{
+              name: "Leg press",
+              sets: [{ actual: "8 reps", status: "completed" as const, target: null }],
+            }],
+            state: "active" as const,
+            version: 1 as const,
+          },
+        },
+        version: 1 as const,
+      };
+
+      const outcome = await executeHostedMemberActionWake({
+        vaultRoot: "/vault",
+        wake: {
+          eventId: "member.action.requested:2f1c1fdc-c7b0-4d90-b902-8e6295959243",
+          kind: "member.action.requested",
+          occurredAt: "2026-08-12T15:00:00.000Z",
+          request: {
+            action,
+            actionId: "2f1c1fdc-c7b0-4d90-b902-8e6295959243",
+            requestedAt: "2026-08-12T15:00:00.000Z",
+            schemaVersion: 1,
+          },
+          userId: "member-1",
+        },
+      });
+
+      expect(outcome.postCheckpointRecord).toMatchObject({
+        kind: "member-action.outcome-recorded",
+        outcome: {
+          reason: null,
+          result,
+          status,
+        },
+      });
+    },
+  );
 
   it("records a typed terminal rejection for the client", async () => {
     mocks.applyLiveWorkoutMemberAction.mockResolvedValueOnce({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-causal-input.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-causal-input.test.ts
@@ -26,6 +26,7 @@ import {
 } from "./hosted-runtime-workspace-entrypoint.harness.ts";
 
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { access, appendFile, chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -56,10 +57,11 @@ import {
   buildHostedExecutionRuntimeControlWake,
   deriveHostedExecutionErrorCode,
 } from "@murphai/hosted-execution";
-import type {
-  MemberActionRequestV1,
-  WorkoutLiveApplyMemberActionV1,
-  WorkoutLiveSnapshotMemberActionV1,
+import {
+  parseWorkoutSessionAppCardEnvelopeV4,
+  type MemberActionRequestV1,
+  type WorkoutLiveApplyMemberActionV1,
+  type WorkoutLiveSnapshotMemberActionV1,
 } from "@murphai/contracts";
 import {
   addLiveWorkoutExercise,
@@ -841,6 +843,12 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
                             result: { kind: "reps", reps: 9 },
                             setPosition: 1,
                           }],
+                          presentation: {
+                            footer: null,
+                            subtitle: null,
+                            title: "Workout",
+                            workout: initialCard.workout,
+                          },
                           version: 1,
                         }
                       : {
@@ -986,6 +994,21 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
 
         if (actionKind === "workout.live.apply") {
           assert.equal(recordedOutcomes[0]?.status, "applied");
+          const applyResult = recordedOutcomes[0]?.result;
+          assert.equal(applyResult?.kind, "workout.live.apply");
+          if (applyResult?.kind !== "workout.live.apply") {
+            throw new TypeError("Expected the canonical direct-save card result.");
+          }
+          const encoded = new URL(applyResult.cardUrl).hash
+            .replace(/^#murph-card=/u, "");
+          const envelope = JSON.parse(
+            Buffer.from(encoded, "base64url").toString("utf8"),
+          );
+          assert.equal(
+            parseWorkoutSessionAppCardEnvelopeV4(envelope)
+              ?.workout.exercises[0]?.sets[0]?.actual,
+            "9 reps",
+          );
           assert.ok(workoutId);
           const refreshedCard = await readLiveWorkoutCardEditor({
             presentation: embeddedWorkout,

--- a/packages/contracts/src/member-action.ts
+++ b/packages/contracts/src/member-action.ts
@@ -274,6 +274,7 @@ export const workoutLiveApplyMemberActionV1Schema = z
       .array(workoutMemberActionMutationV1Schema)
       .min(1)
       .max(memberActionV1Bounds.mutations),
+    presentation: workoutSessionPresentationV1Schema.optional(),
     version: z.literal(1),
   })
   .strict()
@@ -479,7 +480,20 @@ export type WorkoutLiveSnapshotMemberActionResultV1 = z.infer<
   typeof workoutLiveSnapshotMemberActionResultV1Schema
 >;
 
+export const workoutLiveApplyMemberActionResultV1Schema = z
+  .object({
+    cardUrl: z.string().max(2_047).regex(WORKOUT_APP_CARD_URL_PATTERN),
+    kind: z.literal("workout.live.apply"),
+    version: z.literal(1),
+  })
+  .strict();
+
+export type WorkoutLiveApplyMemberActionResultV1 = z.infer<
+  typeof workoutLiveApplyMemberActionResultV1Schema
+>;
+
 export const memberActionResultV1Schema = z.discriminatedUnion("kind", [
+  workoutLiveApplyMemberActionResultV1Schema,
   workoutLiveSnapshotMemberActionResultV1Schema,
 ]);
 
@@ -503,10 +517,19 @@ export const memberActionOutcomeV1Schema = z
         path: ["reason"],
       });
     }
-    if (outcome.result !== undefined && outcome.status !== "unchanged") {
+    if (
+      outcome.result !== undefined
+      && (
+        outcome.status === "rejected"
+        || (
+          outcome.result.kind === "workout.live.snapshot"
+          && outcome.status !== "unchanged"
+        )
+      )
+    ) {
       context.addIssue({
         code: "custom",
-        message: "A member-action result requires a successful read-only outcome.",
+        message: "The member-action result is not valid for this terminal status.",
         path: ["result"],
       });
     }

--- a/packages/contracts/test/member-action.test.ts
+++ b/packages/contracts/test/member-action.test.ts
@@ -37,11 +37,104 @@ function validRequest() {
   };
 }
 
+function validPresentation() {
+  return {
+    title: "Strength",
+    subtitle: null,
+    footer: "Log each set.",
+    workout: {
+      version: 1 as const,
+      state: "active" as const,
+      exercises: [{
+        name: "Leg press",
+        sets: [{ status: "pending" as const, target: "8 reps", actual: null }],
+      }],
+    },
+  };
+}
+
 describe("member action contract", () => {
   it("parses a closed, versioned workout action", () => {
     const request = validRequest();
 
     expect(parseMemberActionRequestV1(request)).toEqual(request);
+  });
+
+  it("accepts one bounded apply presentation and an apply-only success result", () => {
+    const request = validRequest();
+    const presentedRequest = {
+      ...request,
+      action: {
+        ...request.action,
+        presentation: validPresentation(),
+      },
+    };
+    expect(parseMemberActionRequestV1(presentedRequest)).toEqual(
+      presentedRequest,
+    );
+
+    const result = {
+      cardUrl: "https://www.withmurph.ai/#murph-card=abc_123",
+      kind: "workout.live.apply" as const,
+      version: 1 as const,
+    };
+    for (const status of ["applied", "unchanged"] as const) {
+      const outcome = {
+        actionId: request.actionId,
+        completedAt: "2026-08-12T15:00:01.000Z",
+        reason: null,
+        result,
+        schemaVersion: 1 as const,
+        status,
+      };
+      expect(memberActionOutcomeV1Schema.parse(outcome)).toEqual(outcome);
+    }
+    expect(memberActionOutcomeV1Schema.safeParse({
+      actionId: request.actionId,
+      completedAt: "2026-08-12T15:00:01.000Z",
+      reason: "workout_changed",
+      result,
+      schemaVersion: 1,
+      status: "rejected",
+    }).success).toBe(false);
+    expect(memberActionOutcomeV1Schema.safeParse({
+      actionId: request.actionId,
+      completedAt: "2026-08-12T15:00:01.000Z",
+      reason: null,
+      result: { ...result, kind: "workout.live.snapshot" },
+      schemaVersion: 1,
+      status: "applied",
+    }).success).toBe(false);
+  });
+
+  it("rejects malformed or unbounded optional apply presentation", () => {
+    const request = validRequest();
+    expect(memberActionRequestV1Schema.safeParse({
+      ...request,
+      action: {
+        ...request.action,
+        presentation: {
+          ...validPresentation(),
+          canonicalWorkoutId: "evt_private",
+        },
+      },
+    }).success).toBe(false);
+    expect(memberActionRequestV1Schema.safeParse({
+      ...request,
+      action: {
+        ...request.action,
+        presentation: {
+          ...validPresentation(),
+          workout: {
+            ...validPresentation().workout,
+            exercises: Array.from({ length: 17 }, (_, index) => ({
+              name: `Exercise ${index + 1}`,
+              sets: [{ status: "pending", target: null, actual: null }],
+            })),
+          },
+        },
+      },
+    }).success).toBe(false);
   });
 
   it("accepts pull-up and push-up results as typed reps", () => {

--- a/packages/vault-usecases/src/usecases/workout-live-model.ts
+++ b/packages/vault-usecases/src/usecases/workout-live-model.ts
@@ -1,6 +1,7 @@
 import {
   renderWorkoutSessionEditorResultV1,
   workoutSessionCardV1Bounds,
+  type WorkoutLiveApplyMemberActionResultV1,
   type WorkoutLiveApplyMemberActionV1,
   type WorkoutMemberActionExpectedSetResultV1,
   type WorkoutSessionDetailV1,
@@ -111,7 +112,10 @@ export interface ApplyLiveWorkoutMemberActionInput {
 }
 
 export type ApplyLiveWorkoutMemberActionResult =
-  | { status: 'applied' | 'unchanged' }
+  | {
+      result?: WorkoutLiveApplyMemberActionResultV1
+      status: 'applied' | 'unchanged'
+    }
   | { reason: 'workout_changed'; status: 'rejected' }
 
 export function isOpenLiveWorkout(workout: WorkoutSession): boolean {

--- a/packages/vault-usecases/src/usecases/workout-live.ts
+++ b/packages/vault-usecases/src/usecases/workout-live.ts
@@ -8,6 +8,7 @@ import {
   type WorkoutMemberActionSetResultV1,
   type WorkoutSession,
   type WorkoutSessionDetailV1,
+  type WorkoutSessionPresentationV1,
   type WorkoutSet,
   memberActionIdV1Schema,
   workoutLiveApplyMemberActionV1Schema,
@@ -107,31 +108,59 @@ export async function readLiveWorkoutCardSnapshot(input: {
   if (targets.length !== 1) {
     return { reason: 'workout_changed', status: 'rejected' }
   }
-  try {
-    const shown = targets[0]!
-    const snapshot = buildLiveWorkoutCardSnapshot({
-      presentation: input.action.presentation.workout,
-      workout: parseShownWorkout(shown),
-      workoutId: shown.entity.id,
-    })
-    if (snapshot === null) {
-      return { reason: 'workout_changed', status: 'rejected' }
-    }
-    return {
-      result: {
-        cardUrl: encodeWorkoutSessionSnapshotAppCardUrl({
-          ...input.action.presentation,
-          ...(snapshot.editor === null ? {} : { editor: snapshot.editor }),
-          workout: snapshot.workout,
-        }),
-        kind: 'workout.live.snapshot',
-        version: 1,
-      },
-      status: 'unchanged',
-    }
-  } catch {
+  const cardUrl = buildLiveWorkoutMemberActionCardUrl({
+    presentation: input.action.presentation,
+    shown: targets[0]!,
+  })
+  if (cardUrl === null) {
     return { reason: 'workout_changed', status: 'rejected' }
   }
+  return {
+    result: { cardUrl, kind: 'workout.live.snapshot', version: 1 },
+    status: 'unchanged',
+  }
+}
+
+function buildLiveWorkoutMemberActionCardUrl(input: {
+  presentation: WorkoutSessionPresentationV1
+  shown: WorkoutShowResult
+}): string | null {
+  try {
+    const snapshot = buildLiveWorkoutCardSnapshot({
+      presentation: input.presentation.workout,
+      workout: parseShownWorkout(input.shown),
+      workoutId: input.shown.entity.id,
+    })
+    if (snapshot === null) return null
+
+    return encodeWorkoutSessionSnapshotAppCardUrl({
+      ...input.presentation,
+      ...(snapshot.editor === null ? {} : { editor: snapshot.editor }),
+      workout: snapshot.workout,
+    })
+  } catch {
+    return null
+  }
+}
+
+function buildLiveWorkoutApplySuccess(input: {
+  action: WorkoutLiveApplyMemberActionV1
+  shown: WorkoutShowResult
+  status: 'applied' | 'unchanged'
+}): ApplyLiveWorkoutMemberActionResult {
+  if (input.action.presentation === undefined) {
+    return { status: input.status }
+  }
+  const cardUrl = buildLiveWorkoutMemberActionCardUrl({
+    presentation: input.action.presentation,
+    shown: input.shown,
+  })
+  return cardUrl === null
+    ? { status: input.status }
+    : {
+        result: { cardUrl, kind: 'workout.live.apply', version: 1 },
+        status: input.status,
+      }
 }
 
 const MAX_LIVE_WORKOUT_EXERCISES = 100
@@ -153,9 +182,14 @@ export async function applyLiveWorkoutMemberAction(
     input.action.expectedWorkout.actionBinding,
   )
   if (targets.exactReplays.length > 0) {
-    return targets.exactReplays.length === 1
-      ? { status: 'unchanged' }
-      : { reason: 'workout_changed', status: 'rejected' }
+    if (targets.exactReplays.length !== 1) {
+      return { reason: 'workout_changed', status: 'rejected' }
+    }
+    return buildLiveWorkoutApplySuccess({
+      action: input.action,
+      shown: targets.exactReplays[0]!,
+      status: 'unchanged',
+    })
   }
   if (targets.bindingMatches.length !== 1) {
     return { reason: 'workout_changed', status: 'rejected' }
@@ -181,7 +215,11 @@ async function applyLiveWorkoutMemberActionWithLockHeld(
     })
     workout = parseShownWorkout(shown)
     if (workout.lastMemberActionId === input.actionId) {
-      return { status: 'unchanged' }
+      return buildLiveWorkoutApplySuccess({
+        action: input.action,
+        shown,
+        status: 'unchanged',
+      })
     }
     if (!isOpenLiveWorkout(workout)) {
       return { reason: 'workout_changed', status: 'rejected' }
@@ -330,12 +368,21 @@ async function applyLiveWorkoutMemberActionWithLockHeld(
       !== JSON.stringify(workout.exercises)
     || endedAt !== undefined
 
-  await updateLiveWorkoutExercises(shown, workout, parsed.data.exercises, {
-    ...(endedAt === undefined ? {} : { endedAt }),
-    lastMemberActionId: input.actionId,
-    observedAt: acceptedAt,
+  const updated = await updateLiveWorkoutExercises(
+    shown,
+    workout,
+    parsed.data.exercises,
+    {
+      ...(endedAt === undefined ? {} : { endedAt }),
+      lastMemberActionId: input.actionId,
+      observedAt: acceptedAt,
+    },
+  )
+  return buildLiveWorkoutApplySuccess({
+    action: input.action,
+    shown: updated,
+    status: changed ? 'applied' : 'unchanged',
   })
-  return { status: changed ? 'applied' : 'unchanged' }
 }
 
 function memberActionCompletesPendingSet(

--- a/packages/vault-usecases/test/workout-live-member-action-real.test.ts
+++ b/packages/vault-usecases/test/workout-live-member-action-real.test.ts
@@ -704,28 +704,27 @@ test("a stale snapshot cannot re-arm a card after a hidden same-name reorder", a
   }
 });
 
-test("a stale snapshot refreshes after a direct result save", async () => {
+test("a direct result save returns its canonical card without a second action", async () => {
   const fixture = await createLoggedWorkout([10, 10]);
   try {
-    const action = snapshotAction(fixture);
-    await expect(applyLiveWorkoutMemberAction({
-      acceptedAt: ACCEPTED_AT,
-      action: putFirstSetAction({
-        actionBinding: action.workoutBinding,
+    const snapshot = snapshotAction(fixture);
+    const action = {
+      ...putFirstSetAction({
+        actionBinding: snapshot.workoutBinding,
         reps: 12,
       }),
-      vault: fixture.vault,
-    })).resolves.toEqual({ status: "applied" });
-
-    const refreshed = await readLiveWorkoutCardSnapshot({
+      presentation: snapshot.presentation,
+    };
+    const applied = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
       action,
       vault: fixture.vault,
     });
-    expect(refreshed.status).toBe("unchanged");
-    if (refreshed.status !== "unchanged") {
-      throw new TypeError("Expected a fresh snapshot after a direct save.");
+    expect(applied.status).toBe("applied");
+    if (applied.status !== "applied" || applied.result === undefined) {
+      throw new TypeError("Expected the direct-save card result.");
     }
-    const encoded = new URL(refreshed.result.cardUrl).hash
+    const encoded = new URL(applied.result.cardUrl).hash
       .replace(/^#murph-card=/u, "");
     const envelope = JSON.parse(
       Buffer.from(encoded, "base64url").toString("utf8"),
@@ -735,6 +734,16 @@ test("a stale snapshot refreshes after a direct result save", async () => {
       parseWorkoutSessionAppCardEnvelopeV4(envelope)
         ?.workout.exercises[0]?.sets[0]?.actual,
     ).toBe("12 reps");
+
+    const replayed = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action,
+      vault: fixture.vault,
+    });
+    expect(replayed).toEqual({
+      result: applied.result,
+      status: "unchanged",
+    });
   } finally {
     await rm(fixture.vault, { force: true, recursive: true });
   }

--- a/packages/vault-usecases/test/workout-live-member-action.test.ts
+++ b/packages/vault-usecases/test/workout-live-member-action.test.ts
@@ -1,12 +1,14 @@
 import { Buffer } from "node:buffer";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  WorkoutMemberActionExpectedSetResultV1,
-  WorkoutMemberActionExpectedSetStateV1,
-  WorkoutMemberActionSetResultV1,
-  WorkoutSession,
-  WorkoutSet,
+import {
+  parseWorkoutSessionAppCardEnvelopeV4,
+  type WorkoutMemberActionExpectedSetResultV1,
+  type WorkoutMemberActionExpectedSetStateV1,
+  type WorkoutMemberActionSetResultV1,
+  type WorkoutSession,
+  type WorkoutSessionPresentationV1,
+  type WorkoutSet,
 } from "@murphai/contracts";
 import {
   deriveLegacyWorkoutActionBindingV4,
@@ -137,6 +139,33 @@ function appendAction(setCount = 1) {
     ],
     version: 1 as const,
   };
+}
+
+function workoutPresentation(input: {
+  exercises?: WorkoutSessionPresentationV1["workout"]["exercises"];
+  state?: WorkoutSessionPresentationV1["workout"]["state"];
+} = {}): WorkoutSessionPresentationV1 {
+  return {
+    footer: "Log each set.",
+    subtitle: null,
+    title: "Strength",
+    workout: {
+      exercises: input.exercises ?? [{
+        name: "Leg press",
+        sets: [{ actual: null, status: "pending", target: "8 reps" }],
+      }],
+      state: input.state ?? "active",
+      version: 1,
+    },
+  };
+}
+
+function decodeWorkoutCardUrl(cardUrl: string) {
+  const payload = cardUrl.split("#murph-card=")[1];
+  if (payload === undefined) {
+    throw new TypeError("Expected one canonical workout card URL.");
+  }
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
 }
 
 function removeAction(input: {
@@ -293,6 +322,182 @@ describe("live workout member action", () => {
     });
   });
 
+  it("returns one authoritative V6 card for an apply and its exact replay", async () => {
+    const action = {
+      ...setAction({ kind: "reps" as const, reps: 8 }),
+      presentation: workoutPresentation({
+        exercises: [{
+          name: "Leg press",
+          sets: [{
+            actual: "999 reps",
+            status: "completed",
+            target: "8 reps",
+          }],
+        }],
+      }),
+    };
+    const persistedWorkout: WorkoutSession = {
+      ...BASE_WORKOUT,
+      lastMemberActionId: ACTION_ID,
+      exercises: [{
+        ...BASE_WORKOUT.exercises[0],
+        sets: [{ order: 1, reps: 8 }],
+      }],
+    };
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(
+      shownWorkout(persistedWorkout),
+    );
+
+    const applied = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action,
+      vault: "/vault",
+    });
+    expect(applied.status).toBe("applied");
+    if (applied.status !== "applied" || applied.result === undefined) {
+      throw new TypeError("Expected the authoritative apply card result.");
+    }
+    expect(applied.result.kind).toBe("workout.live.apply");
+    const envelope = decodeWorkoutCardUrl(applied.result.cardUrl);
+    expect(envelope).toMatchObject({
+      card: {
+        b: deriveWorkoutActionBinding("evt_test_workout", persistedWorkout),
+      },
+      schemaVersion: 6,
+    });
+    expect(
+      parseWorkoutSessionAppCardEnvelopeV4(envelope)
+        ?.workout.exercises[0]?.sets[0]?.actual,
+    ).toBe("8 reps");
+
+    mocks.candidateWorkouts.mockResolvedValueOnce([
+      shownWorkout(persistedWorkout),
+    ]);
+    const replayed = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action,
+      vault: "/vault",
+    });
+    expect(replayed).toEqual({
+      result: applied.result,
+      status: "unchanged",
+    });
+    expect(mocks.resolveLiveWorkout).toHaveBeenCalledTimes(1);
+    expect(mocks.updateLiveWorkoutExercises).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an authoritative card for a first-application no-op", async () => {
+    const currentWorkout: WorkoutSession = {
+      ...BASE_WORKOUT,
+      exercises: [{
+        ...BASE_WORKOUT.exercises[0],
+        sets: [{ order: 1, reps: 8 }],
+      }],
+    };
+    const action = {
+      ...setAction(
+        { kind: "reps" as const, reps: 8 },
+        { expectedResult: { kind: "reps", reps: 8 }, logged: true },
+      ),
+      expectedWorkout: {
+        ...setAction(
+          { kind: "reps" as const, reps: 8 },
+          { expectedResult: { kind: "reps", reps: 8 }, logged: true },
+        ).expectedWorkout,
+        actionBinding: deriveWorkoutActionBinding(
+          "evt_test_workout",
+          currentWorkout,
+        ),
+      },
+      presentation: workoutPresentation({
+        exercises: [{
+          name: "Leg press",
+          sets: [{ actual: "8 reps", status: "completed", target: "8 reps" }],
+        }],
+      }),
+    };
+    mocks.candidateWorkouts.mockResolvedValueOnce([shownWorkout(currentWorkout)]);
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(shownWorkout({
+      ...currentWorkout,
+      lastMemberActionId: ACTION_ID,
+    }));
+
+    const result = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action,
+      vault: "/vault",
+    });
+    expect(result.status).toBe("unchanged");
+    if (result.status !== "unchanged") {
+      throw new TypeError("Expected an unchanged canonical apply.");
+    }
+    expect(result.result?.kind).toBe("workout.live.apply");
+    expect(mocks.updateLiveWorkoutExercises).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an applied write successful when the complete V4 URL is oversized", async () => {
+    const exercises: WorkoutSession["exercises"] = Array.from(
+      { length: 8 },
+      (_, exerciseIndex) => ({
+        mode: "bodyweight" as const,
+        name: `Exercise ${exerciseIndex + 1}`,
+        order: exerciseIndex + 1,
+        sets: Array.from({ length: 8 }, (_, setIndex) => ({
+          order: setIndex + 1,
+        })),
+      }),
+    );
+    const workout: WorkoutSession = {
+      exercises,
+      sourceApp: "murph-live",
+      startedAt: BASE_WORKOUT.startedAt,
+    };
+    const action = {
+      expectedWorkout: {
+        actionBinding: deriveWorkoutActionBinding("evt_test_workout", workout),
+        exercises: exercises.map((exercise) => ({
+          name: exercise.name,
+          sets: exercise.sets.map(() => ({ logged: false })),
+        })),
+      },
+      kind: "workout.live.apply" as const,
+      mutations: [{
+        exerciseName: exercises[0]!.name,
+        exercisePosition: 1,
+        expectedResult: null,
+        kind: "set.put" as const,
+        result: { kind: "reps" as const, reps: 8 },
+        setPosition: 1,
+      }],
+      presentation: workoutPresentation({
+        exercises: exercises.map((exercise) => ({
+          name: exercise.name,
+          sets: exercise.sets.map(() => ({
+            actual: null,
+            status: "pending" as const,
+            target: "T".repeat(40),
+          })),
+        })),
+      }),
+      version: 1 as const,
+    };
+    const persistedExercises = structuredClone(exercises);
+    persistedExercises[0]!.sets[0] = { order: 1, reps: 8 };
+    mocks.candidateWorkouts.mockResolvedValueOnce([shownWorkout(workout)]);
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(shownWorkout({
+      ...workout,
+      exercises: persistedExercises,
+      lastMemberActionId: ACTION_ID,
+    }));
+
+    await expect(applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action,
+      vault: "/vault",
+    })).resolves.toEqual({ status: "applied" });
+    expect(mocks.updateLiveWorkoutExercises).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps already-sent V6 cards valid through the legacy binding check", async () => {
     const action = setAction({ kind: "reps", reps: 8 });
     action.expectedWorkout.actionBinding = deriveLegacyWorkoutActionBindingV4(
@@ -324,16 +529,38 @@ describe("live workout member action", () => {
           finiteWorkout,
         ),
       },
+      presentation: workoutPresentation({
+        exercises: [{
+          name: "Leg press",
+          sets: [{ actual: "8 reps", status: "completed", target: "8 reps" }],
+        }],
+      }),
     };
     mocks.candidateWorkouts.mockResolvedValueOnce([
       shownWorkout(finiteWorkout, "evt_finite_workout"),
     ]);
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(shownWorkout({
+      ...finiteWorkout,
+      endedAt: ACCEPTED_AT,
+      lastMemberActionId: ACTION_ID,
+      exercises: [{
+        ...finiteWorkout.exercises[0],
+        sets: [{ order: 1, reps: 8 }],
+      }],
+    }, "evt_finite_workout"));
 
-    await expect(applyLiveWorkoutMemberAction({
+    const result = await applyLiveWorkoutMemberAction({
       acceptedAt: ACCEPTED_AT,
       action,
       vault: "/vault",
-    })).resolves.toEqual({ status: "applied" });
+    });
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied" || result.result === undefined) {
+      throw new TypeError("Expected the completed apply card result.");
+    }
+    expect(decodeWorkoutCardUrl(result.result.cardUrl)).toMatchObject({
+      schemaVersion: 4,
+    });
 
     expect(mocks.withLiveWorkoutMutationLock).toHaveBeenCalledWith(
       "/vault",
@@ -358,7 +585,10 @@ describe("live workout member action", () => {
 
     await expect(applyLiveWorkoutMemberAction({
       acceptedAt: ACCEPTED_AT,
-      action: setAction({ kind: "reps", reps: 8 }),
+      action: {
+        ...setAction({ kind: "reps", reps: 8 }),
+        presentation: workoutPresentation(),
+      },
       vault: "/vault",
     })).resolves.toEqual({
       reason: "workout_changed",
@@ -1272,21 +1502,78 @@ describe("live workout member action", () => {
   });
 
   it("appends an exercise and fills its sets in the same write", async () => {
-    await expect(applyLiveWorkoutMemberAction({
-      acceptedAt: ACCEPTED_AT,
-      action: appendAction(),
-      vault: "/vault",
-    })).resolves.toEqual({ status: "applied" });
-    expect(mocks.updateLiveWorkoutExercises.mock.calls[0]?.[2]).toEqual([
+    const finalExercises = [
       BASE_WORKOUT.exercises[0],
       {
-        mode: "bodyweight",
+        mode: "bodyweight" as const,
         name: "Push-up",
         order: 2,
         setPlanIsFinite: true,
         sets: [{ order: 1, reps: 12 }],
       },
-    ]);
+    ];
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(shownWorkout({
+      ...BASE_WORKOUT,
+      exercises: finalExercises,
+      lastMemberActionId: ACTION_ID,
+    }));
+    const result = await applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action: {
+        ...appendAction(),
+        presentation: workoutPresentation({
+          exercises: [
+            {
+              name: "Leg press",
+              sets: [{ actual: null, status: "pending", target: "8 reps" }],
+            },
+            {
+              name: "Push-up",
+              sets: [{ actual: "12 reps", status: "completed", target: null }],
+            },
+          ],
+        }),
+      },
+      vault: "/vault",
+    });
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied" || result.result === undefined) {
+      throw new TypeError("Expected the structural apply card result.");
+    }
+    expect(decodeWorkoutCardUrl(result.result.cardUrl)).toMatchObject({
+      schemaVersion: 6,
+    });
+    expect(mocks.updateLiveWorkoutExercises.mock.calls[0]?.[2]).toEqual(
+      finalExercises,
+    );
+  });
+
+  it("keeps a structural mutation successful when presentation cannot reconcile", async () => {
+    const finalExercises = [
+      BASE_WORKOUT.exercises[0],
+      {
+        mode: "bodyweight" as const,
+        name: "Push-up",
+        order: 2,
+        setPlanIsFinite: true,
+        sets: [{ order: 1, reps: 12 }],
+      },
+    ];
+    mocks.updateLiveWorkoutExercises.mockResolvedValueOnce(shownWorkout({
+      ...BASE_WORKOUT,
+      exercises: finalExercises,
+      lastMemberActionId: ACTION_ID,
+    }));
+
+    await expect(applyLiveWorkoutMemberAction({
+      acceptedAt: ACCEPTED_AT,
+      action: {
+        ...appendAction(),
+        presentation: workoutPresentation(),
+      },
+      vault: "/vault",
+    })).resolves.toEqual({ status: "applied" });
+    expect(mocks.updateLiveWorkoutExercises).toHaveBeenCalledTimes(1);
   });
 
   it("treats an exact appended exercise retry as unchanged", async () => {


### PR DESCRIPTION
## Why and outcome

Direct workout mutations save canonically, but the expanded Messages card previously needed a later snapshot read before showing the saved state. This change lets an apply request opt into an authoritative post-write card in its existing terminal receipt, allowing the native client to project immediately and reconcile without a second backend refresh.

Rendering presentation is optional and non-authoritative. Mutation targeting, conflicts, values, completion, and bindings still come from the locked canonical workout.

## Product UX

- Effort: Patch
- Walkthrough: Hold pending physical Messages proof of the cross-repository journey.
- Affected journeys: immediate saves, slow or interrupted confirmation, definitive conflicts, exact retries, and older clients. The transcript bubble remains immutable; no offline workout store or concurrent-write queue is introduced.

## Evidence

- Contracts: 330 tests passed; generated schema artifacts verified.
- Vault: 385 tests passed; the two focused workout files passed 67 tests.
- Hosted runtime: 2,518 tests passed with 5 intentional skips; the focused member-action and causal-entrypoint files passed 47 tests.
- Contracts, vault-usecases, and assistant-runtime typechecks passed.
- Agent-doc drift, dependency policy, and diff integrity checks passed.
- The production-faithful causal test carries presentation from mailbox ingestion through the real apply path and decodes the canonical updated 9-rep card from the terminal receipt.
- Closest native proof: the linked iOS PR encodes the shared presentation shape and strictly decodes ordinary V4/V6 returned card URLs. Physical Messages proof remains pending.

## Non-obvious affected surfaces

- Member-action contract: optional apply presentation and typed apply result, with additive rollout and illegal result/status coverage.
- Hosted runtime receipt: threads only successful optional results through the existing mailbox outcome; rejected outcomes cannot carry one.
- Vault workout mutation: derives a response card from the canonical post-write object already returned under the existing lock; mocked and real-workout tests cover apply and exact replay.
- Causal harness: extends the existing mailbox-to-runtime-to-vault proof; it introduces no integration owner.

## Architecture and reuse

- Existing systems reused: the member-action mailbox, live-workout mutation lock, canonical workout show result, snapshot card encoder, and native V4/V6 decoder.
- New logic: one optional rendering presentation and one small success helper that derives a result from the already-available canonical post-write workout.
- New abstractions: only a typed `workout.live.apply` member-action result in the existing result union; no new service, repository, queue, or persistence owner.
- Complexity intentionally avoided: no canonical reread, second snapshot action, model turn, client cache, local database, or parallel mutation pipeline.

## Hot reply path impact

Not applicable. This changes the closed iMessage member-action path, not durable acceptance of a current conversation message through provider start and durable reply handoff. It adds no operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool/schema guidance, or provider-visible request assembly changed.
- Group runtime: Not applicable; no prompt, tool/schema guidance, or provider-visible request assembly changed.

## Cross-repository contract

- Counterpart: cobuildwithus/murph-ios#116, merged from reviewed head `9fb15f5df662f75cbfb9ae1b5551d188c9a33d1a` by `072fa2ba268c819730a4f73ea909796089818d44`.
- Status: merged after canonical ReviewGPT round 2 passed and exact-head checks were green. Native binary release remains on Hold for physical Messages verification.
- Compatible order: deploy backend Web/Worker and current runner support first, verify current runner containers, then release the native sender.

## Change-shape breakdown

Classification: production package code is source; `test/**` files are tests/fixtures; agent docs and the execution plan are docs; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 109 | 32 |
| Tests/fixtures | 518 | 33 |
| Docs | 162 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 789 | 65 |

## Deployment concerns

- Deployment: applicable
- Supported skew: old native clients omit `presentation` and retain result-free receipts; the new backend emits a result only for opted-in requests.
- Safe order: exact-SHA Web production verification completed first, followed by the protected Worker/current-runner deployment with immediate convergence and managed smoke. The native binary remains unreleased pending physical Messages proof.
- Rollback floor: retain optional-presentation acceptance after native release; rolling backend below that floor would reject new-client submissions.
- Expected exposure: direct active-workout card actions from the new Messages extension; legacy clients keep their existing path.
- Reversibility: before native release the backend addition is independently reversible; afterward preserve its acceptance floor and roll back native first.
- Convergence proof: applied actions and exact replays render from the canonical post-write or replay object; card-construction failure omits only the optional result.
- Post-deploy checks: verify applied and exact-replay cards, legacy result-free actions, current warm-runner acceptance, and no spike in `workout_changed` conflicts.

## Changelog

- Changelog: not applicable
- Reason: The backend-first capability is not a complete member-visible release until the native counterpart and physical Messages proof ship.

## ReviewGPT disposition history

- The replaced PR's preliminary specialists accepted removal of a premature public changelog and extension of the existing causal test to inspect the returned card.
- Its canonical round 1 independently accepted only the same changelog finding.
- Its round 2 found unrelated Environment/Frog history in GitHub's PR file set after reconciliation. This replacement branch starts directly from current `main`, carries the byte-equivalent workout patch only, and does not rewrite the published branch.
- Replacement preliminary specialists reviewed `afe1550b943a4e3c71ed68313de12773357e131e` with `FINDINGS`: Product UX remains on Hold for the physical Messages walkthrough. That is accepted as a release-evidence requirement; prompt and frontend lenses were not applicable, coverage was sufficient, and no code correction was requested.
- Replacement canonical round 1 reviewed `afe1550b943a4e3c71ed68313de12773357e131e` with `PASS`: no qualifying code, UX, purpose, architecture, complexity, or coverage finding. The review independently confirmed the single-session optimistic projection, exact idempotent retry, canonical locked apply/replay receipt, and additive backend-first skew contract.

ReviewGPT context sensitivity: sensitive
Reason: This is a cross-repository protocol change with backend-first rollout and warm-runner skew.
ReviewGPT first-reviewed head: afe1550b943a4e3c71ed68313de12773357e131e
ReviewGPT latest valid round: 1
ReviewGPT latest reviewed head: afe1550b943a4e3c71ed68313de12773357e131e

