### PR TITLE
Fix consent reposts and restaurant nutrition lookup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,8 +164,10 @@ intended for a provider-room participant who has not joined the hosted group
 yet. A room's explicit request to repost the native offer is the narrow
 exception: the model supplies that current accepted Message ref, Assistant
 Engine verifies it against current group input, and Web incorporates the exact
-accepted-input identity into provider idempotency. Replay of that request
-converges on one provider message; a later request can post one replacement.
+accepted-input identity into provider idempotency. Web resends the locked
+current join-policy snapshot; reposting never defaults or replaces its scopes.
+Replay of that request converges on one provider message; a later request can
+post one replacement.
 Older active offers are revoked only after the replacement message is durably
 bound, so a failed send does not destroy the existing recovery path.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,13 @@ sent. Missing additive rollout evidence is handled but never recency-eligible.
 An explicit native offer is suppressed only by a covering active offer, never
 by the scopes already granted by current members, because access may be
 intended for a provider-room participant who has not joined the hosted group
-yet.
+yet. A room's explicit request to repost the native offer is the narrow
+exception: the model supplies that current accepted Message ref, Assistant
+Engine verifies it against current group input, and Web incorporates the exact
+accepted-input identity into provider idempotency. Replay of that request
+converges on one provider message; a later request can post one replacement.
+Older active offers are revoked only after the replacement message is durably
+bound, so a failed send does not destroy the existing recovery path.
 
 Challenge kickoff and later interactive identity repair stay inside that same
 model-triggered `read_shared` request. At request time, the runtime adds only

--- a/agent-docs/exec-plans/active/2026-08-26-group-consent-repost-restaurant-nutrition.md
+++ b/agent-docs/exec-plans/active/2026-08-26-group-consent-repost-restaurant-nutrition.md
@@ -1,0 +1,118 @@
+# Group consent repost and restaurant nutrition resolution
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Let a hosted iMessage group explicitly request a fresh native join-and-share
+  consent message even when an older matching offer remains active.
+- Make named restaurant meal logging resolve nutrition before the meal write,
+  using the existing food database first and an official restaurant source only
+  when the database cannot identify the item.
+
+## Root cause
+
+- The model-facing group tool advertised an accepted-message reference, but the
+  strict `offer_access` parser rejected that field. The lower Web owner then
+  reused any matching active offer indefinitely, so a later resend request had
+  neither an accepted contract nor a provider-send identity.
+- The food-journal skill contained the correct source precedence, but the
+  restaurant path was buried after the low-friction mutation guidance and had
+  no focused real-model journey. A turn could therefore save a nutrition-free
+  meal before attempting the required lookup.
+
+## Architecture
+
+- Reuse the existing accepted-input authority as the explicit repost identity.
+  Assistant Engine validates the exact current Message ref and maps it to the
+  lower `post_join_offer` request. Web includes that identity in provider
+  idempotency, posts one replacement, and revokes older matching offers only
+  after the new message is durably bound. Ordinary offers keep the existing
+  covering-offer reuse behavior.
+- Keep restaurant resolution in the existing food-journal policy and existing
+  CLI/browser primitives. Move the lookup-before-write invariant to the capture
+  path, state the database-miss official-source fallback explicitly, and add
+  deterministic plus real-Codex regression proof. Add no resolver service,
+  persistence owner, queue, dependency, or meal schema.
+
+## Product UX journeys
+
+- Effort: Patch.
+- Outcome: explicit consent-message resend requests post a fresh native prompt,
+  and recognizable restaurant meals are saved with grounded nutrition.
+- Reaches: existing hosted-group join consent and private meal-capture journeys.
+- Proof: provider-shaped replacement/replay tests plus focused real-Codex
+  journeys with inspected effects and replies.
+
+- A room participant asks in the current message to resend a join prompt: one
+  new native prompt is posted and the assistant does not falsely claim a
+  link-only fallback.
+- The exact same accepted request replays: provider idempotency and the durable
+  binding converge on the same prompt without a duplicate effect.
+- A normal repeated offer without an explicit repost request: the existing
+  active prompt is reused and the first-party link remains available.
+- A private member names a restaurant and recognizable menu item: Murph searches
+  the existing food-label database before saving, records source-labeled
+  nutrition, and asks only about a materially different variant.
+- The database has no exact restaurant match: Murph checks an official
+  restaurant source before using a clearly labeled estimate; unavailable
+  evidence stays truthful and does not become invented exact nutrition.
+- A number-sensitive or eating-disorder-risk context: the existing safety
+  exception continues to suppress unsolicited numeric estimates.
+
+## Tasks
+
+1. [x] Add the request-bound consent repost contract across Assistant Engine,
+   hosted transport, Web, and focused tests.
+2. [x] Clarify the restaurant lookup-before-write contract and add deterministic
+   and focused real-Codex coverage.
+3. [x] Run focused tests, package typechecks, actual-reply review, Product UX
+   replay, privacy inspection, and candidate diff review.
+4. [ ] Commit and push the candidate, open the draft PR, and start the required
+   specialist and final ReviewGPT passes concurrently with exact-head CI.
+5. [ ] Resolve accepted findings, archive this plan with `scripts/finish-task`,
+   and confirm the final PR head is green.
+
+## Verification
+
+- Assistant Engine group-tool parser/authority tests and real-Codex journeys.
+- Hosted Execution and Assistant Runtime request/parser/context tests.
+- Web group-store/group-tool replay and replacement tests.
+- Food-journal prompt tests and real-Codex restaurant logging journey.
+- Assistant Engine, Hosted Execution, Assistant Runtime, and Web typechecks.
+- `git diff --check`, privacy-sensitive diff inspection, exact-head CI, and
+  required ReviewGPT gates.
+
+## Local evidence and Product UX walkthrough
+
+- Consent requester: the focused real-Codex group journey issued one native
+  offer call with the exact current Message ref and lowered one request-bound
+  repost. Deterministic Assistant Engine, transport, runtime, store, and Web
+  tests prove wrong-ref rejection, ordinary active-offer reuse, replay-stable
+  provider idempotency, and revoke-after-binding replacement order.
+- Restaurant member: the focused real-Codex journey searched an exact synthetic
+  restaurant menu item before mutation, saved the returned calories and macros
+  with valid label provenance, and replied without asking the member to repeat
+  the item. The production-shaped fixture rejects unsupported meal fields.
+- Existing exclusions: deterministic food-journal coverage preserves the
+  official-source fallback and existing number-sensitive safety exception.
+- Regression proof: Assistant Engine completed 4,133 tests, Assistant Runtime
+  2,516 tests, Hosted Execution 560 tests, focused Web consent coverage 243
+  tests, and all four affected package typechecks passed.
+- Provider input: normalized complete first-request captures for representative
+  direct and group turns were byte- and token-identical at base and head. The
+  changed group schema stays deferred until tool discovery; the meal skill stays
+  deferred until selected.
+- Walkthrough result: **Ready**. Both existing journeys reach their promised
+  observable result, failure preserves the prior working consent offer, and
+  there were no differences from the Patch plan.
+
+## Deployment concerns
+
+- The repost field is additive. Deploy Web before the hosted runtime so old
+  runners continue their ordinary no-field behavior while the new producer
+  waits for a consumer that understands request-bound reposting.
+- The food-journal change is prompt-only at runtime and has no cross-service
+  skew requirement.

--- a/agent-docs/exec-plans/active/2026-08-26-group-consent-repost-restaurant-nutrition.md
+++ b/agent-docs/exec-plans/active/2026-08-26-group-consent-repost-restaurant-nutrition.md
@@ -27,10 +27,11 @@ Updated: 2026-08-26
 
 - Reuse the existing accepted-input authority as the explicit repost identity.
   Assistant Engine validates the exact current Message ref and maps it to the
-  lower `post_join_offer` request. Web includes that identity in provider
-  idempotency, posts one replacement, and revokes older matching offers only
-  after the new message is durably bound. Ordinary offers keep the existing
-  covering-offer reuse behavior.
+  lower `post_join_offer` request. Web reads the locked current policy snapshot,
+  includes the request identity in provider idempotency, posts one replacement,
+  and revokes older matching offers only after the new message is durably bound.
+  Reposting never creates or changes a group policy. Ordinary offers keep the
+  existing covering-offer reuse behavior.
 - Keep restaurant resolution in the existing food-journal policy and existing
   CLI/browser primitives. Move the lookup-before-write invariant to the capture
   path, state the database-miss official-source fallback explicitly, and add
@@ -70,10 +71,10 @@ Updated: 2026-08-26
    and focused real-Codex coverage.
 3. [x] Run focused tests, package typechecks, actual-reply review, Product UX
    replay, privacy inspection, and candidate diff review.
-4. [ ] Commit and push the candidate, open the draft PR, and start the required
+4. [x] Commit and push the candidate, open the draft PR, and start the required
    specialist and final ReviewGPT passes concurrently with exact-head CI.
-5. [ ] Resolve accepted findings, archive this plan with `scripts/finish-task`,
-   and confirm the final PR head is green.
+5. [ ] Resolve accepted findings, run ReviewGPT round two, archive this plan
+   with `scripts/finish-task`, and confirm the final PR head is green.
 
 ## Verification
 
@@ -90,16 +91,18 @@ Updated: 2026-08-26
 - Consent requester: the focused real-Codex group journey issued one native
   offer call with the exact current Message ref and lowered one request-bound
   repost. Deterministic Assistant Engine, transport, runtime, store, and Web
-  tests prove wrong-ref rejection, ordinary active-offer reuse, replay-stable
-  provider idempotency, and revoke-after-binding replacement order.
-- Restaurant member: the focused real-Codex journey searched an exact synthetic
-  restaurant menu item before mutation, saved the returned calories and macros
-  with valid label provenance, and replied without asking the member to repeat
-  the item. The production-shaped fixture rejects unsupported meal fields.
+  tests prove wrong-ref rejection, immutable current-policy reposting, ordinary
+  active-offer reuse, request-distinct replay-stable provider idempotency, and
+  revoke-after-binding replacement order.
+- Restaurant member: focused real-Codex journeys cover both an exact synthetic
+  menu database hit and a database miss followed by the restaurant's synthetic
+  official nutrition page. Both save after sourcing, preserve valid provenance,
+  and do not ask the member to repeat the item. The production-shaped fixture
+  rejects generic restaurant queries and unsupported meal fields.
 - Existing exclusions: deterministic food-journal coverage preserves the
   official-source fallback and existing number-sensitive safety exception.
 - Regression proof: Assistant Engine completed 4,133 tests, Assistant Runtime
-  2,516 tests, Hosted Execution 560 tests, focused Web consent coverage 243
+  2,516 tests, Hosted Execution 560 tests, focused Web consent coverage 247
   tests, and all four affected package typechecks passed.
 - Provider input: normalized complete first-request captures for representative
   direct and group turns were byte- and token-identical at base and head. The

--- a/agent-docs/exec-plans/completed/2026-08-26-group-consent-repost-restaurant-nutrition.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-group-consent-repost-restaurant-nutrition.md
@@ -1,8 +1,8 @@
 # Group consent repost and restaurant nutrition resolution
 
-Status: active
+Status: completed
 Created: 2026-08-26
-Updated: 2026-08-26
+Updated: 2026-08-27
 
 ## Goal
 
@@ -73,8 +73,9 @@ Updated: 2026-08-26
    replay, privacy inspection, and candidate diff review.
 4. [x] Commit and push the candidate, open the draft PR, and start the required
    specialist and final ReviewGPT passes concurrently with exact-head CI.
-5. [ ] Resolve accepted findings, run ReviewGPT round two, archive this plan
-   with `scripts/finish-task`, and confirm the final PR head is green.
+5. [x] Resolve accepted findings, complete the required retrospective and
+   ReviewGPT follow-up, then archive this plan with `scripts/finish-task` for
+   exact-head CI and merge.
 
 ## Verification
 
@@ -100,7 +101,11 @@ Updated: 2026-08-26
   and do not ask the member to repeat the item. The production-shaped fixture
   rejects generic restaurant queries and unsupported meal fields.
 - Existing exclusions: deterministic food-journal coverage preserves the
-  official-source fallback and existing number-sensitive safety exception.
+  official-source fallback and existing number-sensitive safety exception. A
+  focused real-Codex protected-context journey performed no nutrition lookup,
+  saved one meal without nutrition fields, asked no question, and returned a
+  short confirmation. The ordinary database-hit and database-miss journeys
+  continued to resolve nutrition before their single meal writes.
 - Regression proof: Assistant Engine completed 4,133 tests, Assistant Runtime
   2,516 tests, Hosted Execution 560 tests, focused Web consent coverage 247
   tests, and all four affected package typechecks passed.
@@ -111,6 +116,10 @@ Updated: 2026-08-26
 - Walkthrough result: **Ready**. Both existing journeys reach their promised
   observable result, failure preserves the prior working consent offer, and
   there were no differences from the Patch plan.
+- Final review: ReviewGPT round three returned `ROUND_OUTCOME: PASS` with no
+  qualifying findings on the production-bearing candidate. The current-base
+  merge-tree proof is clean, focused deterministic and real-model checks pass,
+  and the final plan archive is non-production-only.
 
 ## Deployment concerns
 
@@ -119,3 +128,4 @@ Updated: 2026-08-26
   waits for a consumer that understands request-bound reposting.
 - The food-journal change is prompt-only at runtime and has no cross-service
   skew requirement.
+Completed: 2026-08-27

--- a/agent-docs/product-specs/group-challenge-data-diagnostics.md
+++ b/agent-docs/product-specs/group-challenge-data-diagnostics.md
@@ -401,10 +401,11 @@ inside the current send attempt adds `offeredAt` evidence. This matches Linq's
 accepted whole-second timestamp precision. An idempotent replay
 retains its original provider time, is still durably bound, and returns
 unavailable recency evidence instead of claiming a new adjacent message or
-minting a fresh window. When Web finds a covering active native offer instead
-of posting another card, assistant-engine exposes the returned first-party URL
-as `presentation="link"` so the model never claims another native message
-appeared. Standalone and scheduled links use the same presentation. Murph
+minting a fresh window. Absent an explicit current-message repost request, when
+Web finds a covering active native offer instead of posting another card,
+assistant-engine exposes the returned first-party URL as `presentation="link"`
+so the model never claims another native message appeared. Standalone and
+scheduled links use the same presentation. Murph
 includes a returned `joinUrl` once in the substantive response, but link
 delivery has no canonical presentation receipt and therefore returns
 unavailable recency evidence. Neither presentation proves acceptance.

--- a/agent-docs/product-specs/group-challenge-data-diagnostics.md
+++ b/agent-docs/product-specs/group-challenge-data-diagnostics.md
@@ -401,8 +401,10 @@ inside the current send attempt adds `offeredAt` evidence. This matches Linq's
 accepted whole-second timestamp precision. An idempotent replay
 retains its original provider time, is still durably bound, and returns
 unavailable recency evidence instead of claiming a new adjacent message or
-minting a fresh window. Absent an explicit current-message repost request, when
-Web finds a covering active native offer instead of posting another card,
+minting a fresh window. An explicit current-message repost resends the locked
+current permission snapshot; it never changes the challenge's requested scope.
+Absent such a repost request, when Web finds a covering active native offer
+instead of posting another card,
 assistant-engine exposes the returned first-party URL as `presentation="link"`
 so the model never claims another native message appeared. Standalone and
 scheduled links use the same presentation. Murph

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1229,7 +1229,13 @@ health values include source names and that sleep-stage values also include each
 source's recorded time. The same source-aware meaning applies to existing health
 scope keys and active grants; there is no separate source-details permission.
 A fresh request returns `sent` only after the provider send succeeds and its
-message binding is durably recorded.
+message binding is durably recorded. When the room explicitly asks to repost,
+the semantic `offer_access` action carries the exact current accepted Message
+ref. Assistant Engine verifies that ref in the current group turn and maps it to
+an additive request identity; Web uses it in provider idempotency and bypasses
+covering-offer reuse for that request only. Exact replay remains one send. After
+the replacement binding commits, Web revokes older active offers in the same
+transaction; send or binding failure leaves them active.
 
 An unfinished child leaves the request pending. Before invocation return,
 checkpoint, shutdown, fence loss, or workspace replacement, the runtime

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1233,9 +1233,12 @@ message binding is durably recorded. When the room explicitly asks to repost,
 the semantic `offer_access` action carries the exact current accepted Message
 ref. Assistant Engine verifies that ref in the current group turn and maps it to
 an additive request identity; Web uses it in provider idempotency and bypasses
-covering-offer reuse for that request only. Exact replay remains one send. After
-the replacement binding commits, Web revokes older active offers in the same
-transaction; send or binding failure leaves them active.
+covering-offer reuse for that request only. Web reads the locked current policy
+and join code without creating or replacing group configuration; omitted scopes
+therefore retain the exact current permission set, while conflicting supplied
+scopes fail closed. Exact replay remains one send. After the replacement
+binding commits, Web revokes older active offers in the same transaction; send
+or binding failure leaves them active.
 
 An unfinished child leaves the request pending. Before invocation return,
 checkpoint, shutdown, fence loss, or workspace replacement, the runtime

--- a/apps/web/changelog/entries/2026-08-26/group-consent-prompts-can-be-reposted.json
+++ b/apps/web/changelog/entries/2026-08-26/group-consent-prompts-can-be-reposted.json
@@ -7,7 +7,7 @@
     "priority": 3,
     "title": "Group consent prompts can be reposted",
     "summary": "When a group asks Murph to post a fresh join-and-share prompt, Murph now sends a new native consent message even if an older prompt is still active.",
-    "details": "Retried delivery does not create a duplicate, and the older prompt remains usable if the replacement cannot be sent. Each person still approves their own access and sharing.",
+    "details": "The new prompt keeps the same sharing choices. Retried delivery does not create a duplicate, and the older prompt remains usable if the replacement cannot be sent. Each person still approves their own access and sharing.",
     "relevanceTags": ["assistant", "groups", "consent", "reliability"],
     "sourcePullRequests": [2386]
   }

--- a/apps/web/changelog/entries/2026-08-26/group-consent-prompts-can-be-reposted.json
+++ b/apps/web/changelog/entries/2026-08-26/group-consent-prompts-can-be-reposted.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "group-consent-prompts-can-be-reposted",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Group consent prompts can be reposted",
+    "summary": "When a group asks Murph to post a fresh join-and-share prompt, Murph now sends a new native consent message even if an older prompt is still active.",
+    "details": "Retried delivery does not create a duplicate, and the older prompt remains usable if the replacement cannot be sent. Each person still approves their own access and sharing.",
+    "relevanceTags": ["assistant", "groups", "consent", "reliability"],
+    "sourcePullRequests": [2386]
+  }
+}

--- a/apps/web/changelog/entries/2026-08-26/restaurant-meals-use-grounded-nutrition.json
+++ b/apps/web/changelog/entries/2026-08-26/restaurant-meals-use-grounded-nutrition.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "restaurant-meals-use-grounded-nutrition",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Restaurant meals use grounded nutrition",
+    "summary": "When you log a recognizable restaurant menu item, Murph now looks up available menu nutrition before saving the meal.",
+    "details": "Murph uses its food database first, checks the restaurant's official source when an exact match is unavailable, and labels estimates when the evidence is still incomplete.",
+    "relevanceTags": ["assistant", "meals", "nutrition", "restaurants"],
+    "sourcePullRequests": [2386]
+  }
+}

--- a/apps/web/src/lib/hosted-groups/group-store.ts
+++ b/apps/web/src/lib/hosted-groups/group-store.ts
@@ -1561,6 +1561,61 @@ export async function createHostedGroupJoinLinkForOwnedThreadContainerTx(input: 
   };
 }
 
+/**
+ * Reads the existing join offer policy for a resend without changing the
+ * group's policy, join code, memberships, or active offers.
+ */
+export async function readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx(input: {
+  tx: Prisma.TransactionClient;
+  actorMemberId: string;
+  containerMemberId: string;
+}): Promise<{
+  group: HostedGroupSummary;
+  joinCode: string;
+}> {
+  const container = await readLockedHostedGroupThreadContainerTx(
+    input.tx,
+    input.containerMemberId,
+  );
+  if (container.ownerMemberId !== input.actorMemberId) {
+    throw hostedOnboardingError({
+      code: "HOSTED_GROUP_OWNER_REQUIRED",
+      httpStatus: 403,
+      message: "Only the group owner can resend a join offer.",
+    });
+  }
+
+  const existing = await input.tx.hostedGroup.findUnique({
+    where: { runtimeMemberId: input.containerMemberId },
+    select: { id: true },
+  });
+  if (!existing) {
+    throw hostedOnboardingError({
+      code: "HOSTED_GROUP_NOT_ACTIVE",
+      httpStatus: 410,
+      message: "This hosted group is not active.",
+    });
+  }
+
+  await lockHostedGroupRow(input.tx, existing.id);
+  const current = await input.tx.hostedGroup.findUnique({
+    where: { id: existing.id },
+    select: { joinCode: true },
+  });
+  const group = await readHostedGroupSummaryById(input.tx, existing.id);
+  if (!current?.joinCode || !group) {
+    throw hostedOnboardingError({
+      code: "HOSTED_GROUP_JOIN_LINK_NOT_ACTIVE",
+      httpStatus: 410,
+      message: "This hosted group does not have an active join offer.",
+    });
+  }
+  return {
+    group,
+    joinCode: current.joinCode,
+  };
+}
+
 export async function readHostedGroupJoinView(input: {
   joinCode: string;
   memberId?: string | null;

--- a/apps/web/src/lib/hosted-groups/group-store.ts
+++ b/apps/web/src/lib/hosted-groups/group-store.ts
@@ -1679,6 +1679,7 @@ export async function recordHostedGroupJoinOfferTx(input: {
   postedAt: Date;
   projectionKinds?: readonly HostedVaultShareProjectionKind[] | null;
   projectionScopes?: readonly HostedVaultShareProjectionScope[] | null;
+  replaceActiveOffersAt?: Date;
   tx: Prisma.TransactionClient;
 }): Promise<HostedGroupJoinOfferBindingTxResult> {
   const messageLookupKey = createHostedGroupOfferMessageLookupKey(input.message);
@@ -1759,6 +1760,17 @@ export async function recordHostedGroupJoinOfferTx(input: {
     },
   });
 
+  if (input.replaceActiveOffersAt) {
+    await input.tx.hostedGroupJoinOffer.updateMany({
+      where: {
+        groupId: input.groupId,
+        messageLookupKey: { not: messageLookupKey },
+        revokedAt: null,
+      },
+      data: { revokedAt: input.replaceActiveOffersAt },
+    });
+  }
+
   return binding;
 }
 
@@ -1772,6 +1784,7 @@ export async function prepareHostedGroupJoinOfferPostTx(input: {
   groupId: string;
   now: Date;
   projectionScopes: readonly HostedVaultShareProjectionScope[];
+  replaceActiveOffer?: boolean;
   tx: Prisma.TransactionClient;
 }): Promise<HostedGroupJoinOfferPostPreparation> {
   const projectionScopes = normalizeHostedVaultShareProjectionScopes(
@@ -1801,6 +1814,14 @@ export async function prepareHostedGroupJoinOfferPostTx(input: {
     )
   ) {
     return { kind: "unavailable" };
+  }
+
+  if (input.replaceActiveOffer === true) {
+    return {
+      joinCode: group.joinCode,
+      kind: "post",
+      offerGeneration: policy.offerGeneration,
+    };
   }
 
   const offers = await input.tx.hostedGroupJoinOffer.findMany({

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -232,6 +232,7 @@ export function buildHostedGroupJoinOfferProviderIdempotencyKey(input: {
   joinCode: string;
   offerGeneration: string;
   projectionScopes: readonly HostedVaultShareProjectionScope[];
+  repostOriginAssistantInputId?: string;
 }): string {
   const projectionScopes = normalizeHostedVaultShareProjectionScopes(
     input.projectionScopes,
@@ -247,6 +248,11 @@ export function buildHostedGroupJoinOfferProviderIdempotencyKey(input: {
     joinCode: input.joinCode,
     offerGeneration: input.offerGeneration,
     projectionScopeKeys,
+    ...(input.repostOriginAssistantInputId === undefined
+      ? {}
+      : {
+          repostOriginAssistantInputId: input.repostOriginAssistantInputId,
+        }),
   }));
   return `${HOSTED_GROUP_JOIN_OFFER_IDEMPOTENCY_PREFIX}${digest.slice(
     0,
@@ -469,6 +475,8 @@ export async function handleHostedRuntimeGroupTool(input: {
       joinOffer: input.request.joinOffer ?? null,
       linqThread: input.request.linqThread ?? null,
       memberId: input.memberId,
+      repostOriginAssistantInputId:
+        input.request.repostOriginAssistantInputId ?? null,
     });
   }
 
@@ -1369,6 +1377,7 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
   joinOffer: HostedRuntimeGroupPostJoinOfferRequest | null;
   linqThread: HostedRuntimeGroupToolLinqThreadContext | null;
   memberId: string;
+  repostOriginAssistantInputId: string | null;
 }): Promise<HostedRuntimeGroupToolResponse> {
   const unavailable = (unavailableReason: string): HostedRuntimeGroupToolResponse => ({
     action: "post_join_offer",
@@ -1413,6 +1422,9 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
       groupId: result.group.id,
       now,
       projectionScopes,
+      ...(input.repostOriginAssistantInputId === null
+        ? {}
+        : { replaceActiveOffer: true }),
       tx,
     });
     if (offerPost.kind === "unavailable") {
@@ -1463,6 +1475,12 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
         joinCode: created.offerPost.joinCode,
         offerGeneration,
         projectionScopes,
+        ...(input.repostOriginAssistantInputId === null
+          ? {}
+          : {
+              repostOriginAssistantInputId:
+                input.repostOriginAssistantInputId,
+            }),
       }),
       message,
     });
@@ -1502,6 +1520,9 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
         message: { channel: "linq", messageId: sent.messageId },
         postedAt,
         projectionScopes,
+        ...(input.repostOriginAssistantInputId === null
+          ? {}
+          : { replaceActiveOffersAt: providerSendCompletedAt }),
         tx,
       });
     }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);

--- a/apps/web/src/lib/hosted-groups/group-tool.ts
+++ b/apps/web/src/lib/hosted-groups/group-tool.ts
@@ -128,6 +128,7 @@ import {
   prepareHostedGroupJoinOfferPostTx,
   readHostedGroupByRuntimeMemberId,
   readHostedGroupIdByRuntimeMemberId,
+  readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx,
   readHostedGroupMembershipsForMember,
   readHostedGroupParticipantDisplayNameCandidatesByRuntimeMemberId,
   readHostedGroupSharedDataByRuntimeMemberId,
@@ -258,6 +259,16 @@ export function buildHostedGroupJoinOfferProviderIdempotencyKey(input: {
     0,
     HOSTED_GROUP_JOIN_OFFER_IDEMPOTENCY_DIGEST_LENGTH,
   )}`;
+}
+
+function hostedGroupProjectionScopeSetsEqual(
+  left: readonly HostedVaultShareProjectionScope[],
+  right: readonly HostedVaultShareProjectionScope[],
+): boolean {
+  const leftKeys = new Set(left.map(buildHostedVaultShareProjectionScopeKey));
+  const rightKeys = new Set(right.map(buildHostedVaultShareProjectionScopeKey));
+  return leftKeys.size === rightKeys.size
+    && [...leftKeys].every((scopeKey) => rightKeys.has(scopeKey));
 }
 
 export type HostedRuntimeGroupToolAccessClassification =
@@ -1398,10 +1409,11 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
 
   const prisma = getPrisma();
   const now = new Date();
-  const projectionScopes = resolveHostedGroupAccessOfferProjectionScopes(
-    input.joinOffer?.projectionScopes
-      ?? input.joinOffer?.projectionKinds,
-  );
+  const requestedProjectionScopes = input.joinOffer?.projectionScopes
+    ?? input.joinOffer?.projectionKinds;
+  const newProjectionScopes = input.repostOriginAssistantInputId === null
+    ? resolveHostedGroupAccessOfferProjectionScopes(requestedProjectionScopes)
+    : null;
   const created = await prisma.$transaction(async (tx) => {
     const ownerAccess = await readHostedRuntimeGroupOwnerActiveAccess({
       memberId: input.memberId,
@@ -1410,14 +1422,33 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
     if (ownerAccess.status !== "ok") {
       return { kind: ownerAccess.unavailableReason };
     }
-    const result = await createHostedGroupJoinLinkForOwnedThreadContainerTx({
-      actorMemberId: ownerAccess.ownerMemberId,
-      containerMemberId: input.memberId,
-      displayName: input.joinOffer?.displayName ?? null,
-      now,
-      requestedVaultShareProjectionScopes: projectionScopes,
-      tx,
-    });
+    const result = input.repostOriginAssistantInputId === null
+      ? await createHostedGroupJoinLinkForOwnedThreadContainerTx({
+          actorMemberId: ownerAccess.ownerMemberId,
+          containerMemberId: input.memberId,
+          displayName: input.joinOffer?.displayName ?? null,
+          now,
+          requestedVaultShareProjectionScopes: newProjectionScopes,
+          tx,
+        })
+      : await readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx({
+          actorMemberId: ownerAccess.ownerMemberId,
+          containerMemberId: input.memberId,
+          tx,
+        });
+    const projectionScopes = newProjectionScopes
+      ?? result.group.requestedVaultShareProjectionScopes;
+    if (
+      input.repostOriginAssistantInputId !== null
+      && requestedProjectionScopes !== undefined
+      && requestedProjectionScopes !== null
+      && !hostedGroupProjectionScopeSetsEqual(
+        resolveHostedGroupAccessOfferProjectionScopes(requestedProjectionScopes),
+        projectionScopes,
+      )
+    ) {
+      return { kind: "repost_scope_change_unavailable" as const };
+    }
     const offerPost = await prepareHostedGroupJoinOfferPostTx({
       groupId: result.group.id,
       now,
@@ -1434,6 +1465,7 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
       kind: "ok" as const,
       offerPost,
       ownerMemberId: ownerAccess.ownerMemberId,
+      projectionScopes,
       ...result,
     };
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
@@ -1463,7 +1495,7 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
 
   const message = buildHostedGroupJoinOfferMessage({
     joinUrl,
-    projectionScopes,
+    projectionScopes: created.projectionScopes,
   });
   const providerSendStartedAt = new Date();
   let sent: Awaited<ReturnType<typeof sendHostedLinqChatMessage>>;
@@ -1474,7 +1506,7 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
         groupId: created.group.id,
         joinCode: created.offerPost.joinCode,
         offerGeneration,
-        projectionScopes,
+        projectionScopes: created.projectionScopes,
         ...(input.repostOriginAssistantInputId === null
           ? {}
           : {
@@ -1519,7 +1551,7 @@ async function handleHostedRuntimeGroupPostJoinOffer(input: {
         groupId: created.group.id,
         message: { channel: "linq", messageId: sent.messageId },
         postedAt,
-        projectionScopes,
+        projectionScopes: created.projectionScopes,
         ...(input.repostOriginAssistantInputId === null
           ? {}
           : { replaceActiveOffersAt: providerSendCompletedAt }),

--- a/apps/web/test/hosted-group-store.test.ts
+++ b/apps/web/test/hosted-group-store.test.ts
@@ -74,6 +74,7 @@ import {
   leaveHostedGroupMemberTx,
   prepareHostedGroupJoinOfferPostTx,
   readHostedGroupJoinView,
+  readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx,
   readHostedGroupSharedDataByRuntimeMemberId,
   readHostedGroupMembershipsForMember,
   recordHostedGroupJoinOfferTx,
@@ -2673,6 +2674,38 @@ describe("createHostedGroupJoinLinkForOwnedThreadContainerTx", () => {
     expect(tx.hostedGroup.update).not.toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ displayName: expect.any(String) }),
     }));
+  });
+});
+
+describe("readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads the exact current policy without changing policy or active offers", async () => {
+    const tx = buildGroupLinkTx({
+      existingGroup: true,
+      joinCode: "join_existing",
+      ownerMemberId: "member_owner",
+      requestedProjectionKinds: ["sleep-times.v0"],
+    });
+
+    await expect(readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx({
+      actorMemberId: "member_owner",
+      containerMemberId: "member_group_runtime",
+      tx,
+    })).resolves.toMatchObject({
+      group: {
+        requestedVaultShareProjectionScopes: [SLEEP_SCOPE],
+      },
+      joinCode: "join_existing",
+    });
+
+    expect(tx.hostedGroup.create).not.toHaveBeenCalled();
+    expect(tx.hostedGroup.update).not.toHaveBeenCalled();
+    expect(tx.hostedGroupJoinOffer.updateMany).not.toHaveBeenCalled();
+    expect(tx.hostedGroupMember.upsert).not.toHaveBeenCalled();
+    expect(mocks.grantHostedVaultShareTx).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/test/hosted-group-store.test.ts
+++ b/apps/web/test/hosted-group-store.test.ts
@@ -1189,6 +1189,36 @@ describe("acceptHostedGroupJoinCodeTx", () => {
     });
   });
 
+  it("retires older active offers only after a replacement binding is created", async () => {
+    const tx = buildTx();
+    const postedAt = new Date("2026-07-01T00:00:00.000Z");
+
+    await recordHostedGroupJoinOfferTx({
+      expectedOfferGeneration: OFFER_GENERATION_A,
+      groupId: "group_1",
+      message: { channel: "linq", messageId: "msg_offer_replacement" },
+      postedAt,
+      projectionScopes: [SLEEP_SCOPE],
+      replaceActiveOffersAt: postedAt,
+      tx,
+    });
+
+    expect(
+      tx.hostedGroupJoinOffer.create.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      tx.hostedGroupJoinOffer.updateMany.mock.invocationCallOrder[0]
+        ?? Number.POSITIVE_INFINITY,
+    );
+    expect(tx.hostedGroupJoinOffer.updateMany).toHaveBeenCalledWith({
+      data: { revokedAt: postedAt },
+      where: {
+        groupId: "group_1",
+        messageLookupKey: { not: expect.stringMatching(/^hbidx:linq-message:/u) },
+        revokedAt: null,
+      },
+    });
+  });
+
   it("rejects a provider completion from a replaced offer generation", async () => {
     const tx = buildTx();
     tx.hostedGroup.findUnique.mockResolvedValueOnce({
@@ -1241,6 +1271,35 @@ describe("acceptHostedGroupJoinCodeTx", () => {
       select: { projectionKindsJson: true },
       take: HOSTED_GROUP_ACTIVE_JOIN_OFFER_SCAN_MAX + 1,
     });
+  });
+
+  it("prepares an explicit replacement without inspecting or revoking the active offer", async () => {
+    const findMany = vi.fn();
+    const updateMany = vi.fn();
+    const tx = createPrismaStub({
+      $queryRaw: vi.fn(async () => []),
+      hostedGroup: {
+        findUnique: vi.fn(async () => ({
+          joinCode: "join_generation_1",
+          joinPolicyJson: JOIN_POLICY,
+        })),
+      },
+      hostedGroupJoinOffer: { findMany, updateMany },
+    });
+
+    await expect(prepareHostedGroupJoinOfferPostTx({
+      groupId: "group_1",
+      now: new Date("2026-07-01T00:00:00.000Z"),
+      projectionScopes: [SLEEP_SCOPE],
+      replaceActiveOffer: true,
+      tx,
+    })).resolves.toEqual({
+      joinCode: "join_generation_1",
+      kind: "post",
+      offerGeneration: OFFER_GENERATION_A,
+    });
+    expect(findMany).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
   });
 
   it("revokes a broader active offer before posting a narrower replacement", async () => {

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -4013,6 +4013,63 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
     expect(mocks.recordHostedGroupJoinOfferTx).not.toHaveBeenCalled();
   });
 
+  it("posts a request-bound replacement for an explicit consent resend", async () => {
+    const requestedScopes = [{ projectionKind: "steps-days.v0" as const }];
+    const repostOriginAssistantInputId = `ain_${"a".repeat(32)}`;
+    mocks.prepareHostedGroupJoinOfferPostTx.mockResolvedValueOnce({
+      joinCode: "abc123",
+      kind: "post",
+      offerGeneration: OFFER_GENERATION_A,
+    });
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        joinOffer: { projectionScopes: requestedScopes },
+        linqThread: LINQ_THREAD,
+        repostOriginAssistantInputId,
+      },
+    })).resolves.toMatchObject({
+      action: "post_join_offer",
+      result: { offerState: "posted", status: "sent" },
+    });
+
+    expect(mocks.prepareHostedGroupJoinOfferPostTx).toHaveBeenCalledWith({
+      groupId: GROUP_SUMMARY.id,
+      now: expect.any(Date),
+      projectionScopes: requestedScopes,
+      replaceActiveOffer: true,
+      tx: fakeTx,
+    });
+    expect(mocks.recordHostedGroupJoinOfferTx).toHaveBeenCalledWith({
+      expectedOfferGeneration: OFFER_GENERATION_A,
+      groupId: GROUP_SUMMARY.id,
+      message: { channel: "linq", messageId: "msg_offer_1" },
+      postedAt: expect.any(Date),
+      projectionScopes: requestedScopes,
+      replaceActiveOffersAt: expect.any(Date),
+      tx: fakeTx,
+    });
+
+    const ordinaryKey = buildHostedGroupJoinOfferProviderIdempotencyKey({
+      groupId: GROUP_SUMMARY.id,
+      joinCode: "abc123",
+      offerGeneration: OFFER_GENERATION_A,
+      projectionScopes: requestedScopes,
+    });
+    const repostKey = mocks.sendHostedLinqChatMessage.mock.calls[0]?.[0]
+      .idempotencyKey;
+    expect(repostKey).not.toBe(ordinaryKey);
+    expect(buildHostedGroupJoinOfferProviderIdempotencyKey({
+      groupId: GROUP_SUMMARY.id,
+      joinCode: "abc123",
+      offerGeneration: OFFER_GENERATION_A,
+      projectionScopes: requestedScopes,
+      repostOriginAssistantInputId,
+    })).toBe(repostKey);
+  });
+
   it("posts an explicit offer when every current member already grants every requested scope", async () => {
     const requestedScopes = [{ projectionKind: "steps-days.v0" as const }];
     const fullyGrantedGroup = {

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   requestHostedGroupMemberAssistantAsk: vi.fn(),
   readHostedGroupByRuntimeMemberId: vi.fn(),
   readHostedGroupIdByRuntimeMemberId: vi.fn(),
+  readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx: vi.fn(),
   readHostedGroupMembershipsForMember: vi.fn(),
   readHostedGroupParticipantDisplayNameCandidatesByRuntimeMemberId: vi.fn(),
   readHostedGroupFundingRecoveryStatus: vi.fn(),
@@ -220,6 +221,8 @@ vi.mock("@/src/lib/hosted-groups/group-store", () => ({
   prepareHostedGroupJoinOfferPostTx: mocks.prepareHostedGroupJoinOfferPostTx,
   readHostedGroupByRuntimeMemberId: mocks.readHostedGroupByRuntimeMemberId,
   readHostedGroupIdByRuntimeMemberId: mocks.readHostedGroupIdByRuntimeMemberId,
+  readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx:
+    mocks.readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx,
   readHostedGroupMembershipsForMember: mocks.readHostedGroupMembershipsForMember,
   readHostedGroupParticipantDisplayNameCandidatesByRuntimeMemberId:
     mocks.readHostedGroupParticipantDisplayNameCandidatesByRuntimeMemberId,
@@ -344,6 +347,7 @@ import {
   resolveHostedGroupAccessOfferProjectionScopes,
 } from "@/src/lib/hosted-groups/join-policy";
 
+const SLEEP_SCOPE = { projectionKind: "sleep-times.v0" } as const;
 const GROUP_SUMMARY = {
   displayName: "Sunday sleep crew",
   id: "hgrp_123",
@@ -351,13 +355,13 @@ const GROUP_SUMMARY = {
   memberCount: 3,
   members: [],
   requestedVaultShareProjectionKinds: ["sleep-times.v0" as const],
+  requestedVaultShareProjectionScopes: [SLEEP_SCOPE],
   status: "active",
 };
 const RENAMED_GROUP_SUMMARY = {
   ...GROUP_SUMMARY,
   displayName: "Weekly Health Crew",
 };
-const SLEEP_SCOPE = { projectionKind: "sleep-times.v0" } as const;
 const SLEEP_DURATION_SCOPE = { projectionKind: "sleep-duration-days.v0" } as const;
 const DEEP_SLEEP_SCOPE = { projectionKind: "deep-sleep-days.v0" } as const;
 const DEEP_SLEEP_SOURCES_SCOPE = {
@@ -602,6 +606,10 @@ describe("handleHostedRuntimeGroupTool", () => {
     mocks.hostedMemberFindUnique.mockResolvedValue({ suspendedAt: null });
     mocks.hostedThreadContainerParticipantExecuteRaw.mockResolvedValue(0);
     mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx.mockResolvedValue({
+      group: GROUP_SUMMARY,
+      joinCode: "abc123",
+    });
+    mocks.readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx.mockResolvedValue({
       group: GROUP_SUMMARY,
       joinCode: "abc123",
     });
@@ -4014,7 +4022,7 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
   });
 
   it("posts a request-bound replacement for an explicit consent resend", async () => {
-    const requestedScopes = [{ projectionKind: "steps-days.v0" as const }];
+    const requestedScopes = [SLEEP_SCOPE];
     const repostOriginAssistantInputId = `ain_${"a".repeat(32)}`;
     mocks.prepareHostedGroupJoinOfferPostTx.mockResolvedValueOnce({
       joinCode: "abc123",
@@ -4026,7 +4034,6 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       memberId: "member_container",
       request: {
         action: "post_join_offer",
-        joinOffer: { projectionScopes: requestedScopes },
         linqThread: LINQ_THREAD,
         repostOriginAssistantInputId,
       },
@@ -4035,6 +4042,16 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       result: { offerState: "posted", status: "sent" },
     });
 
+    expect(
+      mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.readHostedGroupJoinOfferSnapshotForOwnedThreadContainerTx,
+    ).toHaveBeenCalledWith({
+      actorMemberId: "member_owner",
+      containerMemberId: "member_container",
+      tx: fakeTx,
+    });
     expect(mocks.prepareHostedGroupJoinOfferPostTx).toHaveBeenCalledWith({
       groupId: GROUP_SUMMARY.id,
       now: expect.any(Date),
@@ -4068,6 +4085,93 @@ describe("handleHostedRuntimeGroupTool chat-scoped actions", () => {
       projectionScopes: requestedScopes,
       repostOriginAssistantInputId,
     })).toBe(repostKey);
+    expect(buildHostedGroupJoinOfferProviderIdempotencyKey({
+      groupId: GROUP_SUMMARY.id,
+      joinCode: "abc123",
+      offerGeneration: OFFER_GENERATION_A,
+      projectionScopes: requestedScopes,
+      repostOriginAssistantInputId: `ain_${"b".repeat(32)}`,
+    })).not.toBe(repostKey);
+  });
+
+  it("rejects a scope change disguised as a consent resend", async () => {
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        joinOffer: {
+          projectionScopes: [{ projectionKind: "steps-days.v0" }],
+        },
+        linqThread: LINQ_THREAD,
+        repostOriginAssistantInputId: `ain_${"a".repeat(32)}`,
+      },
+    })).resolves.toEqual({
+      action: "post_join_offer",
+      result: {
+        group: null,
+        status: "unavailable",
+        unavailableReason: "repost_scope_change_unavailable",
+      },
+    });
+
+    expect(mocks.prepareHostedGroupJoinOfferPostTx).not.toHaveBeenCalled();
+    expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
+    expect(mocks.recordHostedGroupJoinOfferTx).not.toHaveBeenCalled();
+  });
+
+  it("keeps the prior offer when an explicit resend fails at the provider", async () => {
+    mocks.sendHostedLinqChatMessage.mockRejectedValueOnce(
+      new Error("synthetic provider failure"),
+    );
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        linqThread: LINQ_THREAD,
+        repostOriginAssistantInputId: `ain_${"a".repeat(32)}`,
+      },
+    })).resolves.toMatchObject({
+      result: {
+        status: "unavailable",
+        unavailableReason: "send_failed",
+      },
+    });
+
+    expect(
+      mocks.createHostedGroupJoinLinkForOwnedThreadContainerTx,
+    ).not.toHaveBeenCalled();
+    expect(mocks.recordHostedGroupJoinOfferTx).not.toHaveBeenCalled();
+  });
+
+  it("retires the prior offer only inside a successful replacement binding", async () => {
+    mocks.recordHostedGroupJoinOfferTx.mockRejectedValueOnce(
+      new Error("synthetic binding failure"),
+    );
+
+    await expect(handleHostedRuntimeGroupTool({
+      memberId: "member_container",
+      request: {
+        action: "post_join_offer",
+        linqThread: LINQ_THREAD,
+        repostOriginAssistantInputId: `ain_${"a".repeat(32)}`,
+      },
+    })).resolves.toMatchObject({
+      result: {
+        status: "unavailable",
+        unavailableReason: "offer_binding_failed",
+      },
+    });
+
+    expect(mocks.recordHostedGroupJoinOfferTx).toHaveBeenCalledWith({
+      expectedOfferGeneration: OFFER_GENERATION_A,
+      groupId: GROUP_SUMMARY.id,
+      message: { channel: "linq", messageId: "msg_offer_1" },
+      postedAt: expect.any(Date),
+      projectionScopes: [SLEEP_SCOPE],
+      replaceActiveOffersAt: expect.any(Date),
+      tx: fakeTx,
+    });
   });
 
   it("posts an explicit offer when every current member already grants every requested scope", async () => {

--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -68,17 +68,15 @@ questions.
 - Preserve useful real-life context when the user volunteers it, such as eating out, alcohol, a late meal, stress, travel, illness, or social context.
 - Use existing canonical surfaces. Save meal facts to meal records, symptoms to their typed surface, and durable unstructured context to the best-fit existing journal or memory surface. Do not duplicate the same fact across stores.
 
-For an ordinary numeric-eligible meal capture, resolve nutrition before the
-meal mutation. First search the hosted food-label database for every material
-component. When the user names a restaurant and recognizable menu item, use a
-normal exact restaurant/menu search rather than a generic substitute. If that
-search has no exact result, read `computer-use` and inspect the restaurant's
-official nutrition or menu source. Only after the database result, official
-source, or clearly marked last-resort estimate is resolved may you call
-`meal add` or `meal edit` with the available nutrition and provenance. Do not
-save a nutrition-free restaurant meal first and then ask the member to repeat
-the item. Ask one narrow question only when a variant or portion difference
-would materially change the record.
+When the user names a restaurant and recognizable menu item, resolve nutrition
+before the meal mutation. Use a normal exact restaurant/menu search rather
+than a generic substitute. If that search has no exact result, read
+`computer-use` and inspect the restaurant's official nutrition or menu source.
+Only after the database result, official source, or clearly marked last-resort
+estimate is resolved may you call `meal add` or `meal edit` with the available
+nutrition and provenance. Do not save a nutrition-free restaurant meal first
+and then ask the member to repeat the item. Ask one narrow question only when a
+variant or portion difference would materially change the record.
 
 - After every verified private meal mutation, apply default attachment intent for its eligible daily nutrition card. For response-card attachment eligibility only, treat the accepted meal message as explicitly requesting that card; this is not an explicit numeric-card request and does not authorize target derivation, a paused proposal, or any Goal mutation. When the complete card safety, accepted active-goal authority, fresh same-date totals, route, and bounded-card checks pass and the card alone completely answers the turn, attach that card as the complete response with no companion prose. Without an already accepted complete bundle, or when any other prerequisite fails, keep the truthful fallback short and aligned with the user's focus. Never replace a failed card gate with improvised totals, goals, analysis, or a second response surface.
 

--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -67,6 +67,19 @@ questions.
 - A photo, voice note, or rough phrase can be a complete meal log.
 - Preserve useful real-life context when the user volunteers it, such as eating out, alcohol, a late meal, stress, travel, illness, or social context.
 - Use existing canonical surfaces. Save meal facts to meal records, symptoms to their typed surface, and durable unstructured context to the best-fit existing journal or memory surface. Do not duplicate the same fact across stores.
+
+For an ordinary numeric-eligible meal capture, resolve nutrition before the
+meal mutation. First search the hosted food-label database for every material
+component. When the user names a restaurant and recognizable menu item, use a
+normal exact restaurant/menu search rather than a generic substitute. If that
+search has no exact result, read `computer-use` and inspect the restaurant's
+official nutrition or menu source. Only after the database result, official
+source, or clearly marked last-resort estimate is resolved may you call
+`meal add` or `meal edit` with the available nutrition and provenance. Do not
+save a nutrition-free restaurant meal first and then ask the member to repeat
+the item. Ask one narrow question only when a variant or portion difference
+would materially change the record.
+
 - After every verified private meal mutation, apply default attachment intent for its eligible daily nutrition card. For response-card attachment eligibility only, treat the accepted meal message as explicitly requesting that card; this is not an explicit numeric-card request and does not authorize target derivation, a paused proposal, or any Goal mutation. When the complete card safety, accepted active-goal authority, fresh same-date totals, route, and bounded-card checks pass and the card alone completely answers the turn, attach that card as the complete response with no companion prose. Without an already accepted complete bundle, or when any other prerequisite fails, keep the truthful fallback short and aligned with the user's focus. Never replace a failed card gate with improvised totals, goals, analysis, or a second response surface.
 
 ## Provide numbers by default, with safety exceptions
@@ -162,11 +175,11 @@ Before calculating a meal total:
   the weakest material identity, quantity, or preparation assumption.
 
 Increase the result limit only when the first match is ambiguous or missing a
-likely variant. If the database is unavailable or incomplete, use an
-official label, manufacturer, or restaurant menu source. Only after those fail
-may you use a clearly marked memory-based estimate with the assumptions and
-material uncertainty stated. Never invent an exact label or imply that a visual
-portion estimate was database-measured.
+likely variant. The database-miss fallback above also applies to packaged and
+manufacturer labels. Only after the applicable official source fails may you
+use a clearly marked memory-based estimate with the assumptions and material
+uncertainty stated. Never invent an exact label or imply that a visual portion
+estimate was database-measured.
 
 For a fridge or pantry photo, enumerate distinct visible products and resolve
 them in one batch. Summarize only relevant nutrition, ingredient, allergen, and

--- a/packages/assistant-engine/skills/food-journal/SKILL.md
+++ b/packages/assistant-engine/skills/food-journal/SKILL.md
@@ -68,15 +68,22 @@ questions.
 - Preserve useful real-life context when the user volunteers it, such as eating out, alcohol, a late meal, stress, travel, illness, or social context.
 - Use existing canonical surfaces. Save meal facts to meal records, symptoms to their typed surface, and durable unstructured context to the best-fit existing journal or memory surface. Do not duplicate the same fact across stores.
 
-When the user names a restaurant and recognizable menu item, resolve nutrition
+When the user names a restaurant and recognizable menu item, and known context
+does not trigger one of the numeric safety exceptions below, resolve nutrition
 before the meal mutation. Use a normal exact restaurant/menu search rather
-than a generic substitute. If that search has no exact result, read
+than a generic substitute. Run this database search first even when the user
+supplies an official restaurant URL. If that search has no exact result, read
 `computer-use` and inspect the restaurant's official nutrition or menu source.
+When using that official source, retain its URL in nutrition source detail.
 Only after the database result, official source, or clearly marked last-resort
 estimate is resolved may you call `meal add` or `meal edit` with the available
 nutrition and provenance. Do not save a nutrition-free restaurant meal first
 and then ask the member to repeat the item. Ask one narrow question only when a
 variant or portion difference would materially change the record.
+
+When a numeric safety exception already applies, save the meal without calorie
+or macro estimates. Do not force a nutrition lookup, clarification, or safety
+preflight just to capture the meal.
 
 - After every verified private meal mutation, apply default attachment intent for its eligible daily nutrition card. For response-card attachment eligibility only, treat the accepted meal message as explicitly requesting that card; this is not an explicit numeric-card request and does not authorize target derivation, a paused proposal, or any Goal mutation. When the complete card safety, accepted active-goal authority, fresh same-date totals, route, and bounded-card checks pass and the card alone completely answers the turn, attach that card as the complete response with no companion prose. Without an already accepted complete bundle, or when any other prerequisite fails, keep the truthful fallback short and aligned with the user's focus. Never replace a failed card gate with improvised totals, goals, analysis, or a second response surface.
 

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
@@ -1260,7 +1260,7 @@ export const MURPH_GROUP_CONSULT_TOOL = buildMurphGroupFamilyTool({
 export const MURPH_GROUP_DATA_TOOL = buildMurphGroupFamilyTool({
   name: 'group_data',
   description:
-    'Read shared data, record sender metrics, or manage disclosure/access. Exact current message_ref is required only to repost native access.',
+    'Read shared data, record sender metrics, or manage disclosure/access.',
 })
 
 export const MURPH_GROUP_MEMBERSHIP_TOOL = buildMurphGroupFamilyTool({

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tool-catalog.ts
@@ -878,7 +878,7 @@ const ASSISTANT_ACCEPTED_MESSAGE_REF_SCHEMA = {
   type: 'string',
   pattern: ASSISTANT_ACCEPTED_MESSAGE_REF_PATTERN,
   description:
-    'Opaque Message ref shown beside an accepted inbound message in the current prompt. Required for current-sender actions, record_current_sender_daily_metric, and revoke_own_email_share; optional only for create_signup_referral_link and read_usage_referral. Use the exact ref beside the relevant request or clarification answer; this is not a provider message id.',
+    'Opaque Message ref shown beside an accepted inbound message in the current prompt. Required for current-sender actions, record_current_sender_daily_metric, and revoke_own_email_share. For offer_access, include it only when the group explicitly asks to repost the native access message; the trusted host binds the replacement to that exact request. It is otherwise optional only for create_signup_referral_link and read_usage_referral. Use the exact ref beside the relevant request or clarification answer; this is not a provider message id.',
 } as const
 
 export const GROUP_ACCESS_FRESH_NATIVE_RESPONSE_HANDLING =
@@ -1260,7 +1260,7 @@ export const MURPH_GROUP_CONSULT_TOOL = buildMurphGroupFamilyTool({
 export const MURPH_GROUP_DATA_TOOL = buildMurphGroupFamilyTool({
   name: 'group_data',
   description:
-    'Read shared data, record sender metrics, or manage disclosure/access.',
+    'Read shared data, record sender metrics, or manage disclosure/access. Exact current message_ref is required only to repost native access.',
 })
 
 export const MURPH_GROUP_MEMBERSHIP_TOOL = buildMurphGroupFamilyTool({

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -776,6 +776,10 @@ const groupArgumentsSchema = z.discriminatedUnion('action', [
         )
         .optional(),
       standaloneLink: z.boolean().optional(),
+      message_ref: z
+        .string()
+        .regex(new RegExp(ASSISTANT_ACCEPTED_MESSAGE_REF_PATTERN, 'u'))
+        .optional(),
     })
     .strict(),
   z
@@ -1222,6 +1226,7 @@ type MurphGroupToolRequest =
   | {
       action: 'offer_access'
       displayName?: string
+      messageRef?: string
       projectionScopes?: readonly HostedVaultShareSelectableProjectionScope[]
       standaloneLink?: boolean
     }
@@ -4750,6 +4755,7 @@ function hasExactStringEntries(
 
 function buildGroupAccessOfferHostRequest(
   request: Extract<MurphGroupToolRequest, { action: 'offer_access' }>,
+  repostOriginAssistantInputId: string | null,
 ): Extract<
   HostedRuntimeGroupToolRequest,
   { action: 'create_join_link' | 'post_join_offer' }
@@ -4782,6 +4788,9 @@ function buildGroupAccessOfferHostRequest(
         ? {}
         : { projectionScopes: [...request.projectionScopes] }),
     },
+    ...(repostOriginAssistantInputId === null
+      ? {}
+      : { repostOriginAssistantInputId }),
   }
 }
 
@@ -4858,7 +4867,25 @@ async function executeGroupTool(input: {
     | { savedCaptureId: string | null; savedImageRef: string }
     | null = null
   if (input.request.action === 'offer_access') {
-    request = buildGroupAccessOfferHostRequest(input.request)
+    let repostOriginAssistantInputId: string | null = null
+    if (input.request.messageRef !== undefined) {
+      const userActionScope =
+        input.hostedToolContext?.currentUserActionScope?.() ?? null
+      if (
+        userActionScope?.conversationScope !== 'group'
+        || !userActionScope.acceptedInputIds.includes(input.request.messageRef)
+      ) {
+        return toolTextResult(
+          false,
+          'reposting group access requires the exact current accepted Message ref from this group conversation',
+        )
+      }
+      repostOriginAssistantInputId = input.request.messageRef
+    }
+    request = buildGroupAccessOfferHostRequest(
+      input.request,
+      repostOriginAssistantInputId,
+    )
   } else if (isPreparedContactCardRequest(input.request)) {
     const userActionScope =
       input.hostedToolContext?.currentUserActionScope?.() ?? null
@@ -7181,7 +7208,24 @@ function parseGroupArguments(
     return { ok: true, request: parsed.data }
   }
   if (parsed.data.action === 'offer_access') {
-    return { ok: true, request: parsed.data }
+    return {
+      ok: true,
+      request: {
+        action: 'offer_access',
+        ...(parsed.data.displayName === undefined
+          ? {}
+          : { displayName: parsed.data.displayName }),
+        ...(parsed.data.message_ref === undefined
+          ? {}
+          : { messageRef: parsed.data.message_ref }),
+        ...(parsed.data.projectionScopes === undefined
+          ? {}
+          : { projectionScopes: parsed.data.projectionScopes }),
+        ...(parsed.data.standaloneLink === undefined
+          ? {}
+          : { standaloneLink: parsed.data.standaloneLink }),
+      },
+    }
   }
   if (parsed.data.action === 'update_display_name') {
     return {

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -3658,6 +3658,17 @@ describe("murph.group dynamic tool", () => {
 
     expect(readMurphDynamicToolRequest(groupToolCall({
       action: "offer_access",
+      message_ref: FRESH_ASSISTANT_INPUT_ID,
+    }))).toMatchObject({
+      kind: "group",
+      request: {
+        action: "offer_access",
+        messageRef: FRESH_ASSISTANT_INPUT_ID,
+      },
+    });
+
+    expect(readMurphDynamicToolRequest(groupToolCall({
+      action: "offer_access",
       standaloneLink: true,
     }))).toMatchObject({
       kind: "group",
@@ -3880,6 +3891,99 @@ describe("murph.group dynamic tool", () => {
     );
     expect(standaloneResult.finalActionPatch).toBeUndefined();
     expect(nativeResult.finalActionPatch).toBeUndefined();
+  });
+
+  it("binds an explicit native access repost to the exact current Message ref", async () => {
+    const groupRequest = vi.fn<GroupToolRequest>(async () => ({
+      action: "post_join_offer",
+      result: {
+        group: {
+          displayName: null,
+          id: "private-group-id",
+          kind: "friends",
+          memberCount: 0,
+          members: [],
+          requestedVaultShareProjectionKinds: ["steps-days.v0"],
+          requestedVaultShareProjectionScopes: [
+            { projectionKind: "steps-days.v0" },
+          ],
+          status: "active",
+        },
+        joinUrl: "https://example.test/groups/join/native-hidden",
+        offerState: "posted",
+        status: "sent",
+      },
+    }));
+    const request = readMurphDynamicToolRequest(groupToolCall({
+      action: "offer_access",
+      message_ref: FRESH_ASSISTANT_INPUT_ID,
+      projectionScopes: [{ projectionKind: "steps-days.v0" }],
+    }));
+    if (!request || request.kind !== "group") {
+      throw new Error("Expected access-offer repost request.");
+    }
+
+    const result = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createGroupHostedToolContext({
+        currentUserActionScope: () => ({
+          acceptedInputIds: [FRESH_ASSISTANT_INPUT_ID],
+          conversationId: "conversation_group",
+          conversationScope: "group",
+          inboundMailboxItemIds: ["mailbox_group"],
+          originSessionId: "session_group",
+          recipientKey: "recipient_group",
+        }),
+        groupRequest,
+      }),
+      nextUsageOrdinal: () => 1,
+      progressDelivery: null,
+      request,
+      vaultRoot: null,
+    });
+
+    expect(groupRequest).toHaveBeenCalledWith({
+      action: "post_join_offer",
+      joinOffer: {
+        messageTemplate: HOSTED_RUNTIME_GROUP_JOIN_OFFER_LEGACY_MESSAGE_TEMPLATE,
+        projectionScopes: [{ projectionKind: "steps-days.v0" }],
+      },
+      repostOriginAssistantInputId: FRESH_ASSISTANT_INPUT_ID,
+    });
+    expect(readGroupToolPayload(result)).toMatchObject({
+      action: "offer_access",
+      result: { presentation: "native", status: "ok" },
+    });
+
+    const wrongMessageRequest = readMurphDynamicToolRequest(groupToolCall({
+      action: "offer_access",
+      message_ref: EARLIER_ASSISTANT_INPUT_ID,
+    }));
+    if (!wrongMessageRequest || wrongMessageRequest.kind !== "group") {
+      throw new Error("Expected access-offer repost request.");
+    }
+    const rejected = await executeMurphDynamicToolRequest({
+      env: {},
+      fetchImpl: fetch,
+      hostedToolContext: createGroupHostedToolContext({
+        currentUserActionScope: () => ({
+          acceptedInputIds: [FRESH_ASSISTANT_INPUT_ID],
+          conversationId: "conversation_group",
+          conversationScope: "group",
+          inboundMailboxItemIds: ["mailbox_group"],
+          originSessionId: "session_group",
+          recipientKey: "recipient_group",
+        }),
+        groupRequest,
+      }),
+      nextUsageOrdinal: () => 2,
+      progressDelivery: null,
+      request: wrongMessageRequest,
+      vaultRoot: null,
+    });
+    expect(rejected.rpcResult.success).toBe(false);
+    expect(groupRequest).toHaveBeenCalledTimes(1);
   });
 
   it("shows a fresh exact link for a reused native offer and fails closed without recency evidence", async () => {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -79,6 +79,7 @@ import {
   MURPH_ATTACH_RESPONSE_CARD_TOOL,
   MURPH_ATTACH_TELEGRAM_RICH_CONTENT_TOOL,
   MURPH_GROUP_CONSULT_TOOL,
+  MURPH_GROUP_DATA_TOOL,
 } from '../src/assistant-codex/dynamic-tool-catalog.ts'
 import {
   MURPH_SEND_PHYSICAL_NOTE_TOOL,
@@ -2999,6 +3000,128 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
       }
     },
     360_000,
+  )
+
+  it(
+    'binds a requested native access repost to the current group message',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-group-access-repost-e2e-'),
+      )
+      const messageRef = `ain_${'a'.repeat(32)}`
+      const groupRequests: unknown[] = []
+
+      try {
+        const skillsRoot = path.join(workingDirectory, 'skills')
+        await materializeAssistantSkill({
+          skillsRoot,
+          slug: 'group-chat',
+        })
+        const result = await executeRealCodexAppServerTurn({
+          allowFinishWithoutReply: true,
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions:
+            buildHostedGroupStatusDeveloperInstructions(),
+          dynamicTools: [MURPH_GROUP_DATA_TOOL, MURPH_FINISH_WITHOUT_REPLY_TOOL],
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          },
+          excludeResumeTurns: true,
+          groupConversation: true,
+          hostedToolContext: {
+            computerToolsAvailable: false,
+            currentHostedDeliveryContext: () => null,
+            currentHostedMailboxItemIds: () => [],
+            currentUserActionScope: () => ({
+              acceptedInputIds: [messageRef],
+              conversationId: 'conversation-group-repost',
+              conversationScope: 'group',
+              inboundMailboxItemIds: ['mailbox-group-repost'],
+              originSessionId: 'session-group-repost',
+              recipientKey: 'recipient-group-repost',
+            }),
+            groupTool: {
+              request: async (request) => {
+                groupRequests.push(request)
+                return {
+                  action: 'post_join_offer',
+                  result: {
+                    group: {
+                      displayName: null,
+                      id: 'group_synthetic_repost',
+                      kind: 'friends',
+                      memberCount: 1,
+                      members: [],
+                      requestedVaultShareProjectionKinds: [],
+                      requestedVaultShareProjectionScopes: [],
+                      status: 'active',
+                    },
+                    joinUrl: 'https://example.test/groups/join/synthetic',
+                    offeredAt: '2026-08-26T18:00:00.000Z',
+                    offerState: 'posted',
+                    status: 'sent',
+                  },
+                }
+              },
+            },
+            sendVaultFile: async () => ({
+              filename: 'unused',
+              status: 'denied',
+            }),
+            vaultFileSendAvailable: false,
+          },
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: [
+            `Message ref: ${messageRef}`,
+            'Sender: participant-a',
+            'Current member message:',
+            '"The group access prompt is buried now. Please post a fresh native one in this chat so another participant can join."',
+          ].join('\n'),
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+        const accessCalls = actions.filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_GROUP_DATA_TOOL.name
+        )
+
+        process.stdout.write(
+          `[group-access-repost-e2e] ${JSON.stringify({
+            accessCallCount: accessCalls.length,
+            finalMessage: result.finalMessage,
+            groupRequests,
+          })}\n`,
+        )
+        expect(accessCalls).toHaveLength(1)
+        expect(accessCalls[0]).toMatchObject({
+          argumentsValue: {
+            action: 'offer_access',
+            message_ref: messageRef,
+          },
+        })
+        expect(groupRequests).toHaveLength(1)
+        expect(groupRequests[0]).toMatchObject({
+          action: 'post_join_offer',
+          repostOriginAssistantInputId: messageRef,
+        })
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    480_000,
   )
 
   it(
@@ -9220,6 +9343,205 @@ describe('real Codex app-server cache usage e2e harness', () => {
     ])
   })
 })
+
+describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
+  it('resolves an exact menu label before saving a restaurant meal', {
+    timeout: 900_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-restaurant-meal-e2e-'),
+    )
+
+    try {
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'meal-commands.log')
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      await Promise.all([
+        materializeAssistantSkill({ skillsRoot, slug: 'food-journal' }),
+        materializeRestaurantMealVaultCli({
+          binDirectory,
+          commandLogPath,
+        }),
+        writeFile(commandLogPath, '', 'utf8'),
+      ])
+
+      const inheritedPath = normalizeEnvString(config.env.PATH)
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand:
+          normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: 'Use vault-cli for canonical member data.',
+          assistantContextSnapshotPrompt: null,
+          assistantHostedDeviceConnectAvailable: false,
+          assistantHostedDeviceConnectProviders: [],
+          assistantKnowledgeToolsAvailable: false,
+          channel: 'linq',
+          cliAccess: {
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+          conversationScope: 'direct',
+          currentLocalDate: '2026-08-26',
+          currentTimeZone: 'America/New_York',
+          hostedRuntime: true,
+          modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+          ordinaryInboundTurn: true,
+          turnTrigger: 'automation-auto-reply',
+        }),
+        dynamicTools: [],
+        env: {
+          ...config.env,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          PATH: inheritedPath
+            ? `${binDirectory}${path.delimiter}${inheritedPath}`
+            : binDirectory,
+        },
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        prompt: [
+          'Log dinner: one standard chicken plate from Harbor Bowl, no substitutions.',
+          'The standard plate is the complete item and portion description.',
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+      const commands = (await readFile(commandLogPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+      const searchIndex = commands.findIndex((command) =>
+        command.startsWith('food search-labels ')
+      )
+      const addIndex = commands.findIndex((command) =>
+        command.startsWith('meal add ')
+        && !command.includes(' --help')
+        && command.includes(' --note ')
+        && !command.includes(' --name ')
+      )
+      const addCommand = commands[addIndex] ?? ''
+
+      process.stdout.write(
+        `[restaurant-meal-nutrition-e2e] ${JSON.stringify({
+          commands,
+          finalMessage: result.finalMessage,
+        })}\n`,
+      )
+      expect(searchIndex).toBeGreaterThanOrEqual(0)
+      expect(addIndex).toBeGreaterThan(searchIndex)
+      expect(addCommand).toMatch(/--nutrition-calories\s+620\b/u)
+      expect(addCommand).toMatch(/--nutrition-protein-grams\s+42\b/u)
+      expect(addCommand).toMatch(
+        /--nutrition-source(?:=|\s+)["']?(?:database|label)["']?(?:\s|$)/u,
+      )
+      expect(result.finalMessage).not.toMatch(
+        /what (?:did you|was)|which (?:item|meal)|\?\s*$/iu,
+      )
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  })
+})
+
+async function materializeRestaurantMealVaultCli(input: {
+  binDirectory: string
+  commandLogPath: string
+}): Promise<void> {
+  await mkdir(input.binDirectory, { recursive: true })
+  const executablePath = path.join(input.binDirectory, 'vault-cli')
+  const exactMenuResult = {
+    items: [{
+      brand: 'Harbor Bowl',
+      contaminantSummary: { status: 'no_known_product_tests' },
+      dataOrigin: 'restaurant_menu',
+      id: 'menu:harbor-bowl:chicken-plate',
+      label: {
+        calories: 620,
+        carbohydrateGrams: 68,
+        fatGrams: 20,
+        fiberGrams: 8,
+        proteinGrams: 42,
+        servingSize: 1,
+        servingSizeUnit: 'plate',
+      },
+      name: 'Harbor Bowl Standard Chicken Plate',
+    }],
+    source: 'murph-data-api',
+  }
+  const savedMeal = {
+    entity: {
+      id: 'meal_01SYNTHETICRESTAURANT00001',
+      kind: 'meal',
+      mealId: 'meal_01SYNTHETICRESTAURANT00001',
+      note: 'One standard chicken plate from Harbor Bowl, no substitutions.',
+      nutrition: {
+        provenance: {
+          confidence: 'high',
+          source: 'database',
+          sourceDetail: 'menu:harbor-bowl:chicken-plate',
+        },
+        totals: {
+          calories: 620,
+          carbsGrams: 68,
+          fatGrams: 20,
+          fiberGrams: 8,
+          proteinGrams: 42,
+        },
+      },
+      occurredAt: '2026-08-26T19:00:00-04:00',
+      source: 'manual',
+    },
+    vault: 'synthetic-vault',
+  }
+  const emit = (value: unknown) =>
+    `printf '%s\\n' ${quoteNutritionShellLiteral(JSON.stringify(value))}`
+
+  await writeFile(
+    executablePath,
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `printf '%s\\n' "$*" >> ${quoteNutritionShellLiteral(input.commandLogPath)}`,
+      'case "$*" in',
+      `  meal\\ --help|meal\\ add\\ --help) printf '%s\\n' ${quoteNutritionShellLiteral([
+        'Usage: vault-cli meal add [options]',
+        'Options:',
+        '  --note <text>',
+        '  --occurred-at <ISO-8601-or-date>',
+        '  --nutrition-calories <number>',
+        '  --nutrition-protein-grams <number>',
+        '  --nutrition-carbs-grams <number>',
+        '  --nutrition-fat-grams <number>',
+        '  --nutrition-fiber-grams <number>',
+        '  --nutrition-source <database|label|estimated>',
+        '  --nutrition-confidence <level>',
+        '  --nutrition-source-detail <text>',
+        '  --format json',
+      ].join('\\n'))} ;;`,
+      `  food\\ search-labels\\ *) ${emit(exactMenuResult)} ;;`,
+      '  meal\\ add*--name*) printf \'unknown option: --name\\n\' >&2; exit 64 ;;',
+      `  meal\\ add\\ *) ${emit(savedMeal)} ;;`,
+      `  meal\\ show\\ *) ${emit(savedMeal)} ;;`,
+      `  goal\\ list\\ *) ${emit({ count: 0, items: [], nextCursor: null })} ;;`,
+      `  memory\\ show\\ *) ${emit({ document: { records: [] }, memory: null })} ;;`,
+      '  *) printf \'unsupported restaurant meal fixture command: %s\\n\' "$*" >&2; exit 64 ;;',
+      'esac',
+      '',
+    ].join('\n'),
+    { encoding: 'utf8', mode: 0o700 },
+  )
+  await chmod(executablePath, 0o700)
+}
 
 describeRealCodex('real Codex automatic meal closeout recovery e2e', () => {
   it('recovers one automatic meal edit and retains unresolved photos', {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -9479,7 +9479,7 @@ describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
         materializeRestaurantMealVaultCli({
           binDirectory,
           commandLogPath,
-          exactMenuMatch: false,
+          scenario: 'official-source',
         }),
         writeFile(commandLogPath, '', 'utf8'),
       ])
@@ -9637,17 +9637,123 @@ describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
       ])
     }
   })
+
+  it('saves without nutrition in an already-known number-sensitive context', {
+    timeout: 900_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-restaurant-nonnumeric-e2e-'),
+    )
+
+    try {
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'meal-commands.log')
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      await Promise.all([
+        materializeAssistantSkill({ skillsRoot, slug: 'food-journal' }),
+        materializeRestaurantMealVaultCli({
+          binDirectory,
+          commandLogPath,
+          scenario: 'nonnumeric',
+        }),
+        writeFile(commandLogPath, '', 'utf8'),
+      ])
+
+      const inheritedPath = normalizeEnvString(config.env.PATH)
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand:
+          normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: 'Use vault-cli for canonical member data.',
+          assistantContextSnapshotPrompt: [
+            'Known member context:',
+            '- The member uses intuitive eating and is number-sensitive.',
+            '- Do not estimate or surface calories or macros, and minimize food prompts.',
+          ].join('\n'),
+          assistantHostedDeviceConnectAvailable: false,
+          assistantHostedDeviceConnectProviders: [],
+          assistantKnowledgeToolsAvailable: false,
+          channel: 'linq',
+          cliAccess: {
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+          conversationScope: 'direct',
+          currentLocalDate: '2026-08-26',
+          currentTimeZone: 'America/New_York',
+          hostedRuntime: true,
+          modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+          ordinaryInboundTurn: true,
+          turnTrigger: 'automation-auto-reply',
+        }),
+        dynamicTools: [],
+        env: {
+          ...config.env,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          PATH: inheritedPath
+            ? `${binDirectory}${path.delimiter}${inheritedPath}`
+            : binDirectory,
+        },
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        prompt: [
+          'Log dinner: one standard chicken plate from Harbor Bowl, no substitutions.',
+          'The standard plate is the complete item and portion description.',
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+      const commands = (await readFile(commandLogPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+      const searchCommands = commands.filter((command) =>
+        command.startsWith('food search-labels ')
+      )
+      const addCommands = commands.filter((command) =>
+        command.startsWith('meal add ')
+        && !command.includes(' --help')
+        && command.includes(' --note ')
+      )
+
+      process.stdout.write(
+        `[restaurant-meal-nonnumeric-e2e] ${JSON.stringify({
+          commands,
+          finalMessage: result.finalMessage,
+        })}\n`,
+      )
+      expect(searchCommands).toEqual([])
+      expect(addCommands).toHaveLength(1)
+      expect(addCommands[0]).not.toContain('--nutrition-')
+      expect(result.finalMessage).not.toMatch(/calor|protein|carb|macro|fat/iu)
+      expect(result.finalMessage).not.toMatch(/\?\s*$/u)
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  })
 })
 
 async function materializeRestaurantMealVaultCli(input: {
   binDirectory: string
   commandLogPath: string
-  exactMenuMatch?: boolean
+  scenario?: 'database' | 'nonnumeric' | 'official-source'
 }): Promise<void> {
   await mkdir(input.binDirectory, { recursive: true })
   const executablePath = path.join(input.binDirectory, 'vault-cli')
+  const scenario = input.scenario ?? 'database'
   const exactMenuResult = {
-    items: input.exactMenuMatch === false ? [] : [{
+    items: scenario === 'database' ? [{
       brand: 'Harbor Bowl',
       contaminantSummary: { status: 'no_known_product_tests' },
       dataOrigin: 'restaurant_menu',
@@ -9662,10 +9768,10 @@ async function materializeRestaurantMealVaultCli(input: {
         servingSizeUnit: 'plate',
       },
       name: 'Harbor Bowl Standard Chicken Plate',
-    }],
+    }] : [],
     source: 'murph-data-api',
   }
-  const savedNutrition = input.exactMenuMatch === false
+  const savedNutrition = scenario === 'official-source'
     ? {
         calories: 640,
         carbohydrateGrams: 70,
@@ -9690,20 +9796,24 @@ async function materializeRestaurantMealVaultCli(input: {
       kind: 'meal',
       mealId: 'meal_01SYNTHETICRESTAURANT00001',
       note: 'One standard chicken plate from Harbor Bowl, no substitutions.',
-      nutrition: {
-        provenance: {
-          confidence: 'high',
-          source: savedNutrition.source,
-          sourceDetail: savedNutrition.sourceDetail,
-        },
-        totals: {
-          calories: savedNutrition.calories,
-          carbsGrams: savedNutrition.carbohydrateGrams,
-          fatGrams: savedNutrition.fatGrams,
-          fiberGrams: savedNutrition.fiberGrams,
-          proteinGrams: savedNutrition.proteinGrams,
-        },
-      },
+      ...(scenario === 'nonnumeric'
+        ? {}
+        : {
+            nutrition: {
+              provenance: {
+                confidence: 'high',
+                source: savedNutrition.source,
+                sourceDetail: savedNutrition.sourceDetail,
+              },
+              totals: {
+                calories: savedNutrition.calories,
+                carbsGrams: savedNutrition.carbohydrateGrams,
+                fatGrams: savedNutrition.fatGrams,
+                fiberGrams: savedNutrition.fiberGrams,
+                proteinGrams: savedNutrition.proteinGrams,
+              },
+            },
+          }),
       occurredAt: '2026-08-26T19:00:00-04:00',
       source: 'manual',
     },
@@ -9735,9 +9845,16 @@ async function materializeRestaurantMealVaultCli(input: {
         '  --format json',
       ].join('\\n'))} ;;`,
       '  food\\ search-labels\\ *)',
-      '    case "$*" in *Harbor*Bowl*|*harbor*bowl*) ;; *) printf \'exact restaurant required\\n\' >&2; exit 64 ;; esac',
-      '    case "$*" in *chicken*plate*|*Chicken*Plate*) ;; *) printf \'exact menu item required\\n\' >&2; exit 64 ;; esac',
-      `    ${emit(exactMenuResult)} ;;`,
+      ...(scenario === 'nonnumeric'
+        ? [
+            '    printf \'unexpected nutrition lookup in number-sensitive context\\n\' >&2',
+            '    exit 65 ;;',
+          ]
+        : [
+            '    case "$*" in *Harbor*Bowl*|*harbor*bowl*) ;; *) printf \'exact restaurant required\\n\' >&2; exit 64 ;; esac',
+            '    case "$*" in *chicken*plate*|*Chicken*Plate*) ;; *) printf \'exact menu item required\\n\' >&2; exit 64 ;; esac',
+            `    ${emit(exactMenuResult)} ;;`,
+          ]),
       '  meal\\ add*--name*) printf \'unknown option: --name\\n\' >&2; exit 64 ;;',
       `  meal\\ add\\ *) ${emit(savedMeal)} ;;`,
       `  meal\\ show\\ *) ${emit(savedMeal)} ;;`,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -3114,6 +3114,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
           action: 'post_join_offer',
           repostOriginAssistantInputId: messageRef,
         })
+        expect(result.finalMessage.trim()).toBe('')
       } finally {
         await removeRealCodexTemporaryPaths([
           workingDirectory,
@@ -9435,6 +9436,8 @@ describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
         })}\n`,
       )
       expect(searchIndex).toBeGreaterThanOrEqual(0)
+      expect(commands[searchIndex]).toMatch(/Harbor\s+Bowl/iu)
+      expect(commands[searchIndex]).toMatch(/chicken\s+plate/iu)
       expect(addIndex).toBeGreaterThan(searchIndex)
       expect(addCommand).toMatch(/--nutrition-calories\s+620\b/u)
       expect(addCommand).toMatch(/--nutrition-protein-grams\s+42\b/u)
@@ -9451,16 +9454,200 @@ describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
       ])
     }
   })
+
+  it('uses the official restaurant source after an exact menu miss', {
+    timeout: 900_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-restaurant-official-source-e2e-'),
+    )
+    const officialNutritionUrl =
+      'https://harbor-bowl.example.test/nutrition'
+    const computerRequests: Array<{
+      body: Record<string, unknown>
+      url: string
+    }> = []
+
+    try {
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'meal-commands.log')
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      await Promise.all([
+        materializeAssistantSkill({ skillsRoot, slug: 'food-journal' }),
+        materializeAssistantSkill({ skillsRoot, slug: 'computer-use' }),
+        materializeRestaurantMealVaultCli({
+          binDirectory,
+          commandLogPath,
+          exactMenuMatch: false,
+        }),
+        writeFile(commandLogPath, '', 'utf8'),
+      ])
+
+      const inheritedPath = normalizeEnvString(config.env.PATH)
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand:
+          normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: 'Use vault-cli for canonical member data.',
+          assistantContextSnapshotPrompt: null,
+          assistantHostedDeviceConnectAvailable: false,
+          assistantHostedDeviceConnectProviders: [],
+          assistantKnowledgeToolsAvailable: false,
+          channel: 'linq',
+          cliAccess: {
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+          conversationScope: 'direct',
+          currentLocalDate: '2026-08-26',
+          currentTimeZone: 'America/New_York',
+          hostedRuntime: true,
+          modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+          ordinaryInboundTurn: true,
+          turnTrigger: 'automation-auto-reply',
+        }),
+        env: {
+          ...config.env,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          PATH: inheritedPath
+            ? `${binDirectory}${path.delimiter}${inheritedPath}`
+            : binDirectory,
+        },
+        excludeResumeTurns: true,
+        fetchImpl: async (
+          request: string | URL | Request,
+          init?: RequestInit,
+        ): Promise<Response> => {
+          const url = request instanceof Request ? request.url : String(request)
+          const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+          computerRequests.push({ body, url })
+          if (url === 'http://web-control.worker/api/internal/computer/runs') {
+            return new Response(JSON.stringify({
+              expiresAt: '2026-08-26T20:00:00.000Z',
+              reused: false,
+              runId: 'run_synthetic_restaurant_nutrition',
+              status: 'running',
+              title: 'Harbor Bowl official nutrition',
+              url: officialNutritionUrl,
+              visibleText: [
+                'Harbor Bowl official nutrition',
+                'Standard Chicken Plate — serving size: 1 plate',
+                'Calories 640; protein 44 g; carbohydrates 70 g; fat 21 g; fiber 9 g.',
+              ].join('\n'),
+            }), {
+              headers: { 'content-type': 'application/json' },
+              status: 200,
+            })
+          }
+          if (
+            url
+            === 'http://web-control.worker/api/internal/computer/runs/run_synthetic_restaurant_nutrition/finish'
+          ) {
+            return new Response(JSON.stringify({
+              ok: true,
+              runId: 'run_synthetic_restaurant_nutrition',
+              status: 'completed',
+            }), {
+              headers: { 'content-type': 'application/json' },
+              status: 200,
+            })
+          }
+          throw new Error(`Unexpected hosted computer request: ${url}`)
+        },
+        hostedToolContext: createRealCodexComputerHostedToolContext(),
+        model: config.model,
+        modelProvider: config.modelProvider,
+        prompt: [
+          'Log dinner: one standard chicken plate from Harbor Bowl, no substitutions.',
+          `The restaurant lists its official nutrition at ${officialNutritionUrl}.`,
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+      const commands = (await readFile(commandLogPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+      const searchIndex = commands.findIndex((command) =>
+        command.startsWith('food search-labels ')
+      )
+      const addIndex = commands.findIndex((command) =>
+        command.startsWith('meal add ')
+        && !command.includes(' --help')
+        && command.includes(' --note ')
+      )
+      const addCommand = commands[addIndex] ?? ''
+      const actions = readCapabilityRoutingActions(result.jsonEvents)
+      const searchAction = actions.find((action) =>
+        action.kind === 'command'
+        && action.command.includes('food search-labels')
+      )
+      const openAction = actions.find((action) =>
+        action.kind === 'dynamic'
+        && action.tool === MURPH_COMPUTER_OPEN_TOOL.name
+      )
+      const addAction = actions.find((action) =>
+        action.kind === 'command'
+        && action.command.includes('meal add')
+        && !action.command.includes('--help')
+      )
+
+      process.stdout.write(
+        `[restaurant-meal-official-source-e2e] ${JSON.stringify({
+          commands,
+          computerRequests,
+          finalMessage: result.finalMessage,
+        })}\n`,
+      )
+      expect(searchIndex).toBeGreaterThanOrEqual(0)
+      expect(commands[searchIndex]).toMatch(/Harbor\s+Bowl/iu)
+      expect(commands[searchIndex]).toMatch(/chicken\s+plate/iu)
+      expect(addIndex).toBeGreaterThan(searchIndex)
+      expect(searchAction).toBeDefined()
+      expect(openAction).toMatchObject({
+        argumentsValue: { startUrl: officialNutritionUrl },
+      })
+      expect(addAction).toBeDefined()
+      expect(openAction?.eventIndex).toBeGreaterThan(
+        searchAction?.eventIndex ?? Number.POSITIVE_INFINITY,
+      )
+      expect(addAction?.eventIndex).toBeGreaterThan(
+        openAction?.eventIndex ?? Number.POSITIVE_INFINITY,
+      )
+      expect(addCommand).toMatch(/--nutrition-calories\s+640\b/u)
+      expect(addCommand).toMatch(/--nutrition-protein-grams\s+44\b/u)
+      expect(addCommand).toMatch(
+        /--nutrition-source(?:=|\s+)["']?label["']?(?:\s|$)/u,
+      )
+      expect(addCommand).toContain(officialNutritionUrl)
+      expect(addCommand).not.toMatch(
+        /--nutrition-source(?:=|\s+)["']?estimated["']?(?:\s|$)/u,
+      )
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  })
 })
 
 async function materializeRestaurantMealVaultCli(input: {
   binDirectory: string
   commandLogPath: string
+  exactMenuMatch?: boolean
 }): Promise<void> {
   await mkdir(input.binDirectory, { recursive: true })
   const executablePath = path.join(input.binDirectory, 'vault-cli')
   const exactMenuResult = {
-    items: [{
+    items: input.exactMenuMatch === false ? [] : [{
       brand: 'Harbor Bowl',
       contaminantSummary: { status: 'no_known_product_tests' },
       dataOrigin: 'restaurant_menu',
@@ -9478,6 +9665,25 @@ async function materializeRestaurantMealVaultCli(input: {
     }],
     source: 'murph-data-api',
   }
+  const savedNutrition = input.exactMenuMatch === false
+    ? {
+        calories: 640,
+        carbohydrateGrams: 70,
+        fatGrams: 21,
+        fiberGrams: 9,
+        proteinGrams: 44,
+        source: 'label',
+        sourceDetail: 'https://harbor-bowl.example.test/nutrition',
+      }
+    : {
+        calories: 620,
+        carbohydrateGrams: 68,
+        fatGrams: 20,
+        fiberGrams: 8,
+        proteinGrams: 42,
+        source: 'database',
+        sourceDetail: 'menu:harbor-bowl:chicken-plate',
+      }
   const savedMeal = {
     entity: {
       id: 'meal_01SYNTHETICRESTAURANT00001',
@@ -9487,15 +9693,15 @@ async function materializeRestaurantMealVaultCli(input: {
       nutrition: {
         provenance: {
           confidence: 'high',
-          source: 'database',
-          sourceDetail: 'menu:harbor-bowl:chicken-plate',
+          source: savedNutrition.source,
+          sourceDetail: savedNutrition.sourceDetail,
         },
         totals: {
-          calories: 620,
-          carbsGrams: 68,
-          fatGrams: 20,
-          fiberGrams: 8,
-          proteinGrams: 42,
+          calories: savedNutrition.calories,
+          carbsGrams: savedNutrition.carbohydrateGrams,
+          fatGrams: savedNutrition.fatGrams,
+          fiberGrams: savedNutrition.fiberGrams,
+          proteinGrams: savedNutrition.proteinGrams,
         },
       },
       occurredAt: '2026-08-26T19:00:00-04:00',
@@ -9528,7 +9734,10 @@ async function materializeRestaurantMealVaultCli(input: {
         '  --nutrition-source-detail <text>',
         '  --format json',
       ].join('\\n'))} ;;`,
-      `  food\\ search-labels\\ *) ${emit(exactMenuResult)} ;;`,
+      '  food\\ search-labels\\ *)',
+      '    case "$*" in *Harbor*Bowl*|*harbor*bowl*) ;; *) printf \'exact restaurant required\\n\' >&2; exit 64 ;; esac',
+      '    case "$*" in *chicken*plate*|*Chicken*Plate*) ;; *) printf \'exact menu item required\\n\' >&2; exit 64 ;; esac',
+      `    ${emit(exactMenuResult)} ;;`,
       '  meal\\ add*--name*) printf \'unknown option: --name\\n\' >&2; exit 64 ;;',
       `  meal\\ add\\ *) ${emit(savedMeal)} ;;`,
       `  meal\\ show\\ *) ${emit(savedMeal)} ;;`,

--- a/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
@@ -180,6 +180,21 @@ describe('assistant food journal skill', () => {
     )
     expect(skill).toContain('vault-cli food search-labels`')
     expect(skill).toContain('vault-cli food search-labels-batch`')
+    expect(skill).toContain(
+      'For an ordinary numeric-eligible meal capture, resolve nutrition before the\nmeal mutation.',
+    )
+    expect(skill).toContain(
+      'When the user names a restaurant and recognizable menu item, use a\nnormal exact restaurant/menu search rather than a generic substitute.',
+    )
+    expect(skill).toContain(
+      "If that\nsearch has no exact result, read `computer-use` and inspect the restaurant's\nofficial nutrition or menu source.",
+    )
+    expect(skill).toContain(
+      'Only after the database result, official\nsource, or clearly marked last-resort estimate is resolved may you call\n`meal add` or `meal edit`',
+    )
+    expect(skill).toContain(
+      'Do not\nsave a nutrition-free restaurant meal first and then ask the member to repeat\nthe item.',
+    )
     expect(skill).toContain('Use `--generic` for ordinary ingredients')
     expect(skill).toContain(
       'For a fridge or pantry photo, enumerate distinct visible products and resolve\nthem in one batch.',

--- a/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
@@ -181,14 +181,25 @@ describe('assistant food journal skill', () => {
     expect(skill).toContain('vault-cli food search-labels`')
     expect(skill).toContain('vault-cli food search-labels-batch`')
     expect(skill).toContain(
-      'When the user names a restaurant and recognizable menu item, resolve nutrition\nbefore the meal mutation.',
+      'When the user names a restaurant and recognizable menu item, and known context\ndoes not trigger one of the numeric safety exceptions below, resolve nutrition\nbefore the meal mutation.',
     )
     expect(skill).toContain(
       'Use a normal exact restaurant/menu search rather\nthan a generic substitute.',
     )
-    expect(skill).not.toContain('For an ordinary numeric-eligible meal capture')
+    expect(skill).toContain(
+      'Run this database search first even when the user\nsupplies an official restaurant URL.',
+    )
+    expect(skill).toContain(
+      'When a numeric safety exception already applies, save the meal without calorie\nor macro estimates.',
+    )
+    expect(skill).toContain(
+      'Do not force a nutrition lookup, clarification, or safety\npreflight just to capture the meal.',
+    )
     expect(skill).toContain(
       "If that search has no exact result, read\n`computer-use` and inspect the restaurant's official nutrition or menu source.",
+    )
+    expect(skill).toContain(
+      'When using that official source, retain its URL in nutrition source detail.',
     )
     expect(skill).toContain(
       'Only after the database result, official source, or clearly marked last-resort\nestimate is resolved may you call `meal add` or `meal edit`',

--- a/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-food-journal-skill.test.ts
@@ -181,19 +181,20 @@ describe('assistant food journal skill', () => {
     expect(skill).toContain('vault-cli food search-labels`')
     expect(skill).toContain('vault-cli food search-labels-batch`')
     expect(skill).toContain(
-      'For an ordinary numeric-eligible meal capture, resolve nutrition before the\nmeal mutation.',
+      'When the user names a restaurant and recognizable menu item, resolve nutrition\nbefore the meal mutation.',
     )
     expect(skill).toContain(
-      'When the user names a restaurant and recognizable menu item, use a\nnormal exact restaurant/menu search rather than a generic substitute.',
+      'Use a normal exact restaurant/menu search rather\nthan a generic substitute.',
+    )
+    expect(skill).not.toContain('For an ordinary numeric-eligible meal capture')
+    expect(skill).toContain(
+      "If that search has no exact result, read\n`computer-use` and inspect the restaurant's official nutrition or menu source.",
     )
     expect(skill).toContain(
-      "If that\nsearch has no exact result, read `computer-use` and inspect the restaurant's\nofficial nutrition or menu source.",
+      'Only after the database result, official source, or clearly marked last-resort\nestimate is resolved may you call `meal add` or `meal edit`',
     )
     expect(skill).toContain(
-      'Only after the database result, official\nsource, or clearly marked last-resort estimate is resolved may you call\n`meal add` or `meal edit`',
-    )
-    expect(skill).toContain(
-      'Do not\nsave a nutrition-free restaurant meal first and then ask the member to repeat\nthe item.',
+      'Do not save a nutrition-free restaurant meal first\nand then ask the member to repeat the item.',
     )
     expect(skill).toContain('Use `--generic` for ordinary ingredients')
     expect(skill).toContain(

--- a/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
@@ -81,11 +81,12 @@ describe('assistant nutrition source grounding', () => {
       'Do not silently assume restaurant or prepared food has no added fat.',
     )
     expect(food).toContain(
-      'For an ordinary numeric-eligible meal capture, resolve nutrition before the meal mutation.',
+      'When the user names a restaurant and recognizable menu item, resolve nutrition before the meal mutation.',
     )
     expect(food).toContain(
-      'When the user names a restaurant and recognizable menu item, use a normal exact restaurant/menu search rather than a generic substitute.',
+      'Use a normal exact restaurant/menu search rather than a generic substitute.',
     )
+    expect(food).not.toContain('For an ordinary numeric-eligible meal capture')
     expect(food).toContain(
       "If that search has no exact result, read `computer-use` and inspect the restaurant's official nutrition or menu source.",
     )

--- a/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
@@ -81,14 +81,25 @@ describe('assistant nutrition source grounding', () => {
       'Do not silently assume restaurant or prepared food has no added fat.',
     )
     expect(food).toContain(
-      'When the user names a restaurant and recognizable menu item, resolve nutrition before the meal mutation.',
+      'When the user names a restaurant and recognizable menu item, and known context does not trigger one of the numeric safety exceptions below, resolve nutrition before the meal mutation.',
     )
     expect(food).toContain(
       'Use a normal exact restaurant/menu search rather than a generic substitute.',
     )
-    expect(food).not.toContain('For an ordinary numeric-eligible meal capture')
+    expect(food).toContain(
+      'Run this database search first even when the user supplies an official restaurant URL.',
+    )
+    expect(food).toContain(
+      'When a numeric safety exception already applies, save the meal without calorie or macro estimates.',
+    )
+    expect(food).toContain(
+      'Do not force a nutrition lookup, clarification, or safety preflight just to capture the meal.',
+    )
     expect(food).toContain(
       "If that search has no exact result, read `computer-use` and inspect the restaurant's official nutrition or menu source.",
+    )
+    expect(food).toContain(
+      'When using that official source, retain its URL in nutrition source detail.',
     )
     expect(food).toContain(
       'Only after the database result, official source, or clearly marked last-resort estimate is resolved may you call `meal add` or `meal edit` with the available nutrition and provenance.',

--- a/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-source-grounding.test.ts
@@ -81,7 +81,19 @@ describe('assistant nutrition source grounding', () => {
       'Do not silently assume restaurant or prepared food has no added fat.',
     )
     expect(food).toContain(
-      'Only after those fail may you use a clearly marked memory-based estimate',
+      'For an ordinary numeric-eligible meal capture, resolve nutrition before the meal mutation.',
+    )
+    expect(food).toContain(
+      'When the user names a restaurant and recognizable menu item, use a normal exact restaurant/menu search rather than a generic substitute.',
+    )
+    expect(food).toContain(
+      "If that search has no exact result, read `computer-use` and inspect the restaurant's official nutrition or menu source.",
+    )
+    expect(food).toContain(
+      'Only after the database result, official source, or clearly marked last-resort estimate is resolved may you call `meal add` or `meal edit` with the available nutrition and provenance.',
+    )
+    expect(food).toContain(
+      'Only after the applicable official source fails may you use a clearly marked memory-based estimate',
     )
     expect(automatic).toContain(
       'Read `$MURPH_ASSISTANT_SKILLS_ROOT/food-journal/SKILL.md` before estimating nutrition',

--- a/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-group-tool-linq-context.test.ts
@@ -464,6 +464,7 @@ describe("createHostedGroupToolWithCurrentTurnContext", () => {
           "React here to join. This shares {{share_scope}} with the group. Details: {{join_url}}.",
         projectionKinds: ["sleep-times.v0"],
       },
+      repostOriginAssistantInputId: PRIVATE_ASSISTANT_INPUT_ID,
     });
     expect(request).toHaveBeenLastCalledWith({
       action: "post_join_offer",
@@ -472,6 +473,7 @@ describe("createHostedGroupToolWithCurrentTurnContext", () => {
           "React here to join. This shares {{share_scope}} with the group. Details: {{join_url}}.",
         projectionKinds: ["sleep-times.v0"],
       },
+      repostOriginAssistantInputId: PRIVATE_ASSISTANT_INPUT_ID,
       linqThread: {
         authority: ROUTE_AUTHORITY,
         chatId: "chat_group_1",

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1570,7 +1570,12 @@ export function parseHostedRuntimeGroupToolRequest(
   if (action === "post_join_offer") {
     assertAllowedObjectKeys(
       record,
-      new Set(["action", "joinOffer", "linqThread"]),
+      new Set([
+        "action",
+        "joinOffer",
+        "linqThread",
+        "repostOriginAssistantInputId",
+      ]),
       "Hosted runtime group tool post_join_offer request",
     );
     return {
@@ -1586,6 +1591,15 @@ export function parseHostedRuntimeGroupToolRequest(
               "Hosted runtime group tool post_join_offer request linqThread",
             ),
       }),
+      ...(record.repostOriginAssistantInputId === undefined
+        ? {}
+        : {
+            repostOriginAssistantInputId:
+              parseHostedExecutionAssistantAskOriginInputId(
+                record.repostOriginAssistantInputId,
+                "Hosted runtime group tool post_join_offer request repostOriginAssistantInputId",
+              ),
+          }),
     };
   }
   if (action === "set_chat_avatar") {

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -1586,6 +1586,8 @@ export type HostedRuntimeGroupToolRequest =
       action: "post_join_offer";
       joinOffer?: HostedRuntimeGroupPostJoinOfferRequest | null;
       linqThread?: HostedRuntimeGroupToolLinqThreadContext | null;
+      /** Exact accepted-input identity for an explicitly requested native repost. */
+      repostOriginAssistantInputId?: string;
     }
   | {
       action: "preflight_set_chat_avatar";

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -1080,6 +1080,7 @@ describe("parseHostedRuntimeGroupTool", () => {
           "  React here to join. Shares {{share_scope}}. Page: {{join_url}}.  ",
         projectionScopes: [{ projectionKind: "group-email.v0" }],
       },
+      repostOriginAssistantInputId: `ain_${"a".repeat(32)}`,
     })).toEqual({
       action: "post_join_offer",
       joinOffer: {
@@ -1088,6 +1089,7 @@ describe("parseHostedRuntimeGroupTool", () => {
         projectionKinds: null,
         projectionScopes: [{ projectionKind: "group-email.v0" }],
       },
+      repostOriginAssistantInputId: `ain_${"a".repeat(32)}`,
     });
     expect(parseHostedRuntimeGroupToolRequest({
       action: "post_join_offer",
@@ -1300,6 +1302,12 @@ describe("parseHostedRuntimeGroupTool", () => {
         joinLink: { displayName: "   " },
       })
     ).toThrow(/must not be blank/u);
+    expect(() =>
+      parseHostedRuntimeGroupToolRequest({
+        action: "post_join_offer",
+        repostOriginAssistantInputId: "provider-message-id",
+      })
+    ).toThrow(/repostOriginAssistantInputId/u);
     expect(() =>
       parseHostedRuntimeGroupToolRequest({
         action: "post_join_offer",


### PR DESCRIPTION
## Why and outcome

A hosted group could ask for a fresh native join-and-share consent prompt, but the tool contract rejected the current message reference and Web reused the older active prompt. Separately, recognizable restaurant meals could be saved without nutrition before Murph attempted the required lookup.

This patch makes an explicit current-message resend publish one replay-safe native replacement with the exact current sharing choices, while preserving the older prompt on failure. It also resolves restaurant nutrition before the meal write for ordinary contexts, using the existing food database and official-source fallback. Already-known numeric safety exceptions keep low-friction number-free saving.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: a group participant requesting a fresh consent prompt, the person using that prompt to join and choose sharing, and a private member logging a recognizable restaurant meal.
- Exclusions: per-person approval and ordinary non-restaurant meal capture are unchanged; number-sensitive nutrition safety remains unchanged; no hosted Web layout or interaction changed.
- Plan differences: ReviewGPT found that the first consent implementation traversed the normal policy-replacement path and that the first restaurant wording gated all numeric meal capture. Round two then caught that the narrowed restaurant rule had lost the existing number-sensitive exception. After the required retrospective, the final candidate uses one explicit conjunction: ordinary recognizable restaurant items resolve nutrition before save; an already-known numeric safety exception saves without numbers or a new preflight.

## Evidence

- Real-Codex consent journey: one group-data call included the exact current Message ref, lowered one request-bound native repost, and produced no redundant text reply.
- Real-Codex restaurant database-hit journey: the query contained both the restaurant and menu item, exact lookup preceded mutation, and returned nutrition was saved with database provenance.
- Real-Codex restaurant database-miss journey: exact lookup returned no result, Murph inspected a synthetic official restaurant page, retained its URL in provenance, then saved its nutrition with label provenance rather than estimating.
- Real-Codex protected restaurant journey: an already-known number-sensitive context performed no nutrition lookup, saved one meal without nutrition fields, asked no question, and returned a short confirmation.
- Final-boundary deterministic tests: 4 passed. All three focused real-Codex restaurant journeys passed. The earlier broader Assistant Engine package run passed 4,133 tests with 116 skipped.
- Assistant Runtime: focused 34 tests passed; broader package run passed 2,516 tests with 5 skipped.
- Hosted Execution parser: focused 67 tests passed; broader package run passed 560 tests.
- Hosted Web consent/store paths: 247 focused tests passed.
- Changelog registry/fragments: 45 focused tests passed.
- Typechecks: Assistant Engine, Assistant Runtime, Hosted Execution, and hosted Web passed.
- Focused Web ESLint: zero errors; two unrelated existing unused-import warnings remain in group-store.

## Non-obvious affected surfaces

- Assistant tool authority: only the exact current group request can opt into replacement behavior. The action-specific field contract is the single owner of Message-ref requirements.
- Hosted runtime protocol: carries one optional accepted-input identity; parser and forwarding tests cover both old no-field requests and the new field.
- Web group policy and offer persistence: a dedicated transaction reader locks and returns the current join-policy snapshot without creating a group, changing scopes, or revoking offers.
- Food-journal skill: the restaurant-specific capture rule owns exact database lookup and official-source fallback. Generic meal nutrition continues through the existing grounding section.
- Public changelog: two content-only entries describe the member-visible outcomes without private incident evidence.

## Architecture and reuse

- Existing systems reused: accepted-input authority, hosted group-tool protocol, group row locks, offer bindings, provider idempotency, food-label search, computer-use fallback, and canonical meal mutation.
- New logic: ordinary offers retain the existing create/replace path; explicit reposts use a named read-only snapshot path. Supplied scopes must match the current snapshot. The request identity enters provider idempotency, and older offers retire only in the successful replacement-binding transaction.
- Restaurant data flow: exact menu database lookup, official restaurant source on exact miss, clearly labeled last-resort estimate, then canonical meal mutation.
- New abstractions: one narrow current-policy snapshot reader separates resend from the existing mutating group-configuration path.
- Complexity intentionally avoided: no new consent state, table, queue, resolver service, nutrition schema, dependency, or background reconciliation path.

## Hot reply path impact

- Status: Touched.
- Consent database operations: explicit resend locks and reads the existing thread/group policy before provider work and performs no policy, join-code, membership, or active-offer mutation. After provider success, the existing binding transaction creates the new binding and revokes older offers atomically. Ordinary offers keep their existing path.
- Consent provider operations: at most one existing Linq native-message send occurs per unique accepted request. Different accepted requests produce different provider keys; exact retry converges on one effect.
- Failure behavior: provider failure performs no binding work. Binding failure rolls back old-offer retirement. The prior prompt remains usable in both cases.
- Restaurant operations: one existing exact food-label search precedes one canonical meal write. An exact miss uses the already-supported computer-use source before a labeled estimate. No new network client, timeout, retry loop, or persistence owner was added.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 26,943 | 26,943 | 0 | 0.0000% | 123,347 | 123,347 | 0 |
| Group Murph | 23,064 | 23,064 | 0 | 0.0000% | 105,867 | 105,867 | 0 |

- Assembled instructions: unchanged on the complete first request. The food-journal skill remains deferred until selected.
- Tool/schema/generated guidance: unchanged on the complete first request. The changed group family schema remains deferred until tool discovery.
- Other provider-visible input: unchanged after normalizing temporary paths, opaque generated IDs, and client metadata.
- Measurement method: compared origin/main 0ea0e749cf2e23994a9e01a5a725c46e6d8b5dcb with first-reviewed candidate 95b97ac994b5103da9a764e2fb01b7ce64af5961 using identical synthetic direct/group fixtures through the pinned real Codex App Server, gpt-5.6-terra, low reasoning, production code mode, and a deterministic local Responses stub. gpt-tokenizer 3.4.0 o200k_harmony counted normalized complete serialized requests.
- Round-three correction impact: the final head changes only deferred food-journal content and its tests relative to round two. No eager first-request assembler or input changed, so the measured complete first requests remain byte-identical.

## Design proof

- Design page: [Production changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: the hosted Web change is content-only changelog JSON. Reviewing copy through the unchanged production archive is the relevant proof; a new screenshot would not prove conversational runtime behavior.
- Coverage: the unchanged archive study covers responsive presentation, and focused registry/fragment tests prove the authored entries load through the production path.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 231 | 24 |
| Tests/fixtures | 1,068 | 2 |
| Docs | 185 | 6 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 1,484 | 32 |

Runtime TypeScript and the food skill are source; Vitest and real-Codex journeys are tests; architecture, protocol, plan/spec, and changelog content are docs. No binaries or generated files changed.

## Risks

- Consent remains sender-bound to the exact accepted group input. A wrong or stale ref fails before host dispatch.
- Repost reads the locked current policy; omitted scopes cannot broaden it, and conflicting supplied scopes fail closed.
- Replacement is bind-then-retire in one transaction. Provider or binding failure preserves the previously usable offer.
- Restaurant nutrition stays subject to existing numeric-suitability exclusions and truthful estimate provenance.

ReviewGPT context sensitivity: sensitive
Classification reason: This patch crosses hosted runtime and Web consent/idempotency boundaries and changes health-nutrition tool behavior.
ReviewGPT first-reviewed head: 95b97ac994b5103da9a764e2fb01b7ce64af5961
ReviewGPT reviewed behavior head: c2266bddb93937581e565f66da4738ec0fe456f6
ReviewGPT current candidate head: 60445bfbf09af24f749b72b1479dd4f6fb01fafe
Final-head delta: plan completion and active-to-completed archive only; production code and tests are unchanged.

## Preliminary specialist lenses

- Product UX: applicable because consent delivery/recovery and meal logging outcomes change.
- Prompt: applicable because the food-journal policy and group field guidance change model behavior.
- Frontend: not applicable because no Web component, layout, interaction, or responsive behavior changed; changelog content uses the documented content-only path.
- Coverage: applicable because executable behavior, prompt behavior, and direct real-model proof changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: new Web accepts old requests without the repost identity and new request-bound reposts. Old warm runners remain safe but keep prior reuse behavior. New runners against old Web reject only explicit reposts, so that order is unsupported.
- Safe order: deploy Web first, then the hosted Worker/runtime bundle.
- Rollback floor: after new runners can emit the field, keep compatible Web deployed. For full rollback, revert the runtime producer before Web.
- Expected exposure: normal offers remain available while explicit repost behavior appears as runners converge. No migration exists.
- Reversibility: runtime-first rollback restores old behavior without transforming data.
- Convergence proof: exercise one fresh group resend and one restaurant exact-miss lookup on a newly started runtime, then verify the native offer binding and nutrition-bearing meal effect.
- Post-deploy checks: inspect bounded metadata-only aggregates for group-tool invalid arguments, post-join-offer failures, and restaurant turns that mutate a meal without a preceding food lookup.

## Changelog

- Changelog: updated
- Items: 2026-08-26 · group-consent-prompts-can-be-reposted; 2026-08-26 · restaurant-meals-use-grounded-nutrition