### PR TITLE
Fix system mailbox import checkpoint handoff

### DIFF
--- a/apps/web/changelog/entries/2026-08-29/device-updates-keep-their-progress.json
+++ b/apps/web/changelog/entries/2026-08-29/device-updates-keep-their-progress.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-29",
+  "order": 100,
+  "item": {
+    "id": "device-updates-keep-their-progress",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Device updates keep their progress",
+    "summary": "When a device update and a new conversation overlap, Murph now keeps the progress the device update has already made.",
+    "details": "Your conversation still comes first, and the device update does not start again from an older saved point.",
+    "relevanceTags": ["assistant", "devices", "reliability"],
+    "sourcePullRequests": [2526]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -2869,6 +2869,11 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
       const returnSystemMailboxModeResult = async (
         extraCandidates: readonly HostedRuntimeWakeCandidate[] = [],
       ): Promise<HostedWorkspaceInvocationResult> => {
+        if (foregroundWakeObserved && importOrStartupCheckpointPending) {
+          await checkpointSystemMailboxMode(
+            "system_mailbox.checkpoint.due_assistant_handoff",
+          );
+        }
         const projectedWake = await resolveCurrentSystemMailboxModeWake(extraCandidates);
         const requestedDefaultOwnerWakeAt = defaultOwnerWakeObserved
           ? new Date(Date.now()).toISOString()

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
@@ -442,6 +442,111 @@ describe("hosted workspace runtime entrypoint", () => {test("fresh foreground in
     }
   });
 
+  test("checkpoints an imported system row before yielding a fetch-race owner handoff", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    const baseDeviceSyncPort = createEmptyDeviceSyncPort();
+    const deviceItem = createMailboxItem({
+      dedupeKey: "device-sync.wake:import-fetch-race",
+      id: "mailbox_item_system_mailbox_import_fetch_race",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      mocks.cancelPendingWarmCodexPreinitialization.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/system-mailbox-import-fetch-race-before.bundle.json",
+        vaultRoot,
+      });
+      const baseMailboxPort = createMailboxPort({
+        events,
+        fetchRequests,
+        items: [deviceItem],
+      });
+      const mailboxPort: HostedRuntimeMailboxPort = {
+        ...baseMailboxPort,
+        async fetch(request) {
+          runtimeWakeSignal.notify({ requestedProcessingMode: "default" });
+          return await baseMailboxPort.fetch(request);
+        },
+      };
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_system_mailbox_import_fetch_race",
+            processingMode: "system_mailbox",
+            workspaceVersion: "0",
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "1".repeat(64),
+                key: "users/bundles/member-synthetic/system-mailbox-import-fetch-race.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            await enqueueDeviceSyncSystemMailboxItemForTest({
+              item: deviceItem,
+              vaultRoot,
+            });
+            return { status: "imported" as const };
+          },
+          platform: createPlatform({
+            artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
+            deviceSyncPort: baseDeviceSyncPort,
+            mailboxPort,
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({
+                snapshotRef: restoredWorkspace.snapshotRef,
+                version: "0",
+              }),
+            }),
+          }),
+          runtimeWakeSignal,
+          async runAssistantPhase() {
+            throw new Error("System mailbox mode must not enter assistant phase.");
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.equal(result.immediateRecheckRequested, true);
+      assert.equal(result.nextWakeAt, TEST_NOW);
+      assert.equal(result.nextWakeReason, "assistant");
+      assert.equal(baseDeviceSyncPort.fetchSnapshotCalls, 0);
+      assert.equal(baseDeviceSyncPort.fetchDirtyStatesCalls, 0);
+      assert.equal(fetchRequests.length, 2);
+      assert.equal(checkpointRequests.length, 1);
+      assert.equal(
+        checkpointRequests[0]?.redactedStatus?.hostedMailboxSystemImportedSeq,
+        "1",
+      );
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.equal(mocks.cancelPendingWarmCodexPreinitialization.mock.calls.length, 0);
+      assert.equal((await readHostedSystemMailboxState(vaultRoot)).pending.length, 1);
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("foreground input during a blocked system pass yields after checkpointing the bounded unit once", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];


### PR DESCRIPTION
## Why and outcome

A foreground/default-owner wake could arrive after a system-mailbox row changed the restored vault but before that import was checkpointed. The runtime then handed off immediately, restored the older snapshot on the next alarm, and imported the same device wake again.

Checkpoint pending imported/startup state before returning that handoff. Empty fetches remain checkpoint-free, and fresh member messages still retain priority over device work.

## Product UX

- Effort: Patch
- Outcome: Device updates survive an overlapping conversation instead of repeatedly restarting.
- Reaches: Members whose device mailbox work overlaps a fresh message.
- Proof: The synthetic fetch-race journey preserves the imported watermark in one checkpoint, keeps the device row pending, performs no device pass, and immediately returns the assistant wake.
- Walkthrough: Ready. The device-sync member recovers durable progress; the concurrently messaging member still reaches the foreground owner before model-free device work starts.

## Evidence

- New regression failed on `main` with zero checkpoints where one was required.
- The exact two-file patch passed all 27 system-preemption tests and the assistant-runtime package typecheck before transfer to the sanctioned worktree.
- The ReviewGPT-authored changelog fragment passes its focused archive test (9/9) and the hosted Web typecheck.
- `git diff --check` passes and the sanctioned checkout contains the exact reviewed file contents.
- A redundant sanctioned-worktree rerun was stopped after prolonged shared-host contention without a test failure; exact-head CI remains the fresh-host broad proof owner.

## Non-obvious affected surfaces

- Hosted system-mailbox owner handoff: required to persist the import watermark before releasing ownership; covered by the focused fetch-race regression.
- Cloudflare hosted runner bundle: consumes assistant-runtime source at deployment; no Worker protocol, schema, binding, or configuration changes.

## Architecture and reuse

- Existing systems reused: The existing system-mailbox checkpoint owner and foreground-wake selection.
- New logic: One guard checkpoints only when a foreground wake and pending imported/startup state coexist.
- New abstractions: None; the existing handoff result helper owns the ordering correction.
- Complexity intentionally avoided: No new queue, scheduler, retry loop, state owner, provider branch, or compatibility path.

## Hot reply path impact

- Affected only in the rare overlap where a background system-mailbox invocation imported state before observing a fresh foreground wake.
- Adds at most one existing checkpoint operation before the immediate foreground recheck: one snapshot persistence and its existing workspace checkpoint write/CAS path.
- Adds no provider/model call, device collection, retry loop, or unbounded work. Empty or unchanged imports add no checkpoint.
- Foreground priority is preserved: no model-free device pass starts after the wake is observed.

## Murph initial provider input impact

- Assistant runtime: Not applicable; no prompt, instructions, tool schema, or provider-visible input changed.
- Group runtime: Not applicable; no prompt, instructions, tool schema, or provider-visible input changed.

## Design proof

Not applicable. No hosted Web presentation or interaction changed.

## Change-shape breakdown

Classification rule: production TypeScript is source; the focused Vitest file is tests/fixtures; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 0 |
| Tests/fixtures | 105 | 0 |
| Docs | 14 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 124 | 0 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new runner code share the same protocol, persisted state, and bindings.
- Safe order: Merge after required gates, then run the normal Cloudflare hosted-runtime deployment; no Vercel tandem deploy is required.
- Rollback floor: Safe because no state or protocol shape changes.
- Expected exposure: Existing old runner instances can retain the race until rollout convergence.
- Reversibility: Revert the runtime patch and redeploy; no data migration or repair is required.
- Convergence proof: Verify the deployed Worker/runner revision through repository smoke and deployment metadata.
- Post-deploy checks: Compare bounded repeated-import aggregates and confirm device-wake and dirty-revision backlogs begin draining without foreground-priority regressions.

## Changelog

- Changelog: updated
- Items: 2026-08-29 · device-updates-keep-their-progress

ReviewGPT first-reviewed head: 788477b51c357d513e7a8826d512580872b3ca8a

ReviewGPT context sensitivity: sensitive — hosted execution ordering, checkpoint durability, concurrency, and foreground priority change.

## Risks

- Correctness: A checkpoint failure still fails closed through the existing checkpoint owner instead of losing imported progress.
- Privacy: No production evidence, identifiers, payloads, health values, or provider data are included.
- Deferred work: None in the patch; production backlog convergence is verified after deployment rather than triggering replay or resync.
