### PR TITLE
fix release CLI manifest packaging timeout

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-29-frog-2438-release-cli-manifest.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-frog-2438-release-cli-manifest.md
@@ -1,0 +1,84 @@
+# Bound release CLI manifest packaging wait
+
+Status: completed
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Let release packaging finish the real schema-bearing CLI manifest on a
+  contended supported host while preserving the ordinary manifest reader's
+  bounded 60-second default.
+
+## Success criteria
+
+- The release-only generator supplies an explicit bounded wait longer than the
+  observed valid packaging duration.
+- The shared CLI-manifest reader honors an explicit timeout without changing
+  callers that omit it.
+- Focused regression tests prove both the release override and unchanged
+  default timer, and assistant-engine typecheck passes.
+- The exact pushed PR head completes required ReviewGPT and CI gates, or is
+  preserved as a clean Draft handoff when shared review capacity is unavailable.
+
+## Scope
+
+- In scope: assistant CLI-manifest process timeout ownership, the release-time
+  generated contract caller, focused assistant-engine regression coverage, and
+  durable release verification documentation if the owner contract changes.
+- Out of scope: environment-driven timeout escape hatches, unbounded waits,
+  changes to ordinary runtime defaults, release workflow restructuring, and
+  adjacent runner-bundle Frog issues.
+
+## Constraints
+
+- Technical constraints: keep the subprocess wait bounded, preserve sanitized
+  child-process environment and termination semantics, and avoid production
+  credentials or provider calls.
+- Product/process constraints: Frog authority is the committed entry for issue
+  #2438; publish only public-safe evidence; keep the PR Draft until focused proof
+  and exact-head review admission are complete.
+
+## Risks and mitigations
+
+1. Risk: a broad timeout increase masks a hung runtime command.
+   Mitigation: retain the existing 60-second default and opt in only from the
+   release artifact generator.
+2. Risk: the new timeout option is diagnostic-only and not honored by the
+   spawned process.
+   Mitigation: spy on the real timer boundary to prove the configured value
+   drives the scheduled subprocess termination deadline.
+
+## Tasks
+
+1. [complete] Add a failing regression that requires a bounded release-only timeout.
+2. [complete] Add the smallest optional reader input and pass it from the generated
+   release artifact owner.
+3. [complete] Run focused unit proof, package typecheck, and the affected release checks.
+4. [in progress] Inspect the final diff, finish the scoped commit, push, and open a Draft PR.
+5. [pending] Run or hand off the exact-head ReviewGPT and CI gates according to available
+   shared capacity.
+
+## Decisions
+
+- The current defect is not obsolete: `pack-publishables.mjs` regenerates the
+  assistant-engine artifact, whose only full-manifest reader still enforces the
+  same fixed 60-second process timeout.
+- A test-only environment override is rejected because the failing path is the
+  real release pack job. The existing typed reader input is the narrow owner for
+  a bounded caller-specific budget, and the packer passes it through one
+  validated internal generator argument.
+
+## Verification
+
+- Commands to run: focused Vitest for
+  `assistant-cli-surface-bootstrap.test.ts`, assistant-engine typecheck, and the
+  affected release packaging/workflow guard tests selected from the CI map.
+- Expected outcomes: the release generator requests the explicit longer bound,
+  the shared reader schedules that bound while its default stays 60 seconds,
+  and all focused owner checks pass.
+- Results: assistant CLI surface bootstrap 23/23 passed; assistant-engine
+  typecheck passed; CLI release-script coverage audit 48/48 passed with its one
+  explicitly gated real-tarball test skipped; docs drift/gardening, Node syntax,
+  and `git diff --check` passed.
+Completed: 2026-08-29

--- a/packages/assistant-engine/src/assistant/cli-surface-manifest.ts
+++ b/packages/assistant-engine/src/assistant/cli-surface-manifest.ts
@@ -110,6 +110,7 @@ export async function readAssistantCliLlmsManifest(input: {
 export async function readAssistantCliLlmsFullManifest(input: {
   cliEnv?: NodeJS.ProcessEnv
   executionContext?: AssistantExecutionContext | null
+  timeoutMs?: number
   workingDirectory?: string | null
 }): Promise<AssistantCliLlmsManifest> {
   const result = await executeAssistantCliManifestCommand({
@@ -117,6 +118,7 @@ export async function readAssistantCliLlmsFullManifest(input: {
     cliEnv: input.cliEnv,
     executionContext: input.executionContext,
     maxOutputChars: assistantCliFullManifestMaxOutputChars,
+    timeoutMs: input.timeoutMs,
     workingDirectory: input.workingDirectory,
   })
 
@@ -155,6 +157,7 @@ async function executeAssistantCliManifestCommand(input: {
   cliEnv?: NodeJS.ProcessEnv
   executionContext?: AssistantExecutionContext | null
   maxOutputChars?: number
+  timeoutMs?: number
   workingDirectory?: string | null
 }): Promise<{
   argv: string[]
@@ -164,6 +167,12 @@ async function executeAssistantCliManifestCommand(input: {
   stdout: string
 }> {
   const disableConfigAutodiscovery = Boolean(input.executionContext?.hosted?.memberId)
+  const timeoutMs = input.timeoutMs ?? assistantCliManifestTimeoutMs
+
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError('Assistant CLI manifest timeout must be a positive safe integer.')
+  }
+
   const argv = disableConfigAutodiscovery
     ? ['--no-config', ...input.args]
     : [...input.args]
@@ -195,12 +204,12 @@ async function executeAssistantCliManifestCommand(input: {
             `vault-cli ${argv.join(' ')} timed out while loading the CLI manifest.`,
             {
               argv,
-              timeoutMs: assistantCliManifestTimeoutMs,
+              timeoutMs,
             },
           ),
         )
       })
-    }, assistantCliManifestTimeoutMs)
+    }, timeoutMs)
 
     const settle = (handler: () => void) => {
       if (settled) {

--- a/packages/assistant-engine/src/assistant/generate-cli-surface-contract.ts
+++ b/packages/assistant-engine/src/assistant/generate-cli-surface-contract.ts
@@ -16,8 +16,10 @@ const artifactPath = path.join(
   moduleDirectory,
   assistantCliSurfacePrebuiltArtifactFileName,
 )
+const manifestTimeoutMs = readManifestTimeoutMs(process.argv.slice(2))
 
 const manifest = await readAssistantCliLlmsFullManifest({
+  timeoutMs: manifestTimeoutMs,
   workingDirectory: workspaceRoot,
 })
 const contract = buildAssistantCliSurfaceContract(manifest)
@@ -32,3 +34,24 @@ const artifact: AssistantCliSurfacePrebuiltArtifact = {
 }
 
 await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8')
+
+function readManifestTimeoutMs(args: readonly string[]): number | undefined {
+  if (args.length === 0) {
+    return undefined
+  }
+
+  const [flag, rawTimeoutMs] = args
+  const timeoutMs = Number(rawTimeoutMs)
+  if (
+    args.length !== 2 ||
+    flag !== '--manifest-timeout-ms' ||
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0
+  ) {
+    throw new Error(
+      'Usage: generate-cli-surface-contract.js [--manifest-timeout-ms <positive-integer>]',
+    )
+  }
+
+  return timeoutMs
+}

--- a/packages/assistant-engine/test/assistant-cli-surface-bootstrap.test.ts
+++ b/packages/assistant-engine/test/assistant-cli-surface-bootstrap.test.ts
@@ -613,10 +613,11 @@ test('readAssistantCliLlmsManifest launches workspace CLI source with base tscon
   assert.equal(spawnCall.cwd, path.join(path.sep, 'tmp', 'murph-workspace'))
 })
 
-test('readAssistantCliLlmsFullManifest launches the full schema-bearing manifest', async () => {
+test('readAssistantCliLlmsFullManifest launches the full manifest with bounded caller timeout support', async () => {
   vi.resetModules()
 
   const fakeTsxBinary = path.join(path.sep, 'tmp', 'murph-test-bin', 'tsx')
+  const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
   const spawnCalls: Array<{
     args: string[]
     command: string
@@ -675,17 +676,26 @@ test('readAssistantCliLlmsFullManifest launches the full schema-bearing manifest
       PATH: path.dirname(fakeTsxBinary),
     },
   })
+  const boundedManifest = await readAssistantCliLlmsFullManifest({
+    cliEnv: {
+      PATH: path.dirname(fakeTsxBinary),
+    },
+    timeoutMs: 5 * 60_000,
+  })
 
   assert.equal(manifest.commands[0]?.name, 'goal save')
-  assert.equal(spawnCalls.length, 1)
+  assert.equal(boundedManifest.commands[0]?.name, 'goal save')
+  assert.equal(spawnCalls.length, 2)
 
   const spawnCall = spawnCalls[0]
   assert.ok(spawnCall)
   assert.equal(spawnCall.command, fakeTsxBinary)
   assert.deepEqual(spawnCall.args.slice(3), ['--llms-full', '--format', 'json'])
+  assert.ok(timeoutSpy.mock.calls.some(([, delay]) => delay === 60_000))
+  assert.ok(timeoutSpy.mock.calls.some(([, delay]) => delay === 5 * 60_000))
 })
 
-test('generate-cli-surface-contract builds the prebuilt artifact from the full manifest', async () => {
+test('generate-cli-surface-contract accepts the release packaging manifest timeout', async () => {
   vi.resetModules()
 
   const writeFileMock = vi.fn(
@@ -707,7 +717,10 @@ test('generate-cli-surface-contract builds the prebuilt artifact from the full m
     },
   )
   const readAssistantCliLlmsFullManifest = vi.fn(
-    async (_input: { workingDirectory?: string | null }) => ({
+    async (_input: {
+      timeoutMs?: number
+      workingDirectory?: string | null
+    }) => ({
       commands: [
         {
           description: 'Create or update one goal from typed command fields.',
@@ -744,7 +757,17 @@ test('generate-cli-surface-contract builds the prebuilt artifact from the full m
     readAssistantCliLlmsManifest,
   }))
 
-  await import('../src/assistant/generate-cli-surface-contract.ts')
+  const originalArgv = process.argv
+  process.argv = [
+    ...originalArgv.slice(0, 2),
+    '--manifest-timeout-ms',
+    String(5 * 60_000),
+  ]
+  try {
+    await import('../src/assistant/generate-cli-surface-contract.ts')
+  } finally {
+    process.argv = originalArgv
+  }
 
   assert.equal(readAssistantCliLlmsManifest.mock.calls.length, 0)
   assert.equal(readAssistantCliLlmsFullManifest.mock.calls.length, 1)
@@ -753,6 +776,10 @@ test('generate-cli-surface-contract builds the prebuilt artifact from the full m
       readAssistantCliLlmsFullManifest.mock.calls[0]?.[0]?.workingDirectory ?? '',
     ),
     repoRoot,
+  )
+  assert.equal(
+    readAssistantCliLlmsFullManifest.mock.calls[0]?.[0]?.timeoutMs,
+    5 * 60_000,
   )
   assert.equal(writeFileMock.mock.calls.length, 1)
 

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -6152,6 +6152,13 @@ exit 1
     expect(packPublishables).toContain("path.basename(sourcePath) === 'node_modules'")
     expect(packPublishables).toContain('isNonRuntimeIncurPayloadPath')
     expect(packPublishables).toContain('/(?:^|\\/)[^/]+\\.test\\.[cm]?[jt]sx?$/u')
+    expect(packPublishables).toContain(
+      'const assistantCliSurfacePackagingTimeoutMs = 5 * 60_000;',
+    )
+    expect(packPublishables).toContain("'--manifest-timeout-ms'")
+    expect(packPublishables).toContain(
+      'String(assistantCliSurfacePackagingTimeoutMs)',
+    )
     expect(cliPackageJson.scripts?.['release:check']).toBeUndefined()
     expect(existsSync(path.join(packageDir, 'scripts', 'release.sh'))).toBe(false)
     expect(existsSync(path.join(packageDir, 'scripts', 'release-check.sh'))).toBe(false)

--- a/scripts/pack-publishables.mjs
+++ b/scripts/pack-publishables.mjs
@@ -15,6 +15,7 @@ import { verifyReleaseArtifacts } from './release-artifact-secret-guard.mjs';
 
 const execFileAsync = promisify(execFile);
 const npmPackMetadataMaxBufferBytes = 64 * 1024 * 1024;
+const assistantCliSurfacePackagingTimeoutMs = 5 * 60_000;
 const assistantCliSurfaceGeneratorPath = path.join(
   'packages',
   'assistant-engine',
@@ -342,7 +343,11 @@ async function ensureGeneratedPackageArtifacts(context) {
   if (context.workspacePackageByName.has('@murphai/assistant-engine')) {
     await execFileAsync(
       process.execPath,
-      [assistantCliSurfaceGeneratorPath],
+      [
+        assistantCliSurfaceGeneratorPath,
+        '--manifest-timeout-ms',
+        String(assistantCliSurfacePackagingTimeoutMs),
+      ],
       {
         cwd: context.repoRoot,
       },


### PR DESCRIPTION
## Why and outcome

Release packaging regenerates the schema-bearing assistant CLI surface. Valid contended-host runs can exceed the shared 60-second manifest deadline, so packaging could stop before artifact verification.

The release packer now supplies a bounded five-minute deadline through the existing manifest reader. Ordinary manifest callers, including package and runner builds, retain the 60-second default.

Frog autofix issue: #2438

ReviewGPT first-reviewed head: 4cbe911eb3bf42257304a9471bcf369cf5b081e2

ReviewGPT context sensitivity: sensitive

Reason: Correctness spans the shared manifest reader, generated-contract entrypoint, and release packer.

## Product UX

Not applicable. This is internal release tooling and does not change member-visible product behavior.

## Evidence

- `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-cli-surface-bootstrap.test.ts` — 23 passed.
- `pnpm --dir packages/assistant-engine typecheck` — passed.
- `pnpm --dir packages/cli exec vitest run --config vitest.config.ts --no-coverage test/release-script-coverage-audit.test.ts` — 48 passed, 1 explicitly gated real-tarball test skipped.
- `pnpm docs:drift`, `pnpm docs:gardening`, `node --check scripts/pack-publishables.mjs`, and `git diff --check` — passed.

## Non-obvious affected surfaces

- The internal assistant CLI surface generator now validates one optional timeout argument so the release packer can select its bounded budget.
- The shared full-manifest reader validates optional caller deadlines; omitted values still use 60 seconds.
- The release packer alone passes five minutes. Runner and ordinary package-build behavior is unchanged.

## Architecture and reuse

- Existing systems reused: the current manifest subprocess owner, timeout termination, error projection, and release artifact generator.
- New logic: one validated optional timeout value and one fixed release-packaging caller value.
- New abstractions: none; the existing reader input remains the single timeout owner.
- Complexity intentionally avoided: no environment override, retry loop, progress supervisor, unbounded wait, or release workflow fork.

## Hot reply path impact

Not applicable. No foreground reply, database, provider, or delivery path changed.

## Murph initial provider input impact

- Individual runtime: not applicable; no prompt, tool schema, or provider-visible input changed.
- Group runtime: not applicable; no prompt, tool schema, or provider-visible input changed.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; Vitest files are tests/fixtures; the closed execution plan is docs; the release packer is config/tooling; no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 34 | 2 |
| Tests/fixtures | 39 | 5 |
| Docs | 84 | 0 |
| Config/tooling | 6 | 1 |
| Generated/other | 0 | 0 |
| Total | 163 | 8 |

## Deployment concerns

- Deployment: not applicable
- Reason: Internal release packaging behavior changes no deployed runtime boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal release tooling only; members cannot experience a product behavior change.