### PR TITLE
Start Linq shell prewarm during message routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3094,9 +3094,12 @@ only to cut wake latency and may be dropped at any time with no correctness
 impact: accepted Linq reply delivery stamps the exact mailbox item with
 `consumedAt`, while Assistant Ask has deterministic request/completion identity,
 mailbox dedupe, and idempotent continuation delivery. The Durable Object write
-fence coalesces runners that overlap in the same invocation. The typing-start
-shell hint is the only established-member Web-to-Cloudflare prewarm before
-durable message acceptance. The separate
+fence coalesces runners that overlap in the same invocation. An established
+Linq message starts the same shell hint as soon as pre-transaction routing
+preparation resolves an active member, before KMS and transaction work. That
+request-local hint is advisory and may be dropped;
+the transaction repeats every authority check and the post-Temporal direct
+ensure remains the immediate processing owner. The separate
 first-contact instant-start shell hint obtains the named `UserRunner` stub
 without binding durable state, enters the same per-user consent-mutation barrier
 as authoritative ensures and withdrawal, and re-reads live Web-owned admission.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-08-29
+Last verified: 2026-08-30
 
 ## Current Guardrails
 
@@ -647,6 +647,11 @@ Last verified: 2026-08-29
   back settlement without creating a synthetic skipped row. The
   active-member replan still owns route promotion, inbound accounting, and the
   canonical inbound mailbox append before any generated reply can be sent.
+  Ordinary established Linq messages use the same authority-free shell hint as
+  soon as pre-transaction routing preparation resolves the eligible active
+  member, before mailbox-root KMS work and transaction entry. This hint may
+  overlap or fail without changing the plan: it creates no fence or mailbox
+  owner, and only the accepted Temporal signal permits the direct ensure.
   A definite route-read or route-projection failure after generation confirms
   that same attempted row was skipped before allowing ordinary-runtime
   fallback; if the skip cannot be confirmed, Web retains ownership and the

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -647,9 +647,9 @@ Last verified: 2026-08-30
   back settlement without creating a synthetic skipped row. The
   active-member replan still owns route promotion, inbound accounting, and the
   canonical inbound mailbox append before any generated reply can be sent.
-  Ordinary established Linq messages use the same authority-free shell hint as
-  soon as pre-transaction routing preparation resolves the eligible active
-  member, before mailbox-root KMS work and transaction entry. This hint may
+  Ordinary established direct Linq messages use the same authority-free shell
+  hint as soon as pre-transaction routing preparation resolves the eligible
+  active member, before mailbox-root KMS work and transaction entry. This hint may
   overlap or fail without changing the plan: it creates no fence or mailbox
   owner, and only the accepted Temporal signal permits the direct ensure.
   A definite route-read or route-projection failure after generation confirms

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -19,10 +19,10 @@ Last verified: 2026-08-30
   ensures, re-read the Web-owned grant, clear its write fence, and stop the
   runner. Every later ensure re-reads the grant; renewal waits behind the stop
   before granting. An instant-start, authenticated established-direct-chat
-  typing, or eligible established-message shell-prewarm hint uses that same
-  per-user barrier and live admission read. The message producer may start only
-  after ordinary routing preparation resolves an extant active member, before
-  KMS and transaction work; the planner still
+  typing, or eligible established-direct-message shell-prewarm hint uses that
+  same per-user barrier and live admission read. The message producer may start
+  only after direct routing preparation resolves an extant active member,
+  before KMS and transaction work; the planner still
   repeats authority inside the transaction. The typing producer resolves only
   the private home-chat blind index and performs an advisory active-access/root
   check after acknowledging the webhook. Neither producer receives a member id

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-Last verified: 2026-08-29
+Last verified: 2026-08-30
 
 ## Non-Negotiable Rules
 
@@ -18,11 +18,15 @@ Last verified: 2026-08-29
   for the per-user Cloudflare execution barrier to serialize behind earlier
   ensures, re-read the Web-owned grant, clear its write fence, and stop the
   runner. Every later ensure re-reads the grant; renewal waits behind the stop
-  before granting. An instant-start or authenticated established-direct-chat
-  typing shell-prewarm hint uses that same per-user barrier and live admission
-  read. The typing producer resolves only the private home-chat blind index and
-  performs an advisory active-access/root check after acknowledging the webhook;
-  it receives no member id from Linq and grants no runtime authority. The shared
+  before granting. An instant-start, authenticated established-direct-chat
+  typing, or eligible established-message shell-prewarm hint uses that same
+  per-user barrier and live admission read. The message producer may start only
+  after ordinary routing preparation resolves an extant active member, before
+  KMS and transaction work; the planner still
+  repeats authority inside the transaction. The typing producer resolves only
+  the private home-chat blind index and performs an advisory active-access/root
+  check after acknowledging the webhook. Neither producer receives a member id
+  from Linq or grants runtime authority. The shared
   HTTP route obtains the named runner stub without binding durable state.
   Because this hint is optional, it is admitted only when the barrier is idle;
   repeated hints and hints arriving during authoritative ensure, withdrawal, or

--- a/agent-docs/exec-plans/active/2026-08-30-linq-message-shell-prewarm.md
+++ b/agent-docs/exec-plans/active/2026-08-30-linq-message-shell-prewarm.md
@@ -1,0 +1,98 @@
+# Early Linq message shell prewarm
+
+Status: active
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Start the existing payloadless Cloudflare shell prewarm as soon as an
+  established Linq message resolves an active hosted member,
+  before the mailbox planning transaction and Temporal signal complete.
+- Preserve the ordinary post-Temporal direct ensure as the only foreground
+  processing owner.
+- Carry enough request-to-container timing through the existing prewarm
+  observation to measure Durable Object activation, admission, and useful
+  overlap without a second telemetry store.
+
+## Protected invariants
+
+- The early hint creates no mailbox, write fence, workspace invocation,
+  processing authority, retry owner, queue, scheduler, or persisted state.
+- Web eligibility remains advisory. Cloudflare rechecks live Web-owned
+  health-data admission under the existing per-user consent-mutation barrier.
+- A failed, skipped, stale, duplicate, or evicted prewarm never blocks webhook
+  planning, provider acknowledgement, Temporal signaling, or direct ensure.
+- Prewarm telemetry remains metadata-only, bounded, and diagnostics-only.
+
+## Evidence
+
+- The latest direct cold trace spent 429 ms between durable mailbox acceptance
+  and Temporal acknowledgement, then 1,384 ms between the Cloudflare route and
+  UserRunner constructor start. No shell-prewarm observation was present.
+- `warmHostedLinqMailboxPayloadRoot` already resolves only active members with
+  usable crypto roots before KMS work and before the planning transaction.
+- `prewarmRuntimeShellForUser` already performs the live Cloudflare admission
+  recheck, reserves the exact container target, and issues only the platform
+  start hint. RunnerContainer already coalesces repeated hints.
+
+## Scope
+
+- In scope: established Linq message routing, existing shell-prewarm contracts,
+  request/activation/admission timing carried by the existing observation,
+  identifier-free cold-start reporting, focused tests, and matching durable
+  runtime/security/deployment documentation.
+- Out of scope: starting real processing before Temporal, keepalive alarms,
+  another queue or scheduler, container image changes, idle-lifetime changes,
+  database schema changes, and production deployment.
+
+## Tasks
+
+1. Add one early eligible-message caller to the existing shell-prewarm path and
+   thread its attempt identity explicitly into the committed wake handoff.
+2. Extend the existing prewarm observation with bounded Web request,
+   Cloudflare route, UserRunner activation/RPC, and admission timestamps.
+3. Update the identifier-free report and focused unit/E2E contracts so only an
+   exactly matched message-routing hint is classified as causal.
+4. Run focused tests, affected package builds/typechecks, diff checks, and the
+   required exact-head ReviewGPT plus CI workflow.
+
+## Deployment concerns
+
+- Web must deploy first because it accepts legacy Cloudflare prewarm responses
+  and sends only additive request fields/source values. Cloudflare then deploys
+  the additive source and timing writer. Old Web ignores the new diagnostics;
+  new Web treats missing diagnostics as an ordinary optional prewarm.
+- Rollback remains safe while the new source is accepted by every live
+  Cloudflare route. Revert the early Web producer before rolling Cloudflare
+  below support for the new source.
+
+## Progress
+
+- Root cause and earliest safe eligibility boundary are confirmed from the
+  production trace and current Web/Cloudflare owners.
+- The established-route hint now starts after the existing active/root-eligible
+  member resolution and before KMS unwrap. The direct-route hint starts as soon
+  as the existing active-member access read resolves, while sibling routing
+  reads continue in parallel. Neither path adds a query.
+- One request-local correlation ID follows the existing Web client, Worker
+  route, UserRunner activation/admission, and first RunnerContainer hint. The
+  final wake expects that exact ID, so the report attributes overlap only when
+  the consumed observation matches it.
+- Product UX Patch:
+  - Outcome: established members can spend less time waiting for the first
+    reply after Murph has been idle.
+  - Reaches: ordinary direct Linq messages that need a cold hosted runtime.
+  - Proof: focused routing tests show the best-effort hint starts before KMS
+    work and the direct ensure remains after Temporal acceptance; exact-ID
+    report contracts expose the resulting overlap without member identifiers.
+- Product UX walkthrough: `Ready`. The ordinary message journey and its final
+  destination are unchanged; only best-effort shell startup moves earlier.
+  Ineligible, failed, duplicate, or skipped hints preserve the existing safe
+  path and never delay durable acceptance or processing.
+- Focused hosted-execution, Cloudflare control, Cloudflare runtime, and hosted
+  Web suites pass. The latest composed Web rerun covered 256 routing, mailbox
+  prewarm, and direct-wake tests after the earliest-access refinement. All four
+  affected typechecks, both changed package builds, the Cloudflare app build,
+  focused Web lint, and `git diff --check` pass. The opt-in PostgreSQL report
+  fixture remains CI-owned when no loopback database is configured.

--- a/agent-docs/exec-plans/active/2026-08-30-linq-message-shell-prewarm.md
+++ b/agent-docs/exec-plans/active/2026-08-30-linq-message-shell-prewarm.md
@@ -7,7 +7,7 @@ Updated: 2026-08-30
 ## Goal
 
 - Start the existing payloadless Cloudflare shell prewarm as soon as an
-  established Linq message resolves an active hosted member,
+  direct Linq message resolves an active hosted member,
   before the mailbox planning transaction and Temporal signal complete.
 - Preserve the ordinary post-Temporal direct ensure as the only foreground
   processing owner.
@@ -38,7 +38,7 @@ Updated: 2026-08-30
 
 ## Scope
 
-- In scope: established Linq message routing, existing shell-prewarm contracts,
+- In scope: established direct Linq message routing, existing shell-prewarm contracts,
   request/activation/admission timing carried by the existing observation,
   identifier-free cold-start reporting, focused tests, and matching durable
   runtime/security/deployment documentation.
@@ -71,10 +71,9 @@ Updated: 2026-08-30
 
 - Root cause and earliest safe eligibility boundary are confirmed from the
   production trace and current Web/Cloudflare owners.
-- The established-route hint now starts after the existing active/root-eligible
-  member resolution and before KMS unwrap. The direct-route hint starts as soon
-  as the existing active-member access read resolves, while sibling routing
-  reads continue in parallel. Neither path adds a query.
+- The direct-route hint starts as soon as the existing active-member access
+  read resolves, while sibling routing reads continue in parallel. Established
+  group/thread routing does not invoke the optimization. No path adds a query.
 - One request-local correlation ID follows the existing Web client, Worker
   route, UserRunner activation/admission, and first RunnerContainer hint. The
   final wake expects that exact ID, so the report attributes overlap only when
@@ -84,15 +83,23 @@ Updated: 2026-08-30
     reply after Murph has been idle.
   - Reaches: ordinary direct Linq messages that need a cold hosted runtime.
   - Proof: focused routing tests show the best-effort hint starts before KMS
-    work and the direct ensure remains after Temporal acceptance; exact-ID
-    report contracts expose the resulting overlap without member identifiers.
+    work and the direct ensure remains after Temporal acceptance; the signed
+    hosted-local journey and exact-ID report contracts tie that hint to the
+    delivered reply without exposing member identifiers.
 - Product UX walkthrough: `Ready`. The ordinary message journey and its final
   destination are unchanged; only best-effort shell startup moves earlier.
   Ineligible, failed, duplicate, or skipped hints preserve the existing safe
   path and never delay durable acceptance or processing.
-- Focused hosted-execution, Cloudflare control, Cloudflare runtime, and hosted
-  Web suites pass. The latest composed Web rerun covered 256 routing, mailbox
-  prewarm, and direct-wake tests after the earliest-access refinement. All four
-  affected typechecks, both changed package builds, the Cloudflare app build,
-  focused Web lint, and `git diff --check` pass. The opt-in PostgreSQL report
-  fixture remains CI-owned when no loopback database is configured.
+- Review follow-up keeps the producer direct-only, records auth timing on the
+  signed shell-prewarm route, and suppresses the message-routing callback on
+  post-enrollment instant-start replans. Tests prove the instant-start wake has
+  no message-routing attempt identity.
+- Focused Cloudflare control/report and hosted Web routing/mailbox suites pass
+  (120, 210, and 24 tests respectively), as do both affected typechecks,
+  focused Web lint, the Cloudflare build exercised by hosted-local preparation,
+  and `git diff --check`.
+- The opt-in PostgreSQL report fixture passes against a disposable loopback
+  PostgreSQL instance, including exact-match and mismatch message-routing rows.
+  The composed hosted-local scenario is checked in but could not start locally
+  because this checkout has no external Temporal worker package configured; CI
+  owns that provisioned run.

--- a/agent-docs/exec-plans/completed/2026-08-30-linq-message-shell-prewarm.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-linq-message-shell-prewarm.md
@@ -1,6 +1,6 @@
 # Early Linq message shell prewarm
 
-Status: active
+Status: completed
 Created: 2026-08-30
 Updated: 2026-08-30
 
@@ -103,3 +103,4 @@ Updated: 2026-08-30
   The composed hosted-local scenario is checked in but could not start locally
   because this checkout has no external Temporal worker package configured; CI
   owns that provisioned run.
+Completed: 2026-08-30

--- a/agent-docs/exec-plans/completed/2026-08-30-linq-message-shell-prewarm.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-linq-message-shell-prewarm.md
@@ -6,7 +6,7 @@ Updated: 2026-08-30
 
 ## Goal
 
-- Start the existing payloadless Cloudflare shell prewarm as soon as an
+- Start the existing payloadless Cloudflare shell prewarm as soon as a
   direct Linq message resolves an active hosted member,
   before the mailbox planning transaction and Temporal signal complete.
 - Preserve the ordinary post-Temporal direct ensure as the only foreground

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1658,8 +1658,19 @@ therefore relinquishes the existing lifecycle boundary without leaving a stale
 hint or partially initialized start ahead of foreground work. If a Worker
 version changes before authoritative start, the `UserRunner` destroys and
 clears a different pending versioned target before binding the current fence.
-The existing Web helper carries its bounded `linq-instant-start` or
-`linq-typing-started` source through the same request and RPC. During additive
+For an ordinary established Linq message, pre-transaction routing preparation
+may fire that same request immediately after it resolves an active member,
+before root KMS work and transaction entry. It threads
+one UUID-shaped attempt id through Web, the authenticated route, UserRunner
+activation and admission, and the container's first coalesced observation. The
+final wake carries the same id as expected evidence; the latency report treats
+the hint as causal only when the consumed observation matches it exactly. No
+attempt id is authority, and a retry that resolves another member starts a new
+hint while the planner remains authoritative.
+
+The existing Web helper carries its bounded `linq-instant-start`,
+`linq-message-routing`, or `linq-typing-started` source through the same request
+and RPC. During additive
 rollout an empty legacy request remains accepted and is recorded as `unknown`;
 unknown is never assumed to mean typing. Cloudflare logs one bounded admission outcome (`scheduled`,
 `skipped_consent_busy`, `skipped_admission_unavailable`,
@@ -1673,8 +1684,9 @@ do not imply port or health readiness.
 
 The container also consumes its in-memory hint observation on the next
 authoritative `ensureReadyForProcessing` call. One observation belongs to one
-shell-prewarm operation and carries its triggering source, first causal hint
-timestamp, completion time and duration, coalesced hint count, and one terminal
+shell-prewarm operation and carries its triggering source, bounded
+orchestration attempt and phase timestamps, first causal hint timestamp,
+completion time and duration, coalesced hint count, and one terminal
 outcome (`cold_start_observed`, `start_issued_warm`, `superseded`, or `failed`).
 After that operation settles, later hints may only increment its bounded hint
 count until readiness consumes it; they cannot launch a second operation or
@@ -1683,12 +1695,12 @@ leaves into the existing orchestration latency phase breakdown; it adds no
 request, persisted state owner, awaited reporting step, or work on the
 message-ingress path. A stop, explicit destroy, or Durable Object eviction may
 erase the optional observation, so an absent observation means `no observed
-prewarm`, not proof that no typing hint occurred. The aggregate cold-start
-report includes only typing-sourced, chronology-safe, uniquely matched
-Web-direct traces whose reply belongs to the same runtime attempt. It omits
-instant-start, unknown-source, ambiguous, backlog, and attempt-handoff rows
-rather than guessing, and returns no member, mailbox, trace, delivery, or
-runtime-attempt identifiers.
+prewarm`, not proof that no hint occurred. The aggregate cold-start report
+includes chronology-safe typing hints and exact-id-matched message-routing
+hints on uniquely matched Web-direct traces whose reply belongs to the same
+runtime attempt. It omits instant-start, unknown-source, ambiguous, backlog,
+and attempt-handoff rows rather than guessing, and returns no member, mailbox,
+trace, delivery, or runtime-attempt identifiers.
 The signal
 reconciles both the foreground conversation lane and the already-durable
 activation item. Web then

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1658,9 +1658,9 @@ therefore relinquishes the existing lifecycle boundary without leaving a stale
 hint or partially initialized start ahead of foreground work. If a Worker
 version changes before authoritative start, the `UserRunner` destroys and
 clears a different pending versioned target before binding the current fence.
-For an ordinary established Linq message, pre-transaction routing preparation
-may fire that same request immediately after it resolves an active member,
-before root KMS work and transaction entry. It threads
+For an ordinary established direct Linq message, pre-transaction routing
+preparation may fire that same request immediately after it resolves an active
+member, before root KMS work and transaction entry. It threads
 one UUID-shaped attempt id through Web, the authenticated route, UserRunner
 activation and admission, and the container's first coalesced observation. The
 final wake carries the same id as expected evidence; the latency report treats

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -2173,8 +2173,8 @@ latency parser and the best-effort message-routing producer, then deploy the
 Cloudflare Worker/runner reader. During that short window the old Worker may
 reject the new optional request shape; the authoritative post-Temporal ensure
 and message path are unchanged. After Cloudflare converges, verify a synthetic
-established-message trace has matching expected/observed prewarm attempt ids and
-the request, auth, UserRunner, admission, and container-hint phase stamps.
+established-direct-message trace has matching expected/observed prewarm attempt
+ids and the request, auth, UserRunner, admission, and container-hint phase stamps.
 
 There is no persisted-state rollback floor. Rolling Web back first stops the
 new producer; rolling Cloudflare back first merely makes remaining hints fail

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -2166,6 +2166,22 @@ Optional smoke env:
 
 If neither managed-container smoke nor `HOSTED_EXECUTION_SMOKE_USER_ID` is configured, smoke stops after the public banner and health checks.
 
+## Linq message shell-prewarm rollout
+
+This additive telemetry cutover is Web-first. Deploy Web with the expanded
+latency parser and the best-effort message-routing producer, then deploy the
+Cloudflare Worker/runner reader. During that short window the old Worker may
+reject the new optional request shape; the authoritative post-Temporal ensure
+and message path are unchanged. After Cloudflare converges, verify a synthetic
+established-message trace has matching expected/observed prewarm attempt ids and
+the request, auth, UserRunner, admission, and container-hint phase stamps.
+
+There is no persisted-state rollback floor. Rolling Web back first stops the
+new producer; rolling Cloudflare back first merely makes remaining hints fail
+best-effort. A Web version without the expanded parser may drop only the
+optional phase breakdown from a newer Worker, never the core latency milestones
+or runtime work.
+
 ## Container Operator Access
 
 ## Operator task rollout

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -47,8 +47,8 @@ Internal control routes:
   cancellation. Callback-signed Temporal/default work retains the cooperative
   wake-and-retry behavior.
 - `POST /internal/users/:userId/runtime/shell-prewarm` is the optional
-  Vercel OIDC-authenticated typing, established-message-routing, or instant-start
-  shell hint. Its bounded source and UUID-shaped attempt id distinguish those
+  Vercel OIDC-authenticated typing, direct-message-routing, or instant-start shell
+  hint. Its bounded source and UUID-shaped attempt id distinguish those
   callers and correlate only diagnostic phase stamps; a legacy request without
   correlation fields remains accepted but cannot enter an exact-id cohort. It
   rechecks live admission and returns after the named

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -47,9 +47,11 @@ Internal control routes:
   cancellation. Callback-signed Temporal/default work retains the cooperative
   wake-and-retry behavior.
 - `POST /internal/users/:userId/runtime/shell-prewarm` is the optional
-  Vercel OIDC-authenticated typing/instant-start shell hint. Its bounded source
-  distinguishes those two existing callers; an empty legacy request remains
-  accepted as `unknown`. It rechecks live admission and returns after the named
+  Vercel OIDC-authenticated typing, established-message-routing, or instant-start
+  shell hint. Its bounded source and UUID-shaped attempt id distinguish those
+  callers and correlate only diagnostic phase stamps; a legacy request without
+  correlation fields remains accepted but cannot enter an exact-id cohort. It
+  rechecks live admission and returns after the named
   container registers an asynchronous start attempt; it does not wait for
   readiness or create runtime authority.
 - `POST /internal/users/:userId/browser-vault/session` creates an encrypted browser-vault read session for the latest web-owned replica ref
@@ -462,17 +464,19 @@ murph-prod-psql-ro -f apps/cloudflare/scripts/cold-start-latency-report.sql
 
 Pass `-v window_hours=6` (or another integer) before `-f` to change the UTC
 window. The first result groups uniquely matched Web-direct Linq runtime
-attempts by the causal typing shell-prewarm observation consumed by their
-container readiness call. It shows causal-hint lead time plus
+attempts by a chronology-safe typing observation or an exact attempt-id-matched
+message-routing shell-prewarm observation consumed by their container readiness
+call. It shows causal-hint lead time plus
 accepted-to-runner, provider, and reply percentiles, all from the same ingress
 trace and same reply runtime attempt. Instant-start, unknown-source, ambiguous,
 backlog, and reply-handoff rows are omitted rather than inferred. A
 `no_observed_prewarm` row is a comparison cohort, not proof that no hint was
 sent, because stop, destroy, or Durable Object eviction may clear optional
-in-memory diagnostics. `prewarm_start_issued_warm` means the platform start call
+in-memory diagnostics. `prewarm_typing_start_issued_warm` and
+`prewarm_message_routing_start_issued_warm` mean the platform start call
 completed without a newly observed lifecycle start;
-`prewarm_cold_start_observed` means the same container lifecycle did observe a
-cold start. Neither means health readiness completed. One observation contains
+their corresponding `*_cold_start_observed` cohorts mean the same container
+lifecycle did observe a cold start. Neither means health readiness completed. One observation contains
 one terminal operation outcome; later hints may increase only its bounded
 coalesced-hint count and never launch another operation before readiness
 consumes it.
@@ -501,8 +505,11 @@ marker differences cannot discard a coherent multi-item invocation. Temporal
 activities that begin after runner acceptance are active wakes, not startup
 candidates, and are removed before ambiguity is assessed. Conflicting
 launch-owner evidence also fails closed. Warm direct
-wakes are omitted because they create no new runner job. The final table splits
-the same causal direct samples across Durable Object dispatch, UserRunner
+wakes are omitted because they create no new runner job. The final table first
+splits an exact matched message-routing hint across Web request/auth,
+prewarm-specific Durable Object activation, consent admission, container-hint
+registration, and effective lead time. It then splits the same causal direct
+samples across Durable Object dispatch, UserRunner
 constructor initialization, consent locking, the existing health-data admission
 callback, runner-state operations, the parallel container-readiness and
 invocation-preparation branches, invocation launch, and runner-job acceptance.

--- a/apps/cloudflare/scripts/cold-start-latency-report.sql
+++ b/apps/cloudflare/scripts/cold-start-latency-report.sql
@@ -7,7 +7,7 @@
 -- Prisma DateTime columns are stored as UTC-naive TIMESTAMP(3) values.
 -- This aggregate report intentionally compares them with a UTC-naive cutoff
 -- and never returns member, mailbox, trace, or attempt identifiers.
-\echo 'Typing shell-prewarm cohorts (milliseconds)'
+\echo 'Causal shell-prewarm cohorts (milliseconds)'
 WITH direct_candidates AS (
   SELECT
     trace.accepted_at,
@@ -52,6 +52,18 @@ WITH direct_candidates AS (
           EXTRACT(EPOCH FROM (trace.accepted_at - TIMESTAMP '1970-01-01')) * 1000
       )
       OR (
+        trace.phase_breakdown_json #>> '{orchestration,shellPrewarmSource}' = 'linq-message-routing'
+        AND trace.phase_breakdown_json #>> '{orchestration,shellPrewarmOutcome}' IN (
+          'cold_start_observed',
+          'failed',
+          'start_issued_warm',
+          'superseded'
+        )
+        AND trace.phase_breakdown_json #>> '{orchestration,shellPrewarmOrchestrationAttemptId}' =
+          trace.phase_breakdown_json #>> '{orchestration,shellPrewarmExpectedOrchestrationAttemptId}'
+        AND trace.phase_breakdown_json #> '{orchestration,shellPrewarmOrchestrationAttemptId}' IS NOT NULL
+      )
+      OR (
         trace.phase_breakdown_json #> '{orchestration,shellPrewarmSource}' IS NULL
         AND trace.phase_breakdown_json #> '{orchestration,shellPrewarmOutcome}' IS NULL
         AND trace.phase_breakdown_json #> '{orchestration,shellPrewarmFirstHintAtEpochMs}' IS NULL
@@ -66,7 +78,9 @@ WITH direct_candidates AS (
     orchestration,
     CASE
       WHEN orchestration ->> 'shellPrewarmSource' = 'linq-typing-started'
-        THEN 'prewarm_' || (orchestration ->> 'shellPrewarmOutcome')
+        THEN 'prewarm_typing_' || (orchestration ->> 'shellPrewarmOutcome')
+      WHEN orchestration ->> 'shellPrewarmSource' = 'linq-message-routing'
+        THEN 'prewarm_message_routing_' || (orchestration ->> 'shellPrewarmOutcome')
       ELSE 'no_observed_prewarm'
     END AS cohort
   FROM direct_candidates
@@ -80,7 +94,7 @@ WITH direct_candidates AS (
   CROSS JOIN LATERAL (
     VALUES
       (
-        'Causal typing hint -> ingress accepted',
+        'Causal shell-prewarm hint -> ingress accepted',
         EXTRACT(EPOCH FROM (accepted_at - TIMESTAMP '1970-01-01')) * 1000
           - (orchestration ->> 'shellPrewarmFirstHintAtEpochMs')::double precision
       ),
@@ -250,6 +264,19 @@ WITH direct_rows AS (
     accepted_ms,
     EXTRACT(EPOCH FROM (runner_job_accepted_at - TIMESTAMP '1970-01-01')) * 1000 AS runner_job_accepted_ms,
     route_received_ms,
+    (orchestration ->> 'shellPrewarmRequestStartedAtEpochMs')::double precision AS prewarm_request_started_ms,
+    (orchestration ->> 'shellPrewarmRuntimeControlAuthStartedAtEpochMs')::double precision AS prewarm_auth_started_ms,
+    (orchestration ->> 'shellPrewarmRuntimeControlAuthFinishedAtEpochMs')::double precision AS prewarm_auth_finished_ms,
+    (orchestration ->> 'shellPrewarmCloudflareRouteReceivedAtEpochMs')::double precision AS prewarm_route_received_ms,
+    (orchestration ->> 'shellPrewarmUserRunnerConstructorStartedAtEpochMs')::double precision AS prewarm_runner_constructor_started_ms,
+    (orchestration ->> 'shellPrewarmUserRunnerConstructorFinishedAtEpochMs')::double precision AS prewarm_runner_constructor_finished_ms,
+    (orchestration ->> 'shellPrewarmUserRunnerRpcStartedAtEpochMs')::double precision AS prewarm_runner_rpc_started_ms,
+    (orchestration ->> 'shellPrewarmConsentLockAcquiredAtEpochMs')::double precision AS prewarm_consent_lock_acquired_ms,
+    (orchestration ->> 'shellPrewarmAdmissionReadStartedAtEpochMs')::double precision AS prewarm_admission_started_ms,
+    (orchestration ->> 'shellPrewarmAdmissionReadFinishedAtEpochMs')::double precision AS prewarm_admission_finished_ms,
+    (orchestration ->> 'shellPrewarmFirstHintAtEpochMs')::double precision AS prewarm_container_hint_ms,
+    orchestration ->> 'shellPrewarmExpectedOrchestrationAttemptId' AS prewarm_expected_orchestration_attempt_id,
+    orchestration ->> 'shellPrewarmOrchestrationAttemptId' AS prewarm_orchestration_attempt_id,
     (orchestration ->> 'userRunnerConstructorStartedAtEpochMs')::double precision AS runner_constructor_started_ms,
     (orchestration ->> 'userRunnerConstructorFinishedAtEpochMs')::double precision AS runner_constructor_finished_ms,
     (orchestration ->> 'userRunnerFirstEnsureRuntimeProcessingAtEpochMs')::double precision AS runner_first_ensure_ms,
@@ -290,7 +317,13 @@ WITH direct_rows AS (
         AND runner_first_ensure_ms = runner_rpc_started_ms
       THEN true
       ELSE false
-    END AS activation_matches_current_request
+    END AS activation_matches_current_request,
+    CASE
+      WHEN prewarm_expected_orchestration_attempt_id = prewarm_orchestration_attempt_id
+        AND prewarm_expected_orchestration_attempt_id IS NOT NULL
+      THEN true
+      ELSE false
+    END AS prewarm_matches_current_request
   FROM stamps
 ), phase_samples AS (
   SELECT
@@ -299,6 +332,59 @@ WITH direct_rows AS (
   FROM activation_stamps
   CROSS JOIN LATERAL (
     VALUES
+      ('Prewarm request -> auth', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_auth_started_ms - prewarm_request_started_ms
+      END),
+      ('Prewarm auth', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_auth_finished_ms - prewarm_auth_started_ms
+      END),
+      ('Prewarm auth -> Cloudflare route', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_route_received_ms - prewarm_auth_finished_ms
+      END),
+      ('Prewarm route -> UserRunner constructor start', CASE
+        WHEN prewarm_matches_current_request
+          AND prewarm_route_received_ms <= prewarm_runner_constructor_started_ms
+          AND prewarm_runner_constructor_started_ms <= prewarm_runner_constructor_finished_ms
+          AND prewarm_runner_constructor_finished_ms <= prewarm_runner_rpc_started_ms
+        THEN prewarm_runner_constructor_started_ms - prewarm_route_received_ms
+      END),
+      ('Prewarm UserRunner constructor', CASE
+        WHEN prewarm_matches_current_request
+          AND prewarm_route_received_ms <= prewarm_runner_constructor_started_ms
+          AND prewarm_runner_constructor_started_ms <= prewarm_runner_constructor_finished_ms
+          AND prewarm_runner_constructor_finished_ms <= prewarm_runner_rpc_started_ms
+        THEN prewarm_runner_constructor_finished_ms - prewarm_runner_constructor_started_ms
+      END),
+      ('Prewarm constructor -> RPC', CASE
+        WHEN prewarm_matches_current_request
+          AND prewarm_route_received_ms <= prewarm_runner_constructor_started_ms
+          AND prewarm_runner_constructor_started_ms <= prewarm_runner_constructor_finished_ms
+          AND prewarm_runner_constructor_finished_ms <= prewarm_runner_rpc_started_ms
+        THEN prewarm_runner_rpc_started_ms - prewarm_runner_constructor_finished_ms
+      END),
+      ('Prewarm RPC -> consent lock', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_consent_lock_acquired_ms - prewarm_runner_rpc_started_ms
+      END),
+      ('Prewarm health-data admission', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_admission_finished_ms - prewarm_admission_started_ms
+      END),
+      ('Prewarm admission -> container hint', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_container_hint_ms - prewarm_admission_finished_ms
+      END),
+      ('Prewarm request -> container hint', CASE
+        WHEN prewarm_matches_current_request
+        THEN prewarm_container_hint_ms - prewarm_request_started_ms
+      END),
+      ('Prewarm container hint -> direct ensure route', CASE
+        WHEN prewarm_matches_current_request
+        THEN route_received_ms - prewarm_container_hint_ms
+      END),
       ('Accepted -> Cloudflare route', route_received_ms - accepted_ms),
       ('Cloudflare route -> UserRunner constructor start', CASE
         WHEN activation_matches_current_request
@@ -354,38 +440,49 @@ FROM phase_samples
 GROUP BY name
 ORDER BY min(
   CASE name
-    WHEN 'Accepted -> Cloudflare route' THEN 1
-    WHEN 'Cloudflare route -> UserRunner constructor start' THEN 2
-    WHEN 'UserRunner constructor start -> finish' THEN 3
-    WHEN 'UserRunner constructor finish -> first ensure instruction' THEN 4
-    WHEN 'Cloudflare route -> UserRunner RPC' THEN 5
-    WHEN 'UserRunner RPC -> consent lock' THEN 6
-    WHEN 'Health-data admission callback' THEN 7
-    WHEN 'Admission complete -> controller' THEN 8
-    WHEN 'Runner state bind' THEN 9
-    WHEN 'Runner state read' THEN 10
-    WHEN 'State ready -> fresh start request' THEN 11
-    WHEN 'Fresh start request -> fence bound' THEN 12
-    WHEN 'Fence bound -> container ready' THEN 13
-    WHEN 'Fence bound -> readiness RPC' THEN 14
-    WHEN 'Container lifecycle lock wait' THEN 15
-    WHEN 'Container state read' THEN 16
-    WHEN 'Container state read -> start issued' THEN 17
-    WHEN 'Container start issued -> onStart' THEN 18
-    WHEN 'Container start issued -> ports ready' THEN 19
-    WHEN 'Container onStart -> ports ready' THEN 20
-    WHEN 'Container start issued -> process start' THEN 21
-    WHEN 'Container process -> TCP listen' THEN 22
-    WHEN 'Container TCP listen -> ports ready' THEN 23
-    WHEN 'Container ports ready -> health check' THEN 24
-    WHEN 'Container health check' THEN 25
-    WHEN 'Container health -> ready observation' THEN 26
-    WHEN 'Container ready observation -> RPC return' THEN 27
-    WHEN 'Fence bound -> invocation prepared' THEN 28
-    WHEN 'Fresh-start parallel preparation' THEN 29
-    WHEN 'Parallel preparation -> invocation launched' THEN 30
-    WHEN 'Invocation launched -> runner job accepted' THEN 31
-    WHEN 'Cloudflare route -> fresh start request' THEN 32
-    ELSE 33
+    WHEN 'Prewarm request -> auth' THEN 1
+    WHEN 'Prewarm auth' THEN 2
+    WHEN 'Prewarm auth -> Cloudflare route' THEN 3
+    WHEN 'Prewarm route -> UserRunner constructor start' THEN 4
+    WHEN 'Prewarm UserRunner constructor' THEN 5
+    WHEN 'Prewarm constructor -> RPC' THEN 6
+    WHEN 'Prewarm RPC -> consent lock' THEN 7
+    WHEN 'Prewarm health-data admission' THEN 8
+    WHEN 'Prewarm admission -> container hint' THEN 9
+    WHEN 'Prewarm request -> container hint' THEN 10
+    WHEN 'Prewarm container hint -> direct ensure route' THEN 11
+    WHEN 'Accepted -> Cloudflare route' THEN 12
+    WHEN 'Cloudflare route -> UserRunner constructor start' THEN 13
+    WHEN 'UserRunner constructor start -> finish' THEN 14
+    WHEN 'UserRunner constructor finish -> first ensure instruction' THEN 15
+    WHEN 'Cloudflare route -> UserRunner RPC' THEN 16
+    WHEN 'UserRunner RPC -> consent lock' THEN 17
+    WHEN 'Health-data admission callback' THEN 18
+    WHEN 'Admission complete -> controller' THEN 19
+    WHEN 'Runner state bind' THEN 20
+    WHEN 'Runner state read' THEN 21
+    WHEN 'State ready -> fresh start request' THEN 22
+    WHEN 'Fresh start request -> fence bound' THEN 23
+    WHEN 'Fence bound -> container ready' THEN 24
+    WHEN 'Fence bound -> readiness RPC' THEN 25
+    WHEN 'Container lifecycle lock wait' THEN 26
+    WHEN 'Container state read' THEN 27
+    WHEN 'Container state read -> start issued' THEN 28
+    WHEN 'Container start issued -> onStart' THEN 29
+    WHEN 'Container start issued -> ports ready' THEN 30
+    WHEN 'Container onStart -> ports ready' THEN 31
+    WHEN 'Container start issued -> process start' THEN 32
+    WHEN 'Container process -> TCP listen' THEN 33
+    WHEN 'Container TCP listen -> ports ready' THEN 34
+    WHEN 'Container ports ready -> health check' THEN 35
+    WHEN 'Container health check' THEN 36
+    WHEN 'Container health -> ready observation' THEN 37
+    WHEN 'Container ready observation -> RPC return' THEN 38
+    WHEN 'Fence bound -> invocation prepared' THEN 39
+    WHEN 'Fresh-start parallel preparation' THEN 40
+    WHEN 'Parallel preparation -> invocation launched' THEN 41
+    WHEN 'Invocation launched -> runner job accepted' THEN 42
+    WHEN 'Cloudflare route -> fresh start request' THEN 43
+    ELSE 44
   END
 );

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -15,7 +15,9 @@ import {
 import {
   HOSTED_RUNTIME_FAILURE_PHASE_CODE_DETAIL_KEY,
   isHostedRuntimeFailurePhaseCode,
+  sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics,
   type HostedRuntimeFailurePhaseCode,
+  type HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   type HostedWorkspaceInvocationProcessingMode,
 } from "@murphai/hosted-execution/runtime-control";
 import { methodNotAllowed } from "./json.ts";
@@ -271,6 +273,7 @@ type RunnerContainerEnsureReadyResult = {
 export interface RunnerContainerShellPrewarmObservation {
   firstHintAtEpochMs: number;
   hintCount: number;
+  orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics;
   finishedAtEpochMs?: number;
   operationElapsedMs?: number;
   outcome?: RunnerContainerShellPrewarmOutcome;
@@ -285,6 +288,7 @@ export type RunnerContainerShellPrewarmOutcome =
 
 export interface RunnerContainerBeginShellPrewarmInput
   extends RunnerContainerEnsureReadyForProcessingInput {
+  orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics;
   source?: CloudflareHostedControlRuntimeShellPrewarmSource;
 }
 
@@ -976,7 +980,10 @@ export class RunnerContainer extends Container {
       );
       return { accepted: true };
     }
-    const observation = this.recordShellPrewarmHint(input.source);
+    const observation = this.recordShellPrewarmHint(
+      input.source,
+      input.orchestration,
+    );
     const operation = this.getOrBeginShellPrewarm(input);
     this.observeShellPrewarmOperation({
       observation,
@@ -3496,11 +3503,13 @@ export class RunnerContainer extends Container {
 
   private recordShellPrewarmHint(
     source: CloudflareHostedControlRuntimeShellPrewarmSource | undefined,
+    orchestration: HostedRuntimeShellPrewarmOrchestrationDiagnostics | undefined,
   ): RunnerContainerShellPrewarmObservation {
     const hintedAtMs = Date.now();
     const observation: RunnerContainerShellPrewarmObservation = {
       firstHintAtEpochMs: hintedAtMs,
       hintCount: 1,
+      ...(orchestration === undefined ? {} : { orchestration }),
       source: source ?? "unknown",
     };
     this.shellPrewarmObservation = observation;
@@ -3540,6 +3549,14 @@ export class RunnerContainer extends Container {
               shellPrewarmColdStartObserved: coldStartObserved,
               shellPrewarmElapsedMs: elapsedMs,
               shellPrewarmHintCountAtCompletion: input.observation.hintCount,
+              ...(input.observation.orchestration
+                ?.shellPrewarmOrchestrationAttemptId === undefined
+                ? {}
+                : {
+                    orchestrationAttemptId:
+                      input.observation.orchestration
+                        .shellPrewarmOrchestrationAttemptId,
+                  }),
               shellPrewarmOutcome: result.action,
               shellPrewarmSource: input.observation.source,
             },
@@ -3565,6 +3582,14 @@ export class RunnerContainer extends Container {
               ...buildHostedExecutionSafeErrorDiagnostics(error),
               shellPrewarmElapsedMs: elapsedMs,
               shellPrewarmHintCountAtCompletion: input.observation.hintCount,
+              ...(input.observation.orchestration
+                ?.shellPrewarmOrchestrationAttemptId === undefined
+                ? {}
+                : {
+                    orchestrationAttemptId:
+                      input.observation.orchestration
+                        .shellPrewarmOrchestrationAttemptId,
+                  }),
               shellPrewarmOutcome: "failed",
               shellPrewarmSource: input.observation.source,
             },
@@ -4511,15 +4536,21 @@ function parseRunnerContainerBeginShellPrewarmInput(
   payload: RunnerContainerBeginShellPrewarmInput,
 ): RunnerContainerBeginShellPrewarmInput {
   const input = parseRunnerContainerEnsureReadyForProcessingInput(payload);
+  const orchestration =
+    sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics(
+      payload.orchestration,
+    );
   if (
     payload.source !== undefined
     && payload.source !== "linq-instant-start"
+    && payload.source !== "linq-message-routing"
     && payload.source !== "linq-typing-started"
   ) {
     throw new TypeError("payload.source must be a supported shell-prewarm source.");
   }
   return {
     ...input,
+    ...(orchestration === null ? {} : { orchestration }),
     ...(payload.source === undefined ? {} : { source: payload.source }),
   };
 }

--- a/apps/cloudflare/src/user-runner/hosted-user-runner.ts
+++ b/apps/cloudflare/src/user-runner/hosted-user-runner.ts
@@ -2,6 +2,7 @@ import {
   type HostedHealthDataConsentState,
   type HostedRunnerStatusResponse,
   type HostedRuntimeHealthDataAdmissionResponse,
+  type HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   type HostedRuntimeWebStatusResponse,
   type HostedWorkspaceReadResponse,
   type HostedWorkspaceState,
@@ -376,12 +377,18 @@ export class HostedUserRunner {
   async prewarmRuntimeShellForUser(
     userId: string,
     source?: CloudflareHostedControlRuntimeShellPrewarmSource,
+    orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   ): Promise<void> {
+    const orchestrationAttemptId =
+      orchestration?.shellPrewarmOrchestrationAttemptId;
     if (this.runtimeConsentMutationLock) {
       emitHostedExecutionStructuredLog({
         component: "hosted.runner",
         details: {
           shellPrewarmAdmissionOutcome: "skipped_consent_busy",
+          ...(orchestrationAttemptId === undefined
+            ? {}
+            : { orchestrationAttemptId }),
           shellPrewarmSource: source ?? "unknown",
         },
         message: "Hosted runner shell prewarm admission decided.",
@@ -391,6 +398,8 @@ export class HostedUserRunner {
       return;
     }
     await this.withRuntimeConsentMutationLock(async () => {
+      const shellPrewarmConsentLockAcquiredAtEpochMs = Date.now();
+      const shellPrewarmAdmissionReadStartedAtEpochMs = Date.now();
       let admission: HostedRuntimeHealthDataAdmissionResponse;
       try {
         admission = await this.readHostedRuntimeHealthDataAdmissionFromWeb(
@@ -402,6 +411,9 @@ export class HostedUserRunner {
           component: "hosted.runner",
           details: {
             shellPrewarmAdmissionOutcome: "skipped_admission_unavailable",
+            ...(orchestrationAttemptId === undefined
+              ? {}
+              : { orchestrationAttemptId }),
             shellPrewarmSource: source ?? "unknown",
           },
           level: "warn",
@@ -411,11 +423,15 @@ export class HostedUserRunner {
         });
         return;
       }
+      const shellPrewarmAdmissionReadFinishedAtEpochMs = Date.now();
       if (!admission.processingAllowed) {
         emitHostedExecutionStructuredLog({
           component: "hosted.runner",
           details: {
             shellPrewarmAdmissionOutcome: "skipped_processing_disallowed",
+            ...(orchestrationAttemptId === undefined
+              ? {}
+              : { orchestrationAttemptId }),
             shellPrewarmSource: source ?? "unknown",
           },
           message: "Hosted runner shell prewarm admission decided.",
@@ -424,7 +440,16 @@ export class HostedUserRunner {
         });
         return;
       }
-      await this.runtimeProcessing.beginShellPrewarmForUser(userId, source);
+      await this.runtimeProcessing.beginShellPrewarmForUser(
+        userId,
+        source,
+        orchestration === undefined ? undefined : {
+          ...orchestration,
+          shellPrewarmAdmissionReadFinishedAtEpochMs,
+          shellPrewarmAdmissionReadStartedAtEpochMs,
+          shellPrewarmConsentLockAcquiredAtEpochMs,
+        },
+      );
     });
   }
 

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -10,6 +10,7 @@ import type {
 } from "@murphai/hosted-execution/orchestration-control";
 import {
   type HostedRuntimeLatencyPhaseBreakdown,
+  type HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   isHostedRuntimeDirectEnsureOrchestrationAttemptId,
 } from "@murphai/hosted-execution/runtime-control";
 
@@ -161,6 +162,7 @@ function toShellPrewarmOrchestrationDiagnostics(
     return null;
   }
   return {
+    ...(observation.orchestration ?? {}),
     shellPrewarmFirstHintAtEpochMs: observation.firstHintAtEpochMs,
     shellPrewarmHintCount: observation.hintCount,
     ...(observation.finishedAtEpochMs === undefined ? {} : {
@@ -271,7 +273,10 @@ export class RuntimeProcessingController {
   async beginShellPrewarmForUser(
     userId: string,
     source?: CloudflareHostedControlRuntimeShellPrewarmSource,
+    orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   ): Promise<void> {
+    const orchestrationAttemptId =
+      orchestration?.shellPrewarmOrchestrationAttemptId;
     const namespace = this.input.runnerContainerNamespace;
     if (!namespace) {
       throw new Error("Runner container namespace is unavailable.");
@@ -294,6 +299,9 @@ export class RuntimeProcessingController {
         component: "hosted.runner",
         details: {
           shellPrewarmAdmissionOutcome: "skipped_runtime_busy",
+          ...(orchestrationAttemptId === undefined
+            ? {}
+            : { orchestrationAttemptId }),
           shellPrewarmSource: source ?? "unknown",
         },
         message: "Hosted runner shell prewarm admission decided.",
@@ -303,6 +311,7 @@ export class RuntimeProcessingController {
       return;
     }
     await container.beginShellPrewarm({
+      ...(orchestration === undefined ? {} : { orchestration }),
       ...(source === undefined ? {} : { source }),
       timeoutMs: RUNTIME_SHELL_PREWARM_TIMEOUT_MS,
       userId,
@@ -311,6 +320,9 @@ export class RuntimeProcessingController {
       component: "hosted.runner",
       details: {
         shellPrewarmAdmissionOutcome: "scheduled",
+        ...(orchestrationAttemptId === undefined
+          ? {}
+          : { orchestrationAttemptId }),
         shellPrewarmSource: source ?? "unknown",
       },
       message: "Hosted runner shell prewarm admission decided.",

--- a/apps/cloudflare/src/worker-contracts.ts
+++ b/apps/cloudflare/src/worker-contracts.ts
@@ -1,5 +1,6 @@
 import type {
   HostedWorkspaceInvocationResult,
+  HostedRuntimeShellPrewarmOrchestrationDiagnostics,
 } from "@murphai/hosted-execution/runtime-control";
 import type {
   CloudflareHostedControlRuntimeShellPrewarmSource,
@@ -141,6 +142,7 @@ export interface WorkerUserRunnerStubLike {
   prewarmRuntimeShellForUser?(
     userId: string,
     source?: CloudflareHostedControlRuntimeShellPrewarmSource,
+    orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   ): Promise<void>;
   reconcileRuntimeHealthDataConsentForUser?(userId: string): Promise<unknown>;
   publishHostedPrivateMedia?(

--- a/apps/cloudflare/src/worker-routes/shared.ts
+++ b/apps/cloudflare/src/worker-routes/shared.ts
@@ -1,5 +1,6 @@
 import type {
   HostedRuntimeLatencyPhaseBreakdown,
+  HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   HostedRunnerStatusResponse,
 } from "@murphai/hosted-execution/runtime-control";
 import type {
@@ -56,6 +57,7 @@ export interface UserRunnerDurableObjectStubLike extends WorkerUserRunnerStubLik
   prewarmRuntimeShellForUser?(
     userId: string,
     source?: CloudflareHostedControlRuntimeShellPrewarmSource,
+    orchestration?: HostedRuntimeShellPrewarmOrchestrationDiagnostics,
   ): Promise<void>;
   validateRuntimeWriteFence?(input: {
     attemptId: string;

--- a/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
+++ b/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
@@ -5,8 +5,10 @@ import type {
   HostedRuntimeEnsureProcessingRequest,
   HostedRuntimeEnsureProcessingResponse,
 } from "@murphai/hosted-execution/orchestration-control";
-import type {
-  HostedRuntimeLatencyPhaseBreakdown,
+import {
+  isHostedRuntimeShellPrewarmOrchestrationAttemptId,
+  type HostedRuntimeLatencyPhaseBreakdown,
+  type HostedRuntimeShellPrewarmOrchestrationDiagnostics,
 } from "@murphai/hosted-execution/runtime-control";
 import {
   assertHostedRuntimeProcessingTimeoutMs,
@@ -315,19 +317,55 @@ async function handleRuntimeShellPrewarmRoute(
   context: WorkerRouteContext,
   encodedUserId: string,
 ): Promise<Response> {
+  const shellPrewarmCloudflareRouteReceivedAtEpochMs = Date.now();
   const userId = decodeRouteParam(encodedUserId);
   try {
     const payload = await readCachedRequestText(context, {
       limitBytes: INTERNAL_CONTROL_JSON_BODY_LIMIT_BYTES,
     });
     const body = requireJsonObject(payload.trim() ? JSON.parse(payload) : {});
-    if (Object.keys(body).some((key) => key !== "source")) {
+    if (Object.keys(body).some((key) => ![
+      "orchestrationAttemptId",
+      "requestStartedAtEpochMs",
+      "source",
+    ].includes(key))) {
       throw new TypeError("Hosted runtime shell prewarm request has unknown fields.");
     }
+    const orchestrationAttemptId = body.orchestrationAttemptId;
+    const requestStartedAtEpochMs = body.requestStartedAtEpochMs;
+    const hasLegacyTelemetryShape = orchestrationAttemptId === undefined
+      && requestStartedAtEpochMs === undefined;
+    if (
+      !hasLegacyTelemetryShape
+      && !isHostedRuntimeShellPrewarmOrchestrationAttemptId(orchestrationAttemptId)
+    ) {
+      throw new TypeError(
+        "Hosted runtime shell prewarm orchestrationAttemptId is invalid.",
+      );
+    }
+    if (
+      !hasLegacyTelemetryShape
+      && (
+        typeof requestStartedAtEpochMs !== "number"
+        || !Number.isSafeInteger(requestStartedAtEpochMs)
+        || requestStartedAtEpochMs < 0
+      )
+    ) {
+      throw new TypeError(
+        "Hosted runtime shell prewarm requestStartedAtEpochMs is invalid.",
+      );
+    }
+    const requestDiagnostics:
+      HostedRuntimeShellPrewarmOrchestrationDiagnostics =
+      hasLegacyTelemetryShape ? {} : {
+        shellPrewarmOrchestrationAttemptId: orchestrationAttemptId,
+        shellPrewarmRequestStartedAtEpochMs: requestStartedAtEpochMs,
+      };
     const source = body.source;
     if (
       source !== undefined
       && source !== "linq-instant-start"
+      && source !== "linq-message-routing"
       && source !== "linq-typing-started"
     ) {
       throw new TypeError("Hosted runtime shell prewarm source is invalid.");
@@ -337,7 +375,17 @@ async function handleRuntimeShellPrewarmRoute(
     if (!stub.prewarmRuntimeShellForUser) {
       throw new Error("User runner shell-prewarm RPC is unavailable.");
     }
-    await stub.prewarmRuntimeShellForUser(userId, source);
+    const orchestration: HostedRuntimeShellPrewarmOrchestrationDiagnostics = {
+      shellPrewarmCloudflareRouteReceivedAtEpochMs,
+      ...requestDiagnostics,
+      ...(context.runtimeControlAuthTiming === undefined ? {} : {
+        shellPrewarmRuntimeControlAuthFinishedAtEpochMs:
+          context.runtimeControlAuthTiming.runtimeControlAuthFinishedAtEpochMs,
+        shellPrewarmRuntimeControlAuthStartedAtEpochMs:
+          context.runtimeControlAuthTiming.runtimeControlAuthStartedAtEpochMs,
+      }),
+    };
+    await stub.prewarmRuntimeShellForUser(userId, source, orchestration);
     return json({ accepted: true }, 202);
   } catch (error) {
     emitHostedExecutionStructuredLog({

--- a/apps/cloudflare/src/worker/routes.ts
+++ b/apps/cloudflare/src/worker/routes.ts
@@ -117,7 +117,10 @@ function recordRuntimeControlAuthTiming(
   runtimeControlAuthStartedAtEpochMs: number,
   runtimeControlAuthFinishedAtEpochMs: number,
 ): void {
-  if (routeName !== "runtime-ensure-processing") {
+  if (
+    routeName !== "runtime-ensure-processing"
+    && routeName !== "runtime-shell-prewarm"
+  ) {
     return;
   }
 

--- a/apps/cloudflare/src/worker/user-runner-durable-object.ts
+++ b/apps/cloudflare/src/worker/user-runner-durable-object.ts
@@ -67,8 +67,16 @@ export class UserRunnerDurableObject extends DurableObject implements UserRunner
   async prewarmRuntimeShellForUser(
     userId: string,
     source?: Parameters<HostedUserRunner["prewarmRuntimeShellForUser"]>[1],
+    orchestration?: Parameters<HostedUserRunner["prewarmRuntimeShellForUser"]>[2],
   ): ReturnType<HostedUserRunner["prewarmRuntimeShellForUser"]> {
-    return this.runner.prewarmRuntimeShellForUser(userId, source);
+    return this.runner.prewarmRuntimeShellForUser(userId, source, {
+      ...(orchestration ?? {}),
+      shellPrewarmUserRunnerConstructorFinishedAtEpochMs:
+        this.activationTiming.userRunnerConstructorFinishedAtEpochMs,
+      shellPrewarmUserRunnerConstructorStartedAtEpochMs:
+        this.activationTiming.userRunnerConstructorStartedAtEpochMs,
+      shellPrewarmUserRunnerRpcStartedAtEpochMs: Date.now(),
+    });
   }
 
   async publishHostedPrivateMedia(

--- a/apps/cloudflare/test/hosted-local-linq-webhook-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-webhook-e2e.test.ts
@@ -37,6 +37,8 @@ const hostedLinqPdfAssistantReplyText = "Read the PDF attachment.";
 const hostedLinqAppCardAssistantReplyText = "Handled the app card.";
 const hostedLinqTypingPrewarmAssistantReplyText =
   "The typing prewarm kept the normal reply path intact.";
+const hostedLinqMessageRoutingPrewarmAssistantReplyText =
+  "The message-routing prewarm stayed attached to this reply.";
 const hostedLinqParticipantAdditionGroupContext =
   "One or more participants were recently added to this group chat.";
 const hostedLinqParticipantAddedDetailedContext =
@@ -150,6 +152,97 @@ describe("hosted local Linq webhook e2e", () => {
       assistantProviderBody.includes("U can call me Rocket Man"),
       summarizeProviderTextRequestShape(assistantProviderBody),
     ).toBe(true);
+  }, 300_000);
+
+  it("attributes an idle direct message prewarm to its delivered reply", async () => {
+    const { chatId, replyChatPath, userId } =
+      await createActiveLinqWebhookMember("message-routing-prewarm");
+    await requireScenario().waitForHostedIdle(userId);
+    const outboundCountBeforeReply = requireLinqStub()
+      .countObservedSends(replyChatPath);
+    const providerCountBeforeReply = requireScenario().assistantProviderRequests.length;
+    const messageText = "Can the direct message wake the runtime early?";
+    const messageEventId = `evt_message_routing_prewarm_${userId}`;
+
+    requireScenario().queueAssistantResponses([
+      hostedLinqMessageRoutingPrewarmAssistantReplyText,
+    ], {
+      matchInputContains: messageText,
+    });
+    const messageResponse = await postSignedLinqWebhook(
+      buildHostedLinqInboundEvent(userId, chatId, {
+        eventId: messageEventId,
+        messageId: `msg_message_routing_prewarm_${userId}`,
+        text: messageText,
+      }),
+    );
+    expect(messageResponse.status).toBe(202);
+    await expect(messageResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+
+    await requireScenario().waitForLatestPendingWake(userId);
+    await requireScenario().waitForHostedCompletion(userId);
+    const reply = await requireLinqStub().waitForAdditionalSend({
+      baselineCount: outboundCountBeforeReply,
+      expectedPath: replyChatPath,
+      scenario: requireScenario(),
+      userId,
+    });
+    expect(requireLinqStub().readObservedMessageText(reply)).toBe(
+      hostedLinqMessageRoutingPrewarmAssistantReplyText,
+    );
+    expect(requireScenario().assistantProviderRequests).toHaveLength(
+      providerCountBeforeReply + 1,
+    );
+
+    const latencyTrace = await waitForShellPrewarmLatencyTrace({
+      mailboxDedupeKey: messageEventId,
+      userId,
+    });
+    const orchestration = latencyTrace.phaseBreakdown?.orchestration;
+    expect(orchestration).toMatchObject({
+      shellPrewarmAdmissionReadFinishedAtEpochMs: expect.any(Number),
+      shellPrewarmAdmissionReadStartedAtEpochMs: expect.any(Number),
+      shellPrewarmCloudflareRouteReceivedAtEpochMs: expect.any(Number),
+      shellPrewarmConsentLockAcquiredAtEpochMs: expect.any(Number),
+      shellPrewarmExpectedOrchestrationAttemptId:
+        expect.stringMatching(/^web-prewarm-[0-9a-f-]{36}$/u),
+      shellPrewarmFirstHintAtEpochMs: expect.any(Number),
+      shellPrewarmHintCount: expect.any(Number),
+      shellPrewarmOrchestrationAttemptId:
+        expect.stringMatching(/^web-prewarm-[0-9a-f-]{36}$/u),
+      shellPrewarmOutcome: expect.stringMatching(
+        /^(?:cold_start_observed|start_issued_warm)$/u,
+      ),
+      shellPrewarmRequestStartedAtEpochMs: expect.any(Number),
+      shellPrewarmRuntimeControlAuthFinishedAtEpochMs: expect.any(Number),
+      shellPrewarmRuntimeControlAuthStartedAtEpochMs: expect.any(Number),
+      shellPrewarmSource: "linq-message-routing",
+      shellPrewarmUserRunnerConstructorFinishedAtEpochMs: expect.any(Number),
+      shellPrewarmUserRunnerConstructorStartedAtEpochMs: expect.any(Number),
+      shellPrewarmUserRunnerRpcStartedAtEpochMs: expect.any(Number),
+    });
+    expect(orchestration?.shellPrewarmExpectedOrchestrationAttemptId).toBe(
+      orchestration?.shellPrewarmOrchestrationAttemptId,
+    );
+    expectNondecreasingEpochs(
+      orchestration?.shellPrewarmRequestStartedAtEpochMs,
+      orchestration?.shellPrewarmRuntimeControlAuthStartedAtEpochMs,
+      orchestration?.shellPrewarmRuntimeControlAuthFinishedAtEpochMs,
+      orchestration?.shellPrewarmCloudflareRouteReceivedAtEpochMs,
+      orchestration?.shellPrewarmUserRunnerRpcStartedAtEpochMs,
+    );
+    expectNondecreasingEpochs(
+      orchestration?.shellPrewarmUserRunnerConstructorStartedAtEpochMs,
+      orchestration?.shellPrewarmUserRunnerConstructorFinishedAtEpochMs,
+      orchestration?.shellPrewarmUserRunnerRpcStartedAtEpochMs,
+      orchestration?.shellPrewarmConsentLockAcquiredAtEpochMs,
+      orchestration?.shellPrewarmAdmissionReadStartedAtEpochMs,
+      orchestration?.shellPrewarmAdmissionReadFinishedAtEpochMs,
+      orchestration?.shellPrewarmFirstHintAtEpochMs,
+    );
   }, 300_000);
 
   it("reduces an inbound iMessage app card to fallback text and replies in the same chat", async () => {
@@ -292,7 +385,7 @@ describe("hosted local Linq webhook e2e", () => {
     expect(requireScenario().assistantProviderRequests).toHaveLength(
       providerCountBeforeTyping + 1,
     );
-    const latencyTrace = await waitForTypingPrewarmLatencyTrace({
+    const latencyTrace = await waitForShellPrewarmLatencyTrace({
       mailboxDedupeKey: messageEventId,
       userId,
     });
@@ -928,7 +1021,7 @@ function signLinqWebhook(secret: string, payload: string, timestamp: string): st
   return `sha256=${signature}`;
 }
 
-async function waitForTypingPrewarmLatencyTrace(input: {
+async function waitForShellPrewarmLatencyTrace(input: {
   mailboxDedupeKey: string;
   userId: string;
 }) {
@@ -959,8 +1052,18 @@ async function waitForTypingPrewarmLatencyTrace(input: {
   }
 
   throw new Error(
-    `Timed out waiting for the typing-prewarm latency trace: ${String(lastError)}`,
+    `Timed out waiting for the shell-prewarm latency trace: ${String(lastError)}`,
   );
+}
+
+function expectNondecreasingEpochs(...values: unknown[]): void {
+  for (const value of values) {
+    expect(value).toEqual(expect.any(Number));
+  }
+  const epochValues = values as number[];
+  for (let index = 1; index < epochValues.length; index += 1) {
+    expect(epochValues[index]).toBeGreaterThanOrEqual(epochValues[index - 1] ?? 0);
+  }
 }
 
 function parseAssistantProviderRequestBody(body: string | undefined): Record<string, unknown> {

--- a/apps/cloudflare/test/index-backpressure.test.ts
+++ b/apps/cloudflare/test/index-backpressure.test.ts
@@ -155,6 +155,63 @@ describe("cloudflare worker queue backpressure routes", () => {
     });
   });
 
+  it("stamps prewarm-specific UserRunner activation before forwarding the hint", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-06T12:00:00.000Z"));
+    const prewarm = vi.spyOn(
+      HostedUserRunner.prototype,
+      "prewarmRuntimeShellForUser",
+    ).mockResolvedValue(undefined);
+    const bucket = createBucketStore();
+    const storage = createStorage();
+    const env = {
+      ...createHostedExecutionTestEnv(),
+      RUNNER_CONTAINER: storage.runnerContainerNamespace,
+      RUNNER_CONTAINER_SMOKE: storage.runnerContainerNamespace,
+    };
+    Object.defineProperty(env, "BUNDLES", {
+      enumerable: true,
+      get() {
+        vi.setSystemTime(new Date("2026-08-06T12:00:00.025Z"));
+        return bucket.api;
+      },
+    });
+    const durableObject = new UserRunnerDurableObject(storage.state, env as never);
+
+    vi.setSystemTime(new Date("2026-08-06T12:00:01.000Z"));
+    await durableObject.prewarmRuntimeShellForUser(
+      "member_123",
+      "linq-message-routing",
+      {
+        shellPrewarmCloudflareRouteReceivedAtEpochMs:
+          Date.parse("2026-08-06T11:59:59.900Z"),
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs:
+          Date.parse("2026-08-06T11:59:59.800Z"),
+      },
+    );
+
+    expect(prewarm).toHaveBeenCalledWith(
+      "member_123",
+      "linq-message-routing",
+      {
+        shellPrewarmCloudflareRouteReceivedAtEpochMs:
+          Date.parse("2026-08-06T11:59:59.900Z"),
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs:
+          Date.parse("2026-08-06T11:59:59.800Z"),
+        shellPrewarmUserRunnerConstructorFinishedAtEpochMs:
+          Date.parse("2026-08-06T12:00:00.025Z"),
+        shellPrewarmUserRunnerConstructorStartedAtEpochMs:
+          Date.parse("2026-08-06T12:00:00.000Z"),
+        shellPrewarmUserRunnerRpcStartedAtEpochMs:
+          Date.parse("2026-08-06T12:00:01.000Z"),
+      },
+    );
+  });
+
   it("forwards managed AI revocation through the UserRunner Durable Object", async () => {
     const revoke = vi.spyOn(
       HostedUserRunner.prototype,

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -3543,7 +3543,9 @@ describe("cloudflare worker routes", () => {
     });
 
     it("routes shell startup through the consent-owning user runner", async () => {
-      const prewarmRuntimeShellForUser = vi.fn(async () => undefined);
+      const prewarmRuntimeShellForUser = vi.fn<
+        NonNullable<UserRunnerDurableObjectStubLike["prewarmRuntimeShellForUser"]>
+      >(async () => undefined);
       const stub = createUserRunnerStub({ prewarmRuntimeShellForUser });
       const runnerContainerGetByName = vi.fn();
       const userRunnerGetByName = vi.fn(() => stub);
@@ -3577,12 +3579,20 @@ describe("cloudflare worker routes", () => {
         "test-user",
         "linq-message-routing",
         expect.objectContaining({
+          shellPrewarmRuntimeControlAuthFinishedAtEpochMs: expect.any(Number),
+          shellPrewarmRuntimeControlAuthStartedAtEpochMs: expect.any(Number),
           shellPrewarmCloudflareRouteReceivedAtEpochMs: expect.any(Number),
           shellPrewarmOrchestrationAttemptId:
             "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
           shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
         }),
       );
+      const orchestration = prewarmRuntimeShellForUser.mock.calls[0]?.[2];
+      expect(orchestration?.shellPrewarmRuntimeControlAuthStartedAtEpochMs)
+        .toBeLessThanOrEqual(
+          orchestration?.shellPrewarmRuntimeControlAuthFinishedAtEpochMs
+            ?? Number.NEGATIVE_INFINITY,
+        );
       expect(runnerContainerGetByName).not.toHaveBeenCalled();
     });
 

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -3556,7 +3556,12 @@ describe("cloudflare worker routes", () => {
         await signControlRequest(new Request(
           "https://runner.example.test/internal/users/test-user/runtime/shell-prewarm",
           {
-            body: JSON.stringify({ source: "linq-typing-started" }),
+            body: JSON.stringify({
+              orchestrationAttemptId:
+                "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+              requestStartedAtEpochMs: 1_788_000_000_000,
+              source: "linq-message-routing",
+            }),
             headers: { "content-type": "application/json; charset=utf-8" },
             method: "POST",
           },
@@ -3570,7 +3575,13 @@ describe("cloudflare worker routes", () => {
       expect(stub.bindUser).not.toHaveBeenCalled();
       expect(prewarmRuntimeShellForUser).toHaveBeenCalledWith(
         "test-user",
-        "linq-typing-started",
+        "linq-message-routing",
+        expect.objectContaining({
+          shellPrewarmCloudflareRouteReceivedAtEpochMs: expect.any(Number),
+          shellPrewarmOrchestrationAttemptId:
+            "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+          shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
+        }),
       );
       expect(runnerContainerGetByName).not.toHaveBeenCalled();
     });
@@ -3598,9 +3609,15 @@ describe("cloudflare worker routes", () => {
       const bindUser = vi.fn(async (userId: string) =>
         await harness.runner.bindUser(userId)
       );
-      const prewarmRuntimeShellForUser = vi.fn(async (userId: string) =>
-        await harness.runner.prewarmRuntimeShellForUser(userId)
-      );
+      const prewarmRuntimeShellForUser = vi.fn(async (
+        userId: string,
+        source?: Parameters<typeof harness.runner.prewarmRuntimeShellForUser>[1],
+        orchestration?: Parameters<typeof harness.runner.prewarmRuntimeShellForUser>[2],
+      ) => await harness.runner.prewarmRuntimeShellForUser(
+        userId,
+        source,
+        orchestration,
+      ));
       const stub = createUserRunnerStub({
         bindUser,
         prewarmRuntimeShellForUser,
@@ -3619,6 +3636,9 @@ describe("cloudflare worker routes", () => {
       expect(prewarmRuntimeShellForUser).toHaveBeenCalledWith(
         "test-user",
         undefined,
+        expect.objectContaining({
+          shellPrewarmCloudflareRouteReceivedAtEpochMs: expect.any(Number),
+        }),
       );
       expect(harness.namespace.getByName).not.toHaveBeenCalled();
       expect(

--- a/apps/cloudflare/test/operational-report-contracts.test.ts
+++ b/apps/cloudflare/test/operational-report-contracts.test.ts
@@ -144,11 +144,27 @@ describe("hosted runtime operational report contracts", () => {
     );
     expect(coldStartReportSql).toContain("Container health check");
     expect(coldStartReportSql).toContain("shellPrewarmSource}' = 'linq-typing-started'");
+    expect(coldStartReportSql).toContain("shellPrewarmSource}' = 'linq-message-routing'");
+    expect(coldStartReportSql).toContain(
+      "shellPrewarmOrchestrationAttemptId}' =",
+    );
+    expect(coldStartReportSql).toContain(
+      "shellPrewarmExpectedOrchestrationAttemptId}'",
+    );
+    expect(coldStartReportSql).toContain(
+      "Prewarm route -> UserRunner constructor start",
+    );
+    expect(coldStartReportSql).toContain(
+      "Prewarm admission -> container hint",
+    );
+    expect(coldStartReportSql).toContain(
+      "Prewarm container hint -> direct ensure route",
+    );
     expect(coldStartReportSql).toContain(
       "trace.reply_runtime_attempt_id = trace.runtime_attempt_id",
     );
     expect(coldStartReportSql).toContain("causal_candidate_count = 1");
-    expect(coldStartReportSql).toContain("Causal typing hint -> ingress accepted");
+    expect(coldStartReportSql).toContain("Causal shell-prewarm hint -> ingress accepted");
     expect(coldStartReportSql).not.toContain("shellPrewarmLastHintAtEpochMs");
   });
 });
@@ -231,23 +247,23 @@ describe.skipIf(!runPostgresProof)(
         ]);
 
         expect(stdout).toContain(
-          "prewarm_cold_start_observed,Causal typing hint -> ingress accepted,1,500.0,500.0,500.0",
+          "prewarm_typing_cold_start_observed,Causal shell-prewarm hint -> ingress accepted,1,500.0,500.0,500.0",
         );
         expect(stdout).toContain(
-          "prewarm_cold_start_observed,Ingress accepted -> runner job,1,1000.0,1000.0,1000.0",
+          "prewarm_typing_cold_start_observed,Ingress accepted -> runner job,1,1000.0,1000.0,1000.0",
         );
         expect(stdout).toContain(
-          "prewarm_cold_start_observed,Ingress accepted -> provider start,1,2000.0,2000.0,2000.0",
+          "prewarm_typing_cold_start_observed,Ingress accepted -> provider start,1,2000.0,2000.0,2000.0",
         );
         expect(stdout).toContain(
-          "prewarm_cold_start_observed,Ingress accepted -> reply accepted,1,3000.0,3000.0,3000.0",
+          "prewarm_typing_cold_start_observed,Ingress accepted -> reply accepted,1,3000.0,3000.0,3000.0",
         );
         expect(stdout).toContain(
           "no_observed_prewarm,Ingress accepted -> reply accepted,1,4000.0,4000.0,4000.0",
         );
-        expect(stdout).not.toContain("prewarm_failed,");
-        expect(stdout).not.toContain("prewarm_start_issued_warm,");
-        expect(stdout).not.toContain("prewarm_superseded,");
+        expect(stdout).not.toContain("prewarm_typing_failed,");
+        expect(stdout).not.toContain("prewarm_typing_start_issued_warm,");
+        expect(stdout).not.toContain("prewarm_typing_superseded,");
       } finally {
         await runPsql(connection, [
           "--quiet",

--- a/apps/cloudflare/test/operational-report-contracts.test.ts
+++ b/apps/cloudflare/test/operational-report-contracts.test.ts
@@ -225,7 +225,7 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
-    it("attributes typing prewarm metrics to one causal trace and excludes ambiguous sources", async () => {
+    it("attributes causal shell prewarm metrics and requires exact message-routing identity", async () => {
       const connection = readLocalPostgresConnection(databaseUrl);
       if (!connection) {
         throw new Error("Expected a validated local PostgreSQL connection.");
@@ -260,6 +260,49 @@ describe.skipIf(!runPostgresProof)(
         );
         expect(stdout).toContain(
           "no_observed_prewarm,Ingress accepted -> reply accepted,1,4000.0,4000.0,4000.0",
+        );
+        expect(stdout).toContain(
+          "prewarm_message_routing_cold_start_observed,Causal shell-prewarm hint -> ingress accepted,1,900.0,900.0,900.0",
+        );
+        expect(stdout).toContain(
+          "prewarm_message_routing_cold_start_observed,Ingress accepted -> runner job,1,1000.0,1000.0,1000.0",
+        );
+        expect(stdout).toContain(
+          "prewarm_message_routing_cold_start_observed,Ingress accepted -> provider start,1,2000.0,2000.0,2000.0",
+        );
+        expect(stdout).toContain(
+          "prewarm_message_routing_cold_start_observed,Ingress accepted -> reply accepted,1,4000.0,4000.0,4000.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm request -> auth,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain("Prewarm auth,1,10.0,10.0,10.0");
+        expect(stdout).toContain(
+          "Prewarm auth -> Cloudflare route,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm route -> UserRunner constructor start,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm UserRunner constructor,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm constructor -> RPC,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm RPC -> consent lock,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm health-data admission,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm admission -> container hint,1,10.0,10.0,10.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm request -> container hint,1,100.0,100.0,100.0",
+        );
+        expect(stdout).toContain(
+          "Prewarm container hint -> direct ensure route,1,1050.0,1050.0,1050.0",
         );
         expect(stdout).not.toContain("prewarm_typing_failed,");
         expect(stdout).not.toContain("prewarm_typing_start_issued_warm,");
@@ -373,7 +416,9 @@ function createShellPrewarmFixtureSql(schemaName: string): string {
     UNION ALL SELECT 'delivery-handoff', t0 + INTERVAL '34 seconds' FROM clock
     UNION ALL SELECT 'delivery-instant', t0 + INTERVAL '44 seconds' FROM clock
     UNION ALL SELECT 'delivery-unknown', t0 + INTERVAL '54 seconds' FROM clock
-    UNION ALL SELECT 'delivery-negative', t0 + INTERVAL '64 seconds' FROM clock;
+    UNION ALL SELECT 'delivery-negative', t0 + INTERVAL '64 seconds' FROM clock
+    UNION ALL SELECT 'delivery-message-routing-exact', t0 + INTERVAL '74 seconds' FROM clock
+    UNION ALL SELECT 'delivery-message-routing-mismatch', t0 + INTERVAL '84 seconds' FROM clock;
     WITH clock AS (
       SELECT
         date_trunc(
@@ -582,6 +627,80 @@ function createShellPrewarmFixtureSql(schemaName: string): string {
         'shellPrewarmFirstHintAtEpochMs', base_ms + 60500,
         'shellPrewarmOutcome', 'cold_start_observed',
         'shellPrewarmSource', 'linq-typing-started'
+      ))
+    FROM fixture
+    UNION ALL
+    SELECT
+      'message-routing-exact',
+      t0 + INTERVAL '70 seconds',
+      t0 + INTERVAL '71 seconds',
+      t0 + INTERVAL '72 seconds',
+      'attempt-message-routing-exact',
+      'attempt-message-routing-exact',
+      'delivery-message-routing-exact',
+      'linq',
+      jsonb_build_object('orchestration', jsonb_build_object(
+        'triggeredByWebDirect', true,
+        'directEnsureRequestStartedAtEpochMs', base_ms + 70100,
+        'directEnsureResponseReceivedAtEpochMs', base_ms + 70200,
+        'directEnsureOrchestrationAttemptId', 'web-ingress-message-routing-exact',
+        'runtimeInvocationOrchestrationAttemptId', 'web-ingress-message-routing-exact',
+        'cloudflareRouteReceivedAtEpochMs', base_ms + 70150,
+        'freshStartRequestedAtEpochMs', base_ms + 70300,
+        'shellPrewarmRequestStartedAtEpochMs', base_ms + 69000,
+        'shellPrewarmRuntimeControlAuthStartedAtEpochMs', base_ms + 69010,
+        'shellPrewarmRuntimeControlAuthFinishedAtEpochMs', base_ms + 69020,
+        'shellPrewarmCloudflareRouteReceivedAtEpochMs', base_ms + 69030,
+        'shellPrewarmUserRunnerConstructorStartedAtEpochMs', base_ms + 69040,
+        'shellPrewarmUserRunnerConstructorFinishedAtEpochMs', base_ms + 69050,
+        'shellPrewarmUserRunnerRpcStartedAtEpochMs', base_ms + 69060,
+        'shellPrewarmConsentLockAcquiredAtEpochMs', base_ms + 69070,
+        'shellPrewarmAdmissionReadStartedAtEpochMs', base_ms + 69080,
+        'shellPrewarmAdmissionReadFinishedAtEpochMs', base_ms + 69090,
+        'shellPrewarmFirstHintAtEpochMs', base_ms + 69100,
+        'shellPrewarmExpectedOrchestrationAttemptId',
+          'web-prewarm-123e4567-e89b-42d3-a456-426614174000',
+        'shellPrewarmOrchestrationAttemptId',
+          'web-prewarm-123e4567-e89b-42d3-a456-426614174000',
+        'shellPrewarmOutcome', 'cold_start_observed',
+        'shellPrewarmSource', 'linq-message-routing'
+      ))
+    FROM fixture
+    UNION ALL
+    SELECT
+      'message-routing-mismatch',
+      t0 + INTERVAL '80 seconds',
+      t0 + INTERVAL '81 seconds',
+      t0 + INTERVAL '82 seconds',
+      'attempt-message-routing-mismatch',
+      'attempt-message-routing-mismatch',
+      'delivery-message-routing-mismatch',
+      'linq',
+      jsonb_build_object('orchestration', jsonb_build_object(
+        'triggeredByWebDirect', true,
+        'directEnsureRequestStartedAtEpochMs', base_ms + 80100,
+        'directEnsureResponseReceivedAtEpochMs', base_ms + 80200,
+        'directEnsureOrchestrationAttemptId', 'web-ingress-message-routing-mismatch',
+        'runtimeInvocationOrchestrationAttemptId', 'web-ingress-message-routing-mismatch',
+        'cloudflareRouteReceivedAtEpochMs', base_ms + 80150,
+        'freshStartRequestedAtEpochMs', base_ms + 80300,
+        'shellPrewarmRequestStartedAtEpochMs', base_ms + 79000,
+        'shellPrewarmRuntimeControlAuthStartedAtEpochMs', base_ms + 79010,
+        'shellPrewarmRuntimeControlAuthFinishedAtEpochMs', base_ms + 79020,
+        'shellPrewarmCloudflareRouteReceivedAtEpochMs', base_ms + 79030,
+        'shellPrewarmUserRunnerConstructorStartedAtEpochMs', base_ms + 79040,
+        'shellPrewarmUserRunnerConstructorFinishedAtEpochMs', base_ms + 79050,
+        'shellPrewarmUserRunnerRpcStartedAtEpochMs', base_ms + 79060,
+        'shellPrewarmConsentLockAcquiredAtEpochMs', base_ms + 79070,
+        'shellPrewarmAdmissionReadStartedAtEpochMs', base_ms + 79080,
+        'shellPrewarmAdmissionReadFinishedAtEpochMs', base_ms + 79090,
+        'shellPrewarmFirstHintAtEpochMs', base_ms + 79100,
+        'shellPrewarmExpectedOrchestrationAttemptId',
+          'web-prewarm-123e4567-e89b-42d3-a456-426614174001',
+        'shellPrewarmOrchestrationAttemptId',
+          'web-prewarm-123e4567-e89b-42d3-a456-426614174002',
+        'shellPrewarmOutcome', 'cold_start_observed',
+        'shellPrewarmSource', 'linq-message-routing'
       ))
     FROM fixture;
   `;

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -3230,7 +3230,13 @@ describe("RunnerContainer", () => {
     });
 
     await expect(container.beginShellPrewarm({
-      source: "linq-typing-started",
+      orchestration: {
+        shellPrewarmCloudflareRouteReceivedAtEpochMs: 1_788_000_000_030,
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
+      },
+      source: "linq-message-routing",
       timeoutMs: 7_500,
       userId: "member_123",
     })).resolves.toEqual({ accepted: true });
@@ -3257,8 +3263,10 @@ describe("RunnerContainer", () => {
           details: expect.objectContaining({
             shellPrewarmColdStartObserved: true,
             shellPrewarmHintCountAtCompletion: 2,
+            orchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
             shellPrewarmOutcome: "start_issued",
-            shellPrewarmSource: "linq-typing-started",
+            shellPrewarmSource: "linq-message-routing",
           }),
           message: "Hosted runner shell prewarm operation completed.",
         }),
@@ -3283,9 +3291,15 @@ describe("RunnerContainer", () => {
         firstHintAtEpochMs: expect.any(Number),
         finishedAtEpochMs: expect.any(Number),
         hintCount: 3,
+        orchestration: {
+          shellPrewarmCloudflareRouteReceivedAtEpochMs: 1_788_000_000_030,
+          shellPrewarmOrchestrationAttemptId:
+            "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+          shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
+        },
         operationElapsedMs: expect.any(Number),
         outcome: "cold_start_observed",
-        source: "linq-typing-started",
+        source: "linq-message-routing",
       },
     });
     expect(JSON.stringify(readiness.shellPrewarmObservation))

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -209,19 +209,34 @@ describe("HostedUserRunner execution coordination", () => {
 
     await runner.prewarmRuntimeShellForUser(
       TEST_USER_ID,
-      "linq-typing-started",
+      "linq-message-routing",
+      {
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
+      },
     );
 
     expect(prewarmShell).toHaveBeenCalledWith({
-      source: "linq-typing-started",
+      orchestration: {
+        shellPrewarmAdmissionReadFinishedAtEpochMs: expect.any(Number),
+        shellPrewarmAdmissionReadStartedAtEpochMs: expect.any(Number),
+        shellPrewarmConsentLockAcquiredAtEpochMs: expect.any(Number),
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs: 1_788_000_000_000,
+      },
+      source: "linq-message-routing",
       timeoutMs: 20_000,
       userId: TEST_USER_ID,
     });
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
         details: {
+          orchestrationAttemptId:
+            "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
           shellPrewarmAdmissionOutcome: "scheduled",
-          shellPrewarmSource: "linq-typing-started",
+          shellPrewarmSource: "linq-message-routing",
         },
       }),
     );

--- a/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
+++ b/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "replies-wake-sooner-after-idle-time",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Replies wake sooner after idle time",
+    "summary": "When an established conversation needs a cold hosted assistant, Murph now starts waking it earlier while safely preparing your message.",
+    "details": "The earlier wake is best-effort; message acceptance and reply processing keep their existing durable path if it is unavailable.",
+    "relevanceTags": ["assistant", "performance", "reliability"],
+    "sourcePullRequests": [2584]
+  }
+}

--- a/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
+++ b/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
@@ -6,7 +6,7 @@
     "kind": "improvement",
     "priority": 2,
     "title": "Replies wake sooner after idle time",
-    "summary": "When an established conversation needs a cold hosted assistant, Murph now starts waking it earlier while safely preparing your message.",
+    "summary": "When an established private conversation needs a cold hosted assistant, Murph now starts waking it earlier while safely preparing your message.",
     "details": "The earlier wake is best-effort; message acceptance and reply processing keep their existing durable path if it is unavailable.",
     "relevanceTags": ["assistant", "performance", "reliability"],
     "sourcePullRequests": [2584]

--- a/apps/web/src/lib/hosted-execution/direct-runtime-wake.ts
+++ b/apps/web/src/lib/hosted-execution/direct-runtime-wake.ts
@@ -27,9 +27,16 @@ const HOSTED_DIRECT_RUNTIME_WAKE_MAX_ATTEMPTS = 2;
  * all of those steps.
  */
 export function startHostedRuntimeShellPrewarmBestEffort(input: {
-  source: "linq-instant-start" | "linq-typing-started";
+  orchestrationAttemptId?: string;
+  source:
+    | "linq-instant-start"
+    | "linq-message-routing"
+    | "linq-typing-started";
   userId: string;
 }): Promise<void> {
+  const orchestrationAttemptId = input.orchestrationAttemptId
+    ?? `web-prewarm-${randomUUID()}`;
+  const requestStartedAtEpochMs = Date.now();
   const wakeSource = input.source;
   let client: ReturnType<typeof readHostedExecutionControlClientIfConfigured>;
   try {
@@ -48,24 +55,29 @@ export function startHostedRuntimeShellPrewarmBestEffort(input: {
   try {
     return client
       .prewarmRuntimeShell({
+        orchestrationAttemptId,
+        requestStartedAtEpochMs,
         source: input.source,
         userId: input.userId,
       })
       .then((result) => {
         console.info("Hosted runtime shell prewarm accepted.", {
           accepted: result.accepted,
+          orchestrationAttemptId,
           source: wakeSource,
         });
       })
       .catch((error: unknown) => {
         console.warn("Hosted runtime shell prewarm failed.", {
           errorName: describeHostedExecutionSafeLogErrorCode(error),
+          orchestrationAttemptId,
           source: wakeSource,
         });
       });
   } catch (error) {
     console.warn("Hosted runtime shell prewarm failed.", {
       errorName: describeHostedExecutionSafeLogErrorCode(error),
+      orchestrationAttemptId,
       source: wakeSource,
     });
     return Promise.resolve();

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-types.ts
@@ -28,6 +28,7 @@ export type HostedWebhookWakeHandoff = {
   eventId: string;
   linqChatId?: string | null;
   mailboxItemId: string;
+  runtimeShellPrewarmOrchestrationAttemptId?: string;
   source: "linq" | "telegram";
   userId: string;
   wakeMailboxCheckpoint?: HostedWebhookWakeMailboxCheckpoint;

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -1,4 +1,5 @@
 import {
+  isHostedRuntimeShellPrewarmOrchestrationAttemptId,
   readHostedIngressLatencySource,
   type HostedIngressLatencySource,
   type HostedRuntimeLatencyPhaseBreakdown,
@@ -58,6 +59,7 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
   const {
     eventId,
     mailboxItemId,
+    runtimeShellPrewarmOrchestrationAttemptId,
     source,
     userId,
     wakeMailboxCheckpoint,
@@ -129,6 +131,7 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
         onTiming: async (timing) => {
           await recordHostedDirectEnsureWakeTimingBestEffort({
             mailboxItemId,
+            runtimeShellPrewarmOrchestrationAttemptId,
             source: "linq",
             timing,
             userId,
@@ -170,6 +173,7 @@ export async function maybeHandoffHostedExecutionWebhookWake(input: {
 
 async function recordHostedDirectEnsureWakeTimingBestEffort(timingRecord: {
   mailboxItemId: string;
+  runtimeShellPrewarmOrchestrationAttemptId?: string;
   source: "linq";
   timing: CloudflareHostedControlRuntimeEnsureProcessingTiming;
   userId: string;
@@ -177,6 +181,12 @@ async function recordHostedDirectEnsureWakeTimingBestEffort(timingRecord: {
   const phaseBreakdown: HostedRuntimeLatencyPhaseBreakdown = {
     schemaVersion: 1,
     orchestration: {
+      ...(isHostedRuntimeShellPrewarmOrchestrationAttemptId(
+        timingRecord.runtimeShellPrewarmOrchestrationAttemptId,
+      ) ? {
+        shellPrewarmExpectedOrchestrationAttemptId:
+          timingRecord.runtimeShellPrewarmOrchestrationAttemptId,
+      } : {}),
       tokenAcquireStartedAtEpochMs: timingRecord.timing.tokenAcquireStartedAtEpochMs,
       tokenAcquiredAtEpochMs: timingRecord.timing.tokenAcquiredAtEpochMs,
       directEnsureRequestStartedAtEpochMs:

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -677,7 +677,14 @@ export async function handleHostedOnboardingLinqWebhook(input: {
         instantFirstTurnGeneration = generation;
       };
       let requiredPendingGroupSetupCandidateId: string | null = null;
-      const runPlan = async (instantStartAllowed = true) => {
+      const runPlan = async (options: {
+        instantStartAllowed?: boolean;
+        messageRoutingShellPrewarmAllowed?: boolean;
+      } = {}) => {
+        const {
+          instantStartAllowed = true,
+          messageRoutingShellPrewarmAllowed = true,
+        } = options;
         let reusableDirectCryptoDomainRoots: {
           memberId: string;
           preparedCryptoDomainRoots: PreparedHostedCryptoDomainRootCandidates;
@@ -772,7 +779,9 @@ export async function handleHostedOnboardingLinqWebhook(input: {
           prepare: async ({ attempt }) => {
             const preparation = await prepareHostedLinqThreadRoutingCrypto({
               event: planningEvent,
-              onEligibleMember: startMessageRoutingShellPrewarm,
+              ...(messageRoutingShellPrewarmAllowed
+                ? { onEligibleMember: startMessageRoutingShellPrewarm }
+                : {}),
               participantMemberIds:
                 planningResolution.pendingGroupParticipantMemberIds ?? [],
               pendingGroupRosterUnavailable:
@@ -819,7 +828,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       const planAfterBlockedAdmission = (reason?: string) =>
         requireFirstContactAdmission
           ? Promise.resolve(buildBlockedHostedLinqFirstContactAdmissionPlan(reason))
-          : runPlan(false);
+          : runPlan({ instantStartAllowed: false });
 
       if (firstContactAdmissionDecision?.kind === "block") {
         plan = await planAfterBlockedAdmission();
@@ -870,7 +879,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
             // under this event id, and instant start is off here: only a
             // classification of this exact inbound may mint that entitlement.
             firstContactAdmissionDecision = admissionBudget.decision;
-            plan = await runPlan(false);
+            plan = await runPlan({ instantStartAllowed: false });
           } else if (admissionBudget.kind === "exhausted") {
             plan = await planAfterBlockedAdmission(
               "first-contact-admission-budget-exhausted",
@@ -962,7 +971,10 @@ export async function handleHostedOnboardingLinqWebhook(input: {
             },
           );
         }
-        plan = await runPlan(!enrollmentFailed);
+        plan = await runPlan({
+          instantStartAllowed: !enrollmentFailed,
+          messageRoutingShellPrewarmAllowed: false,
+        });
         if (plan.instantStartEnrollment) {
           logHostedOnboardingDiagnostic(
             "hosted-onboarding.webhook.linq.instant-start-not-active",
@@ -970,7 +982,10 @@ export async function handleHostedOnboardingLinqWebhook(input: {
               eventIdSuffix: toHostedOnboardingLogIdSuffix(event.event_id),
             },
           );
-          plan = await runPlan(false);
+          plan = await runPlan({
+            instantStartAllowed: false,
+            messageRoutingShellPrewarmAllowed: false,
+          });
         }
       }
 
@@ -2419,7 +2434,6 @@ async function prepareHostedLinqThreadRoutingCrypto(input: {
           }),
         warmMailboxRoot: () => warmHostedLinqMailboxPayloadRoot({
           event: input.event,
-          onEligibleMember: input.onEligibleMember,
           prisma: input.prisma,
           threadRoute,
         }),
@@ -2956,16 +2970,15 @@ async function runHostedThreadRoutingPreparedTransaction<TResult>(input: {
  * scoped around this transaction, so unwrapping beforehand leaves the
  * in-transaction encrypt as local AES work against the cached root.
  *
- * An established group reuses the planning-event route. A direct message uses
- * a narrow blind-index/member-id preflight that mirrors planner precedence
- * without decrypting private identity or routing fields. Both remain hints:
- * the planner repeats every authority check inside the transaction.
+ * An established thread reuses the planning-event route. A direct message
+ * uses a narrow blind-index/member-id preflight that mirrors planner
+ * precedence without decrypting private identity or routing fields. The
+ * planner repeats every authority check inside the transaction.
  * `laneSeq` is authenticated metadata allocated inside the transaction, so
  * only required roots are warmed; the payload is still encrypted in place.
  */
 export async function warmHostedLinqMailboxPayloadRoot(input: {
   event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
-  onEligibleMember?: (memberId: string) => void;
   prisma: PrismaClient | Prisma.TransactionClient;
   threadRoute: Pick<HostedThreadRouteSnapshot, "containerMemberId"> | null;
 }): Promise<{
@@ -2980,8 +2993,6 @@ export async function warmHostedLinqMailboxPayloadRoot(input: {
   if (!memberId) {
     return null;
   }
-  input.onEligibleMember?.(memberId);
-
   return {
     memberId,
     rootKeyId: await warmHostedDomainRootForWeb({

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import type {
   Prisma,
   PrismaClient,
@@ -284,6 +286,24 @@ export async function handleHostedOnboardingLinqWebhook(input: {
   let messagePartsInspection: HostedLinqMessageReceivedPartsInspection | null = null;
   let responseReason: string | null = null;
   let instantStartTypingHint: HostedLinqInstantStartTypingHint | null = null;
+  const messageRoutingShellPrewarm: {
+    current: {
+      orchestrationAttemptId: string;
+      userId: string;
+    } | null;
+  } = { current: null };
+  const startMessageRoutingShellPrewarm = (userId: string): void => {
+    if (messageRoutingShellPrewarm.current?.userId === userId) {
+      return;
+    }
+    const orchestrationAttemptId = `web-prewarm-${randomUUID()}`;
+    messageRoutingShellPrewarm.current = { orchestrationAttemptId, userId };
+    void startHostedRuntimeShellPrewarmBestEffort({
+      orchestrationAttemptId,
+      source: "linq-message-routing",
+      userId,
+    });
+  };
   let pendingInstantStartActivationWake: {
     continuation: HostedLinqInstantStartDeferredActivationWake;
     prisma: PrismaClient;
@@ -752,6 +772,7 @@ export async function handleHostedOnboardingLinqWebhook(input: {
           prepare: async ({ attempt }) => {
             const preparation = await prepareHostedLinqThreadRoutingCrypto({
               event: planningEvent,
+              onEligibleMember: startMessageRoutingShellPrewarm,
               participantMemberIds:
                 planningResolution.pendingGroupParticipantMemberIds ?? [],
               pendingGroupRosterUnavailable:
@@ -1150,6 +1171,17 @@ export async function handleHostedOnboardingLinqWebhook(input: {
           throw error;
         }
       }
+    }
+
+    if (
+      wakeHandoff
+      && messageRoutingShellPrewarm.current?.userId === wakeHandoff.userId
+    ) {
+      wakeHandoff = {
+        ...wakeHandoff,
+        runtimeShellPrewarmOrchestrationAttemptId:
+          messageRoutingShellPrewarm.current.orchestrationAttemptId,
+      };
     }
 
     scheduleHostedLinqProviderEventIngestionBestEffort({
@@ -2342,6 +2374,7 @@ async function prepareHostedThreadDeliveryRouteAndWarmMailbox(input: {
 
 async function prepareHostedLinqThreadRoutingCrypto(input: {
   event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
+  onEligibleMember?: (memberId: string) => void;
   participantMemberIds: readonly string[];
   pendingGroupRosterUnavailable: boolean;
   prisma: PrismaClient;
@@ -2386,6 +2419,7 @@ async function prepareHostedLinqThreadRoutingCrypto(input: {
           }),
         warmMailboxRoot: () => warmHostedLinqMailboxPayloadRoot({
           event: input.event,
+          onEligibleMember: input.onEligibleMember,
           prisma: input.prisma,
           threadRoute,
         }),
@@ -2446,6 +2480,7 @@ async function prepareHostedLinqThreadRoutingCrypto(input: {
       preparedDirectMailboxPayloadRoot:
         await prepareHostedLinqDirectMailboxPayloadRoot({
           event: input.event,
+          onEligibleMember: input.onEligibleMember,
           prisma: input.prisma,
           ...(input.reusableDirectCryptoDomainRoots
             ? {
@@ -2930,6 +2965,7 @@ async function runHostedThreadRoutingPreparedTransaction<TResult>(input: {
  */
 export async function warmHostedLinqMailboxPayloadRoot(input: {
   event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
+  onEligibleMember?: (memberId: string) => void;
   prisma: PrismaClient | Prisma.TransactionClient;
   threadRoute: Pick<HostedThreadRouteSnapshot, "containerMemberId"> | null;
 }): Promise<{
@@ -2944,6 +2980,7 @@ export async function warmHostedLinqMailboxPayloadRoot(input: {
   if (!memberId) {
     return null;
   }
+  input.onEligibleMember?.(memberId);
 
   return {
     memberId,
@@ -2957,6 +2994,7 @@ export async function warmHostedLinqMailboxPayloadRoot(input: {
 
 async function prepareHostedLinqDirectMailboxPayloadRoot(input: {
   event: Parameters<typeof requireHostedLinqMessageReceivedEvent>[0];
+  onEligibleMember?: (memberId: string) => void;
   prisma: PrismaClient;
   reusableDirectCryptoDomainRoots?: {
     memberId: string;
@@ -2983,6 +3021,15 @@ async function prepareHostedLinqDirectMailboxPayloadRoot(input: {
   }
 
   const context = resolveHostedOnboardingLinqMessageContext(input.event);
+  const activeMemberAccess = readActiveHostedMemberAccess({
+    memberId,
+    prisma: input.prisma,
+  }).then((accessAllowed) => {
+    if (accessAllowed) {
+      input.onEligibleMember?.(memberId);
+    }
+    return accessAllowed;
+  });
   const [identityRecord, routingRecord, accessAllowed, preparedFamilyInvite] =
     await Promise.all([
       readHostedMemberIdentityRecord({
@@ -2993,10 +3040,7 @@ async function prepareHostedLinqDirectMailboxPayloadRoot(input: {
         memberId,
         prisma: input.prisma,
       }),
-      readActiveHostedMemberAccess({
-        memberId,
-        prisma: input.prisma,
-      }),
+      activeMemberAccess,
       context.participantContact?.kind === "phone"
         ? resolveHostedFamilyPhoneInvitePreparation({
             acceptedMemberId: memberId,

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -4619,6 +4619,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
 
   it("re-prepares once when the direct mailbox ingress root changes under lock", async () => {
     mocks.enforceDirectMailboxPreparation = true;
+    const prewarmRuntimeShell = vi.fn(async () => ({ accepted: true as const }));
+    mocks.readHostedExecutionControlClientIfConfigured.mockReturnValue({
+      ensureRuntimeProcessing: vi.fn(async () => ({ accepted: true as const })),
+      prewarmRuntimeShell,
+    });
     mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId.mockResolvedValue(
       "member_123",
     );
@@ -4749,6 +4754,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(hostedMemberRouting.findUnique.mock.calls.filter(([query]) =>
       isFullHostedMemberRoutingRecordQuery(query)
     )).toHaveLength(4);
+    expect(prewarmRuntimeShell).toHaveBeenCalledOnce();
+    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
+      source: "linq-message-routing",
+      userId: "member_123",
+    }));
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -151,6 +151,7 @@ const mocks = vi.hoisted(() => {
     })),
     logHostedOnboardingDiagnostic: vi.fn(),
     logHostedOnboardingWarning: vi.fn(),
+    maybeHandoffHostedExecutionWebhookWake: vi.fn(),
     sendHostedLinqChatMessage: vi.fn(),
     createHostedLinqChat: vi.fn(),
     sendHostedLinqReadReceipt: vi.fn(),
@@ -407,6 +408,20 @@ vi.mock("@/src/lib/hosted-onboarding/starter-usage-enrollment-service", async ()
       mocks.ensureHostedLinqInstantStartStarterUsageEnrollment,
     runHostedLinqInstantStartDeferredActivationWakeBestEffort:
       mocks.runHostedLinqInstantStartDeferredActivationWakeBestEffort,
+  };
+});
+
+vi.mock("@/src/lib/hosted-onboarding/webhook-service-wake", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/lib/hosted-onboarding/webhook-service-wake")
+  >("@/src/lib/hosted-onboarding/webhook-service-wake");
+  mocks.maybeHandoffHostedExecutionWebhookWake.mockImplementation(
+    actual.maybeHandoffHostedExecutionWebhookWake,
+  );
+  return {
+    ...actual,
+    maybeHandoffHostedExecutionWebhookWake:
+      mocks.maybeHandoffHostedExecutionWebhookWake,
   };
 });
 
@@ -4759,6 +4774,13 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       source: "linq-message-routing",
       userId: "member_123",
     }));
+    expect(
+      prewarmRuntimeShell.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(prepareHostedCryptoDomainRootCandidates).mock
+        .invocationCallOrder[0]
+        ?? Number.NEGATIVE_INFINITY,
+    );
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
   });
 
@@ -8131,7 +8153,11 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     });
     const typingResult = createDeferred<{ ok: boolean; status: number }>();
     const ensureRuntimeProcessing = vi.fn();
-    const prewarmRuntimeShell = vi.fn(() => {
+    const prewarmRuntimeShell = vi.fn<
+      (request: {
+        source: "linq-instant-start" | "linq-message-routing" | "linq-typing-started";
+      }) => Promise<{ accepted: true }>
+    >(() => {
       callOrder.push("shell-prewarm");
       return new Promise<{ accepted: true }>(() => undefined);
     });
@@ -8243,6 +8269,15 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       source: "linq-instant-start",
       userId: memberId,
     }));
+    expect(prewarmRuntimeShell.mock.calls.map(([request]) => request.source))
+      .toEqual(["linq-instant-start"]);
+    expect(mocks.maybeHandoffHostedExecutionWebhookWake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wakeHandoff: expect.not.objectContaining({
+          runtimeShellPrewarmOrchestrationAttemptId: expect.any(String),
+        }),
+      }),
+    );
     expect(ensureRuntimeProcessing).toHaveBeenCalledOnce();
     expect(ensureRuntimeProcessing).toHaveBeenCalledWith(expect.objectContaining({
       userId: memberId,

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -1333,10 +1333,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       }),
       prisma: expect.any(Object),
     });
-    expect(prewarmRuntimeShell).toHaveBeenCalledWith({
+    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
+      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
+      requestStartedAtEpochMs: expect.any(Number),
       source: "linq-typing-started",
       userId: "member_typing",
-    });
+    }));
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
 
@@ -3445,6 +3447,13 @@ describe("handleHostedOnboardingLinqWebhook", () => {
   });
 
   it("signals Temporal after an active-member mailbox append", async () => {
+    const prewarmRuntimeShell = vi.fn(async () => ({ accepted: true as const }));
+    mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId
+      .mockResolvedValueOnce("member_123");
+    mocks.readHostedExecutionControlClientIfConfigured.mockReturnValue({
+      ensureRuntimeProcessing: vi.fn(async () => ({ accepted: true as const })),
+      prewarmRuntimeShell,
+    });
     const prisma = asPrismaTransactionClient({
       hostedWebhookReceipt: {
         create: vi.fn().mockResolvedValue({}),
@@ -3482,6 +3491,13 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     });
 
     expectHostedLinqPointerSignalAccepted("evt_required_nudge_failed");
+    expect(prewarmRuntimeShell).toHaveBeenCalledOnce();
+    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
+      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
+      requestStartedAtEpochMs: expect.any(Number),
+      source: "linq-message-routing",
+      userId: "member_123",
+    }));
     expectHostedLinqReadReceiptSent();
     expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -8211,10 +8227,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(shellPrewarmIndex).toBeGreaterThanOrEqual(0);
     expect(shellPrewarmIndex).toBeLessThan(enrollmentIndex);
     expect(prewarmRuntimeShell).toHaveBeenCalledOnce();
-    expect(prewarmRuntimeShell).toHaveBeenCalledWith({
+    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
+      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
+      requestStartedAtEpochMs: expect.any(Number),
       source: "linq-instant-start",
       userId: memberId,
-    });
+    }));
     expect(ensureRuntimeProcessing).toHaveBeenCalledOnce();
     expect(ensureRuntimeProcessing).toHaveBeenCalledWith(expect.objectContaining({
       userId: memberId,
@@ -8415,10 +8433,12 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     });
 
     expect(prewarmRuntimeShell).toHaveBeenCalledOnce();
-    expect(prewarmRuntimeShell).toHaveBeenCalledWith({
+    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
+      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
+      requestStartedAtEpochMs: expect.any(Number),
       source: "linq-instant-start",
       userId: memberId,
-    });
+    }));
     expect(ensureRuntimeProcessing).not.toHaveBeenCalled();
     expect(mocks.startHostedLinqChatTypingIndicator).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {

--- a/apps/web/test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts
@@ -525,6 +525,9 @@ describe("hosted Linq mailbox payload root prewarm", () => {
 
     await expect(warmHostedLinqMailboxPayloadRoot({
       event: JSON.parse(buildLinqMessageWebhookBody()),
+      onEligibleMember: (memberId) => {
+        calls.push(`prewarm:${memberId}`);
+      },
       prisma,
       threadRoute: { containerMemberId: "member_prewarm_1" } as never,
     })).resolves.toEqual({
@@ -538,6 +541,10 @@ describe("hosted Linq mailbox payload root prewarm", () => {
       retainFailureInScopedCache: true,
       userId: "member_prewarm_1",
     });
+    expect(calls.slice(0, 2)).toEqual([
+      "prewarm:member_prewarm_1",
+      "unwrap",
+    ]);
     // The scoped cache hands out a private copy and expects it wiped; warming
     // needs the unwrap, not the plaintext.
     expect(issuedRootKeys).toHaveLength(1);

--- a/apps/web/test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts
@@ -525,9 +525,6 @@ describe("hosted Linq mailbox payload root prewarm", () => {
 
     await expect(warmHostedLinqMailboxPayloadRoot({
       event: JSON.parse(buildLinqMessageWebhookBody()),
-      onEligibleMember: (memberId) => {
-        calls.push(`prewarm:${memberId}`);
-      },
       prisma,
       threadRoute: { containerMemberId: "member_prewarm_1" } as never,
     })).resolves.toEqual({
@@ -541,10 +538,7 @@ describe("hosted Linq mailbox payload root prewarm", () => {
       retainFailureInScopedCache: true,
       userId: "member_prewarm_1",
     });
-    expect(calls.slice(0, 2)).toEqual([
-      "prewarm:member_prewarm_1",
-      "unwrap",
-    ]);
+    expect(calls[0]).toBe("unwrap");
     // The scoped cache hands out a private copy and expects it wiped; warming
     // needs the unwrap, not the plaintext.
     expect(issuedRootKeys).toHaveLength(1);

--- a/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
@@ -152,7 +152,10 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       scheduleAfterResponse: (task) => {
         afterResponseTasks.push(task);
       },
-      wakeHandoff: buildWakeHandoff(),
+      wakeHandoff: buildWakeHandoff({
+        runtimeShellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      }),
     });
     void handoff.then(
       () => {
@@ -209,6 +212,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
       phaseBreakdown: {
         schemaVersion: 1,
         orchestration: {
+          shellPrewarmExpectedOrchestrationAttemptId:
+            "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
           tokenAcquireStartedAtEpochMs: 1_777_000_000_000,
           tokenAcquiredAtEpochMs: 1_777_000_000_010,
           directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
@@ -812,12 +817,17 @@ describe("startHostedRuntimeShellPrewarmBestEffort", () => {
 
   it("issues only the shell-prewarm command for the instant-start member", async () => {
     await expect(startHostedRuntimeShellPrewarmBestEffort({
+      orchestrationAttemptId:
+        "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
       source: "linq-instant-start",
       userId: "member_123",
     })).resolves.toBeUndefined();
 
     expect(mocks.prewarmRuntimeShell).toHaveBeenCalledOnce();
     expect(mocks.prewarmRuntimeShell).toHaveBeenCalledWith({
+      orchestrationAttemptId:
+        "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      requestStartedAtEpochMs: expect.any(Number),
       source: "linq-instant-start",
       userId: "member_123",
     });
@@ -832,6 +842,8 @@ describe("startHostedRuntimeShellPrewarmBestEffort", () => {
 
     expect(mocks.prewarmRuntimeShell).toHaveBeenCalledOnce();
     expect(mocks.prewarmRuntimeShell).toHaveBeenCalledWith({
+      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
+      requestStartedAtEpochMs: expect.any(Number),
       source: "linq-typing-started",
       userId: "member_123",
     });

--- a/packages/cloudflare-hosted-control/src/client.ts
+++ b/packages/cloudflare-hosted-control/src/client.ts
@@ -275,6 +275,8 @@ export interface CloudflareHostedControlClient {
     userId: string;
   }): Promise<CloudflareHostedControlRuntimeEnsureProcessingResponse>;
   prewarmRuntimeShell(input: {
+    orchestrationAttemptId: string;
+    requestStartedAtEpochMs: number;
     source: CloudflareHostedControlRuntimeShellPrewarmSource;
     userId: string;
   }): Promise<CloudflareHostedControlRuntimeShellPrewarmAcceptedAck>;
@@ -316,6 +318,7 @@ export interface CloudflareHostedControlRuntimeShellPrewarmAcceptedAck {
 
 export type CloudflareHostedControlRuntimeShellPrewarmSource =
   | "linq-instant-start"
+  | "linq-message-routing"
   | "linq-typing-started";
 
 export type CloudflareHostedControlRuntimeEnsureProcessingResponse =
@@ -672,7 +675,11 @@ export function createCloudflareHostedControlClient(
         parse: parseCloudflareHostedControlRuntimeShellPrewarmResponse,
         path: buildCloudflareHostedControlRuntimeShellPrewarmPath(expectedUserId),
         request: {
-          body: JSON.stringify({ source: input.source }),
+          body: JSON.stringify({
+            orchestrationAttemptId: input.orchestrationAttemptId,
+            requestStartedAtEpochMs: input.requestStartedAtEpochMs,
+            source: input.source,
+          }),
           headers: {
             "content-type": "application/json; charset=utf-8",
           },

--- a/packages/cloudflare-hosted-control/test/client.test.ts
+++ b/packages/cloudflare-hosted-control/test/client.test.ts
@@ -433,6 +433,8 @@ describe("createCloudflareHostedControlClient", () => {
     });
 
     await expect(client.prewarmRuntimeShell({
+      orchestrationAttemptId: "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      requestStartedAtEpochMs: 1_788_000_000_000,
       source: "linq-typing-started",
       userId: "user_123",
     })).resolves.toEqual({
@@ -445,7 +447,7 @@ describe("createCloudflareHostedControlClient", () => {
       "https://runner.example.test/internal/users/user_123/runtime/shell-prewarm",
     );
     expect(init).toMatchObject({
-      body: '{"source":"linq-typing-started"}',
+      body: '{"orchestrationAttemptId":"web-prewarm-123e4567-e89b-42d3-a456-426614174000","requestStartedAtEpochMs":1788000000000,"source":"linq-typing-started"}',
       method: "POST",
     });
     const headers = new Headers(init.headers);
@@ -463,6 +465,8 @@ describe("createCloudflareHostedControlClient", () => {
     });
 
     await expect(client.prewarmRuntimeShell({
+      orchestrationAttemptId: "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      requestStartedAtEpochMs: 1_788_000_000_000,
       source: "linq-typing-started",
       userId: "user_123",
     })).rejects.toThrow(

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -57,6 +57,7 @@ import {
   inspectHostedRuntimeAutomationLaneTimingSubdivision,
   inspectHostedRuntimeMailboxToAssistantTimingSubdivision,
   isHostedRuntimeDirectEnsureOrchestrationAttemptId,
+  isHostedRuntimeShellPrewarmOrchestrationAttemptId,
   HOSTED_RUNTIME_LATENCY_TRACE_MILESTONES,
   HOSTED_MAILBOX_FETCH_CURSOR_MODES,
   HOSTED_MAILBOX_KINDS,
@@ -6417,6 +6418,7 @@ function requireOptionalShellPrewarmSource(
 ): {
   shellPrewarmSource?:
     | "linq-instant-start"
+    | "linq-message-routing"
     | "linq-typing-started"
     | "unknown";
 } {
@@ -6426,6 +6428,7 @@ function requireOptionalShellPrewarmSource(
   }
   if (
     value !== "linq-instant-start"
+    && value !== "linq-message-routing"
     && value !== "linq-typing-started"
     && value !== "unknown"
   ) {
@@ -6495,6 +6498,18 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
       ...requireOptionalNonNegativeInteger(orchestration, "directEnsureResponseReceivedAtEpochMs", orchestrationLabel),
       ...requireOptionalDirectEnsureOrchestrationAttemptId(orchestration, "directEnsureOrchestrationAttemptId", orchestrationLabel),
       ...requireOptionalDirectEnsureOutcome(orchestration, orchestrationLabel),
+      ...requireOptionalShellPrewarmOrchestrationAttemptId(orchestration, "shellPrewarmExpectedOrchestrationAttemptId", orchestrationLabel),
+      ...requireOptionalShellPrewarmOrchestrationAttemptId(orchestration, "shellPrewarmOrchestrationAttemptId", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmRequestStartedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmRuntimeControlAuthStartedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmRuntimeControlAuthFinishedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmCloudflareRouteReceivedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmUserRunnerConstructorStartedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmUserRunnerConstructorFinishedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmUserRunnerRpcStartedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmConsentLockAcquiredAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmAdmissionReadStartedAtEpochMs", orchestrationLabel),
+      ...requireOptionalNonNegativeInteger(orchestration, "shellPrewarmAdmissionReadFinishedAtEpochMs", orchestrationLabel),
       ...requireOptionalNonNegativeInteger(orchestration, "runtimeControlAuthStartedAtEpochMs", orchestrationLabel),
       ...requireOptionalNonNegativeInteger(orchestration, "runtimeControlAuthFinishedAtEpochMs", orchestrationLabel),
       ...requireOptionalNonNegativeInteger(orchestration, "cloudflareRouteReceivedAtEpochMs", orchestrationLabel),
@@ -6776,6 +6791,25 @@ function requireOptionalDirectEnsureOrchestrationAttemptId<
   }
   if (!isHostedRuntimeDirectEnsureOrchestrationAttemptId(value)) {
     throw new TypeError(`${label}.${key} must be a direct-wake orchestration attempt id.`);
+  }
+  return { [key]: value } as Record<Key, string>;
+}
+
+function requireOptionalShellPrewarmOrchestrationAttemptId<
+  Key extends
+    | "shellPrewarmExpectedOrchestrationAttemptId"
+    | "shellPrewarmOrchestrationAttemptId",
+>(
+  record: Record<string, unknown>,
+  key: Key,
+  label: string,
+): Partial<Record<Key, string>> {
+  const value = record[key];
+  if (value === undefined) {
+    return {};
+  }
+  if (!isHostedRuntimeShellPrewarmOrchestrationAttemptId(value)) {
+    throw new TypeError(`${label}.${key} must be a shell-prewarm orchestration attempt id.`);
   }
   return { [key]: value } as Record<Key, string>;
 }

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -2345,6 +2345,18 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
       | "retry_later";
     directEnsureAction?: "started" | "replaced" | "woken" | "already_running";
     directEnsureRuntimeAttemptId?: string;
+    shellPrewarmExpectedOrchestrationAttemptId?: string;
+    shellPrewarmOrchestrationAttemptId?: string;
+    shellPrewarmRequestStartedAtEpochMs?: number;
+    shellPrewarmRuntimeControlAuthStartedAtEpochMs?: number;
+    shellPrewarmRuntimeControlAuthFinishedAtEpochMs?: number;
+    shellPrewarmCloudflareRouteReceivedAtEpochMs?: number;
+    shellPrewarmUserRunnerConstructorStartedAtEpochMs?: number;
+    shellPrewarmUserRunnerConstructorFinishedAtEpochMs?: number;
+    shellPrewarmUserRunnerRpcStartedAtEpochMs?: number;
+    shellPrewarmConsentLockAcquiredAtEpochMs?: number;
+    shellPrewarmAdmissionReadStartedAtEpochMs?: number;
+    shellPrewarmAdmissionReadFinishedAtEpochMs?: number;
     runtimeControlAuthStartedAtEpochMs?: number;
     runtimeControlAuthFinishedAtEpochMs?: number;
     cloudflareRouteReceivedAtEpochMs?: number;
@@ -2400,6 +2412,7 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
       | "superseded";
     shellPrewarmSource?:
       | "linq-instant-start"
+      | "linq-message-routing"
       | "linq-typing-started"
       | "unknown";
     workspaceReadElapsedMs?: number;
@@ -2742,6 +2755,18 @@ export const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS: Record<
     "directEnsureResultKind",
     "directEnsureAction",
     "directEnsureRuntimeAttemptId",
+    "shellPrewarmExpectedOrchestrationAttemptId",
+    "shellPrewarmOrchestrationAttemptId",
+    "shellPrewarmRequestStartedAtEpochMs",
+    "shellPrewarmRuntimeControlAuthStartedAtEpochMs",
+    "shellPrewarmRuntimeControlAuthFinishedAtEpochMs",
+    "shellPrewarmCloudflareRouteReceivedAtEpochMs",
+    "shellPrewarmUserRunnerConstructorStartedAtEpochMs",
+    "shellPrewarmUserRunnerConstructorFinishedAtEpochMs",
+    "shellPrewarmUserRunnerRpcStartedAtEpochMs",
+    "shellPrewarmConsentLockAcquiredAtEpochMs",
+    "shellPrewarmAdmissionReadStartedAtEpochMs",
+    "shellPrewarmAdmissionReadFinishedAtEpochMs",
     "runtimeControlAuthStartedAtEpochMs",
     "runtimeControlAuthFinishedAtEpochMs",
     "cloudflareRouteReceivedAtEpochMs",
@@ -2920,6 +2945,7 @@ const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_STRING_LEAF_VALUES:
     ],
     "orchestration.shellPrewarmSource": [
       "linq-instant-start",
+      "linq-message-routing",
       "linq-typing-started",
       "unknown",
     ],
@@ -2941,6 +2967,7 @@ export type HostedRuntimeLatencyPhaseBreakdownLeafRule =
   | { kind: "enum_string"; values: readonly string[] }
   | { kind: "lease_generation" }
   | { kind: "orchestration_attempt_id" }
+  | { kind: "shell_prewarm_attempt_id" }
   | { kind: "opaque_identifier" }
   | { kind: "safe_integer" };
 
@@ -2989,6 +3016,15 @@ function readHostedRuntimeLatencyPhaseBreakdownLeafRule(
   }
   if (
     phase === "orchestration"
+    && (
+      leafKey === "shellPrewarmExpectedOrchestrationAttemptId"
+      || leafKey === "shellPrewarmOrchestrationAttemptId"
+    )
+  ) {
+    return { kind: "shell_prewarm_attempt_id" };
+  }
+  if (
+    phase === "orchestration"
     && leafKey === "directEnsureRuntimeAttemptId"
   ) {
     return { kind: "opaque_identifier" };
@@ -3014,6 +3050,25 @@ function readHostedRuntimeLatencyPhaseBreakdownLeafRule(
 export type HostedRuntimeLatencyPhaseBreakdownJsonLeaf = number | boolean | string;
 export type HostedRuntimeOrchestrationLatencyDiagnostics = NonNullable<
   HostedRuntimeLatencyPhaseBreakdown["orchestration"]
+>;
+
+export const HOSTED_RUNTIME_SHELL_PREWARM_ORCHESTRATION_DIAGNOSTIC_KEYS = [
+  "shellPrewarmOrchestrationAttemptId",
+  "shellPrewarmRequestStartedAtEpochMs",
+  "shellPrewarmRuntimeControlAuthStartedAtEpochMs",
+  "shellPrewarmRuntimeControlAuthFinishedAtEpochMs",
+  "shellPrewarmCloudflareRouteReceivedAtEpochMs",
+  "shellPrewarmUserRunnerConstructorStartedAtEpochMs",
+  "shellPrewarmUserRunnerConstructorFinishedAtEpochMs",
+  "shellPrewarmUserRunnerRpcStartedAtEpochMs",
+  "shellPrewarmConsentLockAcquiredAtEpochMs",
+  "shellPrewarmAdmissionReadStartedAtEpochMs",
+  "shellPrewarmAdmissionReadFinishedAtEpochMs",
+] as const;
+
+export type HostedRuntimeShellPrewarmOrchestrationDiagnostics = Pick<
+  HostedRuntimeOrchestrationLatencyDiagnostics,
+  (typeof HOSTED_RUNTIME_SHELL_PREWARM_ORCHESTRATION_DIAGNOSTIC_KEYS)[number]
 >;
 
 export const HOSTED_RUNTIME_ORCHESTRATION_LATENCY_DIAGNOSTICS_HEADER =
@@ -3069,6 +3124,25 @@ export function sanitizeHostedRuntimeOrchestrationLatencyDiagnostics(
 
   return Object.keys(diagnostics).length > 0
     ? diagnostics as HostedRuntimeOrchestrationLatencyDiagnostics
+    : null;
+}
+
+export function sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics(
+  value: unknown,
+): HostedRuntimeShellPrewarmOrchestrationDiagnostics | null {
+  const orchestration = sanitizeHostedRuntimeOrchestrationLatencyDiagnostics(value);
+  if (!orchestration) {
+    return null;
+  }
+  const diagnostics = Object.fromEntries(
+    HOSTED_RUNTIME_SHELL_PREWARM_ORCHESTRATION_DIAGNOSTIC_KEYS.flatMap(
+      (key) => orchestration[key] === undefined
+        ? []
+        : [[key, orchestration[key]]],
+    ),
+  ) as Partial<HostedRuntimeShellPrewarmOrchestrationDiagnostics>;
+  return Object.keys(diagnostics).length > 0
+    ? diagnostics as HostedRuntimeShellPrewarmOrchestrationDiagnostics
     : null;
 }
 
@@ -3308,6 +3382,8 @@ function isHostedRuntimeLatencyPhaseBreakdownLeafSafe(
         && /^(?:0|[1-9]\d*)$/u.test(value);
     case "orchestration_attempt_id":
       return isHostedRuntimeDirectEnsureOrchestrationAttemptId(value);
+    case "shell_prewarm_attempt_id":
+      return isHostedRuntimeShellPrewarmOrchestrationAttemptId(value);
     case "opaque_identifier":
       return isHostedRuntimeLatencyOpaqueIdentifier(value);
     case "safe_integer":
@@ -3322,6 +3398,13 @@ export function isHostedRuntimeDirectEnsureOrchestrationAttemptId(
 ): value is string {
   return typeof value === "string"
     && /^web-ingress-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(value);
+}
+
+export function isHostedRuntimeShellPrewarmOrchestrationAttemptId(
+  value: unknown,
+): value is string {
+  return typeof value === "string"
+    && /^web-prewarm-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(value);
 }
 
 function isHostedRuntimeLatencyOpaqueIdentifier(value: unknown): value is string {

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -57,6 +57,7 @@ import {
   resolveHostedAiUsageTokenPricingBasis,
   mergeHostedRuntimeLatencyPhaseBreakdownJson,
   sanitizeHostedRuntimeOrchestrationLatencyDiagnostics,
+  sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics,
   signHostedAiUsageAllowDecision,
   verifyHostedAiUsageAllowDecision,
 } from "../src/runtime-control.ts";
@@ -1614,6 +1615,20 @@ describe("hosted runtime control contracts", () => {
         directEnsureResultKind: "runtime_processing_accepted",
         directEnsureAction: "woken",
         directEnsureRuntimeAttemptId: "runtime-attempt-direct",
+        shellPrewarmExpectedOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmOrchestrationAttemptId:
+          "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+        shellPrewarmRequestStartedAtEpochMs: 1_777_000_000_001,
+        shellPrewarmRuntimeControlAuthStartedAtEpochMs: 1_777_000_000_002,
+        shellPrewarmRuntimeControlAuthFinishedAtEpochMs: 1_777_000_000_003,
+        shellPrewarmCloudflareRouteReceivedAtEpochMs: 1_777_000_000_004,
+        shellPrewarmUserRunnerConstructorStartedAtEpochMs: 1_777_000_000_005,
+        shellPrewarmUserRunnerConstructorFinishedAtEpochMs: 1_777_000_000_006,
+        shellPrewarmUserRunnerRpcStartedAtEpochMs: 1_777_000_000_007,
+        shellPrewarmConsentLockAcquiredAtEpochMs: 1_777_000_000_008,
+        shellPrewarmAdmissionReadStartedAtEpochMs: 1_777_000_000_009,
+        shellPrewarmAdmissionReadFinishedAtEpochMs: 1_777_000_000_010,
         runtimeControlAuthStartedAtEpochMs: 1_777_000_000_015,
         runtimeControlAuthFinishedAtEpochMs: 1_777_000_000_016,
         cloudflareRouteReceivedAtEpochMs: 1_777_000_000_020,
@@ -1663,7 +1678,7 @@ describe("hosted runtime control contracts", () => {
         shellPrewarmOperationElapsedMs: 2,
         shellPrewarmHintCount: 2,
         shellPrewarmOutcome: "cold_start_observed",
-        shellPrewarmSource: "linq-typing-started",
+        shellPrewarmSource: "linq-message-routing",
         workspaceReadElapsedMs: 30,
         runtimeStoreEnsureElapsedMs: 40,
         runtimeInvocationPreparationElapsedMs: 60,
@@ -1933,6 +1948,8 @@ describe("hosted runtime control contracts", () => {
       { tokenAcquireStartedAtEpochMs: -1 }, // web-side negative leaf
       { directEnsureResponseReceivedAtEpochMs: 1.5 }, // web-side non-integer leaf
       { directEnsureOrchestrationAttemptId: "web-ingress-not-a-uuid" }, // correlation id must be bounded
+      { shellPrewarmOrchestrationAttemptId: "web-prewarm-not-a-uuid" }, // prewarm correlation ids have their own exact prefix and shape
+      { shellPrewarmExpectedOrchestrationAttemptId: "web-ingress-123e4567-e89b-42d3-a456-426614174000" }, // direct-wake ids cannot enter the prewarm channel
       { directEnsureResultKind: "failed", rawError: "secret" }, // result values and arbitrary error metadata are forbidden
       { directEnsureResultKind: "retry_later", directEnsureRetryReason: "container_rpc_timeout" }, // retry reasons remain in structured logs only
       { directEnsureResultKind: "retry_later", directEnsureAction: "woken" }, // accepted metadata must match the result
@@ -2327,6 +2344,26 @@ describe("hosted runtime control contracts", () => {
       directEnsureAction: "woken",
       directEnsureRuntimeAttemptId: "runtime-attempt-direct",
       directEnsureRetryReason: "container_rpc_timeout",
+    })).toBeNull();
+  });
+
+  it("projects shell-prewarm diagnostics onto the narrow correlation schema", () => {
+    expect(sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics({
+      directEnsureRequestStartedAtEpochMs: 1_777_000_000_099,
+      shellPrewarmCloudflareRouteReceivedAtEpochMs: 1_777_000_000_030,
+      shellPrewarmOrchestrationAttemptId:
+        "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      shellPrewarmRequestStartedAtEpochMs: 1_777_000_000_000,
+      shellPrewarmSource: "linq-message-routing",
+    })).toEqual({
+      shellPrewarmCloudflareRouteReceivedAtEpochMs: 1_777_000_000_030,
+      shellPrewarmOrchestrationAttemptId:
+        "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+      shellPrewarmRequestStartedAtEpochMs: 1_777_000_000_000,
+    });
+
+    expect(sanitizeHostedRuntimeShellPrewarmOrchestrationDiagnostics({
+      shellPrewarmOrchestrationAttemptId: "invalid",
     })).toBeNull();
   });
 


### PR DESCRIPTION
## Why and outcome

Established direct Linq messages could wait until after durable mailbox acceptance and Temporal signaling before asking Cloudflare to wake a cold hosted runtime. This starts the existing authority-free shell hint during request-local routing preparation, allowing container startup to overlap the remaining Web work without moving real processing ahead of Temporal.

It also carries one bounded correlation ID and phase timestamps through the existing Web → Worker → UserRunner → RunnerContainer observation, so cold-start reporting can separate Web auth, Durable Object activation, consent admission, and container-hint registration. No database schema or telemetry store is added.

ReviewGPT context sensitivity: sensitive — this changes cross-owner hosted-runtime ordering, external control ingress, and Web/Worker/container rollout behavior.

ReviewGPT first-reviewed head: cf3dff595390ae9461f00fcea3a54a4ea0f1ae62

## Product UX

- Effort: Patch.
- Walkthrough: Ready.
- Outcome: established members can spend less time waiting for a first reply after the hosted assistant has been idle.
- Affected journey: an ordinary established direct Linq message that resolves an active runtime member and needs a cold start.
- Safe exclusions: established group/thread routing, new-member instant start, non-Linq ingress, ineligible members, and real processing ownership are unchanged. A failed, skipped, duplicate, stale, or evicted hint falls through to the existing post-Temporal ensure without delaying message acceptance.

## Evidence

- Focused Web routing and mailbox suites: 234 tests passed. They prove only direct preparation invokes the callback, the hint starts before root KMS work, request-local retries deduplicate, and post-enrollment instant-start replans neither send a second message-routing hint nor attach its expected ID.
- Cloudflare Worker route and operational-report suites: 120 tests passed in the ordinary run; the PostgreSQL-enabled report suite then passed all 5 tests against a disposable loopback instance, including exact-match and mismatched message-routing rows.
- ReviewGPT substantive round 2 passed on the corrected production tree with no merge-veto findings and explicitly verified every accepted correction. The later commits only archived the completed execution plan.
- Typechecks: Cloudflare runner and prepared hosted Web passed after the review fixes. Focused Web ESLint, the Cloudflare build exercised by hosted-local preparation, and `git diff --check` passed.
- Composed journey proof is checked in: a signed no-typing direct message waits from idle through the delivered reply and persisted trace, then asserts the exact expected/observed prewarm ID and request/auth/UserRunner/admission/hint stamps. The local harness could not start it because this checkout lacks the required external Temporal worker package; provisioned CI owns that execution.
- Direct journey evidence remains fail-closed: the exact message-routing prewarm ID is attached to the final same-member wake and is classified as causal only when the first consumed container observation carries that same ID. The aggregate SQL returns no member, mailbox, trace, delivery, or attempt identifiers.

## Non-obvious affected surfaces

- Direct Web pre-transaction crypto preparation: exposes an advisory callback after existing active-member resolution so shell startup overlaps KMS/transaction work. Established group/thread routing never receives the callback; covered by routing and mailbox-root ordering tests.
- Hosted control protocol and Worker route: accepts additive source, attempt ID, and request/auth timestamps while preserving the legacy body shape; covered by client and route contract tests.
- UserRunner Durable Object and consent admission: records constructor/RPC/admission timing but still rechecks live Web-owned admission under the existing mutation lock; covered by activation and alarm/admission tests.
- RunnerContainer in-memory observation: the first coalesced hint owns correlation diagnostics until authoritative readiness consumes it; covered by first-observation/coalescing tests.
- Operational cold-start report and deployment docs: exact-ID matching prevents unrelated hints from being credited to a message; covered by static SQL contracts and a passing real-PostgreSQL fixture.

## Architecture and reuse

- Existing systems reused: the payloadless shell-prewarm route, live health-data admission lock, RunnerContainer start/coalescing primitive, direct ensure, and existing orchestration latency breakdown.
- New logic: one request-local direct-message callback, one UUID-shaped correlation value, additive phase stamps, and exact-match report cohorting.
- New abstractions: one narrow shell-prewarm diagnostics type/sanitizer at the shared runtime-control boundary; the existing observation remains the sole carrier and owner.
- Complexity intentionally avoided: no extra database read, persisted state, queue, scheduler, retry owner, map, processing fence, schema migration, or second telemetry pipeline.

## Hot reply path impact

No awaited operation is added or moved onto the Foreground Reply Critical Path. The ordinary established-direct-message preparation performs zero additional database queries. After an existing active-member read resolves, one non-awaited best-effort HTTPS shell hint starts in parallel; the normal preparation run has at most two route-preparation attempts and repeated callbacks for the same resolved member are request-locally deduplicated. Failure is caught and does not alter acknowledgement, Temporal signaling, direct ensure, provider start, or reply handoff. The expected benefit is overlap with the remaining KMS/transaction/Temporal work; exact production latency will be measured from the new causal cohort after rollout rather than claimed from unit timing.

## Murph initial provider input impact

- Murph runtime: Not applicable. No prompt, tool schema, generated guidance, model selection, or provider-visible request assembly changes.
- Codex runtime: Not applicable for the same reason; this change ends at shell startup and diagnostics before workspace invocation.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: content-only changelog copy describes the earlier best-effort wake and its durable fallback without changing presentation.
- Coverage: the production archive component server-rendered the new item in the focused changelog test; no viewport or interaction behavior changed.

## Change-shape breakdown

Classification uses production `.ts` and operational `.sql` as source; `test/**` and `*.test.ts` as tests; Markdown, the execution plan, and changelog content as docs; no config or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 491 | 61 |
| Tests/fixtures | 508 | 35 |
| Docs | 197 | 30 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 1196 | 126 |

Binary files: none.

## Deployment concerns

- Deployment: applicable
- Supported skew: New Web with an old Worker may have the optional new hint rejected; the authoritative post-Temporal path remains unchanged. Old and new Worker/container versions accept legacy hints, while additive diagnostics may be absent during skew.
- Safe order: Deploy Web first so its latency parser accepts both old and new diagnostics, then deploy the Cloudflare Worker/RunnerContainer bundle.
- Rollback floor: There is no persisted-state floor. Roll Web back first to stop the new source, then roll Cloudflare back.
- Expected exposure: At most one rollout window can lose early-prewarm benefit or optional phase diagnostics; no message processing authority or durable state is affected.
- Reversibility: Disable or roll back the Web producer before reverting Cloudflare support.
- Convergence proof: A synthetic established-direct-message cold trace must show matching expected/observed prewarm IDs plus request, auth, UserRunner, admission, and container-hint stamps; the managed container smoke must report the deployed version.
- Post-deploy checks: Run the identifier-free cold-start report and inspect bounded prewarm admission outcomes, route failures, causal cohort counts, container readiness, and reply latency.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · replies-wake-sooner-after-idle-time

