### PR TITLE
fix(health-commons): make concurrent generation collision-safe

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-29-frog-autofix-2496.md
+++ b/agent-docs/exec-plans/active/2026-08-29-frog-autofix-2496.md
@@ -1,0 +1,65 @@
+# Serialize Health Commons generated artifact publication
+
+Status: active
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Let independent hosted Web verification commands safely share deterministic
+  Health Commons generation without a generated-directory publication race.
+
+## Success criteria
+
+- A focused deterministic concurrency regression fails on the original swap
+  sequence and passes with the repair.
+- Concurrent generators either publish or reuse one complete, byte-identical
+  generated tree without leaving temporary or backup directories.
+- Focused Health Commons tests, package typecheck, and affected hosted Web
+  checks pass without committing ignored generated artifacts.
+
+## Scope
+
+- In scope: the Health Commons build-time generated-tree owner, focused
+  concurrency coverage, and affected verification.
+- Out of scope: authored Health Commons content, deployed product behavior,
+  global workspace-artifact locking, and committed generated output.
+
+## Constraints
+
+- Technical constraints: the correction must coordinate independent processes,
+  preserve complete-tree publication and cleanup, and stay scoped to the
+  generated-root owner.
+- Product/process constraints: preserve the existing no-global-artifact-lock
+  contract and keep generated files ignored.
+
+## Risks and mitigations
+
+1. Risk: a collision workaround could accept a partial or different generated
+   tree.
+   Mitigation: accept another publisher only after an exact recursive byte
+   comparison with the already-complete temporary tree.
+2. Risk: synchronization residue could strand later verification.
+   Mitigation: use collision recovery without a persistent lock file or new
+   lifecycle owner.
+
+## Tasks
+
+1. Reproduce the unguarded swap collision under deterministic scheduling.
+2. Add the smallest owner-local collision recovery and regression test.
+3. Run focused package and hosted Web verification and inspect residue.
+4. Commit, push, review, and land only after exact-head gates pass.
+
+## Decisions
+
+- Keep the existing unique temporary-tree build and atomic rename sequence.
+  Resolve only same-output publication collisions at the Health Commons owner;
+  do not restore the global workspace-artifact lock.
+
+## Verification
+
+- Commands to run: focused build determinism test, Health Commons typecheck and
+  tests, concurrent hosted Web repro, affected Web typecheck/test, diff and
+  generated-residue audit.
+- Expected outcomes: all commands pass, the generated tree matches the current
+  catalog, and only intended source/test/plan files are tracked.

--- a/agent-docs/exec-plans/completed/2026-08-29-frog-autofix-2496.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-frog-autofix-2496.md
@@ -1,8 +1,8 @@
 # Serialize Health Commons generated artifact publication
 
-Status: active
+Status: completed
 Created: 2026-08-29
-Updated: 2026-08-29
+Updated: 2026-08-30
 
 ## Goal
 
@@ -63,3 +63,4 @@ Updated: 2026-08-29
   generated-residue audit.
 - Expected outcomes: all commands pass, the generated tree matches the current
   catalog, and only intended source/test/plan files are tracked.
+Completed: 2026-08-30

--- a/packages/health-commons/src/build.ts
+++ b/packages/health-commons/src/build.ts
@@ -89,12 +89,16 @@ async function replaceGeneratedRoot(
     const publishCollision = isGeneratedRootPublishCollision(error);
     const sameTreePublished = publishCollision
       && await generatedTreesMatchExactly(temporaryRoot, targetRoot).catch(() => false);
+    if (sameTreePublished) {
+      await rm(temporaryRoot, { force: true, recursive: true });
+      if (targetMoved) {
+        await rm(backupRoot, { force: true, recursive: true });
+      }
+      return;
+    }
     await rm(temporaryRoot, { force: true, recursive: true }).catch(() => {});
     if (publishCollision && targetMoved) {
-      await rm(backupRoot, { force: true, recursive: true });
-    }
-    if (sameTreePublished) {
-      return;
+      await rm(backupRoot, { force: true, recursive: true }).catch(() => {});
     }
     if (targetMoved && !publishCollision) {
       await rename(backupRoot, targetRoot).catch(() => {});

--- a/packages/health-commons/src/build.ts
+++ b/packages/health-commons/src/build.ts
@@ -86,8 +86,17 @@ async function replaceGeneratedRoot(
     );
     await rename(temporaryRoot, targetRoot);
   } catch (error) {
+    const publishCollision = isGeneratedRootPublishCollision(error);
+    const sameTreePublished = publishCollision
+      && await generatedTreesMatchExactly(temporaryRoot, targetRoot).catch(() => false);
     await rm(temporaryRoot, { force: true, recursive: true }).catch(() => {});
-    if (targetMoved) {
+    if (publishCollision && targetMoved) {
+      await rm(backupRoot, { force: true, recursive: true });
+    }
+    if (sameTreePublished) {
+      return;
+    }
+    if (targetMoved && !publishCollision) {
       await rename(backupRoot, targetRoot).catch(() => {});
     }
     throw error;
@@ -245,6 +254,39 @@ async function readGeneratedTree(root: string): Promise<Map<string, string | nul
   return files;
 }
 
+async function generatedTreesMatchExactly(leftRoot: string, rightRoot: string): Promise<boolean> {
+  const [leftFiles, rightFiles] = await Promise.all([
+    readGeneratedTree(leftRoot),
+    readGeneratedTree(rightRoot),
+  ]);
+  if (leftFiles.size !== rightFiles.size) {
+    return false;
+  }
+
+  for (const [fileName, leftContent] of leftFiles.entries()) {
+    if (!rightFiles.has(fileName)) {
+      return false;
+    }
+    const rightContent = rightFiles.get(fileName);
+    if (leftContent !== null || rightContent !== null) {
+      if (leftContent !== rightContent) {
+        return false;
+      }
+      continue;
+    }
+
+    const [leftBytes, rightBytes] = await Promise.all([
+      readFile(path.join(leftRoot, fileName)),
+      readFile(path.join(rightRoot, fileName)),
+    ]);
+    if (!leftBytes.equals(rightBytes)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 async function collectGeneratedTreeFiles(
   absoluteRoot: string,
   relativeDir: string,
@@ -288,6 +330,10 @@ function formatGeneratedDiff(label: string, files: readonly string[]): string | 
 
 function isNodeErrorWithCode(error: unknown, code: string): boolean {
   return error instanceof Error && "code" in error && error.code === code;
+}
+
+function isGeneratedRootPublishCollision(error: unknown): boolean {
+  return isNodeErrorWithCode(error, "EEXIST") || isNodeErrorWithCode(error, "ENOTEMPTY");
 }
 
 export function parseCliOptions(argv: readonly string[]): CliOptions {

--- a/packages/health-commons/src/build.ts
+++ b/packages/health-commons/src/build.ts
@@ -259,36 +259,65 @@ async function readGeneratedTree(root: string): Promise<Map<string, string | nul
 }
 
 async function generatedTreesMatchExactly(leftRoot: string, rightRoot: string): Promise<boolean> {
-  const [leftFiles, rightFiles] = await Promise.all([
-    readGeneratedTree(leftRoot),
-    readGeneratedTree(rightRoot),
+  const [leftEntries, rightEntries] = await Promise.all([
+    readGeneratedTreeSnapshot(leftRoot),
+    readGeneratedTreeSnapshot(rightRoot),
   ]);
-  if (leftFiles.size !== rightFiles.size) {
+  if (leftEntries.size !== rightEntries.size) {
     return false;
   }
 
-  for (const [fileName, leftContent] of leftFiles.entries()) {
-    if (!rightFiles.has(fileName)) {
+  for (const [entryName, leftEntry] of leftEntries.entries()) {
+    const rightEntry = rightEntries.get(entryName);
+    if (!rightEntry || leftEntry.kind !== rightEntry.kind) {
       return false;
     }
-    const rightContent = rightFiles.get(fileName);
-    if (leftContent !== null || rightContent !== null) {
-      if (leftContent !== rightContent) {
-        return false;
-      }
+    if (leftEntry.kind === "directory") {
       continue;
     }
-
-    const [leftBytes, rightBytes] = await Promise.all([
-      readFile(path.join(leftRoot, fileName)),
-      readFile(path.join(rightRoot, fileName)),
-    ]);
-    if (!leftBytes.equals(rightBytes)) {
+    if (rightEntry.kind !== "file" || !leftEntry.bytes.equals(rightEntry.bytes)) {
       return false;
     }
   }
 
   return true;
+}
+
+type GeneratedTreeSnapshotEntry =
+  | { kind: "directory" }
+  | { bytes: Buffer; kind: "file" };
+
+async function readGeneratedTreeSnapshot(
+  root: string,
+): Promise<Map<string, GeneratedTreeSnapshotEntry>> {
+  const entries = new Map<string, GeneratedTreeSnapshotEntry>();
+  await collectGeneratedTreeSnapshot(path.resolve(root), "", entries);
+  return entries;
+}
+
+async function collectGeneratedTreeSnapshot(
+  absoluteRoot: string,
+  relativeDir: string,
+  entries: Map<string, GeneratedTreeSnapshotEntry>,
+): Promise<void> {
+  const directoryEntries = await readdir(path.join(absoluteRoot, relativeDir), {
+    withFileTypes: true,
+  });
+  directoryEntries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of directoryEntries) {
+    const relativePath = relativeDir ? path.posix.join(relativeDir, entry.name) : entry.name;
+    const absolutePath = path.join(absoluteRoot, relativePath);
+    if (entry.isDirectory()) {
+      entries.set(relativePath, { kind: "directory" });
+      await collectGeneratedTreeSnapshot(absoluteRoot, relativePath, entries);
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error("Unsupported entry in Health Commons generated tree.");
+    }
+    entries.set(relativePath, { bytes: await readFile(absolutePath), kind: "file" });
+  }
 }
 
 async function collectGeneratedTreeFiles(

--- a/packages/health-commons/test/build-determinism.test.ts
+++ b/packages/health-commons/test/build-determinism.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -7,6 +7,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HealthCommonsCatalogEntity } from "@murphai/contracts";
 
 const buildHealthCommonsCatalogMock = vi.hoisted(() => vi.fn());
+const generatedRootRenameControl = vi.hoisted(() => ({
+  delayFirstTargetMove: false,
+  delayedTargetMoves: 0,
+  releaseDelayedTargetMove: null as (() => void) | null,
+  targetRoot: "",
+}));
 const buildHealthCommonsSourceIndexMock = vi.hoisted(() =>
   vi.fn((catalog: { catalogHash: string }) => ({
     schemaVersion: "murph.commons.source-index.v1",
@@ -36,6 +42,32 @@ vi.mock("../src/catalog.ts", () => ({
   buildHealthCommonsSourceArtifactIndex: buildHealthCommonsSourceArtifactIndexMock,
   buildHealthCommonsSourceIndex: buildHealthCommonsSourceIndexMock,
 }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rename: async (oldPath: string, newPath: string): Promise<void> => {
+      await actual.rename(oldPath, newPath);
+      if (
+        generatedRootRenameControl.delayFirstTargetMove
+        && oldPath === generatedRootRenameControl.targetRoot
+        && generatedRootRenameControl.delayedTargetMoves === 0
+      ) {
+        generatedRootRenameControl.delayedTargetMoves += 1;
+        await new Promise<void>((resolve) => {
+          generatedRootRenameControl.releaseDelayedTargetMove = resolve;
+        });
+      } else if (
+        generatedRootRenameControl.delayFirstTargetMove
+        && newPath === generatedRootRenameControl.targetRoot
+      ) {
+        generatedRootRenameControl.releaseDelayedTargetMove?.();
+        generatedRootRenameControl.releaseDelayedTargetMove = null;
+      }
+    },
+  };
+});
 
 import { writeHealthCommonsGeneratedArtifacts } from "../src/build.ts";
 import { buildHealthCommonsWebBiomarkerOverview } from "../src/biomarker-web-artifacts.ts";
@@ -135,6 +167,10 @@ describe("@murphai/health-commons build determinism", () => {
     buildHealthCommonsCatalogMock.mockReset();
     buildHealthCommonsSourceArtifactIndexMock.mockClear();
     buildHealthCommonsSourceIndexMock.mockClear();
+    generatedRootRenameControl.delayFirstTargetMove = false;
+    generatedRootRenameControl.delayedTargetMoves = 0;
+    generatedRootRenameControl.releaseDelayedTargetMove = null;
+    generatedRootRenameControl.targetRoot = "";
   });
 
   it("rejects check mode when two successive builds diverge", async () => {
@@ -230,6 +266,81 @@ describe("@murphai/health-commons build determinism", () => {
         .rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(generatedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("lets concurrent writers publish the same complete generated tree", async () => {
+    const testRoot = await pathFromTempDir("health-commons-concurrent-generated-");
+    const generatedRoot = path.join(testRoot, "generated");
+    buildHealthCommonsCatalogMock.mockResolvedValue(createCatalog("sha256:first"));
+
+    try {
+      await writeHealthCommonsGeneratedArtifacts({
+        check: false,
+        contentRoot: "health-commons-content",
+        generatedRoot,
+      });
+
+      generatedRootRenameControl.delayFirstTargetMove = true;
+      generatedRootRenameControl.targetRoot = generatedRoot;
+
+      await expect(Promise.all([
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+      ])).resolves.toEqual([undefined, undefined]);
+
+      await expect(readFile(path.join(generatedRoot, "catalog.hash"), "utf8"))
+        .resolves.toBe("sha256:first\n");
+      await expect(readdir(testRoot)).resolves.toEqual(["generated"]);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a concurrent generated tree with different contents", async () => {
+    const testRoot = await pathFromTempDir("health-commons-mismatched-generated-");
+    const generatedRoot = path.join(testRoot, "generated");
+    buildHealthCommonsCatalogMock
+      .mockResolvedValueOnce(createCatalog("sha256:original"))
+      .mockResolvedValueOnce(createCatalog("sha256:first"))
+      .mockResolvedValueOnce(createCatalog("sha256:second"));
+
+    try {
+      await writeHealthCommonsGeneratedArtifacts({
+        check: false,
+        contentRoot: "health-commons-content",
+        generatedRoot,
+      });
+
+      generatedRootRenameControl.delayFirstTargetMove = true;
+      generatedRootRenameControl.targetRoot = generatedRoot;
+
+      const outcomes = await Promise.allSettled([
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+      ]);
+
+      expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+      expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+      await expect(readdir(testRoot)).resolves.toEqual(["generated"]);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
     }
   });
 

--- a/packages/health-commons/test/build-determinism.test.ts
+++ b/packages/health-commons/test/build-determinism.test.ts
@@ -308,13 +308,11 @@ describe("@murphai/health-commons build determinism", () => {
     }
   });
 
-  it("rejects a concurrent generated tree with different contents", async () => {
+  it("rejects a changed non-hash tree and preserves the concurrent winner", async () => {
     const testRoot = await pathFromTempDir("health-commons-mismatched-generated-");
     const generatedRoot = path.join(testRoot, "generated");
-    buildHealthCommonsCatalogMock
-      .mockResolvedValueOnce(createCatalog("sha256:original"))
-      .mockResolvedValueOnce(createCatalog("sha256:first"))
-      .mockResolvedValueOnce(createCatalog("sha256:second"));
+    buildHealthCommonsCatalogMock.mockResolvedValue(createCatalog("sha256:first"));
+    let winningTree: Map<string, RawGeneratedTreeEntry> | null = null;
 
     try {
       await writeHealthCommonsGeneratedArtifacts({
@@ -325,6 +323,12 @@ describe("@murphai/health-commons build determinism", () => {
 
       generatedRootRenameControl.delayFirstTargetMove = true;
       generatedRootRenameControl.targetRoot = generatedRoot;
+      generatedRootRenameControl.beforeReleaseDelayedTargetMove = async () => {
+        await writeFile(path.join(generatedRoot, "protocol-index.json"), "{\"winner\":true}\n", "utf8");
+        await mkdir(path.join(generatedRoot, "winner-only"), { recursive: true });
+        await writeFile(path.join(generatedRoot, "winner-only", "artifact.bin"), Buffer.from([0x00, 0xff]));
+        winningTree = await readRawGeneratedTree(generatedRoot);
+      };
 
       const outcomes = await Promise.allSettled([
         writeHealthCommonsGeneratedArtifacts({
@@ -341,6 +345,10 @@ describe("@murphai/health-commons build determinism", () => {
 
       expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
       expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+      if (!winningTree) {
+        throw new Error("Concurrent winner was not captured.");
+      }
+      await expect(readRawGeneratedTree(generatedRoot)).resolves.toEqual(winningTree);
       await expect(readdir(testRoot)).resolves.toEqual(["generated"]);
     } finally {
       await rm(testRoot, { recursive: true, force: true });
@@ -663,4 +671,36 @@ describe("@murphai/health-commons build determinism", () => {
 
 async function pathFromTempDir(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+type RawGeneratedTreeEntry =
+  | { kind: "directory" }
+  | { bytes: Buffer; kind: "file" };
+
+async function readRawGeneratedTree(root: string): Promise<Map<string, RawGeneratedTreeEntry>> {
+  const entries = new Map<string, RawGeneratedTreeEntry>();
+
+  async function collect(relativeDir: string): Promise<void> {
+    const children = await readdir(path.join(root, relativeDir), { withFileTypes: true });
+    children.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const child of children) {
+      const relativePath = relativeDir ? path.posix.join(relativeDir, child.name) : child.name;
+      if (child.isDirectory()) {
+        entries.set(relativePath, { kind: "directory" });
+        await collect(relativePath);
+        continue;
+      }
+      if (!child.isFile()) {
+        throw new Error("Unsupported entry in generated test tree.");
+      }
+      entries.set(relativePath, {
+        bytes: await readFile(path.join(root, relativePath)),
+        kind: "file",
+      });
+    }
+  }
+
+  await collect("");
+  return entries;
 }

--- a/packages/health-commons/test/build-determinism.test.ts
+++ b/packages/health-commons/test/build-determinism.test.ts
@@ -8,6 +8,7 @@ import type { HealthCommonsCatalogEntity } from "@murphai/contracts";
 
 const buildHealthCommonsCatalogMock = vi.hoisted(() => vi.fn());
 const generatedRootRenameControl = vi.hoisted(() => ({
+  beforeReleaseDelayedTargetMove: null as (() => Promise<void>) | null,
   delayFirstTargetMove: false,
   delayedTargetMoves: 0,
   releaseDelayedTargetMove: null as (() => void) | null,
@@ -62,6 +63,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         generatedRootRenameControl.delayFirstTargetMove
         && newPath === generatedRootRenameControl.targetRoot
       ) {
+        await generatedRootRenameControl.beforeReleaseDelayedTargetMove?.();
         generatedRootRenameControl.releaseDelayedTargetMove?.();
         generatedRootRenameControl.releaseDelayedTargetMove = null;
       }
@@ -167,6 +169,7 @@ describe("@murphai/health-commons build determinism", () => {
     buildHealthCommonsCatalogMock.mockReset();
     buildHealthCommonsSourceArtifactIndexMock.mockClear();
     buildHealthCommonsSourceIndexMock.mockClear();
+    generatedRootRenameControl.beforeReleaseDelayedTargetMove = null;
     generatedRootRenameControl.delayFirstTargetMove = false;
     generatedRootRenameControl.delayedTargetMoves = 0;
     generatedRootRenameControl.releaseDelayedTargetMove = null;
@@ -322,6 +325,45 @@ describe("@murphai/health-commons build determinism", () => {
 
       generatedRootRenameControl.delayFirstTargetMove = true;
       generatedRootRenameControl.targetRoot = generatedRoot;
+
+      const outcomes = await Promise.allSettled([
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+        writeHealthCommonsGeneratedArtifacts({
+          check: false,
+          contentRoot: "health-commons-content",
+          generatedRoot,
+        }),
+      ]);
+
+      expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+      expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+      await expect(readdir(testRoot)).resolves.toEqual(["generated"]);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a concurrent generated tree with different bytes", async () => {
+    const testRoot = await pathFromTempDir("health-commons-byte-mismatch-generated-");
+    const generatedRoot = path.join(testRoot, "generated");
+    buildHealthCommonsCatalogMock.mockResolvedValue(createCatalog("�"));
+
+    try {
+      await writeHealthCommonsGeneratedArtifacts({
+        check: false,
+        contentRoot: "health-commons-content",
+        generatedRoot,
+      });
+
+      generatedRootRenameControl.delayFirstTargetMove = true;
+      generatedRootRenameControl.targetRoot = generatedRoot;
+      generatedRootRenameControl.beforeReleaseDelayedTargetMove = async () => {
+        await writeFile(path.join(generatedRoot, "catalog.hash"), Buffer.from([0xff, 0x0a]));
+      };
 
       const outcomes = await Promise.allSettled([
         writeHealthCommonsGeneratedArtifacts({


### PR DESCRIPTION
## Why and outcome

Two repository checks can prepare the same ignored Health Commons artifact tree at once. The generator now treats a competing publication as success only when the complete published tree is byte-identical to its own complete temporary tree; different output still fails closed.

Frog autofix issue: #2496

ReviewGPT first-reviewed head: 89bc175a336c020556ec4fcf4d4b433e56aa61ea
ReviewGPT context sensitivity: sensitive — the patch changes cross-process concurrency and fail-closed publication behavior.

## Product UX

Not applicable. This changes repository-local build and verification behavior only; no member-facing product behavior or interface changes.

## Evidence

- The deterministic concurrency regression failed on the original implementation with `ENOTEMPTY` and passes on this head.
- A focused byte-distinct regression proved the prior UTF-8 comparison could falsely converge; the corrected binary tree proof rejects it.
- `pnpm exec vitest run --config packages/health-commons/vitest.config.ts packages/health-commons/test/build-determinism.test.ts --no-coverage` — 12 tests passed, including byte-distinct UTF-8 replacement decoding.
- `pnpm --filter @murphai/health-commons typecheck` — passed.
- `pnpm --filter @murphai/health-commons test:vitest` — 22 files and 150 tests passed.
- `pnpm --filter @murphai/health-commons generate:check` — passed.
- Concurrent hosted Web typecheck and focused changelog test — both exited successfully.
- `pnpm exec vitest run --config scripts/vitest.config.ts scripts/health-commons-generate.test.ts --no-coverage` — passed and preserves the no-global-artifact-lock contract.

## Non-obvious affected surfaces

- Health Commons generated artifact publication: competing writers compare the complete text and binary tree before converging.
- Hosted Web verification: its existing typecheck and test scripts both invoke the shared generator and now safely overlap when their output is identical.

## Architecture and reuse

- Existing systems reused: the Health Commons generator retains its unique temporary tree, backup, atomic rename, deterministic catalog, and ignored output ownership.
- New logic: a publish-collision path recursively proves exact file names and bytes before accepting another writer's result.
- New abstractions: none; the comparison stays private to the existing build owner.
- Complexity intentionally avoided: no global workspace lock, persistent lock file, stale-lock recovery lifecycle, dependency, service, or caller coordination was added.

## Hot reply path impact

Not applicable. The patch changes only build-time generated artifacts and repository verification; it does not enter the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no provider-input assembly surface changed.
- Codex runtime: Not applicable; no prompt, tool schema, or provider-visible guidance changed.

## Risks

- A competing writer with different bytes remains an error, and both temporary and displaced backup trees are cleaned without replacing the winning tree.
- Exact comparison runs only after a directory-publication collision, so ordinary generation retains its current work and latency shape.

## Change-shape breakdown

Classification rule: authored generator logic is source; Vitest coverage is tests/fixtures; the execution plan is docs; no config/tooling or generated files changed. No binary files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 80 | 1 |
| Tests/fixtures | 194 | 1 |
| Docs | 66 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 340 | 2 |

## Deployment concerns

- Deployment: not applicable
- Reason: This is repository-local build and verification tooling with no runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal generated-artifact preparation only; no member-visible behavior changed.
## Review gates
- Preliminary completion-specialists ReviewGPT on exact head `87fb36c10f7564034f54cf6b39d0631d03f94203`: FINDINGS. Accepted the Medium coverage gap and resolved it on this head with a non-hash structural mismatch plus exact winning-tree preservation proof; focused regression passes 12/12. The preliminary pass is not rerun after substantive remediation.
- Final cross-cutting ReviewGPT round 1: PASS with no findings on exact head `89bc175a336c020556ec4fcf4d4b433e56aa61ea`.