### PR TITLE
docs(reviewgpt): trust cooperative container agents

### DIFF
--- a/scripts/chatgpt-review-presets/pr-deep-review.md
+++ b/scripts/chatgpt-review-presets/pr-deep-review.md
@@ -302,6 +302,8 @@ the output contract below. Do not promote it to a finding merely because a
 repository preference, ideal proof standard, or broader disclosure could be
 improved.
 
+Treat Codex agents and detached subagents inside the same per-member Murph container as trusted cooperative actors; continued background execution across a foreground handoff is not itself a correctness or security finding without evidence of concrete material harm.
+
 Report only:
 
 - **Critical** or **High**: a PR-caused, production-faithful, realistically


### PR DESCRIPTION
## Why and outcome

Final PR review should not turn trusted cooperative Codex work inside one member container into a theoretical correctness or security blocker. This adds one evidence-gated principle sentence so continued detached work across a foreground handoff is reviewable only when concrete material harm is shown.

## Product UX

- Effort: Not applicable — internal ReviewGPT process guidance only.
- Result: Not applicable
- Walkthrough: No member-facing journey, runtime behavior, or product surface changes.

## Evidence

- Direct: Read back the exact one-sentence diff and confirmed `git diff --check` passes.
- Coverage: `pnpm exec vitest run packages/cli/test/release-script-coverage-audit.test.ts --maxWorkers=1 -t 'exposes only the package-backed review-gpt runner'` passed (1 test; 48 skipped). `pnpm test:diff scripts/chatgpt-review-presets/pr-deep-review.md` passed syntax, architecture/privacy guards, provider-boundary checks, and repo-tool typecheck, then completed 672 tests with four unrelated timeout failures in SSH signal-forwarding and worktree-retirement harnesses.

## Non-obvious affected surfaces

None. The only affected surface is the named final ReviewGPT finding policy.

## Architecture and reuse

- Existing systems reused: The existing final ReviewGPT finding bar remains the sole review-policy owner.
- New logic: One sentence classifies same-container Codex agents and detached subagents as trusted cooperative actors and still requires evidence of concrete material harm.
- New abstractions: None; the existing prompt contract is sufficient.
- Complexity intentionally avoided: No runtime guards, lifecycle machinery, new review category, or duplicate policy owner.

## Hot reply path impact

- Path status: Not applicable — this changes internal review guidance, not Murph runtime execution.
- Database calls: None
- Network/provider calls: None
- Other awaited latency: None
- Before/after proof: Not applicable because no production path changes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; the edited prompt is used only by final ReviewGPT.
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no Murph provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal review tooling does not change a runtime deploy boundary.

## Change-shape breakdown

Classification rule: The sole ReviewGPT preset is internal config/tooling; no binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 2 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **2** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal workflow and review tooling only.
