### PR TITLE
chore(release): prepare v1.3.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,814 @@
 
 All notable changes to `@murphai/murph` will be documented in this file.
 
+## [1.3.2] - 2026-08-27
+
+### Added
+- return canonical apply cards
+- energize referral section
+- allow workout exercise renames
+- track silent group conversions
+- track group-to-private conversions (#2311)
+- link directly to connect source cards
+- make wearable no-data outreach adaptive
+- admit versioned Temporal worker bindings (#2158)
+- accept focused group tool parsers (#2151)
+- allow fifty dollar group sponsorship caps
+- analyze attached videos on request (#2108)
+- accept manual meal photo uploads (#2098)
+- add timeout failure diagnostics (#2092)
+- enrich signup notifications
+- add ops usage search and reset all
+- reconsider unsent group replies once
+- trace device-sync interruptions (#2043)
+- verify and render OG image routes (#2056)
+- preserve complete Junction summaries (#1702)
+- preserve Junction metabolic context (#1700)
+- enrich bounded Junction workout streams
+- add authoritative Junction temporal features
+- default sparse clinical facts
+- preserve Junction summary details
+- finalize Junction body composition
+- preserve Junction body composition
+- finalize Junction body composition
+- register sparse clinical Junction resources
+- retain bounded Junction workout features
+- preserve bounded Junction temporal features
+- govern Junction resources and sparse history
+- preserve Junction body composition
+- preserve Junction summary details
+- preserve sparse Junction clinical facts
+
+### Fixed
+- package assistant verification contract (#2403)
+- isolate child-runtime package coverage (#2397)
+- parse coordinated workout exercises (#2340)
+- preserve Docker isolation on macOS (#2367)
+- clarify referral rewards
+- validate Kernel handoffs before publication
+- order roster observation upserts
+- keep referral estimates concise
+- restore live Stripe main proof
+- keep Kernel automation independent of live view
+- complete silent conversion lifecycle
+- negotiate Environment reconciliation fact
+- reconsider live group input (#2321)
+- require absolute alternate Codex home
+- complete Environment priority handoff
+- allow alternate Codex home for live journeys
+- ratchet device sync bundle budget (#2326)
+- preserve canonical preemption ordering
+- make activity errors recoverable (#2204)
+- make workout card authoring deterministic (#2295)
+- make database pool retries observable (#2292)
+- route autofix reviews to isolated lanes (#2309)
+- order latency trace row locks (#2293)
+- bind Junction ECG voltage to summaries (#2300)
+- make experiment and Age errors recoverable (#2207)
+- preserve connect dialog ownership
+- preserve database health provenance (#2290)
+- make held group replies complete
+- honor selected group journey model
+- prevent blank nutrition dead ends
+- keep meal recovery routing compact
+- keep child model live config local
+- keep blank meals in owner recovery
+- route card recovery through owners
+- make nutrition errors recoverable (#2205)
+- bound workout inventory continuation
+- ask before card recovery refusal
+- focus live assistant test runner
+- preserve ordinary resume cleanup
+- converge Browser Vault refresh work (#2226)
+- prioritize nutrition card recovery
+- require nutrition card data recovery
+- preserve composed release provenance
+- require meal recovery before nutrition cards
+- grant draft reset GraphQL authority (#2277)
+- ignore zero-limit overshoot periods
+- close reconsideration failure paths
+- isolate temporary CLI evaluation (#2270)
+- recover unresolved meals for nutrition cards
+- preserve model-repair error details (#2202)
+- preserve workout progress through authority failures
+- preserve stable skill recipes
+- remove contact details from signup notifications (#2260)
+- filter workout index before cap
+- apply direct usage settlements
+- strengthen connect target contrast
+- ratchet workout delivery bundle budget (#2266)
+- preserve current workout admission
+- preserve reconsidered group requests
+- make reminder saves replay-safe
+- use live workout capability
+- prevent duplicate wearable preference calls
+- preserve outreach settings through abort guard
+- require email authority for outreach settings
+- delete wearable outreach preferences with accounts
+- close adaptive outreach review gaps
+- document changelog-only review proof (#2255)
+- validate hosted-local temporal doctor (#2250)
+- propagate typecheck guard failures (#2248)
+- authorize pull request draft resets (#2251)
+- bound migration guard patterns to SQL statements (#2239)
+- classify provider requests by static host (#2249)
+- preserve finish-task deletion scope (#2247)
+- gate scoped workout stream sources
+- decouple DST recovery from titles
+- log completed hosted invocations
+- harden runtime issue provenance
+- gate workout streams by source capability
+- keep titles out of identity checks
+- use generated ids for reminder saves
+- correlate runtime issues with releases and attempts
+- bound model retry usage storms
+- hand off environment work after foreground
+- reactivate archived reminders by stable identity
+- recover the canonical live successor
+- prevent duplicate archived-name retries
+- cover incomplete private handoffs
+- distinguish private handoff continuations
+- anchor group draft cutoff at completion
+- tolerate accepted Temporal run visibility (#2215)
+- allow archived reminder name reuse
+- validate live Temporal compatibility runs (#2198)
+- handle in-flight one-shot edits
+- finalize child usage accounting
+- keep inbound videos transient
+- clarify reminder occurrence projection
+- recover usage link from later work (#2193)
+- preserve Garmin authorization guards
+- wait for Garmin consent readiness
+- await late subagent usage persistence
+- wait for disconnect hydration
+- classify empty workout streams
+- honor terminal garmin departure
+- drop unused reasoning profile field
+- preserve empty replay across retries
+- retain empty stream replay horizon
+- recover empty workout streams
+- submit garmin confirmation once
+- complete garmin consent progression
+- expose bounded pass queue diagnostics (#2160)
+- preserve replacement across delayed stop (#2171)
+- align group guidance with admitted tools
+- simplify split tool validation
+- enforce split group tool contracts
+- simplify workout follow-up identity
+- expose repairable group tool contracts
+- align hosted tool expectation (#2161)
+- include Max in ops growth MRR split
+- require fresh environment conditions
+- harden workout follow-up context
+- harden Kernel canary lifecycle proof
+- load environment conditions from OpenWeather
+- retire native E2E aliases before deployments
+- retain detached subagent usage
+- preserve canonical narrow-read semantics
+- isolate delayed lifecycle errors
+- prepare handoff authority crypto
+- preserve workout follow-up context
+- bind legacy nutrition authority
+- preserve Starter activation lifecycle
+- replay handoffs across transport failures
+- preserve pending health ownership
+- fence handoff replay crypto
+- bind recovery replay intent
+- disambiguate legacy nutrition calories
+- restore Temporal reconciliation compatibility (#2129)
+- accept optional realtime updates (#2128)
+- align environment realtime tools (#2126)
+- make context handoff retries exact
+- keep signup email enrichment optional
+- update GPT-5.6 Sol pricing (#2122)
+- preserve concurrent recovery usage
+- preserve signup notification fallback
+- remove homepage nav links
+- cover code-mode deferred discovery
+- discover deferred tools before denial
+- commit held input transcripts once
+- harden reset-all operator recovery
+- bound signup notification context retention
+- bound reset-all runtime wake latency
+- bound migration guard to SQL statements
+- defer held no-reply persistence
+- centralize progress prompt ownership
+- lock controls during reset restoration
+- harden nutrition card prompt ownership
+- persist exact delivery retry
+- guard refreshed ambiguous usage targets
+- resolve ops recovery review findings
+- fence exact telegram delivery
+- gate signup context capture
+- preserve ambiguous reset recovery
+- remount reset state across operators
+- keep reset wake logs scalar
+- preserve reset-all across tab reloads
+- release exact delivery claim on yield
+- preserve reset-all recovery ownership
+- reconcile exact delivery recovery
+- consolidate nutrition card workflow
+- scope reset-all wake recovery to receipts
+- advance reset-all past empty periods
+- make reset-everyone retries receipt-safe
+- make signup context provenance truthful
+- make physical-note recovery atomic
+- support legacy nutrition card calories
+- keep precommit segments provisional
+- fence recovery turn replays
+- bind cleanup to container starts
+- preserve partial Queue metrics (#2103)
+- close reconsideration review gaps
+- classify checked guard deterministically
+- complete blocked exact notifications
+- separate checked and remaining guards
+- fence legacy history reads
+- use the production Junction config path
+- unblock hosted runtime frontiers
+- restore runner bundle headroom (#2104)
+- fit recovery into runner budget
+- preserve recovery uncertainty
+- align startup convergence budgets
+- document all-resource rollout
+- restore all Junction resources
+- bind destroy ownership to starts
+- bind recovered source history
+- add explicit recovery control
+- bind readiness to replacement starts
+- scope readiness to current start
+- retain pending source webhooks
+- preserve startup transport convergence
+- retain observed pending starts
+- include Apollo in auto lane pool
+- preserve rollout cold starts
+- bind freshness to exact imports
+- require data-bearing import proof
+- prove exact Vercel production deployment (#2085)
+- preserve recovery delivery timer
+- preserve partial recovery windows
+- stop duplicate due reconcile signals (#2081)
+- harden worktree retirement (#2052)
+- project canonical imports into freshness
+- recover missing junction sources
+- make frontend evidence reproducible (#2066)
+- sync existing lockfile importers transactionally (#2061)
+- preserve native iOS cleanup failures (#2053)
+- bound and retry the Playwright Chromium install (#2022)
+- require provider occurrence for Fitbit cutover
+- tighten Fitbit migration copy
+- bind migration freshness to logical facts
+- advance usage link recovery claim
+- retry usage limit rich link partial
+- bind migration freshness to webhook trace
+- resume missing usage limit link
+- replay partial usage limit links
+- preserve delivery-only wake ownership
+- honor provider day timezone
+- admit model-free delivery retries
+- reconcile terminal foreground replies
+- isolate foreground quiet windows
+- supersede stale migration proof jobs
+- preserve source authorization epochs
+- unify Junction canonical imports
+- prove Fitbit history before migration
+- preserve source-scoped history evidence
+- fence migration freshness
+- simplify Fitbit migration continuation
+- keep migration identity browser safe
+- apply ReviewGPT remediation
+- preserve member deletions on changed replay
+- preserve activity heart-rate facts
+- preserve profile replay identity
+- pin extended history to 180 days
+- preserve ordinary sync ahead of temporal history
+- harden Junction workout feature projection
+- refresh generated skill hash
+- expose bounded Junction workout details
+- enforce repository trust floor
+- pin review trust floor
+- open explicit reconnect lifecycle
+- remove speculative routing policy
+- bind workout remote authority by id
+- gate onboarding subagent routing
+- preserve semantic source lifecycle
+- migrate unversioned Junction profiles
+- preserve established source lifecycle
+- migrate Junction profile identity safely
+- preserve capped webhook days
+- keep ordinary pull floor unconditional
+- preserve Junction history completion
+- fence Junction webhook pulls
+- retry superseded Junction fetches
+- preserve deployed m1 history
+- reconcile summary ownership after restack
+- preserve delayed provider revision ordering
+- preserve legacy activity heart-rate aliases
+- align Junction replay verification
+- recover Junction member edit conflicts
+- preserve member summary edits
+- resolve Junction summary review findings
+- reconcile Junction summary corrections
+- bound Junction menstrual evidence
+- complete rejected body history
+- harden body composition history
+- reconcile body composition stack
+- rebuild legacy body projections
+- unify sparse body selection
+- close body composition read gaps
+- complete body composition reads
+- pin exact workout connection
+- ignore physical alias rekeys in webhook proof
+- close workout authority gaps
+- retain ordinary reconcile completion
+- align Link callback lifecycle admission
+- resolve workout lifecycle source
+- fence workout source lifecycles
+- preserve Junction window ownership
+- advance each completed Link lifecycle
+- ratchet runner bundle budget
+- ratchet runner bundle size
+- fence hosted source reconnect history
+- fence reconnect-start worker completion
+- make history priority fair
+- bound reopened history priority
+- preserve legacy epoch wire absence
+- unify Junction alias lifecycle identity
+- close reconnect lifecycle gaps
+- resolve device sync reconnect subpath
+- finalize Junction lifecycle candidate
+- fence Junction lifecycle history
+- checkpoint Junction lifecycle fences
+- persist sparse history terminal state
+- preserve sparse history lineage
+- preserve delayed provider revision ordering
+- preserve legacy activity heart-rate aliases
+- align Junction replay verification
+- reopen local junction history
+- require current history terminality
+- close moving sparse history gaps
+- persist terminal history coordinates
+- terminate empty history scans
+- require workout companions for history
+- checkpoint Junction resource progress
+- co-import historical workout summaries
+- resume Junction reconcile resources safely
+- expand hosted lifecycle epoch safely
+- cover historical workout identity shapes
+- preserve Junction reconnect history fences
+- complete temporal history recovery
+- fence reconnect history by source epoch
+- recover Junction member edit conflicts
+- close temporal authority gaps
+- preserve grouped workout attribution
+- preserve workout identity and retries
+- align temporal day ownership
+- preserve member summary edits
+- preserve bounded clinical durability
+- bound sparse clinical daily imports
+- preserve Junction resource progress
+- unify sparse body selection
+- consolidate workout ingestion ownership
+- fence temporal facts to complete days
+- close body composition read gaps
+- resolve Junction summary review findings
+- complete body composition reads
+- tighten Junction history ownership
+- reconcile Junction summary corrections
+- harden bounded workout imports
+- require bounded temporal evidence
+- bound sparse clinical imports deterministically
+- harden bounded temporal features
+- reserve stacked history coverage
+- bound Junction menstrual evidence
+- bound sparse history completion
+- refresh Junction release artifacts
+- preserve compact webhook payloads
+- preserve sparse clinical record identity
+
+### Changed
+- gate local shell proof by platform (#2415)
+- Suppress completed reminder occurrences (#2406)
+- Bound growth dashboard database fanout (#2346)
+- Fix Codex token usage compatibility (#2408)
+- align mailbox fixture sequences (#2410)
+- Warn while long database transactions are still open (#2399)
+- Fix consent reposts and restaurant nutrition lookup (#2386)
+- Keep phone-transfer locks provider-free (#2405)
+- Add Stripe reconciliation error telemetry (#2409)
+- cover Linux MinIO bridge endpoint (#2411)
+- stop local production-secret work (#2380)
+- Classify wrapped Prisma pool failures accurately (#2355)
+- Fail fast on hosted latency trace lock contention (#2350)
+- Prepare Codex auth mailbox crypto before transaction (#2341)
+- Reuse saved nutrition context before card recovery (#2336)
+- Add recent-member retention view to Growth (#2384)
+- bound meal nutrition reads to events (#2394)
+- sync friction log (#2398)
+- archive weekly digest prompt plan (#2395)
+- ignore generated Graft graph (#2396)
+- sync friction log (#2376)
+- Keep Messages workout auth renewable (#2370)
+- Recover product-feedback validation errors (#2349)
+- Honor saved prompts for weekly digest automations (#2359)
+- Document alternate Codex home approval (#2379)
+- finish ReviewGPT 0.5.138 rollout
+- update ReviewGPT to 0.5.138
+- prove canonical apply receipts
+- close silent conversion implementation
+- defer workout card changelog
+- sync friction log (#2362)
+- harden Stripe skip regression proof
+- tighten referral copy
+- Retire the legacy Frog autofixer (#2357)
+- state roster evidence expiry contract
+- Improve cold conversation reconstruction (#2342)
+- keep roster evidence expiry-only
+- note clearer referral rewards
+- polish referral section
+- sync friction log (#2316)
+- note browser task resilience
+- Fix broad private food search timeouts (#2318)
+- exercise negotiated Environment fact
+- Add durable hosted operator tasks (#2304)
+- close Environment wire compatibility
+- Compare vault-cli bundle growth to exact base (#2344)
+- remove completed group backfill (#2339)
+- close Environment priority handoff
+- align Environment wire fixtures
+- announce easier workout card editing
+- clarify alternate Codex home fallback
+- Complete Environment voice report coverage (#2335)
+- Refresh expanded workout cards from canonical state (#2332)
+- compose alternate Codex home selection
+- Route group backfill through protected production workflow (#2324)
+- Fix physical-note recovery lookup (#2327)
+- Preserve speakers in private-to-group handoffs (#2319)
+- make Markdown-only pull requests cheap (#2313)
+- close foreground preemption plan
+- Correlate workspace snapshot start diagnostics (#2323)
+- prove shared foreground wake handoff
+- Remove the Fitbit Junction note (#2320)
+- Fix hosted device-sync snapshot import bottleneck (#2322)
+- Fix organic group discovery (#2303)
+- Enforce production food-search index contract (#2294)
+- bound static generation concurrency (#2312)
+- split oversized runtime suites (#2307)
+- Add foreground reply changelog entry
+- Prioritize foreground replies over system work
+- Fix Codex 0.149.1 auth deploy guard (#2310)
+- Resume approved files in active hosted turns (#2269)
+- upgrade Codex CLI to 0.149.1 (#2288)
+- bound home projection fanout (#2289)
+- complete live assistant verification plan
+- Fix connection deep links with a dialog (#2283)
+- remove redundant reconciliation reads (#2291)
+- print group journey reply
+- record canonical Murph domain (#2296)
+- Compact broad group consent offers (#2298)
+- sync friction log (#2302)
+- Add stage diagnostics for companion address-book timeouts (#2276)
+- split local service runtime coverage (#2299)
+- close group reconsideration rollout
+- record autofix launcher gate failure (#2297)
+- close nutrition card meal recovery
+- Compact iMessage workout comparison cards (#2285)
+- record live verification retrospective
+- close workout stream remediation
+- Extend hosted device-sync pass telemetry (#2267)
+- Preserve exact context for direct native replies (#2279)
+- Make the Environment voice report readable on a phone (#2282)
+- clarify workout failure handling
+- distinguish meal edit help from mutation
+- require verification steps in final handoffs (#2287)
+- sync friction log (#2272)
+- trim Terra recovery diagnostics
+- model live card turn as private direct
+- launch live meal CLI without IPC
+- summarize live meal recovery actions
+- make live meal fixture self-contained
+- expose live meal recovery actions
+- execute overshoot predicate in postgres
+- Fix scheduled card delivery intent (#2262)
+- use the repository Node version for live prompt proof
+- prove live disconnect blocks workout egress
+- drop replay fingerprinting
+- record PR draft reset permission gap
+- distinguish Luna child from parent
+- align live Starter settings check (#2263)
+- expose live child model override
+- record draft-reset workflow friction
+- smoke live Luna subagent selection
+- register runtime issue provenance migration
+- Pin hosted subagent model selection on (#2225)
+- complete runtime issue provenance plan
+- track group reconsideration rollout
+- streamline live assistant verification
+- align usage settlement mock
+- attribute group reconsideration fix
+- Preserve exact workout identity across replies (#2254)
+- close model loop cap hardening plan
+- remove duplicate image provenance proof
+- catalog Vault CLI recovery gaps (#2203)
+- prove usage settlement fails closed
+- prove image issue provenance export
+- announce direct connection links
+- complete adaptive wearable outreach
+- pin wearable outreach rollback floor
+- sync friction log (#2256)
+- Fix hosted web prebuilt workflow triggers (#2258)
+- Fix repeated scans during batch worktree retirement (#2259)
+- generate prisma before hosted vitest (#2257)
+- sync friction log (#2246)
+- Recover nutrition cards and automatic meal captures (#2240)
+- add adaptive outreach changelog
+- Ask when automatic meal nutrition is unclear (#2241)
+- Prune completed generated deliveries from hosted checkpoints (#2231)
+- record terminal event rollout
+- cover default completion mode
+- Answer every rapid group request in one reply (#2232)
+- close workout stream capability fix
+- note mixed-source workout recovery
+- Reduce reply recovery delay during runner shutdown (#2235)
+- Raise worktree ceiling to 200
+- allow ordinary managed-name reminders
+- Stop obsolete device-sync environment log churn (#2233)
+- note reliable environment saves
+- sync friction log (#2073)
+- continue specialist remediation
+- Speed up Android hosted E2E admission (#2227)
+- drop cross-repository Frog entries (#2230)
+- Archive stale reminder projection plan
+- Keep stale reminder timing authoritative
+- close group reply reconsideration
+- record handoff proof
+- note reliable private handoffs
+- complete hosted video transience
+- Simplify nutrition card safety prompts (#2196)
+- Keep workout set confirmations on one canonical owner (#2195)
+- clarify quiet draft selection
+- define held group draft exception
+- Fix delegated Murph message recovery (#2168)
+- Fix stale reminder occurrence projection
+- note reminder name recovery
+- Stop inactive runtime mailbox churn (#2165)
+- allow non-production review fixes
+- complete Temporal compatibility rollout (#2214)
+- protect active zero-window videos
+- Text members when Garmin delivery stalls (#2189)
+- advance Temporal compatibility controller (#2201)
+- clarify shared native Privy client (#2118)
+- announce temporary chat videos
+- announce clearer reminder edits
+- close Garmin consent readiness
+- unify Garmin authorization readiness
+- close Garmin canary recovery
+- cover complexity collapse exception
+- continue accepted complexity collapses
+- Recover stalled usage-limit links after overlapping receipts (#2185)
+- record draft reset permission gap
+- prove hydrated disconnect
+- align onboarding proofs with checkpoints (#2184)
+- close workout stream recovery plan
+- expose garmin confirmation surface
+- prove delayed garmin departure
+- note workout sync recovery
+- align ReviewGPT policy assertions
+- preserve current index guidance
+- record pr draft reset failure
+- preserve garmin canary index truth
+- restore garmin route departure proof
+- reserve Ready for merge candidates
+- record PR draft reset permission failure
+- Make Starter signup completion consent-owned (#2166)
+- close workout stream diagnostics
+- use split newsletter tools
+- skip pause after final ReviewGPT pass
+- Make onboarding follow-up enrollment activation-owned (#2097)
+- expose workout stream cardinality diagnostics
+- Gate expensive CI on ready PR heads (#2136)
+- Pin authenticated Temporal deployment controller (#2177)
+- Require exact Temporal reader compatibility before merge (#2147)
+- Complete Garmin consent in the Junction canary (#2174)
+- Fix Garmin canary Cloudflare challenge with headed Kernel (#2172)
+- delete legacy group tool schema
+- Switch the live Junction canary to Garmin (#2170)
+- Simplify child usage finalization
+- Simplify Codex child usage accounting
+- close pass-budget plan (#2146)
+- Prove Kernel tunnel child lifetime
+- complete ops growth Max MRR fix
+- Fix Kernel canary tunnel lifetime
+- note reliable environment conditions
+- close native E2E alias retirement plan
+- enforce complete native E2E alias retirement
+- complete Codex subagent usage plan
+- complete vault query narrow-reader plan
+- Clean up timed-out subagent metadata requests
+- Fix Codex subagent usage review findings
+- bound vault query reads by family
+- Meter Codex child-agent provider usage
+- compact automation tool schema (#2125)
+- Meter exact Codex subagent usage
+- Improve public agent readiness (#2120)
+- keep workout replies connected
+- complete mailbox test mock
+- Remove brittle Codex permission attestation (#2143)
+- Use Kernel for WHOOP canary browser
+- record ReviewGPT composer friction
+- Extend hosted device-sync passes to 90 seconds (#2119)
+- Self-heal duplicate Junction daily event aliases (#2089)
+- keep sponsorship verification current
+- update group email mailbox mock
+- cover fifty dollar sponsorship choices
+- Extend ReviewGPT default timeout to 250 minutes (#2138)
+- link sponsorship changelog to pr
+- ratchet nutrition authority prompt
+- keep foreground storm on generic owner (#2139)
+- mirror startup lifecycle state
+- Keep automatic sponsorship refills retryable (#2132)
+- preserve mailbox completion contracts (#2137)
+- verify system mailbox checkpoint (#2135)
+- keep ReviewGPT findings proportional
+- wait for interview mailbox consumption (#2134)
+- use valid interview completion id (#2131)
+- cover environment interview system wake (#2130)
+- Polish the group funding success mark (#2046)
+- complete signup notification follow-up
+- Require literal Junction connection proof for webhook recovery (#2117)
+- Add realtime Environment interview (#2100)
+- Disambiguate physical-note recovery targets
+- record schema 7 workout card plan
+- Remove redundant member-memory sandbox profile (#2086)
+- Fix hosted Android E2E credential ownership (#2115)
+- centralize scheduled nutrition safety
+- trust Codex for ordinary tasks
+- Batch workout starts and bypass exact-command projection rebuilds (#2070)
+- Classify terminal recovery targets
+- Recheck nonterminal recovery targets
+- Complete device webhooks for unregistered sources (#2114)
+- Forward physical-note recovery targets
+- Bind physical-note recovery targets
+- close nutrition card legacy compatibility
+- stabilize signup route test env
+- Fix legacy nutrition card eligibility owner
+- record runtime review retrospective
+- Cover paid recovery replay after note deletion
+- Report recovered physical-note usage
+- Fix group handoff release contracts (#2113)
+- log hosted-local doctor friction
+- Add private-to-group context handoff
+- acknowledge ops reset receipt schema
+- type signup context fixture
+- preserve Prisma schema formatting
+- Add protected native Android hosted E2E (#2109)
+- note nutrition card compatibility
+- record product walkthrough
+- record candidate verification
+- note current group replies
+- update mailbox frontier projection
+- Let existing members email Murph from any inbox (#2083)
+- note hosted runtime recovery
+- prove durable retry checkpoint order
+- Migrate stable Junction profile timestamps (#2096)
+- Retry transient hosted device-sync reads (#2095)
+- link recovery changelog PR
+- Delete obsolete device-sync dirty retention (#2094)
+- Fix signup notification ownership (#2068)
+- Prioritize approved foreground continuations (#2077)
+- align six-lane release contract
+- update recovery pr reference
+- prove missing-source replay
+- Simplify record-scoped workout tracking (#2063)
+- Recover KMS reads and Garmin sync (#2048)
+- Confirm safe partial database telemetry before warning (#2050)
+- Prove Messages workout rep contract (#2075)
+- parallelize release verification (#2042)
+- Honor scheduled device retries in runtime progress alerts (#2049)
+- Restore silent hosted memory maintenance (#2047)
+- Prune restored delivery residue before cold snapshots (#2074)
+- clarify import freshness proof
+- update freshness signal mock
+- define ordinary merge commit exception (#2082)
+- stabilize usage-credit fixture assertions (#2080)
+- Keep pre-merge and release guards aligned (#2072)
+- Route native iOS reruns through a fresh validated run (#2071)
+- Harden ReviewGPT configuration and consume v0.5.136 (#2076)
+- Serialize concurrent ReviewGPT base refreshes (#2051)
+- Separate test and release heap budgets (#2058)
+- note Apple Health freshness recovery
+- enforce runner bundle budgets (#2057)
+- note wearable recovery
+- fail closed on Prisma mutation drift (#2067)
+- Keep focused schema checks and CLI test commits narrow (#2060)
+- Stop re-signaling imported mailbox handoffs (#2044)
+- Retry untouched group sponsorship refills (#2035)
+- Reduce native iOS hosted E2E queue waste (#2040)
+- Add actionable blood oxygen normalization diagnostics (#2036)
+- Simplify the group funding success receipt (#2034)
+- close PR 1977 completion plan
+- update review-gpt to 0.5.134 (#1975)
+- Stop sponsorship near-cap notices (#2038)
+- Publish system mailbox frontier ownership (#2024)
+- Keep reliability work out of Murph product notes (#2023)
+- Restore PR review disclosures and LOC breakdown (#2020)
+- track current usage recovery link
+- Fix retained hosted device-sync retries (#2021)
+- Fix group sponsorship payment recovery (#2010)
+- finalize ReviewGPT completion watcher rule
+- prefer ReviewGPT completion watchers
+- extend ReviewGPT wake timeout
+- require exclusive PR ownership
+- track dirty-marker mutation boundary
+- require UI screenshots
+- note usage recovery delivery
+- record round seven remediation evidence
+- record combined Junction rollout decision
+- clear ReviewGPT lint warning
+- align ReviewGPT migration fixtures
+- Replace Fitbit migration with Google Health
+- refresh generated skill hash
+- align hosted temporal priority
+- reconcile current Junction base
+- fix training week boundary
+- reconcile runner bundle baselines
+- anchor training week fixture
+- ratchet runner bundle baselines
+- pin workout projection schema version
+- rebaseline Junction runner bundle budgets
+- Require a unique zone instant for floating temporal clocks
+- Require semantics agreement before authorized-day exclusion
+- Prove Gregorian validity inside complete-day timestamp acceptance
+- Own complete-day timestamp acceptance with one anchored parse
+- Anchor temporal replacement identity and fail closed on ambiguity
+- Require array shapes inside strict grouped collection proof
+- Guard raw retention and member deletions under temporal authority
+- Derive temporal samples only from provider clocks
+- Preserve temporal authority across hosted cold restore
+- Converge temporal facets through the symmetric set seam
+- Make temporal imports facet-only with fail-closed authority
+- Regenerate event-record schema for merged qualifiers
+- Align device-sync tests with merged dual-owner shape
+- Restore ordinary Junction ingestion ownership
+- Make the ReviewGPT wrapper own the trust floor
+- Close ReviewGPT config override bypass
+- refresh vault cli skill hash
+- update review gpt to 0.5.132
+- record ReviewGPT lane preference friction
+- update ReviewGPT to 0.5.132
+- Fix Junction temporal history refresh
+- sync friction log
+- sync friction log
+- align runner bundle budget expectation
+- align profile replay regression
+- record ReviewGPT round 13
+- assert automatic member precedence
+- preserve member edits at event spine
+- preserve Junction policy order
+- refresh generated skill hash
+- use stable Junction row identities
+- bound clinical lifecycle reads
+- cover member edit conflict jobs
+- expect member ownership after event edit
+- announce complete summaries
+- complete Junction summary details
+- align interval timestamp rejection
+- refresh generated vault skill hash
+- align body integration coverage
+- align body hint and schemas
+- announce body composition
+- record round 12 pass
+- make source fixtures type-safe
+- cover workout lifecycle export
+- expect current Junction coverage encoding
+- expect current Junction coverage encoding
+- reuse hosted source authority read
+- regenerate config schema from clean build
+- refresh generated config schema
+- assert compact coverage semantics
+- reproduce prepared reconnect race
+- Fix Junction temporal parent continuation
+- ratchet runner bundle budget
+- coalesce Junction source projection reads
+- close temporal remediation plan
+- expect member ownership after event edit
+- ratchet stacked runner bundle budget
+- record Junction temporal ownership retrospective
+- align body hint and schemas
+- refresh generated skill hash
+- close Junction temporal remediation
+- prove Junction retry and fanout bounds
+- compose reserved history coordinates
+- keep history coordinates composable
+- announce body composition
+- announce complete summaries
+- announce temporal features
+- announce workout context
+- announce sparse clinical events
+- close Junction workout feature plan
+- complete Junction summary details
+- complete temporal feature integration
+- narrow sparse history window payload
+
 ## [1.3.1] - 2026-08-19
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murphai/murph",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "description": "Murph is a personal health assistant you run locally. Install this package to get the murph CLI.",
   "license": "Apache-2.0",

--- a/packages/cli/release-notes/v1.3.2.md
+++ b/packages/cli/release-notes/v1.3.2.md
@@ -1,0 +1,1292 @@
+1.3.2 Latest
+
+New Features
+- return canonical apply cards
+- energize referral section
+- allow workout exercise renames
+- track silent group conversions
+- track group-to-private conversions (#2311)
+- link directly to connect source cards
+- make wearable no-data outreach adaptive
+- admit versioned Temporal worker bindings (#2158)
+- accept focused group tool parsers (#2151)
+- allow fifty dollar group sponsorship caps
+- analyze attached videos on request (#2108)
+- accept manual meal photo uploads (#2098)
+- add timeout failure diagnostics (#2092)
+- enrich signup notifications
+- add ops usage search and reset all
+- reconsider unsent group replies once
+- trace device-sync interruptions (#2043)
+- verify and render OG image routes (#2056)
+- preserve complete Junction summaries (#1702)
+- preserve Junction metabolic context (#1700)
+- enrich bounded Junction workout streams
+- add authoritative Junction temporal features
+- default sparse clinical facts
+- preserve Junction summary details
+- finalize Junction body composition
+- preserve Junction body composition
+- finalize Junction body composition
+- register sparse clinical Junction resources
+- retain bounded Junction workout features
+- preserve bounded Junction temporal features
+- govern Junction resources and sparse history
+- preserve Junction body composition
+- preserve Junction summary details
+- preserve sparse Junction clinical facts
+
+Bug Fixes
+- package assistant verification contract (#2403)
+- isolate child-runtime package coverage (#2397)
+- parse coordinated workout exercises (#2340)
+- preserve Docker isolation on macOS (#2367)
+- clarify referral rewards
+- validate Kernel handoffs before publication
+- order roster observation upserts
+- keep referral estimates concise
+- restore live Stripe main proof
+- keep Kernel automation independent of live view
+- complete silent conversion lifecycle
+- negotiate Environment reconciliation fact
+- reconsider live group input (#2321)
+- require absolute alternate Codex home
+- complete Environment priority handoff
+- allow alternate Codex home for live journeys
+- ratchet device sync bundle budget (#2326)
+- preserve canonical preemption ordering
+- make activity errors recoverable (#2204)
+- make workout card authoring deterministic (#2295)
+- make database pool retries observable (#2292)
+- route autofix reviews to isolated lanes (#2309)
+- order latency trace row locks (#2293)
+- bind Junction ECG voltage to summaries (#2300)
+- make experiment and Age errors recoverable (#2207)
+- preserve connect dialog ownership
+- preserve database health provenance (#2290)
+- make held group replies complete
+- honor selected group journey model
+- prevent blank nutrition dead ends
+- keep meal recovery routing compact
+- keep child model live config local
+- keep blank meals in owner recovery
+- route card recovery through owners
+- make nutrition errors recoverable (#2205)
+- bound workout inventory continuation
+- ask before card recovery refusal
+- focus live assistant test runner
+- preserve ordinary resume cleanup
+- converge Browser Vault refresh work (#2226)
+- prioritize nutrition card recovery
+- require nutrition card data recovery
+- preserve composed release provenance
+- require meal recovery before nutrition cards
+- grant draft reset GraphQL authority (#2277)
+- ignore zero-limit overshoot periods
+- close reconsideration failure paths
+- isolate temporary CLI evaluation (#2270)
+- recover unresolved meals for nutrition cards
+- preserve model-repair error details (#2202)
+- preserve workout progress through authority failures
+- preserve stable skill recipes
+- remove contact details from signup notifications (#2260)
+- filter workout index before cap
+- apply direct usage settlements
+- strengthen connect target contrast
+- ratchet workout delivery bundle budget (#2266)
+- preserve current workout admission
+- preserve reconsidered group requests
+- make reminder saves replay-safe
+- use live workout capability
+- prevent duplicate wearable preference calls
+- preserve outreach settings through abort guard
+- require email authority for outreach settings
+- delete wearable outreach preferences with accounts
+- close adaptive outreach review gaps
+- document changelog-only review proof (#2255)
+- validate hosted-local temporal doctor (#2250)
+- propagate typecheck guard failures (#2248)
+- authorize pull request draft resets (#2251)
+- bound migration guard patterns to SQL statements (#2239)
+- classify provider requests by static host (#2249)
+- preserve finish-task deletion scope (#2247)
+- gate scoped workout stream sources
+- decouple DST recovery from titles
+- log completed hosted invocations
+- harden runtime issue provenance
+- gate workout streams by source capability
+- keep titles out of identity checks
+- use generated ids for reminder saves
+- correlate runtime issues with releases and attempts
+- bound model retry usage storms
+- hand off environment work after foreground
+- reactivate archived reminders by stable identity
+- recover the canonical live successor
+- prevent duplicate archived-name retries
+- cover incomplete private handoffs
+- distinguish private handoff continuations
+- anchor group draft cutoff at completion
+- tolerate accepted Temporal run visibility (#2215)
+- allow archived reminder name reuse
+- validate live Temporal compatibility runs (#2198)
+- handle in-flight one-shot edits
+- finalize child usage accounting
+- keep inbound videos transient
+- clarify reminder occurrence projection
+- recover usage link from later work (#2193)
+- preserve Garmin authorization guards
+- wait for Garmin consent readiness
+- await late subagent usage persistence
+- wait for disconnect hydration
+- classify empty workout streams
+- honor terminal garmin departure
+- drop unused reasoning profile field
+- preserve empty replay across retries
+- retain empty stream replay horizon
+- recover empty workout streams
+- submit garmin confirmation once
+- complete garmin consent progression
+- expose bounded pass queue diagnostics (#2160)
+- preserve replacement across delayed stop (#2171)
+- align group guidance with admitted tools
+- simplify split tool validation
+- enforce split group tool contracts
+- simplify workout follow-up identity
+- expose repairable group tool contracts
+- align hosted tool expectation (#2161)
+- include Max in ops growth MRR split
+- require fresh environment conditions
+- harden workout follow-up context
+- harden Kernel canary lifecycle proof
+- load environment conditions from OpenWeather
+- retire native E2E aliases before deployments
+- retain detached subagent usage
+- preserve canonical narrow-read semantics
+- isolate delayed lifecycle errors
+- prepare handoff authority crypto
+- preserve workout follow-up context
+- bind legacy nutrition authority
+- preserve Starter activation lifecycle
+- replay handoffs across transport failures
+- preserve pending health ownership
+- fence handoff replay crypto
+- bind recovery replay intent
+- disambiguate legacy nutrition calories
+- restore Temporal reconciliation compatibility (#2129)
+- accept optional realtime updates (#2128)
+- align environment realtime tools (#2126)
+- make context handoff retries exact
+- keep signup email enrichment optional
+- update GPT-5.6 Sol pricing (#2122)
+- preserve concurrent recovery usage
+- preserve signup notification fallback
+- remove homepage nav links
+- cover code-mode deferred discovery
+- discover deferred tools before denial
+- commit held input transcripts once
+- harden reset-all operator recovery
+- bound signup notification context retention
+- bound reset-all runtime wake latency
+- bound migration guard to SQL statements
+- defer held no-reply persistence
+- centralize progress prompt ownership
+- lock controls during reset restoration
+- harden nutrition card prompt ownership
+- persist exact delivery retry
+- guard refreshed ambiguous usage targets
+- resolve ops recovery review findings
+- fence exact telegram delivery
+- gate signup context capture
+- preserve ambiguous reset recovery
+- remount reset state across operators
+- keep reset wake logs scalar
+- preserve reset-all across tab reloads
+- release exact delivery claim on yield
+- preserve reset-all recovery ownership
+- reconcile exact delivery recovery
+- consolidate nutrition card workflow
+- scope reset-all wake recovery to receipts
+- advance reset-all past empty periods
+- make reset-everyone retries receipt-safe
+- make signup context provenance truthful
+- make physical-note recovery atomic
+- support legacy nutrition card calories
+- keep precommit segments provisional
+- fence recovery turn replays
+- bind cleanup to container starts
+- preserve partial Queue metrics (#2103)
+- close reconsideration review gaps
+- classify checked guard deterministically
+- complete blocked exact notifications
+- separate checked and remaining guards
+- fence legacy history reads
+- use the production Junction config path
+- unblock hosted runtime frontiers
+- restore runner bundle headroom (#2104)
+- fit recovery into runner budget
+- preserve recovery uncertainty
+- align startup convergence budgets
+- document all-resource rollout
+- restore all Junction resources
+- bind destroy ownership to starts
+- bind recovered source history
+- add explicit recovery control
+- bind readiness to replacement starts
+- scope readiness to current start
+- retain pending source webhooks
+- preserve startup transport convergence
+- retain observed pending starts
+- include Apollo in auto lane pool
+- preserve rollout cold starts
+- bind freshness to exact imports
+- require data-bearing import proof
+- prove exact Vercel production deployment (#2085)
+- preserve recovery delivery timer
+- preserve partial recovery windows
+- stop duplicate due reconcile signals (#2081)
+- harden worktree retirement (#2052)
+- project canonical imports into freshness
+- recover missing junction sources
+- make frontend evidence reproducible (#2066)
+- sync existing lockfile importers transactionally (#2061)
+- preserve native iOS cleanup failures (#2053)
+- bound and retry the Playwright Chromium install (#2022)
+- require provider occurrence for Fitbit cutover
+- tighten Fitbit migration copy
+- bind migration freshness to logical facts
+- advance usage link recovery claim
+- retry usage limit rich link partial
+- bind migration freshness to webhook trace
+- resume missing usage limit link
+- replay partial usage limit links
+- preserve delivery-only wake ownership
+- honor provider day timezone
+- admit model-free delivery retries
+- reconcile terminal foreground replies
+- isolate foreground quiet windows
+- supersede stale migration proof jobs
+- preserve source authorization epochs
+- unify Junction canonical imports
+- prove Fitbit history before migration
+- preserve source-scoped history evidence
+- fence migration freshness
+- simplify Fitbit migration continuation
+- keep migration identity browser safe
+- apply ReviewGPT remediation
+- preserve member deletions on changed replay
+- preserve activity heart-rate facts
+- preserve profile replay identity
+- pin extended history to 180 days
+- preserve ordinary sync ahead of temporal history
+- harden Junction workout feature projection
+- refresh generated skill hash
+- expose bounded Junction workout details
+- enforce repository trust floor
+- pin review trust floor
+- open explicit reconnect lifecycle
+- remove speculative routing policy
+- bind workout remote authority by id
+- gate onboarding subagent routing
+- preserve semantic source lifecycle
+- migrate unversioned Junction profiles
+- preserve established source lifecycle
+- migrate Junction profile identity safely
+- preserve capped webhook days
+- keep ordinary pull floor unconditional
+- preserve Junction history completion
+- fence Junction webhook pulls
+- retry superseded Junction fetches
+- preserve deployed m1 history
+- reconcile summary ownership after restack
+- preserve delayed provider revision ordering
+- preserve legacy activity heart-rate aliases
+- align Junction replay verification
+- recover Junction member edit conflicts
+- preserve member summary edits
+- resolve Junction summary review findings
+- reconcile Junction summary corrections
+- bound Junction menstrual evidence
+- complete rejected body history
+- harden body composition history
+- reconcile body composition stack
+- rebuild legacy body projections
+- unify sparse body selection
+- close body composition read gaps
+- complete body composition reads
+- pin exact workout connection
+- ignore physical alias rekeys in webhook proof
+- close workout authority gaps
+- retain ordinary reconcile completion
+- align Link callback lifecycle admission
+- resolve workout lifecycle source
+- fence workout source lifecycles
+- preserve Junction window ownership
+- advance each completed Link lifecycle
+- ratchet runner bundle budget
+- ratchet runner bundle size
+- fence hosted source reconnect history
+- fence reconnect-start worker completion
+- make history priority fair
+- bound reopened history priority
+- preserve legacy epoch wire absence
+- unify Junction alias lifecycle identity
+- close reconnect lifecycle gaps
+- resolve device sync reconnect subpath
+- finalize Junction lifecycle candidate
+- fence Junction lifecycle history
+- checkpoint Junction lifecycle fences
+- persist sparse history terminal state
+- preserve sparse history lineage
+- preserve delayed provider revision ordering
+- preserve legacy activity heart-rate aliases
+- align Junction replay verification
+- reopen local junction history
+- require current history terminality
+- close moving sparse history gaps
+- persist terminal history coordinates
+- terminate empty history scans
+- require workout companions for history
+- checkpoint Junction resource progress
+- co-import historical workout summaries
+- resume Junction reconcile resources safely
+- expand hosted lifecycle epoch safely
+- cover historical workout identity shapes
+- preserve Junction reconnect history fences
+- complete temporal history recovery
+- fence reconnect history by source epoch
+- recover Junction member edit conflicts
+- close temporal authority gaps
+- preserve grouped workout attribution
+- preserve workout identity and retries
+- align temporal day ownership
+- preserve member summary edits
+- preserve bounded clinical durability
+- bound sparse clinical daily imports
+- preserve Junction resource progress
+- unify sparse body selection
+- consolidate workout ingestion ownership
+- fence temporal facts to complete days
+- close body composition read gaps
+- resolve Junction summary review findings
+- complete body composition reads
+- tighten Junction history ownership
+- reconcile Junction summary corrections
+- harden bounded workout imports
+- require bounded temporal evidence
+- bound sparse clinical imports deterministically
+- harden bounded temporal features
+- reserve stacked history coverage
+- bound Junction menstrual evidence
+- bound sparse history completion
+- refresh Junction release artifacts
+- preserve compact webhook payloads
+- preserve sparse clinical record identity
+
+Documentation
+- stop local production-secret work (#2380)
+- archive weekly digest prompt plan (#2395)
+- close silent conversion implementation
+- state roster evidence expiry contract
+- note clearer referral rewards
+- note browser task resilience
+- close Environment wire compatibility
+- close Environment priority handoff
+- announce easier workout card editing
+- clarify alternate Codex home fallback
+- complete live assistant verification plan
+- record canonical Murph domain (#2296)
+- close group reconsideration rollout
+- record autofix launcher gate failure (#2297)
+- close nutrition card meal recovery
+- record live verification retrospective
+- clarify workout failure handling
+- require verification steps in final handoffs (#2287)
+- record PR draft reset permission gap
+- record draft-reset workflow friction
+- track group reconsideration rollout
+- attribute group reconsideration fix
+- close model loop cap hardening plan
+- catalog Vault CLI recovery gaps (#2203)
+- announce direct connection links
+- complete adaptive wearable outreach
+- pin wearable outreach rollback floor
+- add adaptive outreach changelog
+- record terminal event rollout
+- note mixed-source workout recovery
+- note reliable environment saves
+- continue specialist remediation
+- close group reply reconsideration
+- record handoff proof
+- note reliable private handoffs
+- complete hosted video transience
+- clarify quiet draft selection
+- define held group draft exception
+- note reminder name recovery
+- allow non-production review fixes
+- complete Temporal compatibility rollout (#2214)
+- clarify shared native Privy client (#2118)
+- announce temporary chat videos
+- announce clearer reminder edits
+- close Garmin consent readiness
+- close Garmin canary recovery
+- continue accepted complexity collapses
+- record draft reset permission gap
+- close workout stream recovery plan
+- note workout sync recovery
+- preserve current index guidance
+- record pr draft reset failure
+- preserve garmin canary index truth
+- reserve Ready for merge candidates
+- close workout stream diagnostics
+- skip pause after final ReviewGPT pass
+- close pass-budget plan (#2146)
+- complete ops growth Max MRR fix
+- note reliable environment conditions
+- complete Codex subagent usage plan
+- complete vault query narrow-reader plan
+- keep workout replies connected
+- keep ReviewGPT findings proportional
+- complete signup notification follow-up
+- record schema 7 workout card plan
+- trust Codex for ordinary tasks
+- close nutrition card legacy compatibility
+- record runtime review retrospective
+- log hosted-local doctor friction
+- note nutrition card compatibility
+- record product walkthrough
+- record candidate verification
+- note current group replies
+- note hosted runtime recovery
+- link recovery changelog PR
+- update recovery pr reference
+- clarify import freshness proof
+- define ordinary merge commit exception (#2082)
+- note Apple Health freshness recovery
+- note wearable recovery
+- close PR 1977 completion plan
+- finalize ReviewGPT completion watcher rule
+- prefer ReviewGPT completion watchers
+- extend ReviewGPT wake timeout
+- require exclusive PR ownership
+- note usage recovery delivery
+- record round seven remediation evidence
+- record combined Junction rollout decision
+- record ReviewGPT lane preference friction
+- record ReviewGPT round 13
+- announce complete summaries
+- announce body composition
+- record round 12 pass
+- close temporal remediation plan
+- record Junction temporal ownership retrospective
+- close Junction temporal remediation
+- announce body composition
+- announce complete summaries
+- announce temporal features
+- announce workout context
+- announce sparse clinical events
+- close Junction workout feature plan
+- complete temporal feature integration
+
+Changelog
+Full Changelog: v1.3.1...HEAD
+
+- test(assistant): gate local shell proof by platform (#2415) (eb1cada)
+- Suppress completed reminder occurrences (#2406) (42cda28)
+- Bound growth dashboard database fanout (#2346) (563bf80)
+- Fix Codex token usage compatibility (#2408) (e736ba1)
+- test(web): align mailbox fixture sequences (#2410) (d8e6b50)
+- Warn while long database transactions are still open (#2399) (dce29b2)
+- Fix consent reposts and restaurant nutrition lookup (#2386) (6b7f29c)
+- Keep phone-transfer locks provider-free (#2405) (86d1863)
+- Add Stripe reconciliation error telemetry (#2409) (258d8e6)
+- test(hosted-local): cover Linux MinIO bridge endpoint (#2411) (387938a)
+- docs: stop local production-secret work (#2380) (b3ef670)
+- Classify wrapped Prisma pool failures accurately (#2355) (7ad27c9)
+- Fail fast on hosted latency trace lock contention (#2350) (475a96a)
+- Prepare Codex auth mailbox crypto before transaction (#2341) (7e9e661)
+- Reuse saved nutrition context before card recovery (#2336) (e85ffdd)
+- Add recent-member retention view to Growth (#2384) (618159c)
+- fix(review): package assistant verification contract (#2403) (b92d62c)
+- perf(query): bound meal nutrition reads to events (#2394) (313206f)
+- fix(verification): isolate child-runtime package coverage (#2397) (95137b3)
+- chore: sync friction log (#2398) (f953213)
+- docs: archive weekly digest prompt plan (#2395) (e1f8899)
+- chore(repo): ignore generated Graft graph (#2396) (be65311)
+- chore: sync friction log (#2376) (b859ba2)
+- fix(assistant): parse coordinated workout exercises (#2340) (287d43a)
+- Keep Messages workout auth renewable (#2370) (b9be11e)
+- Recover product-feedback validation errors (#2349) (11eb7d2)
+- Honor saved prompts for weekly digest automations (#2359) (5ca1cef)
+- Document alternate Codex home approval (#2379) (1cb09cb)
+- chore(deps): finish ReviewGPT 0.5.138 rollout (2c9a38c)
+- fix(hosted-local): preserve Docker isolation on macOS (#2367) (9110726)
+- chore(deps): update ReviewGPT to 0.5.138 (e6d8039)
+- test(workouts): prove canonical apply receipts (afe1550)
+- feat(workouts): return canonical apply cards (486fa23)
+- fix(web): clarify referral rewards (67c80c9)
+- feat(web): energize referral section (f1c0aae)
+- docs(plan): close silent conversion implementation (2ac07cd)
+- fix(web): validate Kernel handoffs before publication (28b6832)
+- fix(web): order roster observation upserts (5083d85)
+- chore: defer workout card changelog (6b51d76)
+- fix(web): keep referral estimates concise (2080272)
+- chore: sync friction log (#2362) (4de5e02)
+- test(ci): harden Stripe skip regression proof (3d55b3f)
+- refactor(web): tighten referral copy (68f54c1)
+- Retire the legacy Frog autofixer (#2357) (3925957)
+- fix(ci): restore live Stripe main proof (0ea0933)
+- docs(privacy): state roster evidence expiry contract (488d9a2)
+- Improve cold conversation reconstruction (#2342) (b2ce456)
+- refactor(web): keep roster evidence expiry-only (3ea8ad0)
+- docs(changelog): note clearer referral rewards (0a3c855)
+- refactor(web): polish referral section (c41e30e)
+- chore: sync friction log (#2316) (47717ee)
+- docs(changelog): note browser task resilience (3ad6f4e)
+- Fix broad private food search timeouts (#2318) (7381920)
+- test(web): exercise negotiated Environment fact (e33dd68)
+- fix(web): keep Kernel automation independent of live view (163dc3e)
+- Add durable hosted operator tasks (#2304) (1a17635)
+- docs(plan): close Environment wire compatibility (d8b9019)
+- Compare vault-cli bundle growth to exact base (#2344) (e59227e)
+- chore(web): remove completed group backfill (#2339) (a77d387)
+- fix(web): complete silent conversion lifecycle (1558fe1)
+- fix(hosted): negotiate Environment reconciliation fact (b5f57a9)
+- docs(plan): close Environment priority handoff (ff21aa1)
+- test(hosted): align Environment wire fixtures (fd6b183)
+- fix(assistant): reconsider live group input (#2321) (f6d4a13)
+- docs: announce easier workout card editing (eb456f7)
+- docs(test): clarify alternate Codex home fallback (c7e1c96)
+- feat: allow workout exercise renames (cc8982b)
+- fix(test): require absolute alternate Codex home (2aa268c)
+- Complete Environment voice report coverage (#2335) (a56b39f)
+- Refresh expanded workout cards from canonical state (#2332) (ff0d09c)
+- test(assistant): compose alternate Codex home selection (26ab475)
+- fix(hosted): complete Environment priority handoff (ef3bf39)
+- fix(test): allow alternate Codex home for live journeys (b08c2fd)
+- Route group backfill through protected production workflow (#2324) (712a84e)
+- Fix physical-note recovery lookup (#2327) (012adb1)
+- feat(web): track silent group conversions (93b6e09)
+- Preserve speakers in private-to-group handoffs (#2319) (085abb7)
+- ci: make Markdown-only pull requests cheap (#2313) (4448892)
+- chore(hosted): close foreground preemption plan (6ab7827)
+- Correlate workspace snapshot start diagnostics (#2323) (7f7805b)
+- test(hosted): prove shared foreground wake handoff (54d8002)
+- fix(cloudflare): ratchet device sync bundle budget (#2326) (fa5af06)
+- feat(web): track group-to-private conversions (#2311) (c0b662d)
+- Remove the Fitbit Junction note (#2320) (2df42f0)
+- fix(cloudflare): preserve canonical preemption ordering (f61fd29)
+- Fix hosted device-sync snapshot import bottleneck (#2322) (6eaadf4)
+- Fix organic group discovery (#2303) (80c66dd)
+- fix(cli): make activity errors recoverable (#2204) (2945c0d)
+- fix: make workout card authoring deterministic (#2295) (4ccd547)
+- Enforce production food-search index contract (#2294) (e45be4e)
+- perf(web): bound static generation concurrency (#2312) (f0c726f)
+- fix(web): make database pool retries observable (#2292) (875c8ad)
+- test: split oversized runtime suites (#2307) (b09ea4b)
+- fix(frog): route autofix reviews to isolated lanes (#2309) (89e814f)
+- Add foreground reply changelog entry (dd9d533)
+- Prioritize foreground replies over system work (2055be0)
+- Fix Codex 0.149.1 auth deploy guard (#2310) (ed7e3fe)
+- fix(web): order latency trace row locks (#2293) (52205b8)
+- Resume approved files in active hosted turns (#2269) (25b1787)
+- fix(device-sync): bind Junction ECG voltage to summaries (#2300) (9cb0ca5)
+- fix(cli): make experiment and Age errors recoverable (#2207) (b9f8de1)
+- chore(deps): upgrade Codex CLI to 0.149.1 (#2288) (3beac93)
+- perf(web): bound home projection fanout (#2289) (611727f)
+- fix(web): preserve connect dialog ownership (49ea327)
+- docs: complete live assistant verification plan (9496617)
+- Fix connection deep links with a dialog (#2283) (808a4cd)
+- perf(web): remove redundant reconciliation reads (#2291) (5447098)
+- fix(cloudflare): preserve database health provenance (#2290) (14769b3)
+- test: print group journey reply (b6f4f1e)
+- docs: record canonical Murph domain (#2296) (7eb5670)
+- Compact broad group consent offers (#2298) (7e3e8c8)
+- chore: sync friction log (#2302) (388c345)
+- fix: make held group replies complete (bbdeb09)
+- Add stage diagnostics for companion address-book timeouts (#2276) (ecefee0)
+- test(assistant-engine): split local service runtime coverage (#2299) (5681f2d)
+- fix: honor selected group journey model (0649eb8)
+- docs(plan): close group reconsideration rollout (7019355)
+- docs(frog): record autofix launcher gate failure (#2297) (fbbf94d)
+- docs(plan): close nutrition card meal recovery (39f7c95)
+- Compact iMessage workout comparison cards (#2285) (53ba33c)
+- fix(assistant): prevent blank nutrition dead ends (47aed3d)
+- docs: record live verification retrospective (3881261)
+- fix(assistant): keep meal recovery routing compact (77c737e)
+- fix: keep child model live config local (4a5773f)
+- chore(device-syncd): close workout stream remediation (a1c767e)
+- Extend hosted device-sync pass telemetry (#2267) (065d47b)
+- Preserve exact context for direct native replies (#2279) (216765d)
+- Make the Environment voice report readable on a phone (#2282) (f90fe6d)
+- docs(reliability): clarify workout failure handling (8cb4d76)
+- test(assistant): distinguish meal edit help from mutation (50cda5e)
+- docs: require verification steps in final handoffs (#2287) (d89b25d)
+- fix(assistant): keep blank meals in owner recovery (854679d)
+- chore: sync friction log (#2272) (3da93c4)
+- fix(assistant): route card recovery through owners (ea01bc5)
+- fix(cli): make nutrition errors recoverable (#2205) (e389de5)
+- fix(device-syncd): bound workout inventory continuation (4344794)
+- test(assistant): trim Terra recovery diagnostics (04df48a)
+- fix(assistant): ask before card recovery refusal (7667218)
+- test(assistant): model live card turn as private direct (6e4b02e)
+- fix: focus live assistant test runner (20d08ed)
+- test(assistant): launch live meal CLI without IPC (fe2fd41)
+- test(assistant): summarize live meal recovery actions (681b2d6)
+- test(assistant): make live meal fixture self-contained (bb4729f)
+- test(assistant): expose live meal recovery actions (85b381d)
+- fix(assistant): preserve ordinary resume cleanup (6d98d44)
+- test(web): execute overshoot predicate in postgres (5be3a1d)
+- fix(runtime): converge Browser Vault refresh work (#2226) (72bd9e4)
+- fix(assistant): prioritize nutrition card recovery (08dd80f)
+- Fix scheduled card delivery intent (#2262) (debbe70)
+- fix(assistant): require nutrition card data recovery (8ba2316)
+- fix(cloudflare): preserve composed release provenance (97d3124)
+- fix(assistant): require meal recovery before nutrition cards (04993bf)
+- fix(ci): grant draft reset GraphQL authority (#2277) (3ee597f)
+- fix(web): ignore zero-limit overshoot periods (3ff4ede)
+- fix(assistant): close reconsideration failure paths (84b987b)
+- fix: isolate temporary CLI evaluation (#2270) (16c49b4)
+- ci: use the repository Node version for live prompt proof (05e44b7)
+- fix(assistant): recover unresolved meals for nutrition cards (478a26e)
+- fix(cli): preserve model-repair error details (#2202) (e5edf46)
+- fix(device-sync): preserve workout progress through authority failures (f79de50)
+- fix(automation): preserve stable skill recipes (3212f9d)
+- test(device-sync): prove live disconnect blocks workout egress (311a68f)
+- fix: remove contact details from signup notifications (#2260) (9a38e04)
+- refactor(automation): drop replay fingerprinting (37add27)
+- docs(friction): record PR draft reset permission gap (ddf3d73)
+- fix(device-sync): filter workout index before cap (a84ef7f)
+- test(assistant): distinguish Luna child from parent (9038f02)
+- test: align live Starter settings check (#2263) (b479ad2)
+- fix(cloudflare): apply direct usage settlements (3de4228)
+- fix(web): strengthen connect target contrast (555b1fc)
+- test(assistant): expose live child model override (0460773)
+- docs: record draft-reset workflow friction (8a0311f)
+- test(assistant): smoke live Luna subagent selection (95dda14)
+- fix(cloudflare): ratchet workout delivery bundle budget (#2266) (2395f5a)
+- test: register runtime issue provenance migration (1f89906)
+- Pin hosted subagent model selection on (#2225) (1d46bb8)
+- chore: complete runtime issue provenance plan (2636a9b)
+- docs(plan): track group reconsideration rollout (f2a5320)
+- test: streamline live assistant verification (26dfc03)
+- test(web): align usage settlement mock (215b1ee)
+- fix(device-sync): preserve current workout admission (7863496)
+- docs(changelog): attribute group reconsideration fix (74d8435)
+- fix(assistant): preserve reconsidered group requests (3652be8)
+- Preserve exact workout identity across replies (#2254) (35f7d53)
+- docs: close model loop cap hardening plan (d67d60d)
+- fix(automation): make reminder saves replay-safe (cbd299c)
+- fix(device-sync): use live workout capability (d1244ae)
+- test: remove duplicate image provenance proof (d17a43a)
+- docs(audit): catalog Vault CLI recovery gaps (#2203) (9eb403c)
+- test: prove usage settlement fails closed (684cffe)
+- test: prove image issue provenance export (a3415b4)
+- docs(changelog): announce direct connection links (b238444)
+- feat(web): link directly to connect source cards (39c6a6e)
+- fix: prevent duplicate wearable preference calls (b87c5b7)
+- docs(plan): complete adaptive wearable outreach (d0e6d92)
+- docs(web): pin wearable outreach rollback floor (a686634)
+- fix(runtime): preserve outreach settings through abort guard (9eecfef)
+- chore: sync friction log (#2256) (4dde147)
+- fix(web): require email authority for outreach settings (5c6fc58)
+- Fix hosted web prebuilt workflow triggers (#2258) (361927d)
+- Fix repeated scans during batch worktree retirement (#2259) (5f28c42)
+- fix: delete wearable outreach preferences with accounts (ebce603)
+- test(web): generate prisma before hosted vitest (#2257) (d67bfd8)
+- fix: close adaptive outreach review gaps (6a41826)
+- fix: document changelog-only review proof (#2255) (9e7b850)
+- fix: validate hosted-local temporal doctor (#2250) (131db2d)
+- chore: sync friction log (#2246) (77ea8a5)
+- fix: propagate typecheck guard failures (#2248) (41d0e12)
+- fix(ci): authorize pull request draft resets (#2251) (64416f1)
+- Recover nutrition cards and automatic meal captures (#2240) (5fc3fd1)
+- docs: add adaptive outreach changelog (f60d49a)
+- feat: make wearable no-data outreach adaptive (e49548b)
+- fix(web): bound migration guard patterns to SQL statements (#2239) (4254bda)
+- fix(repo): classify provider requests by static host (#2249) (5fbe322)
+- Ask when automatic meal nutrition is unclear (#2241) (00eb876)
+- fix(workflow): preserve finish-task deletion scope (#2247) (1e0a344)
+- Prune completed generated deliveries from hosted checkpoints (#2231) (945c6aa)
+- docs(runtime): record terminal event rollout (379384f)
+- test(runtime): cover default completion mode (dfbf207)
+- fix(device-sync): gate scoped workout stream sources (9d2e9e6)
+- Answer every rapid group request in one reply (#2232) (9145472)
+- chore(plan): close workout stream capability fix (e0819a1)
+- docs(changelog): note mixed-source workout recovery (4707b32)
+- fix(automation): decouple DST recovery from titles (08b61d5)
+- fix(runtime): log completed hosted invocations (0e39dd1)
+- fix: harden runtime issue provenance (d6bbce2)
+- fix(device-sync): gate workout streams by source capability (760b620)
+- Reduce reply recovery delay during runner shutdown (#2235) (336de42)
+- Raise worktree ceiling to 200 (8c6c589)
+- test(automation): allow ordinary managed-name reminders (bbc356f)
+- Stop obsolete device-sync environment log churn (#2233) (91c366e)
+- fix(automation): keep titles out of identity checks (e9beed4)
+- fix(automation): use generated ids for reminder saves (25a1f3e)
+- fix: correlate runtime issues with releases and attempts (f72cec6)
+- fix: bound model retry usage storms (7f6b4b4)
+- docs(changelog): note reliable environment saves (47028ce)
+- chore: sync friction log (#2073) (5b485c8)
+- fix(hosted): hand off environment work after foreground (814478d)
+- docs(workflow): continue specialist remediation (239fa27)
+- Speed up Android hosted E2E admission (#2227) (7f23b2d)
+- chore: drop cross-repository Frog entries (#2230) (02fbe90)
+- fix(automation): reactivate archived reminders by stable identity (1a10903)
+- fix(automation): recover the canonical live successor (d5fc78e)
+- Archive stale reminder projection plan (4287b04)
+- Keep stale reminder timing authoritative (f646f62)
+- fix(automation): prevent duplicate archived-name retries (364d7e6)
+- docs(plan): close group reply reconsideration (cb3065d)
+- fix(assistant): cover incomplete private handoffs (f06e8c9)
+- docs(plan): record handoff proof (0627698)
+- docs(changelog): note reliable private handoffs (18bc87b)
+- fix(assistant): distinguish private handoff continuations (8f98d1e)
+- docs(plans): complete hosted video transience (e376d28)
+- Simplify nutrition card safety prompts (#2196) (2d79966)
+- fix(assistant): anchor group draft cutoff at completion (e35a0e3)
+- Keep workout set confirmations on one canonical owner (#2195) (fdfae54)
+- fix(ci): tolerate accepted Temporal run visibility (#2215) (3ea4cad)
+- docs(architecture): clarify quiet draft selection (26f1ccb)
+- docs(architecture): define held group draft exception (2647d5f)
+- Fix delegated Murph message recovery (#2168) (6a34916)
+- Fix stale reminder occurrence projection (b23c282)
+- docs(changelog): note reminder name recovery (3e83d60)
+- fix(core): allow archived reminder name reuse (b2acf66)
+- Stop inactive runtime mailbox churn (#2165) (4de5f24)
+- docs(workflow): allow non-production review fixes (1f598f3)
+- docs: complete Temporal compatibility rollout (#2214) (debd41a)
+- fix(ci): validate live Temporal compatibility runs (#2198) (0b4c381)
+- fix(assistant): handle in-flight one-shot edits (c99a45b)
+- test(inbox): protect active zero-window videos (01a0e1c)
+- Text members when Garmin delivery stalls (#2189) (057bd31)
+- fix(assistant): finalize child usage accounting (2fb8701)
+- chore: advance Temporal compatibility controller (#2201) (614b154)
+- docs(ops): clarify shared native Privy client (#2118) (441935b)
+- docs(changelog): announce temporary chat videos (eb36e7c)
+- fix(hosted): keep inbound videos transient (bfa7df1)
+- docs(changelog): announce clearer reminder edits (6fc892d)
+- fix(assistant): clarify reminder occurrence projection (8c75db1)
+- docs(plans): close Garmin consent readiness (edf2596)
+- fix(hosted): recover usage link from later work (#2193) (cd0eb3f)
+- refactor(web): unify Garmin authorization readiness (a2c5133)
+- fix(web): preserve Garmin authorization guards (8e17d1d)
+- fix(web): wait for Garmin consent readiness (3cd9dab)
+- docs(plans): close Garmin canary recovery (28225c8)
+- test(workflow): cover complexity collapse exception (c080037)
+- docs(workflow): continue accepted complexity collapses (1eab79b)
+- Recover stalled usage-limit links after overlapping receipts (#2185) (f42388f)
+- fix(assistant): await late subagent usage persistence (fdd7271)
+- docs(frog): record draft reset permission gap (53ced43)
+- test(canary): prove hydrated disconnect (e0801ac)
+- test(hosted): align onboarding proofs with checkpoints (#2184) (2e807a3)
+- docs(plans): close workout stream recovery plan (8ae1ccb)
+- fix(canary): wait for disconnect hydration (e54c269)
+- fix(device-sync): classify empty workout streams (2b3cddf)
+- fix(canary): honor terminal garmin departure (808767d)
+- chore(canary): expose garmin confirmation surface (b1b1c41)
+- test(canary): prove delayed garmin departure (5de499f)
+- fix(hosted-execution): drop unused reasoning profile field (ad2cf11)
+- fix(device-sync): preserve empty replay across retries (591e80e)
+- fix(device-sync): retain empty stream replay horizon (454a91a)
+- docs(changelog): note workout sync recovery (5929b66)
+- fix(device-sync): recover empty workout streams (79968a2)
+- fix(canary): submit garmin confirmation once (abf9af6)
+- test(release): align ReviewGPT policy assertions (a13421e)
+- docs(canary): preserve current index guidance (a713734)
+- docs: record pr draft reset failure (60e6f6a)
+- docs: preserve garmin canary index truth (b625a22)
+- test(canary): restore garmin route departure proof (567ead5)
+- fix(canary): complete garmin consent progression (491e9c5)
+- docs(workflow): reserve Ready for merge candidates (844525e)
+- chore(frog): record PR draft reset permission failure (f6cd9ad)
+- Make Starter signup completion consent-owned (#2166) (a296d95)
+- docs(exec-plan): close workout stream diagnostics (e3ba10f)
+- test(hosted): use split newsletter tools (a7b1009)
+- docs(workflow): skip pause after final ReviewGPT pass (85a9b2c)
+- Make onboarding follow-up enrollment activation-owned (#2097) (985f959)
+- chore(device-sync): expose workout stream cardinality diagnostics (1941eb1)
+- Gate expensive CI on ready PR heads (#2136) (bc038be)
+- Pin authenticated Temporal deployment controller (#2177) (33693ab)
+- Require exact Temporal reader compatibility before merge (#2147) (8d7140f)
+- Complete Garmin consent in the Junction canary (#2174) (9561f4d)
+- Fix Garmin canary Cloudflare challenge with headed Kernel (#2172) (5d349c4)
+- refactor(assistant): delete legacy group tool schema (b70bf51)
+- Switch the live Junction canary to Garmin (#2170) (9d43b21)
+- Simplify child usage finalization (61adb73)
+- fix(device-sync): expose bounded pass queue diagnostics (#2160) (2a13c2c)
+- fix(cloudflare): preserve replacement across delayed stop (#2171) (2cfd304)
+- fix(assistant): align group guidance with admitted tools (a63f218)
+- fix(assistant): simplify split tool validation (feadd44)
+- Simplify Codex child usage accounting (21ce164)
+- fix(assistant): enforce split group tool contracts (e2ae51f)
+- docs(device-sync): close pass-budget plan (#2146) (0dc5fbb)
+- fix(assistant): simplify workout follow-up identity (a592864)
+- Prove Kernel tunnel child lifetime (bb30561)
+- docs: complete ops growth Max MRR fix (995d59b)
+- fix(assistant): expose repairable group tool contracts (218b948)
+- fix(cloudflare): align hosted tool expectation (#2161) (b641199)
+- Fix Kernel canary tunnel lifetime (af37769)
+- feat(hosted): admit versioned Temporal worker bindings (#2158) (5e11a3c)
+- fix(web): include Max in ops growth MRR split (622d2dd)
+- fix(web): require fresh environment conditions (63c2694)
+- fix(assistant): harden workout follow-up context (1094a9c)
+- fix(web): harden Kernel canary lifecycle proof (0c3a038)
+- docs(changelog): note reliable environment conditions (d3174b5)
+- fix(web): load environment conditions from OpenWeather (0e36817)
+- chore: close native E2E alias retirement plan (c8f7884)
+- test: enforce complete native E2E alias retirement (59b035d)
+- fix: retire native E2E aliases before deployments (daf46d7)
+- docs: complete Codex subagent usage plan (3b4c5cb)
+- fix(assistant-engine): retain detached subagent usage (44773ca)
+- docs: complete vault query narrow-reader plan (3eb8398)
+- fix: preserve canonical narrow-read semantics (57f6ed4)
+- fix(hosted): isolate delayed lifecycle errors (d7da7d3)
+- Clean up timed-out subagent metadata requests (4f8bb0a)
+- Fix Codex subagent usage review findings (d38f90a)
+- feat(assistant): accept focused group tool parsers (#2151) (d778cff)
+- perf: bound vault query reads by family (ed49c7e)
+- Meter Codex child-agent provider usage (4e76169)
+- perf(assistant): compact automation tool schema (#2125) (78d2292)
+- Meter exact Codex subagent usage (6928dc5)
+- Improve public agent readiness (#2120) (82a9a6c)
+- fix(groups): prepare handoff authority crypto (52d1e39)
+- docs(changelog): keep workout replies connected (1a275d3)
+- fix(assistant): preserve workout follow-up context (c6b31a6)
+- fix(assistant): bind legacy nutrition authority (0590f31)
+- test(web): complete mailbox test mock (f16cee1)
+- Remove brittle Codex permission attestation (#2143) (4911e7b)
+- Use Kernel for WHOOP canary browser (9e1cbd8)
+- chore: record ReviewGPT composer friction (de54b34)
+- Extend hosted device-sync passes to 90 seconds (#2119) (60b9333)
+- Self-heal duplicate Junction daily event aliases (#2089) (91a3449)
+- fix(test): preserve Starter activation lifecycle (b342ae5)
+- test(web): keep sponsorship verification current (7d1a2bf)
+- test(web): update group email mailbox mock (aa33cf3)
+- test(web): cover fifty dollar sponsorship choices (0f65b82)
+- Extend ReviewGPT default timeout to 250 minutes (#2138) (9dfb71d)
+- chore(web): link sponsorship changelog to pr (55b8b5c)
+- test(assistant): ratchet nutrition authority prompt (6ce7aad)
+- feat(web): allow fifty dollar group sponsorship caps (f13cacd)
+- fix(groups): replay handoffs across transport failures (839c0a9)
+- test(hosted): keep foreground storm on generic owner (#2139) (562bf22)
+- test(cloudflare): mirror startup lifecycle state (42aaf2b)
+- Keep automatic sponsorship refills retryable (#2132) (a50cd87)
+- test(hosted): preserve mailbox completion contracts (#2137) (3189374)
+- fix(hosted): preserve pending health ownership (b663167)
+- fix(groups): fence handoff replay crypto (d0b1893)
+- fix(physical-notes): bind recovery replay intent (9ad89a4)
+- fix(assistant): disambiguate legacy nutrition calories (cf2baa2)
+- test(hosted): verify system mailbox checkpoint (#2135) (0e5e663)
+- docs(review): keep ReviewGPT findings proportional (6bb4c65)
+- test(hosted): wait for interview mailbox consumption (#2134) (887ba9a)
+- test(hosted): use valid interview completion id (#2131) (41e2433)
+- test(hosted): cover environment interview system wake (#2130) (b30d8a2)
+- fix(web): restore Temporal reconciliation compatibility (#2129) (10ee89b)
+- Polish the group funding success mark (#2046) (f91fee8)
+- docs: complete signup notification follow-up (6878efa)
+- fix: accept optional realtime updates (#2128) (e332c40)
+- fix: align environment realtime tools (#2126) (ca689ae)
+- fix(groups): make context handoff retries exact (5e369af)
+- fix(web): keep signup email enrichment optional (3030016)
+- Require literal Junction connection proof for webhook recovery (#2117) (b9b3597)
+- fix(web): update GPT-5.6 Sol pricing (#2122) (c400b31)
+- fix(physical-notes): preserve concurrent recovery usage (30281b2)
+- fix(web): preserve signup notification fallback (c7ae5a1)
+- Add realtime Environment interview (#2100) (6ac4457)
+- Disambiguate physical-note recovery targets (f3486c9)
+- docs(imessage): record schema 7 workout card plan (f108fa8)
+- Remove redundant member-memory sandbox profile (#2086) (ae6dfb9)
+- fix(web): remove homepage nav links (8c39a61)
+- fix(assistant): cover code-mode deferred discovery (14a2a2f)
+- fix(assistant): discover deferred tools before denial (74e8f53)
+- fix(assistant): commit held input transcripts once (274cf02)
+- Fix hosted Android E2E credential ownership (#2115) (d0a43cb)
+- feat(assistant): analyze attached videos on request (#2108) (e7c8015)
+- fix: harden reset-all operator recovery (3bcc689)
+- fix(web): bound signup notification context retention (fe9c0c0)
+- refactor(assistant): centralize scheduled nutrition safety (767b94c)
+- fix: bound reset-all runtime wake latency (332c507)
+- docs: trust Codex for ordinary tasks (77539e2)
+- Batch workout starts and bypass exact-command projection rebuilds (#2070) (41569a4)
+- fix(web): bound migration guard to SQL statements (ab76bbe)
+- Classify terminal recovery targets (9a77634)
+- fix(assistant): defer held no-reply persistence (2031471)
+- feat: accept manual meal photo uploads (#2098) (dfd74f4)
+- Recheck nonterminal recovery targets (217fbc2)
+- fix(assistant): centralize progress prompt ownership (024db76)
+- Complete device webhooks for unregistered sources (#2114) (916066a)
+- fix(web): lock controls during reset restoration (7d96dd7)
+- Forward physical-note recovery targets (ce004a8)
+- fix(assistant): harden nutrition card prompt ownership (7318541)
+- Bind physical-note recovery targets (f3e8aec)
+- fix(runtime): persist exact delivery retry (4a6a2f1)
+- fix(web): guard refreshed ambiguous usage targets (4d64ed7)
+- fix(web): resolve ops recovery review findings (86af859)
+- docs(plan): close nutrition card legacy compatibility (273df78)
+- fix(runtime): fence exact telegram delivery (c17be42)
+- test(web): stabilize signup route test env (2bf016f)
+- Fix legacy nutrition card eligibility owner (585bc20)
+- docs: record runtime review retrospective (d97374a)
+- fix(web): gate signup context capture (b0a7352)
+- fix(web): preserve ambiguous reset recovery (8eb923a)
+- fix(web): remount reset state across operators (4dbf593)
+- fix(web): keep reset wake logs scalar (9d8128b)
+- Cover paid recovery replay after note deletion (351f29b)
+- fix(web): preserve reset-all across tab reloads (72488a4)
+- Report recovered physical-note usage (ac495bb)
+- fix(runtime): release exact delivery claim on yield (1c57313)
+- Fix group handoff release contracts (#2113) (4d38e2f)
+- docs: log hosted-local doctor friction (419f5f2)
+- fix(web): preserve reset-all recovery ownership (c10fc86)
+- fix(runtime): reconcile exact delivery recovery (59e0956)
+- fix(assistant): consolidate nutrition card workflow (756e935)
+- fix(web): scope reset-all wake recovery to receipts (55b125f)
+- fix(web): advance reset-all past empty periods (342b2a0)
+- Add private-to-group context handoff (999ef9d)
+- test(web): acknowledge ops reset receipt schema (8fdeb08)
+- fix(web): make reset-everyone retries receipt-safe (ef180f0)
+- fix(web): make signup context provenance truthful (8771702)
+- feat: add timeout failure diagnostics (#2092) (8091098)
+- test(web): type signup context fixture (a344085)
+- chore(web): preserve Prisma schema formatting (cb85113)
+- feat(web): enrich signup notifications (b84fe00)
+- Add protected native Android hosted E2E (#2109) (b22f627)
+- fix(web): make physical-note recovery atomic (d110efd)
+- feat(web): add ops usage search and reset all (815cfc5)
+- docs(changelog): note nutrition card compatibility (31877d2)
+- fix(assistant): support legacy nutrition card calories (a53bc57)
+- fix(assistant): keep precommit segments provisional (528f09e)
+- fix(physical-notes): fence recovery turn replays (738b099)
+- fix(hosted): bind cleanup to container starts (f3005e4)
+- fix(cloudflare): preserve partial Queue metrics (#2103) (b01cd6e)
+- fix(assistant): close reconsideration review gaps (0169f75)
+- fix(physical-notes): classify checked guard deterministically (539836f)
+- fix(runtime): complete blocked exact notifications (99d3619)
+- fix(physical-notes): separate checked and remaining guards (519b8c6)
+- docs(plan): record product walkthrough (7f3b839)
+- docs(plan): record candidate verification (603ea8f)
+- docs(changelog): note current group replies (01d29e7)
+- test(web): update mailbox frontier projection (eece64d)
+- feat(assistant): reconsider unsent group replies once (91a10d6)
+- fix(device-sync): fence legacy history reads (b160e33)
+- Let existing members email Murph from any inbox (#2083) (d60a99f)
+- fix(device-sync): use the production Junction config path (3afa918)
+- docs(changelog): note hosted runtime recovery (5890c67)
+- test(runtime): prove durable retry checkpoint order (cae7881)
+- fix(runtime): unblock hosted runtime frontiers (045b8ca)
+- fix(cloudflare): restore runner bundle headroom (#2104) (8d5fd00)
+- fix(physical-notes): fit recovery into runner budget (1be28df)
+- fix(physical-notes): preserve recovery uncertainty (3da4bcd)
+- fix(hosted): align startup convergence budgets (c96e070)
+- fix(device-sync): document all-resource rollout (85c5d93)
+- fix(device-sync): restore all Junction resources (f25d578)
+- Migrate stable Junction profile timestamps (#2096) (9ebf4a4)
+- fix(cloudflare): bind destroy ownership to starts (826f874)
+- fix(device-sync): bind recovered source history (a08c2f3)
+- Retry transient hosted device-sync reads (#2095) (99ced05)
+- docs(physical-notes): link recovery changelog PR (babf790)
+- fix(physical-notes): add explicit recovery control (cd59c17)
+- fix(cloudflare): bind readiness to replacement starts (6fcc5d6)
+- fix(cloudflare): scope readiness to current start (4fd9641)
+- Delete obsolete device-sync dirty retention (#2094) (3f7786f)
+- fix(web): retain pending source webhooks (43a9ee4)
+- fix(cloudflare): preserve startup transport convergence (8e120fc)
+- Fix signup notification ownership (#2068) (a782308)
+- Prioritize approved foreground continuations (#2077) (118f7a3)
+- fix(cloudflare): retain observed pending starts (5d519ac)
+- test(review): align six-lane release contract (ee89c80)
+- fix(review): include Apollo in auto lane pool (93b9e5b)
+- fix(cloudflare): preserve rollout cold starts (1288c1e)
+- docs(changelog): update recovery pr reference (6034828)
+- test(device-sync): prove missing-source replay (578b5f0)
+- fix(device-sync): bind freshness to exact imports (f301bf7)
+- feat(runtime): trace device-sync interruptions (#2043) (0fe9fe0)
+- Simplify record-scoped workout tracking (#2063) (8e7e91e)
+- Recover KMS reads and Garmin sync (#2048) (9a755f3)
+- Confirm safe partial database telemetry before warning (#2050) (902599e)
+- Prove Messages workout rep contract (#2075) (347171e)
+- ci: parallelize release verification (#2042) (58f2970)
+- Honor scheduled device retries in runtime progress alerts (#2049) (69d621c)
+- Restore silent hosted memory maintenance (#2047) (4f660db)
+- fix(device-sync): require data-bearing import proof (ffe6eda)
+- fix(web): prove exact Vercel production deployment (#2085) (e2c1563)
+- Prune restored delivery residue before cold snapshots (#2074) (59ac463)
+- fix(hosted): preserve recovery delivery timer (cc73044)
+- docs(device-sync): clarify import freshness proof (1a121bd)
+- test(device-sync): update freshness signal mock (2ac2ba7)
+- fix(hosted): preserve partial recovery windows (ac0d972)
+- fix(web): stop duplicate due reconcile signals (#2081) (2b8de03)
+- docs: define ordinary merge commit exception (#2082) (4098153)
+- test: stabilize usage-credit fixture assertions (#2080) (9445833)
+- Keep pre-merge and release guards aligned (#2072) (0f97212)
+- Route native iOS reruns through a fresh validated run (#2071) (e38bb08)
+- Harden ReviewGPT configuration and consume v0.5.136 (#2076) (2c98e8a)
+- Serialize concurrent ReviewGPT base refreshes (#2051) (dd2e4b8)
+- Separate test and release heap budgets (#2058) (3c1f6cd)
+- fix: harden worktree retirement (#2052) (9f6582c)
+- docs(changelog): note Apple Health freshness recovery (d4a8cfe)
+- fix(device-sync): project canonical imports into freshness (17bd485)
+- ci: enforce runner bundle budgets (#2057) (06d7843)
+- docs(changelog): note wearable recovery (ce59560)
+- fix(device-sync): recover missing junction sources (f3976fa)
+- test: fail closed on Prisma mutation drift (#2067) (e4efdf2)
+- fix: make frontend evidence reproducible (#2066) (d521470)
+- fix: sync existing lockfile importers transactionally (#2061) (2109833)
+- Keep focused schema checks and CLI test commits narrow (#2060) (7e2ec4c)
+- feat: verify and render OG image routes (#2056) (b8433fe)
+- fix: preserve native iOS cleanup failures (#2053) (179aeb5)
+- Stop re-signaling imported mailbox handoffs (#2044) (302875f)
+- Retry untouched group sponsorship refills (#2035) (2198e0f)
+- Reduce native iOS hosted E2E queue waste (#2040) (f0884ee)
+- Add actionable blood oxygen normalization diagnostics (#2036) (29c0e62)
+- Simplify the group funding success receipt (#2034) (8980104)
+- docs: close PR 1977 completion plan (b89d023)
+- fix(ci): bound and retry the Playwright Chromium install (#2022) (0c0676e)
+- chore: update review-gpt to 0.5.134 (#1975) (7fd8322)
+- Stop sponsorship near-cap notices (#2038) (fcb8b04)
+- fix(device-sync): require provider occurrence for Fitbit cutover (db98548)
+- Publish system mailbox frontier ownership (#2024) (91a09de)
+- Keep reliability work out of Murph product notes (#2023) (f937c3a)
+- fix(connect): tighten Fitbit migration copy (a6e56c7)
+- Restore PR review disclosures and LOC breakdown (#2020) (3dfda68)
+- test(hosted): track current usage recovery link (c3a1a71)
+- Fix retained hosted device-sync retries (#2021) (578c7a2)
+- Fix group sponsorship payment recovery (#2010) (c18c1aa)
+- docs: finalize ReviewGPT completion watcher rule (8d37532)
+- docs: prefer ReviewGPT completion watchers (4e3fcec)
+- docs: extend ReviewGPT wake timeout (b0e38b5)
+- docs: require exclusive PR ownership (7c8b90c)
+- fix(device-sync): bind migration freshness to logical facts (ba6c771)
+- fix(web): advance usage link recovery claim (712dd08)
+- fix(web): retry usage limit rich link partial (65b90f3)
+- fix(device-sync): bind migration freshness to webhook trace (4172583)
+- fix(web): resume missing usage limit link (7da5aa6)
+- fix(web): replay partial usage limit links (993aad1)
+- test(web): track dirty-marker mutation boundary (02f1385)
+- fix(runtime): preserve delivery-only wake ownership (d4579d0)
+- chore(workflow): require UI screenshots (aea3e21)
+- fix(device-sync): honor provider day timezone (2e6a6f2)
+- fix(runtime): admit model-free delivery retries (197c193)
+- fix(runtime): reconcile terminal foreground replies (76a4e7b)
+- docs(changelog): note usage recovery delivery (958d6d0)
+- fix(runtime): isolate foreground quiet windows (5173b13)
+- docs(review): record round seven remediation evidence (604258c)
+- fix(device-sync): supersede stale migration proof jobs (edf2585)
+- fix(device-sync): preserve source authorization epochs (fdb18cd)
+- fix(device-sync): unify Junction canonical imports (1ba0e51)
+- fix(device-sync): prove Fitbit history before migration (5c8d794)
+- docs(plan): record combined Junction rollout decision (f0b6674)
+- fix(device-sync): preserve source-scoped history evidence (0a01e6f)
+- fix(device-sync): fence migration freshness (e18d43a)
+- fix(web): simplify Fitbit migration continuation (f98a7b3)
+- fix(device-sync): keep migration identity browser safe (6d972c6)
+- test(device-sync): clear ReviewGPT lint warning (cee269c)
+- test(device-sync): align ReviewGPT migration fixtures (7a204de)
+- fix(device-sync): apply ReviewGPT remediation (13fa651)
+- Replace Fitbit migration with Google Health (bb600b7)
+- feat(device-sync): preserve complete Junction summaries (#1702) (1200e74)
+- feat(device-sync): preserve Junction metabolic context (#1700) (9613a14)
+- fix(device-sync): preserve member deletions on changed replay (f2445cd)
+- chore(cli): refresh generated skill hash (a331de7)
+- fix(cli): preserve activity heart-rate facts (fba7de3)
+- fix(junction): preserve profile replay identity (6a54057)
+- test(device-sync): align hosted temporal priority (37d8772)
+- fix(device-sync): pin extended history to 180 days (3052069)
+- merge: reconcile current Junction base (18f1b46)
+- fix(device-sync): preserve ordinary sync ahead of temporal history (4bbfdbf)
+- test(web): fix training week boundary (5dcfbd6)
+- merge: reconcile runner bundle baselines (979bf09)
+- test(web): anchor training week fixture (f71015b)
+- chore(cloudflare): ratchet runner bundle baselines (a37b363)
+- test(query): pin workout projection schema version (c375045)
+- chore: rebaseline Junction runner bundle budgets (2d4ca8a)
+- Require a unique zone instant for floating temporal clocks (1dc0531)
+- Require semantics agreement before authorized-day exclusion (b6c05a7)
+- Prove Gregorian validity inside complete-day timestamp acceptance (c8b72ee)
+- Own complete-day timestamp acceptance with one anchored parse (6d6778d)
+- Anchor temporal replacement identity and fail closed on ambiguity (69e5f1e)
+- Require array shapes inside strict grouped collection proof (cd71e83)
+- Guard raw retention and member deletions under temporal authority (0193d19)
+- Derive temporal samples only from provider clocks (840ddc5)
+- Preserve temporal authority across hosted cold restore (508ca33)
+- Converge temporal facets through the symmetric set seam (bc38f74)
+- Make temporal imports facet-only with fail-closed authority (d26fce1)
+- Regenerate event-record schema for merged qualifiers (fcf9888)
+- Align device-sync tests with merged dual-owner shape (9168b4e)
+- Restore ordinary Junction ingestion ownership (592371f)
+- fix: harden Junction workout feature projection (bba8ec1)
+- fix(cli): refresh generated skill hash (1fc4b02)
+- Make the ReviewGPT wrapper own the trust floor (f7e963c)
+- Close ReviewGPT config override bypass (eaddf71)
+- chore: refresh vault cli skill hash (213aa34)
+- fix: expose bounded Junction workout details (b287023)
+- fix(reviews): enforce repository trust floor (fc9cfe0)
+- chore(reviews): update review gpt to 0.5.132 (43cfc9e)
+- docs(tooling): record ReviewGPT lane preference friction (9e26ec9)
+- fix(reviews): pin review trust floor (54500d1)
+- feat(device-sync): enrich bounded Junction workout streams (24a78c3)
+- chore(tooling): update ReviewGPT to 0.5.132 (7831580)
+- Fix Junction temporal history refresh (3cdc73d)
+- fix(device-sync): open explicit reconnect lifecycle (18d3a06)
+- fix(assistant): remove speculative routing policy (238453a)
+- fix(device-sync): bind workout remote authority by id (935111c)
+- chore: sync friction log (e1611a9)
+- chore: sync friction log (e6a129a)
+- fix(assistant): gate onboarding subagent routing (a8df910)
+- fix(device-sync): preserve semantic source lifecycle (0eb0e97)
+- test(cloudflare): align runner bundle budget expectation (0367465)
+- fix(core): migrate unversioned Junction profiles (86fa520)
+- test(cli): align profile replay regression (8124256)
+- feat(device-sync): add authoritative Junction temporal features (a556e0b)
+- docs(agent): record ReviewGPT round 13 (3d3f535)
+- fix(device-sync): preserve established source lifecycle (0186631)
+- fix(importers): migrate Junction profile identity safely (c43e13c)
+- test(core): assert automatic member precedence (748c8ad)
+- fix(device-sync): preserve capped webhook days (63389c0)
+- refactor(junction): preserve member edits at event spine (61a039e)
+- fix(device-sync): keep ordinary pull floor unconditional (2346eef)
+- fix(device-sync): preserve Junction history completion (06f2d43)
+- fix(device-sync): fence Junction webhook pulls (5f3943b)
+- test(importers): preserve Junction policy order (447ca02)
+- chore(cli): refresh generated skill hash (b516357)
+- fix(device-sync): retry superseded Junction fetches (7d7a25a)
+- fix(device-sync): preserve deployed m1 history (4db4418)
+- test(cli): use stable Junction row identities (025ae33)
+- perf(device-syncd): bound clinical lifecycle reads (c722f69)
+- feat(junction): default sparse clinical facts (32c2ec6)
+- test(device-syncd): cover member edit conflict jobs (cf06fba)
+- fix(junction): reconcile summary ownership after restack (0b3ec6d)
+- fix(core): preserve delayed provider revision ordering (fbcdbc2)
+- fix(query): preserve legacy activity heart-rate aliases (db2402b)
+- fix(device-sync): align Junction replay verification (486ed97)
+- fix(device-sync): recover Junction member edit conflicts (de1cf0e)
+- test(cli): expect member ownership after event edit (2961f3f)
+- fix(device-sync): preserve member summary edits (05f4550)
+- fix(device-sync): resolve Junction summary review findings (0893c30)
+- fix(importers): reconcile Junction summary corrections (153e313)
+- fix(importers): bound Junction menstrual evidence (a100723)
+- docs(changelog): announce complete summaries (3e84588)
+- chore(importers): complete Junction summary details (bae074f)
+- feat(importers): preserve Junction summary details (6605d47)
+- fix(device-syncd): complete rejected body history (08e6e78)
+- fix(junction): harden body composition history (f6755a4)
+- test(junction): align interval timestamp rejection (f42ecf9)
+- chore(cli): refresh generated vault skill hash (9fb5a81)
+- fix(junction): reconcile body composition stack (46f5fde)
+- test(junction): align body integration coverage (a3e2e9e)
+- fix(query): rebuild legacy body projections (ebbdecc)
+- fix(query): unify sparse body selection (efcbc15)
+- test(wearables): align body hint and schemas (2d10870)
+- fix(wearables): close body composition read gaps (16e84ca)
+- fix(wearables): complete body composition reads (84c9445)
+- docs(changelog): announce body composition (eb8c9cb)
+- feat(device-sync): finalize Junction body composition (8ed1aee)
+- feat(importers): preserve Junction body composition (fa15562)
+- docs(review): record round 12 pass (11c44bf)
+- fix(device-sync): pin exact workout connection (f4feda7)
+- fix(device-sync): ignore physical alias rekeys in webhook proof (1c01b72)
+- test(device-sync): make source fixtures type-safe (6a03fea)
+- fix(device-sync): close workout authority gaps (f2fcede)
+- fix(device-sync): retain ordinary reconcile completion (5f5c1c1)
+- test(device-sync): cover workout lifecycle export (cec2260)
+- fix(device-sync): align Link callback lifecycle admission (b2c71ef)
+- fix(web): resolve workout lifecycle source (4dd7f2a)
+- fix(device-sync): fence workout source lifecycles (3da848c)
+- fix(device-sync): preserve Junction window ownership (40618d5)
+- test(web): expect current Junction coverage encoding (27b19a8)
+- fix(device-sync): advance each completed Link lifecycle (c3efefa)
+- test(assistant-runtime): expect current Junction coverage encoding (805e6f0)
+- fix(cloudflare): ratchet runner bundle budget (1af4d67)
+- fix(cloudflare): ratchet runner bundle size (f1ce48d)
+- refactor(device-sync): reuse hosted source authority read (f205e8a)
+- fix(device-sync): fence hosted source reconnect history (2f6d78c)
+- fix(device-sync): fence reconnect-start worker completion (0857bcf)
+- fix(device-sync): make history priority fair (11d9c13)
+- fix(device-sync): bound reopened history priority (83dd248)
+- fix(device-sync): preserve legacy epoch wire absence (7b1b380)
+- chore(cli): regenerate config schema from clean build (5ada9bf)
+- chore(cli): refresh generated config schema (91b7a47)
+- fix(device-sync): unify Junction alias lifecycle identity (934caa2)
+- fix(device-sync): close reconnect lifecycle gaps (cf1229b)
+- fix(web): resolve device sync reconnect subpath (e46164a)
+- fix(device-sync): finalize Junction lifecycle candidate (37ab85e)
+- fix(device-sync): fence Junction lifecycle history (e4c34b4)
+- fix(device-sync): checkpoint Junction lifecycle fences (5679751)
+- fix(device-sync): persist sparse history terminal state (158f4fe)
+- fix(device-sync): preserve sparse history lineage (ca2e9ea)
+- fix(core): preserve delayed provider revision ordering (4ecf232)
+- fix(query): preserve legacy activity heart-rate aliases (dd50256)
+- fix(device-sync): align Junction replay verification (fcc1002)
+- test(device-sync): assert compact coverage semantics (66f8fb6)
+- test(device-sync): reproduce prepared reconnect race (215cba7)
+- Fix Junction temporal parent continuation (48cd2f0)
+- fix(device-sync): reopen local junction history (e789946)
+- fix(device-sync): require current history terminality (4966352)
+- fix(device-sync): close moving sparse history gaps (b4aa6b7)
+- fix(device-sync): persist terminal history coordinates (ebd609d)
+- fix(junction): terminate empty history scans (f257585)
+- fix(device-sync): require workout companions for history (53fb334)
+- chore(cloudflare): ratchet runner bundle budget (72c5963)
+- fix(device-sync): checkpoint Junction resource progress (2f22996)
+- fix(device-sync): co-import historical workout summaries (7475698)
+- fix(device-sync): resume Junction reconcile resources safely (858807f)
+- fix(device-sync): expand hosted lifecycle epoch safely (15ccaa2)
+- fix(importers): cover historical workout identity shapes (66d5b88)
+- fix(device-sync): preserve Junction reconnect history fences (b5da013)
+- fix(device-sync): complete temporal history recovery (56c7e7f)
+- perf(device-sync): coalesce Junction source projection reads (356ab91)
+- fix(device-sync): fence reconnect history by source epoch (5fc85dc)
+- fix(device-sync): recover Junction member edit conflicts (d99898c)
+- docs(device-sync): close temporal remediation plan (5f77ade)
+- fix(device-sync): close temporal authority gaps (e3f704b)
+- fix(device-sync): preserve grouped workout attribution (a653e57)
+- fix(device-sync): preserve workout identity and retries (07eba92)
+- test(cli): expect member ownership after event edit (c51f2ff)
+- fix(device-sync): align temporal day ownership (25d2ecf)
+- fix(device-sync): preserve member summary edits (30d4320)
+- fix(device-sync): preserve bounded clinical durability (89a6a7d)
+- fix(device-sync): bound sparse clinical daily imports (ec6fe97)
+- chore(cloudflare): ratchet stacked runner bundle budget (9152212)
+- fix(device-sync): preserve Junction resource progress (20ed59c)
+- docs(plan): record Junction temporal ownership retrospective (e17cd50)
+- fix(query): unify sparse body selection (7a86e51)
+- fix(device-sync): consolidate workout ingestion ownership (35df01b)
+- test(wearables): align body hint and schemas (f908be3)
+- chore(cli): refresh generated skill hash (7cf58be)
+- docs(plan): close Junction temporal remediation (79edb1c)
+- fix(device-sync): fence temporal facts to complete days (f99d466)
+- fix(wearables): close body composition read gaps (4b7682a)
+- fix(device-sync): resolve Junction summary review findings (05ed856)
+- test: prove Junction retry and fanout bounds (de81453)
+- fix(wearables): complete body composition reads (f236e8d)
+- fix(device-sync): tighten Junction history ownership (22573bc)
+- fix(importers): reconcile Junction summary corrections (05a82e5)
+- fix(device-sync): harden bounded workout imports (d4c0d11)
+- fix(importers): require bounded temporal evidence (3dc4453)
+- fix: bound sparse clinical imports deterministically (c7ba919)
+- fix(importers): harden bounded temporal features (a07664a)
+- test(device-sync): compose reserved history coordinates (e0635f3)
+- test(device-sync): keep history coordinates composable (2fee50b)
+- fix(device-sync): reserve stacked history coverage (29566f0)
+- fix(importers): bound Junction menstrual evidence (928e2e5)
+- fix(device-sync): bound sparse history completion (7432e85)
+- fix(ci): refresh Junction release artifacts (c1b0627)
+- fix(device-sync): preserve compact webhook payloads (296fb54)
+- fix(device-sync): preserve sparse clinical record identity (d45e710)
+- docs(changelog): announce body composition (27b02e1)
+- docs(changelog): announce complete summaries (36b9d69)
+- docs(changelog): announce temporal features (7cf4325)
+- docs(changelog): announce workout context (180afff)
+- docs(changelog): announce sparse clinical events (a59c064)
+- feat(device-sync): finalize Junction body composition (f6419b6)
+- docs(agent): close Junction workout feature plan (b46faaa)
+- chore(importers): complete Junction summary details (40448e6)
+- docs(importers): complete temporal feature integration (2569bd5)
+- feat(importers): register sparse clinical Junction resources (21ea308)
+- feat(device-sync): retain bounded Junction workout features (3526256)
+- test(device-sync): narrow sparse history window payload (63bd78c)
+- feat(importers): preserve bounded Junction temporal features (0474f88)
+- feat(device-sync): govern Junction resources and sparse history (76c6ce0)
+- feat(importers): preserve Junction body composition (d224780)
+- feat(importers): preserve Junction summary details (80b5c11)
+- feat(importers): preserve sparse Junction clinical facts (6840dbb)

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murphai/contracts",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "type": "module",
   "sideEffects": false,

--- a/packages/gateway-core/package.json
+++ b/packages/gateway-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murphai/gateway-core",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/hosted-execution/package.json
+++ b/packages/hosted-execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murphai/hosted-execution",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murphai/openclaw-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Outcome

- Land the already-verified fixed-version 1.3.2 public package set on protected `main`.
- Make the existing `v1.3.2` tag commit reachable from `main` so the unchanged tag workflow can be rerun and publish to npm.

## Product UX result

No new member-visible behavior is introduced by this release-only commit. It packages the public changes already reviewed and merged on `main`.

## Direct evidence

- `pnpm release:patch` completed release checks and exact-candidate `pnpm verify:acceptance` on the delegated Linux Testbox in 8m5s.
- Acceptance passed all package coverage, hosted Web verification, Cloudflare verification, fixture coverage, typechecks, architecture guards, and artifact-secret checks.
- `git show --check d745d7c0efe2f8fd4c9f40584969ab635684196d` passed.
- npm remains at `@murphai/hosted-execution@1.3.1`; no package publication occurred before this PR.

## Non-obvious affected surfaces

The tag-driven npm release workflow and the private Murph Cloud dependency pin. The existing tag workflow remains fail-closed until this exact release commit is reachable from `main`.

## Architecture and reuse

- Existing systems reused: `scripts/release.sh`, the shared-version release manifest, the generated CLI changelog/release notes, protected-branch PR checks, and the tag-driven npm workflow.
- New logic: None; this commit contains only generated release metadata and synchronized public package versions.
- New abstractions: None; the existing release commit and workflow own this boundary.
- Complexity intentionally avoided: no alternate publisher, compatibility shim, manual npm publish path, or duplicate release service.

## Hot reply path impact

Not applicable; this commit changes only release metadata and public package versions.

## Provider-input impact

Not applicable; no provider-visible input, prompt, tool schema, or runtime wrapper changes.

## Deployment concerns

- Deployment: not applicable
- Reason: This PR only lands release metadata; the existing tag workflow separately verifies and publishes the public package set after merge.

## Changelog

- Changelog: not applicable

- Reason: The release commit aggregates already-merged public changes and does not introduce a new member-visible change of its own.

## LOC breakdown

- Source: +0 / -0
- Tests and fixtures: +0 / -0
- Docs: +2,100 / -0
- Config and tooling: +5 / -5
- Generated and other: +0 / -0
