### PR TITLE
Classify hosted startup confirmation failures

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-29-hosted-startup-failure-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-hosted-startup-failure-telemetry.md
@@ -1,0 +1,61 @@
+# Classify hosted startup confirmation failures
+
+Status: completed
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Add the smallest behavior-preserving, privacy-safe typed telemetry needed to classify hosted startup-confirmation failures that currently collapse to a generic runtime error and recover only after a later orchestration attempt.
+
+## Success criteria
+
+- The existing startup-confirmation failure owner emits a bounded failure-stage enum and numeric elapsed timing sufficient to distinguish container/RPC, lifecycle/state, health/readiness, and deadline hypotheses.
+- No member, workspace, message, command, provider, path, prompt, transcript, health, credential, raw error, or unbounded value is recorded.
+- Telemetry adds no awaited I/O, state, retry, control-flow, provider, or user-visible behavior change.
+- Focused tests and Cloudflare typecheck pass; the exact pushed PR head passes required CI and final ReviewGPT review.
+- The later production query is documented and groups only the new bounded fields against the existing retry outcome.
+
+## Scope
+
+- In scope: the `RunnerContainer.ensureReadyForProcessing` / UserRunner startup-confirmation failure boundary, its existing structured log pipeline, focused tests, and durable observability/deployment documentation.
+- Out of scope: fixing an unproven startup cause, changing retries/timeouts/readiness behavior, adding storage or a telemetry backend, device-sync work, R2 snapshot behavior, and unrelated runtime optimization.
+
+## Constraints
+
+- Technical constraints: typed low-cardinality fields only; bounded volume; no additional network/database/provider work; no new persisted state; old Worker/container skew remains safe.
+- Product/process constraints: ReviewGPT exclusively authors the repository patch; the local agent may apply only a reviewed patch, validates it independently, and leaves any ordinary bug fix for human merge. Autonomous merge/deploy is allowed only if the final diff remains telemetry/tests/docs-only and every repository gate passes.
+
+## Risks and mitigations
+
+1. Risk: telemetry accidentally exposes private or high-cardinality runtime data.
+   Mitigation: use a closed enum and numeric duration only; prohibit identifiers, paths, raw errors, and input-derived values; inspect the full emitted object and test assertions.
+2. Risk: instrumentation changes startup behavior or adds hot-path latency.
+   Mitigation: reuse the existing failure log call without new awaited work or control-flow branches; test behavior parity.
+3. Risk: an active task owns the same question.
+   Mitigation: compare the exact active task and PR diffs; proceed only after proving their root causes and intended changes are different.
+
+## Tasks
+
+1. Preserve the bounded production evidence and exact-overlap comparison.
+2. Ask ReviewGPT for the smallest complete telemetry/tests/docs patch.
+3. Inspect and, if accepted, apply the ReviewGPT patch exactly.
+4. Run focused tests, Cloudflare typecheck, privacy/static checks, and parent review.
+5. Commit, push, open the telemetry PR, and run preliminary/final ReviewGPT plus required CI.
+6. If every telemetry-only deployment gate passes, merge/deploy through the canonical protected workflow and record the natural-traffic verification query; otherwise leave the exact human action.
+
+## Decisions
+
+- Selected the startup-confirmation retry storm over historical recovered signals because it is current, broad, repository-owned, and presently unclassifiable at the narrow failure boundary.
+- Existing readiness telemetry measures successful cold-start phases and returned no direct causal samples; it does not identify the failed startup-confirmation stage.
+- Active optimizer work targets `vault-cli memory show`; open snapshot, automation, and browser-vault PRs address different root causes and can coexist.
+- Accepted ReviewGPT's six-value closed taxonomy: four RunnerContainer-local stages plus caller deadline and an explicit unattributed RPC category. The local observation is failure-only, contains three bounded fields, and does not transport custom error properties across Durable Object RPC.
+- Returned the initial 9,000 ms synthetic assertion to ReviewGPT after focused verification proved the fixture starts confirmation 50 ms after the absolute command clock. Applied ReviewGPT's revised 8,950 ms expectation; no production code changed in that revision.
+
+## Verification
+
+- Passed: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-container.test.ts apps/cloudflare/test/user-runner-alarm.test.ts` (2 files, 379 tests).
+- Passed: `pnpm --dir apps/cloudflare typecheck`.
+- Passed: `git diff --check` and added-line searches for local paths, credentials, authorization headers, database URLs, and private keys.
+- Pending external gates: exact-head GitHub checks, the preliminary coverage specialist pass, and the final sensitive ReviewGPT gate.
+Completed: 2026-08-29

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1,6 +1,6 @@
 # Hosted Mailbox Runtime Protocol
 
-Last verified: 2026-08-27
+Last verified: 2026-08-29
 
 ## Decision
 
@@ -3752,6 +3752,45 @@ platform wait. Old warm containers may omit the health
 timestamps, and a lifecycle generation whose hook was not observed may omit the
 `onStart` stamp. Missing diagnostic fields never fail readiness. These stamps
 add no request, polling loop, persisted state owner, or reply-path work.
+
+Failed authoritative startup confirmation has one failure-only local
+observation because Durable Object RPC does not preserve custom properties on a
+thrown error. `Hosted execution container startup confirmation failed.` carries
+only `runtimeStartupFailureStage`, `runtimeStartupFailureElapsedMs`, and
+`runtimeStartupCleanupUnsettled`; it carries no user, workspace, message,
+command, provider, path, URL, prompt, transcript, argument, payload, health
+value, credential, environment value, raw error, stack, hash, or correlation
+identifier. Elapsed time is a non-negative integer saturated at 60,000 ms. The
+four container-local stages are `lifecycle_lock_or_state_read`,
+`warm_health_or_cleanup`, `cold_start_or_ports`, and
+`cold_health_or_finalization`. The cleanup boolean overlays the stage that
+triggered cleanup instead of replacing it.
+
+The existing UserRunner startup-confirmation warnings add the same bounded
+elapsed field and one of two caller-owned stages. `rpc_unattributed` means the
+RPC failed, timed out, was unavailable, or returned legacy cleanup-unsettled
+without a safely transported local stage; it must never be guessed into a
+container-local bucket. `caller_deadline` means the command budget or the outer
+startup guard elapsed. The generic
+`Hosted runner runtime processing startup confirmation failed.` warning also
+records its already-selected closed retry reason. Retry selection, fence
+clearing or preservation, cleanup, readiness, and exception/RPC behavior remain
+unchanged. Both observations reuse the existing structured logger and add no
+awaited I/O, timer, retry, state, queue, or telemetry backend. During skew, an
+old RunnerContainer simply lacks the local observation while a new UserRunner
+retains `rpc_unattributed`; an old UserRunner
+ignores the new local log, so either side can roll back independently.
+
+After at least two hours of natural traffic, aggregate the exact UserRunner
+warning by stage, retry reason/error code, and coarse elapsed bucket; aggregate
+the exact RunnerContainer failure-only message separately by the same stage
+enum and cleanup flag. Cloudflare-owned event metadata may be used internally
+to compare failed instances with later runtime-processing acceptance, but only
+aggregate counts leave that boundary. Confirm whether the dominant category
+still recurs on the deployed revision without synthetic production traffic.
+This instrumentation is internal-only: no Product UX review outcome or
+changelog item applies.
+
 Fence-attempt diagnostics remain one coherent bundle across replacement races.
 When a replacement compare-and-swap loses, UserRunner drops the superseded
 fence's observation, active-wake, and replacement-clear leaves before probing

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -79,6 +79,7 @@ const DEFAULT_RUNNER_RUNTIME_WAKE_TIMEOUT_MS = 5_000;
 const RUNNER_RUNTIME_COMPLETION_RECEIPT_TIMEOUT_MS = 1_000;
 const RUNNER_RECENT_READINESS_PROOF_MAX_AGE_MS = 5_000;
 const RUNNER_READINESS_ABORT_SETTLEMENT_TIMEOUT_MS = 5_000;
+export const RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS = 60_000;
 const RUNNER_METADATA_RESPONSE_BODY_MAX_BYTES = 64 * 1024;
 const RUNNER_METADATA_RESPONSE_BODY_DRAIN_TIMEOUT_MS = 5_000;
 const RUNNER_TRANSPORT_FAILURE_DETAIL_MAX_CHARS = 1_024;
@@ -213,6 +214,23 @@ type HostedExecutionContainerInvokeInput = HostedExecutionContainerInvokeRequest
 export interface RunnerContainerEnsureReadyForProcessingInput {
   timeoutMs: number;
   userId: string;
+}
+
+export type RunnerContainerStartupFailureStage =
+  | "caller_deadline"
+  | "cold_health_or_finalization"
+  | "cold_start_or_ports"
+  | "lifecycle_lock_or_state_read"
+  | "rpc_unattributed"
+  | "warm_health_or_cleanup";
+
+type RunnerContainerLocalStartupFailureStage = Exclude<
+  RunnerContainerStartupFailureStage,
+  "caller_deadline" | "rpc_unattributed"
+>;
+
+interface RunnerContainerStartupFailureObservation {
+  stage: RunnerContainerLocalStartupFailureStage;
 }
 
 export type RunnerContainerEnsureReadyForProcessingResult =
@@ -850,6 +868,9 @@ export class RunnerContainer extends Container {
     const readinessSignal = AbortSignal.timeout(input.timeoutMs);
     let lifecycleLockAcquired = false;
     let cleanupSettlementTimedOut = false;
+    const startupFailureObservation: RunnerContainerStartupFailureObservation = {
+      stage: "lifecycle_lock_or_state_read",
+    };
     const readiness = this.withLifecycleLock(async () => {
       lifecycleLockAcquired = true;
       const lifecycleLockAcquiredAtEpochMs = Date.now();
@@ -866,6 +887,7 @@ export class RunnerContainer extends Container {
             readinessSignal,
             {
               completeSupersededShellPrewarm: supersededShellPrewarm,
+              startupFailureObservation,
               surfaceCleanupUnsettled: true,
             },
           );
@@ -896,7 +918,7 @@ export class RunnerContainer extends Container {
       }
     });
     try {
-      return await raceRunnerContainerOperationAbort(
+      const result = await raceRunnerContainerOperationAbort(
         readiness,
         readinessSignal,
         async () => {
@@ -915,7 +937,20 @@ export class RunnerContainer extends Container {
           return settled ? "use_operation_outcome" : undefined;
         },
       );
+      if (result.kind === "cleanup_unsettled") {
+        emitRunnerContainerStartupFailureObservation({
+          cleanupUnsettled: true,
+          readinessRequestedAtEpochMs,
+          stage: startupFailureObservation.stage,
+        });
+      }
+      return result;
     } catch (error) {
+      emitRunnerContainerStartupFailureObservation({
+        cleanupUnsettled: cleanupSettlementTimedOut,
+        readinessRequestedAtEpochMs,
+        stage: startupFailureObservation.stage,
+      });
       if (cleanupSettlementTimedOut) {
         return { kind: "cleanup_unsettled" };
       }
@@ -2276,6 +2311,7 @@ export class RunnerContainer extends Container {
     operationAbortSignal: AbortSignal,
     options: {
       completeSupersededShellPrewarm?: boolean;
+      startupFailureObservation?: RunnerContainerStartupFailureObservation;
       surfaceCleanupUnsettled?: boolean;
     } = {},
   ): Promise<RunnerContainerEnsureReadyResult> {
@@ -2291,6 +2327,9 @@ export class RunnerContainer extends Container {
       this.recordCurrentContainerStopped();
       this.warmShellInvalidatedByUnsettledDestroy = false;
     } else if (this.warmShellInvalidatedByUnsettledDestroy) {
+      if (options.startupFailureObservation) {
+        options.startupFailureObservation.stage = "warm_health_or_cleanup";
+      }
       const invalidatedStart = this.currentContainerStart;
       this.clearRecentReadinessProof();
       emitHostedExecutionStructuredLog({
@@ -2323,6 +2362,9 @@ export class RunnerContainer extends Container {
       !isRunnerContainerStopped(status)
       && !options.completeSupersededShellPrewarm
     ) {
+      if (options.startupFailureObservation) {
+        options.startupFailureObservation.stage = "warm_health_or_cleanup";
+      }
       const observedStart = this.observeRecentPlatformStart(
         initialState,
         readyTimeoutMs,
@@ -2438,6 +2480,9 @@ export class RunnerContainer extends Container {
       }
     }
     throwIfRunnerContainerOperationAborted(operationAbortSignal);
+    if (options.startupFailureObservation) {
+      options.startupFailureObservation.stage = "cold_start_or_ports";
+    }
 
     emitHostedExecutionStructuredLog({
       component: "container",
@@ -2477,6 +2522,9 @@ export class RunnerContainer extends Container {
           waitInterval: RUNNER_WAIT_INTERVAL_MS,
         },
       });
+      if (options.startupFailureObservation) {
+        options.startupFailureObservation.stage = "cold_health_or_finalization";
+      }
       const portsReadyAtEpochMs = Date.now();
       const healthCheckStartedAtEpochMs = Date.now();
       const healthStartupTiming = await assertRunnerHealthy(
@@ -4279,6 +4327,35 @@ function hostedRunnerContainerFragmentsOverlap(left: string, right: string): boo
   return normalizedLeft.length > 0
     && normalizedRight.length > 0
     && (normalizedLeft.includes(normalizedRight) || normalizedRight.includes(normalizedLeft));
+}
+
+function emitRunnerContainerStartupFailureObservation(input: {
+  cleanupUnsettled: boolean;
+  readinessRequestedAtEpochMs: number;
+  stage: RunnerContainerLocalStartupFailureStage;
+}): void {
+  try {
+    const rawElapsedMs = Date.now() - input.readinessRequestedAtEpochMs;
+    const elapsedMs = Number.isFinite(rawElapsedMs) && rawElapsedMs > 0
+      ? Math.min(
+          Math.floor(rawElapsedMs),
+          RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
+        )
+      : 0;
+    emitHostedExecutionStructuredLog({
+      component: "container",
+      details: {
+        runtimeStartupCleanupUnsettled: input.cleanupUnsettled,
+        runtimeStartupFailureElapsedMs: elapsedMs,
+        runtimeStartupFailureStage: input.stage,
+      },
+      level: "warn",
+      message: "Hosted execution container startup confirmation failed.",
+      phase: "container.starting",
+    });
+  } catch {
+    // Telemetry must not replace or mutate the startup failure returned to the caller.
+  }
 }
 
 function emitRunnerContainerLifecycleFailure(input: {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -19,9 +19,11 @@ import type {
 } from "../worker-contracts.js";
 import {
   destroyHostedExecutionContainer,
+  RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
   type HostedExecutionContainerNamespaceLike,
   type RunnerContainerColdStartTiming,
   type RunnerContainerShellPrewarmObservation,
+  type RunnerContainerStartupFailureStage,
 } from "../runner-container.js";
 import {
   HOSTED_WORKSPACE_SNAPSHOT_HANDOFF_HEARTBEAT_STALE_MS,
@@ -105,6 +107,11 @@ export interface RuntimeHealthDataConsentStopResult {
 
 type RuntimeProcessingOrchestrationDiagnostics = NonNullable<
   HostedRuntimeLatencyPhaseBreakdown["orchestration"]
+>;
+
+type RuntimeStartupCallerFailureStage = Extract<
+  RunnerContainerStartupFailureStage,
+  "caller_deadline" | "rpc_unattributed"
 >;
 
 type FreshRuntimeStartPreparation =
@@ -1323,14 +1330,17 @@ export class RuntimeProcessingController {
       };
     }
 
+    const startupConfirmationStartedAtEpochMs = Date.now();
     const container = this.input.runnerContainerNamespace.getByName(
       input.runnerContainerName,
     );
     if (!container.ensureReadyForProcessing) {
       return await this.clearWriteFenceAfterStartupConfirmationFailure({
         error: new Error("Hosted runner container readiness method is unavailable."),
+        failureStage: "rpc_unattributed",
         input: input.input,
         retryReason: "container_rpc_error",
+        startupConfirmationStartedAtEpochMs,
         token: input.token,
       });
     }
@@ -1369,6 +1379,12 @@ export class RuntimeProcessingController {
           details: {
             orchestrationAttemptId: input.input.orchestrationAttemptId,
             runtimeProcessingRetryReason: "container_rpc_timeout",
+            runtimeStartupCleanupUnsettled: true,
+            runtimeStartupFailureElapsedMs:
+              readBoundedRuntimeStartupFailureElapsedMs(
+                startupConfirmationStartedAtEpochMs,
+              ),
+            runtimeStartupFailureStage: "rpc_unattributed",
             runtimeStartupWriteFencePreserved: true,
             workspaceAttemptId: input.token.attemptId,
           },
@@ -1420,6 +1436,11 @@ export class RuntimeProcessingController {
             ...buildHostedRunnerMetadataOnlyErrorDetails(error),
             orchestrationAttemptId: input.input.orchestrationAttemptId,
             runtimeProcessingRetryReason: "container_rpc_timeout",
+            runtimeStartupFailureElapsedMs:
+              readBoundedRuntimeStartupFailureElapsedMs(
+                startupConfirmationStartedAtEpochMs,
+              ),
+            runtimeStartupFailureStage: "caller_deadline",
             runtimeStartupWriteFencePreserved: true,
             workspaceAttemptId: input.token.attemptId,
           },
@@ -1439,10 +1460,14 @@ export class RuntimeProcessingController {
       }
       return await this.clearWriteFenceAfterStartupConfirmationFailure({
         error,
+        failureStage: isRuntimeProcessingCommandBudgetTimeout(error)
+          ? "caller_deadline"
+          : "rpc_unattributed",
         input: input.input,
         retryReason: isRuntimeProcessingCommandBudgetTimeout(error)
           ? "command_budget_exhausted"
           : undefined,
+        startupConfirmationStartedAtEpochMs,
         token: input.token,
       });
     }
@@ -1450,8 +1475,10 @@ export class RuntimeProcessingController {
 
   private async clearWriteFenceAfterStartupConfirmationFailure(input: {
     error: unknown;
+    failureStage: RuntimeStartupCallerFailureStage;
     input: RuntimeProcessingInput;
     retryReason?: RuntimeProcessingStartFailureRetryReason;
+    startupConfirmationStartedAtEpochMs: number;
     token: RunnerWriteFenceToken;
   }): Promise<{
     confirmed: false;
@@ -1462,6 +1489,12 @@ export class RuntimeProcessingController {
       input: input.input,
       message: "Hosted runner runtime processing startup confirmation failed.",
       retryReason: input.retryReason,
+      startupFailure: {
+        elapsedMs: readBoundedRuntimeStartupFailureElapsedMs(
+          input.startupConfirmationStartedAtEpochMs,
+        ),
+        stage: input.failureStage,
+      },
       token: input.token,
     });
   }
@@ -1471,6 +1504,10 @@ export class RuntimeProcessingController {
     input: RuntimeProcessingInput;
     message: string;
     retryReason?: RuntimeProcessingStartFailureRetryReason;
+    startupFailure?: {
+      elapsedMs: number;
+      stage: RuntimeStartupCallerFailureStage;
+    };
     token: RunnerWriteFenceToken;
   }): Promise<{
     confirmed: false;
@@ -1488,6 +1525,11 @@ export class RuntimeProcessingController {
       details: {
         ...buildHostedRunnerMetadataOnlyErrorDetails(input.error),
         orchestrationAttemptId: input.input.orchestrationAttemptId,
+        ...(input.startupFailure === undefined ? {} : {
+          runtimeProcessingRetryReason: retryReason,
+          runtimeStartupFailureElapsedMs: input.startupFailure.elapsedMs,
+          runtimeStartupFailureStage: input.startupFailure.stage,
+        }),
         transportFailureFenceCleared: failed.failed,
         workspaceAttemptId: input.token.attemptId,
       },
@@ -1547,6 +1589,18 @@ class HostedRuntimeHealthDataConsentStopError extends Error {
     super("Hosted runner container cleanup failed after health-data consent withdrawal.");
     this.name = "HostedRuntimeHealthDataConsentStopError";
   }
+}
+
+function readBoundedRuntimeStartupFailureElapsedMs(
+  startedAtEpochMs: number,
+): number {
+  const rawElapsedMs = Date.now() - startedAtEpochMs;
+  return Number.isFinite(rawElapsedMs) && rawElapsedMs > 0
+    ? Math.min(
+        Math.floor(rawElapsedMs),
+        RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
+      )
+    : 0;
 }
 
 function normalizeRuntimeProcessingMode(

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -29,7 +29,9 @@ import {
   type HostedExecutionContainerStubLike,
   invokeHostedExecutionContainerRunner,
   resolveHostedExecutionRunnerContainerName,
+  RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
   RunnerContainer,
+  type RunnerContainerStartupFailureStage,
 } from "../src/runner-container.ts";
 import {
   HOSTED_RUNNER_OUTBOUND_BY_HOST,
@@ -70,6 +72,61 @@ function requireObject(value: unknown, label: string): Record<string, unknown> {
   }
 
   return value;
+}
+
+type RunnerContainerLocalStartupFailureStage = Exclude<
+  RunnerContainerStartupFailureStage,
+  "caller_deadline" | "rpc_unattributed"
+>;
+
+function expectRunnerContainerStartupFailureObservation(input: {
+  cleanupUnsettled: boolean;
+  expectedElapsedMs?: number;
+  forbiddenValues?: readonly string[];
+  stage: RunnerContainerLocalStartupFailureStage;
+}): void {
+  const observations = mocks.emitHostedExecutionStructuredLog.mock.calls
+    .map(([observation]) => observation)
+    .filter((observation) =>
+      observation.message
+        === "Hosted execution container startup confirmation failed."
+    );
+  expect(observations).toHaveLength(1);
+  const observation = observations[0];
+  if (!observation) {
+    throw new Error("Expected one startup failure observation.");
+  }
+  expect(observation).toEqual({
+    component: "container",
+    details: {
+      runtimeStartupCleanupUnsettled: input.cleanupUnsettled,
+      runtimeStartupFailureElapsedMs: expect.any(Number),
+      runtimeStartupFailureStage: input.stage,
+    },
+    level: "warn",
+    message: "Hosted execution container startup confirmation failed.",
+    phase: "container.starting",
+  });
+  const details = requireObject(
+    observation.details,
+    "startup failure observation details",
+  );
+  const elapsedMs = details.runtimeStartupFailureElapsedMs;
+  expect(typeof elapsedMs).toBe("number");
+  if (typeof elapsedMs !== "number") {
+    throw new Error("Expected numeric startup failure elapsed milliseconds.");
+  }
+  expect(elapsedMs).toBeGreaterThanOrEqual(0);
+  expect(elapsedMs).toBeLessThanOrEqual(
+    RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
+  );
+  if (input.expectedElapsedMs !== undefined) {
+    expect(elapsedMs).toBe(input.expectedElapsedMs);
+  }
+  const serialized = JSON.stringify(observation);
+  for (const forbiddenValue of input.forbiddenValues ?? []) {
+    expect(serialized).not.toContain(forbiddenValue);
+  }
 }
 
 describe("RunnerContainer", () => {
@@ -1942,6 +1999,106 @@ describe("RunnerContainer", () => {
     expect(result.coldStartTiming).not.toHaveProperty("serverListeningAtEpochMs");
   });
 
+  it("classifies lifecycle and state-read failures with bounded privacy-safe details", async () => {
+    const privateUserId = "member_startup_telemetry_private";
+    const privateErrorText =
+      "state read failed for https://private.example.test/workspace/secret";
+    const stateReadFailure = new Error(privateErrorText);
+    let nowMs = Date.parse("2026-08-29T20:00:00.000Z");
+    const now = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const { container } = createContainerDouble({
+      getState: vi.fn(async () => {
+        nowMs += 120_000;
+        throw stateReadFailure;
+      }),
+    });
+
+    try {
+      await expect(container.ensureReadyForProcessing({
+        timeoutMs: 15_000,
+        userId: privateUserId,
+      })).rejects.toBe(stateReadFailure);
+
+      expectRunnerContainerStartupFailureObservation({
+        cleanupUnsettled: false,
+        expectedElapsedMs: RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
+        forbiddenValues: [privateErrorText, privateUserId, "private.example.test"],
+        stage: "lifecycle_lock_or_state_read",
+      });
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("keeps startup failure telemetry fail-open", async () => {
+    const stateReadFailure = new Error("original startup state-read failure");
+    const { container } = createContainerDouble({
+      getState: vi.fn(async () => {
+        throw stateReadFailure;
+      }),
+    });
+    mocks.emitHostedExecutionStructuredLog.mockImplementationOnce(() => {
+      throw new Error("telemetry sink failed");
+    });
+
+    await expect(container.ensureReadyForProcessing({
+      timeoutMs: 15_000,
+      userId: "member_123",
+    })).rejects.toBe(stateReadFailure);
+  });
+
+  it("classifies cold start and port-readiness failures", async () => {
+    const privateErrorText = "port wait failed with token=private-start-token";
+    const startFailure = new Error(privateErrorText);
+    const { container } = createContainerDouble({
+      startAndWaitForPorts: vi.fn(async () => {
+        throw startFailure;
+      }),
+    });
+
+    await expect(container.ensureReadyForProcessing({
+      timeoutMs: 15_000,
+      userId: "member_private_cold_start",
+    })).rejects.toBe(startFailure);
+
+    expectRunnerContainerStartupFailureObservation({
+      cleanupUnsettled: false,
+      forbiddenValues: [privateErrorText, "member_private_cold_start"],
+      stage: "cold_start_or_ports",
+    });
+  });
+
+  it("classifies cold health and readiness-finalization failures", async () => {
+    const privateHealthValue = "private-health-payload";
+    const { container } = createContainerDouble({
+      containerFetch: vi.fn(async () =>
+        new Response(JSON.stringify({
+          error: privateHealthValue,
+          hostedRuntimeArchitectureVersion: "stale-architecture",
+          ok: true,
+        }), {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+          status: 200,
+        })
+      ),
+    });
+
+    await expect(container.ensureReadyForProcessing({
+      timeoutMs: 15_000,
+      userId: "member_private_cold_health",
+    })).rejects.toThrow(
+      "Hosted runner container architecture version mismatch.",
+    );
+
+    expectRunnerContainerStartupFailureObservation({
+      cleanupUnsettled: false,
+      forbiddenValues: [privateHealthValue, "member_private_cold_health"],
+      stage: "cold_health_or_finalization",
+    });
+  });
+
   it("starts the readiness deadline before lifecycle-lock admission", async () => {
     const firstDeadline = new AbortController();
     const queuedDeadline = new AbortController();
@@ -1983,6 +2140,10 @@ describe("RunnerContainer", () => {
     queuedDeadline.abort(new DOMException("Timed out", "TimeoutError"));
 
     await expect(queued).rejects.toMatchObject({ name: "TimeoutError" });
+    expectRunnerContainerStartupFailureObservation({
+      cleanupUnsettled: false,
+      stage: "lifecycle_lock_or_state_read",
+    });
     expect(healthCalls).toBe(1);
     releaseFirstHealth.resolve(undefined);
     await expect(first).resolves.toMatchObject({ kind: "ready" });
@@ -2789,8 +2950,10 @@ describe("RunnerContainer", () => {
   });
 
   it("reports unsettled warm-invalidated cleanup to readiness callers", async () => {
+    const privateErrorText = "destroy failed for /private/workspace/path";
+    const privateUserId = "member_private_warm_cleanup";
     const destroy = vi.fn(async () => {
-      throw new Error("destroy failed");
+      throw new Error(privateErrorText);
     });
     const { container } = createContainerDouble({
       destroy,
@@ -2802,9 +2965,14 @@ describe("RunnerContainer", () => {
 
     await expect(container.ensureReadyForProcessing({
       timeoutMs: 15_000,
-      userId: "member_123",
+      userId: privateUserId,
     })).resolves.toEqual({ kind: "cleanup_unsettled" });
     expect(destroy).toHaveBeenCalledOnce();
+    expectRunnerContainerStartupFailureObservation({
+      cleanupUnsettled: true,
+      forbiddenValues: [privateErrorText, privateUserId, "/private/workspace/path"],
+      stage: "warm_health_or_cleanup",
+    });
   });
 
   it("reports unsettled warm-health-failure cleanup to readiness callers", async () => {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -1962,6 +1962,13 @@ describe("RunnerContainer", () => {
     );
     expect(healthCalls).toHaveLength(1);
     expect(executeCalls).toHaveLength(0);
+    expect(
+      mocks.emitHostedExecutionStructuredLog.mock.calls.filter(
+        ([observation]) =>
+          observation.message
+            === "Hosted execution container startup confirmation failed.",
+      ),
+    ).toHaveLength(0);
   });
 
   it("keeps cold readiness compatible with health responses that omit startup timestamps", async () => {
@@ -3017,6 +3024,10 @@ describe("RunnerContainer", () => {
 
       await expect(readiness).resolves.toEqual({ kind: "cleanup_unsettled" });
       expect(destroy).toHaveBeenCalledOnce();
+      expectRunnerContainerStartupFailureObservation({
+        cleanupUnsettled: true,
+        stage: "warm_health_or_cleanup",
+      });
     } finally {
       timeout.mockRestore();
     }
@@ -3157,6 +3168,10 @@ describe("RunnerContainer", () => {
       });
       expect(destroy).toHaveBeenCalledTimes(2);
       expect(startAndWaitForPorts).toHaveBeenCalledTimes(2);
+      expectRunnerContainerStartupFailureObservation({
+        cleanupUnsettled: true,
+        stage: "cold_start_or_ports",
+      });
     } finally {
       timeout.mockRestore();
       vi.useRealTimers();

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -3243,7 +3243,7 @@ describe("HostedUserRunner execution coordination", () => {
     const { invoke, runner, sql } = createRunnerHarness({
       ensureReadyForProcessing,
       runnerContainerStubForName(_name, stub) {
-        vi.setSystemTime(new Date("2026-04-27T00:00:05.000Z"));
+        vi.setSystemTime(new Date("2026-04-27T00:01:05.000Z"));
         return stub;
       },
       workspace: createWorkspaceState({ version: "5" }),
@@ -3256,7 +3256,7 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     })).resolves.toEqual({
       kind: "retry_later",
-      retryAt: "2026-04-27T00:00:15.000Z",
+      retryAt: "2026-04-27T00:01:15.000Z",
     });
 
     expect(ensureReadyForProcessing).not.toHaveBeenCalled();
@@ -3283,7 +3283,7 @@ describe("HostedUserRunner execution coordination", () => {
       "Hosted runner runtime processing startup confirmation failed.",
     )).toMatchObject({
       runtimeProcessingRetryReason: "command_budget_exhausted",
-      runtimeStartupFailureElapsedMs: 5_000,
+      runtimeStartupFailureElapsedMs: 60_000,
       runtimeStartupFailureStage: "caller_deadline",
       transportFailureFenceCleared: true,
     });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -125,6 +125,22 @@ const TEST_RUNNER_RUNTIME_ENV_SOURCE = {
   OPENAI_API_KEY: "test-openai-key",
 } as const;
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStructuredLogDetails(message: string): Record<string, unknown> {
+  const matchingLogs = mocks.emitHostedExecutionStructuredLog.mock.calls
+    .map(([input]) => input)
+    .filter((input) => input.message === message);
+  expect(matchingLogs).toHaveLength(1);
+  const details = matchingLogs[0]?.details;
+  if (!isUnknownRecord(details)) {
+    throw new Error(`Expected structured details for ${message}`);
+  }
+  return details;
+}
+
 describe("HostedUserRunner execution coordination", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -3036,6 +3052,14 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
+    expect(readStructuredLogDetails(
+      "Hosted runner runtime processing startup confirmation failed.",
+    )).toMatchObject({
+      runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupFailureElapsedMs: 0,
+      runtimeStartupFailureStage: "rpc_unattributed",
+      transportFailureFenceCleared: true,
+    });
   });
 
   it("settles 15-second readiness cleanup before the 21-second controller guard", async () => {
@@ -3136,6 +3160,15 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
+    expect(readStructuredLogDetails(
+      "Hosted runner runtime processing startup cleanup did not settle.",
+    )).toMatchObject({
+      runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupCleanupUnsettled: true,
+      runtimeStartupFailureElapsedMs: 0,
+      runtimeStartupFailureStage: "rpc_unattributed",
+      runtimeStartupWriteFencePreserved: true,
+    });
   });
 
   it("preserves the fresh fence when only the outer startup guard settles", async () => {
@@ -3191,6 +3224,14 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
+    expect(readStructuredLogDetails(
+      "Hosted runner runtime processing startup confirmation guard elapsed.",
+    )).toMatchObject({
+      runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupFailureElapsedMs: 8_950,
+      runtimeStartupFailureStage: "caller_deadline",
+      runtimeStartupWriteFencePreserved: true,
+    });
   });
 
   it("clears a fresh fence when the command budget expires before readiness dispatch", async () => {
@@ -3238,6 +3279,14 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
+    expect(readStructuredLogDetails(
+      "Hosted runner runtime processing startup confirmation failed.",
+    )).toMatchObject({
+      runtimeProcessingRetryReason: "command_budget_exhausted",
+      runtimeStartupFailureElapsedMs: 5_000,
+      runtimeStartupFailureStage: "caller_deadline",
+      transportFailureFenceCleared: true,
+    });
   });
 
   it("invokes startup readiness directly on the container stub", async () => {
@@ -3342,6 +3391,14 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
+    expect(readStructuredLogDetails(
+      "Hosted runner runtime processing startup confirmation failed.",
+    )).toMatchObject({
+      runtimeProcessingRetryReason: "container_rpc_error",
+      runtimeStartupFailureElapsedMs: 0,
+      runtimeStartupFailureStage: "rpc_unattributed",
+      transportFailureFenceCleared: true,
+    });
   });
 
   it("sends activation diagnostics behind an active write fence without starting another container run", async () => {


### PR DESCRIPTION
## Why and outcome

Current hosted startup confirmation repeatedly collapses failures to a generic RPC/runtime category before later attempts recover. This adds a closed, privacy-safe six-stage taxonomy and bounded elapsed timing so natural production traffic can distinguish caller deadline, unattributed RPC, lifecycle/state, warm health/cleanup, cold start/ports, and cold health/finalization failures.

The change is telemetry-only. It does not alter readiness, cleanup, timeout, retry, write-fence, authorization, provider, canonical-state, or user-visible behavior.

## Product UX

- Effort: not applicable
- Result: Internal operational observability only; no member-visible surface, timing contract, action, or copy changes.

## Evidence

- A bounded current sample observed 228 startup-confirmation warnings (172 generic runtime errors and 56 timeouts); a separate 10-minute recovery sample found every failed instance later accepted runtime processing within the same sample.
- The deployed successful-readiness telemetry returned no direct causal cold-start samples and cannot classify this failed boundary.
- Focused Cloudflare suites passed on the corrected head: 2 files, 379 tests.
- `pnpm --dir apps/cloudflare typecheck` passed.
- `git diff --check` and added-line secret/private-path searches passed.
- ReviewGPT authored the production, test, and protocol patch. A first test expectation failed deterministically at 8,950 ms instead of 9,000 ms; ReviewGPT authored the one-line corrected replacement patch, after which all focused tests passed.
- The preliminary coverage-specialist pass found two mutation-test gaps. Both were accepted; ReviewGPT authored a test-only remediation that pins failure-only emission, warm/cold cleanup classification, and the caller-side 60-second clamp. The focused suites remained green.

## Non-obvious affected surfaces

- `RunnerContainer.ensureReadyForProcessing`: emits one failure-only local observation because the local stage is not safely transported across Durable Object RPC.
- UserRunner startup warnings: add caller-owned deadline/unattributed classification and bounded elapsed timing while retaining the existing retry reason.
- Production log interpretation: later analysis compares the two aggregate distributions; it does not emit or return a new correlation identifier.

## Architecture and reuse

- **Existing systems reused:** The existing Workers structured logger, startup confirmation boundary, sanitizer types, and retry/fence owners remain authoritative.
- **New logic:** One mutable in-memory closed stage marker and one failure-only log; caller warnings add a bounded enum and elapsed integer.
- **New abstractions:** One shared six-value TypeScript union and a small bounded elapsed helper; no service, storage, queue, event table, or backend is added.
- **Complexity intentionally avoided:** No custom RPC error transport, persisted telemetry state, new Analytics Engine dataset, scheduler, retry path, or functional startup fix.

## Hot reply path impact

No successful foreground reply work is added. The new RunnerContainer log runs only after startup confirmation has already failed; existing UserRunner failure warnings add only `Date.now()` arithmetic and bounded fields. No database, network/provider, queue, or other awaited call is added or moved.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool, schema, model request, or generated guidance changes.
- Codex runtime: Not applicable for the same reason.

## Preliminary specialist lenses

- Product UX: not applicable; internal telemetry only.
- Prompt: not applicable; no prompt surface changes.
- Frontend: not applicable; no Web presentation changes.
- Coverage: applicable; the patch makes a material privacy and failure-classification proof across six bounded categories while preserving retry and fence outcomes.

## Change-shape breakdown

Classification: production TypeScript is source; Vitest files are tests/fixtures; Markdown and the completed execution plan are docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 132 | 1 |
| Tests/fixtures | 245 | 5 |
| Docs | 101 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **478** | **7** |

## Deployment concerns

- Deployment: applicable
- Supported skew: New and old UserRunner/RunnerContainer isolates accept the same RPC and result shapes. Missing observations remain explicitly unattributed; fields are additive logs only.
- Safe order: Merge the exact reviewed head, then run the canonical protected-main Cloudflare production workflow. No tandem Vercel deploy or runner-container image rollout is required.
- Rollback floor: The prior Worker revision remains safe; rollback simply stops the additive fields.
- Expected exposure: During the Worker rollout, some failed attempts may lack one side of the additive observations and remain in the unattributed aggregate.
- Reversibility: Redeploy the prior Worker revision; no data migration or cleanup is required.
- Convergence proof: Require the protected workflow's deployed-source receipt for the merged commit and a successful Worker smoke.
- Post-deploy checks: After at least two hours of natural traffic, aggregate both exact failure messages by the bounded stage, existing retry reason/error code, coarse elapsed bucket, and cleanup flag; return aggregate counts only and generate no synthetic traffic.

## Changelog

- Changelog: not applicable
- Reason: Internal-only telemetry with no member-visible behavior or capability change.

ReviewGPT context sensitivity: sensitive
Reason: This touches Cloudflare hosted execution and production failure observability, although the patch is behavior-preserving and telemetry-only.

ReviewGPT first-reviewed head: 22d3cadd41c1441ee89fb4a1992e183c4134f566
