### PR TITLE
fix(cli): reject conflicting automation schedule flags

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-cli-automation-flag-conflicts.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-cli-automation-flag-conflicts.md
@@ -1,0 +1,53 @@
+# Reject contradictory automation schedule flags
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Outcome
+
+`automation save` and schedule-changing `automation edit` reject contradictory
+canonical/legacy aliases and schedule fields that do not belong to the selected
+trigger kind. Errors remain machine-readable, point to the exact public
+`schedule.*` field, and never echo submitted values. Valid legacy aliases,
+matching duplicate aliases, cron expressions, and timezones retain their
+existing behavior.
+
+## Reaches
+
+- Shared typed schedule construction for `automation save` and `automation edit`.
+- Validation envelopes for trigger kind, timestamp, interval, cron, local-time,
+  timezone, and device-activity schedule options.
+- Focused CLI regression proof for rejected creates and rejected edits.
+- No changes to structured `automation import-json`, stored automation schemas,
+  query behavior, or runtime scheduling.
+
+## Invariants
+
+- Validation completes before `upsertAutomation` or `patchAutomation` receives
+  an invalid typed schedule.
+- Error messages name public option flags only; submitted schedule,
+  instructions, and route values are not projected.
+- Each rejected field maps to its canonical public schedule path.
+- Matching canonical and legacy values continue to resolve to one stored value.
+
+## Proof
+
+- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts
+  --no-coverage packages/cli/test/automation.test.ts`: 1 file and 35 tests
+  passed.
+- `pnpm --dir packages/cli typecheck`: passed with the package TypeScript
+  checker.
+- The regression proves three rejected saves leave an empty automation list,
+  then proves an invalid edit leaves the original cron expression, timezone,
+  and instructions unchanged.
+- The same regression verifies `invalid_option`, non-retryable validation-stage
+  envelopes, exact public field paths, and omission of submitted private values.
+
+## Progress
+
+- [x] Reproduced silent acceptance of conflicting aliases and irrelevant fields.
+- [x] Added owner-local validation in the shared typed schedule builder.
+- [x] Added focused safe-envelope, no-create, and unchanged-edit regression proof.
+- [x] Run focused tests and package typecheck, then record the results.
+Completed: 2026-08-30

--- a/apps/web/changelog/entries/2026-08-30/safer-reminder-schedule-changes.json
+++ b/apps/web/changelog/entries/2026-08-30/safer-reminder-schedule-changes.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "safer-reminder-schedule-changes",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Safer reminder schedule changes",
+    "summary": "Reminder saves and edits now stop when schedule details conflict, instead of silently choosing one value and risking the wrong time.",
+    "details": "The correction points to the exact schedule field without repeating its contents. Existing one-time, interval, recurring, local-time, time-zone, and device-activity schedules keep working when their fields agree.",
+    "relevanceTags": ["assistant", "reminders", "reliability"],
+    "sourcePullRequests": [2596]
+  }
+}

--- a/packages/cli/src/commands/automation.ts
+++ b/packages/cli/src/commands/automation.ts
@@ -387,7 +387,10 @@ function requireNumberOption(
 
 function resolveAutomationTriggerKind(options: AutomationScheduleOptions): AutomationScheduleKind {
   if (options.triggerKind && options.scheduleKind && options.triggerKind !== options.scheduleKind) {
-    return invalidAutomationOption("--trigger-kind and --schedule-kind must match when both are provided.");
+    return invalidAutomationOption(
+      "--trigger-kind and --schedule-kind must match when both are provided.",
+      ["schedule", "kind"],
+    );
   }
 
   return options.triggerKind ?? options.scheduleKind ?? invalidAutomationOption(
@@ -421,15 +424,92 @@ function resolveAutomationTimeZone(
   return timeZone;
 }
 
+function assertAutomationScheduleValueOptionsMatchKind(
+  options: AutomationScheduleOptions,
+  kind: AutomationScheduleKind,
+): void {
+  const fields = [
+    {
+      canonicalName: "trigger-at",
+      canonicalValue: options.triggerAt,
+      kind: "at",
+      legacyName: "schedule-at",
+      legacyValue: options.scheduleAt,
+      publicField: "at",
+    },
+    {
+      canonicalName: "trigger-every-ms",
+      canonicalValue: options.triggerEveryMs,
+      kind: "every",
+      legacyName: "schedule-every-ms",
+      legacyValue: options.scheduleEveryMs,
+      publicField: "everyMs",
+    },
+    {
+      canonicalName: "trigger-cron",
+      canonicalValue: options.triggerCron,
+      kind: "cron",
+      legacyName: "schedule-cron",
+      legacyValue: options.scheduleCron,
+      publicField: "expression",
+    },
+    {
+      canonicalName: "trigger-local-time",
+      canonicalValue: options.triggerLocalTime,
+      kind: "dailyLocal",
+      legacyName: "schedule-local-time",
+      legacyValue: options.scheduleLocalTime,
+      publicField: "localTime",
+    },
+  ] as const;
+
+  for (const field of fields) {
+    const canonicalProvided = field.canonicalValue !== undefined;
+    const legacyProvided = field.legacyValue !== undefined;
+    if (!canonicalProvided && !legacyProvided) continue;
+
+    const publicPath = ["schedule", field.publicField] as const;
+    if (field.kind !== kind) {
+      const providedOptions = [
+        ...(canonicalProvided ? [`--${field.canonicalName}`] : []),
+        ...(legacyProvided ? [`--${field.legacyName}`] : []),
+      ];
+      return invalidAutomationOption(
+        `${providedOptions.join(" and ")} can only be used with --trigger-kind=${field.kind}.`,
+        publicPath,
+      );
+    }
+
+    if (
+      canonicalProvided &&
+      legacyProvided &&
+      field.canonicalValue !== field.legacyValue
+    ) {
+      return invalidAutomationOption(
+        `--${field.canonicalName} and --${field.legacyName} must match when both are provided.`,
+        publicPath,
+      );
+    }
+  }
+}
+
 function buildAutomationScheduleFromOptions(
   options: AutomationScheduleOptions,
   defaults: { now: string },
 ): AutomationSchedule {
   const kind = resolveAutomationTriggerKind(options);
   const timeZone = resolveAutomationTimeZone(options, kind);
-  if (kind !== "deviceActivity" && (options.deviceSource || options.activityKind)) {
+  assertAutomationScheduleValueOptionsMatchKind(options, kind);
+  if (kind !== "deviceActivity" && options.deviceSource !== undefined) {
     return invalidAutomationOption(
-      "--device-source and --activity-kind can only be used with --trigger-kind=deviceActivity.",
+      "--device-source can only be used with --trigger-kind=deviceActivity.",
+      ["schedule", "source"],
+    );
+  }
+  if (kind !== "deviceActivity" && options.activityKind !== undefined) {
+    return invalidAutomationOption(
+      "--activity-kind can only be used with --trigger-kind=deviceActivity.",
+      ["schedule", "activityKind"],
     );
   }
 

--- a/packages/cli/test/automation.test.ts
+++ b/packages/cli/test/automation.test.ts
@@ -2633,6 +2633,7 @@ test("automation save maps trigger flags and keeps legacy schedule flags working
       description: "automation test cli",
       version: "0.0.0-test",
     });
+    cli.use(incurErrorBridge);
     registerAutomationCommands(cli);
 
     const schedules = [
@@ -2752,7 +2753,11 @@ test("automation save maps trigger flags and keeps legacy schedule flags working
     assert.equal(rejectedDeviceFlag.envelope.ok, false);
     assert.match(
       rejectedDeviceFlag.envelope.error.message ?? "",
-      /--device-source and --activity-kind/u,
+      /--device-source/u,
+    );
+    assert.equal(
+      rejectedDeviceFlag.envelope.error.fieldErrors?.[0]?.path,
+      "schedule.source",
     );
 
     const rejectedLegacyScheduleKindDeviceActivity = await runInProcessJsonCli(cli, [
@@ -2775,6 +2780,223 @@ test("automation save maps trigger flags and keeps legacy schedule flags working
 
     assert.equal(rejectedLegacyScheduleKindDeviceActivity.exitCode, 1);
     assert.equal(rejectedLegacyScheduleKindDeviceActivity.envelope.ok, false);
+  } finally {
+    await rm(parentRoot, { force: true, recursive: true });
+  }
+});
+
+test("automation rejects conflicting and irrelevant schedule flags before mutation", async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    "murph-automation-schedule-flag-conflicts-",
+  );
+
+  try {
+    const cli = Cli.create("vault-cli", {
+      description: "automation schedule flag validation test cli",
+      version: "0.0.0-test",
+    });
+    cli.use(incurErrorBridge);
+    registerAutomationCommands(cli);
+
+    const rejectedSchedules: Array<{
+      expectedPath: string;
+      privateValues: string[];
+      scheduleArgs: string[];
+      slug: string;
+    }> = [
+      {
+        expectedPath: "schedule.kind",
+        privateValues: ["private-kind-conflict-instructions"],
+        scheduleArgs: [
+          "--trigger-kind",
+          "at",
+          "--schedule-kind",
+          "every",
+          "--trigger-at",
+          "2099-01-01T00:00:00.000Z",
+          "--schedule-every-ms",
+          "3600000",
+        ],
+        slug: "kind-conflict",
+      },
+      {
+        expectedPath: "schedule.at",
+        privateValues: [
+          "private-at-conflict-instructions",
+          "2099-01-01T00:00:00.000Z",
+          "2099-02-01T00:00:00.000Z",
+        ],
+        scheduleArgs: [
+          "--trigger-kind",
+          "at",
+          "--schedule-kind",
+          "at",
+          "--trigger-at",
+          "2099-01-01T00:00:00.000Z",
+          "--schedule-at",
+          "2099-02-01T00:00:00.000Z",
+        ],
+        slug: "at-alias-conflict",
+      },
+      {
+        expectedPath: "schedule.expression",
+        privateValues: [
+          "private-irrelevant-cron-instructions",
+          "private-irrelevant-cron-expression",
+        ],
+        scheduleArgs: [
+          "--trigger-kind",
+          "at",
+          "--trigger-at",
+          "2099-03-01T00:00:00.000Z",
+          "--trigger-cron",
+          "private-irrelevant-cron-expression",
+        ],
+        slug: "irrelevant-cron",
+      },
+    ];
+
+    for (const rejectedSchedule of rejectedSchedules) {
+      const result = await runInProcessJsonCli(cli, [
+        "automation",
+        "save",
+        rejectedSchedule.slug,
+        "--slug",
+        rejectedSchedule.slug,
+        "--instructions",
+        rejectedSchedule.privateValues[0] ?? "private-schedule-instructions",
+        "--status",
+        "paused",
+        ...rejectedSchedule.scheduleArgs,
+        "--channel",
+        "telegram",
+        "--delivery-target",
+        `telegram-thread-${rejectedSchedule.slug}`,
+        "--vault",
+        vaultRoot,
+      ]);
+
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.envelope.ok, false);
+      if (result.envelope.ok) assert.fail("invalid schedule flags must fail");
+      assert.equal(result.envelope.error.code, "invalid_option");
+      assert.equal(result.envelope.error.retryable, false);
+      assert.equal(result.envelope.error.stage, "validation");
+      assert.equal(
+        result.envelope.error.fieldErrors?.[0]?.path,
+        rejectedSchedule.expectedPath,
+      );
+      for (const privateValue of rejectedSchedule.privateValues) {
+        assert.equal(JSON.stringify(result.envelope).includes(privateValue), false);
+      }
+    }
+
+    const listedAfterRejectedSaves = await runInProcessJsonCli<{
+      count: number;
+      items: unknown[];
+      totalCount: number;
+    }>(cli, [
+      "automation",
+      "list",
+      "--compact",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(listedAfterRejectedSaves.exitCode, null);
+    assert.equal(listedAfterRejectedSaves.envelope.ok, true);
+    assert.equal(listedAfterRejectedSaves.envelope.data?.count, 0);
+    assert.equal(listedAfterRejectedSaves.envelope.data?.totalCount, 0);
+    assert.deepEqual(listedAfterRejectedSaves.envelope.data?.items, []);
+
+    const cronExpression = "0 9 * * 1";
+    const saved = await runInProcessJsonCli(cli, [
+      "automation",
+      "save",
+      "Matching aliases",
+      "--slug",
+      "matching-aliases",
+      "--instructions",
+      "Keep the original instructions.",
+      "--status",
+      "paused",
+      "--trigger-kind",
+      "cron",
+      "--schedule-kind",
+      "cron",
+      "--trigger-cron",
+      cronExpression,
+      "--schedule-cron",
+      cronExpression,
+      "--trigger-time-zone",
+      "America/New_York",
+      "--schedule-time-zone",
+      "America/New_York",
+      "--channel",
+      "telegram",
+      "--delivery-target",
+      "telegram-thread-matching-aliases",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(saved.exitCode, null);
+    assert.equal(saved.envelope.ok, true);
+
+    const rejectedEdit = await runInProcessJsonCli(cli, [
+      "automation",
+      "edit",
+      "matching-aliases",
+      "--instructions",
+      "private-edit-replacement",
+      "--trigger-kind",
+      "cron",
+      "--trigger-cron",
+      "0 10 * * 2",
+      "--trigger-at",
+      "private-irrelevant-at",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(rejectedEdit.exitCode, 1);
+    assert.equal(rejectedEdit.envelope.ok, false);
+    if (rejectedEdit.envelope.ok) assert.fail("irrelevant edit flags must fail");
+    assert.equal(rejectedEdit.envelope.error.code, "invalid_option");
+    assert.equal(rejectedEdit.envelope.error.stage, "validation");
+    assert.equal(
+      rejectedEdit.envelope.error.fieldErrors?.[0]?.path,
+      "schedule.at",
+    );
+    assert.equal(
+      JSON.stringify(rejectedEdit.envelope).includes("private-edit-replacement"),
+      false,
+    );
+    assert.equal(
+      JSON.stringify(rejectedEdit.envelope).includes("private-irrelevant-at"),
+      false,
+    );
+
+    const shown = await runInProcessJsonCli<{
+      automation: {
+        instructions: string;
+        schedule: unknown;
+      } | null;
+    }>(cli, [
+      "automation",
+      "show",
+      "matching-aliases",
+      "--vault",
+      vaultRoot,
+    ]);
+    assert.equal(shown.exitCode, null);
+    assert.equal(shown.envelope.ok, true);
+    assert.equal(
+      shown.envelope.data?.automation?.instructions,
+      "Keep the original instructions.",
+    );
+    assert.deepEqual(shown.envelope.data?.automation?.schedule, {
+      expression: cronExpression,
+      kind: "cron",
+      timeZone: "America/New_York",
+    });
   } finally {
     await rm(parentRoot, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Why and outcome

Vault agents could provide contradictory aliases or fields that did not belong to the selected automation schedule and still receive a successful save. The CLI now stops those writes before mutation and returns a stable, exact `schedule.*` recovery path without repeating the submitted value.

Matching canonical and legacy aliases, one-time, interval, recurring, local-time, time-zone, and device-activity schedules continue through the existing automation owner unchanged.

## Product UX

- Effort: Patch.
- Walkthrough: Ready.
- Affected people: Agents and operators saving or editing reminders on a member's behalf now get one precise, machine-readable field to correct instead of a silent winner that could schedule the wrong reminder.
- Material exclusions: Structured `automation import-json`, scheduler execution, storage schemas, and correctly matched schedule inputs are unchanged.
- Plan variance: None; the implemented boundary matches the approved fail-closed validation plan.

## Evidence

- Original reproduction: a save containing different canonical and legacy `at` values plus a cron field exited successfully and stored only the canonical one-time value.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/automation.test.ts` — 35/35 passed. Three invalid saves left list count and total count at zero; invalid edit preserved instructions, cron, and time zone; matching aliases remained valid.
- `pnpm --dir packages/cli typecheck` — passed.
- `pnpm --dir apps/web test -- changelog-page.test.tsx` — 9/9 passed on the decisive warm retry in 9.63 seconds. The first attempt's unrelated major-feature visual case exceeded its 60-second timeout during cold setup; its other eight cases passed.
- `pnpm --dir apps/web typecheck` — passed.
- `git diff --check` — passed.

## Non-obvious affected surfaces

- `automation edit` shares the same typed schedule builder as save, so failed edits now preserve the existing record; the focused regression test proves that behavior.
- Public CLI validation projection now identifies conflicts with exact paths such as `schedule.at`, `schedule.cron`, or `schedule.source`; tests prove submitted private values are not echoed.
- The production changelog archive gains one authored improvement item. Its renderer, layout, styles, and interaction are unchanged.
- Runtime scheduling, storage ownership, database shape, and `automation import-json` are not changed.

## Architecture and reuse

- Existing systems reused: The shared typed schedule builder, existing public validation-error projection, and core automation upsert and patch owners remain the only command and mutation paths.
- New logic: One validation pass checks alias agreement, schedule-kind field relevance, and device source/activity agreement before either save or edit can mutate state.
- New abstractions: No service, state owner, dependency, or cross-package API was added; a local schedule-field descriptor list keeps the checks data-driven inside the existing command owner.
- Complexity intentionally avoided: No compatibility layer, state machine, second schedule representation, import rewrite, or runtime scheduler branch was introduced.

## Hot reply path impact

- Not applicable: Local Vault CLI validation and static changelog content do not touch durable acceptance of a current conversation message, provider start, or durable reply handoff.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool descriptor, schema, generated guidance, or other provider-visible request field changed.
- Group runtime: Not applicable for the same reason; the diff is limited to local CLI parsing and validation, regression tests, an archived execution plan, and static changelog content.

## Design proof

- Design page: [Production changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Direct JSON copy review and the focused changelog page test prove the authored item renders through the unchanged production archive component.
- Coverage: The server-rendered item uses the archive's existing responsive presentation; no renderer, component, style, visual, state, or interaction changed, so a new branch preview would add no changed-state proof.

## Risks

- Correctness risk is bounded to schedule admission: only contradictory aliases, irrelevant fields, and mismatched device source/activity pairs newly fail. Focused tests preserve equal aliases and valid legacy, cron, time-zone, and device schedules.

## Change-shape breakdown

Classification rule: production CLI code is source; regression coverage is tests/fixtures; the archived execution plan and authored changelog fragment are docs; no config, tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 83 | 3 |
| Tests/fixtures | 223 | 1 |
| Docs | 67 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **373** | **4** |

## Deployment concerns

- Deployment: applicable
- Supported skew: The CLI/runtime validation and static Web changelog entry are independent, so either version can serve while the other updates; an older CLI can still accept the now-rejected input until its release converges.
- Safe order: Publish the updated CLI/runtime package first, then deploy Web so the changelog describes behavior already available.
- Rollback floor: Roll back Web first to remove the public claim, then roll back the CLI/runtime package if required.
- Expected exposure: Between runtime publication and Web deployment, safer validation can be active without its changelog item; the ordered rollout avoids a claim-before-runtime window.
- Reversibility: The changelog is static content and the CLI validation can be reverted without a persisted-schema migration; previously valid matching schedules remain unchanged.
- Convergence proof: Verify the released CLI rejects contradictory and irrelevant schedule inputs without a write, then verify the production changelog item renders with this pull request as provenance.
- Post-deploy checks: Run one contradictory-alias and one irrelevant-field CLI probe and confirm non-retryable validation errors with exact `schedule.*` paths and no write; then open the production changelog archive and confirm “Safer reminder schedule changes” is visible.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · safer-reminder-schedule-changes

## Review metadata

ReviewGPT context sensitivity: sensitive

Reason: Fail-closed validation changes which reminder schedule writes are admitted and prevents silent mutations.

ReviewGPT first-reviewed head: 92584427f6ccc4e8138eec281e912be36d3ae7e6
