### PR TITLE
fix(test): normalize package Vitest roots

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-27-frog-autofix-2369.md
+++ b/agent-docs/exec-plans/active/2026-08-27-frog-autofix-2369.md
@@ -1,0 +1,65 @@
+# Normalize package Vitest roots
+
+Status: active
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Make package-owned Vitest configs resolve their package root consistently so
+  documented repository-root invocations accept repository-relative test file
+  filters without changing package-local behavior.
+
+## Success criteria
+
+- The reproduced repository-root assistant-runtime invocation runs its target
+  instead of reporting that no files match.
+- Package-local Vitest invocation remains supported.
+- Focused repo-tools coverage locks the default and explicit-root behavior.
+- Routed typecheck, ReviewGPT, and required PR checks pass the exact candidate.
+
+## Scope
+
+- In scope: the shared package Vitest config helper and focused repo-tools tests.
+- Out of scope: package test behavior, coverage policy, dependency changes, and
+  product/runtime code.
+
+## Constraints
+
+- Technical constraints: preserve explicit `rootRelativePath` overrides and
+  existing workspace alias resolution.
+- Product/process constraints: use the committed Frog entry as authority, keep
+  the patch internal-only and public-safe, and follow the draft PR review lane.
+
+## Risks and mitigations
+
+1. Risk: changing the default root could alter package-local discovery.
+   Mitigation: set the default to the config-owning package directory, which is
+   the package-local behavior already observed, and cover both invocation forms.
+
+## Tasks
+
+1. [x] Reproduce repository-root failure and package-directory success.
+2. [x] Add a focused regression test for shared config root resolution.
+3. [x] Apply the smallest shared-helper correction.
+4. [ ] Run completion review and PR gates.
+
+## Decisions
+
+- The shared helper is the owning boundary because every affected package config
+  delegates to it and most omit `rootRelativePath`.
+- Product UX and changelog are not applicable because this changes only
+  repository-local test tooling.
+- The preliminary coverage lens applies. The separate final ReviewGPT gate does
+  not: the patch is low-risk developer tooling, has one owner, and does not
+  touch production behavior or a cross-cutting risk boundary.
+
+## Verification
+
+- Before fix: the repository-root assistant-runtime invocation exited 1 with no
+  matching files; the package-local invocation passed 1 file and 5 tests.
+- After fix: the repository-root and package-local invocations each passed 1
+  file and 5 tests; the focused config test passed 2 tests.
+- `pnpm test:repo-tools`: passed 48 files and 674 tests.
+- `pnpm typecheck`: passed the full workspace type proof.
+- Pending: preliminary coverage ReviewGPT and exact-head required GitHub checks.

--- a/agent-docs/exec-plans/completed/2026-08-27-frog-autofix-2369.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-frog-autofix-2369.md
@@ -1,6 +1,6 @@
 # Normalize package Vitest roots
 
-Status: active
+Status: completed
 Created: 2026-08-27
 Updated: 2026-08-27
 
@@ -42,7 +42,7 @@ Updated: 2026-08-27
 1. [x] Reproduce repository-root failure and package-directory success.
 2. [x] Add a focused regression test for shared config root resolution.
 3. [x] Apply the smallest shared-helper correction.
-4. [ ] Run completion review and PR gates.
+4. [x] Complete local and preliminary review and prepare the final CI candidate.
 
 ## Decisions
 
@@ -62,4 +62,8 @@ Updated: 2026-08-27
   file and 5 tests; the focused config test passed 2 tests.
 - `pnpm test:repo-tools`: passed 48 files and 674 tests.
 - `pnpm typecheck`: passed the full workspace type proof.
-- Pending: preliminary coverage ReviewGPT and exact-head required GitHub checks.
+- Preliminary ReviewGPT coverage lens: `SPECIALIST_OUTCOME: PASS` on the pushed
+  behavior-bearing head, with no findings and no patch artifact.
+- Parent final review: no remaining scope, correctness, privacy, or proof gap.
+- Pending after plan closure: required GitHub checks on the final ready head.
+Completed: 2026-08-27

--- a/config/vitest-package.ts
+++ b/config/vitest-package.ts
@@ -41,9 +41,7 @@ export function createMurphPackageVitestConfig(input: MurphPackageVitestConfigIn
   });
 
   return defineConfig({
-    ...(input.rootRelativePath
-      ? { root: path.resolve(packageDir, input.rootRelativePath) }
-      : {}),
+    root: path.resolve(packageDir, input.rootRelativePath ?? "."),
     ...(aliases.length > 0 ? { resolve: { alias: aliases } } : {}),
     test: {
       ...(input.useDefaultTimeouts === false ? {} : murphVitestNoTimeouts),

--- a/scripts/vitest-package.test.ts
+++ b/scripts/vitest-package.test.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { createMurphPackageVitestConfig } from "../config/vitest-package.js";
+
+describe("package Vitest roots", () => {
+  const packageConfigUrl = new URL(
+    "../packages/core/vitest.config.ts",
+    import.meta.url,
+  ).href;
+  const packageDir = path.dirname(fileURLToPath(packageConfigUrl));
+
+  it("defaults the root to the package that owns the config", () => {
+    expect(
+      createMurphPackageVitestConfig({
+        configUrl: packageConfigUrl,
+        name: "package-root-default",
+      }),
+    ).toMatchObject({ root: packageDir });
+  });
+
+  it("resolves an explicit root relative to the package config", () => {
+    expect(
+      createMurphPackageVitestConfig({
+        configUrl: packageConfigUrl,
+        name: "package-root-override",
+        rootRelativePath: "../..",
+      }),
+    ).toMatchObject({ root: path.resolve(packageDir, "../..") });
+  });
+});


### PR DESCRIPTION
## Why and outcome

Package-owned Vitest configs now anchor discovery to their config directory, so supported root-level invocations and package-local invocations resolve the same tests. Explicit relative-root overrides remain supported.

Frog autofix issue: #2369

## Product UX

Not applicable. This changes repository-local test configuration only and has no member-visible behavior.

## Evidence

- Before the fix, the focused repository-root invocation found no matching file; the equivalent package-local invocation passed 1 file and 5 tests.
- After the fix, both invocation forms passed 1 file and 5 tests.
- Focused config regression: 2 tests passed.
- pnpm test:repo-tools: 48 files and 674 tests passed.
- pnpm typecheck: full workspace type proof passed.

## Non-obvious affected surfaces

- Shared package Vitest configuration: package configs that omit an explicit root now receive the config-owning package directory. Focused default and override coverage plus both invocation forms prove the behavior.
- Production behavior: none.

## Architecture and reuse

- **Existing systems reused:** The existing createMurphPackageVitestConfig helper remains the single package-test configuration owner.
- **New logic:** The helper always resolves root from the config directory, defaulting the relative segment to the directory itself.
- **New abstractions:** None; the existing optional override remains sufficient.
- **Complexity intentionally avoided:** No wrapper commands, path rewriting, or package-specific compatibility handling were added.

## Hot reply path impact

Not applicable. The change does not touch runtime message acceptance, provider start, or reply handoff.

## Murph initial provider input impact

- Local assistant runtime: Not applicable; no prompt, tool, schema, or provider-visible input changed.
- Hosted assistant runtime: Not applicable; no prompt, tool, schema, or provider-visible input changed.

## Review gates

- Preliminary ReviewGPT: coverage lens required on the exact pushed candidate.
- Final ReviewGPT: not applicable under the low-risk developer-tooling exemption; no cross-cutting trigger applies.

## Change-shape breakdown

Classification rule: authored test files are tests/fixtures; the execution plan is docs; the shared Vitest helper is config/tooling. No binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 33 | 0 |
| Docs | 69 | 0 |
| Config/tooling | 1 | 3 |
| Generated/other | 0 | 0 |
| **Total** | **103** | **3** |

## Deployment concerns

- Deployment: not applicable
- Reason: Repository-local test tooling does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal test tooling has no member-visible outcome.

