### PR TITLE
Add assistant notification validation telemetry

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-29-assistant-notification-validation-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-29-assistant-notification-validation-telemetry.md
@@ -1,0 +1,183 @@
+# Assistant-notification validation telemetry
+
+Status: active
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+Attribute each hosted `ASSISTANT_NOTIFICATION_INVALID_RESPONSE` retry warning to
+its exact current validation boundary using one closed, privacy-safe field on
+the existing `mailbox.system_processed` log, without changing notification
+behavior or durable state.
+
+## Success criteria
+
+- Every current throw site for `ASSISTANT_NOTIFICATION_INVALID_RESPONSE` carries
+  exactly one compile-time closed validation reason.
+- The reason survives the existing assistant-notification error context and
+  structured-redaction boundary into the existing system-mailbox warning.
+- Provider output, prompts, messages, payloads, identifiers, paths, stacks, raw
+  errors, and free-form reason values cannot enter the emitted field.
+- Existing error codes and messages, retryability, attempt increments,
+  one-minute retry scheduling, wake ownership, delivery, and persisted mailbox
+  state remain unchanged.
+- Focused owner-package tests cover all four validation branches, redaction,
+  retry preparation, durable-state exclusion, and warning emission.
+- The hosted-runtime observability contract documents the vocabulary, privacy
+  boundary, zero-volume-change claim, and bounded post-deploy query.
+
+## Scope
+
+- In scope:
+  - `packages/assistant-engine/src/assistant/notification-turn.ts`
+  - `packages/hosted-execution/src/observability.ts`
+  - `packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts`
+  - `packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts`
+  - focused tests in those owning packages
+  - `docs/hosted-runtime-log-database.md`
+  - this execution plan
+- Out of scope:
+  - retry caps, drops, reclassification, rescheduling, or terminalization
+  - device-sync code or behavior
+  - new events, success-path logs, metrics, backends, tables, queues, schedulers,
+    alerts, requests, timers, persistence, configuration, or migrations
+  - provider, user-visible, canonical-state, auth, billing, or delivery changes
+
+## Constraints
+
+- Base implementation packet: `5cb8a299b41ba8d097bd1401364d83c28e2132db`.
+- The vocabulary is exactly:
+  - `decision_json_unparseable`
+  - `decision_schema_invalid`
+  - `runtime_presentation_non_send_decision`
+  - `creative_response_media_invalid`
+- The field name is
+  `assistantNotificationValidationFailureReason` and remains optional for
+  old/new runner schema compatibility.
+- No private response content or distinctive scenario data may be logged.
+- No `as any`, `as unknown`, or double assertion is permitted.
+- The deployment is Cloudflare-hosted-runner-only and code-only reversible.
+
+## Risks and mitigations
+
+1. Risk: an unconstrained string turns provider content into high-cardinality
+   telemetry.
+   Mitigation: define the literals once in hosted-execution, expose a type guard,
+   and omit values outside that exact vocabulary at the redaction boundary.
+2. Risk: adding telemetry accidentally changes mailbox retry state.
+   Mitigation: derive the reason after the existing normalized failure, return it
+   only in ephemeral checkpoint preparation, and assert it is absent from the
+   persisted pending item while the existing retry timestamp remains exact.
+3. Risk: mixed old/new runners produce missing fields during rollout.
+   Mitigation: keep the field optional and query missing values as `NULL`; do not
+   require a migration or synchronized consumer deployment.
+4. Risk: verification creates user-visible or production traffic.
+   Mitigation: use synthetic local tests before deploy and natural traffic only
+   after serving-revision proof.
+
+## Tasks
+
+1. [x] Enumerate every current `ASSISTANT_NOTIFICATION_INVALID_RESPONSE` throw
+   site and derive the four-value semantic vocabulary.
+2. [x] Attach the typed reason to the existing `VaultCliError` context without
+   changing codes, messages, or control flow.
+3. [x] Allow only the closed values through hosted-execution structured
+   redaction and carry the result through retry preparation.
+4. [x] Add the optional field to the existing `mailbox.system_processed`
+   warning without adding log volume or persistence.
+5. [x] Add focused synthetic tests for all validators, privacy filtering,
+   retry scheduling/state, and warning propagation.
+6. [x] Update the durable hosted-runtime observability contract.
+7. [ ] Merge through the public repository review path and deploy only through
+   the protected Cloudflare hosted-runner workflow.
+8. [ ] Prove the serving Cloudflare hosted-runner revision after deployment.
+9. [ ] Wait for natural traffic, then run the fixed latest/predecessor four-hour,
+   rolling 24-hour, and rolling seven-day aggregate queries documented in
+   `docs/hosted-runtime-log-database.md`.
+10. [ ] Record zero events when there is no natural recurrence; do not generate
+    production traffic.
+
+## Decisions
+
+- Product UX is not applicable: the PR is telemetry-only and has no user-visible
+  state, copy, interaction, or delivery change.
+- ReviewGPT authored the production patch.
+- The PR is telemetry-only.
+- The ordinary system-mailbox retry owner remains unchanged until root cause is
+  known.
+- The field is ephemeral observability, not canonical or durable mailbox state.
+- No Vercel tandem deployment is required or permitted for this patch.
+
+## Verification
+
+Run from an exact repository checkout with dependencies installed:
+
+```bash
+pnpm --dir packages/hosted-execution test -- \
+  test/hosted-execution-observability-side-effects.test.ts
+pnpm --dir packages/assistant-engine test -- \
+  test/assistant-notification-turn-runtime.test.ts
+pnpm --dir packages/assistant-runtime test -- \
+  test/hosted-runtime-system-mailbox-notification.test.ts \
+  test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
+pnpm --dir packages/hosted-execution typecheck
+pnpm --dir packages/assistant-engine typecheck
+pnpm --dir packages/assistant-runtime typecheck
+pnpm docs:drift
+pnpm docs:gardening
+```
+
+Expected outcomes:
+
+- all four reason assertions pass with unchanged error codes and messages;
+- hostile/private marker strings are absent after redaction and retry
+  preparation;
+- the pending mailbox item retains the existing one-minute retry and contains no
+  telemetry field;
+- the existing `mailbox.system_processed` warning carries the closed reason
+  in its `redactedJson`;
+- all touched packages typecheck and documentation guards pass.
+
+Candidate evidence:
+
+- Accepted ReviewGPT implementation artifact SHA-256:
+  `ae7d3cedcb90c32dd3d4837dfcb4ed89640e84b849668b7500db56e528c67015`.
+- Passed focused Vitest: 29 hosted-execution privacy/redaction tests, 80
+  assistant-engine notification-validator tests, and 141 assistant-runtime
+  system-mailbox and warning-emission tests.
+- Passed affected-package typechecks for `hosted-execution`,
+  `assistant-engine`, and `assistant-runtime`.
+- Passed raw-log privacy, provider-request boundary, agent-doc drift,
+  documentation gardening, and diff-hygiene guards.
+- Parent inspection accepted every implementation hunk without modification:
+  the parser remains behavior-equivalent, annotation preserves the typed error
+  context, the retry delay and durable state are unchanged, and no device-sync
+  path is modified.
+
+## Deployment and rollback
+
+1. Merge the public repository PR after required review and exact-head checks.
+2. Deploy through the protected Cloudflare hosted-runner workflow only.
+3. Prove the serving revision before interpreting natural-traffic results.
+4. Do not deploy Vercel, run a migration, add a binding or secret, change a
+   permission, queue, or configuration, or coordinate a tandem rollout.
+5. Roll back by redeploying the prior Cloudflare hosted-runner revision. The
+   optional field requires no data rollback, migration reversal, or consumer
+   coordination.
+
+## Post-deploy observation
+
+Use one fixed observation end timestamp. Run the documented aggregate query for
+these four windows:
+
+1. latest four hours: `[end - 4h, end)`;
+2. predecessor four hours: `[end - 8h, end - 4h)`;
+3. rolling 24 hours: `[end - 24h, end)`;
+4. rolling seven days: `[end - 7d, end)`.
+
+Filter only `event_code = 'mailbox.system_processed'` and
+`error_code = 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE'`. Group only by the
+closed reason, `status`, `wakeKind`, and `routeAction`; return event count,
+privacy-safe distinct-subject count, minimum/maximum attempt count, and
+first/last timestamps. Never return subject keys or raw JSON.

--- a/agent-docs/exec-plans/completed/2026-08-29-assistant-notification-validation-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-assistant-notification-validation-telemetry.md
@@ -1,6 +1,6 @@
 # Assistant-notification validation telemetry
 
-Status: active
+Status: completed
 Created: 2026-08-29
 Updated: 2026-08-29
 
@@ -89,8 +89,9 @@ behavior or durable state.
 5. [x] Add focused synthetic tests for all validators, privacy filtering,
    retry scheduling/state, and warning propagation.
 6. [x] Update the durable hosted-runtime observability contract.
-7. [ ] Merge through the public repository review path and deploy only through
-   the protected Cloudflare hosted-runner workflow.
+7. [x] Prepare the public telemetry-only PR for exact-head checks and human
+   merge; do not cross the protected private deployment boundary from this
+   repository-only automation.
 8. [ ] Prove the serving Cloudflare hosted-runner revision after deployment.
 9. [ ] Wait for natural traffic, then run the fixed latest/predecessor four-hour,
    rolling 24-hour, and rolling seven-day aggregate queries documented in
@@ -154,6 +155,20 @@ Candidate evidence:
   the parser remains behavior-equivalent, annotation preserves the typed error
   context, the retry delay and durable state are unchanged, and no device-sync
   path is modified.
+- The preliminary completion-specialists ReviewGPT pass found that the original
+  producer and consumer assertions were not composed through the real mailbox
+  boundary. That finding was accepted.
+- ReviewGPT supplied the one-file, test-only remediation through the declared
+  `@murphai/assistant-engine/assistant-codex` public entrypoint. The applied
+  result has the exact ReviewGPT-declared Git blob
+  `d55974ffc199850ad0005549dd25059a297d2661`; no production source changed.
+- The new real-boundary regression passed alone, all 81 tests in its affected
+  runtime test file passed together, and `@murphai/assistant-runtime` typecheck
+  passed after remediation.
+- Final cross-cutting ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` on the
+  exact production candidate head with no findings. Per the final-gate rule,
+  the later isolated regression-test correction requires focused verification
+  and CI, not another substantive final round.
 
 ## Deployment and rollback
 
@@ -181,3 +196,4 @@ Filter only `event_code = 'mailbox.system_processed'` and
 closed reason, `status`, `wakeKind`, and `routeAction`; return event count,
 privacy-safe distinct-subject count, minimum/maximum attempt count, and
 first/last timestamps. Never return subject keys or raw JSON.
+Completed: 2026-08-29

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -101,6 +101,75 @@ conversation and turn-scoped automation overrides resolve and is the normalized
 value passed to the Codex provider attempt. Raw provider configuration, prompts,
 messages, credentials, and paths remain excluded.
 
+### Assistant-notification validation attribution
+
+An existing `mailbox.system_processed` warning with
+`error_code = 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE'` may include the
+optional `redacted_json.assistantNotificationValidationFailureReason` field.
+The field is a closed validation-boundary vocabulary:
+
+- `decision_json_unparseable`: no parseable JSON decision object was present.
+- `decision_schema_invalid`: a parsed JSON object failed the notification
+  decision schema.
+- `runtime_presentation_non_send_decision`: a runtime-owned presentation was
+  paired with a decision other than `send_message`.
+- `creative_response_media_invalid`: creative-response media was not exactly
+  one generated voice memo.
+
+Only those four literal values pass the existing assistant-notification
+structured-redaction allowlist. Provider output, response text, prompts,
+messages, payloads, route values, identifiers, paths, stacks, and free-form
+errors are not copied into this field. The value is pass-local observability:
+it is not written into system-mailbox state and does not alter validation,
+retryability, attempt counts, wake selection, delivery, or canonical state.
+
+This is a zero-volume-change extension. It adds no event, success-path log,
+metric, database write, request, queue, timer, await, or fanout. For a retrying
+validation failure, a new runner attaches the field to the already-emitted
+warning; older runners and unrelated warnings remain schema-compatible because
+the field is optional.
+
+For post-deploy verification, choose one fixed observation end timestamp and
+run the query below separately for the latest four-hour window, its immediately
+preceding four-hour window, the rolling 24-hour window, and the rolling
+seven-day window. Supply fixed `:window_start` and `:window_end` values for each
+run so the windows do not move while results are compared. A `NULL` reason is
+the unattributed mixed-version bucket:
+
+```sql
+SELECT
+  redacted_json->>'assistantNotificationValidationFailureReason'
+    AS assistant_notification_validation_failure_reason,
+  redacted_json->>'status' AS status,
+  redacted_json->>'wakeKind' AS wake_kind,
+  redacted_json->>'routeAction' AS route_action,
+  COUNT(*) AS event_count,
+  COUNT(DISTINCT subject_key) AS distinct_subject_count,
+  MIN((redacted_json->>'attemptCount')::bigint) AS min_attempt_count,
+  MAX((redacted_json->>'attemptCount')::bigint) AS max_attempt_count,
+  MIN(at) AS first_at,
+  MAX(at) AS last_at
+FROM hosted_runtime_log
+WHERE at >= :window_start
+  AND at < :window_end
+  AND event_code = 'mailbox.system_processed'
+  AND error_code = 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE'
+GROUP BY
+  redacted_json->>'assistantNotificationValidationFailureReason',
+  redacted_json->>'status',
+  redacted_json->>'wakeKind',
+  redacted_json->>'routeAction'
+ORDER BY
+  assistant_notification_validation_failure_reason,
+  status,
+  wake_kind,
+  route_action;
+```
+
+Return only those aggregates. Never return `subject_key` values or raw JSON.
+If natural traffic produces no recurrence, report zero events; do not generate
+production traffic to exercise the telemetry.
+
 ## Append and deletion serialization
 
 Every append runs in one short transaction:

--- a/packages/assistant-engine/src/assistant/notification-turn.ts
+++ b/packages/assistant-engine/src/assistant/notification-turn.ts
@@ -10,6 +10,9 @@ import {
   createHostedExecutionPrivateAssistantAskCompletionDeliveryKey,
 } from '@murphai/hosted-execution/assistant-identifiers'
 import type {
+  HostedAssistantNotificationValidationFailureReason,
+} from '@murphai/hosted-execution'
+import type {
   HostedRuntimeGroupEmailEffectResponse,
 } from '@murphai/hosted-execution/runtime-control'
 import type { AutomationScheduleKind } from '@murphai/contracts'
@@ -676,8 +679,8 @@ export async function sendAssistantNotificationLocal(
                   runtimeResponse: providerResult.response,
                 })
           if (runtimeOwnsFinalPresentation && decision.kind !== 'send_message') {
-            throw new VaultCliError(
-              'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+            throw createAssistantNotificationInvalidResponseError(
+              'runtime_presentation_non_send_decision',
               'A runtime-owned notification presentation requires a send_message decision.',
             )
           }
@@ -2071,19 +2074,27 @@ export function parseAssistantNotificationDecision(
   } catch (error) {
     const extracted = tryExtractAssistantNotificationDecisionObject(normalized)
     if (!extracted) {
-      throw new VaultCliError(
-        'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      throw createAssistantNotificationInvalidResponseError(
+        'decision_json_unparseable',
         'Assistant notification turn must return a single valid JSON decision object.',
       )
     }
 
+    let parsedDecision: unknown
     try {
-      return assistantNotificationDecisionSchema.parse(
-        JSON.parse(extracted),
-      )
+      parsedDecision = JSON.parse(extracted)
     } catch {
-      throw new VaultCliError(
-        'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      throw createAssistantNotificationInvalidResponseError(
+        'decision_json_unparseable',
+        'Assistant notification turn returned an invalid decision object.',
+      )
+    }
+
+    try {
+      return assistantNotificationDecisionSchema.parse(parsedDecision)
+    } catch {
+      throw createAssistantNotificationInvalidResponseError(
+        'decision_schema_invalid',
         'Assistant notification turn returned an invalid decision object.',
       )
     }
@@ -2148,12 +2159,23 @@ function resolveAssistantNotificationResponseMedia(input: {
   }
   const media = normalizeAssistantResponseMediaList(input.responseMedia)
   if (media.length !== 1 || media[0]?.kind !== 'voice_memo') {
-    throw new VaultCliError(
-      'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+    throw createAssistantNotificationInvalidResponseError(
+      'creative_response_media_invalid',
       'A song notification requires exactly one generated song attachment.',
     )
   }
   return media
+}
+
+function createAssistantNotificationInvalidResponseError(
+  reason: HostedAssistantNotificationValidationFailureReason,
+  message: string,
+): VaultCliError {
+  return new VaultCliError(
+    'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+    message,
+    { assistantNotificationValidationFailureReason: reason },
+  )
 }
 
 function normalizeAssistantNotificationDecisionJson(value: string): string {

--- a/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-notification-turn-runtime.test.ts
@@ -3869,6 +3869,12 @@ test('sendAssistantNotificationLocal rejects an append-only clarification after 
     vault: '/vaults/scheduled-local-time-clarification-skip',
   })).rejects.toMatchObject({
     code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+    context: {
+      assistantNotificationValidationFailureReason:
+        'runtime_presentation_non_send_decision',
+    },
+    message:
+      'A runtime-owned notification presentation requires a send_message decision.',
   })
 
   expect(deliverMessage).not.toHaveBeenCalled()
@@ -4142,9 +4148,14 @@ test('sendAssistantNotificationLocal rejects a selected song without generated m
     vault: '/vaults/group-sponsorship-text',
   })).rejects.toMatchObject({
     code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+    context: {
+      assistantNotificationValidationFailureReason:
+        'creative_response_media_invalid',
+    },
     details: expect.objectContaining({
       assistantNotificationProviderNonReplayableWork: false,
     }),
+    message: 'A song notification requires exactly one generated song attachment.',
   })
 
   expect(observedProviderInputs[0]).toMatchObject({
@@ -5474,31 +5485,63 @@ describe('parseAssistantNotificationDecision', () => {
     const { parseAssistantNotificationDecision } = await import(
       '../src/assistant/notification-turn.ts'
     )
+    const captureDecisionError = (value: string): unknown => {
+      try {
+        parseAssistantNotificationDecision(value)
+      } catch (error) {
+        return error
+      }
+      throw new Error('Expected assistant notification decision parsing to fail.')
+    }
+    const hostilePrivateResponse =
+      'HOSTILE_PRIVATE_PROVIDER_RESPONSE_DO_NOT_EMIT_7f3b2f'
 
-    expect(() => parseAssistantNotificationDecision('not json at all')).toThrowError(
-      new VaultCliError(
-        'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+    const unparseableError = captureDecisionError(hostilePrivateResponse)
+    expect(unparseableError).toMatchObject({
+      code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      context: {
+        assistantNotificationValidationFailureReason: 'decision_json_unparseable',
+      },
+      message:
         'Assistant notification turn must return a single valid JSON decision object.',
-      ),
+    })
+    expect(JSON.stringify(unparseableError)).not.toContain(hostilePrivateResponse)
+
+    const malformedJsonError = captureDecisionError(
+      `{"kind":"send_message","text":${hostilePrivateResponse}}`,
     )
-    expect(() =>
-      parseAssistantNotificationDecision('{"kind":"send_message","privateSummary":"brief"}'),
-    ).toThrowError(
-      new VaultCliError(
-        'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
-        'Assistant notification turn returned an invalid decision object.',
-      ),
-    )
-    expect(() =>
-      parseAssistantNotificationDecision(
-        '{"kind":"skip","unexpected":"value","privateSummary":"No action"}',
-      ),
-    ).toThrowError(
-      new VaultCliError(
-        'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
-        'Assistant notification turn returned an invalid decision object.',
-      ),
-    )
+    expect(malformedJsonError).toMatchObject({
+      code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      context: {
+        assistantNotificationValidationFailureReason: 'decision_json_unparseable',
+      },
+      message: 'Assistant notification turn returned an invalid decision object.',
+    })
+    expect(JSON.stringify(malformedJsonError)).not.toContain(hostilePrivateResponse)
+
+    const schemaPrivateResponse =
+      'PRIVATE_SCHEMA_RESPONSE_DO_NOT_EMIT_902c45'
+    const schemaError = captureDecisionError(JSON.stringify({
+      kind: 'send_message',
+      privateSummary: schemaPrivateResponse,
+    }))
+    expect(schemaError).toMatchObject({
+      code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      context: {
+        assistantNotificationValidationFailureReason: 'decision_schema_invalid',
+      },
+      message: 'Assistant notification turn returned an invalid decision object.',
+    })
+    expect(JSON.stringify(schemaError)).not.toContain(schemaPrivateResponse)
+    expect(captureDecisionError(
+      '{"kind":"skip","unexpected":"value","privateSummary":"No action"}',
+    )).toMatchObject({
+      code: 'ASSISTANT_NOTIFICATION_INVALID_RESPONSE',
+      context: {
+        assistantNotificationValidationFailureReason: 'decision_schema_invalid',
+      },
+      message: 'Assistant notification turn returned an invalid decision object.',
+    })
   })
 })
 

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 import {
   buildHostedExecutionSafeErrorDiagnostics,
   deriveHostedExecutionErrorCode,
+  extractHostedAssistantNotificationRedactedDetails,
+  isHostedAssistantNotificationValidationFailureReason,
   readHostedRuntimeSafeErrorText,
   sanitizeHostedExecutionStructuredLogText,
+  type HostedAssistantNotificationValidationFailureReason,
 } from "@murphai/hosted-execution";
 import {
   HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
@@ -94,6 +97,8 @@ export type {
 
 export type HostedSystemMailboxCheckpointPreparation =
   | {
+      assistantNotificationValidationFailureReason?:
+        HostedAssistantNotificationValidationFailureReason;
       attemptCount: number;
       errorCode: string | null;
       errorMessage: string | null;
@@ -567,7 +572,15 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
             wake: prepared.wake,
           })
         : null;
+    const assistantNotificationValidationFailureReason =
+      prepared.wake.kind === "assistant.notification.requested"
+      && normalized.code === "ASSISTANT_NOTIFICATION_INVALID_RESPONSE"
+        ? readHostedAssistantNotificationValidationFailureReason(error)
+        : null;
     return {
+      ...(assistantNotificationValidationFailureReason
+        ? { assistantNotificationValidationFailureReason }
+        : {}),
       attemptCount: prepared.attemptCount,
       errorCode: normalized.code,
       errorMessage: normalized.message,
@@ -580,6 +593,16 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
       wakeKind: prepared.wake.kind,
     };
   }
+}
+
+function readHostedAssistantNotificationValidationFailureReason(
+  error: unknown,
+): HostedAssistantNotificationValidationFailureReason | null {
+  const reason = extractHostedAssistantNotificationRedactedDetails(error)
+    ?.assistantNotificationValidationFailureReason;
+  return isHostedAssistantNotificationValidationFailureReason(reason)
+    ? reason
+    : null;
 }
 
 function shouldResumeHostedBrowserVaultRecordingItemReadOnly(

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -6,6 +6,7 @@ import {
   deriveHostedExecutionErrorCode,
   sanitizeHostedExecutionStructuredLogDetails,
   sanitizeHostedExecutionStructuredLogText,
+  type HostedAssistantNotificationValidationFailureReason,
   type HostedExecutionSystemWake,
   type HostedExecutionRedactedLogEntry,
   type HostedExecutionStructuredLogDetails,
@@ -6414,6 +6415,10 @@ async function runSystemMailboxMaintenancePhase(input: {
     });
   }
   await writeHostedSystemMailboxRuntimeLog({
+    assistantNotificationValidationFailureReason:
+      systemMailboxPreparation.status === "retryable_failed"
+        ? systemMailboxPreparation.assistantNotificationValidationFailureReason ?? null
+        : null,
     assistantAskCompletionFirstAttemptDelayed,
     attemptCount: systemMailboxPreparation.status === "retryable_failed"
       ? systemMailboxPreparation.attemptCount
@@ -8478,6 +8483,8 @@ async function resolveHostedLocalDeviceSyncScheduledWake(
 }
 
 async function writeHostedSystemMailboxRuntimeLog(input: {
+  assistantNotificationValidationFailureReason?:
+    HostedAssistantNotificationValidationFailureReason | null;
   assistantAskCompletionFirstAttemptDelayed?: boolean;
   attemptCount: number | null;
   errorCode?: string | null;
@@ -8517,6 +8524,12 @@ async function writeHostedSystemMailboxRuntimeLog(input: {
       phase: "checkpoint",
       redactedJson: {
         attemptCount: input.attemptCount,
+        ...(input.assistantNotificationValidationFailureReason
+          ? {
+              assistantNotificationValidationFailureReason:
+                input.assistantNotificationValidationFailureReason,
+            }
+          : {}),
         assistantAskCompletionFirstAttemptDelayed:
           input.assistantAskCompletionFirstAttemptDelayed ?? false,
         errorCode: input.errorCode ? errorCode : null,

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -100,6 +100,93 @@ beforeEach(() => {
 });
 
 describe("hosted system mailbox notification execution context", () => {
+  it("carries a closed validation reason without persisting private response text", async () => {
+    const workspace = await createHostedRuntimeWorkspace(
+      "murph-hosted-system-mailbox-validation-reason-",
+    );
+    const privateResponseMarker = "PRIVATE_NOTIFICATION_RESPONSE_b469d7_DO_NOT_EMIT";
+    const wake = buildHostedExecutionAssistantNotificationRequestedWake({
+      eventId: "assistant.notification.requested:validation-reason",
+      memberId: "member_123",
+      notification: {
+        instructions: "Send the prepared account update.",
+        route: {
+          actorId: "+15550001111",
+          channel: "linq",
+          delivery: {
+            kind: "thread",
+            target: "linq_thread_123",
+          },
+          identityId: "hbidx:phone:v1:test",
+          threadId: "linq_thread_123",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: FIXED_NOW,
+    });
+    mocks.executeHostedMailboxEvent.mockRejectedValueOnce(new VaultCliError(
+      "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+      "Assistant notification turn must return a single valid JSON decision object.",
+      {
+        assistantNotificationValidationFailureReason: "decision_json_unparseable",
+        providerResponse: privateResponseMarker,
+      },
+    ));
+
+    try {
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedNotificationItem({
+          dedupeKey: wake.eventId,
+          id: "mailbox_notification_validation_reason",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake,
+      });
+
+      const preparation = await prepareHostedSystemMailboxItemForCheckpoint({
+        executionContext: null,
+        now: () => FIXED_NOW,
+        runtime: createRuntime({}),
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+
+      expect(preparation).toMatchObject({
+        assistantNotificationValidationFailureReason: "decision_json_unparseable",
+        attemptCount: 1,
+        errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+        errorMessage:
+          "Assistant notification turn must return a single valid JSON decision object.",
+        itemId: "mailbox_notification_validation_reason",
+        nextWakeAt: "2026-04-27T00:01:00.000Z",
+        nextWakeReason: null,
+        routeAction: "dispatch-assistant-notification",
+        status: "retryable_failed",
+        wakeKind: "assistant.notification.requested",
+      });
+      expect(JSON.stringify(preparation)).not.toContain(privateResponseMarker);
+
+      const state = await readHostedSystemMailboxState(workspace.vaultRoot);
+      expect(state.pending).toEqual([
+        expect.objectContaining({
+          attemptCount: 1,
+          itemId: "mailbox_notification_validation_reason",
+          lastErrorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+          lastErrorMessage:
+            "Assistant notification turn must return a single valid JSON decision object.",
+          nextAttemptAt: "2026-04-27T00:01:00.000Z",
+          status: "pending",
+        }),
+      ]);
+      expect(state.pending[0]).not.toHaveProperty(
+        "assistantNotificationValidationFailureReason",
+      );
+      expect(JSON.stringify(state)).not.toContain(privateResponseMarker);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
   it("deletes staged environment audio only after the checkpoint boundary", async () => {
     const workspace = await createHostedRuntimeWorkspace(
       "murph-hosted-system-mailbox-",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
@@ -4154,22 +4154,29 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
     expect(mocks.recordHostedDeviceSyncDirtyPostCheckpointRecord).not.toHaveBeenCalled();
   });
 
-  it("does not record a retryable mailbox item during an unrelated checkpoint", async () => {
+  it("emits a closed validation reason without recording a retryable mailbox item", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
-    mocks.readHostedProviderCleanupCheckpoint.mockResolvedValueOnce({
-      nextWakeAt: null,
-    });
-    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce({
+    const privateResponseMarker = "PRIVATE_WARNING_RESPONSE_a4158c_DO_NOT_EMIT";
+    const retryablePreparation = {
+      assistantNotificationValidationFailureReason: "decision_json_unparseable",
       attemptCount: 2,
-      errorCode: "system_mailbox.retryable",
-      errorMessage: "redacted",
+      errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+      errorMessage:
+        "Assistant notification turn must return a single valid JSON decision object.",
       itemId: "system_mailbox_item_retryable",
       legacyUsageReferralAuthorityClassification: null,
       nextWakeAt: "2026-04-27T00:10:00.000Z",
+      providerResponse: privateResponseMarker,
       routeAction: "dispatch-assistant-notification",
       status: "retryable_failed",
       wakeKind: "assistant.notification.requested",
+    } as const;
+    mocks.readHostedProviderCleanupCheckpoint.mockResolvedValueOnce({
+      nextWakeAt: null,
     });
+    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce(
+      retryablePreparation,
+    );
 
     const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
       logRequests,
@@ -4184,11 +4191,17 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       ),
     ).toEqual([
       expect.objectContaining({
+        level: "warn",
         redactedJson: expect.objectContaining({
+          assistantNotificationValidationFailureReason: "decision_json_unparseable",
+          errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+          routeAction: "dispatch-assistant-notification",
           status: "retryable_failed",
+          wakeKind: "assistant.notification.requested",
         }),
       }),
     ]);
+    expect(JSON.stringify(logRequests)).not.toContain(privateResponseMarker);
   });
 
   it("preserves a device-sync mailbox follow-up wake after recording the mailbox item", async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
@@ -2,6 +2,7 @@ import {
   createCodexAuthSystemMailboxItem,
   createDeliveryEffect,
   createDueAssistantWorkspace,
+  createExternalCompletionSystemMailboxItem,
   createFailedDeliveryOutcome,
   createMemberActivationSignupWelcomeSystemMailboxItem,
   createPhaseInput,
@@ -10,6 +11,7 @@ import {
   createSystemMailboxItem,
   createTerminalFailureOutboxIntent,
   expectAssistantLaneCallWithoutDeviceSyncOptions,
+  loadHostedSystemMailboxRealImplementation,
   mocks,
   resolveHostedPendingAssistantInputWakeAtWithRealImplementation,
   seedDirectLinqAssistantInputRoute,
@@ -54,6 +56,9 @@ import {
   type AssistantExecutionContext,
 } from "@murphai/assistant-engine";
 import {
+  executeCodexAppServerTurn,
+} from "@murphai/assistant-engine/assistant-codex";
+import {
   runHostedWorkspaceAssistantPhase,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
@@ -63,6 +68,13 @@ import {
   readExistingHostedPendingAssistantInputIds,
   resolveHostedPendingAssistantInputStatePath,
 } from "../src/hosted-runtime/pending-input-index.ts";
+
+vi.mock("@murphai/assistant-engine/assistant-codex", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@murphai/assistant-engine/assistant-codex")
+  >()),
+  executeCodexAppServerTurn: vi.fn(),
+}));
 
 describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes foreground delivery finished timing after deferred delivery drains", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
@@ -4154,54 +4166,127 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
     expect(mocks.recordHostedDeviceSyncDirtyPostCheckpointRecord).not.toHaveBeenCalled();
   });
 
-  it("emits a closed validation reason without recording a retryable mailbox item", async () => {
+  it("composes invalid assistant notification responses through the mailbox retry log", async () => {
+    const now = "2026-04-27T00:02:00.000Z";
+    const nextWakeAt = new Date(Date.parse(now) + 60_000).toISOString();
+    const hostileResponseMarker =
+      "HOSTILE_PRIVATE_PROVIDER_RESPONSE_DO_NOT_EMIT_a4158c";
     const logRequests: HostedRuntimeLogRequest[] = [];
-    const privateResponseMarker = "PRIVATE_WARNING_RESPONSE_a4158c_DO_NOT_EMIT";
-    const retryablePreparation = {
-      assistantNotificationValidationFailureReason: "decision_json_unparseable",
-      attemptCount: 2,
-      errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
-      errorMessage:
-        "Assistant notification turn must return a single valid JSON decision object.",
-      itemId: "system_mailbox_item_retryable",
-      legacyUsageReferralAuthorityClassification: null,
-      nextWakeAt: "2026-04-27T00:10:00.000Z",
-      providerResponse: privateResponseMarker,
-      routeAction: "dispatch-assistant-notification",
-      status: "retryable_failed",
-      wakeKind: "assistant.notification.requested",
-    } as const;
-    mocks.readHostedProviderCleanupCheckpoint.mockResolvedValueOnce({
-      nextWakeAt: null,
-    });
-    mocks.prepareHostedSystemMailboxItemForCheckpoint.mockResolvedValueOnce(
-      retryablePreparation,
+    const parentRoot = await mkdtemp(
+      path.join(tmpdir(), "hosted-notification-validation-"),
     );
+    const operatorHomeRoot = path.join(parentRoot, "home");
+    const vaultRoot = path.join(parentRoot, "vault");
+    const systemMailbox = await loadHostedSystemMailboxRealImplementation();
+    const baseMailboxItem = createExternalCompletionSystemMailboxItem({
+      dedupeKey:
+        "assistant.notification.requested:phone-call-result:validation-reason",
+    });
+    const mailboxItem = {
+      ...baseMailboxItem,
+      attemptCount: 0,
+      wake: {
+        ...baseMailboxItem.wake,
+        notification: {
+          ...baseMailboxItem.wake.notification,
+          responsePolicy: { kind: "require_send" as const },
+        },
+      },
+    };
 
-    const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
-      logRequests,
-      now: () => "2026-04-27T00:00:00.000Z",
-    }));
-    await result.afterCheckpoint?.();
+    vi.mocked(executeCodexAppServerTurn).mockResolvedValueOnce({
+      acceptedNoReplyDeliveryContextOrdinals: [],
+      additionalUsages: [],
+      finalAction: null,
+      finalActionExplicit: false,
+      finalMessage: hostileResponseMarker,
+      jsonEvents: [],
+      precedingAgentMessageSegments: [],
+      providerActionCount: 0,
+      reactions: [],
+      responseCard: null,
+      responseDeliveryContextOrdinal: 0,
+      responseMedia: [],
+      rolloutRelativePath: null,
+      runtimeIssueInputs: [],
+      sessionId: "codex-thread-notification-validation",
+      stderr: "",
+      stdout: "",
+      targetInputId: null,
+      threadId: "codex-thread-notification-validation",
+      transcriptMessage: hostileResponseMarker,
+      turnId: "codex-turn-notification-validation",
+    });
 
-    expect(mocks.recordHostedSystemMailboxItemAfterCheckpoint).not.toHaveBeenCalled();
-    expect(
-      logRequests.flatMap((request) => request.entries).filter((entry) =>
-        entry.eventCode === "mailbox.system_processed"
-      ),
-    ).toEqual([
-      expect.objectContaining({
-        level: "warn",
-        redactedJson: expect.objectContaining({
-          assistantNotificationValidationFailureReason: "decision_json_unparseable",
-          errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
-          routeAction: "dispatch-assistant-notification",
-          status: "retryable_failed",
-          wakeKind: "assistant.notification.requested",
+    try {
+      await initializeVault({ createdAt: now, vaultRoot });
+      await mkdir(operatorHomeRoot, { recursive: true });
+      await systemMailbox.restoreHostedSystemMailboxCheckpointRollbackState({
+        state: {
+          pending: [mailboxItem],
+        },
+        vaultRoot,
+      });
+      mocks.prepareHostedSystemMailboxItemForCheckpoint.mockImplementation(
+        (request) =>
+          systemMailbox.prepareHostedSystemMailboxItemForCheckpoint({
+            ...request,
+            now: () => now,
+          }),
+      );
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        logRequests,
+        now: () => now,
+        operatorHomeRoot,
+        vaultRoot,
+      }));
+      await result.afterCheckpoint?.();
+
+      expect(executeCodexAppServerTurn).toHaveBeenCalledTimes(1);
+      expect(result.nextWakeAt).toBe(nextWakeAt);
+      expect(
+        mocks.recordHostedSystemMailboxItemAfterCheckpoint,
+      ).not.toHaveBeenCalled();
+      const parsedLogRequests = logRequests.map((request) =>
+        parseHostedRuntimeLogRequest(request),
+      );
+      expect(
+        parsedLogRequests.flatMap((request) => request.entries).filter((entry) =>
+          entry.eventCode === "mailbox.system_processed"
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          level: "warn",
+          redactedJson: expect.objectContaining({
+            assistantNotificationValidationFailureReason:
+              "decision_json_unparseable",
+            errorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+            routeAction: "dispatch-assistant-notification",
+            status: "retryable_failed",
+            wakeKind: "assistant.notification.requested",
+          }),
         }),
-      }),
-    ]);
-    expect(JSON.stringify(logRequests)).not.toContain(privateResponseMarker);
+      ]);
+
+      const mailboxState =
+        await systemMailbox.readHostedSystemMailboxCheckpointRollbackState({
+          vaultRoot,
+        });
+      expect(mailboxState.pending).toEqual([
+        expect.objectContaining({
+          attemptCount: 1,
+          lastErrorCode: "ASSISTANT_NOTIFICATION_INVALID_RESPONSE",
+          nextAttemptAt: nextWakeAt,
+        }),
+      ]);
+      expect(mailboxState.pending[0]).not.toHaveProperty(
+        "assistantNotificationValidationFailureReason",
+      );
+      expect(JSON.stringify(logRequests)).not.toContain(hostileResponseMarker);
+      expect(JSON.stringify(mailboxState)).not.toContain(hostileResponseMarker);
+    } finally {
+      await rm(parentRoot, { force: true, recursive: true });
+    }
   });
 
   it("preserves a device-sync mailbox follow-up wake after recording the mailbox item", async () => {

--- a/packages/hosted-execution/src/observability.ts
+++ b/packages/hosted-execution/src/observability.ts
@@ -161,6 +161,25 @@ export type HostedExecutionStructuredLogDetails = {
   [key: string]: HostedExecutionStructuredLogDetailValue;
 };
 
+export const HOSTED_ASSISTANT_NOTIFICATION_VALIDATION_FAILURE_REASONS = [
+  "decision_json_unparseable",
+  "decision_schema_invalid",
+  "runtime_presentation_non_send_decision",
+  "creative_response_media_invalid",
+] as const;
+
+export type HostedAssistantNotificationValidationFailureReason =
+  (typeof HOSTED_ASSISTANT_NOTIFICATION_VALIDATION_FAILURE_REASONS)[number];
+
+export function isHostedAssistantNotificationValidationFailureReason(
+  value: unknown,
+): value is HostedAssistantNotificationValidationFailureReason {
+  return typeof value === "string"
+    && HOSTED_ASSISTANT_NOTIFICATION_VALIDATION_FAILURE_REASONS.some(
+      (reason) => reason === value,
+    );
+}
+
 const HOSTED_ASSISTANT_NOTIFICATION_STRING_DETAIL_KEYS = [
   "assistantNotificationChannel",
   "assistantNotificationDeliveryDispatchMode",
@@ -575,15 +594,24 @@ export function extractHostedAssistantNotificationRedactedDetails(
     return null;
   }
 
+  const contextDetails = sanitizeHostedExecutionStructuredLogDetails(
+    readHostedExecutionObjectErrorProperty(error, ["context"]),
+  );
   const mergedDetails = mergeHostedExecutionStructuredLogDetails(
-    sanitizeHostedExecutionStructuredLogDetails(
-      readHostedExecutionObjectErrorProperty(error, ["context"]),
-    ),
+    contextDetails,
     sanitizeHostedExecutionStructuredLogDetails(
       readHostedExecutionObjectErrorProperty(error, ["details"]),
     ),
   );
   const details: HostedExecutionStructuredLogDetails = {};
+
+  const validationFailureReason =
+    contextDetails?.assistantNotificationValidationFailureReason;
+  if (
+    isHostedAssistantNotificationValidationFailureReason(validationFailureReason)
+  ) {
+    details.assistantNotificationValidationFailureReason = validationFailureReason;
+  }
 
   for (const key of HOSTED_ASSISTANT_NOTIFICATION_STRING_DETAIL_KEYS) {
     const value = mergedDetails?.[key];

--- a/packages/hosted-execution/test/hosted-execution-observability-side-effects.test.ts
+++ b/packages/hosted-execution/test/hosted-execution-observability-side-effects.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   HOSTED_ASSISTANT_DELIVERY_KIND,
+  HOSTED_ASSISTANT_NOTIFICATION_VALIDATION_FAILURE_REASONS,
   buildHostedAssistantDeliverySendingRecord,
   buildHostedAssistantDeliverySentRecord,
   buildHostedAssistantDeliverySideEffect,
@@ -533,13 +534,20 @@ describe("hosted execution observability", () => {
   });
 
   it("extracts a privacy-bounded assistant-notification detail subset from annotated errors", () => {
+    const privateResponseMarker = "PRIVATE_PROVIDER_RESPONSE_5a2d9c_DO_NOT_EMIT";
     const error = Object.assign(new Error("provider failed"), {
       cause: Object.assign(new Error("Gateway rejected provider credentials."), {
         code: "invalid_api_key",
         statusCode: 401,
       }),
+      context: {
+        assistantNotificationValidationFailureReason: "decision_schema_invalid",
+        providerResponse: privateResponseMarker,
+      },
       details: {
         assistantNotificationChannel: "linq",
+        assistantNotificationValidationFailureReason:
+          "creative_response_media_invalid",
         assistantNotificationDeliveryKind: "thread",
         assistantNotificationExplicitTargetPresent: false,
         assistantNotificationGatewayOnlyProviders: "openai",
@@ -580,7 +588,8 @@ describe("hosted execution observability", () => {
       notificationErrorStatus: 401,
     });
 
-    expect(extractHostedAssistantNotificationRedactedDetails(error)).toEqual({
+    const redacted = extractHostedAssistantNotificationRedactedDetails(error);
+    expect(redacted).toEqual({
       assistantNotificationChannel: "linq",
       assistantNotificationDeliveryKind: "thread",
       assistantNotificationErrorCause: "Gateway rejected provider credentials.",
@@ -604,6 +613,7 @@ describe("hosted execution observability", () => {
       assistantNotificationThreadIdPresent: true,
       assistantNotificationThreadIsDirect: true,
       assistantNotificationTurnTrigger: "automation-cron",
+      assistantNotificationValidationFailureReason: "decision_schema_invalid",
       assistantNotificationWorkingDirectoryPresent: false,
       assistantProviderAdapter: "openai-compatible",
       assistantProviderErrorBodyCode: "invalid_request",
@@ -616,6 +626,34 @@ describe("hosted execution observability", () => {
       assistantProviderGatewayTarget: true,
       assistantProviderModel: "openai/gpt-5.4",
     });
+    expect(JSON.stringify(redacted)).not.toContain(privateResponseMarker);
+    expect(JSON.stringify(redacted)).not.toContain("do not keep me");
+  });
+
+  it("keeps assistant-notification validation attribution on its four-value contract", () => {
+    expect(HOSTED_ASSISTANT_NOTIFICATION_VALIDATION_FAILURE_REASONS).toEqual([
+      "decision_json_unparseable",
+      "decision_schema_invalid",
+      "runtime_presentation_non_send_decision",
+      "creative_response_media_invalid",
+    ]);
+  });
+
+  it("drops assistant-notification validation reasons outside the closed vocabulary", () => {
+    const privateResponseMarker = "PRIVATE_REASON_VALUE_790bfd_DO_NOT_EMIT";
+    const redacted = extractHostedAssistantNotificationRedactedDetails(
+      Object.assign(new Error("fixed validation failure"), {
+        context: {
+          assistantNotificationValidationFailureReason: privateResponseMarker,
+          providerResponse: privateResponseMarker,
+        },
+      }),
+    );
+
+    expect(redacted).not.toHaveProperty(
+      "assistantNotificationValidationFailureReason",
+    );
+    expect(JSON.stringify(redacted)).not.toContain(privateResponseMarker);
   });
 
   it("keeps notification error diagnostics even when no annotation details exist", () => {


### PR DESCRIPTION
## Why and outcome

A bounded production sweep found one non-device assistant-notification mailbox subject emit 428 retry warnings with `ASSISTANT_NOTIFICATION_INVALID_RESPONSE` over about 22 hours. Existing logs collapse four current validator boundaries into the same code, so a safe behavioral fix cannot yet distinguish malformed JSON, schema rejection, runtime-presentation mismatch, or creative-media mismatch.

This telemetry-only change adds one closed four-value failure-reason field to the existing `mailbox.system_processed` warning. It does not change validation, retryability, timing, wake ownership, delivery, durable state, or log volume.

## Product UX

- Effort: not applicable; internal failure telemetry only.
- Result: no user-visible state, copy, interaction, notification, or delivery change.

## Evidence

- ReviewGPT authored the complete production/test/doc patch; artifact SHA-256: `ae7d3cedcb90c32dd3d4837dfcb4ed89640e84b849668b7500db56e528c67015`.
- Parent review accepted every implementation hunk unchanged and proved the stable patch ID remained identical after rebasing to current `main`.
- Focused Vitest passed: 29 hosted-execution privacy/redaction tests, 80 assistant-engine validator tests, and the original 141 assistant-runtime mailbox/warning tests.
- The preliminary completion-specialists ReviewGPT pass found one integration-proof gap: the warning producer and consumer were tested separately. The finding was accepted.
- ReviewGPT authored the isolated one-file regression remediation through the declared public `assistant-codex` entrypoint. The applied file exactly matches ReviewGPT result blob `d55974ffc199850ad0005549dd25059a297d2661`.
- The new composed regression passed alone; all 81 tests in its affected runtime test file passed together; the affected package typecheck passed.
- Typechecks passed for hosted-execution, assistant-engine, and assistant-runtime. Raw-log privacy, provider-request boundary, agent-doc drift, docs gardening, and diff-hygiene guards passed.
- Final cross-cutting ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` on first-reviewed production head `bc4f1a1270f1abe981bcd143929844ea42afa283` with no findings. The later isolated test-only correction follows the repository exception: focused proof plus exact-head CI, without another substantive final round.

## Non-obvious affected surfaces

- Assistant-engine validation errors gain a typed context value; existing codes and messages are unchanged.
- Hosted-execution redaction admits only the four declared literals and drops all other values.
- System-mailbox checkpoint preparation carries the field ephemerally; persisted pending state is unchanged.
- The existing warning adds the optional field only for matching retryable assistant-notification failures.

## Architecture and reuse

- Existing systems reused: the existing `VaultCliError` context, assistant-notification redaction owner, checkpoint preparation, and hosted-runtime log.
- New logic: one closed four-value validation-failure reason is attached on already-failing notification paths and emitted through the existing warning.
- New abstractions: no generic abstraction was added; only the narrow shared literal type and validator required at existing package boundaries.
- Complexity intentionally avoided: no backend, event, metric, table, queue, scheduler, alert, timer, request, persistence, retry change, or generic telemetry layer was introduced.
- The field remains optional for old/new runner compatibility and code-only rollback.

## Hot reply path impact

- No new I/O, await, timer, provider call, database work, or success-path log.
- The added work is a closed-value context assignment and validation on an already-failing notification path.

## Murph initial provider input impact

- Individual runtime: none; prompts, tools, schemas, history, routing, and provider inputs are unchanged.
- Group runtime: none; prompts, tools, schemas, history, routing, and provider inputs are unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: the field is optional; old and new runners remain compatible.
- Safe order: merge the public repository, deploy through the protected Cloudflare hosted-runner workflow, then prove the serving revision.
- Rollback floor: redeploy the prior hosted-runner revision; no data, migration, binding, secret, permission, queue, or state rollback.
- Expected exposure: only existing retryable assistant-notification warning entries gain the closed optional field after the new runner serves.
- Reversibility: code-only rollback restores the prior log schema without changing canonical state or provider interaction.
- Convergence proof: confirm the managed Cloudflare hosted-runner serving revision matches the merged public SHA before interpreting natural traffic.
- No Vercel tandem deploy is required.
- Post-deploy checks: wait for natural traffic, then run the bounded four-hour comparison, 24-hour inventory, and seven-day aggregate query documented in `docs/hosted-runtime-log-database.md`; never generate production traffic.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 99 | 13 |
| Tests / fixtures | 319 | 53 |
| Docs | 268 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **686** | **66** |

## Changelog

- Changelog: not applicable
- Reason: internal observability only; no member-visible behavior changed.

ReviewGPT context sensitivity: sensitive — hosted assistant-notification validation, retry diagnostics, and privacy-safe failure metadata.

ReviewGPT first-reviewed head: bc4f1a1270f1abe981bcd143929844ea42afa283
