### PR TITLE
Document alternate Codex home approval

### DIFF
--- a/.agents/friction-log/20260826170824-assistant-live-verification/friction.md
+++ b/.agents/friction-log/20260826170824-assistant-live-verification/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Assistant live verification requires repeated alternate-home authorization'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+When the default local subscription is usage-limited before any provider action, the focused assistant journey should make one bounded retry through an already-authenticated alternate local Codex home without requiring repeated per-run approval.
+
+## Current Behavior
+
+The workflow requires an explicitly authorized absolute alternate path for every retry. This can leave otherwise complete assistant changes at Hold even when safe authenticated alternate profiles are already available.
+
+## Possible Solution
+
+Grant standing repository authorization to discover authentication status only, select one unused alternate home, and retry the same focused journey once without copying credentials or cycling profiles.
+
+## Minimal Reproducible Example
+
+1. Run one focused assistant live journey through the default subscription home.
+2. Receive `ASSISTANT_CODEX_USAGE_LIMIT` before any provider action.
+3. Observe that the workflow stops even though an authenticated alternate profile is available.
+
+## Context
+
+This delays required assistant Product UX proof while preserving no additional security boundary beyond the existing no-credential-copy and single-retry rules.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -68,7 +68,10 @@ are specified by
 Changes that can alter Murph's interpretation, tool behavior, silence
 decision, or user-visible reply require deterministic boundary proof plus one
 focused production-derived real-Codex journey and manual review of the actual
-synthetic replies. The one-command local subscription runner, provider-key
+synthetic replies. When the default subscription is usage-limited before any
+provider action, the repository grants one bounded retry through a discovered
+already-authenticated alternate Codex home without reading or copying auth or
+cycling profiles. The one-command local subscription runner, provider-key
 boundary, UX verdict, and PR evidence contract are specified by
 `.agents/skills/verify-murph-assistant/SKILL.md`,
 `agent-docs/operations/completion-workflow.md`,

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -1,6 +1,6 @@
 # Verification And Runtime
 
-Last verified: 2026-08-25
+Last verified: 2026-08-26
 ## Verification Ownership By Delivery Path
 
 The delivery path decides who owns broad verification:
@@ -259,12 +259,14 @@ count, repetition, clarity, warmth, autonomy, and truthful recovery. Routine CI
 must never depend on local subscription state or make the paid call.
 
 If the default subscription home returns `ASSISTANT_CODEX_USAGE_LIMIT` before
-any provider action and an explicitly authorized absolute alternate path is
-already available, rerun that same focused journey once with
-`--codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>`. The runner selects that home's
-existing auth and config without copying credentials. Do not auto-discover
-profiles or cycle through homes. If no authorized alternate path is available,
-or if the supplied alternate is also blocked, record `Hold`.
+any provider action, this repository grants standing authorization to discover
+alternate local Codex homes by directory and non-empty auth-file presence only,
+select one already-authenticated home that has not been used for that focused
+journey, and rerun the same journey once with
+`--codex-home <ABSOLUTE_ALTERNATE_CODEX_HOME>`. Never read, print, copy, or move
+auth material. Do not cycle through additional homes. If no authenticated
+alternate is available, or if that one alternate is also blocked, record
+`Hold`.
 
 Assistant Engine's lower-level opt-in live Codex journeys still use
 `MURPH_RUN_REAL_CODEX_E2E=1`; provider-key mode requires a supported provider


### PR DESCRIPTION
## Outcome

Murph workflow docs now grant one standing, secret-safe alternate local Codex-home retry when a required assistant journey hits the subscription usage limit. The retry must use an already-authenticated unused home, may inspect only directory and non-empty auth-file presence, and may never read, print, copy, or move authentication material.

## Product UX

- Effort: Not applicable; this is repository workflow guidance only.
- Result: Required assistant verification can continue without repeated per-run authorization while retaining an explicit one-retry boundary and fail-closed fallback.

## Evidence

- `pnpm docs:drift` passed before and after rebasing onto current `main`.
- `git diff --check` passed.
- The scoped patch identity was unchanged by the rebase.
- A full acceptance attempt ran on Blacksmith Testbox `tbx_01m102x59a6d24jbb51a3wv5vy`; repository typecheck, doc gardening, app build, and most coverage passed, while pre-existing package-coverage failures were reported for Assistant Engine and Hosted Local Harness. This docs/Frog-only patch does not touch either package.

## Architecture and reuse

- Existing systems reused: The assistant-verification usage-limit branch, explicit `--codex-home` boundary, and Frog friction log.
- New logic: Workflow guidance grants one standing alternate-home discovery and retry after the exact usage-limit result.
- New abstractions: None. The change adds no runtime owner, dependency, configuration surface, or authentication handling.
- Complexity intentionally avoided: No credential copying, auth-file reads, profile cycling, new profile manager, or per-run approval state.

## Deployment concerns

- Deployment: not applicable
- Reason: Repository workflow documentation and a Frog record have no deployed runtime surface.

## Changelog

- Changelog: not applicable
- Reason: No member-visible product behavior changes.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 39 | 8 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 39 | 8 |
