### PR TITLE
fix: drain mailboxes blocked by expired ask content

### DIFF
--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -1087,13 +1087,15 @@ Last verified: 2026-08-27
   authorize a send. Conversely, expired detached-control replay re-hands a
   still-valid private effect instead of appending another group terminal; only
   its provider-entry authority may convert that effect to the fixed fallback.
-  An unconsumed `assistant.ask.requested` keeps its encrypted wake after the
-  ten-minute request expiry so Web can still persist that terminal result, but
-  never beyond the mailbox content's 14-day privacy deadline. If that deadline
+  A current-sender `assistant.ask.requested` keeps its encrypted wake after the
+  ten-minute request expiry only while its system sequence remains ahead of the
+  durable consumed watermark, so Web can still persist that terminal result.
+  The mailbox's 14-day privacy deadline remains absolute. If that deadline
   retires the wake first, Web returns the explicit `content_expired` terminal
   reason and the runtime may retire only that unrecoverable request; ordinary
   `expired` or `unavailable` responses still cannot substitute for the required
-  current-sender completion.
+  current-sender completion. Other Assistant Ask targets retain their ordinary
+  expiry behavior.
 - Rolling compatibility is legacy-facing only. New callers use one strict body
   marker. New Web rejects deployed unmarked old `ask_current_sender` requests:
   the old runtime cannot prove the required exact-room notice happened before

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -1087,6 +1087,13 @@ Last verified: 2026-08-27
   authorize a send. Conversely, expired detached-control replay re-hands a
   still-valid private effect instead of appending another group terminal; only
   its provider-entry authority may convert that effect to the fixed fallback.
+  An unconsumed `assistant.ask.requested` keeps its encrypted wake after the
+  ten-minute request expiry so Web can still persist that terminal result, but
+  never beyond the mailbox content's 14-day privacy deadline. If that deadline
+  retires the wake first, Web returns the explicit `content_expired` terminal
+  reason and the runtime may retire only that unrecoverable request; ordinary
+  `expired` or `unavailable` responses still cannot substitute for the required
+  current-sender completion.
 - Rolling compatibility is legacy-facing only. New callers use one strict body
   marker. New Web rejects deployed unmarked old `ask_current_sender` requests:
   the old runtime cannot prove the required exact-room notice happened before

--- a/agent-docs/exec-plans/active/2026-08-28-expired-assistant-ask-head.md
+++ b/agent-docs/exec-plans/active/2026-08-28-expired-assistant-ask-head.md
@@ -1,0 +1,71 @@
+# Recover queues blocked by expired Assistant Ask content
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Let a hosted system mailbox advance when an expired current-sender Assistant
+  Ask can no longer persist its required fallback because content retention
+  already retired the encrypted request.
+
+## Success criteria
+
+- New unconsumed requests retain recoverable content only until the existing
+  14-day privacy deadline, allowing the ordinary expired fallback to persist.
+- Already-retired legacy requests reach one explicit terminal state and leave
+  the runtime queue without starting Codex.
+- Ordinary `expired` and `unavailable` current-sender responses still retry
+  rather than silently dropping the required fallback.
+- Focused Web, runtime, protocol, PostgreSQL retention, typecheck, and required
+  exact-head CI checks pass.
+- The production mailbox advances after Web and hosted runtime deployment.
+
+## Scope
+
+- In scope: Assistant Ask retention, terminal control protocol, hosted runtime
+  retirement, focused regression coverage, deployment, and live recovery proof.
+- Out of scope: queue redesign, retention-policy expansion, new state owners,
+  or changes to connected-health import semantics.
+
+## Constraints
+
+- Technical constraints: preserve one canonical mailbox state owner; preserve
+  the 14-day maximum content-retention deadline; remain safe under rolling Web,
+  Worker, and container version skew.
+- Product/process constraints: avoid sending a misleading very-late fallback
+  when its encrypted source content is already irrecoverable; keep normal
+  current-sender completion behavior unchanged.
+
+## Risks and mitigations
+
+1. Risk: a broad terminal exception could silently drop recoverable requests.
+   Mitigation: permit retirement only for the exact `content_expired` reason
+   and keep regression tests for ordinary terminal reasons.
+2. Risk: retaining expired requests could exceed the privacy boundary.
+   Mitigation: exempt only unconsumed request content from the business TTL;
+   the existing created-at privacy cutoff remains authoritative.
+
+## Tasks
+
+1. Prove the coupled-state failure from production state and code paths.
+2. Add the smallest explicit terminal state and bounded retention correction.
+3. Verify every owner boundary and rolling-version behavior.
+4. Merge, deploy, and prove the affected mailbox advances.
+
+## Decisions
+
+- Use the existing mailbox item as the sole durable owner; add no repair queue
+  or reconciliation service.
+- Treat retired encrypted content as distinct from ordinary request expiry
+  because only the former makes the required fallback impossible to persist.
+
+## Verification
+
+- Commands to run: focused Vitest suites for Web control, PostgreSQL retention,
+  runtime dequeueing, and protocol parsing; package typechecks; docs drift;
+  required exact-head CI; bounded production mailbox and runtime-log queries.
+- Expected outcomes: tests and checks pass; content remains available for
+  ordinary expiry recovery but retires at the privacy deadline; the legacy
+  head leaves the local queue and the production lane resumes advancing.

--- a/agent-docs/exec-plans/active/2026-08-28-expired-assistant-ask-head.md
+++ b/agent-docs/exec-plans/active/2026-08-28-expired-assistant-ask-head.md
@@ -12,8 +12,10 @@ Updated: 2026-08-28
 
 ## Success criteria
 
-- New unconsumed requests retain recoverable content only until the existing
-  14-day privacy deadline, allowing the ordinary expired fallback to persist.
+- New current-sender requests retain recoverable content only while their
+  system sequence remains ahead of the durable consumed watermark and never
+  beyond the existing 14-day privacy deadline, allowing the ordinary expired
+  fallback to persist without extending other Assistant Ask retention.
 - Already-retired legacy requests reach one explicit terminal state and leave
   the runtime queue without starting Codex.
 - Ordinary `expired` and `unavailable` current-sender responses still retry
@@ -31,8 +33,9 @@ Updated: 2026-08-28
 
 ## Constraints
 
-- Technical constraints: preserve one canonical mailbox state owner; preserve
-  the 14-day maximum content-retention deadline; remain safe under rolling Web,
+- Technical constraints: preserve one canonical mailbox state owner; derive
+  settlement from the existing system-lane consumed watermark; preserve the
+  14-day maximum content-retention deadline; remain safe under rolling Web,
   Worker, and container version skew.
 - Product/process constraints: avoid sending a misleading very-late fallback
   when its encrypted source content is already irrecoverable; keep normal
@@ -43,9 +46,10 @@ Updated: 2026-08-28
 1. Risk: a broad terminal exception could silently drop recoverable requests.
    Mitigation: permit retirement only for the exact `content_expired` reason
    and keep regression tests for ordinary terminal reasons.
-2. Risk: retaining expired requests could exceed the privacy boundary.
-   Mitigation: exempt only unconsumed request content from the business TTL;
-   the existing created-at privacy cutoff remains authoritative.
+2. Risk: retaining expired requests could broaden private-data retention.
+   Mitigation: mark only current-sender admission at the mailbox owner, require
+   its sequence to remain ahead of the existing durable consumed watermark,
+   and keep the created-at privacy cutoff authoritative.
 
 ## Tasks
 

--- a/agent-docs/exec-plans/completed/2026-08-28-expired-assistant-ask-head.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-expired-assistant-ask-head.md
@@ -1,8 +1,8 @@
 # Recover queues blocked by expired Assistant Ask content
 
-Status: active
+Status: completed
 Created: 2026-08-28
-Updated: 2026-08-28
+Updated: 2026-08-29
 
 ## Goal
 
@@ -73,3 +73,4 @@ Updated: 2026-08-28
 - Expected outcomes: tests and checks pass; content remains available for
   ordinary expiry recovery but retires at the privacy deadline; the legacy
   head leaves the local queue and the production lane resumes advancing.
+Completed: 2026-08-29

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -7,6 +7,11 @@ Last verified: 2026-08-28
 This index is the table of contents for the current canonical docs in this repository.
 It intentionally lists live architecture, product, verification, and package-boundary docs only.
 
+Current-sender Assistant Ask recovery retains encrypted request content only
+while its system sequence remains ahead of the durable consumed watermark and
+never beyond the mailbox privacy deadline; `agent-docs/SECURITY.md` owns that
+boundary.
+
 Receipt-owned positive Stripe payment notifications cover subscription starts
 and renewals, paid plan-change and recurring-usage invoices, and fulfilled
 usage-credit payments without exposing member or customer identity. Their

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -1,6 +1,6 @@
 # Murph Agent Docs Index
 
-Last verified: 2026-08-27
+Last verified: 2026-08-28
 
 ## Purpose
 

--- a/apps/web/src/lib/hosted-groups/group-assistant-ask.ts
+++ b/apps/web/src/lib/hosted-groups/group-assistant-ask.ts
@@ -34,6 +34,7 @@ import {
   HOSTED_RUNTIME_GROUP_CLARIFICATION_LABELS_MAX,
   type HostedRuntimeAssistantAskControlRequest,
   type HostedRuntimeAssistantAskControlResponse,
+  type HostedRuntimeAssistantAskTerminalReason,
   type HostedRuntimeGroupAskResult,
   type HostedRuntimeGroupMemberAskResult,
   type HostedRuntimeGroupParticipantTarget,
@@ -170,7 +171,7 @@ type HostedAssistantAskAuthority =
 
 interface HostedAssistantAskRequestReadResult {
   authority: HostedAssistantAskAuthority | null;
-  terminalReason: "expired" | "unavailable" | null;
+  terminalReason: HostedRuntimeAssistantAskTerminalReason | null;
 }
 
 export function createHostedAssistantAskRequestId(input: {
@@ -1786,7 +1787,7 @@ function readHostedAssistantAskItemExpiresAt(
 
 function terminalHostedAssistantAskControlResult(
   action: HostedRuntimeAssistantAskControlRequest["action"],
-  terminalReason: "expired" | "unavailable",
+  terminalReason: HostedRuntimeAssistantAskTerminalReason,
 ): HostedAssistantAskControlResult {
   return {
     mailboxWake: null,
@@ -2451,7 +2452,12 @@ async function readHostedAssistantAskAuthorityTx(input: {
     return { authority: null, terminalReason: "unavailable" };
   }
   if (isHostedAssistantAskExpired(item.expiresAt ?? null, input.now)) {
-    return { authority: null, terminalReason: "expired" };
+    return {
+      authority: null,
+      terminalReason: item.contentRetiredAt === null
+        ? "expired"
+        : "content_expired",
+    };
   }
   if (
     item.dedupeKey !== input.requestId

--- a/apps/web/src/lib/hosted-groups/group-current-sender-assistant-ask.ts
+++ b/apps/web/src/lib/hosted-groups/group-current-sender-assistant-ask.ts
@@ -34,6 +34,7 @@ import type {
 
 import {
   appendHostedMailboxEnvelopeWithIdentityTx,
+  HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
   readHostedMailboxConversationInputAuthorityByAssistantInputIdTx,
   readHostedMailboxConversationWakeByAssistantInputId,
   readHostedMailboxItemById,
@@ -386,6 +387,13 @@ async function requestHostedGroupCurrentSenderAssistantAskTx(input: {
   if (append.dedupeConflict || append.item.id !== requestId) {
     return unavailableHostedCurrentSenderAdmission("request_conflict");
   }
+  await input.tx.hostedMailboxItem.update({
+    data: {
+      retentionDisposition:
+        HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
+    },
+    where: { id: requestId },
+  });
   return {
     mailboxWake: { expectedUserId: authority.targetMemberId, mailboxItemId: requestId },
     result: { status: "accepted" },

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -85,6 +85,9 @@ export {
   HOSTED_MAILBOX_PAYLOAD_SCHEMA,
 };
 
+export const HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION =
+  "assistant_ask.current_sender_pending";
+
 export type HostedMailboxStoreClient = PrismaClient | Prisma.TransactionClient;
 export type HostedMailboxMutationTx = Prisma.TransactionClient;
 

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -119,6 +119,9 @@ export interface HostedMailboxPayloadRow {
 }
 
 export type HostedMailboxItemRecord = HostedMailboxItem;
+export type HostedMailboxItemRecordWithRetention = HostedMailboxItemRecord & {
+  contentRetiredAt: string | null;
+};
 export type HostedMailboxPayloadRecord = HostedMailboxPayload;
 
 export interface HostedMailboxItemCheckpointRecord {
@@ -2537,7 +2540,7 @@ export async function readHostedMailboxItemCheckpointById(input: {
 export async function readHostedMailboxItemById(input: {
   mailboxItemId: string;
   prisma?: HostedMailboxStoreClient;
-}): Promise<HostedMailboxItemRecord | null> {
+}): Promise<HostedMailboxItemRecordWithRetention | null> {
   const prisma = input.prisma ?? getPrisma();
   const mailboxItemId = requireNonEmptyString(
     input.mailboxItemId,
@@ -2550,7 +2553,12 @@ export async function readHostedMailboxItemById(input: {
     },
   });
 
-  return record ? projectHostedMailboxItem(record) : null;
+  return record
+    ? {
+        ...projectHostedMailboxItem(record),
+        contentRetiredAt: record.contentRetiredAt?.toISOString() ?? null,
+      }
+    : null;
 }
 
 export async function readHostedMailboxLiveItemById(input: {

--- a/apps/web/src/lib/hosted-retention/cleanup.ts
+++ b/apps/web/src/lib/hosted-retention/cleanup.ts
@@ -4,7 +4,10 @@ import { hostedConnectedAppStartedIntentOwnerCutoff } from "../connected-apps/co
 import { getPrisma } from "../prisma";
 import { ComputerUseService } from "../computer-use/service";
 import { PrismaComputerUseStore } from "../computer-use/store";
-import { HOSTED_MAILBOX_RETENTION_MS } from "../hosted-mailbox/store";
+import {
+  HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
+  HOSTED_MAILBOX_RETENTION_MS,
+} from "../hosted-mailbox/store";
 import {
   formatHostedExecutionSafeLogErrorDetails,
 } from "../hosted-execution/logging";
@@ -411,7 +414,18 @@ export async function retireExpiredMailboxContent(input: {
               "expires_at" <= ${input.now}
               AND NOT (
                 "kind" = 'assistant.ask.requested'
-                AND "consumed_at" IS NULL
+                AND "lane" = 'system'
+                AND "retention_disposition" IS NOT DISTINCT FROM
+                  ${HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION}
+                AND "lane_seq" > COALESCE(
+                  (
+                    SELECT counter."consumed_seq"
+                    FROM "hosted_mailbox_lane_counter" AS counter
+                    WHERE counter."user_id" = "hosted_mailbox_item"."user_id"
+                      AND counter."lane" = 'system'
+                  ),
+                  0
+                )
               )
             )
             OR "created_at" <= ${cutoff}

--- a/apps/web/src/lib/hosted-retention/cleanup.ts
+++ b/apps/web/src/lib/hosted-retention/cleanup.ts
@@ -407,7 +407,13 @@ export async function retireExpiredMailboxContent(input: {
         FROM "hosted_mailbox_item"
         WHERE "content_retired_at" IS NULL
           AND (
-            "expires_at" <= ${input.now}
+            (
+              "expires_at" <= ${input.now}
+              AND NOT (
+                "kind" = 'assistant.ask.requested'
+                AND "consumed_at" IS NULL
+              )
+            )
             OR "created_at" <= ${cutoff}
           )
         ORDER BY "created_at" ASC, "id" ASC

--- a/apps/web/test/hosted-assistant-ask-retention-postgres.test.ts
+++ b/apps/web/test/hosted-assistant-ask-retention-postgres.test.ts
@@ -52,6 +52,7 @@ describe.skipIf(!runPostgresProof)(
       memberIds.push(memberId);
       const requestId = `aask_req_retention_${suffix}`;
       const completionId = `aask_done_retention_${suffix}`;
+      const createdAt = new Date("2026-07-16T12:00:00.000Z");
       const expiresAt = new Date("2026-07-16T12:10:00.000Z");
       const cleanupAt = new Date("2026-07-16T13:00:00.000Z");
 
@@ -61,6 +62,7 @@ describe.skipIf(!runPostgresProof)(
       await client.hostedMailboxItem.createMany({
         data: [
           {
+            createdAt,
             dedupeKey: requestId,
             expiresAt,
             id: requestId,
@@ -73,6 +75,7 @@ describe.skipIf(!runPostgresProof)(
             userId: memberId,
           },
           {
+            createdAt,
             dedupeKey: completionId,
             expiresAt,
             id: completionId,
@@ -104,10 +107,11 @@ describe.skipIf(!runPostgresProof)(
         prisma: client,
         signalRuntimeRecheck: async () => undefined,
       });
-      expect(cleanup.expiredMailboxContentRetired).toBeGreaterThanOrEqual(2);
+      expect(cleanup.expiredMailboxContentRetired).toBeGreaterThanOrEqual(1);
       const retiredItems = await client.hostedMailboxItem.findMany({
         select: {
           contentRetiredAt: true,
+          id: true,
           payloadInlineCiphertext: true,
           payloadRef: true,
         },
@@ -116,14 +120,20 @@ describe.skipIf(!runPostgresProof)(
       expect(retiredItems).toHaveLength(2);
       expect(retiredItems).toEqual(expect.arrayContaining([
         expect.objectContaining({
+          contentRetiredAt: null,
+          id: requestId,
+          payloadRef: `hosted-mailbox-payload:${requestId}`,
+        }),
+        expect.objectContaining({
           contentRetiredAt: cleanupAt,
+          id: completionId,
           payloadInlineCiphertext: null,
           payloadRef: null,
         }),
       ]));
       await expect(client.hostedMailboxPayload.count({
         where: { mailboxItemId: requestId },
-      })).resolves.toBe(0);
+      })).resolves.toBe(1);
 
       const delivery = {
         answeredMailboxItemIds: [completionId],
@@ -149,6 +159,25 @@ describe.skipIf(!runPostgresProof)(
           tx,
         })
       )).resolves.toBeUndefined();
+
+      const privacyDeadline = new Date(
+        createdAt.getTime() + 14 * 24 * 60 * 60 * 1_000,
+      );
+      await runHostedRetentionCleanup({
+        now: privacyDeadline,
+        prisma: client,
+        signalRuntimeRecheck: async () => undefined,
+      });
+      await expect(client.hostedMailboxItem.findUniqueOrThrow({
+        select: { contentRetiredAt: true, payloadRef: true },
+        where: { id: requestId },
+      })).resolves.toEqual({
+        contentRetiredAt: privacyDeadline,
+        payloadRef: null,
+      });
+      await expect(client.hostedMailboxPayload.count({
+        where: { mailboxItemId: requestId },
+      })).resolves.toBe(0);
     });
 
     it("records policy non-replies without advancing across a younger conversation gap", async () => {

--- a/apps/web/test/hosted-assistant-ask-retention-postgres.test.ts
+++ b/apps/web/test/hosted-assistant-ask-retention-postgres.test.ts
@@ -107,7 +107,7 @@ describe.skipIf(!runPostgresProof)(
         prisma: client,
         signalRuntimeRecheck: async () => undefined,
       });
-      expect(cleanup.expiredMailboxContentRetired).toBeGreaterThanOrEqual(1);
+      expect(cleanup.expiredMailboxContentRetired).toBeGreaterThanOrEqual(2);
       const retiredItems = await client.hostedMailboxItem.findMany({
         select: {
           contentRetiredAt: true,
@@ -120,9 +120,10 @@ describe.skipIf(!runPostgresProof)(
       expect(retiredItems).toHaveLength(2);
       expect(retiredItems).toEqual(expect.arrayContaining([
         expect.objectContaining({
-          contentRetiredAt: null,
+          contentRetiredAt: cleanupAt,
           id: requestId,
-          payloadRef: `hosted-mailbox-payload:${requestId}`,
+          payloadInlineCiphertext: null,
+          payloadRef: null,
         }),
         expect.objectContaining({
           contentRetiredAt: cleanupAt,
@@ -133,7 +134,7 @@ describe.skipIf(!runPostgresProof)(
       ]));
       await expect(client.hostedMailboxPayload.count({
         where: { mailboxItemId: requestId },
-      })).resolves.toBe(1);
+      })).resolves.toBe(0);
 
       const delivery = {
         answeredMailboxItemIds: [completionId],
@@ -160,24 +161,6 @@ describe.skipIf(!runPostgresProof)(
         })
       )).resolves.toBeUndefined();
 
-      const privacyDeadline = new Date(
-        createdAt.getTime() + 14 * 24 * 60 * 60 * 1_000,
-      );
-      await runHostedRetentionCleanup({
-        now: privacyDeadline,
-        prisma: client,
-        signalRuntimeRecheck: async () => undefined,
-      });
-      await expect(client.hostedMailboxItem.findUniqueOrThrow({
-        select: { contentRetiredAt: true, payloadRef: true },
-        where: { id: requestId },
-      })).resolves.toEqual({
-        contentRetiredAt: privacyDeadline,
-        payloadRef: null,
-      });
-      await expect(client.hostedMailboxPayload.count({
-        where: { mailboxItemId: requestId },
-      })).resolves.toBe(0);
     });
 
     it("records policy non-replies without advancing across a younger conversation gap", async () => {

--- a/apps/web/test/hosted-current-sender-assistant-ask-postgres.test.ts
+++ b/apps/web/test/hosted-current-sender-assistant-ask-postgres.test.ts
@@ -25,8 +25,11 @@ import {
   requestHostedGroupCurrentSenderAssistantAsk,
 } from "@/src/lib/hosted-groups/group-current-sender-assistant-ask";
 import {
+  HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
   readHostedMailboxWakeByItemId,
 } from "@/src/lib/hosted-mailbox/store";
+import { runHostedRetentionCleanup } from "@/src/lib/hosted-retention/cleanup";
+import { checkpointHostedWorkspace } from "@/src/lib/hosted-workspace/store";
 import {
   upsertHostedMemberTelegramRoutingBindingTx,
 } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
@@ -49,6 +52,142 @@ if (runPostgresProof && (!databaseUrl || !isClearlyLocalPostgresUrl(databaseUrl)
 describe.skipIf(!runPostgresProof)(
   "current-sender Assistant Ask privacy with PostgreSQL",
   () => {
+    it("retains only unresolved current-sender content until settlement or the privacy deadline", async () => {
+      const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
+      const now = new Date();
+      const fixtures: HostedCurrentSenderAssistantAskFixture[] = [];
+
+      try {
+        const recoverable = await seedHostedCurrentSenderAssistantAskFixture({
+          now,
+          prisma,
+          question: "Murph, ask my Murph about my synthetic recovery?",
+        });
+        const abandoned = await seedHostedCurrentSenderAssistantAskFixture({
+          now,
+          prisma,
+          question: "Murph, ask my Murph about my synthetic sleep?",
+        });
+        fixtures.push(recoverable, abandoned);
+
+        const recoverableRequestId =
+          createHostedGroupCurrentSenderAssistantAskRequestId({
+            groupRuntimeMemberId: recoverable.groupRuntimeMemberId,
+            originAssistantInputId: recoverable.assistantInputId,
+          });
+        const abandonedRequestId =
+          createHostedGroupCurrentSenderAssistantAskRequestId({
+            groupRuntimeMemberId: abandoned.groupRuntimeMemberId,
+            originAssistantInputId: abandoned.assistantInputId,
+          });
+        for (const [fixture, requestId] of [
+          [recoverable, recoverableRequestId],
+          [abandoned, abandonedRequestId],
+        ] as const) {
+          await expect(requestHostedGroupCurrentSenderAssistantAsk({
+            audience: "group",
+            groupRuntimeMemberId: fixture.groupRuntimeMemberId,
+            mode: "new",
+            now,
+            origin: fixture.origin,
+            prisma,
+          })).resolves.toMatchObject({
+            mailboxWake: { mailboxItemId: requestId },
+            result: { status: "accepted" },
+          });
+        }
+
+        const recoverableRequest = await prisma.hostedMailboxItem
+          .findUniqueOrThrow({ where: { id: recoverableRequestId } });
+        const abandonedRequest = await prisma.hostedMailboxItem
+          .findUniqueOrThrow({ where: { id: abandonedRequestId } });
+        expect(recoverableRequest.retentionDisposition).toBe(
+          HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
+        );
+        expect(abandonedRequest.retentionDisposition).toBe(
+          HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION,
+        );
+
+        const expiredAt = new Date(now.getTime() + 11 * 60 * 1_000);
+        await runHostedRetentionCleanup({
+          now: expiredAt,
+          prisma,
+          signalRuntimeRecheck: async () => undefined,
+        });
+        await expect(prisma.hostedMailboxItem.findMany({
+          orderBy: { id: "asc" },
+          select: { contentRetiredAt: true, id: true },
+          where: { id: { in: [recoverableRequestId, abandonedRequestId] } },
+        })).resolves.toEqual([
+          expect.objectContaining({ contentRetiredAt: null }),
+          expect.objectContaining({ contentRetiredAt: null }),
+        ]);
+
+        await expect(handleHostedRuntimeAssistantAskControl({
+          boundRuntimeMemberId: recoverable.senderMemberId,
+          now: expiredAt,
+          prisma,
+          request: { action: "prepare", requestId: recoverableRequestId },
+        })).resolves.toMatchObject({
+          response: { action: "prepare", status: "already_completed" },
+        });
+        const recoverableWorkspace = await prisma.hostedWorkspace
+          .findUniqueOrThrow({ where: { userId: recoverable.senderMemberId } });
+        await checkpointHostedWorkspace({
+          checkpointedAt: expiredAt,
+          expectedVersion: recoverableWorkspace.version,
+          prisma,
+          reason: "idle_shutdown",
+          redactedStatusJson: {
+            hostedMailboxSystemHandledThroughSeq:
+              recoverableRequest.laneSeq.toString(),
+          },
+          snapshotRef: null,
+          userId: recoverable.senderMemberId,
+        });
+        const settledCleanupAt = new Date(expiredAt.getTime() + 1_000);
+        await runHostedRetentionCleanup({
+          now: settledCleanupAt,
+          prisma,
+          signalRuntimeRecheck: async () => undefined,
+        });
+        await expect(prisma.hostedMailboxItem.findUniqueOrThrow({
+          select: { contentRetiredAt: true, retentionDisposition: true },
+          where: { id: recoverableRequestId },
+        })).resolves.toEqual({
+          contentRetiredAt: settledCleanupAt,
+          retentionDisposition: null,
+        });
+
+        const privacyDeadline = new Date(
+          abandonedRequest.createdAt.getTime() + 14 * 24 * 60 * 60 * 1_000,
+        );
+        await runHostedRetentionCleanup({
+          now: privacyDeadline,
+          prisma,
+          signalRuntimeRecheck: async () => undefined,
+        });
+        await expect(handleHostedRuntimeAssistantAskControl({
+          boundRuntimeMemberId: abandoned.senderMemberId,
+          now: privacyDeadline,
+          prisma,
+          request: { action: "prepare", requestId: abandonedRequestId },
+        })).resolves.toEqual({
+          mailboxWake: null,
+          response: {
+            action: "prepare",
+            status: "terminal",
+            terminalReason: "content_expired",
+          },
+        });
+      } finally {
+        for (const fixture of fixtures) {
+          await deleteHostedCurrentSenderAssistantAskFixture({ fixture, prisma });
+        }
+        await prisma.$disconnect();
+      }
+    }, 60_000);
+
     it("binds a mixed-sender batch and preserves its group terminal across personal access loss", async () => {
       const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
       const now = new Date();

--- a/apps/web/test/hosted-group-assistant-ask.test.ts
+++ b/apps/web/test/hosted-group-assistant-ask.test.ts
@@ -213,6 +213,7 @@ function requestWake(input: {
 
 function mailboxItemForWake(wake: ReturnType<typeof requestWake>) {
   return {
+    contentRetiredAt: null,
     dedupeKey: wake.eventId,
     expiresAt: wake.ask.expiresAt,
     id: wake.eventId,
@@ -1392,6 +1393,32 @@ describe("Hosted Assistant Ask runtime control", () => {
     expect(mocks.readHostedMailboxWakeByDedupeKey).toHaveBeenCalledOnce();
     expect(mocks.readHostedMailboxWakeByItemId).not.toHaveBeenCalled();
     expect(tx.hostedGroupMember.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("reports retired expired request content without trying to reconstruct a fallback", async () => {
+    const wake = requestWake();
+    mocks.readHostedMailboxItemById.mockResolvedValue({
+      ...mailboxItemForWake(wake),
+      contentRetiredAt: NOW.toISOString(),
+      expiresAt: NOW.toISOString(),
+    });
+    const { prisma } = createPrisma();
+
+    await expect(handleHostedRuntimeAssistantAskControl({
+      boundRuntimeMemberId: TARGET_RUNTIME_MEMBER_ID,
+      now: NOW,
+      prisma: prisma as never,
+      request: { action: "prepare", requestId: wake.eventId },
+    })).resolves.toEqual({
+      mailboxWake: null,
+      response: {
+        action: "prepare",
+        status: "terminal",
+        terminalReason: "content_expired",
+      },
+    });
+    expect(mocks.readHostedMailboxWakeByDedupeKey).not.toHaveBeenCalled();
+    expect(mocks.readHostedMailboxWakeByItemId).not.toHaveBeenCalled();
   });
 
   it("does not disclose a request to a different bound runtime", async () => {

--- a/apps/web/test/hosted-group-current-sender-assistant-ask.test.ts
+++ b/apps/web/test/hosted-group-current-sender-assistant-ask.test.ts
@@ -48,6 +48,20 @@ const mocks = vi.hoisted(() => ({
 
 const fakeTx = {
   $executeRaw: vi.fn(async () => 0),
+  hostedMailboxItem: {
+    update: vi.fn(async ({ data, where }: {
+      data: { retentionDisposition: string | null };
+      where: { id: string };
+    }) => {
+      const item = storedItems.get(where.id);
+      if (!item) {
+        throw new Error(`Missing mailbox item: ${where.id}`);
+      }
+      const updated = { ...item, ...data };
+      storedItems.set(where.id, updated);
+      return updated;
+    }),
+  },
   hostedThreadContainer: {
     findUnique: mocks.hostedThreadContainerFindUnique,
   },
@@ -69,6 +83,8 @@ function asPrismaTransactionClient(
 }
 
 vi.mock("@/src/lib/hosted-mailbox/store", () => ({
+  HOSTED_MAILBOX_PENDING_CURRENT_SENDER_ASK_RETENTION_DISPOSITION:
+    "assistant_ask.current_sender_pending",
   appendHostedMailboxEnvelopeTx: mocks.appendHostedMailboxEnvelopeTx,
   appendHostedMailboxEnvelopeWithIdentityTx:
     mocks.appendHostedMailboxEnvelopeWithIdentityTx,
@@ -208,10 +224,12 @@ const DIRECT_ROUTE = {
 };
 
 interface StoredMailboxItem {
+  contentRetiredAt: Date | null;
   dedupeKey: string;
   expiresAt: string | null;
   id: string;
   kind: string;
+  retentionDisposition: string | null;
   userId: string;
 }
 
@@ -383,10 +401,12 @@ function storeLegacyRequest(input: {
     occurredAt: NOW.toISOString(),
   });
   storedItems.set(requestId, {
+    contentRetiredAt: null,
     dedupeKey: requestId,
     expiresAt,
     id: requestId,
     kind: wake.kind,
+    retentionDisposition: null,
     userId: wake.userId,
   });
   storedWakes.set(requestId, wake);
@@ -538,10 +558,12 @@ describe("hosted current-sender Assistant Ask authority", () => {
           return { dedupeConflict: true, item: existing };
         }
         const item = {
+          contentRetiredAt: null,
           dedupeKey: itemId,
           expiresAt: input.expiresAt ?? null,
           id: itemId,
           kind: input.envelope.kind,
+          retentionDisposition: null,
           userId: input.envelope.userId,
         } satisfies StoredMailboxItem;
         storedItems.set(itemId, item);

--- a/apps/web/test/hosted-retention-cleanup.test.ts
+++ b/apps/web/test/hosted-retention-cleanup.test.ts
@@ -244,6 +244,7 @@ describe("hosted retention cleanup", () => {
     expect(mailboxDeleteSql.match(/FOR UPDATE SKIP LOCKED/g)).toHaveLength(2);
     expect(queryRaw.mock.calls[0]?.slice(1)).toEqual([
       now,
+      "assistant_ask.current_sender_pending",
       new Date(now.getTime() - HOSTED_MAILBOX_RETENTION_MS),
       HOSTED_RETENTION_BATCH_SIZE,
       now,

--- a/packages/assistant-runtime/src/hosted-runtime/detached-assistant-ask.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/detached-assistant-ask.ts
@@ -324,9 +324,12 @@ async function runOneHostedDetachedAssistantAsk(input: {
       return "settled";
     }
     if (prepared.status === "terminal") {
-      if (isHostedExecutionAssistantAskCurrentSenderTarget(
-        claimed.wake.ask.target,
-      )) {
+      if (
+        prepared.terminalReason !== "content_expired"
+        && isHostedExecutionAssistantAskCurrentSenderTarget(
+          claimed.wake.ask.target,
+        )
+      ) {
         throw new TypeError(
           "Current-sender assistant ask has no persisted terminal completion.",
         );
@@ -431,6 +434,7 @@ async function runOneHostedDetachedAssistantAsk(input: {
     }
     if (
       completed.status === "terminal"
+      && completed.terminalReason !== "content_expired"
       && isHostedExecutionAssistantAskCurrentSenderTarget(
         claimed.wake.ask.target,
       )

--- a/packages/assistant-runtime/test/hosted-runtime-detached-assistant-ask.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-detached-assistant-ask.test.ts
@@ -1423,6 +1423,47 @@ describe("hosted detached assistant ask controller", () => {
       await removeVaultRoot(vaultRoot);
     }
   });
+
+  test("dequeues a content-expired current-sender request without starting Codex", async () => {
+    const vaultRoot = await createVaultRoot();
+    const executeAsk = vi.fn();
+
+    try {
+      await writePending(vaultRoot, [
+        createPendingAsk({
+          currentSender: true,
+          eventId: "ask_event_content_expired",
+          itemId: "item_content_expired",
+        }),
+      ]);
+      const controller = createHostedDetachedAssistantAskController({
+        assistantAskPort: {
+          async request() {
+            return {
+              action: "prepare",
+              status: "terminal",
+              terminalReason: "content_expired",
+            };
+          },
+        },
+        codexHome: null,
+        env: {},
+        executeAsk,
+        now: () => TEST_NOW,
+        onStateMutation() {},
+        vaultRoot,
+      });
+
+      controller.kick();
+      await waitUntil(async () => {
+        assert.equal((await readHostedSystemMailboxState(vaultRoot)).pending.length, 0);
+      });
+      await controller.closeAndRequeue();
+      assert.equal(executeAsk.mock.calls.length, 0);
+    } finally {
+      await removeVaultRoot(vaultRoot);
+    }
+  });
 });
 
 function createPendingAsk(input: {

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -1088,7 +1088,11 @@ export function parseHostedRuntimeAssistantAskControlResponse(
       record.terminalReason,
       "Hosted runtime assistant ask terminalReason",
     );
-    if (terminalReason !== "expired" && terminalReason !== "unavailable") {
+    if (
+      terminalReason !== "content_expired"
+      && terminalReason !== "expired"
+      && terminalReason !== "unavailable"
+    ) {
       throw new TypeError("Hosted runtime assistant ask terminalReason is invalid.");
     }
     return { action, status, terminalReason };

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -1046,6 +1046,7 @@ export type HostedRuntimeAssistantAskControlRequest =
     };
 
 export type HostedRuntimeAssistantAskTerminalReason =
+  | "content_expired"
   | "expired"
   | "unavailable";
 

--- a/packages/hosted-execution/test/assistant-ask.test.ts
+++ b/packages/hosted-execution/test/assistant-ask.test.ts
@@ -390,6 +390,15 @@ describe("hosted Assistant Ask runtime control", () => {
       terminalReason: "expired",
     });
     expect(parseHostedRuntimeAssistantAskControlResponse({
+      action: "prepare",
+      status: "terminal",
+      terminalReason: "content_expired",
+    })).toEqual({
+      action: "prepare",
+      status: "terminal",
+      terminalReason: "content_expired",
+    });
+    expect(parseHostedRuntimeAssistantAskControlResponse({
       action: "complete",
       status: "already_completed",
     })).toEqual({ action: "complete", status: "already_completed" });


### PR DESCRIPTION
## Why and outcome

An expired current-sender Assistant Ask could remain at the hosted system-mailbox head forever after content retention retired its encrypted wake. The runtime correctly refused to discard a request whose required fallback was not persisted, but Web could no longer reconstruct that fallback.

This marks only current-sender requests for recovery and retains their encrypted content after the ten-minute business expiry only while their system sequence remains ahead of the durable consumed watermark, never beyond the existing 14-day privacy deadline. Web identifies already-retired legacy content explicitly, and the runtime retires only that irrecoverable state so later mailbox work can advance.

## Product UX

- Effort: Patch
- Result: Ready
- Normal expiry still persists the existing cannot-answer fallback.
- Legacy content-retired requests recover without sending a misleading days-late message.
- Other Assistant Ask targets and connected-health import behavior are unchanged.

## Evidence

- Protocol parser: 6 tests passed.
- Detached runtime: 22 tests passed.
- Web control and retention: 47 tests passed.
- PostgreSQL Assistant Ask retention and current-sender authority: 12 tests passed.
- Hosted execution, assistant runtime, and Web typechecks passed.
- Agent docs drift and diff checks passed.

## Non-obvious affected surfaces

- Mailbox content retention: only marked current-sender requests ahead of the system consumed watermark extend past the ten-minute business TTL, with the existing 14-day privacy cutoff remaining absolute.
- Web/runtime control protocol: adds one exact content_expired terminal reason.
- Detached runtime local queue: only content_expired current-sender requests may retire without a persisted fallback.

## Architecture and reuse

- Existing systems reused: canonical mailbox item, existing retention sweep, Assistant Ask control endpoint, and detached runtime queue.
- New logic: one current-sender retention marker, one consumed-watermark predicate, and one explicit terminal reason.
- New abstractions: none beyond a narrow internal mailbox read type.
- Complexity intentionally avoided: no repair queue, scheduler, reconciliation service, migration, or new state owner.

## Hot reply path impact

- No current-inbound reply path changes.
- No database, network, or provider calls were added to foreground replies.
- Recovery runs only through the existing detached mailbox control path and retention sweep.

## Murph initial provider input impact

Not applicable. No prompts, tool schemas, or provider-visible instructions changed.

## Deployment concerns

- Deployment: applicable
- Components: Web and the hosted Cloudflare runtime.
- Safe order: either order is compatible; deploy both before expecting recovery. Web-first leaves old runners retrying. Runtime-first leaves new runners receiving only old terminal reasons.
- Supported skew: old runtimes reject the new terminal reason and retry; new runtimes keep retrying old Web terminal responses, so no request is newly discarded.
- Rollback floor: no schema migration or state rewrite is required; prior versions safely ignore the nullable mailbox marker.
- Expected exposure: recovery remains delayed until both components are live.
- Reversibility: redeploy the prior Web and runtime versions; existing mailbox state remains readable.
- Convergence proof: verify both deployed revisions, then confirm the durable system consumed watermark advances past the former head.
- Post-deploy checks: confirm pending system work falls, repeated zero-work passes stop, and connected-health reconciliation remains healthy.

## Changelog

- Changelog: not applicable
- Reason: this restores the already-described catch-up behavior and adds no new member-facing feature, copy, or surface.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 65 | 11 |
| Tests / fixtures | 229 | 0 |
| Docs | 90 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 384 | 12 |

ReviewGPT context sensitivity: sensitive

Classification reason: Changes mailbox retention privacy behavior and the Web/runtime terminal protocol.

ReviewGPT first-reviewed head: 9278afec0cb82800dae75ed37c6f632720baa383





