### PR TITLE
fix(web): keep Vercel static generation within memory

### DIFF
--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -464,7 +464,8 @@ gate unset and makes no paid request.
   owner for the mutable production build cache, epoch, and deadline contract.
   The CI-relevant fact is that the verify lane's `VERCEL=1 VERCEL_ENV=preview`
   build shape compiles Webpack cold without arming the production-only build
-  deadline. The split reduces the compile-parent peak without
+  deadline. The worker boundary removes compiler residency from the
+  static-generation peak without
   weakening generated-contract validation, while repeated forced-cold Standard
   previews remain the real Vercel acceptance proof. A 2 GiB parent-bound
   candidate passed one forced-cold Standard preview but the next identical

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1848,13 +1848,24 @@ does not write `memory.max`, `memory.swap.max`, or `memory.oom.group`.
 
 The production runner first performs route type generation and an explicit
 app-local generated-contract TypeScript check with a 3.5 GiB limit. It marks
-only that prepared check complete before starting Webpack. Compilation then
-runs in the Next CLI process with a 3 GiB old-space limit; the runner preserves
-unrelated inherited Node options while replacing inherited old-space flags.
-These phases are sequential, so their limits do not compose. The same runner is
-used by the Vercel package build and the CI memory-observation lane. Forced-cold
-Standard previews remain the direct acceptance evidence, and a Next upgrade
-must revalidate the heap boundary.
+only that prepared check complete before starting Webpack. The Next CLI parent
+uses a 1 GiB old-space limit and the isolated Webpack worker uses 3 GiB. The
+worker exits and releases compiler memory before static-generation workers
+start. The runner preserves unrelated inherited Node options while replacing
+inherited old-space flags. TypeScript, Webpack compilation, and static
+generation are sequential, so their heap limits do not compose. The same
+runner is used by the Vercel package build and the CI memory-observation lane.
+Forced-cold Standard previews remain the direct acceptance evidence, and a
+Next upgrade must revalidate the parent/worker heap boundary.
+
+The worker boundary is required by measured composed memory, not by the duration
+of an individual route. A cold single-process GitHub build reached 9.11 GB
+immediately before static generation and 11.18 GB when export workers started,
+including 8.06 GB of anonymous memory. Vercel Standard provides 8 GB total and
+the repository reserves 0.8 GB for host overhead, so reducing only page
+concurrency cannot make that single-process shape fit the 7.2 GB build budget.
+The isolated worker preserves the ordinary `next build` output while removing
+compiler residency from the static-generation peak.
 
 Next's static-generation export loop defaults to eight concurrent pages in each
 of the two configured export workers, allowing up to sixteen page renders at
@@ -1865,14 +1876,17 @@ skipping any static output; exact-head Vercel builds remain the duration and
 capacity proof.
 
 Production builds use Next 16.3's supported Webpack fallback. The production
-script passes `--webpack` and enables `webpackMemoryOptimizations`. The Workflow
-integration contributes custom Webpack configuration, so Next's canonical
-default is to compile in the CLI process. Do not force `webpackBuildWorker`:
-that creates a second compiler-process owner and previously left Standard
-deployments stuck inside an opaque worker after compilation stopped making
-progress. The hosted local-development wrapper remains on Turbopack and rejects
-an explicit Webpack flag. The production runner also owns a versioned cache
-epoch inside `.next/cache`.
+runner passes `--webpack`, and the config enables `webpackBuildWorker` and
+`webpackMemoryOptimizations`. The Workflow integration contributes custom
+Webpack configuration, which disables Next's automatic worker selection, so
+the worker must be enabled explicitly. Three consecutive forced-cold Webpack
+previews, a later integration preview, and the final corrected head previously
+completed on the Standard builder with this worker boundary. The later
+single-process simplification is no longer acceptable: an exact-head cgroup
+trace measured 11.18 GB at static generation, and production reproduced the
+same intermittent 70-page stall. The hosted local-development wrapper remains
+on Turbopack and rejects an explicit Webpack flag. The production runner also
+owns a versioned cache epoch inside `.next/cache`.
 When that stamp is absent or differs, it removes the incompatible cache before
 compilation and writes the epoch only after Next succeeds. Production Webpack
 compiles are additionally cold-cache by policy: the runner removes

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -21,6 +21,12 @@ interface StaticHeader {
   value: string;
 }
 
+interface HostedWebWebpackConfig {
+  resolve: {
+    alias?: Record<string, unknown>;
+  };
+}
+
 const HOSTED_WEB_HEADER_SOURCE = "/(.*)";
 const MURPH_SAFE_HEADER_SOURCE = "/search/:path*";
 const PRIVY_CUSTOM_DOMAIN_ENV_KEYS = ["PRIVY_CUSTOM_AUTH_DOMAIN"] as const;
@@ -271,6 +277,22 @@ export function buildHostedWebTurbopackConfig(): NextConfig["turbopack"] {
   };
 }
 
+export function configureHostedWebWebpack(
+  config: HostedWebWebpackConfig,
+): HostedWebWebpackConfig {
+  if (!hasOptionalModule("@farcaster/mini-app-solana")) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@farcaster/mini-app-solana": path.resolve(
+        appDir,
+        "src/lib/empty-module.ts",
+      ),
+    };
+  }
+
+  return config;
+}
+
 export function configureHostedWebWorkflowLocalDataDir(
   phase: string,
   environment: NodeJS.ProcessEnv = process.env,
@@ -377,6 +399,7 @@ export function buildHostedWebNextConfig(
           === HOSTED_WEB_PREPARED_TYPECHECK_COMPLETE,
       tsconfigPath: HOSTED_WEB_NEXT_TSCONFIG_PATH,
     },
+    webpack: configureHostedWebWebpack,
     headers: async () => [
       {
         source: HOSTED_WEB_HEADER_SOURCE,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -342,8 +342,10 @@ export function buildHostedWebNextConfig(
       turbopackFileSystemCacheForDev: isHostedWebDevFileSystemCacheEnabled(environment),
       // Source-map emission is the largest proven build-memory cost.
       turbopackSourceMaps: false,
-      // Workflow contributes Webpack configuration, so Next keeps compilation
-      // in the CLI process unless webpackBuildWorker is explicitly forced.
+      // Workflow contributes Webpack configuration, which disables Next's
+      // automatic worker selection. Force the supported worker so compiler
+      // memory is released before static-generation workers start.
+      webpackBuildWorker: true,
       webpackMemoryOptimizations: true,
     },
     outputFileTracingIncludes: {

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-build_old_space_mb=3072
+parent_old_space_mb=1024
+build_worker_old_space_mb=3072
 typecheck_old_space_mb=3584
-build_cache_epoch=webpack-next-16.3-v4-in-process-cold-webpack
+build_cache_epoch=webpack-next-16.3-v5-isolated-worker-cold-webpack
 build_cache_stamp=.next/cache/murph-production-build-epoch
 webpack_cache_dir=.next/cache/webpack
 prepared_typecheck_env=MURPH_HOSTED_WEB_PREPARED_TYPECHECK
@@ -44,16 +45,17 @@ else
   node ../../scripts/rm-paths.mjs "$webpack_cache_dir"
 fi
 
-printf '[apps/web build] Next memory policy: compiler=webpack build_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=cold webpack_build_worker=off\n' \
-  "$build_old_space_mb" \
+printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s build_worker_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=cold webpack_build_worker=on\n' \
+  "$parent_old_space_mb" \
+  "$build_worker_old_space_mb" \
   "$typecheck_old_space_mb"
 
 # Generate the route declarations before running Next's app-local TypeScript 5
 # compatibility check. Keeping that check separate gives validation its own
 # heap limit without replacing the route/page contract proof with the
 # repository's TypeScript 7 source check.
-set_node_old_space "$build_old_space_mb"
-node "--max-old-space-size=$build_old_space_mb" "$next_bin" typegen
+set_node_old_space "$build_worker_old_space_mb"
+node "--max-old-space-size=$parent_old_space_mb" "$next_bin" typegen
 
 set_node_old_space "$typecheck_old_space_mb"
 node "--max-old-space-size=$typecheck_old_space_mb" \
@@ -62,8 +64,8 @@ node "--max-old-space-size=$typecheck_old_space_mb" \
   --pretty false
 
 export MURPH_HOSTED_WEB_PREPARED_TYPECHECK=complete
-set_node_old_space "$build_old_space_mb"
-node "--max-old-space-size=$build_old_space_mb" "$next_bin" build --webpack
+set_node_old_space "$build_worker_old_space_mb"
+node "--max-old-space-size=$parent_old_space_mb" "$next_bin" build --webpack
 
 if [[ "$cache_reset" == 1 ]]; then
   mkdir -p "$(dirname "$build_cache_stamp")"

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -27,6 +27,7 @@ import {
   buildHostedWebTurbopackConfig,
   buildHostedWebContentSecurityPolicy,
   buildHostedWebSecurityHeaders,
+  configureHostedWebWebpack,
   configureHostedWebWorkflowLocalDataDir,
   resolveHostedPrivyOrigin,
   resolveHostedPrivyOrigins,
@@ -358,9 +359,9 @@ test("hosted web dev filesystem cache defaults off and allows explicit opt-in", 
   );
 });
 
-test("next.config keeps Turbopack focused on the repo root without custom workspace rewrite rules", () => {
+test("next.config keeps both bundlers focused without custom workspace rewrite rules", () => {
   assert.equal(productionNextConfig.turbopack?.root, process.cwd());
-  assert.equal(productionNextConfig.webpack, undefined);
+  assert.equal(productionNextConfig.webpack, configureHostedWebWebpack);
   assert.deepEqual(productionNextConfig.typescript, {
     ignoreBuildErrors: false,
     tsconfigPath: HOSTED_WEB_NEXT_TSCONFIG_PATH,
@@ -544,6 +545,33 @@ test("buildHostedWebTurbopackConfig always points Turbopack at the repo root", (
   } else {
     assert.deepEqual(resolveAlias, {
       "@farcaster/mini-app-solana": "./src/lib/empty-module.ts",
+    });
+  }
+});
+
+test("configureHostedWebWebpack aliases Privy's missing optional Farcaster peer", () => {
+  const webpackConfig = {
+    resolve: {
+      alias: {
+        existing: "/existing-module.ts",
+      },
+    },
+  };
+  const configured = configureHostedWebWebpack(webpackConfig);
+  const hasOptionalModule = resolveHostedOptionalModule();
+
+  assert.equal(configured, webpackConfig);
+  if (hasOptionalModule) {
+    assert.deepEqual(configured.resolve.alias, {
+      existing: "/existing-module.ts",
+    });
+  } else {
+    assert.deepEqual(configured.resolve.alias, {
+      existing: "/existing-module.ts",
+      "@farcaster/mini-app-solana": path.join(
+        repoRoot,
+        "apps/web/src/lib/empty-module.ts",
+      ),
     });
   }
 });

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -398,10 +398,10 @@ test("next.config leaves agent guidance under repository ownership", () => {
   assert.equal(productionNextConfig.agentRules, false);
 });
 
-test("production build config keeps Webpack compilation in the Next process", () => {
+test("production build config isolates Webpack compilation from static generation", () => {
   assert.equal(productionNextConfig.experimental?.turbopackFileSystemCacheForBuild, false);
   assert.equal(productionNextConfig.experimental?.turbopackSourceMaps, false);
-  assert.equal(productionNextConfig.experimental?.webpackBuildWorker, undefined);
+  assert.equal(productionNextConfig.experimental?.webpackBuildWorker, true);
   assert.equal(productionNextConfig.experimental?.webpackMemoryOptimizations, true);
 });
 

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -1975,12 +1975,12 @@ describe("hosted web production migration guard", () => {
     assert.match(buildScript, /^pnpm public-routes:waf-check/u);
     assert.doesNotMatch(buildScript, /run-with-host-verification-slot/u);
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
-    assert.match(productionNextBuildScript, /build_old_space_mb=3072/u);
-    assert.doesNotMatch(productionNextBuildScript, /build_worker_old_space_mb/u);
+    assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
+    assert.match(productionNextBuildScript, /build_worker_old_space_mb=3072/u);
     assert.match(productionNextBuildScript, /typecheck_old_space_mb=3584/u);
     assert.match(
       productionNextBuildScript,
-      /build_cache_epoch=webpack-next-16\.3-v4-in-process-cold-webpack/u,
+      /build_cache_epoch=webpack-next-16\.3-v5-isolated-worker-cold-webpack/u,
     );
     assert.match(productionNextBuildScript, /webpack_cache_dir=\.next\/cache\/webpack/u);
     assert.match(
@@ -1998,7 +1998,7 @@ describe("hosted web production migration guard", () => {
     );
     assert.match(
       productionNextBuildScript,
-      /node "--max-old-space-size=\$build_old_space_mb" "\$next_bin" build --webpack/u,
+      /node "--max-old-space-size=\$parent_old_space_mb" "\$next_bin" build --webpack/u,
     );
     assert.match(
       productionNextBuildScript,

--- a/apps/web/test/production-next-build-runner.test.ts
+++ b/apps/web/test/production-next-build-runner.test.ts
@@ -11,7 +11,7 @@ const productionBuildScript = path.join(
   "scripts",
   "run-production-next-build.sh",
 );
-const buildCacheEpoch = "webpack-next-16.3-v4-in-process-cold-webpack";
+const buildCacheEpoch = "webpack-next-16.3-v5-isolated-worker-cold-webpack";
 
 async function createRunnerFixture(): Promise<{
   appDir: string;
@@ -141,7 +141,7 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
       `Resetting incompatible Next build cache for epoch=${buildCacheEpoch}`,
     );
     expect(coldBuild.stdout).toContain(
-      "compiler=webpack build_old_space_mb=3072 typecheck_old_space_mb=3584 webpack_cache=cold webpack_build_worker=off",
+      "compiler=webpack parent_old_space_mb=1024 build_worker_old_space_mb=3072 typecheck_old_space_mb=3584 webpack_cache=cold webpack_build_worker=on",
     );
     await expect(readFile(staleCacheEntry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(cacheStamp, "utf8")).resolves.toBe(`${buildCacheEpoch}\n`);
@@ -149,12 +149,12 @@ test("production Next runner owns the cold Webpack cache and fail-closed epoch",
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=",
-      "--max-old-space-size=3072",
+      "--max-old-space-size=1024",
       "/fixture/next",
       "typegen",
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=complete",
-      "--max-old-space-size=3072",
+      "--max-old-space-size=1024",
       "/fixture/next",
       "build",
       "--webpack",
@@ -232,7 +232,7 @@ test("production Next runner fails closed before compilation when the prepared t
     await expect(readFile(fixture.buildLog, "utf8")).resolves.toBe([
       "NODE_OPTIONS=--trace-warnings --max-old-space-size=3072",
       "TYPECHECK_GATE=",
-      "--max-old-space-size=3072",
+      "--max-old-space-size=1024",
       "/fixture/next",
       "typegen",
       "",


### PR DESCRIPTION
## Why and outcome

The failed hosted Web deployment reached 70/281 static pages and then exceeded Vercel's 45-minute build limit. The Privy optional-peer warning in the same log was deterministic but not terminal: unchanged builds could complete with it.

Exact-head cgroup evidence identified the underlying failure shape. The in-process Webpack compiler retained 9.11 GB immediately before static generation and the composed build reached 11.18 GB when export workers started, above the Standard builder's 8 GB capacity. This change restores Next's supported isolated Webpack worker with phase-specific heap limits so compiler memory is released before static generation. It also maps Privy's absent optional Farcaster/Solana peer to the existing empty module for Webpack, matching Turbopack and removing the warning without installing an unused integration.

## Product UX

- Effort: Not applicable — production build configuration only.
- Result: Not applicable.
- Walkthrough: No member-facing state, interaction, copy, accessibility, or recovery path changes.

## Evidence

- Root-cause proof: the exact PR-head Linux build measured 9.11 GB before static generation and 11.18 GB at export-worker startup; production separately reproduced the 70-page stall.
- Hosted proof: the [exact-head forced-cold Vercel preview](https://vercel.com/cobuildwithus/murph/8rABjZrW8Gd5x2K3oxCWNxWhi15y) reached Ready on the 4-core, 8 GB Standard builder. Webpack compiled with the isolated worker, generated 281/281 static pages, emitted no missing Farcaster-module warning, and completed deployment.
- Direct local proof: `bash scripts/run-production-next-build.sh` completed with `webpackBuildWorker` enabled, clean Webpack compilation, 281/281 generated static pages, no missing Farcaster-module warning, and exit status 0.
- Focused coverage: 118 tests passed across the production runner, migration guard, and Next config.
- Package checks: `pnpm --dir apps/web typecheck` passed; `pnpm --dir apps/web lint` passed with pre-existing warnings only.
- Required GitHub checks: green on exact head `6aedb7819256a2e563a4dcad9ef09dedb190bf78`.
- Final ReviewGPT full-snapshot audit: PASS with no qualifying findings.

## Non-obvious affected surfaces

- Hosted Web production bundling: Vercel Workflow contributes custom Webpack configuration, which disables Next's automatic worker selection. The config explicitly enables the supported worker.
- Heap ownership: the Next parent uses 1 GiB, the Webpack worker uses 3 GiB, and the separate generated-contract typecheck uses 3.5 GiB. These phases are sequential.
- Privy optional integrations: only the absent `@farcaster/mini-app-solana` peer is redirected; an installed peer remains untouched.
- Build cache: the versioned cold-Webpack epoch advances so restored single-process cache state cannot cross the boundary.

## Architecture and reuse

- Existing systems reused: Next's supported Webpack build worker and memory optimizations, the existing phase-aware production runner, optional-module detector, and `src/lib/empty-module.ts`.
- New logic: Explicit worker selection, measured parent/worker heap limits, and a narrow Webpack alias only when the optional peer is absent.
- New abstractions: No new abstraction is needed because the existing Next config and production runner already own these build boundaries.
- Complexity intentionally avoided: No dependency, loader, split compile/generate pipeline, compatibility service, runtime flag, or reduced static output. Next 16.3's split generate mode was rejected because its static-env inliner treats the directory-backed `openapi.json` route as a file.

## Hot reply path impact

- Path status: Not applicable — build-time configuration only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Exact production build path and focused config/runner tests.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

The exact-head GitHub job's whole-cgroup peak fell from 11.18 GB to 10.48 GB but remained above its advisory model because that job-wide measurement includes retained anonymous and file-cache memory and does not isolate phase overlap. It is supporting diagnostic evidence, not the acceptance boundary. The decisive 4-core, 8 GB Vercel build completed with the isolated compiler worker and all 281 static pages.

ReviewGPT context sensitivity: sensitive
Classification reason: The patch changes hosted Web production deploy and memory configuration.
ReviewGPT first-reviewed head: 5330e1c91f0c91de6fa5aafa5f62d3ed6affdbc5

## Deployment concerns

- Deployment: applicable
- Supported skew: Each Vercel artifact is self-contained; previous and new hosted Web artifacts require no coordinated schema, reader, or Cloudflare change.
- Safe order: Deploy hosted Web normally; no tandem deployment is required.
- Rollback floor: Any previously successful hosted Web deployment remains safe because persisted state and external contracts are unchanged.
- Expected exposure: Build-time only; mixed runtime state is not created.
- Reversibility: Revert the commits or promote the prior Vercel artifact.
- Convergence proof: The exact-head Vercel build reached Ready and produced one immutable artifact across instances.
- Post-deploy checks: Confirm the production build reaches 281/281 without the missing Farcaster-module warning and verify the production alias health check.

## Change-shape breakdown

Classification rule: production config and runner scripts are config/tooling; regression files are tests/fixtures; README and CI map are docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 41 | 13 |
| Docs | 31 | 16 |
| Config / tooling | 37 | 10 |
| Generated / other | 0 | 0 |
| **Total** | **109** | **39** |

## Changelog

- Changelog: not applicable
- Reason: Internal build reliability and module resolution only; no member-visible behavior changes.
