### PR TITLE
Classify pause-tool schema rejections

### DIFF
--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -1009,6 +1009,14 @@ const COMPUTER_OPEN_ARGUMENT_ROOT_KEYS = [
   'startUrl',
 ] as const
 
+const COMPUTER_PAUSE_FOR_USER_ARGUMENT_ROOT_KEYS = Object.keys(
+  MURPH_COMPUTER_PAUSE_FOR_USER_TOOL.inputSchema.properties,
+)
+const computerPauseForUserValidationPaths =
+  collectSafeJsonSchemaValidationPaths(
+    MURPH_COMPUTER_PAUSE_FOR_USER_TOOL.inputSchema,
+  )
+
 const computerNavigationUrlSchema = z
   .string()
   .trim()
@@ -2104,6 +2112,8 @@ export function readMurphDynamicToolRequest(
         argumentsValue: request.arguments,
         schema: computerPauseForUserArgumentsSchema,
         schemaName: 'murph.computer_pause_for_user.input',
+        schemaPaths: computerPauseForUserValidationPaths,
+        schemaRootKeys: COMPUTER_PAUSE_FOR_USER_ARGUMENT_ROOT_KEYS,
         toolName: 'murph.computer_pause_for_user',
       })
       return parsed.ok
@@ -7729,6 +7739,7 @@ function parseComputerArguments<TArgs>(input: {
   argumentsValue: unknown
   schema: z.ZodType<TArgs> & { shape?: Record<string, unknown> }
   schemaName: string
+  schemaPaths?: readonly string[]
   schemaRootKeys?: readonly string[]
   toolName: string
 }):
@@ -7742,6 +7753,7 @@ function parseComputerArguments<TArgs>(input: {
         error: parsed.error,
         rawInput: input.argumentsValue,
         schemaName: input.schemaName,
+        schemaPaths: input.schemaPaths,
         schemaRootKeys: input.schemaRootKeys ?? readZodObjectRootKeys(input.schema),
         toolName: input.toolName,
       }),

--- a/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
@@ -755,6 +755,33 @@ describe("murph computer dynamic tools", () => {
   });
 
   it("parses the generic pause-for-user checkpoint tool", () => {
+    for (const argumentsValue of [
+      {
+        reason: "other",
+        runId: "run_123",
+      },
+      {
+        handoffPurpose: null,
+        reason: "other",
+        runId: "run_123",
+        suggestedReply: null,
+      },
+    ]) {
+      expect(readTestMurphDynamicToolRequest(dynamicToolCall({
+        argumentsValue,
+        tool: "computer_pause_for_user",
+      }))).toEqual({
+        args: {
+          handoffPurpose: null,
+          pauseDeliveryContext: null,
+          reason: "other",
+          runId: "run_123",
+          suggestedReply: null,
+        },
+        kind: "computer-pause-for-user",
+      });
+    }
+
     const request = readTestMurphDynamicToolRequest(dynamicToolCall({
       argumentsValue: {
         handoffPurpose: "manual_browser_help",
@@ -796,6 +823,147 @@ describe("murph computer dynamic tools", () => {
       },
       kind: "computer-pause-for-user",
     });
+  });
+
+  it("records only schema-owned paths and bounded shapes for invalid pause fields", () => {
+    const invalidHandoffPurpose = "private-invalid-purpose";
+    const privateRunId = "run_private_123";
+    const privateSuggestedReply = "private reply text";
+    const privateReason = {
+      message: "private message text",
+      secret: "private secret value",
+      url: "https://private.example.test/handoff",
+    };
+    const request = readTestMurphDynamicToolRequest(dynamicToolCall({
+      argumentsValue: {
+        handoffPurpose: invalidHandoffPurpose,
+        reason: privateReason,
+        runId: privateRunId,
+        suggestedReply: privateSuggestedReply,
+      },
+      tool: "computer_pause_for_user",
+    }));
+
+    if (!request || request.kind !== "invalid-computer-arguments") {
+      throw new Error("Expected invalid computer pause arguments.");
+    }
+
+    expect(request.validationDigest).toMatchObject({
+      detailsSchema: "murph.tool-call-validation-digest.v1",
+      inputShape: [
+        "root.object.count_1_10",
+        "handoffPurpose.string.len_1_32",
+        "reason.object.count_1_10",
+        "runId.string.len_1_32",
+        "suggestedReply.string.len_1_32",
+      ],
+      invalidPaths: ["handoffPurpose", "reason"],
+      issueCodes: ["custom"],
+      pathIssues: [
+        {
+          code: "custom",
+          path: "handoffPurpose",
+          received: "string.len_1_32",
+        },
+        {
+          code: "custom",
+          path: "reason",
+          received: "object.count_1_10",
+        },
+      ],
+      rootKeyCount: 4,
+      rootKeysPresent: [
+        "handoffPurpose",
+        "reason",
+        "runId",
+        "suggestedReply",
+      ],
+      rootType: "object",
+      schemaName: "murph.computer_pause_for_user.input",
+      toolName: "murph.computer_pause_for_user",
+    });
+    const serialized = JSON.stringify(request.validationDigest);
+    expect(serialized).not.toContain(invalidHandoffPurpose);
+    expect(serialized).not.toContain(privateRunId);
+    expect(serialized).not.toContain(privateSuggestedReply);
+    expect(serialized).not.toContain(privateReason.message);
+    expect(serialized).not.toContain(privateReason.secret);
+    expect(serialized).not.toContain(privateReason.url);
+  });
+
+  it("distinguishes a missing pause field without retaining submitted values", () => {
+    const privateSuggestedReply = "private missing-field reply";
+    const request = readTestMurphDynamicToolRequest(dynamicToolCall({
+      argumentsValue: {
+        reason: "other",
+        suggestedReply: privateSuggestedReply,
+      },
+      tool: "computer_pause_for_user",
+    }));
+
+    if (!request || request.kind !== "invalid-computer-arguments") {
+      throw new Error("Expected invalid computer pause arguments.");
+    }
+
+    expect(request.validationDigest).toMatchObject({
+      inputShape: [
+        "root.object.count_1_10",
+        "reason.string.len_1_32",
+        "suggestedReply.string.len_1_32",
+      ],
+      invalidPaths: ["runId"],
+      issueCodes: ["custom"],
+      pathIssues: [{
+        code: "custom",
+        path: "runId",
+        received: "undefined",
+      }],
+      rootKeyCount: 2,
+      rootKeysPresent: ["reason", "suggestedReply"],
+    });
+    expect(JSON.stringify(request.validationDigest)).not.toContain(
+      privateSuggestedReply,
+    );
+  });
+
+  it("counts an unadvertised pause root key without retaining its name or value", () => {
+    const privateRunId = "run_private_456";
+    const unknownKey = "privateArbitraryField";
+    const unknownValue = "private arbitrary secret";
+    const request = readTestMurphDynamicToolRequest(dynamicToolCall({
+      argumentsValue: {
+        [unknownKey]: unknownValue,
+        reason: "other",
+        runId: privateRunId,
+      },
+      tool: "computer_pause_for_user",
+    }));
+
+    if (!request || request.kind !== "invalid-computer-arguments") {
+      throw new Error("Expected invalid computer pause arguments.");
+    }
+
+    expect(request.validationDigest).toMatchObject({
+      inputShape: [
+        "root.object.count_1_10",
+        "reason.string.len_1_32",
+        "runId.string.len_1_32",
+      ],
+      invalidPaths: ["root"],
+      issueCodes: ["custom"],
+      pathIssues: [{
+        code: "custom",
+        path: "root",
+        received: "object.count_1_10",
+      }],
+      rootKeyCount: 3,
+      rootKeysPresent: ["reason", "runId"],
+      unsafeRootKeyCount: 1,
+    });
+    const serialized = JSON.stringify(request.validationDigest);
+    expect(serialized).not.toContain(privateRunId);
+    expect(serialized).not.toContain(unknownKey);
+    expect(serialized).not.toContain(unknownValue);
   });
 
   it("pauses through web-control and returns the hosted handoff URL to the model", async () => {

--- a/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-tools.test.ts
@@ -1772,6 +1772,144 @@ describe('assistant codex runtime', () => {it('fails closed on unexpected app-se
     expect(JSON.stringify(result.runtimeIssueInputs)).not.toContain('arguments')
   })
 
+  it('persists value-free pause-tool schema rejection details', async () => {
+    const workingDirectory = await createTempDir(
+      'assistant-codex-computer-pause-invalid-',
+    )
+    const invalidHandoffPurpose = 'private-invalid-purpose'
+    const privateRunId = 'run_private_runtime_123'
+    const privateSuggestedReply = 'private suggested reply text'
+    const privateMessage = 'private message text'
+    const privateUrl = 'https://private.example.test/handoff'
+    const unknownKey = 'privateArbitraryField'
+    const unknownValue = 'private arbitrary secret'
+
+    codexMocks.spawn.mockImplementation(() => {
+      const child = new MockChildProcess()
+
+      queueMicrotask(() => {
+        void (async () => {
+          await waitForRpcMethod(child, 'initialize')
+          child.stdout.write(jsonLine({ id: 1, result: {} }))
+          await waitForRpcMethod(child, 'thread/start')
+          child.stdout.write(jsonLine({
+            id: 2,
+            result: {
+              thread: { id: 'thread-computer-pause-invalid' },
+            },
+          }))
+          await waitForRpcMethod(child, 'turn/start')
+          child.stdout.write(jsonLine({
+            id: 3,
+            result: {
+              turn: { id: 'turn-computer-pause-invalid' },
+            },
+          }))
+          child.stdout.write(jsonLine({
+            id: 99,
+            method: 'item/tool/call',
+            params: {
+              arguments: {
+                handoffPurpose: invalidHandoffPurpose,
+                reason: {
+                  message: privateMessage,
+                  url: privateUrl,
+                },
+                runId: privateRunId,
+                suggestedReply: privateSuggestedReply,
+                [unknownKey]: unknownValue,
+              },
+              namespace: 'murph',
+              tool: 'computer_pause_for_user',
+            },
+          }))
+
+          await expect(waitForRpcResponse(child, 99)).resolves.toMatchObject({
+            id: 99,
+            result: { success: false },
+          })
+
+          child.stdout.write(jsonLine({
+            method: 'turn/completed',
+            params: {
+              turn: {
+                id: 'turn-computer-pause-invalid',
+                status: 'completed',
+              },
+            },
+          }))
+        })()
+      })
+
+      return child
+    })
+
+    const result = await executeCodexAppServerTurn({
+      hostedToolContext: createHostedToolContext(),
+      prompt: 'try invalid computer pause tool',
+      workingDirectory,
+    })
+    expect(result.runtimeIssueInputs).toEqual([
+      expect.objectContaining({
+        component: 'assistant.tool-validation',
+        operation: 'murph.computer_pause_for_user',
+        phase: 'tool_call',
+        issueKind: 'schema_rejection',
+        severity: 'warning',
+        errorCode: 'TOOL_INPUT_SCHEMA_REJECTION',
+        summary: 'Tool input failed schema validation.',
+        details: expect.objectContaining({
+          detailsSchema: 'murph.tool-call-validation-digest.v1',
+          inputShape: [
+            'root.object.count_1_10',
+            'handoffPurpose.string.len_1_32',
+            'reason.object.count_1_10',
+            'runId.string.len_1_32',
+            'suggestedReply.string.len_1_32',
+          ],
+          invalidPaths: ['handoffPurpose', 'reason', 'root'],
+          issueCodes: ['custom'],
+          pathIssues: [
+            {
+              code: 'custom',
+              path: 'handoffPurpose',
+              received: 'string.len_1_32',
+            },
+            {
+              code: 'custom',
+              path: 'reason',
+              received: 'object.count_1_10',
+            },
+            {
+              code: 'custom',
+              path: 'root',
+              received: 'object.count_1_10',
+            },
+          ],
+          rootKeyCount: 5,
+          rootKeysPresent: [
+            'handoffPurpose',
+            'reason',
+            'runId',
+            'suggestedReply',
+          ],
+          rootType: 'object',
+          schemaName: 'murph.computer_pause_for_user.input',
+          toolName: 'murph.computer_pause_for_user',
+          unsafeRootKeyCount: 1,
+        }),
+      }),
+    ])
+    const serializedIssues = JSON.stringify(result.runtimeIssueInputs)
+    expect(serializedIssues).not.toContain(invalidHandoffPurpose)
+    expect(serializedIssues).not.toContain(privateRunId)
+    expect(serializedIssues).not.toContain(privateSuggestedReply)
+    expect(serializedIssues).not.toContain(privateMessage)
+    expect(serializedIssues).not.toContain(privateUrl)
+    expect(serializedIssues).not.toContain(unknownKey)
+    expect(serializedIssues).not.toContain(unknownValue)
+  })
+
   it('records pending-file schema rejection through the standard safe diagnostic', async () => {
     const workingDirectory = await createTempDir(
       'assistant-codex-pending-file-invalid-',


### PR DESCRIPTION
## Why and outcome

Two identical `murph.computer_pause_for_user` schema rejections occurred in the preceding 12-hour production window. Existing private-safe telemetry proved a repeated malformed-call cluster but suppressed the failing schema path because this transformed parser had no explicit trusted root-key or path inventory. This PR enriches the existing rejection digest with schema-owned paths and bounded value shapes so a later independent run can classify the contract failure without reading or retaining tool arguments.

This is telemetry-only. It does not change the offered tool schema, prompt, accepted or rejected arguments, model-visible recovery, authorization, pause persistence, delivery, or browser behavior.

## Product UX

- Effort: not applicable; no member-visible behavior, copy, timing, delivery, or authority changes.
- Walkthrough: not applicable; deterministic tests prove the valid pause path and legacy compatibility are unchanged.

## Direct evidence

- Private-safe production aggregate:
  - latest 12 hours: zero observed pause-tool calls and zero rejections;
  - preceding 12 hours: nine calls, two identical `TOOL_INPUT_SCHEMA_REJECTION` records (22.2%), and the same two failed dynamic-tool action records;
  - both rejections shared one validation fingerprint and one deployed release revision.
- Existing digest before this change: `rootType=object`, `rootKeyCount=4`, `unsafeRootKeyCount=4`, `issueCodes=[custom]`, with no safe failing path.
- Current `main` and open-PR/issue search showed no existing fix for this pause-tool validation boundary.
- `pnpm --filter @murphai/assistant-engine exec vitest run test/assistant-codex-computer-tools.test.ts test/assistant-codex-runtime-tools.test.ts --no-coverage`: 67 passed.
- `pnpm --filter @murphai/assistant-engine exec vitest run test/tool-validation-digest.test.ts --no-coverage`: 11 passed.
- `pnpm --filter @murphai/assistant-engine typecheck`: passed.
- `git diff --check`: passed.

## Telemetry contract

- Bounded question: which advertised pause-tool field or trusted schema path is invalid, missing, or wrong-shaped?
- Existing owner reused: `murph.tool-call-validation-digest.v1` inside the existing `TOOL_INPUT_SCHEMA_REJECTION` runtime issue.
- Added facts: schema-owned `rootKeysPresent`, `invalidPaths`/`pathIssues`, bounded `inputShape`, and `unsafeRootKeyCount` already supported by the digest.
- Privacy: no submitted values, arbitrary key names, prompts, messages, run IDs, URLs, tool results, provider payloads, database rows, or direct identifiers are emitted. Focused tests assert their absence both at the parser and persisted runtime-issue boundary.
- Cardinality and volume: field values come from a fixed four-key schema plus existing bounded shape buckets; emission remains limited to schema rejections. The observed baseline is two records in 24 hours.
- Retention: unchanged existing 30-day hosted assistant runtime-issue retention. This is permanent contract classification, so no temporary-field deletion is planned.

### Future query and decision threshold

Query the existing `hosted_assistant_runtime_issue` owner for post-deploy records where `error_code='TOOL_INPUT_SCHEMA_REJECTION'` and `operation='murph.computer_pause_for_user'`, grouping by `details_json->'invalidPaths'`, `details_json->'pathIssues'`, `details_json->'rootKeysPresent'`, `details_json->>'unsafeRootKeyCount'`, validation fingerprint, and release revision. Compare aggregate rejection counts with pause-tool attempt counts from the existing runtime action diagnostics in the same time window.

A behavior fix is warranted only when at least two post-deploy rejections share the same trusted path/shape signature and that specific mismatch can be reproduced synthetically through the production parser and tool contract. A single event or differing signatures remain insufficient evidence. The next scheduled investigator run after at least 24 hours of natural traffic is the earliest useful check; do not provoke, replay, or retry production turns.

## Non-obvious affected surfaces

- Only invalid pause-tool diagnostics gain trusted path/type facts.
- Valid calls, defaulted nullable fields, and the legacy `message` compatibility input keep the same parsed request.
- Other computer tools and all other dynamic-tool digests are unchanged.

## Architecture and reuse

- Existing systems reused: the provider-facing pause schema, `collectSafeJsonSchemaValidationPaths`, `buildSafeToolCallValidationDigest`, and current runtime-issue persistence.
- New logic: explicit schema-owned root keys and validation paths at the transformed parser boundary.
- New abstractions: none; the existing digest accepts the trusted schema inventory directly.
- Complexity intentionally avoided: no new events, fields, dependencies, retries, handlers, or state owners.

## Hot reply path impact

Only failed pause-tool validation performs the existing bounded digest work with four trusted schema keys. Successful calls and ordinary replies do no additional database, network, provider, queue, filesystem, retry, or timeout work.

## Murph initial provider input impact

None. Prompt text, tool description, tool schema, dynamic-tool availability, and serialized provider input are unchanged.

## Deployment concerns

- Deployment: applicable
- Scope: hosted assistant runner only.
- Supported skew: old and new runtimes write the same existing issue schema; readers already accept optional digest fields.
- Safe order: ordinary Cloudflare hosted-runner deployment after merge; no Web or database migration is required.
- Rollback floor: the prior runtime revision remains compatible because no persisted schema or behavior changed.
- Expected exposure: only future invalid pause calls on the new runtime gain additional bounded fields.
- Reversibility: code-only rollback; existing enriched rows remain valid until ordinary retention removes them.
- Convergence proof: verify the exact deployed revision and service health, then wait for natural traffic. Do not replay or synthesize a production turn.
- Post-deploy checks: confirm the runtime revision, existing issue import health, and that any naturally emitted record contains only the allowed bounded keys.

## Changelog

- Changelog: not applicable
- Reason: telemetry-only classification has no member-visible behavior or recovery change.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 0 |
| Tests/fixtures | 306 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **318** | **0** |

ReviewGPT context sensitivity: sensitive

Reason: assistant-runtime telemetry and privacy-safe validation classification changed, while provider-visible behavior did not.

ReviewGPT first-reviewed head: 775a6c7d05cd797480c8d8503770355d38882fbc
