### PR TITLE
test: correlate Linq canary replies by send time

### DIFF
--- a/apps/web/scripts/run-production-conversation-canary.ts
+++ b/apps/web/scripts/run-production-conversation-canary.ts
@@ -66,8 +66,10 @@ export async function runLinqProductionCanary(
     for (const [index, prompt] of CANARY_TURNS.entries()) {
       const turn = index + 1;
       const sentAt = performance.now();
+      const sentAtEpochMs = Date.now();
       const replyPromise = waitForLinqProductionCanaryReply({
         inbound,
+        notBeforeEpochMs: sentAtEpochMs,
         spaceId: space.id,
         timeoutMs: CANARY_REPLY_WAIT_MS,
         userId: target.id,
@@ -102,6 +104,7 @@ export async function runLinqProductionCanary(
 
 export async function waitForLinqProductionCanaryReply(input: {
   inbound: AsyncIterator<[Space, Message]>;
+  notBeforeEpochMs: number;
   spaceId: string;
   timeoutMs: number;
   userId: string;
@@ -124,6 +127,8 @@ export async function waitForLinqProductionCanaryReply(input: {
         || message.platform !== "imessage"
         || message.sender?.id !== input.userId
         || message.content.type !== "text"
+        || !Number.isFinite(message.timestamp.getTime())
+        || message.timestamp.getTime() < input.notBeforeEpochMs
       ) {
         continue;
       }

--- a/apps/web/test/run-production-conversation-canary.test.ts
+++ b/apps/web/test/run-production-conversation-canary.test.ts
@@ -85,15 +85,20 @@ describe("production conversation canary runner", () => {
     }), { status: 200 })));
   });
 
-  it("runs three reciprocal turns, ignores unrelated messages, and stops", async () => {
+  it("runs three reciprocal turns, ignores stale and unrelated messages, and stops", async () => {
+    vi.mocked(Date.now)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000)
+      .mockReturnValueOnce(3_000);
     mocks.now = [0, 100, 200, 300, 400, 500];
     mocks.sendResults = [true, true, true];
     mocks.messages = [
       inboundMessage({ text: "An older reply.", timestampMs: 999 }),
       inboundMessage({ spaceId: "other_space", text: "unrelated" }),
       inboundMessage({ text: MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE }),
-      inboundMessage({ text: "A useful next question." }),
-      inboundMessage({ text: "Start with a consistent wake time." }),
+      inboundMessage({ text: "A useful next question.", timestampMs: 2_000 }),
+      inboundMessage({ text: "A retained earlier reply.", timestampMs: 2_000 }),
+      inboundMessage({ text: "Start with a consistent wake time.", timestampMs: 3_000 }),
     ];
 
     await expect(runLinqProductionCanary(TEST_ENV)).resolves.toEqual({
@@ -109,6 +114,7 @@ describe("production conversation canary runner", () => {
         { latencyMs: 100, turn: 3 },
       ],
     });
+    expect(mocks.messages).toEqual([]);
     expect(mocks.spaceSend).toHaveBeenCalledTimes(3);
     expect(mocks.stop).toHaveBeenCalledOnce();
   });

--- a/apps/web/test/run-production-conversation-canary.test.ts
+++ b/apps/web/test/run-production-conversation-canary.test.ts
@@ -66,6 +66,7 @@ const TEST_ENV = {
 describe("production conversation canary runner", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
     mocks.messages = [];
     mocks.now = [];
     mocks.sendResults = [];
@@ -88,6 +89,7 @@ describe("production conversation canary runner", () => {
     mocks.now = [0, 100, 200, 300, 400, 500];
     mocks.sendResults = [true, true, true];
     mocks.messages = [
+      inboundMessage({ text: "An older reply.", timestampMs: 999 }),
       inboundMessage({ spaceId: "other_space", text: "unrelated" }),
       inboundMessage({ text: MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE }),
       inboundMessage({ text: "A useful next question." }),
@@ -141,6 +143,7 @@ describe("production conversation canary runner", () => {
 function inboundMessage(input: {
   spaceId?: string;
   text: string;
+  timestampMs?: number;
 }): [Record<string, unknown>, Record<string, unknown>] {
   return [
     { id: input.spaceId ?? "space_canary" },
@@ -149,6 +152,7 @@ function inboundMessage(input: {
       direction: "inbound",
       platform: "imessage",
       sender: { id: "target_canary" },
+      timestamp: new Date(input.timestampMs ?? 1_000),
     },
   ];
 }


### PR DESCRIPTION
## Why and outcome

The live production canary proved that a reply retained by Photon from an earlier turn can satisfy a later turn. This change accepts only same-conversation replies whose provider timestamp is at or after the current send, so the canary measures the reply caused by that turn.

## Product UX

- Effort: Not applicable — this is an internal production-verification correction.
- Result: Not applicable.
- Walkthrough: No member-visible behavior or copy changes; only canary reply selection changes.

## Evidence

- Direct: Live production showed a retained reply advance the canary before the current runtime delivery, while the corrected sender reset independently proved Luna delivery.
- Coverage: Focused Vitest passed 3 tests, including a stale same-chat/sender reply followed by the fresh canonical welcome; exact changed-file ESLint and Hosted Web prepared typecheck passed.

## Non-obvious affected surfaces

- Photon/Spectrum inbound stream consumption now requires the provider timestamp to be current for the send. Thresholds, prompts, reset behavior, production workflow, delivery ownership, and application runtime are unchanged.

## Architecture and reuse

- Existing systems reused: The existing Spectrum message timestamp and per-turn canary send loop remain the only owners.
- New logic: One wall-clock send boundary rejects earlier provider messages before ordinary sender, chat, platform, and text validation succeeds.
- New abstractions: None; the direct comparison is sufficient for this single canary boundary.
- Complexity intentionally avoided: No queue, service, dependency, retry, state owner, persisted state, correlation registry, or provider wrapper was added.

## Hot reply path impact

- Path status: Not applicable — this code runs only in the protected GitHub production canary.
- Database calls: None.
- Network/provider calls: None added or moved.
- Other awaited latency: None.
- Before/after proof: The focused regression test proves stale messages are skipped without changing current-reply latency.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: routine
Classification reason: Two-file, nine-line canary-only correction with no production application or authority change.
"ReviewGPT
first-reviewed
head:
b8dce4ac2eab3dbdeb337b1e59631d309374f807"

## Deployment concerns

- Deployment: not applicable
- Reason: The GitHub Actions runner uses the merged repository revision; no application deployment changes.

## Change-shape breakdown

Classification rule: The runner change is source and its focused Vitest change is tests/fixtures; there are no binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 0 |
| Tests / fixtures | 13 | 3 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **18** | **3** |

## Changelog

- Changelog: not applicable
- Reason: Internal production verification only.

ReviewGPT first-reviewed head: b8dce4ac2eab3dbdeb337b1e59631d309374f807