### PR TITLE
chore(repo): ignore generated Graft graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ apps/cloudflare/.runner.env*
 apps/cloudflare/.deploy
 .vercel
 .gstack/
+/graft/
 
 # Local staged research artifacts
 research-artifacts/

--- a/scripts/repository-generated-artifacts.test.ts
+++ b/scripts/repository-generated-artifacts.test.ts
@@ -7,12 +7,14 @@ const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 
 describe("repository-generated artifacts", () => {
   it("keeps the Graft code graph out of task diffs", () => {
-    const ignoredPath = execFileSync(
+    const ignoredRule = execFileSync(
       "git",
-      ["check-ignore", "--no-index", "graft/.graph/wiring.json"],
+      ["check-ignore", "--no-index", "--verbose", "graft/.graph/wiring.json"],
       { cwd: repositoryRoot, encoding: "utf8" },
     ).trim();
 
-    expect(ignoredPath).toBe("graft/.graph/wiring.json");
+    expect(ignoredRule).toMatch(
+      /^\.gitignore:\d+:\/graft\/\tgraft\/\.graph\/wiring\.json$/,
+    );
   });
 });

--- a/scripts/repository-generated-artifacts.test.ts
+++ b/scripts/repository-generated-artifacts.test.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+
+describe("repository-generated artifacts", () => {
+  it("keeps the Graft code graph out of task diffs", () => {
+    const ignoredPath = execFileSync(
+      "git",
+      ["check-ignore", "--no-index", "graft/.graph/wiring.json"],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    ).trim();
+
+    expect(ignoredPath).toBe("graft/.graph/wiring.json");
+  });
+});


### PR DESCRIPTION
## Outcome

Ignore Graft's repository-root generated graph so a query-triggered refresh cannot dirty a fresh task worktree, and lock that behavior with an executable repository check.

Frog autofix issue: #2354

## Product UX result

Not applicable. This changes only local repository cache hygiene and its regression proof; no member-facing behavior or interface changes.

## Evidence

- Base proof: `git check-ignore --no-index --quiet graft/.graph/wiring.json` exits 1 on the pre-repair checkout.
- Direct proof: `git check-ignore --no-index -v graft/.graph/wiring.json` resolves to the new root ignore rule; an ambient-excludes mutation fails the source-rule assertion as intended.
- Focused regression: `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/repository-generated-artifacts.test.ts` (1 passed).
- Scoped tooling lane: `pnpm test:diff .gitignore scripts/repository-generated-artifacts.test.ts` (47 files and 669 tests passed, including syntax, architecture/privacy guards, repo-tools typecheck, and dependency policy).
- `git diff --check` and the bounded credential/private-path pattern scan passed.

## Non-obvious affected surfaces

- The root Git ignore contract now owns Graft's local regenerable graph output.
- The repo-tools Vitest workspace executes the regression against Git's real ignore resolver.
- No Graft dependency, hook, shared cross-branch cache, cleanup daemon, or task-worktree lifecycle changes are introduced.

## Architecture and reuse

- Existing systems reused: Git's root ignore rules, the existing repo-tools Vitest owner, and normal worktree retirement cleanup.
- New logic: One exact root cache exclusion and one exact source-rule check-ignore assertion.
- New abstractions: None.
- Complexity intentionally avoided: No mutable shared graph across branches, wrapper, background cleanup process, or tool-specific state owner.

## Hot reply path impact

- Path status: Not applicable; assistant runtime and reply delivery are unchanged.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The diff is limited to repository-local ignore configuration and its test.

## Murph initial provider input impact

- Individual Murph: Not applicable; no provider-visible input changes.
- Group Murph: Not applicable; no provider-visible input changes.
- Measurement method: Not run because no prompt, tool schema, or provider-input owner changed.

## Change shape

Classification: test code is Tests / fixtures; the root ignore rule is Config / tooling; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 20 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 1 | 0 |
| Generated / other | 0 | 0 |
| Total | 21 | 0 |

## Deployment concerns

- Deployment: not applicable
- Reason: Repository-local generated-cache hygiene does not change any runtime or deployment boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal developer tooling only; no member-visible behavior changes.
