### PR TITLE
fix(cli): reject unsupported meal import fields

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-cli-meal-review-remediation.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-cli-meal-review-remediation.md
@@ -1,0 +1,114 @@
+# Preserve actionable nested meal import diagnostics
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Keep unknown top-level `meal import-json` fields private while preserving
+  concrete nested schema diagnostics that let an agent correct and retry once.
+
+## Success criteria
+
+- Root-level unknown fields still return generic unsupported-field copy without
+  echoing the submitted key, value, or input path.
+- A synthetic typo under `nutrition.micros` retains its concrete nested path and
+  schema correction instead of being flattened to a generic message.
+- Differing `photo`/`photoPath` or `audio`/`audioPath` values reject before a
+  write with fixed field guidance; equal aliases remain accepted.
+- Validation failures expose the existing safe `validation` stage and bounded
+  public field-error projection without submitted values or paths.
+- The rejected command writes no meal.
+- One production-derived real-Codex journey makes exactly one rejected import,
+  exactly one corrected retry, and exactly one meal write with no duplicate.
+- The focused deterministic suite, focused live journey, and touched-owner
+  typechecks pass.
+
+## Product UX
+
+- Effort: Product UX Patch.
+- Affected person: an assistant logging a structured private meal whose first
+  payload contains one unsupported top-level field and one nested micronutrient
+  typo.
+- Ordinary entry: a private request to log a fully specified meal.
+- Last observable boundary: one canonical meal write plus one concise truthful
+  completion reply after the corrected retry.
+- Recovery: the first call fails before persistence, gives a useful nested
+  correction without disclosing the root field, and permits one corrected call.
+
+## Scope
+
+- In scope:
+  - Root-only sanitization in the existing meal schema issue formatter.
+  - Pre-write conflict validation for the two documented path alias pairs.
+  - Reuse of the existing structured validation-error projection.
+  - A deterministic real-command regression for mixed root and nested issues.
+  - One focused production-prompt and food-journal-skill live journey.
+- Out of scope:
+  - New meal fields, nutrition semantics, automatic correction, or retries in
+    the CLI itself.
+  - Changelog semantics beyond the existing top-level typo rejection outcome.
+
+## Tasks
+
+1. Narrow generic issue formatting to root-level unknown fields.
+2. Reject differing media-path aliases before persistence while preserving
+   equal, canonical-only, and alias-only inputs.
+3. Strengthen deterministic proof for nested guidance, alias conflicts,
+   structured recovery, privacy, and zero writes.
+4. Add and run one focused real-Codex reject-correct-write journey.
+5. Run touched-owner typechecks, inspect the final diff and privacy boundary,
+   then close the plan with the scoped remediation commit.
+
+## Verification
+
+- `pnpm exec vitest run packages/cli/test/meal-add-typed-parity.test.ts`
+- `pnpm test:assistant:live -- --test "recovers one strict meal import typo without duplicate write"`
+- `pnpm --filter @murphai/murph typecheck`
+- `pnpm --filter @murphai/assistant-engine typecheck`
+- `git diff --check`
+
+## Outcome
+
+- Root unknown fields retain fixed private-safe copy, while nested validation
+  issues keep their concrete public field path and correction.
+- Differing media alias pairs now fail before persistence with fixed recovery;
+  equal aliases continue through the existing canonical projection.
+- All validation failures reuse the existing bounded `validation` stage and
+  public field-error projection instead of adding a second error contract.
+- The focused real assistant recovered the synthetic malformed import with one
+  rejected call, one corrected retry, exactly one meal write, and no duplicate.
+
+## Reaches
+
+- Production code: the structured `meal import-json` CLI validator only.
+- Deterministic proof: the existing meal typed-parity suite.
+- Live proof: one opt-in production-prompt and food-journal-skill journey.
+- No importer, canonical writer, nutrition semantics, prompt, tool schema,
+  generated CLI artifact, or changelog semantics changed.
+
+## Proof
+
+- `pnpm exec vitest run packages/cli/test/meal-add-typed-parity.test.ts`
+  passed: 1 file, 13 tests.
+- `pnpm --filter @murphai/murph typecheck` passed.
+- `pnpm --filter @murphai/assistant-engine typecheck` passed.
+- `pnpm test:assistant:live -- --test "recovers one strict meal import typo without duplicate write"`
+  passed with `gpt-5.6-terra` and local subscription auth: two import attempts,
+  one canonical write, and the concise reply `Dinner imported successfully.`
+  Product UX verdict: Ready.
+
+## Progress
+
+- 2026-08-30: Accepted the specialist finding after confirming nested Zod
+  `unrecognized_keys` issues carry the actionable `nutrition.micros` path.
+- 2026-08-30: Accepted the parent cross-family finding that differing media
+  aliases were silently resolved by precedence instead of failing closed.
+- 2026-08-30: The first provider-reaching live run proved two import attempts
+  and one write with a concise outcome-only reply; widened the truthful outcome
+  matcher to accept the natural verb `imported` before the required same-home
+  rerun.
+- 2026-08-30: The same-home live rerun passed with one rejected import, one
+  corrected retry, one write, no duplicate, and a truthful outcome-only reply.
+Completed: 2026-08-30

--- a/agent-docs/exec-plans/completed/2026-08-30-cli-meal-strict-import.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-cli-meal-strict-import.md
@@ -1,0 +1,115 @@
+# Reject unknown meal import fields before writing
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Make `vault-cli meal import-json` reject unsupported top-level payload fields
+  before any canonical meal write, while preserving every documented key and
+  legacy path alias.
+
+## Success criteria
+
+- A payload containing an unknown top-level field returns the stable
+  `invalid_payload` error instead of reporting a successful meal import.
+- The recovery error does not echo the submitted unknown key, its value, or an
+  absolute input path.
+- The rejected payload creates no meal record.
+- All documented payload keys, including `photo`/`photoPath` and
+  `audio`/`audioPath`, remain accepted.
+- Focused CLI tests and the touched CLI owner typecheck pass.
+
+## Scope
+
+- In scope:
+  - Strict validation at the CLI-owned structured meal payload boundary.
+  - Privacy-safe recovery copy for unsupported fields.
+  - One focused pre-write/non-echo regression in the existing meal parity test.
+- Out of scope:
+  - Tightening the internal meal importer, whose private orchestration fields
+    are intentionally broader than the public CLI payload.
+  - Changing meal persistence, nutrition semantics, command topology, or other
+    nutrition families.
+
+## Constraints
+
+- Technical constraints:
+  - Keep all nine documented top-level keys and both path aliases unchanged.
+  - Do not project Zod's submitted unknown-key names into model-visible errors.
+  - Validate before invoking the importer or writing any meal artifacts.
+- Product/process constraints:
+  - Product UX Patch: valid callers see no behavior change; typoed payloads get
+    one actionable failure rather than false success.
+  - Keep the fix local to `packages/cli` and use existing schemas/helpers.
+
+## Risks and mitigations
+
+1. Risk: Strictness rejects an undocumented field a caller previously included.
+   Mitigation: Unknown CLI fields are currently discarded and have no effect;
+   preserve every documented key and alias while rejecting only ignored data.
+2. Risk: Zod's unrecognized-key issue echoes a submitted key.
+   Mitigation: Render a fixed unsupported-field message and assert non-echo.
+3. Risk: Validation happens after partial persistence.
+   Mitigation: Exercise the real CLI command and verify a subsequent meal list
+   remains empty.
+
+## Tasks
+
+1. Make the CLI payload schema strict and sanitize unsupported-field recovery.
+2. Add a focused real-command regression proving the error, privacy boundary,
+   and zero writes.
+3. Run the focused CLI test and touched-owner typecheck, then inspect the diff.
+
+## Decisions
+
+- Keep `packages/importers/src/meal-importer.ts` flexible because internal
+  callers legitimately pass `vaultRoot` and `externalRef` there.
+- Treat the unknown field name itself as submitted data and omit it from the
+  error envelope; enumerate the finite supported surface instead.
+- No real-Codex journey is needed because this patch does not change prompts,
+  tool schema/catalog, routing, or reply policy; the owned behavior is fully
+  deterministic at the CLI validation boundary.
+
+## Verification
+
+- Commands to run:
+  - `pnpm exec vitest run packages/cli/test/meal-add-typed-parity.test.ts`
+  - `pnpm --filter @murphai/murph typecheck`
+- Expected outcomes:
+  - The focused meal suite passes, including the new non-echo/no-write case.
+  - CLI TypeScript compilation passes without casts or generated drift.
+
+## Outcome
+
+- `meal import-json` now rejects unsupported top-level fields before calling the
+  importer, while every documented field and alias remains unchanged.
+- Unsupported-field recovery uses fixed copy plus the finite payload shape, so
+  the submitted key, value, and file path do not appear in the error envelope.
+- The focused regression proves the failed invocation leaves the meal list at
+  zero records.
+
+## Reaches
+
+- Production code: `packages/cli/src/commands/meal.ts` only.
+- Regression proof: `packages/cli/test/meal-add-typed-parity.test.ts` only.
+- No command topology, generated CLI artifacts, importer contracts, persisted
+  schemas, provider inputs, or deployment surfaces changed.
+
+## Proof
+
+- `pnpm exec vitest run packages/cli/test/meal-add-typed-parity.test.ts`
+  passed: 1 file, 12 tests.
+- `pnpm --filter @murphai/murph typecheck` passed.
+- `git diff --check` passed.
+
+## Progress
+
+- 2026-08-30: Confirmed unknown CLI fields were silently discarded, while the
+  internal importer intentionally accepts broader orchestration fields.
+- 2026-08-30: Implemented the strict CLI boundary and privacy-safe error copy.
+- 2026-08-30: Added and passed the real-command pre-write/non-echo regression.
+- 2026-08-30: Passed the focused CLI suite and CLI owner typecheck; candidate is
+  ready for the parent-owned review, commit, push, and PR gates.
+Completed: 2026-08-30

--- a/apps/web/changelog/entries/2026-08-30/meal-imports-catch-typos.json
+++ b/apps/web/changelog/entries/2026-08-30/meal-imports-catch-typos.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "meal-imports-catch-typos",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Meal imports catch typos before saving",
+    "summary": "When Murph imports a structured meal, unsupported fields now stop the save instead of being silently ignored.",
+    "details": "The recovery result names the supported meal shape without repeating submitted private values. Existing photo and audio field aliases continue to work.",
+    "relevanceTags": ["assistant", "meals", "nutrition", "reliability"],
+    "sourcePullRequests": [2591]
+  }
+}

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -18317,6 +18317,282 @@ describeRealCodex('real Codex recurring meal-tracking setup e2e', () => {
   })
 })
 
+describeRealCodex('real Codex strict meal import recovery e2e', () => {
+  it('recovers one strict meal import typo without duplicate write', {
+    timeout: 900_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-strict-meal-import-recovery-e2e-'),
+    )
+
+    try {
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'meal-commands.jsonl')
+      const eventLogPath = path.join(workingDirectory, 'meal-events.jsonl')
+      const importPath = path.join(workingDirectory, 'meal-import.json')
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      const stateFile = path.join(workingDirectory, 'meal-write-count.txt')
+      await Promise.all([
+        materializeAssistantSkill({ skillsRoot, slug: 'food-journal' }),
+        materializeStrictMealImportVaultCli({
+          binDirectory,
+          commandLogPath,
+          eventLogPath,
+          stateFile,
+        }),
+        writeFile(commandLogPath, '', 'utf8'),
+        writeFile(eventLogPath, '', 'utf8'),
+        writeFile(stateFile, '0\n', 'utf8'),
+        writeFile(
+          importPath,
+          `${JSON.stringify({
+            ingredientz: ['synthetic duplicate field'],
+            ingredients: ['tofu', 'brown rice', 'broccoli'],
+            note: 'Tofu bowl with brown rice and broccoli.',
+            nutrition: {
+              micros: {
+                vitaminCMG: 48,
+              },
+              provenance: {
+                confidence: 'high',
+                source: 'label',
+                sourceDetail: 'Synthetic package label.',
+              },
+              totals: {
+                calories: 540,
+                carbsGrams: 72,
+                fatGrams: 18,
+                fiberGrams: 11,
+                proteinGrams: 27,
+              },
+            },
+            occurredAt: '2026-08-30T19:00:00-04:00',
+            source: 'manual',
+          }, null, 2)}\n`,
+          'utf8',
+        ),
+      ])
+
+      const inheritedPath = normalizeEnvString(config.env.PATH)
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand:
+          normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: 'Use vault-cli for canonical member data.',
+          assistantContextSnapshotPrompt: null,
+          assistantHostedDeviceConnectAvailable: false,
+          assistantHostedDeviceConnectProviders: [],
+          assistantKnowledgeToolsAvailable: false,
+          channel: 'linq',
+          cliAccess: {
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+          conversationScope: 'direct',
+          currentLocalDate: '2026-08-30',
+          currentTimeZone: 'America/New_York',
+          hostedRuntime: true,
+          modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+          ordinaryInboundTurn: true,
+          turnTrigger: 'automation-auto-reply',
+        }),
+        dynamicTools: [],
+        env: {
+          ...config.env,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          PATH: inheritedPath
+            ? `${binDirectory}${path.delimiter}${inheritedPath}`
+            : binDirectory,
+        },
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        prompt: [
+          'Log the structured dinner in meal-import.json.',
+          'Run the import as-is first so the CLI owns validation.',
+          'If it rejects the payload, apply only the reported field corrections and retry once.',
+          'Do not add a replacement meal or create a duplicate. Reply only with the final outcome.',
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+
+      const importEvents = (await readFile(eventLogPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as {
+          correctMicronutrient: boolean
+          nestedTypo: boolean
+          result: 'rejected' | 'saved'
+          rootUnknown: boolean
+        })
+      const writeCount = Number.parseInt(
+        (await readFile(stateFile, 'utf8')).trim(),
+        10,
+      )
+      const reply = result.finalMessage.trim()
+
+      process.stdout.write(
+        `[strict-meal-import-recovery-e2e] ${JSON.stringify({
+          importAttempts: importEvents.length,
+          reply,
+          writes: writeCount,
+        })}\n`,
+      )
+      expect(importEvents).toEqual([
+        {
+          correctMicronutrient: false,
+          nestedTypo: true,
+          result: 'rejected',
+          rootUnknown: true,
+        },
+        {
+          correctMicronutrient: true,
+          nestedTypo: false,
+          result: 'saved',
+          rootUnknown: false,
+        },
+      ])
+      expect(writeCount).toBe(1)
+      expect(reply).toMatch(/\b(?:imported|logged|recorded|saved|added)\b/iu)
+      expect(reply).not.toMatch(
+        /\b(?:CLI|command|corrected|error|invalid|retry|schema|typo)\b/iu,
+      )
+      expect(reply).not.toMatch(/\?/u)
+      expect(reply.split(/\s+/u).length).toBeLessThanOrEqual(30)
+    } finally {
+      await removeRealCodexTemporaryPaths([
+        workingDirectory,
+        ...config.temporaryPaths,
+      ])
+    }
+  })
+})
+
+async function materializeStrictMealImportVaultCli(input: {
+  binDirectory: string
+  commandLogPath: string
+  eventLogPath: string
+  stateFile: string
+}): Promise<void> {
+  await mkdir(input.binDirectory, { recursive: true })
+  const executablePath = path.join(input.binDirectory, 'vault-cli')
+  const savedMeal = {
+    eventId: 'event_01SYNTHETICSTRICTIMPORT0001',
+    ingredients: ['tofu', 'brown rice', 'broccoli'],
+    mealId: 'meal_01SYNTHETICSTRICTIMPORT00001',
+    note: 'Tofu bowl with brown rice and broccoli.',
+    nutrition: {
+      micros: { vitaminCMg: 48 },
+      provenance: {
+        confidence: 'high',
+        source: 'label',
+        sourceDetail: 'Synthetic package label.',
+      },
+      totals: {
+        calories: 540,
+        carbsGrams: 72,
+        fatGrams: 18,
+        fiberGrams: 11,
+        proteinGrams: 27,
+      },
+    },
+    occurredAt: '2026-08-30T19:00:00-04:00',
+    source: 'manual',
+  }
+  const supportedRootKeys = [
+    'audio',
+    'audioPath',
+    'ingredients',
+    'note',
+    'nutrition',
+    'occurredAt',
+    'photo',
+    'photoPath',
+    'source',
+  ]
+
+  await writeFile(
+    executablePath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs')",
+      "const path = require('node:path')",
+      `const commandLogPath = ${JSON.stringify(input.commandLogPath)}`,
+      `const eventLogPath = ${JSON.stringify(input.eventLogPath)}`,
+      `const stateFile = ${JSON.stringify(input.stateFile)}`,
+      `const savedMeal = ${JSON.stringify(savedMeal)}`,
+      `const supportedRootKeys = ${JSON.stringify(supportedRootKeys)}`,
+      'const args = process.argv.slice(2)',
+      "fs.appendFileSync(commandLogPath, `${JSON.stringify(args)}\\n`, 'utf8')",
+      'function emit(value) { process.stdout.write(`${JSON.stringify(value)}\\n`) }',
+      'function fail(message) { emit({ error: { code: "invalid_payload", message }, ok: false }); process.exitCode = 1 }',
+      'if (args[0] === "meal" && args[1] === "import-json" && args.includes("--help")) {',
+      '  process.stdout.write("Usage: vault-cli meal import-json --input @meal.json --format json\\n")',
+      '} else if (args[0] === "meal" && args[1] === "import-json") {',
+      '  const inputIndex = args.indexOf("--input")',
+      '  const inputArg = inputIndex >= 0 ? args[inputIndex + 1] : undefined',
+      '  if (!inputArg || !inputArg.startsWith("@")) {',
+      '    fail("--input requires @file.json for this structured meal.")',
+      '  } else {',
+      '    const payloadPath = path.resolve(process.cwd(), inputArg.slice(1))',
+      '    const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"))',
+      '    const micros = payload.nutrition && payload.nutrition.micros && typeof payload.nutrition.micros === "object" ? payload.nutrition.micros : {}',
+      '    const rootUnknown = Object.keys(payload).some((key) => !supportedRootKeys.includes(key))',
+      '    const nestedTypo = Object.prototype.hasOwnProperty.call(micros, "vitaminCMG")',
+      '    const correctMicronutrient = Object.prototype.hasOwnProperty.call(micros, "vitaminCMg")',
+      '    if (rootUnknown || nestedTypo) {',
+      '      fs.appendFileSync(eventLogPath, `${JSON.stringify({ correctMicronutrient, nestedTypo, result: "rejected", rootUnknown })}\\n`, "utf8")',
+      '      fail([',
+      '        "Meal payload is not valid.",',
+      '        "nutrition.micros: Unrecognized key: \\"vitaminCMG\\";",',
+      '        "value: contains an unsupported field.",',
+      '        "Structured payload object keys: `ingredients`, `note`, `nutrition`, `occurredAt`, and `source`.",',
+      '      ].join(" "))',
+      '    } else if (!correctMicronutrient) {',
+      '      fail("Meal payload is not valid. nutrition.micros: vitaminCMg is required by this synthetic fixture.")',
+      '    } else {',
+      '      const writeCount = Number.parseInt(fs.readFileSync(stateFile, "utf8").trim(), 10)',
+      '      if (writeCount !== 0) {',
+      '        process.stderr.write("duplicate meal write rejected\\n")',
+      '        process.exitCode = 65',
+      '      } else {',
+      '        fs.writeFileSync(stateFile, "1\\n", "utf8")',
+      '        fs.appendFileSync(eventLogPath, `${JSON.stringify({ correctMicronutrient, nestedTypo, result: "saved", rootUnknown })}\\n`, "utf8")',
+      '        emit(savedMeal)',
+      '      }',
+      '    }',
+      '  }',
+      '} else if (args[0] === "meal" && args[1] === "show") {',
+      '  emit({ entity: savedMeal })',
+      '} else if (args[0] === "meal" && args[1] === "list") {',
+      '  const writeCount = Number.parseInt(fs.readFileSync(stateFile, "utf8").trim(), 10)',
+      '  emit({ count: writeCount, items: writeCount === 1 ? [savedMeal] : [], nextCursor: null })',
+      '} else if (args[0] === "meal" && args[1] === "totals") {',
+      '  emit({ mealCount: 1, totals: { calories: { mealCount: 1, total: 540 }, carbsGrams: { mealCount: 1, total: 72 }, fatGrams: { mealCount: 1, total: 18 }, fiberGrams: { mealCount: 1, total: 11 }, proteinGrams: { mealCount: 1, total: 27 } } })',
+      '} else if (args[0] === "goal" && args[1] === "list") {',
+      '  emit({ count: 0, items: [], nextCursor: null })',
+      '} else if (args[0] === "memory" && args[1] === "show") {',
+      '  emit({ document: { records: [] }, memory: null })',
+      '} else {',
+      '  process.stderr.write(`unsupported strict meal import fixture command: ${args.join(" ")}\\n`)',
+      '  process.exitCode = 64',
+      '}',
+      '',
+    ].join('\n'),
+    { encoding: 'utf8', mode: 0o700 },
+  )
+  await chmod(executablePath, 0o700)
+}
+
 describeRealCodex('real Codex restaurant meal nutrition e2e', () => {
   it('resolves an exact menu label before saving a restaurant meal', {
     timeout: 900_000,

--- a/packages/cli/src/commands/meal.ts
+++ b/packages/cli/src/commands/meal.ts
@@ -50,6 +50,7 @@ import {
   commonListLimitOptionSchema,
 } from './command-factory-primitives.js'
 import { normalizeOccurredAtOption } from './occurred-at-option.js'
+import { publicValidationIssue } from './public-validation-issue.js'
 
 const mealIngredientsSchema = z
   .array(z.string().trim().min(1).max(4000))
@@ -111,12 +112,67 @@ function formatSchemaIssues(
   return issues
     .map((issue) => {
       const path = issue.path.length > 0 ? issue.path.join('.') : 'value'
-      const message = issue.code === 'unrecognized_keys'
+      const message = issue.code === 'unrecognized_keys' && issue.path.length === 0
         ? 'contains an unsupported field'
         : issue.message
       return `${path}: ${message}`
     })
     .join('; ')
+}
+
+function mealPayloadIssuePublicPath(
+  path: readonly PropertyKey[],
+): readonly (string | number)[] {
+  return path.every(
+    (segment): segment is string | number =>
+      typeof segment === 'string' ||
+      (typeof segment === 'number' &&
+        Number.isSafeInteger(segment) &&
+        segment >= 0),
+  )
+    ? path
+    : []
+}
+
+function throwMealPathAliasConflict(
+  canonicalField: 'audio' | 'photo',
+  aliasField: 'audioPath' | 'photoPath',
+): never {
+  throw new VaultCliError(
+    'invalid_payload',
+    `Meal payload is not valid. ${canonicalField} and ${aliasField} must match when both are provided.`,
+    {
+      hint: `Use either ${canonicalField} or ${aliasField}, or pass the same path in both fields. No meal was written.`,
+      issues: [
+        publicValidationIssue({ code: 'custom' }, [canonicalField]),
+        publicValidationIssue({ code: 'custom' }, [aliasField]),
+      ],
+      retryable: false,
+      stage: 'validation',
+    },
+  )
+}
+
+function assertMatchingMealPathAliases(payload: {
+  audio?: string
+  audioPath?: string
+  photo?: string
+  photoPath?: string
+}): void {
+  if (
+    payload.photo !== undefined &&
+    payload.photoPath !== undefined &&
+    payload.photo !== payload.photoPath
+  ) {
+    throwMealPathAliasConflict('photo', 'photoPath')
+  }
+  if (
+    payload.audio !== undefined &&
+    payload.audioPath !== undefined &&
+    payload.audio !== payload.audioPath
+  ) {
+    throwMealPathAliasConflict('audio', 'audioPath')
+  }
 }
 
 function hasMeaningfulMealNutrition(nutrition: MealNutrition | undefined): boolean {
@@ -253,8 +309,20 @@ async function loadStructuredMealPayload(inputFile: string): Promise<StructuredM
     throw new VaultCliError(
       'invalid_payload',
       `Meal payload is not valid. ${formatSchemaIssues(parsed.error.issues)}${unsupportedFieldHint}`,
+      {
+        issues: parsed.error.issues.map((issue) =>
+          publicValidationIssue(
+            issue,
+            mealPayloadIssuePublicPath(issue.path),
+          )
+        ),
+        retryable: false,
+        stage: 'validation',
+      },
     )
   }
+
+  assertMatchingMealPathAliases(parsed.data)
 
   return {
     photo: parsed.data.photo ?? parsed.data.photoPath,

--- a/packages/cli/src/commands/meal.ts
+++ b/packages/cli/src/commands/meal.ts
@@ -84,7 +84,7 @@ const mealInputPayloadSchema = z
     ingredients: mealIngredientsSchema,
     nutrition: mealNutritionSchema.optional(),
   })
-  .passthrough()
+  .strict()
 
 type StructuredMealPayload = {
   photo?: string
@@ -106,12 +106,15 @@ const mealInputPayloadShapeDescription = [
 ].join(' ')
 
 function formatSchemaIssues(
-  issues: readonly { path: PropertyKey[]; message: string }[],
+  issues: readonly { code: string; path: PropertyKey[]; message: string }[],
 ): string {
   return issues
     .map((issue) => {
       const path = issue.path.length > 0 ? issue.path.join('.') : 'value'
-      return `${path}: ${issue.message}`
+      const message = issue.code === 'unrecognized_keys'
+        ? 'contains an unsupported field'
+        : issue.message
+      return `${path}: ${message}`
     })
     .join('; ')
 }
@@ -242,9 +245,14 @@ async function loadStructuredMealPayload(inputFile: string): Promise<StructuredM
   const parsed = mealInputPayloadSchema.safeParse(payload)
 
   if (!parsed.success) {
+    const unsupportedFieldHint = parsed.error.issues.some(
+      (issue) => issue.code === 'unrecognized_keys',
+    )
+      ? ` ${mealInputPayloadShapeDescription}`
+      : ''
     throw new VaultCliError(
       'invalid_payload',
-      `Meal payload is not valid. ${formatSchemaIssues(parsed.error.issues)}`,
+      `Meal payload is not valid. ${formatSchemaIssues(parsed.error.issues)}${unsupportedFieldHint}`,
     )
   }
 

--- a/packages/cli/test/meal-add-typed-parity.test.ts
+++ b/packages/cli/test/meal-add-typed-parity.test.ts
@@ -73,6 +73,11 @@ interface MealCloseoutWorkResult {
   }>
 }
 
+interface MealListResult {
+  count: number
+  items: Array<{ id: string }>
+}
+
 function createMealCli() {
   const cli = Cli.create('vault-cli', {
     description: 'meal add typed parity test cli',
@@ -616,6 +621,67 @@ test.sequential(
           /Meal capture requires/u,
         )
       }
+    } finally {
+      await rm(parentRoot, { force: true, recursive: true })
+    }
+  },
+)
+
+test.sequential(
+  'meal import-json rejects unknown fields without echoing or writing a meal',
+  async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'murph-cli-meal-unknown-field-',
+    )
+
+    try {
+      await initializeVault({ vaultRoot })
+      const cli = createMealCli()
+      const unknownField = 'ingredientz'
+      const unknownValue = 'synthetic private value'
+      const payloadPath = path.join(parentRoot, 'meal.json')
+      await writeFile(
+        payloadPath,
+        `${JSON.stringify({
+          note: 'A valid meal note',
+          [unknownField]: unknownValue,
+        })}\n`,
+        'utf8',
+      )
+
+      const result = await runInProcessJsonCli<MealAddResult>(cli, [
+        'meal',
+        'import-json',
+        '--input',
+        `@${payloadPath}`,
+        '--vault',
+        vaultRoot,
+      ])
+
+      assert.equal(result.exitCode, 1)
+      assert.equal(result.envelope.ok, false)
+      if (!result.envelope.ok) {
+        assert.equal(result.envelope.error.code, 'invalid_payload')
+        assert.match(result.envelope.error.message ?? '', /unsupported field/u)
+        assert.match(result.envelope.error.message ?? '', /ingredients/u)
+      }
+
+      const serializedError = JSON.stringify(result.envelope)
+      assert.equal(serializedError.includes(unknownField), false)
+      assert.equal(serializedError.includes(unknownValue), false)
+      assert.equal(serializedError.includes(payloadPath), false)
+
+      const listed = await runInProcessJsonCli<MealListResult>(cli, [
+        'meal',
+        'list',
+        '--limit',
+        '10',
+        '--vault',
+        vaultRoot,
+      ])
+      assert.equal(listed.exitCode, null)
+      assert.equal(requireData(listed.envelope).count, 0)
+      assert.deepEqual(requireData(listed.envelope).items, [])
     } finally {
       await rm(parentRoot, { force: true, recursive: true })
     }

--- a/packages/cli/test/meal-add-typed-parity.test.ts
+++ b/packages/cli/test/meal-add-typed-parity.test.ts
@@ -628,7 +628,7 @@ test.sequential(
 )
 
 test.sequential(
-  'meal import-json rejects unknown fields without echoing or writing a meal',
+  'meal import-json keeps nested corrections while sanitizing root unknown fields and writing no meal',
   async () => {
     const { parentRoot, vaultRoot } = await createTempVaultContext(
       'murph-cli-meal-unknown-field-',
@@ -639,12 +639,18 @@ test.sequential(
       const cli = createMealCli()
       const unknownField = 'ingredientz'
       const unknownValue = 'synthetic private value'
+      const nestedMicronutrientTypo = 'vitaminCM'
       const payloadPath = path.join(parentRoot, 'meal.json')
       await writeFile(
         payloadPath,
         `${JSON.stringify({
           note: 'A valid meal note',
           [unknownField]: unknownValue,
+          nutrition: {
+            micros: {
+              [nestedMicronutrientTypo]: 12,
+            },
+          },
         })}\n`,
         'utf8',
       )
@@ -662,8 +668,22 @@ test.sequential(
       assert.equal(result.envelope.ok, false)
       if (!result.envelope.ok) {
         assert.equal(result.envelope.error.code, 'invalid_payload')
+        assert.equal(result.envelope.error.stage, 'validation')
         assert.match(result.envelope.error.message ?? '', /unsupported field/u)
         assert.match(result.envelope.error.message ?? '', /ingredients/u)
+        assert.match(
+          result.envelope.error.message ?? '',
+          new RegExp(
+            `nutrition\\.micros: Unrecognized key: "${nestedMicronutrientTypo}"`,
+            'u',
+          ),
+        )
+        assert.deepEqual(
+          result.envelope.error.fieldErrors
+            ?.map((fieldError) => fieldError.path)
+            .sort(),
+          ['$', 'nutrition.micros'],
+        )
       }
 
       const serializedError = JSON.stringify(result.envelope)
@@ -682,6 +702,127 @@ test.sequential(
       assert.equal(listed.exitCode, null)
       assert.equal(requireData(listed.envelope).count, 0)
       assert.deepEqual(requireData(listed.envelope).items, [])
+    } finally {
+      await rm(parentRoot, { force: true, recursive: true })
+    }
+  },
+)
+
+test.sequential(
+  'meal import-json rejects differing media aliases before writing and accepts equal aliases',
+  async () => {
+    const { parentRoot, vaultRoot } = await createTempVaultContext(
+      'murph-cli-meal-media-alias-conflict-',
+    )
+
+    try {
+      await initializeVault({ vaultRoot })
+      const cli = createMealCli()
+      const conflictScenarios = [
+        {
+          aliasField: 'photoPath',
+          canonicalField: 'photo',
+          firstValue: path.join(parentRoot, 'private-photo-a.jpg'),
+          secondValue: path.join(parentRoot, 'private-photo-b.jpg'),
+        },
+        {
+          aliasField: 'audioPath',
+          canonicalField: 'audio',
+          firstValue: path.join(parentRoot, 'private-audio-a.m4a'),
+          secondValue: path.join(parentRoot, 'private-audio-b.m4a'),
+        },
+      ] as const
+
+      for (const [index, scenario] of conflictScenarios.entries()) {
+        const payloadPath = path.join(parentRoot, `conflict-${index}.json`)
+        await writeFile(
+          payloadPath,
+          `${JSON.stringify({
+            [scenario.aliasField]: scenario.secondValue,
+            [scenario.canonicalField]: scenario.firstValue,
+            note: 'Synthetic meal with conflicting media aliases.',
+          })}\n`,
+          'utf8',
+        )
+
+        const result = await runInProcessJsonCli<MealAddResult>(cli, [
+          'meal',
+          'import-json',
+          '--input',
+          `@${payloadPath}`,
+          '--vault',
+          vaultRoot,
+        ])
+
+        assert.equal(result.exitCode, 1)
+        assert.equal(result.envelope.ok, false)
+        if (!result.envelope.ok) {
+          assert.equal(result.envelope.error.code, 'invalid_payload')
+          assert.equal(result.envelope.error.stage, 'validation')
+          assert.match(
+            result.envelope.error.message ?? '',
+            new RegExp(
+              `${scenario.canonicalField} and ${scenario.aliasField} must match`,
+              'u',
+            ),
+          )
+          assert.deepEqual(
+            result.envelope.error.fieldErrors
+              ?.map((fieldError) => fieldError.path)
+              .sort(),
+            [scenario.aliasField, scenario.canonicalField].sort(),
+          )
+          assert.match(result.envelope.error.hint ?? '', /same path/u)
+          assert.match(result.envelope.error.hint ?? '', /No meal was written/u)
+        }
+
+        const serializedError = JSON.stringify(result.envelope)
+        assert.equal(serializedError.includes(scenario.firstValue), false)
+        assert.equal(serializedError.includes(scenario.secondValue), false)
+        assert.equal(serializedError.includes(payloadPath), false)
+      }
+
+      const afterConflicts = await runInProcessJsonCli<MealListResult>(cli, [
+        'meal',
+        'list',
+        '--limit',
+        '10',
+        '--vault',
+        vaultRoot,
+      ])
+      assert.equal(afterConflicts.exitCode, null)
+      assert.equal(requireData(afterConflicts.envelope).count, 0)
+
+      const equalPhotoPath = path.join(parentRoot, 'equal-photo.jpg')
+      const equalAudioPath = path.join(parentRoot, 'equal-audio.m4a')
+      const equalPayloadPath = path.join(parentRoot, 'equal-aliases.json')
+      await Promise.all([
+        writeFile(equalPhotoPath, 'synthetic photo bytes', 'utf8'),
+        writeFile(equalAudioPath, 'synthetic audio bytes', 'utf8'),
+        writeFile(
+          equalPayloadPath,
+          `${JSON.stringify({
+            audio: equalAudioPath,
+            audioPath: equalAudioPath,
+            note: 'Synthetic meal with matching media aliases.',
+            photo: equalPhotoPath,
+            photoPath: equalPhotoPath,
+          })}\n`,
+          'utf8',
+        ),
+      ])
+
+      const equalAliases = await runInProcessJsonCli<MealAddResult>(cli, [
+        'meal',
+        'import-json',
+        '--input',
+        `@${equalPayloadPath}`,
+        '--vault',
+        vaultRoot,
+      ])
+      assert.equal(equalAliases.exitCode, null)
+      assert.ok(requireData(equalAliases.envelope).photoPath)
+      assert.ok(requireData(equalAliases.envelope).audioPath)
     } finally {
       await rm(parentRoot, { force: true, recursive: true })
     }


### PR DESCRIPTION
## Why and outcome

`meal import-json` could silently ignore unsupported top-level keys, flatten useful nested validation diagnostics, or prefer `photo`/`audio` over a differing legacy path alias. The CLI now fails before persistence: root unknowns use privacy-safe fixed copy, nested schema paths remain actionable, and differing media aliases must be reconciled explicitly.

## Product UX

- Effort: Product UX Patch
- Walkthrough: Ready
- Affected people: members whose meals are logged from structured assistant input, plus assistants repairing one rejected call.
- Result: one error provides a safe public field path and the smallest correction; a corrected retry writes exactly one meal. Equal aliases and every documented single-field form remain accepted.
- Exclusions: internal importer orchestration fields, nutrition semantics, and automatic correction remain unchanged.

## Evidence

- `pnpm exec vitest run packages/cli/test/meal-add-typed-parity.test.ts`: 13 tests passed.
- `pnpm --filter @murphai/murph typecheck`: passed.
- `pnpm --filter @murphai/assistant-engine typecheck`: passed.
- `pnpm test:assistant:live -- --test "recovers one strict meal import typo without duplicate write"`: passed on `gpt-5.6-terra` with local subscription auth. The production-prompt and food-journal-skill journey made exactly two import attempts, observed one rejected malformed payload, made one corrected retry, wrote exactly one meal, and produced the concise outcome-only reply `Dinner imported successfully.` Reply review: Ready.
- Real-command regressions prove root keys, submitted values, and absolute input paths stay out of errors; nested `nutrition.micros` guidance remains concrete; both differing alias pairs report `stage: validation` with safe field errors; rejected calls leave the meal list empty; equal aliases persist normally.
- `pnpm --dir apps/web test -- changelog-page.test.tsx`: 9 tests passed for the unchanged authored changelog fragment.
- `pnpm --dir apps/web typecheck`: passed for the unchanged changelog surface.
- `git diff --check`: passed.

## Non-obvious affected surfaces

- Public changelog content: still records only the shipped top-level typo/no-write outcome; the review remediation does not broaden its claim.
- Structured CLI error projection: now receives the existing bounded validation stage and public field paths from meal payload failures.
- Opt-in assistant live proof: adds a private-free synthetic fixture built from the production prompt and real food-journal skill; routine CI compiles it but does not call a provider.
- Internal meal importer: intentionally unchanged because private orchestration callers use a broader input shape.

## Architecture and reuse

- Existing systems reused: the CLI-owned structured meal schema, `VaultCliError`, public validation issue projection, canonical importer, production assistant prompt builder, real food-journal skill, and changelog registry.
- New logic: root-only unknown-key sanitization and two direct pre-write media-alias equality checks.
- New abstractions: none; one local assertion helper reuses the existing error and field-path contract.
- Complexity intentionally avoided: no importer fork, compatibility layer, second validator, retry owner, automatic typo correction, or new persistence path.

## Hot reply path impact

Not applicable. Production validation runs inside an invoked local command and adds no database, network/provider, or durable reply-handoff operation. The real-Codex journey is opt-in test proof only.

## Murph initial provider input impact

- Murph runtime: Not applicable; no production prompt, instruction, tool schema, or provider-visible context changed.
- Codex runtime: Not applicable; no production prompt, instruction, tool schema, or generated guidance changed. The added live test consumes existing production builders only in an opt-in local lane.

ReviewGPT context sensitivity: sensitive
Reason: the patch changes fail-closed handling before persisted nutrition data and spans deterministic CLI recovery plus opt-in real-assistant proof.
ReviewGPT first-reviewed head: 906ddaad224df402bbea821777a38369706fab2f

## Change-shape breakdown

Classification rule: CLI behavior is source; executable deterministic and real-assistant regression coverage is tests/fixtures; archived plans and the authored changelog item are docs/content; no config, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 80 | 4 |
| Tests/fixtures | 483 | 0 |
| Docs | 243 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 806 | 4 |

## Deployment concerns

- Deployment: applicable
- Supported skew: the old CLI can still save typoed payloads or silently select one differing alias, so the public changelog must not lead the runtime behavior.
- Safe order: deploy the hosted CLI/runtime bundle first, verify rejection and no write, then publish the hosted Web changelog.
- Rollback floor: remove or roll back the changelog item before reverting the CLI validation.
- Expected exposure: only a normal rollout window if the Web deployment leads the runtime bundle.
- Reversibility: the validation and changelog fragment can each be reverted without a data migration.
- Post-deploy checks: run one synthetic unsupported-field CLI smoke and one differing-alias smoke with zero-record readbacks, then verify the dated changelog item renders.
- Convergence proof: the same smokes prove the CLI behavior and published outcome have converged.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · meal-imports-catch-typos


## Design proof

- Design page: [Changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: The content-only entry uses the existing production changelog archive; no renderer, component, layout, interaction, or visual primitive changed.
- Coverage: The focused server-rendered changelog page suite passed 9/9 and Web typecheck passed, covering the entry copy, date, source PR, and archive registration without inventing a branch-only UI state.
