### PR TITLE
perf(query): bound meal nutrition reads to events

### DIFF
--- a/apps/web/changelog/entries/2026-08-26/meal-summaries-load-faster.json
+++ b/apps/web/changelog/entries/2026-08-26/meal-summaries-load-faster.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-26",
+  "order": 100,
+  "item": {
+    "id": "meal-summaries-load-faster",
+    "kind": "improvement",
+    "priority": 1,
+    "title": "Meal summaries load faster",
+    "summary": "Meal and nutrient summaries now load faster by going straight to saved meal data instead of checking unrelated records first.",
+    "details": "Totals, date ranges, ordering, units, and freshness are unchanged. Edited, imported, or removed meals keep the same handling, along with existing privacy and access controls.",
+    "relevanceTags": ["nutrition", "meals", "performance"],
+    "sourcePullRequests": [2394]
+  }
+}

--- a/packages/query/src/meal-nutrition.ts
+++ b/packages/query/src/meal-nutrition.ts
@@ -6,10 +6,11 @@ import {
 import type { CanonicalEntity } from "./canonical-entities.ts";
 
 import {
+  createVaultReadModel,
   listEntities,
-  readVault,
   type VaultReadModel,
-} from "./model.ts";
+} from "./read-model.ts";
+import { readCanonicalEntityFamilySource } from "./vault-source.ts";
 
 export interface MealNutritionMetricTotal {
   total: number | null;
@@ -472,7 +473,7 @@ export async function readMealNutritionTotals(
   vaultRoot: string,
   options: MealNutritionTotalsOptions = {},
 ): Promise<MealNutritionTotalsResult> {
-  const readModel = await readVault(vaultRoot);
+  const readModel = await readMealNutritionModel(vaultRoot);
   return summarizeMealNutritionTotals(readModel, options);
 }
 
@@ -480,6 +481,13 @@ export async function readMealNutrientTotals(
   vaultRoot: string,
   options: MealNutritionTotalsOptions = {},
 ): Promise<MealNutrientTotalsResult> {
-  const readModel = await readVault(vaultRoot);
+  const readModel = await readMealNutritionModel(vaultRoot);
   return summarizeMealNutrientTotals(readModel, options);
+}
+
+async function readMealNutritionModel(vaultRoot: string): Promise<VaultReadModel> {
+  return createVaultReadModel({
+    vaultRoot,
+    entities: await readCanonicalEntityFamilySource(vaultRoot, "event"),
+  });
 }

--- a/packages/query/test/meal-nutrition.test.ts
+++ b/packages/query/test/meal-nutrition.test.ts
@@ -12,7 +12,7 @@ import {
   type MealNutrientKey,
   type MealNutrientTotal,
 } from "../src/index.ts";
-import * as modelModule from "../src/model.ts";
+import * as vaultSourceModule from "../src/vault-source.ts";
 
 function createMealEntity(
   entityId: string,
@@ -575,7 +575,7 @@ test("summarizeMealNutritionTotals keeps the latest imported meal revision", () 
   ]);
 });
 
-test("readMealNutritionTotals reads the vault before summarizing", async () => {
+test("readMealNutritionTotals reads only the event family before summarizing", async () => {
   const readModel = createVaultReadModel({
     vaultRoot: "./vault",
     entities: [
@@ -589,27 +589,26 @@ test("readMealNutritionTotals reads the vault before summarizing", async () => {
       }),
     ],
   });
-  const readVaultSpy = vi
-    .spyOn(modelModule, "readVault")
-    .mockResolvedValue(readModel);
+  const readFamilySpy = vi
+    .spyOn(vaultSourceModule, "readCanonicalEntityFamilySource")
+    .mockResolvedValue(readModel.entities);
+  const options = {
+    from: "2026-04-14",
+    to: "2026-04-14",
+  };
 
   try {
-    const result = await readMealNutritionTotals("./vault", {
-      from: "2026-04-14",
-      to: "2026-04-14",
-    });
+    const result = await readMealNutritionTotals("./vault", options);
 
-    assert.equal(readVaultSpy.mock.calls.length, 1);
-    assert.deepEqual(readVaultSpy.mock.calls[0], ["./vault"]);
-    assert.equal(result.mealCount, 1);
-    assert.equal(result.totals.calories.total, 500);
-    assert.equal(result.days[0]?.date, "2026-04-14");
+    assert.equal(readFamilySpy.mock.calls.length, 1);
+    assert.deepEqual(readFamilySpy.mock.calls[0], ["./vault", "event"]);
+    assert.deepEqual(result, summarizeMealNutritionTotals(readModel, options));
   } finally {
-    readVaultSpy.mockRestore();
+    readFamilySpy.mockRestore();
   }
 });
 
-test("readMealNutrientTotals reads the vault before summarizing", async () => {
+test("readMealNutrientTotals reads only the event family before summarizing", async () => {
   const readModel = createVaultReadModel({
     vaultRoot: "./vault",
     entities: [
@@ -623,28 +622,21 @@ test("readMealNutrientTotals reads the vault before summarizing", async () => {
       }),
     ],
   });
-  const readVaultSpy = vi
-    .spyOn(modelModule, "readVault")
-    .mockResolvedValue(readModel);
+  const readFamilySpy = vi
+    .spyOn(vaultSourceModule, "readCanonicalEntityFamilySource")
+    .mockResolvedValue(readModel.entities);
+  const options = {
+    from: "2026-04-14",
+    to: "2026-04-14",
+  };
 
   try {
-    const result = await readMealNutrientTotals("./vault", {
-      from: "2026-04-14",
-      to: "2026-04-14",
-    });
+    const result = await readMealNutrientTotals("./vault", options);
 
-    assert.equal(readVaultSpy.mock.calls.length, 1);
-    assert.deepEqual(readVaultSpy.mock.calls[0], ["./vault"]);
-    assert.equal(result.mealCount, 1);
-    assert.deepEqual(requireNutrient(result.nutrients, "vitaminB12Mcg"), {
-      category: "vitamin",
-      contributingMealCount: 1,
-      key: "vitaminB12Mcg",
-      label: "Vitamin B12",
-      total: 2.4,
-      unit: "mcg",
-    });
+    assert.equal(readFamilySpy.mock.calls.length, 1);
+    assert.deepEqual(readFamilySpy.mock.calls[0], ["./vault", "event"]);
+    assert.deepEqual(result, summarizeMealNutrientTotals(readModel, options));
   } finally {
-    readVaultSpy.mockRestore();
+    readFamilySpy.mockRestore();
   }
 });


### PR DESCRIPTION
## Why and outcome

`meal totals` hydrated every canonical vault family before immediately filtering to meal events. A private-safe 72-hour aggregate showed a recurring latency tail despite a small result payload.

This change reads the canonical event family directly, then reuses the existing meal summarizers. It removes unrelated record parsing while preserving meal totals, nutrient totals, ordering, date bounds, units, freshness, and meal lifecycle semantics.

## Product UX

- Effort: Patch
- Outcome: Meal and nutrient summaries return the same useful result with less avoidable waiting.
- Reaches: Existing private assistant requests that need meal macro or micronutrient totals, plus existing active-consent hosted group projections for daily protein, calories, carbohydrate, fat, and fiber totals.
- Proof: Production-shaped CLI coverage plus a controlled synthetic benchmark with exact output equality.
- Walkthrough: Ready. Private requesters with small, empty, sparse, imported/revised, removed, bounded-date, and large-unrelated histories preserve the existing result and recovery contract. Existing sharing members and authorized group recipients preserve active-scope selection, complete-day fail-closed rules, true-zero data, revision collapse, meal-metadata non-disclosure, destination authority, and delivery; unrelated-family parsing no longer delays or blocks that producer. No new audience, permission, action, surface, or destination was added.

## Evidence

- Private-safe rolling 72-hour aggregate: 23 successful `meal.totals` calls, zero failures, 5.14s mean, 1.60s p50, and 20.20s p95. The preceding window had only one call, so it is not used as a regression claim.
- Synthetic fixture: 2,000 unrelated goal documents plus 30 meal events, 3 warmups, and 20 alternating iterations per path. Median fell from 50.70ms to 0.65ms and p95 from 67.85ms to 1.58ms. The 4,005-byte results were exactly equal. This isolates avoided local parsing and is not a claimed production speedup.
- `pnpm --filter @murphai/query test -- meal-nutrition.test.ts`: 66 files and 699 tests passed.
- `pnpm --filter @murphai/query typecheck`: passed.
- `pnpm --dir packages/cli exec vitest run --config vitest.config.ts --no-coverage test/cli-expansion-document-meal.test.ts`: 9 tests passed.
- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/vault-share-projection.test.ts -t "reads and offers complete local-day protein totals without exposing meal metadata"`: the production-shaped consented share capture/delivery test passed.
- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/vault-share-projection.test.ts -t "selectProjectableMealNutritionDays"`: 12 projection selector tests passed, covering all five nutrient scopes, complete and incomplete days, true zero, bounds, and retention limits.
- `pnpm --dir apps/web test -- changelog-page.test.tsx`: 9 tests passed.
- `pnpm --dir apps/web typecheck`: passed.
- Real-assistant journey: not applicable because tool descriptions, schemas, selection, arguments, result shape, model-visible facts, prompts, and replies are unchanged. The production-shaped CLI path is the direct journey boundary for this latency-only patch.

## Non-obvious affected surfaces

- `meal nutrients` uses the same existing read seam and receives the identical bounded event-family optimization; its focused regression test proves exact summarizer equality.
- Hosted daily nutrition-share capture for the existing protein, calories, carbohydrate, fat, and fiber consent scopes also reuses `readMealNutritionTotals`. Authorization, destination, projection contents, privacy filtering, and delivery ownership are unchanged; only the underlying vault read and unrelated-family failure boundary narrow. The real-vault protein projection test proves bounded capture without meal metadata and authorized delivery, while the existing selector table covers all five nutrient projections.
- Unrelated-family parse failures no longer block a meal-only summary. Required event-family errors still propagate normally.
- The public changelog gains one content-only priority-1 item; its production archive test covers publication.

## Architecture and reuse

- Existing systems reused: `readCanonicalEntityFamilySource`, `createVaultReadModel`, and the existing macro/micronutrient summarizers remain the complete read and calculation owners.
- New logic: One local helper creates a partial read model from the canonical event family for the two meal-summary readers.
- New abstractions: None beyond that file-local helper; the existing family reader already owns lifecycle, visibility, and canonical source semantics.
- Complexity intentionally avoided: No cache, index, pagination contract, telemetry system, concurrency layer, dependency, result truncation, or duplicate reader was added.

## Hot reply path impact

- Not applicable: this tool execution happens after provider start and is outside the Foreground Reply Critical Path. It adds no database, provider, network, retry, timeout, or concurrency work and removes unrelated local file reads.

## Murph initial provider input impact

- Murph runtime: Not applicable. No instructions, tool schemas, generated guidance, or other first-request provider-visible input changed.
- Codex runtime: Not applicable. No instructions, tool schemas, generated guidance, or other first-request provider-visible input changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog copy is the sole hosted Web presentation change; the production archive component and visual language are unchanged.
- Coverage: The focused changelog page test server-rendered the authored fragment through the production archive. No responsive layout or interaction changed, so an additional screenshot adds no proof.

## Change shape

Classification rule: runtime TypeScript is source, Vitest files are tests/fixtures, and the authored changelog fragment is docs/content. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 4 |
| Tests/fixtures | 27 | 35 |
| Docs | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **53** | **39** |

## Deployment concerns

- Deployment: not applicable
- Reason: The read-only query implementation preserves its public result contract and requires no coordinated component rollout, migration, or compatibility window.

## Changelog

- Changelog: updated
- Items: 2026-08-26 · meal-summaries-load-faster

ReviewGPT context sensitivity: sensitive — this narrows a production health-data read path even though authorization and output semantics are unchanged.

ReviewGPT first-reviewed head: f3bebab61eb1aaa7acaf75b1cad4cd2459ab3089
