### PR TITLE
fix(review): package assistant verification contract

### DIFF
--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -4628,6 +4628,11 @@ printf 'ZIP: %s (%s bytes)\n' \
         'agent-docs/operations/product-ux.md',
         'product UX workflow\n',
       )
+      writeHarnessFile(
+        harnessRoot,
+        '.agents/skills/verify-murph-assistant/SKILL.md',
+        'assistant verification workflow\n',
+      )
       writeHarnessFile(harnessRoot, 'PRODUCT.md', 'product guidance\n')
       writeHarnessFile(harnessRoot, 'DESIGN.md', 'design guidance\n')
       execFileSync('git', ['add', '.'], { cwd: harnessRoot })
@@ -4822,6 +4827,7 @@ printf 'ZIP: %s (%s bytes)\n' \
           'agent-docs/prompts/frontend-review.md',
           '.crabbox.yaml',
           'agent-docs/prompts/coverage-write.md',
+          '.agents/skills/verify-murph-assistant/SKILL.md',
           packagedEvidencePath,
           supplementalSkillPath,
           supplementalProofPath,

--- a/scripts/package-audit-context-full.sh
+++ b/scripts/package-audit-context-full.sh
@@ -453,7 +453,7 @@ if [[ -n "$review_gpt_pr_ref" ]]; then
       printf '  "currentReviewedHead": "%s"\n' "$review_gpt_head_oid"
       printf '}\n'
     } > "$review_gpt_pr_context_dir/review-phase.json"
-    COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS="${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"$'\n'"$review_gpt_pr_context_dir/review-phase.json"$'\n'"agent-docs/FRONTEND.md"$'\n'"PRODUCT.md"$'\n'"DESIGN.md"$'\n'"agent-docs/operations/product-ux.md"$'\n'"agent-docs/prompts/prompt-review.md"$'\n'"agent-docs/prompts/frontend-review.md"$'\n'"agent-docs/prompts/coverage-write.md"
+    COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS="${COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS:-}"$'\n'"$review_gpt_pr_context_dir/review-phase.json"$'\n'"agent-docs/FRONTEND.md"$'\n'"PRODUCT.md"$'\n'"DESIGN.md"$'\n'"agent-docs/operations/product-ux.md"$'\n'"agent-docs/prompts/prompt-review.md"$'\n'"agent-docs/prompts/frontend-review.md"$'\n'"agent-docs/prompts/coverage-write.md"$'\n'".agents/skills/verify-murph-assistant/SKILL.md"
   else
     review_gpt_require_available_commit "first-reviewed head" "$review_gpt_first_reviewed_head"
     review_gpt_require_available_commit "context anchor head" "$review_gpt_context_anchor_head"


### PR DESCRIPTION
## Why and outcome

Preliminary ReviewGPT packages omitted the tracked assistant-verification skill because `.agents/**` is outside the ordinary audit scan roots. Include that existing skill in every preliminary specialist archive so assistant-behavior reviews can apply the repository-required verification contract without caller-specific overrides.

Frog autofix issue: #2364

## Product UX

- Effort: Not applicable — internal review tooling only.
- Result: Not applicable.
- Walkthrough: No member-facing journey, copy, or interface changes.

## Evidence

- `bash -n scripts/package-audit-context-full.sh` (passed)
- Focused package-manifest regression first failed on the missing skill and now passes.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/review-gpt-package-concurrency.test.ts` (4 passed)
- `pnpm --dir packages/cli typecheck` (passed)

## Non-obvious affected surfaces

- Preliminary `completion-specialists` `codebase.zip` composition now includes the tracked assistant-verification skill.
- Final ReviewGPT packet composition and review-phase metadata are unchanged.

## Architecture and reuse

- Existing systems reused: The existing preliminary always-include list and tracked assistant-verification skill remain the sole owners.
- New logic: One preliminary-only archive entry makes the required skill available to the reviewer.
- New abstractions: None; the existing packager and manifest test are sufficient.
- Complexity intentionally avoided: No lens detector, environment override, second packet builder, or duplicated verification guidance.

## Hot reply path impact

- Path status: Not applicable — review packaging does not change conversation acceptance, provider start, or durable reply handoff.
- Database calls: None.
- Network/provider calls: None in Murph runtime.
- Other awaited latency: None in Murph runtime.
- Before/after proof: The focused ZIP-manifest regression covers the only changed path.

## Murph initial provider input impact

- Individual Murph: Not applicable — Murph prompt, tools, and provider-visible request assembly are unchanged.
- Group Murph: Not applicable — Murph prompt, tools, and provider-visible request assembly are unchanged.
- Measurement method: Not run because the diff affects only ReviewGPT archive composition.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 6 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 1 | 1 |
| Generated / other | 0 | 0 |
| Total | 7 | 1 |

Classification rule: the shell packager is repository tooling; the Vitest harness change is test coverage. No binaries or generated files changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal review tooling does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal review tooling only; no member-visible behavior changed.
