### PR TITLE
test(assistant): align live Codex feature flags with hosted runs

### DIFF
--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -10578,12 +10578,28 @@ describe('real Codex app-server cache usage e2e harness', () => {
     ])
   })
 
-  it('pins live turns to the hosted shell and plugin boundaries', () => {
-    expect(REAL_CODEX_HOSTED_CONFIG_OVERRIDES).toEqual([
+  it('pins live turns to the hosted shell and plugin boundaries', async () => {
+    let observedConfigOverrides: readonly string[] | undefined
+
+    await expect(executeRealCodexAppServerTurn(
+      {
+        configOverrides: ['features.shell_tool=false'],
+        dynamicTools: [],
+        prompt: 'Capture the real-Codex harness configuration.',
+        workingDirectory: '/synthetic-workspace',
+      },
+      async (input) => {
+        observedConfigOverrides = input.configOverrides
+        throw new Error('Stop after capturing the launch input.')
+      },
+    )).rejects.toThrow('Real Codex cache probe failed')
+
+    expect(observedConfigOverrides).toEqual([
       'allow_login_shell=false',
       'features.plugins=false',
       'skills.include_instructions=false',
       'skills.bundled.enabled=false',
+      'features.shell_tool=false',
     ])
   })
 
@@ -14333,9 +14349,10 @@ async function executeRealCodexAppServerTurn(
   input: Omit<CodexAppServerTurnInput, 'dynamicTools'> & {
     dynamicTools?: CodexAppServerTurnInput['dynamicTools']
   },
+  executeTurn: typeof executeCodexAppServerTurn = executeCodexAppServerTurn,
 ): ReturnType<typeof executeCodexAppServerTurn> {
   try {
-    return await executeCodexAppServerTurn({
+    return await executeTurn({
       ...input,
       configOverrides: [
         ...REAL_CODEX_HOSTED_CONFIG_OVERRIDES,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -187,6 +187,12 @@ function describeRealCodex(name: string, factory: () => void): void {
 }
 const RETIRED_USAGE_TERM = ['cost', 'weighted'].join('-')
 const DEFAULT_REAL_CODEX_MODEL = 'gpt-5.6-terra'
+const REAL_CODEX_HOSTED_CONFIG_OVERRIDES = [
+  'allow_login_shell=false',
+  'features.plugins=false',
+  'skills.include_instructions=false',
+  'skills.bundled.enabled=false',
+] as const
 const REPEATED_SET_REGIMEN_ID = 'reg_01JNV447V6K3SW1Q9NJ7XVQZ7P'
 const REPEATED_SET_ALPHA_EXPERIMENT_ID = 'exp_01JNV447V6K3SW1Q9NJ7XVQZ7Q'
 const REPEATED_SET_BETA_EXPERIMENT_ID = 'exp_01JNV447V6K3SW1Q9NJ7XVQZ7R'
@@ -2734,13 +2740,11 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
             normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
             ?? undefined,
           codexHome: config.codexHome,
-          configOverrides: ['allow_login_shell=false'],
           developerInstructions: [
             buildRoutinePresentationDeveloperInstructions({
               channel: 'telegram' as const,
             }),
             exerciseGuidance,
-            'Test harness tool result contract: when calling a Murph tool inside functions.exec, pass its returned value directly to text(). Do not read a content property from the result.',
           ].join('\n\n'),
           env: {
             ...config.env,
@@ -10574,6 +10578,15 @@ describe('real Codex app-server cache usage e2e harness', () => {
     ])
   })
 
+  it('pins live turns to the hosted shell and plugin boundaries', () => {
+    expect(REAL_CODEX_HOSTED_CONFIG_OVERRIDES).toEqual([
+      'allow_login_shell=false',
+      'features.plugins=false',
+      'skills.include_instructions=false',
+      'skills.bundled.enabled=false',
+    ])
+  })
+
   it('uses normal Codex home only in explicit subscription mode', async () => {
     const config = await resolveRealCodexE2eConfig({
       sourceEnv: {
@@ -14324,6 +14337,10 @@ async function executeRealCodexAppServerTurn(
   try {
     return await executeCodexAppServerTurn({
       ...input,
+      configOverrides: [
+        ...REAL_CODEX_HOSTED_CONFIG_OVERRIDES,
+        ...(input.configOverrides ?? []),
+      ],
       dynamicTools: input.dynamicTools ?? resolveMurphDynamicTools({
         allowFinishWithoutReply: input.allowFinishWithoutReply,
         messageTargetingAvailable:

--- a/scripts/run-assistant-real-codex-e2e.test.ts
+++ b/scripts/run-assistant-real-codex-e2e.test.ts
@@ -200,6 +200,7 @@ describe('assistant real Codex local runner', () => {
 
   it('routes one explicit subscription home through preflight and the live journey', () => {
     const requests: AssistantRealCodexCommandRequest[] = []
+    const output: string[] = []
     const status = executeAssistantRealCodexRun(
       parseAssistantRealCodexRunArgs([
         'adaptive wearable',
@@ -225,7 +226,7 @@ describe('assistant real Codex local runner', () => {
           PATH: '/usr/bin:/bin',
         },
         writeStderr: () => undefined,
-        writeStdout: () => undefined,
+        writeStdout: (value) => output.push(value),
       },
     )
 
@@ -252,6 +253,9 @@ describe('assistant real Codex local runner', () => {
     expect(requests[2]?.env.CODEX_HOME).toBeUndefined()
     expect(requests[2]?.args).toContain(
       '^real Codex adaptive wearable journey$',
+    )
+    expect(output.join('')).toContain(
+      'use a dedicated home for production-like evidence',
     )
   })
 

--- a/scripts/run-assistant-real-codex-e2e.ts
+++ b/scripts/run-assistant-real-codex-e2e.ts
@@ -48,7 +48,7 @@ const USAGE = [
   '',
   'Options:',
   '  --auth subscription|provider  Use local ChatGPT auth (default) or provider env.',
-  '  --codex-home <absolute-path>   Use an explicit local Codex home for subscription auth.',
+  '  --codex-home <absolute-path>   Use a dedicated local Codex home for subscription auth.',
   '  --model <model>               Override the default gpt-5.6-terra model.',
   '  -h, --help                    Show this help.',
 ].join('\n')
@@ -290,6 +290,11 @@ export function executeAssistantRealCodexRun(
   dependencies.writeStdout(
     `Running one real Murph assistant journey with ${effectiveModel} via ${options.authMode} auth.\n`,
   )
+  if (options.authMode === 'subscription') {
+    dependencies.writeStdout(
+      'Subscription runs keep the selected Codex home configuration; use a dedicated home for production-like evidence.\n',
+    )
+  }
 
   const liveCommand = buildPnpmCommand(
     buildAssistantRealCodexVitestArgs(fullTestName),


### PR DESCRIPTION
## Why and outcome

Real-Codex journeys could inherit local Codex plugin, skill, and login-shell behavior that the hosted Murph runtime does not enable. This makes local evidence depend on the operator's Codex home and encouraged a test-only prompt instruction for tool-result handling.

This change applies the hosted shell/plugin/skill flags to every live journey, deletes that prompt workaround, and tells subscription users to choose a dedicated Codex home. It intentionally leaves fixture execution repairs to #2425 instead of duplicating them.

## Product UX

Internal test-harness work only; no member-facing product dimension changes. The focused quiet/card journey was **Ready**: all three expected card-repair outcomes passed, tool effects occurred exactly once per expected attempt, and no post-attachment reply was emitted.

## Evidence

- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/run-assistant-real-codex-e2e.test.ts` — 9 passed.
- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-codex-real-e2e.test.ts --testNamePattern 'real Codex app-server cache usage e2e harness'` — 8 passed, 111 skipped, including exact wrapper-input composition after specialist remediation.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- `pnpm test:assistant:live -- --test "keeps phase-grouped Telegram movements through bounded card repair" --codex-home <DEDICATED_CODEX_HOME>` — 1 passed, 118 skipped with `gpt-5.6-terra`; three scenarios produced the expected 1/2/2 routine-card attempts, no media calls, and no post-attachment text. The default subscription profile reached its usage limit before the journey; the one permitted retry on a different signed-in profile passed.
- Preliminary specialist review — prompt lens passed; one coverage finding was accepted and fixed by asserting the exact ordered wrapper input. The supplied patch artifact touched only the real-Codex test file and was inspected before application.
- `git diff --check origin/main...HEAD` — passed.

## Non-obvious affected surfaces

None. Production runtime configuration, prompt assembly, tool contracts, and fixture wrapper execution are unchanged.

## Architecture and reuse

- **Existing systems reused:** Uses Codex CLI's supported per-turn `-c` configuration overrides and the existing focused live-runner path.
- **New logic:** Adds one ordered baseline of four hosted-aligned overrides before any scenario-specific override, so focused scenarios may still override a baseline deliberately.
- **New abstractions:** None in production; the test wrapper accepts a defaulted executor solely so deterministic proof can capture its exact launch input.
- **Complexity intentionally avoided:** Does not parse or clone Codex homes, enumerate or rewrite MCP configuration, normalize tool results, add wait/retry state, or duplicate #2425's fixture process repairs.

## Hot reply path impact

Not applicable. Only the opt-in local real-Codex test harness and its runner changed; no production acceptance, provider-start, or reply-handoff code changed.

## Murph initial provider input impact

- **Production individual turns:** Not applicable; no production request builder, prompt, tool schema, or runtime configuration changed.
- **Production group turns:** Not applicable for the same reason.
- **Test-only live turns:** Intentionally disable local plugin and bundled/instruction skill injection and login shells through Codex CLI configuration. One test-only developer-instruction sentence was deleted. Production token deltas are therefore not applicable.

## Risks

A subscription run still uses authentication and other configuration from the selected Codex home, including any configured MCP servers. The runner now states this explicitly and recommends a dedicated home; this PR does not build a second configuration owner.

## Change-shape breakdown

Classification rule: `packages/**/test/**` and `*.test.ts` are tests/fixtures; the executable runner under `scripts/` is config/tooling. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 42 | 4 |
| Docs | 0 | 0 |
| Config/tooling | 6 | 1 |
| Generated/other | 0 | 0 |
| **Total** | **48** | **5** |

## Deployment concerns

- Deployment: not applicable
- Reason: This is an opt-in local test harness change and does not alter a deployed artifact or runtime contract.

## Changelog

- Changelog: not applicable
- Reason: The change is internal test tooling with no member-visible outcome.
