### PR TITLE
Attribute container-busy retries by stage

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-container-busy-stage-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-28-container-busy-stage-telemetry.md
@@ -1,0 +1,132 @@
+# Attribute hosted container-busy retries
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Explain the production `container_busy` retry burst by attributing every
+  existing busy-return path to one closed, privacy-safe stage at the current
+  UserRunner retry owner.
+- Preserve runtime behavior exactly: telemetry remains best-effort,
+  identifier-free in Analytics Engine, and unable to delay or alter retry,
+  wake, preemption, fence, or user-visible processing behavior.
+
+## Success criteria
+
+- Every `container_busy` return site supplies one compile-time-required stage
+  from a closed low-cardinality enum.
+- The existing structured warning includes that stage and the existing
+  Analytics Engine point adds only the stage dimension; row volume, index
+  cardinality, retry timing, and control flow are unchanged.
+- The operational SQL report groups sampling-corrected retry counts by reason
+  and stage while remaining compatible with historical points.
+- Focused tests prove the emitted shape, privacy boundary, best-effort failure
+  behavior, representative busy-stage attribution, and SQL/report contract.
+- Cloudflare typecheck, focused Vitest suites, privacy/log guards, required
+  completion audits, final ReviewGPT review, and exact-head CI pass.
+
+## Scope
+
+- In scope:
+  - `apps/cloudflare` UserRunner retry telemetry types, call-site attribution,
+    existing Analytics Engine point, structured warning, focused tests, the
+    existing retry report, and its durable README contract.
+  - A privacy-safe later query over naturally emitted production points.
+- Out of scope:
+  - Runtime retry/preemption/fence behavior, retry delays, Temporal state,
+    database state, new bindings/backends/queues/schedulers, unique attempt
+    identifiers in Analytics Engine, synthetic production traffic, and
+    device-sync behavior.
+
+## Constraints
+
+- Technical constraints:
+  - Reuse `HOSTED_RUNTIME_RETRY_ANALYTICS`; do not add a binding or data owner.
+  - Keep the existing reason as the sole Analytics Engine index. Put the stage
+    in a blob so the index stays bounded; maximum stage cardinality is the
+    finite number of current `container_busy` paths.
+  - Do not emit user/workspace/message/command/health/provider data or any new
+    identifier. Preserve the existing immediate best-effort `try/catch` write.
+  - No additional database/network call, await, timer, retry, or persisted
+    runtime state.
+- Product/process constraints:
+  - Internal telemetry only; Product UX is not applicable and no member-visible
+    behavior may change.
+  - The user explicitly overrode the production-sweep limit on concurrent
+    telemetry PRs. All other automation and repository gates remain in force.
+  - ReviewGPT exclusively authors production telemetry and remediation. The
+    local owner inspects, applies, validates, commits, and owns the PR.
+  - Draft PR #2448 changes the same controller region for mailbox behavior but
+    not this telemetry boundary; require clean merge proof and do not merge on
+    a substantive conflict.
+
+## Risks and mitigations
+
+1. Risk: stage values expose private work or expand cardinality.
+   Mitigation: use semantic control-path labels only, with no processing-mode
+   values, identifiers, content, errors, or free text; keep reason as the only
+   Analytics Engine index.
+2. Risk: telemetry changes retry behavior or adds hot-path latency.
+   Mitigation: reuse the existing synchronous best-effort point and structured
+   log, add no await or branch affecting the returned response, and prove the
+   same retry response/timestamp in focused tests.
+3. Risk: historical `v1` points disappear from the report.
+   Mitigation: keep the query explicitly backward-compatible and test the
+   schema predicate and stage grouping contract.
+4. Risk: PR #2448 creates a moving same-file conflict.
+   Mitigation: keep attribution additions mechanically local, inspect that PR's
+   exact diff, and require current-base `merge-tree` proof before any merge.
+
+## Tasks
+
+1. Freeze the telemetry question, competing causes, owner boundary, privacy and
+   cardinality constraints, and later verification query.
+2. Give ReviewGPT the privacy-safe implementation packet and obtain its patch.
+3. Inspect the full patch for scope, behavior preservation, privacy, cost,
+   device overlap, and compatibility; return substantive mismatches to
+   ReviewGPT rather than hand-editing production code.
+4. Apply the accepted ReviewGPT patch and run focused tests, Cloudflare
+   typecheck, direct privacy/report proof, and parent diff review.
+5. Commit and push a draft PR candidate, then run the preliminary specialist
+   and final ReviewGPT gates concurrently with exact-head CI.
+6. Resolve accepted findings through ReviewGPT, close the plan, mark Ready only
+   when every gate passes, and evaluate the telemetry-only autonomous
+   merge/deployment conditions.
+
+## Decisions
+
+- Product UX: not applicable because the change is internal, behavior-preserving
+  operational telemetry with no user-visible state or interaction.
+- Existing owner: `RuntimeProcessingController.createRetryLater` and
+  `createRuntimeProcessingRetryLater` already own the retry response, warning,
+  and Analytics Engine point.
+- Exact question: which closed UserRunner control path produced the
+  `container_busy` burst?
+- Competing causes to distinguish: non-runtime write-fence contention, active
+  runtime mode contention, cooperative handoff waiting, unavailable or
+  rejected preemption, and pending stopped-container state that could not yet
+  be cleared. ReviewGPT must derive the final finite labels from current code
+  and avoid encoding private processing-mode values.
+- Future query: over a fixed UTC window, filter the existing retry schema,
+  group sampling-corrected counts by retry reason plus optional busy stage, and
+  compare the latest two hours with the preceding two hours. Historical rows
+  without a stage must remain visible as unattributed rather than dropped.
+
+## Verification
+
+- Commands to run:
+  - Focused `apps/cloudflare` Vitest files for retry responses, UserRunner busy
+    paths, index/backpressure privacy, and operational report contracts.
+  - `pnpm --dir apps/cloudflare typecheck`.
+  - Repository privacy/log guard and diff-scoped checks selected by
+    `agent-docs/operations/verification-and-runtime.md`.
+  - Preliminary `completion-specialists` ReviewGPT pass and final ReviewGPT
+    round against the exact pushed head, concurrent with required GitHub CI.
+- Expected outcomes:
+  - Every busy path emits exactly one finite stage in logs and Analytics Engine
+    without any new identifier or free text.
+  - Non-busy telemetry remains compatible, retry responses/timing are
+    unchanged, Analytics write failure is swallowed, and the updated report
+    includes historical points.

--- a/agent-docs/exec-plans/completed/2026-08-28-container-busy-stage-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-container-busy-stage-telemetry.md
@@ -1,6 +1,6 @@
 # Attribute hosted container-busy retries
 
-Status: active
+Status: completed
 Created: 2026-08-28
 Updated: 2026-08-28
 
@@ -130,3 +130,4 @@ Updated: 2026-08-28
   - Non-busy telemetry remains compatible, retry responses/timing are
     unchanged, Analytics write failure is swallowed, and the updated report
     includes historical points.
+Completed: 2026-08-28

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -417,16 +417,41 @@ Cloudflare keeps only the wake-payload decryption lane plus the worker-owned cal
 
 The `HOSTED_RUNTIME_RETRY_ANALYTICS` Analytics Engine binding records one
 identifier-free data point only after UserRunner has decided to return
-`retry_later`. `index1` and `blob2` are the bounded retry reason, `blob1` is the
-schema `murph.hosted-runtime-retry.v1`, `double1` is the event count, and
-`double2` is the selected retry delay in milliseconds. The write is immediate,
-unawaited, best-effort, and absent from successful processing. Run
+`retry_later`. `index1` is the sole index and `blob2` repeats the bounded retry
+reason, `blob1` is the schema `murph.hosted-runtime-retry.v1`, `double1` is the
+event count, and `double2` is the selected retry delay in milliseconds. For
+`container_busy` only, optional `blob3` records one of these closed control-path
+stages:
+
+- `non_runtime_write_fence`: the active write fence is not runtime-owned.
+- `active_runtime_contention`: an active runtime fence remains contended after
+  the liveness check.
+- `cooperative_handoff_pending`: the active child accepted a release wake but
+  has not handed off yet.
+- `background_preemption_unavailable`: the active container exposes no
+  background-abort capability.
+- `background_preemption_not_accepted`: background abort returned a bounded
+  non-accepted, non-failure status.
+- `stopped_container_record_pending`: a destroyed pending stop target could not
+  yet be cleared from the runner record.
+
+The stage is a finite mechanism label, not a processing mode, scenario name,
+identifier, free-text value, or private-state projection. Other retry reasons
+must omit it. This is an optional-field evolution of the existing v1 point:
+historical points have no `blob3`, and the report groups them explicitly as
+`unattributed`. The write remains exactly one immediate, unawaited,
+best-effort point per existing retry and is absent from successful processing.
+Run
 [`scripts/runtime-retry-reasons.sql`](./scripts/runtime-retry-reasons.sql)
 through the private Cloudflare Analytics Engine SQL API or dashboard to get a
-sampling-corrected 24-hour reason breakdown.
-The corresponding Workers structured log includes the bounded retry reason and
-`orchestrationAttemptId` for request-level joins. That identifier is never
-copied into Analytics Engine blobs, indexes, or doubles.
+sampling-corrected reason-plus-stage breakdown. It defaults to the trailing 24
+hours; for later two-hour comparisons, replace its first timestamp predicate
+with the commented half-open fixed UTC bounds and run once for each adjacent
+window. The corresponding Workers structured log includes the bounded retry
+reason, `runtimeProcessingRetryStage` for `container_busy`, and the existing
+`orchestrationAttemptId` for request-level joins. No identifier or user,
+workspace, message, command, provider, health, path, content, credential, or
+raw-error value is copied into Analytics Engine blobs, indexes, or doubles.
 
 For the primary production control database, run the identifier-free cold-start
 report through the read-only helper:

--- a/apps/cloudflare/scripts/runtime-retry-reasons.sql
+++ b/apps/cloudflare/scripts/runtime-retry-reasons.sql
@@ -1,9 +1,14 @@
+-- Default: trailing 24 hours.
+-- For a fixed UTC window, replace the first WHERE predicate with both bounds:
+--   timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS', 'Etc/UTC')
+--   AND timestamp < toDateTime('YYYY-MM-DD HH:MM:SS', 'Etc/UTC')
 SELECT
   index1 AS reason,
+  if(blob3 = '', 'unattributed', blob3) AS stage,
   SUM(_sample_interval * double1) AS retry_count,
   SUM(_sample_interval * double2) / SUM(_sample_interval) AS average_retry_delay_ms
 FROM murph_hosted_runtime_retries
 WHERE timestamp > NOW() - INTERVAL '1' DAY
   AND blob1 = 'murph.hosted-runtime-retry.v1'
-GROUP BY index1
-ORDER BY retry_count DESC;
+GROUP BY index1, stage
+ORDER BY retry_count DESC, reason, stage;

--- a/apps/cloudflare/src/user-runner/diagnostics.ts
+++ b/apps/cloudflare/src/user-runner/diagnostics.ts
@@ -25,6 +25,24 @@ export type RuntimeProcessingRetryReason =
   | "missing_container_binding"
   | "starting_fence_preserved";
 
+export type RuntimeProcessingContainerBusyStage =
+  | "active_runtime_contention"
+  | "background_preemption_not_accepted"
+  | "background_preemption_unavailable"
+  | "cooperative_handoff_pending"
+  | "non_runtime_write_fence"
+  | "stopped_container_record_pending";
+
+export type RuntimeProcessingRetryAttribution =
+  | {
+      reason: "container_busy";
+      stage: RuntimeProcessingContainerBusyStage;
+    }
+  | {
+      reason: Exclude<RuntimeProcessingRetryReason, "container_busy">;
+      stage?: never;
+    };
+
 export type RuntimeProcessingStartFailureRetryReason = Extract<
   RuntimeProcessingRetryReason,
   | "command_budget_exhausted"
@@ -239,7 +257,7 @@ export function mapRunnerProcessingRetryReason(
     RunnerContainerEnsureProcessingResult,
     { kind: "wake-unconfirmed" }
   >["reason"],
-): RuntimeProcessingRetryReason {
+): Exclude<RuntimeProcessingRetryReason, "container_busy"> {
   switch (reason) {
     case "active-child-rejected":
       return "active_child_rejected";

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -34,6 +34,7 @@ import {
   buildRunnerRecordTimingLogDetails,
   classifyRuntimeStartFailureRetryReason,
   mapRunnerProcessingRetryReason,
+  type RuntimeProcessingRetryAttribution,
   type RuntimeProcessingRetryReason,
   type RuntimeProcessingStartFailureRetryReason,
 } from "./diagnostics.js";
@@ -211,11 +212,12 @@ export class RuntimeProcessingController {
     },
   ) {}
 
-  private createRetryLater(input: {
-    orchestrationAttemptId: string;
-    reason: RuntimeProcessingRetryReason;
-    userId: string;
-  }): HostedRuntimeEnsureProcessingResponse {
+  private createRetryLater(
+    input: RuntimeProcessingRetryAttribution & {
+      orchestrationAttemptId: string;
+      userId: string;
+    },
+  ): HostedRuntimeEnsureProcessingResponse {
     return createRuntimeProcessingRetryLaterResponse({
       ...input,
       analytics: this.input.runtimeRetryAnalytics ?? null,
@@ -433,6 +435,7 @@ export class RuntimeProcessingController {
       return this.createRetryLater({
         orchestrationAttemptId: input.input.orchestrationAttemptId,
         reason: "container_busy",
+        stage: "non_runtime_write_fence",
         userId: input.input.userId,
       });
     }
@@ -500,6 +503,7 @@ export class RuntimeProcessingController {
         return this.createRetryLater({
           orchestrationAttemptId: input.input.orchestrationAttemptId,
           reason: "container_busy",
+          stage: "active_runtime_contention",
           userId: input.input.userId,
         });
       }
@@ -591,6 +595,7 @@ export class RuntimeProcessingController {
         return this.createRetryLater({
           orchestrationAttemptId: input.input.orchestrationAttemptId,
           reason: "container_busy",
+          stage: "cooperative_handoff_pending",
           userId: input.input.userId,
         });
       }
@@ -792,6 +797,7 @@ export class RuntimeProcessingController {
         response: this.createRetryLater({
           orchestrationAttemptId: input.orchestrationAttemptId,
           reason: "container_busy",
+          stage: "background_preemption_unavailable",
           userId: input.record.userId,
         }),
       };
@@ -814,13 +820,22 @@ export class RuntimeProcessingController {
       ) {
         return { aborted: true };
       }
+      if (abortStatus === "failed") {
+        return {
+          aborted: false,
+          response: this.createRetryLater({
+            orchestrationAttemptId: input.orchestrationAttemptId,
+            reason: "container_rpc_error",
+            userId: input.record.userId,
+          }),
+        };
+      }
       return {
         aborted: false,
         response: this.createRetryLater({
           orchestrationAttemptId: input.orchestrationAttemptId,
-          reason: abortStatus === "failed"
-            ? "container_rpc_error"
-            : "container_busy",
+          reason: "container_busy",
+          stage: "background_preemption_not_accepted",
           userId: input.record.userId,
         }),
       };
@@ -986,6 +1001,7 @@ export class RuntimeProcessingController {
         return this.createRetryLater({
           orchestrationAttemptId: processingInput.orchestrationAttemptId,
           reason: "container_busy",
+          stage: "stopped_container_record_pending",
           userId: processingInput.userId,
         });
       }

--- a/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-responses.ts
@@ -13,11 +13,19 @@ import {
   computeHostedRuntimeProcessingRecheckDelayMs,
 } from "../runtime-processing-timing.ts";
 import type {
+  RuntimeProcessingRetryAttribution,
   RuntimeProcessingRetryReason,
 } from "./diagnostics.js";
 
 export const HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA =
   "murph.hosted-runtime-retry.v1";
+
+type RuntimeProcessingRetryLaterInput =
+  RuntimeProcessingRetryAttribution & {
+    analytics?: WorkerAnalyticsEngineDatasetLike | null;
+    orchestrationAttemptId?: string;
+    userId: string;
+  };
 
 export function readRuntimeProcessingRetryDelayMs(
   reason: RuntimeProcessingRetryReason,
@@ -46,12 +54,9 @@ export function computeRuntimeProcessingOwnerRecheckAt(input: {
   return computeActiveRuntimeWakeRecheckAt(input.env);
 }
 
-export function createRuntimeProcessingRetryLater(input: {
-  analytics?: WorkerAnalyticsEngineDatasetLike | null;
-  orchestrationAttemptId?: string;
-  reason: RuntimeProcessingRetryReason;
-  userId: string;
-}): HostedRuntimeEnsureProcessingResponse {
+export function createRuntimeProcessingRetryLater(
+  input: RuntimeProcessingRetryLaterInput,
+): HostedRuntimeEnsureProcessingResponse {
   emitHostedExecutionStructuredLog({
     component: "hosted.runner",
     details: {
@@ -59,6 +64,9 @@ export function createRuntimeProcessingRetryLater(input: {
         ? {}
         : { orchestrationAttemptId: input.orchestrationAttemptId }),
       runtimeProcessingRetryReason: input.reason,
+      ...(input.reason === "container_busy"
+        ? { runtimeProcessingRetryStage: input.stage }
+        : {}),
     },
     level: "warn",
     message: "Hosted runner runtime processing could not be accepted yet.",
@@ -67,7 +75,11 @@ export function createRuntimeProcessingRetryLater(input: {
   });
   // Analytics Engine remains deliberately identifier-free; correlation lives
   // only in the structured Workers log above.
-  recordRuntimeProcessingRetry(input.analytics ?? null, input.reason);
+  const attribution: RuntimeProcessingRetryAttribution =
+    input.reason === "container_busy"
+      ? { reason: input.reason, stage: input.stage }
+      : { reason: input.reason };
+  recordRuntimeProcessingRetry(input.analytics ?? null, attribution);
   return {
     kind: "retry_later",
     retryAt: computeRuntimeProcessingRetryAt(input.reason),
@@ -76,15 +88,22 @@ export function createRuntimeProcessingRetryLater(input: {
 
 function recordRuntimeProcessingRetry(
   analytics: WorkerAnalyticsEngineDatasetLike | null,
-  reason: RuntimeProcessingRetryReason,
+  attribution: RuntimeProcessingRetryAttribution,
 ): void {
   if (!analytics) {
     return;
   }
+  const reason = attribution.reason;
   try {
     analytics.writeDataPoint({
       indexes: [reason],
-      blobs: [HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA, reason],
+      blobs: attribution.reason === "container_busy"
+        ? [
+            HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+            reason,
+            attribution.stage,
+          ]
+        : [HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA, reason],
       doubles: [1, readRuntimeProcessingRetryDelayMs(reason)],
     });
   } catch {

--- a/apps/cloudflare/test/operational-report-contracts.test.ts
+++ b/apps/cloudflare/test/operational-report-contracts.test.ts
@@ -19,6 +19,10 @@ const retryReasonsSql = readFileSync(
   new URL("../scripts/runtime-retry-reasons.sql", import.meta.url),
   "utf8",
 );
+const cloudflareReadme = readFileSync(
+  new URL("../README.md", import.meta.url),
+  "utf8",
+);
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
 const runPostgresProof =
   process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
@@ -35,9 +39,37 @@ describe("hosted runtime operational report contracts", () => {
       `blob1 = '${HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA}'`,
     );
     expect(retryReasonsSql).toContain("index1 AS reason");
+    expect(retryReasonsSql).toContain(
+      "if(blob3 = '', 'unattributed', blob3) AS stage",
+    );
     expect(retryReasonsSql).toContain("SUM(_sample_interval * double1)");
     expect(retryReasonsSql).toContain("SUM(_sample_interval * double2)");
+    expect(retryReasonsSql).toContain("GROUP BY index1, stage");
     expect(retryReasonsSql).toContain("INTERVAL '1' DAY");
+    expect(retryReasonsSql).toContain(
+      "timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS', 'Etc/UTC')",
+    );
+    expect(retryReasonsSql).toContain(
+      "timestamp < toDateTime('YYYY-MM-DD HH:MM:SS', 'Etc/UTC')",
+    );
+    expect(retryReasonsSql).not.toMatch(/blob3\s*(?:!=|<>)/u);
+  });
+
+  it("documents the bounded optional container-busy stage contract", () => {
+    for (const stage of [
+      "non_runtime_write_fence",
+      "active_runtime_contention",
+      "cooperative_handoff_pending",
+      "background_preemption_unavailable",
+      "background_preemption_not_accepted",
+      "stopped_container_record_pending",
+    ]) {
+      expect(cloudflareReadme).toContain(`\`${stage}\``);
+    }
+    expect(cloudflareReadme).toContain("optional `blob3`");
+    expect(cloudflareReadme).toContain("`unattributed`");
+    expect(cloudflareReadme).toContain("`runtimeProcessingRetryStage`");
+    expect(cloudflareReadme).toContain("`index1` is the sole index");
   });
 
   it("keeps direct cold starts causal and phase samples chronology-safe", () => {

--- a/apps/cloudflare/test/runtime-processing-responses.test.ts
+++ b/apps/cloudflare/test/runtime-processing-responses.test.ts
@@ -5,11 +5,48 @@ import {
   HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
 } from "../src/user-runner/runtime-processing-responses.ts";
 
+type RuntimeProcessingRetryLaterInput = Parameters<
+  typeof createRuntimeProcessingRetryLater
+>[0];
+
 describe("runtime processing retry telemetry", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it("requires a stage only for container-busy retries", () => {
+    const acceptRetryInput = (
+      _input: RuntimeProcessingRetryLaterInput,
+    ): void => undefined;
+    const attributedBusyRetry = {
+      reason: "container_busy",
+      stage: "active_runtime_contention",
+      userId: "member_123",
+    } satisfies RuntimeProcessingRetryLaterInput;
+    const unattributedNonBusyRetry = {
+      reason: "container_rpc_error",
+      userId: "member_123",
+    } satisfies RuntimeProcessingRetryLaterInput;
+
+    expect(attributedBusyRetry.stage).toBe("active_runtime_contention");
+    expect("stage" in unattributedNonBusyRetry).toBe(false);
+
+    // @ts-expect-error A container-busy retry must select a closed stage.
+    acceptRetryInput({ reason: "container_busy", userId: "member_123" });
+    acceptRetryInput({
+      reason: "container_rpc_error",
+      // @ts-expect-error Other retry reasons must not carry a busy stage.
+      stage: "active_runtime_contention",
+      userId: "member_123",
+    });
+    acceptRetryInput({
+      reason: "container_busy",
+      // @ts-expect-error Container-busy stages are a closed vocabulary.
+      stage: "request_specific_state",
+      userId: "member_123",
+    });
   });
 
   it("keeps Analytics Engine identifier-free while correlating the structured retry log", () => {
@@ -45,23 +82,77 @@ describe("runtime processing retry telemetry", () => {
       orchestrationAttemptId: "web-ingress-attempt-test",
       runtimeProcessingRetryReason: "container_rpc_timeout",
     });
+    expect(structuredLog.details).not.toHaveProperty(
+      "runtimeProcessingRetryStage",
+    );
+  });
+
+  it("records the same finite container-busy stage in the log and blob dimension", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-06T12:00:00.000Z"));
+    vi.stubEnv("MURPH_HOSTED_EXECUTION_STDIO_LOGS", "1");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const writeDataPoint = vi.fn();
+
+    expect(createRuntimeProcessingRetryLater({
+      analytics: { writeDataPoint },
+      orchestrationAttemptId: "web-ingress-attempt-test",
+      reason: "container_busy",
+      stage: "cooperative_handoff_pending",
+      userId: "member_123",
+    })).toEqual({
+      kind: "retry_later",
+      retryAt: "2026-08-06T12:00:05.000Z",
+    });
+    expect(writeDataPoint).toHaveBeenCalledOnce();
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: [
+        HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+        "container_busy",
+        "cooperative_handoff_pending",
+      ],
+      doubles: [1, 5_000],
+      indexes: ["container_busy"],
+    });
+    const serializedAnalytics = JSON.stringify(writeDataPoint.mock.calls);
+    expect(serializedAnalytics).not.toContain("member_123");
+    expect(serializedAnalytics).not.toContain("web-ingress-attempt-test");
+
+    const structuredLog = JSON.parse(String(warn.mock.calls[0]?.[0])) as {
+      details: Record<string, unknown>;
+    };
+    expect(structuredLog.details).toMatchObject({
+      orchestrationAttemptId: "web-ingress-attempt-test",
+      runtimeProcessingRetryReason: "container_busy",
+      runtimeProcessingRetryStage: "cooperative_handoff_pending",
+    });
   });
 
   it("keeps retry behavior unchanged when the telemetry binding throws", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-06T12:00:00.000Z"));
+    const analytics = {
+      writeDataPoint() {
+        throw new Error("analytics unavailable");
+      },
+    };
 
     expect(createRuntimeProcessingRetryLater({
-      analytics: {
-        writeDataPoint() {
-          throw new Error("analytics unavailable");
-        },
-      },
+      analytics,
       reason: "container_rpc_error",
       userId: "member_123",
     })).toEqual({
       kind: "retry_later",
       retryAt: "2026-08-06T12:00:30.000Z",
+    });
+    expect(createRuntimeProcessingRetryLater({
+      analytics,
+      reason: "container_busy",
+      stage: "background_preemption_unavailable",
+      userId: "member_123",
+    })).toEqual({
+      kind: "retry_later",
+      retryAt: "2026-08-06T12:00:05.000Z",
     });
   });
 });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -51,6 +51,9 @@ import {
 } from "../src/storage-paths.ts";
 import { HostedUserRunner } from "../src/user-runner.ts";
 import { HostedUserRunnerWithTestControls } from "../src/user-runner/hosted-user-runner-test.ts";
+import {
+  HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+} from "../src/user-runner/runtime-processing-responses.ts";
 import { RunnerStateStore } from "../src/user-runner/runner-state-store.ts";
 import type {
   DurableObjectStateLike,
@@ -3449,6 +3452,7 @@ describe("HostedUserRunner execution coordination", () => {
         kind: "accepted" as const,
       }),
     );
+    const writeDataPoint = vi.fn();
     let activeAttemptId = "";
     let activeGeneration = "";
     const readActiveRuntimeUserFence = vi.fn<
@@ -3463,6 +3467,7 @@ describe("HostedUserRunner execution coordination", () => {
       abortWorkspaceInvocation,
       ensureProcessing,
       readActiveRuntimeUserFence,
+      runtimeRetryAnalytics: { writeDataPoint },
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
@@ -3487,6 +3492,15 @@ describe("HostedUserRunner execution coordination", () => {
     expect(abortWorkspaceInvocation).not.toHaveBeenCalled();
     expect(ensureProcessing).not.toHaveBeenCalled();
     expect(invoke).not.toHaveBeenCalled();
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: [
+        HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+        "container_busy",
+        "active_runtime_contention",
+      ],
+      doubles: [1, 5_000],
+      indexes: ["container_busy"],
+    });
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: token.attemptId,
       active_expires_at: null,
@@ -3836,9 +3850,11 @@ describe("HostedUserRunner execution coordination", () => {
         action: "woken" as const,
         kind: "accepted" as const,
       }));
+      const writeDataPoint = vi.fn();
       const { invoke, runner, sql } = createRunnerHarness({
         abortWorkspaceInvocation,
         ensureProcessing,
+        runtimeRetryAnalytics: { writeDataPoint },
         workspace: createWorkspaceState({ version: "7" }),
       });
       await runner.bindUser(TEST_USER_ID);
@@ -3867,6 +3883,15 @@ describe("HostedUserRunner execution coordination", () => {
       });
       expect(abortWorkspaceInvocation).not.toHaveBeenCalled();
       expect(invoke).not.toHaveBeenCalled();
+      expect(writeDataPoint).toHaveBeenCalledWith({
+        blobs: [
+          HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+          "container_busy",
+          "cooperative_handoff_pending",
+        ],
+        doubles: [1, 5_000],
+        indexes: ["container_busy"],
+      });
       expect(readRunnerMeta(sql)).toMatchObject({
         active_attempt_id: token.attemptId,
         active_expires_at: null,
@@ -3976,6 +4001,46 @@ describe("HostedUserRunner execution coordination", () => {
     });
   });
 
+  it("attributes unavailable background preemption before preserving the active fence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+    const writeDataPoint = vi.fn();
+    const { invoke, runner, sql } = createRunnerHarness({
+      runtimeRetryAnalytics: { writeDataPoint },
+      workspace: createWorkspaceState({ version: "7" }),
+    });
+    await runner.bindUser(TEST_USER_ID);
+    const token = writeRuntimeFenceForTest(sql, {
+      processingMode: "inbox_media_retention",
+      runnerContainerName: TEST_USER_ID,
+      workspaceVersion: "7",
+    });
+
+    await expect(runner.ensureRuntimeProcessingForUser({
+      orchestrationAttemptId: "test-default-behind-retention-without-abort",
+      userId: TEST_USER_ID,
+    })).resolves.toEqual({
+      kind: "retry_later",
+      retryAt: "2026-04-27T00:00:05.000Z",
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: [
+        HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+        "container_busy",
+        "background_preemption_unavailable",
+      ],
+      doubles: [1, 5_000],
+      indexes: ["container_busy"],
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(readRunnerMeta(sql)).toMatchObject({
+      active_attempt_id: token.attemptId,
+      active_generation: token.generation,
+      active_reason: "inbox_media_retention",
+    });
+  });
+
   it.each([
     ["retention", "stale", "inbox_media_retention", false, "2026-04-27T00:00:05.000Z"],
     ["retention", "queued", "inbox_media_retention", false, "2026-04-27T00:00:05.000Z"],
@@ -3997,6 +4062,7 @@ describe("HostedUserRunner execution coordination", () => {
     const abortWorkspaceInvocation = vi.fn<
       NonNullable<HostedExecutionContainerStubLike["abortWorkspaceInvocation"]>
     >(async () => abortStatus);
+    const writeDataPoint = vi.fn();
     let activeAttemptId = "";
     let activeGeneration = "";
     const readActiveRuntimeUserFence = vi.fn<
@@ -4010,6 +4076,7 @@ describe("HostedUserRunner execution coordination", () => {
     const { invoke, runner, sql } = createRunnerHarness({
       abortWorkspaceInvocation,
       readActiveRuntimeUserFence,
+      runtimeRetryAnalytics: { writeDataPoint },
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
@@ -4042,6 +4109,26 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     });
     expect(invoke).not.toHaveBeenCalled();
+    expect(writeDataPoint).toHaveBeenCalledWith(
+      abortStatus === "failed"
+        ? {
+            blobs: [
+              HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+              "container_rpc_error",
+            ],
+            doubles: [1, 30_000],
+            indexes: ["container_rpc_error"],
+          }
+        : {
+            blobs: [
+              HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
+              "container_busy",
+              "background_preemption_not_accepted",
+            ],
+            doubles: [1, 5_000],
+            indexes: ["container_busy"],
+          },
+    );
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: token.attemptId,
       active_expires_at: null,


### PR DESCRIPTION
## Why and outcome

Production sampling-corrected `container_busy` retries rose to 111 in the
selected current window versus zero in the preceding window, but the existing
retry event collapses six different UserRunner control paths into one reason.
This PR adds one closed stage dimension to the existing structured warning and
Analytics Engine point so natural production traffic can identify the cause.

The change is telemetry-only. It does not alter retry timing, control flow,
fence ownership, preemption, durable state, provider interaction, or
user-visible behavior.

## Product UX

- Effort: Patch — internal operational telemetry only.
- Result: Ready.
- Walkthrough: No member journey changes; existing busy retries and recovery
  behavior are preserved.

## Evidence

- Direct: focused retry-response and operational-report tests passed (7 passed,
  2 skipped), and the focused UserRunner alarm suite passed all 164 tests.
- Broader: diff-aware Cloudflare verification passed 150 Node test files / 2,713
  tests (2 skipped) and 5 workerd test files / 14 tests.
- Guards: Cloudflare typecheck, dependency policy, workspace boundaries,
  hosted-runtime architecture guards, provider-request boundaries, raw-health
  log privacy guard, and `git diff --check` passed.
- Review: preliminary `completion-specialists` returned PASS with no findings,
  and final ReviewGPT round 1 returned PASS with no findings, both on
  `bbcceaccaf061eafa49fea7d46beb6358133e3a2`. The only later commit archives
  the completed execution plan; current head is
  `7643bd18f42dbcce6237b9233a331d45a0626ddf`.
- Provenance: ReviewGPT exclusively authored the accepted production, test, and
  contract patch. Applied artifact SHA-256:
  `2b6221bf321661913fc2764c2f11f2064508ca894141d3e3cfb62727624dd5b1`.

## Non-obvious affected surfaces

- The existing `murph.hosted-runtime-retry.v1` Analytics Engine point gains
  optional `blob3` only for `container_busy`; historical rows remain readable
  as `unattributed`.
- The existing retry reason remains the sole Analytics Engine index and point
  volume remains exactly one best-effort point per existing retry.
- No Web, Temporal, database, billing, messaging, provider, or device-sync
  surface changes.

## Architecture and reuse

- Existing systems reused: UserRunner's retry owner, structured Workers log,
  `HOSTED_RUNTIME_RETRY_ANALYTICS`, and the existing operational SQL report.
- New logic: one six-value discriminated stage union and mechanically local
  attribution at each existing `container_busy` return site.
- New abstractions: no backend, binding, service, state owner, persistence,
  scheduler, queue, metric pipeline, or compatibility shim.
- Complexity intentionally avoided: no additional await, network/database
  call, identifier, free text, processing-mode label, retry, or control branch.

## Hot reply path impact

- Path status: Existing retry-only path; successful processing is unchanged.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: focused tests preserve the exact retry response and
  timestamp, including when Analytics Engine throws.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no prompt, tool, history, or provider-visible
  fixture surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: Production hosted-runtime telemetry at a Cloudflare
Durable Object retry owner, despite behavior-preserving scope.

## Deployment concerns

- Deployment: applicable
- Supported skew: Additive observability-only field; old/new Workers, runners,
  Web, and historical Analytics Engine rows remain compatible.
- Safe order: No Vercel deployment is required. After merge, deploy the
  Cloudflare Worker/runner through the protected `murph-cloud` production
  workflow using its currently approved container rollout setting.
- Rollback floor: None; no persisted state or wire contract changes.
- Expected exposure: Existing `container_busy` retries only; each gains one of
  six low-cardinality mechanism labels in the existing log and point.
- Reversibility: Deploy the preceding Cloudflare revision through the same
  protected workflow.
- Convergence proof: Managed-container smoke must prove the merged public
  release SHA and runner/Worker fingerprints.
- Post-deploy checks: On natural traffic only, run the updated half-open UTC
  `runtime-retry-reasons.sql` query for the latest two hours and preceding two
  hours. Filter `blob1 = 'murph.hosted-runtime-retry.v1'`, group
  sampling-corrected counts by reason plus stage, and retain missing historical
  `blob3` as `unattributed`. Do not generate synthetic traffic.

## Coordination and deduplication

- PR #2448 changes nearby mailbox behavior in the same controller file but
  does not own this retry-attribution question or Analytics Engine boundary.
- Other active telemetry PRs cover foreground execution and Browser Vault
  refresh boundaries; none covers `container_busy` stage attribution.
- No competing device-sync task, PR, issue, branch, or recent merge owns this
  cross-cutting non-device telemetry question.

## Change-shape breakdown

Classification rule: runtime `.ts` files are Source; test files are Tests /
fixtures; README plus execution plan are Docs; the SQL report is Config /
tooling. No generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 71 | 18 |
| Tests / fixtures | 215 | 5 |
| Docs | 165 | 8 |
| Config / tooling | 7 | 2 |
| Generated / other | 0 | 0 |
| **Total** | **458** | **33** |

## Changelog

- Changelog: not applicable
- Reason: Internal diagnostics only; no member-visible behavior or recovery
  outcome changes.

ReviewGPT first-reviewed head: bbcceaccaf061eafa49fea7d46beb6358133e3a2
