### PR TITLE
Classify hosted reconciliation failures

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-30-reconciliation-facts-failure-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-08-30-reconciliation-facts-failure-telemetry.md
@@ -1,0 +1,85 @@
+# Reconciliation facts failure telemetry
+
+Status: active
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Make the next hosted reconciliation-facts 500 failure distinguishable by a
+  closed processing stage and bounded error class through the existing Vercel
+  failure log, without changing reconciliation behavior.
+
+## Success criteria
+
+- Failure-only telemetry identifies whether canonical facts, visible-access
+  enrichment, or notice/recheck work failed, plus a safe low-cardinality error
+  classification.
+- No messages, payloads, prompts, health values, member/contact identifiers,
+  request paths, raw errors, stacks, provider text, credentials, or query text
+  enter the log.
+- The patch adds no success-path event, database/provider call, retry, write,
+  state owner, queue, scheduler, response change, or user-visible behavior.
+- Focused tests, privacy/log guards, Web typecheck, exact-head ReviewGPT gates,
+  and required CI pass.
+
+## Scope
+
+- In scope: the existing Web-owned reconciliation-facts failure boundary,
+  focused tests, and the durable hosted Web observability contract.
+- Out of scope: functional reconciliation changes, Temporal behavior, database
+  or provider state, device sync, retries, alerts, or production traffic.
+
+## Constraints
+
+- ReviewGPT exclusively authors production implementation and remediation; the
+  parent applies only an exact inspected patch.
+- Reuse the existing failure log and emit one bounded record only when the
+  route already fails.
+- Keep stage and error-class values closed and low-cardinality; preserve and
+  rethrow the original error unchanged.
+
+## Risks and mitigations
+
+1. Risk: instrumentation changes response or retry behavior.
+   Mitigation: assign only closed stage values, log in the existing failure
+   path, and rethrow the identical error; prove the response remains unchanged.
+2. Risk: error metadata leaks private or high-cardinality values.
+   Mitigation: log only closed enums and explicitly allowlisted stable codes,
+   with exact negative assertions for raw messages, stacks, IDs, paths, and
+   payload values.
+3. Risk: adjacent work is mistaken for duplicate ownership.
+   Mitigation: exact-diff review found no active PR, issue, plan, or branch
+   answering this telemetry question; nearby cold-runner, Codex upgrade, and
+   call-circle work is semantically independent.
+
+## Tasks
+
+1. Obtain the smallest ReviewGPT-authored telemetry, test, and documentation
+   patch from a privacy-safe implementation packet.
+2. Inspect question coverage, privacy, cardinality, runtime overhead, behavior
+   preservation, device-lane isolation, and deployment compatibility.
+3. Apply the accepted patch exactly and run focused proof.
+4. Commit, push, open the telemetry-only PR, and run specialist/final ReviewGPT
+   concurrently with CI.
+5. Merge and deploy only if every autonomous telemetry gate remains satisfied;
+   otherwise leave the PR ready and report the exact external action.
+
+## Decisions
+
+- Seven-day Vercel evidence contains five reconciliation-facts 500 responses,
+  including one in the preceding four-hour window and none in the latest four
+  hours. Temporal has no terminal non-device workflow failure or queue backlog,
+  but the retained Vercel fingerprint does not classify the failing owner step.
+- The exact later query will aggregate the new stage and error class for the
+  fixed failure message from deployment readiness until the next natural
+  occurrence. No synthetic production traffic will be generated.
+- Internal-only observability is not member-visible, so no changelog item is
+  required.
+
+## Verification
+
+- Run focused reconciliation-facts and visible-route tests.
+- Run targeted lint, Web typecheck, logging/privacy guards, and `git diff --check`.
+- Run preliminary `completion-specialists` with the coverage lens and final
+  sensitive ReviewGPT on the exact pushed head, concurrently with CI.

--- a/agent-docs/exec-plans/completed/2026-08-30-reconciliation-facts-failure-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-reconciliation-facts-failure-telemetry.md
@@ -1,6 +1,6 @@
 # Reconciliation facts failure telemetry
 
-Status: active
+Status: completed
 Created: 2026-08-30
 Updated: 2026-08-30
 
@@ -83,3 +83,19 @@ Updated: 2026-08-30
 - Run targeted lint, Web typecheck, logging/privacy guards, and `git diff --check`.
 - Run preliminary `completion-specialists` with the coverage lens and final
   sensitive ReviewGPT on the exact pushed head, concurrently with CI.
+
+## Completion evidence
+
+- ReviewGPT-authored implementation patch SHA-256:
+  `68da1a193879343c297a96ca410493d84647b35edf719414bacef9b54cba67bc`.
+- ReviewGPT-authored privacy-guard remediation SHA-256:
+  `fe91889032d739c54564b8ae291e572d1db9e81a5b6f3c7d1889153f7d82081e`.
+- Four focused Vitest files passed all 83 tests; Web typecheck,
+  `pnpm logs:guard`, targeted ESLint, and `git diff --check` passed.
+- Preliminary coverage-specialist ReviewGPT returned
+  `SPECIALIST_OUTCOME: PASS` with no findings on
+  `153b7c091648f1acd713b09e25c1999eaf196b5b`.
+- Final sensitive ReviewGPT returned `ROUND_OUTCOME: PASS` with no findings on
+  the same immutable head; all required GitHub checks passed.
+- Draft PR: https://github.com/cobuildwithus/murph/pull/2579
+Completed: 2026-08-30

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -85,6 +85,27 @@ workspace-runtime pass, and checkpoints through the web-owned workspace CAS. It 
 opaque encrypted runtime blobs and explicit execution-time callback data, but it is not the
 canonical owner of hosted product facts.
 
+## Reconciliation-facts failure observability
+
+The Web-owned reconciliation-facts route emits one additional failure-only
+Vercel record with the fixed message
+`Hosted runtime reconciliation facts failed.` and schema
+`murph.hosted-runtime.reconciliation-facts.failure.v1`. Its `stage` is one of
+`canonical_access_workspace`, `canonical_consent`, `canonical_mailbox`,
+`canonical_projection`, `canonical_usage`, `visible_access`,
+`blocked_access_notice`, or `canonical_recheck`; its `errorClass` is one of
+`hosted_onboarding`, `type_error`, `error`, or `non_error`. Its structured
+metadata contains only `schema`, `stage`, and `errorClass`. It never includes
+raw errors, messages,
+stacks, causes, identifiers, route or request data, payloads, provider or query
+text, or arbitrary metadata. No record is emitted on success.
+
+Verification uses natural traffic only. From the Web deployment-ready timestamp
+through the next natural occurrence, filter Vercel logs by the exact message and
+schema, then count grouped only by message, `stage`, and `errorClass`. The record
+is additive and Web-only: older deployments and readers tolerate its absence,
+and rollback is an ordinary Web rollback with no state or cross-plane drain.
+
 ## Health-data withdrawal rollback floor
 
 Deploy the consent-aware Cloudflare Worker before the Web deployment that can

--- a/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
+++ b/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
 import {
   hostedOnboardingError,
+  isHostedOnboardingError,
 } from "@/src/lib/hosted-onboarding/errors";
 import {
   jsonOk,
@@ -17,12 +18,23 @@ import {
 } from "@/src/lib/hosted-onboarding/http";
 import {
   readHostedRuntimeReconciliationFactsWithVisibleAccess,
+  type HostedRuntimeReconciliationFactsProcessingStage,
 } from "@/src/lib/hosted-orchestration/visible-runtime-reconciliation";
 import {
   resolveDecodedRouteParam,
 } from "@/src/lib/http";
 
 const HOSTED_ORCHESTRATION_RECONCILIATION_FACTS_CALLBACK_BODY_LIMIT_BYTES = 0;
+const HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_MESSAGE =
+  "Hosted runtime reconciliation facts failed.";
+const HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_SCHEMA =
+  "murph.hosted-runtime.reconciliation-facts.failure.v1";
+
+type HostedRuntimeReconciliationFailureErrorClass =
+  | "hosted_onboarding"
+  | "type_error"
+  | "error"
+  | "non_error";
 
 export const GET = withJsonError(async (
   request: Request,
@@ -41,9 +53,25 @@ export const GET = withJsonError(async (
     userId: routeUserId,
   });
 
-  const facts = await readHostedRuntimeReconciliationFactsWithVisibleAccess(
-    factsRequest,
-  );
+  let failureStage: HostedRuntimeReconciliationFactsProcessingStage =
+    "canonical_access_workspace";
+  let facts: Awaited<
+    ReturnType<typeof readHostedRuntimeReconciliationFactsWithVisibleAccess>
+  >;
+  try {
+    facts = await readHostedRuntimeReconciliationFactsWithVisibleAccess(
+      factsRequest,
+      (stage) => {
+        failureStage = stage;
+      },
+    );
+  } catch (error) {
+    emitHostedRuntimeReconciliationFailure({
+      error,
+      stage: failureStage,
+    });
+    throw error;
+  }
 
   return jsonOk(projectHostedRuntimeReconciliationFactsWireResponse(facts));
 });
@@ -61,4 +89,36 @@ function assertHostedOrchestrationUserMatches(input: {
     httpStatus: 403,
     message: "Hosted orchestration request is not authorized for this user.",
   });
+}
+
+function emitHostedRuntimeReconciliationFailure(input: {
+  error: unknown;
+  stage: HostedRuntimeReconciliationFactsProcessingStage;
+}): void {
+  try {
+    const errorClass = classifyHostedRuntimeReconciliationFailure(input.error);
+    const stage = input.stage;
+    console.error(HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_MESSAGE, {
+      errorClass,
+      schema: HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_SCHEMA,
+      stage,
+    });
+  } catch {
+    // Failure telemetry must never replace the original reconciliation failure.
+  }
+}
+
+function classifyHostedRuntimeReconciliationFailure(
+  error: unknown,
+): HostedRuntimeReconciliationFailureErrorClass {
+  if (isHostedOnboardingError(error)) {
+    return "hosted_onboarding";
+  }
+  if (error instanceof TypeError) {
+    return "type_error";
+  }
+  if (error instanceof Error) {
+    return "error";
+  }
+  return "non_error";
 }

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -86,6 +86,13 @@ type HostedRuntimeReconciliationDecisionSource = "workflow" | "status";
 type HostedRuntimeDeniedAiUsageDecision =
   Extract<HostedRuntimeUsageGateCheck, { status: "denied" }>["decision"];
 
+export type HostedRuntimeReconciliationFactsStage =
+  | "canonical_access_workspace"
+  | "canonical_consent"
+  | "canonical_mailbox"
+  | "canonical_projection"
+  | "canonical_usage";
+
 const HOSTED_RUNTIME_RECONCILIATION_FACTS_LOG_SCHEMA =
   "murph.hosted-runtime.reconciliation-facts.v1";
 const HOSTED_RUNTIME_RECONCILIATION_ENGAGEMENT_PAUSE_RETRY_MS =
@@ -134,7 +141,9 @@ export async function readHostedRuntimeReconciliationFacts(
     now?: Date | string;
     usageGateMode?: HostedRuntimeReconciliationUsageGateMode;
   },
+  reportStage?: (stage: HostedRuntimeReconciliationFactsStage) => void,
 ): Promise<HostedRuntimeReconciliationFacts> {
+  reportStage?.("canonical_access_workspace");
   const prisma = getPrisma();
   const now = normalizeHostedRuntimeReconciliationDate(input.now);
   const [hasActiveAccess, workspace] = await Promise.all([
@@ -144,6 +153,7 @@ export async function readHostedRuntimeReconciliationFacts(
     }),
     readHostedWorkspace({ prisma, userId: input.userId }),
   ]);
+  reportStage?.("canonical_projection");
   const projectedWorkspace = projectHostedRuntimeReconciliationWorkspace(workspace);
 
   if (!hasActiveAccess) {
@@ -169,10 +179,13 @@ export async function readHostedRuntimeReconciliationFacts(
     return facts;
   }
 
-  if (await readHostedHealthDataConsentState({
+  reportStage?.("canonical_consent");
+  const healthDataConsentState = await readHostedHealthDataConsentState({
     memberId: input.userId,
     prisma,
-  }) === "revoked") {
+  });
+  reportStage?.("canonical_projection");
+  if (healthDataConsentState === "revoked") {
     const facts = buildHostedRuntimeBlockedFacts({
       mailboxLag: [],
       reason: "health_data_consent_withdrawn",
@@ -188,6 +201,7 @@ export async function readHostedRuntimeReconciliationFacts(
     return facts;
   }
 
+  reportStage?.("canonical_mailbox");
   const [
     maxSeqByLane,
     consumedSeqByLane,
@@ -199,6 +213,7 @@ export async function readHostedRuntimeReconciliationFacts(
       userId: input.userId,
     }),
   ]);
+  reportStage?.("canonical_projection");
   const redactedStatus = readHostedMailboxRedactedStatusRecord(
     workspace?.redactedStatusJson,
   );
@@ -225,6 +240,7 @@ export async function readHostedRuntimeReconciliationFacts(
     return facts;
   }
 
+  reportStage?.("canonical_mailbox");
   const workspaceWithSystemMailboxFrontier = {
     ...projectedWorkspace,
     systemMailboxFrontier: await readHostedRuntimeSystemMailboxFrontier({
@@ -237,6 +253,7 @@ export async function readHostedRuntimeReconciliationFacts(
     }),
   } satisfies HostedRuntimeReconciliationFactsWorkspace;
 
+  reportStage?.("canonical_projection");
   const freshConversationMailboxLag = hasHostedFreshConversationMailboxLag({
     consumedSeqByLane,
     mailboxLag,
@@ -283,6 +300,7 @@ export async function readHostedRuntimeReconciliationFacts(
     return facts;
   }
 
+  reportStage?.("canonical_usage");
   const usageGateRequired = hostedRuntimeReconciliationNeedsAiUsageGate({
     freshConversationMailboxLag,
     now,
@@ -303,6 +321,7 @@ export async function readHostedRuntimeReconciliationFacts(
     ]);
 
     if (gate.status === "health_data_consent_withdrawn") {
+      reportStage?.("canonical_projection");
       const facts = buildHostedRuntimeBlockedFacts({
         mailboxLag,
         reason: "health_data_consent_withdrawn",
@@ -343,6 +362,7 @@ export async function readHostedRuntimeReconciliationFacts(
           userId: input.userId,
         });
       }
+      reportStage?.("canonical_projection");
       const facts = buildHostedRuntimeBlockedFacts({
         mailboxLag,
         reason: "ai_usage_denied",
@@ -363,6 +383,7 @@ export async function readHostedRuntimeReconciliationFacts(
       return facts;
     }
 
+    reportStage?.("canonical_projection");
     const facts = parseHostedRuntimeReconciliationFacts({
       blocked: null,
       mailboxLag,
@@ -377,6 +398,7 @@ export async function readHostedRuntimeReconciliationFacts(
     return facts;
   }
 
+  reportStage?.("canonical_projection");
   const facts = parseHostedRuntimeReconciliationFacts({
     blocked: null,
     mailboxLag,

--- a/apps/web/src/lib/hosted-orchestration/visible-runtime-reconciliation.ts
+++ b/apps/web/src/lib/hosted-orchestration/visible-runtime-reconciliation.ts
@@ -31,18 +31,25 @@ import {
 import { getPrisma } from "../prisma";
 import {
   readHostedRuntimeReconciliationFacts,
+  type HostedRuntimeReconciliationFactsStage,
 } from "./runtime-reconciliation-facts";
 
 const HOSTED_VISIBLE_ACCESS_RETRY_MS = 30_000;
 type HostedRuntimeReconciliationFacts = Awaited<
   ReturnType<typeof readHostedRuntimeReconciliationFacts>
 >;
+export type HostedRuntimeReconciliationFactsProcessingStage =
+  | HostedRuntimeReconciliationFactsStage
+  | "visible_access"
+  | "blocked_access_notice"
+  | "canonical_recheck";
 
 export async function readHostedRuntimeReconciliationFactsWithVisibleAccess(
   input: Parameters<typeof readHostedRuntimeReconciliationFacts>[0],
+  reportStage?: (stage: HostedRuntimeReconciliationFactsProcessingStage) => void,
 ): Promise<HostedRuntimeReconciliationFacts> {
   const reconciledAt = new Date();
-  const facts = await readHostedRuntimeReconciliationFacts(input);
+  const facts = await readHostedRuntimeReconciliationFacts(input, reportStage);
   const blockedReason = facts.blocked?.reason;
   if (
     blockedReason !== "user_not_active"
@@ -52,6 +59,7 @@ export async function readHostedRuntimeReconciliationFactsWithVisibleAccess(
     return facts;
   }
 
+  reportStage?.("visible_access");
   const prisma = getPrisma();
   const item = await readHostedMailboxLatestPendingConversationItem({
     afterSeq: 0n,
@@ -106,15 +114,20 @@ export async function readHostedRuntimeReconciliationFactsWithVisibleAccess(
     prisma,
   });
   if (access.kind === "allowed") {
-    return blockedReason === "user_not_active"
-        || blockedReason === "health_data_consent_withdrawn"
-      ? await readHostedRuntimeReconciliationFacts(input)
-      : facts;
+    if (
+      blockedReason === "user_not_active"
+      || blockedReason === "health_data_consent_withdrawn"
+    ) {
+      reportStage?.("canonical_recheck");
+      return await readHostedRuntimeReconciliationFacts(input);
+    }
+    return facts;
   }
   if (access.kind === "silent") {
     return facts;
   }
 
+  reportStage?.("blocked_access_notice");
   if (isHostedLinqConversationMessageWake(wake)) {
     const participantContact = createHostedLinqParticipantContact({
       kind: wake.message.contactKind ?? "phone",

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -397,6 +397,85 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(JSON.stringify(loggedMetadata)).not.toContain(MEMBER_ID);
   });
 
+  it.each([
+    {
+      arrange: (failure: Error) => {
+        mocks.readHostedWorkspace.mockRejectedValueOnce(failure);
+      },
+      stage: "canonical_access_workspace",
+    },
+    {
+      arrange: (failure: Error) => {
+        mocks.hostedConsentGrantFindUnique.mockRejectedValueOnce(failure);
+      },
+      stage: "canonical_consent",
+    },
+    {
+      arrange: (failure: Error) => {
+        mocks.readHostedMailboxMaxSeqByLane.mockRejectedValueOnce(failure);
+      },
+      stage: "canonical_mailbox",
+    },
+    {
+      arrange: (failure: Error) => {
+        mocks.readHostedWorkspace.mockResolvedValueOnce(buildWorkspaceRecord({
+          nextWakeAt: "2026-05-20T11:59:59.000Z",
+          nextWakeReason: "assistant_due",
+        }));
+        mocks.hasHostedMemberEstablishedLinqHomeRoute
+          .mockRejectedValueOnce(failure);
+      },
+      stage: "canonical_projection",
+    },
+    {
+      arrange: (failure: Error) => {
+        mocks.readHostedWorkspace.mockResolvedValueOnce(buildWorkspaceRecord({
+          nextWakeAt: "2026-05-20T11:59:59.000Z",
+          nextWakeReason: "assistant_due",
+        }));
+        mocks.resolveHostedRuntimeAiUsageGate.mockRejectedValueOnce(failure);
+      },
+      stage: "canonical_usage",
+    },
+  ] as const)(
+    "logs a fixed failure record for $stage",
+    async ({ arrange, stage }) => {
+      const failure = new Error("synthetic canonical reconciliation failure");
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      arrange(failure);
+
+      const response = await reconciliationRoute.GET(
+        requestForFacts(),
+        routeContext(),
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Internal error.",
+        },
+      });
+      expect(
+        consoleErrorSpy.mock.calls.filter(
+          ([message]) =>
+            message === "Hosted runtime reconciliation facts failed.",
+        ),
+      ).toEqual([
+        [
+          "Hosted runtime reconciliation facts failed.",
+          {
+            errorClass: "error",
+            schema: "murph.hosted-runtime.reconciliation-facts.failure.v1",
+            stage,
+          },
+        ],
+      ]);
+    },
+  );
+
   it("imports pending system mailbox work before applying model gates", async () => {
     mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
       redactedStatusJson: {

--- a/apps/web/test/hosted-reconciliation-failure-telemetry.test.ts
+++ b/apps/web/test/hosted-reconciliation-failure-telemetry.test.ts
@@ -1,0 +1,226 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import type {
+  HostedRuntimeReconciliationFactsProcessingStage,
+} from "@/src/lib/hosted-orchestration/visible-runtime-reconciliation";
+
+const FAILURE_MESSAGE = "Hosted runtime reconciliation facts failed.";
+const FAILURE_SCHEMA = "murph.hosted-runtime.reconciliation-facts.failure.v1";
+const FAILURE_CASES = [
+  {
+    error: hostedOnboardingError({
+      code: "SYNTHETIC_HOSTED_FAILURE",
+      httpStatus: 500,
+      message: "synthetic hosted failure",
+    }),
+    errorClass: "hosted_onboarding",
+    stage: "canonical_access_workspace",
+  },
+  {
+    error: new TypeError("synthetic type failure"),
+    errorClass: "type_error",
+    stage: "canonical_consent",
+  },
+  {
+    error: new Error("synthetic mailbox failure"),
+    errorClass: "error",
+    stage: "canonical_mailbox",
+  },
+  {
+    error: Object.freeze({ synthetic: true }),
+    errorClass: "non_error",
+    stage: "canonical_projection",
+  },
+  {
+    error: new Error("synthetic usage failure"),
+    errorClass: "error",
+    stage: "canonical_usage",
+  },
+  {
+    error: new Error("synthetic visible-access failure"),
+    errorClass: "error",
+    stage: "visible_access",
+  },
+  {
+    error: new Error("synthetic notice failure"),
+    errorClass: "error",
+    stage: "blocked_access_notice",
+  },
+  {
+    error: new Error("synthetic recheck failure"),
+    errorClass: "error",
+    stage: "canonical_recheck",
+  },
+] as const;
+
+const mocks = vi.hoisted(() => ({
+  readHostedRuntimeReconciliationFactsWithVisibleAccess: vi.fn(),
+  requireHostedCloudflareCallbackRequest: vi.fn(),
+}));
+
+vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
+  requireHostedCloudflareCallbackRequest:
+    mocks.requireHostedCloudflareCallbackRequest,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/http", () => ({
+  jsonOk: (body: unknown) => Response.json(body),
+  withJsonError: (handler: unknown) => handler,
+}));
+
+vi.mock("@/src/lib/hosted-orchestration/visible-runtime-reconciliation", () => ({
+  readHostedRuntimeReconciliationFactsWithVisibleAccess:
+    mocks.readHostedRuntimeReconciliationFactsWithVisibleAccess,
+}));
+
+type ReconciliationRoute = typeof import(
+  "../app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route"
+);
+
+let reconciliationRoute: ReconciliationRoute;
+
+describe("hosted reconciliation failure telemetry", () => {
+  beforeAll(async () => {
+    reconciliationRoute = await import(
+      "../app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route"
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireHostedCloudflareCallbackRequest.mockResolvedValue("member_test");
+    mocks.readHostedRuntimeReconciliationFactsWithVisibleAccess
+      .mockResolvedValue({
+        blocked: null,
+        mailboxLag: [],
+        workspace: null,
+      });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(FAILURE_CASES)(
+    "emits one $errorClass record for $stage and rethrows identically",
+    async ({ error, errorClass, stage }) => {
+      failReconciliationAt(stage, error);
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await expect(callRoute()).rejects.toBe(error);
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(FAILURE_MESSAGE, {
+        errorClass,
+        schema: FAILURE_SCHEMA,
+        stage,
+      });
+    },
+  );
+
+  it("excludes raw errors and every private or arbitrary field", async () => {
+    const privateValue = "private-value-sentinel";
+    const failure = Object.assign(
+      new Error(privateValue, { cause: new Error(privateValue) }),
+      {
+        authorization: privateValue,
+        contactId: privateValue,
+        credential: privateValue,
+        healthValue: privateValue,
+        mailboxId: privateValue,
+        mailboxSequence: privateValue,
+        metadata: { scenario: privateValue },
+        path: privateValue,
+        payload: { value: privateValue },
+        prompt: privateValue,
+        providerText: privateValue,
+        queryText: privateValue,
+        requestId: privateValue,
+        routeParameter: privateValue,
+        transcript: privateValue,
+        url: privateValue,
+        userId: privateValue,
+        workflowId: privateValue,
+      },
+    );
+    failure.stack = privateValue;
+    failReconciliationAt("blocked_access_notice", failure);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(callRoute()).rejects.toBe(failure);
+
+    expect(consoleErrorSpy.mock.calls).toEqual([
+      [
+        FAILURE_MESSAGE,
+        {
+          errorClass: "error",
+          schema: FAILURE_SCHEMA,
+          stage: "blocked_access_notice",
+        },
+      ],
+    ]);
+    expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(privateValue);
+  });
+
+  it("emits no failure record on success", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const response = await callRoute();
+
+    expect(response.status).toBe(200);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original failure when console logging throws", async () => {
+    const failure = new Error("synthetic original failure");
+    failReconciliationAt("canonical_recheck", failure);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {
+        throw new Error("synthetic console failure");
+      });
+
+    await expect(callRoute()).rejects.toBe(failure);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+function failReconciliationAt(
+  stage: HostedRuntimeReconciliationFactsProcessingStage,
+  error: unknown,
+): void {
+  mocks.readHostedRuntimeReconciliationFactsWithVisibleAccess
+    .mockImplementationOnce(async (
+      _input: unknown,
+      reportStage?: (
+        stage: HostedRuntimeReconciliationFactsProcessingStage,
+      ) => void,
+    ) => {
+      reportStage?.(stage);
+      throw error;
+    });
+}
+
+function callRoute(): Promise<Response> {
+  return reconciliationRoute.GET(
+    new Request(
+      "https://join.example.test/api/internal/hosted-orchestration/users/member_test/reconciliation-facts",
+    ),
+    { params: Promise.resolve({ userId: "member_test" }) },
+  );
+}

--- a/apps/web/test/hosted-visible-reconciliation-route.test.ts
+++ b/apps/web/test/hosted-visible-reconciliation-route.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   readHostedRuntimeReconciliationFactsWithVisibleAccess: vi.fn(),
@@ -38,6 +38,10 @@ describe("visible reconciliation facts route", () => {
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("routes authenticated facts reads through the visible-access wrapper", async () => {
     const response = await reconciliationRoute.GET(
       new Request(
@@ -49,11 +53,49 @@ describe("visible reconciliation facts route", () => {
     expect(response.status).toBe(200);
     expect(
       mocks.readHostedRuntimeReconciliationFactsWithVisibleAccess,
-    ).toHaveBeenCalledWith({ userId: "member_123" });
+    ).toHaveBeenCalledWith(
+      { userId: "member_123" },
+      expect.any(Function),
+    );
     await expect(response.json()).resolves.toEqual({
       blocked: null,
       mailboxLag: [],
       workspace: null,
     });
+  });
+
+  it("preserves the existing generic response when reconciliation fails", async () => {
+    const failure = new Error("synthetic reconciliation failure");
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.readHostedRuntimeReconciliationFactsWithVisibleAccess
+      .mockImplementationOnce(async (
+        _input: unknown,
+        reportStage?: (stage: "visible_access") => void,
+      ) => {
+        reportStage?.("visible_access");
+        throw failure;
+      });
+
+    const response = await reconciliationRoute.GET(
+      new Request(
+        "https://join.example.test/api/internal/hosted-orchestration/users/member_123/reconciliation-facts",
+      ),
+      { params: Promise.resolve({ userId: "member_123" }) },
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal error.",
+      },
+    });
+    expect(
+      consoleErrorSpy.mock.calls.filter(
+        ([message]) => message === "Hosted runtime reconciliation facts failed.",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/apps/web/test/hosted-visible-runtime-reconciliation.test.ts
+++ b/apps/web/test/hosted-visible-runtime-reconciliation.test.ts
@@ -535,6 +535,87 @@ describe("visible runtime access reconciliation", () => {
     expect(mocks.resolveHostedRecognizedInboundAccess).not.toHaveBeenCalled();
     expect(mocks.sendHostedTelegramAccessNotice).not.toHaveBeenCalled();
   });
+
+  it("reports visible access before a pending-conversation read fails", async () => {
+    const facts = blockedFacts("user_not_active");
+    const failure = new Error("synthetic visible-access failure");
+    const stages: string[] = [];
+    mocks.readHostedRuntimeReconciliationFacts.mockResolvedValue(facts);
+    mocks.readHostedMailboxLatestPendingConversationItem.mockRejectedValue(failure);
+
+    await expect(readHostedRuntimeReconciliationFactsWithVisibleAccess(
+      { userId: "member_123" },
+      (stage) => stages.push(stage),
+    )).rejects.toBe(failure);
+
+    expect(stages.at(-1)).toBe("visible_access");
+  });
+
+  it("reports canonical recheck before a restored-access recheck fails", async () => {
+    const blocked = blockedFacts("user_not_active");
+    const failure = new Error("synthetic canonical-recheck failure");
+    const stages: string[] = [];
+    mocks.readHostedRuntimeReconciliationFacts
+      .mockResolvedValueOnce(blocked)
+      .mockRejectedValueOnce(failure);
+    mocks.readHostedMailboxWakeByItemId.mockResolvedValue({
+      channel: "telegram",
+      eventId: "telegram:update:recheck",
+      kind: "conversation.message",
+      message: {
+        telegramMessage: {
+          messageId: "7",
+          threadId: "456",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: "2026-07-25T12:00:00.000Z",
+    });
+    mocks.resolveHostedRecognizedInboundAccess.mockResolvedValue({
+      kind: "allowed",
+    });
+
+    await expect(readHostedRuntimeReconciliationFactsWithVisibleAccess(
+      { userId: "member_123" },
+      (stage) => stages.push(stage),
+    )).rejects.toBe(failure);
+
+    expect(stages.at(-1)).toBe("canonical_recheck");
+  });
+
+  it("reports blocked-access notice before Telegram delivery fails", async () => {
+    const facts = blockedFacts("ai_usage_denied");
+    const failure = new Error("synthetic access-notice failure");
+    const stages: string[] = [];
+    mocks.readHostedRuntimeReconciliationFacts.mockResolvedValue(facts);
+    mocks.readHostedMailboxWakeByItemId.mockResolvedValue({
+      channel: "telegram",
+      eventId: "telegram:update:notice",
+      kind: "conversation.message",
+      message: {
+        telegramMessage: {
+          messageId: "7",
+          threadId: "456",
+          threadIsDirect: true,
+        },
+      },
+      occurredAt: "2026-07-25T12:00:00.000Z",
+    });
+    mocks.resolveHostedRecognizedInboundAccess.mockResolvedValue({
+      kind: "access_notice",
+      message: "Synthetic account notice.",
+      noticeCode: "billing_inactive",
+      responseReason: "sent-billing-inactive-notice",
+    });
+    mocks.sendHostedTelegramAccessNotice.mockRejectedValue(failure);
+
+    await expect(readHostedRuntimeReconciliationFactsWithVisibleAccess(
+      { userId: "member_123" },
+      (stage) => stages.push(stage),
+    )).rejects.toBe(failure);
+
+    expect(stages.at(-1)).toBe("blocked_access_notice");
+  });
 });
 
 function blockedFacts(reason: "ai_usage_denied" | "user_not_active") {


### PR DESCRIPTION
## Why and outcome

Intermittent production 500s from the Web-owned hosted reconciliation-facts
route are visible in Vercel, while Temporal remains terminally healthy and the
current failure log cannot identify which owning step failed. That leaves three
concrete hypotheses unresolved: canonical fact collection, visible-access
enrichment, or access-notice/recheck work.

This telemetry-only change emits one failure record through the existing
Vercel log boundary with a closed processing stage and closed error class. It
does not log raw errors or private values and does not change the response,
retry behavior, control flow, state, database/provider calls, or user-visible
behavior.

## Product UX

- Effort: internal observability only; no product-owned dimension changed.
- Walkthrough: not applicable because no member/operator UI, copy, timing,
  permission, delivery, or recovery journey changes.
- Members receive the same response and hosted-runtime behavior as before.

## Evidence

- Bounded seven-day production evidence found five reconciliation-facts 500s,
  including one in the preceding four-hour window and none in the latest four
  hours. Temporal showed no terminal non-device workflow failure or queue
  backlog, so the generic Vercel fingerprint cannot distinguish the failing
  owner step.
- Focused Vitest: 4 files and 83 tests passed. Coverage includes all eight
  closed stages, four closed error classes, identical error rethrow, unchanged
  generic 500 response, one record per failure, no success record, logger
  failure isolation, and private-field exclusions.
- Web typecheck passed after generating the repository's ignored Health Commons
  build artifact required by a clean worktree.
- Targeted ESLint completed with zero errors; its one unused-helper warning is
  pre-existing and outside the changed hunks.
- `pnpm logs:guard` passed after ReviewGPT's narrow privacy-scanner
  correction; `git diff --check` passed.
- No synthetic production traffic, provider request, message, replay, or state
  mutation was generated.

## Non-obvious affected surfaces

- Internal hosted reconciliation-facts route: emits the record only after the
  existing facts read fails and rethrows the identical error.
- Canonical reconciliation reader and visible-access adapter: report only
  synchronous closed stage assignments through optional callbacks.
- Vercel observability: receives one fixed message plus `schema`, `stage`, and
  `errorClass`; no identifier or arbitrary value is present.
- Temporal, Cloudflare, device sync, billing, messaging, canonical state, and
  provider interaction are unchanged.

## Architecture and reuse

- Existing systems reused: the Web route, canonical and visible-access owners,
  Vercel console-log ingestion, existing error mapping, and existing tests.
- New logic: one failure-only log and request-local closed stage tracking.
- New abstractions: none; the existing route and readers remain the owners.
- Complexity intentionally avoided: no backend, database truth, trace store,
  metric service, scheduler, queue, alert, retry, state machine, or success log.

## Hot reply path impact

- No database, network, provider, crypto, or awaited operation is added or
  moved.
- Success path: only bounded in-memory enum assignments through an optional
  callback; no log is emitted.
- Existing failure path: one best-effort `console.error`; logging failure is
  isolated, and the identical original error continues to the existing HTTP
  mapper.
- Call counts, ordering, timeouts, retries, responses, notice behavior, and
  state transitions are unchanged and covered by focused tests.

## Murph initial provider input impact

- Individual runtime: not applicable; no prompt, instruction, tool schema,
  generated guidance, model selection, or provider-visible input changed.
- Group runtime: not applicable for the same reason.
- Measurement: owner-boundary inspection; provider-input token/byte comparison
  is not applicable because no provider request construction changed.

## Change-shape breakdown

Classification uses base-to-head authored lines: runtime TypeScript as source,
Vitest files as tests/fixtures, and the Web observability contract plus closed
execution plan as docs. No config, binary, or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 105 | 10 |
| Tests/fixtures | 430 | 2 |
| Docs | 122 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **657** | **12** |

## Deployment concerns

- Deployment: applicable
- Supported skew: the record is additive and failure-only; old Web revisions
  omit it and new revisions emit it. Existing readers require neither shape.
  Cloudflare and Temporal tolerate both, so no tandem deployment is required.
- Safe order: merge through the protected branch and use the canonical Vercel
  production deployment for Web.
- Rollback floor: ordinary Web rollback; there is no persisted state, schema,
  binding, queue, retention, secret, or configuration change.
- Expected exposure: during rollout, only naturally failing requests served by
  the new revision emit the new bounded record.
- Reversibility: roll back Web; no drain, replay, cleanup, or provider action is
  required.
- Convergence proof: verify the production alias serves the merged revision.
- Post-deploy checks: from deployment readiness through the next natural
  occurrence, filter Vercel logs by the exact fixed message and schema and
  group only by `stage` and `errorClass`; compare Temporal terminal failures
  and queue backlog. Do not generate synthetic traffic.

## Changelog

- Changelog: not applicable
- Reason: internal failure observability only; no member-visible feature, fix,
  copy, workflow, or recovery behavior changes.

## ReviewGPT provenance

- ReviewGPT authored the production/test/docs implementation patch.
- The original patch SHA-256 is
  `68da1a193879343c297a96ca410493d84647b35edf719414bacef9b54cba67bc`.
- ReviewGPT's behavior-preserving privacy-guard correction SHA-256 is
  `fe91889032d739c54564b8ae291e572d1db9e81a5b6f3c7d1889153f7d82081e`.
- Preliminary `completion-specialists` review returned
  `SPECIALIST_OUTCOME: PASS` with no findings on the immutable reviewed head.
- Final sensitive round 1 returned `ROUND_OUTCOME: PASS` with no qualifying
  findings on the same head. The later `35bc9f698686` commit only archives the
  execution plan and records completion evidence; production, tests, and the
  reviewed behavior are unchanged.

ReviewGPT context sensitivity: sensitive — adds production observability at a
hosted-runtime route boundary and must preserve privacy and behavior.
ReviewGPT first-reviewed head: 153b7c091648f1acd713b09e25c1999eaf196b5b
