### PR TITLE
Attribute Browser Vault refresh timeouts by stage

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-27-browser-vault-timeout-stage-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-27-browser-vault-timeout-stage-telemetry.md
@@ -1,0 +1,111 @@
+# Identify Browser Vault refresh timeout stage
+
+Status: active
+Created: 2026-08-27
+Updated: 2026-08-27
+
+## Goal
+
+- Make the existing hosted Browser Vault refresh timeout log identify the exact
+  bounded refresh stage that exhausted its 20-second budget, without exposing
+  vault paths, content, identifiers, or health values and without changing
+  refresh behavior.
+
+## Success criteria
+
+- A `deferred_timeout` result carries one closed, low-cardinality stage value
+  covering the existing source-hash, replica-build, serialization, write, and
+  publication boundaries.
+- The existing hosted structured log emits that stage and preserves any source
+  count/byte summary already known before the timeout.
+- Focused tests prove stage attribution at local-build and injected-port
+  boundaries while preserving cancellation, no-publication, terminalization,
+  and foreground-preemption behavior.
+- The durable hosted-runtime contract records the field, privacy boundary, and
+  exact bounded later-production query.
+- ReviewGPT authors the production patch and performs the required final review;
+  focused local verification and required PR checks pass on the pushed head.
+
+## Scope
+
+- In scope: Browser Vault refresh result metadata, existing structured log
+  details, focused tests, and the owning hosted-runtime contract.
+- Out of scope: retries, timeout changes, scheduling/wake behavior, replica
+  format or content, database/schema changes, device sync, new observability
+  infrastructure, synthetic production traffic, merge, or deployment.
+
+## Constraints
+
+- Technical constraints: reuse the existing hosted runtime log pipeline; add
+  only typed, closed-vocabulary metadata; keep runtime overhead effectively
+  constant and do not add I/O or persistence.
+- Product/process constraints: internal telemetry only, so Product UX impact is
+  none; ReviewGPT exclusively authors production code; apply an accepted patch
+  exactly and leave the resulting PR ready for human merge.
+
+## Risks and mitigations
+
+1. Risk: stage tracking accidentally changes cancellation or retry behavior.
+   Mitigation: observe the existing sequence only and assert the current
+   no-publication/no-wake terminal behavior in focused tests.
+2. Risk: log metadata leaks private vault structure or creates cardinality/cost.
+   Mitigation: expose only one closed stage enum plus existing numeric
+   count/byte summaries; never log paths, source hashes, content, or IDs.
+3. Risk: concurrent hosted-runtime work owns the same fix.
+   Mitigation: deduplicate against active plans, PRs, issues, recent merges, and
+   overlapping files before implementation; keep the patch boundary distinct.
+
+## Tasks
+
+1. Reconfirm current ownership, code path, production symptom, and telemetry
+   question on current `origin/main`.
+2. Send ReviewGPT a privacy-safe implementation packet with exact hypotheses,
+   field constraints, tests, deployment contract, and later query.
+3. Inspect the returned patch for behavior, privacy, scope, cost, conflicts, and
+   device-sync overlap; apply it unchanged only if accepted.
+4. Run focused tests, typechecks, privacy/log guards, and direct diff proof.
+5. Commit, push, open the PR, run preliminary/final ReviewGPT concurrently with
+   CI, disposition findings, and leave the PR ready for human merge.
+
+## Decisions
+
+- The concrete unanswered question is: which existing refresh stage is active
+  when a `deferred_timeout` result is produced?
+- Competing hypotheses are initial source hashing, replica construction,
+  serialization/measurement, second source hashing, encrypted replica write,
+  or ref publication.
+- The existing `deferred_timeout` result is already terminal for the current
+  mailbox item. This task does not reinterpret it as retryable.
+- PR #2461 instruments foreground-input admission and PR #2448 changes generic
+  Environment scheduling; neither owns Browser Vault timeout-stage telemetry.
+- ReviewGPT implementation v1 was rejected before application because an
+  unused import and an already-started promise left typecheck and exact-stage
+  attribution gaps. V2 corrected both, but its attachment failed the guarded
+  checksum. The same accepted turn regenerated hash-matching v3; exact local
+  typecheck then exposed lost workspace narrowing in the new write thunk.
+  ReviewGPT's complete v4 replacement captures the already-proven ref and
+  publish method before the thunks, removes the assertion, and is the only
+  accepted production implementation.
+
+## Verification
+
+- Commands to run: focused Browser Vault replica and workspace-entrypoint
+  Vitest cases, `@murphai/assistant-runtime` typecheck, repository log/privacy
+  guard, `git diff --check`, exact-head CI, preliminary coverage review, and
+  final ReviewGPT.
+- Expected outcomes: each forced timeout reports the correct closed stage,
+  logs contain no private data, existing cancellation and terminal behavior are
+  unchanged, and the exact later query can aggregate timeout counts by stage.
+
+## Candidate evidence
+
+- Accepted ReviewGPT artifact:
+  `browser-vault-timeout-stage-telemetry-v4.patch`, exact SHA-256
+  `692972685f2fe00e2b9ad5bb3d86a0aaf18d02cc15a18602b3bd98fbec4e7ff0`.
+- Passed: 76 focused Vitest cases across the Browser Vault replica owner and
+  assembled workspace scheduling/preemption paths.
+- Passed: `@murphai/assistant-runtime` TypeScript typecheck.
+- Passed: repository raw-log privacy guard and `git diff --check`.
+- Product UX result: not applicable; this patch changes only failure metadata
+  and leaves timing, control flow, replies, recovery, and user-visible state
+  unchanged.

--- a/agent-docs/exec-plans/completed/2026-08-27-browser-vault-timeout-stage-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-27-browser-vault-timeout-stage-telemetry.md
@@ -1,8 +1,8 @@
 # Identify Browser Vault refresh timeout stage
 
-Status: active
+Status: completed
 Created: 2026-08-27
-Updated: 2026-08-27
+Updated: 2026-08-28
 
 ## Goal
 
@@ -86,6 +86,12 @@ Updated: 2026-08-27
   ReviewGPT's complete v4 replacement captures the already-proven ref and
   publish method before the thunks, removes the assertion, and is the only
   accepted production implementation.
+- The preliminary coverage specialist found that the v4 cancellation owner
+  also returned the captured source summary for post-hash runtime-wake and
+  external-abort deferrals. That widened non-timeout telemetry beyond this
+  plan's timeout-only contract. The finding was accepted and ReviewGPT's exact
+  correction now attaches captured source only to `deferred_timeout`; focused
+  exact-result tests preserve zero source summaries for both non-timeout paths.
 
 ## Verification
 
@@ -102,10 +108,14 @@ Updated: 2026-08-27
 - Accepted ReviewGPT artifact:
   `browser-vault-timeout-stage-telemetry-v4.patch`, exact SHA-256
   `692972685f2fe00e2b9ad5bb3d86a0aaf18d02cc15a18602b3bd98fbec4e7ff0`.
-- Passed: 76 focused Vitest cases across the Browser Vault replica owner and
+- Passed: 77 focused Vitest cases across the Browser Vault replica owner and
   assembled workspace scheduling/preemption paths.
 - Passed: `@murphai/assistant-runtime` TypeScript typecheck.
 - Passed: repository raw-log privacy guard and `git diff --check`.
+- Passed: final ReviewGPT round 2 on corrected head
+  `c3348500d9d67c5fe204d6f9c52329ac67dcb1d1`, with no qualifying findings.
+- Opened: PR #2486, ready for human merge after exact-final-head CI.
 - Product UX result: not applicable; this patch changes only failure metadata
   and leaves timing, control flow, replies, recovery, and user-visible state
   unchanged.
+Completed: 2026-08-28

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -3166,6 +3166,29 @@ state untouched for the next foreground-safe opportunity. Timeout, source
 change, publication conflict, generic failure, and an oversized replica
 terminally record the current item without a future retry; a later browser
 freshness request may enqueue new work after the underlying state changes.
+A timeout result also carries the closed refresh-stage vocabulary
+`initial_source_hash`, `replica_construction`, `replica_serialization`,
+`second_source_hash`, `replica_write`, or `ref_publication`; the
+`replica_serialization` value covers cooperative serialization and byte
+measurement. The existing hosted phase log emits that value only as
+`details.browserVaultRefreshStage`. Once the initial source hash finishes, the
+same deferred result and log retain the existing numeric source file-count and
+byte-total summary; before then both remain zero. The closed stage is the only
+new production log value. These details never include paths, filenames, source
+hashes, content, messages, prompts, transcripts, health values, member or
+workspace identifiers, credentials, provider payloads, raw errors, or
+distinctive private scenarios.
+
+A later bounded production query filters
+`details.browserVaultRefreshStatus = deferred_timeout`, aggregates only
+`details.browserVaultRefreshStage` by count and, when already available, the
+existing bounded duration bucket, then compares those counts with privacy-safe
+Web aggregates for refresh-requested state, replica-age bucket, and next-wake
+presence. Use natural traffic only; do not issue synthetic production refresh
+requests for this diagnosis. This additive field ships through the normal
+protected Cloudflare runner-bundle deployment, has no Web deployment ordering
+or persisted compatibility floor, and rolls back with the prior runner bundle.
+
 Fresh work and recording items that own post-checkpoint effects retain their
 existing pre-effect preparation checkpoint. Missing optional publication
 support and missing workspace context remain explicit terminal no-op

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -6877,6 +6877,9 @@ function buildHostedBrowserVaultRefreshLogDetails(
     ...("maxBytes" in refresh
       ? { browserVaultReplicaMaxBytes: refresh.maxBytes }
       : {}),
+    ...(refresh.status === "deferred_timeout"
+      ? { browserVaultRefreshStage: refresh.refreshStage }
+      : {}),
     ...("source" in refresh
       ? {
           browserVaultReplicaSourceFileCount: refresh.source.fileCount,

--- a/packages/assistant-runtime/src/hosted-runtime/browser-vault-replica.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/browser-vault-replica.ts
@@ -81,6 +81,14 @@ export interface HostedBrowserVaultReplicaRestoreSummary {
   restoreWasCold: boolean;
 }
 
+export type HostedBrowserVaultReplicaRefreshStage =
+  | "initial_source_hash"
+  | "replica_construction"
+  | "replica_serialization"
+  | "second_source_hash"
+  | "replica_write"
+  | "ref_publication";
+
 export interface HostedBrowserVaultReplicaRefreshPreparation {
   content: HostedBrowserVaultReplicaContentSummary;
   replica: BrowserVaultReplica;
@@ -110,8 +118,13 @@ export type HostedBrowserVaultReplicaRefreshResult =
       status: "refresh_failed_too_large";
     }
   | {
+      refreshStage: HostedBrowserVaultReplicaRefreshStage;
       source: HostedBrowserVaultReplicaSourceSummary;
-      status: "deferred_runtime_wake" | "deferred_timeout" | "deferred_aborted";
+      status: "deferred_timeout";
+    }
+  | {
+      source: HostedBrowserVaultReplicaSourceSummary;
+      status: "deferred_runtime_wake" | "deferred_aborted";
     }
   | {
       source: HostedBrowserVaultReplicaSourceSummary;
@@ -208,6 +221,7 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
   if (!port?.write || !port.publishRef) {
     return { status: "skipped_no_port" };
   }
+  const publishRef = port.publishRef;
   if (!input.workspace) {
     return { status: "workspace_missing" };
   }
@@ -229,9 +243,11 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
 
   try {
     const sourceBefore = await cancellation.runOwned(
+      "initial_source_hash",
       (signal) => hashHostedBrowserVaultReplicaSources(input.vaultRoot, signal),
     );
     const source = summarizeHostedBrowserVaultReplicaSource(sourceBefore);
+    cancellation.recordSource(source);
     const freshness = assessBrowserVaultReplicaFreshness({
       currentSourceHash: sourceBefore.hash,
       maxAgeMs: input.maxAgeMs,
@@ -248,6 +264,7 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     }
 
     const replica = await cancellation.runOwned(
+      "replica_construction",
       (signal) => createHostedBrowserVaultReplicaForSourceState({
         generatedAt,
         signal,
@@ -258,6 +275,7 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     cancellation.throwIfCancelled();
     const content = summarizeHostedBrowserVaultReplicaContent(replica);
     const byteLength = await cancellation.runOwned(
+      "replica_serialization",
       (signal) => measureHostedBrowserVaultReplicaBytes(replica, signal),
     );
     cancellation.throwIfCancelled();
@@ -272,6 +290,7 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     }
 
     const sourceAfter = await cancellation.runOwned(
+      "second_source_hash",
       (signal) => hashHostedBrowserVaultReplicaSources(input.vaultRoot, signal),
     );
     if (sourceAfter.hash !== sourceBefore.hash) {
@@ -282,10 +301,12 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     }
 
     cancellation.throwIfCancelled();
+    const replacedReplicaRef = input.workspace.browserVaultReplicaRef ?? null;
     const replicaRef = await cancellation.race(
-      port.write({
+      "replica_write",
+      () => port.write({
         replica,
-        replacedReplicaRef: input.workspace.browserVaultReplicaRef ?? null,
+        replacedReplicaRef,
         signal: cancellation.signal,
       }),
     );
@@ -297,7 +318,8 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
 
     cancellation.throwIfCancelled();
     const publish = await cancellation.race(
-      port.publishRef({
+      "ref_publication",
+      () => publishRef.call(port, {
         replicaRef,
         signal: cancellation.signal,
       }),
@@ -318,11 +340,19 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     };
   } catch (error) {
     if (error instanceof HostedBrowserVaultRefreshDeferredError) {
+      const source = error.source ?? {
+        fileCount: 0,
+        totalBytes: 0,
+      };
+      if (error.status === "deferred_timeout") {
+        return {
+          refreshStage: error.refreshStage,
+          source,
+          status: error.status,
+        };
+      }
       return {
-        source: error.source ?? {
-          fileCount: 0,
-          totalBytes: 0,
-        },
+        source,
         status: error.status,
       };
     }
@@ -650,6 +680,7 @@ function assertHostedBrowserVaultReplicaWriteMatchesRefresh(input: {
 }
 
 class HostedBrowserVaultRefreshDeferredError extends Error {
+  readonly refreshStage: HostedBrowserVaultReplicaRefreshStage;
   readonly source: HostedBrowserVaultReplicaSourceSummary | null;
   readonly status: Extract<
     HostedBrowserVaultReplicaRefreshResult["status"],
@@ -657,11 +688,13 @@ class HostedBrowserVaultRefreshDeferredError extends Error {
   >;
 
   constructor(input: {
+    refreshStage: HostedBrowserVaultReplicaRefreshStage;
     source?: HostedBrowserVaultReplicaSourceSummary | null;
     status: HostedBrowserVaultRefreshDeferredError["status"];
   }) {
     super(`Hosted browser-vault refresh ${input.status}.`);
     this.name = "HostedBrowserVaultRefreshDeferredError";
+    this.refreshStage = input.refreshStage;
     this.source = input.source ?? null;
     this.status = input.status;
   }
@@ -673,12 +706,21 @@ function createBrowserVaultRefreshCancellation(input: {
   timeoutMs: number;
 }): {
   cleanup(): void;
-  race<T>(promise: Promise<T>): Promise<T>;
-  runOwned<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T>;
+  race<T>(
+    refreshStage: HostedBrowserVaultReplicaRefreshStage,
+    operation: () => Promise<T>,
+  ): Promise<T>;
+  recordSource(source: HostedBrowserVaultReplicaSourceSummary): void;
+  runOwned<T>(
+    refreshStage: HostedBrowserVaultReplicaRefreshStage,
+    operation: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T>;
   signal: AbortSignal;
   throwIfCancelled(): void;
 } {
   let deferred: HostedBrowserVaultRefreshDeferredError | null = null;
+  let refreshStage: HostedBrowserVaultReplicaRefreshStage = "initial_source_hash";
+  let source: HostedBrowserVaultReplicaSourceSummary | null = null;
   let rejectDeferred: (error: HostedBrowserVaultRefreshDeferredError) => void = () => {};
   const waiterAbortController = new AbortController();
   const deferredPromise = new Promise<never>((_resolve, reject) => {
@@ -689,7 +731,11 @@ function createBrowserVaultRefreshCancellation(input: {
     if (deferred) {
       return;
     }
-    deferred = new HostedBrowserVaultRefreshDeferredError({ status });
+    deferred = new HostedBrowserVaultRefreshDeferredError({
+      refreshStage,
+      source,
+      status,
+    });
     if (!waiterAbortController.signal.aborted) {
       waiterAbortController.abort(deferred);
     }
@@ -717,13 +763,25 @@ function createBrowserVaultRefreshCancellation(input: {
         );
       }
     },
-    async race<T>(promise: Promise<T>): Promise<T> {
+    async race<T>(
+      nextRefreshStage: HostedBrowserVaultReplicaRefreshStage,
+      operation: () => Promise<T>,
+    ): Promise<T> {
+      refreshStage = nextRefreshStage;
+      const promise = operation();
       if (deferred) {
         throw deferred;
       }
       return await Promise.race([promise, deferredPromise]);
     },
-    async runOwned<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    recordSource(nextSource: HostedBrowserVaultReplicaSourceSummary) {
+      source = nextSource;
+    },
+    async runOwned<T>(
+      nextRefreshStage: HostedBrowserVaultReplicaRefreshStage,
+      operation: (signal: AbortSignal) => Promise<T>,
+    ): Promise<T> {
+      refreshStage = nextRefreshStage;
       if (deferred) {
         throw deferred;
       }

--- a/packages/assistant-runtime/src/hosted-runtime/browser-vault-replica.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/browser-vault-replica.ts
@@ -340,11 +340,11 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
     };
   } catch (error) {
     if (error instanceof HostedBrowserVaultRefreshDeferredError) {
-      const source = error.source ?? {
-        fileCount: 0,
-        totalBytes: 0,
-      };
       if (error.status === "deferred_timeout") {
+        const source = error.source ?? {
+          fileCount: 0,
+          totalBytes: 0,
+        };
         return {
           refreshStage: error.refreshStage,
           source,
@@ -352,7 +352,10 @@ export async function refreshHostedBrowserVaultReplicaFromRuntime(input: {
         };
       }
       return {
-        source,
+        source: {
+          fileCount: 0,
+          totalBytes: 0,
+        },
         status: error.status,
       };
     }

--- a/packages/assistant-runtime/test/hosted-browser-vault-replica.test.ts
+++ b/packages/assistant-runtime/test/hosted-browser-vault-replica.test.ts
@@ -1342,8 +1342,64 @@ describe("hosted browser-vault replica refresh preparation", () => {
         workspace,
       });
 
-      expect(result).toMatchObject({
+      expect(result).toEqual({
+        source: {
+          fileCount: 0,
+          totalBytes: 0,
+        },
         status: "deferred_runtime_wake",
+      });
+      expect(write).toHaveBeenCalledOnce();
+      expect(publishRef).not.toHaveBeenCalled();
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("retains the zero source summary when externally aborted after source hashing", async () => {
+    const {
+      refreshHostedBrowserVaultReplicaFromRuntime,
+    } = await import("../src/hosted-runtime/browser-vault-replica.ts");
+    const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-browser-vault-refresh-"));
+    const controller = new AbortController();
+    const workspace = createWorkspaceState({
+      browserVaultReplicaRef: null,
+      checkpointedAt: "2026-05-10T00:00:00.000Z",
+    });
+    const publishRef = vi.fn(async (input: { replicaRef: HostedBrowserVaultReplicaRef }) => ({
+      published: true,
+      workspace: {
+        ...workspace,
+        browserVaultReplicaRef: input.replicaRef,
+      },
+    }));
+    const write = vi.fn(async (input: { replica: unknown }) => {
+      controller.abort(new DOMException("Foreground work took priority.", "AbortError"));
+      return createReplicaRefFromReplica(input.replica);
+    });
+
+    try {
+      await writeBrowserVaultStageSource(vaultRoot);
+      const result = await refreshHostedBrowserVaultReplicaFromRuntime({
+        force: true,
+        generatedAt: "2026-05-10T00:01:00.000Z",
+        platform: createPlatform({
+          browserVaultReplicaPort: {
+            publishRef,
+            write,
+          },
+        }),
+        signal: controller.signal,
+        vaultRoot,
+        workspace,
+      });
+
+      expect(result).toEqual({
+        source: {
+          fileCount: 0,
+          totalBytes: 0,
+        },
+        status: "deferred_aborted",
       });
       expect(write).toHaveBeenCalledOnce();
       expect(publishRef).not.toHaveBeenCalled();
@@ -1413,7 +1469,11 @@ describe("hosted browser-vault replica refresh preparation", () => {
         workspace,
       });
 
-      expect(result).toMatchObject({
+      expect(result).toEqual({
+        source: {
+          fileCount: 0,
+          totalBytes: 0,
+        },
         status: "deferred_runtime_wake",
       });
       expect(write).toHaveBeenCalledOnce();

--- a/packages/assistant-runtime/test/hosted-browser-vault-replica.test.ts
+++ b/packages/assistant-runtime/test/hosted-browser-vault-replica.test.ts
@@ -267,7 +267,11 @@ describe("hosted browser-vault replica refresh preparation", () => {
         workspace,
       });
 
-      expect(timedOut).toMatchObject({ status: "deferred_timeout" });
+      expect(timedOut).toEqual({
+        refreshStage: "initial_source_hash",
+        source: { fileCount: 0, totalBytes: 0 },
+        status: "deferred_timeout",
+      });
       expect(write).not.toHaveBeenCalled();
       expect(publishRef).not.toHaveBeenCalled();
 
@@ -824,6 +828,7 @@ describe("hosted browser-vault replica refresh preparation", () => {
 
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
       const resultPromise = refreshHostedBrowserVaultReplicaFromRuntime({
         force: true,
         generatedAt: "2026-05-10T00:01:00.000Z",
@@ -846,10 +851,61 @@ describe("hosted browser-vault replica refresh preparation", () => {
       expect(settled).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
 
-      await expect(resultPromise).resolves.toMatchObject({
+      await expect(resultPromise).resolves.toEqual({
+        refreshStage: "replica_write",
+        source: expectedSource,
         status: "deferred_timeout",
       });
       expect(writeStopped).toBe(true);
+      expect(publishRef).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("@murphai/query/browser-replica-server");
+      vi.useRealTimers();
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("records the replica-write stage before invoking the injected write", async () => {
+    mockImmediateBrowserVaultReplicaBuild();
+    const {
+      refreshHostedBrowserVaultReplicaFromRuntime,
+    } = await import("../src/hosted-runtime/browser-vault-replica.ts");
+    const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-browser-vault-refresh-"));
+    let signalWasAbortedBeforeTimeout: boolean | null = null;
+    let signalWasAbortedAfterTimeout: boolean | null = null;
+    const publishRef = vi.fn();
+    const write = vi.fn((input: { signal?: AbortSignal | null }) => {
+      signalWasAbortedBeforeTimeout = input.signal?.aborted ?? null;
+      vi.advanceTimersByTime(1_000);
+      signalWasAbortedAfterTimeout = input.signal?.aborted ?? null;
+      return new Promise<never>(() => undefined);
+    });
+
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
+      const result = await refreshHostedBrowserVaultReplicaFromRuntime({
+        force: true,
+        generatedAt: "2026-05-10T00:01:00.000Z",
+        platform: createPlatform({
+          browserVaultReplicaPort: {
+            publishRef,
+            write,
+          },
+        }),
+        timeoutMs: 1_000,
+        vaultRoot,
+        workspace: createWorkspaceState(),
+      });
+
+      expect(result).toEqual({
+        refreshStage: "replica_write",
+        source: expectedSource,
+        status: "deferred_timeout",
+      });
+      expect(signalWasAbortedBeforeTimeout).toBe(false);
+      expect(signalWasAbortedAfterTimeout).toBe(true);
+      expect(write).toHaveBeenCalledOnce();
       expect(publishRef).not.toHaveBeenCalled();
     } finally {
       vi.doUnmock("@murphai/query/browser-replica-server");
@@ -901,6 +957,7 @@ describe("hosted browser-vault replica refresh preparation", () => {
 
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
       const resultPromise = refreshHostedBrowserVaultReplicaFromRuntime({
         force: true,
         generatedAt: "2026-05-10T00:01:00.000Z",
@@ -917,12 +974,226 @@ describe("hosted browser-vault replica refresh preparation", () => {
       await buildStarted;
       await vi.advanceTimersByTimeAsync(1_000);
 
-      await expect(resultPromise).resolves.toMatchObject({
+      await expect(resultPromise).resolves.toEqual({
+        refreshStage: "replica_construction",
+        source: expectedSource,
         status: "deferred_timeout",
       });
       expect(buildStopped).toBe(true);
       expect(write).not.toHaveBeenCalled();
       expect(publishRef).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("@murphai/query/browser-replica-server");
+      vi.useRealTimers();
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("attributes a timeout during replica serialization and retains the known source summary", async () => {
+    let resolveSerializationStarted: (() => void) | null = null;
+    const serializationStarted = new Promise<void>((resolve) => {
+      resolveSerializationStarted = resolve;
+    });
+    let serializationStopped = false;
+    vi.doMock(
+      "@murphai/query/browser-replica-server",
+      async (importOriginal) => {
+        const actual = await importOriginal<
+          typeof import("@murphai/query/browser-replica-server")
+        >();
+        return {
+          ...actual,
+          async createBrowserVaultReplica(
+            input: Parameters<typeof actual.createBrowserVaultReplica>[0],
+          ) {
+            const { signal: _signal, ...uncancelledInput } = input;
+            return await actual.createBrowserVaultReplica(uncancelledInput);
+          },
+          async stringifyJsonCooperatively(
+            value: Parameters<typeof actual.stringifyJsonCooperatively>[0],
+            options?: Parameters<typeof actual.stringifyJsonCooperatively>[1],
+          ) {
+            const signal = options?.signal;
+            if (!signal) {
+              throw new Error("Browser Vault serialization must receive cancellation.");
+            }
+            resolveSerializationStarted?.();
+            await waitForAbort(signal);
+            serializationStopped = true;
+            signal.throwIfAborted();
+            return await actual.stringifyJsonCooperatively(value, options);
+          },
+        };
+      },
+    );
+    const {
+      refreshHostedBrowserVaultReplicaFromRuntime,
+    } = await import("../src/hosted-runtime/browser-vault-replica.ts");
+    const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-browser-vault-refresh-"));
+    const publishRef = vi.fn();
+    const write = vi.fn();
+
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
+      const resultPromise = refreshHostedBrowserVaultReplicaFromRuntime({
+        force: true,
+        generatedAt: "2026-05-10T00:01:00.000Z",
+        platform: createPlatform({
+          browserVaultReplicaPort: {
+            publishRef,
+            write,
+          },
+        }),
+        timeoutMs: 1_000,
+        vaultRoot,
+        workspace: createWorkspaceState(),
+      });
+      await serializationStarted;
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(resultPromise).resolves.toEqual({
+        refreshStage: "replica_serialization",
+        source: expectedSource,
+        status: "deferred_timeout",
+      });
+      expect(serializationStopped).toBe(true);
+      expect(write).not.toHaveBeenCalled();
+      expect(publishRef).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("@murphai/query/browser-replica-server");
+      vi.useRealTimers();
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("attributes a timeout during the second source hash before replica write", async () => {
+    let hashCallCount = 0;
+    let resolveSecondHashStarted: (() => void) | null = null;
+    const secondHashStarted = new Promise<void>((resolve) => {
+      resolveSecondHashStarted = resolve;
+    });
+    let secondHashStopped = false;
+    vi.doMock(
+      "@murphai/query/browser-replica-server",
+      async (importOriginal) => {
+        const actual = await importOriginal<
+          typeof import("@murphai/query/browser-replica-server")
+        >();
+        return {
+          ...actual,
+          async createBrowserVaultReplica(
+            input: Parameters<typeof actual.createBrowserVaultReplica>[0],
+          ) {
+            const { signal: _signal, ...uncancelledInput } = input;
+            return await actual.createBrowserVaultReplica(uncancelledInput);
+          },
+          async hashCanonicalQuerySources(
+            vaultRoot: Parameters<typeof actual.hashCanonicalQuerySources>[0],
+            options?: Parameters<typeof actual.hashCanonicalQuerySources>[1],
+          ) {
+            hashCallCount += 1;
+            if (hashCallCount === 1) {
+              return await actual.hashCanonicalQuerySources(vaultRoot, options);
+            }
+            const signal = options?.signal;
+            if (!signal) {
+              throw new Error("Browser Vault source hashing must receive cancellation.");
+            }
+            resolveSecondHashStarted?.();
+            await waitForAbort(signal);
+            secondHashStopped = true;
+            signal.throwIfAborted();
+            return await actual.hashCanonicalQuerySources(vaultRoot, options);
+          },
+        };
+      },
+    );
+    const {
+      refreshHostedBrowserVaultReplicaFromRuntime,
+    } = await import("../src/hosted-runtime/browser-vault-replica.ts");
+    const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-browser-vault-refresh-"));
+    const publishRef = vi.fn();
+    const write = vi.fn();
+
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
+      const resultPromise = refreshHostedBrowserVaultReplicaFromRuntime({
+        force: true,
+        generatedAt: "2026-05-10T00:01:00.000Z",
+        platform: createPlatform({
+          browserVaultReplicaPort: {
+            publishRef,
+            write,
+          },
+        }),
+        timeoutMs: 1_000,
+        vaultRoot,
+        workspace: createWorkspaceState(),
+      });
+      await secondHashStarted;
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(resultPromise).resolves.toEqual({
+        refreshStage: "second_source_hash",
+        source: expectedSource,
+        status: "deferred_timeout",
+      });
+      expect(secondHashStopped).toBe(true);
+      expect(write).not.toHaveBeenCalled();
+      expect(publishRef).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("@murphai/query/browser-replica-server");
+      vi.useRealTimers();
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("records the ref-publication stage before invoking the injected publication", async () => {
+    mockImmediateBrowserVaultReplicaBuild();
+    const {
+      refreshHostedBrowserVaultReplicaFromRuntime,
+    } = await import("../src/hosted-runtime/browser-vault-replica.ts");
+    const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "murph-browser-vault-refresh-"));
+    let signalWasAbortedBeforeTimeout: boolean | null = null;
+    let signalWasAbortedAfterTimeout: boolean | null = null;
+    const publishRef = vi.fn((input: { signal?: AbortSignal | null }) => {
+      signalWasAbortedBeforeTimeout = input.signal?.aborted ?? null;
+      vi.advanceTimersByTime(1_000);
+      signalWasAbortedAfterTimeout = input.signal?.aborted ?? null;
+      return new Promise<never>(() => undefined);
+    });
+    const write = vi.fn(async (input: { replica: unknown }) =>
+      createReplicaRefFromReplica(input.replica)
+    );
+
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      const expectedSource = await writeBrowserVaultStageSource(vaultRoot);
+      const result = await refreshHostedBrowserVaultReplicaFromRuntime({
+        force: true,
+        generatedAt: "2026-05-10T00:01:00.000Z",
+        platform: createPlatform({
+          browserVaultReplicaPort: {
+            publishRef,
+            write,
+          },
+        }),
+        timeoutMs: 1_000,
+        vaultRoot,
+        workspace: createWorkspaceState(),
+      });
+
+      expect(result).toEqual({
+        refreshStage: "ref_publication",
+        source: expectedSource,
+        status: "deferred_timeout",
+      });
+      expect(signalWasAbortedBeforeTimeout).toBe(false);
+      expect(signalWasAbortedAfterTimeout).toBe(true);
+      expect(write).toHaveBeenCalledOnce();
+      expect(publishRef).toHaveBeenCalledOnce();
     } finally {
       vi.doUnmock("@murphai/query/browser-replica-server");
       vi.useRealTimers();
@@ -1261,6 +1532,36 @@ function createBrowserVaultCancellationLedger(recordCount: number): string {
       title: "Synthetic cancellation panel",
     })
   ).join("\n")}\n`;
+}
+
+const BROWSER_VAULT_STAGE_SOURCE_DOCUMENT = createExperimentDocument({
+  experimentId: "exp_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  slug: "timeout-stage",
+  status: "active",
+});
+
+async function writeBrowserVaultStageSource(vaultRoot: string): Promise<{
+  fileCount: number;
+  totalBytes: number;
+}> {
+  await writeVaultFile(
+    vaultRoot,
+    "bank/experiments/timeout-stage.md",
+    BROWSER_VAULT_STAGE_SOURCE_DOCUMENT,
+  );
+  return {
+    fileCount: 1,
+    totalBytes: new TextEncoder().encode(BROWSER_VAULT_STAGE_SOURCE_DOCUMENT).byteLength,
+  };
+}
+
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
 }
 
 async function writeVaultFile(

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
@@ -15,6 +15,7 @@ import {
   createWorkspaceState,
   importRuntimeControlSystemMailboxItemForTest,
   mocks,
+  readCapturedRuntimePhaseLogs,
   readCheckpointConversationWatermark,
   removeTempRoot,
   requireEventIndex,
@@ -2576,21 +2577,26 @@ describe("hosted workspace runtime entrypoint", () => {test("reports mailbox bud
 
   test("does not schedule a continuation when forced browser-vault refresh maintenance times out", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const attemptId = "attempt_synthetic_browser_vault_marker_force";
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const events: string[] = [];
+    const previousStdIoLogSetting = process.env.MURPH_HOSTED_EXECUTION_STDIO_LOGS;
 
     mocks.refreshHostedBrowserVaultReplicaFromRuntime.mockClear();
     mocks.refreshHostedBrowserVaultReplicaFromRuntime.mockResolvedValueOnce({
-      source: { fileCount: 0, totalBytes: 0 },
+      refreshStage: "replica_write",
+      source: { fileCount: 7, totalBytes: 4_096 },
       status: "deferred_timeout",
     });
 
     try {
+      process.env.MURPH_HOSTED_EXECUTION_STDIO_LOGS = "1";
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
 
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
-            attemptId: "attempt_synthetic_browser_vault_marker_force",
+            attemptId,
             workspaceVersion: "0",
           },
         }),
@@ -2631,7 +2637,30 @@ describe("hosted workspace runtime entrypoint", () => {test("reports mailbox bud
       );
       expect(result.status).toBe("idle");
       expect(result.nextWakeAt).toBeNull();
+      const refreshLog = readCapturedRuntimePhaseLogs({
+        attemptId,
+        spy: consoleInfo,
+      }).find((entry) =>
+        entry.details.runtimePhase === "browser_vault.refresh"
+        && entry.details.runtimePhaseStatus === "done"
+        && entry.details.browserVaultRefreshStatus === "deferred_timeout"
+      );
+      assert.ok(refreshLog);
+      expect(Object.fromEntries(
+        Object.entries(refreshLog.details).filter(([key]) => key.startsWith("browserVault")),
+      )).toEqual({
+        browserVaultRefreshStage: "replica_write",
+        browserVaultRefreshStatus: "deferred_timeout",
+        browserVaultReplicaSourceFileCount: 7,
+        browserVaultReplicaSourceTotalBytes: 4_096,
+      });
     } finally {
+      if (previousStdIoLogSetting === undefined) {
+        delete process.env.MURPH_HOSTED_EXECUTION_STDIO_LOGS;
+      } else {
+        process.env.MURPH_HOSTED_EXECUTION_STDIO_LOGS = previousStdIoLogSetting;
+      }
+      consoleInfo.mockRestore();
       mocks.refreshHostedBrowserVaultReplicaFromRuntime.mockClear();
       await removeTempRoot(vaultRoot);
     }

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
@@ -2355,6 +2355,7 @@ describe("hosted workspace runtime entrypoint", () => {test("fresh foreground in
       assert.equal(input.deadlineMs, Date.parse(reminderAt));
       vi.setSystemTime(new Date(reminderAt));
       return {
+        refreshStage: "replica_write" as const,
         source: { fileCount: 0, totalBytes: 0 },
         status: "deferred_timeout" as const,
       };


### PR DESCRIPTION
## Why and outcome

Production Browser Vault refreshes repeatedly reach the existing 20-second
`deferred_timeout` result, but current logs cannot distinguish source hashing,
replica construction, serialization, the second source hash, replica write, or
ref publication. This PR adds one closed `browserVaultRefreshStage` field to the
existing timeout log and preserves the existing safe source count/byte summary
once the initial hash has completed.

The change is telemetry-only. It does not alter the timeout, work sequence,
cancellation joining, retry/terminalization policy, publication behavior,
canonical state, or user-visible behavior.

## Product UX

- Effort: Patch — internal failure metadata only.
- Result: Ready.
- Walkthrough: No member journey changes. Browser Vault refresh, foreground
  preemption, idle completion, and later browser freshness behavior are
  preserved.

## Evidence

- Direct: Focused Browser Vault and assembled workspace-entrypoint suites pass
  77 tests, including all six stage values, synchronous write/publication
  boundaries, safe source-summary retention, no early write/publication, and
  the existing idle/no-continuation timeout outcome. Exact regression proof also
  preserves the pre-existing zero source summary for non-timeout wake and abort
  deferrals after source hashing.
- Coverage: `@murphai/assistant-runtime` typecheck, the repository raw-log
  privacy guard, and `git diff --check` pass on
  `c3348500d9d67c5fe204d6f9c52329ac67dcb1d1`.
- Provenance: ReviewGPT exclusively authored the accepted complete production,
  test, and contract patch. The applied v4 artifact SHA-256 is
  `692972685f2fe00e2b9ad5bb3d86a0aaf18d02cc15a18602b3bd98fbec4e7ff0`.
  ReviewGPT also authored the accepted specialist correction; its artifact
  SHA-256 is
  `cfd2291fcf88d287b83b2959ecfc4ea0be1c1fdc818c273b5793f82fade13886`.

## Non-obvious affected surfaces

- The assistant-runtime package is embedded in the Cloudflare hosted runner
  bundle. The existing `browser_vault.refresh` done-phase log gains one field
  only when status is `deferred_timeout`.
- Browser Vault mailbox terminalization remains unchanged and is covered by the
  workspace-entrypoint scheduling test.
- No Web, Temporal, database, provider, message-delivery, or device-sync surface
  changes.

## Architecture and reuse

- Existing systems reused: the current Browser Vault refresh cancellation
  owner, result union, hosted structured phase logger, and Cloudflare runner
  deployment path.
- New logic: function-local tracking of the currently executing closed refresh
  stage and the already-computed numeric source summary for timeout metadata.
- New abstractions: one six-value TypeScript stage union; no service, state
  owner, persistence, scheduler, queue, or generalized telemetry layer.
- Complexity intentionally avoided: no retry policy, timeout change, new event,
  backend, database write, network call, serialization pass, compatibility
  shim, or device-sync overlap.

## Hot reply path impact

- Path status: Not applicable — Browser Vault refresh is low-priority
  maintenance and the patch adds only synchronous metadata assignments.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The existing refresh order and call count are unchanged;
  focused tests preserve foreground preemption and no-continuation timeout
  behavior.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no prompt, tool, provider wrapper, history, or
  provider-visible fixture surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: Production hosted-runtime failure telemetry and
Cloudflare runner-bundle code change, despite behavior-preserving scope.

## Deployment concerns

- Deployment: applicable
- Supported skew: The field is additive and consumed only by observability;
  old/new runner and Web versions remain wire- and state-compatible.
- Safe order: After human merge, deploy through the protected Cloudflare hosted
  runner workflow using its then-current approved container rollout setting.
  No Vercel/Web deployment is required.
- Rollback floor: None; no persisted format or producer/consumer contract
  changes.
- Expected exposure: Existing Browser Vault refresh attempts only; timeout logs
  add one low-cardinality field and may report already-known numeric source
  counts/bytes accurately.
- Reversibility: Deploy the preceding runner bundle through the same protected
  workflow.
- Convergence proof: Confirm the deployed runner fingerprint includes the
  merged revision and the optional field schema is accepted by Workers
  Observability.
- Post-deploy checks: On natural traffic only, filter
  `details.browserVaultRefreshStatus = deferred_timeout`, aggregate
  `details.browserVaultRefreshStage` by count and existing duration bucket, and
  compare with privacy-safe Web aggregates for refresh-requested state,
  replica-age bucket, and next-wake presence. Do not generate synthetic traffic.

## Change-shape breakdown

Classification rule: Runtime `.ts` files are Source; test files are Tests /
fixtures; the execution plan and hosted-runtime contract are Docs. No binary or
generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 74 | 10 |
| Tests / fixtures | 398 | 7 |
| Docs | 134 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **606** | **17** |

## Changelog

- Changelog: not applicable
- Reason: Internal production diagnostics only; no member-visible behavior or
  recovery outcome changes.

ReviewGPT first-reviewed head: c64cade13afb134e9464d5da6f748c1c8e614a3e
