### PR TITLE
fix(runtime): recover unavailable Linq chats

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-29-linq-unavailable-chat-recovery.md
+++ b/agent-docs/exec-plans/active/2026-08-29-linq-unavailable-chat-recovery.md
@@ -1,0 +1,97 @@
+# Recover replies from unavailable Linq chats
+
+Status: active
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Restore an already-supported private Linq reply when its stored direct chat has
+  become unavailable, using the existing safe direct-thread materialization
+  owner and without broadening message, retry, route, or provider authority.
+
+## Success criteria
+
+- A provider-shaped HTTP 409 / Linq code 2013 send failure reaches the same
+  bounded direct-thread materialization path as the existing definitive stale
+  chat classification when every existing recovery precondition holds.
+- The original reply remains single-owner and idempotent; no second send occurs
+  after an ambiguous provider outcome.
+- Other 409s and unclassified failures remain terminal and do not gain fallback.
+- Focused regression tests, affected typechecks, completion audits, exact-head
+  CI, and final ReviewGPT pass are green on the PR head.
+
+## Scope
+
+- In scope: the Linq provider error classifier, the existing hosted direct-chat
+  recovery predicate, focused provider-shaped tests, and durable contract text
+  only where the final implementation changes an operational guarantee.
+- Out of scope: device sync, line selection, message content, copy, retry timing,
+  database schema, provider configuration, production state repair, canaries,
+  and recovery for any failure that could be ambiguous after provider entry.
+
+## Constraints
+
+- Technical constraints: reuse existing error context and direct-thread
+  materialization; add no state owner, queue, scheduler, provider call, or
+  unbounded telemetry. Preserve current home-route, native-reply, media, and
+  idempotency gates.
+- Product/process constraints: ReviewGPT exclusively authors production code and
+  remediation. Production evidence and review packets remain privacy-safe.
+
+## Risks and mitigations
+
+1. Risk: treating a generic conflict as a stale chat could send a duplicate or
+   reroute into the wrong conversation.
+   Mitigation: admit only the exact provider code 2013 / HTTP 409 / send-message
+   tuple and retain every existing direct-thread recovery precondition.
+2. Risk: the provider may have accepted the message before returning failure.
+   Mitigation: rely on the documented resource-state error and test that no
+   transport, timeout, 5xx, generic 409, or unknown 2xxx code gains fallback.
+3. Risk: a recovery attempt can change iMessage delivery behavior unexpectedly.
+   Mitigation: run provider-shaped boundary tests plus the existing hosted
+   delivery recovery suite and inspect the composed outbox path.
+
+## Tasks
+
+1. Add a focused failing test proving code 2013 is currently terminal while the
+   existing safe recovery preconditions are satisfied.
+2. Send ReviewGPT the redacted root-cause and implementation packet.
+3. Inspect and apply only a scoped ReviewGPT patch, then run focused proof.
+4. Commit, push, open the PR, and run preliminary specialists plus final
+   ReviewGPT concurrently with required CI.
+5. Resolve findings, finish the plan, and leave the ordinary bug-fix PR ready
+   for human merge.
+
+## Decisions
+
+- Product UX effort: Patch.
+- Outcome: a member's ordinary reply continues in a valid direct chat when the
+  previously stored Linq chat is definitively unavailable.
+- Reaches: private Linq replies using existing direct-thread recovery authority.
+- Proof: a provider-shaped code-2013 regression reaches one materialization
+  attempt and one accepted send, while generic conflicts remain terminal.
+- Production root cause: one terminal reply received HTTP 409 / provider code
+  2013; current classification admits only HTTP 404 `chat_not_found` to the
+  existing materialization path.
+
+## Verification
+
+- Red proof: the provider-shaped code-2013 assistant-runtime regression failed
+  with the original HTTP 409 `VaultCliError` before the implementation patch.
+- Green proof: the full hosted-provider-effects test file passes 24/24 and the
+  full HTTP Linq runtime test file passes 74/74 after the patch.
+- Boundary proof: the classifier accepts only the existing 404
+  `chat_not_found` tuple and the exact 409/code-2013 tuple; generic 404/409,
+  nearby status codes, transport failures, different operations, paths, and
+  providers remain excluded.
+- Type proof: the affected assistant-runtime and operator-config package
+  typechecks pass.
+- Product UX walkthrough: Ready (Patch). The affected member's private reply
+  reaches one newly materialized direct chat and sends once; the existing
+  safety, idempotency, route, media, and ambiguity gates remain unchanged.
+- Changelog decision: update in the same PR because a member can experience the
+  restored reply. Keep the item generic, privacy-safe, and free of incident or
+  provider internals.
+- Remaining gates: repository privacy/identifier guards, changelog proof,
+  preliminary specialists, final ReviewGPT, and exact-head PR checks.

--- a/agent-docs/operations/imessage-deliverability.md
+++ b/agent-docs/operations/imessage-deliverability.md
@@ -144,8 +144,9 @@ V4 cards already in transcripts remain readable but do not expose the editor.
 V6 does not change provider fallback text, pacing, or delivery ownership.
 
 For this contract, the definitive pre-acceptance set also includes an exact
-classified HTTP 404 `chat_not_found`; generic or unclassified 404 responses
-remain outside the fallback path.
+classified HTTP 404 `chat_not_found` or an exact HTTP 409 response with provider
+error code `2013` classified as an unavailable chat; generic 404, generic 409,
+and all unclassified responses remain outside the fallback path.
 
 Same-route inputs accepted during a live inbound turn may update the reply
 message, reaction capability, and idempotency inputs, but they must retain the

--- a/apps/web/changelog/entries/2026-08-29/replies-recover-from-unavailable-chats.json
+++ b/apps/web/changelog/entries/2026-08-29/replies-recover-from-unavailable-chats.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-29",
+  "order": 100,
+  "item": {
+    "id": "replies-recover-from-unavailable-chats",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Replies recover from unavailable chats",
+    "summary": "When a private conversation becomes unavailable, Murph can open a valid direct chat and continue the reply.",
+    "details": "Recovery is limited to definitive unavailable-chat failures; ambiguous delivery failures still stop without retrying.",
+    "relevanceTags": ["assistant", "messages", "reliability"],
+    "sourcePullRequests": [2524]
+  }
+}

--- a/packages/assistant-runtime/test/hosted-provider-effects.test.ts
+++ b/packages/assistant-runtime/test/hosted-provider-effects.test.ts
@@ -914,6 +914,75 @@ describe("hosted provider effects", () => {
     );
   });
 
+  it("recovers a definitively unavailable Linq direct chat", async () => {
+    const fetchImplementation = vi.fn(async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/chats/unavailable-chat/messages")) {
+        return new Response(JSON.stringify({
+          error: {
+            code: 2013,
+            message: "This chat is unavailable",
+            status: 409,
+          },
+          success: false,
+          trace_id: "trace-unavailable-chat",
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 409,
+        });
+      }
+      if (url.endsWith("/chats")) {
+        return new Response(JSON.stringify({
+          chat: {
+            id: "recovered-chat",
+            message: {
+              id: "recovered-message",
+            },
+          },
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        });
+      }
+
+      return new Response(null, { status: 500 });
+    });
+
+    await expect(sendHostedProviderLinqMessage({
+      directRecipientPhoneNumber: "+15550001",
+      fromPhoneNumber: "+15550000",
+      homeRouteFallbackAllowed: true,
+      idempotencyKey: "hosted-unavailable-chat",
+      message: "hello",
+      target: "unavailable-chat",
+      targetKind: "thread",
+      threadIsDirect: true,
+    }, {
+      env: {
+        LINQ_API_TOKEN: "linq-token",
+      },
+      fetchImplementation,
+    })).resolves.toEqual({
+      idempotencyKey: "hosted-unavailable-chat",
+      providerMessageEffects: [{
+        message: "hello",
+        providerMessageId: "recovered-message",
+      }],
+      providerMessageId: "recovered-message",
+      providerThreadId: "recovered-chat",
+      target: "recovered-chat",
+    });
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry Linq recovery after an ambiguous create-chat response", async () => {
     const fetchImplementation = vi.fn(async (
       input: RequestInfo | URL,

--- a/packages/operator-config/src/linq-runtime.ts
+++ b/packages/operator-config/src/linq-runtime.ts
@@ -378,9 +378,17 @@ export function isLinqChatNotFoundSendMessageError(
     && error.context?.operation === 'send_message'
     && error.context?.method === 'POST'
     && error.context?.path === '/chats/[chat]/messages'
-    && error.context?.status === 404
     && error.context?.failureStage === 'http'
-    && error.context?.linqFailureKind === 'chat_not_found'
+    && (
+      (
+        error.context?.status === 404
+        && error.context?.linqFailureKind === 'chat_not_found'
+      )
+      || (
+        error.context?.status === 409
+        && error.context?.providerErrorCode === '2013'
+      )
+    )
 }
 
 export function isDefinitiveLinqIMessageAppCardRejection(

--- a/packages/operator-config/test/http-linq-device-runtime.test.ts
+++ b/packages/operator-config/test/http-linq-device-runtime.test.ts
@@ -27,6 +27,7 @@ import {
   createLinqWebhookSubscription,
   deleteLinqMessage,
   isDefinitiveLinqIMessageAppCardRejection,
+  isLinqChatNotFoundSendMessageError,
   markLinqChatRead,
   probeLinqApi,
   sendLinqChatMessage,
@@ -691,6 +692,49 @@ test('linq app-card failure diagnostics do not expose nutrition values', async (
         !serialized.includes('private-chat-route')
     },
   )
+})
+
+test('linq missing-chat classification permits only definitive provider tuples', () => {
+  const createError = (details: Record<string, unknown>): VaultCliError =>
+    new VaultCliError(
+      'LINQ_API_REQUEST_FAILED',
+      'Linq rejected the message.',
+      {
+        failureStage: 'http',
+        method: 'POST',
+        operation: 'send_message',
+        path: '/chats/[chat]/messages',
+        provider: 'linq',
+        retryable: false,
+        ...details,
+      },
+    )
+
+  expect(isLinqChatNotFoundSendMessageError(createError({
+    linqFailureKind: 'chat_not_found',
+    status: 404,
+  }))).toBe(true)
+  expect(isLinqChatNotFoundSendMessageError(createError({
+    providerErrorCode: '2013',
+    status: 409,
+  }))).toBe(true)
+
+  for (const details of [
+    { status: 404 },
+    { status: 409 },
+    { providerErrorCode: '2014', status: 409 },
+    { providerErrorCode: '2013', status: 400 },
+    { providerErrorCode: '2013', status: 408 },
+    { providerErrorCode: '2013', status: 429 },
+    { providerErrorCode: '2013', status: 500 },
+    { failureStage: 'transport', providerErrorCode: '2013', status: 409 },
+    { method: 'GET', providerErrorCode: '2013', status: 409 },
+    { operation: 'create_chat', providerErrorCode: '2013', status: 409 },
+    { path: '/chats', providerErrorCode: '2013', status: 409 },
+    { provider: 'telegram', providerErrorCode: '2013', status: 409 },
+  ]) {
+    expect(isLinqChatNotFoundSendMessageError(createError(details))).toBe(false)
+  }
 })
 
 test('linq app-card rejection classification permits only definitive pre-acceptance statuses', () => {


### PR DESCRIPTION
## Outcome

Private Linq replies now recover through the existing direct-chat materialization path when the provider definitively reports that the stored chat is unavailable. Generic conflicts and ambiguous failures remain terminal.

## Product UX

- Effort: Patch
- Result: Ready
- Affected person: a member replying in an authorized private Linq conversation whose stored provider chat is no longer usable.
- Walkthrough: the original reply materializes one valid direct chat and sends once; all existing direct-route, sender, media, idempotency, and ambiguity gates remain in force.

## Evidence

- A provider-shaped regression reproduced the terminal HTTP 409 before implementation.
- The full hosted provider-effects file passes 24/24.
- The full HTTP Linq runtime file passes 74/74, including exclusions for generic 404/409, nearby status codes, transport failures, other methods, paths, operations, and providers.
- Affected assistant-runtime and operator-config typechecks pass.
- Logging privacy, provider-request ownership, dependency policy, and `git diff --check` pass.

## Architecture and reuse

- Existing systems reused: the Linq error context, existing missing-chat classifier, and direct-thread materialization owner.
- New logic: one exact HTTP 409/provider-code-2013 classifier branch. The recovered path retains the existing maximum of one failed send followed by one create-chat request.
- New abstractions: none, because the existing predicate owns provider classification and the existing fallback owns direct-chat recovery.
- Complexity intentionally avoided: no new state, queue, scheduler, retry policy, provider request, database access, or device-sync behavior.
- Provider input: no new message content or provider-visible fields.

## Deployment concerns

- Deployment: applicable
- Supported skew: the hosted-runtime classifier and Web changelog are independently compatible; unrecognized failures retain their prior terminal behavior.
- Safe order: Cloudflare hosted runtime and the Web changelog may deploy in either order without a tandem compatibility window.
- Rollback floor: the prior runtime revision remains valid because this change has no persisted-state, schema, or provider-contract migration.
- Expected exposure: only authorized private Linq direct replies that receive the exact unavailable-chat classification enter the existing recovery path.
- Reversibility: revert the code-only runtime change through the normal repository workflow; no production state repair is required.
- Convergence proof: canonical deployment workflows must report the merged revision serving Cloudflare and the Web production deployment.
- Post-deploy checks: query bounded `hosted_runtime_linq_delivery` failures for the unavailable-chat classification and confirm natural later direct-chat deliveries reach terminal success without duplicate effects.

## ReviewGPT provenance

- ReviewGPT authored the production classifier patch, boundary tests, and durable contract update from a privacy-safe implementation packet.
- Preliminary specialists passed. Final exact-head ReviewGPT found an accepted native app-card recovery omission; this PR remains draft pending ReviewGPT remediation after the required review-boundary resume.

ReviewGPT first-reviewed head: de461f50875e01426401715fdbfdd135c47f465a

## Changelog

- Changelog: updated
- Items: 2026-08-29 · replies-recover-from-unavailable-chats
- Presentation reference: https://www.withmurph.ai/screenshots/ops#changelog-archive

## LOC

- Source: +10 / -2
- Tests and fixtures: +113 / -0
- Docs and plans: +114 / -2
- Config and tooling: +0 / -0
- Generated and other: +0 / -0
