### PR TITLE
test(hosted): align integration fixtures with runtime owners

### DIFF
--- a/apps/cloudflare/test/hosted-local-computer-handoff-linq-roundtrip-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-computer-handoff-linq-roundtrip-e2e.test.ts
@@ -108,6 +108,7 @@ describe("hosted local computer handoff Linq roundtrip e2e", () => {
     });
     await seedHostedComputerRunForTest({
       environment: requireScenario().runtimeEnv,
+      liveViewUrl: `https://proxy.test-browser.onkernel.com:8443/live/${computerRunId}`,
       memberId,
       runId: computerRunId,
     });

--- a/apps/web/test/support/hosted-web-testkit.ts
+++ b/apps/web/test/support/hosted-web-testkit.ts
@@ -144,6 +144,10 @@ const hostedComputerUseServiceModuleSpecifier = new URL(
   "../../src/lib/computer-use/service.ts",
   import.meta.url,
 ).href;
+const hostedComputerUseCryptoModuleSpecifier = new URL(
+  "../../src/lib/computer-use/crypto.ts",
+  import.meta.url,
+).href;
 const hostedComputerUseStoreModuleSpecifier = new URL(
   "../../src/lib/computer-use/store.ts",
   import.meta.url,
@@ -297,7 +301,10 @@ interface HostedLinqWorkspaceIsolationForTestPrismaClient {
     } | null>;
   };
   hostedThreadContainer: {
-    findUnique(args: unknown): Promise<{ memberId: string } | null>;
+    findUnique(args: unknown): Promise<{
+      memberId: string;
+      monthlyUsageLimitUsdMicros: bigint;
+    } | null>;
   };
   hostedWorkspace: {
     findUnique(args: unknown): Promise<{ version: bigint } | null>;
@@ -523,6 +530,16 @@ interface HostedComputerUseServiceModule {
     env: NodeJS.ProcessEnv;
     store: HostedComputerUseStoreForTest;
   }) => HostedComputerUseServiceForTest;
+}
+
+interface HostedComputerUseCryptoModule {
+  encryptComputerRunSecret(input: {
+    field: "kernel-live-view-url";
+    memberId: string;
+    prisma: HostedTestPrismaClient;
+    runId: string;
+    value: string;
+  }): Promise<string | null>;
 }
 
 export interface HostedComputerRunForTest {
@@ -1796,15 +1813,20 @@ export async function seedHostedAiUsageLimitPeriodForTest(input: {
   periodStart: Date;
   remainingUsdMicros?: bigint;
 }): Promise<HostedAiUsagePeriodForTest> {
-  const limitUsdMicros = 10_000_000n;
-  const remainingUsdMicros = input.remainingUsdMicros ?? 0n;
-  if (remainingUsdMicros < 0n || remainingUsdMicros > limitUsdMicros) {
-    throw new RangeError("Hosted AI usage test balance must be within the period limit.");
-  }
-  const spentUsdMicros = limitUsdMicros - remainingUsdMicros;
-  const blockedAt = remainingUsdMicros === 0n ? input.periodStart : null;
-  return withHostedWebTestkitDeps(input.environment, async (deps) =>
-    await deps.prisma.hostedAiUsagePeriod.upsert({
+  return withHostedWebTestkitDeps(input.environment, async (deps) => {
+    const threadContainer = await deps.prisma.hostedThreadContainer.findUnique({
+      select: { monthlyUsageLimitUsdMicros: true },
+      where: { memberId: input.memberId },
+    });
+    const limitUsdMicros =
+      threadContainer?.monthlyUsageLimitUsdMicros ?? 10_000_000n;
+    const remainingUsdMicros = input.remainingUsdMicros ?? 0n;
+    if (remainingUsdMicros < 0n || remainingUsdMicros > limitUsdMicros) {
+      throw new RangeError("Hosted AI usage test balance must be within the period limit.");
+    }
+    const spentUsdMicros = limitUsdMicros - remainingUsdMicros;
+    const blockedAt = remainingUsdMicros === 0n ? input.periodStart : null;
+    return await deps.prisma.hostedAiUsagePeriod.upsert({
       create: {
         billingPlanCode: "launch_monthly",
         blockedAt,
@@ -1829,8 +1851,8 @@ export async function seedHostedAiUsageLimitPeriodForTest(input: {
           periodStart: input.periodStart,
         },
       },
-    })
-  );
+    });
+  });
 }
 
 export async function readHostedAiUsageLimitPeriodForTest(input: {
@@ -1910,14 +1932,29 @@ export async function seedHostedComputerRunForTest(input: {
   environment?: NodeJS.ProcessEnv;
   expiresAt?: Date;
   kernelSessionId?: string;
+  liveViewUrl: string;
   memberId: string;
   runId: string;
 }): Promise<HostedComputerRunForTest> {
   return withHostedWebTestkitDeps(input.environment, async (deps) => {
+    const cryptoModule = await import(
+      hostedComputerUseCryptoModuleSpecifier
+    ) as HostedComputerUseCryptoModule;
+    const kernelLiveViewUrlEncrypted = await cryptoModule.encryptComputerRunSecret({
+      field: "kernel-live-view-url",
+      memberId: input.memberId,
+      prisma: deps.prisma,
+      runId: input.runId,
+      value: input.liveViewUrl,
+    });
+    if (!kernelLiveViewUrlEncrypted) {
+      throw new Error("Hosted computer test run live-view encryption failed.");
+    }
     const run = await deps.prisma.hostedComputerRun.create({
       data: {
         expiresAt: input.expiresAt ?? new Date(Date.now() + 60 * 60 * 1_000),
         id: input.runId,
+        kernelLiveViewUrlEncrypted,
         kernelProfileName: `hosted-local-${input.runId}`,
         kernelSessionId: input.kernelSessionId ?? `hosted-local-${input.runId}`,
         memberId: input.memberId,


### PR DESCRIPTION
## Why and outcome

Hosted integration checks were constructing two impossible states: computer handoffs without the encrypted live-view URL required by production, and group usage periods whose hard-coded limit did not match the owning thread container. This made valid runtime invariants look broken.

The fixtures now reuse production encryption for the live-view URL and derive a group runtime's allowance from its canonical thread-container record. Direct-member fixtures retain their existing fallback limit.

## Product UX

- Product UX: not applicable
- Reason: This PR changes test fixtures only; no member-visible behavior or production code changes.

## Evidence

- PASS: `pnpm --filter @murphai/hosted-web prisma:generate`
- PASS: `pnpm --filter @murphai/hosted-web typecheck:prepared`
- PASS: exact private-worker computer-handoff journey.
- PASS: exact private-worker private-to-group handoff journey, including one final allowed call and the next-call usage fence.
- The combined local suite later reported an unrelated runner completion timeout in the multi-sender backlog case. Exact-head CI remains the broad admission gate.

## Non-obvious affected surfaces

None. The changed helper and scenario are test-only and do not alter production runtime behavior, schemas, deploy configuration, or member data.

## Architecture and reuse

- Existing systems reused: Production `encryptComputerRunSecret` owns live-view fixture encryption, and the existing `HostedThreadContainer` row owns group allowance limits.
- New logic: The usage-period seed reads the target's thread-container limit when one exists; direct-member seeds preserve the existing fallback.
- New abstractions: None; the existing testkit boundary is sufficient.
- Complexity intentionally avoided: No duplicate crypto, production compatibility shim, new state owner, or retry behavior was added.

## Hot reply path impact

Not applicable. Only integration fixture setup changes; the foreground reply critical path is unchanged.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-input assembly surface changed.
- Codex runtime: Not applicable; no prompt, tool schema, or generated provider guidance changed.

## Change-shape breakdown

Classification rule: both changed files are tests/fixtures; no generated or binary files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 50 | 12 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 50 | 12 |

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only changes do not cross a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Members cannot see test-fixture corrections.