### PR TITLE
Require phone or Telegram during onboarding

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-28-required-messaging-channels.md
+++ b/agent-docs/exec-plans/active/2026-08-28-required-messaging-channels.md
@@ -80,9 +80,9 @@ email when the account is still email-only.
 - Assistant: a deterministic regression plus one focused real-Codex journey
   proves that the three-day onboarding occurrence reaches a useful email reply
   when the fallback is selected.
-- iOS: unit tests prove linked-account operations, canonical refresh, gate
+- iOS: unit tests prove linked-account operations, canonical refresh, phone-code
   recovery, and semantic contact labels; exact-pushed-head simulator evidence
-  shows phone entry, code entry, and Telegram/recovery presentation.
+  shows the required phone-or-Telegram choice gate.
 - Cross-repo: the iOS field is additive and tolerant of an older Web response;
   Web deploys first so the canonical setup projection exists before the native
   gate ships.
@@ -150,10 +150,10 @@ email when the account is still email-only.
       routes, native onboarding flow, and pinned Privy linked-account surface.
 - [x] Implement the Web/server contract and focused proof.
 - [x] Implement the iOS gate, recovery, and focused proof.
-- [ ] Update canonical documentation and changelog after both PR numbers exist.
-- [ ] Run scoped verification, assistant journey, simulator visual proof,
-      required reviews, and exact-head CI.
-- [ ] Commit, open coordinated PRs, and record deploy order.
+- [x] Update canonical documentation and changelog after both PR numbers exist.
+- [ ] Run scoped verification, assistant journey, required reviews, and
+      exact-head CI; simulator visual proof is captured.
+- [x] Commit, open coordinated PRs, and record the Web-first deploy order.
 
 ## Verification
 

--- a/agent-docs/exec-plans/active/2026-08-28-required-messaging-channels.md
+++ b/agent-docs/exec-plans/active/2026-08-28-required-messaging-channels.md
@@ -1,0 +1,171 @@
+# Required Messaging Channels Across Web And iOS
+
+Status: active
+Owner: Codex
+Started: 2026-08-28
+Updated: 2026-08-28
+
+## Goal
+
+Require every hosted member who enters through Web or the native companion app
+to add either a verified phone number or a linked Telegram account before
+normal onboarding continues. Keep verified email as a valid authentication and
+delivery fallback, restore the founder welcome email for native email signup,
+and preserve the existing immediate welcome plus three-day onboarding sequence
+over the best available authorized route.
+
+## Product UX Plan
+
+Effort: Product change.
+
+### Requirement Boundary
+
+- Email remains valid for sign-in, account recovery, and founder outreach, but
+  no longer completes messaging setup by itself.
+- A verified phone/Linq route or linked Telegram identity completes setup.
+  Telegram may be awaiting the member's first inbound message and still count
+  as linked.
+- Web keeps its existing phone/Telegram setup surface. iOS adds one native gate
+  backed by Privy's linked-account APIs and the canonical Web/Postgres
+  projection; the app does not own a second completion flag.
+- Founder email is sent whenever the existing verified-email recipient policy
+  permits it, including companion onboarding.
+- The founder welcome email and assistant welcome are distinct effects and may
+  both use verified email. The assistant welcome and finite three-day follow-up
+  prefer an established direct route, then use verified email when activation
+  happens before a conversational route exists.
+- Failed, cancelled, or unavailable provider work leaves the member signed in
+  at a retryable gate with a sign-out escape hatch. It does not suspend or
+  delete the account.
+- This change does not retroactively resend founder welcomes or activation
+  sequences that were already consumed.
+
+### Outcome
+
+Every newly onboarded member leaves setup with a conversational phone or
+Telegram route that Murph can use, while email-authenticated members still
+receive the founder welcome and never see a mislabeled contact action.
+
+### Entry And Promise
+
+A person can sign in with phone or email on either surface. If their canonical
+member lacks both phone and Telegram, setup explains why a messaging route is
+needed and offers both choices. A successful link is synchronized to the
+canonical member before onboarding continues. The founder email is best-effort
+after starter enrollment. Murph's distinct assistant welcome and the existing
+three-day sequence use the route selected at activation, including verified
+email when the account is still email-only.
+
+### Affected People
+
+- A new email-authenticated Web member sees the existing phone/Telegram setup
+  before starter enrollment, can retry either option, and continues on success.
+- A new or returning email-only iOS member sees a compact native setup gate
+  before persona or health setup. Successful phone or Telegram linking is
+  re-admitted through the backend before the gate disappears.
+- A phone-authenticated or already Telegram-linked member passes through with
+  no extra step and keeps the current direct-channel welcome behavior.
+- A member whose link is cancelled, times out, or fails remains signed in with
+  a clear retry and sign-out path. No new health authority begins behind the
+  gate; a returning member's already-established sync remains intact.
+- A member whose activation temporarily lacks a usable direct route can still
+  receive the assistant sequence through the current verified email, which is
+  revalidated at the email provider boundary.
+
+### Proof Path
+
+- Web: focused predicate, invite/readiness, companion enrollment, activation,
+  route privacy, and runtime delivery tests prove required setup, founder email
+  dispatch, direct-channel priority, and verified-email fallback.
+- Assistant: a deterministic regression plus one focused real-Codex journey
+  proves that the three-day onboarding occurrence reaches a useful email reply
+  when the fallback is selected.
+- iOS: unit tests prove linked-account operations, canonical refresh, gate
+  recovery, and semantic contact labels; exact-pushed-head simulator evidence
+  shows phone entry, code entry, and Telegram/recovery presentation.
+- Cross-repo: the iOS field is additive and tolerant of an older Web response;
+  Web deploys first so the canonical setup projection exists before the native
+  gate ships.
+
+### UX Finish
+
+- Lead with “Choose how to message Murph,” not acquisition or notification
+  language.
+- Explain that email remains on the account while conversations happen through
+  Messages or Telegram.
+- Use “Text Murph,” “Message Murph on Telegram,” and “Email Murph” only when
+  the action actually opens that channel.
+- Disable repeated submissions while work is in flight, retain the entered
+  phone number through code verification, and keep errors adjacent to the
+  action that can recover them.
+
+### Done When
+
+- Email alone cannot pass the shared messaging-setup predicate.
+- Web and iOS each block normal onboarding until phone or Telegram is linked.
+- Companion enrollment no longer suppresses the founder welcome email.
+- Activation prefers phone/Telegram and seeds both immediate and three-day
+  assistant outreach, with a privacy-preserving verified-email fallback.
+- The native completion CTA always names the channel it opens.
+- Focused Web, assistant, and iOS proof passes; iOS visual evidence, both PR
+  heads, required reviews, and exact-head CI are complete.
+
+## Architecture
+
+- Web/Postgres remains the sole owner of member identity, messaging readiness,
+  activation, and automation state.
+- Privy remains the identity-linking authority. iOS accesses it only through
+  `AuthProviding`, then reuses companion admission to synchronize the linked
+  identity into the canonical member.
+- The existing initial-onboarding projection gains one additive optional
+  readiness field so old Web and iOS builds can overlap safely.
+- No database table, queue, onboarding state owner, dependency, or provider
+  credential is added.
+
+## Planned Changes
+
+### `murph`
+
+- Restore phone/Telegram-only messaging readiness.
+- Project messaging readiness through companion initial onboarding.
+- Restore companion founder email and add activation email fallback without
+  broadening unrelated notification routes.
+- Add focused tests, a real-Codex journey, canonical docs, and changelog.
+
+### `murph-ios`
+
+- Add phone-link and Telegram-link operations behind `AuthProviding`.
+- Present a canonical messaging-setup gate and refresh through companion
+  admission after linking.
+- Render contact action labels from their actual channel.
+- Add focused tests, simulator evidence, and canonical docs.
+
+## Progress
+
+- [x] Re-read both repositories' instructions and relevant product,
+      architecture, security, reliability, and verification guidance.
+- [x] Confirm no overlapping branch or pull request and create isolated task
+      worktrees from current main heads.
+- [x] Inspect the production symptom, shared readiness predicate, activation
+      routes, native onboarding flow, and pinned Privy linked-account surface.
+- [x] Implement the Web/server contract and focused proof.
+- [x] Implement the iOS gate, recovery, and focused proof.
+- [ ] Update canonical documentation and changelog after both PR numbers exist.
+- [ ] Run scoped verification, assistant journey, simulator visual proof,
+      required reviews, and exact-head CI.
+- [ ] Commit, open coordinated PRs, and record deploy order.
+
+## Verification
+
+Use the smallest focused Web Vitest suites plus affected typechecks, the named
+real-Codex assistant journey, `xcodegen generate`, `swiftformat --lint .`, and
+focused/full simulator tests required by the iOS repository. Broad acceptance
+remains owned by exact-head GitHub Actions.
+
+## Rollout
+
+Deploy Web before releasing iOS. The additive optional projection keeps the
+new iOS build compatible with old Web during review, but enforcement becomes
+canonical only after Web is live. Verify one email-authenticated and one
+phone-authenticated journey, then one Telegram link, before declaring the
+native release complete.

--- a/agent-docs/exec-plans/completed/2026-08-28-required-messaging-channels.md
+++ b/agent-docs/exec-plans/completed/2026-08-28-required-messaging-channels.md
@@ -1,9 +1,9 @@
 # Required Messaging Channels Across Web And iOS
 
-Status: active
+Status: completed
 Owner: Codex
 Started: 2026-08-28
-Updated: 2026-08-28
+Updated: 2026-08-29
 
 ## Goal
 
@@ -151,7 +151,7 @@ email when the account is still email-only.
 - [x] Implement the Web/server contract and focused proof.
 - [x] Implement the iOS gate, recovery, and focused proof.
 - [x] Update canonical documentation and changelog after both PR numbers exist.
-- [ ] Run scoped verification, assistant journey, required reviews, and
+- [x] Run scoped verification, assistant journey, required reviews, and
       exact-head CI; simulator visual proof is captured.
 - [x] Commit, open coordinated PRs, and record the Web-first deploy order.
 
@@ -162,6 +162,15 @@ real-Codex assistant journey, `xcodegen generate`, `swiftformat --lint .`, and
 focused/full simulator tests required by the iOS repository. Broad acceptance
 remains owned by exact-head GitHub Actions.
 
+Completed proof: 60 focused Web onboarding tests, 213 assistant cron tests,
+59 hosted-runtime event tests, the focused real-Codex journey, and the Web,
+assistant-engine, and assistant-runtime typechecks passed. The companion retry
+regression proves 503-before-convergence and 200-after-convergence. The hosted
+email automation regression proves local-profile rejection, hosted-profile
+persistence, and one due email delivery. Final ReviewGPT round 3 returned
+`ROUND_OUTCOME: PASS`; the coordinated iOS PR passed its final review and native
+verification.
+
 ## Rollout
 
 Deploy Web before releasing iOS. The additive optional projection keeps the
@@ -169,3 +178,4 @@ new iOS build compatible with old Web during review, but enforcement becomes
 canonical only after Web is live. Verify one email-authenticated and one
 phone-authenticated journey, then one Telegram link, before declaring the
 native release complete.
+Completed: 2026-08-29

--- a/agent-docs/product-specs/companion-app-mvp.md
+++ b/agent-docs/product-specs/companion-app-mvp.md
@@ -1,6 +1,6 @@
 # iOS Companion App — MVP Build Spec
 
-Last verified: 2026-08-15
+Last verified: 2026-08-28
 
 Parent spec: `agent-docs/product-specs/companion-app.md` (strategy, phases,
 review posture). This doc is the concrete build plan for the first shippable
@@ -118,14 +118,17 @@ installed build rather than the static fallback.
 
 ### Login methods: verified constraint
 
-Privy's Swift SDK natively supports **email OTP and SMS OTP**. Its native
-OAuth support is currently **Google-only — Telegram login is web-only and
-not available in the iOS SDK**. MVP ships **phone + email**; Telegram joins
-when Privy lands it on iOS.
+Privy's Swift SDK natively supports **email OTP and SMS OTP** for primary
+authentication. Pinned Privy 2.12 also supports post-authentication Telegram
+OAuth linking. Telegram is a messaging setup choice, not a login method.
+Email-only authentication therefore remains at the canonical setup gate until
+the member links a phone number or Telegram account.
 
 Guideline note: Apple's 4.8 (must offer Sign in with Apple) is triggered by
-third-party *social* login. Email/SMS OTP does not trigger it. The day we
-add Telegram or Google, we must add Sign in with Apple in the same release.
+third-party *social* login. Email/SMS OTP does not trigger it, and the bounded
+post-authentication Telegram link does not authenticate app access. If
+Telegram or Google becomes a login method, add Sign in with Apple in the same
+release.
 
 ## Stack (verified 2026-06-10)
 
@@ -163,6 +166,10 @@ Launch
 Login screen
   └─ phone → privy.sms.sendCode(to:) → privy.sms.loginWithCode(_:sentTo:)
   └─ email → equivalent email OTP flow
+Messaging setup after canonical admission
+  ├─ verified phone or linked Telegram → continue
+  └─ email only → link phone by OTP or Telegram by OAuth → repeat admission
+       → continue only after the canonical projection clears the gate
 Token exchange (on demand, immediately before SDK exchange; retry = new token)
   └─ app sends Privy auth token to Murph web API
   └─ backend verifies Privy identity (@privy-io/node, already a dependency)

--- a/agent-docs/product-specs/companion-app.md
+++ b/agent-docs/product-specs/companion-app.md
@@ -1,6 +1,6 @@
 # Native Companion Apps (Health Sync)
 
-Last verified: 2026-08-15
+Last verified: 2026-08-28
 
 Current iOS distribution status: approved for the App Store. The canonical
 public listing is `https://apps.apple.com/us/app/murph-ai/id6786145859`.
@@ -182,10 +182,12 @@ attested direct message can bind the contacted managed line when the existing
 reply-egress policy permits it, including at-risk and delivery-warning lines
 that cannot initiate outreach. Unmanaged, disabled, ambiguous, or unsafe lines
 cannot establish that exact-line authority; ordinary fallback selection still
-fails closed when no eligible line exists. A successfully delivered welcome uses the existing finite
-unfinished-onboarding continuation: at most one low-pressure opportunity on
-each of the next three local days, with the ordinary stop rules. Companion
-admission does not also send the signup welcome email. A committed activation
+fails closed when no eligible line exists. A successfully delivered assistant
+welcome uses the existing finite unfinished-onboarding continuation: at most
+one low-pressure opportunity on each of the next three local days, with the
+ordinary stop rules. A verified email also receives the separate founder
+welcome email; email remains a valid assistant delivery fallback when
+activation has no established phone or Telegram thread. A committed activation
 whose runtime wake is not accepted stays on the retryable account gate; retry
 re-signals only the exact pending Starter activation mailbox item. Canonical starter-usage activation, active-access
 proof, and the internal `member.activated` fact remain intact. Existing

--- a/apps/web/app/api/device-sync/companion/initial-onboarding/route.ts
+++ b/apps/web/app/api/device-sync/companion/initial-onboarding/route.ts
@@ -24,6 +24,12 @@ import {
 import {
   requireActivePrivyMemberAuthFromBearerToken,
 } from "@/src/lib/hosted-onboarding/request-auth";
+import {
+  readHostedMemberMessagingSetupState,
+} from "@/src/lib/hosted-onboarding/hosted-member-store";
+import {
+  isHostedMemberMessagingSetupRequired,
+} from "@/src/lib/hosted-onboarding/messaging-state";
 import { HOSTED_ONBOARDING_TRANSACTION_OPTIONS } from
   "@/src/lib/hosted-onboarding/shared";
 import {
@@ -51,12 +57,18 @@ const INITIAL_MESSAGE = {
 export const GET = withJsonError(async (request: Request) => {
   const prisma = getPrisma();
   const auth = await requireActivePrivyMemberAuthFromBearerToken(request, prisma);
-  const state = await readHostedInitialOnboardingState({
-    memberId: auth.member.id,
-    prisma,
-  });
+  const [state, messagingSetupRequired] = await Promise.all([
+    readHostedInitialOnboardingState({
+      memberId: auth.member.id,
+      prisma,
+    }),
+    readCompanionMessagingSetupRequired({
+      memberId: auth.member.id,
+      prisma,
+    }),
+  ]);
   if (state.status === "completed") {
-    return jsonOk(projectCompletedState(state));
+    return jsonOk(projectCompletedState(state, messagingSetupRequired));
   }
 
   let contactAction: MurphContactOption | null = null;
@@ -79,6 +91,7 @@ export const GET = withJsonError(async (request: Request) => {
 
   return jsonOk(projectPendingState({
     contactAction,
+    messagingSetupRequired,
     origin: resolveHostedPublicBaseUrl() ?? new URL(request.url).origin,
     state,
   }));
@@ -109,15 +122,21 @@ export const POST = withJsonError(async (request: Request) => {
     });
   }
 
-  return jsonOk(projectCompletedState(result));
+  const messagingSetupRequired = await readCompanionMessagingSetupRequired({
+    memberId: auth.member.id,
+    prisma,
+  });
+  return jsonOk(projectCompletedState(result, messagingSetupRequired));
 });
 
 function projectCompletedState(
   state: HostedInitialOnboardingState | HostedInitialOnboardingCompletionResult,
+  messagingSetupRequired: boolean,
 ) {
   return {
     schema: COMPANION_INITIAL_ONBOARDING_SCHEMA,
     status: "completed" as const,
+    messagingSetupRequired,
     ...(state.status === "completed" && "completedNow" in state
       ? { completedNow: state.completedNow }
       : {}),
@@ -130,6 +149,7 @@ function projectCompletedState(
 
 function projectPendingState(input: {
   contactAction: MurphContactOption | null;
+  messagingSetupRequired: boolean;
   origin: string;
   state: HostedInitialOnboardingState;
 }) {
@@ -137,6 +157,7 @@ function projectPendingState(input: {
   return {
     schema: COMPANION_INITIAL_ONBOARDING_SCHEMA,
     status: "pending" as const,
+    messagingSetupRequired: input.messagingSetupRequired,
     preferences: input.state.preferences,
     catalog: {
       personas: assistantBasePersonaOptions.map((option) => ({
@@ -188,6 +209,17 @@ function projectPendingState(input: {
         }
       : null,
   };
+}
+
+async function readCompanionMessagingSetupRequired(input: {
+  memberId: string;
+  prisma: Parameters<typeof readHostedMemberMessagingSetupState>[0]["prisma"];
+}): Promise<boolean> {
+  const messagingState = await readHostedMemberMessagingSetupState(input);
+  return isHostedMemberMessagingSetupRequired({
+    identity: messagingState?.identity ?? null,
+    routing: messagingState?.routing ?? null,
+  });
 }
 
 async function signalHostedMailboxAppendBestEffort(input: {

--- a/apps/web/changelog/entries/2026-08-28/choose-a-messaging-channel.json
+++ b/apps/web/changelog/entries/2026-08-28/choose-a-messaging-channel.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-28",
+  "order": 100,
+  "item": {
+    "id": "choose-a-messaging-channel",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Choose how to message Murph",
+    "summary": "Email sign-ins now keep their email welcome and follow-up while setup asks for Messages or Telegram on Web and iPhone.",
+    "details": "A verified phone or linked Telegram account completes messaging setup; email remains available for account access and verified outreach.",
+    "relevanceTags": ["onboarding", "messaging", "ios", "email"],
+    "sourcePullRequests": [2521, 122]
+  }
+}

--- a/apps/web/src/lib/hosted-onboarding/billing-start-preconditions.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-start-preconditions.ts
@@ -3,15 +3,10 @@ import { projectHostedMemberRoutingState } from "./hosted-member-routing-store";
 import { isHostedMemberMessagingSetupRequired } from "./messaging-state";
 import type { HostedOnboardingReadClient } from "./shared";
 
-type HostedBillingMessagingIdentity = Exclude<
-  Parameters<typeof isHostedMemberMessagingSetupRequired>[0]["identity"],
-  null
-> & {
-  memberId?: string | null;
-};
-
 export async function assertHostedMemberBillingStartMessagingReady(input: {
-  identity: HostedBillingMessagingIdentity | null;
+  identity: Parameters<
+    typeof isHostedMemberMessagingSetupRequired
+  >[0]["identity"];
   prisma: HostedOnboardingReadClient;
   routing: Parameters<typeof projectHostedMemberRoutingState>[0] | null;
 }): Promise<void> {
@@ -21,28 +16,6 @@ export async function assertHostedMemberBillingStartMessagingReady(input: {
 
   if (!isHostedMemberMessagingSetupRequired({
     identity: input.identity,
-    routing,
-  })) {
-    return;
-  }
-
-  const memberId = input.identity?.memberId ?? input.routing?.memberId ?? null;
-  const emailAuthorization = memberId
-    ? await input.prisma.hostedMemberEmailAuthorization.findUnique({
-        select: {
-          verifiedEmailVerifiedAt: true,
-        },
-        where: {
-          memberId,
-        },
-      })
-    : null;
-
-  if (!isHostedMemberMessagingSetupRequired({
-    identity: {
-      ...(input.identity ?? {}),
-      emailLinked: Boolean(emailAuthorization?.verifiedEmailVerifiedAt),
-    },
     routing,
   })) {
     return;

--- a/apps/web/src/lib/hosted-onboarding/billing-start-preconditions.ts
+++ b/apps/web/src/lib/hosted-onboarding/billing-start-preconditions.ts
@@ -51,7 +51,7 @@ export async function assertHostedMemberBillingStartMessagingReady(input: {
   throw hostedOnboardingError({
     code: "HOSTED_MESSAGING_CHANNEL_REQUIRED",
     message:
-      "Verify a phone number or email address, or connect Telegram before checkout so Murph can message you.",
+      "Verify a phone number or connect Telegram before checkout so Murph can message you.",
     httpStatus: 409,
   });
 }

--- a/apps/web/src/lib/hosted-onboarding/companion-member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/companion-member-access.ts
@@ -116,7 +116,7 @@ export async function ensureHostedCompanionMemberId(input: {
         // A member whose live Privy identity now includes phone or Telegram is
         // the narrow exception: repeating canonical completion synchronizes
         // the newly linked account before readiness is projected again.
-        await completeHostedPrivyVerification({
+        const completion = await completeHostedPrivyVerification({
           identity: input.identity,
           now,
           prisma,
@@ -124,6 +124,15 @@ export async function ensureHostedCompanionMemberId(input: {
         }).catch((error: unknown) => {
           throw remapHostedPrivyCompletionLagError(error);
         });
+        if (completion.messagingSetupRequired) {
+          throw hostedOnboardingError({
+            code: "PRIVY_ACCOUNT_NOT_READY",
+            httpStatus: 409,
+            message:
+              "Your verified messaging account has not reached Murph yet. Wait a moment and try again.",
+            retryable: true,
+          });
+        }
       }
       await requireHostedCompanionActivationRuntimeWake({
         memberId: existingMember.id,

--- a/apps/web/src/lib/hosted-onboarding/companion-member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/companion-member-access.ts
@@ -26,6 +26,12 @@ import {
   type HostedSignupNotificationContextV1,
 } from "./signup-notification-context";
 import {
+  readHostedMemberMessagingSetupState,
+} from "./hosted-member-store";
+import {
+  isHostedMemberMessagingSetupRequired,
+} from "./messaging-state";
+import {
   isHostedSignupNotificationEmailConfigured,
 } from "./signup-notification-email-config";
 import { resolveHostedPrivySessionFromBearerToken } from "./hosted-session";
@@ -95,6 +101,30 @@ export async function ensureHostedCompanionMemberId(input: {
         memberId: existingMember.id,
         prisma,
       });
+      const messagingState = await readHostedMemberMessagingSetupState({
+        memberId: existingMember.id,
+        prisma,
+      });
+      if (
+        isHostedMemberMessagingSetupRequired({
+          identity: messagingState?.identity ?? null,
+          routing: messagingState?.routing ?? null,
+        })
+        && (input.identity.phone || input.identity.telegram)
+      ) {
+        // Existing active members normally stay on the read-only fast path.
+        // A member whose live Privy identity now includes phone or Telegram is
+        // the narrow exception: repeating canonical completion synchronizes
+        // the newly linked account before readiness is projected again.
+        await completeHostedPrivyVerification({
+          identity: input.identity,
+          now,
+          prisma,
+          ...(input.timeZone ? { timeZone: input.timeZone } : {}),
+        }).catch((error: unknown) => {
+          throw remapHostedPrivyCompletionLagError(error);
+        });
+      }
       await requireHostedCompanionActivationRuntimeWake({
         memberId: existingMember.id,
         prisma,

--- a/apps/web/src/lib/hosted-onboarding/member-activation.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-activation.ts
@@ -398,25 +398,6 @@ async function prewarmHostedMemberActivationWriteDomainRoots(input: {
   }
 }
 
-export function buildHostedMemberActivationWelcomeRoute(input: {
-  emailAddress?: string | null;
-  emailLookupKey?: string | null;
-  linqChatId: string | null;
-  linqContactLookupKey?: string | null;
-  linqRecipientPhone?: string | null;
-  memberId: string;
-  memberPhoneNumber?: string | null;
-  phoneLookupKey: string | null;
-  pendingLinqChatId?: string | null;
-  pendingLinqParticipantContact?: {
-    lookupKey?: string | null;
-  } | null;
-  telegramThreadId: string | null;
-  telegramUserId: string | null;
-}): HostedExecutionAssistantNotificationRoute | null {
-  return buildHostedMemberActivationOnboardingFollowupRoute(input);
-}
-
 export function buildHostedMemberActivationOnboardingFollowupRoute(input: {
   emailAddress?: string | null;
   emailLookupKey?: string | null;

--- a/apps/web/src/lib/hosted-onboarding/member-activation.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-activation.ts
@@ -344,7 +344,7 @@ async function activateHostedMemberForPositiveSourceTxInner(input: {
     );
   const signupWelcomeRoute = input.suppressSignupWelcome
     ? null
-    : resolvedLinqRoute;
+    : onboardingFollowupRoute;
   const activationWake = buildHostedMemberActivationWakeForMember({
     emailLinked: input.emailLinked ?? resolveHostedMemberActivationEmailLinked(currentMember),
     member: currentMember,
@@ -399,6 +399,8 @@ async function prewarmHostedMemberActivationWriteDomainRoots(input: {
 }
 
 export function buildHostedMemberActivationWelcomeRoute(input: {
+  emailAddress?: string | null;
+  emailLookupKey?: string | null;
   linqChatId: string | null;
   linqContactLookupKey?: string | null;
   linqRecipientPhone?: string | null;
@@ -412,12 +414,12 @@ export function buildHostedMemberActivationWelcomeRoute(input: {
   telegramThreadId: string | null;
   telegramUserId: string | null;
 }): HostedExecutionAssistantNotificationRoute | null {
-  const route = buildHostedMemberActivationOnboardingFollowupRoute(input);
-
-  return route?.channel === "linq" ? route : null;
+  return buildHostedMemberActivationOnboardingFollowupRoute(input);
 }
 
 export function buildHostedMemberActivationOnboardingFollowupRoute(input: {
+  emailAddress?: string | null;
+  emailLookupKey?: string | null;
   linqChatId: string | null;
   linqContactLookupKey?: string | null;
   linqRecipientPhone?: string | null;
@@ -432,6 +434,8 @@ export function buildHostedMemberActivationOnboardingFollowupRoute(input: {
   telegramUserId: string | null;
 }): HostedExecutionAssistantNotificationRoute | null {
   return resolveHostedMemberAssistantNotificationRoute({
+    emailAddress: input.emailAddress ?? null,
+    emailLookupKey: input.emailLookupKey ?? null,
     linqChatId: input.linqChatId,
     linqContactLookupKey: input.linqContactLookupKey,
     linqRecipientPhone: input.linqRecipientPhone ?? null,
@@ -456,6 +460,8 @@ function buildHostedMemberActivationOnboardingFollowupRouteForMember(
   member: HostedMemberActivationSnapshot,
 ): HostedExecutionAssistantNotificationRoute | null {
   return buildHostedMemberActivationOnboardingFollowupRoute({
+    emailAddress: member.emailAuthorization?.verifiedEmail?.address ?? null,
+    emailLookupKey: member.emailAuthorization?.verifiedEmail?.lookupKey ?? null,
     linqChatId: member.routing?.linqChatId ?? null,
     linqContactLookupKey:
       member.identity?.phoneLookupKey

--- a/apps/web/src/lib/hosted-onboarding/messaging-state.ts
+++ b/apps/web/src/lib/hosted-onboarding/messaging-state.ts
@@ -43,7 +43,9 @@ export type HostedMemberAssistantNotificationRoute =
   | null;
 
 type HostedMemberAssistantNotificationRouteInput = {
-  channel?: "linq" | "telegram";
+  channel?: "email" | "linq" | "telegram";
+  emailAddress?: string | null;
+  emailLookupKey?: string | null;
   linqChatId: string | null;
   linqContactLookupKey?: string | null;
   linqRecipientPhone?: string | null;
@@ -77,8 +79,8 @@ export function resolveHostedMemberMessagingState(input: {
 
   return {
     // Preserve the historical chat-specific meaning used by the dashboard.
-    // Verified email satisfies onboarding readiness below, but it does not
-    // imply that a Linq or Telegram conversation thread already exists.
+    // Verified email remains a delivery route, but it does not imply that a
+    // Linq or Telegram conversation thread already exists.
     hasDirectMessagingChannel: hasLinq || hasTelegram,
     hasEmail,
     hasLinq,
@@ -98,12 +100,10 @@ export function isHostedMemberMessagingSetupRequired(input: {
 }): boolean {
   const messaging = resolveHostedMemberMessagingState(input);
 
-  // Verified email is already a real Murph route. A linked Telegram account
-  // also completes setup even before its first inbound thread exists: the
-  // member has told us how to reach them, while delivery remains an independent
-  // concern surfaced as telegramAwaitingInbound.
-  return !messaging.hasEmail
-    && !messaging.hasDirectMessagingChannel
+  // Messaging setup deliberately requires a conversational phone or Telegram
+  // identity. Verified email remains available for authentication and fallback
+  // delivery, but it no longer skips this onboarding step.
+  return !messaging.hasDirectMessagingChannel
     && !messaging.telegramAwaitingInbound;
 }
 
@@ -138,7 +138,8 @@ export function resolveHostedMemberAssistantNotificationRoute(
     ?? input.messaging.phoneLookupKey;
 
   if (
-    input.channel !== "telegram"
+    input.channel !== "email"
+    && input.channel !== "telegram"
     && input.linqChatId
     && linqContactLookupKey
   ) {
@@ -169,7 +170,8 @@ export function resolveHostedMemberAssistantNotificationRoute(
   }
 
   if (
-    input.channel !== "telegram"
+    input.channel !== "email"
+    && input.channel !== "telegram"
     && linqRecipientPhone
     && memberPhoneNumber
     && input.messaging.phoneLookupKey
@@ -202,7 +204,8 @@ export function resolveHostedMemberAssistantNotificationRoute(
   }
 
   if (
-    input.channel !== "linq"
+    input.channel !== "email"
+    && input.channel !== "linq"
     && input.messaging.telegramTarget
   ) {
     const identifierBlind = createHostedAssistantConversationIdentifierBlind({
@@ -221,6 +224,34 @@ export function resolveHostedMemberAssistantNotificationRoute(
         identifierBlind,
         input.messaging.telegramTarget,
       ),
+      threadIsDirect: true,
+    };
+  }
+
+  const emailAddress = normalizeMessagingIdentity(input.emailAddress);
+  const emailLookupKey = normalizeMessagingIdentity(input.emailLookupKey);
+  if (
+    input.channel !== "linq"
+    && input.channel !== "telegram"
+    && emailAddress
+    && emailLookupKey
+  ) {
+    const identifierBlind = createHostedAssistantConversationIdentifierBlind({
+      secret: emailLookupKey,
+      userId: input.memberId,
+    });
+    return {
+      actorId: null,
+      channel: "email",
+      delivery: {
+        kind: "explicit",
+        target: emailAddress,
+      },
+      identityId: hashHostedAssistantConversationIdentifier(
+        identifierBlind,
+        emailLookupKey,
+      ),
+      threadId: null,
       threadIsDirect: true,
     };
   }

--- a/apps/web/src/lib/hosted-onboarding/messaging-state.ts
+++ b/apps/web/src/lib/hosted-onboarding/messaging-state.ts
@@ -43,7 +43,7 @@ export type HostedMemberAssistantNotificationRoute =
   | null;
 
 type HostedMemberAssistantNotificationRouteInput = {
-  channel?: "email" | "linq" | "telegram";
+  channel?: "linq" | "telegram";
   emailAddress?: string | null;
   emailLookupKey?: string | null;
   linqChatId: string | null;
@@ -138,8 +138,7 @@ export function resolveHostedMemberAssistantNotificationRoute(
     ?? input.messaging.phoneLookupKey;
 
   if (
-    input.channel !== "email"
-    && input.channel !== "telegram"
+    input.channel !== "telegram"
     && input.linqChatId
     && linqContactLookupKey
   ) {
@@ -170,8 +169,7 @@ export function resolveHostedMemberAssistantNotificationRoute(
   }
 
   if (
-    input.channel !== "email"
-    && input.channel !== "telegram"
+    input.channel !== "telegram"
     && linqRecipientPhone
     && memberPhoneNumber
     && input.messaging.phoneLookupKey
@@ -204,8 +202,7 @@ export function resolveHostedMemberAssistantNotificationRoute(
   }
 
   if (
-    input.channel !== "email"
-    && input.channel !== "linq"
+    input.channel !== "linq"
     && input.messaging.telegramTarget
   ) {
     const identifierBlind = createHostedAssistantConversationIdentifierBlind({

--- a/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/starter-usage-enrollment-service.ts
@@ -164,8 +164,7 @@ export async function ensureHostedStarterUsageEnrollment(
     requireLaunchConsent: true,
     source: input.source,
     suppressSignupWelcome,
-    suppressSignupWelcomeEmail:
-      suppressSignupWelcome || companionOnboarding,
+    suppressSignupWelcomeEmail: suppressSignupWelcome,
   });
   return enrollment.result;
 }
@@ -315,7 +314,10 @@ async function ensureHostedStarterUsageEnrollmentWithPolicy(
       prisma,
     });
   }
-  if (!policy.instantStartAdmission) {
+  if (
+    !policy.instantStartAdmission
+    && policy.source !== "companion_onboarding"
+  ) {
     await assertHostedMemberBillingStartMessagingReady({
       identity: invite.member.identity,
       prisma,

--- a/apps/web/test/device-sync-companion-initial-onboarding-route.test.ts
+++ b/apps/web/test/device-sync-companion-initial-onboarding-route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   issueMurphContactCardHandoffClaim: vi.fn(),
   parseHostedInitialOnboardingCompletionRequest: vi.fn(),
   readHostedInitialOnboardingState: vi.fn(),
+  readHostedMemberMessagingSetupState: vi.fn(),
   readHostedMurphContactContextForMember: vi.fn(),
   requireActivePrivyMemberAuthFromBearerToken: vi.fn(),
   signalHostedMailboxAppendRuntime: vi.fn(),
@@ -29,6 +30,11 @@ vi.mock("@/src/lib/hosted-onboarding/initial-onboarding", () => ({
 vi.mock("@/src/lib/hosted-onboarding/hosted-contact-context", () => ({
   readHostedMurphContactContextForMember:
     mocks.readHostedMurphContactContextForMember,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
+  readHostedMemberMessagingSetupState:
+    mocks.readHostedMemberMessagingSetupState,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/contact-card-handoff", () => ({
@@ -74,6 +80,10 @@ describe("companion initial onboarding routes", () => {
       preferences: { persona: null, tone: null, voice: null },
       status: "pending",
     });
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: "hbidx:phone:v1:member" },
+      routing: null,
+    });
     mocks.readHostedMurphContactContextForMember.mockResolvedValue({
       initialContactChannels: { email: false, telegram: false, text: true },
       murphEmailAddress: null,
@@ -103,6 +113,7 @@ describe("companion initial onboarding routes", () => {
     expect(payload).toMatchObject({
       schema: "murph.companion.initial-onboarding.v1",
       status: "pending",
+      messagingSetupRequired: false,
       preferences: { persona: null, tone: null, voice: null },
       contactAction: { kind: "text" },
       contactCard: { defaultAvatarId: "classic" },
@@ -140,6 +151,27 @@ describe("companion initial onboarding routes", () => {
     expect(warn).toHaveBeenCalledWith(
       "Companion initial onboarding contact projection unavailable.",
     );
+  });
+
+  it("projects required messaging setup independently of onboarding completion", async () => {
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: null },
+      routing: null,
+    });
+    mocks.readHostedInitialOnboardingState.mockResolvedValue({
+      completedAt: new Date("2026-08-04T12:00:00.000Z"),
+      preferences: { persona: "classic", tone: "formal", voice: "murph" },
+      status: "completed",
+    });
+    const response = await route.GET(new Request(
+      "https://app.example.test/api/device-sync/companion/initial-onboarding",
+      { headers: { authorization: "Bearer identity-token" } },
+    ));
+
+    await expect(response.json()).resolves.toMatchObject({
+      messagingSetupRequired: true,
+      status: "completed",
+    });
   });
 
   it("short-circuits completed onboarding before optional contact projection", async () => {

--- a/apps/web/test/device-sync-companion-routes.test.ts
+++ b/apps/web/test/device-sync-companion-routes.test.ts
@@ -124,6 +124,10 @@ function mockVerifiedPrivyUser(): void {
   mocks.prismaClient.hostedMember.findUnique.mockResolvedValue({
     accountGroupMemberships: [],
     billingStatus: ACTIVE_MEMBER.billingStatus,
+    identity: {
+      phoneLookupKey: "synced-phone-lookup-key",
+    },
+    routing: null,
     suspendedAt: ACTIVE_MEMBER.suspendedAt,
     threadContainer: null,
   });

--- a/apps/web/test/hosted-onboarding-billing-start-preconditions.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-start-preconditions.test.ts
@@ -32,7 +32,7 @@ describe("hosted billing messaging readiness", () => {
     expect(prisma.hostedMemberEmailAuthorization.findUnique).not.toHaveBeenCalled();
   });
 
-  it("accepts a verified email when no phone or Telegram route exists", async () => {
+  it("requires a conversational channel even when email is verified", async () => {
     const verifiedAt = new Date("2026-07-31T10:00:00.000Z");
     const prisma = makePrisma(verifiedAt);
 
@@ -43,7 +43,9 @@ describe("hosted billing messaging readiness", () => {
       },
       prisma: prisma as never,
       routing: null,
-    })).resolves.toBeUndefined();
+    })).rejects.toMatchObject({
+      code: "HOSTED_MESSAGING_CHANNEL_REQUIRED",
+    });
 
     expect(prisma.hostedMemberEmailAuthorization.findUnique).toHaveBeenCalledWith({
       select: {
@@ -69,7 +71,7 @@ describe("hosted billing messaging readiness", () => {
       code: "HOSTED_MESSAGING_CHANNEL_REQUIRED",
       httpStatus: 409,
       message:
-        "Verify a phone number or email address, or connect Telegram before checkout so Murph can message you.",
+        "Verify a phone number or connect Telegram before checkout so Murph can message you.",
     });
   });
 

--- a/apps/web/test/hosted-onboarding-billing-start-preconditions.test.ts
+++ b/apps/web/test/hosted-onboarding-billing-start-preconditions.test.ts
@@ -4,25 +4,20 @@ import {
   assertHostedMemberBillingStartMessagingReady,
 } from "@/src/lib/hosted-onboarding/billing-start-preconditions";
 
-function makePrisma(verifiedEmailVerifiedAt: Date | null) {
+function makePrisma() {
   return {
     hostedMemberEmailAuthorization: {
-      findUnique: vi.fn().mockResolvedValue(
-        verifiedEmailVerifiedAt
-          ? { verifiedEmailVerifiedAt }
-          : null,
-      ),
+      findUnique: vi.fn(),
     },
   };
 }
 
 describe("hosted billing messaging readiness", () => {
   it("accepts a verified phone without reading email state", async () => {
-    const prisma = makePrisma(null);
+    const prisma = makePrisma();
 
     await expect(assertHostedMemberBillingStartMessagingReady({
       identity: {
-        memberId: "member_phone",
         phoneLookupKey: "hbidx:phone:v1:ready",
       },
       prisma: prisma as never,
@@ -33,12 +28,11 @@ describe("hosted billing messaging readiness", () => {
   });
 
   it("requires a conversational channel even when email is verified", async () => {
-    const verifiedAt = new Date("2026-07-31T10:00:00.000Z");
-    const prisma = makePrisma(verifiedAt);
+    const prisma = makePrisma();
 
     await expect(assertHostedMemberBillingStartMessagingReady({
       identity: {
-        memberId: "member_email",
+        emailLinked: true,
         phoneLookupKey: null,
       },
       prisma: prisma as never,
@@ -47,22 +41,14 @@ describe("hosted billing messaging readiness", () => {
       code: "HOSTED_MESSAGING_CHANNEL_REQUIRED",
     });
 
-    expect(prisma.hostedMemberEmailAuthorization.findUnique).toHaveBeenCalledWith({
-      select: {
-        verifiedEmailVerifiedAt: true,
-      },
-      where: {
-        memberId: "member_email",
-      },
-    });
+    expect(prisma.hostedMemberEmailAuthorization.findUnique).not.toHaveBeenCalled();
   });
 
   it("still rejects a member with no reachable messaging channel", async () => {
-    const prisma = makePrisma(null);
+    const prisma = makePrisma();
 
     await expect(assertHostedMemberBillingStartMessagingReady({
       identity: {
-        memberId: "member_unreachable",
         phoneLookupKey: null,
       },
       prisma: prisma as never,
@@ -73,21 +59,5 @@ describe("hosted billing messaging readiness", () => {
       message:
         "Verify a phone number or connect Telegram before checkout so Murph can message you.",
     });
-  });
-
-  it("fails closed when an incomplete snapshot cannot name the member", async () => {
-    const prisma = makePrisma(new Date("2026-07-31T10:00:00.000Z"));
-
-    await expect(assertHostedMemberBillingStartMessagingReady({
-      identity: {
-        phoneLookupKey: null,
-      },
-      prisma: prisma as never,
-      routing: null,
-    })).rejects.toMatchObject({
-      code: "HOSTED_MESSAGING_CHANNEL_REQUIRED",
-    });
-
-    expect(prisma.hostedMemberEmailAuthorization.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/test/hosted-onboarding-companion-member-access.test.ts
+++ b/apps/web/test/hosted-onboarding-companion-member-access.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   lookupHostedMemberForPrivyPrincipal: vi.fn(),
   readActiveHostedMemberAccess: vi.fn(),
+  readHostedMemberMessagingSetupState: vi.fn(),
   retryPendingHostedStarterUsageActivationRuntimeWake: vi.fn(),
   remapHostedPrivyCompletionLagError: vi.fn((error: unknown) => error),
   resolveHostedPrivySessionFromBearerToken: vi.fn(),
@@ -52,6 +53,11 @@ vi.mock("@/src/lib/hosted-onboarding/member-access", () => ({
   assertActiveHostedMemberAccessAllowed:
     mocks.assertActiveHostedMemberAccessAllowed,
   readActiveHostedMemberAccess: mocks.readActiveHostedMemberAccess,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", () => ({
+  readHostedMemberMessagingSetupState:
+    mocks.readHostedMemberMessagingSetupState,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/member-identity-service", () => ({
@@ -167,6 +173,10 @@ describe("native companion hosted member admission", () => {
     });
     mocks.retryPendingHostedStarterUsageActivationRuntimeWake
       .mockResolvedValue(null);
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: "hbidx:phone:v1:member" },
+      routing: null,
+    });
   });
 
   afterEach(() => {
@@ -456,6 +466,49 @@ describe("native companion hosted member admission", () => {
     expect(mocks.completeHostedPrivyVerification).not.toHaveBeenCalled();
     expect(mocks.ensureHostedStarterUsageEnrollment).not.toHaveBeenCalled();
     expect(mocks.assertActiveHostedMemberAccessAllowed).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes a newly linked channel for an active email-only member", async () => {
+    const activeMember = member(HostedBillingStatus.active);
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(activeMember);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(true);
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: null },
+      routing: null,
+    });
+    mocks.completeHostedPrivyVerification.mockResolvedValue(
+      completion(HostedBillingStatus.active),
+    );
+
+    await expect(ensureHostedCompanionMemberId({
+      identity,
+      prisma,
+    })).resolves.toBe(activeMember.id);
+
+    expect(mocks.completeHostedPrivyVerification).toHaveBeenCalledWith({
+      identity,
+      now: expect.any(Date),
+      prisma,
+    });
+    expect(mocks.ensureHostedStarterUsageEnrollment).not.toHaveBeenCalled();
+  });
+
+  it("keeps an active email-only member on the read path until Privy has a linked channel", async () => {
+    const activeMember = member(HostedBillingStatus.active);
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(activeMember);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(true);
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: null },
+      routing: null,
+    });
+
+    await expect(ensureHostedCompanionMemberId({
+      identity: emailIdentity,
+      prisma,
+    })).resolves.toBe(activeMember.id);
+
+    expect(mocks.completeHostedPrivyVerification).not.toHaveBeenCalled();
+    expect(mocks.ensureHostedStarterUsageEnrollment).not.toHaveBeenCalled();
   });
 
   it("returns retryable admission until a pending activation wake is accepted", async () => {

--- a/apps/web/test/hosted-onboarding-companion-member-access.test.ts
+++ b/apps/web/test/hosted-onboarding-companion-member-access.test.ts
@@ -493,6 +493,37 @@ describe("native companion hosted member admission", () => {
     expect(mocks.ensureHostedStarterUsageEnrollment).not.toHaveBeenCalled();
   });
 
+  it("returns retryable admission until a newly linked channel is canonical", async () => {
+    const activeMember = member(HostedBillingStatus.active);
+    mocks.resolveHostedPrivySessionFromBearerToken.mockResolvedValue({ identity });
+    mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(activeMember);
+    mocks.readActiveHostedMemberAccess.mockResolvedValue(true);
+    mocks.readHostedMemberMessagingSetupState.mockResolvedValue({
+      identity: { phoneLookupKey: null },
+      routing: null,
+    });
+    mocks.completeHostedPrivyVerification
+      .mockResolvedValueOnce({
+        ...completion(HostedBillingStatus.active),
+        messagingSetupRequired: true,
+      })
+      .mockResolvedValueOnce(completion(HostedBillingStatus.active));
+
+    const firstResponse = await admissionRoute.POST(admissionRequest());
+    const retryResponse = await admissionRoute.POST(admissionRequest());
+
+    expect(firstResponse.status).toBe(503);
+    await expect(firstResponse.json()).resolves.toMatchObject({
+      error: {
+        code: "COMPANION_ADMISSION_RETRYABLE",
+        retryable: true,
+      },
+    });
+    expect(retryResponse.status).toBe(200);
+    await expect(retryResponse.json()).resolves.toEqual({ ok: true });
+    expect(mocks.completeHostedPrivyVerification).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps an active email-only member on the read path until Privy has a linked channel", async () => {
     const activeMember = member(HostedBillingStatus.active);
     mocks.lookupHostedMemberForPrivyPrincipal.mockResolvedValue(activeMember);

--- a/apps/web/test/hosted-onboarding-member-activation.test.ts
+++ b/apps/web/test/hosted-onboarding-member-activation.test.ts
@@ -105,7 +105,6 @@ import {
   activateHostedMemberForFamilySponsorshipTx,
   activateHostedMemberForPositiveSourceTx,
   buildHostedMemberActivationOnboardingFollowupRoute,
-  buildHostedMemberActivationWelcomeRoute,
   hasHostedMemberActivationProof,
   readHostedMemberActivationProofMemberIds,
 } from "@/src/lib/hosted-onboarding/member-activation";
@@ -1161,8 +1160,8 @@ describe("hosted onboarding member activation", () => {
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
   });
 
-  it("builds a proactive Telegram welcome route after an inbound thread exists", () => {
-    expect(buildHostedMemberActivationWelcomeRoute({
+  it("builds a Telegram onboarding follow-up route after an inbound thread exists", () => {
+    expect(buildHostedMemberActivationOnboardingFollowupRoute({
       linqChatId: null,
       linqRecipientPhone: null,
       memberId: "member_telegram_route",
@@ -1179,8 +1178,8 @@ describe("hosted onboarding member activation", () => {
     });
   });
 
-  it("builds a verified-email welcome fallback with blinded identity", () => {
-    expect(buildHostedMemberActivationWelcomeRoute({
+  it("builds a verified-email onboarding fallback with blinded identity", () => {
+    expect(buildHostedMemberActivationOnboardingFollowupRoute({
       emailAddress: "member@example.test",
       emailLookupKey: "hbidx:email:v1:member",
       linqChatId: null,
@@ -1199,8 +1198,8 @@ describe("hosted onboarding member activation", () => {
     });
   });
 
-  it("builds a Linq participant welcome route when activation only knows the chosen home line", () => {
-    expect(buildHostedMemberActivationWelcomeRoute({
+  it("builds a Linq participant onboarding route when activation only knows the chosen home line", () => {
+    expect(buildHostedMemberActivationOnboardingFollowupRoute({
       linqChatId: null,
       linqRecipientPhone: "+15550100099",
       memberId: "member_linq_participant_route",
@@ -1214,13 +1213,13 @@ describe("hosted onboarding member activation", () => {
     }));
   });
 
-  it("builds a Linq thread welcome route with blinded assistant identifiers", () => {
+  it("builds a Linq thread onboarding route with blinded assistant identifiers", () => {
     const identifierBlind = createHostedAssistantConversationIdentifierBlind({
       secret: "hbidx:phone:v1:lookup",
       userId: "member_linq_thread_route",
     });
 
-    expect(buildHostedMemberActivationWelcomeRoute({
+    expect(buildHostedMemberActivationOnboardingFollowupRoute({
       linqChatId: "chat_home_123",
       linqContactLookupKey: "hbidx:phone:v1:lookup",
       linqRecipientPhone: null,

--- a/apps/web/test/hosted-onboarding-member-activation.test.ts
+++ b/apps/web/test/hosted-onboarding-member-activation.test.ts
@@ -700,8 +700,8 @@ describe("hosted onboarding member activation", () => {
     });
 
     expect(mocks.resolveHostedMemberActivationLinqRoute).not.toHaveBeenCalled();
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledWith({
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenNthCalledWith(1, {
       envelope: expect.objectContaining({
         kind: "member.activated",
         memberChannels: {
@@ -709,7 +709,16 @@ describe("hosted onboarding member activation", () => {
           linq: false,
           telegram: false,
         },
-        signupWelcome: null,
+        onboardingFollowupRoute: expect.objectContaining({
+          channel: "email",
+          delivery: {
+            kind: "explicit",
+            target: "member@example.com",
+          },
+        }),
+        signupWelcome: expect.objectContaining({
+          route: expect.objectContaining({ channel: "email" }),
+        }),
       }),
       tx: expect.anything(),
     });
@@ -1073,7 +1082,7 @@ describe("hosted onboarding member activation", () => {
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
   });
 
-  it("does not enqueue a proactive Telegram welcome for email-linked phone-less members", async () => {
+  it("enqueues the welcome and follow-up on an established Telegram route", async () => {
     const member = makeMemberSnapshot({
       emailAuthorization: {
         directPublicSender: null,
@@ -1122,6 +1131,19 @@ describe("hosted onboarding member activation", () => {
     });
 
     expect(mocks.resolveHostedMemberActivationLinqRoute).not.toHaveBeenCalled();
+    const telegramRoute = buildHostedMemberActivationOnboardingFollowupRoute({
+      emailAddress: "member@example.com",
+      emailLookupKey: "hbidx:email:v1:lookup",
+      linqChatId: null,
+      linqContactLookupKey: "hbidx:email:v1:lookup",
+      linqRecipientPhone: null,
+      memberId: "member_123",
+      memberPhoneNumber: null,
+      phoneLookupKey: null,
+      telegramThreadId:
+        "telegram_user_123:business:biz-42:dm-topic:9",
+      telegramUserId: "telegram_user_123",
+    });
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenNthCalledWith(1, {
       envelope: expect.objectContaining({
         kind: "member.activated",
@@ -1131,26 +1153,15 @@ describe("hosted onboarding member activation", () => {
           telegram: true,
         },
         onboardingFollowupEnrollment: true,
-        onboardingFollowupRoute:
-          buildHostedMemberActivationOnboardingFollowupRoute({
-            linqChatId: null,
-            linqContactLookupKey: "hbidx:email:v1:lookup",
-            linqRecipientPhone: null,
-            memberId: "member_123",
-            memberPhoneNumber: null,
-            phoneLookupKey: null,
-            telegramThreadId:
-              "telegram_user_123:business:biz-42:dm-topic:9",
-            telegramUserId: "telegram_user_123",
-          }),
-        signupWelcome: null,
+        onboardingFollowupRoute: telegramRoute,
+        signupWelcome: expect.objectContaining({ route: telegramRoute }),
       }),
       tx: expect.anything(),
     });
-    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
+    expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(2);
   });
 
-  it("does not build a proactive Telegram welcome route", () => {
+  it("builds a proactive Telegram welcome route after an inbound thread exists", () => {
     expect(buildHostedMemberActivationWelcomeRoute({
       linqChatId: null,
       linqRecipientPhone: null,
@@ -1159,7 +1170,33 @@ describe("hosted onboarding member activation", () => {
       phoneLookupKey: null,
       telegramThreadId: "telegram_user_456:business:biz-42:dm-topic:9",
       telegramUserId: "telegram_user_456",
-    })).toBeNull();
+    })).toMatchObject({
+      channel: "telegram",
+      delivery: {
+        kind: "thread",
+        target: "telegram_user_456:business:biz-42:dm-topic:9",
+      },
+    });
+  });
+
+  it("builds a verified-email welcome fallback with blinded identity", () => {
+    expect(buildHostedMemberActivationWelcomeRoute({
+      emailAddress: "member@example.test",
+      emailLookupKey: "hbidx:email:v1:member",
+      linqChatId: null,
+      memberId: "member_email_route",
+      phoneLookupKey: null,
+      telegramThreadId: null,
+      telegramUserId: null,
+    })).toMatchObject({
+      channel: "email",
+      delivery: {
+        kind: "explicit",
+        target: "member@example.test",
+      },
+      identityId: expect.stringMatching(/^hid_/u),
+      threadIsDirect: true,
+    });
   });
 
   it("builds a Linq participant welcome route when activation only knows the chosen home line", () => {

--- a/apps/web/test/hosted-onboarding-messaging-state.test.ts
+++ b/apps/web/test/hosted-onboarding-messaging-state.test.ts
@@ -138,7 +138,7 @@ describe("hosted member messaging authority", () => {
     });
   });
 
-  it("treats verified email as setup-complete without inventing a direct chat", () => {
+  it("keeps verified email available without treating it as messaging setup", () => {
     const input = {
       identity: {
         emailLinked: true,
@@ -155,7 +155,7 @@ describe("hosted member messaging authority", () => {
       hasPhone: false,
       hasTelegram: false,
     });
-    expect(isHostedMemberMessagingSetupRequired(input)).toBe(false);
+    expect(isHostedMemberMessagingSetupRequired(input)).toBe(true);
     expect(resolveHostedMemberChannels({
       emailLinked: true,
       identity: {
@@ -168,10 +168,19 @@ describe("hosted member messaging authority", () => {
       telegram: false,
     });
     expect(resolveHostedMemberAssistantNotificationRoute({
+      emailAddress: "member@example.test",
+      emailLookupKey: "hbidx:email:v1:member",
       linqChatId: null,
       memberId: "member_email",
       messaging,
-    })).toBeNull();
+    })).toMatchObject({
+      channel: "email",
+      delivery: {
+        kind: "explicit",
+        target: "member@example.test",
+      },
+      threadIsDirect: true,
+    });
   });
 
   it("treats a linked Telegram identity as setup-complete while delivery still waits for an inbound thread", () => {

--- a/apps/web/test/hosted-onboarding-privy-service.test.ts
+++ b/apps/web/test/hosted-onboarding-privy-service.test.ts
@@ -1444,9 +1444,9 @@ describe("completeHostedPrivyVerification", () => {
       inviteCode: expect.any(String),
       joinUrl: expect.stringContaining("/join/"),
       memberId: existingMember.id,
-      // Verified email already gives Murph a delivery route, so signup no
-      // longer holds this member on messaging setup.
-      messagingSetupRequired: false,
+      // Email remains available for onboarding outreach, but the member must
+      // still add phone or Telegram before onboarding can finish.
+      messagingSetupRequired: true,
       stage: "checkout",
     });
 

--- a/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
+++ b/apps/web/test/hosted-onboarding-starter-usage-enrollment-service.test.ts
@@ -444,7 +444,7 @@ describe("Starter usage enrollment owner", () => {
     expect(mocks.signalHostedMemberActivationRuntimeWakeBestEffortResult)
       .toHaveBeenCalledOnce();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
-      .not.toHaveBeenCalled();
+      .toHaveBeenCalledOnce();
     expect(mocks.scheduleHostedSignupNotificationEmails).toHaveBeenCalledWith({
       activationSurface: "mobile_app",
       memberIds: [memberState.id],
@@ -636,7 +636,7 @@ describe("Starter usage enrollment owner", () => {
         memberId: memberState.id,
       }));
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
-      .not.toHaveBeenCalled();
+      .toHaveBeenCalledOnce();
   });
 
   it("commits companion activation but requires retry when the runtime wake is not accepted", async () => {
@@ -666,7 +666,7 @@ describe("Starter usage enrollment owner", () => {
     expect(activationWritten).toBe(true);
     expect(grantState).not.toBeNull();
     expect(mocks.sendHostedSignupWelcomeEmailForMemberBestEffort)
-      .not.toHaveBeenCalled();
+      .toHaveBeenCalledOnce();
   });
 
   it("re-signals only the exact pending Starter activation mailbox item", async () => {

--- a/packages/assistant-engine/src/assistant/cron/authoring.ts
+++ b/packages/assistant-engine/src/assistant/cron/authoring.ts
@@ -49,6 +49,7 @@ import {
   assistantCronTargetAudienceEquals,
   buildCanonicalAutomationRoute,
   resolveAssistantCronTargetDefaults,
+  type AssistantCronDeliveryRouteValidationProfile,
   validateAssistantCronDeliveryTarget,
 } from './targets.js'
 
@@ -80,6 +81,7 @@ export interface UpsertAssistantCronAutomationInput {
   instructions: string
   now?: Date
   route: AutomationRoute
+  routeValidationProfile?: AssistantCronDeliveryRouteValidationProfile
   schedule: AssistantCronScheduleInput
   slug: string
   summary?: string | null
@@ -225,7 +227,10 @@ export async function upsertAssistantCronAutomation(
       schedule: input.schedule,
       vault: input.vault,
     })
-    const target = validateAssistantCronDeliveryTarget(input.route)
+    const target = validateAssistantCronDeliveryTarget(
+      input.route,
+      input.routeValidationProfile ?? 'local',
+    )
     const localStore = await readAssistantCronStore(resolvedCreation.paths)
     assertAssistantCronJobNameIsAvailable(localStore, resolvedCreation.name)
 

--- a/packages/assistant-engine/src/assistant/onboarding-followup-seed.ts
+++ b/packages/assistant-engine/src/assistant/onboarding-followup-seed.ts
@@ -12,6 +12,9 @@ import {
   computeAssistantCronFirstRunAfterCurrentLocalDay,
   computeAssistantCronNextRunAt,
 } from './cron/schedule.js'
+import type {
+  AssistantCronDeliveryRouteValidationProfile,
+} from './cron/targets.js'
 
 export type MurphOnboardingFollowupSeedResult =
   | { kind: 'not-applicable' }
@@ -23,6 +26,7 @@ export async function seedMurphOnboardingFollowupAutomation(input: {
   firstOccurrenceAt?: string
   now?: Date
   route: AutomationRoute
+  routeValidationProfile?: AssistantCronDeliveryRouteValidationProfile
   stableKey: string
   vault: string
 }): Promise<AssistantCronJob | null> {
@@ -41,6 +45,9 @@ export async function seedMurphOnboardingFollowupAutomation(input: {
     instructions: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
     ...(input.now === undefined ? {} : { now: input.now }),
     route: input.route,
+    ...(input.routeValidationProfile === undefined
+      ? {}
+      : { routeValidationProfile: input.routeValidationProfile }),
     schedule: resolveMurphOnboardingFollowupSchedule(input.stableKey),
     slug: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug,
     summary: MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.summary,
@@ -54,6 +61,7 @@ export async function seedMurphOnboardingFollowupFromStartedOnboarding(
   input: {
     now?: Date
     route: AutomationRoute
+    routeValidationProfile?: AssistantCronDeliveryRouteValidationProfile
     stableKey: string
     vault: string
   },
@@ -103,6 +111,9 @@ export async function seedMurphOnboardingFollowupFromStartedOnboarding(
     firstOccurrenceAt,
     now,
     route: input.route,
+    ...(input.routeValidationProfile === undefined
+      ? {}
+      : { routeValidationProfile: input.routeValidationProfile }),
     stableKey: input.stableKey,
     vault: input.vault,
   })

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -153,6 +153,9 @@ import {
   MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
 } from '../src/assistant/managed-automations.ts'
 import {
+  MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
+} from '../src/assistant/onboarding-followup-automation.ts'
+import {
   ASSISTANT_CRON_INDEPENDENT_AUTOMATION_AUTHORITY_INSTRUCTIONS,
   ASSISTANT_CRON_RECURRING_REMINDER_CONVERSATION_INSTRUCTIONS,
   buildAssistantCronExecutionInstructions,
@@ -1264,6 +1267,57 @@ describeRealCodex('real Codex onboarding progressive disclosure e2e', () => {
     },
     360_000,
   )
+})
+
+describeRealCodex('real Codex email onboarding follow-up e2e', () => {
+  it('renders the finite onboarding continuation as one reply-oriented email question', async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await prepareRealCodexOnboardingDirectory()
+
+    try {
+      await writeRealCodexOnboardingResumeContext(
+        workingDirectory,
+        'missing_identity',
+      )
+      const turnInput = buildRealCodexOnboardingTurnInput({
+        config,
+        workingDirectory,
+      })
+      const result = await executeRealCodexAppServerTurn({
+        ...turnInput,
+        developerInstructions: buildScheduledAutomationDeveloperInstructions(
+          'direct',
+          'none',
+          'email',
+        ),
+        prompt: [
+          MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.instructions,
+          'Trusted context for this occurrence:',
+          '- This is the first available day in the finite follow-up window.',
+          '- No earlier follow-up question is unanswered.',
+          '- Recent messages contain no answer, defer, decline, or newer topic.',
+        ].join('\n\n'),
+      })
+      const decision = parseAssistantNotificationDecision(result.finalMessage)
+
+      expect(decision.kind).toBe('send_message')
+      if (decision.kind !== 'send_message') {
+        throw new Error('Expected the email onboarding follow-up to send.')
+      }
+      expect(decision.text.match(/\?/gu) ?? []).toHaveLength(1)
+      expect(decision.text).not.toMatch(
+        /automation|follow-up window|internal state|setup completion|final attempt/iu,
+      )
+      process.stdout.write(
+        `[real-codex email onboarding follow-up] ${decision.text.replaceAll(/\s+/gu, ' ').trim()}\n`,
+      )
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  }, 360_000)
 })
 
 describe('onboarding policy read detection', () => {
@@ -21637,6 +21691,7 @@ function buildScheduledAutomationDeveloperInstructions(
     | 'families'
     | 'shared_read'
     | 'none' = 'families',
+  channel: 'email' | 'linq' = 'linq',
 ): string {
   return buildAssistantSystemPrompt({
     assistantCliContract: null,
@@ -21645,7 +21700,7 @@ function buildScheduledAutomationDeveloperInstructions(
     assistantHostedDeviceConnectProviders: [],
     assistantHostedGroupToolSurface,
     assistantKnowledgeToolsAvailable: false,
-    channel: 'linq',
+    channel,
     cliAccess: {
       rawCommand: 'vault-cli',
       setupCommand: 'murph',

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -221,6 +221,9 @@ import {
   resolveAssistantOnboardingStatePath,
 } from '../src/assistant/onboarding-state.ts'
 import {
+  seedMurphOnboardingFollowupAutomation,
+} from '../src/assistant/onboarding-followup-seed.ts'
+import {
   ASSISTANT_BOUNDED_CONVERSATION_HISTORY_INCOMPLETE_TEXT,
 } from '../src/assistant/shared.ts'
 import type { AssistantExecutionContext } from '../src/assistant/execution-context.ts'
@@ -802,6 +805,101 @@ describe('assistant cron runtime orchestration', () => {
       'archived',
     )
     expect(cronMocks.upsertAutomation).toHaveBeenCalledTimes(3)
+  })
+
+  it('persists hosted email onboarding follow-up and delivers a due occurrence', async () => {
+    vi.useFakeTimers()
+    const now = new Date('2026-04-08T15:00:00.000Z')
+    const dueAt = '2026-04-09T13:45:00.000Z'
+    vi.setSystemTime(now)
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-hosted-email-onboarding-followup-',
+    )
+    const route = {
+      channel: 'email' as const,
+      deliverySource: null,
+      deliveryTarget: 'member@example.test',
+      identityId: 'hid_email_member',
+      participantId: null,
+      threadId: null,
+      threadIsDirect: true,
+    }
+    const seedInput = {
+      activeUntil: '2026-04-11T15:00:00.000Z',
+      firstOccurrenceAt: dueAt,
+      now,
+      route,
+      stableKey: 'member_email_onboarding_followup',
+      vault: vaultRoot,
+    }
+
+    await expect(
+      seedMurphOnboardingFollowupAutomation(seedInput),
+    ).rejects.toMatchObject({
+      code: 'ASSISTANT_CRON_DELIVERY_REQUIRED',
+    })
+
+    const job = await seedMurphOnboardingFollowupAutomation({
+      ...seedInput,
+      routeValidationProfile: 'hosted',
+    })
+    if (!job) {
+      throw new Error('Expected hosted email onboarding follow-up to be seeded.')
+    }
+    expect(findCanonicalAutomation(
+      vaultRoot,
+      MURPH_ONBOARDING_FOLLOWUP_AUTOMATION.slug,
+    )?.route).toEqual(route)
+
+    cronMocks.sendAssistantMessageLocal.mockResolvedValueOnce({
+      decision: {
+        kind: 'send_message',
+        privateSummary: 'Prepared the onboarding continuation.',
+        text: 'Want to pick this back up?',
+      },
+      deliveryOutcome: {
+        delivery: {
+          channel: 'email',
+          sentAt: '2026-04-09T13:45:05.000Z',
+          target: 'member@example.test',
+          targetKind: 'explicit',
+        },
+        intentId: 'outbox_hosted_email_onboarding_followup',
+        kind: 'sent',
+        media: [],
+        session: {
+          sessionId: 'session_hosted_email_onboarding_followup',
+        },
+      },
+      response: 'Want to pick this back up?',
+      session: {
+        sessionId: 'session_hosted_email_onboarding_followup',
+      },
+    })
+    vi.setSystemTime(new Date('2026-04-09T13:45:05.000Z'))
+
+    await expect(processDueAssistantCronJobsLocal({
+      executionContext: {
+        hosted: {
+          memberId: 'member_email_onboarding_followup',
+          userEnvKeys: [],
+        },
+      },
+      limit: 1,
+      vault: vaultRoot,
+    })).resolves.toEqual({
+      failed: 0,
+      processed: 1,
+      succeeded: 1,
+    })
+    expect(cronMocks.sendAssistantMessageLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bindingDeliveryTarget: 'member@example.test',
+        channel: 'email',
+        deliveryTarget: 'member@example.test',
+        threadIsDirect: true,
+      }),
+    )
   })
 
   it('keeps an explicit recurring timezone instead of reinterpreting its wall clock in the vault timezone', async () => {

--- a/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/events/assistant-notification.ts
@@ -516,6 +516,7 @@ async function seedOnboardingFollowupAutomation(input: {
     // Linq participant routes without a Linq delivery source).
     const result = await seedMurphOnboardingFollowupFromStartedOnboarding({
       route: buildOnboardingFollowupAutomationRoute(input.route),
+      routeValidationProfile: "hosted",
       stableKey: input.stableKey,
       vault: input.vaultRoot,
     });

--- a/packages/assistant-runtime/test/hosted-runtime-events.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-events.test.ts
@@ -2640,6 +2640,7 @@ describe("executeHostedMailboxEvent", () => {
           threadId: null,
           threadIsDirect: true,
         },
+        routeValidationProfile: "hosted",
         stableKey: "member_123",
         vault: "/tmp/assistant-runtime-events",
       }),
@@ -2695,10 +2696,69 @@ describe("executeHostedMailboxEvent", () => {
           deliveryTarget: "thread_123",
           threadIsDirect: true,
         }),
+        routeValidationProfile: "hosted",
         stableKey: "member_123",
         vault: "/tmp/assistant-runtime-events",
       }),
     );
+    expect(result).toMatchObject({
+      mailboxLane: "member-activated",
+      nextWakeAt: seededNextWakeAt,
+      nextWakeReason: "assistant",
+    });
+  });
+
+  it("seeds hosted email onboarding follow-up with hosted route validation", async () => {
+    const seededNextWakeAt = "2026-04-09T17:30:00.000Z";
+    mocks.seedMurphOnboardingFollowupFromStartedOnboarding.mockResolvedValueOnce(
+      createReadyOnboardingFollowupSeedResult(seededNextWakeAt),
+    );
+    const wake = buildHostedExecutionMemberActivatedWake({
+      eventId: "member.activated:email:member_123:evt_email_followup",
+      memberChannels: {
+        email: true,
+        linq: false,
+        telegram: false,
+      },
+      memberId: "member_123",
+      onboardingFollowupRoute: {
+        actorId: null,
+        channel: "email",
+        delivery: {
+          kind: "explicit",
+          target: "member@example.test",
+        },
+        identityId: "hid_email_identity_123",
+        threadId: null,
+        threadIsDirect: true,
+      },
+      occurredAt: "2026-04-08T00:00:00.000Z",
+      signupWelcome: null,
+    });
+
+    const result = await executeHostedMailboxEvent({
+      wake,
+      executionContext,
+      runtime: createRuntime(),
+      runtimeEnv: {},
+      vaultRoot: "/tmp/assistant-runtime-events",
+    });
+
+    expect(mocks.sendAssistantNotification).not.toHaveBeenCalled();
+    expect(mocks.seedMurphOnboardingFollowupFromStartedOnboarding).toHaveBeenCalledWith({
+      route: {
+        channel: "email",
+        deliverySource: null,
+        deliveryTarget: "member@example.test",
+        identityId: "hid_email_identity_123",
+        participantId: null,
+        threadId: null,
+        threadIsDirect: true,
+      },
+      routeValidationProfile: "hosted",
+      stableKey: "member_123",
+      vault: "/tmp/assistant-runtime-events",
+    });
     expect(result).toMatchObject({
       mailboxLane: "member-activated",
       nextWakeAt: seededNextWakeAt,
@@ -2756,6 +2816,7 @@ describe("executeHostedMailboxEvent", () => {
         threadId: "hid_telegram_thread_123",
         threadIsDirect: true,
       },
+      routeValidationProfile: "hosted",
       stableKey: "member_123",
       vault: "/tmp/assistant-runtime-events",
     });
@@ -2825,6 +2886,7 @@ describe("executeHostedMailboxEvent", () => {
     expect(mocks.sendAssistantNotification).toHaveBeenCalledOnce();
     expect(mocks.seedMurphOnboardingFollowupFromStartedOnboarding).toHaveBeenCalledWith(
       expect.objectContaining({
+        routeValidationProfile: "hosted",
         stableKey: "member_123",
         vault: "/tmp/assistant-runtime-events",
       }),


### PR DESCRIPTION
## Why and outcome

Email authentication was treated as messaging-ready on some paths, so a companion email signup could skip the phone/Telegram join gate and suppress the founder welcome. This makes phone or Telegram the shared conversational-readiness requirement while keeping verified email valid for authentication, founder outreach, the assistant welcome, and the finite three-day follow-up.

The founder email and assistant welcome remain distinct effects and may both be delivered by email. This change does not retroactively resend already-consumed welcome or follow-up effects.

## Product UX

- Effort: Product change
- Walkthrough: Ready
- Affected people: New email-authenticated Web members must finish the existing phone/Telegram join step; new or returning email-only companion members receive the native gate from the counterpart PR. Phone-authenticated and Telegram-linked members continue without a new step.
- Failure/recovery: Provider failure leaves the member signed in at the retryable setup surface; successful native linking is re-admitted before readiness clears.
- Material exclusion: Existing active email-only Web sessions are not globally revoked, and no historical welcome/follow-up backfill is introduced.
- Plan variance: Final review identified one companion false-success path and the specialist pass identified hosted email follow-up persistence using local-only route validation; both are remediated below. The existing proactive Telegram welcome suppression remains intentionally unchanged per product direction.

## Evidence

- Focused Web onboarding regression set: 173 passed, 5 skipped; the final active-member synchronization refinement reran 17/17 companion-access tests.
- Final companion retry remediation: 37/37 route and owner tests passed, including 503-before-convergence and 200-after-convergence.
- Current onboarding owner regression: 60/60 Web tests passed.
- Broad app-verification remediation: 38/38 Privy-service tests and 109/109 companion-route tests passed after aligning the email-only expectation and synced-phone fixture with the canonical requirement.
- Hosted email onboarding follow-up proof: 213/213 assistant-engine cron tests passed; the focused scenario rejects email under the local route profile, persists it under the hosted profile, and delivers one due occurrence through the email delivery test double.
- Hosted activation boundary: 59/59 assistant-runtime event tests passed, including an explicit email route propagated with hosted validation.
- Deterministic onboarding-follow-up automation regression: 4/4 passed.
- Focused real-Codex journey: 1/1 passed; the email occurrence produced one natural, reply-oriented onboarding question without automation language.
- `pnpm --filter @murphai/hosted-web typecheck`
- `pnpm --filter @murphai/assistant-engine typecheck`
- `pnpm --filter @murphai/assistant-runtime typecheck`
- Counterpart iOS PR: https://github.com/cobuildwithus/murph-ios/pull/122 at `f19bf56bfb4fa98060d20beeec397d4f00f32d5f`.

## Non-obvious affected surfaces

- Companion active-member admission: reads canonical messaging readiness and repeats Privy completion only when a newly linked live phone/Telegram identity must be synchronized. Regression: companion-member-access tests.
- Starter enrollment and billing readiness: companion onboarding retains its released-client compatibility exception, while shared checkout readiness now rejects email alone. Regression: enrollment and billing-precondition tests.
- Assistant activation routing: direct Linq/Telegram remains preferred; verified email is the privacy-preserving fallback for immediate and three-day onboarding effects. Hosted activation now selects hosted route validation explicitly while all other cron authoring retains the local default. Regression: activation, routing, cron persistence/delivery, runtime event, automation, and real-Codex tests.
- Companion initial-onboarding API: adds the canonical `messagingSetupRequired` projection consumed by iOS. Regression: route contract tests and counterpart decode/session tests.

## Architecture and reuse

- Existing systems reused: Canonical Postgres member identity/routing, Privy completion, starter enrollment, activation wake, existing Web join UI, existing assistant cron persistence, and existing assistant email delivery.
- New logic: One shared readiness interpretation, additive companion projection, automatic email fallback route, narrow active-member identity resynchronization, and an optional route-validation profile passed only by hosted onboarding seeding.
- New abstractions: None; the existing messaging-state, activation, and cron authoring owners were extended.
- Complexity intentionally avoided: No table, queue, migration, backfill, second onboarding owner, delivery service, or historical replay was added. Review cleanup deleted the obsolete email authorization reread, duplicate activation route wrapper, and forced-email selector path.

## Hot reply path impact

Not applicable. The foreground reply critical path for accepting a current conversation message through reply handoff is unchanged; this affects signup activation and finite onboarding automation only.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt assembly, tool schema, generated guidance, or first provider-visible request changed.
- Codex runtime: Not applicable; no provider-input surface changed. The new real-Codex journey is proof-only and does not alter runtime instructions.

## Design proof

Not applicable. No hosted Web component, style, interaction, or route UI changed; the member-visible Web experience reuses the existing phone/Telegram join surface. The changelog entry uses its repository-owned changelog review route.

## Change-shape breakdown

Classification: runtime TypeScript is source; Vitest and real-Codex journey files are tests/fixtures; the exec plan, product specs, and authored changelog entry are docs. No generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 147 | 69 |
| Tests/fixtures | 428 | 76 |
| Docs | 206 | 12 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **781** | **157** |

## Risks

- Database load: Companion onboarding GET adds one messaging-state read in parallel with the existing onboarding read; POST adds one bounded read after completion. Active companion admission adds one bounded readiness read and performs the existing completion write path only for canonical-missing/live-linked phone or Telegram. The obsolete billing-time email authorization reread was removed. There is no collection fanout, external work inside a database transaction, or added concurrency loop.
- Rollout: Released iOS remains functional through the companion enrollment exception; enforcement becomes canonical after Web is deployed and the new iOS build consumes the additive field.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old iOS ignores the additive projection; new iOS treats an omitted field as the pre-gate behavior. Released iOS can continue companion enrollment during rollout.
- Safe order: Deploy Web first, verify the projection and email effects, register the production/development Privy callback schemes, then release iOS PR 122.
- Rollback floor: The Web field is additive and safe for old iOS; rolling Web back removes native enforcement without breaking decoding, while rolling iOS back leaves Web onboarding intact.
- Expected exposure: During the bounded rollout window, released iOS may still admit an email-only member without the native gate; Web and the new iOS enforce it after convergence.
- Reversibility: Pause the iOS release before reverting Web; no data migration or backfill must be undone.
- Convergence proof: Verify one email-authenticated, one phone-authenticated, and one Telegram-link journey against the deployed Web projection before declaring the native release complete.
- Post-deploy checks: Confirm founder email, assistant welcome, three-day seed, and canonical readiness for those bounded journeys; inspect onboarding/admission error aggregates.

## Changelog

- Changelog: updated
- Items: 2026-08-28 · choose-a-messaging-channel

## ReviewGPT disposition

- Round 1: `FINDINGS` at the immutable first-reviewed head.
- Rejected by product direction: enabling proactive Telegram activation welcomes. The existing Telegram suppression remains unchanged.
- Accepted and remediated: active companion admission now converts a still-required canonical messaging projection into the existing retryable 503 boundary; focused proof covers later convergence to 200.
- Preliminary specialist: accepted the hosted email follow-up persistence finding. The root cause was the onboarding seed inheriting local-only email validation; hosted activation now opts into the existing hosted profile while every non-hosted caller retains the local default. Focused proof covers activation propagation, persistence, and one due email delivery.
- Round 2: accepted the behavior-preserving `Complexity Collapse`. The obsolete email authorization reread and second readiness decision, duplicate welcome-route wrapper, and explicit forced-email selector path were deleted; automatic email fallback remains.

- Round 3: `PASS` on the behavior-bearing head with no qualifying findings; the plan-closure commit that followed is documentation-only. A later test-only CI remediation corrected one stale expectation and one incomplete active-member fixture; production source is unchanged.

## Review anomaly retrospective

- Original requirement: require phone or Telegram after email authentication across Web and iOS while preserving founder email, immediate email onboarding outreach, and the finite three-day email follow-up.
- Shape comparison: the immutable first-reviewed head had 127 source additions and 26 source deletions; the current candidate has 147 source additions and 69 source deletions. Review remediation added 20 source lines while deleting 43, with the remaining growth concentrated in focused regression proof.
- Mechanisms: the companion false-success and hosted email cron profile were separate ownership-boundary omissions. Neither introduced a new owner, queue, state machine, migration, compatibility mechanism, or repair path.
- Decision: continue as one PR. The cross-repository contract is indivisible for safe Web-first rollout, production source remains small, and splitting would separate the companion projection from the onboarding effects it must preserve. The final review cleanup reduced concepts and net source size rather than layering machinery.

ReviewGPT context sensitivity: sensitive — authentication identity synchronization and a cross-repository onboarding contract.
ReviewGPT first-reviewed head: 1655665417a4a2b007dc76da123fa6225cb32135


