### PR TITLE
perf(cloudflare): skip current runner schema scans

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-27-do-schema-fastpath.md
+++ b/agent-docs/exec-plans/active/2026-08-27-do-schema-fastpath.md
@@ -1,0 +1,95 @@
+# Durable Object schema activation fast path
+
+Status: active
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Reduce post-hibernation UserRunner Durable Object initialization work by
+  trusting the persisted exact schema version and skipping repeated migration
+  inspection when the schema is already current.
+
+## Success criteria
+
+- Current-version objects perform only the minimum schema-version admission work
+  and skip repeated runner-table DDL, per-column PRAGMA scans, legacy migration
+  checks, retired-table cleanup, and final migration assertions.
+- New, older-version, missing-version, and future-version objects preserve their
+  current create/migrate/fail-closed behavior.
+- Focused tests prove both the reduced SQL call shape and every migration floor.
+- The change adds no cache, state owner, dependency, background work, or retry.
+- The exact pushed PR head clears required specialist/final ReviewGPT gates and
+  required GitHub checks before merge.
+
+## Scope
+
+- In scope:
+  - `RunnerStateStore` schema admission and its focused tests/docs.
+  - A member-visible performance changelog entry if required by the changelog contract.
+- Out of scope:
+  - Changing schema version 17, persisted row shape, migrations, or runtime ownership.
+  - Durable Object keepalive/prewarming, queues, container boot, or Cloudflare config.
+
+## Constraints
+
+- Technical constraints:
+  - Reject a stored future version before constructing runtime services.
+  - Keep first-use and legacy migration paths behaviorally identical.
+  - Prefer deletion/early return over a cache or new abstraction.
+- Product/process constraints:
+  - ReviewGPT implements the production/test patch; the parent verifies and
+    lands it through the normal PR lane.
+  - Treat the member journey as a Product UX Patch: a reply after object idle
+    should begin sooner with no visible semantic change or recovery regression.
+
+## Risks and mitigations
+
+1. Risk: trusting the version marker hides a partially migrated schema.
+   Mitigation: prove the write ordering makes the current marker terminal, retain
+   fail-closed runtime queries, and cover interrupted/legacy shapes directly.
+2. Risk: optimization changes new-object or rollback behavior.
+   Mitigation: keep all non-current versions on the existing full path and test
+   exact SQL ordering for new, old, current, and future versions.
+
+## Tasks
+
+1. Completed: asked ReviewGPT to implement the smallest exact-version fast
+   path and proof.
+2. Completed: verified the exact artifact identity, read every hunk, and
+   applied the returned three-file patch unchanged.
+3. Completed: ran the focused schema/store suite, deterministic before/after
+   operation proof, Cloudflare typecheck, changelog page suite, Web typecheck,
+   and diff checks.
+4. In progress: the candidate is pushed on PR #2462; complete required
+   ReviewGPT and CI gates.
+5. Merge the exact reviewed head and retire the task worktree.
+
+## Decisions
+
+- Use one persisted-version early return; do not add in-memory caching.
+- Keep this PR independent of the observability PR so each can be reviewed and
+  rolled back separately.
+- Deterministic baseline proof on the production function records 21 SQL
+  operations for an already-current version-17 schema: one metadata-table
+  ensure, one runner-table ensure, two version reads, sixteen table-info
+  scans, and one retired-table drop. The target exact-current path is two
+  operations: the metadata-table ensure and one version read.
+
+## Verification
+
+- Commands to run:
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/runner-state-store.bundle-slots.test.ts`
+  - `pnpm --dir apps/cloudflare typecheck`
+  - `pnpm --dir apps/web test -- changelog-page.test.tsx`
+  - `pnpm --dir apps/web typecheck`
+  - `git diff --check`
+- Expected outcomes:
+  - All focused checks pass, current-version SQL work is materially smaller, and
+    every non-current schema path retains its existing behavior.
+- Results:
+  - Schema/store suite: 19 passed.
+  - Exact-current production function: 21 SQL operations before, 2 after.
+  - Changelog page suite: 9 passed.
+  - Cloudflare and Web typechecks passed.
+  - `git diff --check` passed.

--- a/agent-docs/exec-plans/completed/2026-08-27-do-schema-fastpath.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-do-schema-fastpath.md
@@ -1,6 +1,6 @@
 # Durable Object schema activation fast path
 
-Status: active
+Status: completed
 Created: 2026-08-27
 Updated: 2026-08-27
 
@@ -61,9 +61,10 @@ Updated: 2026-08-27
 3. Completed: ran the focused schema/store suite, deterministic before/after
    operation proof, Cloudflare typecheck, changelog page suite, Web typecheck,
    and diff checks.
-4. In progress: the candidate is pushed on PR #2462; complete required
-   ReviewGPT and CI gates.
-5. Merge the exact reviewed head and retire the task worktree.
+4. Completed: PR #2462 passed the Product UX/coverage specialist review, final
+   full-patch audit, and required exact-head CI with no findings or failures.
+5. In progress: merge the reviewed production candidate plus this plan-only
+   closure and retire the task worktree.
 
 ## Decisions
 
@@ -93,3 +94,4 @@ Updated: 2026-08-27
   - Changelog page suite: 9 passed.
   - Cloudflare and Web typechecks passed.
   - `git diff --check` passed.
+Completed: 2026-08-27

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -541,12 +541,18 @@ Foreground progress recovery is write-fenced instead of container-destroy
 driven. A write fence is commit authority, not liveness proof; the exact wake,
 replacement, ambiguous-wake, and fresh-startup retry contract is documented in
 `agent-docs/references/hosted-runtime-protocol.md`. Durable Object activation
-migrates legacy persisted active-invocation identity into the current write
-fence so dormant objects retain commit authority; it does not restore retired
-wake, backoff, or deadline state. Live runner side effects validate the
-runtime-kind write fence by attempt, generation, and user identity. Hosted
-OpenAI and Venice provider egress paths validate the signed Murph provider
-credential's user and runner against UserRunner's current active runtime state.
+always ensures `runner_schema_meta` and reads its version before touching
+`runner_meta`. An exact-current version returns immediately; missing, invalid,
+zero, or older versions retain the full create, migration, retired-table
+cleanup, version-mark, and final-assertion path, while a future version fails
+before `runner_meta` or retired-table mutation. Activation migrates
+legacy persisted active-invocation identity into the current write fence so
+dormant objects retain commit authority; it does not restore retired wake,
+backoff, or deadline state.
+Live runner side effects validate the runtime-kind write fence by attempt,
+generation, and user identity. Hosted OpenAI and Venice provider egress paths
+validate the signed Murph provider credential's user and runner against
+UserRunner's current active runtime state.
 Workspace version remains a checkpoint/restore freshness guard, not generic
 side-effect authority.
 Active, unsupported, error, and timeout liveness outcomes preserve the write

--- a/apps/cloudflare/src/user-runner/runner-state-schema.ts
+++ b/apps/cloudflare/src/user-runner/runner-state-schema.ts
@@ -11,6 +11,16 @@ export function ensureRunnerStateSchema(sql: DurableObjectSqlStorageLike): void 
       value INTEGER NOT NULL
     )
   `);
+
+  const storedVersion = readRunnerStateSchemaVersion(sql);
+  assertRunnerStateSchemaVersionSupported({
+    observedVersion: storedVersion,
+    supportedVersion: RUNNER_STATE_SCHEMA_VERSION,
+  });
+  if (storedVersion === RUNNER_STATE_SCHEMA_VERSION) {
+    return;
+  }
+
   sql.exec(`
     CREATE TABLE IF NOT EXISTS runner_meta (
       singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -32,7 +42,6 @@ export function ensureRunnerStateSchema(sql: DurableObjectSqlStorageLike): void 
     )
   `);
 
-  assertStoredRunnerStateSchemaVersionSupported(sql);
   for (const [columnName, definition] of Object.entries({
     active_attempt_id: "TEXT",
     active_generation: "INTEGER NOT NULL DEFAULT 0",
@@ -77,15 +86,6 @@ export function ensureRunnerStateSchema(sql: DurableObjectSqlStorageLike): void 
   });
 }
 
-function assertStoredRunnerStateSchemaVersionSupported(
-  sql: DurableObjectSqlStorageLike,
-): void {
-  assertRunnerStateSchemaVersionSupported({
-    observedVersion: readRunnerStateSchemaVersion(sql),
-    supportedVersion: RUNNER_STATE_SCHEMA_VERSION,
-  });
-}
-
 export function assertRunnerStateSchemaVersionSupported(input: {
   observedVersion: number;
   supportedVersion: number;
@@ -98,11 +98,6 @@ export function assertRunnerStateSchemaVersionSupported(input: {
 }
 
 function markRunnerStateSchemaVersion(sql: DurableObjectSqlStorageLike): void {
-  const version = readRunnerStateSchemaVersion(sql);
-  if (version >= RUNNER_STATE_SCHEMA_VERSION) {
-    return;
-  }
-
   sql.exec(
     `INSERT INTO runner_schema_meta (key, value)
      VALUES ('runner_state_schema_version', ${RUNNER_STATE_SCHEMA_VERSION})

--- a/apps/cloudflare/test/runner-state-store.bundle-slots.test.ts
+++ b/apps/cloudflare/test/runner-state-store.bundle-slots.test.ts
@@ -33,6 +33,20 @@ const CURRENT_RUNNER_META_COLUMNS = [
   "last_invocation_at",
 ];
 
+function normalizeSql(query: string): string {
+  return query.replace(/\s+/gu, " ").trim();
+}
+
+const ENSURE_RUNNER_SCHEMA_META_SQL = normalizeSql(`
+  CREATE TABLE IF NOT EXISTS runner_schema_meta (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+  )
+`);
+const READ_RUNNER_STATE_SCHEMA_VERSION_SQL =
+  "SELECT value FROM runner_schema_meta WHERE key = 'runner_state_schema_version'";
+const READ_RUNNER_META_COLUMNS_SQL = "PRAGMA table_info(runner_meta)";
+
 class SqliteCursor<T extends Record<string, DurableObjectSqlValue>>
   implements DurableObjectSqlCursorLike<T> {
   private index = 0;
@@ -85,12 +99,19 @@ class SqliteCursor<T extends Record<string, DurableObjectSqlValue>>
 }
 
 class SqliteDurableObjectSqlStorage {
+  readonly queries: string[] = [];
+
   constructor(private readonly db: DatabaseSync) {}
+
+  resetQueries(): void {
+    this.queries.length = 0;
+  }
 
   exec<T extends Record<string, DurableObjectSqlValue>>(
     query: string,
     ...bindings: DurableObjectSqlValue[]
   ): DurableObjectSqlCursorLike<T> {
+    this.queries.push(normalizeSql(query));
     const statement = this.db.prepare(query);
     const normalized = query.trimStart().toUpperCase();
 
@@ -112,6 +133,7 @@ class SqliteDurableObjectSqlStorage {
 function createDurableObjectState(
   db: DatabaseSync,
   values: Map<string, unknown> = new Map(),
+  sql: SqliteDurableObjectSqlStorage = new SqliteDurableObjectSqlStorage(db),
 ): DurableObjectStateLike {
   return {
     storage: {
@@ -123,7 +145,7 @@ function createDurableObjectState(
         values.set(key, value);
       },
       setAlarm: async () => {},
-      sql: new SqliteDurableObjectSqlStorage(db),
+      sql,
     },
     waitUntil() {},
   };
@@ -196,7 +218,117 @@ function runnerBundleSlotsTableExists(db: DatabaseSync): boolean {
   return row?.name === "runner_bundle_slots";
 }
 
-  describe("RunnerStateStore schema guard", () => {
+describe("RunnerStateStore schema guard", () => {
+  it("uses only the ordered metadata calls for exact-current activation", () => {
+    const db = new DatabaseSync(":memory:");
+    const sql = new SqliteDurableObjectSqlStorage(db);
+    const state = createDurableObjectState(db, new Map(), sql);
+    expect(() => new RunnerStateStore(state)).not.toThrow();
+    expect(readRunnerStateSchemaVersion(db)).toBe(RUNNER_STATE_SCHEMA_VERSION);
+    db.exec(`
+      CREATE TABLE runner_bundle_slots (
+        slot TEXT PRIMARY KEY
+      )
+    `);
+    sql.resetQueries();
+
+    expect(() => new RunnerStateStore(state)).not.toThrow();
+
+    expect(sql.queries).toEqual([
+      ENSURE_RUNNER_SCHEMA_META_SQL,
+      READ_RUNNER_STATE_SCHEMA_VERSION_SQL,
+    ]);
+    expect(sql.queries).toHaveLength(2);
+    expect(sql.queries.join("\n"))
+      .not.toMatch(/\brunner_meta\b|PRAGMA|active_invocation|DROP TABLE/u);
+    expect(runnerBundleSlotsTableExists(db)).toBe(true);
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["invalid", "invalid"],
+    ["zero", 0],
+    ["older", RUNNER_STATE_SCHEMA_VERSION - 1],
+  ] as const)("runs the full schema path for a %s stored version", (_label, storedVersion) => {
+    const db = new DatabaseSync(":memory:");
+    const sql = new SqliteDurableObjectSqlStorage(db);
+    const state = createDurableObjectState(db, new Map(), sql);
+    expect(() => new RunnerStateStore(state)).not.toThrow();
+    if (storedVersion === undefined) {
+      db.exec("DELETE FROM runner_schema_meta WHERE key = 'runner_state_schema_version'");
+    } else {
+      db.prepare(`
+        UPDATE runner_schema_meta
+        SET value = ?
+        WHERE key = 'runner_state_schema_version'
+      `).run(storedVersion);
+    }
+    db.exec(`
+      CREATE TABLE runner_bundle_slots (
+        slot TEXT PRIMARY KEY
+      )
+    `);
+    sql.resetQueries();
+
+    expect(() => new RunnerStateStore(state)).not.toThrow();
+
+    expect(sql.queries).toHaveLength(21);
+    expect(sql.queries[0]).toBe(ENSURE_RUNNER_SCHEMA_META_SQL);
+    expect(sql.queries[1]).toBe(READ_RUNNER_STATE_SCHEMA_VERSION_SQL);
+    expect(sql.queries.filter((query) => query === READ_RUNNER_STATE_SCHEMA_VERSION_SQL))
+      .toHaveLength(1);
+    expect(sql.queries[2]).toMatch(/^CREATE TABLE IF NOT EXISTS runner_meta/u);
+    expect(sql.queries.filter((query) => query === READ_RUNNER_META_COLUMNS_SQL))
+      .toHaveLength(16);
+    expect(sql.queries.at(-3)).toBe("DROP TABLE IF EXISTS runner_bundle_slots");
+    expect(sql.queries.at(-2)).toBe(normalizeSql(`
+      INSERT INTO runner_schema_meta (key, value)
+      VALUES ('runner_state_schema_version', ${RUNNER_STATE_SCHEMA_VERSION})
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `));
+    expect(sql.queries.at(-1)).toBe(READ_RUNNER_META_COLUMNS_SQL);
+    expect(readRunnerStateSchemaVersion(db)).toBe(RUNNER_STATE_SCHEMA_VERSION);
+    expect(runnerBundleSlotsTableExists(db)).toBe(false);
+  });
+
+  it("rejects a future schema before touching runner or retired tables", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE runner_schema_meta (
+        key TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+      );
+      INSERT INTO runner_schema_meta (key, value)
+      VALUES ('runner_state_schema_version', ${RUNNER_STATE_SCHEMA_VERSION + 1});
+      CREATE TABLE runner_meta (
+        singleton INTEGER PRIMARY KEY,
+        marker TEXT NOT NULL
+      );
+      INSERT INTO runner_meta (singleton, marker)
+      VALUES (1, 'preserve');
+      CREATE TABLE runner_bundle_slots (
+        slot TEXT PRIMARY KEY
+      );
+    `);
+    const sql = new SqliteDurableObjectSqlStorage(db);
+    const state = createDurableObjectState(db, new Map(), sql);
+
+    expect(() => new RunnerStateStore(state)).toThrow(
+      `Hosted runner Durable Object schema version ${RUNNER_STATE_SCHEMA_VERSION + 1} `
+        + `is newer than supported version ${RUNNER_STATE_SCHEMA_VERSION}.`,
+    );
+
+    expect(sql.queries).toEqual([
+      ENSURE_RUNNER_SCHEMA_META_SQL,
+      READ_RUNNER_STATE_SCHEMA_VERSION_SQL,
+    ]);
+    expect(readRunnerStateSchemaVersion(db)).toBe(RUNNER_STATE_SCHEMA_VERSION + 1);
+    expect(db.prepare("SELECT marker FROM runner_meta WHERE singleton = 1").get()).toEqual({
+      marker: "preserve",
+    });
+    expect(runnerBundleSlotsTableExists(db)).toBe(true);
+  });
+
   it("drops the retired split runner bundle table during schema migration", async () => {
     const setupLegacyBundleSchema = (database: DatabaseSync) => {
       database.exec(`

--- a/apps/web/changelog/entries/2026-08-27/faster-replies-after-idle-time.json
+++ b/apps/web/changelog/entries/2026-08-27/faster-replies-after-idle-time.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-27",
+  "order": 50,
+  "item": {
+    "id": "faster-replies-after-idle-time",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Faster wake-ups for replies",
+    "summary": "When Murph's hosted assistant wakes with current local state, it now skips repeated setup checks before working on your message.",
+    "details": "Older state still receives the full compatibility checks, and a newer unsupported version still stops safely without rewriting its data.",
+    "relevanceTags": ["assistant", "performance", "reliability"],
+    "sourcePullRequests": [2462]
+  }
+}


### PR DESCRIPTION
## Outcome

Reduces UserRunner Durable Object activation work when its persisted schema is already exactly current. The current path now performs only the metadata-table ensure and one version read instead of repeating runner-table DDL, column scans, legacy checks, retired-table cleanup, and a final assertion.

## Product UX result

Product UX effort: Patch. An idle-returning member reaches assistant work with less synchronous setup before the reply path continues. New, missing, older, and future-version objects keep their existing create, repair, migration, or fail-closed behavior. The walkthrough result is Ready: no reply semantics, recovery copy, permissions, routing, or member data shape changes.

## Direct evidence

- Production-composed schema/store suite: 19 passed.
- Deterministic exact-current operation proof: 21 SQL operations before, 2 after.
- `pnpm --dir apps/cloudflare typecheck`: passed.
- Production changelog page suite: 9 passed.
- `pnpm --dir apps/web typecheck`: passed.
- `git diff --check`: passed.
- ReviewGPT implemented the production/test/doc patch; the parent verified the exact artifact identity and applied it unchanged.

## Non-obvious affected surfaces

- Missing, invalid, zero, and older schema markers: still execute the complete existing repair path; parameterized production SQLite tests assert 21 ordered operations and the terminal current marker.
- Future schema markers: still fail after only metadata admission and before touching `runner_meta` or retired tables; the fixture proves both tables remain unchanged.
- Retired-table cleanup: remains part of migration only and is intentionally skipped when the exact current marker is authoritative.
- Public changelog: adds one content-only fragment using the existing archive renderer and fragment registry.

## Architecture and reuse

- Existing systems reused: The persisted `runner_schema_meta` version remains the sole schema authority, and the existing synchronous migration path remains the owner for every non-current state.
- New logic: One stored-version read moves to the top, future versions fail there, and an exact-current version returns before runner-table inspection.
- New abstractions: No new abstraction is needed because the existing version marker already provides the required terminal migration authority.
- Complexity intentionally avoided: No cache, state owner, dependency, background task, queue, retry, keepalive, prewarm mechanism, or schema-version bump was added.

## Hot reply path impact

Applicable. Durable Object activation can occur between durable message acceptance and provider start. The exact-current path removes 19 synchronous local SQL operations: one runner-table ensure, one redundant version read, sixteen `PRAGMA table_info` scans, and one retired-table drop. Before: 21 serial SQL operations. After: 2 serial SQL operations. The diff adds zero database operations, network/provider calls, awaited operations, timeouts, retries, or fallbacks. End-to-end milliseconds are not claimed; deterministic call-count proof avoids a timing-flaky benchmark.

## Murph initial provider input impact

- Web runtime: Not applicable because no prompt, tool schema, generated guidance, or provider-visible input surface changed.
- Runner runtime: Not applicable because schema admission is completed before provider request assembly and contributes no provider-visible content.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: The only hosted Web change is an authored changelog fragment rendered by the unchanged production archive component; direct copy review is the material proof.
- Coverage: The production changelog page test loads and server-renders the fragment through the archive registry. No renderer, interaction, responsive behavior, component, style, or visual changed.

## Change-shape breakdown

Classification uses production TypeScript as source, the production-composed SQLite suite as tests/fixtures, and README plus public changelog content as docs. No binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 15 |
| Tests/fixtures | 134 | 2 |
| Docs | 121 | 6 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 265 | 23 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Cloudflare code read the same schema version and row shape; the Web changelog is content-only.
- Safe order: Deploy Cloudflare first, verify the reduced current-version activation path, then deploy Web so the public changelog follows the shipped improvement.
- Rollback floor: Cloudflare rollback restores repeated checks but does not change persisted schema or data; Web can roll back independently.
- Expected exposure: If Web deploys first, members could briefly read the improvement before every Cloudflare instance runs it.
- Reversibility: Revert Cloudflare to restore the prior admission path; no data migration or repair is required.
- Convergence proof: Exact-current, non-current, and future-version production SQLite cases pass on the candidate head.
- Post-deploy checks: Confirm hosted-runtime schema errors do not increase and compare the new activation phase aggregates from PR #2460.

## Changelog

- Changelog: updated
- Items: 2026-08-27 · faster-replies-after-idle-time

## ReviewGPT

ReviewGPT first-reviewed head: e1606d6bd0607ea7872a85583c3bf4b37b8fbac4

- Context sensitivity: sensitive
- Implementation thread verified as GPT-5.6 Pro against the exact base extraction.
