### PR TITLE
fix(cloudflare): restore hosted integration contracts

### DIFF
--- a/.agents/friction-log/20260830165335-hosted-local-setup/friction.md
+++ b/.agents/friction-log/20260830165335-hosted-local-setup/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Hosted-local setup timeout leaves owned child processes running'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+When a hosted-local Vitest `beforeAll` hook times out or its parent E2E process exits, every child process started by that scenario should stop before the command returns.
+
+## Current Behavior
+
+A timed-out hosted-local full-stack scenario can return while its Caddy, Wrangler, workerd, or generated-artifact child processes continue running. A later retry then competes with those abandoned processes and requires exact-PID cleanup after ownership is proved.
+
+## Possible Solution
+
+Make the scenario launcher retain process ownership before setup completes and always run its bounded teardown path on hook timeout, parent exit, and interrupted setup.
+
+## Minimal Reproducible Example
+
+1. Run one hosted-local full-stack E2E scenario from a clean task worktree.
+2. Let stack setup exceed the test hook timeout before the scenario object is returned.
+3. Observe that the test command exits but worktree-scoped child processes remain active.
+
+## Context
+
+This delayed focused verification and made a retry less reliable. The product behavior under test was never reached.

--- a/agent-docs/exec-plans/active/2026-08-30-hosted-integration-contract-recovery.md
+++ b/agent-docs/exec-plans/active/2026-08-30-hosted-integration-contract-recovery.md
@@ -1,0 +1,98 @@
+# Restore hosted integration contracts
+
+Status: active
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Restore the hosted integration gate by aligning with the current Codex and
+  group-tool contracts, including the narrow Venice provider-boundary adapter
+  for the current Responses Lite item identity.
+
+## Success criteria
+
+- The Venice Responses Lite scenario accepts the current stable
+  `additional_tools` item identity, removes it at the provider boundary, and
+  still rejects malformed identities and tool envelopes.
+- The usage-limit private-to-group handoff scenario follows the production
+  membership-inventory and exact-membership consultation path and delivers once.
+- The private integration job initializes its PostgreSQL service database
+  explicitly before the focused concurrency suite.
+- The exact public and private PR heads pass focused local proof, required
+  ReviewGPT gates, and required CI.
+
+## Scope
+
+- In scope:
+  - The current Codex Responses Lite item identity at the Venice adapter and
+    its hosted-local proof.
+  - The stale private-to-group handoff fixture.
+  - The private integration workflow's empty PostgreSQL service setup.
+  - Cross-repository exact-head verification of those corrections.
+- Out of scope:
+  - Runtime, mailbox, Temporal, or database behavior outside the Venice
+    Responses Lite compatibility adapter.
+  - The unrelated device-sync/runtime changes preserved in the older dirty
+    recovery worktree.
+  - New queues, schedulers, fallback owners, or compatibility machinery.
+
+## Constraints
+
+- Technical constraints:
+  - Reuse current tool and database setup owners; add no dependency or new
+    abstraction.
+  - Preserve every existing provider-envelope, authority, settlement, and
+    exact-delivery assertion not disproven by the current contract.
+  - Keep the other dirty worktree untouched.
+- Product/process constraints:
+  - Internal proof recovery only; no member-visible behavior change or
+    changelog entry.
+  - Use separate public and private PRs because each repository owns its own
+    correction.
+
+## Risks and mitigations
+
+1. Risk: Updating a fixture could hide a production regression.
+   Mitigation: assert the exact current upstream identity shape, derive the
+   handoff target only from protocol-owned inventory output, and preserve the
+   existing delivery and settlement assertions.
+2. Risk: Database setup could restore the old destructive inherited-database
+   coupling.
+   Mitigation: initialize only the job-owned PostgreSQL service through the
+   repository's canonical schema command; hosted-local scenarios remain
+   isolated.
+3. Risk: Cross-repository movement could invalidate proof.
+   Mitigation: record and verify the immutable public SHA used by the private
+   integration run.
+
+## Tasks
+
+1. Reproduce and classify all failures on the latest private main run.
+2. Correct the two public test contracts with focused deterministic coverage.
+3. Correct the private PostgreSQL setup at the workflow owner.
+4. Run focused public tests/typecheck and private verification.
+5. Push exact candidates, run required specialist/final reviews concurrently
+   with CI, resolve accepted findings, and close the plan.
+
+## Decisions
+
+- The Temporal compatibility failure is already resolved by the merged public
+  controller advance and is not part of this diff.
+- The group-handoff and PostgreSQL failures do not justify production runtime
+  changes. The Codex failure does require the narrow provider-boundary adapter
+  to accept and discard the new upstream `at_` item identity.
+
+## Verification
+
+- Commands to run:
+  - Focused Vitest coverage for both public hosted-local fixtures or their
+    narrowest stable contract owners.
+  - Cloudflare package typecheck and `git diff --check`.
+  - Focused Venice adapter unit coverage for accepted and malformed identities.
+  - Private `pnpm verify` plus the narrowest workflow contract tests.
+  - Exact-head Public Murph Integration CI using the public candidate SHA.
+- Expected outcomes:
+  - Both scenarios pass with their existing terminal/delivery assertions.
+  - The PostgreSQL concurrency step starts from a fully initialized schema.
+  - The only production source change is the narrow Venice identity validator.

--- a/agent-docs/exec-plans/completed/2026-08-30-hosted-integration-contract-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-hosted-integration-contract-recovery.md
@@ -1,6 +1,6 @@
 # Restore hosted integration contracts
 
-Status: active
+Status: completed
 Created: 2026-08-30
 Updated: 2026-08-30
 
@@ -96,3 +96,4 @@ Updated: 2026-08-30
   - Both scenarios pass with their existing terminal/delivery assertions.
   - The PostgreSQL concurrency step starts from a fully initialized schema.
   - The only production source change is the narrow Venice identity validator.
+Completed: 2026-08-30

--- a/apps/cloudflare/src/runner-egress-venice.ts
+++ b/apps/cloudflare/src/runner-egress-venice.ts
@@ -172,7 +172,7 @@ function adaptHostedVeniceResponsesLiteRequest(
     if (
       responsesLiteTools
       || item.role !== "developer"
-      || (item.id !== undefined && item.id !== null)
+      || !isSupportedResponsesLiteToolsId(item.id)
       || !Array.isArray(item.tools)
       || item.tools.some((tool) =>
         !isJsonObject(tool) || typeof tool.type !== "string"
@@ -204,6 +204,16 @@ function adaptHostedVeniceResponsesLiteRequest(
   return pathnameSuffix === "/responses"
     ? addHostedVenicePromptCacheBreakpoint(providerRecord)
     : providerRecord;
+}
+
+function isSupportedResponsesLiteToolsId(value: unknown): boolean {
+  return value === undefined
+    || value === null
+    || (
+      typeof value === "string"
+      && value.startsWith("at_")
+      && value.length > "at_".length
+    );
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {

--- a/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
@@ -22,6 +22,9 @@ import {
 } from "./helpers/hosted-local-full-stack-scenario.js";
 import {
   buildAssistantProviderMurphToolCall,
+  buildAssistantProviderRequestDerivedMurphToolCall,
+  type HostedLocalAssistantProviderRequestContext,
+  readHostedLocalAssistantProviderToolOutputs,
 } from "./helpers/hosted-local-e2e-support.js";
 import {
   buildHostedLinqInboundEvent,
@@ -808,10 +811,14 @@ describe("hosted local usage-limit ambiguous send e2e", () => {
     });
 
     requireScenario().queueAssistantResponses([
-      buildAssistantProviderMurphToolCall("group", {
+      buildAssistantProviderMurphToolCall("group_membership", {
+        action: "list_memberships",
+      }),
+      buildAssistantProviderRequestDerivedMurphToolCall("group_consult", (input) => ({
         action: "handoff",
         context: handoffContext,
-      }),
+        membershipId: requireSingleMembershipId(input),
+      })),
       privateHandoffAcknowledgment,
     ], {
       matchInputContains: privateHandoffRequestText,
@@ -1060,6 +1067,25 @@ function collectJsonStrings(value: unknown): string[] {
     return Object.values(value).flatMap(collectJsonStrings);
   }
   return [];
+}
+
+function requireSingleMembershipId(
+  input: HostedLocalAssistantProviderRequestContext,
+): string {
+  const membershipIds = new Set(
+    readHostedLocalAssistantProviderToolOutputs({
+      body: input.requestBody,
+      method: "POST",
+      url: "/v1/responses",
+    }).flatMap((output) =>
+      [...output.matchAll(/\\?"membershipId\\?"\s*:\s*\\?"([^"]+?)\\?"/gu)]
+        .flatMap((match) => match[1] ? [match[1]] : [])
+    ),
+  );
+  if (membershipIds.size !== 1) {
+    throw new Error("Expected exactly one opaque membership id from group inventory.");
+  }
+  return [...membershipIds][0]!;
 }
 
 function readConversationMailboxLane(

--- a/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
@@ -63,7 +63,7 @@ const groupBacklogReply = "I caught up with the whole group in one reply.";
 const handoffGroupBootstrapText = "Start a synthetic group conversation.";
 const handoffGroupBootstrapReply = "The synthetic group conversation is ready.";
 const privateHandoffRequestText = "Please share a short update with my joined group.";
-const privateHandoffAcknowledgment = "I shared the update with your group.";
+const privateHandoffAcknowledgment = "I queued the update for your group.";
 const handoffContext = `COMPOSED_HANDOFF_CONTEXT_${runId}`;
 const handoffGroupMessage = "The weekly check-in is ready for the group.";
 const blockedGroupFollowUpText = `BLOCKED_GROUP_FOLLOW_UP_${runId}`;
@@ -90,6 +90,22 @@ afterAll(async () => {
 describe("hosted local usage-limit ambiguous send e2e", () => {
   beforeAll(async () => {
     linqStub = await startHostedLocalLinqStub({
+      canonicalChats: [{
+        chatId: handoffGroupChatId,
+        handles: [
+          {
+            handle: buildLinqHomePhoneNumber(handoffOwnerUserId),
+            isMe: true,
+            status: "active",
+          },
+          {
+            handle: handoffOwnerPhone,
+            isMe: false,
+            status: "active",
+          },
+        ],
+        isGroup: true,
+      }],
       expectedAuthorizationToken: linqApiToken,
     });
     scenario = await startHostedLocalFullStackScenario({
@@ -742,7 +758,6 @@ describe("hosted local usage-limit ambiguous send e2e", () => {
   }, 600_000);
 
   it("composes a plain-text private handoff through settlement and the next-call fence", async () => {
-    requireLinqStub().setChatIsGroup(handoffGroupChatId, true);
     const groupReplyPath =
       `/chats/${encodeURIComponent(handoffGroupChatId)}/messages`;
     const bootstrapReplyMatcher = (request: ObservedLinqRequest): boolean =>
@@ -819,7 +834,12 @@ describe("hosted local usage-limit ambiguous send e2e", () => {
         context: handoffContext,
         membershipId: requireSingleMembershipId(input),
       })),
-      privateHandoffAcknowledgment,
+      {
+        deriveResponse(input) {
+          requireQueuedGroupHandoff(input);
+          return privateHandoffAcknowledgment;
+        },
+      },
     ], {
       matchInputContains: privateHandoffRequestText,
     });
@@ -1086,6 +1106,33 @@ function requireSingleMembershipId(
     throw new Error("Expected exactly one opaque membership id from group inventory.");
   }
   return [...membershipIds][0]!;
+}
+
+function requireQueuedGroupHandoff(
+  input: HostedLocalAssistantProviderRequestContext,
+): void {
+  const outputs = readHostedLocalAssistantProviderToolOutputs({
+    body: input.requestBody,
+    method: "POST",
+    url: "/v1/responses",
+  });
+  const queued = outputs.some((output) =>
+    /\\?"action\\?"\s*:\s*\\?"handoff\\?"/u.test(output)
+    && /\\?"status\\?"\s*:\s*\\?"queued\\?"/u.test(output)
+  );
+  if (queued) {
+    return;
+  }
+  const unavailableReason = outputs.flatMap((output) =>
+    [...output.matchAll(
+      /\\?"unavailableReason\\?"\s*:\s*\\?"([a-z_]+)\\?"/gu,
+    )].flatMap((match) => match[1] ? [match[1]] : [])
+  )[0];
+  throw new Error(
+    unavailableReason
+      ? `Expected the group handoff to be queued; unavailableReason=${unavailableReason}.`
+      : "Expected the group handoff to be queued.",
+  );
 }
 
 function readConversationMailboxLane(

--- a/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-usage-limit-ambiguous-send-e2e.test.ts
@@ -63,7 +63,8 @@ const groupBacklogReply = "I caught up with the whole group in one reply.";
 const handoffGroupBootstrapText = "Start a synthetic group conversation.";
 const handoffGroupBootstrapReply = "The synthetic group conversation is ready.";
 const privateHandoffRequestText = "Please share a short update with my joined group.";
-const privateHandoffAcknowledgment = "I queued the update for your group.";
+const privateHandoffAcknowledgment =
+  "I queued that for your group; delivery isn't confirmed yet.";
 const handoffContext = `COMPOSED_HANDOFF_CONTEXT_${runId}`;
 const handoffGroupMessage = "The weekly check-in is ready for the group.";
 const blockedGroupFollowUpText = `BLOCKED_GROUP_FOLLOW_UP_${runId}`;
@@ -760,12 +761,23 @@ describe("hosted local usage-limit ambiguous send e2e", () => {
   it("composes a plain-text private handoff through settlement and the next-call fence", async () => {
     const groupReplyPath =
       `/chats/${encodeURIComponent(handoffGroupChatId)}/messages`;
+    const privateReplyPath =
+      `/chats/${encodeURIComponent(handoffPrivateChatId)}/messages`;
     const bootstrapReplyMatcher = (request: ObservedLinqRequest): boolean =>
       requireLinqStub().readObservedMessageText(request)
         === handoffGroupBootstrapReply;
+    const privateAcknowledgmentMatcher = (
+      request: ObservedLinqRequest,
+    ): boolean =>
+      requireLinqStub().readObservedMessageText(request)
+        === privateHandoffAcknowledgment;
     const bootstrapSendBaseline = requireLinqStub().countObservedSends(
       groupReplyPath,
       bootstrapReplyMatcher,
+    );
+    const privateAcknowledgmentBaseline = requireLinqStub().countObservedSends(
+      privateReplyPath,
+      privateAcknowledgmentMatcher,
     );
     requireScenario().queueAssistantResponses([handoffGroupBootstrapReply], {
       matchInputContains: handoffGroupBootstrapText,
@@ -871,6 +883,13 @@ describe("hosted local usage-limit ambiguous send e2e", () => {
       reason: "wake-appended-active-member",
     });
 
+    await requireLinqStub().waitForMatchingSendCount({
+      expectedCount: privateAcknowledgmentBaseline + 1,
+      expectedPath: privateReplyPath,
+      matchRequest: privateAcknowledgmentMatcher,
+      scenario: requireScenario(),
+      userId: handoffOwnerUserId,
+    });
     await requireLinqStub().waitForMatchingSendCount({
       expectedCount: handoffSendBaseline + 1,
       expectedPath: groupReplyPath,

--- a/apps/cloudflare/test/hosted-local-warm-reuse-egress-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-warm-reuse-egress-e2e.test.ts
@@ -274,7 +274,9 @@ function expectCurrentResponsesLiteToolEnvelope(body: string): void {
   ) {
     throw new TypeError("Expected one Responses Lite tool envelope.");
   }
-  expect(Reflect.has(additionalTools, "id")).toBe(false);
+  expect(Reflect.get(additionalTools, "id")).toEqual(
+    expect.stringMatching(/^at_.+/u),
+  );
   expect(Reflect.get(additionalTools, "role")).toBe("developer");
   const tools: unknown = Reflect.get(additionalTools, "tools");
   if (!Array.isArray(tools) || tools.length === 0) {

--- a/apps/cloudflare/test/runner-egress-venice.test.ts
+++ b/apps/cloudflare/test/runner-egress-venice.test.ts
@@ -102,6 +102,7 @@ test("Venice egress restores Codex Responses Lite tools to the standard top-leve
       body: encodeJson({
         input: [
           {
+            id: "at_current_tools",
             role: "developer",
             tools: MURPH_NAMESPACE_TOOLS,
             type: "additional_tools",
@@ -301,7 +302,12 @@ test("Venice egress fails closed for malformed or conflicting Responses Lite too
     },
     {
       input: [{ ...additionalTools, id: "item_123" }],
-      label: "identified additional_tools item",
+      label: "unsupported additional_tools id",
+      tools: null,
+    },
+    {
+      input: [{ ...additionalTools, id: "at_" }],
+      label: "empty additional_tools id suffix",
       tools: null,
     },
     {


### PR DESCRIPTION
## Why and outcome

Codex 0.151 adds an `at_…` identity to Responses Lite `additional_tools` items, while the Venice egress adapter rejected every identified item. The hosted handoff proof also used a retired group-tool shape and modeled a group with an empty complete route roster. This restores the current contracts at their existing owners: Venice accepts and discards the current item identity before restoring top-level tools, and the handoff fixture discovers the opaque membership, validates a canonical Linq route, proves queue acceptance, and observes both the truthful private acknowledgement and the separate group send.

## Product UX

Applicable as regression restoration, with no new production interaction or copy. Existing Venice-backed turns can again reach the provider. The handoff journey now preserves the existing promise boundary: durable queue acceptance is acknowledged as queued with delivery unconfirmed, while the target group's separate Linq POST remains the delivery proof.

## Evidence

- PASS: focused Venice adapter Vitest (10 tests).
- PASS: focused assistant-engine handoff contract (1 targeted test; 110 skipped).
- PASS: Cloudflare package typecheck, `git diff --check`, privacy scan, parent candidate review, and focused read-only reviews.
- PASS: final ReviewGPT round 1 at the immutable first-reviewed head.
- ACCEPTED/RESOLVED: preliminary specialist finding about overclaiming delivery; the fixture now asserts race-safe queued/unconfirmed copy on the exact private route.
- BLOCKED LOCALLY: the full hosted scenario correctly requires the external Temporal worker package; Temporal was not disabled.
- PASS: [exact paired Public Murph Integration run](https://github.com/cobuildwithus/murph-cloud/actions/runs/33338596042) across all 12 scenario jobs, PostgreSQL proof, and the aggregate Temporal sentinel.

## Non-obvious affected surfaces

- Venice provider egress accepts missing/null legacy identity or a non-empty current `at_` identity and still rejects malformed or unknown identities.
- Warm old runner bundles can reject current identities until fresh containers converge; the deployment contract below makes that skew explicit.
- The handoff fixture uses protocol-owned membership output, a canonical active Linq roster, a queued-result assertion, and independent private/group send observations. Production route validation is unchanged.
- The Frog entry records the independently observed hosted-local setup/teardown gap; it does not change runtime behavior.

## Architecture and reuse

- Existing systems reused: the Venice boundary adapter, canonical group membership/consult tools, request-derived provider fixture helper, protocol output reader, and Linq observation helpers.
- New logic: one private boundary predicate plus fixture-only route and outcome assertions.
- New abstractions: none; the behavior stays in the existing provider boundary and E2E helper surfaces because no new runtime owner is needed.
- Complexity intentionally avoided: no new service, state owner, compatibility layer, dependency, retry path, or production handoff machinery.

## Hot reply path impact

The Venice provider-start boundary is on the foreground reply path. This adds no database, network, provider, transaction, retry, timeout, or fallback operation. It replaces a rejecting metadata check with constant-time prefix/length validation; current envelopes regain the existing single Venice call. Other providers and production handoff/delivery behavior are unchanged.

## Murph initial provider input impact

- Individual runtime: no request-assembly, instruction, tool, schema, or generated-guidance change. The adapter only validates and removes existing Codex envelope metadata at final Venice egress.
- Group runtime: no production provider-input change; the group changes are E2E scripting and observation only.
- Measurement: source/diff inspection plus focused serialization assertions; no token/byte delta is claimed because provider-input assembly is unchanged.

#### Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 11 | 1 |
| Tests/fixtures | 107 | 7 |
| Docs | 125 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **243** | **8** |

## Deployment concerns

- Deployment: applicable
- Supported skew: the new bundle accepts legacy missing/null identities and current non-empty `at_` identities; warm old bundles still reject current identities.
- Safe order: deploy the Cloudflare Worker/runner bundle, then prove a fresh `RunnerContainer` accepts the current Venice envelope before relying on rollout completion.
- Rollback floor: reverting reintroduces the current Codex-to-Venice rejection unless Venice traffic is routed away or the producer is reverted.
- Expected exposure: during gradual convergence, only Venice turns landing on warm old runner bundles can fail before provider start; no persisted data is at risk.
- Reversibility: redeploy the fixed bundle or temporarily route away from Venice; there is no schema, persisted-state, or backfill dependency.
- Convergence proof: a controlled fresh-`RunnerContainer` Venice canary accepts the current envelope and records the expected provider start.
- Post-deploy checks: verify the fresh-container canary and inspect bounded Venice egress error aggregates for rejected Responses Lite envelopes.

## Changelog

- Changelog: not applicable
- Reason: this is an internal compatibility and integration-proof correction, not a new member-visible feature.

ReviewGPT context sensitivity: sensitive

Sensitivity reason: external provider egress, Cloudflare hosted execution, and multi-owner runtime proof change.

ReviewGPT first-reviewed head: c5ee78871f2b1b58fc035dffc51936ea85c56f7b

ReviewGPT current candidate head: a44f876c36444167c135ab30370e41e8bd911e1c
