### PR TITLE
Warn while long database transactions are still open

### DIFF
--- a/apps/web/src/lib/hosted-privacy/account-data-service.ts
+++ b/apps/web/src/lib/hosted-privacy/account-data-service.ts
@@ -109,6 +109,7 @@ import type { HostedRunnerUserDataDeletionBestEffortResult } from "../hosted-exe
 import {
   terminateHostedUserRuntimeWorkflowBestEffort,
 } from "../hosted-orchestration/workflow-termination";
+import { runPrismaInteractiveTransaction } from "../prisma";
 import { decryptHostedWebNullableFields } from "../hosted-web/encryption";
 import {
   assertHostedPhoneCallsReadyForAccountDeletionTx,
@@ -1145,7 +1146,9 @@ async function deleteHostedAccountDataInternal(input: {
           session: phoneTransferSession,
         })
       : null;
-  const databaseDeletion: HostedAccountDeletionDatabaseResult = await input.prisma.$transaction(async (tx) => {
+  const deleteHostedAccountDataCallback = async (
+    tx: Prisma.TransactionClient,
+  ): Promise<HostedAccountDeletionDatabaseResult> => {
     if (input.phoneTransfer && phoneTransferSession) {
       await acquireHostedPrivyPhoneTransferPhoneLocksTx({
         prisma: tx,
@@ -1323,7 +1326,13 @@ async function deleteHostedAccountDataInternal(input: {
       deletedCounts,
       deletedRuntimeMemberIds: transactionDeletionMemberIds,
     };
-  }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+  };
+  const databaseDeletion = await runPrismaInteractiveTransaction(
+    input.prisma,
+    "account_deletion.database_delete",
+    deleteHostedAccountDataCallback,
+    HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+  );
   const deletedCounts = databaseDeletion.deletedCounts;
   const deletedRuntimeMemberIds = databaseDeletion.deletedRuntimeMemberIds.length > 0
     ? databaseDeletion.deletedRuntimeMemberIds
@@ -1876,7 +1885,9 @@ async function markHostedMembersSuspendedForAccountDeletion(input: {
   prisma: PrismaClient;
   providerAccessRemovalConfirmationToken: string | null;
 }): Promise<string[]> {
-  return input.prisma.$transaction(async (tx) => {
+  const suspendHostedMembersCallback = async (
+    tx: Prisma.TransactionClient,
+  ): Promise<string[]> => {
     const preparedMemberIds = uniqueStrings([
       input.ownerMemberId,
       ...await listOwnedHostedThreadContainerMemberIds({
@@ -2006,7 +2017,13 @@ async function markHostedMembersSuspendedForAccountDeletion(input: {
     // the suspended group runtime.
     await acquireHostedGroupJoinOutreachDrainLockTx(tx);
     return memberIds;
-  }, HOSTED_ACCOUNT_DELETION_SUSPENSION_FENCE_TRANSACTION_OPTIONS);
+  };
+  return runPrismaInteractiveTransaction(
+    input.prisma,
+    "account_deletion.suspension_fence",
+    suspendHostedMembersCallback,
+    HOSTED_ACCOUNT_DELETION_SUSPENSION_FENCE_TRANSACTION_OPTIONS,
+  );
 }
 
 export async function assertNoDeviceRefreshLeasesBeforeAccountSuspensionTx(

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -1,5 +1,5 @@
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, type Prisma } from "@prisma/client";
 import { attachDatabasePool } from "@vercel/functions";
 import pg, { type Pool as PgPool } from "pg";
 
@@ -27,6 +27,15 @@ const DATABASE_RETRY_MIN_DELAY_MS = 50;
 const DATABASE_RETRY_MAX_DELAY_MS = 250;
 const POOL_PRESSURE_SAMPLE_INTERVAL_MS = 10_000;
 const SLOW_TRANSACTION_MS = 5_000;
+
+export type PrismaInteractiveTransactionOperation =
+  | "account_deletion.database_delete"
+  | "account_deletion.suspension_fence";
+
+interface PrismaInteractiveTransactionOptions {
+  maxWait?: number;
+  timeout?: number;
+}
 
 /**
  * Last pressure sample per pool. Keyed by pool rather than held in a module
@@ -120,6 +129,43 @@ installHostedWebWarningFilters();
 export interface CreatePrismaClientInput {
   databaseUrl: string;
   poolMax?: number;
+}
+
+/**
+ * Adds one closed, low-cardinality label to a proven long interactive
+ * transaction without widening Prisma's public transaction signature.
+ */
+export function runPrismaInteractiveTransaction<T>(
+  prisma: PrismaClient,
+  operation: PrismaInteractiveTransactionOperation,
+  callback: (tx: Prisma.TransactionClient) => Promise<T>,
+  options?: PrismaInteractiveTransactionOptions,
+): Promise<T> {
+  const allowedOperation =
+    requirePrismaInteractiveTransactionOperation(operation);
+  const transactionTimeoutMs = resolveConfiguredTransactionTimeoutMs(
+    options?.timeout,
+  );
+  const labeledCallback = async (
+    tx: Prisma.TransactionClient,
+  ): Promise<T> => {
+    const inFlightWarningTimer =
+      scheduleDatabaseTransactionCallbackInFlightWarning(
+        allowedOperation,
+        transactionTimeoutMs,
+      );
+    try {
+      return await callback(tx);
+    } finally {
+      if (inFlightWarningTimer !== null) {
+        clearTimeout(inFlightWarningTimer);
+      }
+    }
+  };
+
+  return options
+    ? prisma.$transaction(labeledCallback, options)
+    : prisma.$transaction(labeledCallback);
 }
 
 function createPrismaPool(input: CreatePrismaClientInput): PgPool {
@@ -660,6 +706,36 @@ function reportSlowDatabaseTransactionCallback(
   );
 }
 
+function scheduleDatabaseTransactionCallbackInFlightWarning(
+  operation: PrismaInteractiveTransactionOperation,
+  timeoutMs: number,
+): ReturnType<typeof setTimeout> | null {
+  // Do not leave this diagnostic armed past an equal or earlier Prisma
+  // transaction timeout.
+  if (timeoutMs <= SLOW_TRANSACTION_MS) {
+    return null;
+  }
+
+  try {
+    return setTimeout(() => {
+      try {
+        console.warn(
+          "Hosted web database transaction callback still in flight.",
+          {
+            durationMs: SLOW_TRANSACTION_MS,
+            operation,
+            timeoutMs,
+          },
+        );
+      } catch {
+        // Diagnostic-only logging must never alter transaction ownership.
+      }
+    }, SLOW_TRANSACTION_MS);
+  } catch {
+    return null;
+  }
+}
+
 function reportSlowDatabaseBatchTransaction(
   durationMs: number,
   timeoutMs: number,
@@ -698,12 +774,34 @@ function readDatabasePoolSnapshot(pool: PgPool): DatabasePoolSnapshot {
 }
 
 function resolveTransactionTimeoutMs(args: readonly unknown[]): number {
-  const configuredTimeout = readUnknownProperty(args[1], "timeout");
+  return resolveConfiguredTransactionTimeoutMs(
+    readUnknownProperty(args[1], "timeout"),
+  );
+}
+
+function resolveConfiguredTransactionTimeoutMs(
+  configuredTimeout: unknown,
+): number {
   return typeof configuredTimeout === "number"
       && Number.isFinite(configuredTimeout)
       && configuredTimeout > 0
     ? Math.trunc(configuredTimeout)
     : PRISMA_TRANSACTION_TIMEOUT_MS;
+}
+
+function requirePrismaInteractiveTransactionOperation(
+  operation: PrismaInteractiveTransactionOperation,
+): PrismaInteractiveTransactionOperation {
+  switch (operation) {
+    case "account_deletion.database_delete":
+    case "account_deletion.suspension_fence":
+      return operation;
+    default: {
+      const unsupportedOperation: never = operation;
+      void unsupportedOperation;
+      throw new TypeError("Unsupported Prisma interactive transaction operation.");
+    }
+  }
 }
 
 function isExpiredTransactionError(error: unknown): boolean {

--- a/apps/web/test/hosted-account-data-service.test.ts
+++ b/apps/web/test/hosted-account-data-service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type HostedWebEncryptionModule =
   typeof import("@/src/lib/hosted-web/encryption");
+type PrismaModule = typeof import("@/src/lib/prisma");
 
 const serviceMocks = vi.hoisted(() => ({
   acquireHostedPrivyPhoneTransferPhoneLocksTx: vi.fn(),
@@ -50,6 +51,11 @@ const serviceMocks = vi.hoisted(() => ({
   readHostedMemberIdentity: vi.fn(),
   readHostedMemberSnapshot: vi.fn(),
   runHostedAccountDeletionCleanup: vi.fn(),
+  runPrismaInteractiveTransaction:
+    vi.fn<PrismaModule["runPrismaInteractiveTransaction"]>(),
+  runPrismaInteractiveTransactionOriginal: null as
+    | PrismaModule["runPrismaInteractiveTransaction"]
+    | null,
   assertHostedUsageCreditPurchasesReadyForAccountDeletionTx: vi.fn(),
   closeHostedUsageCreditPurchasesForAccountDeletion: vi.fn(),
   assertHostedPhoneCallsReadyForAccountDeletionTx: vi.fn(),
@@ -59,6 +65,20 @@ const serviceMocks = vi.hoisted(() => ({
   resolveDeviceProviderApplicationForConnection: vi.fn(),
   revokeStravaDeviceSyncAccess: vi.fn(),
 }));
+
+vi.mock("@/src/lib/prisma", async (importOriginal) => {
+  const original = await importOriginal<PrismaModule>();
+  serviceMocks.runPrismaInteractiveTransactionOriginal =
+    original.runPrismaInteractiveTransaction;
+  serviceMocks.runPrismaInteractiveTransaction.mockImplementation(
+    original.runPrismaInteractiveTransaction,
+  );
+  return {
+    ...original,
+    runPrismaInteractiveTransaction:
+      serviceMocks.runPrismaInteractiveTransaction,
+  };
+});
 
 vi.mock("@/src/lib/hosted-web/encryption", async (importOriginal) => {
   const original = await importOriginal<HostedWebEncryptionModule>();
@@ -424,6 +444,10 @@ const HOSTED_ACCOUNT_DELETION_ERASURE_STATEMENT_BOUND = 14;
 
 beforeEach(() => {
   vi.stubEnv("KERNEL_API_KEY", "");
+  serviceMocks.runPrismaInteractiveTransaction.mockReset();
+  serviceMocks.runPrismaInteractiveTransaction.mockImplementation(
+    serviceMocks.runPrismaInteractiveTransactionOriginal!,
+  );
   serviceMocks.acquireHostedPrivyPhoneTransferPhoneLocksTx.mockReset();
   serviceMocks.acquireHostedPrivyPhoneTransferPhoneLocksTx.mockResolvedValue(
     undefined,
@@ -833,6 +857,40 @@ describe("deleteHostedAccountData", () => {
     expect(
       serviceMocks.closeHostedUsageCreditPurchasesForAccountDeletion,
     ).not.toHaveBeenCalled();
+  });
+
+  it("labels the long callbacks without changing account-deletion transaction budgets", async () => {
+    const transactionOptions: unknown[] = [];
+    const prisma = createHostedAccountDeletionPrismaForTest({
+      onTransaction: vi.fn(),
+      transactionOptions,
+    });
+
+    await expect(deleteHostedAccountData({
+      memberId: "member_123",
+      prisma,
+      request: new Request("https://join.example.test/settings"),
+    })).resolves.toMatchObject({ memberId: "member_123" });
+
+    expect(
+      serviceMocks.runPrismaInteractiveTransaction.mock.calls.map(
+        ([, operation, , options]) => ({ operation, options }),
+      ),
+    ).toEqual([
+      {
+        operation: "account_deletion.suspension_fence",
+        options: { maxWait: 5_000, timeout: 20_000 },
+      },
+      {
+        operation: "account_deletion.database_delete",
+        options: { maxWait: 5_000 },
+      },
+    ]);
+    expect(transactionOptions).toEqual([
+      { maxWait: 5_000, timeout: 20_000 },
+      { maxWait: 5_000 },
+      { maxWait: 5_000 },
+    ]);
   });
 
   it("starts all four ordinary target reads before waiting and holds the terminal transaction", async () => {
@@ -5774,6 +5832,7 @@ function createHostedAccountDeletionPrismaForTest(input: {
   transactionFamilyClaimOwnerMemberIds?: string[];
   transactionFamilyGroups?: Array<{ id: string }>;
   transactionIdentityRecord?: Record<string, unknown> | null;
+  transactionOptions?: unknown[];
   transactionOwnedThreadContainerMemberIds?: string[];
 }): Parameters<typeof deleteHostedAccountData>[0]["prisma"] {
   let transactionCallCount = 0;
@@ -6246,9 +6305,13 @@ function createHostedAccountDeletionPrismaForTest(input: {
         return input.hostedComputerRunRows ?? [];
       },
     },
-    $transaction: async (callback: (prisma: typeof transactionPrisma) => Promise<unknown>) => {
+    $transaction: async (
+      callback: (prisma: typeof transactionPrisma) => Promise<unknown>,
+      options?: unknown,
+    ) => {
       transactionCallCount += 1;
       input.onTransaction();
+      input.transactionOptions?.push(options);
       return callback(transactionPrisma);
     },
   };

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -1,4 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
+
+import type { PrismaInteractiveTransactionOperation } from "@/src/lib/prisma";
 
 const mocks = vi.hoisted(() => {
   interface AdapterOptions {
@@ -1248,6 +1258,185 @@ describe("prisma module", () => {
     expect(pressureLogs(warn)).toEqual([]);
   });
 
+  it("warns five seconds after a labeled callback enters, not during acquisition", async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      const { getPrisma, runPrismaInteractiveTransaction } =
+        await import("@/src/lib/prisma");
+      const callbackEntered = deferred();
+      const releaseCallback = deferred();
+      mocks.transaction.mockImplementation(
+        async (callback: (tx: unknown) => unknown) => {
+          vi.advanceTimersByTime(5_000);
+          return callback({ transaction: true });
+        },
+      );
+
+      const pending = runPrismaInteractiveTransaction(
+        getPrisma(),
+        "account_deletion.database_delete",
+        async () => {
+          callbackEntered.resolve();
+          await releaseCallback.promise;
+          return "committed";
+        },
+        { timeout: 20_000 },
+      );
+      await callbackEntered.promise;
+
+      expect(inFlightTransactionLogs(warn)).toEqual([]);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(inFlightTransactionLogs(warn)).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(inFlightTransactionLogs(warn)).toEqual([{
+        durationMs: 5_000,
+        operation: "account_deletion.database_delete",
+        timeoutMs: 20_000,
+      }]);
+
+      releaseCallback.resolve();
+      await expect(pending).resolves.toBe("committed");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the in-flight timer for a fast labeled callback", async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      const { getPrisma, runPrismaInteractiveTransaction } =
+        await import("@/src/lib/prisma");
+      mocks.transaction.mockImplementation(
+        async (callback: (tx: unknown) => unknown) =>
+          callback({ transaction: true }),
+      );
+
+      await expect(runPrismaInteractiveTransaction(
+        getPrisma(),
+        "account_deletion.suspension_fence",
+        async () => "committed",
+      )).resolves.toBe("committed");
+
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(inFlightTransactionLogs(warn)).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns once while a labeled callback remains open", async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      const { getPrisma, runPrismaInteractiveTransaction } =
+        await import("@/src/lib/prisma");
+      const callbackEntered = deferred();
+      const releaseCallback = deferred();
+      mocks.transaction.mockImplementation(
+        async (callback: (tx: unknown) => unknown) =>
+          callback({ transaction: true }),
+      );
+
+      const pending = runPrismaInteractiveTransaction(
+        getPrisma(),
+        "account_deletion.suspension_fence",
+        async () => {
+          callbackEntered.resolve();
+          await releaseCallback.promise;
+          return "committed";
+        },
+        { timeout: 60_000 },
+      );
+      await callbackEntered.promise;
+
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(inFlightTransactionLogs(warn)).toEqual([{
+        durationMs: 5_000,
+        operation: "account_deletion.suspension_fence",
+        timeoutMs: 60_000,
+      }]);
+
+      releaseCallback.resolve();
+      await expect(pending).resolves.toBe("committed");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    new Error("callback rejected"),
+    Object.assign(
+      new Error("Transaction API error: Transaction already closed."),
+      { code: "P2028" },
+    ),
+  ])("clears the in-flight timer after rejection", async (error) => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://example.invalid/db?sslmode=require",
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      const { getPrisma, runPrismaInteractiveTransaction } =
+        await import("@/src/lib/prisma");
+      mocks.transaction.mockImplementation(
+        async (callback: (tx: unknown) => unknown) =>
+          callback({ transaction: true }),
+      );
+
+      await expect(runPrismaInteractiveTransaction(
+        getPrisma(),
+        "account_deletion.database_delete",
+        async () => {
+          throw error;
+        },
+      )).rejects.toBe(error);
+
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(inFlightTransactionLogs(warn)).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects arbitrary runtime labels and exposes a closed label type", async () => {
+    expectTypeOf<PrismaInteractiveTransactionOperation>().toEqualTypeOf<
+      | "account_deletion.database_delete"
+      | "account_deletion.suspension_fence"
+    >();
+    const { runPrismaInteractiveTransaction } = await import("@/src/lib/prisma");
+
+    expect(() => Reflect.apply(
+      runPrismaInteractiveTransaction,
+      undefined,
+      [null, "account_deletion.member_123", async () => undefined],
+    )).toThrowError(
+      new TypeError("Unsupported Prisma interactive transaction operation."),
+    );
+  });
+
   it("reports callback wall time separately from acquisition wait", async () => {
     process.env = {
       ...process.env,
@@ -1275,6 +1464,7 @@ describe("prisma module", () => {
         timeoutMs: 15_000,
       }]);
       expect(slowTransactionLogs(warn, "acquisition")).toEqual([]);
+      expect(inFlightTransactionLogs(warn)).toEqual([]);
     } finally {
       vi.useRealTimers();
     }
@@ -1490,6 +1680,18 @@ function failureDispositions(warn: { mock: { calls: unknown[][] } }): unknown[] 
     .map((call) => (call[1] as { disposition: unknown }).disposition);
 }
 
+function inFlightTransactionLogs(
+  warn: { mock: { calls: unknown[][] } },
+): unknown[] {
+  return warn.mock.calls
+    .filter(
+      (call) =>
+        call[0]
+        === "Hosted web database transaction callback still in flight.",
+    )
+    .map((call) => call[1]);
+}
+
 function slowTransactionLogs(
   warn: { mock: { calls: unknown[][] } },
   category: "acquisition" | "batch" | "callback",
@@ -1501,6 +1703,15 @@ function slowTransactionLogs(
         : `transaction ${category}`}.`,
     )
     .map((call) => call[1]);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = () => resolvePromise();
+  });
+
+  return { promise, resolve };
 }
 
 

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -1302,6 +1302,12 @@ describe("prisma module", () => {
 
       releaseCallback.resolve();
       await expect(pending).resolves.toBe("committed");
+      expect(slowTransactionLogs(warn, "callback")).toEqual([{
+        callbackOutcome: "completed",
+        durationMs: 5_000,
+        operation: "transaction.interactive",
+        timeoutMs: 20_000,
+      }]);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Outcome

Adds a one-shot warning when either proven long account-deletion transaction callback remains open for five seconds, while preserving existing completion-time slow-transaction telemetry.

## Product UX result

No user-facing behavior changes. Operators gain attribution before an unusually long transaction finishes or times out.

## Direct evidence

- Prisma instrumentation and account-data service suites on the candidate head: 189 passed.
- The isolated specialist test patch proves operation labels remain paired with the existing timeout budgets and that the completion log still follows the five-second in-flight warning.
- Web TypeScript check on the reviewed production patch: passed.
- ESLint on all changed files: passed.
- `git diff --check` and privacy scan: passed.
- Final ReviewGPT full-patch round: PASS at `c130456b359b4f01d7b939848d55e76d95ebeba3`; the only later change is the accepted, behavior-preserving specialist test patch.

## Non-obvious affected surfaces

Only account-deletion database-delete and suspension-fence transactions receive labels. Transaction options, lock order, return values, retry behavior, and provider ownership are unchanged.

## Architecture and reuse

- Existing systems reused: the existing Prisma instrumentation owner and account-deletion transaction helper.
- New logic: one typed helper emits a one-shot in-flight warning and preserves the existing completion warning.
- New abstractions: none beyond the narrow typed helper and closed two-value label union.
- Complexity intentionally avoided: no new state, registry, service, schema, dependency, queue, retry, or background work.

## Hot reply path impact

None.

## Provider-input impact

None.

## Deployment concerns

- Deployment: applicable

- Supported skew: old and new Vercel Web instances can overlap safely; telemetry is additive and does not change transaction behavior.
- Safe order: deploy Web normally; no Cloudflare, schema, environment, or tandem rollout is required.
- Rollback floor: revert or redeploy the prior Web build directly.
- Expected exposure: operator logs only; no member-visible state changes.
- Reversibility: complete because no persisted state or schema changes are introduced.
- Convergence proof: each process emits telemetry according to its own deployed code and naturally converges when rollout completes.
- Post-deploy checks: verify the merged commit is active in Vercel and confirm labeled in-flight/completion events retain operation and timeout fields.

## Changelog

- Changelog: not applicable
- Reason: Operator-only telemetry with no member-visible behavior change.

## LOC

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 121 | 6 |
| Tests/fixtures | 282 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **403** | **8** |

ReviewGPT context sensitivity: sensitive
ReviewGPT context reason: production database transaction telemetry and account-deletion paths.
ReviewGPT first-reviewed head: c130456b359b4f01d7b939848d55e76d95ebeba3



