### PR TITLE
Simplify assistant tool boundaries

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-simplify-assistant-tool-boundaries.md
+++ b/agent-docs/exec-plans/active/2026-08-28-simplify-assistant-tool-boundaries.md
@@ -1,0 +1,77 @@
+# Simplify assistant tool boundaries
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Delete duplicate assistant tool-availability and App Server approval-policy
+  checks while preserving the exact existing tool, authority, and request
+  behavior at their canonical boundaries.
+
+## Success criteria
+
+- Exact offered-tool admission remains the sole tool-availability gate before
+  execution; maintenance, accepted-input, vault, and hosted-port authority
+  checks remain unchanged.
+- `executeCodexAppServerTurn` remains the sole approval-policy normalization and
+  validation boundary; prepared requests carry the normalized `never` policy.
+- Focused deterministic tests prove offered/unoffered tool behavior and direct
+  approval-policy rejection plus start/resume request shapes.
+- A focused synthetic real-Codex journey proves an offered tool still executes
+  once with the correct user-visible result and no internal boundary language.
+- Package typecheck, exact-head CI, sequential preliminary/final ReviewGPT, and
+  parent final review complete with no unresolved accepted finding.
+
+## Scope
+
+- In scope: Assistant Engine dynamic-tool admission/execution plumbing, App
+  Server request construction, focused deterministic/live journey proof.
+- Out of scope: tool catalog policy, tool descriptions, maintenance/user-action
+  authority, provider behavior, new abstractions, deployment, and merge.
+
+## Constraints
+
+- Technical constraints: preserve exact externally observable behavior and
+  existing canonical authority checks; add no compatibility layer or state.
+- Product/process constraints: private-free synthetic proof only; sanctioned
+  worktree; draft PR; ReviewGPT lane `hercules`, preliminary then final
+  sequentially; do not merge.
+
+## Risks and mitigations
+
+1. Risk: deleting the wrong check exposes an unoffered or unauthorized tool.
+   Mitigation: retain and directly test exact offered-key admission plus every
+   independent maintenance/user-action/vault/host-port check.
+2. Risk: approval-policy validation moves too late or request builders emit an
+   unsupported value.
+   Mitigation: keep validation before process preparation in the central entry
+   point and type the prepared request policy as the normalized literal.
+
+## Tasks
+
+1. Trace exact production callers and focused existing tests.
+2. Delete duplicate availability and approval-policy plumbing.
+3. Update deterministic tests and add one focused live journey.
+4. Run focused tests, package typecheck, and the live journey; inspect effects.
+5. Commit, push, open draft PR, run preliminary then final ReviewGPT with CI,
+   resolve permitted findings, close the plan, and report without merging.
+
+## Decisions
+
+- Product UX classification: internal behavior-preserving architecture cleanup;
+  no product-owned dimension changes. Coverage lens applies; prompt/frontend
+  lenses do not.
+- Changelog: not applicable because member-visible behavior, copy, action count,
+  recovery, delivery, and tool availability are intentionally unchanged.
+
+## Verification
+
+- Commands to run: focused Assistant Engine Vitest slices, Assistant Engine
+  typecheck, `pnpm test:assistant:live -- --test <focused-pattern>`, exact-head
+  CI, preliminary and final ReviewGPT.
+- Expected outcomes: deterministic checks green; one offered tool effect and
+  truthful reply in the live journey; no unoffered tool execution; unsupported
+  approval policy rejected centrally; normalized `never` emitted for start and
+  resume; no unresolved accepted review finding.

--- a/agent-docs/exec-plans/completed/2026-08-28-simplify-assistant-tool-boundaries.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-simplify-assistant-tool-boundaries.md
@@ -1,6 +1,6 @@
 # Simplify assistant tool boundaries
 
-Status: active
+Status: completed
 Created: 2026-08-28
 Updated: 2026-08-28
 
@@ -75,3 +75,4 @@ Updated: 2026-08-28
   truthful reply in the live journey; no unoffered tool execution; unsupported
   approval policy rejected centrally; normalized `never` emitted for start and
   resume; no unresolved accepted review finding.
+Completed: 2026-08-28

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -63,7 +63,6 @@ import {
   buildCodexThreadStartParams,
   buildCodexTurnSteerParams,
   buildCodexTurnStartParams,
-  mapCodexAppServerApprovalPolicy,
   mapCodexAppServerSandboxMode,
   resolveSupportedCodexAppServerApprovalPolicy,
 } from './assistant-codex/app-server-requests.js'
@@ -81,9 +80,6 @@ import type {
   MurphDynamicToolRequest,
 } from './assistant-codex/dynamic-tools.js'
 import {
-  MURPH_ASSISTANT_STYLE_TOOL,
-  MURPH_GROUP_ROOM_MODEL_TOOL,
-  MURPH_MEMBER_MEMORY_TOOL,
   type AssistantStyleTurnSettingsOverlay,
 } from './assistant-codex/dynamic-tool-catalog.js'
 import type {
@@ -306,7 +302,11 @@ type CodexAppServerSpawnInput = CodexAppServerProcessInput & {
   coldStartReason: CodexAppServerColdStartReason
 }
 
-type CodexAppServerPreparedTurnInput = CodexAppServerTurnInput & {
+type CodexAppServerPreparedTurnInput = Omit<
+  CodexAppServerTurnInput,
+  'approvalPolicy'
+> & {
+  approvalPolicy: 'never'
   args: readonly string[]
   codexCommand: string
   env: NodeJS.ProcessEnv
@@ -494,7 +494,7 @@ export interface CodexAppServerTurnInput {
   automationRelativeDateReferenceWindow?: AssistantAcceptedTurnInputReferenceWindow | null
   authorizeAcceptedMessageTarget?: AssistantAcceptedMessageTargetAuthorizer | null
   abortSignal?: AbortSignal
-  approvalPolicy?: string
+  approvalPolicy?: string | null
   configOverrides?: readonly string[]
   codexCommand?: string
   codexHome?: string | null
@@ -4775,23 +4775,8 @@ async function runCodexAppServerTurnOnProcess(
           authorizeAcceptedMessageTarget:
             input.authorizeAcceptedMessageTarget ?? null,
           assistantStyleSettingsOverlay,
-          assistantStyleSettingsAvailable: input.dynamicTools.some(
-            (tool) =>
-              tool.namespace === MURPH_ASSISTANT_STYLE_TOOL.namespace &&
-              tool.name === MURPH_ASSISTANT_STYLE_TOOL.name,
-          ),
-          groupRoomModelAvailable: input.dynamicTools.some(
-            (tool) =>
-              tool.namespace === MURPH_GROUP_ROOM_MODEL_TOOL.namespace &&
-              tool.name === MURPH_GROUP_ROOM_MODEL_TOOL.name,
-          ),
           groupRoomModelMaintenanceAuthorized:
             input.groupRoomModelMaintenanceAuthorized === true,
-          memberMemoryAvailable: input.dynamicTools.some(
-            (tool) =>
-              tool.namespace === MURPH_MEMBER_MEMORY_TOOL.namespace &&
-              tool.name === MURPH_MEMBER_MEMORY_TOOL.name,
-          ),
           memberMemoryMaintenanceAuthorized:
             input.memberMemoryMaintenanceAuthorized === true,
           abortSignal: input.abortSignal
@@ -6490,7 +6475,7 @@ function assertCodexResumeContextMatches(input: {
     ],
     [
       'approvalPolicy',
-      mapCodexAppServerApprovalPolicy(input.input.approvalPolicy),
+      input.input.approvalPolicy,
       asCodexString(result?.approvalPolicy),
     ],
     ['cwd', input.input.workingDirectory, actualCwd ? path.resolve(actualCwd) : null],

--- a/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
+++ b/packages/assistant-engine/src/assistant-codex/app-server-requests.ts
@@ -39,10 +39,16 @@ export type CodexAppServerSteerRequestInput = Omit<
   images?: readonly CodexAppServerPreparedImageInput[] | null
 }
 
+type CodexAppServerPreparedThreadInput = Omit<
+  CodexAppServerTurnInput,
+  'approvalPolicy'
+> & {
+  approvalPolicy: 'never'
+  workingDirectory: string
+}
+
 export function buildCodexThreadStartParams(
-  input: CodexAppServerTurnInput & {
-    workingDirectory: string
-  },
+  input: CodexAppServerPreparedThreadInput,
 ): Record<string, unknown> {
   return {
     ...buildCodexThreadContextParams({
@@ -66,9 +72,7 @@ export function buildCodexThreadMetadataResumeParams(
 }
 
 export function buildCodexThreadResumeParams(input: {
-  input: CodexAppServerTurnInput & {
-    workingDirectory: string
-  }
+  input: CodexAppServerPreparedThreadInput
   codexThreadId: string
 }): Record<string, unknown> {
   return stripUndefinedRpcParams({
@@ -81,9 +85,7 @@ export function buildCodexThreadResumeParams(input: {
 export function buildCodexThreadContextParams(input: {
   includeInstructions: boolean
   includeServiceName: boolean
-  input: CodexAppServerTurnInput & {
-    workingDirectory: string
-  }
+  input: CodexAppServerPreparedThreadInput
 }): Record<string, unknown> {
   const permissions = normalizeNullableString(input.input.permissions)
   if (permissions && input.input.sandbox) {
@@ -98,7 +100,7 @@ export function buildCodexThreadContextParams(input: {
   }
 
   return stripUndefinedRpcParams({
-    approvalPolicy: mapCodexAppServerApprovalPolicy(input.input.approvalPolicy),
+    approvalPolicy: input.input.approvalPolicy,
     baseInstructions: input.includeInstructions
       ? normalizeNullableString(input.input.baseInstructions)
       : undefined,
@@ -128,9 +130,7 @@ export function buildCodexThreadContextParams(input: {
 }
 
 function buildCodexThreadResumeContextParams(
-  input: CodexAppServerTurnInput & {
-    workingDirectory: string
-  },
+  input: CodexAppServerPreparedThreadInput,
 ): Record<string, unknown> {
   const permissions = normalizeNullableString(input.permissions)
   if (permissions && input.sandbox) {
@@ -145,7 +145,7 @@ function buildCodexThreadResumeContextParams(
   }
 
   return {
-    approvalPolicy: mapCodexAppServerApprovalPolicy(input.approvalPolicy),
+    approvalPolicy: input.approvalPolicy,
     cwd: input.workingDirectory,
     model: normalizeNullableString(input.model),
     modelProvider: normalizeNullableString(input.modelProvider),
@@ -236,12 +236,6 @@ export function buildCodexAppServerInputItems(input: {
       path: image.path,
     })),
   ]
-}
-
-export function mapCodexAppServerApprovalPolicy(
-  approvalPolicy: string | null | undefined,
-): 'never' {
-  return resolveSupportedCodexAppServerApprovalPolicy(approvalPolicy)
 }
 
 export function mapCodexAppServerSandboxMode(

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -2209,10 +2209,7 @@ function readGeneratedImageToolCallId(
 export async function executeMurphDynamicToolRequest(input: {
   authorizeAcceptedMessageTarget?: AssistantAcceptedMessageTargetAuthorizer | null
   assistantStyleSettingsOverlay?: AssistantStyleTurnSettingsOverlay | null
-  assistantStyleSettingsAvailable?: boolean | null
-  groupRoomModelAvailable?: boolean | null
   groupRoomModelMaintenanceAuthorized?: boolean | null
-  memberMemoryAvailable?: boolean | null
   memberMemoryMaintenanceAuthorized?: boolean | null
   abortSignal?: AbortSignal | null
   codexHome?: string | null
@@ -2480,7 +2477,6 @@ export async function executeMurphDynamicToolRequest(input: {
     }
     case 'group-room-model':
       return await executeGroupRoomModelDynamicTool({
-        available: input.groupRoomModelAvailable === true,
         managedMaintenanceAuthorized:
           input.groupRoomModelMaintenanceAuthorized === true,
         request: input.request,
@@ -2490,7 +2486,6 @@ export async function executeMurphDynamicToolRequest(input: {
       })
     case 'member-memory':
       return await executeMemberMemoryDynamicTool({
-        available: input.memberMemoryAvailable === true,
         managedMaintenanceAuthorized:
           input.memberMemoryMaintenanceAuthorized === true,
         request: input.request,
@@ -2546,7 +2541,6 @@ export async function executeMurphDynamicToolRequest(input: {
         authority: resolveHostedAssistantPersonalizationToolAuthority(
           hostedToolContext,
         ),
-        available: input.assistantStyleSettingsAvailable === true,
         hosted: hostedToolContext != null,
         hostedPersonalizationTool:
           hostedToolContext?.personalizationTool ?? null,

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/assistant-style.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/assistant-style.ts
@@ -92,7 +92,6 @@ export function readAssistantStyleDynamicToolRequest(input: {
 
 export async function executeAssistantStyleDynamicTool(input: {
   authority: HostedRuntimeAssistantPersonalizationToolAuthority | null
-  available: boolean
   hosted: boolean
   hostedPersonalizationTool: {
     request(
@@ -109,13 +108,6 @@ export async function executeAssistantStyleDynamicTool(input: {
     success: boolean
   }
 }> {
-  if (!input.available) {
-    return assistantStyleTextResult(
-      false,
-      'assistant style settings are unavailable for this conversation',
-    )
-  }
-
   try {
     const { args } = input.request
     if (!input.vaultRoot) {

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/group-room-model.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/group-room-model.ts
@@ -84,7 +84,6 @@ export function readGroupRoomModelDynamicToolRequest(input: {
 }
 
 export async function executeGroupRoomModelDynamicTool(input: {
-  available: boolean
   request: Extract<
     GroupRoomModelDynamicToolRequest,
     { kind: 'group-room-model' }
@@ -100,13 +99,10 @@ export async function executeGroupRoomModelDynamicTool(input: {
   }
 }> {
   if (
-    !input.available ||
+    input.managedMaintenanceAuthorized !== true &&
     (
-      input.managedMaintenanceAuthorized !== true &&
-      (
-        input.userActionScope?.conversationScope !== 'group' ||
-        input.userActionScope.acceptedInputIds.length === 0
-      )
+      input.userActionScope?.conversationScope !== 'group' ||
+      input.userActionScope.acceptedInputIds.length === 0
     )
   ) {
     return groupRoomModelTextResult(

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools/member-memory.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools/member-memory.ts
@@ -74,7 +74,6 @@ export function readMemberMemoryDynamicToolRequest(input: {
 }
 
 export async function executeMemberMemoryDynamicTool(input: {
-  available: boolean
   managedMaintenanceAuthorized: boolean
   request: Extract<MemberMemoryDynamicToolRequest, { kind: 'member-memory' }>
   vaultRoot: string | null
@@ -84,7 +83,7 @@ export async function executeMemberMemoryDynamicTool(input: {
     success: boolean
   }
 }> {
-  if (!input.available || !input.managedMaintenanceAuthorized) {
+  if (!input.managedMaintenanceAuthorized) {
     return memberMemoryTextResult(
       false,
       'member-memory maintenance is unavailable for this turn',

--- a/packages/assistant-engine/src/assistant/providers/codex-cli.ts
+++ b/packages/assistant-engine/src/assistant/providers/codex-cli.ts
@@ -16,9 +16,6 @@ import {
   createAnalyzeVideoToolRuntimeFromEnv,
 } from '../../assistant-codex/analyze-video-tool.js'
 import {
-  resolveSupportedCodexAppServerApprovalPolicy,
-} from '../../assistant-codex/app-server-requests.js'
-import {
   resolveStrictAssistantCodexModelProvider,
 } from '@murphai/operator-config/assistant/target-runtime'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
@@ -208,9 +205,6 @@ export async function executeCodexAssistantTurnAttempt(
             process.env[modelProviderConfig.envKey],
         )
       : null
-  const approvalPolicy = resolveSupportedCodexAppServerApprovalPolicy(
-    providerConfig.policy.approvalPolicy,
-  )
   const developerInstructions = normalizeNullableString(input.developerInstructions)
 
   const voiceMemoRuntime = createVoiceMemoToolRuntimeFromEnv({
@@ -242,7 +236,7 @@ export async function executeCodexAssistantTurnAttempt(
       input.automationRelativeDateReferenceWindow ?? null,
     authorizeAcceptedMessageTarget:
       input.authorizeAcceptedMessageTarget ?? null,
-    approvalPolicy,
+    approvalPolicy: providerConfig.policy.approvalPolicy,
     baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
     developerInstructions,
     dynamicTools: input.dynamicTools,

--- a/packages/assistant-engine/test/assistant-codex-dynamic-tool-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-dynamic-tool-runtime.test.ts
@@ -8,7 +8,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const codexMocks = vi.hoisted(() => ({
   dynamicToolCalls: [] as Array<{
-    assistantStyleSettingsAvailable?: boolean
     deliveryContextOrdinal: number | null
     generateSongTurnState?: unknown
     kind: string
@@ -38,12 +37,6 @@ vi.mock('../src/assistant-codex/dynamic-tools.ts', async (importOriginal) => {
         input: Parameters<typeof actual.executeMurphDynamicToolRequest>[0],
       ): Promise<Awaited<ReturnType<typeof actual.executeMurphDynamicToolRequest>>> => {
         codexMocks.dynamicToolCalls.push({
-          ...(input.request.kind === 'assistant-style'
-            ? {
-                assistantStyleSettingsAvailable:
-                  input.assistantStyleSettingsAvailable === true,
-              }
-            : {}),
           deliveryContextOrdinal: input.deliveryContextOrdinal ?? null,
           ...(input.request.kind === 'generate-song'
             ? {
@@ -361,7 +354,6 @@ describe('Codex dynamic tool runtime routing', () => {
         voiceMemoRuntime,
       },
       {
-        assistantStyleSettingsAvailable: true,
         deliveryContextOrdinal: 1,
         kind: 'assistant-style',
         voiceMemoRuntime: null,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -36,6 +36,7 @@ import {
   vaultCliBatchResultSchema,
 } from '@murphai/operator-config/vault-cli-contracts'
 import { readVaultRawTolerant } from '@murphai/query'
+import { showAssistantPersonality } from '@murphai/vault-usecases/preferences'
 import {
   logLiveWorkoutSet,
   saveWorkoutFormat,
@@ -64,6 +65,7 @@ import {
 } from '../src/assistant-ask.ts'
 import {
   MURPH_ANALYZE_VIDEO_TOOL,
+  MURPH_ASSISTANT_STYLE_TOOL,
   MURPH_AUTOMATION_TOOL,
   MURPH_ATTACH_RESPONSE_MEDIA_TOOL,
   MURPH_COMPUTER_ACT_TOOL,
@@ -2986,6 +2988,90 @@ describeRealCodex('real Codex video-analysis detail e2e', () => {
       }
     },
     480_000,
+  )
+})
+
+describeRealCodex('real Codex assistant-style boundary e2e', () => {
+  it(
+    'executes one offered style update and persists the requested setting',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-assistant-style-boundary-e2e-'),
+      )
+
+      try {
+        await initializeVault({
+          timezone: 'America/New_York',
+          vaultRoot: workingDirectory,
+        })
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions:
+            buildDirectConversationDeveloperInstructions(),
+          dynamicTools: [MURPH_ASSISTANT_STYLE_TOOL],
+          env: config.env,
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt:
+            'Set your humor level to 2 for this conversation, then briefly confirm the new setting.',
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          vaultRoot: workingDirectory,
+          workingDirectory,
+        })
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+        const styleActions = actions.filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_ASSISTANT_STYLE_TOOL.name
+        )
+        const personality = await showAssistantPersonality(workingDirectory)
+
+        process.stdout.write(
+          `[assistant-style-boundary-e2e] ${JSON.stringify({
+            reply: result.finalMessage,
+            styleActions,
+          })}\n`,
+        )
+
+        expect(styleActions).toEqual([
+          expect.objectContaining({
+            argumentsValue: {
+              action: 'set',
+              setting: 'humor',
+              value: 2,
+            },
+            success: true,
+            tool: MURPH_ASSISTANT_STYLE_TOOL.name,
+          }),
+        ])
+        expect(
+          actions.filter((action) => action.kind === 'command'),
+          'no shell command should bypass the offered style tool',
+        ).toEqual([])
+        expect(personality.settings.humor).toEqual({
+          source: 'custom',
+          value: 2,
+        })
+        expect(result.finalMessage).toMatch(/humor/iu)
+        expect(result.finalMessage).toMatch(/2/iu)
+        expect(result.finalMessage).not.toMatch(
+          /app[- ]server|availability|guard|internal|tool call/iu,
+        )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
   )
 })
 

--- a/packages/assistant-engine/test/assistant-codex-runtime-config.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-config.test.ts
@@ -184,7 +184,7 @@ describe('assistant codex runtime', () => {
 
   it('puts instructions and dynamic tools on thread start but keeps resume and turn input scoped', () => {
     const baseInput = {
-      approvalPolicy: 'never',
+      approvalPolicy: 'never' as const,
       baseInstructions: 'Do not use this in normal Murph config.',
       developerInstructions: 'Stable Murph instructions.',
       dynamicTools: MURPH_DYNAMIC_TOOLS_WITHOUT_PROGRESS,

--- a/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
@@ -100,6 +100,21 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
               },
             }),
           )
+
+          const progressMessages = await waitForRpcMessages(child, 5)
+          expect(progressMessages[4]).toEqual({
+            id: 99,
+            result: {
+              success: false,
+              contentItems: [
+                {
+                  type: 'inputText',
+                  text: 'tool was not offered for this turn',
+                },
+              ],
+            },
+          })
+
           child.stdout.write(
             jsonLine({
               id: 99,
@@ -943,7 +958,7 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
     })
   })
 
-  it('returns unavailable for progress tool calls when no progress sink exists', async () => {
+  it('rejects unoffered progress and assistant-style calls at the canonical turn boundary', async () => {
     const workingDirectory = await createTempDir('assistant-codex-progress-disabled-')
 
     codexMocks.spawn.mockImplementation(() => {
@@ -991,10 +1006,23 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
               },
             }),
           )
+          child.stdout.write(
+            jsonLine({
+              id: 100,
+              method: 'item/tool/call',
+              params: {
+                namespace: 'murph',
+                tool: 'assistant_style',
+                arguments: {
+                  action: 'show',
+                },
+              },
+            }),
+          )
 
-          const messages = await waitForRpcMessages(child, 5)
-          expect(messages[4]).toEqual({
-            id: 99,
+          const messages = await waitForRpcMessages(child, 6)
+          expect(messages[5]).toEqual({
+            id: 100,
             result: {
               success: false,
               contentItems: [
@@ -1025,7 +1053,7 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
 
     await expect(
       executeCodexAppServerTurn({
-        prompt: 'try disabled progress tool',
+        prompt: 'try disabled tools',
         workingDirectory,
       }),
     ).resolves.toMatchObject({

--- a/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
@@ -101,20 +101,6 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
             }),
           )
 
-          const progressMessages = await waitForRpcMessages(child, 5)
-          expect(progressMessages[4]).toEqual({
-            id: 99,
-            result: {
-              success: false,
-              contentItems: [
-                {
-                  type: 'inputText',
-                  text: 'tool was not offered for this turn',
-                },
-              ],
-            },
-          })
-
           child.stdout.write(
             jsonLine({
               id: 99,
@@ -1006,6 +992,18 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
               },
             }),
           )
+          await expect(waitForRpcResponse(child, 99)).resolves.toEqual({
+            id: 99,
+            result: {
+              success: false,
+              contentItems: [
+                {
+                  type: 'inputText',
+                  text: 'tool was not offered for this turn',
+                },
+              ],
+            },
+          })
           child.stdout.write(
             jsonLine({
               id: 100,
@@ -1019,9 +1017,7 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
               },
             }),
           )
-
-          const messages = await waitForRpcMessages(child, 6)
-          expect(messages[5]).toEqual({
+          await expect(waitForRpcResponse(child, 100)).resolves.toEqual({
             id: 100,
             result: {
               success: false,

--- a/packages/assistant-engine/test/assistant-group-room-model-maintenance.test.ts
+++ b/packages/assistant-engine/test/assistant-group-room-model-maintenance.test.ts
@@ -72,7 +72,6 @@ async function execute(
   state: AssistantGroupRoomModelReadState,
 ): Promise<Awaited<ReturnType<typeof executeGroupRoomModelDynamicTool>>> {
   return await executeGroupRoomModelDynamicTool({
-    available: true,
     managedMaintenanceAuthorized: true,
     readGroupRoomModelState: async () => state,
     request: { args, kind: 'group-room-model' },

--- a/packages/assistant-engine/test/assistant-group-room-model-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-group-room-model-tool.test.ts
@@ -86,7 +86,6 @@ describe('authenticated group room-model tool', () => {
 
     const missing = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -99,13 +98,11 @@ describe('authenticated group room-model tool', () => {
         body: firstBody,
         expectedDigest: missingState.digest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
     const show = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -119,7 +116,6 @@ describe('authenticated group room-model tool', () => {
           }
         ).digest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -144,7 +140,6 @@ describe('authenticated group room-model tool', () => {
 
     const showMissing = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -169,7 +164,6 @@ describe('authenticated group room-model tool', () => {
           body,
           expectedDigest: missingDigest,
         },
-        available: true,
         scope: createUserActionScope('group'),
         vaultRoot,
       })
@@ -182,7 +176,6 @@ describe('authenticated group room-model tool', () => {
         body: '## People\n- Casey likes dry rulings.',
         expectedDigest: missingDigest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -194,7 +187,6 @@ describe('authenticated group room-model tool', () => {
         body: '## People\n- stale replacement',
         expectedDigest: missingDigest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -202,7 +194,6 @@ describe('authenticated group room-model tool', () => {
 
     const showCreated = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -216,7 +207,6 @@ describe('authenticated group room-model tool', () => {
         action: 'delete',
         expectedDigest: createdState.digest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -226,7 +216,6 @@ describe('authenticated group room-model tool', () => {
 
     const recreatedShow = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -241,25 +230,23 @@ describe('authenticated group room-model tool', () => {
         body: '## What to avoid\n- Keep the old nickname retired.',
         expectedDigest: recreatedMissingDigest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
     expect(recreated.rpcResult.success).toBe(true)
   })
 
-  it('fails closed without declared-tool and current group-input authority', async () => {
+  it('fails closed without current group-input authority', async () => {
     const { parentRoot, vaultRoot } = await createTempVaultContext(
       'murph-group-room-model-tool-denied-',
     )
     cleanupPaths.push(parentRoot)
     await initializeVault({ vaultRoot })
 
-    for (const [available, scope] of [
-      [false, createUserActionScope('group')],
-      [true, createUserActionScope('direct')],
-      [true, { ...createUserActionScope('group'), acceptedInputIds: [] }],
-      [true, null],
+    for (const scope of [
+      createUserActionScope('direct'),
+      { ...createUserActionScope('group'), acceptedInputIds: [] },
+      null,
     ] as const) {
       const result = await executeRequest({
         args: {
@@ -267,7 +254,6 @@ describe('authenticated group room-model tool', () => {
           body: '## Tips\n- should not persist',
           expectedDigest: 'a'.repeat(64),
         },
-        available,
         scope,
         vaultRoot,
       })
@@ -289,7 +275,6 @@ describe('authenticated group room-model tool', () => {
     await initializeVault({ vaultRoot })
 
     const show = await executeGroupRoomModelDynamicTool({
-      available: true,
       managedMaintenanceAuthorized: true,
       request: requireGroupRoomModelRequest({ action: 'show' }),
       userActionScope: null,
@@ -301,7 +286,6 @@ describe('authenticated group room-model tool', () => {
       }
     ).digest
     const write = await executeGroupRoomModelDynamicTool({
-      available: true,
       managedMaintenanceAuthorized: true,
       request: requireGroupRoomModelRequest({
         action: 'upsert',
@@ -317,7 +301,6 @@ describe('authenticated group room-model tool', () => {
       .resolves.toContain('Keep mock rulings dry.')
 
     const current = await executeGroupRoomModelDynamicTool({
-      available: true,
       managedMaintenanceAuthorized: true,
       request: requireGroupRoomModelRequest({ action: 'show' }),
       userActionScope: null,
@@ -336,7 +319,6 @@ describe('authenticated group room-model tool', () => {
       '## People\n- _Sender_: `456` likes dry rulings.',
     ]) {
       const identifyingWrite = await executeGroupRoomModelDynamicTool({
-        available: true,
         managedMaintenanceAuthorized: true,
         request: requireGroupRoomModelRequest({
           action: 'upsert',
@@ -384,7 +366,6 @@ describe('authenticated group room-model tool', () => {
     )
     const missing = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -399,7 +380,6 @@ describe('authenticated group room-model tool', () => {
         body: '## Tips\n- prior valid tip',
         expectedDigest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -445,7 +425,6 @@ describe('authenticated group room-model tool', () => {
 
       const show = await executeRequest({
         args: { action: 'show' },
-        available: true,
         scope: createUserActionScope('group'),
         vaultRoot,
       })
@@ -455,7 +434,6 @@ describe('authenticated group room-model tool', () => {
           body: '## Tips\n- replacement',
           expectedDigest,
         },
-        available: true,
         scope: createUserActionScope('group'),
         vaultRoot,
       })
@@ -485,7 +463,6 @@ describe('authenticated group room-model tool', () => {
     await initializeVault({ vaultRoot })
     const missing = await executeRequest({
       args: { action: 'show' },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -500,7 +477,6 @@ describe('authenticated group room-model tool', () => {
         body: '## Tips\n- prior valid tip',
         expectedDigest,
       },
-      available: true,
       scope: createUserActionScope('group'),
       vaultRoot,
     })
@@ -523,7 +499,6 @@ describe('authenticated group room-model tool', () => {
       },
     ] as const) {
       const result = await executeGroupRoomModelDynamicTool({
-        available: true,
         readGroupRoomModelState: readFailure,
         request: requireGroupRoomModelRequest(args),
         userActionScope: createUserActionScope('group'),
@@ -559,7 +534,6 @@ function readRequest(args: unknown) {
 
 async function executeRequest(input: {
   args: unknown
-  available: boolean
   scope: AssistantHostedUserActionScope | null
   vaultRoot: string
 }) {
@@ -570,7 +544,6 @@ async function executeRequest(input: {
   return await executeMurphDynamicToolRequest({
     env: {},
     fetchImpl: fetch,
-    groupRoomModelAvailable: input.available,
     hostedToolContext: createHostedToolContext(input.scope),
     nextUsageOrdinal: () => 0,
     progressDelivery: null,

--- a/packages/assistant-engine/test/assistant-hosted-image-completion-authority.test.ts
+++ b/packages/assistant-engine/test/assistant-hosted-image-completion-authority.test.ts
@@ -123,7 +123,6 @@ describe('hosted image completion effect authority', () => {
     }
 
     const styleResult = await executeMurphDynamicToolRequest({
-      assistantStyleSettingsAvailable: true,
       env: {},
       fetchImpl: fetch,
       hostedToolContext,

--- a/packages/assistant-engine/test/assistant-member-memory-maintenance.test.ts
+++ b/packages/assistant-engine/test/assistant-member-memory-maintenance.test.ts
@@ -72,7 +72,6 @@ describe('member-memory maintenance boundary', () => {
   it('rejects calls without exact managed-maintenance authority', async () => {
     const vaultRoot = await makeVaultRoot()
     const result = await executeMemberMemoryDynamicTool({
-      available: true,
       managedMaintenanceAuthorized: false,
       request: {
         args: {
@@ -122,7 +121,6 @@ async function execute(
   >['args'],
 ): Promise<Awaited<ReturnType<typeof executeMemberMemoryDynamicTool>>> {
   return await executeMemberMemoryDynamicTool({
-    available: true,
     managedMaintenanceAuthorized: true,
     request: { args, kind: 'member-memory' },
     vaultRoot,

--- a/packages/assistant-engine/test/assistant-scheduled-tool-authority.test.ts
+++ b/packages/assistant-engine/test/assistant-scheduled-tool-authority.test.ts
@@ -149,7 +149,6 @@ describe("scheduled assistant tool authority", () => {
     });
 
     const result = await executeMurphDynamicToolRequest({
-      assistantStyleSettingsAvailable: true,
       env: {},
       fetchImpl: fetch,
       hostedToolContext: context,

--- a/packages/assistant-engine/test/assistant-style-dynamic-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-style-dynamic-tool.test.ts
@@ -82,16 +82,6 @@ describe('assistant style dynamic tool', () => {
     })?.kind).toBe('invalid-assistant-style-arguments')
   })
 
-  it('fails closed without exact-turn authority before reading preferences', async () => {
-    const result = await executeStyleRequest({ action: 'show' }, false)
-
-    expect(result.rpcResult.success).toBe(false)
-    expect(result.rpcResult.contentItems[0]?.text).toContain(
-      'unavailable for this conversation',
-    )
-    expect(preferenceMocks.showAssistantPersonality).not.toHaveBeenCalled()
-  })
-
   it('describes direct-member and synthetic-room ownership without a target selector', () => {
     expect(MURPH_ASSISTANT_STYLE_TOOL.description).toContain(
       'current conversation runtime',
@@ -139,18 +129,17 @@ describe('assistant style dynamic tool', () => {
 
     const show = await executeStyleRequest(
       { action: 'show' },
-      true,
       { hosted: true },
     )
     const set = await executeStyleRequest({
       action: 'set',
       setting: 'humor',
       value: 8,
-    }, true, { hosted: true })
+    }, { hosted: true })
     const reset = await executeStyleRequest({
       action: 'reset',
       setting: 'all',
-    }, true, { hosted: true })
+    }, { hosted: true })
 
     expect(show.rpcResult.success).toBe(true)
     expect(hostedMocks.requestPersonalization).toHaveBeenNthCalledWith(1, {
@@ -194,7 +183,6 @@ describe('assistant style dynamic tool', () => {
 
     const result = await executeStyleRequest(
       { action: 'reset', setting: 'push' },
-      true,
       { hosted: true },
     )
 
@@ -223,7 +211,6 @@ describe('assistant style dynamic tool', () => {
 
     const result = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true, toolCallId: 'call_style_one' },
     )
 
@@ -248,7 +235,6 @@ describe('assistant style dynamic tool', () => {
 
     const set = await executeStyleRequest(
       { action: 'set', setting: 'unhinged', value: 8 },
-      true,
       { hosted: true },
     )
 
@@ -282,15 +268,13 @@ describe('assistant style dynamic tool', () => {
 
   it('fails hosted mutations closed without provider-accepted input authority', async () => {
     const hostedWithoutInput = { assistantInputId: null, hosted: true }
-    const show = await executeStyleRequest({ action: 'show' }, true, hostedWithoutInput)
+    const show = await executeStyleRequest({ action: 'show' }, hostedWithoutInput)
     const set = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       hostedWithoutInput,
     )
     const reset = await executeStyleRequest(
       { action: 'reset', setting: 'all' },
-      true,
       hostedWithoutInput,
     )
 
@@ -308,7 +292,6 @@ describe('assistant style dynamic tool', () => {
 
     const result = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true },
     )
 
@@ -319,29 +302,15 @@ describe('assistant style dynamic tool', () => {
   it('keeps canonical show available when the Web mutation port is missing', async () => {
     const missingShow = await executeStyleRequest(
       { action: 'show' },
-      true,
       { hosted: true, personalizationAvailable: false },
     )
     const missingSet = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true, personalizationAvailable: false },
     )
 
     expect(missingShow.rpcResult.success).toBe(true)
     expect(missingSet.rpcResult.success).toBe(false)
-    expect(hostedMocks.requestPersonalization).not.toHaveBeenCalled()
-    expect(preferenceMocks.setAssistantPersonalitySetting).not.toHaveBeenCalled()
-  })
-
-  it('does not call the hosted owner before the availability guard', async () => {
-    const unavailable = await executeStyleRequest(
-      { action: 'set', setting: 'humor', value: 8 },
-      false,
-      { hosted: true },
-    )
-
-    expect(unavailable.rpcResult.success).toBe(false)
     expect(hostedMocks.requestPersonalization).not.toHaveBeenCalled()
     expect(preferenceMocks.setAssistantPersonalitySetting).not.toHaveBeenCalled()
   })
@@ -366,7 +335,6 @@ describe('assistant style dynamic tool', () => {
 
     const result = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true },
     )
 
@@ -397,12 +365,10 @@ describe('assistant style dynamic tool', () => {
 
     const set = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true, settingsOverlay },
     )
     const show = await executeStyleRequest(
       { action: 'show' },
-      true,
       { hosted: true, settingsOverlay },
     )
 
@@ -434,7 +400,6 @@ describe('assistant style dynamic tool', () => {
 
     const result = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
       { hosted: true, settingsOverlay },
     )
 
@@ -467,7 +432,6 @@ describe('assistant style dynamic tool', () => {
 
       const response = await executeStyleRequest(
         { action: 'set', setting: 'humor', value: 8 },
-        true,
         { hosted: true },
       )
 
@@ -489,14 +453,12 @@ describe('assistant style dynamic tool', () => {
       updated: true,
     })
 
-    const show = await executeStyleRequest({ action: 'show' }, true)
+    const show = await executeStyleRequest({ action: 'show' })
     const set = await executeStyleRequest(
       { action: 'set', setting: 'humor', value: 8 },
-      true,
     )
     const reset = await executeStyleRequest(
       { action: 'reset', setting: 'all' },
-      true,
     )
 
     expect(show.rpcResult.success).toBe(true)
@@ -517,12 +479,10 @@ describe('assistant style dynamic tool', () => {
   it('requires a vault for hosted and local style actions', async () => {
     const hosted = await executeStyleRequest(
       { action: 'show' },
-      true,
       { hosted: true, vaultRoot: null },
     )
     const local = await executeStyleRequest(
       { action: 'show' },
-      true,
       { vaultRoot: null },
     )
 
@@ -563,7 +523,6 @@ function readStyleRequest(argumentsValue: unknown, toolCallId?: string) {
 
 async function executeStyleRequest(
   argumentsValue: unknown,
-  assistantStyleSettingsAvailable: boolean,
   options: {
     assistantInputId?: string | null
     hosted?: boolean
@@ -582,7 +541,6 @@ async function executeStyleRequest(
 
   return await executeMurphDynamicToolRequest({
     assistantStyleSettingsOverlay: options.settingsOverlay,
-    assistantStyleSettingsAvailable,
     env: {},
     fetchImpl: fetch,
     hostedToolContext: options.hosted !== true


### PR DESCRIPTION
## Outcome

Deletes duplicate assistant tool-availability checks after exact offered-tool admission and removes duplicate approval-policy validation from provider/request construction. Canonical maintenance, accepted-input, vault, hosted-port, and App Server turn boundaries remain intact.

## Product UX result

Internal behavior-preserving cleanup. Tool availability, action counts, user-visible copy, recovery, and delivery are unchanged. A real assistant journey confirmed the same direct style update and truthful reply.

## Direct evidence

- `pnpm --filter @murphai/assistant-engine typecheck` - passed before and after specialist remediation.
- Seven focused leaf/runtime test files - 46 tests passed.
- Three focused App Server boundary tests - 3 passed, 121 skipped.
- Focused specialist-remediation boundary proof - 2 tests passed, 29 skipped.
- `pnpm test:assistant:live -- --test "executes one offered style update and persists the requested setting"` - passed with effective model `gpt-5.6-terra` using subscription auth; exactly one `assistant_style` call persisted humor 2, zero shell/command actions, and a truthful reply. Verdict: Ready.
- `git diff --check` - passed.
- Final ReviewGPT round 1 on `f61ba260fc4eb7148a85f9382272a67a8ec666d2` - `ROUND_OUTCOME: PASS`; no qualifying findings.

## Non-obvious affected surfaces

- Exact tool namespace/name admission remains in the App Server runtime before dynamic-tool execution.
- Group room-model and member-memory maintenance authority remains independent of ordinary user-action authority.
- Resume diagnostics now compare the already-normalized prepared approval policy directly.

## Architecture and reuse

- Existing systems reused: exact offered-tool admission, `executeCodexAppServerTurn`, and existing maintenance, user-action, vault, and hosted-port authorities.
- New logic: none; prepared App Server request types now carry the already-normalized `never` literal.
- New abstractions: none; existing turn-admission and request-construction boundaries already own these responsibilities.
- Complexity intentionally avoided: repeated dynamic-tool scans, leaf availability booleans, provider prevalidation, alias mapping, and request-layer revalidation.

## Hot reply path impact

Compatible and behavior-preserving. The hot path performs fewer repeated dynamic-tool scans and leaf checks after the canonical admission decision.

## Provider-input impact

No prompt, model, tool schema, or provider behavior change. Provider configuration passes its approval policy to the central turn boundary, which still rejects unsupported interactive values before process preparation.

## Deployment concerns

- Deployment: not applicable
- Reason: This assistant-package cleanup changes no Web, Cloudflare, data, or cross-service contract and rolls out within one runtime.

## Changelog

- Changelog: not applicable
- Reason: The cleanup preserves member-visible behavior, copy, action count, recovery, delivery, and tool availability.

## LOC breakdown

- Source: +26 / -72
- Tests and fixtures: +125 / -97
- Docs and plans: +78 / -0
- Config and tooling: +0 / -0
- Generated and other: +0 / -0
- Total: +229 / -169

## Review context

ReviewGPT context sensitivity: sensitive

Reason: executable assistant runtime and tool-admission behavior changed; prompt and coverage lenses apply because the change affects which tools Codex can call and is verified by a real-Codex journey, while Product UX and frontend lenses do not.

ReviewGPT first-reviewed head: f61ba260fc4eb7148a85f9382272a67a8ec666d2

