### PR TITLE
Fix scheduled exercise reminder guidance

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-scheduled-exercise-reminder-guidance.md
+++ b/agent-docs/exec-plans/active/2026-08-28-scheduled-exercise-reminder-guidance.md
@@ -1,0 +1,100 @@
+# Scheduled exercise reminder guidance
+
+Status: active
+Created: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+- Make scheduled Messages exercise cues use natural movement names, keep
+  internal catalog routing labels out of visible text, and attach useful
+  reviewed catalog media when available.
+
+## Success criteria
+
+- A production-shaped scheduled exercise reminder loads the movement owner and
+  shared exercise-catalog guidance before composing the cue.
+- Member-visible text contains natural exercise names and no catalog id, slug,
+  source token, or path.
+- The cue attaches the smallest useful returned catalog-media set without
+  generating substitutes when useful reviewed media exists.
+- Non-exercise reminders and check-in or review support scopes keep their
+  existing behavior.
+
+## Scope
+
+- In scope: the engine-owned reminder execution prompt, deterministic prompt
+  coverage, one synthetic production-derived real-Codex journey, and the
+  existing public changelog item for this outcome.
+- Out of scope: model defaults, exercise selection or safety policy, catalog
+  content, delivery infrastructure, database state, and image generation.
+
+## Constraints
+
+- Keep this prompt-primary and add no sanitizer, state owner, retry path, or
+  runtime fallback.
+- Reuse the existing movement skills, shared exercise-catalog reference,
+  catalog lookup, and response-media tool.
+- Keep production evidence, private conversation wording, and direct
+  identifiers out of repository artifacts.
+
+## Product UX Patch
+
+- A member receiving a scheduled movement cue gets concise, natural guidance
+  and useful reviewed demonstrations rather than internal routing labels.
+- A member receiving a non-exercise reminder sees no behavior change.
+- A member whose selected movement has no useful catalog media keeps clear text
+  and the existing catalog-gap behavior; this patch does not promise an image.
+
+## Risks and mitigations
+
+1. Risk: broad prompt wording could force catalog work for setup-only or
+   non-instructional reminders.
+   Mitigation: scope the resident rule to reminders that actually cue or teach
+   an exercise or movement.
+2. Risk: a saved instruction could still leak a catalog label through copied
+   prose.
+   Mitigation: place the privacy rule after saved instructions in the trusted
+   engine overlay and assert the composed provider input.
+3. Risk: the fix could look green only because the live test preloads deferred
+   guidance.
+   Mitigation: run a production-shaped Luna journey that starts with only the
+   resident system and scheduled execution prompts and verifies the actual
+   reads, tool order, media, and visible reply.
+
+## Tasks
+
+1. [completed] Add the smallest reminder-owned prompt correction and focused
+   deterministic coverage.
+2. [completed] Add or run the production-shaped Luna journey and inspect its
+   visible reply and tool trace.
+3. [in_progress] Update the existing changelog outcome with this PR provenance.
+4. [pending] Run focused verification, candidate review, and the combined
+   prompt, Product UX, and coverage specialist pass.
+5. [pending] Require exact-head CI, close the plan, prove mergeability, merge,
+   verify deployment, and retire the worktree.
+
+## Decisions
+
+- Keep Luna's scheduled default at high reasoning. The production failure and
+  local reproduction both occurred at high, so xhigh does not address the
+  missing resident instruction and would add cost and latency to every cue.
+- Put the correction in the engine-supplied reminder overlay. That owner is
+  present on the exact scheduled turn and follows the saved instructions, so
+  it does not depend on the model discovering a deferred reference first.
+
+## Verification
+
+- Focused Assistant Engine cron prompt and exercise-guidance contract proof:
+  2 files passed with 4 tests passed and 209 skipped.
+- Focused real-Codex journey on `gpt-5.6-luna` with production-shaped scheduled
+  prompt assembly and synthetic exercise/catalog fixtures passed at high
+  reasoning. Luna read both required guidance files, looked up both exercises,
+  attached both reviewed images, and produced concise identifier-free text.
+- Assistant Engine package typecheck passed.
+- Changelog fragment tests remain pending until the draft PR supplies exact
+  provenance.
+- Preliminary ReviewGPT prompt, Product UX, and coverage lenses on the exact
+  pushed candidate head; this prompt-primary patch skips the separate final
+  ReviewGPT gate unless the completed diff gains another risk trigger.
+- Required exact-head CI and current-base merge-tree proof.

--- a/agent-docs/exec-plans/active/2026-08-28-scheduled-exercise-reminder-guidance.md
+++ b/agent-docs/exec-plans/active/2026-08-28-scheduled-exercise-reminder-guidance.md
@@ -68,8 +68,8 @@ Updated: 2026-08-28
    deterministic coverage.
 2. [completed] Add or run the production-shaped Luna journey and inspect its
    visible reply and tool trace.
-3. [in_progress] Update the existing changelog outcome with this PR provenance.
-4. [pending] Run focused verification, candidate review, and the combined
+3. [completed] Update the existing changelog outcome with this PR provenance.
+4. [in_progress] Run focused verification, candidate review, and the combined
    prompt, Product UX, and coverage specialist pass.
 5. [pending] Require exact-head CI, close the plan, prove mergeability, merge,
    verify deployment, and retire the worktree.

--- a/agent-docs/exec-plans/completed/2026-08-28-scheduled-exercise-reminder-guidance.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-scheduled-exercise-reminder-guidance.md
@@ -1,6 +1,6 @@
 # Scheduled exercise reminder guidance
 
-Status: active
+Status: completed
 Created: 2026-08-28
 Updated: 2026-08-28
 
@@ -69,32 +69,46 @@ Updated: 2026-08-28
 2. [completed] Add or run the production-shaped Luna journey and inspect its
    visible reply and tool trace.
 3. [completed] Update the existing changelog outcome with this PR provenance.
-4. [in_progress] Run focused verification, candidate review, and the combined
+4. [completed] Run focused verification, candidate review, and the combined
    prompt, Product UX, and coverage specialist pass.
-5. [pending] Require exact-head CI, close the plan, prove mergeability, merge,
-   verify deployment, and retire the worktree.
+5. [completed] Close the implementation plan on the reviewed candidate. Exact-head
+   CI, mergeability, merge, deployment verification, and worktree retirement
+   remain external PR gates.
 
 ## Decisions
 
 - Keep Luna's scheduled default at high reasoning. The production failure and
   local reproduction both occurred at high, so xhigh does not address the
   missing resident instruction and would add cost and latency to every cue.
-- Put the correction in the engine-supplied reminder overlay. That owner is
+- Put the correction in an engine-supplied exercise-cue overlay. That owner is
   present on the exact scheduled turn and follows the saved instructions, so
   it does not depend on the model discovering a deferred reference first.
+- Accepted preliminary specialist finding: ordinary member-created reminders
+  omit plan-owned support metadata and therefore use `supportKind: null`. The
+  exercise-cue overlay now covers those independent automations as well as
+  plan-owned reminders while excluding check-ins, reviews, weekly digests, and
+  managed maintenance.
 
 ## Verification
 
 - Focused Assistant Engine cron prompt and exercise-guidance contract proof:
-  2 files passed with 4 tests passed and 209 skipped.
+  2 files passed with 214 tests passed.
 - Focused real-Codex journey on `gpt-5.6-luna` with production-shaped scheduled
   prompt assembly and synthetic exercise/catalog fixtures passed at high
   reasoning. Luna read both required guidance files, looked up both exercises,
   attached both reviewed images, and produced concise identifier-free text.
 - Assistant Engine package typecheck passed.
-- Changelog fragment tests remain pending until the draft PR supplies exact
-  provenance.
+- Changelog archive proof passed 9 tests and Web typecheck passed.
+- Preliminary specialist review returned one accepted high-severity Product UX
+  and coverage finding: the first candidate covered only plan-owned reminders.
+  The corrected ordinary reminder omits support metadata, passed the same Luna
+  journey at high reasoning, and retains focused exclusions for managed
+  check-ins, reviews, weekly digests, and maintenance. Parent revalidation:
+  Ready.
 - Preliminary ReviewGPT prompt, Product UX, and coverage lenses on the exact
   pushed candidate head; this prompt-primary patch skips the separate final
   ReviewGPT gate unless the completed diff gains another risk trigger.
 - Required exact-head CI and current-base merge-tree proof.
+
+Completed: 2026-08-28
+Completed: 2026-08-28

--- a/apps/web/changelog/entries/2026-08-27/exercise-pictures-arrive-with-the-cue.json
+++ b/apps/web/changelog/entries/2026-08-27/exercise-pictures-arrive-with-the-cue.json
@@ -9,6 +9,6 @@
     "summary": "When Murph teaches a movement in a scheduled Messages cue, it now includes a reviewed exercise picture when one is available and keeps internal catalog labels out of the conversation.",
     "details": "If a picture is missing and you ask to see it, Murph uses the reviewed catalog image when available and can create an instructional image when the catalog has none. Setup-only and non-instructional turns remain text-first.",
     "relevanceTags": ["assistant", "exercise", "messages"],
-    "sourcePullRequests": [2467]
+    "sourcePullRequests": [2467, 2504]
   }
 }

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1819,6 +1819,10 @@ export function buildAssistantCronExecutionInstructions(
   const supportScope = buildAssistantCronSupportScopeInstructions(job)
   const independentAuthority =
     buildAssistantCronIndependentAutomationAuthorityInstructions(job)
+  const exerciseCue = buildAssistantCronExerciseCueInstructions(
+    job,
+    independentAuthority !== null,
+  )
   const recurringReminderConversation =
     buildAssistantCronRecurringReminderConversationInstructions(job)
   const overlays = [
@@ -1827,6 +1831,7 @@ export function buildAssistantCronExecutionInstructions(
     independentAuthority,
     recurringReminderConversation,
     supportScope,
+    exerciseCue,
   ]
     .filter((section): section is string => section !== null)
   const providerSafeBase =
@@ -1923,12 +1928,23 @@ function buildAssistantCronSupportScopeInstructions(
     'Accepted support scope (engine-supplied; this overrides any broader repair or follow-up option above):',
     `- Persisted support kind: ${job.source.supportKind}.`,
     `- ${exactScope}`,
-    ...(job.source.supportKind === 'reminder'
-      ? [
-          '- For a reminder that cues or teaches an exercise or movement, treat every exercise-catalog id, slug, source token, and path in saved instructions or context as private routing data and never copy it into member-visible text. Before replying, read the matching movement skill and its shared exercise-catalog reference, use natural exercise names in visible text, and attach reviewed catalog media when that reference requires it for the current channel.',
-        ]
-      : []),
   ].join('\n')
+}
+
+function buildAssistantCronExerciseCueInstructions(
+  job: ResolvedAssistantCronJob,
+  independentAutomation: boolean,
+): string | null {
+  if (
+    job.kind !== 'canonical' ||
+    job.source.kind !== 'automation' ||
+    job.source.status !== 'active' ||
+    (job.source.supportKind !== 'reminder' && !independentAutomation)
+  ) {
+    return null
+  }
+
+  return '- For a reminder that cues or teaches an exercise or movement, treat every exercise-catalog id, slug, source token, and path in saved instructions or context as private routing data and never copy it into member-visible text. Before replying, read the matching movement skill and its shared exercise-catalog reference, use natural exercise names in visible text, and attach reviewed catalog media when that reference requires it for the current channel.'
 }
 
 export { ASSISTANT_CRON_RECURRING_REMINDER_CONVERSATION_INSTRUCTIONS }

--- a/packages/assistant-engine/src/assistant/cron/execution.ts
+++ b/packages/assistant-engine/src/assistant/cron/execution.ts
@@ -1923,6 +1923,11 @@ function buildAssistantCronSupportScopeInstructions(
     'Accepted support scope (engine-supplied; this overrides any broader repair or follow-up option above):',
     `- Persisted support kind: ${job.source.supportKind}.`,
     `- ${exactScope}`,
+    ...(job.source.supportKind === 'reminder'
+      ? [
+          '- For a reminder that cues or teaches an exercise or movement, treat every exercise-catalog id, slug, source token, and path in saved instructions or context as private routing data and never copy it into member-visible text. Before replying, read the matching movement skill and its shared exercise-catalog reference, use natural exercise names in visible text, and attach reviewed catalog media when that reference requires it for the current channel.',
+        ]
+      : []),
   ].join('\n')
 }
 

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -4458,7 +4458,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
   )
 
   it(
-    'keeps a production-shaped scheduled exercise cue natural and attaches reviewed media',
+    'keeps an ordinary production-shaped scheduled exercise cue natural and attaches reviewed media',
     async () => {
       const config = await resolveRealCodexE2eConfig()
       const workingDirectory = await mkdtemp(
@@ -4506,7 +4506,6 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
           schedule: { kind: 'dailyLocal', localTime: '14:00' },
           slug: 'synthetic-mobility-reminder',
           status: 'active',
-          supportKind: 'reminder',
           tags: [],
           title: 'Synthetic mobility reminder',
           vaultRoot: workingDirectory,
@@ -4519,6 +4518,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         if (!source || source.kind !== 'automation') {
           throw new Error('Expected the canonical reminder automation source.')
         }
+        expect(source.supportKind).toBeNull()
         const jobId = resolveCanonicalAssistantCronJobId(source)
         const runtimeState = createAssistantCronCanonicalRuntimeRecord({
           jobId,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -4458,6 +4458,233 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
   )
 
   it(
+    'keeps a production-shaped scheduled exercise cue natural and attaches reviewed media',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-scheduled-exercise-cue-e2e-'),
+      )
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const skillsRoot = path.join(workingDirectory, 'skills')
+
+      try {
+        await initializeVault({
+          timezone: 'America/New_York',
+          vaultRoot: workingDirectory,
+        })
+        await Promise.all([
+          materializeRoutinePresentationVaultCli(binDirectory),
+          materializeAssistantSkill({
+            skillsRoot,
+            slug: 'mobility-posture',
+          }),
+          materializeAssistantSkillAsset({
+            relativePath: path.join(
+              'shared',
+              'exercise-catalog-runtime.md',
+            ),
+            skillsRoot,
+          }),
+        ])
+        const savedInstructions = [
+          'Send the saved two-minute non-pain mobility break now.',
+          'Alternate 30 seconds of Ankle circles (MB101) with 30 seconds of Torso turns (MB102), repeated twice.',
+          'Use stable support and skip any movement that causes pain.',
+        ].join(' ')
+        const createdAutomation = await upsertAutomation({
+          continuityPolicy: 'fresh',
+          instructions: savedInstructions,
+          now: new Date('2026-08-28T12:00:00.000Z'),
+          route: {
+            channel: 'linq',
+            deliveryTarget: 'synthetic-mobility-reminder',
+            identityId: null,
+            participantId: null,
+            threadId: 'synthetic-mobility-reminder',
+            threadIsDirect: true,
+          },
+          schedule: { kind: 'dailyLocal', localTime: '14:00' },
+          slug: 'synthetic-mobility-reminder',
+          status: 'active',
+          supportKind: 'reminder',
+          tags: [],
+          title: 'Synthetic mobility reminder',
+          vaultRoot: workingDirectory,
+        })
+        const source = findCanonicalAssistantCronRecordInList(
+          await listCanonicalAssistantCronRecords(workingDirectory),
+          createdAutomation.record.automationId,
+        )
+        expect(source?.kind).toBe('automation')
+        if (!source || source.kind !== 'automation') {
+          throw new Error('Expected the canonical reminder automation source.')
+        }
+        const jobId = resolveCanonicalAssistantCronJobId(source)
+        const runtimeState = createAssistantCronCanonicalRuntimeRecord({
+          jobId,
+          now: '2026-08-28T12:00:00.000Z',
+        })
+        const instructions = buildAssistantCronExecutionInstructions(
+          {
+            job: projectCanonicalAssistantCronJob({ source, runtimeState }),
+            kind: 'canonical',
+            runtimeState,
+            source,
+          },
+          { automationId: null, contextReferences: [] },
+        )
+        const occurrenceAt = '2026-08-28T18:00:00.000Z'
+        const notificationInput = {
+          instructions,
+          outboxAutomationAuthority: {
+            automationId: createdAutomation.record.automationId,
+            expectedUpdatedAt: createdAutomation.record.updatedAt,
+          },
+          recurringReminderConversation: true,
+          scheduledAutomationScheduleKind: source.schedule.kind,
+          scheduledInvocationAuthority: {
+            automationId: createdAutomation.record.automationId,
+            occurrenceAt,
+          },
+          turnTrigger: 'automation-cron',
+          vault: workingDirectory,
+          workingDirectory,
+        } satisfies AssistantNotificationInput
+        const preparedInput = await prepareAssistantCronNotificationInput(
+          notificationInput,
+          { sessionId: 'session-synthetic-mobility-reminder' },
+        )
+
+        expect(preparedInput.instructions).toContain(savedInstructions)
+        expect(preparedInput.instructions).toContain(
+          'read the matching movement skill and its shared exercise-catalog reference',
+        )
+        expect(preparedInput.instructions.indexOf(savedInstructions)).toBeLessThan(
+          preparedInput.instructions.indexOf(
+            'read the matching movement skill and its shared exercise-catalog reference',
+          ),
+        )
+
+        const inheritedPath = normalizeEnvString(config.env.PATH)
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions: buildScheduledAutomationDeveloperInstructions(),
+          dynamicTools: [MURPH_ATTACH_RESPONSE_MEDIA_TOOL],
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+            PATH: inheritedPath
+              ? `${binDirectory}${path.delimiter}${inheritedPath}`
+              : binDirectory,
+          },
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: preparedInput.instructions,
+          reasoningEffort: 'high',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const decision = parseAssistantNotificationDecision(
+          result.finalMessage,
+        )
+        expect(decision.kind).toBe('send_message')
+        if (decision.kind !== 'send_message') {
+          throw new Error('Expected the scheduled exercise cue to send.')
+        }
+
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+        const movementSkillRead = actions.find((action) =>
+          action.kind === 'command'
+          && action.command.includes('mobility-posture/SKILL.md')
+        )
+        const catalogReferenceRead = actions.find((action) =>
+          action.kind === 'command'
+          && action.command.includes('shared/exercise-catalog-runtime.md')
+        )
+        const ankleShow = actions.find((action) =>
+          action.kind === 'command'
+          && /vault-cli exercise show (?:ankle-circles|MB101) --format json/iu
+            .test(action.command)
+        )
+        const torsoShow = actions.find((action) =>
+          action.kind === 'command'
+          && /vault-cli exercise show (?:torso-turns|MB102) --format json/iu
+            .test(action.command)
+        )
+        const mediaCalls = actions.filter(
+          (action): action is Extract<
+            CapabilityRoutingAction,
+            { kind: 'dynamic' }
+          > =>
+            action.kind === 'dynamic'
+            && action.tool === MURPH_ATTACH_RESPONSE_MEDIA_TOOL.name,
+        )
+
+        expect(movementSkillRead, 'movement skill read').toBeDefined()
+        expect(catalogReferenceRead, 'catalog reference read').toBeDefined()
+        expect(ankleShow, 'ankle catalog show').toBeDefined()
+        expect(torsoShow, 'torso catalog show').toBeDefined()
+        expect(mediaCalls, 'response-media calls').toHaveLength(1)
+        expect(
+          catalogReferenceRead?.eventIndex,
+          'catalog guidance before catalog lookup',
+        ).toBeLessThan(ankleShow?.eventIndex ?? -1)
+        expect(ankleShow?.eventIndex, 'catalog lookup before attachment')
+          .toBeLessThan(mediaCalls[0]?.eventIndex ?? -1)
+        expect(torsoShow?.eventIndex, 'catalog lookup before attachment')
+          .toBeLessThan(mediaCalls[0]?.eventIndex ?? -1)
+        expect(mediaCalls[0]?.argumentsValue).toMatchObject({
+          media: [
+            {
+              alt: 'Person making a small ankle circle while standing with support.',
+              source: 'exercise_catalog:MB101:1',
+              url: 'https://cdn.example.test/ankle-circles.png',
+            },
+            {
+              alt: 'Person turning the torso gently while standing.',
+              source: 'exercise_catalog:MB102:1',
+              url: 'https://cdn.example.test/torso-turns.png',
+            },
+          ],
+        })
+        expect(result.responseMedia).toEqual([
+          expect.objectContaining({
+            source: 'exercise_catalog:MB101:1',
+            url: 'https://cdn.example.test/ankle-circles.png',
+          }),
+          expect.objectContaining({
+            source: 'exercise_catalog:MB102:1',
+            url: 'https://cdn.example.test/torso-turns.png',
+          }),
+        ])
+        expect(decision.text).toMatch(/ankle circles/iu)
+        expect(decision.text).toMatch(/torso turns/iu)
+        expect(decision.text).not.toMatch(
+          /MB101|MB102|ankle-circles|torso-turns|exercise_catalog/iu,
+        )
+        process.stdout.write(
+          `[real-codex scheduled exercise cue] ${JSON.stringify({
+            mediaCount: result.responseMedia.length,
+            reply: decision.text.replaceAll(/\s+/gu, ' ').trim(),
+          })}\n`,
+        )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+
+  it(
     'keeps exercise ids private, uses catalog media, and generates only when catalog media is missing',
     async () => {
       const config = await resolveRealCodexE2eConfig()

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -4207,6 +4207,48 @@ describe('assistant cron runtime orchestration', () => {
     },
   )
 
+  it('passes exercise cue guidance into an ordinary independent automation after its saved task', async () => {
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-independent-exercise-cue-',
+    )
+    const canonicalJob = await createCanonicalJob(
+      vaultRoot,
+      'independent-exercise-cue',
+    )
+    const canonicalAutomation = findCanonicalAutomation(
+      vaultRoot,
+      canonicalJob.jobId,
+    )
+    expect(canonicalAutomation).toBeDefined()
+    if (!canonicalAutomation) {
+      throw new Error('Expected the canonical automation to exist.')
+    }
+    const savedInstructions =
+      'Send the saved mobility cue using Ankle circles (MB101).'
+    canonicalAutomation.instructions = savedInstructions
+    canonicalAutomation.supportKind = null
+
+    await runAssistantCronJobNow({
+      job: canonicalJob.jobId,
+      vault: vaultRoot,
+    })
+
+    const providerInput = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0] as
+      | { instructions?: string }
+      | undefined
+    expect(providerInput?.instructions).toContain(
+      'Independent automation authority (engine-supplied):',
+    )
+    expect(providerInput?.instructions).toContain(
+      'read the matching movement skill and its shared exercise-catalog reference',
+    )
+    expect(providerInput?.instructions?.indexOf(savedInstructions)).toBeLessThan(
+      providerInput?.instructions?.indexOf(
+        'read the matching movement skill and its shared exercise-catalog reference',
+      ) ?? -1,
+    )
+  })
+
   it('omits the support-scope override for weekly_digest consent metadata', async () => {
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-weekly-digest-prompt-only-',
@@ -4263,6 +4305,9 @@ describe('assistant cron runtime orchestration', () => {
     )
     expect(providerInput?.instructions).not.toContain(
       'surprise accountability, repair, or coaching question',
+    )
+    expect(providerInput?.instructions).not.toContain(
+      'read the matching movement skill and its shared exercise-catalog reference',
     )
   })
 
@@ -4329,6 +4374,12 @@ describe('assistant cron runtime orchestration', () => {
           'Recurring reminder conversation (engine-supplied',
         ),
       }),
+    )
+    const providerInput = cronMocks.sendAssistantMessageLocal.mock.calls.at(-1)?.[0] as
+      | { instructions?: string }
+      | undefined
+    expect(providerInput?.instructions).not.toContain(
+      'read the matching movement skill and its shared exercise-catalog reference',
     )
   })
 

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -4165,6 +4165,21 @@ describe('assistant cron runtime orchestration', () => {
         | undefined
       expect(providerInput?.instructions).toContain(expectedScope)
       expect(providerInput?.instructions).toContain(expectedBoundary)
+      if (supportKind === 'reminder') {
+        expect(providerInput?.instructions).toContain(
+          'treat every exercise-catalog id, slug, source token, and path in saved instructions or context as private routing data',
+        )
+        expect(providerInput?.instructions).toContain(
+          'read the matching movement skill and its shared exercise-catalog reference',
+        )
+        expect(providerInput?.instructions).toContain(
+          'attach reviewed catalog media when that reference requires it for the current channel',
+        )
+      } else {
+        expect(providerInput?.instructions).not.toContain(
+          'treat every exercise-catalog id, slug, source token, and path in saved instructions or context as private routing data',
+        )
+      }
       expect(providerInput?.instructions).toContain(
         `- automationId: ${canonicalAutomation.automationId}`,
       )


### PR DESCRIPTION
## Why and outcome

Scheduled exercise reminders could repeat internal catalog labels and omit reviewed movement media because the trusted scheduled-turn prompt did not require the deferred exercise guidance to be loaded.

This adds one engine-owned instruction after the saved task for both ordinary member-created reminders and plan-owned reminder support: exercise catalog labels remain private routing data, and movement cues must load the matching movement skill plus the shared catalog reference before composing visible text or media. Luna remains at its existing high reasoning default.

## Product UX

- Effort: Product UX Patch
- Result: Ready
- Affected people: a member receiving an ordinary scheduled movement cue, a member receiving plan-owned reminder support, a member receiving an unrelated reminder, and a member whose selected movement has no useful catalog image.
- Walkthrough: the exercise cue uses concise natural names, gives the saved dose and stop rule, and attaches the smallest useful reviewed image set. Unrelated reminders are unchanged. Check-ins, reviews, weekly digests, and managed maintenance keep their existing scopes. Missing catalog media keeps the existing clear-text and catalog-gap behavior.
- Difference from plan: the preliminary specialist review found that ordinary member-created reminders omit plan support metadata. The final overlay now covers both that ordinary path and plan-owned reminders.

## Evidence

- Focused cron and exercise-guidance proof: 2 files passed; 214 tests passed.
- Assistant Engine package typecheck passed.
- Exact post-remediation production-shaped real-Codex journey on `gpt-5.6-luna` at high reasoning passed. Starting from an ordinary saved automation with `supportKind: null` and real notification composition without preloaded deferred guidance, Luna read the movement skill and shared catalog reference, looked up both synthetic exercises, attached both reviewed images, and produced concise text with no catalog id, slug, or source token.
- Changelog archive proof: 9 tests passed; Web typecheck passed.
- `git diff --check` passed.

## Non-obvious affected surfaces

- Ordinary independent automations and plan-owned scheduled reminders receive one short provider-visible conditional rule; catalog reads and media attachment occur only when the reminder actually cues or teaches movement.
- Plan-owned check-ins and reviews, weekly digests, managed maintenance, scheduled logs, ordinary conversation, catalog content, and delivery ownership are unchanged.
- The existing public changelog outcome now records this PR as contributing provenance; its member-visible wording and presentation are unchanged.

## Preliminary specialist review

- Result: `SPECIALIST_OUTCOME: FINDINGS` on reviewed head `71324f98d217724635d025456ecf87cd1652670d`.
- Finding: accepted. The first candidate applied the instruction only to plan-owned `supportKind: reminder` automations, while ordinary member-created reminders intentionally persist with `supportKind: null`.
- Remediation: the final overlay reuses the existing independent-automation authority result and also admits plan-owned reminders. Deterministic coverage proves the ordinary path and the managed exclusions; the corrected ordinary Luna journey passed.
- Parent Product UX revalidation: Ready. The same requested natural-name and reviewed-media outcome now reaches the normal reminder path without broadening check-ins, reviews, digests, or maintenance.
- The preliminary pass is intentionally one-shot and was not rerun after substantive remediation.

## Final ReviewGPT gate

- Not applicable: the completed production change is prompt-primary, has no auth, privacy-enforcement, schema, persistence, API, concurrency, retry, billing, or other independent cross-cutting trigger, and is covered by the required specialist pass plus parent revalidation.

## Architecture and reuse

- Existing systems reused: the engine-owned support-scope overlay, existing independent-automation authority classification, movement-domain skills, shared exercise-catalog reference, catalog `list`/`show` reads, and `murph.attach_response_media`.
- New logic: one conditional prompt line for ordinary independent automations and plan-owned reminder support.
- New abstractions: No new abstraction was added; the existing independent-automation authority result selects the same small exercise-cue overlay.
- Complexity intentionally avoided: no sanitizer, model-default change, fallback queue, second media owner, persisted state, or delivery machinery.

## Hot reply path impact

Not applicable. This changes scheduled automation prompt composition only and adds no operation to inbound acceptance or ordinary replies.

## Murph initial provider input impact

- Individual scheduled reminders: one conditional engine-owned line is appended after saved instructions. When the reminder cues movement, it requires deferred skill/reference reads before the reply.
- Group scheduled reminders: the same line is present, with channel-specific presentation still owned by the loaded reference.
- Ordinary individual and group turns: unchanged.

## Change-shape breakdown

Classification uses `git diff --numstat origin/main...HEAD`; runtime prompt code and the changelog fragment are source, behavior journeys are tests/fixtures, and the completed execution plan is docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 22 | 1 |
| Tests/fixtures | 293 | 0 |
| Docs | 114 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **429** | **1** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new hosted runner containers can coexist during gradual replacement because the catalog, tools, media, and delivery contracts are unchanged.
- Safe order: the Web changelog and hosted assistant bundle may deploy in either order; no tandem deploy is required.
- Rollback floor: safe; no persisted state or schema changes.
- Expected exposure: warm old containers may retain the prior prompt until replaced.
- Reversibility: revert the prompt bundle independently with no cleanup.
- Convergence proof: a hosted ordinary scheduled exercise smoke should show guidance reads, catalog lookup, and response-media attachment with identifier-free visible text.
- Post-deploy checks: inspect a bounded scheduled exercise cue trace and confirm the public changelog item renders.

## Changelog

- Changelog: updated
- Items: 2026-08-27 · exercise-pictures-arrive-with-the-cue
