### PR TITLE
test(assistant): exercise hosted permission profiles

### DIFF
--- a/apps/cloudflare/src/hosted-runner-smoke-child.ts
+++ b/apps/cloudflare/src/hosted-runner-smoke-child.ts
@@ -25,10 +25,7 @@ import {
   restoreHostedExecutionContext,
 } from "@murphai/runtime-state/node";
 import {
-  buildMurphGroupReadPermissionProfileTomlLines,
-  buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines,
-  buildMurphMemberReadPermissionProfileTomlLines,
-  buildMurphMemberWorkspacePermissionProfileTomlLines,
+  buildMurphHostedPermissionProfileTomlLines,
   MURPH_GROUP_READ_PERMISSION_PROFILE,
   MURPH_MEMBER_READ_PERMISSION_PROFILE,
   MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE,
@@ -776,10 +773,7 @@ function buildHostedRunnerSmokeCodexConfigToml(): string {
     // exercises the same PATH semantics as production turns.
     "allow_login_shell = false",
     "",
-    ...buildMurphGroupReadPermissionProfileTomlLines(),
-    ...buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines(),
-    ...buildMurphMemberReadPermissionProfileTomlLines(),
-    ...buildMurphMemberWorkspacePermissionProfileTomlLines(),
+    ...buildMurphHostedPermissionProfileTomlLines(),
     "[skills]",
     "include_instructions = false",
     "",

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -8374,11 +8374,13 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         await stopWarmCodexAppServer(
           'group-private-handoff-flow-e2e-cold-follow-up',
         )
+        const followUpTraceEvents: unknown[] = []
         const followUp = await sendAssistantMessageLocal({
           ...route,
           deliverResponse: false,
           executionContext,
           includeEarlySessionOnboarding: false,
+          onTraceEvent: (event) => followUpTraceEvents.push(event),
           persistUserPromptOnFailure: false,
           prompt: 'What do you think about 8,000 over four months?',
           sessionId: handoff.session.sessionId,
@@ -8394,6 +8396,15 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
           })}\n`,
         )
         expect(followUp.session.sessionId).toBe(handoff.session.sessionId)
+        expect(followUpTraceEvents).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            rawEvent: expect.objectContaining({
+              type: 'assistant.context.diagnostics',
+              stage: 'assistant-session-resolved',
+              source: 'assistant-message',
+            }),
+          }),
+        ]))
         expect(followUp.response).toMatch(/steps?|days?|months?|long-term|pattern|activity/iu)
         expect(followUp.response).not.toMatch(
           /8,?000 of what|of what, averaged|what does 8,?000 refer to|can you clarify what 8,?000/iu,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -29,7 +29,8 @@ import {
   buildHostedExecutionGroupContextHandoffInstructions,
 } from '@murphai/hosted-execution'
 import {
-  buildMurphGroupReadPermissionProfileTomlLines,
+  buildMurphHostedPermissionProfileTomlLines,
+  MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE,
 } from '@murphai/hosted-execution/assistant-permissions'
 import {
   createAssistantModelTarget,
@@ -6871,7 +6872,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         )
 
         const consultationConfig =
-          await materializeRealCodexGroupReadPermissionHome(config)
+          await materializeRealCodexHostedPermissionHome(config)
         consultationTemporaryPaths = consultationConfig.temporaryPaths
         const executeConsultation = (question: string) =>
           executeReadOnlyAssistantAsk({
@@ -8295,6 +8296,8 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
     'keeps a named private handoff in a synthetic group follow-up',
     async () => {
       const config = await resolveRealCodexE2eConfig()
+      const hostedPermissionConfig =
+        await materializeRealCodexHostedPermissionHome(config)
       const workingDirectory = await mkdtemp(
         path.join(tmpdir(), 'murph-group-private-handoff-flow-e2e-'),
       )
@@ -8302,7 +8305,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         approvalPolicy: 'never',
         codexCommand:
           normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND),
-        codexHome: config.codexHome,
+        codexHome: hostedPermissionConfig.codexHome,
         model: config.model,
         modelProvider: config.modelProvider,
         provider: 'codex-cli',
@@ -8374,6 +8377,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         const followUp = await sendAssistantMessageLocal({
           ...route,
           deliverResponse: false,
+          executionContext,
           includeEarlySessionOnboarding: false,
           persistUserPromptOnFailure: false,
           prompt: 'What do you think about 8,000 over four months?',
@@ -8398,6 +8402,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         await stopWarmCodexAppServer('group-private-handoff-flow-e2e-complete')
         await removeRealCodexTemporaryPaths([
           workingDirectory,
+          ...hostedPermissionConfig.temporaryPaths,
           ...config.temporaryPaths,
         ])
       }
@@ -16908,7 +16913,7 @@ describe('real Codex app-server cache usage e2e harness', () => {
       model: 'gpt-5.6-terra',
       modelProvider: OPENAI_ENV_MODEL_PROVIDER,
     })
-    const groupReadConfigToml = buildRealCodexGroupReadPermissionConfigToml({
+    const hostedPermissionConfigToml = buildRealCodexHostedPermissionConfigToml({
       codexHome: null,
       env: {},
       model: 'gpt-5.6-terra',
@@ -16916,14 +16921,38 @@ describe('real Codex app-server cache usage e2e harness', () => {
       providerApiKeyEnv: 'PROVIDER_AUTH',
       temporaryPaths: [],
     })
+    const subscriptionPermissionConfigToml =
+      buildRealCodexHostedPermissionConfigToml({
+        codexHome: null,
+        env: {},
+        model: 'gpt-5.6-terra',
+        modelProvider: OPENAI_SUBSCRIPTION_MODEL_PROVIDER,
+        providerApiKeyEnv: null,
+        temporaryPaths: [],
+      })
 
     expect(configToml).toContain('[shell_environment_policy]')
+    expect(configToml).toContain('sandbox_mode = "workspace-write"')
     expect(configToml).toContain('include_only = [')
     expect(configToml).toContain('[model_providers.openai-env]')
     expect(configToml).toContain('env_key = "PROVIDER_AUTH"')
     expect(configToml).not.toContain('provider-value')
-    expect(groupReadConfigToml).toContain('env_key = "PROVIDER_AUTH"')
-    expect(groupReadConfigToml).not.toContain('provider-value')
+    expect(hostedPermissionConfigToml).toContain('env_key = "PROVIDER_AUTH"')
+    expect(hostedPermissionConfigToml).toContain(
+      '[permissions.murph-member-workspace.filesystem]',
+    )
+    expect(hostedPermissionConfigToml).toContain(
+      'default_permissions = "murph-member-workspace"',
+    )
+    expect(hostedPermissionConfigToml).not.toContain('sandbox_mode =')
+    expect(hostedPermissionConfigToml).not.toContain('provider-value')
+    expect(subscriptionPermissionConfigToml).toContain(
+      'default_permissions = "murph-member-workspace"',
+    )
+    expect(subscriptionPermissionConfigToml).toContain(
+      '[permissions.murph-member-workspace.filesystem]',
+    )
+    expect(subscriptionPermissionConfigToml).not.toContain('sandbox_mode =')
     expect(configToml).not.toContain('[features.multi_agent_v2]')
     expect(CHILD_MODEL_SELECTION_CONFIG_OVERRIDES).toEqual([
       'features.multi_agent_v2.enabled=true',
@@ -25039,8 +25068,10 @@ function resolveRealCodexProviderApiKeyEnv(modelProvider: string): string | null
 
 function buildRealCodexConfigToml(input: {
   apiKeyEnv: string
+  defaultPermissions?: string | null
   model: string
   modelProvider: string
+  sandboxMode?: 'workspace-write' | null
 }): string {
   const baseUrl =
     input.modelProvider === VERCEL_AI_GATEWAY_MODEL_PROVIDER
@@ -25056,7 +25087,12 @@ function buildRealCodexConfigToml(input: {
     `model_provider = ${tomlString(input.modelProvider)}`,
     'model_reasoning_effort = "low"',
     'approval_policy = "never"',
-    'sandbox_mode = "workspace-write"',
+    ...(input.defaultPermissions
+      ? [`default_permissions = ${tomlString(input.defaultPermissions)}`]
+      : []),
+    ...(input.sandboxMode === null
+      ? []
+      : [`sandbox_mode = ${tomlString(input.sandboxMode ?? 'workspace-write')}`]),
     'allow_login_shell = false',
     '',
     '[shell_environment_policy]',
@@ -25078,17 +25114,17 @@ function buildRealCodexConfigToml(input: {
   ].join('\n')
 }
 
-async function materializeRealCodexGroupReadPermissionHome(
+async function materializeRealCodexHostedPermissionHome(
   config: RealCodexE2eConfig,
 ): Promise<{ codexHome: string; temporaryPaths: string[] }> {
   const codexHome = await mkdtemp(
-    path.join(tmpdir(), 'murph-codex-group-read-home-'),
+    path.join(tmpdir(), 'murph-codex-hosted-permissions-home-'),
   )
 
   try {
     await writeFile(
       path.join(codexHome, 'config.toml'),
-      buildRealCodexGroupReadPermissionConfigToml(config),
+      buildRealCodexHostedPermissionConfigToml(config),
       {
         encoding: 'utf8',
         mode: 0o600,
@@ -25113,7 +25149,7 @@ async function materializeRealCodexGroupReadPermissionHome(
   }
 }
 
-function buildRealCodexGroupReadPermissionConfigToml(
+function buildRealCodexHostedPermissionConfigToml(
   config: RealCodexE2eConfig,
 ): string {
   const providerApiKeyEnv = config.providerApiKeyEnv
@@ -25124,25 +25160,28 @@ function buildRealCodexGroupReadPermissionConfigToml(
       `model_provider = ${tomlString(config.modelProvider)}`,
       'model_reasoning_effort = "low"',
       'approval_policy = "never"',
+      `default_permissions = ${tomlString(MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE)}`,
       '',
     ].join('\n')
   } else {
     if (!providerApiKeyEnv) {
       throw new Error(
-        'Provider-auth group-read config requires the resolved credential key name.',
+        'Provider-auth hosted permission config requires the resolved credential key name.',
       )
     }
     baseConfig = buildRealCodexConfigToml({
-        apiKeyEnv: providerApiKeyEnv,
-        model: config.model,
-        modelProvider: config.modelProvider,
-      })
+      apiKeyEnv: providerApiKeyEnv,
+      defaultPermissions: MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE,
+      model: config.model,
+      modelProvider: config.modelProvider,
+      sandboxMode: null,
+    })
   }
 
   return [
     baseConfig.trimEnd(),
     '',
-    ...buildMurphGroupReadPermissionProfileTomlLines(),
+    ...buildMurphHostedPermissionProfileTomlLines(),
   ].join('\n')
 }
 

--- a/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/codex-config.ts
@@ -6,10 +6,7 @@ import {
   resolveAssistantSkillsRoot,
 } from "@murphai/assistant-engine/assistant-skill-assets";
 import {
-  buildMurphGroupReadPermissionProfileTomlLines,
-  buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines,
-  buildMurphMemberReadPermissionProfileTomlLines,
-  buildMurphMemberWorkspacePermissionProfileTomlLines,
+  buildMurphHostedPermissionProfileTomlLines,
 } from "@murphai/hosted-execution/assistant-permissions";
 import {
   HOSTED_RUNTIME_CODEX_APP_SERVER_COMMAND_ENV,
@@ -633,10 +630,7 @@ export function buildHostedCodexConfigToml(input: {
     "allow_login_shell = false",
     "",
     ...providerConfigLines,
-    ...buildMurphGroupReadPermissionProfileTomlLines(),
-    ...buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines(),
-    ...buildMurphMemberReadPermissionProfileTomlLines(),
-    ...buildMurphMemberWorkspacePermissionProfileTomlLines(),
+    ...buildMurphHostedPermissionProfileTomlLines(),
     "# Hosted runs should not perform Codex plugin marketplace or remote plugin",
     "# sync work on cold wake; Murph owns the hosted runtime tool surface.",
     "[features]",

--- a/packages/hosted-execution/src/assistant-permissions.ts
+++ b/packages/hosted-execution/src/assistant-permissions.ts
@@ -83,3 +83,12 @@ export function buildMurphMemberWorkspacePermissionProfileTomlLines(): readonly 
     "",
   ];
 }
+
+export function buildMurphHostedPermissionProfileTomlLines(): readonly string[] {
+  return [
+    ...buildMurphGroupReadPermissionProfileTomlLines(),
+    ...buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines(),
+    ...buildMurphMemberReadPermissionProfileTomlLines(),
+    ...buildMurphMemberWorkspacePermissionProfileTomlLines(),
+  ];
+}

--- a/packages/hosted-execution/test/assistant-permissions.test.ts
+++ b/packages/hosted-execution/test/assistant-permissions.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildMurphGroupReadPermissionProfileTomlLines,
   buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines,
+  buildMurphHostedPermissionProfileTomlLines,
+  buildMurphMemberReadPermissionProfileTomlLines,
   buildMurphMemberWorkspacePermissionProfileTomlLines,
 } from "../src/assistant-permissions.ts";
 
@@ -64,6 +66,15 @@ describe("group-read Codex permissions", () => {
       "[permissions.murph-member-workspace.network]",
       "enabled = true",
       "",
+    ]);
+  });
+
+  it("composes every hosted permission profile from the canonical builders", () => {
+    expect(buildMurphHostedPermissionProfileTomlLines()).toEqual([
+      ...buildMurphGroupReadPermissionProfileTomlLines(),
+      ...buildMurphGroupRoomModelMaintenancePermissionProfileTomlLines(),
+      ...buildMurphMemberReadPermissionProfileTomlLines(),
+      ...buildMurphMemberWorkspacePermissionProfileTomlLines(),
     ]);
   });
 


### PR DESCRIPTION
## Why and outcome

The focused real-Codex hosted handoff journey used a subscription home without the named production permission profiles, so its ordinary cold follow-up silently fell back to the local path. This composes the existing hosted permission tables once, materializes a production-like test home without copying auth, and keeps the hosted execution context through the follow-up.

Frog autofix issue: #2498

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: ce620bf86df3dcc58201a08cc6a1517765006e2e

## Product UX

- Product UX: not applicable; production behavior and member-visible output are unchanged.
- Live journey verdict: Ready. The named synthetic attribution and longitudinal step context survived the output-only handoff and cold ordinary hosted follow-up. The follow-up was correct, single-action, concise, autonomy-respecting, and truthful; no transcript is included.

## Evidence

- Canonical hosted permission-profile composition test — 4 passed.
- Exact production hosted Codex config test — 1 passed, 49 skipped.
- Subscription/provider permission-home config test — 1 passed, 168 skipped.
- Cloudflare runner image/config contract — 1 passed, 10 skipped.
- Typechecks passed for hosted-execution, assistant-runtime, assistant-engine, and the Cloudflare runner.
- `pnpm test:assistant:live -- --test "keeps a named private handoff in a synthetic group follow-up"` — initial and corrected local-subscription runs each passed 1 test with 168 skipped on `gpt-5.6-terra`; both synthetic replies were manually reviewed as Ready.
- Preliminary completion-specialists ReviewGPT found that reply/session assertions did not distinguish the hosted follow-up path. The accepted finding was corrected with the existing `assistant.context.diagnostics` session-resolution trace boundary; the corrected live run passed that assertion.
- Diff hygiene and privacy review passed.

## Non-obvious affected surfaces

- Hosted runtime and Cloudflare smoke config now call the single hosted-permission composition owner. The emitted profile order and values are unchanged; their exact config and runner-contract tests passed.
- The temporary real-Codex home declares the existing ordinary hosted profile as its default because current Codex rejects named profile tables without a default, and omits the mutually exclusive legacy sandbox key. This is test-only configuration.
- The cold live follow-up now proves its supplied hosted execution context survived session resolution, rather than inferring that path from a coherent reply alone.

## Architecture and reuse

- Existing systems reused: the four permission-profile builders in `@murphai/hosted-execution` remain the only policy-value owners, and the established hosted-context diagnostic remains the path proof owner.
- New logic: one composition helper returns those existing tables in their existing production order, and the live harness materializes that composition.
- New abstractions: one narrow composition helper prevents production, smoke, and live proof from maintaining separate profile inventories.
- Complexity intentionally avoided: no new profile, permission table, auth copy, sandbox layer, runtime branch, compatibility path, or diagnostic surface was added.

## Hot reply path impact

Not applicable. No production await, provider call, database operation, timeout, retry, or fallback changed; the hosted config refactor emits the same permission tables and the behavioral change is confined to opt-in live verification.

## Murph initial provider input impact

- Individual runtime: not applicable; no production prompt, tool schema, generated guidance, or provider-visible input changed.
- Group runtime: not applicable; no production prompt, tool schema, generated guidance, or provider-visible input changed.

## Change-shape breakdown

Classification rule: runtime TypeScript under `src/` is source; Vitest and real-Codex journey files are tests/fixtures; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 13 | 16 |
| Tests/fixtures | 78 | 17 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 91 | 33 |

## Deployment concerns

- Deployment: not applicable
- Reason: the production and smoke builders emit the same existing permission tables in the same order; only opt-in live verification gains production-like test-home configuration.

## Changelog

- Changelog: not applicable
- Reason: Internal verification-harness repair; no member-visible behavior changed.
