### PR TITLE
fix(web): prevent branded food label search timeouts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1843,9 +1843,11 @@ Private food-name search bounds indexed matches before similarity scoring,
 canonical-key deduplication, and window sorting. A literal-equality btree lane
 admits up to 250 exact names without SQL-pattern semantics, an unordered GIN
 lane admits up to 10,000 full-text matches without sorting the whole match set,
-and one GiST trigram branch is realized per query. Full-text searches supplement
-GIN recall with up to 10,000 strict-word-nearest names. When FTS finds nothing,
-typo recovery instead admits up to 10,000 names by whole-name distance and then
+and at most one GiST trigram branch is realized per query. A full-text search
+supplements GIN recall with up to 10,000 strict-word-nearest names only when
+the GIN set reaches its cap and may be truncated; an unsaturated set is
+exhaustive and skips that whole-catalog scan. When FTS finds nothing, typo
+recovery instead admits up to 10,000 names by whole-name distance and then
 applies the matching whole-name threshold; eligible names necessarily precede
 ineligible names because ordering and eligibility use the same similarity.
 Canonical-key deduplication happens only after those bounded admissions.

--- a/agent-docs/exec-plans/active/2026-08-29-food-label-search-conditional-knn.md
+++ b/agent-docs/exec-plans/active/2026-08-29-food-label-search-conditional-knn.md
@@ -1,0 +1,93 @@
+# Prevent branded food label search timeouts
+
+Status: active
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Keep private branded food-label searches within the existing eight-second
+  database statement budget so meal capture can use label-backed nutrition
+  instead of receiving a retryable hosted API failure.
+
+## Success criteria
+
+- A deterministic PostgreSQL regression proves that the expensive nearest-name
+  branch is skipped when indexed full-text retrieval is exhaustive below its
+  cap and remains available when the cap is saturated.
+- Representative synthetic branded-cracker searches complete successfully
+  against the configured labels database under the production timeout.
+- Existing food-label ranking, exact-id/UPC lookup, generic-food search, and
+  contaminant attachment contracts remain unchanged.
+- Focused Web tests and typecheck pass, exact-head CI is green, and required
+  review gates resolve with no accepted findings.
+
+## Scope
+
+- In scope: private food-name search SQL, its focused PostgreSQL/unit coverage,
+  the member-facing changelog, and the owning product-label documentation.
+- Out of scope: label imports, database schema changes, new indexes, supplement
+  ranking, public product search, CLI error semantics, and assistant prompts.
+
+## Constraints
+
+- Technical constraints: retain the current pool, indexes, 10,000-row retrieval
+  caps, deterministic ranking, and eight-second statement timeout; add no new
+  dependency or runtime owner.
+- Product/process constraints: use only synthetic reproduction queries in
+  durable artifacts, preserve the active contaminant-data plan, and ship from
+  an isolated worktree without modifying the older overlapping draft PR.
+
+## Risks and mitigations
+
+1. Risk: skipping nearest-name retrieval could reduce recall for a full-text
+   query whose GIN candidate set was truncated.
+   Mitigation: skip it only when the materialized full-text set is below the
+   existing cap, which proves that set was not truncated.
+2. Risk: a planner rewrite could still execute the expensive GiST scan.
+   Mitigation: inspect the real labels-database plan and assert the generated
+   SQL places the cap-saturation predicate inside the KNN input branch.
+
+## Tasks
+
+1. Correlate the alert with safe runtime evidence and reproduce the exact
+   `search_rows` timeout class against the configured labels database.
+2. Profile the production SQL and prove the root-cause branch.
+3. Make nearest-name retrieval conditional on full-text cap saturation and add
+   focused regression coverage.
+4. Run deterministic and real-database proof, update member-facing docs, and
+   complete the PR review/CI workflow.
+
+## Decisions
+
+- Root cause: unsaturated full-text searches still materialize 10,000 whole-
+  catalog GiST nearest-name rows before filtering them back to the small FTS
+  set. A synthetic branded-cracker query spent about 10.9 seconds in that scan
+  and exceeded the production eight-second statement timeout with PostgreSQL
+  code `57014`.
+- The smallest correction is to run that KNN branch only when the bounded FTS
+  set reaches its 10,000-row cap; no schema, index, timeout, retry, or fallback
+  change is needed.
+
+## Product UX Patch
+
+- Outcome: an existing private meal-capture journey receives a matching branded
+  food label instead of a retryable service-unavailable result.
+- Reaches: current private assistant turns that call `food search-labels`; no
+  new audience, surface, data source, permission, or reply policy is added.
+- Proof: the same representative branded-cracker search class that canceled at
+  eight seconds returns a label under the unchanged production timeout.
+- Walkthrough: `Ready`. Five representative food searches returned one matching
+  label each against the configured labels database; the two pre-fix timeout
+  cases completed in 54 ms and 59 ms after the change. Exact ID, UPC, generic,
+  saturated-FTS, and typo recovery remain covered by focused tests. No behavior
+  differed from the plan.
+
+## Verification
+
+- Commands to run: focused product-label unit and PostgreSQL tests, Web
+  typecheck, a safe labels-database reproduction using representative synthetic
+  searches, and exact-head CI plus routed ReviewGPT gates.
+- Expected outcomes: focused checks pass; affected searches return inside the
+  statement budget; unsaturated plans show zero loops for the nearest-name GiST
+  scan; saturated fixtures preserve current ranked recall.

--- a/agent-docs/exec-plans/completed/2026-08-29-food-label-search-conditional-knn.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-food-label-search-conditional-knn.md
@@ -1,6 +1,6 @@
 # Prevent branded food label search timeouts
 
-Status: active
+Status: completed
 Created: 2026-08-29
 Updated: 2026-08-29
 
@@ -85,9 +85,21 @@ Updated: 2026-08-29
 
 ## Verification
 
-- Commands to run: focused product-label unit and PostgreSQL tests, Web
-  typecheck, a safe labels-database reproduction using representative synthetic
-  searches, and exact-head CI plus routed ReviewGPT gates.
-- Expected outcomes: focused checks pass; affected searches return inside the
-  statement budget; unsaturated plans show zero loops for the nearest-name GiST
-  scan; saturated fixtures preserve current ranked recall.
+- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage
+  apps/web/test/foods-lib.test.ts` passed 32 tests.
+- The focused large-catalog PostgreSQL test passed its one selected case with
+  133 unrelated cases skipped. It proved one active GiST scan for saturated FTS
+  and zero for unsaturated FTS under the production eight-second timeout.
+- Five representative synthetic food searches passed against the configured
+  labels database. The two pre-fix timeout cases completed in 54 ms and 59 ms;
+  direct `EXPLAIN ANALYZE` completed in 7 ms with zero active name-rank scans.
+- `pnpm --dir apps/web typecheck`, focused ESLint, and `git diff --check`
+  passed.
+- `pnpm --dir apps/web test -- changelog-page.test.tsx` passed 9 tests.
+- Preliminary ReviewGPT specialists returned `SPECIALIST_OUTCOME: PASS` with
+  no findings on `9210aabf24bab783c3383ad54b628bda65121fef`.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no qualifying
+  findings on the same exact pushed head.
+- PR 2549 remains the exact-head CI owner after plan closure and Ready
+  admission.
+Completed: 2026-08-29

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -767,10 +767,12 @@ The current search path uses built-in Postgres full-text search plus the
 their existing 250-candidate SQL bound, and supplement searches retain their
 existing ranking path. Private food-name search uses a separate bounded
 retrieval contract for the roughly two-million-row foods corpus: it admits at
-most 250 literal exact-name rows, 10,000 GIN full-text matches, and 10,000 GiST
-nearest-name candidates before similarity scoring, canonical-key deduplication,
-and window sorting. Exactly one GiST branch is realized: full-text searches use
-strict-word-nearest names, while no-FTS typo searches use whole-name distance
+most 250 literal exact-name rows and 10,000 GIN full-text matches before
+similarity scoring, canonical-key deduplication, and window sorting. When the
+GIN set reaches that cap and may be truncated, one GiST branch admits up to
+10,000 strict-word-nearest names to recover stronger full-text candidates. An
+unsaturated GIN set is already exhaustive and skips that whole-catalog scan.
+When FTS finds nothing, the one GiST branch instead uses whole-name distance
 and its matching whole-name threshold. That shared metric keeps eligible typo
 matches ahead of ineligible names before the cap. The bounded admissions
 preserve representative choice and canonical diversity across the established

--- a/apps/web/changelog/entries/2026-08-14/reliable-food-lookups.json
+++ b/apps/web/changelog/entries/2026-08-14/reliable-food-lookups.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 3,
     "title": "More reliable food lookups",
-    "summary": "Murph now keeps broad food-label searches responsive instead of letting unusually large matching catalogs time out.",
-    "details": "Exact food IDs and barcodes still use direct lookups. Name searches remain ranked and deduplicated while Murph limits the catalog work behind each request.",
+    "summary": "Murph now keeps broad and specific food-label searches responsive instead of letting large matching catalogs time out.",
+    "details": "Exact food IDs and barcodes still use direct lookups. Name searches stay ranked and deduplicated while Murph limits catalog work to what each request needs.",
     "relevanceTags": ["nutrition", "food", "reliability", "performance"],
-    "sourcePullRequests": [1804]
+    "sourcePullRequests": [1804, 2549]
   }
 }

--- a/apps/web/src/lib/product-labels.ts
+++ b/apps/web/src/lib/product-labels.ts
@@ -2194,12 +2194,17 @@ async function searchGenericProductLabels(
             data_origin_priority
           FROM ${tableSql}
           WHERE
+            -- Below the FTS cap, fts_index_matches already contains every
+            -- indexed full-text match, so this whole-catalog KNN scan can add
+            -- no candidate. Only pay for it when the bounded GIN result is
+            -- saturated and may have omitted a better nearest-name match.
+            (SELECT count(*) FROM fts_index_matches) = ${PRODUCT_LABEL_SEARCH_MATCH_LIMIT}
+            AND
             ($2::boolean OR off_market = false)
             AND ${PRODUCT_LABEL_SOURCE_FILTER_SQL}
             AND ($4::text[] IS NULL OR data_origin = ANY($4::text[]))
             AND ${excludedDataOriginsSql}
-          -- This GiST KNN branch runs only when indexed FTS found rows. The
-          -- mutually exclusive typo branch below owns no-FTS searches.
+          -- The mutually exclusive typo branch below owns no-FTS searches.
           ORDER BY name <->>> $1::text
           LIMIT ${PRODUCT_LABEL_SEARCH_MATCH_LIMIT}
         ),
@@ -2217,8 +2222,7 @@ async function searchGenericProductLabels(
             data_origin_priority
           FROM name_nearest_matches
           WHERE
-            EXISTS (SELECT 1 FROM fts_index_matches)
-            AND ${stemmed ? `(
+            ${stemmed ? `(
               to_tsvector('simple', search_text) @@ websearch_to_tsquery('simple', $1)
               OR to_tsvector('english', search_text) @@ websearch_to_tsquery('english', $1)
             )` : `to_tsvector('simple', search_text) @@ websearch_to_tsquery('simple', $1)`}

--- a/apps/web/test/foods-lib.test.ts
+++ b/apps/web/test/foods-lib.test.ts
@@ -624,17 +624,18 @@ describe("foods query helpers", () => {
     expect(ftsIndexSql).toContain("to_tsvector");
     expect(ftsIndexSql).not.toContain("ORDER BY");
     expect(nameNearestSql).not.toContain("to_tsvector");
+    expect(nameNearestSql).toContain(
+      "(SELECT count(*) FROM fts_index_matches) = 10000",
+    );
     expect(nameNearestSql).toContain("ORDER BY name <->>> $1::text");
     expect(ftsNearestSql).toContain("FROM name_nearest_matches");
-    expect(ftsNearestSql).toContain(
-      "EXISTS (SELECT 1 FROM fts_index_matches)",
-    );
+    expect(ftsNearestSql).not.toContain("EXISTS");
     expect(ftsNearestSql).not.toContain("FROM foods");
     expect(searchCall?.text).toMatch(
       /fts_index_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?LIMIT 10000\s*\),\s*name_nearest_matches AS MATERIALIZED/u,
     );
     expect(searchCall?.text).toMatch(
-      /name_nearest_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?ORDER BY name <->>> \$1::text\s*LIMIT 10000/u,
+      /name_nearest_matches AS MATERIALIZED \([\s\S]*?FROM foods[\s\S]*?count\(\*\) FROM fts_index_matches\) = 10000[\s\S]*?ORDER BY name <->>> \$1::text\s*LIMIT 10000/u,
     );
     expect(searchCall?.text).toMatch(
       /fts_nearest_matches AS MATERIALIZED \([\s\S]*?FROM name_nearest_matches[\s\S]*?to_tsvector/u,

--- a/apps/web/test/supplements-search-postgres.test.ts
+++ b/apps/web/test/supplements-search-postgres.test.ts
@@ -1297,9 +1297,10 @@ describe.runIf(Boolean(testDatabaseUrl))(
         const broadPlan = broadExplain.rows[0]?.["QUERY PLAN"][0]?.Plan;
         expect(broadPlan).toBeDefined();
         const broadNodes = flattenExplainPlan(broadPlan ?? {});
-        expect(broadNodes.some((node) =>
-          node["Index Name"] === "foods_perf_name_rank_idx"
-        )).toBe(true);
+        expect(broadNodes.filter((node) =>
+          node["Index Name"] === "foods_perf_name_rank_idx" &&
+          (node["Actual Loops"] ?? 0) > 0
+        )).toHaveLength(1);
         expectBoundedFoodSortInputs(broadNodes);
         await client.query("SET LOCAL statement_timeout = '8s'");
 
@@ -1321,10 +1322,15 @@ describe.runIf(Boolean(testDatabaseUrl))(
         );
         const brandPlan = brandExplain.rows[0]?.["QUERY PLAN"][0]?.Plan;
         expect(brandPlan).toBeDefined();
-        expect(flattenExplainPlan(brandPlan ?? {}).some((node) =>
+        const brandNodes = flattenExplainPlan(brandPlan ?? {});
+        expect(brandNodes.some((node) =>
           node["Index Name"] === "foods_perf_search_idx" ||
           node["Index Name"] === "foods_perf_search_english_idx"
         )).toBe(true);
+        expect(brandNodes.filter((node) =>
+          node["Index Name"] === "foods_perf_name_rank_idx" &&
+          (node["Actual Loops"] ?? 0) > 0
+        )).toHaveLength(0);
 
         const exact = await queries.searchFoods({
           includeOffMarket: false,


### PR DESCRIPTION
## Why and outcome

Private branded food-label searches could exceed the labels database statement budget and surface as a retryable service-unavailable result during meal capture. This keeps the existing ranked search contract while skipping a whole-catalog nearest-name scan when full-text retrieval is already exhaustive.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: existing members whose private meal-capture turn looks up a branded packaged food.
- Outcome: the existing label-backed meal workflow returns a matching label instead of an avoidable retryable error.
- Exclusions: no new audience, surface, data source, permission, reply policy, public-search behavior, or supplement behavior.

## Evidence

- Five synthetic representative food searches completed against the configured labels database; the two pre-fix timeout cases completed in 54 ms and 59 ms after the change.
- Real-database `EXPLAIN ANALYZE` completed in 7 ms and showed zero active nearest-name GiST scans for the unsaturated branded query.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/foods-lib.test.ts` (32 passed).
- `MURPH_SUPPLEMENT_SEARCH_TEST_DB_URL=<LOCAL_TEST_DATABASE> pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/supplements-search-postgres.test.ts --testNamePattern "large-catalog food PostgreSQL search bound"` (1 passed; 133 skipped).
- `pnpm --dir apps/web test -- changelog-page.test.tsx` (9 passed).
- `pnpm --dir apps/web typecheck` (passed).
- Focused ESLint and `git diff --check` (passed).
- Preliminary Product UX specialists and final ReviewGPT round 1 both returned PASS with no findings on the immutable first-reviewed production head; the final push only archived the completed execution plan.

## Non-obvious affected surfaces

- Product-label search documentation in `ARCHITECTURE.md` and `apps/web/README.md` now records the conditional GiST admission contract.
- The optional large-catalog PostgreSQL proof now asserts both sides of the planner boundary: saturated FTS executes one GiST recall scan, while unsaturated FTS executes none.
- The existing `2026-08-14 · reliable-food-lookups` public changelog item now includes both broad and specific food-label searches and records this PR as a contributing source.

## Architecture and reuse

- Existing systems reused: the existing GIN full-text result, GiST name-rank index, 10,000-row cap, deterministic ranking, pool, and eight-second statement timeout.
- New logic: one cap-saturation predicate gates the existing full-text nearest-name branch.
- New abstractions: none; the current query owner and SQL CTE boundary are sufficient.
- Complexity intentionally avoided: no new index, cache, retry, fallback query, timeout increase, dependency, service, or state owner.

## Hot reply path impact

This improves an existing awaited food-label tool call on the foreground reply path but adds or moves no database, network, provider, or other awaited operation. One Web request still performs one bounded label-search query and, for returned rows, the existing bounded contaminant-summary query; ordering, call counts, retry behavior, and the eight-second database timeout are unchanged. Representative affected searches moved from PostgreSQL cancellation at about 8.0 seconds to 54-59 ms after warm-up.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated guidance, or other provider-visible input changed.
- Group runtime: Not applicable; no prompt, tool schema, generated guidance, or other provider-visible input changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: authored changelog copy reviewed directly and exercised through the production archive test; production presentation is unchanged.
- Coverage: content-only archive copy on the existing responsive production component; no visual state, interaction, or viewport behavior changed.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; executable test files are tests/fixtures; architecture, package docs, execution plan, and changelog copy are docs; generated files are separate. No binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 8 | 4 |
| Tests/fixtures | 15 | 8 |
| Docs | 119 | 10 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 142 | 22 |

## Changelog

- Changelog: updated
- Items: 2026-08-14 · reliable-food-lookups

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new Web instances share the same request, response, database, and index contracts; old instances may still time out on the affected query class.
- Safe order: deploy Web normally; Cloudflare, CLI, and labels-database changes are not required.
- Rollback floor: an ordinary Web rollback is safe and only restores the prior timeout risk.
- Expected exposure: during a mixed Web rollout, requests routed to old instances may still receive the retryable 500.
- Reversibility: revert the Web code without data or schema rollback.
- Convergence proof: run the representative synthetic branded-food lookup under the eight-second production statement budget.
- Post-deploy checks: verify the representative lookup succeeds and inspect bounded `/api/foods` 500/error-code aggregates.

ReviewGPT context sensitivity: sensitive — production Web database-query and deploy behavior change.

ReviewGPT first-reviewed head: 9210aabf24bab783c3383ad54b628bda65121fef