### PR TITLE
fix(cli): compact schema discovery indexes

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-cli-schema-index.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-cli-schema-index.md
@@ -1,0 +1,66 @@
+# Keep agent schema discovery compact and format-correct
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Outcome: Agents can discover root and command-group schemas without receiving every descendant leaf schema, and repeated format or token flags behave predictably.
+- Reaches: `vault-cli` root and group `--schema --format json` discovery requests, including fallback rendering and its supported token controls.
+- Proof: Focused synthetic wrapper tests plus the real source CLI prove compact descriptor-only indexes, final format precedence, token count/pagination, and unchanged leaf-schema behavior.
+
+## Success criteria
+
+- Root and group JSON schema indexes contain only bounded child command descriptors; descendant `schema` and `examples` payloads are absent.
+- The last pre-terminator `--json` / `--format` selection determines whether the JSON schema-index fallback applies.
+- `--token-count`, `--token-limit`, and `--token-offset` apply to the compact fallback output instead of being silently discarded.
+- Focused CLI tests and package typecheck pass.
+
+## Scope
+
+- In scope: the shared schema-index wrapper and focused regression coverage.
+- Out of scope: LLMS lazy-loading, credential redaction, command-family validation, native Incur error envelopes, and unrelated CLI UX findings.
+
+## Constraints
+
+- Technical constraints: keep the existing leaf `--schema` path unchanged; reuse the package's existing `tokenx` dependency; do not add dependencies or another discovery owner.
+- Product/process constraints: smallest Product UX Patch; synthetic tests only; no production/private data; parent agent owns commit, push, and PR creation.
+
+## Risks and mitigations
+
+1. Risk: Compacting the index could hide the command path agents need to choose the next request.
+   Mitigation: Preserve each valid manifest command's full `name` and optional `description`, plus the existing leaf-schema note.
+2. Risk: Reimplementing token rendering could drift from Incur semantics.
+   Mitigation: Use the same `tokenx` functions and mirror Incur's offset/limit/truncation marker behavior in one small helper with focused tests.
+3. Risk: The fallback could intercept a non-JSON final format after an earlier JSON flag.
+   Mitigation: Parse flags in order, stop at `--`, and test both precedence directions.
+
+## Tasks
+
+1. Add compact schema-index projection and final-format parsing.
+2. Preserve supported token controls when rendering the fallback index.
+3. Add focused synthetic and real-CLI regressions for shape, size, precedence, pagination, and leaf passthrough.
+4. Run focused tests and package typecheck; inspect the diff for privacy and scope.
+
+## Decisions
+
+- Use only `{name, description?}` for index entries. Arguments, options, output schemas, and examples remain available from the documented leaf `--schema` follow-up.
+- Apply token controls to the compact rendered index after the unbounded internal LLMS manifest is parsed; forwarding them to the internal manifest request would truncate it before JSON parsing.
+- The existing Frog entry for fresh task-worktree dependency linking covers the only setup friction encountered, so no duplicate entry was created.
+
+## Verification
+
+- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/vault-cli-schema-index.test.ts`: 4 tests passed, including schema/help flag detection at the positional terminator.
+- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/incur-smoke.test.ts -t 'root and group schema json requests return command indexes'`: 1 test passed, 69 skipped.
+- `pnpm --filter @murphai/murph typecheck`: passed.
+- Direct proof locked by tests: the real root index is below 100 KB, the real `goal` index is below 20 KB, all entries are descriptor-only, token count/offset/limit operate on the compact fallback result, and literal `--schema` / `--help` values after `--` do not change wrapper routing.
+
+## Progress
+
+- [x] Reproduced the multi-megabyte root/group index, stale-format interception, and ignored token flags on the current head.
+- [x] Selected the existing schema-index owner and a dependency-free rendering approach.
+- [x] Implemented compact projection and rendering fixes.
+- [x] Added and ran focused proof.
+- [x] Inspected the final diff for scope and privacy; implementation is ready for parent-agent review and commit ownership.
+Completed: 2026-08-30

--- a/agent-docs/exec-plans/completed/2026-08-30-schema-token-equals-remediation.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-schema-token-equals-remediation.md
@@ -1,0 +1,72 @@
+# Schema token equals-form remediation
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Make compact schema-index token pagination honor supported equals-form flags so agents can reliably bound discovery output regardless of ordinary CLI spelling.
+
+## Success criteria
+
+- `--token-limit=<value>` and `--token-offset=<value>` use the same validation and last-explicit-value behavior as separated forms before `--`.
+- Token-control-looking literals after `--` do not affect schema-index pagination.
+- The existing single-pass token-control owner remains the only parser for fallback pagination.
+- Focused schema-index tests, the real CLI Incur smoke, and CLI typecheck pass.
+
+## Scope
+
+- In scope: `extractTokenControls` equals-form handling and focused regression coverage.
+- Out of scope: schema-index shape, leaf schemas, new output modes, unrelated CLI parsing, and preliminary specialist reruns.
+
+## Constraints
+
+- Technical constraints: extend the existing loop without a second parser, state abstraction, dependency, or schema-output owner; preserve separated-form behavior.
+- Product/process constraints: remediate only the accepted PR #2599 specialist finding, keep the PR draft until parent review gates are satisfied, and keep identifiers/private evidence out of durable artifacts.
+
+## Risks and mitigations
+
+1. Risk: equals-form parsing could change invalid-value or repeated-option precedence.
+   Mitigation: normalize both spellings through Incur's same validation and test mixed repeated values plus identical invalid-value results.
+2. Risk: arguments intended as positional literals could unexpectedly paginate discovery output.
+   Mitigation: preserve the loop's immediate stop at `--` and add a direct delimiter regression.
+
+## Tasks
+
+1. Reproduce the accepted equals-form gap on the exact pushed candidate.
+2. Extend the existing single-pass token-control extraction for equals forms.
+3. Add focused equals, repetition, validation, and delimiter regressions.
+4. Run focused schema-index and real CLI smoke tests plus CLI typecheck.
+5. Inspect the diff for scope/privacy, archive this plan with `scripts/finish-task`, push, and refresh PR evidence.
+
+## Decisions
+
+- Equals-form values are normalized before delegation, so Incur applies exactly the same validation as separated forms; valid repeated options still use the final explicit value.
+- `--token-count` precedence remains unchanged; this remediation only fills the supported value-option spelling gap.
+- The single extraction pass also supplies the delegate argv and omits the positional terminator suffix, keeping literal token-control-shaped arguments outside both parsing and Incur validation.
+
+## Verification
+
+- Commands to run:
+  - `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/vault-cli-schema-index.test.ts`
+  - `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/incur-smoke.test.ts -t 'root and group schema json requests return command indexes'`
+  - `pnpm --filter @murphai/murph typecheck`
+- Expected outcomes: equals-form token controls bound compact synthetic and real-root output exactly like separated forms, literals after `--` are ignored, and all checks pass.
+
+## Results
+
+- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/vault-cli-schema-index.test.ts`: 8 tests passed.
+- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/incur-smoke.test.ts -t 'root and group schema json requests return command indexes'`: 1 test passed, 69 skipped; the real root equals-form request returned a 24-token truncated page.
+- `pnpm --filter @murphai/murph typecheck`: passed.
+- `git diff --check`: passed.
+- Direct proof: equals limit, equals offset plus limit, mixed repeated spellings, invalid-value parity, and literal options after `--` all exercise the compact schema-index owner without a second parser or output mode.
+
+## Progress
+
+- [x] Reproduced the accepted equals-form failure on the exact pushed PR head.
+- [x] Normalized equals-form controls in the existing single extraction pass.
+- [x] Added synthetic and real-tree regression coverage.
+- [x] Ran focused tests, typecheck, and diff hygiene checks.
+- [x] Inspected the scoped diff for privacy, architecture, and unrelated changes.
+Completed: 2026-08-30

--- a/packages/cli/src/vault-cli-schema-index.ts
+++ b/packages/cli/src/vault-cli-schema-index.ts
@@ -26,6 +26,13 @@ interface SchemaIndex {
   version: 'murph.schema-index.v1'
 }
 
+interface SchemaIndexTokenControls {
+  argv: string[]
+  count: boolean
+  limit?: number
+  offset?: number
+}
+
 const SCHEMA_INDEX_NOTE =
   'This is a command index for a root or command group. Run one leaf command with --schema --format json for its args/options/output schema. File-body contracts for supported JSON/JSONL imports live under payload-schema commands.'
 
@@ -38,7 +45,12 @@ export function installVaultCliSchemaIndex(cli: Cli.Cli): void {
       return
     }
 
-    const originalResult = await captureServeOutput(serve, argv, options)
+    const tokenControls = extractTokenControls(argv)
+    const originalResult = await captureServeOutput(
+      serve,
+      tokenControls.argv,
+      options,
+    )
     if (originalResult.exitCode !== null || parsesAsJson(originalResult.output)) {
       replayServeResult(originalResult, options)
       return
@@ -61,7 +73,10 @@ export function installVaultCliSchemaIndex(cli: Cli.Cli): void {
       return
     }
 
-    writeStdout(options, renderSchemaIndex(buildSchemaIndex(commandPath, manifest), argv))
+    writeStdout(
+      options,
+      renderSchemaIndex(buildSchemaIndex(commandPath, manifest), tokenControls),
+    )
   }
 }
 
@@ -226,9 +241,11 @@ function projectSchemaIndexCommands(
   return projected
 }
 
-function renderSchemaIndex(index: SchemaIndex, argv: readonly string[]): string {
+function renderSchemaIndex(
+  index: SchemaIndex,
+  tokenControls: SchemaIndexTokenControls,
+): string {
   const formatted = JSON.stringify(index, null, 2)
-  const tokenControls = extractTokenControls(argv)
 
   if (tokenControls.count) {
     return `${estimateTokenCount(formatted)}\n`
@@ -252,11 +269,8 @@ function renderSchemaIndex(index: SchemaIndex, argv: readonly string[]): string 
   return `${sliced}\n[truncated: showing tokens ${offset}–${actualEnd} of ${total}]\n`
 }
 
-function extractTokenControls(argv: readonly string[]): {
-  count: boolean
-  limit?: number
-  offset?: number
-} {
+function extractTokenControls(argv: readonly string[]): SchemaIndexTokenControls {
+  const delegateArgv: string[] = []
   let count = false
   let limit: number | undefined
   let offset: number | undefined
@@ -267,27 +281,51 @@ function extractTokenControls(argv: readonly string[]): {
       break
     }
     if (token === '--token-count') {
+      delegateArgv.push(token)
       count = true
       continue
     }
-    if (token === '--token-limit' || token === '--token-offset') {
-      const value = argv[index + 1]
+    if (
+      token === '--token-limit' ||
+      token === '--token-offset' ||
+      token.startsWith('--token-limit=') ||
+      token.startsWith('--token-offset=')
+    ) {
+      const isLimit =
+        token === '--token-limit' || token.startsWith('--token-limit=')
+      const isSeparated = token === '--token-limit' || token === '--token-offset'
+      const value = isSeparated
+        ? argv[index + 1]
+        : token.slice(token.indexOf('=') + 1)
+      const delegateFlag = isLimit ? '--token-limit' : '--token-offset'
+
+      delegateArgv.push(delegateFlag)
+      if (value !== undefined) {
+        delegateArgv.push(value)
+      }
+
       const parsed = value === undefined ? Number.NaN : Number(value)
-      index += 1
+      if (isSeparated) {
+        index += 1
+      }
 
       if (!Number.isFinite(parsed) || value?.trim() === '') {
         continue
       }
 
-      if (token === '--token-limit') {
+      if (isLimit) {
         limit = parsed
       } else {
         offset = parsed
       }
+      continue
     }
+
+    delegateArgv.push(token)
   }
 
   return {
+    argv: delegateArgv,
     count,
     ...(limit === undefined ? {} : { limit }),
     ...(offset === undefined ? {} : { offset }),

--- a/packages/cli/src/vault-cli-schema-index.ts
+++ b/packages/cli/src/vault-cli-schema-index.ts
@@ -1,4 +1,5 @@
 import type { Cli } from 'incur'
+import { estimateTokenCount, sliceByTokens } from 'tokenx'
 
 type CliServeOptions = Parameters<Cli.Cli['serve']>[1]
 
@@ -9,13 +10,16 @@ interface CommandManifest {
 
 interface CommandManifestEntry {
   description?: string
-  examples?: unknown[]
   name?: string
-  schema?: unknown
+}
+
+interface SchemaIndexCommand {
+  description?: string
+  name: string
 }
 
 interface SchemaIndex {
-  commands: CommandManifestEntry[]
+  commands: SchemaIndexCommand[]
   command: string | null
   kind: 'group' | 'root'
   note: string
@@ -57,7 +61,7 @@ export function installVaultCliSchemaIndex(cli: Cli.Cli): void {
       return
     }
 
-    writeStdout(options, `${JSON.stringify(buildSchemaIndex(commandPath, manifest), null, 2)}\n`)
+    writeStdout(options, renderSchemaIndex(buildSchemaIndex(commandPath, manifest), argv))
   }
 }
 
@@ -113,28 +117,52 @@ function exitProcess(options: CliServeOptions | undefined, code: number): void {
 }
 
 function isJsonSchemaRequest(argv: readonly string[]): boolean {
-  return argv.includes('--schema') && usesJsonFormat(argv)
+  return hasFlagBeforeTerminator(argv, ['--schema']) && usesJsonFormat(argv)
 }
 
 function isHelpRequest(argv: readonly string[]): boolean {
-  return argv.includes('--help') || argv.includes('-h')
+  return hasFlagBeforeTerminator(argv, ['--help', '-h'])
 }
 
-function usesJsonFormat(argv: readonly string[]): boolean {
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index]
-    if (token === '--json') {
-      return true
+function hasFlagBeforeTerminator(
+  argv: readonly string[],
+  flags: readonly string[],
+): boolean {
+  for (const token of argv) {
+    if (token === '--') {
+      break
     }
-    if (token === '--format' && argv[index + 1] === 'json') {
-      return true
-    }
-    if (token === '--format=json') {
+    if (flags.includes(token)) {
       return true
     }
   }
 
   return false
+}
+
+function usesJsonFormat(argv: readonly string[]): boolean {
+  let format: string | null = null
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (token === '--') {
+      break
+    }
+    if (token === '--json') {
+      format = 'json'
+      continue
+    }
+    if (token === '--format') {
+      format = argv[index + 1] ?? null
+      index += 1
+      continue
+    }
+    if (token.startsWith('--format=')) {
+      format = token.slice('--format='.length)
+    }
+  }
+
+  return format === 'json'
 }
 
 function parsesAsJson(output: string): boolean {
@@ -173,7 +201,96 @@ function buildSchemaIndex(
     kind: commandPath.length === 0 ? 'root' : 'group',
     command: commandPath.length === 0 ? null : commandPath.join(' '),
     note: SCHEMA_INDEX_NOTE,
-    commands: manifest.commands ?? [],
+    commands: projectSchemaIndexCommands(manifest.commands ?? []),
+  }
+}
+
+function projectSchemaIndexCommands(
+  commands: readonly CommandManifestEntry[],
+): SchemaIndexCommand[] {
+  const projected: SchemaIndexCommand[] = []
+
+  for (const command of commands) {
+    if (typeof command.name !== 'string' || command.name.length === 0) {
+      continue
+    }
+
+    projected.push({
+      name: command.name,
+      ...(typeof command.description === 'string' && command.description.length > 0
+        ? { description: command.description }
+        : {}),
+    })
+  }
+
+  return projected
+}
+
+function renderSchemaIndex(index: SchemaIndex, argv: readonly string[]): string {
+  const formatted = JSON.stringify(index, null, 2)
+  const tokenControls = extractTokenControls(argv)
+
+  if (tokenControls.count) {
+    return `${estimateTokenCount(formatted)}\n`
+  }
+
+  if (tokenControls.limit === undefined && tokenControls.offset === undefined) {
+    return `${formatted}\n`
+  }
+
+  const total = estimateTokenCount(formatted)
+  const offset = tokenControls.offset ?? 0
+  const end =
+    tokenControls.limit === undefined ? total : offset + tokenControls.limit
+
+  if (offset === 0 && end >= total) {
+    return `${formatted}\n`
+  }
+
+  const sliced = sliceByTokens(formatted, offset, end)
+  const actualEnd = Math.min(end, total)
+  return `${sliced}\n[truncated: showing tokens ${offset}–${actualEnd} of ${total}]\n`
+}
+
+function extractTokenControls(argv: readonly string[]): {
+  count: boolean
+  limit?: number
+  offset?: number
+} {
+  let count = false
+  let limit: number | undefined
+  let offset: number | undefined
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (token === '--') {
+      break
+    }
+    if (token === '--token-count') {
+      count = true
+      continue
+    }
+    if (token === '--token-limit' || token === '--token-offset') {
+      const value = argv[index + 1]
+      const parsed = value === undefined ? Number.NaN : Number(value)
+      index += 1
+
+      if (!Number.isFinite(parsed) || value?.trim() === '') {
+        continue
+      }
+
+      if (token === '--token-limit') {
+        limit = parsed
+      } else {
+        offset = parsed
+      }
+    }
+  }
+
+  return {
+    count,
+    ...(limit === undefined ? {} : { limit }),
+    ...(offset === undefined ? {} : { offset }),
   }
 }
 

--- a/packages/cli/test/incur-smoke.test.ts
+++ b/packages/cli/test/incur-smoke.test.ts
@@ -1412,6 +1412,12 @@ test('descriptor direct service bindings resolve against the declared service su
 
 test('root and group schema json requests return command indexes', async () => {
   const rootOutput = await runSourceCliRaw(['--schema', '--format', 'json'])
+  const pagedRootOutput = await runSourceCliRaw([
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit=24',
+  ])
   const groupOutput = await runSourceCliRaw([
     'goal',
     '--schema',
@@ -1432,6 +1438,11 @@ test('root and group schema json requests return command indexes', async () => {
   assert.equal(rootIndex.commands.some((command) => command.name === 'vault show'), true)
   assert.equal(rootIndex.commands.some((command) => command.name?.startsWith('inbox')), false)
   assert.ok(Buffer.byteLength(rootOutput, 'utf8') < 100_000)
+  assert.match(
+    pagedRootOutput,
+    /\[truncated: showing tokens 0–24 of \d+\]/u,
+  )
+  assert.ok(pagedRootOutput.length < rootOutput.length)
   assert.equal(
     rootIndex.commands.every((command) =>
       Object.keys(command).every((key) => key === 'name' || key === 'description'),

--- a/packages/cli/test/incur-smoke.test.ts
+++ b/packages/cli/test/incur-smoke.test.ts
@@ -1411,20 +1411,39 @@ test('descriptor direct service bindings resolve against the declared service su
 })
 
 test('root and group schema json requests return command indexes', async () => {
-  const rootIndex = JSON.parse(
-    await runSourceCliRaw(['--schema', '--format', 'json']),
-  ) as {
+  const rootOutput = await runSourceCliRaw(['--schema', '--format', 'json'])
+  const groupOutput = await runSourceCliRaw([
+    'goal',
+    '--schema',
+    '--format',
+    'json',
+  ])
+  const rootIndex = JSON.parse(rootOutput) as {
     command: string | null
-    commands: Array<{ name?: string }>
+    commands: Array<{ description?: string; name: string }>
     kind: string
     version: string
   }
+  const groupIndex = JSON.parse(groupOutput) as typeof rootIndex
 
   assert.equal(rootIndex.version, 'murph.schema-index.v1')
   assert.equal(rootIndex.kind, 'root')
   assert.equal(rootIndex.command, null)
   assert.equal(rootIndex.commands.some((command) => command.name === 'vault show'), true)
   assert.equal(rootIndex.commands.some((command) => command.name?.startsWith('inbox')), false)
+  assert.ok(Buffer.byteLength(rootOutput, 'utf8') < 100_000)
+  assert.equal(
+    rootIndex.commands.every((command) =>
+      Object.keys(command).every((key) => key === 'name' || key === 'description'),
+    ),
+    true,
+  )
+
+  assert.equal(groupIndex.version, 'murph.schema-index.v1')
+  assert.equal(groupIndex.kind, 'group')
+  assert.equal(groupIndex.command, 'goal')
+  assert.equal(groupIndex.commands.some((command) => command.name === 'goal list'), true)
+  assert.ok(Buffer.byteLength(groupOutput, 'utf8') < 20_000)
 })
 
 test('read-only vault commands reject uninitialized vault roots before query reads', async () => {

--- a/packages/cli/test/vault-cli-schema-index.test.ts
+++ b/packages/cli/test/vault-cli-schema-index.test.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict'
+import { Cli, z } from 'incur'
+import { estimateTokenCount } from 'tokenx'
+import { test } from 'vitest'
+
+import { installVaultCliSchemaIndex } from '../src/vault-cli-schema-index.js'
+
+interface RawCliResult {
+  exitCode: number | null
+  output: string
+}
+
+function createSchemaIndexCli(): Cli.Cli {
+  const cli = Cli.create('vault-cli', {
+    description: 'Synthetic schema index test CLI.',
+  })
+  const records = Cli.create('records', {
+    description: 'Inspect synthetic records.',
+  })
+
+  for (let index = 0; index < 24; index += 1) {
+    const commandName = `read-${index}`
+    records.command(commandName, {
+      description: `Read synthetic record ${index}.`,
+      args: z.object({
+        id: z.string().describe(`Synthetic identifier ${'detail '.repeat(120)}`),
+      }),
+      output: z.object({
+        id: z.string(),
+        payload: z.string().describe(`Synthetic payload ${'shape '.repeat(120)}`),
+      }),
+      run({ args }) {
+        return {
+          id: args.id,
+          payload: 'synthetic',
+        }
+      },
+    })
+  }
+
+  cli.command(records)
+  installVaultCliSchemaIndex(cli)
+  return cli
+}
+
+async function runRawCli(cli: Cli.Cli, argv: string[]): Promise<RawCliResult> {
+  const output: string[] = []
+  let exitCode: number | null = null
+
+  await cli.serve(argv, {
+    exit(code) {
+      exitCode = code
+    },
+    stdout(chunk) {
+      output.push(chunk)
+    },
+  })
+
+  return {
+    exitCode,
+    output: output.join(''),
+  }
+}
+
+test('root and group schema indexes project compact command descriptors', async () => {
+  const cli = createSchemaIndexCli()
+  const rootResult = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const groupResult = await runRawCli(cli, [
+    'records',
+    '--schema',
+    '--format',
+    'json',
+  ])
+  const manifestResult = await runRawCli(cli, [
+    '--llms-full',
+    '--format',
+    'json',
+  ])
+
+  assert.equal(rootResult.exitCode, null)
+  assert.equal(groupResult.exitCode, null)
+  assert.equal(manifestResult.exitCode, null)
+
+  const rootIndex = JSON.parse(rootResult.output) as {
+    command: string | null
+    commands: Array<Record<string, unknown>>
+    kind: string
+    version: string
+  }
+  const groupIndex = JSON.parse(groupResult.output) as typeof rootIndex
+
+  assert.equal(rootIndex.version, 'murph.schema-index.v1')
+  assert.equal(rootIndex.kind, 'root')
+  assert.equal(rootIndex.command, null)
+  assert.equal(groupIndex.kind, 'group')
+  assert.equal(groupIndex.command, 'records')
+  assert.deepEqual(rootIndex.commands, groupIndex.commands)
+  assert.equal(rootIndex.commands.length, 24)
+  assert.deepEqual(rootIndex.commands[0], {
+    name: 'records read-0',
+    description: 'Read synthetic record 0.',
+  })
+
+  for (const command of rootIndex.commands) {
+    assert.deepEqual(Object.keys(command).sort(), ['description', 'name'])
+  }
+
+  assert.equal(rootResult.output.includes('Synthetic identifier'), false)
+  assert.equal(rootResult.output.includes('Synthetic payload'), false)
+  assert.equal(manifestResult.output.includes('Synthetic identifier'), true)
+  assert.ok(manifestResult.output.length > rootResult.output.length * 8)
+  assert.ok(rootResult.output.length < 5_000)
+})
+
+test('schema indexes honor the final explicit output format and preserve leaf schemas', async () => {
+  const cli = createSchemaIndexCli()
+  const finalYaml = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--format',
+    'yaml',
+  ])
+  const finalYamlAfterJsonAlias = await runRawCli(cli, [
+    '--schema',
+    '--json',
+    '--format',
+    'yaml',
+  ])
+  const finalJson = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'yaml',
+    '--format',
+    'json',
+  ])
+  const leaf = await runRawCli(cli, [
+    'records',
+    'read-0',
+    '--schema',
+    '--format',
+    'json',
+  ])
+
+  assert.equal(finalYaml.exitCode, null)
+  assert.doesNotMatch(finalYaml.output, /murph\.schema-index\.v1/u)
+  assert.doesNotMatch(finalYamlAfterJsonAlias.output, /murph\.schema-index\.v1/u)
+
+  const finalJsonIndex = JSON.parse(finalJson.output) as { version: string }
+  assert.equal(finalJsonIndex.version, 'murph.schema-index.v1')
+
+  const leafSchema = JSON.parse(leaf.output) as {
+    args: { properties: Record<string, unknown> }
+    output: { properties: Record<string, unknown> }
+  }
+  assert.equal('id' in leafSchema.args.properties, true)
+  assert.equal('payload' in leafSchema.output.properties, true)
+  assert.equal('version' in leafSchema, false)
+})
+
+test('schema-index flag detection stops at the positional terminator', async () => {
+  const cli = createSchemaIndexCli()
+  const literalSchema = await runRawCli(cli, [
+    '--format',
+    'json',
+    '--',
+    '--schema',
+  ])
+  const literalHelp = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--',
+    '--help',
+  ])
+
+  assert.doesNotMatch(literalSchema.output, /murph\.schema-index\.v1/u)
+  const literalHelpIndex = JSON.parse(literalHelp.output) as { version: string }
+  assert.equal(literalHelpIndex.version, 'murph.schema-index.v1')
+})
+
+test('schema-index fallback applies token counting and pagination to compact output', async () => {
+  const cli = createSchemaIndexCli()
+  const full = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const count = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-count',
+  ])
+  const firstPage = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit',
+    '24',
+  ])
+  const secondPage = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-offset',
+    '24',
+    '--token-limit',
+    '24',
+  ])
+
+  const total = estimateTokenCount(full.output.trimEnd())
+  assert.equal(Number(count.output.trim()), total)
+  assert.match(
+    firstPage.output,
+    new RegExp(`\\[truncated: showing tokens 0–24 of ${total}\\]`, 'u'),
+  )
+  assert.match(
+    secondPage.output,
+    new RegExp(`\\[truncated: showing tokens 24–48 of ${total}\\]`, 'u'),
+  )
+  assert.notEqual(firstPage.output, secondPage.output)
+  assert.ok(firstPage.output.length < full.output.length)
+  assert.ok(secondPage.output.length < full.output.length)
+})

--- a/packages/cli/test/vault-cli-schema-index.test.ts
+++ b/packages/cli/test/vault-cli-schema-index.test.ts
@@ -219,3 +219,97 @@ test('schema-index fallback applies token counting and pagination to compact out
   assert.ok(firstPage.output.length < full.output.length)
   assert.ok(secondPage.output.length < full.output.length)
 })
+
+test('schema-index fallback accepts equals-form token limits', async () => {
+  const cli = createSchemaIndexCli()
+  const full = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const firstPage = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit=24',
+  ])
+
+  const total = estimateTokenCount(full.output.trimEnd())
+  assert.match(
+    firstPage.output,
+    new RegExp(`\\[truncated: showing tokens 0–24 of ${total}\\]`, 'u'),
+  )
+  assert.ok(firstPage.output.length < full.output.length)
+})
+
+test('schema-index fallback accepts equals-form offsets and limits', async () => {
+  const cli = createSchemaIndexCli()
+  const full = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const secondPage = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-offset=24',
+    '--token-limit=24',
+  ])
+
+  const total = estimateTokenCount(full.output.trimEnd())
+  assert.match(
+    secondPage.output,
+    new RegExp(`\\[truncated: showing tokens 24–48 of ${total}\\]`, 'u'),
+  )
+  assert.ok(secondPage.output.length < full.output.length)
+})
+
+test('schema-index fallback keeps the last explicit value across mixed token-control spellings', async () => {
+  const cli = createSchemaIndexCli()
+  const full = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const mixed = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-offset=8',
+    '--token-offset',
+    '24',
+    '--token-limit',
+    '12',
+    '--token-limit=24',
+  ])
+
+  const total = estimateTokenCount(full.output.trimEnd())
+  assert.match(
+    mixed.output,
+    new RegExp(`\\[truncated: showing tokens 24–48 of ${total}\\]`, 'u'),
+  )
+
+  const invalidEquals = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit=not-a-number',
+  ])
+  const invalidSeparated = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit',
+    'not-a-number',
+  ])
+  assert.deepEqual(invalidEquals, invalidSeparated)
+})
+
+test('schema-index fallback ignores token-control literals after the positional terminator', async () => {
+  const cli = createSchemaIndexCli()
+  const full = await runRawCli(cli, ['--schema', '--format', 'json'])
+  const page = await runRawCli(cli, [
+    '--schema',
+    '--format',
+    'json',
+    '--token-limit=24',
+    '--',
+    '--token-offset=24',
+    '--token-limit=1',
+  ])
+
+  const total = estimateTokenCount(full.output.trimEnd())
+  assert.match(
+    page.output,
+    new RegExp(`\\[truncated: showing tokens 0–24 of ${total}\\]`, 'u'),
+  )
+})


### PR DESCRIPTION
## Why and outcome

Agents querying root or command-group `--schema --format json` received every descendant leaf schema, making root discovery roughly 5.6 MB and contradicting the command-index guidance. This change keeps complete schemas on leaf requests while returning compact `{name, description?}` descriptors for root and group discovery.

Repeated output-format flags honor the final explicit selection. Token count and pagination apply to the compact result, including ordinary `--token-limit=<value>` and `--token-offset=<value>` spellings, and literal flag-shaped positionals after `--` do not affect routing or pagination.

## Product UX

- Product UX: Ready
- Effort: Patch
- Affected people: Agents discovering Vault CLI commands before selecting a leaf command.
- Walkthrough: Root and group discovery now return a bounded descriptor index; agents can page it with either supported token-control spelling, choose a leaf, and request its complete schema.
- Material exclusions: Leaf schema shape, LLMS normalization and lazy loading, credential redaction, command behavior, and member-facing surfaces are unchanged.
- Plan variance: The preliminary specialist found that equals-form token controls were rejected before fallback rendering. The accepted remediation normalizes them in the existing extraction pass and adds focused real-tree proof.

## Evidence

- Base reproduction: root JSON schema discovery emitted 5,612,014 bytes and included descendant argument, option, output, and example payloads.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/vault-cli-schema-index.test.ts`: 8 tests passed, covering compact shape and size, final-format precedence, leaf passthrough, both token-control spellings, repeated-value precedence, invalid-value parity, and positional-terminator routing.
- `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/incur-smoke.test.ts -t "root and group schema json requests return command indexes"`: 1 test passed and 69 skipped; the real root equals-form request returned a 24-token truncated page, and the root and group indexes remained descriptor-only.
- `pnpm --filter @murphai/murph typecheck`: passed.
- `git diff --check`: passed.

- Final-finding reproduction: `pnpm --filter @murphai/murph exec tsx src/bin.ts goal list --schema --format json --token-offset 8 --token-limit 24` returned complete, parseable native leaf JSON with no truncation marker and no `murph.schema-index.v1`; source inspection confirms Incur writes and returns from its schema branch before generic output truncation.

## Non-obvious affected surfaces

- Machine-output token controls: `--token-count`, `--token-limit`, and `--token-offset` operate on the compact schema index after the internal manifest is parsed; equals forms are normalized before delegation so Incur owns the same validation as separated forms.
- CLI flag routing: schema, help, format, and token-control parsing stop at the positional `--` boundary and preserve final-explicit-value precedence.
- Internal full-manifest fallback: it remains the discovery source, but descendant schemas and examples are not copied into root or group index output.
- Leaf `--schema` requests remain native Incur output and retain passthrough regression proof.

## Architecture and reuse

- Existing systems reused: The schema-index wrapper, Incur full-manifest fallback and option validation, and the already-declared `tokenx` dependency remain the owners for discovery and token estimation.
- New logic: One local projection reduces manifest entries to `name` plus optional `description`; the existing single-pass token-control extraction now also normalizes equals forms for delegation and supplies rendering controls.
- New abstractions: No cross-package abstraction or dependency was added; one local token-control result keeps parsing and delegated argv normalization in the existing owner.
- Complexity intentionally avoided: No second token parser, command registry, manifest format, compatibility layer, LLMS rewrite, persisted state, or background process was introduced.

## Hot reply path impact

- Not applicable: This changes offline CLI discovery output only and does not touch the Foreground Reply Critical Path, database work, provider calls, durable acceptance, or reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable because no prompt assembly, tool schema, generated guidance, or other first provider-visible request surface changed.
- Codex runtime: Not applicable because the compact document is returned only after an agent invokes the CLI; it is not part of the initial provider-visible request.
- Measurement method and exclusions: Static call-path and diff review; no token or byte deltas are reported because neither runtime initial-input surface changed.

## ReviewGPT

ReviewGPT context sensitivity: sensitive
Reason: This changes the public agent-facing CLI machine-output and token-pagination contract.
ReviewGPT first-reviewed head: e6db7cc796a00b2158c64a69663671d3770402a6
Final finding disposition: Rejected as disproven. Current Incur returns from its native `--schema` branch before generic token truncation, and direct CLI proof shows the leaf output stays parseable JSON. The proposed manifest guard would therefore be unreachable defensive code for hypothetical dependency behavior, so it was omitted to preserve the existing single-owner architecture.
Current remediation candidate head: 9e12b8f9c8417cf54f436575e0665b575d106690

## Change-shape breakdown

Classification rule: base-to-head authored lines are grouped by production source, tests and fixtures, documentation and completed plans, config or tooling, and generated or other artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 169 | 14 |
| Tests/fixtures | 349 | 4 |
| Docs | 138 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |

Total: 656 added, 18 deleted. Binary files: none.

## Deployment concerns

- Deployment: not applicable
- Reason: The behavior is local to each CLI process and changes no shared state or cross-component protocol, so mixed CLI versions require no deployment order or compatibility window.

## Changelog

- Changelog: not applicable
- Reason: Agent-facing schema discovery only; no member-visible product behavior or hosted Web UI changes.
