### PR TITLE
test(hosted): gate calendar link assertions

### DIFF
--- a/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-e2e-support.ts
@@ -240,6 +240,7 @@ export function expectAdvertisedMurphDynamicTools(
   requests: readonly HostedLocalAssistantProviderStubRequest[],
   options: {
     analyzeVideoAvailable?: boolean;
+    calendarLinkAvailable?: boolean;
     connectedAppsAvailable?: boolean;
     computerToolsAvailable?: boolean;
     exerciseRoutineResponseCardAvailable?: boolean;
@@ -266,6 +267,13 @@ export function expectAdvertisedMurphDynamicTools(
       if (
         options.analyzeVideoAvailable !== true
         && name === "murph.analyze_video"
+      ) {
+        return false;
+      }
+
+      if (
+        options.calendarLinkAvailable !== true
+        && name === "murph.create_calendar_link"
       ) {
         return false;
       }

--- a/apps/cloudflare/test/hosted-local-analyze-video-roundtrip-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-analyze-video-roundtrip-e2e.test.ts
@@ -156,6 +156,7 @@ describe("hosted local analyze-video Linq roundtrip e2e", () => {
     )).toBe(true);
     expectAdvertisedMurphDynamicTools(successProviderRequests, {
       analyzeVideoAvailable: true,
+      calendarLinkAvailable: true,
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
       messageTargetingAvailable: true,

--- a/apps/cloudflare/test/hosted-local-codex-image-media-delivery-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-codex-image-media-delivery-e2e.test.ts
@@ -142,6 +142,7 @@ describe("hosted local Codex image media delivery e2e", () => {
     expect(finalStatus.lastErrorCode ?? null).toBeNull();
     expect(finalStatus.mailboxLag.every((lane) => lane.lag === "0")).toBe(true);
     expectAdvertisedMurphDynamicTools(requireScenario().assistantProviderRequests, {
+      calendarLinkAvailable: true,
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
       messageTargetingAvailable: true,

--- a/apps/cloudflare/test/hosted-local-e2e-support.test.ts
+++ b/apps/cloudflare/test/hosted-local-e2e-support.test.ts
@@ -597,6 +597,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     const allToolNames = listMurphDynamicToolNames();
     const baseToolNames = allToolNames.filter((name) =>
       name !== "murph.analyze_video"
+      && name !== "murph.create_calendar_link"
       && !name.startsWith("murph.computer_")
       && !name.startsWith("murph.connected_apps_")
       && !hostedGroupFamilyToolNames.includes(name)
@@ -620,6 +621,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     const allToolsAvailable = {
       analyzeVideoAvailable: true,
       askGrokAvailable: true,
+      calendarLinkAvailable: true,
       connectedAppsAvailable: true,
       computerToolsAvailable: true,
       exerciseRoutineResponseCardAvailable: true,
@@ -642,6 +644,7 @@ describe("expectAdvertisedMurphDynamicTools", () => {
     expect(allToolNames).toContain("murph.computer_open");
     expect(allToolNames).toContain("murph.connected_apps_manage");
     expect(allToolNames).toContain("murph.create_phone_call");
+    expect(allToolNames).toContain("murph.create_calendar_link");
     expect(hostedGroupFamilyToolNames).toHaveLength(6);
     expect(allToolNames)
       .toEqual(expect.arrayContaining(hostedGroupFamilyToolNames));

--- a/apps/cloudflare/test/hosted-local-linq-first-contact-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-first-contact-e2e.test.ts
@@ -523,6 +523,7 @@ productionDescribe("hosted local Linq first-contact e2e", () => {
     expect(finalStatus.mailboxLag.every((lane) => lane.lag === "0")).toBe(true);
     expect(finalStatus.lastErrorCode ?? null).toBeNull();
     expectAdvertisedMurphDynamicTools(requireScenario().assistantProviderRequests, {
+      calendarLinkAvailable: true,
       computerToolsAvailable: true,
       connectedAppsAvailable: true,
       messageTargetingAvailable: true,


### PR DESCRIPTION
## Outcome

Updates the hosted-local dynamic-tool assertion to model the existing `calendarLinkAvailable` gate. Direct Linq scenarios opt in; Telegram and other unsupported audiences continue to expect the tool to be absent.

This is the paired public test-contract correction for private Murph Cloud PR #59 after public PR #2508 added the direct-Linq-only tool.

## Product UX result

No runtime or member-facing behavior changes. The tests now preserve the intended audience boundary: calendar links are available for private direct Linq turns and are not advertised on Telegram.

## Direct evidence

- The private integration run failed because the shared helper expected `create_calendar_link` on Telegram while the runtime correctly omitted it.
- The preceding private run used public commit `b84a1f11b27294176d11d49f7985414a1f73fbb6`; the regression appeared only after public PR #2508 added the gated tool.
- Focused helper suite: 24 tests passed.
- `@murphai/cloudflare-runner` typecheck passed.
- Diff check and privacy inspection passed.
- Preliminary ReviewGPT specialist pass: no findings; prompt and coverage lenses passed.

## Affected surfaces and invariants

Test and E2E assertion code only. The calendar tool remains default-off and available only when the production planning boundary admits a private direct Linq turn with accepted user input.

## Architecture and reuse

- Existing systems reused: the shared hosted-local dynamic-tool assertion and its existing availability-option pattern.
- New logic: one calendar-link availability branch plus explicit opt-ins for three direct Linq scenarios.
- New abstractions: none because the existing availability-option pattern already owns this boundary.
- Complexity intentionally avoided: no runtime special case, duplicated expected-tool list, new fixture layer, or production change.

## Hot reply path impact

None. Production hot-reply code is unchanged.

## Provider-input impact

Production provider input is unchanged. E2E expectations now distinguish supported direct Linq turns from unsupported channels.

## Deployment concerns

- Deployment: not applicable
- Reason: test-only assertion code changed; no deployable runtime artifact changed.

## Changelog

- Changelog: not applicable
- Reason: test-only assertion correction; no runtime or member-visible behavior changed.

## LOC breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 14 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 14 | 0 |

ReviewGPT context sensitivity: sensitive


