### PR TITLE
Fix hosted integration convergence

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-27-hosted-integration-convergence.md
+++ b/agent-docs/exec-plans/active/2026-08-27-hosted-integration-convergence.md
@@ -1,0 +1,88 @@
+# Stabilize hosted integration convergence
+
+Status: active
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Restore deterministic hosted integration admission so the stale Temporal
+  workflow migration can ship without weakening foreground replies, durable
+  handoffs, or database concurrency guarantees.
+
+## Success criteria
+
+- The foreground-to-Environment handoff completes without an unnecessary
+  assistant pass or a stranded default-processing fence.
+- Serializable contention is handled at its existing database boundary and
+  does not abort an otherwise recoverable hosted handoff.
+- Computer-handoff proof waits for the durable awaiting-user transition rather
+  than sampling an intermediate running state.
+- Focused tests, typecheck, preliminary specialist review, and exact-head CI
+  pass before merge.
+
+## Scope
+
+- In scope: the smallest public runtime, database-boundary, and test-proof
+  corrections needed by the failing hosted integration shards.
+- Out of scope: changing private migration behavior, broad scheduler rewrites,
+  Linq routing files owned by another open PR, and unrelated test cleanup.
+
+## Constraints
+
+- Technical constraints: preserve current state ownership, keep transactions
+  database-only, avoid new services or abstractions, and remain compatible with
+  mixed public/private blue-green deployment.
+- Product/process constraints: preserve active foreground replies and handoffs,
+  avoid overlapping files owned by open PRs, and use the worktree/PR lane.
+
+## Risks and mitigations
+
+1. Risk: treating nondeterministic CI symptoms as one bug could hide distinct
+   failures.
+   Mitigation: require a focused reproduction or direct code-path proof for
+   each correction and keep fixes independently testable.
+2. Risk: a scheduler fix could preempt legitimate foreground work.
+   Mitigation: preserve the current foreground owner and correct only the
+   durable successor classification or wake derived from committed state.
+3. Risk: retry logic could duplicate external effects.
+   Mitigation: place retry only around the database transaction before effect
+   execution, using the existing idempotent boundary.
+
+## Tasks
+
+1. Prove the three observed failure paths from exact CI evidence and current
+   source.
+2. Add focused failing coverage at each owning boundary.
+3. Implement the smallest non-overlapping corrections.
+4. Run focused verification and review the complete diff.
+5. Push a draft PR, complete specialist and final gates, then merge.
+6. Rerun the private integration, merge the migration PR, and execute its
+   documented blue-green rollout with post-deploy proof.
+
+## Decisions
+
+- Treat the foreground stall, serializable collision, and early handoff read as
+  separate defects because their exact CI evidence has different owners and
+  failure modes.
+- Do not edit the open Linq lock-order PR's files; fix only independent owner
+  boundaries.
+- Do not edit assistant-phase files owned by other live PRs. Exact integration
+  evidence instead places the remaining Environment correction in the private
+  Temporal owner: negotiate the existing fact and select the existing mode.
+- Do not take over the concurrently owned public package-release PR. Land the
+  independent public fixes while its owner completes the registry publication
+  required by the private worker.
+
+## Verification
+
+- Passed: usage-limit claim Vitest (9/9), Hosted Web prepared typecheck, scoped
+  Web lint, Cloudflare typecheck, and diff whitespace validation.
+- The selected hosted-local scenarios build successfully but cannot start on
+  macOS because the unchanged runner bundle exceeds the platform's ratcheted
+  byte budget. Exact-head Linux CI owns the full-stack proof.
+- Remaining: repository-required specialist/final review, exact-head CI, and
+  the private integration rerun after the public package is available.
+- Expected outcomes: every focused regression passes repeatedly, no unrelated
+  path changes, and the public/private integration gates are green on the exact
+  heads merged and deployed.

--- a/agent-docs/exec-plans/completed/2026-08-27-hosted-integration-convergence.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-hosted-integration-convergence.md
@@ -1,6 +1,6 @@
 # Stabilize hosted integration convergence
 
-Status: active
+Status: completed
 Created: 2026-08-27
 Updated: 2026-08-27
 
@@ -76,13 +76,21 @@ Updated: 2026-08-27
 
 ## Verification
 
-- Passed: usage-limit claim Vitest (9/9), Hosted Web prepared typecheck, scoped
-  Web lint, Cloudflare typecheck, and diff whitespace validation.
+- Passed: usage-limit claim Vitest (10/10), changelog archive Vitest (9/9),
+  Hosted Web prepared typecheck, scoped Web lint, Cloudflare typecheck, and
+  diff whitespace validation.
 - The selected hosted-local scenarios build successfully but cannot start on
   macOS because the unchanged runner bundle exceeds the platform's ratcheted
   byte budget. Exact-head Linux CI owns the full-stack proof.
-- Remaining: repository-required specialist/final review, exact-head CI, and
-  the private integration rerun after the public package is available.
+- The preliminary specialist review accepted one isolated coverage gap: prove
+  the ordinary Prisma serialization shape and the two-attempt ceiling. The
+  inspected test-only patch now proves both, with no production change.
+- Final ReviewGPT round 1 reviewed the exact pushed production candidate and
+  returned `ROUND_OUTCOME: PASS` with no correctness findings. The requested
+  model was verified through its compatible response metadata.
+- Pull-request evidence is green. Remaining external gates are exact-head CI,
+  merge, and the separately owned private integration and rollout.
 - Expected outcomes: every focused regression passes repeatedly, no unrelated
   path changes, and the public/private integration gates are green on the exact
   heads merged and deployed.
+Completed: 2026-08-27

--- a/apps/cloudflare/test/hosted-local-computer-handoff-linq-roundtrip-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-computer-handoff-linq-roundtrip-e2e.test.ts
@@ -140,14 +140,21 @@ describe("hosted local computer handoff Linq roundtrip e2e", () => {
     expect(requireLinqStub().readObservedMessageText(pausedReply)).toBe(pausedReplyText);
     await requireScenario().waitForHostedCompletion(memberId);
 
-    const awaiting = await readHostedComputerRunHandoffForTest({
-      environment: requireScenario().runtimeEnv,
-      runId: computerRunId,
-    });
-    expect(awaiting.run).toMatchObject({
-      awaitingReason: "other",
-      pendingHandoffId: awaiting.handoff?.id,
-      status: "awaiting_user",
+    const awaiting = await vi.waitFor(async () => {
+      const state = await readHostedComputerRunHandoffForTest({
+        environment: requireScenario().runtimeEnv,
+        runId: computerRunId,
+      });
+      expect(state.run).toMatchObject({
+        awaitingReason: "other",
+        pendingHandoffId: state.handoff?.id,
+        status: "awaiting_user",
+      });
+      expect(state.handoff).toMatchObject({ status: "open" });
+      return state;
+    }, {
+      interval: 250,
+      timeout: 30_000,
     });
     expect(readLinqCheckpointConversationParts(
       awaiting.run?.checkpointContext?.conversationId ?? null,

--- a/apps/web/changelog/entries/2026-08-27/usage-limit-notices-recover.json
+++ b/apps/web/changelog/entries/2026-08-27/usage-limit-notices-recover.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-27",
+  "order": 50,
+  "item": {
+    "id": "usage-limit-notices-recover",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Usage-limit notices recover reliably",
+    "summary": "If a brief account update collision happens as Murph reaches its hosted usage limit, the one-time explanation now retries instead of disappearing.",
+    "details": "Only the pre-delivery claim retries, and only once; message delivery itself is not repeated.",
+    "relevanceTags": ["hosted-runtime", "reliability"],
+    "sourcePullRequests": [2424]
+  }
+}

--- a/apps/web/src/lib/hosted-execution/usage-limit-notice-claim.ts
+++ b/apps/web/src/lib/hosted-execution/usage-limit-notice-claim.ts
@@ -33,6 +33,10 @@ export type HostedAiUsageLimitNoticeAuthorizedDeliveryClaim =
   | HostedAiUsageLimitNoticeDeliveryClaim
   | { status: "not_authorized" };
 
+// This transaction is the complete pre-provider claim boundary, so one
+// serializable replay is safe while provider delivery remains outside it.
+const HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_ATTEMPTS = 2;
+
 export async function startAuthorizedHostedAiUsageLimitNoticeDispatchTx(input: {
   assertDispatchAuthority?: (
     prisma: Prisma.TransactionClient,
@@ -54,65 +58,122 @@ export async function startAuthorizedHostedAiUsageLimitNoticeDispatchTx(input: {
   const noticeNotEligible = new Error(
     "Hosted AI usage-limit notice allowance period is no longer blocked.",
   );
-
-  try {
-    return await input.prisma.$transaction(async (prisma) => {
-      return await startHostedAiUsageLimitNoticeDispatchTx({
-        assertDispatchAuthority: async (claimPrisma) => {
-          if (!await lockHostedAiUsageLimitNoticeCapacityEpochTx({
-            memberId: input.memberId,
-            tx: claimPrisma,
-            usageCreditLedgerVersion: input.usageCreditLedgerVersion,
-          })) {
-            throw noticeNotEligible;
-          }
-          if (!await isHostedAiUsageLimitNoticeTargetAuthorizedTx({
-            memberId: input.memberId,
-            noticeDeliveryTarget: input.noticeDeliveryTarget,
-            prisma: claimPrisma,
-          })) {
-            throw targetNotAuthorized;
-          }
-          await input.assertDispatchAuthority?.(claimPrisma);
-          if (!await lockHostedAiUsageLimitNoticeEligibilityTx({
-            attemptedAt: input.attemptedAt,
-            memberId: input.memberId,
-            periodStart: input.periodStart,
-            planResetAt: input.planResetAt ?? null,
-            tx: claimPrisma,
-          })) {
-            throw noticeNotEligible;
-          }
-        },
-        attemptedAt: input.attemptedAt,
-        ...(input.noticeDeliveryTarget.channel === "linq"
-          ? { linqChatId: input.noticeDeliveryTarget.target }
-          : {}),
-        memberId: input.memberId,
-        periodStart: input.periodStart,
-        planResetAt: input.planResetAt ?? null,
-        prisma,
-        source: input.source,
-        sourceRef: input.sourceRef,
-        targetKind: input.targetKind,
-        usageCreditLedgerVersion: input.usageCreditLedgerVersion,
-      });
-    }, {
-      ...HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
-      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  const claim = () => input.prisma.$transaction(async (prisma) => {
+    return await startHostedAiUsageLimitNoticeDispatchTx({
+      assertDispatchAuthority: async (claimPrisma) => {
+        if (!await lockHostedAiUsageLimitNoticeCapacityEpochTx({
+          memberId: input.memberId,
+          tx: claimPrisma,
+          usageCreditLedgerVersion: input.usageCreditLedgerVersion,
+        })) {
+          throw noticeNotEligible;
+        }
+        if (!await isHostedAiUsageLimitNoticeTargetAuthorizedTx({
+          memberId: input.memberId,
+          noticeDeliveryTarget: input.noticeDeliveryTarget,
+          prisma: claimPrisma,
+        })) {
+          throw targetNotAuthorized;
+        }
+        await input.assertDispatchAuthority?.(claimPrisma);
+        if (!await lockHostedAiUsageLimitNoticeEligibilityTx({
+          attemptedAt: input.attemptedAt,
+          memberId: input.memberId,
+          periodStart: input.periodStart,
+          planResetAt: input.planResetAt ?? null,
+          tx: claimPrisma,
+        })) {
+          throw noticeNotEligible;
+        }
+      },
+      attemptedAt: input.attemptedAt,
+      ...(input.noticeDeliveryTarget.channel === "linq"
+        ? { linqChatId: input.noticeDeliveryTarget.target }
+        : {}),
+      memberId: input.memberId,
+      periodStart: input.periodStart,
+      planResetAt: input.planResetAt ?? null,
+      prisma,
+      source: input.source,
+      sourceRef: input.sourceRef,
+      targetKind: input.targetKind,
+      usageCreditLedgerVersion: input.usageCreditLedgerVersion,
     });
-  } catch (error) {
-    if (error === noticeNotEligible) {
-      return { status: "already_notified" };
+  }, {
+    ...HOSTED_ONBOARDING_TRANSACTION_OPTIONS,
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await claim();
+    } catch (error) {
+      if (error === noticeNotEligible) {
+        return { status: "already_notified" };
+      }
+      if (
+        error === targetNotAuthorized
+        || (isHostedOnboardingError(error) && error.httpStatus === 403)
+      ) {
+        return { status: "not_authorized" };
+      }
+      if (
+        attempt < HOSTED_AI_USAGE_LIMIT_NOTICE_CLAIM_ATTEMPTS
+        && isHostedAiUsageLimitNoticeClaimSerializationConflict(error)
+      ) {
+        continue;
+      }
+      throw error;
     }
-    if (
-      error === targetNotAuthorized
-      || (isHostedOnboardingError(error) && error.httpStatus === 403)
-    ) {
-      return { status: "not_authorized" };
-    }
-    throw error;
   }
+}
+
+function isHostedAiUsageLimitNoticeClaimSerializationConflict(
+  error: unknown,
+): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return false;
+  }
+  if (error.code === "P2034") {
+    return true;
+  }
+  if (error.code !== "P2010" || !("meta" in error)) {
+    return false;
+  }
+
+  return readHostedAiUsageLimitNoticeClaimPostgresCode(error.meta) === "40001";
+}
+
+function readHostedAiUsageLimitNoticeClaimPostgresCode(
+  meta: unknown,
+): string | null {
+  if (!meta || typeof meta !== "object") {
+    return null;
+  }
+  if ("code" in meta && typeof meta.code === "string") {
+    return meta.code;
+  }
+  if (!("driverAdapterError" in meta)) {
+    return null;
+  }
+  const driverAdapterError = meta.driverAdapterError;
+  if (
+    !driverAdapterError
+    || typeof driverAdapterError !== "object"
+    || !("cause" in driverAdapterError)
+  ) {
+    return null;
+  }
+  const cause = driverAdapterError.cause;
+  if (!cause || typeof cause !== "object") {
+    return null;
+  }
+  if ("originalCode" in cause && typeof cause.originalCode === "string") {
+    return cause.originalCode;
+  }
+  return "code" in cause && typeof cause.code === "string"
+    ? cause.code
+    : null;
 }
 
 async function lockHostedAiUsageLimitNoticeCapacityEpochTx(input: {

--- a/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
+++ b/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
@@ -152,6 +152,42 @@ describe("hosted usage-limit notice claim authority", () => {
     expect(claimMocks.startHostedAiUsageLimitNoticeDispatchTx).toHaveBeenCalledTimes(2);
   });
 
+  it("stops after one retry when a serializable claim conflict repeats", async () => {
+    claimMocks.readHostedMemberRoutingState.mockResolvedValue({
+      linqChatId: "linq_chat_current",
+    });
+    const serializationConflict = { code: "P2034" };
+    prisma.$transaction
+      .mockImplementationOnce(async (operation) => {
+        await operation(transaction);
+        throw serializationConflict;
+      })
+      .mockImplementationOnce(async (operation) => {
+        await operation(transaction);
+        throw serializationConflict;
+      });
+
+    await expect(startAuthorizedHostedAiUsageLimitNoticeDispatchTx({
+      attemptedAt,
+      memberId: "member_usage_notice_1",
+      noticeDeliveryTarget: {
+        channel: "linq",
+        replyToMessageId: "linq_message_1",
+        routeAuthority: null,
+        target: "linq_chat_current",
+      },
+      periodStart,
+      prisma: prisma as never,
+      source: "hosted_webhook_side_effect",
+      sourceRef: "usage_event_1",
+      targetKind: "thread",
+      usageCreditLedgerVersion: 4n,
+    })).rejects.toBe(serializationConflict);
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(claimMocks.startHostedAiUsageLimitNoticeDispatchTx).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry a non-serialization claim failure", async () => {
     const terminalError = new Error("Synthetic terminal claim failure.");
     transaction.$queryRaw.mockRejectedValueOnce(terminalError);

--- a/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
+++ b/apps/web/test/hosted-execution-usage-limit-notice-claim.test.ts
@@ -116,6 +116,66 @@ describe("hosted usage-limit notice claim authority", () => {
     });
   });
 
+  it("retries one serializable claim conflict before returning the claim", async () => {
+    claimMocks.readHostedMemberRoutingState.mockResolvedValue({
+      linqChatId: "linq_chat_current",
+    });
+    transaction.$queryRaw
+      .mockRejectedValueOnce({
+        code: "P2010",
+        meta: {
+          driverAdapterError: {
+            cause: { originalCode: "40001" },
+          },
+        },
+      })
+      .mockResolvedValue([{ eligible: true }]);
+
+    await expect(startAuthorizedHostedAiUsageLimitNoticeDispatchTx({
+      attemptedAt,
+      memberId: "member_usage_notice_1",
+      noticeDeliveryTarget: {
+        channel: "linq",
+        replyToMessageId: "linq_message_1",
+        routeAuthority: null,
+        target: "linq_chat_current",
+      },
+      periodStart,
+      prisma: prisma as never,
+      source: "hosted_webhook_side_effect",
+      sourceRef: "usage_event_1",
+      targetKind: "thread",
+      usageCreditLedgerVersion: 4n,
+    })).resolves.toMatchObject({ status: "claimed" });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(claimMocks.startHostedAiUsageLimitNoticeDispatchTx).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-serialization claim failure", async () => {
+    const terminalError = new Error("Synthetic terminal claim failure.");
+    transaction.$queryRaw.mockRejectedValueOnce(terminalError);
+
+    await expect(startAuthorizedHostedAiUsageLimitNoticeDispatchTx({
+      attemptedAt,
+      memberId: "member_usage_notice_1",
+      noticeDeliveryTarget: {
+        channel: "linq",
+        replyToMessageId: "linq_message_1",
+        routeAuthority: null,
+        target: "linq_chat_current",
+      },
+      periodStart,
+      prisma: prisma as never,
+      source: "hosted_webhook_side_effect",
+      sourceRef: "usage_event_1",
+      targetKind: "thread",
+      usageCreditLedgerVersion: 4n,
+    })).rejects.toBe(terminalError);
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects a stale personal Linq target inside the delivery claim transaction", async () => {
     claimMocks.readHostedMemberRoutingState.mockResolvedValue({
       linqChatId: "linq_chat_new",


### PR DESCRIPTION
## Why and outcome

Hosted integration runs exposed two bounded convergence races: a serializable database conflict could abort the pre-delivery usage-limit notice claim, and an end-to-end assertion could read the durable computer handoff during its valid running-to-awaiting-user transition.

This change retries the complete database-only claim once for recognized serializable conflicts and makes the end-to-end proof wait for the existing durable terminal handoff state. Provider delivery remains outside the transaction and is never retried by the new logic.

## Product UX

- Effort: Patch.
- Affected person: a member reaching their hosted usage limit while another claim transaction commits concurrently.
- Result: the one-time notice can recover from that bounded collision instead of silently missing the member-facing explanation.
- Recovery boundary: an unrelated or repeated database failure still fails normally; no duplicate provider send is introduced.

## Evidence

- Focused usage-limit claim tests: 10 passed, including both retryable error shapes and the exact two-attempt ceiling.
- Changelog archive tests: 9 passed.
- Web prepared typecheck: passed.
- Cloudflare typecheck: passed.
- Scoped Web lint, diff check, and privacy scan: passed.
- Preliminary specialist review found one accepted isolated coverage gap; its inspected test-only patch is applied and green.
- Final ReviewGPT round 1 reviewed the exact production candidate and returned ROUND_OUTCOME: PASS with no correctness findings. The later delta is isolated test proof plus plan closure, so repository guidance does not require a second model audit.
- The selected macOS hosted-local suite reached the existing runner-bundle byte guard before scenarios; the exact-head Linux PR integration check owns full-stack proof. The budget was not weakened.

## Non-obvious affected surfaces

- Usage-limit notice claiming only; provider delivery and durable delivered-state recording are unchanged.
- Computer handoff production behavior is unchanged; only its asynchronous end-to-end assertion is made convergence-aware.
- The completed execution plan records the production root-cause and ownership evidence without private member data.
- Public changelog content adds one private-free member outcome; no renderer or interaction changes.

## Architecture and reuse

- Existing systems reused: the current serializable claim transaction, Prisma error metadata, PostgreSQL serialization code, and durable handoff owner.
- New logic: one local claim closure retries the complete database-only claim once for recognized serializable conflicts; the end-to-end test waits for the existing terminal handoff state.
- New abstractions: none, because both corrections remain inside the existing claim transaction and durable handoff owners.
- Complexity intentionally avoided: no dependency, shared retry layer, queue, persisted state, second lifecycle owner, or provider-delivery retry. All provider and network work remains outside the transaction.

## Hot reply path impact

None. This runs only while claiming a usage-limit notice before its provider send.

## Murph initial provider input impact

None. No prompt, tool, schema, or provider-input assembly changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: one content-only changelog fragment using the repository-owned archive presentation.
- Coverage: authored copy review plus server-rendered archive test; no component, layout, interaction, or responsive behavior changed.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; Vitest and hosted-local checks are tests/fixtures; the completed execution plan and changelog fragment are docs/content.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 117 | 56 |
| Tests/fixtures | 111 | 8 |
| Docs/content | 110 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 338 | 64 |

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new Web instances share the same database and delivery contracts; the Cloudflare change is test-only.
- Safe order: deploy through the ordinary Vercel path after exact-head gates. No database migration or tandem Cloudflare deployment is required.
- Rollback floor: the prior Web deployment, with no database or durable-state rollback.
- Expected exposure: mixed Web instances may briefly differ only in whether one claim conflict is retried; both preserve one-time delivery ownership.
- Reversibility: revert the Web deployment because the change adds no schema, durable field, or state transition.
- Convergence proof: confirm the intended Web revision is active and bounded claim-conflict failures no longer terminate otherwise eligible notice delivery.
- Post-deploy checks: verify the active Web revision, then inspect bounded usage-limit claim and delivery error aggregates for regressions.

## Changelog

- Changelog: updated
- Items: 2026-08-27 · usage-limit-notices-recover

ReviewGPT context sensitivity: sensitive because this path gates a member-facing usage-limit notice and touches a serializable database transaction.

ReviewGPT first-reviewed head: 6337069f7dd36a2a863ffea08ac802ce19a5fc61
