### PR TITLE
Simplify assistant response guards

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-simplify-assistant-response-guards.md
+++ b/agent-docs/exec-plans/active/2026-08-28-simplify-assistant-response-guards.md
@@ -1,0 +1,62 @@
+# Simplify assistant response guards
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Let a later live-steered context finish without another reply while preserving
+  an earlier answer that is already the correct response to the earlier input.
+- Reject delayed response media when accepted input has advanced, matching the
+  existing response-card boundary.
+- Delete duplicate response-card and response-media conflict checks from the
+  private patch applicators while preserving the existing public tool contract
+  and final delivery invariant.
+
+## Product UX Patch
+
+- Outcome: fast follow-ups keep the answer they need, acknowledgements can stay
+  quiet, and late attachments never land on the wrong reply.
+- Reaches: the existing private-direct live-steering journey when a member sends
+  another message before the current Codex turn finishes.
+- Proof: focused deterministic steering regressions plus one private-free real
+  Codex journey that inspects the actual reply and final effects.
+
+## Scope
+
+- In scope: response patch acceptance in Assistant Engine, focused deterministic
+  coverage, one real-Codex journey, and one public changelog fragment.
+- Out of scope: prompts, tool schemas, provider delivery, persisted state,
+  response-card rendering, media preparation, and group or scheduled behavior.
+
+## Constraints
+
+- Preserve current-context equality for cards, text recovery, and media.
+- Preserve accepted-no-reply, response-media cardinality, required vault-file
+  approval, and final card-versus-media delivery boundaries.
+- Keep conflict validation at the dynamic-tool owner instead of duplicating it
+  inside private patch applicators in the same serialized trust domain.
+- Preserve unrelated worktree state and use the task worktree/PR lane.
+
+## Tasks
+
+1. Remove the two earlier-context no-reply rejections, add response-media context
+   equality, and delete duplicate private conflict checks.
+2. Update focused deterministic steering coverage, including delayed old media
+   after accepted live steering.
+3. Add and run a focused private-free real-Codex journey; inspect the actual
+   response and effects.
+4. Run focused tests and typecheck, inspect the privacy-safe diff, commit and
+   push a draft PR candidate, then add the PR-linked changelog fragment.
+5. Run the preliminary completion-specialists pass and disposition it, then run
+   final ReviewGPT round 1 on the same Eragon lane while CI runs.
+
+## Verification
+
+- Focused Assistant Engine steering and response-tool tests.
+- Assistant Engine typecheck.
+- Focused real-Codex assistant journey.
+- Changelog fragment test.
+- `git diff --check` and privacy-sensitive diff inspection.
+- Exact-head CI, preliminary specialist ReviewGPT, and final ReviewGPT round 1.

--- a/agent-docs/exec-plans/completed/2026-08-28-simplify-assistant-response-guards.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-simplify-assistant-response-guards.md
@@ -1,6 +1,6 @@
 # Simplify assistant response guards
 
-Status: active
+Status: completed
 Created: 2026-08-28
 Updated: 2026-08-28
 
@@ -50,7 +50,26 @@ Updated: 2026-08-28
 4. Run focused tests and typecheck, inspect the privacy-safe diff, commit and
    push a draft PR candidate, then add the PR-linked changelog fragment.
 5. Run the preliminary completion-specialists pass and disposition it, then run
-   final ReviewGPT round 1 on the same Eragon lane while CI runs.
+   the final ReviewGPT loop while CI runs.
+
+## Review resolution
+
+- Preliminary specialists found that the original real-Codex journey started
+  steering after admission had closed and used test-only silence instructions.
+  The focused proof was corrected to admit the acknowledgement before cutoff,
+  and the real journey now uses unchanged production instructions and a natural
+  acknowledgement.
+- Final ReviewGPT round 1 found two production races: cumulative no-reply
+  settlement could retire an earlier useful answer, and already-applied media
+  could survive a later context advance. Both were accepted.
+- The reply correction carries the exact preceding-reply ordinal, limits
+  suppression to the silent suffix, defers that suppression until the earlier
+  delivery is durable, and prevents empty-success recovery while the earlier
+  reply remains undelivered.
+- The media correction clears current response media on every accepted context
+  advance after preserving it only for an actually completed earlier response.
+- A fresh full round-2 audit of the corrected exact head returned
+  `ROUND_OUTCOME: PASS` with no findings.
 
 ## Verification
 
@@ -60,3 +79,15 @@ Updated: 2026-08-28
 - Changelog fragment test.
 - `git diff --check` and privacy-sensitive diff inspection.
 - Exact-head CI, preliminary specialist ReviewGPT, and final ReviewGPT round 1.
+
+Completed proof:
+
+- 460 focused tests across seven files passed.
+- Assistant Engine typecheck passed.
+- The focused real-Codex journey delivered the earlier `ORBIT.` reply once,
+  emitted no final reply for the acknowledgement, and recorded one finish
+  attempt.
+- Exact-head required CI passed.
+- Final ReviewGPT round 2 passed on commit
+  `94a00376ea960e386f4794e9ac4be601b266e64b`.
+Completed: 2026-08-28

--- a/apps/web/changelog/entries/2026-08-28/fast-follow-ups-keep-the-right-reply.json
+++ b/apps/web/changelog/entries/2026-08-28/fast-follow-ups-keep-the-right-reply.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-28",
+  "order": 100,
+  "item": {
+    "id": "fast-follow-ups-keep-the-right-reply",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Fast follow-ups keep the right reply",
+    "summary": "If you send a quick acknowledgement while Murph is still answering, Murph can keep the useful earlier answer without adding another reply.",
+    "details": "Attachments that finish for an older message are also kept off the newer reply.",
+    "relevanceTags": ["assistant", "messages", "reliability"],
+    "sourcePullRequests": [2476]
+  }
+}

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -4069,6 +4069,12 @@ async function runCodexAppServerTurnOnProcess(
     },
     deliveryContextOrdinal: number,
   ): void => {
+    if (currentDeliveryContextOrdinal() !== deliveryContextOrdinal) {
+      throw new VaultCliError(
+        'ASSISTANT_RESPONSE_MEDIA_CONTEXT_ADVANCED',
+        'Response media cannot attach after accepted input advances the response context.',
+      )
+    }
     if (hasAcceptedNoReplyPatchForDeliveryContext(deliveryContextOrdinal)) {
       throw new VaultCliError(
         'ASSISTANT_RESPONSE_MEDIA_AFTER_NO_REPLY',
@@ -4082,18 +4088,6 @@ async function runCodexAppServerTurnOnProcess(
       throw new VaultCliError(
         'ASSISTANT_RESPONSE_MEDIA_LIMIT_EXCEEDED',
         `Assistant responses may attach at most ${ASSISTANT_AUTHORED_RESPONSE_MEDIA_MAX_ITEMS} media items.`,
-      )
-    }
-    if (responseCard !== null && nextMedia.length > 0) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',
-        'Response media cannot be combined with a response card.',
-      )
-    }
-    if (responseCardTextFallback !== null && nextMedia.length > 0) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',
-        'Response media cannot be combined with response card text recovery.',
       )
     }
     responseMedia = nextMedia
@@ -4113,24 +4107,6 @@ async function runCodexAppServerTurnOnProcess(
       throw new VaultCliError(
         'ASSISTANT_RESPONSE_CARD_AFTER_NO_REPLY',
         'A response card cannot be attached after finish_without_reply.',
-      )
-    }
-    if (responseCard !== null) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_LIMIT_REACHED',
-        'Only one response card may be attached to a final response.',
-      )
-    }
-    if (responseCardTextFallback !== null) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_LIMIT_REACHED',
-        'Only one response card outcome may be attached to a final response.',
-      )
-    }
-    if (responseMedia.length > 0) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',
-        'A response card cannot be combined with response media.',
       )
     }
     if (requiredVaultFileApprovalUrls.length > 0) {
@@ -4158,18 +4134,6 @@ async function runCodexAppServerTurnOnProcess(
         'Response card text recovery cannot attach after finish_without_reply.',
       )
     }
-    if (responseCard !== null || responseCardTextFallback !== null) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_LIMIT_REACHED',
-        'Only one response card outcome may be attached to a final response.',
-      )
-    }
-    if (responseMedia.length > 0) {
-      throw new VaultCliError(
-        'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',
-        'Response card text recovery cannot be combined with response media.',
-      )
-    }
     if (requiredVaultFileApprovalUrls.length > 0) {
       throw new VaultCliError(
         'ASSISTANT_RESPONSE_CARD_VAULT_FILE_CONFLICT',
@@ -4180,17 +4144,9 @@ async function runCodexAppServerTurnOnProcess(
   }
 
   const canApplyNoReplyPatch = (deliveryContextOrdinal: number): boolean => {
-    const trailingSteerCandidateOrdinal =
-      trailingSteerCandidate?.deliveryContextOrdinal
     if (
       externallyVisibleAssistantOutputDeliveryContexts.has(deliveryContextOrdinal) ||
       hasPendingExternallyVisibleAssistantOutput(deliveryContextOrdinal)
-    ) {
-      return false
-    }
-    if (
-      typeof trailingSteerCandidateOrdinal === 'number' &&
-      trailingSteerCandidateOrdinal < deliveryContextOrdinal
     ) {
       return false
     }
@@ -4201,13 +4157,6 @@ async function runCodexAppServerTurnOnProcess(
       return false
     }
     if (responseCardTextFallback !== null) {
-      return false
-    }
-    if (
-      precedingAgentMessageSegments.some((segment) =>
-        segment.deliveryContextOrdinal < deliveryContextOrdinal
-      )
-    ) {
       return false
     }
     return true
@@ -4972,7 +4921,10 @@ async function runCodexAppServerTurnOnProcess(
           const text = error instanceof VaultCliError &&
             error.code === 'ASSISTANT_RESPONSE_MEDIA_AFTER_NO_REPLY'
             ? 'response media unavailable after finish_without_reply'
-            : 'response media limit reached'
+            : error instanceof VaultCliError &&
+                error.code === 'ASSISTANT_RESPONSE_MEDIA_CONTEXT_ADVANCED'
+              ? 'response media unavailable for this final response'
+              : 'response media limit reached'
           void tryWriteRpcMessage({
             id: requestId,
             result: {

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -3491,15 +3491,29 @@ async function runCodexAppServerTurnOnProcess(
     }
     noReplySettlementStarted = true
     for (const deliveryContextOrdinal of listNoReplyFinalActionPatchOrdinals()) {
+      const precedingReplyDeliveryContextOrdinal = Math.max(
+        -1,
+        ...precedingAgentMessageSegments
+          .map((segment) => segment.deliveryContextOrdinal)
+          .filter((ordinal) => ordinal < deliveryContextOrdinal),
+        trailingSteerCandidate !== null &&
+            trailingSteerCandidate.deliveryContextOrdinal < deliveryContextOrdinal
+          ? trailingSteerCandidate.deliveryContextOrdinal
+          : -1,
+      )
       await input.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal,
         // The accepted event settles the cumulative accepted-turn prefix
-        // through this ordinal, so a reaction recorded for any covered
-        // earlier context must keep terminal suppression evidence deferred
-        // until reaction delivery settles.
+        // only when no earlier reply owns part of that prefix. A reaction
+        // recorded for any covered earlier context must keep terminal
+        // suppression evidence deferred until reaction delivery settles.
         messageReactionPending: reactionPatches.some(
           (entry) => entry.deliveryContextOrdinal <= deliveryContextOrdinal,
         ),
+        precedingReplyDeliveryContextOrdinal:
+          precedingReplyDeliveryContextOrdinal < 0
+            ? null
+            : precedingReplyDeliveryContextOrdinal,
       })
       acceptedNoReplyDeliveryContextOrdinals.push(deliveryContextOrdinal)
       await input.onFinishWithoutReplyRecorded?.({
@@ -5245,8 +5259,8 @@ async function runCodexAppServerTurnOnProcess(
         completedFinalAgentMessage = null
         assistantStreams.clear()
         assistantStreamOrder.length = 0
-        responseMedia = []
       }
+      responseMedia = []
       responseCard = null
       responseCardTextFallback = null
       completedUserMessageOrdinal += 1

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -795,7 +795,10 @@ async function resolveAssistantAutoReplyGroupOutcome(input: {
           : [],
         reason: ASSISTANT_NO_REPLY_SUPPRESSION_REASON,
       }
-      if (event.messageReactionPending) {
+      if (
+        event.messageReactionPending ||
+        event.precedingReplyDeliveryContextOrdinal !== null
+      ) {
         deferredTerminalSuppressionEvidence.push(evidenceDraft)
       } else {
         const recordedAt = new Date().toISOString()

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -1369,6 +1369,37 @@ export async function sendAssistantMessageLocal(
             ),
           ]
         }
+        function resolveNoReplyAcceptedInputIds(
+          deliveryContextOrdinal: number,
+          precedingReplyDeliveryContextOrdinal: number | null,
+        ): readonly string[] {
+          if (precedingReplyDeliveryContextOrdinal === null) {
+            return resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
+              deliveryContextOrdinal,
+            )
+          }
+          if (
+            precedingReplyDeliveryContextOrdinal < 0 ||
+            precedingReplyDeliveryContextOrdinal >= deliveryContextOrdinal ||
+            deliveryContextOrdinal >=
+              acceptedInputIdsByDeliveryContextOrdinal.length
+          ) {
+            throw new VaultCliError(
+              'ASSISTANT_DELIVERY_CONTEXT_ORDINAL_INVALID',
+              'Assistant no-reply selection referenced an invalid delivery context ordinal.',
+            )
+          }
+          return [
+            ...new Set(
+              acceptedInputIdsByDeliveryContextOrdinal
+                .slice(
+                  precedingReplyDeliveryContextOrdinal + 1,
+                  deliveryContextOrdinal + 1,
+                )
+                .flat(),
+            ),
+          ]
+        }
         const authorizeAcceptedMessageTarget: AssistantAcceptedMessageTargetAuthorizer =
           async (authorizationInput) => {
             const deliveryContextOrdinal =
@@ -1553,17 +1584,29 @@ export async function sendAssistantMessageLocal(
           const deliveryContextOrdinal =
             selectedProviderResult.acceptedNoReplyDeliveryContextOrdinals?.at(-1)
             ?? selectedProviderResult.responseDeliveryContextOrdinal
+          const precedingReplyDeliveryContextOrdinal = Math.max(
+            -1,
+            ...(selectedProviderResult.precedingResponseSegments ?? [])
+              .map((segment) => segment.deliveryContextOrdinal)
+              .filter((ordinal) => ordinal < deliveryContextOrdinal),
+          )
           await currentInput.onFinishWithoutReplyAccepted?.({
-            acceptedInputIds:
-              resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
-                deliveryContextOrdinal,
-              ),
+            acceptedInputIds: resolveNoReplyAcceptedInputIds(
+              deliveryContextOrdinal,
+              precedingReplyDeliveryContextOrdinal < 0
+                ? null
+                : precedingReplyDeliveryContextOrdinal,
+            ),
             deliveryContextOrdinal,
             messageReactionPending:
               (selectedProviderResult.reactions ?? []).some(
                 (reaction) =>
                   reaction.deliveryContextOrdinal <= deliveryContextOrdinal,
               ),
+            precedingReplyDeliveryContextOrdinal:
+              precedingReplyDeliveryContextOrdinal < 0
+                ? null
+                : precedingReplyDeliveryContextOrdinal,
           })
         }
         type CurrentProviderRequestResult =
@@ -1584,6 +1627,7 @@ export async function sendAssistantMessageLocal(
           providerRequestAcceptedInputItems = acceptedInputItemsForProviderRequest
           providerRequestStartedAtMs = null
           providerResultReturnedAt = null
+          let failedNoReplyRecoveryBlocked = false
 
           const onFirstAssistantResponseCompleted = () => {
             if (holdGroupReplyDraft && providerRequestOrdinal === 0) {
@@ -1611,6 +1655,8 @@ export async function sendAssistantMessageLocal(
               const deliveryContextOrdinal =
                 providerRequestDeliveryContextBaseOrdinal +
                 event.deliveryContextOrdinal
+              failedNoReplyRecoveryBlocked ||=
+                event.precedingReplyDeliveryContextOrdinal !== null
               await drainLiveSteeredActiveTurnInputs({
                 continuation: providerRequestContinuation,
                 sessionId: currentSession.sessionId,
@@ -1622,14 +1668,16 @@ export async function sendAssistantMessageLocal(
                   prompt: currentInput.prompt,
                   vault: currentInput.vault,
                 })
-                const acceptedInputIds =
-                  resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
-                    deliveryContextOrdinal,
-                  )
+                const acceptedInputIds = resolveNoReplyAcceptedInputIds(
+                  deliveryContextOrdinal,
+                  event.precedingReplyDeliveryContextOrdinal,
+                )
                 await currentInput.onFinishWithoutReplyAccepted?.({
                   acceptedInputIds,
                   deliveryContextOrdinal,
                   messageReactionPending: event.messageReactionPending,
+                  precedingReplyDeliveryContextOrdinal:
+                    event.precedingReplyDeliveryContextOrdinal,
                 })
               }
             },
@@ -1759,6 +1807,7 @@ export async function sendAssistantMessageLocal(
               providerOutcome.acceptedNoReplyDeliveryContextOrdinals ?? []
             const latestAcceptedDeliveryContextOrdinal = replyDeliveryContexts.length - 1
             const recoverableNoReplyDeliveryContextOrdinal =
+              !failedNoReplyRecoveryBlocked &&
               latestAcceptedDeliveryContextOrdinal >= 0 &&
               acceptedNoReplyOrdinals.includes(latestAcceptedDeliveryContextOrdinal)
                 ? latestAcceptedDeliveryContextOrdinal

--- a/packages/assistant-engine/src/assistant/providers/types.ts
+++ b/packages/assistant-engine/src/assistant/providers/types.ts
@@ -113,6 +113,7 @@ export interface AssistantProviderRequestStartedEvent
 export interface AssistantProviderFinishWithoutReplyAcceptedEvent {
   deliveryContextOrdinal: number
   messageReactionPending: boolean
+  precedingReplyDeliveryContextOrdinal: number | null
 }
 
 /**

--- a/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-reply-event-path.test.ts
@@ -4183,6 +4183,7 @@ describe('assistant auto-reply event-first path', () => {
         acceptedInputIds: [candidate.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       throw new Error('provider connection dropped after final action')
     })

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -12904,12 +12904,14 @@ describe('assistant auto-reply runtime', () => {
         acceptedInputIds: readonly string[]
         deliveryContextOrdinal: number
         messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
       }) => Promise<void>
     }) => {
       await input.onFinishWithoutReplyAccepted?.({
         acceptedInputIds: [initialInput.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       const admitted = await input.activeTurnInput?.({
         sessionId: 'session-1',
@@ -12991,6 +12993,191 @@ describe('assistant auto-reply runtime', () => {
       }))
   })
 
+  it('commits an earlier reply before suppressing the later no-reply suffix', async () => {
+    const earlierInput = createCapturelessAssistantInputCandidate({
+      conversationThreadId: 'safe_thread_reply_then_no_reply',
+      inputId: 'ain_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12',
+      occurredAt: '2026-04-08T00:11:00.000Z',
+      receivedAt: '2026-04-08T00:11:01.000Z',
+      replyTarget: {
+        channel: 'linq',
+        messageId: 'real_msg_reply_then_no_reply_earlier',
+        threadId: 'real_thread_reply_then_no_reply',
+      },
+      source: 'linq',
+      text: 'question with a useful answer',
+    })
+    const acknowledgementInput = createCapturelessAssistantInputCandidate({
+      conversationThreadId: 'safe_thread_reply_then_no_reply',
+      inputId: 'ain_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb12',
+      occurredAt: '2026-04-08T00:11:10.000Z',
+      receivedAt: '2026-04-08T00:11:11.000Z',
+      replyTarget: {
+        channel: 'linq',
+        messageId: 'real_msg_reply_then_no_reply_ack',
+        threadId: 'real_thread_reply_then_no_reply',
+      },
+      source: 'linq',
+      text: 'thanks, no need to reply',
+    })
+    replyMocks.sendAssistantMessage.mockImplementation(async (input: {
+      onFinishWithoutReplyAccepted?: (event: {
+        acceptedInputIds: readonly string[]
+        deliveryContextOrdinal: number
+        messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
+      }) => Promise<void>
+    }) => {
+      await input.onFinishWithoutReplyAccepted?.({
+        acceptedInputIds: [acknowledgementInput.event.inputId],
+        deliveryContextOrdinal: 1,
+        messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: 0,
+      })
+      expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
+        .not.toHaveBeenCalled()
+      return {
+        delivery: {
+          channel: 'linq',
+          target: 'real_thread_reply_then_no_reply',
+          sentAt: '2026-04-08T00:11:20.000Z',
+        },
+        deliveryDeferred: false,
+        deliveryError: null,
+        deliveryIntentId: 'intent-reply-then-no-reply',
+        response: '',
+        responseDisposition: 'none' as const,
+        session: {
+          sessionId: 'session-reply-then-no-reply',
+        },
+      }
+    })
+    const reply = await vi.importActual<typeof import('../src/assistant/automation/reply.ts')>(
+      '../src/assistant/automation/reply.ts',
+    )
+    const context = reply.createAssistantAutoReplyGroupContext([
+      createCapturelessReplyGroupItem(earlierInput),
+      createCapturelessReplyGroupItem(acknowledgementInput),
+    ])
+
+    if (!context) {
+      throw new Error('expected reply context')
+    }
+
+    const result = await reply.processAssistantAutoReplyGroup({
+      allowSelfAuthored: false,
+      context,
+      deliveryDispatchMode: 'immediate',
+      enabledChannels: ['linq'],
+      inboxServices: createInboxServices({ show: vi.fn() }),
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault: '/tmp/assistant-automation-vault',
+    })
+
+    expect(result).toMatchObject({
+      advanceCursor: true,
+      failed: 0,
+      replied: 1,
+      stopScanning: false,
+    })
+    expect(evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence)
+      .toHaveBeenCalledWith(expect.objectContaining({
+        inputIds: [earlierInput.event.inputId],
+        linqMessageIds: ['real_msg_reply_then_no_reply_earlier'],
+      }))
+    expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
+      .toHaveBeenCalledWith(expect.objectContaining({
+        inputIds: [acknowledgementInput.event.inputId],
+        linqMessageIds: ['real_msg_reply_then_no_reply_ack'],
+      }))
+    expect(
+      evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence
+        .mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      evidenceMocks.writeAssistantAutoReplySuppressionEvidence
+        .mock.invocationCallOrder[0]!,
+    )
+  })
+
+  it('retries a mixed no-reply turn when the provider fails before reply evidence', async () => {
+    const earlierInput = createCapturelessAssistantInputCandidate({
+      conversationThreadId: 'safe_thread_reply_then_no_reply_failure',
+      inputId: 'ain_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13',
+      occurredAt: '2026-04-08T00:12:00.000Z',
+      receivedAt: '2026-04-08T00:12:01.000Z',
+      replyTarget: {
+        channel: 'linq',
+        messageId: 'real_msg_reply_then_no_reply_failure_earlier',
+        threadId: 'real_thread_reply_then_no_reply_failure',
+      },
+      source: 'linq',
+      text: 'question whose answer must survive retry',
+    })
+    const acknowledgementInput = createCapturelessAssistantInputCandidate({
+      conversationThreadId: 'safe_thread_reply_then_no_reply_failure',
+      inputId: 'ain_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb13',
+      occurredAt: '2026-04-08T00:12:10.000Z',
+      receivedAt: '2026-04-08T00:12:11.000Z',
+      replyTarget: {
+        channel: 'linq',
+        messageId: 'real_msg_reply_then_no_reply_failure_ack',
+        threadId: 'real_thread_reply_then_no_reply_failure',
+      },
+      source: 'linq',
+      text: 'thanks, no need to reply',
+    })
+    replyMocks.sendAssistantMessage.mockImplementation(async (input: {
+      onFinishWithoutReplyAccepted?: (event: {
+        acceptedInputIds: readonly string[]
+        deliveryContextOrdinal: number
+        messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
+      }) => Promise<void>
+    }) => {
+      await input.onFinishWithoutReplyAccepted?.({
+        acceptedInputIds: [acknowledgementInput.event.inputId],
+        deliveryContextOrdinal: 1,
+        messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: 0,
+      })
+      throw new Error('provider failed before earlier reply delivery')
+    })
+    const reply = await vi.importActual<typeof import('../src/assistant/automation/reply.ts')>(
+      '../src/assistant/automation/reply.ts',
+    )
+    const context = reply.createAssistantAutoReplyGroupContext([
+      createCapturelessReplyGroupItem(earlierInput),
+      createCapturelessReplyGroupItem(acknowledgementInput),
+    ])
+
+    if (!context) {
+      throw new Error('expected reply context')
+    }
+
+    const result = await reply.processAssistantAutoReplyGroup({
+      allowSelfAuthored: false,
+      context,
+      deliveryDispatchMode: 'immediate',
+      enabledChannels: ['linq'],
+      inboxServices: createInboxServices({ show: vi.fn() }),
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault: '/tmp/assistant-automation-vault',
+    })
+
+    expect(result).toMatchObject({
+      advanceCursor: false,
+      failed: 1,
+      replied: 0,
+      stopScanning: true,
+    })
+    expect(evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence)
+      .not.toHaveBeenCalled()
+    expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
+      .not.toHaveBeenCalled()
+  })
+
   it('preserves no-reply suppression evidence when a later active-turn input succeeds', async () => {
     const initialInput = createCapturelessAssistantInputCandidate({
       conversationThreadId: 'safe_thread_no_reply_then_reply',
@@ -13042,12 +13229,14 @@ describe('assistant auto-reply runtime', () => {
         acceptedInputIds: readonly string[]
         deliveryContextOrdinal: number
         messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
       }) => Promise<void>
     }) => {
       await input.onFinishWithoutReplyAccepted?.({
         acceptedInputIds: [initialInput.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       const admitted = await input.activeTurnInput?.({
         sessionId: 'session-1',
@@ -13168,12 +13357,14 @@ describe('assistant auto-reply runtime', () => {
         acceptedInputIds: readonly string[]
         deliveryContextOrdinal: number
         messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
       }) => Promise<void>
     }) => {
       await input.onFinishWithoutReplyAccepted?.({
         acceptedInputIds: [telegramInput.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
         .not.toHaveBeenCalled()
@@ -13260,12 +13451,14 @@ describe('assistant auto-reply runtime', () => {
         acceptedInputIds: readonly string[]
         deliveryContextOrdinal: number
         messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
       }) => Promise<void>
     }) => {
       await input.onFinishWithoutReplyAccepted?.({
         acceptedInputIds: [telegramInput.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
         .not.toHaveBeenCalled()
@@ -13343,12 +13536,14 @@ describe('assistant auto-reply runtime', () => {
         acceptedInputIds: readonly string[]
         deliveryContextOrdinal: number
         messageReactionPending: boolean
+        precedingReplyDeliveryContextOrdinal: number | null
       }) => Promise<void>
     }) => {
       await input.onFinishWithoutReplyAccepted?.({
         acceptedInputIds: [telegramInput.event.inputId],
         deliveryContextOrdinal: 0,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       expect(evidenceMocks.writeAssistantAutoReplySuppressionEvidence)
         .not.toHaveBeenCalled()

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -15300,6 +15300,99 @@ describeRealCodex('real Codex latest-context nutrition-card e2e', () => {
   })
 })
 
+describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
+  it('keeps the earlier answer and stays quiet for the later acknowledgement', {
+    timeout: 1_800_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-steered-acknowledgement-real-e2e-'),
+    )
+    const steerCompleted = createDeferred<void>()
+    let steerAcknowledgement: (() => Promise<void>) | null = null
+
+    try {
+      const result = await executeRealCodexAppServerTurn({
+        allowFinishWithoutReply: true,
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: [
+          buildDirectConversationDeveloperInstructions(),
+          'When the latest user message explicitly needs no response, call finish_without_reply and emit no text.',
+        ].join('\n\n'),
+        dynamicTools: [MURPH_FINISH_WITHOUT_REPLY_TOOL],
+        env: config.env,
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        onFirstAssistantResponseCompleted: () => {
+          const steer = steerAcknowledgement
+          if (!steer) {
+            steerCompleted.reject(
+              new Error('Expected a live turn before the first completed answer.'),
+            )
+            return
+          }
+          void steer().then(
+            () => steerCompleted.resolve(),
+            (error) => steerCompleted.reject(error),
+          )
+        },
+        onLiveTurn: (turn) => {
+          steerAcknowledgement = () => turn.steer({
+            prompt: [
+              'Thanks, that answered it.',
+              'Do not send another message.',
+              'Call finish_without_reply now and emit no text.',
+            ].join(' '),
+          })
+        },
+        prompt: [
+          'Reply with exactly "ORBIT." and no other text.',
+          'Do not call any tools for this first reply.',
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'read-only',
+        workingDirectory,
+      })
+      await steerCompleted.promise
+
+      const finishAttempts = readDynamicToolAttempts(result.jsonEvents).filter(
+        (attempt) => attempt.tool === MURPH_FINISH_WITHOUT_REPLY_TOOL.name,
+      )
+      const earlierReply = result.precedingAgentMessageSegments[0]?.response.trim()
+
+      process.stdout.write(
+        `[steered-acknowledgement-no-reply-e2e] ${JSON.stringify({
+          earlierReply,
+          finalAction: result.finalAction,
+          finalMessage: result.finalMessage,
+          finishAttemptCount: finishAttempts.length,
+        })}\n`,
+      )
+
+      expect(earlierReply).toBe('ORBIT.')
+      expect(result.precedingAgentMessageSegments).toHaveLength(1)
+      expect(result.precedingAgentMessageSegments[0]?.deliveryContextOrdinal).toBe(0)
+      expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([1])
+      expect(result.finalAction).toEqual({ kind: 'none' })
+      expect(result.finalActionExplicit).toBe(true)
+      expect(result.finalMessage).toBe('')
+      expect(result.responseMedia).toEqual([])
+      expect(result.responseCard).toBeNull()
+      expect(finishAttempts).toHaveLength(1)
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  })
+})
+
 async function materializeAutomaticMealCloseoutVaultCli(input: {
   binDirectory: string
   commandLogPath: string

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -15310,6 +15310,7 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
     )
     const steerCompleted = createDeferred<void>()
     let steerAcknowledgement: (() => Promise<void>) | null = null
+    let steerStarted = false
 
     try {
       const result = await executeRealCodexAppServerTurn({
@@ -15319,20 +15320,24 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
         codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
           ?? undefined,
         codexHome: config.codexHome,
-        developerInstructions: [
-          buildDirectConversationDeveloperInstructions(),
-          'When the latest user message explicitly needs no response, call finish_without_reply and emit no text.',
-        ].join('\n\n'),
+        developerInstructions: buildDirectConversationDeveloperInstructions(),
         dynamicTools: [MURPH_FINISH_WITHOUT_REPLY_TOOL],
         env: config.env,
         excludeResumeTurns: true,
         model: config.model,
         modelProvider: config.modelProvider,
-        onFirstAssistantResponseCompleted: () => {
+        onTraceEvent: ({ rawEvent }) => {
+          if (
+            steerStarted ||
+            readRecord(rawEvent)?.method !== 'item/agentMessage/delta'
+          ) {
+            return
+          }
+          steerStarted = true
           const steer = steerAcknowledgement
           if (!steer) {
             steerCompleted.reject(
-              new Error('Expected a live turn before the first completed answer.'),
+              new Error('Expected a live turn before the first answer delta.'),
             )
             return
           }
@@ -15343,11 +15348,7 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
         },
         onLiveTurn: (turn) => {
           steerAcknowledgement = () => turn.steer({
-            prompt: [
-              'Thanks, that answered it.',
-              'Do not send another message.',
-              'Call finish_without_reply now and emit no text.',
-            ].join(' '),
+            prompt: 'Thanks, that answered it—no need to reply.',
           })
         },
         prompt: [
@@ -15358,6 +15359,11 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
         sandbox: 'read-only',
         workingDirectory,
       })
+      if (!steerStarted) {
+        throw new Error(
+          'Expected the acknowledgement steer to begin before the first answer completed.',
+        )
+      }
       await steerCompleted.promise
 
       const finishAttempts = readDynamicToolAttempts(result.jsonEvents).filter(

--- a/packages/assistant-engine/test/assistant-codex-runtime-events.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-events.test.ts
@@ -2087,6 +2087,7 @@ describe('assistant codex event shaping', () => {
       expect(onFinishWithoutReplyAccepted).toHaveBeenCalledWith({
         deliveryContextOrdinal: 0,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       expect(onFinishWithoutReplyRecorded).toHaveBeenCalledOnce()
       expect(onFinishWithoutReplyRecorded).toHaveBeenCalledWith({
@@ -2150,6 +2151,16 @@ describe('assistant codex event shaping', () => {
                   id: 'user-cross-context-initial',
                   type: 'userMessage',
                   content: [{ type: 'text', text: 'react to my earlier message' }],
+                },
+              },
+            }))
+            child.stdout.write(jsonLine({
+              method: 'item/completed',
+              params: {
+                item: {
+                  id: 'assistant-cross-context-initial',
+                  text: 'Earlier answer.',
+                  type: 'agentMessage',
                 },
               },
             }))
@@ -2229,12 +2240,13 @@ describe('assistant codex event shaping', () => {
           },
         ],
       })
-      // The accepted event settles the cumulative prefix through ordinal 1,
-      // so the ordinal-0 reaction must keep suppression evidence deferred.
+      // The earlier reply owns ordinal 0, while its reaction and the later
+      // no-reply suffix both require deferred suppression evidence.
       expect(onFinishWithoutReplyAccepted).toHaveBeenCalledOnce()
       expect(onFinishWithoutReplyAccepted).toHaveBeenCalledWith({
         deliveryContextOrdinal: 1,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: 0,
       })
     })
 
@@ -2332,6 +2344,7 @@ describe('assistant codex event shaping', () => {
       expect(onFinishWithoutReplyAccepted).toHaveBeenCalledWith({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       expect(onFinishWithoutReplyRecorded).toHaveBeenCalledWith({
         deliveryContextOrdinal: 0,

--- a/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
@@ -1418,6 +1418,45 @@ describe('steered final segments', () => {
     )
   })
 
+  it('clears attached media when accepted input advances before a response completes', async () => {
+    const result = await runScriptedSteeredFinalSegmentsTurn([
+      completedItemEvent({
+        id: 'user-before-attached-media',
+        type: 'user_message',
+        message: 'Attach the image to this answer',
+      }),
+      {
+        expectedText: '1 response image attached',
+        id: 863,
+        kind: 'attach-response-media',
+        media: [{
+          alt: 'Old-context image',
+          source: 'old-context',
+          url: 'https://cdn.example.test/assistant/old-context.png',
+        }],
+      },
+      completedItemEvent({
+        id: 'user-after-attached-media',
+        type: 'user_message',
+        message: 'Answer this newer request without that image',
+      }),
+      completedItemEvent({
+        id: 'assistant-after-attached-media',
+        type: 'assistant_message',
+        message: 'Latest-context answer without old media.',
+      }),
+    ])
+
+    expect(result.precedingAgentMessageSegments).toEqual([])
+    expect(result.responseCard).toBeNull()
+    expect(result.responseMedia).toEqual([])
+    expect(result.responseDeliveryContextOrdinal).toBe(1)
+    expect(result.finalMessage).toBe('Latest-context answer without old media.')
+    expect(result.providerAuthoredFinalMessage).toBe(
+      'Latest-context answer without old media.',
+    )
+  })
+
   it('keeps independent last-successful reply and reaction targets per steered segment', async () => {
     const firstReplyRef = `ain_${'1'.repeat(32)}`
     const firstReactionRef = `ain_${'2'.repeat(32)}`

--- a/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
@@ -54,6 +54,7 @@ describe('steered final segments', () => {
         event: Record<string, unknown>
       }
     | {
+        deferResponse?: boolean
         expectedSuccess?: boolean
         expectedText: string
         id: number
@@ -229,7 +230,7 @@ describe('steered final segments', () => {
 
       queueMicrotask(() => {
         void (async () => {
-          const deferredCardResponses: Promise<unknown>[] = []
+          const deferredToolResponses: Promise<unknown>[] = []
           const initialize = await waitForRpcMethod(child, 'initialize')
           child.stdout.write(jsonLine({ id: initialize.id, result: {} }))
 
@@ -295,7 +296,7 @@ describe('steered final segments', () => {
                 },
               })
               if (step.deferResponse === true) {
-                deferredCardResponses.push(responseAssertion)
+                deferredToolResponses.push(responseAssertion)
               } else {
                 await responseAssertion
               }
@@ -315,7 +316,9 @@ describe('steered final segments', () => {
                   turnId: 'turn-steered-finals',
                 },
               }))
-              await expect(waitForRpcResponse(child, step.id)).resolves.toEqual({
+              const responseAssertion = expect(
+                waitForRpcResponse(child, step.id),
+              ).resolves.toEqual({
                 id: step.id,
                 result: {
                   success: step.expectedSuccess ?? true,
@@ -327,6 +330,11 @@ describe('steered final segments', () => {
                   ],
                 },
               })
+              if (step.deferResponse === true) {
+                deferredToolResponses.push(responseAssertion)
+              } else {
+                await responseAssertion
+              }
               continue
             }
 
@@ -541,7 +549,7 @@ describe('steered final segments', () => {
             child.stdout.write(jsonLine(normalizeScriptedSteeredFinalEvent(step)))
           }
 
-          await Promise.all(deferredCardResponses)
+          await Promise.all(deferredToolResponses)
 
           child.stdout.write(jsonLine({
             method: 'turn/completed',
@@ -1351,6 +1359,64 @@ describe('steered final segments', () => {
       expect(result.providerAuthoredFinalMessage).toBe('Latest-context answer.')
     },
   )
+
+  it('rejects in-flight response media after accepted input advances', async () => {
+    const executionStarted = createDeferred<void>()
+    const releaseExecution = createDeferred<void>()
+    const result = await runScriptedSteeredFinalSegmentsTurn([
+      completedItemEvent({
+        id: 'user-before-in-flight-media',
+        type: 'user_message',
+        message: 'Attach the image to this answer',
+      }),
+      {
+        deferResponse: true,
+        expectedSuccess: false,
+        expectedText: 'response media unavailable for this final response',
+        id: 862,
+        kind: 'attach-response-media',
+        media: [{
+          alt: 'Old-context image',
+          source: 'old-context',
+          url: 'https://cdn.example.test/assistant/old-context.png',
+        }],
+      },
+      completedItemEvent({
+        id: 'user-after-in-flight-media',
+        type: 'user_message',
+        message: 'Answer this newer request without that image',
+      }),
+      {
+        kind: 'callback',
+        run: async () => {
+          await executionStarted.promise
+          await Promise.resolve()
+          releaseExecution.resolve()
+        },
+      },
+      completedItemEvent({
+        id: 'assistant-after-in-flight-media',
+        type: 'assistant_message',
+        message: 'Latest-context answer without old media.',
+      }),
+    ], {
+      hostedToolContext: createHostedToolContext({
+        beforeToolExecution: async (deliveryContextOrdinal) => {
+          expect(deliveryContextOrdinal).toBe(0)
+          executionStarted.resolve()
+          await releaseExecution.promise
+        },
+      }),
+    })
+
+    expect(result.responseCard).toBeNull()
+    expect(result.responseMedia).toEqual([])
+    expect(result.responseDeliveryContextOrdinal).toBe(1)
+    expect(result.finalMessage).toBe('Latest-context answer without old media.')
+    expect(result.providerAuthoredFinalMessage).toBe(
+      'Latest-context answer without old media.',
+    )
+  })
 
   it('keeps independent last-successful reply and reaction targets per steered segment', async () => {
     const firstReplyRef = `ain_${'1'.repeat(32)}`
@@ -2399,7 +2465,7 @@ describe('steered final segments', () => {
     expect(result.precedingAgentMessageSegments).toEqual([])
   })
 
-  it('rejects a later no-reply while an earlier steered answer is still pending', async () => {
+  it('accepts a later no-reply while preserving an earlier pending answer', async () => {
     const result = await runScriptedSteeredFinalSegmentsTurn([
       completedItemEvent({
         id: 'user-1',
@@ -2419,19 +2485,22 @@ describe('steered final segments', () => {
       {
         kind: 'finish-without-reply',
         id: 74,
-        expectedSuccess: false,
-        expectedText: 'finish_without_reply unavailable after assistant output',
+        expectedText: 'finished without reply',
       },
     ])
 
-    expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([])
-    expect(result.finalMessage).toBe('Answer one.')
-    expect(result.finalAction).toBeNull()
-    expect(result.finalActionExplicit).toBe(false)
-    expect(result.precedingAgentMessageSegments).toEqual([])
+    expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([1])
+    expect(result.finalMessage).toBe('')
+    expect(result.finalAction).toEqual({ kind: 'none' })
+    expect(result.finalActionExplicit).toBe(true)
+    expect(result.precedingAgentMessageSegments).toEqual([{
+      deliveryContextOrdinal: 0,
+      media: [],
+      response: 'Answer one.',
+    }])
   })
 
-  it('rejects a later no-reply after an earlier steered answer was promoted', async () => {
+  it('accepts a later no-reply after preserving an earlier promoted answer', async () => {
     const result = await runScriptedSteeredFinalSegmentsTurn([
       completedItemEvent({
         id: 'user-1',
@@ -2456,15 +2525,14 @@ describe('steered final segments', () => {
       {
         kind: 'finish-without-reply',
         id: 75,
-        expectedSuccess: false,
-        expectedText: 'finish_without_reply unavailable after assistant output',
+        expectedText: 'finished without reply',
       },
     ])
 
-    expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([])
-    expect(result.finalMessage).toBe('Answer two.')
-    expect(result.finalAction).toBeNull()
-    expect(result.finalActionExplicit).toBe(false)
+    expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([1])
+    expect(result.finalMessage).toBe('')
+    expect(result.finalAction).toEqual({ kind: 'none' })
+    expect(result.finalActionExplicit).toBe(true)
     expect(result.precedingAgentMessageSegments).toEqual([
       {
         deliveryContextOrdinal: 0,

--- a/packages/assistant-engine/test/assistant-local-service-delivery.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-delivery.test.ts
@@ -1922,6 +1922,7 @@ test('sendAssistantMessageLocal resolves required progress to one exact accepted
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 0,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 0,
@@ -2251,6 +2252,7 @@ test('sendAssistantMessageLocal carries the provider reaction patch into the no-
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 0,
       messageReactionPending: true,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 0,
@@ -2313,6 +2315,7 @@ test('sendAssistantMessageLocal carries the provider reaction patch into the no-
     ],
     deliveryContextOrdinal: 0,
     messageReactionPending: true,
+    precedingReplyDeliveryContextOrdinal: null,
   })
   expect(mocks.deliverAssistantReaction.mock.calls[0]?.[0]?.input).toMatchObject({
     deliveryReplyToMessageId: 'linq-message-older-eligible',

--- a/packages/assistant-engine/test/assistant-local-service-failures.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-failures.test.ts
@@ -785,6 +785,7 @@ test('sendAssistantMessageLocal recovers reaction no-reply before draining later
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 0,
       messageReactionPending: true,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 0,
@@ -1485,6 +1486,7 @@ test('sendAssistantMessageLocal durably records accepted no-reply markers before
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 0,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 0,
@@ -1570,6 +1572,7 @@ test('sendAssistantMessageLocal writes no-reply markers after caller retry fence
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 0,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     throw new Error('unreachable after no-reply callback failure')
   })
@@ -1614,6 +1617,7 @@ test('sendAssistantMessageLocal completes no-reply if marker persistence fails a
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       await providerInput.onFinishWithoutReplyRecorded?.({
         deliveryContextOrdinal: 0,
@@ -1754,6 +1758,7 @@ test('sendAssistantMessageLocal persists live-steered input before its no-reply 
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 1,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal: null,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 1,
@@ -1850,7 +1855,21 @@ test('sendAssistantMessageLocal persists live-steered input before its no-reply 
   expect(mocks.clearAssistantSessionCodexResumeState).not.toHaveBeenCalled()
 })
 
-test('sendAssistantMessageLocal completes terminal provider failures after live-steered no-reply', async () => {
+test.each([
+  {
+    caseName: 'completes a pure live-steered no-reply',
+    precedingReplyDeliveryContextOrdinal: null,
+    recovers: true,
+  },
+  {
+    caseName: 'retries when an earlier reply still needs delivery',
+    precedingReplyDeliveryContextOrdinal: 0,
+    recovers: false,
+  },
+])('sendAssistantMessageLocal $caseName after a terminal provider failure', async ({
+  precedingReplyDeliveryContextOrdinal,
+  recovers,
+}) => {
   const terminalError = new Error('provider failed after steered no-reply')
   const session = createAssistantSession({
     binding: {
@@ -1900,6 +1919,7 @@ test('sendAssistantMessageLocal completes terminal provider failures after live-
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 1,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal,
     })
     await providerInput.onFinishWithoutReplyRecorded?.({
       deliveryContextOrdinal: 1,
@@ -1952,10 +1972,34 @@ test('sendAssistantMessageLocal completes terminal provider failures after live-
   })
   providerRelease.resolve()
 
-  const [initialResult, steeredResult] = await Promise.all([
+  const [initialOutcome, steeredOutcome] = await Promise.allSettled([
     initialResultPromise,
     steeredResultPromise,
   ])
+
+  if (!recovers) {
+    expect(initialOutcome).toEqual({
+      reason: terminalError,
+      status: 'rejected',
+    })
+    expect(steeredOutcome).toEqual({
+      reason: terminalError,
+      status: 'rejected',
+    })
+    expect(
+      mocks.runtimeState.turns.acceptedInputs.updateAdmissionState,
+    ).not.toHaveBeenCalledWith({
+      admissionState: 'commit-started',
+      turnId: 'turn-1',
+    })
+    expect(mocks.finalizeAssistantTurnArtifacts).not.toHaveBeenCalled()
+    return
+  }
+
+  assert.equal(initialOutcome.status, 'fulfilled')
+  assert.equal(steeredOutcome.status, 'fulfilled')
+  const initialResult = initialOutcome.value
+  const steeredResult = steeredOutcome.value
 
   assert.equal(initialResult.responseDisposition, 'none')
   assert.equal(steeredResult.responseDisposition, 'none')

--- a/packages/assistant-engine/test/assistant-local-service-live-input.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-live-input.test.ts
@@ -360,6 +360,134 @@ test('sendAssistantMessageLocal live-steers same-conversation input without prov
   assert.equal(steeredResult.response, 'final after late input')
 })
 
+test('sendAssistantMessageLocal delivers the earlier answer once when a pre-cutoff acknowledgement settles late', async () => {
+  const session = createAssistantSession({
+    binding: {
+      actorId: null,
+      channel: 'telegram',
+      conversationKey: 'channel:telegram|identity:identity-1|thread:thread-1',
+      delivery: {
+        kind: 'thread',
+        target: 'thread-1',
+      },
+      identityId: 'identity-1',
+      threadId: 'thread-1',
+      threadIsDirect: true,
+    },
+  })
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    session,
+  })
+  const providerStarted = createDeferred<void>()
+  const acknowledgementAdmissionStarted = createDeferred<void>()
+  const releaseAcknowledgementAdmission = createDeferred<void>()
+  const acknowledgementSteered = createDeferred<void>()
+  const liveSteeredPrompts: string[] = []
+
+  mocks.executeCodexTurnWithRecovery.mockImplementationOnce(async (providerInput) => {
+    const releaseLiveTurn = providerInput.activeTurnSteering?.registerLiveProviderTurn({
+      interrupt: async () => undefined,
+      codexThreadId: 'provider-thread-acknowledgement',
+      providerTurnId: 'provider-turn-acknowledgement',
+      sessionId: session.sessionId,
+      steer: async (input) => {
+        liveSteeredPrompts.push(input.prompt)
+        acknowledgementSteered.resolve()
+      },
+      turnId: 'turn-1',
+    })
+    providerStarted.resolve()
+    await acknowledgementAdmissionStarted.promise
+    providerInput.activeTurnSteering?.onFirstAssistantResponseCompleted()
+    releaseAcknowledgementAdmission.resolve()
+    await acknowledgementSteered.promise
+    await providerInput.onFinishWithoutReplyAccepted?.({
+      deliveryContextOrdinal: 1,
+      messageReactionPending: false,
+    })
+    releaseLiveTurn?.()
+    return {
+      kind: 'succeeded',
+      providerTurn: {
+        acceptedNoReplyDeliveryContextOrdinals: [1],
+        onboardingGuidanceInjected: true,
+        codexContinuation: {
+          kind: 'explicit-structured-history',
+        },
+        codexThreadId: 'provider-thread-acknowledgement',
+        finalAction: { kind: 'none' },
+        precedingResponseSegments: [{
+          deliveryContextOrdinal: 0,
+          media: [],
+          response: 'Earlier useful answer.',
+        }],
+        response: '',
+        responseDeliveryContextOrdinal: 1,
+        route: {
+          routeId: 'route-acknowledgement',
+        },
+        session,
+        transcriptResponse: null,
+      },
+    }
+  })
+
+  const initialResultPromise = sendAssistantMessageLocal({
+    beforeProviderAcceptedInputs: async ({ acceptedInputs }) => {
+      expect(acceptedInputs).toEqual([
+        expect.objectContaining({
+          promptFallbackText: 'Thanks, that answered it—no need to reply.',
+        }),
+      ])
+      acknowledgementAdmissionStarted.resolve()
+      await releaseAcknowledgementAdmission.promise
+    },
+    deliverResponse: true,
+    prompt: 'Initial question',
+    vault: '/vaults/test',
+  })
+  await providerStarted.promise
+
+  const acknowledgementResultPromise = sendAssistantMessageLocal({
+    conversation: {
+      channel: 'telegram',
+      directness: 'direct',
+      identityId: 'identity-1',
+      threadId: 'thread-1',
+    },
+    expectedActiveTurnId: 'turn-1',
+    prompt: 'Thanks, that answered it—no need to reply.',
+    vault: '/vaults/test',
+  })
+
+  const [initialResult, acknowledgementResult] = await Promise.all([
+    initialResultPromise,
+    acknowledgementResultPromise,
+  ])
+
+  expect(liveSteeredPrompts).toEqual([
+    'Thanks, that answered it—no need to reply.',
+  ])
+  expect(initialResult).toMatchObject({
+    response: '',
+    responseDisposition: 'none',
+  })
+  expect(acknowledgementResult).toMatchObject({
+    response: '',
+    responseDisposition: 'none',
+  })
+  expect(mocks.executeCodexTurnWithRecovery).toHaveBeenCalledOnce()
+  expect(mocks.deliverAssistantPrecedingReplies).toHaveBeenCalledOnce()
+  expect(
+    mocks.deliverAssistantPrecedingReplies.mock.calls[0]?.[0]?.segments,
+  ).toEqual([
+    expect.objectContaining({
+      response: 'Earlier useful answer.',
+    }),
+  ])
+  expect(mocks.dispatchAssistantReply).not.toHaveBeenCalled()
+})
+
 test('sendAssistantMessageLocal leaves an acknowledged uncovered steer pending after provider success', async () => {
   const context = await createTempVaultContext(
     'assistant-local-service-uncovered-steer-',

--- a/packages/assistant-engine/test/assistant-local-service-live-input.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-live-input.test.ts
@@ -383,6 +383,7 @@ test('sendAssistantMessageLocal delivers the earlier answer once when a pre-cuto
   const releaseAcknowledgementAdmission = createDeferred<void>()
   const acknowledgementSteered = createDeferred<void>()
   const liveSteeredPrompts: string[] = []
+  const noReplyAccepted = vi.fn()
 
   mocks.executeCodexTurnWithRecovery.mockImplementationOnce(async (providerInput) => {
     const releaseLiveTurn = providerInput.activeTurnSteering?.registerLiveProviderTurn({
@@ -404,6 +405,7 @@ test('sendAssistantMessageLocal delivers the earlier answer once when a pre-cuto
     await providerInput.onFinishWithoutReplyAccepted?.({
       deliveryContextOrdinal: 1,
       messageReactionPending: false,
+      precedingReplyDeliveryContextOrdinal: 0,
     })
     releaseLiveTurn?.()
     return {
@@ -443,6 +445,7 @@ test('sendAssistantMessageLocal delivers the earlier answer once when a pre-cuto
       await releaseAcknowledgementAdmission.promise
     },
     deliverResponse: true,
+    onFinishWithoutReplyAccepted: noReplyAccepted,
     prompt: 'Initial question',
     vault: '/vaults/test',
   })
@@ -477,6 +480,12 @@ test('sendAssistantMessageLocal delivers the earlier answer once when a pre-cuto
     responseDisposition: 'none',
   })
   expect(mocks.executeCodexTurnWithRecovery).toHaveBeenCalledOnce()
+  expect(noReplyAccepted).toHaveBeenCalledWith({
+    acceptedInputIds: ['manual-1'],
+    deliveryContextOrdinal: 1,
+    messageReactionPending: false,
+    precedingReplyDeliveryContextOrdinal: 0,
+  })
   expect(mocks.deliverAssistantPrecedingReplies).toHaveBeenCalledOnce()
   expect(
     mocks.deliverAssistantPrecedingReplies.mock.calls[0]?.[0]?.segments,
@@ -3837,6 +3846,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: true,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       return {
         kind: 'succeeded',
@@ -3890,6 +3900,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
     acceptedInputIds: ['initial', 'manual-1'],
     deliveryContextOrdinal: 1,
     messageReactionPending: true,
+    precedingReplyDeliveryContextOrdinal: null,
   })
   expect(
     mocks.finalizeAssistantTurnArtifacts.mock.calls[0]?.[0]?.providerResult,
@@ -3917,6 +3928,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       abortedSilenceDraftReady.resolve()
       return {
@@ -3972,6 +3984,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       quietSilenceDraftReady.resolve()
       return {
@@ -4057,6 +4070,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       return {
         acceptedNoReplyDeliveryContextOrdinals: [0],
@@ -4116,6 +4130,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       return {
         acceptedNoReplyDeliveryContextOrdinals: [0],
@@ -4410,6 +4425,7 @@ test('sendAssistantMessageLocal commits only the selected held-group result', as
       await providerInput.onFinishWithoutReplyAccepted?.({
         deliveryContextOrdinal: 0,
         messageReactionPending: false,
+        precedingReplyDeliveryContextOrdinal: null,
       })
       return {
         kind: 'succeeded',


### PR DESCRIPTION
## Why and outcome

Fast live-steered follow-ups could reject a valid later silence decision merely because an earlier answer existed. Delayed media could also cross an accepted context boundary.

This preserves and delivers the useful earlier answer, allows only the later acknowledgement suffix to remain quiet, and prevents old media from attaching to a newer reply while deleting duplicate same-domain checks.

## Product UX

- Effort: Patch
- Result: Ready
- Affected people: members in the existing private-direct conversation path who send a fast follow-up while Murph is answering.
- Exclusions: no group, scheduled, prompt, tool-schema, rendering, or persisted-state behavior changes.
- Plan difference: final review found two timing bugs in the first candidate; both were corrected at existing ownership boundaries.
- Walkthrough: the production-shaped path admits an acknowledgement before cutoff, delivers the earlier answer exactly once, records only the later suffix as suppressed after delivery is durable, and emits no redundant final reply.

## Evidence

- 460 focused tests passed across seven files, including sent, queued, failed, retry, provider-failure, live-steering, and stale-media boundaries.
- Assistant Engine typecheck passed.
- Focused real-Codex journey passed with unchanged direct-conversation instructions: the earlier reply was preserved, the acknowledgement produced no final reply, and one finish attempt was recorded.
- Changelog archive: 9 focused tests passed through the production archive component.
- Exact-head required CI passed on the reviewed production candidate; the plan-only closeout head is running its required CI.

## Non-obvious affected surfaces

- The provider finish-without-reply event carries the exact preceding-reply ordinal so downstream owners can partition answered input from the silent suffix.
- Suppression evidence for a mixed reply/no-reply turn is deferred until the earlier reply has durable sent or queued evidence. Pure no-reply turns retain their existing recovery path.
- Response media is cleared whenever accepted context advances and is preserved only when copied into an actually completed preceding response.
- Serialized dynamic response-tool execution remains the card/media conflict owner, and final response assembly remains the final card-versus-media invariant.

## Architecture and reuse

- Existing systems reused: delivery-context ordinals, ordered preceding segments, reply/suppression evidence writers, serialized dynamic-tool validation, and final response assembly.
- New logic: one ephemeral ordinal boundary and one local delivery-recovery boolean; neither is persisted.
- New abstractions: No new abstraction is needed because the existing ordinal and evidence owners already express the required boundary.
- Complexity intentionally avoided: no second state owner, queue, service, scheduler, supervisor, retry loop, lifecycle, compatibility path, or duplicate card/media validation.

## Hot reply path impact

This changes the Foreground Reply Critical Path after provider tool execution and before reply handoff. It adds no database, network, provider, crypto, or awaited operations. Work is limited to in-memory ordinal partitioning and media cleanup. Existing timeout, retry, and fallback behavior remains unchanged except that mixed turns can no longer report empty success while their earlier answer is undelivered.

## Murph initial provider input impact

- Individual: Not applicable; no prompt, instructions, tool descriptions, schemas, generated guidance, or provider request assembly changed.
- Group: Not applicable for the same reason; group behavior is outside this patch.
- Measurement: no provider-input surface changed, so token/byte comparison is not claimed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: the only hosted Web change is one authored changelog fragment rendered by the existing production archive component.
- Coverage: no component, layout, visual, or interaction code changed.

## Change shape

Classification rule: production TypeScript is source; Vitest files are tests/fixtures; the completed execution plan and changelog fragment are docs; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 90 | 71 |
| Tests/fixtures | 629 | 23 |
| Docs | 107 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **826** | **94** |

ReviewGPT context sensitivity: sensitive — hosted runtime response ownership and user-visible no-reply behavior change.
ReviewGPT first-reviewed head: a67d9f010d0e9b4cb5325a89c193779f0ea78186

## ReviewGPT

- Preliminary specialists: `FINDINGS`; accepted proof-only concerns were corrected by making acknowledgement admission production-shaped and using unchanged production instructions in the real journey.
- Final round 1: `FINDINGS`; accepted the mixed-turn suppression race and stale-media-after-context-advance race.
- Corrections: partition suppression at the exact reply boundary, defer silent-suffix evidence behind durable earlier delivery, block empty-success recovery for undelivered earlier replies, and clear current media on every accepted context advance.
- Final round 2: `ROUND_OUTCOME: PASS` with no findings on production head `94a00376ea960e386f4794e9ac4be601b266e64b`.
- Final thread: https://chatgpt.com/c/6a920385-f1d8-83ea-aa0c-7c77781b89ff

## Changelog

- Changelog: updated
- Items: 2026-08-28 · fast-follow-ups-keep-the-right-reply

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new runner processes share the same inputs, outputs, tool schemas, and persisted state; only in-memory response selection differs. The changelog Web deploy is independent.
- Safe order: deploy the ordinary runner bundle before final Web promotion so runtime behavior converges first.
- Rollback floor: none; no new persisted state or protocol shape is written.
- Expected exposure: warm old runner processes may retain the prior guard behavior until replaced during rollout.
- Reversibility: revert the runner bundle normally; no migration or cleanup is required.
- Convergence proof: confirm active runner bundle/version convergence after rollout.
- Post-deploy checks: replay the focused fast answer-plus-acknowledgement journey and inspect bounded response-card/media error aggregates.