### PR TITLE
fix(cloudflare): ratchet integrated runner bundle budget

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -306,13 +306,15 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // macOS production assembly measured an 8,683,649B static closure and
 // 11,409,047B total on 2026-08-26. Ratchet those integrated baselines and
 // retain the fixed 96KB static and 32KB total cross-platform allowances.
-// Event-ledger gzip compatibility extends existing Core/query read and canonical
-// write paths without adding a forbidden boot input. Exact Linux production
-// assembly measured 11,457,689B total on 2026-08-28. Ratchet that baseline and
-// retain the fixed 32KB total cross-platform allowance.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_457_689 + 32_768;
+// Event-ledger gzip compatibility and the merged mailbox-owner graph extend the
+// existing Core/query/runtime paths without adding a forbidden boot input.
+// Exact Linux production assembly with the private managed-runtime overlay
+// measured 11,490,500B total on 2026-08-28; exact macOS public assembly measured
+// 11,531,130B total and an 8,787,302B static closure. Ratchet the higher measured
+// value for each dimension and retain the fixed cross-platform allowances.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_531_130 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 1_739_005;
-const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_683_649;
+const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 8_787_302;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_TOLERANCE_BYTES = 48_000;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_TOLERANCE_BYTES = 96_000;
 // The @murphai package markers are path suffixes, not node_modules-anchored:

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -608,8 +608,8 @@ describe("runner bundle container-entrypoint esbuild step", () => {
     // budget-policy changes remain explicit and reviewed.
     expect(budgets).toEqual({
       entryBytes: 1_739_005 + 48_000,
-      staticClosureBytes: 8_683_649 + 96_000,
-      totalBytes: 11_457_689 + 32_768,
+      staticClosureBytes: 8_787_302 + 96_000,
+      totalBytes: 11_531_130 + 32_768,
     });
   });
 


### PR DESCRIPTION
## Why and outcome
Current public `main` passes the Linux-only bundle budget, but the production-shaped private integration adds its managed-runtime overlay and exceeds the total cap by 43 bytes. The current macOS production assembly also exceeds the older total and static-closure baselines.

Ratchet the existing per-dimension baselines to the higher exact measured production values while retaining the unchanged 32 KiB total, 96 KiB static-closure, and 48 KiB entry allowances. No runtime graph, behavior, dependency, or abstraction changes.

Closes #2375

## Product UX
Not applicable. This is an internal build/deploy guard correction with no member-visible behavior or interface change.

## Evidence
- Protected Linux integration measured 11,490,500B total after managed-runtime materialization.
- Two consecutive macOS production-style assemblies measured exactly 11,531,130B total and 8,787,302B static closure.
- Final production-style assembly passed all bundle budgets and bundled/unbundled parity probes.
- Focused runner-entrypoint budget suite: 42 tests passed.
- Cloudflare typecheck passed.
- `git diff --check` passed.

## Non-obvious affected surfaces
- Cloudflare runner artifact assembly uses these limits to fail closed before packaging. Entry-chunk, static-closure, forbidden-input, and parity guards remain independently enforced.
- Protected private integration consumes the public source and adds the managed-runtime overlay before invoking the same guard.

## Architecture and reuse
- **Existing systems reused:** The existing measured-baseline budget resolver, esbuild metafile accounting, and locked policy test remain the sole owners.
- **New logic:** None; only measured baseline values change.
- **New abstractions:** None; the existing guard remains sufficient.
- **Complexity intentionally avoided:** No alternate private budget path, conditional bypass, runtime deletion, or new configuration surface.

## Hot reply path impact
Not applicable. This changes build-time size limits only and adds no runtime work.

## Murph initial provider input impact
Not applicable for both Murph and Codex. No prompts, tools, schemas, or provider-visible request assembly change.

ReviewGPT context sensitivity: sensitive
Reason: This adjusts a fail-closed Cloudflare runner deployment boundary consumed by protected integration.
ReviewGPT first-reviewed head: 0bd0147428a45db44b3ddc95a5ed23e46b56923d

## Change-shape breakdown
| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 6 |
| Tests/fixtures | 2 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **10** | **8** |

## Changelog
- Changelog: not applicable
- Reason: Internal build/deploy reliability only; no member-visible behavior changes.

## Deployment concerns
- Deployment: applicable
- Supported skew: Existing deployed runners are unchanged because this PR changes only a build-time guard.
- Safe order: Merge this public prerequisite, then rerun the protected private integration against the exact merged public revision before merging or rolling out its dependent worker change.
- Rollback floor: Existing runner artifacts remain valid; rebuilding the current integrated graph with the former baselines reproduces the gate failure.
- Expected exposure: None at runtime; the only exposure is whether a valid integrated bundle can pass predeploy assembly.
- Reversibility: Reverting restores the known failing build gate and should occur only after the integrated graph is reduced below the former limits.
- Convergence proof: Require exact-head public CI, then require the protected private integration to assemble the managed overlay and pass its full scenario matrix.
- Post-deploy checks: Confirm the protected private integration reports the expected public revision and all runner budget, Temporal, and hosted-local gates succeed.