### PR TITLE
docs(changelog): document try-it schema

### DIFF
--- a/apps/web/changelog/README.md
+++ b/apps/web/changelog/README.md
@@ -23,10 +23,19 @@ when order matters, and do not renumber unrelated entries.
     "summary": "One sentence describing what changed for the member.",
     "details": "The most important boundary, limitation, or recovery behavior.",
     "relevanceTags": ["product-area"],
-    "sourcePullRequests": [1234]
+    "sourcePullRequests": [1234],
+    "tryIt": {
+      "label": "Ask about recovery",
+      "prompt": "Help me review my recovery today."
+    }
   }
 }
 ```
+
+`item.tryIt` is optional. When present, it must be an object with a `label`
+string and exactly one action: either an `href` string for a supported route or
+a `prompt` string for a supported conversation request. Those are the only
+accepted keys; a string value or any additional key is invalid.
 
 Optional edition-level title and summary live at
 `editions/YYYY-MM-DD.json`. They are not required: dates without metadata use a


### PR DESCRIPTION
## Outcome
The authoritative changelog fragment README now documents the structured optional try-it contract and includes one valid synthetic prompt-mode example. Authors can see that a plain string or additional key is invalid before running fragment generation.

Frog autofix issue: #2426

## Product UX
Not applicable. This changes internal contributor guidance only and does not alter the public changelog or member behavior.

## Evidence
- Read back the complete changed README section.
- Parsed the embedded JSON example and asserted its exact try-it object.
- git diff --check passed.

## Non-obvious affected surfaces
None. Changelog parsing, rendering, fragments, generated output, and production behavior are unchanged.

## Architecture and reuse
- Existing systems reused: The fragment README remains the single authoring owner beside the existing loader contract.
- New logic: None; the documentation now states the loader and registry requirements already enforced in source and tests.
- New abstractions: None; one schema paragraph and one inline example are sufficient.
- Complexity intentionally avoided: No duplicate skill contract, schema file, parser change, or new validation layer was added.

## Hot reply path impact
Not applicable. Contributor documentation cannot affect the foreground reply path.

## Murph initial provider input impact
- Individual runtime: Not applicable; no provider-visible input changed.
- Group runtime: Not applicable; no provider-visible input changed.

## Change-shape breakdown
Classification: the only changed file is authored Markdown documentation. No binaries or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 10 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 10 | 1 |

## Deployment concerns
- Deployment: not applicable
- Reason: Internal contributor documentation does not cross a deploy boundary.

## Changelog
- Changelog: not applicable
- Reason: Internal contributor guidance only; no member-visible behavior changed.