### PR TITLE
Classify hosted workspace read failures

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-workspace-read-error-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-workspace-read-error-telemetry.md
@@ -1,0 +1,74 @@
+# Classify hosted workspace read failures
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Classify hosted workspace-read HTTP failures with privacy-safe telemetry while
+  preserving the existing request, exception, retry, and user-visible behavior.
+
+## Success criteria
+
+- A bounded background probe records only status, allowlisted code,
+  retryability, forwarded-response state, and a fixed envelope outcome.
+- Unknown, malformed, missing, oversized, or unreadable bodies never expose raw
+  code, messages, payloads, or identifiers.
+- Focused tests prove the exact legacy error and fetch count remain unchanged.
+- Cloudflare focused tests, typecheck, privacy checks, review gates, and CI pass.
+
+## Scope
+
+- In scope: the HostedUserRunner workspace-read failure boundary, its test
+  controls and focused tests, plus the owning runtime protocol documentation.
+- Out of scope: functional retries, Web route behavior, provider interaction,
+  device sync, new persistence, and production traffic generation.
+
+## Constraints
+
+- Technical constraints: reuse Durable Object `waitUntil`, the existing bounded
+  response-body reader, and the existing structured logger; cap bytes and time.
+- Product/process constraints: one telemetry-only PR; no autonomous deployment
+  unless every repository and automation gate passes on the exact head.
+
+## Risks and mitigations
+
+1. Risk: telemetry body inspection delays or changes the caller failure.
+   Mitigation: clone the response and run the bounded probe under `waitUntil`
+   before throwing the same plain `Error` immediately.
+2. Risk: private Web error detail reaches logs.
+   Mitigation: parse only an envelope shape, map codes through a closed allowlist,
+   ignore messages/details, and test private sentinels.
+3. Risk: an unbounded stream consumes Worker resources.
+   Mitigation: enforce a small byte ceiling and existing abort-aware read timeout.
+
+## Tasks
+
+1. Done: implement the bounded failure classifier and background structured log.
+2. Done: add direct regression tests for classified, unknown, malformed, and oversized
+   responses plus unchanged exception/control-flow behavior.
+3. Done: update the runtime protocol, run focused proof, and inspect the full patch.
+4. In progress: commit, push, open the PR, and complete exact-head CI gates.
+
+## Decisions
+
+- The current code discards the Web JSON error envelope and retains only HTTP
+  status, so existing evidence cannot distinguish request-contract, callback
+  authorization/replay, or another handled validation failure.
+- Active rollout, OpenAI paging, and Browser Vault work do not own this narrow
+  response-classification boundary.
+- The user explicitly replaced ReviewGPT implementation/review with local
+  authorship and parent review for this continuation.
+
+## Verification
+
+- Passed: 363 focused Cloudflare tests covering HostedUserRunner and the shared
+  Web-control transport; Cloudflare typecheck; docs drift; log privacy guard;
+  source-sidecar guard; and diff whitespace checks.
+- Passed: canonical `pnpm --dir apps/cloudflare verify` with 151 Node test files
+  (2,726 tests passed, two skipped) and five Workers-runtime files (14 passed).
+- Parent review confirmed the diff is telemetry/tests/docs only, reuses the
+  existing body reader/logger/lifecycle owner, and changes no request, retry,
+  persisted state, provider call, or user-visible behavior.
+Completed: 2026-08-30

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -60,6 +60,11 @@ timeout retry, the 30-second deadline, fixed-schema timeout diagnostics,
 joined-cancellation ownership, and direct proof expectations are specified by
 `agent-docs/references/hosted-runtime-protocol.md`.
 
+Hosted workspace-read failure classification, including the unchanged caller
+error, background bounded envelope inspection, closed error-code allowlist, and
+privacy-safe Worker fields, is specified by
+`agent-docs/references/hosted-runtime-protocol.md`.
+
 Joined-group inventory v2/v3 compatibility, Web-first rollout, and exact
 routed-account availability are jointly specified by
 `agent-docs/product-specs/personal-group-awareness.md` and

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -3803,6 +3803,20 @@ four container-local stages are `lifecycle_lock_or_state_read`,
 `cold_health_or_finalization`. The cleanup boolean overlays the stage that
 triggered cleanup instead of replacing it.
 
+A non-OK Web workspace read also retains one failure-only Worker diagnostic
+without changing its caller-visible exception or retry behavior. The Durable
+Object throws the same plain HTTP-status error immediately and schedules a
+bounded inspection of a cloned response under its existing `waitUntil` owner.
+`Hosted workspace read failure classified.` carries only HTTP status, whether
+the response had the existing forwarded-Web header, a typed retryable boolean
+when present, a closed workspace-route error-code allowlist or `unknown`, and a
+fixed envelope outcome. Inspection is capped at 4 KiB and one second. Unknown,
+missing, malformed, oversized, timed-out, or unreadable bodies collapse to
+fixed buckets; response messages, details, arbitrary codes, request or member
+identifiers, payloads, credentials, and headers other than the forwarded-Web
+boolean never enter the log. The diagnostic adds no retry, request, persisted
+state, provider interaction, or user-visible behavior.
+
 The existing UserRunner startup-confirmation warnings add the same bounded
 elapsed field and one of two caller-owned stages. `rpc_unattributed` means the
 RPC failed, timed out, was unavailable, or returned legacy cleanup-unsettled

--- a/apps/cloudflare/src/runtime-platform/web-control-transport.ts
+++ b/apps/cloudflare/src/runtime-platform/web-control-transport.ts
@@ -464,7 +464,7 @@ async function fetchHostedWebControlPlaneJsonAttempt(
   }
 }
 
-async function readHostedWebControlPlaneResponseText(input: {
+export async function readHostedWebControlPlaneResponseText(input: {
   description: string;
   maxBytes: number | undefined;
   response: Response;

--- a/apps/cloudflare/src/user-runner/hosted-user-runner-test.ts
+++ b/apps/cloudflare/src/user-runner/hosted-user-runner-test.ts
@@ -1,5 +1,6 @@
 import type {
   HostedWorkspaceInvocationResult,
+  HostedWorkspaceReadResponse,
 } from "@murphai/hosted-execution/runtime-control";
 
 import {
@@ -96,6 +97,15 @@ export class HostedUserRunnerWithTestControls extends HostedUserRunner {
       },
       runtimeWakeStartedAt,
       token,
+    });
+  }
+
+  async readHostedWorkspaceFromWebForTest(input: {
+    timeoutMs?: number;
+    userId: string;
+  }): Promise<HostedWorkspaceReadResponse> {
+    return await this.readHostedWorkspaceFromWeb(input.userId, {
+      ...(input.timeoutMs === undefined ? {} : { timeoutMs: input.timeoutMs }),
     });
   }
 

--- a/apps/cloudflare/src/user-runner/hosted-user-runner.ts
+++ b/apps/cloudflare/src/user-runner/hosted-user-runner.ts
@@ -14,6 +14,7 @@ import type {
 } from "@murphai/hosted-execution/orchestration-control";
 import {
   emitHostedExecutionStructuredLog,
+  type HostedExecutionStructuredLogDetails,
 } from "@murphai/hosted-execution";
 import {
   parseHostedRuntimeHealthDataAdmissionResponse,
@@ -36,6 +37,12 @@ import {
   type HostedPrivateMediaPublishResult,
 } from "../private-media.ts";
 import type { HostedExecutionContainerNamespaceLike } from "../runner-container.js";
+import {
+  HOSTED_WEB_CONTROL_FORWARDED_RESPONSE_HEADER,
+} from "../runner-outbound/headers.ts";
+import {
+  readHostedWebControlPlaneResponseText,
+} from "../runtime-platform/web-control-transport.ts";
 import { withSerializedLock } from "../serialized-lock.js";
 import type {
   WorkerAnalyticsEngineDatasetLike,
@@ -97,11 +104,49 @@ const HOSTED_RUNTIME_WITHDRAWN_CONSENT_RETRY_MS = 60_000;
 // The retained hint measured a 693 ms provider-start p50 gain. Abandon its
 // optional admission before it can consume even half of that useful overlap.
 const HOSTED_RUNTIME_SHELL_PREWARM_ADMISSION_TIMEOUT_MS = 250;
+const HOSTED_WORKSPACE_READ_FAILURE_BODY_MAX_BYTES = 4 * 1_024;
+const HOSTED_WORKSPACE_READ_FAILURE_BODY_TIMEOUT_MS = 1_000;
+const HOSTED_WORKSPACE_READ_FAILURE_CODES = [
+  "HOSTED_CLOUDFLARE_CALLBACK_REPLAYED",
+  "HOSTED_CLOUDFLARE_CALLBACK_UNAUTHORIZED",
+  "HOSTED_CUSTOM_CHAT_COMPLETIONS_UNAVAILABLE",
+  "HOSTED_CUSTOM_INFERENCE_CONSUMER_UNSUPPORTED",
+  "HOSTED_CUSTOM_INFERENCE_UNAVAILABLE",
+  "HOSTED_EXECUTION_USER_ID_REQUIRED",
+  "HOSTED_INFERENCE_CONNECTION_INVALID",
+  "HOSTED_INFERENCE_CONNECTION_REVERIFICATION_REQUIRED",
+  "INTERNAL_ERROR",
+  "INVALID_JSON",
+  "INVALID_REQUEST",
+  "REQUEST_BODY_TOO_LARGE",
+] as const;
+
+type HostedWorkspaceReadFailureCode =
+  | (typeof HOSTED_WORKSPACE_READ_FAILURE_CODES)[number]
+  | "unknown";
+
+type HostedWorkspaceReadFailureEnvelopeOutcome =
+  | "body_read_failed"
+  | "body_too_large"
+  | "body_unavailable"
+  | "classified"
+  | "code_missing"
+  | "code_unknown"
+  | "invalid_envelope";
+
+type HostedWorkspaceReadFailureDetails = HostedExecutionStructuredLogDetails & {
+  workspaceReadFailureCode: HostedWorkspaceReadFailureCode;
+  workspaceReadFailureEnvelopeOutcome: HostedWorkspaceReadFailureEnvelopeOutcome;
+  workspaceReadFailureForwardedFromWeb: boolean;
+  workspaceReadFailureRetryable: boolean | null;
+  workspaceReadFailureStatus: number;
+};
 
 export class HostedUserRunner {
   protected readonly stateStore: RunnerStateStore;
   protected readonly runtimeInvocation: RuntimeInvocationService;
   protected readonly runtimeProcessing: RuntimeProcessingController;
+  private readonly state: DurableObjectStateLike;
   private readonly userDataDeletionInput: HostedRunnerUserDataDeletionServiceInput;
   private readonly workspaceSnapshotSessions: WorkspaceSnapshotSessionService;
   private readonly runnerStoreCache: RunnerStoreCache;
@@ -127,6 +172,7 @@ export class HostedUserRunner {
     // Keep this first. The schema floor must reject an older Worker before it
     // can construct any service capable of waking a runner or reading a workspace.
     this.stateStore = new RunnerStateStore(state);
+    this.state = state;
     this.privateMediaBucket = bucket;
     this.privateMediaCapabilitySecret =
       readHostedPrivateMediaCapabilitySecret(runnerRuntimeEnvSource);
@@ -747,7 +793,7 @@ export class HostedUserRunner {
     return admission;
   }
 
-  private async readHostedWorkspaceFromWeb(
+  protected async readHostedWorkspaceFromWeb(
     userId: string,
     input: { timeoutMs?: number } = {},
   ): Promise<HostedWorkspaceReadResponse> {
@@ -764,10 +810,22 @@ export class HostedUserRunner {
     });
 
     if (!response.ok) {
+      this.scheduleHostedWorkspaceReadFailureTelemetry(response);
       throw new Error(`Hosted workspace read failed with HTTP ${response.status}.`);
     }
 
     return parseHostedWorkspaceReadResponse(await response.json());
+  }
+
+  private scheduleHostedWorkspaceReadFailureTelemetry(response: Response): void {
+    try {
+      const telemetry = emitHostedWorkspaceReadFailureTelemetry(response.clone())
+        .catch(() => undefined);
+      this.state.waitUntil(telemetry);
+    } catch {
+      // Observability must never replace or delay the authoritative workspace
+      // read failure that the caller already owns.
+    }
   }
 
   private assertWorkspaceBelongsToRunnerUser(
@@ -782,6 +840,122 @@ export class HostedUserRunner {
   private readHostedWebControlBaseUrl(): string {
     return this.env.hostedWebBaseUrl;
   }
+}
+
+async function emitHostedWorkspaceReadFailureTelemetry(
+  response: Response,
+): Promise<void> {
+  emitHostedExecutionStructuredLog({
+    component: "hosted.runner",
+    details: await buildHostedWorkspaceReadFailureDetails(response),
+    level: "warn",
+    message: "Hosted workspace read failure classified.",
+    phase: "runtime.starting",
+  });
+}
+
+async function buildHostedWorkspaceReadFailureDetails(
+  response: Response,
+): Promise<HostedWorkspaceReadFailureDetails> {
+  const base = {
+    workspaceReadFailureForwardedFromWeb:
+      response.headers.get(HOSTED_WEB_CONTROL_FORWARDED_RESPONSE_HEADER) === "1",
+    workspaceReadFailureStatus: response.status,
+  };
+  const contentLengthText = response.headers.get("content-length")?.trim() ?? "";
+  const contentLength = /^\d+$/u.test(contentLengthText)
+    ? Number(contentLengthText)
+    : null;
+  if (
+    contentLength !== null
+    && Number.isSafeInteger(contentLength)
+    && contentLength > HOSTED_WORKSPACE_READ_FAILURE_BODY_MAX_BYTES
+  ) {
+    return buildUnknownHostedWorkspaceReadFailureDetails(base, "body_too_large");
+  }
+  if (!response.body) {
+    return buildUnknownHostedWorkspaceReadFailureDetails(base, "body_unavailable");
+  }
+
+  let body: string;
+  try {
+    body = await readHostedWebControlPlaneResponseText({
+      description: "Hosted workspace read failure telemetry",
+      maxBytes: HOSTED_WORKSPACE_READ_FAILURE_BODY_MAX_BYTES,
+      response,
+      signal: null,
+      timeoutMs: HOSTED_WORKSPACE_READ_FAILURE_BODY_TIMEOUT_MS,
+    });
+  } catch {
+    return buildUnknownHostedWorkspaceReadFailureDetails(base, "body_read_failed");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return buildUnknownHostedWorkspaceReadFailureDetails(base, "invalid_envelope");
+  }
+  const record = readHostedWorkspaceFailureRecord(parsed);
+  const error = readHostedWorkspaceFailureRecord(record?.error);
+  if (!error) {
+    return buildUnknownHostedWorkspaceReadFailureDetails(base, "invalid_envelope");
+  }
+
+  const rawCode = typeof error.code === "string" ? error.code.trim() : "";
+  const retryable = typeof error.retryable === "boolean" ? error.retryable : null;
+  if (!rawCode) {
+    return {
+      ...base,
+      workspaceReadFailureCode: "unknown",
+      workspaceReadFailureEnvelopeOutcome: "code_missing",
+      workspaceReadFailureRetryable: retryable,
+    };
+  }
+  if (!isHostedWorkspaceReadFailureCode(rawCode)) {
+    return {
+      ...base,
+      workspaceReadFailureCode: "unknown",
+      workspaceReadFailureEnvelopeOutcome: "code_unknown",
+      workspaceReadFailureRetryable: retryable,
+    };
+  }
+
+  return {
+    ...base,
+    workspaceReadFailureCode: rawCode,
+    workspaceReadFailureEnvelopeOutcome: "classified",
+    workspaceReadFailureRetryable: retryable,
+  };
+}
+
+function buildUnknownHostedWorkspaceReadFailureDetails(
+  base: Pick<
+    HostedWorkspaceReadFailureDetails,
+    "workspaceReadFailureForwardedFromWeb" | "workspaceReadFailureStatus"
+  >,
+  outcome: Exclude<HostedWorkspaceReadFailureEnvelopeOutcome, "classified" | "code_missing" | "code_unknown">,
+): HostedWorkspaceReadFailureDetails {
+  return {
+    ...base,
+    workspaceReadFailureCode: "unknown",
+    workspaceReadFailureEnvelopeOutcome: outcome,
+    workspaceReadFailureRetryable: null,
+  };
+}
+
+function readHostedWorkspaceFailureRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function isHostedWorkspaceReadFailureCode(
+  value: string,
+): value is Exclude<HostedWorkspaceReadFailureCode, "unknown"> {
+  return HOSTED_WORKSPACE_READ_FAILURE_CODES.some((code) => code === value);
 }
 
 function withRuntimeOrchestration(

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -52,6 +52,9 @@ import {
 import { HostedUserRunner } from "../src/user-runner.ts";
 import { HostedUserRunnerWithTestControls } from "../src/user-runner/hosted-user-runner-test.ts";
 import {
+  HOSTED_WEB_CONTROL_FORWARDED_RESPONSE_HEADER,
+} from "../src/runner-outbound/headers.ts";
+import {
   HOSTED_RUNTIME_RETRY_ANALYTICS_SCHEMA,
 } from "../src/user-runner/runtime-processing-responses.ts";
 import {
@@ -147,6 +150,166 @@ describe("HostedUserRunner execution coordination", () => {
     vi.clearAllMocks();
     mocks.emitHostedExecutionStructuredLog.mockReset();
     mocks.fetchHostedExecutionWebControlPlaneResponse.mockReset();
+  });
+
+  it("classifies a hosted workspace failure without changing the plain caller error", async () => {
+    const privateDetail = "private workspace failure detail";
+    const responseBody: {
+      controller?: ReadableStreamDefaultController<Uint8Array>;
+    } = {};
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        responseBody.controller = controller;
+      },
+    }), {
+      headers: {
+        [HOSTED_WEB_CONTROL_FORWARDED_RESPONSE_HEADER]: "1",
+      },
+      status: 400,
+    });
+    const { flushWaitUntil, runner } = createRunnerHarness({
+      workspaceResponse: () => response,
+    });
+
+    let caught: unknown;
+    try {
+      await runner.readHostedWorkspaceFromWebForTest({
+        timeoutMs: 321,
+        userId: TEST_USER_ID,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    if (!(caught instanceof Error)) {
+      throw new TypeError("Expected hosted workspace read to throw Error.");
+    }
+    expect(Object.getPrototypeOf(caught)).toBe(Error.prototype);
+    expect(caught.message).toBe("Hosted workspace read failed with HTTP 400.");
+    expect(mocks.fetchHostedExecutionWebControlPlaneResponse).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchHostedExecutionWebControlPlaneResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundUserId: TEST_USER_ID,
+        path: HOSTED_RUNTIME_WORKSPACE_PATH,
+        timeoutMs: 321,
+      }),
+    );
+    expect(mocks.emitHostedExecutionStructuredLog).not.toHaveBeenCalled();
+
+    const responseBodyController = responseBody.controller;
+    if (!responseBodyController) {
+      throw new TypeError("Expected hosted workspace response body controller.");
+    }
+    responseBodyController.enqueue(new TextEncoder().encode(JSON.stringify({
+      error: {
+        code: "HOSTED_EXECUTION_USER_ID_REQUIRED",
+        message: privateDetail,
+        retryable: false,
+      },
+    })));
+    responseBodyController.close();
+
+    await flushWaitUntil();
+
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith({
+      component: "hosted.runner",
+      details: {
+        workspaceReadFailureCode: "HOSTED_EXECUTION_USER_ID_REQUIRED",
+        workspaceReadFailureEnvelopeOutcome: "classified",
+        workspaceReadFailureForwardedFromWeb: true,
+        workspaceReadFailureRetryable: false,
+        workspaceReadFailureStatus: 400,
+      },
+      level: "warn",
+      message: "Hosted workspace read failure classified.",
+      phase: "runtime.starting",
+    });
+    expect(JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls))
+      .not.toContain(privateDetail);
+  });
+
+  it("buckets an unrecognized hosted workspace error code without logging it", async () => {
+    const privateCode = "PRIVATE_DYNAMIC_WORKSPACE_CODE";
+    const privateDetail = "private dynamic workspace detail";
+    const { flushWaitUntil, runner } = createRunnerHarness({
+      workspaceResponse: () => createWorkspaceFailureResponse({
+        code: privateCode,
+        message: privateDetail,
+        retryable: true,
+        status: 400,
+      }),
+    });
+
+    await expect(runner.readHostedWorkspaceFromWebForTest({
+      userId: TEST_USER_ID,
+    })).rejects.toThrow("Hosted workspace read failed with HTTP 400.");
+    await flushWaitUntil();
+
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: {
+          workspaceReadFailureCode: "unknown",
+          workspaceReadFailureEnvelopeOutcome: "code_unknown",
+          workspaceReadFailureForwardedFromWeb: false,
+          workspaceReadFailureRetryable: true,
+          workspaceReadFailureStatus: 400,
+        },
+        message: "Hosted workspace read failure classified.",
+      }),
+    );
+    const emitted = JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls);
+    expect(emitted).not.toContain(privateCode);
+    expect(emitted).not.toContain(privateDetail);
+  });
+
+  it("classifies malformed and oversized workspace failure bodies without logging them", async () => {
+    const malformedDetail = "private malformed workspace detail";
+    const oversizedDetail = "private oversized workspace detail";
+    let responseIndex = 0;
+    const responses = [
+      new Response(`{"error":{"message":"${malformedDetail}"`, {
+        status: 400,
+      }),
+      new Response(oversizedDetail, {
+        headers: {
+          "content-length": "4097",
+        },
+        status: 400,
+      }),
+    ];
+    const { flushWaitUntil, runner } = createRunnerHarness({
+      workspaceResponse: () => responses[responseIndex++]!,
+    });
+
+    await expect(runner.readHostedWorkspaceFromWebForTest({
+      userId: TEST_USER_ID,
+    })).rejects.toThrow("Hosted workspace read failed with HTTP 400.");
+    await expect(runner.readHostedWorkspaceFromWebForTest({
+      userId: TEST_USER_ID,
+    })).rejects.toThrow("Hosted workspace read failed with HTTP 400.");
+    await flushWaitUntil();
+
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          workspaceReadFailureCode: "unknown",
+          workspaceReadFailureEnvelopeOutcome: "invalid_envelope",
+        }),
+      }),
+    );
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          workspaceReadFailureCode: "unknown",
+          workspaceReadFailureEnvelopeOutcome: "body_too_large",
+        }),
+      }),
+    );
+    expect(mocks.fetchHostedExecutionWebControlPlaneResponse).toHaveBeenCalledTimes(2);
+    const emitted = JSON.stringify(mocks.emitHostedExecutionStructuredLog.mock.calls);
+    expect(emitted).not.toContain(malformedDetail);
+    expect(emitted).not.toContain(oversizedDetail);
   });
 
   it("denies runtime processing when the authoritative consent read is revoked", async () => {
@@ -8226,6 +8389,7 @@ function createRunnerHarness(input: {
   onStorageList?: (input: { prefix?: string }) => Promise<void> | void;
   onStoragePut?: (input: { key: string; value: unknown }) => Promise<void> | void;
   onWorkspaceRead?: (input: { timeoutMs: number }) => Promise<void> | void;
+  workspaceResponse?: () => Promise<Response> | Response;
   platformAiUsageAllowed?: boolean | (() => boolean);
   prewarmShell?: HostedExecutionContainerStubLike["prewarmShell"];
   readActiveRuntimeUserFence?: HostedExecutionContainerStubLike["readActiveRuntimeUserFence"];
@@ -8398,6 +8562,7 @@ function createRunnerHarness(input: {
     platformAiUsageAllowed: input.platformAiUsageAllowed,
     runtimeLogResponse: input.runtimeLogResponse,
     ownerReleaseResponse: input.ownerReleaseResponse,
+    workspaceResponse: input.workspaceResponse,
   });
 
   const bucket = input.bucket ?? new MemoryEncryptedR2Bucket();
@@ -8598,6 +8763,7 @@ function installWebControlResponses(
       | "revoked"
       | Promise<"granted" | "missing" | "revoked">;
     onWorkspaceRead?: (input: { timeoutMs: number }) => Promise<void> | void;
+    workspaceResponse?: () => Promise<Response> | Response;
     onOwnerReleased?: (input: { timeoutMs: number }) => Promise<void> | void;
     onStatusRead?: () => Promise<void> | void;
     readMailboxLag?: () => HostedRuntimeWebStatusResponse["mailboxLag"];
@@ -8614,6 +8780,9 @@ function installWebControlResponses(
     }) => {
       if (input.path === HOSTED_RUNTIME_WORKSPACE_PATH) {
         await hooks.onWorkspaceRead?.({ timeoutMs: input.timeoutMs });
+        if (hooks.workspaceResponse) {
+          return await hooks.workspaceResponse();
+        }
         return jsonResponse({
           fetchedAt: FIXED_NOW,
           ...(hooks.platformAiUsageAllowed === undefined
@@ -8683,6 +8852,27 @@ function jsonResponse(value: unknown): Response {
       "content-type": "application/json; charset=utf-8",
     },
     status: 200,
+  });
+}
+
+function createWorkspaceFailureResponse(input: {
+  code: string;
+  forwardedFromWeb?: boolean;
+  message: string;
+  retryable: boolean;
+  status: number;
+}): Response {
+  return Response.json({
+    error: {
+      code: input.code,
+      message: input.message,
+      retryable: input.retryable,
+    },
+  }, {
+    headers: input.forwardedFromWeb
+      ? { [HOSTED_WEB_CONTROL_FORWARDED_RESPONSE_HEADER]: "1" }
+      : undefined,
+    status: input.status,
   });
 }
 


### PR DESCRIPTION
## Why and outcome

Fourteen deploy-window hosted workspace reads returned HTTP 400, but Worker telemetry retained only the status and discarded the handled Web error code. This adds bounded, privacy-safe failure classification so a later natural-traffic query can distinguish request-contract, callback-auth/replay, and other validation failures. Caller behavior is unchanged.

## Product UX

Not applicable: internal telemetry only; no user-visible behavior or required action changes.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/user-runner-alarm.test.ts apps/cloudflare/test/runner-platform.test.ts --no-coverage` — 363 tests passed
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm --dir apps/cloudflare verify` — 151 Node files / 2,726 passed / 2 skipped; 5 Workers files / 14 passed
- `pnpm docs:drift`
- `pnpm logs:guard`
- `pnpm no-js`
- `git diff --check`
- Current-base `git merge-tree --write-tree` completed cleanly

Implementation and parent review were performed locally per the explicit user instruction not to use ReviewGPT.

## Non-obvious affected surfaces

- HostedUserRunner workspace reads: failure response clone only; the original request, plain Error, retries, and control flow remain unchanged.
- Durable Object lifecycle: existing `waitUntil` keeps bounded telemetry off the caller path.
- Shared Web-control body reader: exported for reuse; implementation unchanged.

## Architecture and reuse

- Existing systems reused: structured logger, Durable Object `waitUntil`, and the bounded Web-control response reader.
- New logic: a closed workspace error-code allowlist and fixed envelope outcomes.
- New abstractions: None were needed because the existing runner owner, structured logger, lifecycle primitive, and bounded response reader fully own this observation.
- Complexity intentionally avoided: no new backend, state, metric owner, retry, route, queue, scheduler, or provider interaction.

## Hot reply path

No awaited work was added. The caller throws immediately while classification runs under the existing `waitUntil` owner.

## Provider-input impact

None.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web error envelopes and older Workers remain compatible; older Workers simply omit this telemetry.
- Safe order: Deploy the Cloudflare Worker after merge; no tandem Web or container deployment is required.
- Rollback floor: Roll back to the preceding Cloudflare Worker version; no persisted schema or state needs reversal.
- Expected exposure: Only failed hosted workspace reads perform bounded asynchronous classification; the success path is unchanged.
- Reversibility: One ordinary Worker rollback removes the telemetry with no migration, backfill, or cleanup.
- Convergence proof: Confirm the production Worker revision matches the merged commit and the structured event schema is queryable.
- Post-deploy checks: Verify the serving Worker revision, unchanged workspace-read behavior, and natural emission of the fixed classification fields.

## Changelog

- Changelog: not applicable
- Reason: This telemetry-only change preserves the existing caller error and control flow, so no member-visible behavior changed.

## LOC

- Source: +176 / -2
- Tests and fixtures: +200 / -0
- Docs: +93 / -0
- Config and tooling: +0 / -0
- Generated and other: +0 / -0

ReviewGPT context sensitivity: sensitive





