### PR TITLE
Keep device-sync changelog copy outcome-focused

### DIFF
--- a/apps/web/changelog/entries/2026-08-29/device-sync-follow-through.json
+++ b/apps/web/changelog/entries/2026-08-29/device-sync-follow-through.json
@@ -7,7 +7,7 @@
     "priority": 3,
     "title": "Connected data keeps moving",
     "summary": "Murph now finishes retained wearable imports before starting another scheduled sync pass, helping connected activity and health data reach follow-up work without repeated delay.",
-    "details": "Scheduled provider work remains Web-owned and resumes after retained imports drain, so one or more bounded continuation passes can run first. Data is not marked processed until its existing import work reaches a terminal result.",
+    "details": "Scheduled sync checks resume only after retained imports finish. Murph may need more than one pass to work through the backlog, and it does not mark data processed until the import succeeds or reaches a confirmed failure.",
     "relevanceTags": ["wearables", "assistant", "reliability"],
     "sourcePullRequests": [2568]
   }


### PR DESCRIPTION
## Outcome

Replace internal implementation wording in the August 29 device-sync recovery changelog item with member-oriented copy. Production behavior is unchanged; this restores the existing outcome-copy guard on current main.

## Product UX result

- Classification: tiny meaning-preserving copy correction.
- Outcome: the public archive explains that retained imports finish before later sync checks, without exposing internal owner or provider terminology.
- Walkthrough: Ready. The same recovery claim remains visible through the unchanged production archive component.

## Direct evidence

- `pnpm --dir apps/web test -- changelog.test.ts` - 39 passed, including the previously failing outcome-oriented copy guard.
- `pnpm --dir apps/web test -- changelog-page.test.tsx` - 9 passed.
- `pnpm --dir apps/web typecheck` - passed.
- `git diff --check` - passed.

## Non-obvious affected surfaces

Only the authored public changelog fragment changes. Changelog rendering, feed shape, source PR attribution, and device-sync runtime behavior are unchanged.

## Architecture and reuse

- Existing systems reused: the existing dated changelog fragment, generated registry, archive renderer, and copy guard.
- New logic: none; one details string is rewritten without changing its factual boundary.
- New abstractions: no abstraction is needed because the existing fragment owns this public copy.
- Complexity intentionally avoided: no test weakening, renderer change, new entry, or runtime compatibility path.

## Hot reply path impact

None. No runtime code, database access, provider call, or assistant reply path changes.

## Provider-input impact

None. No prompt, tool schema, model routing, or provider-visible request changes.

## Design proof

- Production reference: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: content-only copy uses the unchanged production archive component.

## Change shape

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 1 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1** | **1** |

## Changelog

- Changelog: updated
- Items: 2026-08-29 · device-sync-follow-through

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new Web versions differ only in public archive wording.
- Safe order: merge normally; no Cloudflare or database coordination is required.
- Rollback floor: the prior Web revision remains valid and needs no data repair.
- Expected exposure: archive readers may see either wording during normal Web rollout convergence.
- Reversibility: redeploy the prior Web revision to restore the prior wording.
- Convergence proof: the production Web deployment reaches the merged revision.
- Post-deploy checks: open the August 29 archive item and confirm the outcome-oriented details render.

ReviewGPT context sensitivity: routine - meaning-preserving public copy correction only.
