### PR TITLE
Fix Codex token usage compatibility

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-26-codex-01491-token-usage.md
+++ b/agent-docs/exec-plans/active/2026-08-26-codex-01491-token-usage.md
@@ -21,12 +21,14 @@ Updated: 2026-08-26
   fail closed.
 - A raw protocol event with both omissions reaches downstream provider-usage
   extraction with exact non-null counters.
+- The same current-shape event updates parent-thread vitals and reaches the
+  existing bounded idle-compaction owner without duplicate compact requests.
 - Focused tests, package typecheck, required review gates, and exact-head CI pass.
 
 ## Scope
 
 - In scope: the shared Codex App Server token-usage reader and deterministic
-  Assistant Engine protocol/accounting regressions.
+  Assistant Engine protocol, accounting, and warm-process regressions.
 - Out of scope: changing usage pricing, allowance policy, persistence schemas,
   Codex dependency versions, or unrelated protocol readers.
 
@@ -48,6 +50,11 @@ Updated: 2026-08-26
    and mask a regression again.
    Mitigation: stop synthesizing those optional fields in the shared fixture
    helper and add a raw extraction regression that bypasses fixture completion.
+3. Risk: accepting the valid event also restores warm parent-thread vitals, so
+   hosted idle maintenance can invoke its existing provider compaction path.
+   Mitigation: remove the process harness's synthetic context-window field and
+   prove one bounded compaction request with preserved usage attribution; keep
+   the existing single-record hosted maintenance proof.
 
 ## Tasks
 
@@ -57,7 +64,8 @@ Updated: 2026-08-26
 3. Replace the brittle complete-shape assertion with table-driven required,
    optional, invalid, and additive-field protocol coverage.
 4. Add raw downstream usage-extraction proof and run focused verification.
-5. Complete ReviewGPT, CI, parent review, plan closure, and scoped commit.
+5. Prove the restored warm-thread-vitals path reaches one bounded idle compact.
+6. Complete ReviewGPT, CI, parent review, plan closure, and scoped commit.
 
 ## Decisions
 

--- a/agent-docs/exec-plans/active/2026-08-26-codex-01491-token-usage.md
+++ b/agent-docs/exec-plans/active/2026-08-26-codex-01491-token-usage.md
@@ -1,0 +1,74 @@
+# Accept Codex 0.149.1 token usage shape
+
+Status: active
+Created: 2026-08-26
+Updated: 2026-08-26
+
+## Goal
+
+- Preserve valid Codex App Server token-usage events so Murph records accurate
+  usage, allowance, cost, and billing inputs when upstream omits defaulted or
+  optional fields.
+
+## Success criteria
+
+- The current Codex 0.149.1 token-usage shape is accepted.
+- Omitted `cacheWriteInputTokens` values normalize to `0` in both `last` and
+  `total` usage.
+- An omitted or explicit-null `modelContextWindow` normalizes to `null`.
+- Additive upstream fields do not discard otherwise valid known usage.
+- Missing or invalid required counters and invalid known optional fields still
+  fail closed.
+- A raw protocol event with both omissions reaches downstream provider-usage
+  extraction with exact non-null counters.
+- Focused tests, package typecheck, required review gates, and exact-head CI pass.
+
+## Scope
+
+- In scope: the shared Codex App Server token-usage reader and deterministic
+  Assistant Engine protocol/accounting regressions.
+- Out of scope: changing usage pricing, allowance policy, persistence schemas,
+  Codex dependency versions, or unrelated protocol readers.
+
+## Constraints
+
+- Technical constraints: keep one normalized internal shape for every existing
+  root-turn, profile, and subagent consumer; ignore only additive fields while
+  validating every known consumed field.
+- Product/process constraints: smallest owner-boundary fix, no new dependency,
+  state owner, compatibility service, or duplicated upstream schema mechanism.
+
+## Risks and mitigations
+
+1. Risk: permissive parsing could admit malformed accounting values.
+   Mitigation: required counters remain exact non-negative safe integers, and a
+   present known optional field must also be a non-negative safe integer or null
+   where upstream permits null.
+2. Risk: compact test fixtures could silently fill the omitted upstream fields
+   and mask a regression again.
+   Mitigation: stop synthesizing those optional fields in the shared fixture
+   helper and add a raw extraction regression that bypasses fixture completion.
+
+## Tasks
+
+1. Prove the current reader rejects the pinned upstream schema shape.
+2. Normalize omitted optional/defaulted fields at the shared protocol boundary
+   while tolerating additive payload fields.
+3. Replace the brittle complete-shape assertion with table-driven required,
+   optional, invalid, and additive-field protocol coverage.
+4. Add raw downstream usage-extraction proof and run focused verification.
+5. Complete ReviewGPT, CI, parent review, plan closure, and scoped commit.
+
+## Decisions
+
+- Keep strict JSON-RPC envelope validation unchanged; only payload-specific
+  token-usage readers become additive-field tolerant.
+- Do not add an upgrade-specific schema service or network test. The reader's
+  consumed-field contract is version-agnostic for additive upstream evolution.
+
+## Verification
+
+- Commands to run: focused Assistant Engine Vitest files, Assistant Engine
+  typecheck, diff checks, required PR review gates, and exact-head CI.
+- Expected outcomes: current-shape events normalize deterministically, malformed
+  known fields remain rejected, downstream usage is non-null, and all checks pass.

--- a/agent-docs/exec-plans/completed/2026-08-26-codex-01491-token-usage.md
+++ b/agent-docs/exec-plans/completed/2026-08-26-codex-01491-token-usage.md
@@ -1,8 +1,8 @@
 # Accept Codex 0.149.1 token usage shape
 
-Status: active
+Status: completed
 Created: 2026-08-26
-Updated: 2026-08-26
+Updated: 2026-08-27
 
 ## Goal
 
@@ -80,3 +80,4 @@ Updated: 2026-08-26
   typecheck, diff checks, required PR review gates, and exact-head CI.
 - Expected outcomes: current-shape events normalize deterministically, malformed
   known fields remain rejected, downstream usage is non-null, and all checks pass.
+Completed: 2026-08-27

--- a/packages/assistant-engine/src/assistant-codex/app-server-protocol.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-protocol.ts
@@ -156,20 +156,13 @@ export function readCodexTokenUsageBreakdown(
   value: unknown,
 ): CodexTokenUsageBreakdown | null {
   const usage = readCodexRecord(value)
-  if (!usage || !hasOnlyOwn(usage, [
-    'cacheWriteInputTokens',
-    'cachedInputTokens',
-    'inputTokens',
-    'outputTokens',
-    'reasoningOutputTokens',
-    'totalTokens',
-  ])) {
+  if (!usage) {
     return null
   }
 
-  const cacheWriteInputTokens = readCodexNonNegativeInteger(
-    usage.cacheWriteInputTokens,
-  )
+  const cacheWriteInputTokens = Object.hasOwn(usage, 'cacheWriteInputTokens')
+    ? readCodexNonNegativeInteger(usage.cacheWriteInputTokens)
+    : 0
   const cachedInputTokens = readCodexNonNegativeInteger(usage.cachedInputTokens)
   const inputTokens = readCodexNonNegativeInteger(usage.inputTokens)
   const outputTokens = readCodexNonNegativeInteger(usage.outputTokens)
@@ -203,20 +196,24 @@ export function readCodexThreadTokenUsage(
   value: unknown,
 ): CodexThreadTokenUsage | null {
   const usage = readCodexRecord(value)
-  if (!usage || !hasOnlyOwn(usage, ['last', 'modelContextWindow', 'total'])) {
+  if (!usage) {
     return null
   }
 
   const last = readCodexTokenUsageBreakdown(usage.last)
   const total = readCodexTokenUsageBreakdown(usage.total)
-  const modelContextWindow = usage.modelContextWindow === null
+  const hasModelContextWindow = Object.hasOwn(usage, 'modelContextWindow')
+  const modelContextWindow = !hasModelContextWindow
+    || usage.modelContextWindow === null
     ? null
     : readCodexNonNegativeInteger(usage.modelContextWindow)
 
   if (
     !last ||
     !total ||
-    (modelContextWindow === null && usage.modelContextWindow !== null)
+    (hasModelContextWindow &&
+      modelContextWindow === null &&
+      usage.modelContextWindow !== null)
   ) {
     return null
   }

--- a/packages/assistant-engine/test/app-server-protocol.test.ts
+++ b/packages/assistant-engine/test/app-server-protocol.test.ts
@@ -19,6 +19,14 @@ const usage = {
   totalTokens: 18,
 }
 
+const minimumUsage = {
+  cachedInputTokens: 5,
+  inputTokens: 11,
+  outputTokens: 7,
+  reasoningOutputTokens: 2,
+  totalTokens: 18,
+}
+
 describe('Codex app-server protocol boundary', () => {
   it.each([
     {
@@ -117,7 +125,7 @@ describe('Codex app-server protocol boundary', () => {
     expect(readCodexRpcResponseId({ id: -7, result: {} })).toBe(-7)
   })
 
-  it('requires the complete pinned token-usage shape', () => {
+  it('accepts explicitly present token-usage optional fields', () => {
     expect(readCodexThreadTokenUsage({
       last: usage,
       modelContextWindow: 200_000,
@@ -127,11 +135,102 @@ describe('Codex app-server protocol boundary', () => {
       modelContextWindow: 200_000,
       total: usage,
     })
+  })
+
+  it('normalizes the current upstream minimum token-usage shape', () => {
     expect(readCodexThreadTokenUsage({
-      last: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      modelContextWindow: 200_000,
-      total: usage,
+      last: minimumUsage,
+      total: minimumUsage,
+    })).toEqual({
+      last: {
+        cacheWriteInputTokens: 0,
+        ...minimumUsage,
+      },
+      modelContextWindow: null,
+      total: {
+        cacheWriteInputTokens: 0,
+        ...minimumUsage,
+      },
+    })
+  })
+
+  it('ignores additive token-usage fields without dropping known counters', () => {
+    expect(readCodexThreadTokenUsage({
+      futureUsageMetadata: { source: 'future-codex' },
+      last: {
+        ...minimumUsage,
+        futureInputTokens: 13,
+      },
+      modelContextWindow: null,
+      total: {
+        ...minimumUsage,
+        futureInputTokens: 21,
+      },
+    })).toEqual({
+      last: {
+        cacheWriteInputTokens: 0,
+        ...minimumUsage,
+      },
+      modelContextWindow: null,
+      total: {
+        cacheWriteInputTokens: 0,
+        ...minimumUsage,
+      },
+    })
+  })
+
+  it.each([
+    'cachedInputTokens',
+    'inputTokens',
+    'outputTokens',
+    'reasoningOutputTokens',
+    'totalTokens',
+  ])('rejects a missing required %s counter in either breakdown', (field) => {
+    const incompleteLast: Record<string, unknown> = { ...minimumUsage }
+    delete incompleteLast[field]
+    expect(readCodexThreadTokenUsage({
+      last: incompleteLast,
+      total: minimumUsage,
     })).toBeNull()
+
+    const incompleteTotal: Record<string, unknown> = { ...minimumUsage }
+    delete incompleteTotal[field]
+    expect(readCodexThreadTokenUsage({
+      last: minimumUsage,
+      total: incompleteTotal,
+    })).toBeNull()
+  })
+
+  it.each([null, -1, 1.5, '3'])(
+    'rejects invalid explicit cache-write token value %j',
+    (cacheWriteInputTokens) => {
+      expect(readCodexThreadTokenUsage({
+        last: { ...minimumUsage, cacheWriteInputTokens },
+        total: minimumUsage,
+      })).toBeNull()
+      expect(readCodexThreadTokenUsage({
+        last: minimumUsage,
+        total: { ...minimumUsage, cacheWriteInputTokens },
+      })).toBeNull()
+    },
+  )
+
+  it.each([undefined, -1, 1.5, '200000'])(
+    'rejects invalid explicit context-window value %j',
+    (modelContextWindow) => {
+      expect(readCodexThreadTokenUsage({
+        last: minimumUsage,
+        modelContextWindow,
+        total: minimumUsage,
+      })).toBeNull()
+    },
+  )
+
+  it.each([
+    { total: minimumUsage },
+    { last: minimumUsage },
+  ])('rejects a missing required token-usage breakdown %#', (tokenUsage) => {
+    expect(readCodexThreadTokenUsage(tokenUsage)).toBeNull()
   })
 
   it.each(['', ' ', 'not-json', '[]', 'null'])('rejects invalid line %j', (line) => {

--- a/packages/assistant-engine/test/assistant-codex-runtime-process.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-process.test.ts
@@ -2350,14 +2350,16 @@ describe('assistant codex runtime', () => {it('coalesces process-only preinitial
     },
   )
 
-  it('uses-the-lower-group-threshold and preserves pre-compaction usage attribution', async () => {
+  it('compacts current-shape group usage and preserves pre-compaction attribution', async () => {
     const workingDirectory = await createTempDir('assistant-codex-compact-provider-usage-work-')
     const codexHome = await createTempDir('assistant-codex-compact-provider-usage-home-')
     const threadId = 'thread-compact-provider-usage'
     const turnId = 'turn-compact-provider-usage'
+    const spawnedChildren: MockChildProcess[] = []
 
     codexMocks.spawn.mockImplementation(() => {
       const child = new MockChildProcess()
+      spawnedChildren.push(child)
 
       queueMicrotask(() => {
         void (async () => {
@@ -2376,19 +2378,18 @@ describe('assistant codex runtime', () => {it('coalesces process-only preinitial
               threadId,
               turnId,
               tokenUsage: {
-                last: { cacheWriteInputTokens: 0, reasoningOutputTokens: 0,
+                last: { reasoningOutputTokens: 0,
                   cachedInputTokens: 25_000,
                   inputTokens: 50_000,
                   outputTokens: 12,
                   totalTokens: 50_012,
                 },
-                total: { cacheWriteInputTokens: 0, reasoningOutputTokens: 0,
+                total: { reasoningOutputTokens: 0,
                   cachedInputTokens: 25_000,
                   inputTokens: 50_000,
                   outputTokens: 12,
                   totalTokens: 50_012,
                 },
-                modelContextWindow: 128_000,
               },
             },
           }))
@@ -2518,6 +2519,11 @@ describe('assistant codex runtime', () => {it('coalesces process-only preinitial
         totalTokens: 50_000,
       },
     })
+    expect(
+      readWrittenRpcMessages(
+        requireMockChildProcess(spawnedChildren[0] ?? null),
+      ).filter((message) => message.method === 'thread/compact/start'),
+    ).toHaveLength(1)
   })
 
   it('uses the pre-compaction estimate when the exact completion has no billing payload', async () => {

--- a/packages/assistant-engine/test/assistant-codex-runtime.harness.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime.harness.ts
@@ -871,8 +871,8 @@ class MockStdout extends PassThrough {
             params: {
               ...params,
               tokenUsage: {
+                ...tokenUsage,
                 last,
-                modelContextWindow: tokenUsage.modelContextWindow ?? null,
                 total: tokenUsage.total ?? last,
               },
             },

--- a/packages/assistant-engine/test/codex-runtime-helpers.test.ts
+++ b/packages/assistant-engine/test/codex-runtime-helpers.test.ts
@@ -156,7 +156,6 @@ function completeTestCodexProtocolEvents(
       params: {
         ...completedParams,
         tokenUsage: {
-          modelContextWindow: null,
           ...tokenUsage,
           last,
           total,
@@ -191,7 +190,6 @@ function completeTestTokenUsageBreakdown(
     : 0
   return breakdown
     ? {
-        cacheWriteInputTokens: 0,
         cachedInputTokens: 0,
         inputTokens,
         outputTokens,
@@ -440,6 +438,81 @@ describe('Codex assistant registry helpers', () => {
       servedModel: 'codex-mini',
       tokenPricingBasis: 'standard',
       totalTokens: null,
+    })
+  })
+
+  it('retains raw current-shape token usage with optional fields omitted', () => {
+    const extracted = extractExactCodexAssistantProviderUsage({
+      providerConfig: normalizeAssistantProviderConfig({
+        provider: 'codex-cli',
+        model: 'gpt-5.4',
+        modelProvider: 'openai',
+        oss: false,
+      }),
+      rawEvents: [
+        {
+          method: 'turn/started',
+          params: {
+            turn: { id: 'turn-current-token-usage-shape' },
+          },
+        },
+        {
+          method: 'thread/tokenUsage/updated',
+          params: {
+            threadId: 'thread-current-token-usage-shape',
+            tokenUsage: {
+              last: {
+                cachedInputTokens: 7,
+                inputTokens: 41,
+                outputTokens: 11,
+                reasoningOutputTokens: 3,
+                totalTokens: 52,
+              },
+              total: {
+                cachedInputTokens: 7,
+                inputTokens: 41,
+                outputTokens: 11,
+                reasoningOutputTokens: 3,
+                totalTokens: 52,
+              },
+            },
+            turnId: 'turn-current-token-usage-shape',
+          },
+        },
+        {
+          method: 'turn/completed',
+          params: {
+            turn: {
+              id: 'turn-current-token-usage-shape',
+              model: 'gpt-5.4',
+            },
+          },
+        },
+      ],
+    })
+
+    expect(extracted).toMatchObject({
+      cacheWriteTokens: 0,
+      cachedInputTokens: 7,
+      inputTokens: 41,
+      outputTokens: 11,
+      providerRequestId: 'turn-current-token-usage-shape',
+      rawUsageJson: {
+        cacheWriteInputTokens: 0,
+        cachedInputTokens: 7,
+        inputTokens: 41,
+        outputTokens: 11,
+        reasoningOutputTokens: 3,
+        totalTokens: 52,
+      },
+      reasoningTokens: 3,
+      totalTokens: 52,
+      turnProfileJson: {
+        modelContextWindow: null,
+        requestCount: 1,
+        requests: [{ cachedInput: 7, input: 41, output: 11 }],
+      },
+      usageExtractionSourcePath: 'thread.tokenUsage.total.delta',
     })
   })
 


### PR DESCRIPTION
## Why and outcome

Codex App Server 0.149.1 can omit `cacheWriteInputTokens` and `modelContextWindow`, but Murph's exact-shape reader treated both as mandatory and discarded the entire otherwise-valid usage event.

This change normalizes omitted cache-write tokens to `0`, normalizes an omitted context window to `null`, and ignores additive upstream fields while still rejecting missing required counters or malformed known fields.

## Product UX

Effort: Patch. Walkthrough result: Ready. Members whose valid Codex usage events omit documented optional fields retain accurate usage, allowance, and cost inputs; at the existing idle threshold, the same event also restores the existing bounded warm-thread compaction path. No UI, copy, new policy, or new journey is introduced. The shared compaction consumer was added to proof and disclosure after review; production behavior remains owned by the existing protocol boundary and idle-maintenance owner.

## Evidence

- Pre-fix direct reproduction: the current upstream minimum `ThreadTokenUsage` shape returned `null` from the shared reader.
- Upstream contract: Codex 0.149.1 requires `last` and `total`, makes `modelContextWindow` optional, and defaults omitted `cacheWriteInputTokens` to zero.
- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/app-server-protocol.test.ts` — 48/48 passed.
- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/codex-runtime-helpers.test.ts` — 81/81 passed.
- Focused raw current-shape extraction regression — 1/1 passed.
- Full process-level warm-thread/compaction suite — 41/41 passed, including the exact omitted-field event and exactly one compact request.
- Focused hosted idle-maintenance usage-recording proof — 1/1 passed with exactly one `assistant_idle_compact` record.
- `pnpm --dir packages/assistant-engine typecheck` — passed on the final code.
- `git diff --check` — passed.

## Non-obvious affected surfaces

- Root-turn usage totals, turn profiles, and subagent usage all reuse this protocol reader; the raw extraction regression and full helper suite prove the normalized event reaches the shared accounting extractor.
- Warm parent-thread vitals reuse the same reader. At the existing hosted idle threshold, accepting the valid event can issue the existing bounded `thread/compact/start`, mutate the provider-native thread before checkpointing, and record separately attributed `assistant_idle_compact` usage. The process suite proves one request and preserved attribution; hosted idle-maintenance coverage proves one usage record.
- Hosted Cloudflare, CLI, and assistant-runtime consumers reuse `@murphai/assistant-engine`; no pricing policy, allowance policy, persistence schema, or provider-input assembly changes.

## Architecture and reuse

- **Existing systems reused:** The existing Codex protocol normalization boundary, provider-usage extractor, warm-thread-vitals owner, idle-compaction owner, and maintenance usage recorder remain the single owners.
- **New logic:** Two omitted upstream fields receive their documented neutral defaults, and unknown additive payload fields are ignored after known fields validate.
- **New abstractions:** None; the existing record and non-negative-integer readers are sufficient.
- **Complexity intentionally avoided:** No Codex-version branching, copied upstream schema, compatibility service, dependency, or alternate accounting path.

## Hot reply path impact

Not applicable: the change parses token-usage notifications after provider execution and adds no database, network, provider, or other awaited operation to the Foreground Reply Critical Path. The restored compaction consumer runs only in existing off-turn idle maintenance.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool/schema, generated guidance, or request assembly changed.
- Codex runtime: Not applicable; only provider output parsing changed, so the first provider-visible request is unchanged.

## Change-shape breakdown

Classification rule: production TypeScript is source; Vitest files are tests/fixtures; the execution plan is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 11 | 14 |
| Tests/fixtures | 189 | 11 |
| Docs | 83 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **283** | **25** |

## Risks

- Billing/accounting correctness: required consumed counters remain non-negative safe integers, and explicitly present optional fields must remain valid; only documented omissions receive neutral defaults.
- Forward compatibility: additive fields cannot alter normalized known counters, while removal or corruption of a required counter still fails closed rather than silently undercounting.
- Provider effect: restoring parent-thread vitals can activate the pre-existing idle compaction RPC and mutate Codex rollout state before checkpointing. Existing threshold, single-owner reservation, timeout/teardown, checkpoint, and separate usage-accounting behavior are unchanged and covered at their owning seams.

## Deployment concerns

- Deployment: applicable
- Supported skew: New readers accept both the earlier complete shape and the current omitted-field shape; old readers may still drop current-shape events.
- Safe order: Deploy the updated hosted runner/Assistant Engine bundle; no coordinated Web or database deployment is required. Replace or drain warm old runner instances afterward.
- Rollback floor: No schema or persisted-state migration constrains rollback, but reverting restores the known undercount for current Codex events.
- Expected exposure: Mixed runner versions can continue dropping affected events only on old instances during the rollout window.
- Reversibility: Revert the reader code independently; no data rollback is required, with the accounting-loss caveat above.
- Convergence proof: Confirm active hosted runner instances report the candidate version and no older warm instances remain.
- Post-deploy checks: Inspect bounded, identifier-free usage-event acceptance and accounting aggregates for missing-event anomalies, plus idle-compaction outcome and usage-record counts for unexpected duplication or failure.

## Changelog

- Changelog: not applicable
- Reason: This is an internal provider compatibility and accounting-correctness fix with no new member-facing feature, UI, or copy.

ReviewGPT context sensitivity: sensitive — the parser feeds billing and allowance accounting across hosted and local execution surfaces.

ReviewGPT first-reviewed head: b118e928f29965297ba77bc93e31462336087866
