### PR TITLE
fix(hosted-local): clean stale runner resources

### DIFF
--- a/.agents/friction-log/20260828190337-hosted-local-runner/friction.md
+++ b/.agents/friction-log/20260828190337-hosted-local-runner/friction.md
@@ -1,0 +1,6 @@
+---
+title: "Hosted-local runner cleanup leaves anonymous Docker resources"
+severity: "minor"
+---
+
+Interrupted hosted-local sessions could leave stopped runner containers, attached anonymous volumes, and generated runner images. The startup path had no safe best-effort cleanup for these resources, so repeated runs consumed local storage until manual cleanup.

--- a/Dockerfile.cloudflare-hosted-runner
+++ b/Dockerfile.cloudflare-hosted-runner
@@ -32,8 +32,10 @@ COPY --from=runner-app-permissions --chown=root:root /app/ /app/
 USER runner
 
 ARG HOSTED_RUNNER_LOCAL_BUILD_ID=local
+ARG HOSTED_RUNNER_LOCAL_WORKER_NAME=murph-hosted
 
 LABEL murph.hosted.local-build-id="${HOSTED_RUNNER_LOCAL_BUILD_ID}"
+LABEL murph.hosted.local-worker-name="${HOSTED_RUNNER_LOCAL_WORKER_NAME}"
 
 # Differentiates the per-class image config so sibling container classes built
 # from this shared Dockerfile (RunnerContainer, DeploySmokeRunnerContainer)

--- a/agent-docs/operations/hosted-local-worktree-dev.md
+++ b/agent-docs/operations/hosted-local-worktree-dev.md
@@ -1,6 +1,6 @@
 # Hosted Local Worktree Dev
 
-Last verified: 2026-08-20
+Last verified: 2026-08-28
 
 ## Purpose
 
@@ -35,6 +35,13 @@ the helper below. That profile scopes runner cleanup to the slug-derived local
 build id, skips broad image cleanup, keeps generated hosted-local crypto state
 under the worktree's `.tmp/`, and never coordinates by symlinking
 `apps/cloudflare/.dev.vars`.
+
+Before startup, the harness makes one best-effort cleanup pass over its runner
+resources. It removes stopped runner containers and their attached anonymous
+volumes. It also removes stale generated runner images without forcing removal,
+while preserving images used by running containers and the current build.
+Cleanup failures do not block startup. The pass does not prune named volumes,
+build cache, unrelated containers, or unrelated images.
 
 ## Worktree Helper
 

--- a/agent-docs/operations/hosted-local-worktree-dev.md
+++ b/agent-docs/operations/hosted-local-worktree-dev.md
@@ -36,12 +36,14 @@ build id, skips broad image cleanup, keeps generated hosted-local crypto state
 under the worktree's `.tmp/`, and never coordinates by symlinking
 `apps/cloudflare/.dev.vars`.
 
-Before startup, the harness makes one best-effort cleanup pass over its runner
-resources. It removes stopped runner containers and their attached anonymous
-volumes. It also removes stale generated runner images without forcing removal,
-while preserving images used by running containers and the current build.
-Cleanup failures do not block startup. The pass does not prune named volumes,
-build cache, unrelated containers, or unrelated images.
+Before root-profile startup, the harness makes one best-effort cleanup pass over
+all local runner builds. It removes stopped runner containers and their attached
+anonymous volumes. It also removes stale generated runner images without forcing
+removal, while preserving images used by running containers and the current
+build. Isolated worktree startup limits the pass to stopped current-build
+containers and their anonymous volumes. It continues to skip broad stale-image
+cleanup. Cleanup failures do not block startup. Neither path prunes named
+volumes, build cache, unrelated containers, or unrelated images.
 
 ## Worktree Helper
 

--- a/agent-docs/operations/hosted-local-worktree-dev.md
+++ b/agent-docs/operations/hosted-local-worktree-dev.md
@@ -37,12 +37,12 @@ under the worktree's `.tmp/`, and never coordinates by symlinking
 `apps/cloudflare/.dev.vars`.
 
 Before root-profile startup, the harness makes one best-effort cleanup pass over
-all local runner builds. It removes stopped runner containers and their attached
-anonymous volumes. It also removes stale generated runner images without forcing
-removal, while preserving images used by running containers and the current
-build. Isolated worktree startup limits the pass to stopped current-build
-containers and their anonymous volumes. It continues to skip broad stale-image
-cleanup. Cleanup failures do not block startup. Neither path prunes named
+all root-worker runner builds. It removes stopped runner containers and their
+attached anonymous volumes. It also removes stale root-worker runner images
+without forcing removal, while preserving images used by running containers and
+the current build. Isolated worktree startup limits the pass to stopped
+current-build containers and their anonymous volumes. It continues to skip
+broad stale-image cleanup. Cleanup failures do not block startup. Neither path prunes named
 volumes, build cache, unrelated containers, or unrelated images.
 
 ## Worktree Helper

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -564,6 +564,12 @@ describe("hosted runner container image contract", () => {
     const finalLocalBuildIdLabelIndex = finalDockerfile.indexOf(
       'LABEL murph.hosted.local-build-id="${HOSTED_RUNNER_LOCAL_BUILD_ID}"',
     );
+    const finalLocalWorkerNameArgIndex = finalDockerfile.indexOf(
+      "ARG HOSTED_RUNNER_LOCAL_WORKER_NAME=murph-hosted",
+    );
+    const finalLocalWorkerNameLabelIndex = finalDockerfile.indexOf(
+      'LABEL murph.hosted.local-worker-name="${HOSTED_RUNNER_LOCAL_WORKER_NAME}"',
+    );
     expect(permissionStageRootUserIndex).toBeGreaterThan(-1);
     expect(finalRunnerBundleDirArgIndex).toBeGreaterThan(permissionStageRootUserIndex);
     expect(permissionStageBundleCopyIndex).toBeGreaterThan(finalRunnerBundleDirArgIndex);
@@ -577,6 +583,8 @@ describe("hosted runner container image contract", () => {
     expect(finalLocalBuildIdArgIndex).toBeGreaterThan(finalRunnerUserIndex);
     expect(finalLocalBuildIdArgIndex).toBeGreaterThan(finalRunnerBundleCopyIndex);
     expect(finalLocalBuildIdLabelIndex).toBeGreaterThan(finalLocalBuildIdArgIndex);
+    expect(finalLocalWorkerNameArgIndex).toBeGreaterThan(finalRunnerUserIndex);
+    expect(finalLocalWorkerNameLabelIndex).toBeGreaterThan(finalLocalWorkerNameArgIndex);
     expect(finalDockerfile).toContain("ARG HOSTED_RUNNER_LOCAL_BUILD_ID=local");
     expect(finalDockerfile).toContain("ARG HOSTED_RUNNER_BUNDLE_DIR=.deploy/runner-bundle");
     for (const slug of hostedRunnerProductModelSlugs) {
@@ -590,6 +598,9 @@ describe("hosted runner container image contract", () => {
     );
     expect(finalDockerfile).toContain(
       'LABEL murph.hosted.local-build-id="${HOSTED_RUNNER_LOCAL_BUILD_ID}"',
+    );
+    expect(finalDockerfile).toContain(
+      'LABEL murph.hosted.local-worker-name="${HOSTED_RUNNER_LOCAL_WORKER_NAME}"',
     );
     expect(finalDockerfile).toContain(
       "COPY --from=runner-app-permissions --chown=root:root /app/ /app/",

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -1069,6 +1069,7 @@ export function buildWranglerLocalDevConfig(
       // cloudflare-dev/runnercontainer:<tag>" until the harness times out.
       HOSTED_RUNNER_CONTAINER_CLASS: input.className,
       HOSTED_RUNNER_LOCAL_BUILD_ID: hostedRunnerLocalBuildId,
+      HOSTED_RUNNER_LOCAL_WORKER_NAME: workerName,
     },
     instance_type: "standard-1",
     max_instances: input.maxInstances,

--- a/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
@@ -57,6 +57,7 @@ interface BoundedCommandResult {
 }
 
 const HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL = "murph.hosted.local-build-id";
+const HOSTED_RUNNER_LOCAL_WORKER_NAME_LABEL = "murph.hosted.local-worker-name";
 const HOSTED_RUNNER_LOCAL_IMAGE_REPOSITORIES = [
   "cloudflare-dev/deploysmokerunnercontainer",
   "cloudflare-dev/runnercontainer",
@@ -826,6 +827,7 @@ async function listHostedRunnerImageRefs(input: {
   const localBuildId = input.scope === "all-builds"
     ? null
     : resolveHostedRunnerCleanupLocalBuildId(input.env);
+  const workerName = resolveWranglerLocalDevWorkerName(input.env ?? {});
 
   if (!localBuildId && input.scope !== "all-builds") {
     return {
@@ -849,7 +851,12 @@ async function listHostedRunnerImageRefs(input: {
           "--filter",
           `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}=${localBuildId}`,
         ]
-        : ["--filter", `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}`]),
+        : [
+          "--filter",
+          `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}`,
+          "--filter",
+          `label=${HOSTED_RUNNER_LOCAL_WORKER_NAME_LABEL}=${workerName}`,
+        ]),
     ],
     command: "docker",
     cwd: input.cwd,

--- a/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
@@ -656,6 +656,7 @@ export async function cleanupHostedRunnerContainers(input: {
   env?: NodeJS.ProcessEnv;
   ignoreErrors?: boolean;
   scope?: HostedRunnerContainerCleanupScope;
+  stoppedOnly?: boolean;
   timeoutMs?: number;
 }): Promise<void> {
   const timeoutMs = input.timeoutMs ?? 15_000;
@@ -663,6 +664,7 @@ export async function cleanupHostedRunnerContainers(input: {
     cwd: input.cwd,
     env: input.env,
     scope: input.scope,
+    stoppedOnly: input.stoppedOnly,
     timeoutMs,
   });
 
@@ -684,7 +686,7 @@ export async function cleanupHostedRunnerContainers(input: {
   }
 
   const removed = await runBoundedCommand({
-    args: ["rm", "-f", ...containerIds],
+    args: ["rm", "-f", "-v", ...containerIds],
     command: "docker",
     cwd: input.cwd,
     env: input.env,
@@ -699,6 +701,7 @@ export async function cleanupHostedRunnerContainers(input: {
       cwd: input.cwd,
       env: input.env,
       scope: input.scope,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: Math.min(timeoutMs, 3_000),
     });
     if (disappeared || input.ignoreErrors) {
@@ -708,7 +711,7 @@ export async function cleanupHostedRunnerContainers(input: {
     throw new Error(
       [
         "Failed to remove stale local Cloudflare runner containers.",
-        formatBoundedCommandResult(`docker rm -f (${containerIds.length})`, removed),
+        formatBoundedCommandResult(`docker rm -f -v (${containerIds.length})`, removed),
       ].join("\n"),
     );
   }
@@ -717,7 +720,9 @@ export async function cleanupHostedRunnerContainers(input: {
 export async function cleanupHostedRunnerImages(input: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  force?: boolean;
   ignoreErrors?: boolean;
+  preserveCurrentBuild?: boolean;
   scope?: HostedRunnerContainerCleanupScope;
   timeoutMs?: number;
 }): Promise<void> {
@@ -725,6 +730,7 @@ export async function cleanupHostedRunnerImages(input: {
   const listed = await listHostedRunnerImageRefs({
     cwd: input.cwd,
     env: input.env,
+    preserveCurrentBuild: input.preserveCurrentBuild,
     scope: input.scope,
     timeoutMs,
   });
@@ -748,7 +754,7 @@ export async function cleanupHostedRunnerImages(input: {
 
   for (const batch of chunk(imageRefs, HOSTED_RUNNER_IMAGE_RM_BATCH_SIZE)) {
     const removed = await runBoundedCommand({
-      args: ["image", "rm", "-f", ...batch],
+      args: ["image", "rm", ...(input.force === false ? [] : ["-f"]), ...batch],
       command: "docker",
       cwd: input.cwd,
       env: input.env,
@@ -798,6 +804,7 @@ export async function cleanupHostedRunnerContainerLocalState(input: {
 async function listHostedRunnerImageRefs(input: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  preserveCurrentBuild?: boolean;
   scope?: HostedRunnerContainerCleanupScope;
   timeoutMs: number;
 }): Promise<{
@@ -884,10 +891,66 @@ async function listHostedRunnerImageRefs(input: {
       .map((row) => row.id),
   );
 
+  const preservedImageIds = new Set<string>();
+  if (input.preserveCurrentBuild) {
+    const currentBuildId = resolveHostedRunnerCleanupLocalBuildId(input.env);
+    if (currentBuildId) {
+      const currentBuildImages = await listHostedRunnerImageIdsByLocalBuildId({
+        cwd: input.cwd,
+        env: input.env,
+        localBuildId: currentBuildId,
+        timeoutMs: input.timeoutMs,
+      });
+      if (
+        currentBuildImages.result.timedOut
+        || currentBuildImages.result.exitCode !== 0
+      ) {
+        return {
+          imageRefs: [],
+          result: currentBuildImages.result,
+        };
+      }
+      for (const imageId of currentBuildImages.imageIds) {
+        preservedImageIds.add(imageId);
+      }
+    }
+  }
+
   return {
     imageRefs: uniqueStrings(rows
-      .filter((row) => !runningImageIds.has(row.id))
+      .filter((row) => (
+        !runningImageIds.has(row.id) && !preservedImageIds.has(row.id)
+      ))
       .map((row) => row.ref)),
+    result,
+  };
+}
+
+async function listHostedRunnerImageIdsByLocalBuildId(input: {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  localBuildId: string;
+  timeoutMs: number;
+}): Promise<{
+  imageIds: string[];
+  result: BoundedCommandResult;
+}> {
+  const result = await runBoundedCommand({
+    args: [
+      "images",
+      "--format",
+      "{{.ID}}",
+      "--filter",
+      `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}=${input.localBuildId}`,
+    ],
+    command: "docker",
+    cwd: input.cwd,
+    env: input.env,
+    timeoutMs: input.timeoutMs,
+  });
+
+  return {
+    imageIds: parseWhitespaceSeparatedDockerIds(result.stdout),
     result,
   };
 }
@@ -925,6 +988,7 @@ async function listHostedRunnerContainerIds(input: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   scope?: HostedRunnerContainerCleanupScope;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<{
   containerIds: string[];
@@ -936,6 +1000,7 @@ async function listHostedRunnerContainerIds(input: {
       env: input.env,
       namePrefix: HOSTED_LOCAL_E2E_WORKER_CONTAINER_NAME_PREFIX,
       requireLocalBuildLabel: true,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: input.timeoutMs,
     });
     if (listed.result.timedOut || listed.result.exitCode !== 0) {
@@ -949,6 +1014,7 @@ async function listHostedRunnerContainerIds(input: {
       env: input.env,
       namePrefix: HOSTED_LOCAL_E2E_WORKER_CONTAINER_NAME_PREFIX,
       requireLocalBuildLabel: false,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: input.timeoutMs,
     });
     if (proxies.result.timedOut || proxies.result.exitCode !== 0) {
@@ -969,6 +1035,7 @@ async function listHostedRunnerContainerIds(input: {
       containers: listed.containers,
       cwd: input.cwd,
       env: input.env,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: input.timeoutMs,
     });
     if (proxyResult !== null) {
@@ -990,6 +1057,7 @@ async function listHostedRunnerContainerIds(input: {
       env: input.env,
       namePrefix: resolveHostedRunnerContainerNamePrefix(input.env),
       requireLocalBuildLabel: true,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: input.timeoutMs,
     });
     if (listed.result.timedOut || listed.result.exitCode !== 0) {
@@ -1005,6 +1073,7 @@ async function listHostedRunnerContainerIds(input: {
       containers: listed.containers,
       cwd: input.cwd,
       env: input.env,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: input.timeoutMs,
     });
     if (proxyResult !== null) {
@@ -1037,6 +1106,7 @@ async function listHostedRunnerContainerIds(input: {
     cwd: input.cwd,
     env: input.env,
     localBuildId,
+    stoppedOnly: input.stoppedOnly,
     timeoutMs: input.timeoutMs,
   });
   if (labeled.result.timedOut || labeled.result.exitCode !== 0) {
@@ -1051,6 +1121,7 @@ async function listHostedRunnerContainerIds(input: {
     containers: labeled.containers,
     cwd: input.cwd,
     env: input.env,
+    stoppedOnly: input.stoppedOnly,
     timeoutMs: input.timeoutMs,
   });
   if (proxyResult !== null) {
@@ -1063,6 +1134,7 @@ async function listHostedRunnerContainerIds(input: {
     containerIds,
     cwd: input.cwd,
     env: input.env,
+    stoppedOnly: input.stoppedOnly,
     timeoutMs: input.timeoutMs,
   });
   if (orphanProxyResult !== null) {
@@ -1082,6 +1154,7 @@ async function listHostedRunnerContainersByNamePrefix(input: {
   env?: NodeJS.ProcessEnv;
   namePrefix: string;
   requireLocalBuildLabel: boolean;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<{
   containers: Array<{ id: string; name: string }>;
@@ -1098,6 +1171,7 @@ async function listHostedRunnerContainersByNamePrefix(input: {
       ...(input.requireLocalBuildLabel
         ? ["--filter", `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}`]
         : []),
+      ...buildStoppedContainerStatusFilters(input.stoppedOnly),
     ],
     command: "docker",
     cwd: input.cwd,
@@ -1115,6 +1189,7 @@ async function listHostedRunnerContainersByLocalBuildId(input: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   localBuildId: string;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<{
   containers: Array<{ id: string; name: string }>;
@@ -1128,6 +1203,7 @@ async function listHostedRunnerContainersByLocalBuildId(input: {
       "{{.ID}} {{.Names}}",
       "--filter",
       `label=${HOSTED_RUNNER_CONTAINER_LOCAL_BUILD_ID_LABEL}=${input.localBuildId}`,
+      ...buildStoppedContainerStatusFilters(input.stoppedOnly),
     ],
     command: "docker",
     cwd: input.cwd,
@@ -1146,6 +1222,7 @@ async function addHostedRunnerProxyContainerIds(input: {
   containers: ReadonlyArray<{ id: string; name: string }>;
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<BoundedCommandResult | null> {
   for (const container of input.containers) {
@@ -1155,6 +1232,7 @@ async function addHostedRunnerProxyContainerIds(input: {
         "-aq",
         "--filter",
         `name=${container.name}-proxy`,
+        ...buildStoppedContainerStatusFilters(input.stoppedOnly),
       ],
       command: "docker",
       cwd: input.cwd,
@@ -1176,6 +1254,7 @@ async function addCurrentHostedLocalIsolatedRunnerProxyContainerIds(input: {
   containerIds: Set<string>;
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<BoundedCommandResult | null> {
   const namePrefix = resolveHostedRunnerContainerNamePrefix(input.env);
@@ -1188,6 +1267,7 @@ async function addCurrentHostedLocalIsolatedRunnerProxyContainerIds(input: {
     env: input.env,
     namePrefix,
     requireLocalBuildLabel: false,
+    stoppedOnly: input.stoppedOnly,
     timeoutMs: input.timeoutMs,
   });
   if (proxies.result.timedOut || proxies.result.exitCode !== 0) {
@@ -1204,6 +1284,21 @@ async function addCurrentHostedLocalIsolatedRunnerProxyContainerIds(input: {
   }
 
   return null;
+}
+
+function buildStoppedContainerStatusFilters(stoppedOnly: boolean | undefined): string[] {
+  if (!stoppedOnly) {
+    return [];
+  }
+
+  return [
+    "--filter",
+    "status=created",
+    "--filter",
+    "status=exited",
+    "--filter",
+    "status=dead",
+  ];
 }
 
 function parseHostedRunnerContainerIdNameRows(
@@ -1307,6 +1402,7 @@ async function waitForHostedRunnerContainersToDisappear(input: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   scope?: HostedRunnerContainerCleanupScope;
+  stoppedOnly?: boolean;
   timeoutMs: number;
 }): Promise<boolean> {
   const startedAt = Date.now();
@@ -1316,6 +1412,7 @@ async function waitForHostedRunnerContainersToDisappear(input: {
       cwd: input.cwd,
       env: input.env,
       scope: input.scope,
+      stoppedOnly: input.stoppedOnly,
       timeoutMs: Math.min(input.timeoutMs, 1_000),
     });
     if (!listed.result.timedOut && listed.result.exitCode === 0 && listed.containerIds.length === 0) {

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -735,6 +735,16 @@ export async function startHostedLocalDevStack(input: {
       await cleanupHostedRunnerContainers({
         cwd: repoRoot,
         env: workerProcessEnv ?? workerRuntimeEnv,
+        ignoreErrors: true,
+        scope: runnerCleanupScope,
+        stoppedOnly: true,
+      });
+      await cleanupHostedRunnerImages({
+        cwd: repoRoot,
+        env: workerProcessEnv ?? workerRuntimeEnv,
+        force: false,
+        ignoreErrors: true,
+        preserveCurrentBuild: true,
         scope: runnerCleanupScope,
       });
       await cleanupHostedRunnerContainerLocalState({

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -1651,6 +1651,7 @@ describe("buildWranglerLocalDevConfig", () => {
     expect(container.image_vars).toEqual({
       HOSTED_RUNNER_CONTAINER_CLASS: "RunnerContainer",
       HOSTED_RUNNER_LOCAL_BUILD_ID: "local",
+      HOSTED_RUNNER_LOCAL_WORKER_NAME: "murph-hosted",
     });
     expect(smokeContainer).toMatchObject({
       image: container.image,
@@ -1662,6 +1663,7 @@ describe("buildWranglerLocalDevConfig", () => {
       image_vars: {
         HOSTED_RUNNER_CONTAINER_CLASS: "DeploySmokeRunnerContainer",
         HOSTED_RUNNER_LOCAL_BUILD_ID: "local",
+        HOSTED_RUNNER_LOCAL_WORKER_NAME: "murph-hosted",
       },
       max_instances: 1,
     });
@@ -1674,9 +1676,16 @@ describe("buildWranglerLocalDevConfig", () => {
       MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID: "worktree-feature-a",
     };
     const workerName = resolveWranglerLocalDevWorkerName(source);
+    const config = buildWranglerLocalDevConfig(source);
+    const containers = config.containers as Array<{
+      image_vars: Record<string, string>;
+    }>;
 
     expect(workerName).toMatch(/^murph-worktree-[a-f0-9]{24}$/u);
     expect(workerName.startsWith("murph-hosted-")).toBe(false);
+    expect(containers.every((container) =>
+      container.image_vars.HOSTED_RUNNER_LOCAL_WORKER_NAME === workerName
+    )).toBe(true);
     expect(buildWranglerEnvFileText(source)).not.toContain("MURPH_DEV_WORKTREE_SCOPE");
     expect(buildWranglerVarArgs(source).join("\n")).not.toContain("MURPH_DEV_WORKTREE_SCOPE");
   });
@@ -1768,6 +1777,7 @@ describe("buildWranglerLocalDevConfig", () => {
       expect(container.image_vars).toEqual({
         HOSTED_RUNNER_CONTAINER_CLASS: container.class_name,
         HOSTED_RUNNER_LOCAL_BUILD_ID: buildHostedRunnerLocalBuildId("stack-test-build-id"),
+        HOSTED_RUNNER_LOCAL_WORKER_NAME: "murph-hosted",
       });
     }
     expect(

--- a/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
@@ -736,6 +736,8 @@ describe("cleanupHostedRunnerImages", () => {
       "{{.Repository}}:{{.Tag}}\t{{.ID}}",
       "--filter",
       "label=murph.hosted.local-build-id",
+      "--filter",
+      "label=murph.hosted.local-worker-name=murph-hosted",
     ]);
     expect(spawn.mock.calls[1]?.[1]).toEqual([
       "ps",
@@ -748,6 +750,35 @@ describe("cleanupHostedRunnerImages", () => {
       "-f",
       "cloudflare-dev/runnercontainer:old",
       "murph-cloudflare-runner:latest",
+    ]);
+  });
+
+  it("scopes all-build image cleanup to the current worktree worker namespace", async () => {
+    const { cleanupHostedRunnerImages, spawn } = await importRuntimeWithSpawnSequence([
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    await expect(cleanupHostedRunnerImages({
+      cwd: "/tmp",
+      env: {
+        MURPH_DEV_WORKTREE_SCOPE: "feature-a",
+        MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID: "worktree-feature-a",
+      },
+      scope: "all-builds",
+      timeoutMs: 200,
+    })).resolves.toBeUndefined();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]?.[1]).toEqual([
+      "images",
+      "--format",
+      "{{.Repository}}:{{.Tag}}\t{{.ID}}",
+      "--filter",
+      "label=murph.hosted.local-build-id",
+      "--filter",
+      expect.stringMatching(
+        /^label=murph\.hosted\.local-worker-name=murph-worktree-[a-f0-9]{24}$/u,
+      ),
     ]);
   });
 

--- a/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
@@ -156,6 +156,7 @@ describe("cleanupHostedRunnerContainers", () => {
     expect(spawn.mock.calls[2]?.[1]).toEqual([
       "rm",
       "-f",
+      "-v",
       "runner456",
       "proxy456",
     ]);
@@ -194,7 +195,52 @@ describe("cleanupHostedRunnerContainers", () => {
       "--filter",
       "name=workerd-murph-hosted-RunnerContainer-old-proxy",
     ]);
-    expect(spawn.mock.calls[2]?.[1]).toEqual(["rm", "-f", "abc123", "proxy123"]);
+    expect(spawn.mock.calls[2]?.[1]).toEqual(["rm", "-f", "-v", "abc123", "proxy123"]);
+  });
+
+  it("limits startup cleanup to stopped runner containers and their anonymous volumes", async () => {
+    const { cleanupHostedRunnerContainers, spawn } = await importRuntimeWithSpawnSequence([
+      { exitCode: 0, stdout: "abc123 workerd-murph-hosted-RunnerContainer-old\n" },
+      { exitCode: 0, stdout: "proxy123\n" },
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    await expect(cleanupHostedRunnerContainers({
+      cwd: "/tmp",
+      scope: "all-builds",
+      stoppedOnly: true,
+      timeoutMs: 200,
+    })).resolves.toBeUndefined();
+
+    expect(spawn.mock.calls[0]?.[1]).toEqual([
+      "ps",
+      "-a",
+      "--format",
+      "{{.ID}} {{.Names}}",
+      "--filter",
+      "name=workerd-murph-hosted-",
+      "--filter",
+      "label=murph.hosted.local-build-id",
+      "--filter",
+      "status=created",
+      "--filter",
+      "status=exited",
+      "--filter",
+      "status=dead",
+    ]);
+    expect(spawn.mock.calls[1]?.[1]).toEqual([
+      "ps",
+      "-aq",
+      "--filter",
+      "name=workerd-murph-hosted-RunnerContainer-old-proxy",
+      "--filter",
+      "status=created",
+      "--filter",
+      "status=exited",
+      "--filter",
+      "status=dead",
+    ]);
+    expect(spawn.mock.calls[2]?.[1]).toEqual(["rm", "-f", "-v", "abc123", "proxy123"]);
   });
 
   it("keeps all-builds scope while checking whether failed removals disappeared", async () => {
@@ -298,6 +344,7 @@ describe("cleanupHostedRunnerContainers", () => {
     expect(spawn.mock.calls[2]?.[1]).toEqual([
       "rm",
       "-f",
+      "-v",
       "proxy123",
     ]);
   });
@@ -336,6 +383,7 @@ describe("cleanupHostedRunnerContainers", () => {
     expect(spawn.mock.calls[2]?.[1]).toEqual([
       "rm",
       "-f",
+      "-v",
       "proxy123",
     ]);
   });
@@ -398,6 +446,7 @@ describe("cleanupHostedRunnerContainers", () => {
     expect(spawn.mock.calls[4]?.[1]).toEqual([
       "rm",
       "-f",
+      "-v",
       "runner123",
       "smoke456",
       "proxy789",
@@ -444,6 +493,7 @@ describe("cleanupHostedRunnerContainers", () => {
     expect(spawn.mock.calls[2]?.[1]).toEqual([
       "rm",
       "-f",
+      "-v",
       "proxy123",
     ]);
   });
@@ -698,6 +748,45 @@ describe("cleanupHostedRunnerImages", () => {
       "-f",
       "cloudflare-dev/runnercontainer:old",
       "murph-cloudflare-runner:latest",
+    ]);
+  });
+
+  it("keeps the current build image and avoids forcing startup image cleanup", async () => {
+    const { cleanupHostedRunnerImages, spawn } = await importRuntimeWithSpawnSequence([
+      {
+        exitCode: 0,
+        stdout: [
+          "cloudflare-dev/runnercontainer:current\timg-current",
+          "cloudflare-dev/runnercontainer:old\timg-old",
+        ].join("\n"),
+      },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "img-current\n" },
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    await expect(cleanupHostedRunnerImages({
+      cwd: "/tmp",
+      env: { MURPH_HOSTED_RUNNER_LOCAL_BUILD_ID: "current-build" },
+      force: false,
+      preserveCurrentBuild: true,
+      scope: "all-builds",
+      timeoutMs: 200,
+    })).resolves.toBeUndefined();
+
+    expect(spawn.mock.calls[2]?.[1]).toEqual([
+      "images",
+      "--format",
+      "{{.ID}}",
+      "--filter",
+      expect.stringMatching(
+        /^label=murph\.hosted\.local-build-id=sha256-[a-f0-9]{24}$/u,
+      ),
+    ]);
+    expect(spawn.mock.calls[3]?.[1]).toEqual([
+      "image",
+      "rm",
+      "cloudflare-dev/runnercontainer:old",
     ]);
   });
 });

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -2497,7 +2497,12 @@ describe("hosted local dev stack", () => {
     expect(cleanupHostedRunnerContainers).toHaveBeenCalledWith(expect.objectContaining({
       scope: "current-build",
     }));
-    expect(cleanupHostedRunnerImages).not.toHaveBeenCalled();
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledTimes(1);
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledWith(expect.objectContaining({
+      force: false,
+      preserveCurrentBuild: true,
+      scope: "current-build",
+    }));
   });
 
   it("skips repeated aggregate E2E runner container smoke only for the proved build id", async () => {
@@ -2555,7 +2560,12 @@ describe("hosted local dev stack", () => {
     expect(stderrTarget.text()).toContain(
       "Skipping runner container deploy-smoke; already proved for this hosted-local E2E run.",
     );
-    expect(cleanupHostedRunnerImages).not.toHaveBeenCalled();
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledTimes(1);
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledWith(expect.objectContaining({
+      force: false,
+      preserveCurrentBuild: true,
+      scope: "current-build",
+    }));
   });
 
   it("keeps interactive dev running when the runner container smoke proof fails", async () => {
@@ -2622,7 +2632,12 @@ describe("hosted local dev stack", () => {
 
     await expect(stack.ready).rejects.toThrow("fetch failed");
     expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
-    expect(cleanupHostedRunnerImages).not.toHaveBeenCalled();
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledTimes(1);
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledWith(expect.objectContaining({
+      force: false,
+      preserveCurrentBuild: true,
+      scope: "current-build",
+    }));
   });
 
   it("starts a managed Linq cloudflared tunnel and registers the local webhook target", async () => {


### PR DESCRIPTION
## Outcome

Hosted-local startup now removes stopped runner containers, their attached anonymous volumes, and stale generated runner images.

Repeated local runs no longer leave these unused Docker resources for manual cleanup.

## Product UX result

Product UX does not apply. This changes local developer tooling and has no member-facing journey.

## Direct evidence

- `pnpm --dir packages/hosted-local-harness typecheck`
- `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts test/dev-hosted-local/runtime.cleanup.test.ts test/dev-hosted-local/environment.test.ts test/dev-hosted-local/stack.test.ts --no-coverage` (190 passed)
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/container-image-contract.test.ts --no-coverage` (11 passed)
- Specialist finding resolved: the operations guide now distinguishes root-profile image cleanup from isolated worktree cleanup.
- Final round 1 finding resolved: every generated runner image carries its worker namespace, and broad cleanup filters by that owner.

## Non-obvious affected surfaces

The cleanup runs before hosted-local startup. It uses the existing best-effort cleanup path, so a cleanup failure does not block startup. Root cleanup can remove historical images only from the root worker namespace. It cannot remove prepared images owned by an active isolated worktree.

## Architecture and reuse

- Existing systems reused: The change extends the existing hosted runner cleanup functions, Wrangler worker namespace, and Docker labels.
- New logic: Startup selects stopped runner containers, removes their anonymous volumes, and removes stale generated images without forcing removal.
- New abstractions: No new abstraction is needed because the existing worker namespace is the image owner.
- Complexity intentionally avoided: The change does not add a cleanup service, persisted state, broad Docker prune, or another lifecycle owner.

## Hot reply path impact

Not applicable. This local developer tool does not run on the foreground reply path.

## Murph initial provider input impact

Not applicable for Murph and Codex. The change does not alter prompts, tools, schemas, or other provider-visible input.

## Preliminary specialist lenses

- Product UX: Not applicable. No member-facing journey changes.
- Prompt: Not applicable. No prompt or instruction surface changes.
- Frontend: Not applicable. No hosted Web UI changes.
- Coverage: Applicable. Focused tests cover stopped-container filters, anonymous-volume removal, worker-owned image cleanup, current-build image preservation, and startup calls.

## Deployment concerns

- Deployment: not applicable
- Reason: This changes local developer tooling only and does not cross a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Members cannot see this local developer-tooling change.

## Change shape

Classification uses the base-to-head diff. Source includes runtime code. Tests include test files. Docs include the operations guide and friction record. Dockerfile changes are config/tooling. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 120 | 5 |
| Tests/fixtures | 160 | 4 |
| Docs | 16 | 1 |
| Config/tooling | 2 | 0 |
| Generated/other | 0 | 0 |
| Total | 298 | 10 |

ReviewGPT context sensitivity: routine

Reason: The patch is narrow local developer tooling. It does not change production behavior or a trust boundary.

ReviewGPT first-reviewed head: af9cdd942eb6e88212d4f26efc7acda126a09702
