### PR TITLE
fix(repo): archive staged active plans

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-29-frog-2412-finish-task-staged-plan.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-frog-2412-finish-task-staged-plan.md
@@ -1,0 +1,49 @@
+# Frog #2412: finish-task staged plan archival
+
+Status: completed
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Make `scripts/finish-task` archive and commit a newly created active plan even when that plan is already staged.
+
+## Success criteria
+
+- A focused harness reproduces the current staged-plan failure before the fix.
+- `finish-task` records only the completed plan in the commit and leaves no active-plan residue or staged duplicate.
+- Existing tracked-plan, untracked-plan, and deleted-task-path behavior remains covered.
+- Focused verification, repository tooling checks, ReviewGPT, and required PR CI pass.
+
+## Scope
+
+- In scope: `scripts/finish-task`, its focused release-script harness, and this plan.
+- Out of scope: repo-tools package changes, unrelated commit behavior, product/runtime behavior, and dependency changes.
+
+## Constraints
+
+- Technical constraints: preserve exact-path commit scoping and staged-index safety; do not weaken worktree or hook guards.
+- Product/process constraints: keep the patch repository-local and low-risk; use the exact committed Frog entry as authority.
+
+## Risks and mitigations
+
+1. Risk: staging the archive could leave a duplicate active plan or disturb unrelated staged work.
+   Mitigation: stage only the old/new plan paths, exercise the real repo-tools committer in a synthetic Git harness, and assert exact final index/commit state.
+
+## Tasks
+
+1. Add and run a focused failing regression for an already-staged new active plan.
+2. Implement the smallest archive-staging correction in `scripts/finish-task`.
+3. Run focused and repository-tooling verification, inspect the diff, and complete the PR review/CI lane.
+
+## Decisions
+
+- Treat a newly staged plan separately from a plan tracked in `HEAD`: the former has no source path for the scoped committer to resolve after archival.
+- Normalize the exact archive paths in the real index before invoking the isolated committer, so failure leaves one staged completed plan instead of a staged vanished source plus an untracked destination.
+
+## Verification
+
+- Commands to run: focused Vitest for the finish-task harness, shell syntax, repo-tools test suite, and diff/privacy checks.
+- Expected outcomes: the staged-plan regression commits only the completed plan and task path, while all existing finish-task cases continue to pass.
+- Completed: the focused staged/untracked pair passed 2/2; the full release-script audit passed 49 tests with one intentional skip; `packages/cli` typecheck passed; `pnpm test:repo-tools` passed 49 files / 677 tests; Bash syntax and diff hygiene passed.
+Completed: 2026-08-29

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1137,7 +1137,10 @@ function runFinishTaskHarnessGit(harnessRoot: string, ...command: string[]) {
   return result.stdout.trim()
 }
 
-function createFinishTaskHarness(baselineFiles: Record<string, string>) {
+function createFinishTaskHarness(
+  baselineFiles: Record<string, string>,
+  options: { useRealCommitter?: boolean } = {},
+) {
   const harnessRoot = mkdtempSync(path.join(os.tmpdir(), 'murph-finish-task-harness-'))
 
   try {
@@ -1203,13 +1206,19 @@ printf '%s\\n' "$plan_path" "$completed_path" > .fake-tools/close-exec-plan.args
 `,
       true,
     )
+    const committerContents = options.useRealCommitter
+      ? readFileSync(
+          path.join(repoRoot, 'node_modules', '@cobuild', 'repo-tools', 'src', 'committer.sh'),
+          'utf8',
+        )
+      : `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > .fake-tools/committer.args
+`
     writeHarnessFile(
       harnessRoot,
       '.fake-tools/cobuild-committer',
-      `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$@" > .fake-tools/committer.args
-`,
+      committerContents,
       true,
     )
 
@@ -4313,6 +4322,68 @@ Updated: 2026-04-24
       expect(commitArgs).not.toContain(
         'agent-docs/exec-plans/active/COORDINATION_LEDGER.md',
       )
+    } finally {
+      rmSync(harnessRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('commits a newly staged active plan through its archived path', () => {
+    const planPath = 'agent-docs/exec-plans/active/2026-04-24-staged.md'
+    const completedPlanPath = 'agent-docs/exec-plans/completed/2026-04-24-staged.md'
+    const taskPath = 'docs/touched.md'
+    const harnessRoot = createFinishTaskHarness(
+      {
+        'agent-docs/exec-plans/completed/README.md': '# Completed\n',
+        [taskPath]: '# Before\n',
+      },
+      { useRealCommitter: true },
+    )
+
+    try {
+      writeHarnessFile(harnessRoot, planPath, '# Harness Plan\n')
+      runFinishTaskHarnessGit(harnessRoot, 'add', planPath)
+      writeHarnessFile(harnessRoot, taskPath, '# Before\n\nAfter\n')
+
+      const result = spawnSync(
+        'bash',
+        [
+          'scripts/finish-task',
+          planPath,
+          'fix(repo): close staged harness plan',
+          taskPath,
+        ],
+        {
+          cwd: harnessRoot,
+          encoding: 'utf8',
+          env: withoutNodeV8Coverage(),
+        },
+      )
+
+      if (result.status !== 0) {
+        throw new Error(
+          `finish-task staged-plan harness failed:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+        )
+      }
+
+      rmSync(path.join(harnessRoot, '.fake-tools', 'install-git-hooks.called'), { force: true })
+      rmSync(path.join(harnessRoot, '.fake-tools', 'close-exec-plan.args'), { force: true })
+      expect(runFinishTaskHarnessGit(harnessRoot, 'status', '--porcelain')).toBe('')
+      expect(
+        runFinishTaskHarnessGit(
+          harnessRoot,
+          'diff-tree',
+          '--no-commit-id',
+          '--name-only',
+          '-r',
+          'HEAD',
+        )
+          .split(/\r?\n/u)
+          .sort(),
+      ).toEqual([completedPlanPath, taskPath].sort())
+      expect(runFinishTaskHarnessGit(harnessRoot, 'show', `HEAD:${completedPlanPath}`)).toBe(
+        '# Harness Plan',
+      )
+      expect(existsSync(path.join(harnessRoot, planPath))).toBe(false)
     } finally {
       rmSync(harnessRoot, { recursive: true, force: true })
     }

--- a/scripts/finish-task
+++ b/scripts/finish-task
@@ -34,6 +34,14 @@ if [[ ! -f "$plan_path" ]]; then
 fi
 
 completed_plan_path="agent-docs/exec-plans/completed/$(basename "$plan_path")"
+plan_tracked_in_head=false
+if git cat-file -e "HEAD:$plan_path" 2>/dev/null; then
+  plan_tracked_in_head=true
+fi
+plan_indexed=false
+if git ls-files --error-unmatch -- "$plan_path" >/dev/null 2>&1; then
+  plan_indexed=true
+fi
 
 resolved_commit_paths=()
 
@@ -132,9 +140,14 @@ for target in "$@"; do
 done
 
 bash scripts/close-exec-plan.sh "$plan_path"
+if [[ "$plan_indexed" == true ]]; then
+  git add -A -- "$plan_path" "$completed_plan_path"
+else
+  git add -A -- "$completed_plan_path"
+fi
 
 commit_paths=("$completed_plan_path")
-if git ls-files --error-unmatch -- "$plan_path" >/dev/null 2>&1; then
+if [[ "$plan_tracked_in_head" == true ]]; then
   commit_paths=("$plan_path" "$completed_plan_path")
 fi
 


### PR DESCRIPTION
## Why and outcome

The repository task finisher now normalizes an active plan's exact old and completed paths before the scoped commit. A newly staged plan is committed only at its completed location, without forwarding a source path that never existed in `HEAD`.

Frog autofix issue: #2412

## Product UX

Not applicable. This is repository-local developer tooling and does not change member-facing behavior.

## Evidence

- Focused staged-plan and untracked-plan harness: 2 passed.
- Complete release-script coverage audit: 49 passed, 1 intentionally skipped.
- `packages/cli` typecheck passed.
- Repository-tooling suite: 49 files and 677 tests passed.
- The final scoped commit itself used a pre-staged active plan and finished with a clean index.
- Bash syntax, diff hygiene, and public-safety scan passed.

## Preliminary specialist review

- Product UX lens: not applicable — repository-local commit tooling does not alter a member journey.
- Prompt lens: not applicable — no prompt, instruction stack, tool description, or prompt proof changed.
- Frontend lens: not applicable — no hosted Web presentation changed.
- Coverage lens: applicable — stable regression proof for the real scoped committer is a primary PR outcome.

## Non-obvious affected surfaces

- Scoped commit index reconciliation: the archive pair is staged before delegation so the existing isolated committer receives only resolvable exact paths. Regression proof uses the real pinned repo-tools committer in a synthetic Git repository.

## Architecture and reuse

- Existing systems reused: the existing plan closer and scoped repo-tools committer remain the sole archive and commit owners.
- New logic: `finish-task` records whether the source plan existed in `HEAD` and whether it was indexed before archival, then stages only the exact applicable archive paths.
- New abstractions: none; the existing shell entrypoint owns the two small state checks.
- Complexity intentionally avoided: no repo-tools fork, compatibility wrapper, broad directory staging, or alternate commit path.

## Hot reply path impact

Not applicable. The change only affects a repository-local developer commit helper.

## Murph initial provider input impact

- Assistant runtime: not applicable; no prompt, tool schema, or provider-visible input changed.
- Codex runtime: not applicable; no prompt, tool schema, or provider-visible input changed.

## Design proof

Not applicable. No hosted Web UI changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Repository-local tooling and tests only; no deployed artifact changes.

## Changelog

- Changelog: not applicable
- Reason: No member-visible behavior changed.

## Change shape

Classification: `scripts/finish-task` is config/tooling, the release-script harness is tests/fixtures, and the completed execution plan is docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 76 | 5 |
| Docs | 49 | 0 |
| Config/tooling | 14 | 1 |
| Generated/other | 0 | 0 |
| Total | 139 | 6 |
