### PR TITLE
test(hosted): require explicit database reuse

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
@@ -80,6 +80,7 @@ import {
   assertHostedRunNoProviderEgressAuthFailures,
   buildHostedLocalRuntimeLogDatabaseNameForTest,
   buildHostedLocalFullStackWebProcessEnvOverrides,
+  shouldReuseExplicitHostedLocalScenarioDatabaseUrl,
 } from "./hosted-local-full-stack-scenario.js";
 
 afterEach(() => {
@@ -117,6 +118,20 @@ it("bounds the derived runtime-log database name to PostgreSQL's identifier limi
 
   expect(runtimeLogDatabaseName).toBe(`${"p".repeat(50)}_runtime_logs`);
   expect(runtimeLogDatabaseName).toHaveLength(63);
+});
+
+describe("hosted local database reuse authority", () => {
+  it("does not treat generic CI mode as database reuse authority", () => {
+    expect(shouldReuseExplicitHostedLocalScenarioDatabaseUrl({
+      CI: "true",
+    })).toBe(false);
+  });
+
+  it("requires the dedicated database reuse control", () => {
+    expect(shouldReuseExplicitHostedLocalScenarioDatabaseUrl({
+      MURPH_HOSTED_LOCAL_E2E_REUSE_DATABASE_URL: "1",
+    })).toBe(true);
+  });
 });
 
 it("fails the negative runtime-log oracle when no evidence was persisted", async () => {

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.ts
@@ -829,8 +829,10 @@ async function resolveHostedLocalScenarioDatabase(input: {
   return await createEphemeralHostedLocalDatabase(input.scenarioPrefix);
 }
 
-function shouldReuseExplicitHostedLocalScenarioDatabaseUrl(): boolean {
-  return process.env.CI === "true" || process.env[reuseExplicitDatabaseUrlEnv] === "1";
+export function shouldReuseExplicitHostedLocalScenarioDatabaseUrl(
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return environment[reuseExplicitDatabaseUrlEnv] === "1";
 }
 
 function buildHostedLocalRunnerBundleCacheKey(env: NodeJS.ProcessEnv): string {


### PR DESCRIPTION
## Outcome
Hosted-local full-stack scenarios now accept a caller-supplied database target only through the dedicated reuse control or an explicit scenario option. Generic CI mode no longer grants destructive database-reuse authority.

Frog autofix issue: #2420

ReviewGPT first-reviewed head: 39cf2d784a713342c62fea6277de56e27f9d4f2e
ReviewGPT context sensitivity: sensitive — this is test-only code, but it hardens a fail-closed local database target boundary.

## Product UX
Not applicable. This changes only an internal hosted-local test harness and has no member-facing behavior.

## Evidence
- Focused helper test: 18 passed.
- Cloudflare package typecheck: passed.
- Diff-aware verification: passed, including 151 Node test files with 2,716 passing tests and 5 Workers test files with 14 passing tests.
- The regression uses synthetic environment objects and does not connect to or reset a database.

## Non-obvious affected surfaces
- Shared hosted-local full-stack scenario database selection: every scenario using this helper now requires the dedicated environment control or its explicit reuseLocalDatabase option before reusing a supplied target. The focused synthetic policy tests cover both rejection and acceptance.
- Production behavior: none; the changed files are test-harness source and tests only.

## Architecture and reuse
- Existing systems reused: The existing MURPH_HOSTED_LOCAL_E2E_REUSE_DATABASE_URL control and reuseLocalDatabase scenario option remain the sole reuse authorities.
- New logic: The reuse predicate now checks only the dedicated environment control.
- New abstractions: None; the existing predicate was exported only for direct pure-policy coverage.
- Complexity intentionally avoided: No database allowlist, wrapper-specific behavior, alternate state owner, or production guard was added because explicit opt-in is sufficient.

## Hot reply path impact
Not applicable. No production request, database, provider, or reply path changes.

## Murph initial provider input impact
- Individual runtime: Not applicable; no provider-visible input surface changed.
- Group runtime: Not applicable; no provider-visible input surface changed.

## Risks
The affected boundary can precede destructive local test setup. Direct tests prove generic CI cannot authorize reuse and the dedicated control still can; no real database was used during verification.

## Change-shape breakdown
Classification: the shared scenario helper is source; its Vitest file is tests/fixtures. No binaries or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 2 |
| Tests/fixtures | 15 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 19 | 2 |

## Deployment concerns
- Deployment: not applicable
- Reason: Test-harness-only code does not cross a production deploy boundary.

## Changelog
- Changelog: not applicable
- Reason: Internal test-harness safety behavior is not member-visible.