### PR TITLE
Add Stripe reconciliation error telemetry

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-27-stripe-reconciliation-error-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-27-stripe-reconciliation-error-telemetry.md
@@ -1,0 +1,87 @@
+# Stripe reconciliation error telemetry
+
+## Goal
+
+Make the next failed or poisoned hosted Stripe receipt diagnosable from existing
+production logs by retaining a privacy-safe processing stage plus the complete
+available safe error classification (name, stable code, Stripe type/code/status,
+and opaque request correlation when present).
+
+Success means the existing reconciliation failure log answers which coarse
+owner stage failed and what bounded error class/code was available, without
+changing billing behavior, retries, receipt state, provider calls, alerting,
+storage, or control flow.
+
+## Scope
+
+- Reuse the Web-owned hosted Stripe reconciliation log and existing Stripe-safe
+  error-field parser.
+- Add focused tests that prove typed fields and sanitization for representative
+  plain, coded, Stripe-provider, and wrapped failures.
+- Update the owning observability/runtime contract only if the new field schema
+  needs durable documentation.
+- Do not add a migration, new backend, metric, alert, queue, scheduler, retry,
+  replay path, or production mutation.
+- Do not touch device-sync code or surfaces.
+
+## Evidence and question
+
+- Four retained `customer.subscription.deleted` receipts from July 23–28 were
+  poisoned with the generic durable code `Error`; provider retention had already
+  expired for three when investigated.
+- Current code derives the durable code from `error.code` or `error.name`, and
+  the reconciliation-level log emits Prisma detail but otherwise only a
+  sanitized message. It does not include the safe Stripe fields already exposed
+  by `stripe-error-log.ts`, nor a reconciliation stage.
+- Exact question for later production evidence: for each new failed/poisoned
+  receipt, which coarse reconciliation stage failed, and what safe error name,
+  stable code, Stripe type/code/status, or request correlation was available?
+- Competing hypotheses to distinguish include provider event retrieval,
+  event/domain application, post-commit side-effect cleanup, and receipt
+  finalization failures.
+
+## Constraints
+
+- ReviewGPT authors all production telemetry code and its focused tests. The
+  parent inspects and applies an accepted patch exactly.
+- Typed fields must be low-cardinality. Stage values are a closed vocabulary;
+  error tokens use existing validation and length bounds; opaque request IDs
+  remain correlation metadata only.
+- Never log payloads, messages/prompts/transcripts, customer/member/contact IDs,
+  checkout contents, health values, raw errors, stacks, credentials, URLs,
+  paths, or unsanitized provider messages.
+- Emit once through the existing reconciliation failure log only; no added
+  success-path volume or database load.
+- Preserve existing retry, poison, alert, persistence, provider, and user-visible
+  behavior exactly.
+
+## Deduplication
+
+- Open PR #2383 modifies the same reconciliation file for payment-notification
+  email but does not own error telemetry. Keep this patch additive and
+  conflict-minimal; do not edit or co-author its branch.
+- No open issue, PR, recent merge, active task, or device-sync lane was found to
+  own this telemetry question.
+
+## Tasks
+
+1. Obtain a scoped attachment patch from ReviewGPT against current `origin/main`.
+2. Inspect privacy, security, cardinality, volume, runtime overhead, control-flow
+   neutrality, file overlap, and exact question coverage before applying it.
+3. Run focused Stripe reconciliation/logging tests, Web typecheck, privacy/log
+   guards, billing/provider guards, and required completion audits.
+4. Commit and push a draft PR, run preliminary and final exact-head ReviewGPT
+   gates concurrently with CI, and resolve every accepted finding.
+5. If every telemetry-only autonomous-merge condition is proven, merge through
+   the protected path and verify the deployed Web revision read-only. Otherwise
+   leave the PR ready and report the exact human action.
+
+## Later verification query
+
+In the next bounded production sweep, query Vercel production logs for the exact
+message `Hosted Stripe event reconciliation failed.` over the latest two hours,
+aggregate only the typed `stage`, `errorName`, `errorCode`, `stripeType`,
+`stripeCode`, and `stripeStatusCode` fields, and compare with failed/poisoned
+receipt counts and event types from `hosted_stripe_event`. Use the opaque request
+ID only for one narrow Stripe CLI retrieve when needed; never report the raw ID.
+

--- a/agent-docs/exec-plans/completed/2026-08-27-stripe-reconciliation-error-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-stripe-reconciliation-error-telemetry.md
@@ -85,3 +85,25 @@ aggregate only the typed `stage`, `errorName`, `errorCode`, `stripeType`,
 receipt counts and event types from `hosted_stripe_event`. Use the opaque request
 ID only for one narrow Stripe CLI retrieve when needed; never report the raw ID.
 
+## Outcome
+
+- ReviewGPT authored the accepted production implementation and focused tests.
+  The implementation adds four closed processing stages plus bounded safe error
+  classification to the existing failure-only log and changes no persistence,
+  retry, poison, provider, alert, billing, or user-visible behavior.
+- Focused reconciliation proof passed with 87 tests, including every stage,
+  direct and one-level provider classification, sanitization and exclusion of
+  raw payload data, and the accepted specialist regression for hostile error
+  metadata. Web typecheck, targeted lint, logging/privacy guards, hosted billing
+  and provider-request guards, and diff hygiene also passed.
+- Preliminary ReviewGPT accepted one test-only coverage finding for a throwing
+  `cause` getter combined with an unsafe overlong error name. The exact
+  ReviewGPT-authored regression test was applied and passed.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` on the complete
+  production patch with no qualifying finding.
+- PR #2409 owns the telemetry boundary. Production convergence and the later
+  natural-traffic query remain deployment-time checks rather than synthetic
+  production traffic.
+Status: completed
+Updated: 2026-08-27
+Completed: 2026-08-27

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -292,6 +292,18 @@ The Overview Personal Patterns section also uses the encrypted browser-vault rep
   usage-credit reconciliation, and onboarding webhook receipts
 - local-agent pairing plus sparse signal/token routes for hosted integrations
 
+Hosted Stripe receipt reconciliation emits one failure-only structured log per
+failed attempt. Its closed `stage` vocabulary is `event_retrieval`,
+`event_application`, `post_commit`, and `receipt_finalization`. The payload keeps
+the existing bounded event suffix and may add only a bounded sanitized error
+name, stable error code, sanitized top-level error message, and the existing
+Stripe-safe type, raw type, code, decline code, parameter, status, and validated
+opaque request-id projection. A top-level retry wrapper may inspect only its
+direct cause for those same Stripe-safe fields. The log never includes a raw
+error, stack, provider object or payload, member/customer/subscription/payment
+identifiers, submitted values, credentials, URLs, paths, or message content;
+Stripe request ids are correlation-only.
+
 ## Non-goals
 
 - canonical health-data storage

--- a/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/stripe-event-reconciliation.ts
@@ -85,6 +85,8 @@ import {
   requireHostedStripeApiMode,
 } from "./runtime";
 import {
+  describeHostedStripeError,
+  isHostedStripeProviderError,
   logHostedStripeFailure,
   withHostedStripeFailureLog,
 } from "./stripe-error-log";
@@ -168,6 +170,7 @@ const STRIPE_EVENT_RETRY_DELAYS_MS = [
 ] as const;
 const HOSTED_STRIPE_RUNTIME_RECHECK_PENDING_CODE =
   "HOSTED_STRIPE_RUNTIME_RECHECK_PENDING";
+const STRIPE_EVENT_ERROR_NAME_MAX_LENGTH = 120;
 const STRIPE_EVENT_LOG_STRING_MAX_LENGTH = 500;
 const STRIPE_EVENT_SAFE_PRISMA_META_KEYS = new Set([
   "column",
@@ -187,6 +190,12 @@ const STRIPE_EVENT_RETRYABLE_PRISMA_CODES = new Set([
   "P2037",
 ]);
 const HOSTED_LEGACY_FAMILY_REFUND_INVOICE_METADATA_KEY = "hosted_family_legacy_invoice_id";
+
+type HostedStripeEventReconciliationStage =
+  | "event_retrieval"
+  | "event_application"
+  | "post_commit"
+  | "receipt_finalization";
 
 class HostedLegacyFamilyCleanupPendingError extends Error {
   readonly code = "HOSTED_LEGACY_FAMILY_CLEANUP_PENDING";
@@ -898,10 +907,12 @@ async function processClaimedHostedStripeEvent(
     attemptCount: claimed.attemptCount,
     eventType: claimed.type,
   });
+  let reconciliationStage: HostedStripeEventReconciliationStage = "event_retrieval";
   let usageCreditEventHandled = false;
 
   try {
     const stripeEvent = await fetchHostedStripeEventForReconciliation(claimed.eventId);
+    reconciliationStage = "event_application";
     const usageCreditReconciliation = await reconcileHostedUsageCreditStripeEvent({
       event: stripeEvent,
       prisma,
@@ -945,6 +956,7 @@ async function processClaimedHostedStripeEvent(
           prisma,
           preflightProcessingContext,
         );
+    reconciliationStage = "post_commit";
     const { memberId: processingMemberId, result } = processing;
     if (result.newlyActivatedMemberIds.length > 0) {
       scheduleHostedSignupNotificationEmails({
@@ -1058,6 +1070,7 @@ async function processClaimedHostedStripeEvent(
         }
       }
     }
+    reconciliationStage = "receipt_finalization";
     const completed = await prisma.hostedStripeEvent.updateMany({
       where: {
         attemptCount: claimed.attemptCount,
@@ -1129,6 +1142,7 @@ async function processClaimedHostedStripeEvent(
       eventId: claimed.eventId,
       eventType: claimed.type,
       poisoned,
+      stage: reconciliationStage,
     });
     if (claimed.attemptCount === 1) {
       scheduleHostedStripeReconciliationFailureAlert({
@@ -1527,29 +1541,54 @@ async function markHostedStripeSubscriptionCancellationEmailSent(input: {
   });
 }
 
+type HostedStripeEventReconciliationErrorLogDetails = {
+  errorCode?: string;
+  errorMessage?: string;
+  prismaClientVersion?: string;
+  prismaCode?: string;
+  prismaMessage?: string;
+  prismaMeta?: Record<string, unknown>;
+  stripeCode?: string;
+  stripeDeclineCode?: string;
+  stripeParam?: string;
+  stripeRawType?: string;
+  stripeRequestId?: string;
+  stripeStatusCode?: number;
+  stripeType?: string;
+};
+
 function logHostedStripeEventReconciliationFailure(input: {
   attemptCount: number;
   error: unknown;
   eventId: string;
   eventType: string;
   poisoned: boolean;
+  stage: HostedStripeEventReconciliationStage;
 }): void {
   console.error("Hosted Stripe event reconciliation failed.", {
     attemptCount: input.attemptCount,
-    errorName: deriveHostedOnboardingTimingErrorName(input.error),
+    errorName:
+      sanitizeHostedOnboardingLogString(
+        deriveHostedOnboardingTimingErrorName(input.error),
+        STRIPE_EVENT_ERROR_NAME_MAX_LENGTH,
+      ) ?? "UnknownError",
     eventIdSuffix: input.eventId.slice(-6),
     eventType: sanitizeHostedOnboardingLogString(
       input.eventType,
       STRIPE_EVENT_LOG_STRING_MAX_LENGTH,
     ) ?? "unknown",
     poisoned: input.poisoned,
+    stage: input.stage,
     ...describeHostedStripeEventReconciliationErrorForLog(input.error),
   });
 }
 
 function describeHostedStripeEventReconciliationErrorForLog(
   error: unknown,
-): Record<string, unknown> {
+): HostedStripeEventReconciliationErrorLogDetails {
+  const classification =
+    describeHostedStripeEventReconciliationErrorClassificationForLog(error);
+
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     const prismaMessage = sanitizeHostedOnboardingLogString(
       error.message,
@@ -1558,6 +1597,7 @@ function describeHostedStripeEventReconciliationErrorForLog(
     const prismaMeta = sanitizeHostedStripeEventPrismaMeta(error.meta);
 
     return {
+      ...classification,
       errorCode: error.code,
       prismaClientVersion: error.clientVersion,
       prismaCode: error.code,
@@ -1573,6 +1613,7 @@ function describeHostedStripeEventReconciliationErrorForLog(
     );
 
     return {
+      ...classification,
       ...(typeof error.errorCode === "string" && error.errorCode
         ? { errorCode: error.errorCode, prismaCode: error.errorCode }
         : {}),
@@ -1587,7 +1628,58 @@ function describeHostedStripeEventReconciliationErrorForLog(
     ? sanitizeHostedOnboardingLogString(error.message, STRIPE_EVENT_LOG_STRING_MAX_LENGTH)
     : sanitizeHostedOnboardingLogString(String(error), STRIPE_EVENT_LOG_STRING_MAX_LENGTH);
 
-  return errorMessage ? { errorMessage } : {};
+  return {
+    ...classification,
+    ...(errorMessage ? { errorMessage } : {}),
+  };
+}
+
+function describeHostedStripeEventReconciliationErrorClassificationForLog(
+  error: unknown,
+): HostedStripeEventReconciliationErrorLogDetails {
+  const directFields = describeHostedStripeError(error);
+  const providerError = findHostedStripeEventProviderError(error);
+  const providerFields = providerError === null
+    ? null
+    : describeHostedStripeError(providerError);
+
+  return {
+    ...(directFields.code ? { errorCode: directFields.code } : {}),
+    ...(providerFields?.type ? { stripeType: providerFields.type } : {}),
+    ...(providerFields?.rawType ? { stripeRawType: providerFields.rawType } : {}),
+    ...(providerFields?.code ? { stripeCode: providerFields.code } : {}),
+    ...(providerFields?.declineCode
+      ? { stripeDeclineCode: providerFields.declineCode }
+      : {}),
+    ...(providerFields?.param ? { stripeParam: providerFields.param } : {}),
+    ...(providerFields && providerFields.statusCode !== null
+      ? { stripeStatusCode: providerFields.statusCode }
+      : {}),
+    ...(providerFields?.requestId
+      ? { stripeRequestId: providerFields.requestId }
+      : {}),
+  };
+}
+
+function findHostedStripeEventProviderError(error: unknown): unknown | null {
+  if (isHostedStripeProviderError(error)) {
+    return error;
+  }
+
+  const cause = readHostedStripeEventDirectCause(error);
+  return isHostedStripeProviderError(cause) ? cause : null;
+}
+
+function readHostedStripeEventDirectCause(error: unknown): unknown {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  try {
+    return Reflect.get(error, "cause");
+  } catch {
+    return null;
+  }
 }
 
 function sanitizeHostedStripeEventPrismaMeta(meta: unknown): Record<string, unknown> | null {

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -796,6 +796,11 @@ describe("hosted Stripe event reconciliation", () => {
     });
     mocks.cleanupHostedStandardCheckoutLoser.mockRejectedValue(
       Object.assign(new Error("Stripe rejected cleanup"), {
+        code: "parameter_missing",
+        decline_code: "do_not_honor",
+        param: "payment_method[card]",
+        rawType: "invalid_request_error",
+        requestId: "req_cleanup_123",
         statusCode: 400,
         type: "StripeInvalidRequestError",
       }),
@@ -816,7 +821,19 @@ describe("hosted Stripe event reconciliation", () => {
     }));
     expect(errorSpy).toHaveBeenCalledWith(
       "Hosted Stripe event reconciliation failed.",
-      expect.objectContaining({ poisoned: true }),
+      expect.objectContaining({
+        errorCode: "parameter_missing",
+        errorName: "Error",
+        poisoned: true,
+        stage: "post_commit",
+        stripeCode: "parameter_missing",
+        stripeDeclineCode: "do_not_honor",
+        stripeParam: "payment_method[card]",
+        stripeRawType: "invalid_request_error",
+        stripeRequestId: "req_cleanup_123",
+        stripeStatusCode: 400,
+        stripeType: "StripeInvalidRequestError",
+      }),
     );
     errorSpy.mockRestore();
   });
@@ -1036,6 +1053,14 @@ describe("hosted Stripe event reconciliation", () => {
       processedAt: null,
       status: HostedStripeEventStatus.failed,
     }));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Hosted Stripe event reconciliation failed.",
+      expect.objectContaining({
+        errorCode: "ETIMEDOUT",
+        errorName: "Error",
+        stage: "event_application",
+      }),
+    );
 
     prisma.rows[0]!.nextAttemptAt = new Date(0);
     await expect(reconcileHostedStripeEventById({
@@ -1482,17 +1507,31 @@ describe("hosted Stripe event reconciliation", () => {
     };
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     let grantCount = 0;
-    mocks.stripe.events.retrieve
-      .mockRejectedValueOnce(Object.assign(
-        new Error("Stripe requested a retry"),
-        {
-          headers: {
-            "StRiPe-ShOuLd-ReTrY": " TRUE ",
-          },
-          statusCode: 400,
-          type: "StripeInvalidRequestError",
+    const providerError = Object.assign(
+      new Error(
+        "Stripe retry for person@example.com at https://example.com/private",
+      ),
+      {
+        code: "api_connection_error",
+        decline_code: "do_not_honor",
+        headers: {
+          "StRiPe-ShOuLd-ReTrY": " TRUE ",
         },
-      ))
+        param: "payment method for person@example.com",
+        payload: {
+          value: "do_not_log_payload_value",
+        },
+        raw: {
+          message: "do_not_log_raw_value",
+        },
+        rawType: "api_error",
+        requestId: "req_reconciliation_retry_123",
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+      },
+    );
+    mocks.stripe.events.retrieve
+      .mockRejectedValueOnce(providerError)
       .mockResolvedValueOnce(event);
     mocks.reconcileHostedUsageCreditStripeEvent.mockImplementation(async () => {
       grantCount += 1;
@@ -1519,6 +1558,43 @@ describe("hosted Stripe event reconciliation", () => {
       status: HostedStripeEventStatus.failed,
     }));
     expect(mocks.reconcileHostedUsageCreditStripeEvent).not.toHaveBeenCalled();
+
+    const reconciliationFailureLogs = errorSpy.mock.calls.filter(
+      ([message]) => message === "Hosted Stripe event reconciliation failed.",
+    );
+    expect(reconciliationFailureLogs).toHaveLength(1);
+    const reconciliationFailureLog = reconciliationFailureLogs[0]?.[1];
+    expect(reconciliationFailureLog).toEqual(expect.objectContaining({
+      errorCode: "HOSTED_STRIPE_EVENT_RETRIEVE_RETRYABLE",
+      errorMessage:
+        "Stripe retry for <redacted-email> at <redacted-url>",
+      errorName: "HostedStripeEventRetrieveRetryableError",
+      stage: "event_retrieval",
+      stripeCode: "api_connection_error",
+      stripeDeclineCode: "do_not_honor",
+      stripeRawType: "api_error",
+      stripeRequestId: "req_reconciliation_retry_123",
+      stripeStatusCode: 400,
+      stripeType: "StripeInvalidRequestError",
+    }));
+    expect(reconciliationFailureLog).not.toHaveProperty("error");
+    expect(reconciliationFailureLog).not.toHaveProperty("errorStack");
+    expect(reconciliationFailureLog).not.toHaveProperty("payload");
+    expect(reconciliationFailureLog).not.toHaveProperty("raw");
+    expect(reconciliationFailureLog).not.toHaveProperty("stripeParam");
+    const serializedReconciliationFailureLog = JSON.stringify(
+      reconciliationFailureLog ?? {},
+    );
+    expect(serializedReconciliationFailureLog).not.toContain("person@example.com");
+    expect(serializedReconciliationFailureLog).not.toContain(
+      "https://example.com/private",
+    );
+    expect(serializedReconciliationFailureLog).not.toContain(
+      "do_not_log_payload_value",
+    );
+    expect(serializedReconciliationFailureLog).not.toContain(
+      "do_not_log_raw_value",
+    );
 
     prisma.rows[0]!.nextAttemptAt = new Date(0);
     await expect(reconcileHostedStripeEventById({
@@ -3750,6 +3826,14 @@ describe("hosted Stripe event reconciliation", () => {
       status: HostedStripeEventStatus.failed,
       subscriptionCancellationEmailSentAt: expect.any(Date),
     }));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Hosted Stripe event reconciliation failed.",
+      expect.objectContaining({
+        errorMessage: "receipt completion failed",
+        errorName: "Error",
+        stage: "receipt_finalization",
+      }),
+    );
 
     prisma.rows[0].nextAttemptAt = new Date(0);
 
@@ -3826,6 +3910,7 @@ describe("hosted Stripe event reconciliation", () => {
       eventIdSuffix: "ed_123",
       eventType: "customer.subscription.deleted",
       poisoned: false,
+      stage: "event_application",
     });
     errorSpy.mockRestore();
   });
@@ -4072,11 +4157,13 @@ describe("hosted Stripe event reconciliation", () => {
     }));
     expect(errorSpy).toHaveBeenCalledWith("Hosted Stripe event reconciliation failed.", {
       attemptCount: 1,
+      errorCode: "HOSTED_STRIPE_EVENT_RETRIEVE_RETRYABLE",
       errorMessage: "Stripe unavailable",
       errorName: "HostedStripeEventRetrieveRetryableError",
       eventIdSuffix: "id_123",
       eventType: "invoice.paid",
       poisoned: false,
+      stage: "event_retrieval",
     });
   });
 
@@ -4133,6 +4220,7 @@ describe("hosted Stripe event reconciliation", () => {
         modelName: "HostedMailboxItem",
         table: "missing_table",
       },
+      stage: "event_application",
     });
     expect(prisma.rows[0]).toEqual(expect.objectContaining({
       lastErrorCode: "P2010",

--- a/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
+++ b/apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts
@@ -4167,6 +4167,67 @@ describe("hosted Stripe event reconciliation", () => {
     });
   });
 
+  it("keeps failure telemetry safe when error metadata getters are hostile", async () => {
+    const prisma = createStripeEventPrismaHarness();
+    const event = makeInvoicePaidEvent();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failure = Object.assign(new Error("database request timed out"), {
+      code: "ETIMEDOUT",
+    });
+    Object.defineProperty(failure, "name", {
+      configurable: true,
+      value: `UnsafeError person@example.com ${"x".repeat(160)}`,
+    });
+    Object.defineProperty(failure, "cause", {
+      configurable: true,
+      get: () => {
+        throw new Error("do_not_log_throwing_cause");
+      },
+    });
+    mocks.stripe.events.retrieve.mockResolvedValue(event);
+    mocks.applyStripeInvoicePaid.mockRejectedValue(failure);
+
+    await recordHostedStripeEvent({
+      event,
+      prisma: prisma.client,
+    });
+
+    await expect(
+      reconcileHostedStripeEventById({
+        eventId: event.id,
+        prisma: prisma.client,
+      }),
+    ).resolves.toMatchObject({ status: "failed" });
+
+    expect(prisma.rows[0]).toEqual(expect.objectContaining({
+      lastErrorCode: "ETIMEDOUT",
+      processedAt: null,
+      status: HostedStripeEventStatus.failed,
+    }));
+    const reconciliationFailureLogs = errorSpy.mock.calls.filter(
+      ([message]) => message === "Hosted Stripe event reconciliation failed.",
+    );
+    expect(reconciliationFailureLogs).toHaveLength(1);
+    const reconciliationFailureLog = reconciliationFailureLogs[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(reconciliationFailureLog).toEqual(expect.objectContaining({
+      errorCode: "ETIMEDOUT",
+      errorMessage: "database request timed out",
+      stage: "event_application",
+    }));
+    const errorName = typeof reconciliationFailureLog?.errorName === "string"
+      ? reconciliationFailureLog.errorName
+      : "";
+    expect(errorName).toContain("<redacted-email>");
+    expect(errorName).not.toContain("person@example.com");
+    expect(errorName.length).toBeLessThanOrEqual(120);
+    expect(JSON.stringify(reconciliationFailureLog ?? {})).not.toContain(
+      "do_not_log_throwing_cause",
+    );
+    errorSpy.mockRestore();
+  });
+
   it("logs bounded Prisma diagnostics when Stripe reconciliation fails after retrieval", async () => {
     const prisma = createStripeEventPrismaHarness();
     const event = makeInvoicePaidEvent();


### PR DESCRIPTION
## Why and outcome

Four retained hosted Stripe cancellation receipts had poisoned with the generic
durable code `Error`, and later investigation could no longer distinguish which
reconciliation boundary failed. This adds failure-only structured telemetry so
future receipt failures expose a closed processing stage plus bounded safe error
name/code and Stripe classification fields.

The change is observability-only: it does not alter receipt persistence,
retry/poison decisions, alerts, provider calls, billing state, or user-visible
behavior.

ReviewGPT context sensitivity: sensitive — hosted billing and provider-error telemetry.
ReviewGPT first-reviewed head: 792eee4a68d5b102299111215b3812d57e3e8ac9
ReviewGPT final-reviewed head: a486f4c5eb949f02f89ab9b12b4d6fe8edbb2e13

## Product UX

Not applicable. This is internal production telemetry with no user-visible
journey, copy, interaction, timing, delivery, permission, or recovery change.

## Evidence

- Baseline proof: the existing focused cleanup regression persisted
  `lastErrorCode: "Error"` and omitted stage/provider classification.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-onboarding-stripe-event-reconciliation.test.ts` — 87/87 passed.
- `pnpm --dir apps/web typecheck` — passed.
- Targeted Web ESLint for the changed source/test — passed.
- `pnpm logs:guard` — passed.
- `pnpm hosted-billing:ci-guard` — passed.
- `pnpm provider-requests:guard` — passed.
- `git diff --check` — passed.

## Non-obvious affected surfaces

- Vercel production function logs: the existing reconciliation-failure record
  gains typed fields only on the existing failure path. Focused tests prove the
  closed stages, bounded direct-cause projection, sanitizer behavior, and
  exclusion of raw errors, stacks, payloads, and unsafe parameters.
- Open PR #2383 also edits the reconciliation owner for payment-notification
  email. It does not own this telemetry question; this PR adds no part of that
  feature and will retain current-base merge proof.

## Architecture and reuse

- Existing systems reused: the Web-owned receipt reconciliation log,
  `describeHostedStripeError`, the existing log sanitizer, and current Vercel
  observability.
- New logic: four local stage assignments and a bounded one-level safe error
  classifier on the existing catch path.
- New abstractions: one local stage union and one local typed log-detail shape;
  no new service, backend, state owner, queue, metric, or dependency.
- Complexity intentionally avoided: no schema/migration, durable diagnostic
  record, retry/replay path, new alert, or provider-side mutation.

## Hot reply path impact

Not applicable. The current-conversation foreground reply path is unchanged.

## Murph initial provider input impact

Not applicable. No assistant prompt, tool schema, model request, or provider
input changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: all old/new Web instances remain mutually compatible because
  no persisted schema, API, or cross-runtime contract changes.
- Safe order: merge through protected `main`; the canonical Vercel Web deploy
  may roll out independently of Cloudflare and Temporal.
- Rollback floor: none; an ordinary revert removes only extra log fields.
- Expected exposure: one bounded projection on an already-failing receipt
  attempt; no success-path volume or database load.
- Reversibility: fully reversible in code with no cleanup or backfill.
- Convergence proof: verify the Vercel production deployment SHA equals the
  merged protected-main revision.
- Post-deploy checks: read-only query for the exact failure message and aggregate
  only stage/error classification fields when natural traffic exercises it; do
  not generate synthetic production traffic.

## Change-shape breakdown

Classification rule: runtime TypeScript is Source, the Vitest file is Tests,
and the Web contract plus execution plan are Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 95 | 3 |
| Tests / fixtures | 160 | 11 |
| Docs | 121 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **376** | **14** |

## Changelog

- Changelog: not applicable
- Reason: Internal observability only; no member-visible behavior changed.

## ReviewGPT provenance

ReviewGPT `gpt-5.6-sol` authored the production implementation and focused test
patch from the proven telemetry packet. The captured implementation response
SHA-256 is `ef764fff6a4dfbefb38b928e7b6ae560ed73fbc969257e6b40bd6a13d7a5db6e`.
The parent accepted the behavior, mechanically normalized only malformed inline
diff metadata, applied the resulting unchanged content, and added three
test-only expected-field updates after the focused suite exposed them.
The preliminary specialist's accepted test-only coverage finding was resolved
with its exact ReviewGPT-authored regression patch. Final ReviewGPT rounds 1
and 2 returned `ROUND_OUTCOME: PASS` with no qualifying finding; round 2 audited
the exact final candidate head.
