### PR TITLE
test(hosted-local): cover Linux MinIO bridge endpoint

### DIFF
--- a/packages/hosted-local-harness/test/dev-hosted-local/minio.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/minio.test.ts
@@ -355,6 +355,10 @@ describe("hosted-local MinIO sidecar", () => {
     });
 
     expect(server?.process).toBe(child);
+    const expectedControlHost = process.platform === "linux" ? "172.17.0.1" : "127.0.0.1";
+    const expectedEndpointHost = process.platform === "linux"
+      ? "172.17.0.1"
+      : "host.docker.internal";
     const dockerEnv = runtimeMocks.spawnChildProcess.mock.calls[0]?.[3] as Record<string, string>;
     expect(dockerEnv.MINIO_ROOT_USER).toMatch(/^murph-local-[a-f0-9]{24}$/u);
     expect(dockerEnv.MINIO_ROOT_PASSWORD).toMatch(/^[A-Za-z0-9_-]{43}$/u);
@@ -363,12 +367,22 @@ describe("hosted-local MinIO sidecar", () => {
       HOSTED_R2_PRESIGN_ACCOUNT_ID: "hosted-local-r2-account",
       HOSTED_R2_PRESIGN_ALLOW_LOCAL_ENDPOINT: "1",
       HOSTED_R2_PRESIGN_BUCKET_NAME: "hosted-local-r2-bundles",
-      HOSTED_R2_PRESIGN_CONTROL_ENDPOINT: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/u),
-      HOSTED_R2_PRESIGN_ENDPOINT: expect.stringMatching(/^http:\/\/host\.docker\.internal:\d+$/u),
+      HOSTED_R2_PRESIGN_CONTROL_ENDPOINT:
+        expect.stringMatching(new RegExp(`^http://${expectedControlHost.replace(/\./gu, "\\.")}:\\d+$`, "u")),
+      HOSTED_R2_PRESIGN_ENDPOINT:
+        expect.stringMatching(new RegExp(`^http://${expectedEndpointHost.replace(/\./gu, "\\.")}:\\d+$`, "u")),
       HOSTED_R2_PRESIGN_SECRET_ACCESS_KEY: dockerEnv.MINIO_ROOT_PASSWORD,
       MURPH_HOSTED_LOCAL_PROFILE: "dev",
     }));
     expect(server?.env).not.toHaveProperty("MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED");
+    if (process.platform === "linux") {
+      expect(server?.env).toHaveProperty(
+        "MURPH_HOSTED_LOCAL_R2_DOCKER_BRIDGE_HOST",
+        "172.17.0.1",
+      );
+    } else {
+      expect(server?.env).not.toHaveProperty("MURPH_HOSTED_LOCAL_R2_DOCKER_BRIDGE_HOST");
+    }
     expect(runtimeMocks.spawnChildProcess).toHaveBeenCalledWith(
       "minio",
       "docker",


### PR DESCRIPTION
## Why and outcome

Canonical release acceptance failed on Linux because the normal hosted-local MinIO test asserted macOS Docker host aliases even though the runtime correctly selected Linux's Docker bridge gateway. This makes the assertion platform-aware and verifies the Linux bridge marker.

## Product UX

- Effort: Not applicable — test-only verification repair
- Result: Not applicable
- Walkthrough: No member-facing behavior changes

## Evidence

- Direct: Hosted-local MinIO focused suite passed: 19 tests.
- Coverage: The changed assertion now follows the same Linux-versus-macOS endpoint contract already proved by the adjacent hosted-local E2E test. Package typecheck passed.

## Non-obvious affected surfaces

Normal hosted-local development MinIO startup verification. Production runtime code is unchanged.

## Architecture and reuse

- Existing systems reused: Existing platform detection and Docker bridge endpoint contract in the MinIO test suite
- New logic: Test expectation only; no product or runtime logic
- New abstractions: None; the existing platform-specific contract is asserted directly
- Complexity intentionally avoided: No runtime compatibility shim or new helper for one test-local expectation

## Hot reply path impact

- Path status: Not applicable — test-only change
- Database calls: None
- Network/provider calls: None
- Other awaited latency: None
- Before/after proof: Not applicable

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no provider-input surface changed

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only change; no deployable artifact or runtime behavior changes

## Change-shape breakdown

Classification rule: The only changed file is a Vitest test; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 16 | 2 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **16** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Internal test correction with no member-visible change

<!-- ReviewGPT context sensitivity: routine -->
<!-- Classification reason: One test-only platform-aware expectation below both size cutoffs. -->
