### PR TITLE
fix(web): guard full Prisma formatting

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-27-frog-2377-prisma-format-opt-in.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-frog-2377-prisma-format-opt-in.md
@@ -1,0 +1,76 @@
+# Guard hosted Prisma formatting
+
+Status: completed
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Prevent ordinary focused hosted-Web Prisma work from accidentally rewriting
+  the full checked-in schema while retaining an explicit path for intentional
+  repository-wide schema normalization.
+
+## Success criteria
+
+- The default hosted-Web `prisma format` command fails before mutating a schema
+  and points contributors to the non-mutating validation command.
+- An explicit, documented opt-in still permits intentional full-schema format
+  work.
+- Prisma validation, generation, and other CLI commands are unaffected.
+- Focused tests and direct CLI proof cover the policy boundary.
+
+## Scope
+
+- In scope: the hosted-Web Prisma CLI config, its focused policy test, and the
+  existing Prisma workflow documentation.
+- Out of scope: formatting or otherwise changing the checked-in Prisma schema,
+  migrations, product runtime behavior, dependencies, and CI configuration.
+
+## Constraints
+
+- Technical constraints: Prisma 7.8 formats only whole schema files; it exposes
+  no model- or range-scoped formatter. The opt-in must be checked before local
+  env files load so a persistent local file cannot silently authorize it.
+- Product/process constraints: keep the repair repository-local, narrow, and
+  reversible; do not change deployed behavior or database shape.
+
+## Risks and mitigations
+
+1. Risk: a broad argv match could block unrelated Prisma commands.
+   Mitigation: match the exact `format` subcommand and cover non-format and help
+   invocations in focused tests.
+2. Risk: the guard could make intentional normalization impossible.
+   Mitigation: preserve a named process-level opt-in and document the exact
+   command beside the existing schema workflow.
+
+## Tasks
+
+1. Add a focused failing regression test for the real Prisma CLI boundary.
+2. Add the opt-in policy directly to `apps/web/prisma.config.ts` before
+   env-file loading.
+3. Document focused validation and the explicit full-format opt-in.
+4. Run focused tests, Prisma validation, direct mutation/no-mutation proof,
+   typecheck, and diff/privacy inspection.
+5. Commit, push, open the draft Frog PR, and drive the required exact-head
+   review and CI gates.
+
+## Decisions
+
+- Rejected another prose-only warning because the current README warning
+  predates the friction report and did not prevent the recurrence.
+- Rejected whole-schema normalization because the reproduced mechanical diff
+  changes 1,868 lines and is unrelated to the ordinary additive schema task.
+- Use a process-level opt-in rather than a new dependency or formatter.
+
+## Verification
+
+- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/prisma-format-policy.test.ts`
+  passed with both real-CLI regression cases.
+- `pnpm --dir apps/web exec eslint prisma.config.ts test/prisma-format-policy.test.ts`
+  passed.
+- `pnpm --dir apps/web typecheck` passed.
+- `pnpm --dir apps/web prisma:validate` passed.
+- Direct isolated CLI proof shows default `prisma format` fails without changing
+  the target and explicit opt-in formats the target successfully; passed.
+- `git diff --check` and the added-line public-safety scan passed.
+Completed: 2026-08-27

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1445,9 +1445,14 @@ pnpm --dir apps/web release:production:contract-migrate
 ```
 
 Use `prisma:validate` for focused schema verification. It checks the schema
-without rewriting it. Run `prisma format` only when a repository-wide schema
-layout change is intentional, and review that mechanical diff separately from
-the migration change.
+without rewriting it. The hosted-Web Prisma config rejects `prisma format` by
+default because Prisma formats the entire schema rather than one edited model.
+For an intentional repository-wide schema layout change, opt in explicitly and
+review that mechanical diff separately from the migration change:
+
+```bash
+MURPH_ALLOW_FULL_PRISMA_FORMAT=1 pnpm --dir apps/web exec prisma format
+```
 
 The checked-in Vercel build command runs the guarded production migration
 wrapper before building. That wrapper generates the Prisma client because the

--- a/apps/web/prisma.config.ts
+++ b/apps/web/prisma.config.ts
@@ -6,6 +6,20 @@ import { existsSync } from "node:fs";
 import { defineConfig } from "prisma/config";
 
 const CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
+const isFormatCommand = process.argv[2] === "format";
+const isHelpRequest = process.argv.includes("--help") || process.argv.includes("-h");
+
+if (
+  isFormatCommand
+  && !isHelpRequest
+  && process.env.MURPH_ALLOW_FULL_PRISMA_FORMAT !== "1"
+) {
+  throw new Error(
+    "Refusing to format the full hosted Web Prisma schema. "
+      + "Use `pnpm --dir apps/web prisma:validate` for focused verification. "
+      + "Set MURPH_ALLOW_FULL_PRISMA_FORMAT=1 only for an intentional repository-wide schema layout change.",
+  );
+}
 
 for (const envPath of [".env.local", ".env"]) {
   const absoluteEnvPath = path.join(CONFIG_DIR, envPath);

--- a/apps/web/test/prisma-format-policy.test.ts
+++ b/apps/web/test/prisma-format-policy.test.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const tempRoots: string[] = [];
+const fullPrismaFormatOptIn = "MURPH_ALLOW_FULL_PRISMA_FORMAT";
+
+function createSchemaFixture(): string {
+  const sharedTempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
+  if (!sharedTempRoot) throw new Error("MURPH_VITEST_TEMP_ROOT is required.");
+
+  const root = mkdtempSync(path.join(sharedTempRoot, "prisma-format-policy-"));
+  const schemaPath = path.join(root, "schema.prisma");
+  tempRoots.push(root);
+  writeFileSync(
+    schemaPath,
+    `datasource db {
+  provider = "postgresql"
+}
+
+model Example {
+  id String @id
+  displayName String?
+}
+`,
+  );
+  return schemaPath;
+}
+
+function runPrisma(
+  args: readonly string[],
+  environment: Readonly<Record<string, string | undefined>> = {},
+) {
+  return spawnSync(
+    "pnpm",
+    ["--dir", "apps/web", "exec", "prisma", ...args],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        [fullPrismaFormatOptIn]: "",
+        ...environment,
+      },
+    },
+  );
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) rmSync(tempRoots.pop()!, { force: true, recursive: true });
+});
+
+describe("hosted Web Prisma format policy", () => {
+  it("blocks the real Prisma formatter before it mutates the target", () => {
+    const schemaPath = createSchemaFixture();
+    const before = readFileSync(schemaPath, "utf8");
+    const result = runPrisma(["format", "--schema", schemaPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "Refusing to format the full hosted Web Prisma schema",
+    );
+    expect(readFileSync(schemaPath, "utf8")).toBe(before);
+  });
+
+  it("retains explicit full formatting and format help", () => {
+    const schemaPath = createSchemaFixture();
+    const before = readFileSync(schemaPath, "utf8");
+    const formatResult = runPrisma(
+      ["format", "--schema", schemaPath],
+      { [fullPrismaFormatOptIn]: "1" },
+    );
+    const helpResult = runPrisma(["format", "--help"]);
+
+    expect(formatResult.status, formatResult.stderr).toBe(0);
+    expect(readFileSync(schemaPath, "utf8")).not.toBe(before);
+    expect(helpResult.status, helpResult.stderr).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why and outcome

Prisma's formatter only operates on whole schema files, and the hosted schema's established layout means a focused model addition can trigger nearly two thousand unrelated line changes. This makes full formatting opt-in at the hosted-Web Prisma config boundary while preserving non-mutating validation and an explicit repository-wide normalization path.

Frog autofix issue: #2377

## Product UX

- Effort: Not applicable — repository-local developer tooling only.
- Result: Not applicable — no member-facing behavior or interface changes.
- Walkthrough: The default formatter refusal, explicit opt-in, help, validation, generation, and typecheck paths were exercised locally.

## Evidence

- Direct: Formatting an isolated copy of the 2,500-line schema on the base produced 933 additions and 935 deletions. On this head, the default command exits before changing the target; the explicit opt-in formats it successfully.
- Focused regression: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/prisma-format-policy.test.ts`
- Static checks: scoped ESLint and `pnpm --dir apps/web typecheck`
- Prisma: `pnpm --dir apps/web prisma:validate`
- Diff hygiene: `git diff --check` and an added-line public-safety scan

## Non-obvious affected surfaces

- `apps/web/prisma.config.ts` is loaded by hosted-Web Prisma CLI commands. The new check matches only the exact `format` subcommand, permits help and an explicit process-level opt-in, and runs before local env-file loading. Focused CLI regression plus validation, generation, and typecheck prove the unaffected paths.
- No Prisma schema, migration, generated client, dependency, production runtime, or deploy configuration changes.

## Architecture and reuse

- Existing systems reused: The existing hosted-Web Prisma config and `prisma:validate` script remain the workflow owners.
- New logic: One exact CLI-subcommand check refuses implicit whole-schema formatting and explains the supported alternatives.
- New abstractions: None; the guard stays directly in the existing Prisma config.
- Complexity intentionally avoided: No new formatter, dependency, git hook, schema normalization, service, or compatibility layer.

## Hot reply path impact

- Path status: Not applicable — this changes only local Prisma CLI behavior and adds no database, network, provider, or awaited operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual Murph: Not applicable — no prompt, tool, schema, or provider-input assembly surface changes.
- Group Murph: Not applicable — no prompt, tool, schema, or provider-input assembly surface changes.
- Measurement method: Not run because the diff is limited to repository-local Prisma CLI behavior, tests, and documentation.

## Change-shape breakdown

Classification rule: authored files are grouped by their repository role; the completed execution plan is documentation, and there are no generated or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 87 | 0 |
| Docs | 84 | 3 |
| Config/tooling | 14 | 0 |
| Generated/other | 0 | 0 |
| Total | 185 | 3 |

## Deployment concerns

- Deployment: not applicable
- Reason: The guard runs only while loading the repository's Prisma CLI config and does not change application runtime or a deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: This is internal developer tooling with no member-visible outcome.
