### PR TITLE
perf(browser-vault): linearize JSON serialization

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-30-browser-vault-json-linear.md
+++ b/agent-docs/exec-plans/active/2026-08-30-browser-vault-json-linear.md
@@ -1,0 +1,111 @@
+# Linear Browser Vault JSON serialization
+
+Status: active
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Make large Browser Vault refreshes serialize in linear time so the existing
+  30-second background deadline is spent on useful projection and publication
+  work, without changing replica bytes, hashes, schema, or compatibility.
+
+## Product UX
+
+- Outcome: larger private dashboards regain fresh saved health data more
+  reliably within the existing background refresh promise.
+- Reaches: authenticated Web surfaces backed by Browser Vault refreshes,
+  especially members with multi-megabyte replicas.
+- Proof: on one neutral 5.85 MB fixture, the two serializer calls fell from
+  12.69 seconds to 1.59 seconds while producing the same byte count; focused
+  tests prove native JSON bytes, stable sorted bytes, failures, and
+  cancellation remain unchanged.
+- Walkthrough: ready. Large, sparse, escaped, and shared-reference values keep
+  their existing output; unsupported roots, cycles, and foreground-priority
+  cancellation keep their existing failures.
+
+## Success criteria
+
+- Cooperative serialization no longer rebuilds a growing partial chunk for
+  every JSON token.
+- Unsorted output remains byte-for-byte equal to the current supported
+  `JSON.stringify` domain, and recursive sorted-key output remains unchanged for
+  the Browser Vault `dataVersion` hash ABI.
+- Abort, unsupported-root, array omission, shared-reference, and cycle behavior
+  remain explicit and covered by focused tests.
+- A production-shaped local benchmark records the before/after elapsed time
+  without adding a timing-sensitive CI assertion.
+- Focused package tests, typecheck, exact-head CI, and the repository review
+  gates pass for the final PR head.
+
+## Scope
+
+- In scope:
+  - The private cooperative JSON accumulator in `packages/query`.
+  - Focused serializer behavior and regression coverage.
+  - One member-visible changelog outcome shared with the related projection
+    optimization when repository workflow permits that attribution.
+- Out of scope:
+  - Replica schema, projection generation, sharding, encryption, R2 transport,
+    timeout policy, or retry behavior.
+  - Removing the legacy monolith before its documented compatibility window.
+  - Expanding the serializer to arbitrary ECMAScript `toJSON`, proxy, boxed
+    primitive, or side-effectful getter semantics outside the replica domain.
+
+## Constraints
+
+- Technical constraints:
+  - Preserve the iterative traversal, recursive key ordering, 16 KiB character
+    chunk target, cancellation checks, and current public function signature.
+  - Add no dependency, state owner, codec, or exported abstraction.
+- Product/process constraints:
+  - Browser Vault remains lower-priority, abortable runtime work and must not
+    enter the foreground reply path.
+  - Keep the generation-10 legacy producer until the dual-reader and rollback
+    floor have remained in production for the documented minimum window.
+
+## Risks and mitigations
+
+1. Risk: A byte-level serializer change invalidates every replica data version.
+   Mitigation: Preserve traversal/token ordering and assert exact bytes for
+   representative nested, escaped, sparse, sorted, and oversized inputs.
+2. Risk: Reducing yields or cancellation checks lets large refreshes outlive
+   their owner.
+   Mitigation: Leave the existing cooperative cadence intact and retain direct
+   abort proof.
+3. Risk: A wall-clock regression test becomes flaky across CI machines.
+   Mitigation: Test semantics in CI and keep measured before/after timing in PR
+   evidence only.
+
+## Tasks
+
+1. Capture the current focused serializer proof and a production-shaped local
+   timing baseline.
+2. Replace repeated partial-string concatenation with one bounded private
+   fragment accumulator.
+3. Extend focused tests for exact bytes and error/cancellation behavior.
+4. Run focused proof, package typecheck, privacy/diff checks, and measured
+   after-timing.
+5. Open a draft PR, complete ReviewGPT and exact-head CI, close this plan, and
+   mark the PR ready only after all completion gates pass.
+
+## Decisions
+
+- Preserve the existing serializer boundary instead of switching to native
+  `JSON.stringify`, because recursive stable ordering and cooperative abort are
+  current requirements.
+- Use arrays of bounded fragments plus one join per completed chunk; do not add
+  a class, streaming codec, or general-purpose serializer abstraction.
+
+## Verification
+
+- Commands to run:
+  - `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/browser-vault-replica.test.ts`
+  - `pnpm --dir packages/query typecheck`
+  - `pnpm test:scenario-integrity`
+  - Exact-head required GitHub checks and repository ReviewGPT gates.
+- Expected outcomes:
+  - Focused behavior stays byte-compatible and all checks pass.
+  - The neutral 5.85 MB fixture retains its exact 5,854,294-byte output while
+    combined unsorted and sorted serialization falls from 12.69 seconds to
+    1.59 seconds.

--- a/agent-docs/exec-plans/completed/2026-08-30-browser-vault-json-linear.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-browser-vault-json-linear.md
@@ -1,6 +1,6 @@
 # Linear Browser Vault JSON serialization
 
-Status: active
+Status: completed
 Created: 2026-08-30
 Updated: 2026-08-30
 
@@ -109,3 +109,4 @@ Updated: 2026-08-30
   - The neutral 5.85 MB fixture retains its exact 5,854,294-byte output while
     combined unsorted and sorted serialization falls from 12.69 seconds to
     1.59 seconds.
+Completed: 2026-08-30

--- a/apps/web/changelog/entries/2026-08-30/faster-private-dashboard-refreshes.json
+++ b/apps/web/changelog/entries/2026-08-30/faster-private-dashboard-refreshes.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "faster-private-dashboard-refreshes",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Faster private dashboard refreshes",
+    "summary": "Larger private dashboards now spend less time preparing saved health data in the background, helping updates finish more reliably.",
+    "details": "The data shown and privacy boundaries are unchanged. Foreground messages still take priority, and existing pages continue to read the same saved data.",
+    "relevanceTags": ["health-data", "performance", "reliability", "privacy"],
+    "sourcePullRequests": [2593]
+  }
+}

--- a/packages/query/src/browser-replica/json.ts
+++ b/packages/query/src/browser-replica/json.ts
@@ -21,6 +21,12 @@ interface JsonValueAction {
 
 type JsonStringifyAction = JsonExitAction | JsonTextAction | JsonValueAction;
 
+interface JsonChunkBuffer {
+  completedChunks: string[];
+  currentChunkChars: number;
+  currentChunkParts: string[];
+}
+
 const JSON_CHUNK_TARGET_CHARS = 16 * 1_024;
 
 export async function stringifyJsonCooperatively(
@@ -28,7 +34,11 @@ export async function stringifyJsonCooperatively(
   options: CooperativeJsonStringifyOptions = {},
 ): Promise<string> {
   const activeObjects = new Set<object>();
-  const chunks: string[] = [];
+  const output: JsonChunkBuffer = {
+    completedChunks: [],
+    currentChunkChars: 0,
+    currentChunkParts: [],
+  };
   const stack: JsonStringifyAction[] = [{
     kind: "value",
     location: "root",
@@ -49,7 +59,7 @@ export async function stringifyJsonCooperatively(
       continue;
     }
     if (action.kind === "text") {
-      appendJsonChunk(chunks, action.value);
+      appendJsonChunk(output, action.value);
       continue;
     }
     if (action.kind === "exit") {
@@ -62,12 +72,12 @@ export async function stringifyJsonCooperatively(
       const encoded = JSON.stringify(current);
       if (encoded === undefined) {
         if (action.location === "array") {
-          appendJsonChunk(chunks, "null");
+          appendJsonChunk(output, "null");
           continue;
         }
         throw new TypeError("Browser Vault replica values must be JSON serializable.");
       }
-      appendJsonChunk(chunks, encoded);
+      appendJsonChunk(output, encoded);
       continue;
     }
 
@@ -119,20 +129,29 @@ export async function stringifyJsonCooperatively(
   }
 
   options.signal?.throwIfAborted();
-  return chunks.join("");
+  return finishJsonChunks(output);
 }
 
-function appendJsonChunk(chunks: string[], value: string): void {
-  const previousIndex = chunks.length - 1;
-  const previous = chunks[previousIndex];
-  if (
-    previous !== undefined
-    && previous.length + value.length <= JSON_CHUNK_TARGET_CHARS
-  ) {
-    chunks[previousIndex] = previous + value;
+function appendJsonChunk(output: JsonChunkBuffer, value: string): void {
+  if (output.currentChunkChars + value.length > JSON_CHUNK_TARGET_CHARS) {
+    flushJsonChunk(output);
+  }
+  output.currentChunkParts.push(value);
+  output.currentChunkChars += value.length;
+}
+
+function finishJsonChunks(output: JsonChunkBuffer): string {
+  flushJsonChunk(output);
+  return output.completedChunks.join("");
+}
+
+function flushJsonChunk(output: JsonChunkBuffer): void {
+  if (output.currentChunkParts.length === 0) {
     return;
   }
-  chunks.push(value);
+  output.completedChunks.push(output.currentChunkParts.join(""));
+  output.currentChunkChars = 0;
+  output.currentChunkParts = [];
 }
 
 function isOmittedJsonObjectValue(value: unknown): boolean {

--- a/packages/query/test/browser-vault-replica.test.ts
+++ b/packages/query/test/browser-vault-replica.test.ts
@@ -511,16 +511,55 @@ test("browser vault replica generation is content-addressed and legacy-readable"
   );
 });
 
-test("cooperative Browser Vault serialization matches JSON and observes cancellation", async () => {
-  const value = {
-    array: [undefined, Number.NaN, "kept"],
-    omitted: undefined,
-    present: {
+test("cooperative Browser Vault serialization matches JSON across bounded chunks", async () => {
+  const shared = {
+    nested: {
       value: 42,
     },
   };
+  const sparse: unknown[] = [];
+  sparse.length = 3;
+  sparse[1] = "middle";
+  const value = {
+    array: [undefined, Number.NaN, () => "omitted", Symbol("omitted"), sparse],
+    escaped: "line one\nline two \"quoted\" ☃",
+    large: "x".repeat(20_000),
+    omitted: undefined,
+    rows: Array.from({ length: 2_500 }, (_entry, index) => ({ index })),
+    sharedFirst: shared,
+    sharedSecond: shared,
+  };
   assert.equal(await stringifyJsonCooperatively(value), JSON.stringify(value));
+});
 
+test("cooperative Browser Vault serialization preserves recursive sorted-key bytes", async () => {
+  assert.equal(
+    await stringifyJsonCooperatively({
+      zebra: {
+        delta: 4,
+        alpha: 1,
+      },
+      alpha: [{ gamma: 3, beta: 2 }],
+    }, { sortKeys: true }),
+    '{"alpha":[{"beta":2,"gamma":3}],"zebra":{"alpha":1,"delta":4}}',
+  );
+});
+
+test("cooperative Browser Vault serialization rejects unsupported roots and cycles", async () => {
+  await assert.rejects(
+    stringifyJsonCooperatively(undefined),
+    new TypeError("Browser Vault replica values must be JSON serializable."),
+  );
+
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  await assert.rejects(
+    stringifyJsonCooperatively(cyclic),
+    new TypeError("Browser Vault replica values must not contain cycles."),
+  );
+});
+
+test("cooperative Browser Vault serialization observes cancellation", async () => {
   const controller = new AbortController();
   const reason = new DOMException("Foreground work took priority.", "AbortError");
   const serialization = stringifyJsonCooperatively(


### PR DESCRIPTION
## Why and outcome

Large Browser Vault replicas spend excessive time in cooperative JSON serialization, consuming much of the existing 30-second background refresh deadline. This patch changes only the private accumulator so each fragment is copied a bounded number of times.

Replica bytes, stable hashes, schema, cancellation cadence, and failure behavior remain unchanged. On a neutral 5.85 MB fixture, the two production serializer modes fell from 12.69 seconds combined to 1.59 seconds combined, about 8× faster.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Larger authenticated private dashboards refresh the same saved health data with less background waiting. Large, sparse, escaped, and shared-reference values retain their output; unsupported roots, cycles, and foreground-priority cancellation retain their failures. There is no UI, copy, authority, schema, or compatibility change.

## Evidence

- Direct: A neutral 5,854,294-byte fixture measured unsorted plus recursively sorted serialization at 12.69 seconds on base and 1.59 seconds on head, with the same output byte count and native unsorted equality.
- Coverage: packages/query focused Vitest passed 22 tests; packages/query typecheck passed; scenario-integrity passed for 207 scenarios; the focused Web changelog test passed 9 tests; apps/web typecheck passed; diff and identifier/privacy scans passed.
- Benchmark boundary: Local mechanism-scale evidence on identical synthetic content, not a production percentile or timing-sensitive CI assertion.

## Non-obvious affected surfaces

Stable data-version hashing uses recursively sorted output, while runtime byte measurement uses unsorted output. Both modes share this serializer and have exact-byte regression coverage. Sharding, encryption, storage, legacy fallback, and the generation-10 compatibility contract are untouched.

## Architecture and reuse

- Existing systems reused: The current iterative traversal, cancellation cadence, recursively sorted-key option, native primitive encoding, and 16 KiB chunk target.
- New logic: A private bounded fragment accumulator joins each completed chunk once instead of rebuilding a growing chunk for every token.
- New abstractions: None exported; one private buffer shape and two private lifecycle helpers keep the existing public boundary intact.
- Complexity intentionally avoided: No stream or codec, dependency, cache, persisted state, service, schema, generation, retry, timeout, or compatibility layer.

## Hot reply path impact

- Path status: Not applicable — Browser Vault refresh remains lower-priority, abortable background work outside durable message acceptance through provider start and reply handoff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None on the hot reply path.
- Before/after proof: The direct benchmark covers only the existing background serializer boundary.

## Murph initial provider input impact

No provider-input surface changed: no prompt, instruction, tool definition, schema, generated guidance, wrapper, history, fixture, or model routing change.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: [Changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: The member-visible change is one content-only changelog item rendered by the existing archive component; an additional image would not prove the serializer behavior.
- Coverage: The existing responsive archive representation covers this unchanged component and priority-2 entry shape; there is no new visual state or interaction.

## Risks

The only material risk is byte drift in the shared serializer. Exact native JSON bytes, recursive sorted bytes, sparse and escaped values, shared references, errors, cycles, and abort identity are covered directly.

ReviewGPT context sensitivity: sensitive
ReviewGPT context reason: Background runtime serialization is deployable behavior shared by hashing and byte measurement, even though external bytes stay unchanged.
ReviewGPT first-reviewed head: a2eaef0b4839b0b8fe0a772278d807db061bbd83

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new runners emit identical replica bytes and can coexist with current Web and Worker deployments.
- Safe order: Standard runner rollout; Web and Worker changes are not required.
- Rollback floor: None; rollback preserves the same schema, generation, hashes, and bytes.
- Expected exposure: Only background refresh preparation time changes as warm runners roll to the new bundle.
- Reversibility: Revert the runner bundle; stored replicas remain readable by both versions.
- Convergence proof: Existing content hashes, data versions, and generation references remain the publication fingerprint.
- Post-deploy checks: Monitor bounded Browser Vault refresh outcomes and serialization-stage timeout aggregates, plus successful current-generation reference publication.

## Change-shape breakdown

Classification rule: TypeScript implementation is Source, Vitest coverage is Tests / fixtures, and the execution plan plus changelog content are Docs; no binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 33 | 14 |
| Tests / fixtures | 44 | 5 |
| Docs | 125 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **202** | **19** |

## Changelog

- Changelog: updated
- Items: 2026-08-30 · faster-private-dashboard-refreshes
