### PR TITLE
Speed up Luna first replies

### DIFF
--- a/apps/web/changelog/entries/2026-08-22/quicker-first-imessage-replies.json
+++ b/apps/web/changelog/entries/2026-08-22/quicker-first-imessage-replies.json
@@ -14,7 +14,8 @@
       "performance"
     ],
     "sourcePullRequests": [
-      2173
+      2173,
+      2437
     ]
   }
 }

--- a/apps/web/src/lib/hosted-onboarding/linq-instant-first-turn.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-instant-first-turn.ts
@@ -697,7 +697,8 @@ export function buildHostedLinqInstantFirstTurnOpenAiBody(input: {
     }],
     instructions: HOSTED_LINQ_INSTANT_FIRST_TURN_INSTRUCTIONS,
     model: HOSTED_LINQ_INSTANT_FIRST_TURN_MODEL,
-    reasoning: { effort: "high" },
+    reasoning: { effort: "medium" },
+    service_tier: "priority",
     store: false,
     text: {
       format: {

--- a/apps/web/test/hosted-onboarding-linq-instant-first-turn.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-instant-first-turn.test.ts
@@ -463,7 +463,8 @@ describe("hosted Linq instant first turn", () => {
     expect(body).toMatchObject({
       input: [{ content: REQUEST.text, role: "user" }],
       model: "gpt-5.6-luna",
-      reasoning: { effort: "high" },
+      reasoning: { effort: "medium" },
+      service_tier: "priority",
       store: false,
       text: {
         format: {
@@ -474,7 +475,6 @@ describe("hosted Linq instant first turn", () => {
       },
     });
     expect(body).not.toHaveProperty("max_output_tokens");
-    expect(body).not.toHaveProperty("service_tier");
     expect(body.instructions).toContain("cannot see account history");
     expect(body.instructions).toContain("Return kind \"welcome\"");
     expect(body.instructions).not.toContain("Luna");
@@ -496,7 +496,7 @@ describe("hosted Linq instant first turn", () => {
     });
   });
 
-  it("runs one high-reasoning reply from durable claim through the runtime handoff", async () => {
+  it("runs one priority medium-reasoning reply from durable claim through the runtime handoff", async () => {
     const prisma = createPrisma();
     const reply =
       "A short walk after dinner can help your muscles use glucose, which may soften the post-meal blood-sugar rise.";
@@ -531,10 +531,10 @@ describe("hosted Linq instant first turn", () => {
 
     const requestBody = JSON.parse(String(fetchMock.mock.calls[0][1].body));
     expect(requestBody).toMatchObject({
-      reasoning: { effort: "high" },
+      reasoning: { effort: "medium" },
+      service_tier: "priority",
     });
     expect(requestBody).not.toHaveProperty("max_output_tokens");
-    expect(requestBody).not.toHaveProperty("service_tier");
     expect(mocks.claimHostedLinqDeliveryProviderDispatchTx)
       .toHaveBeenNthCalledWith(1, expect.objectContaining({
         sourceRef: REQUEST.eventId,


### PR DESCRIPTION
## Why and outcome

The Web-owned first iMessage reply currently asks Luna to use high reasoning on standard processing. This changes only that request to medium reasoning with OpenAI priority processing so a brand-new direct iMessage sender can get the same bounded Murph reply with less provider wait.

The canonical welcome, prompt, schema, no-tool boundary, delivery claim, runtime handoff, timeout, retries, and fallback behavior remain unchanged.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: The affected person is a brand-new unknown sender starting a plain-text direct iMessage conversation. They receive the same canonical greeting or bounded answer, while unsupported content and provider failure keep the existing full-runtime fallback. No audience, permission, message count, or recovery path changes.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared -- test/hosted-onboarding-linq-instant-first-turn.test.ts` passes 20 tests, including the exact medium-reasoning priority request and the durable claim-to-runtime handoff.
- Changelog: `pnpm --dir apps/web test -- changelog-page.test.tsx` passes 9 archive/component tests with the existing first-reply item attributed to this PR.
- Type safety: `pnpm --dir apps/web typecheck` passes against the installed OpenAI SDK.
- Provider contract: OpenAI's current Responses API documents `service_tier: "priority"` as a request-level Fast-mode value.
- Live semantic matrix: The existing opt-in seven-case matrix composes this exact production body, but was not run locally because no separately authorized non-production provider credential is available in this worktree. No production secret or channel was pulled into local verification.

## Non-obvious affected surfaces

- OpenAI usage for the first-reply generation uses priority pricing and reports the service tier actually served; no other model request changes.
- The first-reply model may use less reasoning compute. The canonical welcome remains package-owned, and the existing bounded semantic matrix covers model-authored answers.
- The existing public first-reply performance changelog item now includes this PR as supporting provenance; its member-facing copy is unchanged.
- No delivery, routing, database, activation, mailbox, or runtime-handoff owner changes.

## Architecture and reuse

- Existing systems reused: The Web-owned Responses API body builder, durable delivery ledger, chat ownership lock, canonical Murph welcome, existing semantic matrix, and runtime handoff remain the complete path.
- New logic: Two request controls change from high/default processing to medium/priority processing.
- New abstractions: None; the existing request body is sufficient.
- Complexity intentionally avoided: No feature flag, fallback tier selector, retry, queue, service, state owner, dependency, or duplicated prompt/eval path.

## Hot reply path impact

- Path status: Applicable - this changes the existing Web-owned provider call before the first durable reply handoff.
- Database calls: No calls added or moved; durable delivery claim and finalization ordering are unchanged.
- Network/provider calls: Still one OpenAI Responses request, followed by the existing Linq send. The OpenAI call now requests priority processing with medium reasoning.
- Other awaited latency: None added or moved.
- Timeouts, retries, fallback: The OpenAI request retains the 18-second timeout and zero retries; an unavailable generation still defers through the existing runtime path.
- Before/after proof: Exact request-body regression coverage is green; live latency remains post-deploy evidence because local verification does not call production channels.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: The standalone Web first-reply request changes only reasoning effort and service tier; its prompt, schema, and message are byte-for-byte unchanged.
- Measurement method: Not run - no assistant-runtime individual or group initial input changes.

## Risks and review

- ReviewGPT context sensitivity: sensitive
- Classification reason: This changes production OpenAI request controls, first-reply latency behavior, and per-token processing price on the foreground reply path.

ReviewGPT first-reviewed head: 6c39117042426c10d54c32095dcb589203f3f714

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Web instances use the same schema, prompt, response, delivery, and handoff contracts; only provider request controls differ during rollout.
- Safe order: Deploy the reviewed Web artifact normally; Cloudflare, migrations, and provider/channel configuration are unchanged.
- Rollback floor: Any prior compatible Web artifact remains safe and restores high reasoning with standard/default processing.
- Expected exposure: During normal rollout, first replies may use either request profile depending on the serving Web revision.
- Reversibility: Revert or redeploy the prior Web artifact; no persisted state needs repair.
- Convergence proof: Confirm the production Web commit, then observe the served Luna request tier and successful first-reply outcome through existing bounded telemetry.
- Post-deploy checks: Verify first-reply success/fallback rates, served service tier, model latency, Linq acceptance, and absence of duplicate runtime replies.

## Change-shape breakdown

Classification rule: The request builder is source; Vitest assertions are tests; the changelog provenance update is docs/content. No binary or generated files change.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 1 |
| Tests / fixtures | 5 | 5 |
| Docs | 2 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **9** | **7** |

## Changelog

- Changelog: updated
- Items: 2026-08-22 · quicker-first-imessage-replies
