### PR TITLE
Bound CLI artifact generation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-29-frog-2439-cli-artifact-generator.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-frog-2439-cli-artifact-generator.md
@@ -1,0 +1,77 @@
+# Bound and surface CLI artifact generation
+
+Status: completed
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Make CLI artifact generation report its active stage and terminate with an
+  actionable error if the Incur generator child stops making bounded progress.
+
+## Success criteria
+
+- The exact `pnpm --dir packages/cli gen:config-schema` command reports the
+  build, Incur-generation, finalization, and write stages.
+- The Incur child has a generous production bound and a deterministic focused
+  regression proves that a wedged child is terminated with a public-safe error.
+- The command regenerates all three committed artifacts without drift.
+
+## Scope
+
+- In scope: the repository-owned CLI artifact generator, its Incur child
+  lifecycle, stage output, and focused regression coverage.
+- Out of scope: release packaging timeouts, changes to generated artifact
+  contents, production CLI runtime behavior, and ReviewGPT infrastructure.
+
+## Constraints
+
+- Technical constraints: preserve the existing Incur invocation and generated
+  outputs; bound only the reported slow child rather than unrelated build work.
+- Product/process constraints: keep the correction repository-local and
+  low-risk; do not consume the related unmerged release-manifest patch.
+
+## Risks and mitigations
+
+1. Risk: a bound that is too short can reject legitimate contended-host work.
+   Mitigation: use a five-minute production bound, while tests inject a short
+   bound into the same child-process owner.
+2. Risk: logging from a shared helper can pollute programmatic callers.
+   Mitigation: make stage reporting opt-in and enable it only in the generator
+   entrypoint.
+
+## Tasks
+
+1. [x] Reproduce and time the exact generator and isolated Incur phase.
+2. [x] Add a process-level failing timeout regression.
+3. [x] Add opt-in stage reporting and a bounded Incur child.
+4. [x] Verify focused behavior, type safety, exact generation, and artifact drift.
+5. [x] Commit and push Draft PR #2556. Preserve it for the required preliminary
+   coverage review because no healthy managed ReviewGPT profile was available.
+
+## Decisions
+
+- The current host completes the exact command in 30.51 seconds and the
+  isolated no-rebuild phase in 13.77 seconds. This proves real slow work rather
+  than a reproduced deadlock, while the unbounded silent child remains unable
+  to distinguish that work from a hang.
+- Bound only `incur gen`; the preceding package build is separately owned and
+  the reported friction begins after that build.
+
+## Verification
+
+- `pnpm --dir packages/cli exec vitest run test/incur-config-schema.test.ts`
+  passed with one process-level timeout regression.
+- `pnpm --dir packages/cli typecheck` passed.
+- `pnpm --dir packages/cli gen:config-schema` passed in 27.67 seconds and
+  printed every intended stage.
+- `git diff --exit-code -- packages/cli/config.schema.json
+  packages/cli/src/incur.generated.ts
+  packages/cli/src/vault-cli-skill-hash.generated.ts` passed: generated files
+  remained byte-for-byte clean.
+- Changelog: not applicable because this changes only repository-local
+  developer tooling and its regression coverage; members cannot experience it.
+- Review: preliminary completion-specialists remains required but not run or
+  credited; final ReviewGPT is policy-exempt for this developer-tooling-only
+  diff. The Draft PR remains the exact resumable handoff.
+Completed: 2026-08-29

--- a/packages/cli/scripts/generate-incur-config-schema.ts
+++ b/packages/cli/scripts/generate-incur-config-schema.ts
@@ -8,7 +8,10 @@ import {
   vaultCliSkillHashPath,
 } from './incur-config-schema.js'
 
-const generatedArtifacts = await generateIncurArtifacts()
+const generatedArtifacts = await generateIncurArtifacts({
+  onStage: (message) => console.log(message),
+})
+console.log('Writing generated CLI artifacts.')
 await writeFile(configSchemaPath, generatedArtifacts.configSchema)
 await writeFile(incurGeneratedTypesPath, generatedArtifacts.types)
 await writeFile(vaultCliSkillHashPath, generatedArtifacts.skillHashModule)

--- a/packages/cli/scripts/incur-config-schema.ts
+++ b/packages/cli/scripts/incur-config-schema.ts
@@ -8,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { Cli } from 'incur'
 
 const execFileAsync = promisify(execFile)
+const INCUR_GENERATION_TIMEOUT_MS = 5 * 60_000
 
 export const packageDir = fileURLToPath(new URL('../', import.meta.url))
 const repoDir = fileURLToPath(new URL('../../../', import.meta.url))
@@ -29,7 +30,17 @@ interface GeneratedIncurOutputs {
 }
 
 interface IncurGenerationOptions {
+  onStage?: (message: string) => void
   rebuildCli?: boolean
+}
+
+interface IncurGeneratorCommandOptions {
+  cwd: string
+  entryPath: string
+  generatorPath: string
+  outputPath: string
+  repoDir: string
+  timeoutMs: number
 }
 
 interface GeneratedIncurArtifacts {
@@ -73,6 +84,7 @@ async function withGeneratedIncurArtifacts<T>(
   }
 
   if ((options.rebuildCli ?? true) || !existsSync(distEntryPath)) {
+    options.onStage?.('Building the CLI package.')
     await execFileAsync('pnpm', ['build'], {
       cwd: packageDir,
       env: process.env,
@@ -85,27 +97,17 @@ async function withGeneratedIncurArtifacts<T>(
     const generatedTypesPath = path.join(tempDir, 'incur.generated.ts')
     const generatedConfigSchemaPath = path.join(tempDir, 'config.schema.json')
 
-    await execFileAsync(
-      process.execPath,
-      [
-        incurBinPath,
-        'gen',
-        '--dir',
-        repoDir,
-        '--entry',
-        distEntryPath,
-        '--output',
-        generatedTypesPath,
-      ],
-      {
-        cwd: packageDir,
-        env: {
-          ...process.env,
-          NODE_NO_WARNINGS: '1',
-        },
-      },
-    )
+    options.onStage?.('Generating Incur types and config schema (timeout: 5 minutes).')
+    await runIncurGeneratorCommand({
+      cwd: packageDir,
+      entryPath: distEntryPath,
+      generatorPath: incurBinPath,
+      outputPath: generatedTypesPath,
+      repoDir,
+      timeoutMs: INCUR_GENERATION_TIMEOUT_MS,
+    })
 
+    options.onStage?.('Finalizing generated artifacts and CLI skill hash.')
     return await run({
       generatedTypesPath,
       generatedConfigSchemaPath,
@@ -113,6 +115,55 @@ async function withGeneratedIncurArtifacts<T>(
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }
+}
+
+export async function runIncurGeneratorCommand(
+  options: IncurGeneratorCommandOptions,
+): Promise<void> {
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        options.generatorPath,
+        'gen',
+        '--dir',
+        options.repoDir,
+        '--entry',
+        options.entryPath,
+        '--output',
+        options.outputPath,
+      ],
+      {
+        cwd: options.cwd,
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: '1',
+        },
+        killSignal: 'SIGTERM',
+        timeout: options.timeoutMs,
+      },
+    )
+  } catch (error) {
+    if (isTimedOutExecFileError(error)) {
+      const timeoutSeconds = Math.max(1, Math.ceil(options.timeoutMs / 1_000))
+      const unit = timeoutSeconds === 1 ? 'second' : 'seconds'
+      throw new Error(
+        `Incur CLI artifact generation timed out after ${timeoutSeconds} ${unit} while importing the built CLI. ` +
+          'Re-run `pnpm --dir packages/cli gen:config-schema` on a prepared workspace; if it repeats, inspect the package build and CLI import graph.',
+      )
+    }
+    throw error
+  }
+}
+
+function isTimedOutExecFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'killed' in error &&
+    error.killed === true &&
+    'signal' in error &&
+    error.signal === 'SIGTERM'
+  )
 }
 
 function quoteInvalidTypePropertyNames(types: string): string {

--- a/packages/cli/test/incur-config-schema.test.ts
+++ b/packages/cli/test/incur-config-schema.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { runIncurGeneratorCommand } from '../scripts/incur-config-schema.js'
+
+test('Incur artifact generation terminates a wedged generator with an actionable error', async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'murph-incur-timeout-'))
+  const fixturePath = path.join(tempDir, 'wedged-incur.mjs')
+
+  try {
+    await writeFile(fixturePath, "setInterval(() => {}, 1_000)\n", 'utf8')
+
+    await assert.rejects(
+      runIncurGeneratorCommand({
+        cwd: tempDir,
+        entryPath: fixturePath,
+        generatorPath: fixturePath,
+        outputPath: path.join(tempDir, 'incur.generated.ts'),
+        repoDir: tempDir,
+        timeoutMs: 50,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error)
+        assert.match(
+          error.message,
+          /Incur CLI artifact generation timed out after 1 second while importing the built CLI/u,
+        )
+        assert.match(error.message, /pnpm --dir packages\/cli gen:config-schema/u)
+        assert.equal(error.message.includes(tempDir), false)
+        return true
+      },
+    )
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Why and outcome

CLI artifact generation did real Incur import work without emitting a stage and allowed that child to run forever. The generator now reports each stage and terminates only a wedged Incur child after a generous five-minute bound with an actionable, public-safe error.

## Product UX

Not applicable. This is repository-local developer tooling and does not alter member-visible behavior or product interaction.

## Evidence

- The prepared-workspace reproduction completed successfully but stayed silent until all generation finished (30.51 seconds before the correction).
- `pnpm --dir packages/cli exec vitest run test/incur-config-schema.test.ts` passes the process-level wedged-child regression.
- `pnpm --dir packages/cli typecheck` passes.
- `pnpm --dir packages/cli gen:config-schema` passes in 27.67 seconds and reports build, Incur generation, finalization, and write stages.
- All three committed generated artifacts remain byte-for-byte unchanged.

## Non-obvious affected surfaces

- The shared Incur artifact helper gains opt-in stage reporting so programmatic callers remain quiet.
- Only the `incur gen` child is bounded. The separately owned package build remains unchanged.
- Production CLI execution and generated artifact contents are unchanged.

## Architecture and reuse

- **Existing systems reused:** the existing `execFile` child owner, generator entrypoint, and Incur invocation remain authoritative.
- **New logic:** one five-minute child timeout, a narrow timeout classifier, opt-in stage callbacks, and an actionable timeout error.
- **New abstractions:** one internal command helper exposes the actual child-process boundary to deterministic regression coverage.
- **Complexity intentionally avoided:** no watchdog service, retry loop, process manager, release-timeout sharing, or generated-artifact changes.

## Hot reply path impact

Not applicable. The foreground reply critical path is untouched; no database, network, provider, or awaited runtime operation changes.

## Murph initial provider input impact

- Hosted runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changes.
- Local runtime: Not applicable for the same reason.

## Review gates

- Preliminary completion-specialists: passed exact head `df19b3c34f793b7a7637813d928781fc61059855` with no findings; the coverage lens found the real wedged-child process regression sufficient.
- Final ReviewGPT: policy-exempt because the meaningful diff is limited to repository-local developer tooling and does not change production behavior, trust boundaries, persisted state, public APIs, deployment, or cross-owner protocols.

## Change-shape breakdown

Classification uses the base-to-head authored diff: generator implementation is source, the Vitest file is tests/fixtures, the completed execution plan is docs, and generated outputs are reported separately.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 67 | 13 |
| Tests/fixtures | 40 | 0 |
| Docs | 77 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **184** | **13** |

No binary files changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Repository-local artifact tooling does not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: Internal developer-tooling reliability and regression coverage only; no member-visible behavior changed.

Frog autofix issue: #2439