### PR TITLE
test(web): align mailbox fixture sequences

### DIFF
--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -17,6 +17,12 @@ const runtimeRecheckBoundary = vi.hoisted(() => ({
     workflowId: "hosted-user-runtime:fixture",
   })),
 }));
+const activationWakeBoundary = vi.hoisted(() => ({
+  signal: vi.fn(async () => ({
+    signalAccepted: true,
+    workflowId: "hosted-user-runtime:fixture",
+  })),
+}));
 const familyPreparationBoundary = vi.hoisted(() => ({
   prepare: vi.fn(async () => new Map()),
 }));
@@ -49,6 +55,7 @@ vi.mock("@/src/lib/hosted-orchestration/signal-runtime", async () => {
 
   return {
     ...actual,
+    signalHostedMailboxAppendRuntime: activationWakeBoundary.signal,
     signalHostedRuntimeRecheckRuntime: runtimeRecheckBoundary.signal,
   };
 });
@@ -1181,6 +1188,7 @@ describe.skipIf(!runPostgresProof)(
       const runtimeGlobals = readHostedStripeRuntimeGlobals();
 
       workflowBoundary.start.mockClear();
+      activationWakeBoundary.signal.mockClear();
       runtimeRecheckBoundary.signal.mockReset();
       runtimeRecheckBoundary.signal.mockRejectedValue(
         new Error("Temporal fixture unavailable"),
@@ -1510,7 +1518,7 @@ describe.skipIf(!runPostgresProof)(
           eventId: stripeEventId,
           prisma,
           timeoutMs: 5_000,
-        })).resolves.toEqual({ accepted: true, required: false });
+        })).resolves.toEqual({ accepted: true, required: true });
 
         await expect(readUsageResetProof({ memberId, periodStart, prisma }))
           .resolves.toEqual({
@@ -1528,9 +1536,16 @@ describe.skipIf(!runPostgresProof)(
           processedAt: expect.any(Date),
           status: HostedStripeEventStatus.completed,
         });
-        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(3);
+        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(2);
         expect(runtimeRecheckBoundary.signal).toHaveBeenLastCalledWith(
-          expect.objectContaining({ userId: ownerMemberId }),
+          expect.objectContaining({ userId: memberId }),
+        );
+        expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(2);
+        expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
+          expect.objectContaining({ expectedUserId: memberId }),
+        );
+        expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
+          expect.objectContaining({ expectedUserId: ownerMemberId }),
         );
       } finally {
         clearHostedStripeFixtureEnvironment(runtimeGlobals);
@@ -1598,6 +1613,10 @@ describe.skipIf(!runPostgresProof)(
       const runtimeGlobals = readHostedStripeRuntimeGlobals();
 
       workflowBoundary.start.mockClear();
+      activationWakeBoundary.signal.mockReset();
+      activationWakeBoundary.signal.mockRejectedValue(
+        new Error("Temporal fixture unavailable"),
+      );
       runtimeRecheckBoundary.signal.mockReset();
       runtimeRecheckBoundary.signal.mockRejectedValue(
         new Error("Temporal fixture unavailable"),
@@ -1677,7 +1696,7 @@ describe.skipIf(!runPostgresProof)(
           eventId: stripeEventId,
           prisma,
           timeoutMs: 5_000,
-        })).rejects.toBeDefined();
+        })).resolves.toEqual({ accepted: false, required: true });
 
         await expect(readHostedMemberBillingSnapshot({
           memberId: ownerMemberId,
@@ -1733,12 +1752,13 @@ describe.skipIf(!runPostgresProof)(
           prisma,
         })).resolves.toMatchObject({
           attemptCount: 1,
-          processedAt: null,
-          status: HostedStripeEventStatus.failed,
+          processedAt: expect.any(Date),
+          status: HostedStripeEventStatus.completed,
         });
-        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(1);
-        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledWith(
-          expect.objectContaining({ userId: ownerMemberId }),
+        expect(runtimeRecheckBoundary.signal).not.toHaveBeenCalled();
+        expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(1);
+        expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
+          expect.objectContaining({ expectedUserId: ownerMemberId }),
         );
 
         await postSignedHostedStripeEvent({
@@ -1765,21 +1785,18 @@ describe.skipIf(!runPostgresProof)(
         })).resolves.toEqual({
           lastStripeEventCreatedAt: newerEventCreatedAt,
         });
-        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(1);
+        expect(runtimeRecheckBoundary.signal).not.toHaveBeenCalled();
+        expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(1);
 
-        runtimeRecheckBoundary.signal.mockResolvedValue({
+        activationWakeBoundary.signal.mockResolvedValue({
           signalAccepted: true,
           workflowId: `hosted-user-runtime:${ownerMemberId}`,
-        });
-        await makeStripeReceiptImmediatelyRetryable({
-          eventId: stripeEventId,
-          prisma,
         });
         await expect(processRecordedHostedStripeWebhookEvent({
           eventId: stripeEventId,
           prisma,
           timeoutMs: 5_000,
-        })).resolves.toEqual({ accepted: true, required: false });
+        })).resolves.toEqual({ accepted: true, required: true });
 
         await expect(readUsageResetProof({
           memberId: ownerMemberId,
@@ -1796,13 +1813,13 @@ describe.skipIf(!runPostgresProof)(
           eventId: stripeEventId,
           prisma,
         })).resolves.toMatchObject({
-          attemptCount: 2,
+          attemptCount: 1,
           processedAt: expect.any(Date),
           status: HostedStripeEventStatus.completed,
         });
-        expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(2);
-        expect(runtimeRecheckBoundary.signal).toHaveBeenLastCalledWith(
-          expect.objectContaining({ userId: ownerMemberId }),
+        expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(2);
+        expect(activationWakeBoundary.signal).toHaveBeenLastCalledWith(
+          expect.objectContaining({ expectedUserId: ownerMemberId }),
         );
       } finally {
         clearHostedStripeFixtureEnvironment(runtimeGlobals);
@@ -2189,6 +2206,12 @@ async function seedUsageBlockedPendingWork(input: {
       userId: input.memberId,
     },
   });
+  await input.prisma.hostedMailboxLaneCounter.createMany({
+    data: [
+      { lane: "causal", nextSeq: 2n, userId: input.memberId },
+      { lane: "conversation", nextSeq: 2n, userId: input.memberId },
+    ],
+  });
   await input.prisma.hostedAiUsagePeriod.create({
     data: {
       billingPlanCode: input.billingPlanCode,
@@ -2224,6 +2247,13 @@ async function seedHostedMemberActivationProof(input: {
       laneSeq: input.sequence,
       occurredAt: new Date(),
       payloadSchema: "murph.hosted-execution.member-activated.v1",
+      userId: input.memberId,
+    },
+  });
+  await input.prisma.hostedMailboxLaneCounter.create({
+    data: {
+      lane: "system",
+      nextSeq: input.sequence + 1n,
       userId: input.memberId,
     },
   });

--- a/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
+++ b/apps/web/test/hosted-stripe-webhook-entitlement-postgres.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   HostedBillingStatus,
   HostedStripeEventStatus,
+  type Prisma,
   type PrismaClient,
 } from "@prisma/client";
 import type Stripe from "stripe";
@@ -1528,25 +1529,40 @@ describe.skipIf(!runPostgresProof)(
             planResetAt: eventCreatedAt,
             spentUsdMicros: 0n,
           });
-        await expect(readStripeReceiptProof({
+        const activationMailboxItems = await readAccessRestorationMailboxProof({
+          memberIds: [memberId, ownerMemberId],
+          prisma,
+        });
+        expect(activationMailboxItems).toHaveLength(2);
+        const completedReceipt = await readStripeReceiptProof({
           eventId: stripeEventId,
           prisma,
-        })).resolves.toMatchObject({
+        });
+        expect(completedReceipt).toMatchObject({
           attemptCount: 2,
           processedAt: expect.any(Date),
           status: HostedStripeEventStatus.completed,
         });
+        const activationMailboxItemIds = readStripeActivationMailboxItemIds(
+          completedReceipt.activationResultJson,
+        );
+        expect(activationMailboxItemIds).toHaveLength(2);
+        expect(activationMailboxItemIds).toEqual(expect.arrayContaining(
+          activationMailboxItems.map((item) => item.id),
+        ));
         expect(runtimeRecheckBoundary.signal).toHaveBeenCalledTimes(2);
         expect(runtimeRecheckBoundary.signal).toHaveBeenLastCalledWith(
           expect.objectContaining({ userId: memberId }),
         );
         expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(2);
-        expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
-          expect.objectContaining({ expectedUserId: memberId }),
-        );
-        expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
-          expect.objectContaining({ expectedUserId: ownerMemberId }),
-        );
+        for (const item of activationMailboxItems) {
+          expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
+            expect.objectContaining({
+              expectedUserId: item.userId,
+              mailboxItemId: item.id,
+            }),
+          );
+        }
       } finally {
         clearHostedStripeFixtureEnvironment(runtimeGlobals);
         await stripeFixture.stop();
@@ -1747,18 +1763,35 @@ describe.skipIf(!runPostgresProof)(
           aiUsageDeniedAt: expect.any(Date),
           consumedAt: null,
         });
-        await expect(readStripeReceiptProof({
+        const activationMailboxItems =
+          await readAccessRestorationMailboxProof({
+            memberIds: [ownerMemberId],
+            prisma,
+          });
+        expect(activationMailboxItems).toHaveLength(1);
+        const [activationMailboxItem] = activationMailboxItems;
+        if (!activationMailboxItem) {
+          throw new Error("Expected a Family access-restoration mailbox item.");
+        }
+        const completedReceipt = await readStripeReceiptProof({
           eventId: stripeEventId,
           prisma,
-        })).resolves.toMatchObject({
+        });
+        expect(completedReceipt).toMatchObject({
           attemptCount: 1,
           processedAt: expect.any(Date),
           status: HostedStripeEventStatus.completed,
         });
+        expect(readStripeActivationMailboxItemIds(
+          completedReceipt.activationResultJson,
+        )).toEqual([activationMailboxItem.id]);
         expect(runtimeRecheckBoundary.signal).not.toHaveBeenCalled();
         expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(1);
         expect(activationWakeBoundary.signal).toHaveBeenCalledWith(
-          expect.objectContaining({ expectedUserId: ownerMemberId }),
+          expect.objectContaining({
+            expectedUserId: ownerMemberId,
+            mailboxItemId: activationMailboxItem.id,
+          }),
         );
 
         await postSignedHostedStripeEvent({
@@ -1819,7 +1852,10 @@ describe.skipIf(!runPostgresProof)(
         });
         expect(activationWakeBoundary.signal).toHaveBeenCalledTimes(2);
         expect(activationWakeBoundary.signal).toHaveBeenLastCalledWith(
-          expect.objectContaining({ expectedUserId: ownerMemberId }),
+          expect.objectContaining({
+            expectedUserId: ownerMemberId,
+            mailboxItemId: activationMailboxItem.id,
+          }),
         );
       } finally {
         clearHostedStripeFixtureEnvironment(runtimeGlobals);
@@ -2300,12 +2336,51 @@ function readStripeReceiptProof(input: {
 }) {
   return input.prisma.hostedStripeEvent.findUniqueOrThrow({
     select: {
+      activationResultJson: true,
       attemptCount: true,
       processedAt: true,
       status: true,
     },
     where: { eventId: input.eventId },
   });
+}
+
+function readAccessRestorationMailboxProof(input: {
+  memberIds: string[];
+  prisma: PrismaClient;
+}) {
+  return input.prisma.hostedMailboxItem.findMany({
+    select: {
+      id: true,
+      userId: true,
+    },
+    where: {
+      kind: "runtime.maintenance-requested",
+      userId: { in: input.memberIds },
+    },
+  });
+}
+
+function readStripeActivationMailboxItemIds(
+  value: Prisma.JsonValue | null,
+): string[] {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || value.schema !== "hosted.stripe.activation-result.v1"
+    || !Array.isArray(value.activationMailboxItemIds)
+  ) {
+    throw new Error("Expected persisted Stripe activation mailbox pointers.");
+  }
+  const mailboxItemIds = value.activationMailboxItemIds;
+  if (!mailboxItemIds.every(
+    (mailboxItemId): mailboxItemId is string =>
+      typeof mailboxItemId === "string",
+  )) {
+    throw new Error("Expected Stripe activation mailbox pointer strings.");
+  }
+  return mailboxItemIds;
 }
 
 function readFamilyCheckoutAttemptProof(input: {


### PR DESCRIPTION
## Why and outcome

The PostgreSQL Stripe entitlement proof inserted mailbox items with explicit lane sequence values but did not seed the matching lane counters. The production allocator then correctly reused sequence 1, so the fixture—not production billing—caused duplicate-key failures and blocked release integration.

This updates the fixture to preserve the mailbox item/counter invariant and updates the two affected expectations to verify the current durable activation-pointer replay contract. Production code is unchanged.

## Product UX

- Effort: Not applicable — internal test-fixture repair only.
- Result: Not applicable.
- Walkthrough: No member-visible behavior changes. The Stripe entitlement release proof again exercises the current mailbox activation behavior.

## Evidence

- Direct: Reproduced the exact two PostgreSQL unique-constraint failures before the change. On the corrected exact head, `hosted-stripe-webhook-entitlement-postgres.test.ts` passes all 12 scenarios.
- Coverage: The full real-PostgreSQL file covers both formerly failing Family activation cases plus the adjacent receipt, locking, refund, and entitlement scenarios. The changed scenarios also prove that completed receipts persist the exact access-restoration mailbox row IDs and replay those same IDs after a later event. Web typecheck and scoped ESLint pass.
- Review: The preliminary specialist pass found one exact-pointer coverage gap. It was accepted and fixed in the existing scenarios; no patch artifact was returned.

## Non-obvious affected surfaces

Public integration CI consumes this database-backed proof. No production runtime surface changes.

## Architecture and reuse

- Existing systems reused: The production mailbox lane-counter invariant and persisted Stripe activation pointers remain the only sources of truth.
- New logic: None in production. Test setup now creates counters alongside explicitly sequenced mailbox rows, and assertions replay the persisted activation pointers.
- New abstractions: None in production; two local proof readers expose the existing receipt JSON and access-restoration rows.
- Complexity intentionally avoided: No production fallback, alternate allocator, compatibility path, retry state, queue, or service was added.

## Hot reply path impact

- Path status: Not applicable — test-only change.
- Database calls: None in production.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable — production path is unchanged.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only change; no runtime artifact or database migration is produced.

## Change-shape breakdown

Classification rule: The sole changed path is a database-backed test fixture; there are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 129 | 24 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **129** | **24** |

## Changelog

- Changelog: not applicable
- Reason: Internal test-fixture repair with no member-visible behavior change.
