### PR TITLE
fix(repo): surface schema generator failures

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -93,8 +93,19 @@ assert_clean_cli_inputs() {
 
 assert_clean_cli_inputs
 
-if ! pnpm --dir "$repo_root/packages/cli" gen:config-schema >/dev/null 2>&1; then
+if schema_generator_output="$(
+  pnpm --dir "$repo_root/packages/cli" gen:config-schema 2>&1
+)"; then
+  :
+else
+  schema_generator_output="${schema_generator_output//$repo_root/<repo>}"
+  schema_generator_output="${schema_generator_output//$HOME/<home>}"
+  if [[ -n "$schema_generator_output" ]]; then
+    echo "pre-commit: CLI config-schema generator output:" >&2
+    printf '%s\n' "$schema_generator_output" >&2
+  fi
   echo "pre-commit: CLI config-schema generation failed; commit continues, CI will verify." >&2
+  echo "pre-commit: refresh workspace artifacts with 'pnpm --dir packages/cli verify:prepared-runtime', then rerun 'pnpm --dir packages/cli gen:config-schema'." >&2
   exit 0
 fi
 

--- a/scripts/developer-workflow-entrypoints.test.ts
+++ b/scripts/developer-workflow-entrypoints.test.ts
@@ -88,6 +88,10 @@ function createPreCommitHarness() {
     `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$@" > "\${MURPH_TEST_PNPM_CAPTURE:?}"
+if [[ "\${MURPH_TEST_GENERATOR_FAIL:-0}" == '1' ]]; then
+  printf '%s\\n' "\${MURPH_TEST_GENERATOR_DIAGNOSTIC:-synthetic generator failure}" >&2
+  exit 1
+fi
 if [[ "\${MURPH_TEST_WRITE_GENERATED:-0}" == '1' ]]; then
   cli_dir="$2"
   case "\${MURPH_TEST_GENERATOR_MUTATION:-}" in
@@ -436,6 +440,30 @@ describe("pre-commit CLI schema generation", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(harness.capture, "utf8")).toContain("gen:config-schema");
+  });
+
+  it("surfaces generator diagnostics and the canonical recovery commands", () => {
+    const harness = createPreCommitHarness();
+    writeFileSync(
+      path.join(harness.repository, "packages", "cli", "src", "input.ts"),
+      "staged\n",
+    );
+    runGit(harness.repository, ["add", "packages/cli/src/input.ts"]);
+    const hookRepoRoot = runGit(harness.repository, ["rev-parse", "--show-toplevel"]);
+    const diagnostic = `${hookRepoRoot}/packages/core/dist/index.d.ts: synthetic stale declaration`;
+
+    const result = runPreCommit(harness, {
+      MURPH_TEST_GENERATOR_DIAGNOSTIC: diagnostic,
+      MURPH_TEST_GENERATOR_FAIL: "1",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "<repo>/packages/core/dist/index.d.ts: synthetic stale declaration",
+    );
+    expect(result.stderr).not.toContain(hookRepoRoot);
+    expect(result.stderr).toContain("pnpm --dir packages/cli verify:prepared-runtime");
+    expect(result.stderr).toContain("pnpm --dir packages/cli gen:config-schema");
   });
 
   it("fails before generation when a tracked CLI input has unstaged changes", () => {


### PR DESCRIPTION
## Why and outcome

The pre-commit hook suppressed CLI schema-generator output when stale workspace declarations made the generator fail, leaving only a generic warning. The hook now preserves its non-blocking contract while printing redacted captured diagnostics and the exact prepared-runtime and generator commands needed to recover.

## Product UX

Not applicable: this changes repository-local developer diagnostics, not a member-facing product journey.

## Evidence

- The focused regression failed before the repair because the synthetic stale-declaration diagnostic was absent, then passed after the repair.
- Full developer-workflow entrypoint suite: 22/22 passed.
- A fresh-worktree generator run reproduced missing sibling declaration output; the documented prepared-runtime command passed, and the generator retry then passed without generated-file drift.
- Bash syntax, diff hygiene, privacy scan, and current-main merge-tree proof passed.
- Broader repository-tooling run passed 48 files and 677 tests; one untouched workspace-verification timing test failed once, then its exact isolated rerun passed.

## Non-obvious affected surfaces

- The branch-independent pre-commit hook's CLI schema generation failure path now captures diagnostics, redacts repository and home prefixes, and emits recovery guidance. Successful generation and generated-artifact staging are unchanged.

## Architecture and reuse

- Existing systems reused: the existing generator, prepared-runtime verifier, non-blocking failure policy, and staged-output owner remain unchanged.
- New logic: the hook captures one existing command's combined output and redacts local path prefixes before displaying it on failure.
- New abstractions: none; the existing hook failure branch remains the sole owner.
- Complexity intentionally avoided: no automatic workspace rebuild, cache state, retry loop, or new helper process was added.

## Hot reply path impact

Not applicable: this repository hook does not touch Murph's foreground reply critical path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changed.
- Group runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changed.

## Change-shape breakdown

Classification treats the hook as config/tooling and its hermetic regression as tests. No binaries or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 28 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 12 | 1 |
| Generated/other | 0 | 0 |
| Total | 40 | 1 |

## Deployment concerns

- Deployment: not applicable
- Reason: This repository-local hook has no hosted deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal developer diagnostics have no member-visible product change.

Frog autofix issue: #2428
