### PR TITLE
fix(repo): open execution plans before install

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-28-frog-autofix-2389.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-frog-autofix-2389.md
@@ -1,0 +1,70 @@
+# Make execution-plan opening dependency-free
+
+Status: completed
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Let a freshly created sanctioned worktree open its required execution plan
+  before the workspace dependency graph is installed.
+
+## Success criteria
+
+- `bash scripts/open-exec-plan.sh <slug> <title>` creates the canonical active
+  plan without `node_modules`, a sibling repo-tools checkout, or a globally
+  installed repo-tools binary.
+- Help, separator handling, slug validation, duplicate protection, and the
+  existing plan template remain intact.
+- Focused developer-workflow tests pass with a harness that intentionally omits
+  repo-tools and dependency links.
+
+## Scope
+
+- In scope: the repository-owned plan-opening entrypoint and its focused tests.
+- Out of scope: other repo-tools consumers, plan closing/committing, dependency
+  installation, and changes to the shared repo-tools package.
+
+## Constraints
+
+- Technical constraints: keep the entrypoint POSIX-environment friendly under
+  Bash and preserve its current CLI contract and artifact format.
+- Product/process constraints: prefer deleting the unnecessary indirection;
+  do not introduce a bootstrap service, network fetch, or compatibility layer.
+
+## Risks and mitigations
+
+1. Risk: the repository-owned template can drift from its established plan
+   contract.
+   Mitigation: preserve the current delegated implementation byte-for-behavior
+   and assert the complete artifact shape in a dependency-free fixture.
+
+## Tasks
+
+1. Reproduce the missing repo-tools failure in a fresh sanctioned worktree.
+2. Move the small plan-creation behavior into the repository entrypoint.
+3. Replace delegate-oriented tests with dependency-absent behavior coverage.
+4. Run focused tests, shell syntax proof, scoped workflow checks, and completion
+   review.
+
+## Decisions
+
+- The plan entrypoint owns its small stable template directly. Loading all of
+  `repo-tools.config.sh` merely to locate one executable is the defect, and a
+  fallback would retain two implementations and an avoidable failure mode.
+
+## Verification
+
+- `bash scripts/open-exec-plan.sh frog-autofix-2389 "Make execution-plan
+  opening dependency-free"` before dependency installation: failed with the
+  expected missing repo-tools consumer error, proving the defect.
+- `bash -n scripts/open-exec-plan.sh`: passed.
+- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage
+  scripts/developer-workflow-entrypoints.test.ts`: passed, 21 tests.
+- `pnpm exec tsc --noEmit -p tsconfig.tools.json`: passed.
+- `bash scripts/check-agent-docs-drift.sh`: passed.
+- `pnpm test:repo-tools`: 674 tests passed and two unrelated storage-guard
+  timing cases exceeded their 15-second limits under the broad parallel run.
+- Focused rerun of those two storage-guard cases: passed, two tests.
+- `git diff --check` and changed-file secret/path scan: passed.
+Completed: 2026-08-28

--- a/scripts/developer-workflow-entrypoints.test.ts
+++ b/scripts/developer-workflow-entrypoints.test.ts
@@ -55,30 +55,15 @@ function listFiles(root: string, relativeDirectory = ""): string[] {
 function createPlanHarness() {
   const root = createTempRoot("open-exec-plan-");
   const scriptsDirectory = path.join(root, "scripts");
-  const delegate = path.join(root, "fake-open-exec-plan");
-  const capture = path.join(root, "delegate-arguments");
   mkdirSync(scriptsDirectory, { recursive: true });
+  mkdirSync(path.join(root, "agent-docs", "exec-plans", "active"), {
+    recursive: true,
+  });
   writeExecutable(
     path.join(scriptsDirectory, "open-exec-plan.sh"),
     readFileSync(path.join(repoRoot, "scripts", "open-exec-plan.sh"), "utf8"),
   );
-  writeFileSync(
-    path.join(scriptsDirectory, "repo-tools.config.sh"),
-    `cobuild_repo_tool_bin() {
-  printf '%s\\n' "\${MURPH_TEST_PLAN_BIN:?}"
-}
-`,
-  );
-  writeExecutable(
-    delegate,
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$@" > "\${MURPH_TEST_PLAN_CAPTURE:?}"
-mkdir -p agent-docs/exec-plans/active
-printf 'created\\n' > "agent-docs/exec-plans/active/$1.md"
-`,
-  );
-  return { capture, delegate, root };
+  return { root };
 }
 
 function createPreCommitHarness() {
@@ -196,7 +181,7 @@ afterEach(() => {
   while (roots.length > 0) rmSync(roots.pop()!, { force: true, recursive: true });
 });
 
-describe("open execution plan wrapper", () => {
+describe("open execution plan entrypoint", () => {
   it.each([
     ["-h", ["-h"]],
     ["--help", ["--help"]],
@@ -214,7 +199,6 @@ describe("open execution plan wrapper", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toBe("Usage: scripts/open-exec-plan.sh <slug> [title]\n");
     expect(listFiles(harness.root)).toEqual(before);
-    expect(existsSync(harness.capture)).toBe(false);
   });
 
   it.each([
@@ -228,22 +212,104 @@ describe("open execution plan wrapper", () => {
       {
         cwd: harness.root,
         encoding: "utf8",
-        env: {
-          ...process.env,
-          MURPH_TEST_PLAN_BIN: harness.delegate,
-          MURPH_TEST_PLAN_CAPTURE: harness.capture,
-        },
       },
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(readFileSync(harness.capture, "utf8")).toBe("routine-change\nRoutine title\n");
+    const activeDirectory = path.join(
+      harness.root,
+      "agent-docs",
+      "exec-plans",
+      "active",
+    );
+    const planFiles = readdirSync(activeDirectory);
+    expect(planFiles).toHaveLength(1);
+    const planFile = planFiles[0]!;
+    const dateMatch = /^(\d{4}-\d{2}-\d{2})-routine-change\.md$/u.exec(planFile);
+    expect(dateMatch).not.toBeNull();
+    const dateStamp = dateMatch![1];
+    expect(result.stdout).toBe(
+      `Created agent-docs/exec-plans/active/${planFile}\n`,
+    );
+    expect(readFileSync(path.join(activeDirectory, planFile), "utf8")).toBe(`# Routine title
+
+Status: active
+Created: ${dateStamp}
+Updated: ${dateStamp}
+
+## Goal
+
+- Define the concrete user-visible and engineering outcome.
+
+## Success criteria
+
+- List objective checks required to call this done.
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Constraints
+
+- Technical constraints:
+- Product/process constraints:
+
+## Risks and mitigations
+
+1. Risk:
+   Mitigation:
+
+## Tasks
+
+1. Replace with ordered concrete tasks.
+
+## Decisions
+
+- None yet.
+
+## Verification
+
+- Commands to run:
+- Expected outcomes:
+`);
+  });
+
+  it("rejects an invalid slug without creating a plan", () => {
+    const harness = createPlanHarness();
+    const result = spawnSync(
+      "bash",
+      ["scripts/open-exec-plan.sh", "Not-Kebab-Case"],
+      { cwd: harness.root, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe(
+      "Slug must be kebab-case: lowercase letters, numbers, hyphens\n",
+    );
     expect(
-      readFileSync(
-        path.join(harness.root, "agent-docs", "exec-plans", "active", "routine-change.md"),
-        "utf8",
-      ),
-    ).toBe("created\n");
+      readdirSync(path.join(harness.root, "agent-docs", "exec-plans", "active")),
+    ).toEqual([]);
+  });
+
+  it("does not overwrite an existing plan", () => {
+    const harness = createPlanHarness();
+    const args = ["scripts/open-exec-plan.sh", "routine-change", "Routine title"];
+    const first = spawnSync("bash", args, {
+      cwd: harness.root,
+      encoding: "utf8",
+    });
+    const second = spawnSync("bash", args, {
+      cwd: harness.root,
+      encoding: "utf8",
+    });
+
+    expect(first.status, first.stderr).toBe(0);
+    expect(second.status).toBe(1);
+    expect(second.stdout).toMatch(/^Plan already exists: /u);
+    expect(
+      readdirSync(path.join(harness.root, "agent-docs", "exec-plans", "active")),
+    ).toHaveLength(1);
   });
 });
 

--- a/scripts/open-exec-plan.sh
+++ b/scripts/open-exec-plan.sh
@@ -12,5 +12,70 @@ if [[ "${1:-}" == '-h' || "${1:-}" == '--help' ]]; then
   exit 0
 fi
 
-source scripts/repo-tools.config.sh
-exec "$(cobuild_repo_tool_bin cobuild-open-exec-plan)" "$@"
+if [[ $# -lt 1 ]]; then
+  echo "Usage: scripts/open-exec-plan.sh <slug> [title]"
+  exit 1
+fi
+
+slug="$1"
+shift || true
+title="${*:-$slug}"
+
+if ! [[ "$slug" =~ ^[a-z0-9-]+$ ]]; then
+  echo "Slug must be kebab-case: lowercase letters, numbers, hyphens"
+  exit 1
+fi
+
+date_stamp="$(date +%Y-%m-%d)"
+plan_path="agent-docs/exec-plans/active/${date_stamp}-${slug}.md"
+
+if [[ -e "$plan_path" ]]; then
+  echo "Plan already exists: $plan_path"
+  exit 1
+fi
+
+cat > "$plan_path" <<PLAN
+# ${title}
+
+Status: active
+Created: ${date_stamp}
+Updated: ${date_stamp}
+
+## Goal
+
+- Define the concrete user-visible and engineering outcome.
+
+## Success criteria
+
+- List objective checks required to call this done.
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Constraints
+
+- Technical constraints:
+- Product/process constraints:
+
+## Risks and mitigations
+
+1. Risk:
+   Mitigation:
+
+## Tasks
+
+1. Replace with ordered concrete tasks.
+
+## Decisions
+
+- None yet.
+
+## Verification
+
+- Commands to run:
+- Expected outcomes:
+PLAN
+
+echo "Created $plan_path"


### PR DESCRIPTION
Frog autofix issue: #2389

## Why and outcome

A fresh sanctioned worktree must be able to create its required execution plan before the workspace dependency graph is linked. The repository plan entrypoint now owns its small validation-and-template operation directly, so plan creation no longer depends on an installed repo-tools package.

## Product UX

- Effort: Not applicable — this is internal developer workflow tooling only.
- Result: Not applicable — no member-facing behavior or product journey changes.
- Walkthrough: Reproduced the fresh-worktree failure, then exercised plan creation in a fixture with no dependency tree or repo-tools configuration.

## Evidence

- Direct reproduction: before dependency installation, the plan entrypoint exited on the missing repo-tools consumer helper.
- Focused regression: `scripts/developer-workflow-entrypoints.test.ts` passed all 21 tests with a dependency-absent plan harness.
- Type proof: `pnpm exec tsc --noEmit -p tsconfig.tools.json` passed.
- Shell and repository proof: Bash syntax, diff checks, and agent-doc drift checks passed.
- Broader suite: 674 repo-tools tests passed; two unrelated storage-guard cases timed out under the broad parallel run and both passed in a focused rerun.

## Non-obvious affected surfaces

- Execution-plan artifact creation: the repository entrypoint now writes the same active-plan filename and Markdown template previously written by the delegated package executable. Focused tests cover help, separators, creation, invalid slugs, and duplicate protection.

## Architecture and reuse

- Existing systems reused: The established active-plan directory, filename convention, Markdown template, and lifecycle commands remain unchanged.
- New logic: The repository entrypoint directly performs the existing slug validation, date-based path selection, duplicate guard, and template write.
- New abstractions: None; the owning shell entrypoint is sufficient for this bounded operation.
- Complexity intentionally avoided: No dependency bootstrap, network fetch, fallback implementation, compatibility layer, or new service was added.

## Hot reply path impact

- Path status: Not applicable — repository plan tooling does not participate in conversation acceptance, provider start, or reply handoff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The diff is limited to developer tooling, its tests, and the completed execution plan.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input surface changes.
- Group Murph: Not applicable — no provider-input surface changes.
- Measurement method: Not run because no prompt, tool schema, generated guidance, or provider-visible input changes.

## Change-shape breakdown

Classification rule: the shell entrypoint is config/tooling, its Vitest coverage is tests/fixtures, and the execution-plan record is docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 98 | 32 |
| Docs | 70 | 0 |
| Config/tooling | 67 | 2 |
| Generated/other | 0 | 0 |
| Total | 235 | 34 |

## Deployment concerns

- Deployment: not applicable
- Reason: Repository-local developer tooling does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: The change is internal workflow tooling with no member-visible behavior.