### PR TITLE
Fix self-authored Linq mailbox acknowledgements

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-27-first-turn-echo-mailbox-ack.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-first-turn-echo-mailbox-ack.md
@@ -1,0 +1,100 @@
+# Acknowledge self-authored first-turn echoes
+
+Status: completed
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Prevent a self-authored Linq delivery echo from leaving its durable
+  conversation mailbox row permanently unacknowledged after an instant first
+  reply, while preserving the current rule that the echo is never offered to
+  the assistant provider as user work.
+
+## Success criteria
+
+- Every imported self-authored Linq event receives a restart-safe terminal
+  disposition and remains visible to the existing pending-input checkpoint
+  compactor until Web confirms the exact mailbox row was consumed.
+- A self-authored reply still terminalizes only the exact pending inbound it
+  answers and preserves the existing assistant transcript exchange.
+- Self-authored input remains absent from runnable assistant selection and does
+  not trigger foreground provider preparation or active-turn notification.
+- Focused regression tests reproduce a contiguous inbound sequence followed by
+  its outbound echo and prove both mailbox rows become selectable for handling.
+- Relevant package tests and typecheck pass, the parent inspection accepts the
+  candidate, and required ReviewGPT/CI gates run against the exact pushed head.
+
+## Scope
+
+- In scope: the assistant-runtime conversation source adapter, its existing
+  pending-input/terminal-evidence owner, focused regression coverage, and the
+  durable owner description if the contract needs clarification.
+- Out of scope: a new queue, scheduler, state schema, retry loop, provider
+  execution path, onboarding follow-up behavior, production data repair,
+  deployment, and unrelated mailbox or delivery refactors.
+
+## Constraints
+
+- Technical constraints: reuse the existing AssistantInputEvent, suppression
+  evidence, pending index, mailbox-item association, checkpoint selection, and
+  runtime write-lock boundaries. Fail closed if terminal bookkeeping cannot be
+  persisted. Preserve replay idempotency and checkpoint ordering.
+- Product/process constraints: ReviewGPT authors the initial proposed patch;
+  the parent inspects and deliberately applies it. Use only synthetic test data,
+  keep the PR draft until local proof and parent review are complete, and run
+  preliminary specialist plus final ReviewGPT concurrently with CI on the exact
+  candidate head.
+
+## Risks and mitigations
+
+1. Risk: indexing the echo could accidentally make it runnable provider work.
+   Mitigation: write terminal suppression evidence before exposing the echo to
+   the existing index and assert runnable selection remains empty.
+2. Risk: a crash between event staging, mailbox association, terminal evidence,
+   and index publication could acknowledge incomplete work or strand the row.
+   Mitigation: preserve fail-closed importer failure/replay semantics and prove
+   the staged transition is idempotent.
+3. Risk: the fix broadens into a second acknowledgement mechanism.
+   Mitigation: extend only the current pending-input owner and checkpoint
+   compactor contract; add no new persisted field, owner, or recovery loop.
+
+## Tasks
+
+1. Give ReviewGPT a privacy-safe implementation brief plus the exact current
+   source and focused tests, and capture its proposed patch.
+2. Inspect the proposal against the production evidence, owner boundaries,
+   replay/failure ordering, and simplicity constraints.
+3. Apply the accepted minimal code and regression changes.
+4. Run focused tests, package typecheck, diff/privacy checks, and parent review.
+5. Finish the scoped plan commit, push, open a draft PR, and start required
+   ReviewGPT gates concurrently with CI on the exact pushed head.
+6. Resolve or disposition gate results under the repository stopping rules.
+
+## Decisions
+
+- Keep self-authored Linq events non-runnable; the missing state is terminal
+  acknowledgement evidence, not reply eligibility.
+- Reuse the pending-input index's deliberate retention of terminal conversation
+  inputs until Web's consumed floor proves the checkpoint committed.
+- Treat the onboarding early-stall follow-up as separate, unchanged behavior.
+- Accepted ReviewGPT's terminal-evidence-before-index production design and
+  categorical `actorIsSelf` replyability guard. Rejected only its redundant
+  test step that changed immutable replay content by adding `durablyConsumed`
+  to an already-staged event; ordinary exact replay and consumed-floor cleanup
+  remain directly covered.
+
+## Verification
+
+- Commands to run: focused assistant-runtime mailbox-import and pending-index
+  Vitest files; assistant-runtime typecheck; `git diff --check`; privacy scan;
+  the repository's scoped commit/PR checks; required exact-head ReviewGPT and CI.
+- Expected outcomes: the synthetic inbound plus self-authored echo are both
+  selected as handled at the contiguous frontier, neither is runnable after the
+  echo, and replay leaves one idempotent terminal/indexed record per mailbox row.
+- Passed: focused assistant-runtime Vitest run for the mailbox-import and
+  pending-index files, 108 tests.
+- Passed: assistant-runtime package typecheck under Node 24.14.1.
+- Passed: `git diff --check`; the added-line privacy scan found no direct
+  identifier or home-directory path.
+Completed: 2026-08-27

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -46,6 +46,9 @@ import {
   notifyAssistantActiveTurnInputAvailableForInputIds,
   type UpsertAssistantInputEventInput,
 } from "@murphai/assistant-engine";
+import {
+  writeAssistantAutoReplySuppressionEvidence,
+} from "@murphai/assistant-engine/assistant-automation";
 import type {
   AssistantModelTarget,
 } from "@murphai/operator-config/assistant-cli-contracts";
@@ -111,6 +114,8 @@ const ASSISTANT_INPUT_SOURCE_METADATA_TEXT_MAX_LENGTH = 512;
 const RUNTIME_WAKE_NOTIFY_STALE_SKEW_TOLERANCE_MS = 5_000;
 const CONVERSATION_MODULE_LOAD_FAILED_CODE =
   "conversation-module-load-failed";
+const SELF_AUTHORED_LINQ_INPUT_SUPPRESSION_REASON =
+  "imported self-authored Linq input is not reply eligible";
 
 type HostedConversationEventsModule = typeof import("./events/conversation.ts");
 
@@ -1019,7 +1024,9 @@ async function stageHostedConversationAssistantInputEvent(input: {
     }),
     vault: input.vaultRoot,
   });
-  const replyToMessageId = linqWake?.message.linqMessage.isFromMe === true
+  const selfAuthoredLinq =
+    linqWake?.message.linqMessage.isFromMe === true;
+  const replyToMessageId = selfAuthoredLinq
     ? normalizeHostedAssistantInputSourceMetadataToken(
         linqWake.message.linqMessage.replyToMessageId ?? null,
       )
@@ -1056,6 +1063,24 @@ async function stageHostedConversationAssistantInputEvent(input: {
     mailboxItemId: input.item.item.id,
     vault: input.vaultRoot,
   });
+  if (selfAuthoredLinq) {
+    // Publish terminal proof before indexing. If the evidence write fails, the
+    // import fails and no indexed self-authored event can become runnable.
+    await writeAssistantAutoReplySuppressionEvidence({
+      captureIds: event.projection.captureId
+        ? [event.projection.captureId]
+        : [],
+      inputIds: [event.inputId],
+      reason: SELF_AUTHORED_LINQ_INPUT_SUPPRESSION_REASON,
+      vault: input.vaultRoot,
+    });
+    if (input.item.durablyConsumed !== true) {
+      await enqueueHostedPendingAssistantInputId({
+        inputId: event.inputId,
+        vaultRoot: input.vaultRoot,
+      });
+    }
+  }
   const projectionRequired = requiresHostedConversationInboxProjection({
     attachmentDescriptorCount: event.content.attachmentDescriptors.length,
     wake: input.wake,

--- a/packages/assistant-runtime/src/hosted-runtime/pending-input-index.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/pending-input-index.ts
@@ -1561,6 +1561,9 @@ export function isHostedPendingAssistantInputStillReplyable(input: {
   ) {
     return false;
   }
+  if (input.event.conversation?.actorIsSelf === true) {
+    return false;
+  }
   if (
     requiresHostedAssistantInputAttachmentEvidence({
       attachmentDescriptorCount:

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -38,6 +38,9 @@ import {
   updateAssistantInputAttachmentEvidence,
 } from "@murphai/assistant-engine";
 import {
+  readAssistantAutoReplyTerminalEvidenceByEvidenceId,
+} from "@murphai/assistant-engine/assistant-automation";
+import {
   reconcileManagedAssistantAutoReplyChannelsLocal,
   readAssistantAutomationState,
   saveAssistantAutomationState,
@@ -60,10 +63,10 @@ import {
   selectHostedAssistantInputIds,
 } from "../src/hosted-runtime/turn-input.ts";
 import {
+  compactHostedConversationMailboxHandledItemSelection,
   compactHostedPendingAssistantInputIds,
   readHostedPendingAssistantInputIds,
   resolveHostedPendingAssistantInputStatePath,
-  suppressHostedPendingLinqInputAnsweredByExternalReply,
 } from "../src/hosted-runtime/pending-input-index.ts";
 import {
   HostedRawEmailMessageMissingError,
@@ -947,42 +950,87 @@ describe("hosted mailbox conversation import adapter", () => {
         phoneLookupKey: "redacted-self-sentinel",
       },
     });
+    const item = createResolvedConversationMailboxItem({
+      dedupeKey: decodedWake.eventId,
+      id: "mailbox_item_self_input",
+    });
     let activityCallbackCount = 0;
+    let activeTurnNotificationCount = 0;
     let preparationCallbackCount = 0;
-
-    const outcome = await importHostedConversationMailboxItem({
-      decodePayload: createDecodedPayloadDecoder(decodedWake),
-      async importConversationWake() {
+    const controller = createAssistantActiveTurnInputController({
+      admissionHook: async () => {
+        activeTurnNotificationCount += 1;
         return {
-          captureId: null,
-          metrics: {
-            nextWakeAt: null,
-            parserProcessed: 0,
-          },
+          kind: "no-new-input",
         };
       },
-      async prepareWakeContext() {},
-      item: createResolvedConversationMailboxItem({
-        dedupeKey: decodedWake.eventId,
-        id: "mailbox_item_self_input",
-      }),
-      onConversationActivityObserved() {
-        activityCallbackCount += 1;
-      },
-      onConversationInputStaged() {
-        preparationCallbackCount += 1;
-      },
-      runtime: createRuntime(),
-      vaultRoot,
+      conversationKeys: [createLinqConversationLookupKey({
+        item,
+        wake: decodedWake,
+      })],
+      sessionId: "session_self_input",
+      turnId: "turn_self_input",
+      vault: vaultRoot,
     });
+
+    const outcome = await (async () => {
+      try {
+        return await importHostedConversationMailboxItem({
+          decodePayload: createDecodedPayloadDecoder(decodedWake),
+          async importConversationWake() {
+            return {
+              captureId: null,
+              metrics: {
+                nextWakeAt: null,
+                parserProcessed: 0,
+              },
+            };
+          },
+          async prepareWakeContext() {},
+          item,
+          onConversationActivityObserved() {
+            activityCallbackCount += 1;
+          },
+          onConversationInputStaged() {
+            preparationCallbackCount += 1;
+          },
+          runtime: createRuntime(),
+          vaultRoot,
+        });
+      } finally {
+        controller.close();
+      }
+    })();
 
     assert.equal(outcome.status, "imported");
     assert.equal(activityCallbackCount, 1);
+    assert.equal(activeTurnNotificationCount, 0);
     assert.equal(preparationCallbackCount, 0);
-    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), []);
+    const events = (await listAssistantInputEvents({ vault: vaultRoot })).events;
+    assert.equal(events.length, 1);
+    const selfAuthoredEvent = events[0]!;
+    assert.equal(selfAuthoredEvent.conversation?.actorIsSelf, true);
+    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), [
+      selfAuthoredEvent.inputId,
+    ]);
+    assert.deepEqual(await compactHostedPendingAssistantInputIds({ vaultRoot }), []);
+    assert.deepEqual(
+      (await selectHostedAssistantInputIds({
+        mode: "background",
+        vaultRoot,
+      })).inputIds,
+      [],
+    );
+    assert.equal(
+      (await readAssistantAutoReplyTerminalEvidenceByEvidenceId(
+        vaultRoot,
+        selfAuthoredEvent.inputId,
+      ))?.terminal.kind,
+      "suppressed",
+    );
   });
 
-  test("treats an imported self-authored Linq reply as terminal proof for the exact pending input", async () => {
+  test("makes an imported self-authored Linq reply terminal at the contiguous mailbox frontier", async () => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-self-reply-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");
@@ -1001,6 +1049,11 @@ describe("hosted mailbox conversation import adapter", () => {
         phoneLookupKey: "redacted-contact-sentinel",
       },
     });
+    const inboundItem = createResolvedConversationMailboxItem({
+      dedupeKey: inboundWake.eventId,
+      id: "mailbox_item_self_reply_inbound",
+      laneSeq: "1",
+    });
     const inbound = await importHostedConversationMailboxItem({
       decodePayload: createDecodedPayloadDecoder(inboundWake),
       async importConversationWake() {
@@ -1010,11 +1063,7 @@ describe("hosted mailbox conversation import adapter", () => {
         };
       },
       async prepareWakeContext() {},
-      item: createResolvedConversationMailboxItem({
-        dedupeKey: inboundWake.eventId,
-        id: "mailbox_item_self_reply_inbound",
-        laneSeq: "1",
-      }),
+      item: inboundItem,
       runtime: createRuntime(),
       vaultRoot,
     });
@@ -1046,7 +1095,9 @@ describe("hosted mailbox conversation import adapter", () => {
       id: "mailbox_item_self_reply_outbound",
       laneSeq: "2",
     });
-    const importOutbound = async () => await importHostedConversationMailboxItem({
+    const importOutbound = async (
+      item: HostedMailboxResolvedImportItem = outboundItem,
+    ) => await importHostedConversationMailboxItem({
       assistantTarget: TEST_ASSISTANT_TARGET,
       decodePayload: createDecodedPayloadDecoder(outboundWake),
       async importConversationWake() {
@@ -1056,7 +1107,7 @@ describe("hosted mailbox conversation import adapter", () => {
         };
       },
       async prepareWakeContext() {},
-      item: outboundItem,
+      item,
       runtime: createRuntime(),
       vaultRoot,
     });
@@ -1064,11 +1115,49 @@ describe("hosted mailbox conversation import adapter", () => {
 
     assert.equal(outbound.status, "imported");
     assert.equal(outbound.status === "imported" && "assistantInputId" in outbound, false);
-    assert.deepEqual(await compactHostedPendingAssistantInputIds({ vaultRoot }), []);
+    const importedEvents = (await listAssistantInputEvents({ vault: vaultRoot })).events;
+    assert.equal(importedEvents.length, 2);
+    const assistantReplyEvent = importedEvents.find(
+      (event) => event.conversation?.actorIsSelf === true,
+    );
+    if (!assistantReplyEvent) {
+      throw new Error("Expected the imported self-authored reply event.");
+    }
     assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), [
       inbound.assistantInputId,
+      assistantReplyEvent.inputId,
     ]);
-    assert.equal((await listAssistantInputEvents({ vault: vaultRoot })).events.length, 2);
+    assert.deepEqual(await compactHostedPendingAssistantInputIds({ vaultRoot }), []);
+    assert.deepEqual(
+      (await selectHostedAssistantInputIds({
+        mode: "background",
+        vaultRoot,
+      })).inputIds,
+      [],
+    );
+    assert.equal(
+      (await readAssistantAutoReplyTerminalEvidenceByEvidenceId(
+        vaultRoot,
+        assistantReplyEvent.inputId,
+      ))?.terminal.kind,
+      "suppressed",
+    );
+
+    const handledAtFrontier =
+      await compactHostedConversationMailboxHandledItemSelection({
+        consumedThroughSeq: "0",
+        vaultRoot,
+      });
+    assert.equal(handledAtFrontier.frontierSelected, true);
+    assert.equal(handledAtFrontier.itemIds.length, 2);
+    assert.deepEqual(
+      new Set(handledAtFrontier.itemIds),
+      new Set([inboundItem.item.id, outboundItem.item.id]),
+    );
+    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), [
+      inbound.assistantInputId,
+      assistantReplyEvent.inputId,
+    ]);
 
     const inboundEvent = await readAssistantInputEvent({
       inputId: inbound.assistantInputId,
@@ -1084,45 +1173,63 @@ describe("hosted mailbox conversation import adapter", () => {
       createIfMissing: false,
       vault: vaultRoot,
     });
-    assert.deepEqual(
+    const expectedTranscript = [
+      {
+        kind: "user",
+        standaloneAssistantContext: false,
+        text: "Hey Murph",
+      },
+      {
+        kind: "assistant",
+        standaloneAssistantContext: true,
+        text: "Canonical Murph welcome",
+      },
+    ];
+    const readTranscript = async () =>
       (await listAssistantTranscriptEntries(vaultRoot, session.session.sessionId))
         .map((entry) => ({
           kind: entry.kind,
           standaloneAssistantContext: entry.standaloneAssistantContext ?? false,
           text: entry.text,
-        })),
-      [
-        {
-          kind: "user",
-          standaloneAssistantContext: false,
-          text: "Hey Murph",
-        },
-        {
-          kind: "assistant",
-          standaloneAssistantContext: true,
-          text: "Canonical Murph welcome",
-        },
-      ],
+        }));
+    assert.deepEqual(await readTranscript(), expectedTranscript);
+
+    const replay = await importOutbound();
+    assert.equal(replay.status, "imported");
+    const replayedEvents = (await listAssistantInputEvents({ vault: vaultRoot })).events;
+    assert.equal(replayedEvents.length, 2);
+    assert.deepEqual(
+      new Set(replayedEvents.map((event) => event.inputId)),
+      new Set([inbound.assistantInputId, assistantReplyEvent.inputId]),
+    );
+    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), [
+      inbound.assistantInputId,
+      assistantReplyEvent.inputId,
+    ]);
+    assert.deepEqual(await readTranscript(), expectedTranscript);
+    const replayedHandled =
+      await compactHostedConversationMailboxHandledItemSelection({
+        consumedThroughSeq: "0",
+        vaultRoot,
+      });
+    assert.equal(replayedHandled.frontierSelected, true);
+    assert.equal(replayedHandled.itemIds.length, 2);
+    assert.deepEqual(
+      new Set(replayedHandled.itemIds),
+      new Set([inboundItem.item.id, outboundItem.item.id]),
     );
 
-    const assistantReplyEvent = (await listAssistantInputEvents({ vault: vaultRoot }))
-      .events.find((event) => event.conversation?.actorIsSelf === true);
-    if (!assistantReplyEvent) {
-      throw new Error("Expected the imported self-authored reply event.");
-    }
-    await suppressHostedPendingLinqInputAnsweredByExternalReply({
-      accountId: inboundEvent.conversation.accountId,
-      assistantReplyEvent,
-      replyToMessageId: "msg_self_reply_inbound",
-      target: TEST_ASSISTANT_TARGET,
-      threadId: inboundEvent.conversation.threadId ?? "",
-      vaultRoot,
-    });
-    assert.equal(
-      (await listAssistantTranscriptEntries(vaultRoot, session.session.sessionId)).length,
-      2,
+    assert.deepEqual(
+      await compactHostedConversationMailboxHandledItemSelection({
+        consumedThroughSeq: "2",
+        vaultRoot,
+      }),
+      {
+        frontierSelected: false,
+        itemIds: [],
+      },
     );
-
+    assert.deepEqual(await readHostedPendingAssistantInputIds({ vaultRoot }), []);
   });
 
   test("does not notify active turn input early for durably consumed replay imports", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-pending-input-index.test.ts
@@ -219,6 +219,54 @@ describe("hosted pending assistant input index", () => {
     ]);
   });
 
+  it("keeps indexed self-authored Linq input non-runnable and unhandled without terminal evidence", async () => {
+    const vaultRoot = await createTempVault();
+    await saveAssistantAutomationState(vaultRoot, {
+      autoReply: [{
+        channel: "linq",
+        eligibleAfter: null,
+        enabledAt: "2026-04-23T00:00:00.000Z",
+      }],
+      updatedAt: "2026-04-23T00:00:00.000Z",
+      version: 1,
+    });
+    const selfAuthored = await upsertAssistantInputEvent({
+      vault: vaultRoot,
+      event: createAssistantInputEvent({
+        actorIsSelf: true,
+        dedupeKey: "dedupe_self_authored_partial",
+        eventId: "evt_self_authored_partial",
+        itemId: "item_self_authored_partial",
+        laneSeq: "1",
+        messageId: "msg_self_authored_partial",
+        occurredAt: "2026-04-23T00:00:01.000Z",
+        receivedAt: "2026-04-23T00:00:02.000Z",
+        text: "self-authored partial input",
+      }),
+    });
+    await enqueueHostedPendingAssistantInputId({
+      inputId: selfAuthored.inputId,
+      vaultRoot,
+    });
+    await recordHostedMailboxAssistantInputItem({
+      inputId: selfAuthored.inputId,
+      mailboxItemId: "item_self_authored_partial",
+      vault: vaultRoot,
+    });
+
+    await expect(compactHostedPendingAssistantInputIds({ vaultRoot }))
+      .resolves.toEqual([]);
+    await expect(compactHostedConversationMailboxHandledItemSelection({
+      consumedThroughSeq: "0",
+      vaultRoot,
+    })).resolves.toEqual({
+      frontierSelected: false,
+      itemIds: [],
+    });
+    await expect(readHostedPendingAssistantInputIds({ vaultRoot }))
+      .resolves.toEqual([selfAuthored.inputId]);
+  });
+
   it("keeps the legacy value shape while appending before v2 compaction", async () => {
     const vaultRoot = await createTempVault();
     const inputId = "ain_00000000000000000000000000000001";
@@ -2212,6 +2260,7 @@ async function writeTerminalEvidence(input: {
 }
 
 function createAssistantInputEvent(input: {
+  actorIsSelf?: boolean;
   dedupeKey: string;
   eventId: string;
   itemId: string;
@@ -2249,7 +2298,7 @@ function createAssistantInputEvent(input: {
     conversation: {
       accountId: "acct_1",
       actorId: "actor_1",
-      actorIsSelf: false,
+      actorIsSelf: input.actorIsSelf ?? false,
       source,
       threadId: "thread_1",
       threadIsDirect: true,


### PR DESCRIPTION
## Why and outcome

A self-authored Linq delivery echo was staged as conversation context but never
received its own terminal disposition or pending-index entry. The existing
checkpoint compactor therefore could not acknowledge that exact durable mailbox
row, leaving the conversation frontier stalled after an otherwise successful
instant reply.

This change terminally suppresses each self-authored echo, indexes it only after
that evidence succeeds, and lets the existing checkpoint/consumed-floor contract
acknowledge and later remove it. Self-authored input remains categorically
ineligible for provider execution.

## Product UX

- Product UX: not applicable.
- Reason: no member-visible copy, action, reply timing, delivery, permission, or
  recovery behavior changes; this corrects internal acknowledgement bookkeeping
  for an already-delivered provider echo.

## Evidence

- Focused mailbox-import and pending-index Vitest files: 108 tests passed.
- Assistant-runtime package typecheck passed under Node 24.14.1.
- Direct synthetic proof covers inbound sequence 1 plus self-authored echo
  sequence 2, exact handled-item selection at the contiguous frontier, consumed
  floor cleanup, exact replay idempotency, transcript preservation, and zero
  foreground/background provider admission.
- `git diff --check` and the added-line privacy scan passed.

## Non-obvious affected surfaces

- Hosted checkpoint handled-item selection now sees self-authored Linq echoes
  through the existing pending-input index; the regression test proves both
  adjacent mailbox rows are selected and later removed by the consumed floor.
- Background replyability now rejects `actorIsSelf` explicitly, protecting
  partial or legacy indexed state without terminal evidence; the isolated test
  proves such state is neither runnable nor acknowledgeable.
- Existing exact-inbound suppression and assistant transcript preservation are
  unchanged and covered through normal replay.

## Architecture and reuse

- Existing systems reused: AssistantInputEvent upsert, mailbox-item association,
  auto-reply terminal evidence, hosted pending-input index, and checkpoint
  compaction remain the only state and acknowledgement owners.
- New logic: after mailbox association, a self-authored Linq event writes terminal
  evidence before entering the existing pending index; replyability also checks
  the already-canonical `actorIsSelf` fact.
- New abstractions: none; the existing source adapter and predicate are sufficient.
- Complexity intentionally avoided: no queue, scheduler, schema, retry loop,
  compatibility layer, dependency, receipt store, or second acknowledgement path.

## Hot reply path impact

- Not applicable: the new work runs only when importing Linq's self-authored echo
  after the Web-owned reply handoff. It adds no database, network, provider, or
  other awaited operation to current inbound acceptance through provider start
  or durable reply handoff.

## Murph initial provider input impact

- Hosted individual turns: Not applicable; no prompt, instruction, tool/schema,
  generated guidance, or other provider-visible input surface changed.
- Hosted group turns: Not applicable for the same reason; no provider request is
  assembled from self-authored Linq input.

## Change-shape breakdown

Classification uses base-to-head authored line counts: production TypeScript is
source, Vitest files are tests/fixtures, the completed execution plan is docs,
and no config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 29 | 1 |
| Tests/fixtures | 221 | 65 |
| Docs | 100 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 350 | 66 |

## Risks

- Terminal evidence is awaited before index publication. A failed evidence write
  fails the import; indexed self-authored partial state remains non-runnable and
  non-acknowledgeable until terminal evidence exists.
- The change deliberately preserves terminal IDs until Web confirms the consumed
  floor, so it cannot turn local staging into premature durable acknowledgement.

## Deployment concerns

- Deployment: not applicable
- Reason: this is one additive assistant-runtime behavior inside the existing
  pending-index v2 and checkpoint protocol; it changes no persisted shape,
  independently deployed reader/writer contract, configuration, or rollback floor.

## Changelog

- Changelog: not applicable
- Reason: this is internal durable-mailbox acknowledgement bookkeeping and does
  not change a member-visible reply or product capability.

ReviewGPT first-reviewed head: 2511e8c4e9a56aab82288298da219531a9375faa

ReviewGPT context sensitivity: sensitive
