### PR TITLE
fix(web): bound private food search latency

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-food-search-latency-budget.md
+++ b/agent-docs/exec-plans/active/2026-08-28-food-search-latency-budget.md
@@ -1,0 +1,103 @@
+# Bound production food search below 2.5 seconds
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Keep private food-name search responsive on the production-scale labels
+  catalog by making candidate admission proportional to the requested result
+  count instead of paying the fixed maximum for five-result searches.
+
+## Success criteria
+
+- Exact repository SQL completes representative broad-FTS and no-FTS typo
+  searches below 2.5 seconds against the current production labels catalog,
+  through a read-only eight-second-bounded diagnostic.
+- The existing ranking, exact-name, generic-origin, off-market, source-filter,
+  canonical-diversity, supplement, public-search, and contaminant contracts
+  remain covered.
+- The production-scale PostgreSQL regression proves the bounded candidate
+  budget and retains the eight-second fail-closed pool timeout.
+- Focused tests, Web typecheck, required completion audits, ReviewGPT, and
+  exact-head CI pass.
+
+## Scope
+
+- In scope: private food generic-search candidate admission, focused query
+  shape and real-PostgreSQL coverage, the durable labels-database contract,
+  and a concise member-facing changelog fragment.
+- Out of scope: public/supplement ranking, pool sizing, timeout increases,
+  schema/index changes, label ingestion, retries, caches, queues, and device
+  sync.
+
+## Constraints
+
+- Technical constraints: keep both FTS and typo work bounded before window
+  ranking; preserve indexed GIN/GiST paths; keep database work read-only and
+  avoid new state, services, dependencies, or migrations.
+- Product/process constraints: ReviewGPT exclusively authors production code;
+  use synthetic search inputs and privacy-safe aggregate evidence only; leave
+  the functional PR ready for human merge.
+
+## Risks and mitigations
+
+1. Risk: a smaller candidate budget can exclude a ranking winner or collapse
+   canonical diversity for larger result requests.
+   Mitigation: derive the budget from requested result count with an explicit
+   floor and ceiling, retain the existing maximum for large result sets, and
+   exercise the established boundary fixtures.
+2. Risk: warm local tests can conceal production I/O sensitivity.
+   Mitigation: retain the production-scale PostgreSQL test and record direct
+   read-only production timings from distinct FTS and typo paths.
+
+## Tasks
+
+1. Deduplicate against active work and prove the production query/index cause.
+2. Give ReviewGPT the implementation packet and inspect its patch for ranking,
+   privacy, load, and scope correctness.
+3. Run focused PostgreSQL, query-helper, route, changelog, and typecheck proof.
+4. Commit and push the exact candidate, open a draft PR, then run preliminary
+   completion-specialist and final ReviewGPT gates concurrently with CI.
+5. Resolve accepted findings, mark the ordinary bug-fix PR ready for human
+   merge, and record the production verification query.
+
+## Decisions
+
+- Live read-only proof on the 2.03M-row labels catalog found all required
+  indexes valid/ready/live. The fixed 10,000-row query took 6.65-6.98 seconds;
+  the GiST nearest-name scan dominated and physical reads drove a fivefold
+  cold/warm difference.
+- A test-only 1,000-candidate variant completed a fresh broad-FTS path in
+  0.79 seconds and a fresh no-FTS typo path in 1.79 seconds. Production code
+  must derive a bounded budget rather than hard-code the diagnostic rewrite.
+
+## Verification
+
+- Commands to run: focused `apps/web` query-helper and route Vitest suites;
+  opt-in real-PostgreSQL food-search regression; Web typecheck; changelog
+  loader coverage; `git diff --check`; required completion audits and CI.
+- Expected outcomes: five-result searches admit the narrow budget, larger
+  requests scale without exceeding the existing 10,000 ceiling, established
+  ranking fixtures remain stable, and the production-scale query stays below
+  2.5 seconds without changing the eight-second timeout.
+
+## Progress
+
+- ReviewGPT authored the accepted four-file implementation patch. The derived
+  budget is `min(10,000, max(1,000, 200 × requested limit))`, rendered as a
+  validated integer SQL literal across all three private-food admission
+  branches. Its two later test-only corrections were also applied unchanged.
+- Focused local proof is green: 37 food-query tests, 134 real-PostgreSQL tests
+  over the 250,000-row synthetic catalog, 46 route/pool/runtime-env tests,
+  scoped ESLint, Web typecheck, and `git diff --check`.
+- Exact candidate SQL completed read-only production probes in 219 ms for the
+  broad full-text path and 1,237 ms for the distinct no-full-text typo path.
+  Both five-result probes admitted 1,000 candidates and used the existing
+  indexes, with no concurrent active query or lock waiter observed.
+- Product UX Patch walkthrough: `Outcome` food-label lookup returns promptly;
+  `Reaches` existing private food searches through the hosted data client;
+  `Proof` exact production-catalog timing covers both expensive query branches.
+  Public foods, supplements, exact ID/UPC lookup, response shape, filtering,
+  and ranking semantics remain unchanged. Verdict: `Ready`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -765,23 +765,35 @@ Attribution lives under `sql/product-tests/`.
 The current search path uses built-in Postgres full-text search plus the
 `pg_trgm` extension for indexed name similarity. Public food searches retain
 their existing 250-candidate SQL bound, and supplement searches retain their
-existing ranking path. Private food-name search uses a separate bounded
+existing ranking path. Private food-name search uses a separate two-stage
 retrieval contract for the roughly two-million-row foods corpus. Literal
-exact-name admission remains capped at 250 rows. Every other indexed admission
-branch derives the same candidate budget from the requested final result count:
-`min(10,000, max(1,000, 200 × limit))`. A five-result request therefore admits
-1,000 candidates per branch, while the supported 50-result maximum reaches the
-existing 10,000 ceiling. The validated integer is rendered as a concrete SQL
-literal for the GIN full-text, full-text nearest-name GiST, and no-FTS typo GiST
-admissions so each indexed branch retains a bounded concrete plan. Exactly one
-GiST branch is realized: full-text searches use strict-word-nearest names,
-while no-FTS typo searches use whole-name distance and its matching whole-name
-threshold. That shared metric keeps eligible typo matches ahead of ineligible
-names before the cap. The bounded admissions preserve representative choice
-and canonical diversity across the established 5,000-row boundary and
-ineligible-neighbor fixtures. Ranking is deterministic within the admitted
-set; it is intentionally not an exhaustive whole-catalog ranking. Exact IDs
-and UPCs continue to use direct lookup paths. On `foods_api_failed` failures
+exact-name admission remains capped at 250 rows. Every supported private-food
+result count, including the 50-result maximum, uses the same concrete 1,000-row
+candidate limit for the GIN full-text, full-text nearest-name GiST, and no-FTS
+typo GiST branches. The fixed SQL literal preserves a bounded concrete plan
+instead of multiplying maximum-cardinality requests into a 10,000-row probe.
+
+The same statement counts distinct `canonical_key` values in that probe. When
+it already has enough groups, the existing exact-name ranking index admits the
+best eligible representative for every bounded canonical-key/name pair before
+canonical dedupe and final ranking. A full-text
+path can expose at most 2,250 such pairs (250 exact-name rows plus two 1,000-row
+branches), while the no-FTS typo path can expose at most 1,000; each pair
+performs one `LIMIT 1` representative lookup and final canonical admission
+remains capped at 1,000. A raw branch therefore cannot hide a higher-priority
+peer behind same-name duplicates or scale representative work with the
+requested result count. When one or more duplicated groups leave the probe
+underfilled, a gated fallback evaluates the eligible indexed full-text or
+trigram matches, chooses the established ranked representative for each
+canonical key, and only then applies the same concrete candidate budget. One
+canonical group therefore cannot consume result admission, and the fallback
+adds no second database round trip. Exactly one
+GiST probe branch is realized: full-text searches use strict-word-nearest
+names, while no-FTS typo searches use whole-name distance and its matching
+whole-name threshold. That shared metric keeps eligible typo matches ahead of
+ineligible names before the cap. Ranking and tie-breaks remain deterministic,
+and the existing eight-second statement timeout still owns both stages. Exact
+IDs and UPCs continue to use direct lookup paths. On `foods_api_failed` failures
 from private food lookup, including exact
 ID/UPC dispatch and ranked search, the existing safe structured log adds only
 the closed `failureStage` value `search_rows` or `contaminant_summary`;

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -766,18 +766,23 @@ The current search path uses built-in Postgres full-text search plus the
 `pg_trgm` extension for indexed name similarity. Public food searches retain
 their existing 250-candidate SQL bound, and supplement searches retain their
 existing ranking path. Private food-name search uses a separate bounded
-retrieval contract for the roughly two-million-row foods corpus: it admits at
-most 250 literal exact-name rows, 10,000 GIN full-text matches, and 10,000 GiST
-nearest-name candidates before similarity scoring, canonical-key deduplication,
-and window sorting. Exactly one GiST branch is realized: full-text searches use
-strict-word-nearest names, while no-FTS typo searches use whole-name distance
-and its matching whole-name threshold. That shared metric keeps eligible typo
-matches ahead of ineligible names before the cap. The bounded admissions
-preserve representative choice and canonical diversity across the established
-5,000-row boundary and ineligible-neighbor fixtures. Ranking is deterministic
-within the admitted set; it is intentionally not an exhaustive whole-catalog
-ranking. Exact IDs and UPCs continue to use direct lookup
-paths. On `foods_api_failed` failures from private food lookup, including exact
+retrieval contract for the roughly two-million-row foods corpus. Literal
+exact-name admission remains capped at 250 rows. Every other indexed admission
+branch derives the same candidate budget from the requested final result count:
+`min(10,000, max(1,000, 200 × limit))`. A five-result request therefore admits
+1,000 candidates per branch, while the supported 50-result maximum reaches the
+existing 10,000 ceiling. The validated integer is rendered as a concrete SQL
+literal for the GIN full-text, full-text nearest-name GiST, and no-FTS typo GiST
+admissions so each indexed branch retains a bounded concrete plan. Exactly one
+GiST branch is realized: full-text searches use strict-word-nearest names,
+while no-FTS typo searches use whole-name distance and its matching whole-name
+threshold. That shared metric keeps eligible typo matches ahead of ineligible
+names before the cap. The bounded admissions preserve representative choice
+and canonical diversity across the established 5,000-row boundary and
+ineligible-neighbor fixtures. Ranking is deterministic within the admitted
+set; it is intentionally not an exhaustive whole-catalog ranking. Exact IDs
+and UPCs continue to use direct lookup paths. On `foods_api_failed` failures
+from private food lookup, including exact
 ID/UPC dispatch and ranked search, the existing safe structured log adds only
 the closed `failureStage` value `search_rows` or `contaminant_summary`;
 PostgreSQL error codes remain in the existing safe error fields, and SQL/query

--- a/apps/web/changelog/entries/2026-08-28/food-label-searches-return-faster.json
+++ b/apps/web/changelog/entries/2026-08-28/food-label-searches-return-faster.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-28",
+  "order": 100,
+  "item": {
+    "id": "food-label-searches-return-faster",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Food label searches return faster",
+    "summary": "Food label searches now respond faster for broad terms and misspellings, especially when Murph needs only a few matches.",
+    "details": "Result ranking, filters, public food search, supplement search, and exact barcode or record lookup keep their existing behavior.",
+    "relevanceTags": ["nutrition", "performance", "reliability"],
+    "sourcePullRequests": [2484]
+  }
+}

--- a/apps/web/src/lib/product-labels.ts
+++ b/apps/web/src/lib/product-labels.ts
@@ -21,9 +21,7 @@ const PRODUCT_CONTAMINANT_ALERT_LIMIT = 5;
 const PRODUCT_CONTAMINANT_OBSERVATION_LIMIT = 20;
 const PUBLIC_PRODUCT_LABEL_JSON_LIMIT_BYTES = 256 * 1_024;
 const PUBLIC_PRODUCT_SEARCH_CANDIDATE_LIMIT = 250;
-const PRIVATE_FOOD_SEARCH_CANDIDATE_FLOOR = 1_000;
-const PRIVATE_FOOD_SEARCH_CANDIDATE_CEILING = 10_000;
-const PRIVATE_FOOD_SEARCH_CANDIDATES_PER_RESULT = 200;
+const PRIVATE_FOOD_SEARCH_CANDIDATE_LIMIT = 1_000;
 const PRODUCT_LABEL_SEARCH_EXACT_NAME_LIMIT = 250;
 const PRODUCT_CONTAMINANT_CONCERN_RANK: Record<
   ProductContaminantConcernLevel,
@@ -2086,24 +2084,6 @@ type GenericProductLabelSearchInput = {
   stemmedSearch: boolean;
 };
 
-function privateFoodSearchCandidateLimit(resultLimit: number): number {
-  const normalizedResultLimit = Number.isFinite(resultLimit)
-    ? Math.max(1, Math.floor(resultLimit))
-    : 1;
-
-  // Five requested results use the proven 1,000-row floor, while the
-  // supported 50-result maximum reaches the existing 10,000-row ceiling. Keep
-  // the clamped integer as a SQL literal so each indexed branch retains its
-  // concrete bounded plan instead of a generic parameterized LIMIT.
-  return Math.min(
-    PRIVATE_FOOD_SEARCH_CANDIDATE_CEILING,
-    Math.max(
-      PRIVATE_FOOD_SEARCH_CANDIDATE_FLOOR,
-      normalizedResultLimit * PRIVATE_FOOD_SEARCH_CANDIDATES_PER_RESULT,
-    ),
-  );
-}
-
 async function searchGenericProductLabels(
   client: ProductLabelsQueryClient,
   tableSql: ProductLabelsTableSql,
@@ -2126,12 +2106,14 @@ async function searchGenericProductLabels(
     return await searchOriginalGenericProductLabels(client, tableSql, input);
   }
 
-  // Food-name results are ranked deterministically within separately bounded
-  // GIN full-text and GiST nearest-name sets. This retrieval contract trades
-  // exhaustive whole-catalog ranking for completion inside the labels database
-  // statement timeout; exact IDs and UPCs use separate direct paths.
+  // Food-name search keeps one fixed 1,000-row GIN/GiST probe as its ordinary
+  // path at every supported result limit. A count-qualified probe completes
+  // each admitted exact-name group's representative through the existing
+  // ranking index; an underfilled probe derives a canonical-first fallback
+  // from the matching indexed rows. Exact IDs and UPCs continue to use
+  // separate direct paths.
   const stemmed = input.stemmedSearch;
-  const candidateLimit = privateFoodSearchCandidateLimit(input.limit);
+  const candidateLimit = PRIVATE_FOOD_SEARCH_CANDIDATE_LIMIT;
   const excludedDataOriginsSql = productLabelExcludedDataOriginsFilterSql(
     "data_origin",
     input.excludedDataOrigins,
@@ -2251,36 +2233,6 @@ async function searchGenericProductLabels(
           UNION
           SELECT * FROM fts_nearest_matches
         ),
-        fts_candidates AS MATERIALIZED (
-          SELECT
-            id,
-            canonical_key,
-            data_origin AS "dataOrigin",
-            data_origin_id AS "dataOriginId",
-            name,
-            brand,
-            upc,
-            off_market AS "offMarket",
-            ${stemmed ? `greatest(
-              ts_rank_cd(to_tsvector('simple', search_text), query.tsq),
-              ts_rank_cd(to_tsvector('english', search_text), query.stemmed_tsq)
-            )` : `ts_rank_cd(to_tsvector('simple', search_text), query.tsq)`} AS search_rank,
-            strict_word_similarity(query.raw_q, name) AS name_similarity,
-            CASE
-              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN 1
-              ELSE 0
-            END AS name_phrase_match,
-            CASE
-              WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN char_length(name)
-              ELSE 0
-            END AS name_phrase_length,
-            ${stemmed ? `CASE
-              WHEN to_tsvector('english', name) = to_tsvector('english', query.raw_q) THEN 1
-              ELSE 0
-            END` : "0"} AS stemmed_name_match,
-            data_origin_priority
-          FROM fts_matches, query
-        ),
         trigram_matches AS MATERIALIZED (
           SELECT
             id,
@@ -2291,6 +2243,7 @@ async function searchGenericProductLabels(
             brand,
             upc,
             off_market,
+            NULL::text AS search_text,
             data_origin_priority
           FROM (
             SELECT
@@ -2318,7 +2271,159 @@ async function searchGenericProductLabels(
           ) nearest_names
           WHERE name % $1::text
         ),
-        trigram_candidates AS MATERIALIZED (
+        bounded_matches AS MATERIALIZED (
+          SELECT
+            *,
+            true AS full_text_match
+          FROM fts_matches
+          UNION ALL
+          SELECT
+            *,
+            false AS full_text_match
+          FROM trigram_matches
+        ),
+        bounded_candidate_summary AS MATERIALIZED (
+          SELECT
+            count(DISTINCT canonical_key)::integer AS canonical_count
+          FROM bounded_matches
+        ),
+        bounded_fast_matches AS MATERIALIZED (
+          SELECT * FROM bounded_matches
+          UNION
+          SELECT preferred.*
+          FROM (
+            SELECT DISTINCT
+              canonical_key,
+              lower(name) AS normalized_name,
+              full_text_match
+            FROM bounded_matches
+            WHERE (
+              SELECT canonical_count >= $3
+              FROM bounded_candidate_summary
+            )
+          ) bounded_names
+          CROSS JOIN LATERAL (
+            SELECT
+              labels.id,
+              labels.canonical_key,
+              labels.data_origin,
+              labels.data_origin_id,
+              labels.name,
+              labels.brand,
+              labels.upc,
+              labels.off_market,
+              CASE
+                WHEN bounded_names.full_text_match THEN labels.search_text
+                ELSE NULL::text
+              END AS search_text,
+              labels.data_origin_priority,
+              bounded_names.full_text_match
+            FROM ${tableSql} labels, query
+            WHERE
+              -- A count-qualified raw probe can still truncate a better
+              -- source-priority peer. Complete only its admitted exact-name
+              -- groups through the existing lower(name) ranking index before
+              -- the bounded fast path performs canonical dedupe.
+              labels.canonical_key = bounded_names.canonical_key
+              AND lower(labels.name) = bounded_names.normalized_name
+              AND ($2::boolean OR labels.off_market = false)
+              AND ${productLabelSourceFilterSql("labels.data_origin")}
+              AND ($4::text[] IS NULL OR labels.data_origin = ANY($4::text[]))
+              AND ${productLabelExcludedDataOriginsFilterSql(
+                "labels.data_origin",
+                input.excludedDataOrigins,
+              )}
+              AND (
+                (
+                  bounded_names.full_text_match
+                  AND ${stemmed ? `(
+                    to_tsvector('simple', labels.search_text) @@ query.tsq
+                    OR to_tsvector('english', labels.search_text) @@ query.stemmed_tsq
+                  )` : `to_tsvector('simple', labels.search_text) @@ query.tsq`}
+                )
+                OR (
+                  NOT bounded_names.full_text_match
+                  AND NOT EXISTS (SELECT 1 FROM fts_index_matches)
+                  AND labels.name % $1::text
+                )
+              )
+            ORDER BY
+              CASE
+                WHEN bounded_names.full_text_match THEN ${stemmed ? `greatest(
+                  ts_rank_cd(to_tsvector('simple', labels.search_text), query.tsq),
+                  ts_rank_cd(to_tsvector('english', labels.search_text), query.stemmed_tsq)
+                )` : `ts_rank_cd(to_tsvector('simple', labels.search_text), query.tsq)`}
+                ELSE 0::real
+              END DESC,
+              labels.off_market ASC,
+              labels.data_origin_priority ASC,
+              labels.name ASC,
+              labels.id ASC
+            LIMIT 1
+          ) preferred
+        ),
+        fts_canonical_fallback_matches AS MATERIALIZED (
+          SELECT
+            id,
+            canonical_key,
+            data_origin,
+            data_origin_id,
+            name,
+            brand,
+            upc,
+            off_market,
+            search_text,
+            data_origin_priority,
+            true AS full_text_match
+          FROM ${tableSql}
+          WHERE
+            -- The indexed bounded probe remains the ordinary path. Only an
+            -- underfilled canonical result set evaluates all indexed matches,
+            -- and its later LIMIT is applied after canonical-key dedupe.
+            (SELECT canonical_count < $3 FROM bounded_candidate_summary)
+            AND EXISTS (SELECT 1 FROM fts_index_matches)
+            AND ${stemmed ? `(
+              to_tsvector('simple', search_text) @@ websearch_to_tsquery('simple', $1)
+              OR to_tsvector('english', search_text) @@ websearch_to_tsquery('english', $1)
+            )` : `to_tsvector('simple', search_text) @@ websearch_to_tsquery('simple', $1)`}
+            AND ($2::boolean OR off_market = false)
+            AND ${PRODUCT_LABEL_SOURCE_FILTER_SQL}
+            AND ($4::text[] IS NULL OR data_origin = ANY($4::text[]))
+            AND ${excludedDataOriginsSql}
+        ),
+        trigram_canonical_fallback_matches AS MATERIALIZED (
+          SELECT
+            id,
+            canonical_key,
+            data_origin,
+            data_origin_id,
+            name,
+            brand,
+            upc,
+            off_market,
+            NULL::text AS search_text,
+            data_origin_priority,
+            false AS full_text_match
+          FROM ${tableSql}
+          WHERE
+            (SELECT canonical_count < $3 FROM bounded_candidate_summary)
+            AND NOT EXISTS (SELECT 1 FROM fts_index_matches)
+            AND name % $1::text
+            AND ($2::boolean OR off_market = false)
+            AND ${PRODUCT_LABEL_SOURCE_FILTER_SQL}
+            AND ($4::text[] IS NULL OR data_origin = ANY($4::text[]))
+            AND ${excludedDataOriginsSql}
+        ),
+        matches AS (
+          SELECT *
+          FROM bounded_fast_matches
+          WHERE (SELECT canonical_count >= $3 FROM bounded_candidate_summary)
+          UNION ALL
+          SELECT * FROM fts_canonical_fallback_matches
+          UNION ALL
+          SELECT * FROM trigram_canonical_fallback_matches
+        ),
+        scored AS (
           SELECT
             id,
             canonical_key,
@@ -2328,7 +2433,13 @@ async function searchGenericProductLabels(
             brand,
             upc,
             off_market AS "offMarket",
-            0::real AS search_rank,
+            CASE
+              WHEN full_text_match THEN ${stemmed ? `greatest(
+                ts_rank_cd(to_tsvector('simple', search_text), query.tsq),
+                ts_rank_cd(to_tsvector('english', search_text), query.stemmed_tsq)
+              )` : `ts_rank_cd(to_tsvector('simple', search_text), query.tsq)`}
+              ELSE 0::real
+            END AS search_rank,
             strict_word_similarity(query.raw_q, name) AS name_similarity,
             CASE
               WHEN strpos(' ' || lower(query.raw_q) || ' ', ' ' || lower(name) || ' ') > 0 THEN 1
@@ -2343,12 +2454,7 @@ async function searchGenericProductLabels(
               ELSE 0
             END` : "0"} AS stemmed_name_match,
             data_origin_priority
-          FROM trigram_matches, query
-        ),
-        candidates AS (
-          SELECT * FROM fts_candidates
-          UNION ALL
-          SELECT * FROM trigram_candidates
+          FROM matches, query
         ),
         ranked AS (
           SELECT
@@ -2366,7 +2472,22 @@ async function searchGenericProductLabels(
                 name ASC,
                 id ASC
             ) AS dedupe_rank
-          FROM candidates
+          FROM scored
+        ),
+        canonical_candidates AS MATERIALIZED (
+          SELECT ranked.*
+          FROM ranked
+          WHERE dedupe_rank = 1
+          ORDER BY
+            name_phrase_match DESC,
+            name_phrase_length DESC,
+            stemmed_name_match DESC,
+            name_similarity DESC,
+            search_rank DESC,
+            data_origin_priority ASC,
+            name ASC,
+            id ASC
+          LIMIT ${candidateLimit}
         ),
         selected AS (
           SELECT
@@ -2382,8 +2503,7 @@ async function searchGenericProductLabels(
                 name ASC,
                 id ASC
             ) AS result_rank
-          FROM ranked
-          WHERE dedupe_rank = 1
+          FROM canonical_candidates
           ORDER BY
             name_phrase_match DESC,
             name_phrase_length DESC,

--- a/apps/web/src/lib/product-labels.ts
+++ b/apps/web/src/lib/product-labels.ts
@@ -21,7 +21,9 @@ const PRODUCT_CONTAMINANT_ALERT_LIMIT = 5;
 const PRODUCT_CONTAMINANT_OBSERVATION_LIMIT = 20;
 const PUBLIC_PRODUCT_LABEL_JSON_LIMIT_BYTES = 256 * 1_024;
 const PUBLIC_PRODUCT_SEARCH_CANDIDATE_LIMIT = 250;
-const PRODUCT_LABEL_SEARCH_MATCH_LIMIT = 10_000;
+const PRIVATE_FOOD_SEARCH_CANDIDATE_FLOOR = 1_000;
+const PRIVATE_FOOD_SEARCH_CANDIDATE_CEILING = 10_000;
+const PRIVATE_FOOD_SEARCH_CANDIDATES_PER_RESULT = 200;
 const PRODUCT_LABEL_SEARCH_EXACT_NAME_LIMIT = 250;
 const PRODUCT_CONTAMINANT_CONCERN_RANK: Record<
   ProductContaminantConcernLevel,
@@ -2084,6 +2086,24 @@ type GenericProductLabelSearchInput = {
   stemmedSearch: boolean;
 };
 
+function privateFoodSearchCandidateLimit(resultLimit: number): number {
+  const normalizedResultLimit = Number.isFinite(resultLimit)
+    ? Math.max(1, Math.floor(resultLimit))
+    : 1;
+
+  // Five requested results use the proven 1,000-row floor, while the
+  // supported 50-result maximum reaches the existing 10,000-row ceiling. Keep
+  // the clamped integer as a SQL literal so each indexed branch retains its
+  // concrete bounded plan instead of a generic parameterized LIMIT.
+  return Math.min(
+    PRIVATE_FOOD_SEARCH_CANDIDATE_CEILING,
+    Math.max(
+      PRIVATE_FOOD_SEARCH_CANDIDATE_FLOOR,
+      normalizedResultLimit * PRIVATE_FOOD_SEARCH_CANDIDATES_PER_RESULT,
+    ),
+  );
+}
+
 async function searchGenericProductLabels(
   client: ProductLabelsQueryClient,
   tableSql: ProductLabelsTableSql,
@@ -2111,6 +2131,7 @@ async function searchGenericProductLabels(
   // exhaustive whole-catalog ranking for completion inside the labels database
   // statement timeout; exact IDs and UPCs use separate direct paths.
   const stemmed = input.stemmedSearch;
+  const candidateLimit = privateFoodSearchCandidateLimit(input.limit);
   const excludedDataOriginsSql = productLabelExcludedDataOriginsFilterSql(
     "data_origin",
     input.excludedDataOrigins,
@@ -2178,7 +2199,7 @@ async function searchGenericProductLabels(
             AND ${PRODUCT_LABEL_SOURCE_FILTER_SQL}
             AND ($4::text[] IS NULL OR data_origin = ANY($4::text[]))
             AND ${excludedDataOriginsSql}
-          LIMIT ${PRODUCT_LABEL_SEARCH_MATCH_LIMIT}
+          LIMIT ${candidateLimit}
         ),
         name_nearest_matches AS MATERIALIZED (
           SELECT
@@ -2201,7 +2222,7 @@ async function searchGenericProductLabels(
           -- This GiST KNN branch runs only when indexed FTS found rows. The
           -- mutually exclusive typo branch below owns no-FTS searches.
           ORDER BY name <->>> $1::text
-          LIMIT ${PRODUCT_LABEL_SEARCH_MATCH_LIMIT}
+          LIMIT ${candidateLimit}
         ),
         fts_nearest_matches AS MATERIALIZED (
           SELECT
@@ -2293,7 +2314,7 @@ async function searchGenericProductLabels(
             -- threshold below, so eligible rows always precede ineligible
             -- rows while the GiST KNN scan remains bounded.
             ORDER BY name <-> $1::text
-            LIMIT ${PRODUCT_LABEL_SEARCH_MATCH_LIMIT}
+            LIMIT ${candidateLimit}
           ) nearest_names
           WHERE name % $1::text
         ),

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -43,7 +43,7 @@ function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
     ],
     [
       "trigram_matches AS MATERIALIZED",
-      "trigram_candidates AS MATERIALIZED",
+      "bounded_matches AS MATERIALIZED",
     ],
   ] as const;
 
@@ -64,6 +64,26 @@ function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
 
     return Number(limits[0]![1]);
   });
+}
+
+function readPrivateFoodCanonicalAdmissionBudget(text: string): number {
+  const startMarker = "canonical_candidates AS MATERIALIZED";
+  const endMarker = "selected AS (";
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start + startMarker.length);
+
+  if (start < 0 || end <= start) {
+    throw new Error("missing private food canonical admission range");
+  }
+
+  const limits = [
+    ...text.slice(start, end).matchAll(/\bLIMIT (\d+)\b/gu),
+  ];
+  if (limits.length !== 1) {
+    throw new Error("unexpected private food canonical admission limits");
+  }
+
+  return Number(limits[0]![1]);
 }
 
 function createFoodsTestRouteHandlers(
@@ -329,14 +349,14 @@ describe("foods query helpers", () => {
     {
       lookup: "ranked search",
       routeQuery: "private-search-value",
-      primarySql: "fts_candidates AS MATERIALIZED",
+      primarySql: "bounded_matches AS MATERIALIZED",
       failureStage: "search_rows" as const,
       failingQuery: 1,
     },
     {
       lookup: "ranked search",
       routeQuery: "private-search-value",
-      primarySql: "fts_candidates AS MATERIALIZED",
+      primarySql: "bounded_matches AS MATERIALIZED",
       failureStage: "contaminant_summary" as const,
       failingQuery: 2,
     },
@@ -637,9 +657,23 @@ describe("foods query helpers", () => {
       "strict_word_similarity(query.raw_q, name)",
     );
     expect(searchCall?.text).toContain("fts_matches AS MATERIALIZED");
-    expect(searchCall?.text).toContain("fts_candidates AS MATERIALIZED");
     expect(searchCall?.text).toContain("trigram_matches AS MATERIALIZED");
-    expect(searchCall?.text).toContain("trigram_candidates AS MATERIALIZED");
+    expect(searchCall?.text).toContain("bounded_matches AS MATERIALIZED");
+    expect(searchCall?.text).toContain(
+      "bounded_candidate_summary AS MATERIALIZED",
+    );
+    expect(searchCall?.text).toContain(
+      "bounded_fast_matches AS MATERIALIZED",
+    );
+    expect(searchCall?.text).toContain(
+      "fts_canonical_fallback_matches AS MATERIALIZED",
+    );
+    expect(searchCall?.text).toContain(
+      "trigram_canonical_fallback_matches AS MATERIALIZED",
+    );
+    expect(searchCall?.text).toContain(
+      "canonical_candidates AS MATERIALIZED",
+    );
     expect(searchCall?.text).toContain(
       "NOT EXISTS (SELECT 1 FROM fts_index_matches)",
     );
@@ -656,6 +690,26 @@ describe("foods query helpers", () => {
       searchSql.indexOf("fts_nearest_matches AS MATERIALIZED"),
       searchSql.indexOf("fts_matches AS MATERIALIZED"),
     );
+    const boundedFastSql = searchSql.slice(
+      searchSql.indexOf("bounded_fast_matches AS MATERIALIZED"),
+      searchSql.indexOf("fts_canonical_fallback_matches AS MATERIALIZED"),
+    );
+    const ftsFallbackSql = searchSql.slice(
+      searchSql.indexOf("fts_canonical_fallback_matches AS MATERIALIZED"),
+      searchSql.indexOf("trigram_canonical_fallback_matches AS MATERIALIZED"),
+    );
+    const trigramFallbackSql = searchSql.slice(
+      searchSql.indexOf("trigram_canonical_fallback_matches AS MATERIALIZED"),
+      searchSql.indexOf("matches AS ("),
+    );
+    const matchesSql = searchSql.slice(
+      searchSql.indexOf("matches AS ("),
+      searchSql.indexOf("scored AS ("),
+    );
+    const canonicalCandidatesSql = searchSql.slice(
+      searchSql.indexOf("canonical_candidates AS MATERIALIZED"),
+      searchSql.indexOf("selected AS ("),
+    );
     expect(ftsIndexSql).toContain("to_tsvector");
     expect(ftsIndexSql).not.toContain("ORDER BY");
     expect(nameNearestSql).not.toContain("to_tsvector");
@@ -665,11 +719,50 @@ describe("foods query helpers", () => {
       "EXISTS (SELECT 1 FROM fts_index_matches)",
     );
     expect(ftsNearestSql).not.toContain("FROM foods");
+    expect(boundedFastSql).toContain("SELECT * FROM bounded_matches");
+    expect(boundedFastSql).toContain("SELECT DISTINCT");
+    expect(boundedFastSql).toContain("SELECT canonical_count >= $3");
+    expect(boundedFastSql).toContain("lower(name) AS normalized_name");
+    expect(boundedFastSql.match(/CROSS JOIN LATERAL/gu)).toHaveLength(1);
+    expect(boundedFastSql).toContain(
+      "labels.canonical_key = bounded_names.canonical_key",
+    );
+    expect(boundedFastSql).toContain(
+      "lower(labels.name) = bounded_names.normalized_name",
+    );
+    expect(boundedFastSql).toContain(
+      "to_tsvector('simple', labels.search_text) @@ query.tsq",
+    );
+    expect(boundedFastSql).toContain("NOT bounded_names.full_text_match");
+    expect(boundedFastSql).toContain(
+      "NOT EXISTS (SELECT 1 FROM fts_index_matches)",
+    );
+    expect(boundedFastSql).toContain("labels.name % $1::text");
+    expect(boundedFastSql).toContain("labels.data_origin_priority ASC");
+    expect(boundedFastSql.match(/\bLIMIT 1\b/gu)).toHaveLength(1);
+    expect(ftsFallbackSql).toContain(
+      "(SELECT canonical_count < $3 FROM bounded_candidate_summary)",
+    );
+    expect(ftsFallbackSql).toContain(
+      "EXISTS (SELECT 1 FROM fts_index_matches)",
+    );
+    expect(ftsFallbackSql).toContain("to_tsvector");
+    expect(ftsFallbackSql).not.toContain("ORDER BY name");
+    expect(trigramFallbackSql).toContain(
+      "(SELECT canonical_count < $3 FROM bounded_candidate_summary)",
+    );
+    expect(trigramFallbackSql).toContain(
+      "NOT EXISTS (SELECT 1 FROM fts_index_matches)",
+    );
+    expect(trigramFallbackSql).toContain("name % $1::text");
+    expect(trigramFallbackSql).not.toContain("<->");
     expect(readPrivateFoodSearchCandidateBudgets(searchSql)).toEqual([
       1_000,
       1_000,
       1_000,
     ]);
+    expect(readPrivateFoodCanonicalAdmissionBudget(searchSql)).toBe(1_000);
+    expect(searchSql).not.toContain("LIMIT 10000");
     expect(searchCall?.text).toMatch(
       /fts_index_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?LIMIT 1000\s*\),\s*name_nearest_matches AS MATERIALIZED/u,
     );
@@ -689,8 +782,17 @@ describe("foods query helpers", () => {
       /trigram_matches AS MATERIALIZED \([\s\S]*?FROM name_nearest_matches/u,
     );
     expect(searchCall?.text).not.toContain("trigram_nearest_matches");
-    expect(searchCall?.text).not.toContain("fts_canonical_matches");
-    expect(searchCall?.text).not.toContain("trigram_canonical_matches");
+    expect(matchesSql).toContain("FROM bounded_fast_matches");
+    expect(matchesSql).toContain(
+      "(SELECT canonical_count >= $3 FROM bounded_candidate_summary)",
+    );
+    expect(canonicalCandidatesSql).toContain("dedupe_rank = 1");
+    expect(canonicalCandidatesSql).toMatch(
+      /dedupe_rank = 1[\s\S]*?LIMIT 1000/u,
+    );
+    expect(searchCall?.text).toContain(
+      "count(DISTINCT canonical_key)::integer AS canonical_count",
+    );
     expect(searchCall?.text).toMatch(
       /fts_exact_name_matches AS MATERIALIZED \([\s\S]*?lower\(name\) = lower\(\$1::text\)[\s\S]*?LIMIT 250/u,
     );
@@ -784,11 +886,11 @@ describe("foods query helpers", () => {
   it.each([
     [1, 1_000],
     [5, 1_000],
-    [20, 4_000],
-    [50, 10_000],
-    [500, 10_000],
+    [20, 1_000],
+    [50, 1_000],
+    [500, 1_000],
   ] as const)(
-    "derives bounded private food candidates for a %i-result request",
+    "keeps private food candidate work fixed for a %i-result request",
     async (limit, expectedCandidateBudget) => {
       const calls: Array<{ text: string; values: unknown[] }> = [];
       const queries = createFoodsQueries({
@@ -814,7 +916,11 @@ describe("foods query helpers", () => {
         expectedCandidateBudget,
         expectedCandidateBudget,
       ]);
-      expect(Math.max(...candidateBudgets)).toBeLessThanOrEqual(10_000);
+      expect(Math.max(...candidateBudgets)).toBeLessThanOrEqual(1_000);
+      expect(readPrivateFoodCanonicalAdmissionBudget(
+        searchCall?.text ?? "",
+      )).toBe(expectedCandidateBudget);
+      expect(searchCall?.text).not.toContain("LIMIT 10000");
       expect(searchCall?.values).toEqual([
         "candidate budget fixture",
         false,
@@ -823,6 +929,43 @@ describe("foods query helpers", () => {
       ]);
     },
   );
+
+  it("keeps supplement search on the original candidate SQL path", async () => {
+    const calls: Array<{ text: string; values: unknown[] }> = [];
+    const queries = createProductLabelsQueries(
+      {
+        async query<T>(text: string, values: unknown[]) {
+          calls.push({ text, values });
+          return { rows: [] as T[] };
+        },
+      },
+      "supplements",
+      { stemmedSearch: true },
+    );
+
+    await expect(queries.search({
+      q: "synthetic supplement search",
+      limit: 5,
+      includeOffMarket: false,
+    })).resolves.toEqual([]);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.values).toEqual([
+      "synthetic supplement search",
+      false,
+      5,
+      null,
+    ]);
+    expect(calls[0]?.text).toContain("fts_candidates AS MATERIALIZED");
+    expect(calls[0]?.text).toContain("trigram_candidates AS MATERIALIZED");
+    expect(calls[0]?.text).toContain("FROM supplements, query");
+    expect(calls[0]?.text).not.toContain("fts_index_matches AS MATERIALIZED");
+    expect(calls[0]?.text).not.toContain("bounded_matches AS MATERIALIZED");
+    expect(calls[0]?.text).not.toContain(
+      "bounded_fast_matches AS MATERIALIZED",
+    );
+    expect(calls[0]?.text).not.toContain("canonical_fallback");
+  });
 
   it("filters generic food searches to USDA non-branded origins", async () => {
     const calls: Array<{ text: string; values: unknown[] }> = [];
@@ -868,7 +1011,7 @@ describe("foods query helpers", () => {
     );
     expect(searchCall?.text.match(
       /\(\$4::text\[\] IS NULL OR data_origin = ANY\(\$4::text\[\]\)\)/gu,
-    )).toHaveLength(4);
+    )).toHaveLength(6);
     expect(searchCall?.values).toEqual([
       "chicken breast cooked skinless",
       false,
@@ -1905,6 +2048,14 @@ describe("foods query helpers", () => {
     expect(calls[0]?.text).toContain("'usda_sr_legacy'");
     expect(calls[0]?.text).toContain("'usda_fndds'");
     expect(calls[0]?.text).toContain("COUNT(DISTINCT product_tests.id)");
+    expect(calls[0]?.text).toContain("fts_candidates AS MATERIALIZED");
+    expect(calls[0]?.text).toContain("trigram_candidates AS MATERIALIZED");
+    expect(calls[0]?.text).not.toContain("fts_index_matches AS MATERIALIZED");
+    expect(calls[0]?.text).not.toContain("bounded_matches AS MATERIALIZED");
+    expect(calls[0]?.text).not.toContain(
+      "bounded_fast_matches AS MATERIALIZED",
+    );
+    expect(calls[0]?.text).not.toContain("canonical_fallback");
     expect(calls[0]?.text).not.toContain("labels.label");
   });
 

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -31,6 +31,41 @@ function isProductTestsQuery(text: string): boolean {
   return text.includes('product_tests.id AS "productTestId"');
 }
 
+function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
+  const ranges = [
+    [
+      "fts_index_matches AS MATERIALIZED",
+      "name_nearest_matches AS MATERIALIZED",
+    ],
+    [
+      "name_nearest_matches AS MATERIALIZED",
+      "fts_nearest_matches AS MATERIALIZED",
+    ],
+    [
+      "trigram_matches AS MATERIALIZED",
+      "trigram_candidates AS MATERIALIZED",
+    ],
+  ] as const;
+
+  return ranges.map(([startMarker, endMarker]) => {
+    const start = text.indexOf(startMarker);
+    const end = text.indexOf(endMarker, start + startMarker.length);
+
+    if (start < 0 || end <= start) {
+      throw new Error(`missing private food search CTE range: ${startMarker}`);
+    }
+
+    const limits = [
+      ...text.slice(start, end).matchAll(/\bLIMIT (\d+)\b/gu),
+    ];
+    if (limits.length !== 1) {
+      throw new Error(`unexpected private food search limits: ${startMarker}`);
+    }
+
+    return Number(limits[0]![1]);
+  });
+}
+
 function createFoodsTestRouteHandlers(
   queries: ReturnType<typeof createFoodsQueries>,
 ) {
@@ -630,11 +665,16 @@ describe("foods query helpers", () => {
       "EXISTS (SELECT 1 FROM fts_index_matches)",
     );
     expect(ftsNearestSql).not.toContain("FROM foods");
+    expect(readPrivateFoodSearchCandidateBudgets(searchSql)).toEqual([
+      1_000,
+      1_000,
+      1_000,
+    ]);
     expect(searchCall?.text).toMatch(
-      /fts_index_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?LIMIT 10000\s*\),\s*name_nearest_matches AS MATERIALIZED/u,
+      /fts_index_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?LIMIT 1000\s*\),\s*name_nearest_matches AS MATERIALIZED/u,
     );
     expect(searchCall?.text).toMatch(
-      /name_nearest_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?ORDER BY name <->>> \$1::text\s*LIMIT 10000/u,
+      /name_nearest_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?ORDER BY name <->>> \$1::text\s*LIMIT 1000/u,
     );
     expect(searchCall?.text).toMatch(
       /fts_nearest_matches AS MATERIALIZED \([\s\S]*?FROM name_nearest_matches[\s\S]*?to_tsvector/u,
@@ -643,7 +683,7 @@ describe("foods query helpers", () => {
       /fts_matches AS MATERIALIZED \([\s\S]*?SELECT \* FROM fts_exact_name_matches[\s\S]*?SELECT \* FROM fts_index_matches[\s\S]*?SELECT \* FROM fts_nearest_matches/u,
     );
     expect(searchCall?.text).toMatch(
-      /trigram_matches AS MATERIALIZED \([\s\S]*?FROM \([\s\S]*?FROM foods[\s\S]*?NOT EXISTS \(SELECT 1 FROM fts_index_matches\)[\s\S]*?ORDER BY name <-> \$1::text\s*LIMIT 10000[\s\S]*?\) nearest_names\s*WHERE name % \$1::text/u,
+      /trigram_matches AS MATERIALIZED \([\s\S]*?FROM \([\s\S]*?FROM foods[\s\S]*?NOT EXISTS \(SELECT 1 FROM fts_index_matches\)[\s\S]*?ORDER BY name <-> \$1::text\s*LIMIT 1000[\s\S]*?\) nearest_names\s*WHERE name % \$1::text/u,
     );
     expect(searchCall?.text).not.toMatch(
       /trigram_matches AS MATERIALIZED \([\s\S]*?FROM name_nearest_matches/u,
@@ -740,6 +780,49 @@ describe("foods query helpers", () => {
     expect(contaminantsCall?.text).not.toContain("threshold_basis IN");
     expect(contaminantsCall?.values).toEqual([["fdc:123"]]);
   });
+
+  it.each([
+    [1, 1_000],
+    [5, 1_000],
+    [20, 4_000],
+    [50, 10_000],
+    [500, 10_000],
+  ] as const)(
+    "derives bounded private food candidates for a %i-result request",
+    async (limit, expectedCandidateBudget) => {
+      const calls: Array<{ text: string; values: unknown[] }> = [];
+      const queries = createFoodsQueries({
+        async query<T>(text: string, values: unknown[]) {
+          calls.push({ text, values });
+          return { rows: [] as T[] };
+        },
+      });
+
+      await queries.searchFoods({
+        q: "candidate budget fixture",
+        limit,
+        includeOffMarket: false,
+      });
+
+      expect(calls).toHaveLength(1);
+      const searchCall = calls[0];
+      const candidateBudgets = readPrivateFoodSearchCandidateBudgets(
+        searchCall?.text ?? "",
+      );
+      expect(candidateBudgets).toEqual([
+        expectedCandidateBudget,
+        expectedCandidateBudget,
+        expectedCandidateBudget,
+      ]);
+      expect(Math.max(...candidateBudgets)).toBeLessThanOrEqual(10_000);
+      expect(searchCall?.values).toEqual([
+        "candidate budget fixture",
+        false,
+        limit,
+        null,
+      ]);
+    },
+  );
 
   it("filters generic food searches to USDA non-branded origins", async () => {
     const calls: Array<{ text: string; values: unknown[] }> = [];

--- a/apps/web/test/supplements-search-postgres.test.ts
+++ b/apps/web/test/supplements-search-postgres.test.ts
@@ -558,6 +558,9 @@ const TYPO_CASES: readonly SearchCase[] = [
 ] as const;
 
 const FOOD_EXACT_ADMISSION_LIMIT = 250;
+const FOOD_CANDIDATE_ADMISSION_LIMIT = 1_000;
+const FOOD_MAX_FTS_REPRESENTATIVE_LOOKUPS =
+  FOOD_EXACT_ADMISSION_LIMIT + FOOD_CANDIDATE_ADMISSION_LIMIT * 2;
 
 function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
   const ranges = [
@@ -571,7 +574,7 @@ function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
     ],
     [
       "trigram_matches AS MATERIALIZED",
-      "trigram_candidates AS MATERIALIZED",
+      "bounded_matches AS MATERIALIZED",
     ],
   ] as const;
 
@@ -592,6 +595,26 @@ function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
 
     return Number(limits[0]![1]);
   });
+}
+
+function readPrivateFoodCanonicalAdmissionBudget(text: string): number {
+  const startMarker = "canonical_candidates AS MATERIALIZED";
+  const endMarker = "selected AS (";
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start + startMarker.length);
+
+  if (start < 0 || end <= start) {
+    throw new Error("missing private food canonical admission range");
+  }
+
+  const limits = [
+    ...text.slice(start, end).matchAll(/\bLIMIT (\d+)\b/gu),
+  ];
+  if (limits.length !== 1) {
+    throw new Error("unexpected private food canonical admission limits");
+  }
+
+  return Number(limits[0]![1]);
 }
 
 const UNICODE_CASES: readonly SearchCase[] = [
@@ -1134,6 +1157,106 @@ describe.runIf(Boolean(testDatabaseUrl))(
       );
     }, 20_000);
 
+    it.each(["Boundaryfts", "Boundryfts"])(
+      "keeps five canonical food results at the 1,000-row candidate floor for %s",
+      async (q) => {
+        const { rows: timeoutRows } = await client.query<{
+          statement_timeout: string;
+        }>("SHOW statement_timeout");
+        expect(
+          timeoutRows[0]?.statement_timeout,
+          `${q}: private food search must keep the existing database timeout`,
+        ).toBe("8s");
+
+        const { rows: fixtureRows } = await client.query<{
+          aliasRows: string;
+          canonicalGroups: string;
+          preferredAliasRows: string;
+          winnerRows: string;
+        }>(`
+          SELECT
+            count(*) FILTER (
+              WHERE canonical_key = 'food-boundary-fts-alias'
+            )::text AS "aliasRows",
+            count(DISTINCT canonical_key) FILTER (
+              WHERE id = 'zz-food-boundary-fts-winner'
+                OR canonical_key = 'food-boundary-fts-alias'
+                OR id LIKE 'food-boundary-fts-distinct-%'
+            )::text AS "canonicalGroups",
+            count(*) FILTER (
+              WHERE id = 'zz-food-boundary-fts-alias-priority'
+            )::text AS "preferredAliasRows",
+            count(*) FILTER (
+              WHERE id = 'zz-food-boundary-fts-winner'
+            )::text AS "winnerRows"
+          FROM foods
+        `);
+        expect(
+          fixtureRows[0],
+          `${q}: the existing synthetic large-alias fixture must be intact`,
+        ).toEqual({
+          aliasRows: "6000",
+          canonicalGroups: "62",
+          preferredAliasRows: "1",
+          winnerRows: "1",
+        });
+
+        const firstStartedAt = performance.now();
+        const first = await foodQueries.searchFoods({
+          includeOffMarket: false,
+          limit: 5,
+          q,
+        });
+        const firstElapsedMs = performance.now() - firstStartedAt;
+        const repeatedStartedAt = performance.now();
+        const repeated = await foodQueries.searchFoods({
+          includeOffMarket: false,
+          limit: 5,
+          q,
+        });
+        const repeatedElapsedMs = performance.now() - repeatedStartedAt;
+        console.info("private-food canonical-diversity diagnostic timing", {
+          firstElapsedMs: Math.round(firstElapsedMs),
+          q,
+          repeatedElapsedMs: Math.round(repeatedElapsedMs),
+        });
+        const ids = first.map((row) => row.id);
+        const preferredAliasId = "zz-food-boundary-fts-alias-priority";
+        const aliasRepresentatives = ids.filter(
+          (id) =>
+            id === preferredAliasId ||
+            id.startsWith("food-boundary-fts-alias-"),
+        );
+        const canonicalKeys = ids.map((id) =>
+          id === preferredAliasId || id.startsWith("food-boundary-fts-alias-")
+            ? "food-boundary-fts-alias"
+            : id,
+        );
+
+        expect.soft(
+          first,
+          `${q}: pre-dedupe candidate admission collapsed below five available canonical groups`,
+        ).toHaveLength(5);
+        expect.soft(
+          new Set(canonicalKeys).size,
+          `${q}: five rows did not represent five distinct canonical keys`,
+        ).toBe(5);
+        expect.soft(
+          ids[0],
+          `${q}: the established top-ranked winner changed`,
+        ).toBe("zz-food-boundary-fts-winner");
+        expect.soft(
+          aliasRepresentatives,
+          `${q}: the large alias group did not keep its preferred representative`,
+        ).toEqual([preferredAliasId]);
+        expect.soft(
+          repeated.map((row) => row.id),
+          `${q}: repeated identical search changed the ordered IDs`,
+        ).toEqual(ids);
+      },
+      20_000,
+    );
+
     it.each(["% boundaryfts", "_ boundaryfts"])(
       "treats SQL wildcard characters as ordinary food-search input for %s",
       async (q) => {
@@ -1205,10 +1328,30 @@ function expectBoundedFoodSortInputs(
   }
 }
 
+function expectBoundedFoodRepresentativeLookups(
+  nodes: readonly ExplainPlanNode[],
+  maximumLookups: number,
+): void {
+  const representativeScans = nodes.filter((node) =>
+    node["Index Name"] === "foods_perf_name_exact_rank_idx" &&
+    (node["Actual Loops"] ?? 0) > 1
+  );
+  expect(representativeScans.length).toBeGreaterThan(0);
+  expect(
+    representativeScans.reduce(
+      (total, node) => total + (node["Actual Loops"] ?? 0),
+      0,
+    ),
+  ).toBeLessThanOrEqual(maximumLookups);
+  for (const scan of representativeScans) {
+    expect(scan["Actual Rows"] ?? 0).toBeLessThanOrEqual(1);
+  }
+}
+
 describe.runIf(Boolean(testDatabaseUrl))(
   "large-catalog food PostgreSQL search bound",
   () => {
-    it("uses derived candidate bounds and indexed plans inside the production statement timeout", async () => {
+    it("keeps maximum-cardinality candidate and representative work bounded inside the production statement timeout", async () => {
       const client = new pg.Client({
         connectionString: testDatabaseUrl ?? undefined,
       });
@@ -1314,22 +1457,27 @@ describe.runIf(Boolean(testDatabaseUrl))(
         }>("SHOW statement_timeout");
         expect(timeoutRows[0]?.statement_timeout).toBe("8s");
 
+        const broadStartedAt = performance.now();
         const broad = await queries.searchFoods({
           includeOffMarket: false,
-          limit: 20,
+          limit: 50,
           q: "commonfood",
         });
-        expect(broad).toHaveLength(20);
+        const broadElapsedMs = performance.now() - broadStartedAt;
+        expect(broad).toHaveLength(50);
         expect(capturedSearch.current).not.toBeNull();
         const broadSearch = capturedSearch.current;
         if (!broadSearch) {
           throw new Error("broad food search SQL was not captured");
         }
         expect(readPrivateFoodSearchCandidateBudgets(broadSearch.text)).toEqual([
-          4_000,
-          4_000,
-          4_000,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
         ]);
+        expect(readPrivateFoodCanonicalAdmissionBudget(broadSearch.text)).toBe(
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        );
         const broadExplain = await client.query<{ "QUERY PLAN": Array<{
           Plan: ExplainPlanNode;
         }> }>(
@@ -1343,7 +1491,17 @@ describe.runIf(Boolean(testDatabaseUrl))(
           node["Index Name"] === "foods_perf_name_rank_idx" &&
           (node["Actual Loops"] ?? 0) > 0
         )).toBe(true);
-        expectBoundedFoodSortInputs(broadNodes, 4_000);
+        expectBoundedFoodSortInputs(
+          broadNodes,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        );
+        expectBoundedFoodRepresentativeLookups(
+          broadNodes,
+          FOOD_MAX_FTS_REPRESENTATIVE_LOOKUPS,
+        );
+        console.info("private-food maximum-cardinality timing", {
+          broadElapsedMs: Math.round(broadElapsedMs),
+        });
 
         const brandOnly = await queries.searchFoods({
           includeOffMarket: false,
@@ -1356,10 +1514,13 @@ describe.runIf(Boolean(testDatabaseUrl))(
           throw new Error("brand-only food search SQL was not captured");
         }
         expect(readPrivateFoodSearchCandidateBudgets(brandSearch.text)).toEqual([
-          1_000,
-          1_000,
-          1_000,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
         ]);
+        expect(readPrivateFoodCanonicalAdmissionBudget(brandSearch.text)).toBe(
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        );
         const brandExplain = await client.query<{ "QUERY PLAN": Array<{
           Plan: ExplainPlanNode;
         }> }>(
@@ -1410,21 +1571,55 @@ describe.runIf(Boolean(testDatabaseUrl))(
           valid_trigram_match: true,
         });
 
-        const ceilingTypo = await queries.searchFoods({
+        const maximumTypoStartedAt = performance.now();
+        const maximumTypo = await queries.searchFoods({
           includeOffMarket: false,
           limit: 50,
           q: typoQ,
         });
-        const ceilingTypoSearch = capturedSearch.current;
-        if (!ceilingTypoSearch) {
+        const maximumTypoElapsedMs = performance.now() - maximumTypoStartedAt;
+        const maximumTypoSearch = capturedSearch.current;
+        if (!maximumTypoSearch) {
           throw new Error(
-            "large-catalog ceiling typo search SQL was not captured",
+            "large-catalog maximum typo search SQL was not captured",
           );
         }
-        expect(ceilingTypo).toHaveLength(50);
+        expect(maximumTypo).toHaveLength(50);
         expect(
-          readPrivateFoodSearchCandidateBudgets(ceilingTypoSearch.text),
-        ).toEqual([10_000, 10_000, 10_000]);
+          readPrivateFoodSearchCandidateBudgets(maximumTypoSearch.text),
+        ).toEqual([
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        ]);
+        expect(
+          readPrivateFoodCanonicalAdmissionBudget(maximumTypoSearch.text),
+        ).toBe(FOOD_CANDIDATE_ADMISSION_LIMIT);
+        const maximumTypoExplain = await client.query<{ "QUERY PLAN": Array<{
+          Plan: ExplainPlanNode;
+        }> }>(
+          `EXPLAIN (ANALYZE, TIMING OFF, FORMAT JSON) ${maximumTypoSearch.text}`,
+          maximumTypoSearch.values,
+        );
+        const maximumTypoPlan =
+          maximumTypoExplain.rows[0]?.["QUERY PLAN"][0]?.Plan;
+        expect(maximumTypoPlan).toBeDefined();
+        const maximumTypoNodes = flattenExplainPlan(maximumTypoPlan ?? {});
+        expect(maximumTypoNodes.filter((node) =>
+          node["Index Name"] === "foods_perf_name_rank_idx" &&
+          (node["Actual Loops"] ?? 0) > 0
+        )).toHaveLength(1);
+        expectBoundedFoodSortInputs(
+          maximumTypoNodes,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        );
+        expectBoundedFoodRepresentativeLookups(
+          maximumTypoNodes,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+        );
+        console.info("private-food maximum-cardinality timing", {
+          maximumTypoElapsedMs: Math.round(maximumTypoElapsedMs),
+        });
 
         const floorTypo = await queries.searchFoods({
           includeOffMarket: false,
@@ -1439,25 +1634,13 @@ describe.runIf(Boolean(testDatabaseUrl))(
         }
         expect(floorTypo).toHaveLength(5);
         expect(readPrivateFoodSearchCandidateBudgets(typoSearch.text)).toEqual([
-          1_000,
-          1_000,
-          1_000,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
         ]);
-
-        const typoExplain = await client.query<{ "QUERY PLAN": Array<{
-          Plan: ExplainPlanNode;
-        }> }>(
-          `EXPLAIN (ANALYZE, TIMING OFF, FORMAT JSON) ${typoSearch.text}`,
-          typoSearch.values,
+        expect(readPrivateFoodCanonicalAdmissionBudget(typoSearch.text)).toBe(
+          FOOD_CANDIDATE_ADMISSION_LIMIT,
         );
-        const typoPlan = typoExplain.rows[0]?.["QUERY PLAN"][0]?.Plan;
-        expect(typoPlan).toBeDefined();
-        const typoNodes = flattenExplainPlan(typoPlan ?? {});
-        expect(typoNodes.filter((node) =>
-          node["Index Name"] === "foods_perf_name_rank_idx" &&
-          (node["Actual Loops"] ?? 0) > 0
-        )).toHaveLength(1);
-        expectBoundedFoodSortInputs(typoNodes, 1_000);
 
         const { rows: obsoleteIndexes } = await client.query<{ name: string | null }>(
           "SELECT to_regclass('foods_perf_canonical_rank_idx')::text AS name",

--- a/apps/web/test/supplements-search-postgres.test.ts
+++ b/apps/web/test/supplements-search-postgres.test.ts
@@ -558,10 +558,41 @@ const TYPO_CASES: readonly SearchCase[] = [
 ] as const;
 
 const FOOD_EXACT_ADMISSION_LIMIT = 250;
-const FOOD_FTS_ADMISSION_LIMIT = 10_000;
-const FOOD_NEAREST_NAME_ADMISSION_LIMIT = 10_000;
-const FOOD_MAX_SORT_INPUT = FOOD_EXACT_ADMISSION_LIMIT +
-  FOOD_FTS_ADMISSION_LIMIT + FOOD_NEAREST_NAME_ADMISSION_LIMIT;
+
+function readPrivateFoodSearchCandidateBudgets(text: string): number[] {
+  const ranges = [
+    [
+      "fts_index_matches AS MATERIALIZED",
+      "name_nearest_matches AS MATERIALIZED",
+    ],
+    [
+      "name_nearest_matches AS MATERIALIZED",
+      "fts_nearest_matches AS MATERIALIZED",
+    ],
+    [
+      "trigram_matches AS MATERIALIZED",
+      "trigram_candidates AS MATERIALIZED",
+    ],
+  ] as const;
+
+  return ranges.map(([startMarker, endMarker]) => {
+    const start = text.indexOf(startMarker);
+    const end = text.indexOf(endMarker, start + startMarker.length);
+
+    if (start < 0 || end <= start) {
+      throw new Error(`missing private food search CTE range: ${startMarker}`);
+    }
+
+    const limits = [
+      ...text.slice(start, end).matchAll(/\bLIMIT (\d+)\b/gu),
+    ];
+    if (limits.length !== 1) {
+      throw new Error(`unexpected private food search limits: ${startMarker}`);
+    }
+
+    return Number(limits[0]![1]);
+  });
+}
 
 const UNICODE_CASES: readonly SearchCase[] = [
   { category: "unicode", name: "curly possessive apostrophe", query: "Doctor’s Best Magnesium", expectedTopId: "doctors-best-magnesium" },
@@ -1154,7 +1185,10 @@ function explainRowsProcessed(node: ExplainPlanNode): number {
   return (node["Actual Rows"] ?? 0) * (node["Actual Loops"] ?? 1);
 }
 
-function expectBoundedFoodSortInputs(nodes: readonly ExplainPlanNode[]): void {
+function expectBoundedFoodSortInputs(
+  nodes: readonly ExplainPlanNode[],
+  candidateBudget: number,
+): void {
   const sortNodes = nodes.filter((node) =>
     node["Node Type"] === "Sort" ||
     node["Node Type"] === "Incremental Sort"
@@ -1166,7 +1200,7 @@ function expectBoundedFoodSortInputs(nodes: readonly ExplainPlanNode[]): void {
     );
     expect(sortInputs).toHaveLength(1);
     expect(explainRowsProcessed(sortInputs[0] ?? {})).toBeLessThanOrEqual(
-      FOOD_MAX_SORT_INPUT,
+      FOOD_EXACT_ADMISSION_LIMIT + candidateBudget * 2,
     );
   }
 }
@@ -1174,7 +1208,7 @@ function expectBoundedFoodSortInputs(nodes: readonly ExplainPlanNode[]): void {
 describe.runIf(Boolean(testDatabaseUrl))(
   "large-catalog food PostgreSQL search bound",
   () => {
-    it("finishes common-token search inside the production statement timeout", async () => {
+    it("uses derived candidate bounds and indexed plans inside the production statement timeout", async () => {
       const client = new pg.Client({
         connectionString: testDatabaseUrl ?? undefined,
       });
@@ -1275,6 +1309,10 @@ describe.runIf(Boolean(testDatabaseUrl))(
         await client.query("ANALYZE foods");
         await client.query("SET LOCAL lock_timeout = '500ms'");
         await client.query("SET LOCAL statement_timeout = '8s'");
+        const { rows: timeoutRows } = await client.query<{
+          statement_timeout: string;
+        }>("SHOW statement_timeout");
+        expect(timeoutRows[0]?.statement_timeout).toBe("8s");
 
         const broad = await queries.searchFoods({
           includeOffMarket: false,
@@ -1287,7 +1325,11 @@ describe.runIf(Boolean(testDatabaseUrl))(
         if (!broadSearch) {
           throw new Error("broad food search SQL was not captured");
         }
-        await client.query("SET LOCAL statement_timeout = '30s'");
+        expect(readPrivateFoodSearchCandidateBudgets(broadSearch.text)).toEqual([
+          4_000,
+          4_000,
+          4_000,
+        ]);
         const broadExplain = await client.query<{ "QUERY PLAN": Array<{
           Plan: ExplainPlanNode;
         }> }>(
@@ -1298,10 +1340,10 @@ describe.runIf(Boolean(testDatabaseUrl))(
         expect(broadPlan).toBeDefined();
         const broadNodes = flattenExplainPlan(broadPlan ?? {});
         expect(broadNodes.some((node) =>
-          node["Index Name"] === "foods_perf_name_rank_idx"
+          node["Index Name"] === "foods_perf_name_rank_idx" &&
+          (node["Actual Loops"] ?? 0) > 0
         )).toBe(true);
-        expectBoundedFoodSortInputs(broadNodes);
-        await client.query("SET LOCAL statement_timeout = '8s'");
+        expectBoundedFoodSortInputs(broadNodes, 4_000);
 
         const brandOnly = await queries.searchFoods({
           includeOffMarket: false,
@@ -1313,6 +1355,11 @@ describe.runIf(Boolean(testDatabaseUrl))(
         if (!brandSearch) {
           throw new Error("brand-only food search SQL was not captured");
         }
+        expect(readPrivateFoodSearchCandidateBudgets(brandSearch.text)).toEqual([
+          1_000,
+          1_000,
+          1_000,
+        ]);
         const brandExplain = await client.query<{ "QUERY PLAN": Array<{
           Plan: ExplainPlanNode;
         }> }>(
@@ -1322,8 +1369,10 @@ describe.runIf(Boolean(testDatabaseUrl))(
         const brandPlan = brandExplain.rows[0]?.["QUERY PLAN"][0]?.Plan;
         expect(brandPlan).toBeDefined();
         expect(flattenExplainPlan(brandPlan ?? {}).some((node) =>
-          node["Index Name"] === "foods_perf_search_idx" ||
-          node["Index Name"] === "foods_perf_search_english_idx"
+          (
+            node["Index Name"] === "foods_perf_search_idx" ||
+            node["Index Name"] === "foods_perf_search_english_idx"
+          ) && (node["Actual Loops"] ?? 0) > 0
         )).toBe(true);
 
         const exact = await queries.searchFoods({
@@ -1361,18 +1410,40 @@ describe.runIf(Boolean(testDatabaseUrl))(
           valid_trigram_match: true,
         });
 
-        const firstTypo = await queries.searchFoods({
+        const ceilingTypo = await queries.searchFoods({
           includeOffMarket: false,
           limit: 50,
           q: typoQ,
         });
+        const ceilingTypoSearch = capturedSearch.current;
+        if (!ceilingTypoSearch) {
+          throw new Error(
+            "large-catalog ceiling typo search SQL was not captured",
+          );
+        }
+        expect(ceilingTypo).toHaveLength(50);
+        expect(
+          readPrivateFoodSearchCandidateBudgets(ceilingTypoSearch.text),
+        ).toEqual([10_000, 10_000, 10_000]);
+
+        const floorTypo = await queries.searchFoods({
+          includeOffMarket: false,
+          limit: 5,
+          q: typoQ,
+        });
         const typoSearch = capturedSearch.current;
         if (!typoSearch) {
-          throw new Error("large-catalog typo food search SQL was not captured");
+          throw new Error(
+            "large-catalog floor typo search SQL was not captured",
+          );
         }
-        expect(firstTypo).toHaveLength(50);
+        expect(floorTypo).toHaveLength(5);
+        expect(readPrivateFoodSearchCandidateBudgets(typoSearch.text)).toEqual([
+          1_000,
+          1_000,
+          1_000,
+        ]);
 
-        await client.query("SET LOCAL statement_timeout = '30s'");
         const typoExplain = await client.query<{ "QUERY PLAN": Array<{
           Plan: ExplainPlanNode;
         }> }>(
@@ -1386,8 +1457,7 @@ describe.runIf(Boolean(testDatabaseUrl))(
           node["Index Name"] === "foods_perf_name_rank_idx" &&
           (node["Actual Loops"] ?? 0) > 0
         )).toHaveLength(1);
-        expectBoundedFoodSortInputs(typoNodes);
-        await client.query("SET LOCAL statement_timeout = '8s'");
+        expectBoundedFoodSortInputs(typoNodes, 1_000);
 
         const { rows: obsoleteIndexes } = await client.query<{ name: string | null }>(
           "SELECT to_regclass('foods_perf_canonical_rank_idx')::text AS name",


### PR DESCRIPTION
## Why and outcome

Private food-label searches paid a fixed 10,000-row candidate cost before this
PR; representative production plans took 6,653–6,983 ms. An interim
result-scaled fix made five-result searches fast, but ReviewGPT proved that raw
candidate admission could lose canonical diversity and preferred aliases. Its
first correction restored those semantics but made the supported 50-result
path exceed the unchanged eight-second statement timeout.

The final query keeps one fixed 1,000-row GIN/GiST probe for every supported
result limit. It completes admitted canonical/name representatives through the
existing rank indexes, and uses the existing same-statement canonical fallback
only when the bounded probe is genuinely underfilled. No timeout, result limit,
schema, index, provider interaction, or database call count changes.

## Product UX

- Effort: Patch
- Result: Blocked pending a first-principles query redesign and final
  ReviewGPT PASS
- Walkthrough: Existing members receive the same deterministic, canonical-key
  diverse private food-label results without multi-second timeout exposure.
  Public food search, supplements, exact ID/UPC lookup, and device sync remain
  unchanged.

## Direct evidence

Read-only production validation used exact candidate-generated SQL inside
`BEGIN READ ONLY` with a 500 ms lock timeout and the unchanged eight-second
statement timeout. Only aggregate plan/timing facts were retained.

| Production path | Limit | Execution | Rows | Whole-catalog fallback |
| --- | ---: | ---: | ---: | --- |
| Broad full-text | 5 | 508 ms | 5 | Not executed |
| Broad full-text | 50 | 536 ms | 50 | Not executed |
| Typo / no-FTS | 5 | 1,339 ms | 5 | Not executed |
| Typo / no-FTS | 50 | 1,272 ms | 50 | Not executed |

All checked plans are below the requested 2.5-second budget. The maximum
candidate and representative workload is identical at limits 5 and 50.

## Verification

- 38/38 private-food SQL-shape tests pass.
- 4/4 focused local PostgreSQL canonical-diversity, preferred-alias, winner,
  deterministic-repeat, and 1,000-row-boundary cases pass.
- 105/105 affected food route, pool, runtime-env, and changelog tests pass.
- Scoped Web ESLint, Web typecheck, and `git diff --check` pass.
- The full local 250,000-row PostgreSQL test file remains unavailable as broad
  proof because this host's fixture table/index construction exhausts its
  120-second guard before reaching changed search SQL. Required exact-head CI
  owns the broad suite; the failure is not query execution evidence.

## Non-obvious affected surfaces

- Production labels-database workload: existing GIN full-text, exact-name
  ranking, canonical-key, and GiST name-rank indexes are reused. The bounded
  path performs at most 2,250 full-text representative pairs or 1,000 typo
  pairs; requested result count no longer multiplies candidate work.
- Ranking: representative selection happens before canonical dedupe, preserving
  the established winner, preferred alias, ordering, and repeated-call
  stability. The underfilled fallback remains one statement and one database
  call.
- Database load: no transaction, call, index, schema, or collection fanout is
  added. Maximum admitted work falls from 10,000 candidates per indexed branch
  to 1,000.

## Architecture and reuse

- Existing systems reused: private-food query, GIN/GiST/ranking indexes,
  deterministic ranking, canonical-key dedupe, and pool statement timeout.
- New logic: one fixed 1,000-row private-food candidate budget for every
  supported result limit, retaining the existing representative completion and
  underfill fallback.
- New abstractions: none; no new service, state owner, or dependency.
- Complexity intentionally avoided: no migration, cache, retry, queue, feature flag, second
  query, or separate observability path.

## Hot reply path and provider input

- Hot reply path: no durable inbound acceptance, provider admission, or reply
  handoff change; this reduces work in an existing downstream labels query.
- Network/provider calls: unchanged.
- Murph initial provider input and tool schemas: unchanged; measurement not
  applicable.

## ReviewGPT provenance

ReviewGPT first-reviewed head: 71189fb954db6f54310a75a8bbc00811dfefe38f
- Preliminary specialist and final round 1 both found the same accepted defect:
  raw-row admission could hide canonical diversity and a preferred alias.
- ReviewGPT authored the focused failing PostgreSQL diagnostic and every
  production-code correction, including the final fixed-budget delta.
- Current candidate head: `ca170f1de790`
- Final round 2: `RETROSPECTIVE_REQUIRED`. ReviewGPT proved that the
  count-qualified fast branch cannot recover a differently named preferred
  representative outside the 1,000-row probe, while the underfill fallback
  removes the claimed database-work bound. No final PASS exists yet.

## ReviewGPT round-2 retrospective

- Trigger: the same accepted round-1 mechanism recurred. Raw truncation still
  happens before canonical identity and final ranking, followed by conditional
  machinery that attempts to reconstruct what truncation discarded.
- Requirement decision: preserve the former ordered IDs, preferred exact food
  representative, and attached contaminant evidence. A newly bounded
  approximation is not an acceptable substitute for the existing member
  result contract.
- Architecture decision: reject another cap, gate, per-name completion, or
  whole-catalog fallback patch on the current shape. The next production patch
  must either shrink/revert the conditional repair or establish canonical
  identity and final-ranking eligibility at one existing query owner before
  result-affecting truncation.
- Required proof before another merge candidate: a broad count-qualified path
  with a differently named preferred alias beyond the 1,000-row boundary; an
  alias-heavy underfill path that actually executes fallback at representative
  cardinality; base-versus-candidate ordered IDs and selected exact food ID;
  preserved contaminant evidence; and maximum work below the unchanged
  eight-second timeout under the existing three-query batch concurrency.

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new Vercel Web revisions may coexist during rollout;
  both use the existing compatible labels schema and valid production indexes.
- Safe order: normal merge-triggered Vercel Web deployment; no Cloudflare
  tandem rollout or separate compatibility step.
- Rollback floor: the immediately previous Web revision; no database,
  configuration, secret, or provider rollback is required.
- Expected exposure: private food-name searches served by the new Web revision;
  public food, supplements, exact ID/UPC, and device-sync paths are unchanged.
- Reversibility: revert the PR or redeploy the previous Web revision; there is
  no data backfill, migration, or irreversible state.
- Convergence proof: Vercel production reports the merged commit as the active
  production revision after rollout completion.
- Post-deploy checks: prove the deployed revision and inspect natural
  privacy-safe food-search timeout/error aggregates; do not generate synthetic
  production traffic.

## Design proof

- Design page: [production changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- This query-only behavior has no visual state. The authored changelog fragment
  is covered by the passing changelog tests.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 190 | 49 |
| Tests / fixtures | 528 | 41 |
| Docs | 147 | 13 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **865** | **103** |

## Changelog

- Changelog: updated
- Items: `2026-08-28 · food-label-searches-return-faster`
