### PR TITLE
Page operators on OpenAI authorization failures

### DIFF
--- a/.agents/friction-log/20260829230530-reviewgpt-patch-attachment/friction.md
+++ b/.agents/friction-log/20260829230530-reviewgpt-patch-attachment/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'ReviewGPT patch attachment download times out after response completion'
+severity: 'major'
+---
+
+## Expected Behavior
+
+A waited ReviewGPT run that returns a patch attachment should download the completed artifact once and make it available for exact hash verification and application.
+
+## Current Behavior
+
+The browser run completed and exposed the attachment, but the downloader repeatedly timed out waiting for a browser download event. The completed artifact bytes were then unavailable to the response-capture path, forcing a second ReviewGPT request to re-encode the patch inline. A later fresh run also failed twice while staging the same repository attachment before a different browser lane succeeded.
+
+## Possible Solution
+
+Capture completed attachment bytes from the response artifact endpoint as a fallback when the browser download event is missed, and retain a bounded invocation-owned copy until response capture confirms artifact recovery.
+
+## Minimal Reproducible Example
+
+1. Run a waited ReviewGPT implementation request with `--artifacts --zip` and ask for a patch attachment.
+2. Let the assistant finish with the requested attachment.
+3. Observe the downloader time out while waiting for the browser download event even though the attachment exists in the completed response.
+4. Attempt exact recovery from the captured response and observe that the attachment bytes are unavailable.
+
+## Context
+
+This blocked exact application of a production-fix patch and required multiple replacement ReviewGPT runs plus an inline gzip/base64 transfer workaround.

--- a/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
+++ b/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
@@ -119,6 +119,13 @@ Updated: 2026-08-30
 - The preliminary coverage finding was accepted and resolved with one
   Workers-pool composition across the alert binding behavior and real Linq
   sender using only synthetic fake transport.
+- ReviewGPT's final round-two silent-loss finding was accepted: when an older
+  incident still owns the single pending tuple, an unpaged current incident is
+  derived from the existing open aggregate plus `alertSequence === 0`. Both
+  quiet-close entry points preserve that aggregate, and alarm selection leaves
+  the older tuple's retry as the sole owner until the unchanged success handoff
+  admits the deferred page. No field, slot, queue, lease, or scheduler was
+  added.
 - Changelog: not applicable. This changes internal operator paging only;
   members receive no new message, response, control, or visible recovery state.
 
@@ -156,6 +163,14 @@ Updated: 2026-08-30
     and decoded patch SHA-256
     `4ab51b92d8c9e45b6730dd30f1e8cb0529ed0f57b8551a422a52dc4938c2f2e5`
     independently matched; `git apply --check --whitespace=error-all` passed.
+  - Final round-two remediation proof:
+    - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts
+      --no-coverage
+      apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts`
+      — 13 tests passed, including alarm-driven and report-driven quiet
+      boundaries with an older page pending.
+    - `pnpm --filter @murphai/cloudflare-runner typecheck` — passed.
+    - `git diff --check` — passed.
 - Direct Product UX walkthrough:
   - Each existing operator recipient gets the same four-line SEV1 page with
     only status, aggregate count, and first/last UTC timestamps.
@@ -168,6 +183,7 @@ Updated: 2026-08-30
 - Remaining gates:
   - The preliminary Product UX/coverage specialist ReviewGPT is complete; its
     one coverage finding is resolved by the composed Worker proof above.
-  - Push the corrected candidate, run final sensitive-context ReviewGPT round
-    two against the immutable round-one baseline, require exact-head GitHub
-    checks, and complete the parent final review.
+  - Push the round-two remediation, run final sensitive-context ReviewGPT round
+    three against the immutable round-one baseline, require exact-head GitHub
+    checks, complete the parent final review, then merge through the protected
+    repository path.

--- a/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
+++ b/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
@@ -1,0 +1,141 @@
+# Page operators on AI egress authorization failure
+
+Status: active
+Created: 2026-08-29
+Updated: 2026-08-29
+
+## Goal
+
+- Reuse Murph's existing operator Linq page transport to send an immediate,
+  privacy-safe SEV1 text when an authorized OpenAI request is rejected with
+  HTTP 401 or 403, without adding work to successful provider requests.
+
+## Success criteria
+
+- The first authorized upstream OpenAI 401/403 opens one durable incident and
+  schedules one stable-idempotency page to both existing operator chats.
+- Repeated failures coalesce, with at most one reminder per hour while failures
+  remain current and a new incident after a quiet recovery window.
+- Failed alert delivery remains pending and is retried by the owning Durable
+  Object's native alarm; Linq destination and line-health checks remain
+  unchanged.
+- The operator message contains only severity, provider, upstream status,
+  aggregate count, and timestamps. It contains no member, request, prompt,
+  message, credential, model input, or provider response body.
+- The upstream OpenAI response and member-facing retry behavior remain
+  unchanged even if alert reporting or alert delivery fails.
+- Focused monitor, Worker, egress, configuration, and deployment-contract tests
+  pass, followed by required ReviewGPT and exact-head CI gates.
+
+## Scope
+
+- In scope:
+  - One new SQLite Durable Object as the narrow global dedupe/retry owner.
+  - Authorized OpenAI 401/403 reporting from the existing Worker egress seam.
+  - Reuse of the existing two operator chats, Linq token, sender health checks,
+    and operator-alert transport.
+  - Additive Cloudflare binding/migration, focused tests, and durable deploy and
+    runtime documentation.
+- Out of scope:
+  - Public status updates or a second incident source of truth.
+  - Member-facing copy, retries, provider selection, or delivery behavior.
+  - Reading, validating, rotating, or exposing the production OpenAI secret.
+  - Generic alerts for every provider/status without production evidence.
+  - New queues, cron expressions, messaging providers, or Web-owned state.
+
+## Constraints
+
+- Technical constraints:
+  - Persist admission before external send and reuse stable provider
+    idempotency keys.
+  - Keep the success path free of Durable Object calls and database work.
+  - Report alert failures as bounded metadata and never mask the original
+    upstream response.
+  - Use an additive SQLite Durable Object migration and its one native alarm
+    for pending-send retry and quiet-window closure.
+- Product/process constraints:
+  - Product UX effort: Product change to the existing operator-page journey.
+  - Outcome: on-call operators learn about a global AI authorization outage in
+    minutes instead of waiting for a manual production sweep.
+  - Entry and promise: the first proven authorized upstream rejection creates
+    one urgent page; continuing failures create bounded reminders.
+  - Affected people: the two existing on-call operator-chat recipients receive
+    short actionable evidence; members receive no new message and their
+    existing provider response path is unchanged.
+  - Failure/recovery: unhealthy Linq destinations fail closed, a failed send
+    remains pending, and incident.io remains the coordination source of truth.
+  - Existing established direct chats, line-health preflight, low volume, and
+    one-hour pacing preserve messaging deliverability.
+
+## Risks and mitigations
+
+1. Risk: concurrent failures send duplicate operator texts.
+   Mitigation: serialize through one named Durable Object, persist one pending
+   body/key, and claim each attempt before provider entry.
+2. Risk: alerting adds latency or changes a failed member request.
+   Mitigation: persist through a best-effort background RPC, catch every alert
+   error, and return the original OpenAI response unchanged.
+3. Risk: operator texts expose private runtime evidence.
+   Mitigation: accept only status and timestamp at the RPC boundary and format
+   a closed aggregate-only message inside the Durable Object.
+4. Risk: a transient single error causes repeated pages.
+   Mitigation: one first-error page is intentional for a global injected
+   credential; reminders are hourly and only while fresh failures continue.
+5. Risk: the new Durable Object cannot be rolled out or rolled back safely.
+   Mitigation: add one SQLite namespace migration and binding, document the
+   Cloudflare-only deployment/forward-fix path, and keep older Workers free to
+   ignore the additive namespace.
+
+## Tasks
+
+1. Add the AI-egress alert store, monitor, and Durable Object wrapper.
+2. Wire authorized OpenAI 401/403 outcomes into the alert RPC without touching
+   successful provider requests.
+3. Reuse the existing Linq operator-alert transport and use the incident
+   Durable Object's one alarm for retry and quiet-window closure.
+4. Add the binding, SQLite migration, worker contracts, exports, tests, and
+   deploy/runtime documentation.
+5. Run focused proof, privacy/deliverability review, preliminary specialist
+   ReviewGPT, final ReviewGPT, CI, and parent final review.
+
+## Decisions
+
+- Alert on the first authorized OpenAI 401/403 because the credential is
+  Worker-owned and global; this is materially different from a per-member bad
+  request or a transient upstream 5xx.
+- Close the incident after fifteen minutes without another authorization
+  rejection. No recovery text is sent; incident.io owns live coordination.
+- Reuse the existing operator chat identities and Linq sender instead of adding
+  phone numbers, recipient state, or another provider configuration.
+
+## Verification
+
+- Completed local proof:
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts
+    --no-coverage apps/cloudflare/test/runner-egress-intercept.test.ts
+    apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
+    apps/cloudflare/test/deploy-automation.test.ts` — 300 tests passed.
+  - `pnpm exec vitest run --config
+    packages/hosted-local-harness/vitest.config.ts --no-coverage
+    packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts` —
+    94 tests passed.
+  - `pnpm exec vitest run --config
+    apps/cloudflare/vitest.workers.config.ts --no-coverage
+    apps/cloudflare/test/workers/database-health-e2e.test.ts` — 5 tests passed
+    and the new Workers binding/class configuration loaded successfully.
+  - `pnpm --filter @murphai/cloudflare-runner typecheck` — passed.
+  - `pnpm --filter @murphai/hosted-local-harness typecheck` — passed.
+  - `git diff --check` — passed.
+- Direct Product UX walkthrough:
+  - Each existing operator recipient gets the same four-line SEV1 page with
+    only status, aggregate count, and first/last UTC timestamps.
+  - A first 401/403 schedules the page immediately; repeated failures coalesce;
+    fresh failures after one hour may schedule one reminder; 15 quiet minutes
+    close the incident without a recovery text.
+  - Failed Linq delivery retains the exact persisted body and idempotency key
+    for five-minute alarm retry. Members receive no new message, and alert
+    failure leaves the original OpenAI response object unchanged.
+- Remaining gates:
+  - Exact pushed-head preliminary Product UX/coverage specialist ReviewGPT,
+    final sensitive-context ReviewGPT, required GitHub checks, and parent final
+    review.

--- a/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
+++ b/agent-docs/exec-plans/active/2026-08-29-ai-egress-sev1-text-alert.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-08-29
-Updated: 2026-08-29
+Updated: 2026-08-30
 
 ## Goal
 
@@ -73,8 +73,9 @@ Updated: 2026-08-29
    Mitigation: serialize through one named Durable Object, persist one pending
    body/key, and claim each attempt before provider entry.
 2. Risk: alerting adds latency or changes a failed member request.
-   Mitigation: persist through a best-effort background RPC, catch every alert
-   error, and return the original OpenAI response unchanged.
+   Mitigation: use `waitUntil` when the runtime owns it; otherwise await only
+   the short failed-401/403 Durable Object admission. Catch every alert error
+   and return the original OpenAI response object unchanged.
 3. Risk: operator texts expose private runtime evidence.
    Mitigation: accept only status and timestamp at the RPC boundary and format
    a closed aggregate-only message inside the Durable Object.
@@ -107,6 +108,19 @@ Updated: 2026-08-29
   rejection. No recovery text is sent; incident.io owns live coordination.
 - Reuse the existing operator chat identities and Linq sender instead of adding
   phone numbers, recipient state, or another provider configuration.
+- ReviewGPT's final round-one lifetime finding was accepted: the real
+  Containers outbound context has no `waitUntil`, so the failed 401/403 path
+  must await the same caught report promise when registration is unavailable or
+  throws. Successful egress and all nonqualifying paths remain non-alerting.
+- ReviewGPT's complexity-collapse finding was accepted: delete the redundant
+  attempt generation and lease state. The exact pending tuple plus its
+  five-minute retry timestamp now owns both reservation and retry timing; the
+  production sender's bounded phases complete well inside that interval.
+- The preliminary coverage finding was accepted and resolved with one
+  Workers-pool composition across the alert binding behavior and real Linq
+  sender using only synthetic fake transport.
+- Changelog: not applicable. This changes internal operator paging only;
+  members receive no new message, response, control, or visible recovery state.
 
 ## Verification
 
@@ -126,6 +140,22 @@ Updated: 2026-08-29
   - `pnpm --filter @murphai/cloudflare-runner typecheck` — passed.
   - `pnpm --filter @murphai/hosted-local-harness typecheck` — passed.
   - `git diff --check` — passed.
+- Corrected-candidate proof after accepted ReviewGPT remediation:
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts
+    --no-coverage apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
+    apps/cloudflare/test/runner-egress-intercept.test.ts` — 275 tests passed.
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.workers.config.ts
+    --no-coverage apps/cloudflare/test/workers/openai-authorization-alert-e2e.test.ts`
+    — 1 composed Workers-pool test passed.
+  - `pnpm --filter @murphai/cloudflare-runner typecheck` — passed after
+    ReviewGPT replaced the package-typed Containers test import with the
+    existing production-shaped repository stub; no cast or production change.
+  - Focused rerun of `runner-egress-intercept.test.ts` — 264 tests passed.
+  - ReviewGPT patch gzip SHA-256
+    `0e049693b56262330ca89a9d131ecaa3e054bbb1f78be203ac9bcd2e84cb7596`
+    and decoded patch SHA-256
+    `4ab51b92d8c9e45b6730dd30f1e8cb0529ed0f57b8551a422a52dc4938c2f2e5`
+    independently matched; `git apply --check --whitespace=error-all` passed.
 - Direct Product UX walkthrough:
   - Each existing operator recipient gets the same four-line SEV1 page with
     only status, aggregate count, and first/last UTC timestamps.
@@ -136,6 +166,8 @@ Updated: 2026-08-29
     for five-minute alarm retry. Members receive no new message, and alert
     failure leaves the original OpenAI response object unchanged.
 - Remaining gates:
-  - Exact pushed-head preliminary Product UX/coverage specialist ReviewGPT,
-    final sensitive-context ReviewGPT, required GitHub checks, and parent final
-    review.
+  - The preliminary Product UX/coverage specialist ReviewGPT is complete; its
+    one coverage finding is resolved by the composed Worker proof above.
+  - Push the corrected candidate, run final sensitive-context ReviewGPT round
+    two against the immutable round-one baseline, require exact-head GitHub
+    checks, and complete the parent final review.

--- a/agent-docs/exec-plans/completed/2026-08-29-ai-egress-sev1-text-alert.md
+++ b/agent-docs/exec-plans/completed/2026-08-29-ai-egress-sev1-text-alert.md
@@ -1,6 +1,6 @@
 # Page operators on AI egress authorization failure
 
-Status: active
+Status: completed
 Created: 2026-08-29
 Updated: 2026-08-30
 
@@ -183,7 +183,26 @@ Updated: 2026-08-30
 - Remaining gates:
   - The preliminary Product UX/coverage specialist ReviewGPT is complete; its
     one coverage finding is resolved by the composed Worker proof above.
-  - Push the round-two remediation, run final sensitive-context ReviewGPT round
-    three against the immutable round-one baseline, require exact-head GitHub
-    checks, complete the parent final review, then merge through the protected
-    repository path.
+  - Final ReviewGPT round three first returned `INVALID` because the invocation
+    did not repeat the complete prior-finding ledger; the corrected invocation
+    then returned the mandatory round-number `RETROSPECTIVE_REQUIRED` gate with
+    no tactical finding.
+  - The completed requirement-level retrospective is recorded on PR #2570. It
+    chooses justified continuation: current production source is 13 lines
+    smaller than the immutable first-reviewed design, the lease/generation
+    lifecycle is deleted, and the implementation retains one Durable Object,
+    one SQLite row and pending tuple, one native alarm, and the existing Linq
+    sender. Splitting or moving the owner would add seams or another service
+    without deleting a required concept.
+  - Final sensitive-context ReviewGPT round four returned
+    `ROUND_OUTCOME: PASS` on exact head `6569469af994` with no qualifying
+    finding and verified every prior correction plus the retrospective.
+  - Exact-head CI initially failed one unrelated assistant-engine assertion in
+    the 4,445-test coverage shard; the PR does not touch assistant-engine and
+    the exact named test passed locally (1 passed, 127 skipped). The failed
+    GitHub jobs were rerun through the normal required-check path with no code
+    change or bypass.
+  - Current-main `git merge-tree --write-tree` is clean. Close this plan, require
+    the final docs-only closure head's GitHub checks, then merge through the
+    protected repository path.
+Completed: 2026-08-30

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -388,8 +388,10 @@ Worker key injection, and the singleton RPC contains only `{ status,
 observedAtMs }`. The owner persists and coalesces the first page, retries the
 exact pending bytes and idempotency key after five minutes, admits at most one
 hourly reminder on a fresh failure, and closes after 15 quiet minutes without a
-recovery message. Reporting failure never changes or delays the upstream
-response beyond scheduling the RPC with `waitUntil`.
+recovery message. Reporting failure never changes the upstream response. It is
+scheduled with `waitUntil` when available; when the Containers outbound context
+cannot own the promise, only the failed 401/403 path awaits the short Durable
+Object admission.
 
 For a safe rollback, deploy a Cloudflare-only compatibility build that disables
 the egress call site while retaining the class export, binding, and append-only

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -371,6 +371,39 @@ the former single-recipient implementation: it can clear that page after only
 the primary provider operation. The two-recipient Worker is the rollback floor
 until alerts are disabled or the pending page has cleared.
 
+## OpenAI Authorization Alert Rollout
+
+Deploy this change on Cloudflare only; no Vercel tandem deploy or compatibility
+window is needed, and successful OpenAI egress is unchanged. The Worker artifact
+and production config must land together with the
+`OpenAiAuthorizationAlertDurableObject` export, the
+`OPENAI_AUTHORIZATION_ALERT_MONITOR` binding, and append-only SQLite migration
+`v6`. Do not alter the existing `*/5 * * * *` cron: this owner uses native
+Durable Object alarms. It adds no secret or recipient and reuses the existing
+`LINQ_API_TOKEN`, `HOSTED_DATABASE_ALERT_LINQ_CHAT_ID`, and
+`HOSTED_DATABASE_ALERT_LINQ_SECONDARY_CHAT_ID`.
+
+The trigger is limited to an authorized OpenAI upstream HTTP 401 or 403 after
+Worker key injection, and the singleton RPC contains only `{ status,
+observedAtMs }`. The owner persists and coalesces the first page, retries the
+exact pending bytes and idempotency key after five minutes, admits at most one
+hourly reminder on a fresh failure, and closes after 15 quiet minutes without a
+recovery message. Reporting failure never changes or delays the upstream
+response beyond scheduling the RPC with `waitUntil`.
+
+For a safe rollback, deploy a Cloudflare-only compatibility build that disables
+the egress call site while retaining the class export, binding, and append-only
+`v6` migration so an already-armed retry or quiet alarm can finish. Do not delete,
+renumber, or reuse the namespace or migration. No Vercel rollback is required.
+For read-only post-deploy proof, compare the active Worker binding metadata with
+the generated config, verify checked-in/generated class, binding, and `v6`
+migration parity, confirm the cron remains unchanged, and inspect Workers
+Observability for the fixed `openai_authorization_alert_report_failed` code. Do
+not invoke `reportFailure`, manufacture an OpenAI 401/403, or send a Linq message
+for smoke;
+the fake-provider integration and Durable Object suites own trigger and delivery
+proof.
+
 ## Device-Sync Wake Epoch Rollout
 
 Connection-scoped `device-sync.wake` items bind their authority to the

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -144,6 +144,8 @@ Bindings:
   Queue metrics
 - `DEVICE_WEBHOOK_QUEUE_MONITOR`, one environment-scoped SQLite Durable Object
   for five-minute Queue-health observations and restart-safe operator paging
+- `OPENAI_AUTHORIZATION_ALERT_MONITOR`, one global SQLite Durable Object for
+  privacy-safe authorized OpenAI upstream 401/403 incident paging
 - `RUNNER_CONTAINER`
 - `BUNDLES`
 - `CF_VERSION_METADATA` version metadata binding, used by deploy smoke to prove the requested Worker version actually handled the request
@@ -210,6 +212,29 @@ production origin or when callback origins use HTTP, localhost, Docker bridge,
 loopback, preview/development, or private-network hosts. The GitHub workflow
 runs that preflight before artifact preparation; the local `deploy:worker`
 path also runs it inside the apply step before artifact validation and upload.
+
+### OpenAI authorization alert monitor
+
+Only an HTTP 401 or 403 returned by OpenAI after provider-egress authorization
+succeeds and the Worker injects `OPENAI_API_KEY` reports to the fixed
+`production` Durable Object. The RPC carries exactly `{ status, observedAtMs }`;
+it carries no member, request, runner, attempt, prompt, body, path, model, URL,
+response, header, token, or other identifier or payload detail. Murph-local
+credential, route, and authorization failures, transport exceptions, other
+providers, and every other upstream status do not touch this namespace. The
+report is failure-isolated, is deferred with the request `waitUntil` when
+available, and never clones, consumes, replaces, or otherwise changes the
+original upstream response. Successful OpenAI egress is unchanged.
+
+`OpenAiAuthorizationAlertDurableObject` reuses the existing `LINQ_API_TOKEN` and
+the two existing database-alert direct operator chats. It persists the first
+page, coalesces repeats, retries the exact pending message and idempotency key
+after five minutes, admits at most one hourly reminder on a fresh failure, and
+closes after 15 quiet minutes without sending a recovery message. Native Durable
+Object alarms own retry and quiet handling; the existing five-minute Worker cron
+is unchanged. Production binds `OPENAI_AUTHORIZATION_ALERT_MONITOR` to the class
+through append-only SQLite migration `v6`. This adds no secret, recipient, cron,
+queue, route, service, or member-facing message.
 
 ### Production database-health monitor
 

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -222,9 +222,11 @@ it carries no member, request, runner, attempt, prompt, body, path, model, URL,
 response, header, token, or other identifier or payload detail. Murph-local
 credential, route, and authorization failures, transport exceptions, other
 providers, and every other upstream status do not touch this namespace. The
-report is failure-isolated, is deferred with the request `waitUntil` when
-available, and never clones, consumes, replaces, or otherwise changes the
-original upstream response. Successful OpenAI egress is unchanged.
+report is failure-isolated and is deferred with the request `waitUntil` when
+available. When the Containers outbound context cannot own the promise, only
+the failed 401/403 path awaits the short Durable Object admission before
+returning the original upstream response unchanged. Successful OpenAI egress is
+unchanged.
 
 `OpenAiAuthorizationAlertDurableObject` reuses the existing `LINQ_API_TOKEN` and
 the two existing database-alert direct operator chats. It persists the first

--- a/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
+++ b/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
@@ -115,6 +115,10 @@ export function buildHostedWranglerDeployConfig(
           class_name: "DeviceWebhookQueueHealthDurableObject",
         },
         {
+          name: "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+          class_name: "OpenAiAuthorizationAlertDurableObject",
+        },
+        {
           name: "RUNNER_CONTAINER",
           class_name: "RunnerContainer",
         },
@@ -147,6 +151,10 @@ export function buildHostedWranglerDeployConfig(
       {
         tag: "v5",
         new_sqlite_classes: ["DeviceWebhookQueueHealthDurableObject"],
+      },
+      {
+        tag: "v6",
+        new_sqlite_classes: ["OpenAiAuthorizationAlertDurableObject"],
       },
     ],
     triggers: {

--- a/apps/cloudflare/src/hosted-local-test-index.ts
+++ b/apps/cloudflare/src/hosted-local-test-index.ts
@@ -14,6 +14,9 @@ export {
 export {
   DeviceWebhookQueueHealthDurableObject,
 } from "./worker/device-webhook-queue-health-durable-object.ts";
+export {
+  OpenAiAuthorizationAlertDurableObject,
+} from "./worker/openai-authorization-alert-durable-object.ts";
 
 import {
   handleHostedEmailIngress,

--- a/apps/cloudflare/src/index.ts
+++ b/apps/cloudflare/src/index.ts
@@ -6,5 +6,8 @@ export {
 export {
   DeviceWebhookQueueHealthDurableObject,
 } from "./worker/device-webhook-queue-health-durable-object.ts";
+export {
+  OpenAiAuthorizationAlertDurableObject,
+} from "./worker/openai-authorization-alert-durable-object.ts";
 export { UserRunnerDurableObject } from "./worker/user-runner-durable-object.ts";
 export { default } from "./worker/index.ts";

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -1517,7 +1517,7 @@ function reportOpenAiAuthorizationFailureSafely(input: {
   ctx?: HostedRunnerOutboundContext;
   env: RunnerOutboundEnvironmentSource;
   status: 401 | 403;
-}): void {
+}): Promise<void> | undefined {
   let failureLogged = false;
   const logFailure = (): void => {
     if (failureLogged) {
@@ -1541,16 +1541,22 @@ function reportOpenAiAuthorizationFailureSafely(input: {
         observedAtMs: Date.now(),
         status: input.status,
       })
+      .then(() => undefined)
       .catch(() => {
         logFailure();
       });
-    try {
-      input.ctx?.waitUntil?.(reportPromise);
-    } catch {
-      logFailure();
+    if (typeof input.ctx?.waitUntil === "function") {
+      try {
+        input.ctx.waitUntil(reportPromise);
+        return;
+      } catch {
+        logFailure();
+      }
     }
+    return reportPromise;
   } catch {
     logFailure();
+    return;
   }
 }
 
@@ -1673,11 +1679,14 @@ async function maybeHandleOpenAiRequest(input: {
     url: input.url,
   });
   if (response.status === 401 || response.status === 403) {
-    reportOpenAiAuthorizationFailureSafely({
+    const reportPromise = reportOpenAiAuthorizationFailureSafely({
       ctx: input.ctx,
       env: input.env,
       status: response.status,
     });
+    if (reportPromise) {
+      await reportPromise;
+    }
   }
   if (diagnosticPromise && typeof input.ctx?.waitUntil !== "function") {
     await diagnosticPromise;

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -167,6 +167,11 @@ const HOSTED_RUNTIME_AUTHORITY_HEADER_NAMES = [
 
 const DEFAULT_LINQ_API_BASE_URL = "https://api.linqapp.com/api/partner/v3";
 const DEFAULT_OPENAI_API_BASE_URL = "https://api.openai.com";
+const OPENAI_AUTHORIZATION_ALERT_SINGLETON_NAME = "production";
+const OPENAI_AUTHORIZATION_ALERT_REPORT_FAILURE_CODE =
+  "openai_authorization_alert_report_failed";
+const OPENAI_AUTHORIZATION_ALERT_REPORT_FAILURE_MESSAGE =
+  "OpenAI authorization alert report failed.";
 const DEFAULT_EXA_API_BASE_URL = "https://api.exa.ai";
 const DEFAULT_MAPBOX_API_BASE_URL = "https://api.mapbox.com";
 const DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org";
@@ -1508,6 +1513,47 @@ async function maybeHandleCustomInferenceRequest(input: {
   }
 }
 
+function reportOpenAiAuthorizationFailureSafely(input: {
+  ctx?: HostedRunnerOutboundContext;
+  env: RunnerOutboundEnvironmentSource;
+  status: 401 | 403;
+}): void {
+  let failureLogged = false;
+  const logFailure = (): void => {
+    if (failureLogged) {
+      return;
+    }
+    failureLogged = true;
+    console.warn(OPENAI_AUTHORIZATION_ALERT_REPORT_FAILURE_MESSAGE, {
+      failureCode: OPENAI_AUTHORIZATION_ALERT_REPORT_FAILURE_CODE,
+    });
+  };
+
+  try {
+    const namespace = input.env.OPENAI_AUTHORIZATION_ALERT_MONITOR;
+    if (!namespace) {
+      logFailure();
+      return;
+    }
+    const reportPromise = namespace
+      .getByName(OPENAI_AUTHORIZATION_ALERT_SINGLETON_NAME)
+      .reportFailure({
+        observedAtMs: Date.now(),
+        status: input.status,
+      })
+      .catch(() => {
+        logFailure();
+      });
+    try {
+      input.ctx?.waitUntil?.(reportPromise);
+    } catch {
+      logFailure();
+    }
+  } catch {
+    logFailure();
+  }
+}
+
 async function maybeHandleOpenAiRequest(input: {
   ctx?: HostedRunnerOutboundContext;
   env: RunnerOutboundEnvironmentSource;
@@ -1626,6 +1672,13 @@ async function maybeHandleOpenAiRequest(input: {
     upstreamFetchImpl: input.upstreamFetchImpl,
     url: input.url,
   });
+  if (response.status === 401 || response.status === 403) {
+    reportOpenAiAuthorizationFailureSafely({
+      ctx: input.ctx,
+      env: input.env,
+      status: response.status,
+    });
+  }
   if (diagnosticPromise && typeof input.ctx?.waitUntil !== "function") {
     await diagnosticPromise;
   }

--- a/apps/cloudflare/src/worker-contracts.ts
+++ b/apps/cloudflare/src/worker-contracts.ts
@@ -264,6 +264,20 @@ export interface WorkerDeviceWebhookQueueHealthNamespaceLike<
   getByName(name: string): TStub;
 }
 
+export interface WorkerOpenAiAuthorizationAlertStubLike {
+  reportFailure(input: {
+    observedAtMs: number;
+    status: 401 | 403;
+  }): Promise<{ accepted: true }>;
+}
+
+export interface WorkerOpenAiAuthorizationAlertNamespaceLike<
+  TStub extends WorkerOpenAiAuthorizationAlertStubLike =
+    WorkerOpenAiAuthorizationAlertStubLike,
+> {
+  getByName(name: string): TStub;
+}
+
 export interface WorkerEnvironmentContract<
   TStub extends WorkerUserRunnerStubLike = WorkerUserRunnerStubLike,
 > extends Readonly<Record<string, unknown>> {
@@ -301,6 +315,7 @@ export interface WorkerEnvironmentContract<
   HOSTED_ASSISTANT_SANDBOX?: string;
   ELEVENLABS_API_KEY?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_AUTHORIZATION_ALERT_MONITOR?: WorkerOpenAiAuthorizationAlertNamespaceLike;
   VENICE_API_KEY?: string;
   HOSTED_PROVIDER_EGRESS_CREDENTIAL_SIGNING_SECRET?: string;
   HOSTED_RUNTIME_CODEX_CHATGPT_AUTH_JSON?: string;

--- a/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
+++ b/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
@@ -36,8 +36,6 @@ export interface OpenAiAuthorizationAlertSender {
 
 export interface OpenAiAuthorizationAlertState {
   alertSequence: number;
-  attemptGeneration: number;
-  attemptLeaseUntilMs: number;
   failureCount: number;
   firstFailureAtMs: number | null;
   incidentOpen: boolean;
@@ -55,8 +53,6 @@ export interface OpenAiAuthorizationAlertState {
 interface OpenAiAuthorizationAlertMetaRow
   extends Record<string, DurableObjectSqlValue> {
   alert_sequence: number;
-  attempt_generation: number;
-  attempt_lease_until_ms: number;
   failure_count: number;
   first_failure_at_ms: number | null;
   incident_open: number;
@@ -77,7 +73,6 @@ interface OpenAiAuthorizationFailureReport {
 }
 
 interface ClaimedOpenAiAuthorizationAlert {
-  attemptGeneration: number;
   idempotencyKey: string;
   incidentSequence: number;
   message: string;
@@ -246,9 +241,10 @@ export class OpenAiAuthorizationAlertDurableObject extends DurableObject {
         try {
           this.transactionSync(() => {
             this.store.recordAlertFailure({
-              attemptGeneration: activeClaim.attemptGeneration,
               failedAtMs,
+              idempotencyKey: activeClaim.idempotencyKey,
               incidentSequence: activeClaim.incidentSequence,
+              message: activeClaim.message,
               sequence: activeClaim.sequence,
             });
           });
@@ -298,8 +294,7 @@ export class OpenAiAuthorizationAlertDurableObject extends DurableObject {
 
   private async reconcileAlarmSafely(): Promise<void> {
     try {
-      const nowMs = normalizeTimestamp(this.nowImplementation());
-      const desiredAlarm = computeDesiredAlarm(this.store.readState(), nowMs);
+      const desiredAlarm = computeDesiredAlarm(this.store.readState());
       const currentAlarm = await this.getAlarm();
       if (desiredAlarm === null) {
         await this.deleteAlarm();
@@ -328,61 +323,41 @@ class OpenAiAuthorizationAlertStore {
       || state.pendingAlertSequence === null
       || state.pendingRetryAtMs === null
       || state.pendingRetryAtMs > nowMs
-      || state.attemptLeaseUntilMs > nowMs
     ) {
       return null;
     }
 
-    const leaseUntilMs = addTimestampDelay(
-      nowMs,
-      OPENAI_AUTHORIZATION_ALERT_RETRY_MS,
-    );
     const claimed = this.sql.exec(
       `UPDATE openai_authorization_alert_meta
-       SET
-         attempt_generation = attempt_generation + 1,
-         attempt_lease_until_ms = ?
+       SET pending_retry_at_ms = ?
        WHERE singleton = 1
          AND pending_alert_incident_sequence = ?
          AND pending_alert_sequence = ?
          AND pending_alert_idempotency_key = ?
          AND pending_alert_message = ?
-         AND pending_retry_at_ms <= ?
-         AND attempt_lease_until_ms <= ?`,
-      leaseUntilMs,
+         AND pending_retry_at_ms <= ?`,
+      addTimestampDelay(nowMs, OPENAI_AUTHORIZATION_ALERT_RETRY_MS),
       state.pendingAlertIncidentSequence,
       state.pendingAlertSequence,
       state.pendingAlertIdempotencyKey,
       state.pendingAlertMessage,
-      nowMs,
       nowMs,
     ).rowsWritten === 1;
     if (!claimed) {
       return null;
     }
 
-    const claimedState = this.readState();
-    if (
-      claimedState.pendingAlertIdempotencyKey === null
-      || claimedState.pendingAlertIncidentSequence === null
-      || claimedState.pendingAlertMessage === null
-      || claimedState.pendingAlertSequence === null
-    ) {
-      throw new Error("Claimed OpenAI authorization alert is missing.");
-    }
     return {
-      attemptGeneration: claimedState.attemptGeneration,
-      idempotencyKey: claimedState.pendingAlertIdempotencyKey,
-      incidentSequence: claimedState.pendingAlertIncidentSequence,
-      message: claimedState.pendingAlertMessage,
-      sequence: claimedState.pendingAlertSequence,
+      idempotencyKey: state.pendingAlertIdempotencyKey,
+      incidentSequence: state.pendingAlertIncidentSequence,
+      message: state.pendingAlertMessage,
+      sequence: state.pendingAlertSequence,
     };
   }
 
   isClaimCurrent(claim: ClaimedOpenAiAuthorizationAlert): boolean {
     const state = this.readState();
-    return state.attemptGeneration === claim.attemptGeneration
-      && state.pendingAlertIdempotencyKey === claim.idempotencyKey
+    return state.pendingAlertIdempotencyKey === claim.idempotencyKey
       && state.pendingAlertIncidentSequence === claim.incidentSequence
       && state.pendingAlertMessage === claim.message
       && state.pendingAlertSequence === claim.sequence;
@@ -415,8 +390,7 @@ class OpenAiAuthorizationAlertStore {
          pending_alert_sequence = alert_sequence + 1,
          pending_alert_idempotency_key = ?,
          pending_alert_message = ?,
-         pending_retry_at_ms = ?,
-         attempt_lease_until_ms = 0
+         pending_retry_at_ms = ?
        WHERE singleton = 1
          AND incident_open = 1
          AND pending_alert_idempotency_key IS NULL`,
@@ -462,9 +436,7 @@ class OpenAiAuthorizationAlertStore {
          pending_alert_sequence,
          pending_alert_idempotency_key,
          pending_alert_message,
-         pending_retry_at_ms,
-         attempt_generation,
-         attempt_lease_until_ms
+         pending_retry_at_ms
        FROM openai_authorization_alert_meta
        WHERE singleton = 1`,
     ).toArray()[0];
@@ -477,8 +449,6 @@ class OpenAiAuthorizationAlertStore {
     }
     return {
       alertSequence: row.alert_sequence,
-      attemptGeneration: row.attempt_generation,
-      attemptLeaseUntilMs: row.attempt_lease_until_ms,
       failureCount: row.failure_count,
       firstFailureAtMs: row.first_failure_at_ms,
       incidentOpen: row.incident_open === 1,
@@ -495,27 +465,28 @@ class OpenAiAuthorizationAlertStore {
   }
 
   recordAlertFailure(input: {
-    attemptGeneration: number;
     failedAtMs: number;
+    idempotencyKey: string;
     incidentSequence: number;
+    message: string;
     sequence: number;
   }): boolean {
     return this.sql.exec(
       `UPDATE openai_authorization_alert_meta
-       SET
-         pending_retry_at_ms = ?,
-         attempt_lease_until_ms = 0
+       SET pending_retry_at_ms = ?
        WHERE singleton = 1
          AND pending_alert_incident_sequence = ?
          AND pending_alert_sequence = ?
-         AND attempt_generation = ?`,
+         AND pending_alert_idempotency_key = ?
+         AND pending_alert_message = ?`,
       addTimestampDelay(
         input.failedAtMs,
         OPENAI_AUTHORIZATION_ALERT_RETRY_MS,
       ),
       input.incidentSequence,
       input.sequence,
-      input.attemptGeneration,
+      input.idempotencyKey,
+      input.message,
     ).rowsWritten === 1;
   }
 
@@ -538,8 +509,7 @@ class OpenAiAuthorizationAlertStore {
          pending_alert_sequence = NULL,
          pending_alert_idempotency_key = NULL,
          pending_alert_message = NULL,
-         pending_retry_at_ms = NULL,
-         attempt_lease_until_ms = 0
+         pending_retry_at_ms = NULL
        WHERE singleton = 1
          AND pending_alert_incident_sequence = ?
          AND pending_alert_sequence = ?
@@ -621,8 +591,6 @@ function ensureOpenAiAuthorizationAlertSchema(
       pending_alert_idempotency_key TEXT,
       pending_alert_message TEXT,
       pending_retry_at_ms INTEGER,
-      attempt_generation INTEGER NOT NULL DEFAULT 0 CHECK (attempt_generation >= 0),
-      attempt_lease_until_ms INTEGER NOT NULL DEFAULT 0 CHECK (attempt_lease_until_ms >= 0),
       CHECK (
         (
           incident_open = 0
@@ -649,7 +617,6 @@ function ensureOpenAiAuthorizationAlertSchema(
           AND pending_alert_idempotency_key IS NULL
           AND pending_alert_message IS NULL
           AND pending_retry_at_ms IS NULL
-          AND attempt_lease_until_ms = 0
         )
         OR
         (
@@ -756,18 +723,13 @@ function buildAlertMessage(state: OpenAiAuthorizationAlertState): string {
 
 function computeDesiredAlarm(
   state: OpenAiAuthorizationAlertState,
-  nowMs: number,
 ): number | null {
   const candidates: number[] = [];
   if (
     state.pendingRetryAtMs !== null
     && state.pendingAlertIdempotencyKey !== null
   ) {
-    candidates.push(
-      state.attemptLeaseUntilMs > nowMs
-        ? Math.max(state.pendingRetryAtMs, state.attemptLeaseUntilMs)
-        : state.pendingRetryAtMs,
-    );
+    candidates.push(state.pendingRetryAtMs);
   }
   if (state.incidentOpen && state.lastFailureAtMs !== null) {
     candidates.push(

--- a/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
+++ b/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
@@ -1,0 +1,874 @@
+import { DurableObject } from "cloudflare:workers";
+
+import {
+  classifyOperatorLinqAlertFailure,
+  sendOperatorLinqAlert,
+} from "../operator-alert/linq.js";
+import type {
+  DurableObjectSqlStorageLike,
+  DurableObjectSqlValue,
+  DurableObjectStateLike,
+} from "../user-runner/types.js";
+
+const DEFAULT_LINQ_API_BASE_URL = "https://api.linqapp.com/api/partner/v3";
+const OPENAI_AUTHORIZATION_ALERT_SCHEMA_VERSION = 1;
+const OPENAI_AUTHORIZATION_ALERT_RETRY_MS = 5 * 60_000;
+const OPENAI_AUTHORIZATION_ALERT_QUIET_MS = 15 * 60_000;
+const OPENAI_AUTHORIZATION_ALERT_REMINDER_MS = 60 * 60_000;
+const OPENAI_AUTHORIZATION_ALERT_MESSAGE_MAX_BYTES = 256;
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+
+export type OpenAiAuthorizationFailureStatus = 401 | 403;
+
+export interface OpenAiAuthorizationAlertEnvironment {
+  HOSTED_DATABASE_ALERT_LINQ_CHAT_ID?: string;
+  HOSTED_DATABASE_ALERT_LINQ_SECONDARY_CHAT_ID?: string;
+  LINQ_API_BASE_URL?: string;
+  LINQ_API_TOKEN?: string;
+}
+
+export interface OpenAiAuthorizationAlertSender {
+  send(input: {
+    idempotencyKey: string;
+    message: string;
+  }): Promise<void>;
+}
+
+export interface OpenAiAuthorizationAlertState {
+  alertSequence: number;
+  attemptGeneration: number;
+  attemptLeaseUntilMs: number;
+  failureCount: number;
+  firstFailureAtMs: number | null;
+  incidentOpen: boolean;
+  incidentSequence: number;
+  lastFailureAtMs: number | null;
+  lastStatus: OpenAiAuthorizationFailureStatus | null;
+  lastSuccessfulPageAtMs: number | null;
+  pendingAlertIdempotencyKey: string | null;
+  pendingAlertIncidentSequence: number | null;
+  pendingAlertMessage: string | null;
+  pendingAlertSequence: number | null;
+  pendingRetryAtMs: number | null;
+}
+
+interface OpenAiAuthorizationAlertMetaRow
+  extends Record<string, DurableObjectSqlValue> {
+  alert_sequence: number;
+  attempt_generation: number;
+  attempt_lease_until_ms: number;
+  failure_count: number;
+  first_failure_at_ms: number | null;
+  incident_open: number;
+  incident_sequence: number;
+  last_failure_at_ms: number | null;
+  last_status: number | null;
+  last_successful_page_at_ms: number | null;
+  pending_alert_idempotency_key: string | null;
+  pending_alert_incident_sequence: number | null;
+  pending_alert_message: string | null;
+  pending_alert_sequence: number | null;
+  pending_retry_at_ms: number | null;
+}
+
+interface OpenAiAuthorizationFailureReport {
+  observedAtMs: number;
+  status: OpenAiAuthorizationFailureStatus;
+}
+
+interface ClaimedOpenAiAuthorizationAlert {
+  attemptGeneration: number;
+  idempotencyKey: string;
+  incidentSequence: number;
+  message: string;
+  sequence: number;
+}
+
+type TransactionSync = <T>(callback: () => T) => T;
+
+type FixedFailureCode =
+  | "alarm_update_failed"
+  | "linq_duplicate_recipient"
+  | "linq_health_suppressed"
+  | "linq_health_unavailable"
+  | "linq_rejected_response"
+  | "linq_retryable_response"
+  | "linq_transport_failed"
+  | "state_transition_failed";
+
+export class OpenAiAuthorizationAlertDurableObject extends DurableObject {
+  private readonly alertSender: OpenAiAuthorizationAlertSender;
+  private backgroundWork: Promise<void> = Promise.resolve();
+  private readonly deleteAlarm: () => Promise<void>;
+  private readonly getAlarm: () => Promise<number | null>;
+  private readonly nowImplementation: () => number;
+  private readonly setAlarm: (scheduledTime: number | Date) => Promise<void>;
+  private readonly state: DurableObjectStateLike;
+  private readonly store: OpenAiAuthorizationAlertStore;
+  private readonly transactionSync: TransactionSync;
+
+  constructor(
+    state: DurableObjectStateLike,
+    environment: OpenAiAuthorizationAlertEnvironment,
+    alertSender: OpenAiAuthorizationAlertSender =
+      createOperatorAlertSender(environment),
+    nowImplementation: () => number = Date.now,
+  ) {
+    super(state as never, environment as never);
+    const sql = state.storage.sql;
+    const transactionSync = state.storage.transactionSync;
+    const deleteAlarm = state.storage.deleteAlarm;
+    if (!sql || !transactionSync || !deleteAlarm) {
+      throw new Error(
+        "OpenAI authorization alert requires SQLite Durable Object storage.",
+      );
+    }
+
+    this.alertSender = alertSender;
+    this.deleteAlarm = deleteAlarm.bind(state.storage);
+    this.getAlarm = state.storage.getAlarm.bind(state.storage);
+    this.nowImplementation = nowImplementation;
+    this.setAlarm = state.storage.setAlarm.bind(state.storage);
+    this.state = state;
+    this.store = new OpenAiAuthorizationAlertStore(sql);
+    this.transactionSync = transactionSync.bind(state.storage);
+  }
+
+  reportFailure(input: unknown): { accepted: true } {
+    const report = parseFailureReport(input);
+    const nowMs = normalizeTimestamp(this.nowImplementation());
+    let claimedAlert: ClaimedOpenAiAuthorizationAlert | null;
+    try {
+      claimedAlert = this.transactionSync(() => {
+        const priorState = this.store.readState();
+        const beginsNewIncident = priorState.incidentOpen
+          && priorState.lastFailureAtMs !== null
+          && report.observedAtMs - priorState.lastFailureAtMs
+            >= OPENAI_AUTHORIZATION_ALERT_QUIET_MS;
+        if (beginsNewIncident) {
+          this.store.closeIncident();
+        }
+
+        const stateBeforeRecord = this.store.readState();
+        const isFreshFailure = !stateBeforeRecord.incidentOpen
+          || stateBeforeRecord.lastFailureAtMs === null
+          || report.observedAtMs > stateBeforeRecord.lastFailureAtMs;
+        if (stateBeforeRecord.incidentOpen) {
+          this.store.recordFailure(report);
+        } else {
+          this.store.openIncident(report);
+        }
+
+        const recordedState = this.store.readState();
+        if (
+          shouldAdmitPage({
+            isFreshFailure,
+            receivedAtMs: nowMs,
+            state: recordedState,
+          })
+        ) {
+          this.store.createPendingAlert({
+            idempotencyKey: buildIdempotencyKey(recordedState),
+            message: buildAlertMessage(recordedState),
+            retryAtMs: nowMs,
+          });
+        }
+        return this.store.claimPendingAlert(nowMs);
+      });
+    } catch {
+      warnFixedFailure("state_transition_failed");
+      throw new Error("OpenAI authorization alert state transition failed.");
+    }
+
+    this.startBackgroundWork(claimedAlert);
+    return { accepted: true };
+  }
+
+  alarm(): void {
+    const nowMs = normalizeTimestamp(this.nowImplementation());
+    let claimedAlert: ClaimedOpenAiAuthorizationAlert | null;
+    try {
+      claimedAlert = this.transactionSync(() => {
+        const state = this.store.readState();
+        if (
+          state.incidentOpen
+          && state.lastFailureAtMs !== null
+          && nowMs - state.lastFailureAtMs
+            >= OPENAI_AUTHORIZATION_ALERT_QUIET_MS
+        ) {
+          this.store.closeIncident();
+        }
+        return this.store.claimPendingAlert(nowMs);
+      });
+    } catch {
+      warnFixedFailure("state_transition_failed");
+      throw new Error("OpenAI authorization alert state transition failed.");
+    }
+    this.startBackgroundWork(claimedAlert);
+  }
+
+  readState(): OpenAiAuthorizationAlertState {
+    return this.store.readState();
+  }
+
+  private startBackgroundWork(
+    claimedAlert: ClaimedOpenAiAuthorizationAlert | null,
+  ): void {
+    const work = this.backgroundWork
+      .then(async () => await this.runBackgroundWork(claimedAlert))
+      .catch(() => {
+        warnFixedFailure("state_transition_failed");
+      });
+    this.backgroundWork = work;
+    this.state.waitUntil(work);
+  }
+
+  private async runBackgroundWork(
+    initialClaim: ClaimedOpenAiAuthorizationAlert | null,
+  ): Promise<void> {
+    await this.reconcileAlarmSafely();
+    let claimedAlert = initialClaim;
+    while (claimedAlert) {
+      const activeClaim = claimedAlert;
+      if (!this.store.isClaimCurrent(activeClaim)) {
+        claimedAlert = null;
+        await this.reconcileAlarmSafely();
+        continue;
+      }
+      try {
+        await this.alertSender.send({
+          idempotencyKey: activeClaim.idempotencyKey,
+          message: activeClaim.message,
+        });
+      } catch (error) {
+        const failedAtMs = normalizeTimestamp(this.nowImplementation());
+        warnFixedFailure(normalizeLinqFailureCode(error));
+        try {
+          this.transactionSync(() => {
+            this.store.recordAlertFailure({
+              attemptGeneration: activeClaim.attemptGeneration,
+              failedAtMs,
+              incidentSequence: activeClaim.incidentSequence,
+              sequence: activeClaim.sequence,
+            });
+          });
+        } catch {
+          warnFixedFailure("state_transition_failed");
+        }
+        claimedAlert = null;
+        await this.reconcileAlarmSafely();
+        continue;
+      }
+
+      const succeededAtMs = normalizeTimestamp(this.nowImplementation());
+      try {
+        claimedAlert = this.transactionSync(() => {
+          const completed = this.store.recordAlertSuccess({
+            idempotencyKey: activeClaim.idempotencyKey,
+            incidentSequence: activeClaim.incidentSequence,
+            message: activeClaim.message,
+            sequence: activeClaim.sequence,
+            succeededAtMs,
+          });
+          if (!completed) {
+            return null;
+          }
+
+          const state = this.store.readState();
+          if (
+            state.incidentOpen
+            && state.alertSequence === 0
+            && state.pendingAlertIdempotencyKey === null
+          ) {
+            this.store.createPendingAlert({
+              idempotencyKey: buildIdempotencyKey(state),
+              message: buildAlertMessage(state),
+              retryAtMs: succeededAtMs,
+            });
+          }
+          return this.store.claimPendingAlert(succeededAtMs);
+        });
+      } catch {
+        warnFixedFailure("state_transition_failed");
+        claimedAlert = null;
+      }
+      await this.reconcileAlarmSafely();
+    }
+  }
+
+  private async reconcileAlarmSafely(): Promise<void> {
+    try {
+      const nowMs = normalizeTimestamp(this.nowImplementation());
+      const desiredAlarm = computeDesiredAlarm(this.store.readState(), nowMs);
+      const currentAlarm = await this.getAlarm();
+      if (desiredAlarm === null) {
+        await this.deleteAlarm();
+        return;
+      }
+      if (currentAlarm !== desiredAlarm) {
+        await this.setAlarm(desiredAlarm);
+      }
+    } catch {
+      warnFixedFailure("alarm_update_failed");
+    }
+  }
+}
+
+class OpenAiAuthorizationAlertStore {
+  constructor(private readonly sql: DurableObjectSqlStorageLike) {
+    ensureOpenAiAuthorizationAlertSchema(sql);
+  }
+
+  claimPendingAlert(nowMs: number): ClaimedOpenAiAuthorizationAlert | null {
+    const state = this.readState();
+    if (
+      state.pendingAlertIdempotencyKey === null
+      || state.pendingAlertIncidentSequence === null
+      || state.pendingAlertMessage === null
+      || state.pendingAlertSequence === null
+      || state.pendingRetryAtMs === null
+      || state.pendingRetryAtMs > nowMs
+      || state.attemptLeaseUntilMs > nowMs
+    ) {
+      return null;
+    }
+
+    const leaseUntilMs = addTimestampDelay(
+      nowMs,
+      OPENAI_AUTHORIZATION_ALERT_RETRY_MS,
+    );
+    const claimed = this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         attempt_generation = attempt_generation + 1,
+         attempt_lease_until_ms = ?
+       WHERE singleton = 1
+         AND pending_alert_incident_sequence = ?
+         AND pending_alert_sequence = ?
+         AND pending_alert_idempotency_key = ?
+         AND pending_alert_message = ?
+         AND pending_retry_at_ms <= ?
+         AND attempt_lease_until_ms <= ?`,
+      leaseUntilMs,
+      state.pendingAlertIncidentSequence,
+      state.pendingAlertSequence,
+      state.pendingAlertIdempotencyKey,
+      state.pendingAlertMessage,
+      nowMs,
+      nowMs,
+    ).rowsWritten === 1;
+    if (!claimed) {
+      return null;
+    }
+
+    const claimedState = this.readState();
+    if (
+      claimedState.pendingAlertIdempotencyKey === null
+      || claimedState.pendingAlertIncidentSequence === null
+      || claimedState.pendingAlertMessage === null
+      || claimedState.pendingAlertSequence === null
+    ) {
+      throw new Error("Claimed OpenAI authorization alert is missing.");
+    }
+    return {
+      attemptGeneration: claimedState.attemptGeneration,
+      idempotencyKey: claimedState.pendingAlertIdempotencyKey,
+      incidentSequence: claimedState.pendingAlertIncidentSequence,
+      message: claimedState.pendingAlertMessage,
+      sequence: claimedState.pendingAlertSequence,
+    };
+  }
+
+  isClaimCurrent(claim: ClaimedOpenAiAuthorizationAlert): boolean {
+    const state = this.readState();
+    return state.attemptGeneration === claim.attemptGeneration
+      && state.pendingAlertIdempotencyKey === claim.idempotencyKey
+      && state.pendingAlertIncidentSequence === claim.incidentSequence
+      && state.pendingAlertMessage === claim.message
+      && state.pendingAlertSequence === claim.sequence;
+  }
+
+  closeIncident(): void {
+    this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         incident_open = 0,
+         alert_sequence = 0,
+         failure_count = 0,
+         first_failure_at_ms = NULL,
+         last_failure_at_ms = NULL,
+         last_status = NULL
+       WHERE singleton = 1`,
+    );
+  }
+
+  createPendingAlert(input: {
+    idempotencyKey: string;
+    message: string;
+    retryAtMs: number;
+  }): void {
+    const result = this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         alert_sequence = alert_sequence + 1,
+         pending_alert_incident_sequence = incident_sequence,
+         pending_alert_sequence = alert_sequence + 1,
+         pending_alert_idempotency_key = ?,
+         pending_alert_message = ?,
+         pending_retry_at_ms = ?,
+         attempt_lease_until_ms = 0
+       WHERE singleton = 1
+         AND incident_open = 1
+         AND pending_alert_idempotency_key IS NULL`,
+      input.idempotencyKey,
+      input.message,
+      input.retryAtMs,
+    );
+    if (result.rowsWritten !== 1) {
+      throw new Error("OpenAI authorization alert admission failed.");
+    }
+  }
+
+  openIncident(report: OpenAiAuthorizationFailureReport): void {
+    this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         incident_open = 1,
+         incident_sequence = incident_sequence + 1,
+         alert_sequence = 0,
+         failure_count = 1,
+         first_failure_at_ms = ?,
+         last_failure_at_ms = ?,
+         last_status = ?
+       WHERE singleton = 1`,
+      report.observedAtMs,
+      report.observedAtMs,
+      report.status,
+    );
+  }
+
+  readState(): OpenAiAuthorizationAlertState {
+    const row = this.sql.exec<OpenAiAuthorizationAlertMetaRow>(
+      `SELECT
+         incident_open,
+         incident_sequence,
+         alert_sequence,
+         failure_count,
+         first_failure_at_ms,
+         last_failure_at_ms,
+         last_status,
+         last_successful_page_at_ms,
+         pending_alert_incident_sequence,
+         pending_alert_sequence,
+         pending_alert_idempotency_key,
+         pending_alert_message,
+         pending_retry_at_ms,
+         attempt_generation,
+         attempt_lease_until_ms
+       FROM openai_authorization_alert_meta
+       WHERE singleton = 1`,
+    ).toArray()[0];
+    if (!row) {
+      throw new Error("OpenAI authorization alert state is missing.");
+    }
+    const lastStatus = row.last_status;
+    if (lastStatus !== null && lastStatus !== 401 && lastStatus !== 403) {
+      throw new Error("Stored OpenAI authorization alert status is invalid.");
+    }
+    return {
+      alertSequence: row.alert_sequence,
+      attemptGeneration: row.attempt_generation,
+      attemptLeaseUntilMs: row.attempt_lease_until_ms,
+      failureCount: row.failure_count,
+      firstFailureAtMs: row.first_failure_at_ms,
+      incidentOpen: row.incident_open === 1,
+      incidentSequence: row.incident_sequence,
+      lastFailureAtMs: row.last_failure_at_ms,
+      lastStatus,
+      lastSuccessfulPageAtMs: row.last_successful_page_at_ms,
+      pendingAlertIdempotencyKey: row.pending_alert_idempotency_key,
+      pendingAlertIncidentSequence: row.pending_alert_incident_sequence,
+      pendingAlertMessage: row.pending_alert_message,
+      pendingAlertSequence: row.pending_alert_sequence,
+      pendingRetryAtMs: row.pending_retry_at_ms,
+    };
+  }
+
+  recordAlertFailure(input: {
+    attemptGeneration: number;
+    failedAtMs: number;
+    incidentSequence: number;
+    sequence: number;
+  }): boolean {
+    return this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         pending_retry_at_ms = ?,
+         attempt_lease_until_ms = 0
+       WHERE singleton = 1
+         AND pending_alert_incident_sequence = ?
+         AND pending_alert_sequence = ?
+         AND attempt_generation = ?`,
+      addTimestampDelay(
+        input.failedAtMs,
+        OPENAI_AUTHORIZATION_ALERT_RETRY_MS,
+      ),
+      input.incidentSequence,
+      input.sequence,
+      input.attemptGeneration,
+    ).rowsWritten === 1;
+  }
+
+  recordAlertSuccess(input: {
+    idempotencyKey: string;
+    incidentSequence: number;
+    message: string;
+    sequence: number;
+    succeededAtMs: number;
+  }): boolean {
+    return this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         last_successful_page_at_ms = CASE
+           WHEN last_successful_page_at_ms IS NULL
+             OR ? > last_successful_page_at_ms THEN ?
+           ELSE last_successful_page_at_ms
+         END,
+         pending_alert_incident_sequence = NULL,
+         pending_alert_sequence = NULL,
+         pending_alert_idempotency_key = NULL,
+         pending_alert_message = NULL,
+         pending_retry_at_ms = NULL,
+         attempt_lease_until_ms = 0
+       WHERE singleton = 1
+         AND pending_alert_incident_sequence = ?
+         AND pending_alert_sequence = ?
+         AND pending_alert_idempotency_key = ?
+         AND pending_alert_message = ?`,
+      input.succeededAtMs,
+      input.succeededAtMs,
+      input.incidentSequence,
+      input.sequence,
+      input.idempotencyKey,
+      input.message,
+    ).rowsWritten === 1;
+  }
+
+  recordFailure(report: OpenAiAuthorizationFailureReport): void {
+    this.sql.exec(
+      `UPDATE openai_authorization_alert_meta
+       SET
+         failure_count = failure_count + 1,
+         last_failure_at_ms = CASE
+           WHEN ? > last_failure_at_ms THEN ?
+           ELSE last_failure_at_ms
+         END,
+         last_status = CASE
+           WHEN ? >= last_failure_at_ms THEN ?
+           ELSE last_status
+         END
+       WHERE singleton = 1
+         AND incident_open = 1`,
+      report.observedAtMs,
+      report.observedAtMs,
+      report.observedAtMs,
+      report.status,
+    );
+  }
+}
+
+function ensureOpenAiAuthorizationAlertSchema(
+  sql: DurableObjectSqlStorageLike,
+): void {
+  sql.exec(`
+    CREATE TABLE IF NOT EXISTS openai_authorization_alert_schema_meta (
+      key TEXT PRIMARY KEY,
+      value INTEGER NOT NULL
+    )
+  `);
+  const versionRow = sql.exec<{ value: DurableObjectSqlValue }>(
+    `SELECT value
+     FROM openai_authorization_alert_schema_meta
+     WHERE key = 'schema_version'`,
+  ).toArray()[0];
+  const version = versionRow === undefined ? 0 : versionRow.value;
+  if (
+    typeof version !== "number"
+    || !Number.isSafeInteger(version)
+    || version < 0
+  ) {
+    throw new Error("OpenAI authorization alert schema version is invalid.");
+  }
+  if (version > OPENAI_AUTHORIZATION_ALERT_SCHEMA_VERSION) {
+    throw new Error(
+      "OpenAI authorization alert schema is newer than this Worker.",
+    );
+  }
+
+  sql.exec(`
+    CREATE TABLE IF NOT EXISTS openai_authorization_alert_meta (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      incident_open INTEGER NOT NULL DEFAULT 0 CHECK (incident_open IN (0, 1)),
+      incident_sequence INTEGER NOT NULL DEFAULT 0 CHECK (incident_sequence >= 0),
+      alert_sequence INTEGER NOT NULL DEFAULT 0 CHECK (alert_sequence >= 0),
+      failure_count INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+      first_failure_at_ms INTEGER,
+      last_failure_at_ms INTEGER,
+      last_status INTEGER CHECK (last_status IN (401, 403)),
+      last_successful_page_at_ms INTEGER,
+      pending_alert_incident_sequence INTEGER,
+      pending_alert_sequence INTEGER,
+      pending_alert_idempotency_key TEXT,
+      pending_alert_message TEXT,
+      pending_retry_at_ms INTEGER,
+      attempt_generation INTEGER NOT NULL DEFAULT 0 CHECK (attempt_generation >= 0),
+      attempt_lease_until_ms INTEGER NOT NULL DEFAULT 0 CHECK (attempt_lease_until_ms >= 0),
+      CHECK (
+        (
+          incident_open = 0
+          AND alert_sequence = 0
+          AND failure_count = 0
+          AND first_failure_at_ms IS NULL
+          AND last_failure_at_ms IS NULL
+          AND last_status IS NULL
+        )
+        OR
+        (
+          incident_open = 1
+          AND failure_count >= 1
+          AND first_failure_at_ms IS NOT NULL
+          AND last_failure_at_ms IS NOT NULL
+          AND last_status IS NOT NULL
+          AND first_failure_at_ms <= last_failure_at_ms
+        )
+      ),
+      CHECK (
+        (
+          pending_alert_incident_sequence IS NULL
+          AND pending_alert_sequence IS NULL
+          AND pending_alert_idempotency_key IS NULL
+          AND pending_alert_message IS NULL
+          AND pending_retry_at_ms IS NULL
+          AND attempt_lease_until_ms = 0
+        )
+        OR
+        (
+          pending_alert_incident_sequence IS NOT NULL
+          AND pending_alert_sequence IS NOT NULL
+          AND pending_alert_idempotency_key IS NOT NULL
+          AND pending_alert_message IS NOT NULL
+          AND pending_retry_at_ms IS NOT NULL
+        )
+      )
+    )
+  `);
+  sql.exec(`
+    INSERT INTO openai_authorization_alert_meta (singleton)
+    VALUES (1)
+    ON CONFLICT(singleton) DO NOTHING
+  `);
+  sql.exec(
+    `INSERT INTO openai_authorization_alert_schema_meta (key, value)
+     VALUES ('schema_version', ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    OPENAI_AUTHORIZATION_ALERT_SCHEMA_VERSION,
+  );
+}
+
+function parseFailureReport(input: unknown): OpenAiAuthorizationFailureReport {
+  if (!isObjectRecord(input)) {
+    throw new TypeError("OpenAI authorization failure report is invalid.");
+  }
+  const keys = Reflect.ownKeys(input);
+  if (
+    keys.length !== 2
+    || !keys.every((key) => key === "observedAtMs" || key === "status")
+  ) {
+    throw new TypeError("OpenAI authorization failure report is invalid.");
+  }
+
+  const status = input.status;
+  const observedAtMs = input.observedAtMs;
+  if (
+    (status !== 401 && status !== 403)
+    || !isValidTimestamp(observedAtMs)
+  ) {
+    throw new TypeError("OpenAI authorization failure report is invalid.");
+  }
+  return { observedAtMs, status };
+}
+
+function shouldAdmitPage(input: {
+  isFreshFailure: boolean;
+  receivedAtMs: number;
+  state: OpenAiAuthorizationAlertState;
+}): boolean {
+  if (
+    !input.state.incidentOpen
+    || input.state.pendingAlertIdempotencyKey !== null
+  ) {
+    return false;
+  }
+  if (input.state.alertSequence === 0) {
+    return true;
+  }
+  const lastSuccessfulPageAtMs = input.state.lastSuccessfulPageAtMs;
+  return input.isFreshFailure
+    && lastSuccessfulPageAtMs !== null
+    && input.receivedAtMs - lastSuccessfulPageAtMs
+      >= OPENAI_AUTHORIZATION_ALERT_REMINDER_MS;
+}
+
+function buildIdempotencyKey(
+  state: OpenAiAuthorizationAlertState,
+): string {
+  return [
+    "openai-authorization-alert",
+    `incident-${state.incidentSequence}`,
+    `page-${state.alertSequence + 1}`,
+  ].join(":");
+}
+
+function buildAlertMessage(state: OpenAiAuthorizationAlertState): string {
+  if (
+    !state.incidentOpen
+    || state.failureCount < 1
+    || state.firstFailureAtMs === null
+    || state.lastFailureAtMs === null
+    || state.lastStatus === null
+  ) {
+    throw new Error("OpenAI authorization alert incident is incomplete.");
+  }
+  const message = [
+    `SEV1 OpenAI ${state.lastStatus}`,
+    `Aggregate count: ${state.failureCount}`,
+    `First observed UTC: ${formatUtcTimestamp(state.firstFailureAtMs)}`,
+    `Last observed UTC: ${formatUtcTimestamp(state.lastFailureAtMs)}`,
+  ].join("\n");
+  if (
+    new TextEncoder().encode(message).byteLength
+      > OPENAI_AUTHORIZATION_ALERT_MESSAGE_MAX_BYTES
+  ) {
+    throw new Error("OpenAI authorization alert message is too large.");
+  }
+  return message;
+}
+
+function computeDesiredAlarm(
+  state: OpenAiAuthorizationAlertState,
+  nowMs: number,
+): number | null {
+  const candidates: number[] = [];
+  if (
+    state.pendingRetryAtMs !== null
+    && state.pendingAlertIdempotencyKey !== null
+  ) {
+    candidates.push(
+      state.attemptLeaseUntilMs > nowMs
+        ? Math.max(state.pendingRetryAtMs, state.attemptLeaseUntilMs)
+        : state.pendingRetryAtMs,
+    );
+  }
+  if (state.incidentOpen && state.lastFailureAtMs !== null) {
+    candidates.push(
+      addTimestampDelay(
+        state.lastFailureAtMs,
+        OPENAI_AUTHORIZATION_ALERT_QUIET_MS,
+      ),
+    );
+  }
+  if (candidates.length === 0) {
+    return null;
+  }
+  return Math.min(...candidates);
+}
+
+function createOperatorAlertSender(
+  environment: OpenAiAuthorizationAlertEnvironment,
+): OpenAiAuthorizationAlertSender {
+  const apiBaseUrl = environment.LINQ_API_BASE_URL?.trim()
+    || DEFAULT_LINQ_API_BASE_URL;
+  const apiToken = readRequiredEnvironmentValue(
+    environment.LINQ_API_TOKEN,
+    "LINQ_API_TOKEN",
+  );
+  const chatIds: readonly [primary: string, secondary: string] = [
+    readRequiredEnvironmentValue(
+      environment.HOSTED_DATABASE_ALERT_LINQ_CHAT_ID,
+      "HOSTED_DATABASE_ALERT_LINQ_CHAT_ID",
+    ),
+    readRequiredEnvironmentValue(
+      environment.HOSTED_DATABASE_ALERT_LINQ_SECONDARY_CHAT_ID,
+      "HOSTED_DATABASE_ALERT_LINQ_SECONDARY_CHAT_ID",
+    ),
+  ];
+  return {
+    async send(input): Promise<void> {
+      await sendOperatorLinqAlert({
+        apiBaseUrl,
+        apiToken,
+        chatIds,
+        idempotencyKey: input.idempotencyKey,
+        message: input.message,
+      });
+    },
+  };
+}
+
+function readRequiredEnvironmentValue(
+  value: string | undefined,
+  name: string,
+): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required for OpenAI authorization alerts.`);
+  }
+  return normalized;
+}
+
+function normalizeLinqFailureCode(error: unknown): FixedFailureCode {
+  const code = classifyOperatorLinqAlertFailure(error);
+  switch (code) {
+    case "linq_duplicate_recipient":
+    case "linq_health_suppressed":
+    case "linq_health_unavailable":
+    case "linq_rejected_response":
+    case "linq_retryable_response":
+    case "linq_transport_failed":
+      return code;
+    default:
+      return "linq_transport_failed";
+  }
+}
+
+function warnFixedFailure(failureCode: FixedFailureCode): void {
+  console.warn("OpenAI authorization alert operation failed.", {
+    failureCode,
+  });
+}
+
+function formatUtcTimestamp(value: number): string {
+  return new Date(value).toISOString();
+}
+
+function addTimestampDelay(timestampMs: number, delayMs: number): number {
+  return Math.min(MAX_DATE_TIMESTAMP_MS, timestampMs + delayMs);
+}
+
+function normalizeTimestamp(value: number): number {
+  if (!isValidTimestamp(value)) {
+    throw new Error("OpenAI authorization alert timestamp is invalid.");
+  }
+  return value;
+}
+
+function isValidTimestamp(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value >= 0
+    && value <= MAX_DATE_TIMESTAMP_MS;
+}
+
+function isObjectRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
+++ b/apps/cloudflare/src/worker/openai-authorization-alert-durable-object.ts
@@ -140,7 +140,10 @@ export class OpenAiAuthorizationAlertDurableObject extends DurableObject {
           && priorState.lastFailureAtMs !== null
           && report.observedAtMs - priorState.lastFailureAtMs
             >= OPENAI_AUTHORIZATION_ALERT_QUIET_MS;
-        if (beginsNewIncident) {
+        if (
+          beginsNewIncident
+          && !isDeferredCurrentIncident(priorState)
+        ) {
           this.store.closeIncident();
         }
 
@@ -190,6 +193,7 @@ export class OpenAiAuthorizationAlertDurableObject extends DurableObject {
           && state.lastFailureAtMs !== null
           && nowMs - state.lastFailureAtMs
             >= OPENAI_AUTHORIZATION_ALERT_QUIET_MS
+          && !isDeferredCurrentIncident(state)
         ) {
           this.store.closeIncident();
         }
@@ -686,6 +690,14 @@ function shouldAdmitPage(input: {
       >= OPENAI_AUTHORIZATION_ALERT_REMINDER_MS;
 }
 
+function isDeferredCurrentIncident(
+  state: OpenAiAuthorizationAlertState,
+): boolean {
+  return state.incidentOpen
+    && state.alertSequence === 0
+    && state.pendingAlertIdempotencyKey !== null;
+}
+
 function buildIdempotencyKey(
   state: OpenAiAuthorizationAlertState,
 ): string {
@@ -731,7 +743,11 @@ function computeDesiredAlarm(
   ) {
     candidates.push(state.pendingRetryAtMs);
   }
-  if (state.incidentOpen && state.lastFailureAtMs !== null) {
+  if (
+    state.incidentOpen
+    && state.lastFailureAtMs !== null
+    && !isDeferredCurrentIncident(state)
+  ) {
     candidates.push(
       addTimestampDelay(
         state.lastFailureAtMs,

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -344,6 +344,10 @@ describe("hosted deploy automation helpers", () => {
         name: "DEVICE_WEBHOOK_QUEUE_MONITOR",
       },
       {
+        class_name: "OpenAiAuthorizationAlertDurableObject",
+        name: "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+      },
+      {
         class_name: "RunnerContainer",
         name: "RUNNER_CONTAINER",
       },
@@ -378,6 +382,10 @@ describe("hosted deploy automation helpers", () => {
       {
         new_sqlite_classes: ["DeviceWebhookQueueHealthDurableObject"],
         tag: "v5",
+      },
+      {
+        new_sqlite_classes: ["OpenAiAuthorizationAlertDurableObject"],
+        tag: "v6",
       },
     ]);
     expect(config).toMatchObject({

--- a/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
+++ b/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
@@ -18,6 +18,10 @@ const BASE_TIME_MS = Date.parse("2026-08-29T12:00:00.000Z");
 const FIVE_MINUTES_MS = 5 * 60_000;
 const FIFTEEN_MINUTES_MS = 15 * 60_000;
 const ONE_HOUR_MS = 60 * 60_000;
+const INCIDENT_ONE_PAGE_KEY =
+  "openai-authorization-alert:incident-1:page-1";
+const INCIDENT_TWO_PAGE_KEY =
+  "openai-authorization-alert:incident-2:page-1";
 
 type AlertInput = Parameters<OpenAiAuthorizationAlertSender["send"]>[0];
 
@@ -225,6 +229,209 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
     recreatedOwner.alert.alarm();
     await recreatedOwner.flushWaitUntil();
     expect(recreatedOwner.deliveries).toHaveLength(1);
+  });
+
+  it("preserves a deferred incident across an alarm-driven quiet boundary", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let linqAvailable = false;
+    const harness = createHarness({
+      async send() {
+        if (!linqAvailable) {
+          throw new OperatorAlertLinqError("linq_retryable_response");
+        }
+      },
+    });
+
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+
+    const incidentTwoStartedAtMs = BASE_TIME_MS + FIFTEEN_MINUTES_MS;
+    harness.setNow(incidentTwoStartedAtMs);
+    harness.alert.reportFailure({
+      observedAtMs: incidentTwoStartedAtMs,
+      status: 403,
+    });
+    const delayedFailureAtMs = BASE_TIME_MS + 26 * 60_000;
+    harness.setNow(delayedFailureAtMs);
+    await harness.flushWaitUntil();
+
+    const incidentOneRetryAtMs = delayedFailureAtMs + FIVE_MINUTES_MS;
+    const incidentTwoQuietAtMs =
+      incidentTwoStartedAtMs + FIFTEEN_MINUTES_MS;
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 0,
+      failureCount: 1,
+      incidentOpen: true,
+      incidentSequence: 2,
+      pendingAlertIdempotencyKey: INCIDENT_ONE_PAGE_KEY,
+      pendingAlertIncidentSequence: 1,
+      pendingRetryAtMs: incidentOneRetryAtMs,
+    });
+    expect(harness.activeAlarm()).toBe(incidentOneRetryAtMs);
+
+    const alarmOperationCount = harness.alarmOperations.length;
+    harness.setNow(incidentTwoQuietAtMs);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 0,
+      failureCount: 1,
+      firstFailureAtMs: incidentTwoStartedAtMs,
+      incidentOpen: true,
+      incidentSequence: 2,
+      lastFailureAtMs: incidentTwoStartedAtMs,
+      lastStatus: 403,
+      pendingAlertIdempotencyKey: INCIDENT_ONE_PAGE_KEY,
+      pendingRetryAtMs: incidentOneRetryAtMs,
+    });
+    expect(harness.activeAlarm()).toBe(incidentOneRetryAtMs);
+    expect(harness.alarmOperations.slice(alarmOperationCount)).toEqual([]);
+    expect(harness.deliveries.map((delivery) => delivery.idempotencyKey))
+      .toEqual([INCIDENT_ONE_PAGE_KEY, INCIDENT_ONE_PAGE_KEY]);
+
+    linqAvailable = true;
+    harness.setNow(incidentOneRetryAtMs);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries.map((delivery) => delivery.idempotencyKey))
+      .toEqual([
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_TWO_PAGE_KEY,
+      ]);
+    expect(harness.deliveries[2]).toEqual(harness.deliveries[0]);
+    expect(harness.deliveries[3]).toEqual({
+      idempotencyKey: INCIDENT_TWO_PAGE_KEY,
+      message: [
+        "SEV1 OpenAI 403",
+        "Aggregate count: 1",
+        "First observed UTC: 2026-08-29T12:15:00.000Z",
+        "Last observed UTC: 2026-08-29T12:15:00.000Z",
+      ].join("\n"),
+    });
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      incidentOpen: true,
+      incidentSequence: 2,
+      pendingAlertIdempotencyKey: null,
+      pendingRetryAtMs: null,
+    });
+    expect(harness.activeAlarm()).toBe(incidentTwoQuietAtMs);
+    expect(harness.alarmOperations.filter(
+      (operation) => operation.kind === "set"
+        && operation.scheduledAtMs === incidentTwoQuietAtMs,
+    )).toHaveLength(1);
+
+    const deliveryCount = harness.deliveries.length;
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toHaveLength(deliveryCount);
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 0,
+      failureCount: 0,
+      incidentOpen: false,
+      incidentSequence: 2,
+      pendingAlertIdempotencyKey: null,
+    });
+    expect(harness.activeAlarm()).toBeNull();
+  });
+
+  it("extends a deferred incident across a report-driven quiet boundary", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let linqAvailable = false;
+    const harness = createHarness({
+      async send() {
+        if (!linqAvailable) {
+          throw new OperatorAlertLinqError("linq_retryable_response");
+        }
+      },
+    });
+
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+
+    const incidentTwoStartedAtMs = BASE_TIME_MS + FIFTEEN_MINUTES_MS;
+    harness.setNow(incidentTwoStartedAtMs);
+    harness.alert.reportFailure({
+      observedAtMs: incidentTwoStartedAtMs,
+      status: 403,
+    });
+    const delayedFailureAtMs = BASE_TIME_MS + 26 * 60_000;
+    harness.setNow(delayedFailureAtMs);
+    await harness.flushWaitUntil();
+
+    const incidentOneRetryAtMs = delayedFailureAtMs + FIVE_MINUTES_MS;
+    const nextFailureAtMs = incidentTwoStartedAtMs + FIFTEEN_MINUTES_MS;
+    harness.setNow(nextFailureAtMs);
+    harness.alert.reportFailure({
+      observedAtMs: nextFailureAtMs,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries.map((delivery) => delivery.idempotencyKey))
+      .toEqual([INCIDENT_ONE_PAGE_KEY, INCIDENT_ONE_PAGE_KEY]);
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 0,
+      failureCount: 2,
+      firstFailureAtMs: incidentTwoStartedAtMs,
+      incidentOpen: true,
+      incidentSequence: 2,
+      lastFailureAtMs: nextFailureAtMs,
+      lastStatus: 401,
+      pendingAlertIdempotencyKey: INCIDENT_ONE_PAGE_KEY,
+      pendingAlertIncidentSequence: 1,
+      pendingRetryAtMs: incidentOneRetryAtMs,
+    });
+    expect(harness.activeAlarm()).toBe(incidentOneRetryAtMs);
+
+    linqAvailable = true;
+    harness.setNow(incidentOneRetryAtMs);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries.map((delivery) => delivery.idempotencyKey))
+      .toEqual([
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_ONE_PAGE_KEY,
+        INCIDENT_TWO_PAGE_KEY,
+      ]);
+    expect(harness.deliveries[2]).toEqual(harness.deliveries[0]);
+    expect(harness.deliveries[3]).toEqual({
+      idempotencyKey: INCIDENT_TWO_PAGE_KEY,
+      message: [
+        "SEV1 OpenAI 401",
+        "Aggregate count: 2",
+        "First observed UTC: 2026-08-29T12:15:00.000Z",
+        "Last observed UTC: 2026-08-29T12:30:00.000Z",
+      ].join("\n"),
+    });
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      failureCount: 2,
+      incidentOpen: true,
+      incidentSequence: 2,
+      lastFailureAtMs: nextFailureAtMs,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertIncidentSequence: null,
+      pendingAlertMessage: null,
+      pendingAlertSequence: null,
+      pendingRetryAtMs: null,
+    });
+    expect(harness.activeAlarm()).toBe(
+      nextFailureAtMs + FIFTEEN_MINUTES_MS,
+    );
   });
 
   it("closes after the quiet window and deletes the alarm", async () => {

--- a/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
+++ b/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
@@ -1,0 +1,579 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OperatorAlertLinqError } from "../src/operator-alert/linq.js";
+import {
+  OpenAiAuthorizationAlertDurableObject,
+  type OpenAiAuthorizationAlertSender,
+} from "../src/worker/openai-authorization-alert-durable-object.js";
+import type {
+  DurableObjectStateLike,
+  DurableObjectStorageLike,
+} from "../src/user-runner/types.js";
+import {
+  createTestSqlStorage,
+  type TestSqlStorageLike,
+} from "./sql-storage.js";
+
+const BASE_TIME_MS = Date.parse("2026-08-29T12:00:00.000Z");
+const FIVE_MINUTES_MS = 5 * 60_000;
+const FIFTEEN_MINUTES_MS = 15 * 60_000;
+const ONE_HOUR_MS = 60 * 60_000;
+
+type AlertInput = Parameters<OpenAiAuthorizationAlertSender["send"]>[0];
+
+describe("OpenAiAuthorizationAlertDurableObject", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("persists and immediately dispatches the first incident page", async () => {
+    const harness = createHarness();
+
+    expect(harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS,
+      status: 401,
+    })).toEqual({ accepted: true });
+
+    const persistedBeforeSend = harness.alert.readState();
+    expect(harness.deliveries).toEqual([]);
+    expect(persistedBeforeSend).toMatchObject({
+      alertSequence: 1,
+      attemptGeneration: 1,
+      attemptLeaseUntilMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+      failureCount: 1,
+      firstFailureAtMs: BASE_TIME_MS,
+      incidentOpen: true,
+      incidentSequence: 1,
+      lastFailureAtMs: BASE_TIME_MS,
+      lastStatus: 401,
+      pendingAlertIdempotencyKey:
+        "openai-authorization-alert:incident-1:page-1",
+      pendingAlertIncidentSequence: 1,
+      pendingAlertSequence: 1,
+      pendingRetryAtMs: BASE_TIME_MS,
+    });
+    expect(persistedBeforeSend.pendingAlertMessage).toBe(
+      [
+        "SEV1 OpenAI 401",
+        "Aggregate count: 1",
+        "First observed UTC: 2026-08-29T12:00:00.000Z",
+        "Last observed UTC: 2026-08-29T12:00:00.000Z",
+      ].join("\n"),
+    );
+
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toEqual([{
+      idempotencyKey: "openai-authorization-alert:incident-1:page-1",
+      message: persistedBeforeSend.pendingAlertMessage,
+    }]);
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      failureCount: 1,
+      incidentOpen: true,
+      lastSuccessfulPageAtMs: BASE_TIME_MS,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+      pendingRetryAtMs: null,
+    });
+    expect(harness.activeAlarm()).toBe(
+      BASE_TIME_MS + FIFTEEN_MINUTES_MS,
+    );
+    expect(harness.waitUntilCount()).toBe(1);
+  });
+
+  it("coalesces failures without mutating the established incident bounds", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + 60_000);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 60_000,
+      status: 403,
+    });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + 2 * 60_000);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 2 * 60_000,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toHaveLength(1);
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      failureCount: 3,
+      firstFailureAtMs: BASE_TIME_MS,
+      incidentOpen: true,
+      lastFailureAtMs: BASE_TIME_MS + 2 * 60_000,
+      lastStatus: 401,
+      pendingAlertIdempotencyKey: null,
+    });
+    expect(harness.activeAlarm()).toBe(
+      BASE_TIME_MS + 2 * 60_000 + FIFTEEN_MINUTES_MS,
+    );
+  });
+
+  it("admits one hourly reminder only on a fresh qualifying failure", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+
+    for (const elapsedMs of [10, 20, 30, 40, 50, 59].map(
+      (minutes) => minutes * 60_000,
+    )) {
+      harness.setNow(BASE_TIME_MS + elapsedMs);
+      harness.alert.reportFailure({
+        observedAtMs: BASE_TIME_MS + elapsedMs,
+        status: 403,
+      });
+      await harness.flushWaitUntil();
+      expect(harness.deliveries).toHaveLength(1);
+    }
+
+    harness.setNow(BASE_TIME_MS + ONE_HOUR_MS);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + ONE_HOUR_MS,
+      status: 403,
+    });
+    const reminder = harness.alert.readState();
+    expect(reminder.pendingAlertIdempotencyKey).toBe(
+      "openai-authorization-alert:incident-1:page-2",
+    );
+    expect(reminder.pendingAlertMessage).toContain("Aggregate count: 8");
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toHaveLength(2);
+    expect(harness.deliveries[1]).toEqual({
+      idempotencyKey: "openai-authorization-alert:incident-1:page-2",
+      message: reminder.pendingAlertMessage,
+    });
+
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + ONE_HOUR_MS,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+    expect(harness.deliveries).toHaveLength(2);
+  });
+
+  it("retries the exact pending key and bytes after five minutes", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const harness = createHarness({
+      async send(_input, attempt) {
+        if (attempt === 1) {
+          throw new OperatorAlertLinqError("linq_retryable_response");
+        }
+      },
+    });
+
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 403 });
+    await harness.flushWaitUntil();
+
+    const failedState = harness.alert.readState();
+    expect(harness.deliveries).toHaveLength(1);
+    expect(failedState).toMatchObject({
+      attemptLeaseUntilMs: 0,
+      pendingAlertIdempotencyKey:
+        "openai-authorization-alert:incident-1:page-1",
+      pendingRetryAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+    });
+    expect(harness.activeAlarm()).toBe(BASE_TIME_MS + FIVE_MINUTES_MS);
+    expect(warning).toHaveBeenCalledWith(
+      "OpenAI authorization alert operation failed.",
+      { failureCode: "linq_retryable_response" },
+    );
+
+    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS - 1);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+    expect(harness.deliveries).toHaveLength(1);
+
+    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toHaveLength(2);
+    expect(harness.deliveries[1]).toEqual(harness.deliveries[0]);
+    expect(harness.alert.readState()).toMatchObject({
+      lastSuccessfulPageAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+      pendingAlertIdempotencyKey: null,
+      pendingAlertMessage: null,
+    });
+
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+    expect(harness.deliveries).toHaveLength(2);
+  });
+
+  it("closes after the quiet window and deletes the alarm", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + FIFTEEN_MINUTES_MS);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 0,
+      failureCount: 0,
+      firstFailureAtMs: null,
+      incidentOpen: false,
+      incidentSequence: 1,
+      lastFailureAtMs: null,
+      lastStatus: null,
+    });
+    expect(harness.activeAlarm()).toBeNull();
+    expect(harness.alarmOperations.at(-1)).toEqual({ kind: "delete" });
+  });
+
+  it("starts a new incident before recording a boundary observation", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + FIFTEEN_MINUTES_MS);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + FIFTEEN_MINUTES_MS,
+      status: 403,
+    });
+
+    expect(harness.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      failureCount: 1,
+      firstFailureAtMs: BASE_TIME_MS + FIFTEEN_MINUTES_MS,
+      incidentOpen: true,
+      incidentSequence: 2,
+      lastFailureAtMs: BASE_TIME_MS + FIFTEEN_MINUTES_MS,
+      lastStatus: 403,
+      pendingAlertIdempotencyKey:
+        "openai-authorization-alert:incident-2:page-1",
+    });
+    await harness.flushWaitUntil();
+    expect(harness.deliveries).toHaveLength(2);
+  });
+
+  it("counts out-of-order observations without regressing timestamps or status", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + 10 * 60_000);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 10 * 60_000,
+      status: 403,
+    });
+    await harness.flushWaitUntil();
+
+    harness.setNow(BASE_TIME_MS + 11 * 60_000);
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 5 * 60_000,
+      status: 401,
+    });
+    await harness.flushWaitUntil();
+
+    expect(harness.deliveries).toHaveLength(1);
+    expect(harness.alert.readState()).toMatchObject({
+      failureCount: 3,
+      firstFailureAtMs: BASE_TIME_MS,
+      lastFailureAtMs: BASE_TIME_MS + 10 * 60_000,
+      lastStatus: 403,
+    });
+    expect(harness.activeAlarm()).toBe(
+      BASE_TIME_MS + 10 * 60_000 + FIFTEEN_MINUTES_MS,
+    );
+  });
+
+  it("rejects invalid or expanded RPC input without changing durable state", () => {
+    const harness = createHarness();
+    const invalidInputs: unknown[] = [
+      null,
+      [],
+      {},
+      { observedAtMs: BASE_TIME_MS, status: 400 },
+      { observedAtMs: -1, status: 401 },
+      { observedAtMs: 1.5, status: 401 },
+      { observedAtMs: Number.NaN, status: 401 },
+      { observedAtMs: Number.MAX_SAFE_INTEGER + 1, status: 401 },
+      {
+        observedAtMs: BASE_TIME_MS,
+        requestId: "must-not-cross-the-boundary",
+        status: 401,
+      },
+      {
+        member: { id: "must-not-cross-the-boundary" },
+        observedAtMs: BASE_TIME_MS,
+        status: 403,
+      },
+      {
+        observedAtMs: BASE_TIME_MS,
+        runner: "must-not-cross-the-boundary",
+        status: 401,
+      },
+      {
+        observedAtMs: BASE_TIME_MS,
+        prompt: "must-not-cross-the-boundary",
+        status: 401,
+      },
+      {
+        observedAtMs: BASE_TIME_MS,
+        providerPayload: {},
+        status: 403,
+      },
+    ];
+
+    for (const input of invalidInputs) {
+      expect(() => harness.alert.reportFailure(input)).toThrow(
+        "OpenAI authorization failure report is invalid.",
+      );
+    }
+    expect(harness.alert.readState()).toMatchObject({
+      failureCount: 0,
+      incidentOpen: false,
+      incidentSequence: 0,
+      pendingAlertIdempotencyKey: null,
+    });
+    expect(harness.deliveries).toEqual([]);
+    expect(harness.waitUntilCount()).toBe(0);
+    expect(harness.activeAlarm()).toBeNull();
+  });
+
+  it("emits only bounded privacy-safe fixed message bytes", async () => {
+    const harness = createHarness();
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 403 });
+    await harness.flushWaitUntil();
+
+    const message = harness.deliveries[0]?.message;
+    expect(message).toBeDefined();
+    if (message === undefined) {
+      throw new Error("Expected an operator alert message.");
+    }
+    expect(message).toMatch(
+      /^SEV1 OpenAI (?:401|403)\nAggregate count: \d+\nFirst observed UTC: [^\n]+\nLast observed UTC: [^\n]+$/u,
+    );
+    expect(new TextEncoder().encode(message).byteLength).toBeLessThanOrEqual(
+      256,
+    );
+    expect(message).not.toMatch(/https?:|member|prompt|provider|request|runner/iu);
+  });
+
+  it("serializes overlapping report and alarm work around one persisted claim", async () => {
+    const sendStarted = createDeferred<void>();
+    const releaseSend = createDeferred<void>();
+    const harness = createHarness({
+      async send() {
+        sendStarted.resolve(undefined);
+        await releaseSend.promise;
+      },
+    });
+
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await sendStarted.promise;
+    expect(harness.deliveries).toHaveLength(1);
+
+    harness.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 1,
+      status: 403,
+    });
+    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS);
+    harness.alert.alarm();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.deliveries).toHaveLength(1);
+    expect(harness.alert.readState()).toMatchObject({
+      attemptGeneration: 2,
+      failureCount: 2,
+      pendingAlertIdempotencyKey:
+        "openai-authorization-alert:incident-1:page-1",
+    });
+
+    releaseSend.resolve(undefined);
+    await harness.flushWaitUntil();
+    expect(harness.deliveries).toHaveLength(1);
+    expect(harness.alert.readState()).toMatchObject({
+      lastSuccessfulPageAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+      pendingAlertIdempotencyKey: null,
+    });
+  });
+
+  it("keeps one alarm on the earliest retry or closure and removes it when idle", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const harness = createHarness({
+      async send(_input, attempt) {
+        if (attempt === 1) {
+          throw new Error("private provider detail");
+        }
+      },
+    });
+
+    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
+    await harness.flushWaitUntil();
+    expect(harness.activeAlarm()).toBe(BASE_TIME_MS + FIVE_MINUTES_MS);
+
+    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+    expect(harness.activeAlarm()).toBe(
+      BASE_TIME_MS + FIFTEEN_MINUTES_MS,
+    );
+
+    harness.setNow(BASE_TIME_MS + FIFTEEN_MINUTES_MS);
+    harness.alert.alarm();
+    await harness.flushWaitUntil();
+    expect(harness.activeAlarm()).toBeNull();
+    expect(harness.alarmOperations).toEqual([
+      { kind: "set", scheduledAtMs: BASE_TIME_MS + FIVE_MINUTES_MS },
+      { kind: "set", scheduledAtMs: BASE_TIME_MS + 2 * FIVE_MINUTES_MS },
+      { kind: "set", scheduledAtMs: BASE_TIME_MS + FIFTEEN_MINUTES_MS },
+      { kind: "delete" },
+    ]);
+    expect(warning).toHaveBeenCalledWith(
+      "OpenAI authorization alert operation failed.",
+      { failureCode: "linq_transport_failed" },
+    );
+  });
+
+  it("rejects a newer schema without downgrading its version", () => {
+    const sql = createTestSqlStorage();
+    sql.exec(`
+      CREATE TABLE openai_authorization_alert_schema_meta (
+        key TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+      )
+    `);
+    sql.exec(
+      `INSERT INTO openai_authorization_alert_schema_meta (key, value)
+       VALUES ('schema_version', ?)`,
+      2,
+    );
+
+    expect(() => createHarness({ sql })).toThrow(
+      "OpenAI authorization alert schema is newer than this Worker.",
+    );
+    expect(sql.exec<{ value: number }>(
+      `SELECT value
+       FROM openai_authorization_alert_schema_meta
+       WHERE key = 'schema_version'`,
+    ).one().value).toBe(2);
+    expect(sql.exec<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table'",
+    ).toArray().map((row) => row.name)).not.toContain(
+      "openai_authorization_alert_meta",
+    );
+  });
+});
+
+function createHarness(input: {
+  send?: (
+    input: AlertInput,
+    attempt: number,
+  ) => Promise<void>;
+  sql?: TestSqlStorageLike;
+} = {}): {
+  activeAlarm(): number | null;
+  alarmOperations: Array<
+    | { kind: "delete" }
+    | { kind: "set"; scheduledAtMs: number }
+  >;
+  alert: OpenAiAuthorizationAlertDurableObject;
+  deliveries: AlertInput[];
+  flushWaitUntil(): Promise<void>;
+  setNow(value: number): void;
+  waitUntilCount(): number;
+} {
+  let activeAlarm: number | null = null;
+  let nowMs = BASE_TIME_MS;
+  let sendAttempt = 0;
+  const alarmOperations: Array<
+    | { kind: "delete" }
+    | { kind: "set"; scheduledAtMs: number }
+  > = [];
+  const deliveries: AlertInput[] = [];
+  const sql = input.sql ?? createTestSqlStorage();
+  const waitUntilPromises: Promise<unknown>[] = [];
+  let waitUntilCalls = 0;
+  const storage: DurableObjectStorageLike = {
+    async delete() {
+      return false;
+    },
+    async deleteAlarm() {
+      activeAlarm = null;
+      alarmOperations.push({ kind: "delete" });
+    },
+    async get<T>() {
+      return undefined as T | undefined;
+    },
+    async getAlarm() {
+      return activeAlarm;
+    },
+    async put<T>(_key: string, _value: T) {},
+    async setAlarm(scheduledTime) {
+      activeAlarm = scheduledTime instanceof Date
+        ? scheduledTime.getTime()
+        : scheduledTime;
+      alarmOperations.push({
+        kind: "set",
+        scheduledAtMs: activeAlarm,
+      });
+    },
+    sql,
+    transactionSync: sql.transactionSync,
+  };
+  const state: DurableObjectStateLike = {
+    storage,
+    waitUntil(promise) {
+      waitUntilCalls += 1;
+      waitUntilPromises.push(promise);
+    },
+  };
+  const sender: OpenAiAuthorizationAlertSender = {
+    async send(alertInput) {
+      const persistedInput = { ...alertInput };
+      deliveries.push(persistedInput);
+      sendAttempt += 1;
+      await input.send?.(persistedInput, sendAttempt);
+    },
+  };
+  const alert = new OpenAiAuthorizationAlertDurableObject(
+    state,
+    {},
+    sender,
+    () => nowMs,
+  );
+
+  return {
+    activeAlarm: () => activeAlarm,
+    alarmOperations,
+    alert,
+    deliveries,
+    async flushWaitUntil() {
+      while (waitUntilPromises.length > 0) {
+        await Promise.all(waitUntilPromises.splice(0));
+      }
+    },
+    setNow(value) {
+      nowMs = value;
+    },
+    waitUntilCount: () => waitUntilCalls,
+  };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolvePromise: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise(value);
+    },
+  };
+}

--- a/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
+++ b/apps/cloudflare/test/openai-authorization-alert-durable-object.test.ts
@@ -38,8 +38,6 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
     expect(harness.deliveries).toEqual([]);
     expect(persistedBeforeSend).toMatchObject({
       alertSequence: 1,
-      attemptGeneration: 1,
-      attemptLeaseUntilMs: BASE_TIME_MS + FIVE_MINUTES_MS,
       failureCount: 1,
       firstFailureAtMs: BASE_TIME_MS,
       incidentOpen: true,
@@ -50,7 +48,7 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
         "openai-authorization-alert:incident-1:page-1",
       pendingAlertIncidentSequence: 1,
       pendingAlertSequence: 1,
-      pendingRetryAtMs: BASE_TIME_MS,
+      pendingRetryAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
     });
     expect(persistedBeforeSend.pendingAlertMessage).toBe(
       [
@@ -159,53 +157,74 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
     expect(harness.deliveries).toHaveLength(2);
   });
 
-  it("retries the exact pending key and bytes after five minutes", async () => {
+  it("retries the exact failed effect from a recreated owner when due", async () => {
     const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const harness = createHarness({
-      async send(_input, attempt) {
-        if (attempt === 1) {
-          throw new OperatorAlertLinqError("linq_retryable_response");
-        }
+    const firstOwner = createHarness({
+      async send() {
+        throw new OperatorAlertLinqError("linq_retryable_response");
       },
     });
 
-    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 403 });
-    await harness.flushWaitUntil();
+    firstOwner.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS,
+      status: 401,
+    });
+    firstOwner.setNow(BASE_TIME_MS + 1);
+    firstOwner.alert.reportFailure({
+      observedAtMs: BASE_TIME_MS + 1,
+      status: 403,
+    });
+    await firstOwner.flushWaitUntil();
 
-    const failedState = harness.alert.readState();
-    expect(harness.deliveries).toHaveLength(1);
+    const retryAtMs = BASE_TIME_MS + 1 + FIVE_MINUTES_MS;
+    const failedState = firstOwner.alert.readState();
+    expect(firstOwner.deliveries).toHaveLength(1);
     expect(failedState).toMatchObject({
-      attemptLeaseUntilMs: 0,
+      failureCount: 2,
+      lastFailureAtMs: BASE_TIME_MS + 1,
+      lastStatus: 403,
       pendingAlertIdempotencyKey:
         "openai-authorization-alert:incident-1:page-1",
-      pendingRetryAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+      pendingRetryAtMs: retryAtMs,
     });
-    expect(harness.activeAlarm()).toBe(BASE_TIME_MS + FIVE_MINUTES_MS);
+    expect(firstOwner.activeAlarm()).toBe(retryAtMs);
     expect(warning).toHaveBeenCalledWith(
       "OpenAI authorization alert operation failed.",
       { failureCode: "linq_retryable_response" },
     );
 
-    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS - 1);
-    harness.alert.alarm();
-    await harness.flushWaitUntil();
-    expect(harness.deliveries).toHaveLength(1);
+    const retriedEffect = firstOwner.deliveries[0];
+    const recreatedOwner = createHarness({
+      persistence: firstOwner.persistence,
+    });
+    recreatedOwner.setNow(retryAtMs - 1);
+    recreatedOwner.alert.alarm();
+    await recreatedOwner.flushWaitUntil();
+    expect(recreatedOwner.deliveries).toEqual([]);
 
-    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS);
-    harness.alert.alarm();
-    await harness.flushWaitUntil();
+    recreatedOwner.setNow(retryAtMs);
+    recreatedOwner.alert.alarm();
+    await recreatedOwner.flushWaitUntil();
 
-    expect(harness.deliveries).toHaveLength(2);
-    expect(harness.deliveries[1]).toEqual(harness.deliveries[0]);
-    expect(harness.alert.readState()).toMatchObject({
-      lastSuccessfulPageAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
+    expect(recreatedOwner.deliveries).toEqual([retriedEffect]);
+    expect(recreatedOwner.alert.readState()).toMatchObject({
+      alertSequence: 1,
+      failureCount: 2,
+      firstFailureAtMs: BASE_TIME_MS,
+      incidentOpen: true,
+      lastFailureAtMs: BASE_TIME_MS + 1,
+      lastStatus: 403,
+      lastSuccessfulPageAtMs: retryAtMs,
       pendingAlertIdempotencyKey: null,
+      pendingAlertIncidentSequence: null,
       pendingAlertMessage: null,
+      pendingAlertSequence: null,
+      pendingRetryAtMs: null,
     });
 
-    harness.alert.alarm();
-    await harness.flushWaitUntil();
-    expect(harness.deliveries).toHaveLength(2);
+    recreatedOwner.alert.alarm();
+    await recreatedOwner.flushWaitUntil();
+    expect(recreatedOwner.deliveries).toHaveLength(1);
   });
 
   it("closes after the quiet window and deletes the alarm", async () => {
@@ -360,45 +379,6 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
     expect(message).not.toMatch(/https?:|member|prompt|provider|request|runner/iu);
   });
 
-  it("serializes overlapping report and alarm work around one persisted claim", async () => {
-    const sendStarted = createDeferred<void>();
-    const releaseSend = createDeferred<void>();
-    const harness = createHarness({
-      async send() {
-        sendStarted.resolve(undefined);
-        await releaseSend.promise;
-      },
-    });
-
-    harness.alert.reportFailure({ observedAtMs: BASE_TIME_MS, status: 401 });
-    await sendStarted.promise;
-    expect(harness.deliveries).toHaveLength(1);
-
-    harness.alert.reportFailure({
-      observedAtMs: BASE_TIME_MS + 1,
-      status: 403,
-    });
-    harness.setNow(BASE_TIME_MS + FIVE_MINUTES_MS);
-    harness.alert.alarm();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(harness.deliveries).toHaveLength(1);
-    expect(harness.alert.readState()).toMatchObject({
-      attemptGeneration: 2,
-      failureCount: 2,
-      pendingAlertIdempotencyKey:
-        "openai-authorization-alert:incident-1:page-1",
-    });
-
-    releaseSend.resolve(undefined);
-    await harness.flushWaitUntil();
-    expect(harness.deliveries).toHaveLength(1);
-    expect(harness.alert.readState()).toMatchObject({
-      lastSuccessfulPageAtMs: BASE_TIME_MS + FIVE_MINUTES_MS,
-      pendingAlertIdempotencyKey: null,
-    });
-  });
 
   it("keeps one alarm on the earliest retry or closure and removes it when idle", async () => {
     const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -467,7 +447,18 @@ describe("OpenAiAuthorizationAlertDurableObject", () => {
   });
 });
 
+type AlarmOperation =
+  | { kind: "delete" }
+  | { kind: "set"; scheduledAtMs: number };
+
+interface HarnessPersistence {
+  activeAlarm: number | null;
+  alarmOperations: AlarmOperation[];
+  sql: TestSqlStorageLike;
+}
+
 function createHarness(input: {
+  persistence?: HarnessPersistence;
   send?: (
     input: AlertInput,
     attempt: number,
@@ -475,25 +466,22 @@ function createHarness(input: {
   sql?: TestSqlStorageLike;
 } = {}): {
   activeAlarm(): number | null;
-  alarmOperations: Array<
-    | { kind: "delete" }
-    | { kind: "set"; scheduledAtMs: number }
-  >;
+  alarmOperations: AlarmOperation[];
   alert: OpenAiAuthorizationAlertDurableObject;
   deliveries: AlertInput[];
   flushWaitUntil(): Promise<void>;
+  persistence: HarnessPersistence;
   setNow(value: number): void;
   waitUntilCount(): number;
 } {
-  let activeAlarm: number | null = null;
   let nowMs = BASE_TIME_MS;
   let sendAttempt = 0;
-  const alarmOperations: Array<
-    | { kind: "delete" }
-    | { kind: "set"; scheduledAtMs: number }
-  > = [];
+  const persistence = input.persistence ?? {
+    activeAlarm: null,
+    alarmOperations: [],
+    sql: input.sql ?? createTestSqlStorage(),
+  };
   const deliveries: AlertInput[] = [];
-  const sql = input.sql ?? createTestSqlStorage();
   const waitUntilPromises: Promise<unknown>[] = [];
   let waitUntilCalls = 0;
   const storage: DurableObjectStorageLike = {
@@ -501,27 +489,27 @@ function createHarness(input: {
       return false;
     },
     async deleteAlarm() {
-      activeAlarm = null;
-      alarmOperations.push({ kind: "delete" });
+      persistence.activeAlarm = null;
+      persistence.alarmOperations.push({ kind: "delete" });
     },
     async get<T>() {
       return undefined as T | undefined;
     },
     async getAlarm() {
-      return activeAlarm;
+      return persistence.activeAlarm;
     },
     async put<T>(_key: string, _value: T) {},
     async setAlarm(scheduledTime) {
-      activeAlarm = scheduledTime instanceof Date
+      persistence.activeAlarm = scheduledTime instanceof Date
         ? scheduledTime.getTime()
         : scheduledTime;
-      alarmOperations.push({
+      persistence.alarmOperations.push({
         kind: "set",
-        scheduledAtMs: activeAlarm,
+        scheduledAtMs: persistence.activeAlarm,
       });
     },
-    sql,
-    transactionSync: sql.transactionSync,
+    sql: persistence.sql,
+    transactionSync: persistence.sql.transactionSync,
   };
   const state: DurableObjectStateLike = {
     storage,
@@ -546,8 +534,8 @@ function createHarness(input: {
   );
 
   return {
-    activeAlarm: () => activeAlarm,
-    alarmOperations,
+    activeAlarm: () => persistence.activeAlarm,
+    alarmOperations: persistence.alarmOperations,
     alert,
     deliveries,
     async flushWaitUntil() {
@@ -555,25 +543,10 @@ function createHarness(input: {
         await Promise.all(waitUntilPromises.splice(0));
       }
     },
+    persistence,
     setNow(value) {
       nowMs = value;
     },
     waitUntilCount: () => waitUntilCalls,
-  };
-}
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve(value: T): void;
-} {
-  let resolvePromise: (value: T) => void = () => {};
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve;
-  });
-  return {
-    promise,
-    resolve(value) {
-      resolvePromise(value);
-    },
   };
 }

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -68,6 +68,7 @@ import type {
 } from "../src/runner-outbound.ts";
 import type {
   WorkerActiveRuntimeUserFenceResult,
+  WorkerOpenAiAuthorizationAlertStubLike,
   WorkerProviderEgressCredentialValidationResult,
   WorkerProviderEgressTokenValidationResult,
 } from "../src/worker-contracts.ts";
@@ -122,6 +123,46 @@ const OPENAI_WEBSOCKET_HANDSHAKE_HEADERS = {
 } as const;
 const TEST_TEXT_ENCODER = new TextEncoder();
 const PROVIDER_REQUEST_STARTED_AT = "2026-07-23T12:00:00.000Z";
+
+type OpenAiAuthorizationAlertReport = Parameters<
+  WorkerOpenAiAuthorizationAlertStubLike["reportFailure"]
+>[0];
+
+function createAuthorizedOpenAiModelsRequest(input: {
+  headers?: Readonly<Record<string, string>>;
+  url?: string;
+} = {}): Request {
+  return new Request(input.url ?? "https://api.openai.com/v1/models", {
+    headers: {
+      ...BOUND_USER_WRITE_FENCE_WITH_BEARER_SENTINEL_HEADERS,
+      ...input.headers,
+    },
+    method: "GET",
+  });
+}
+
+function createOpenAiAuthorizationAlertTestNamespace(
+  reportFailure: WorkerOpenAiAuthorizationAlertStubLike["reportFailure"],
+) {
+  const getByName = vi.fn(
+    (_name: string): WorkerOpenAiAuthorizationAlertStubLike => ({
+      reportFailure,
+    }),
+  );
+  return { getByName, namespace: { getByName } };
+}
+
+function createWaitUntilCollector() {
+  const promises: Promise<unknown>[] = [];
+  return {
+    context: {
+      waitUntil(promise: Promise<unknown>): void {
+        promises.push(promise);
+      },
+    },
+    promises,
+  };
+}
 
 function createHostedExaResearchScoutRequestBody(
   overrides: Record<string, unknown> = {},
@@ -4996,6 +5037,245 @@ describe("hostedRunnerIntercept", () => {
         message: "Hosted runner provider egress completed.",
       }),
     );
+  });
+
+  it("reports an authorized upstream OpenAI 401 with only the privacy-safe fields without delaying the response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T18:42:03.456Z"));
+    let reportCompleted = false;
+    let completeReport = (_value: { accepted: true }): void => {
+      throw new Error("OpenAI authorization alert report did not start.");
+    };
+    const reportFailure = vi.fn(
+      (_report: OpenAiAuthorizationAlertReport) =>
+        new Promise<{ accepted: true }>((resolve) => {
+          completeReport = resolve;
+        }).finally(() => {
+          reportCompleted = true;
+        }),
+    );
+    const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
+    const deferred = createWaitUntilCollector();
+    const upstreamResponse = new Response("private-upstream-response-body", {
+      headers: {
+        "content-type": "application/json",
+        "x-private-response": "private-response-header",
+      },
+      status: 401,
+      statusText: "Unauthorized",
+    });
+    const upstreamFetch = vi.fn<typeof fetch>(async () => upstreamResponse);
+
+    const response = await handleHostedRunnerOpenAiOutbound(
+      createAuthorizedOpenAiModelsRequest({
+        headers: { "x-private-request": "private-request-header" },
+        url:
+          "https://api.openai.com/v1/models?private_query=private-request-query",
+      }),
+      createInterceptEnv({
+        OPENAI_API_KEY: "openai-worker-secret",
+        OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+        validateRuntimeWriteFence: async () => true,
+      }),
+      deferred.context,
+      upstreamFetch,
+    );
+
+    expect(response).toBe(upstreamResponse);
+    expect(response.status).toBe(401);
+    expect(response.statusText).toBe("Unauthorized");
+    expect(response.headers.get("x-private-response")).toBe(
+      "private-response-header",
+    );
+    expect(upstreamFetch).toHaveBeenCalledOnce();
+    expect(reportCompleted).toBe(false);
+    expect(deferred.promises).toHaveLength(1);
+    expect(alert.getByName).toHaveBeenCalledOnce();
+    expect(alert.getByName).toHaveBeenCalledWith("production");
+    expect(reportFailure).toHaveBeenCalledOnce();
+    expect(reportFailure).toHaveBeenCalledWith({
+      observedAtMs: Date.parse("2026-08-29T18:42:03.456Z"),
+      status: 401,
+    });
+    const report = reportFailure.mock.calls[0]![0];
+    expect(Object.keys(report).sort()).toEqual(["observedAtMs", "status"]);
+    expect(JSON.stringify(report)).not.toContain("private-");
+
+    completeReport({ accepted: true });
+    await Promise.all(deferred.promises);
+    expect(reportCompleted).toBe(true);
+    expect(await response.text()).toBe("private-upstream-response-body");
+  });
+
+  it("reports an authorized upstream OpenAI 403", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T19:00:00.000Z"));
+    const reportFailure = vi.fn(
+      async (report: OpenAiAuthorizationAlertReport) => {
+        expect(report).toEqual({
+          observedAtMs: Date.parse("2026-08-29T19:00:00.000Z"),
+          status: 403,
+        });
+        return { accepted: true } as const;
+      },
+    );
+    const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
+    const deferred = createWaitUntilCollector();
+    const upstreamResponse = new Response("forbidden", { status: 403 });
+
+    const response = await handleHostedRunnerOpenAiOutbound(
+      createAuthorizedOpenAiModelsRequest(),
+      createInterceptEnv({
+        OPENAI_API_KEY: "openai-worker-secret",
+        OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+        validateRuntimeWriteFence: async () => true,
+      }),
+      deferred.context,
+      async () => upstreamResponse,
+    );
+
+    expect(response).toBe(upstreamResponse);
+    expect(alert.getByName).toHaveBeenCalledWith("production");
+    expect(reportFailure).toHaveBeenCalledOnce();
+    expect(deferred.promises).toHaveLength(1);
+    await Promise.all(deferred.promises);
+  });
+
+  it("does not report OpenAI success, Murph-local authorization rejection, or transport failure", async () => {
+    const reportFailure = vi.fn(
+      async (_report: OpenAiAuthorizationAlertReport) =>
+        ({ accepted: true }) as const,
+    );
+    const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
+    const successfulUpstreamFetch = vi.fn<typeof fetch>(
+      async () => new Response("ok", { status: 200 }),
+    );
+    const rejectedUpstreamFetch = vi.fn<typeof fetch>(
+      async () => new Response("must not be reached", { status: 401 }),
+    );
+    const transportFailure = new Error("synthetic OpenAI transport failure");
+    const failedUpstreamFetch = vi.fn<typeof fetch>(async () => {
+      throw transportFailure;
+    });
+    const waitUntil = vi.fn();
+    const authorizedEnv = createInterceptEnv({
+      OPENAI_API_KEY: "openai-worker-secret",
+      OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+      validateRuntimeWriteFence: async () => true,
+    });
+
+    const successResponse = await handleHostedRunnerOpenAiOutbound(
+      createAuthorizedOpenAiModelsRequest(),
+      authorizedEnv,
+      { waitUntil },
+      successfulUpstreamFetch,
+    );
+    const rejectedResponse = await handleHostedRunnerOpenAiOutbound(
+      createAuthorizedOpenAiModelsRequest(),
+      createInterceptEnv({
+        OPENAI_API_KEY: "openai-worker-secret",
+        OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+        validateRuntimeWriteFence: async () => false,
+      }),
+      { waitUntil },
+      rejectedUpstreamFetch,
+    );
+    await expect(handleHostedRunnerOpenAiOutbound(
+      createAuthorizedOpenAiModelsRequest(),
+      authorizedEnv,
+      { waitUntil },
+      failedUpstreamFetch,
+    )).rejects.toBe(transportFailure);
+
+    expect(successResponse.status).toBe(200);
+    expect(rejectedResponse.status).toBe(401);
+    expect(successfulUpstreamFetch).toHaveBeenCalledOnce();
+    expect(rejectedUpstreamFetch).not.toHaveBeenCalled();
+    expect(failedUpstreamFetch).toHaveBeenCalledOnce();
+    expect(alert.getByName).not.toHaveBeenCalled();
+    expect(reportFailure).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it("isolates a rejected alert RPC and preserves the exact upstream OpenAI response", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const reportFailure = vi.fn(
+        async (_report: OpenAiAuthorizationAlertReport) => {
+          throw new Error("private-rpc-rejection-detail");
+        },
+      );
+      const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
+      const deferred = createWaitUntilCollector();
+      const upstreamResponse = new Response("original-upstream-body", {
+        headers: {
+          "content-type": "application/problem+json",
+          "x-original-header": "original-header-value",
+        },
+        status: 401,
+        statusText: "Original Unauthorized",
+      });
+
+      const response = await handleHostedRunnerOpenAiOutbound(
+        createAuthorizedOpenAiModelsRequest(),
+        createInterceptEnv({
+          OPENAI_API_KEY: "openai-worker-secret",
+          OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+          validateRuntimeWriteFence: async () => true,
+        }),
+        deferred.context,
+        async () => upstreamResponse,
+      );
+
+      expect(response).toBe(upstreamResponse);
+      expect(response.status).toBe(401);
+      expect(response.statusText).toBe("Original Unauthorized");
+      expect(response.headers.get("content-type")).toBe(
+        "application/problem+json",
+      );
+      expect(response.headers.get("x-original-header")).toBe(
+        "original-header-value",
+      );
+      expect(await response.text()).toBe("original-upstream-body");
+      expect(deferred.promises).toHaveLength(1);
+      await Promise.all(deferred.promises);
+      expect(warning).toHaveBeenCalledOnce();
+      expect(warning).toHaveBeenCalledWith(
+        "OpenAI authorization alert report failed.",
+        { failureCode: "openai_authorization_alert_report_failed" },
+      );
+      expect(JSON.stringify(warning.mock.calls)).not.toContain(
+        "private-rpc-rejection-detail",
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
+  it("logs the same fixed safe failure once when the alert binding is absent", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const upstreamResponse = new Response("forbidden", { status: 403 });
+
+      const response = await handleHostedRunnerOpenAiOutbound(
+        createAuthorizedOpenAiModelsRequest(),
+        createInterceptEnv({
+          OPENAI_API_KEY: "openai-worker-secret",
+          validateRuntimeWriteFence: async () => true,
+        }),
+        { waitUntil: vi.fn() },
+        async () => upstreamResponse,
+      );
+
+      expect(response).toBe(upstreamResponse);
+      expect(warning).toHaveBeenCalledOnce();
+      expect(warning).toHaveBeenCalledWith(
+        "OpenAI authorization alert report failed.",
+        { failureCode: "openai_authorization_alert_report_failed" },
+      );
+    } finally {
+      warning.mockRestore();
+    }
   });
 
   it("injects OpenAI authorization for Responses WebSocket upgrades without body diagnostics", async () => {
@@ -10119,6 +10399,8 @@ function createInterceptEnv(input: {
   MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED?: string;
   MURPH_HOSTED_LOCAL_PROFILE?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_AUTHORIZATION_ALERT_MONITOR?:
+    RunnerOutboundEnvironmentSource["OPENAI_AUTHORIZATION_ALERT_MONITOR"];
   readActiveRuntimeUserFence?: () => Promise<WorkerActiveRuntimeUserFenceResult>;
   readDeploySmokeLiveModelTurnFence?: () => Promise<{
     active: boolean;
@@ -10172,6 +10454,8 @@ function createInterceptEnv(input: {
       input.MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED,
     MURPH_HOSTED_LOCAL_PROFILE: input.MURPH_HOSTED_LOCAL_PROFILE,
     OPENAI_API_KEY: input.OPENAI_API_KEY,
+    OPENAI_AUTHORIZATION_ALERT_MONITOR:
+      input.OPENAI_AUTHORIZATION_ALERT_MONITOR,
     RUNNER_CONTAINER: {
       get: () => ({
         readActiveRuntimeUserFence:

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -1,3 +1,4 @@
+import { ContainerProxy } from "./stubs/cloudflare-containers.ts";
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   buildExaResearchScoutOutputSchema,
@@ -75,6 +76,7 @@ import type {
 import {
   createHostedExecutionTestEnv,
 } from "./hosted-execution-fixtures.ts";
+import { RunnerContainer } from "../src/runner-container.ts";
 import {
   DEPLOY_LIVE_MODEL_TURN_SMOKE_MODEL,
 } from "../src/deploy-smoke-live-model.ts";
@@ -5107,38 +5109,138 @@ describe("hostedRunnerIntercept", () => {
     expect(await response.text()).toBe("private-upstream-response-body");
   });
 
-  it("reports an authorized upstream OpenAI 403", async () => {
+  it("awaits alert admission through the real Containers outbound context", async () => {
+    let admitReport = (_value: { accepted: true }): void => {
+      throw new Error("OpenAI authorization alert report did not start.");
+    };
+    let reportStarted = (_value: void): void => {
+      throw new Error("OpenAI authorization alert report did not start.");
+    };
+    const reportStartedPromise = new Promise<void>((resolve) => {
+      reportStarted = resolve;
+    });
+    const reportFailure = vi.fn(
+      (_report: OpenAiAuthorizationAlertReport) =>
+        new Promise<{ accepted: true }>((resolve) => {
+          admitReport = resolve;
+          reportStarted(undefined);
+        }),
+    );
+    const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
+    const upstreamResponse = new Response("original-upstream-body", {
+      headers: {
+        "content-type": "application/problem+json",
+        "x-original-header": "original-header-value",
+      },
+      status: 401,
+      statusText: "Original Unauthorized",
+    });
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () => upstreamResponse));
+    const proxy = new ContainerProxy(
+      {
+        props: {
+          className: RunnerContainer.name,
+          containerId: "member_123--v-version_1",
+        },
+      },
+      createInterceptEnv({
+        OPENAI_API_KEY: "openai-worker-secret",
+        OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
+        validateRuntimeWriteFence: async () => true,
+      }),
+    );
+
+    let handlerSettled = false;
+    const responsePromise = proxy.fetch(createAuthorizedOpenAiModelsRequest())
+      .then((response) => {
+        handlerSettled = true;
+        return response;
+      });
+    await reportStartedPromise;
+    await Promise.resolve();
+    expect(handlerSettled).toBe(false);
+
+    admitReport({ accepted: true });
+    const response = await responsePromise;
+
+    expect(response).toBe(upstreamResponse);
+    expect(response.status).toBe(401);
+    expect(response.statusText).toBe("Original Unauthorized");
+    expect(response.headers.get("content-type")).toBe(
+      "application/problem+json",
+    );
+    expect(response.headers.get("x-original-header")).toBe(
+      "original-header-value",
+    );
+    expect(await response.text()).toBe("original-upstream-body");
+    expect(alert.getByName).toHaveBeenCalledWith("production");
+    expect(reportFailure).toHaveBeenCalledOnce();
+  });
+
+  it("awaits an authorized upstream OpenAI 403 when waitUntil registration fails", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-29T19:00:00.000Z"));
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let admitReport = (_value: { accepted: true }): void => {
+      throw new Error("OpenAI authorization alert report did not start.");
+    };
+    let reportStarted = (_value: void): void => {
+      throw new Error("OpenAI authorization alert report did not start.");
+    };
+    const reportStartedPromise = new Promise<void>((resolve) => {
+      reportStarted = resolve;
+    });
     const reportFailure = vi.fn(
-      async (report: OpenAiAuthorizationAlertReport) => {
+      (report: OpenAiAuthorizationAlertReport) => {
         expect(report).toEqual({
           observedAtMs: Date.parse("2026-08-29T19:00:00.000Z"),
           status: 403,
         });
-        return { accepted: true } as const;
+        return new Promise<{ accepted: true }>((resolve) => {
+          admitReport = resolve;
+          reportStarted(undefined);
+        });
       },
     );
     const alert = createOpenAiAuthorizationAlertTestNamespace(reportFailure);
-    const deferred = createWaitUntilCollector();
     const upstreamResponse = new Response("forbidden", { status: 403 });
+    const waitUntil = vi.fn((_promise: Promise<unknown>) => {
+      throw new Error("private-wait-until-detail");
+    });
 
-    const response = await handleHostedRunnerOpenAiOutbound(
+    let handlerSettled = false;
+    const responsePromise = handleHostedRunnerOpenAiOutbound(
       createAuthorizedOpenAiModelsRequest(),
       createInterceptEnv({
         OPENAI_API_KEY: "openai-worker-secret",
         OPENAI_AUTHORIZATION_ALERT_MONITOR: alert.namespace,
         validateRuntimeWriteFence: async () => true,
       }),
-      deferred.context,
+      { waitUntil },
       async () => upstreamResponse,
-    );
+    ).then((response) => {
+      handlerSettled = true;
+      return response;
+    });
+    await reportStartedPromise;
+    await Promise.resolve();
+    expect(handlerSettled).toBe(false);
+
+    admitReport({ accepted: true });
+    const response = await responsePromise;
 
     expect(response).toBe(upstreamResponse);
     expect(alert.getByName).toHaveBeenCalledWith("production");
     expect(reportFailure).toHaveBeenCalledOnce();
-    expect(deferred.promises).toHaveLength(1);
-    await Promise.all(deferred.promises);
+    expect(waitUntil).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(
+      "OpenAI authorization alert report failed.",
+      { failureCode: "openai_authorization_alert_report_failed" },
+    );
+    expect(JSON.stringify(warning.mock.calls)).not.toContain(
+      "private-wait-until-detail",
+    );
   });
 
   it("does not report OpenAI success, Murph-local authorization rejection, or transport failure", async () => {

--- a/apps/cloudflare/test/workers/database-health-fetch.ts
+++ b/apps/cloudflare/test/workers/database-health-fetch.ts
@@ -261,6 +261,7 @@ function readValidDatabaseHealthMessageRequest(input: {
       || value.message.parts[0].value.includes(
         "Database monitor telemetry was incomplete",
       )
+      || value.message.parts[0].value.startsWith("SEV1 OpenAI ")
     )
     || !Array.isArray(value.to)
     || value.to.length !== 1

--- a/apps/cloudflare/test/workers/openai-authorization-alert-e2e.test.ts
+++ b/apps/cloudflare/test/workers/openai-authorization-alert-e2e.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { env } from "cloudflare:workers";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+} from "../../src/runner-egress-intercept.ts";
+import type {
+  WorkerEnvironmentSource,
+} from "../../src/worker-routes/shared.ts";
+import worker from "./worker-entry.ts";
+import {
+  readDatabaseHealthMessageRequests,
+  resetDatabaseHealthMessageRequests,
+} from "./database-health-fetch.ts";
+
+describe("OpenAI authorization alert Worker path", () => {
+  it("returns the upstream 401 and sends one privacy-safe page to both operators", async () => {
+    resetDatabaseHealthMessageRequests();
+
+    const response = await worker.fetch(
+      new Request("http://worker.test/__test/openai-authorization-alert", {
+        method: "POST",
+      }),
+      env as WorkerEnvironmentSource,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.statusText).toBe("Synthetic Unauthorized");
+    expect(response.headers.get("content-type")).toBe(
+      "application/problem+json",
+    );
+    expect(response.headers.get("x-private-response-header")).toBe(
+      "private-response-header",
+    );
+    expect(await response.text()).toBe("private-upstream-response-body");
+
+    await vi.waitFor(() => {
+      expect(readDatabaseHealthMessageRequests()).toHaveLength(2);
+    });
+    const messageRequests = readDatabaseHealthMessageRequests();
+    expect(messageRequests.map((request) => ({
+      idempotencyKey: request.idempotencyKey,
+      recipient: request.recipient,
+    })).sort((left, right) => left.recipient.localeCompare(right.recipient)))
+      .toEqual([
+        {
+          idempotencyKey: "openai-authorization-alert:incident-1:page-1",
+          recipient: "+12025550123",
+        },
+        {
+          idempotencyKey:
+            "openai-authorization-alert:incident-1:page-1-recipient-2",
+          recipient: "+12025550124",
+        },
+      ]);
+    expect(messageRequests[1]?.messageParts)
+      .toEqual(messageRequests[0]?.messageParts);
+
+    const message = messageRequests[0]?.messageParts[0]?.value;
+    expect(message).toMatch(
+      /^SEV1 OpenAI 401\nAggregate count: 1\nFirst observed UTC: [^\n]+\nLast observed UTC: [^\n]+$/u,
+    );
+    expect(message?.split("\n")).toHaveLength(4);
+    const forbiddenDetails = [
+      "private-upstream-response-body",
+      "member-private-openai-alert",
+      "private-runner-container-id",
+      "openai-worker-test-key",
+      HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+      "api.openai.com",
+      "application/json",
+      "application/problem+json",
+      "private-provider-payload",
+      "private-query",
+      "private-request-header",
+      "x-private-request-header",
+      "x-private-response-header",
+      "/v1/images/generations",
+      "private-model",
+      "private-attempt-detail",
+    ];
+    for (const request of messageRequests) {
+      const deliveredMessage = request.messageParts[0]?.value ?? "";
+      for (const detail of forbiddenDetails) {
+        expect(deliveredMessage).not.toContain(detail);
+      }
+    }
+  });
+});

--- a/apps/cloudflare/test/workers/worker-entry.ts
+++ b/apps/cloudflare/test/workers/worker-entry.ts
@@ -44,6 +44,9 @@ import {
   DeviceWebhookQueueHealthDurableObject,
 } from "../../src/worker/device-webhook-queue-health-durable-object.ts";
 import {
+  OpenAiAuthorizationAlertDurableObject,
+} from "../../src/worker/openai-authorization-alert-durable-object.ts";
+import {
   armInvalidRunnerOutputBundleFault,
   clearRunnerInvocationState,
   clearRunnerOutputBundleFault,
@@ -62,6 +65,7 @@ import {
 
 export { DatabaseHealthDurableObject };
 export { DeviceWebhookQueueHealthDurableObject };
+export { OpenAiAuthorizationAlertDurableObject };
 
 export class VitestDatabaseHealthDurableObject
   extends DatabaseHealthDurableObject {

--- a/apps/cloudflare/test/workers/worker-entry.ts
+++ b/apps/cloudflare/test/workers/worker-entry.ts
@@ -7,6 +7,14 @@ import {
 } from "@murphai/hosted-execution/parsers";
 
 import worker from "../../src/index.ts";
+import { sendOperatorLinqAlert } from "../../src/operator-alert/linq.ts";
+import {
+  handleHostedRunnerOpenAiOutbound,
+  HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL,
+} from "../../src/runner-egress-intercept.ts";
+import {
+  HOSTED_RUNNER_BOUND_USER_ID_HEADER,
+} from "../../src/runner-outbound/headers.ts";
 import type { R2BucketLike } from "../../src/bundle-store.js";
 import {
   DatabaseHealthMonitor,
@@ -44,7 +52,8 @@ import {
   DeviceWebhookQueueHealthDurableObject,
 } from "../../src/worker/device-webhook-queue-health-durable-object.ts";
 import {
-  OpenAiAuthorizationAlertDurableObject,
+  OpenAiAuthorizationAlertDurableObject as ProductionOpenAiAuthorizationAlertDurableObject,
+  type OpenAiAuthorizationAlertEnvironment,
 } from "../../src/worker/openai-authorization-alert-durable-object.ts";
 import {
   armInvalidRunnerOutputBundleFault,
@@ -65,7 +74,6 @@ import {
 
 export { DatabaseHealthDurableObject };
 export { DeviceWebhookQueueHealthDurableObject };
-export { OpenAiAuthorizationAlertDurableObject };
 
 export class VitestDatabaseHealthDurableObject
   extends DatabaseHealthDurableObject {
@@ -98,6 +106,31 @@ export class VitestDatabaseHealthDurableObject
 
   readAlertState(): DatabaseHealthAlertState {
     return this.testMonitor.readAlertState();
+  }
+}
+
+export class VitestOpenAiAuthorizationAlertDurableObject
+  extends ProductionOpenAiAuthorizationAlertDurableObject {
+  constructor(
+    state: DurableObjectStateLike,
+    environment: OpenAiAuthorizationAlertEnvironment,
+  ) {
+    super(state, environment, {
+      async send(input): Promise<void> {
+        await sendOperatorLinqAlert({
+          apiBaseUrl: environment.LINQ_API_BASE_URL?.trim()
+            || "https://api.linqapp.com/api/partner/v3",
+          apiToken: environment.LINQ_API_TOKEN ?? "",
+          chatIds: [
+            environment.HOSTED_DATABASE_ALERT_LINQ_CHAT_ID ?? "",
+            environment.HOSTED_DATABASE_ALERT_LINQ_SECONDARY_CHAT_ID ?? "",
+          ],
+          fetchImplementation: handleDatabaseHealthEgress,
+          idempotencyKey: input.idempotencyKey,
+          message: input.message,
+        });
+      },
+    });
   }
 }
 
@@ -436,7 +469,61 @@ async function handleTestRoute(request: Request): Promise<Response | null> {
     });
   }
 
+  if (
+    url.pathname === "/__test/openai-authorization-alert"
+    && request.method === "POST"
+  ) {
+    return await runOpenAiAuthorizationAlertTest();
+  }
+
   return null;
+}
+
+async function runOpenAiAuthorizationAlertTest(): Promise<Response> {
+  const userId = "member-private-openai-alert";
+  const runner = getUserRunnerStub(userId);
+  await runner.bindUser(userId);
+  const lease = await runner.beginWriteFenceForTest({
+    userId,
+    workspaceVersion: "7",
+  });
+  const headers = new Headers({
+    authorization: `Bearer ${HOSTED_CLOUDFLARE_INJECTED_CREDENTIAL}`,
+    "content-type": "application/json; charset=utf-8",
+    [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId,
+    "x-private-request-header": "private-request-header",
+  });
+  writeRunnerRuntimeWriteFenceHeaders(headers, {
+    attemptId: lease.attemptId,
+    generation: lease.generation,
+    workspaceVersion: lease.workspaceVersion ?? "7",
+  });
+  const providerRequest = new Request(
+    "https://api.openai.com/v1/images/generations?private_query=private-query",
+    {
+      body: JSON.stringify({
+        attemptDetail: "private-attempt-detail",
+        model: "private-model",
+        prompt: "private-provider-payload",
+      }),
+      headers,
+      method: "POST",
+    },
+  );
+
+  return await handleHostedRunnerOpenAiOutbound(
+    providerRequest,
+    readWorkerEnvironmentSource(),
+    { containerId: "private-runner-container-id" },
+    async () => new Response("private-upstream-response-body", {
+      headers: {
+        "content-type": "application/problem+json",
+        "x-private-response-header": "private-response-header",
+      },
+      status: 401,
+      statusText: "Synthetic Unauthorized",
+    }),
+  );
 }
 
 function getUserRunnerStub(userId: string) {

--- a/apps/cloudflare/test/workers/wrangler.vitest.jsonc
+++ b/apps/cloudflare/test/workers/wrangler.vitest.jsonc
@@ -21,6 +21,10 @@
       {
         "name": "DEVICE_WEBHOOK_QUEUE_MONITOR",
         "class_name": "DeviceWebhookQueueHealthDurableObject"
+      },
+      {
+        "name": "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+        "class_name": "OpenAiAuthorizationAlertDurableObject"
       }
     ]
   },
@@ -40,6 +44,10 @@
     {
       "tag": "v4",
       "new_sqlite_classes": ["DeviceWebhookQueueHealthDurableObject"]
+    },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["OpenAiAuthorizationAlertDurableObject"]
     }
   ],
   "queues": {

--- a/apps/cloudflare/test/workers/wrangler.vitest.jsonc
+++ b/apps/cloudflare/test/workers/wrangler.vitest.jsonc
@@ -24,7 +24,7 @@
       },
       {
         "name": "OPENAI_AUTHORIZATION_ALERT_MONITOR",
-        "class_name": "OpenAiAuthorizationAlertDurableObject"
+        "class_name": "VitestOpenAiAuthorizationAlertDurableObject"
       }
     ]
   },
@@ -47,7 +47,7 @@
     },
     {
       "tag": "v5",
-      "new_sqlite_classes": ["OpenAiAuthorizationAlertDurableObject"]
+      "new_sqlite_classes": ["VitestOpenAiAuthorizationAlertDurableObject"]
     }
   ],
   "queues": {
@@ -91,6 +91,7 @@
     "HOSTED_WEB_BASE_URL": "http://127.0.0.1:8913",
     "HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"xSelVJv6r6LPUS8GCNgj1T_7z5GXOrhgY1cCdzGb5ao\",\"y\":\"8HhciS1cAPKs_fPfgZnb1USdRtBX-4Nvp8XiBHuMcmY\",\"d\":\"HAPljluiFVW3g-UEmrJ9NVYTlclAhaC8N5LT0h7vitQ\",\"ext\":true,\"key_ops\":[\"sign\"]}",
     "LINQ_API_TOKEN": "linq-token",
+    "OPENAI_API_KEY": "openai-worker-test-key",
     "MURPH_HOSTED_EXECUTION_STDIO_LOGS": "0",
     "VITEST": "true"
   }

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -52,6 +52,10 @@
         "class_name": "DeviceWebhookQueueHealthDurableObject"
       },
       {
+        "name": "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+        "class_name": "OpenAiAuthorizationAlertDurableObject"
+      },
+      {
         "name": "RUNNER_CONTAINER",
         "class_name": "RunnerContainer"
       },
@@ -84,6 +88,10 @@
     {
       "tag": "v5",
       "new_sqlite_classes": ["DeviceWebhookQueueHealthDurableObject"]
+    },
+    {
+      "tag": "v6",
+      "new_sqlite_classes": ["OpenAiAuthorizationAlertDurableObject"]
     }
   ],
   "triggers": {

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -1103,6 +1103,10 @@ export function buildWranglerLocalDevConfig(
           class_name: "DeviceWebhookQueueHealthDurableObject",
         },
         {
+          name: "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+          class_name: "OpenAiAuthorizationAlertDurableObject",
+        },
+        {
           name: "RUNNER_CONTAINER",
           class_name: "RunnerContainer",
         },
@@ -1132,6 +1136,10 @@ export function buildWranglerLocalDevConfig(
       {
         tag: "v5",
         new_sqlite_classes: ["DeviceWebhookQueueHealthDurableObject"],
+      },
+      {
+        tag: "v6",
+        new_sqlite_classes: ["OpenAiAuthorizationAlertDurableObject"],
       },
     ],
     triggers: {

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -1625,6 +1625,10 @@ describe("buildWranglerLocalDevConfig", () => {
           class_name: "DeviceWebhookQueueHealthDurableObject",
           name: "DEVICE_WEBHOOK_QUEUE_MONITOR",
         },
+        {
+          class_name: "OpenAiAuthorizationAlertDurableObject",
+          name: "OPENAI_AUTHORIZATION_ALERT_MONITOR",
+        },
       ]),
     });
     expect(config.migrations).toEqual(expect.arrayContaining([
@@ -1635,6 +1639,10 @@ describe("buildWranglerLocalDevConfig", () => {
       {
         new_sqlite_classes: ["DeviceWebhookQueueHealthDurableObject"],
         tag: "v5",
+      },
+      {
+        new_sqlite_classes: ["OpenAiAuthorizationAlertDurableObject"],
+        tag: "v6",
       },
     ]));
     expect(config.triggers).toEqual({


### PR DESCRIPTION
## Why and outcome

Murph can authorize hosted OpenAI egress and inject its Worker-owned credential
while OpenAI still rejects the request with HTTP 401 or 403. That global
authorization failure can prevent hosted AI replies without reaching the
existing database-health text page.

This change sends a privacy-safe SEV1 page to the two existing operator Linq
chats on the first such upstream rejection. Repeats coalesce, delivery retries
reuse exact persisted bytes and idempotency key, fresh failures can admit one
hourly reminder, and 15 quiet minutes close the incident without a recovery
text. The original OpenAI response remains unchanged.

## Product UX

- Effort: Product change to the existing operator-page journey.
- Walkthrough: Ready.
- Affected people: both existing operator-chat recipients receive the same
  four-line SEV1 status/count/timestamp page. Members receive no new message.
- Recovery: failed Linq delivery stays pending for a five-minute native-alarm
  retry; repeated failures remain bounded; quiet closure is silent.
- Plan variance: none.

## Evidence

- Production-derived root-cause boundary: Murph authorization and Worker key
  injection succeeded before the upstream OpenAI 401, making an authorized
  401/403 the narrow global credential/account failure fingerprint.
- Original candidate proof: 300 Cloudflare focused tests, 94 hosted-local
  configuration tests, 5 Workers runtime configuration tests, Cloudflare and
  hosted-local typechecks, and `git diff --check` passed.
- Corrected candidate proof: 277 focused Node tests passed across egress
  interception and alert ownership; the focused egress suite rerun passed all
  264 tests; one Workers-pool composed test passed across the alert binding
  behavior and real Linq sender; Cloudflare typecheck and `git diff --check`
  passed.
- The composed proof returns the identical upstream 401 response, records
  exactly two fake Linq POSTs with stable distinct idempotency keys and equal
  four-line messages, and rejects request, provider, credential, member, and
  runner details from both messages.
- Hosted-local config Vitest: 94 tests passed.
- `@murphai/hosted-local-harness` typecheck: passed.
- Round-two remediation proof: 13 focused Durable Object tests passed,
  including alarm-driven and report-driven quiet boundaries with an older page
  pending; the 277-test Node suite, composed Workers-runtime test, Cloudflare
  typecheck, privacy-shape scan, and `git diff --check` also passed.
- No real provider request or Linq message was generated during verification.

## Non-obvious affected surfaces

- Authorized OpenAI provider egress: inspects only the returned status after
  Murph authorization/key injection; tests prove success, local rejection, and
  transport failures do not report.
- Operator Linq delivery: reuses the existing two-chat sender, preflight, token,
  and idempotency behavior; no recipient or secret is added.
- Cloudflare Durable Objects: adds one global SQLite incident atom, one native
  alarm, the production/local/test binding, and append-only migration `v6`.
- Hosted-local configuration: mirrors the production class/binding/migration so
  local runtime configuration remains faithful.

## Architecture and reuse

- Existing systems reused: the existing operator Linq sender, two direct-chat
  configuration values, line-health preflight, Worker egress authorization
  boundary, Durable Object RPC, and SQLite/alarm primitives.
- New logic: one failure-only reporter and one global incident state machine for
  coalescing, stable delivery retry, hourly reminders, and quiet closure.
- Review simplification deleted the redundant attempt-generation and lease
  lifecycle. The exact pending tuple plus its five-minute retry timestamp now
  owns reservation and retry timing; no replacement state or abstraction was
  added.
- New abstractions: one Durable Object class is the necessary global
  coordination owner; existing Worker contracts are sufficient for every other
  boundary.
- Complexity intentionally avoided: no new provider, recipient, secret, cron,
  queue, service, public route, database truth, recovery text, or generic
  multi-provider alert framework.

## Hot reply path impact

- Applicable only after an authorized OpenAI request has already returned HTTP
  401/403.
- Successful requests add no Durable Object call; they perform only the status
  comparisons already needed to return the response.
- A qualifying failure starts at most one global Durable Object RPC. It remains
  deferred when `waitUntil` successfully owns the promise. The real Containers
  outbound context has no `waitUntil`, so that failed 401/403 path awaits only
  the short Durable Object admission before returning the identical response.
  A thrown `waitUntil` registration uses the same caught promise and fixed
  privacy-safe warning.
- Durable persistence precedes Linq I/O inside the alert owner. Linq retry is
  five minutes by native alarm; reporting and delivery failures are isolated
  and return the original upstream `Response` object unchanged.
- Before: zero alert calls. After: zero on success and at most one RPC per
  authorized upstream 401/403. Focused tests prove response identity, body,
  headers, status, and status text are preserved, and that the no-`waitUntil`
  handler cannot settle before durable admission settles.

## Murph initial provider input impact

- Individual runtime: not applicable; no instructions, prompts, tool schemas,
  generated guidance, model selection, or provider-visible input changed.
- Group runtime: not applicable for the same reason.
- Measurement: static owner-boundary inspection; no provider-input surface was
  modified, so token/byte comparison is not applicable.

## Change-shape breakdown

Classification uses base-to-head authored lines: runtime files are source;
tests and Workers test scaffolding are tests/fixtures; runtime/plan/Frog prose
is docs; config generators and Wrangler/local config are config/tooling. No
binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 943 | 0 |
| Tests/fixtures | 1353 | 0 |
| Docs | 297 | 0 |
| Config/tooling | 16 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **2609** | **0** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old Worker instances ignore the additive namespace; new
  instances carry the class export, binding, migration, and call site together.
  Successful OpenAI egress is unchanged. No Vercel tandem deploy or
  compatibility window is needed.
- Safe order: deploy the Cloudflare Worker artifact and generated production
  config together with `OpenAiAuthorizationAlertDurableObject`,
  `OPENAI_AUTHORIZATION_ALERT_MONITOR`, and append-only SQLite migration `v6`.
  Keep the existing five-minute cron unchanged; this owner uses native alarms.
- Rollback floor: deploy a compatibility build that disables the egress call
  site while retaining the class export, binding, and `v6` migration so armed
  retry/quiet alarms can finish. Never remove or renumber the namespace or
  migration.
- Expected exposure: during rollout, old instances do not page and new
  instances do; no member-visible behavior or provider input changes.
- Reversibility: the call site can be disabled by a Cloudflare-only forward
  fix while the additive state owner remains compatible.
- Convergence proof: verify the serving Worker revision and live binding
  metadata match the generated config.
- Post-deploy checks: confirm class/binding/`v6` parity and unchanged cron;
  inspect only bounded fixed-code observability. Do not manufacture an OpenAI
  401/403 or send a test Linq message.
- Merge does not authorize a manual deployment. Production rollout remains on
  the protected repository workflow and is verified read-only after merge.

## ReviewGPT

- Preliminary `completion-specialists`: one accepted coverage finding required
  a real composed Worker proof; resolved by the Workers-pool binding/Linq test.
- Final round 1 on the immutable first-reviewed head: accepted the missing
  no-`waitUntil` lifetime ownership finding and the behavior-preserving
  complexity collapse. Both are implemented by ReviewGPT.
- ReviewGPT remediation artifact: gzip SHA-256
  `0e049693b56262330ca89a9d131ecaa3e054bbb1f78be203ac9bcd2e84cb7596`;
  decoded patch SHA-256
  `4ab51b92d8c9e45b6730dd30f1e8cb0529ed0f57b8551a422a52dc4938c2f2e5`.
- One ReviewGPT-authored test-import correction aligned TypeScript with the
  existing production-shaped Containers Vitest stub; no cast or production
  change was added.
- Final sensitive-context round 2 on corrected head `b72f60ea207f` returned
  `ROUND_OUTCOME: FINDINGS`. The accepted silent-loss finding is remediated on
  head `6569469af994`: one pure predicate derives the deferred current incident
  from existing fields, both quiet-close entry points preserve it, and alarm
  selection leaves the older pending tuple as sole owner until the unchanged
  success handoff admits the deferred page. No field, slot, queue, lease,
  lifecycle owner, or scheduler was added.
- Final round 3 first had one invocation-only `INVALID` retry, then returned
  the mandatory round-number `RETROSPECTIVE_REQUIRED` gate with no tactical
  finding. The completed PR retrospective chose justified continuation: current
  production source is 13 lines smaller than the immutable first-reviewed
  design and retains one Durable Object, one SQLite row/pending tuple, one
  native alarm, and the existing Linq sender.
- Final sensitive-context round 4 returned `ROUND_OUTCOME: PASS` on exact code
  head `6569469af994` with no qualifying finding and verified every prior
  correction. Final head `b0941060a716` adds only execution-plan closure prose;
  repository policy does not reopen ReviewGPT for that docs-only commit.
- All repository-required GitHub checks are green on final head
  `b0941060a716`: both CLI host matrices, the hosted Stripe billing boundary,
  and exact-SHA Temporal compatibility passed. The prior code head's only
  failing lane was one unrelated assistant-engine test outside this PR; that
  exact named test passed locally before the normal failed-job rerun.

## Changelog

- Changelog: not applicable
- Reason: operator-only incident detection; members receive no new behavior,
  message, copy, or product surface.

ReviewGPT context sensitivity: sensitive
Reason: provider authorization, external operator messaging, persisted SQLite
state, alarms, idempotency, and Cloudflare deployment configuration change.

ReviewGPT first-reviewed head: eeaf87ebe2abdc71c0ea022ed1a92f9734bdf2dd
