### PR TITLE
fix(test): repair event recovery fixtures

### DIFF
--- a/.agents/friction-log/20260827164708-event-recovery-fixtures/friction.md
+++ b/.agents/friction-log/20260827164708-event-recovery-fixtures/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Event recovery fixtures omit required note payload'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Focused event identity and CLI error-mapping tests should reach the behavior they claim to exercise and keep the required package coverage shards green.
+
+## Current Behavior
+
+Two synthetic fixtures declare an event with `kind: "note"` but omit the contract-required `note` field. Event contract validation fails before the identity-precedence or mocked error-mapping boundary. The CLI assertion also expects arbitrary core error details to survive mapping even though event contract failures intentionally replace them with a bounded validation context. Together, these stale expectations block the core and CLI package coverage shards.
+
+## Possible Solution
+
+Keep the fixtures contract-valid by supplying a synthetic note value wherever the test intends to exercise a later boundary, and assert the established bounded validation context for event contract failures.
+
+## Minimal Reproducible Example
+
+Run the focused canonical-id precedence test or the focused renamed-error mapping test on the affected main revision. The former fails before its identity assertion. The latter first fails validation, then—once its fixture is valid—rejects its stale expectation that a private-shaped arbitrary detail is preserved.
+
+## Context
+
+The failures block otherwise unrelated pull requests whose merge-result CI includes the affected main revision.

--- a/packages/cli/test/canonical-write-lock.test.ts
+++ b/packages/cli/test/canonical-write-lock.test.ts
@@ -448,6 +448,7 @@ test.sequential("provider and event CLI usecases map renamed core error codes to
                     kind: "note",
                     occurredAt: "2026-03-12T12:00:00.000Z",
                     title: "Mock note",
+                    note: "Mock note body.",
                   },
                 }),
               (error: unknown) =>
@@ -455,9 +456,9 @@ test.sequential("provider and event CLI usecases map renamed core error codes to
                   code: failure.cliCode,
                   message: failure.message,
                   vaultCode: failure.vaultCode,
-                  context: {
-                    exampleDetail: failure.vaultCode.toLowerCase(),
-                  },
+                  context: failure.vaultCode === "EVENT_CONTRACT_INVALID"
+                    ? { stage: "validation" }
+                    : { exampleDetail: failure.vaultCode.toLowerCase() },
                 }),
             );
           },
@@ -491,9 +492,9 @@ test.sequential("provider and event CLI usecases map renamed core error codes to
                   code: failure.cliCode,
                   message: failure.message,
                   vaultCode: failure.vaultCode,
-                  context: {
-                    exampleDetail: failure.vaultCode.toLowerCase(),
-                  },
+                  context: failure.vaultCode === "EVENT_CONTRACT_INVALID"
+                    ? { stage: "validation" }
+                    : { exampleDetail: failure.vaultCode.toLowerCase() },
                 }),
             );
           },

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -472,6 +472,7 @@ test("upsertEvent gives canonical id precedence over the legacy eventId alias", 
       kind: "note",
       occurredAt: "2026-03-26T21:00:00.000Z",
       title: "Identity precedence baseline",
+      note: "Baseline identity note.",
     },
   });
   const updated = await upsertEvent({
@@ -482,6 +483,7 @@ test("upsertEvent gives canonical id precedence over the legacy eventId alias", 
       kind: "note",
       occurredAt: "2026-03-26T21:00:00.000Z",
       title: "Identity precedence update",
+      note: "Updated identity note.",
     },
   });
 
@@ -498,6 +500,7 @@ test("upsertEvent gives canonical id precedence over the legacy eventId alias", 
           kind: "note",
           occurredAt: "2026-03-26T21:00:00.000Z",
           title: "Invalid canonical identity",
+          note: "Invalid identity note.",
         },
       }),
     (error: unknown) =>


### PR DESCRIPTION
## Why and outcome

Current-main event recovery tests use stale note fixtures, preventing the core and CLI coverage shards from reaching their intended identity-precedence and error-mapping assertions. This repairs only test data and expectations; production behavior is unchanged.

## Product UX

Not applicable: test-only recovery for existing contracts.

## Evidence

- Red-to-green focused core canonical-id precedence test.
- Red-to-green focused CLI renamed-error mapping test.
- Full affected files: core 125/125 and CLI 6/6.
- Core package coverage: 48 files and 823 tests passed.
- Core and CLI package typechecks passed.
- Exact-head GitHub release package coverage (CLI) passed.

## Non-obvious affected surfaces

None. Only tests and the repository friction log change.

## Architecture and reuse

- **Existing systems reused:** Existing event contract validation and bounded VaultCliError mapping remain authoritative.
- **New logic:** No production logic; fixtures now satisfy the note contract and assertions reflect the established sanitized context.
- **New abstractions:** None; direct fixture and assertion corrections are sufficient.
- **Complexity intentionally avoided:** No production workaround, compatibility shim, or relaxed validation.

## Hot reply path impact

None.

## Provider-input impact

None.

## Deployment concerns

- Deployment: not applicable
- Reason: This changes tests only and requires no production deployment or runtime coordination.

## Changelog

- Changelog: not applicable
- Reason: This changes test fixtures and assertions only; member-visible behavior and production code are unchanged.

## Change shape

- Source: +0 / -0
- Tests and fixtures: +10 / -6
- Docs: +24 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0




