### PR TITLE
Correct AI usage accounting and remove duplicate attachment evidence

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-ai-usage-efficiency.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-ai-usage-efficiency.md
@@ -1,0 +1,127 @@
+# AI usage efficiency
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Make customer-assigned AI usage reflect the model actually served and stop
+  paying repeatedly for identical attachment text, without changing model
+  quality, reasoning, tools, or answer content.
+
+## Success criteria
+
+- Venice regular Luna usage is priced at the current regular Luna rates rather
+  than Luna Pro rates.
+- A deterministic canonical-pricer scenario proves the same allowance funds at
+  least 20% more regular Luna work.
+- Exact duplicate normalized source bodies within one attachment are emitted
+  once, while the first provenance, structured summaries, and every distinct
+  source body remain available.
+- A focused real-Codex attachment journey remains useful, correct, and free of
+  unavailable-attachment claims.
+- Focused tests, affected package typechecks, exact-head review, and required CI
+  pass.
+
+## Scope
+
+- In scope: Venice GPT-5.6 Luna allowance pricing, exact per-attachment evidence
+  deduplication, focused regression and live-assistant proof, and an honest
+  member-facing changelog entry.
+- Out of scope: model downgrades or routing, fuzzy or cross-attachment dedupe,
+  total attachment truncation, ambient project-document policy, provider retry
+  policy, usage-callback reliability, new caches, and new usage infrastructure.
+
+## Constraints
+
+- Technical constraints: preserve the existing allowance pricer as the sole
+  pricing owner; preserve the first duplicate fragment's label and path; add no
+  dependency, state owner, queue, or pricing service.
+- Product/process constraints: do not claim a fleet-wide 20% saving when the
+  proven gains apply to the corrected provider/model scenario and duplicated
+  attachment-evidence slice; keep all verification fixtures synthetic.
+
+## Risks and mitigations
+
+1. Risk: a price update could accidentally change Sol or Terra accounting.
+   Mitigation: keep model-specific cases in the focused provider pricing table
+   and assert every rate and total.
+2. Risk: deduplication could hide genuinely different evidence.
+   Mitigation: dedupe only exact normalized text inside one attachment, retain
+   first provenance, and prove distinct fragments remain.
+3. Risk: lower prompt bytes could make the assistant mishandle a voice memo.
+   Mitigation: compose the production prompt, assert the duplicate appears once,
+   and run the focused real-Codex voice-memo journey.
+
+## Tasks
+
+1. Completed: audited accounting, routing, prompt/context, retries, tool loops,
+   background inference, multimodal, caching, and measurement seams in parallel.
+2. Completed: corrected Venice regular Luna rates and added focused
+   canonical-pricer proof.
+3. Completed: deduplicated exact per-attachment source bodies and strengthened
+   deterministic production-bundle coverage, including clamp and summary
+   collision cases.
+4. Completed: ran focused unit tests, typechecks, the live attachment journey,
+   and measured before/after benchmarks.
+5. Completed: prepared the scoped candidate for the standard commit, draft PR,
+   changelog provenance, exact-head specialist/final review, and required CI
+   workflow that follows plan archival.
+
+## Decisions
+
+- Keep model selection and reasoning unchanged; unit-price correction and exact
+  duplicate removal are the only quality-neutral savings proven above 20%.
+- Reject a total attachment budget in this PR because distinct evidence would
+  need an omission policy. The 32 MiB constant is a read budget, not current
+  provider-visible prompt size; projected fragments are already capped.
+- Leave project-document policy and usage-callback replay to separate changes:
+  the former changes global prompt behavior, while the latter improves
+  accounting completeness rather than customer cost efficiency.
+
+## Product UX
+
+- Effort: Patch.
+- Affected people: a member who selects Luna through Venice, and a member who
+  sends an audio/video attachment whose parser exposes the same transcript in
+  more than one representation.
+- Expected experience: allowance declines at the rate of the model actually
+  served, and Murph answers from the same attachment facts without spending
+  context on repeated copies.
+- Recovery and boundaries: unknown pricing still fails closed through the
+  existing pricer; distinct evidence and separate attachments are unchanged.
+
+## Product UX walkthrough
+
+- Venice Luna: select regular Luna with Venice, complete a turn, and observe
+  regular-Luna allowance pricing with no model or reply change.
+- Duplicate attachment evidence: receive a synthetic voice memo with the same
+  transcript projected inline and through both parser text representations,
+  compose one provider-visible copy, and answer the requested fact without
+  asking for a resend.
+- Result: Ready. The deterministic production-bundle test retained the first
+  transcript and distinct table evidence while reducing three identical
+  6,000-character bodies from 18,000 to 6,000 characters. The focused real-Codex
+  journey answered `Amber lighthouse`, made one provider request, reported no
+  missing usage, and made no resend or unavailable-attachment claim.
+
+## Verification
+
+- `pnpm test -- hosted-execution-usage-allowance.test.ts` in `apps/web`: 119
+  passed. A frozen 1M uncached-input plus 1M output reference workload prices at
+  1,870,000 USD micros instead of 8,750,000, so the same allowance funds 4.679x
+  that exact workload.
+- `pnpm exec vitest run --config vitest.config.ts --no-coverage
+  test/inbox-evidence-projection.test.ts
+  test/assistant-attachment-evidence-model.test.ts` in `packages/assistant-engine`:
+  26 passed. Exact 18,000-to-6,000 character reduction, first provenance,
+  distinct tails, structured summaries, and distinct evidence all passed.
+- `pnpm typecheck` in `packages/assistant-engine` and `apps/web`: both passed.
+- `pnpm test:assistant:live -- --codex-home <AUTHENTICATED_HOME> --test
+  "answers from the admitted voice memo transcript without claiming the memo is
+  unavailable"`: 1 passed, 174 skipped; one provider request, complete usage,
+  and a Ready answer. One earlier authenticated attempt was manually stopped
+  after remaining silent beyond its expected wall time; the final isolated run
+  passed on the production-realistic derived-result fixture.
+Completed: 2026-08-30

--- a/apps/web/changelog/entries/2026-08-30/more-accurate-ai-usage.json
+++ b/apps/web/changelog/entries/2026-08-30/more-accurate-ai-usage.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "more-accurate-ai-usage",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "More accurate AI usage",
+    "summary": "Managed AI usage now reflects the regular Luna model when Luna is selected through Venice, instead of counting the higher Luna Pro rate.",
+    "details": "The selected model, reasoning, and reply behavior are unchanged. Murph also includes exact duplicate attachment text once rather than repeatedly, leaving more of your allowance for useful work.",
+    "relevanceTags": ["assistant", "usage", "reliability"],
+    "sourcePullRequests": [2618]
+  }
+}

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -453,7 +453,7 @@ const HOSTED_AI_USAGE_ALLOWANCE_GPT_56_PRICING_VERSION =
 const HOSTED_AI_USAGE_ALLOWANCE_GPT_56_OPENAI_FLEX_PRICING_VERSION =
   "openai-api-pricing-2026-08-21-gpt-5.6-openai-flex";
 const HOSTED_AI_USAGE_ALLOWANCE_GPT_56_VENICE_PRICING_VERSION =
-  "venice-api-pricing-2026-08-04-gpt-5.6-standard";
+  "venice-api-pricing-2026-08-30-gpt-5.6-standard";
 const HOSTED_AI_USAGE_ALLOWANCE_PRICING_SOURCE =
   "https://openai.com/api/pricing/";
 const HOSTED_AI_USAGE_ALLOWANCE_GPT_56_PRICING_SOURCE =
@@ -624,11 +624,12 @@ const HOSTED_AI_USAGE_ALLOWANCE_VENICE_MODEL_PRICES: Record<
     inputUsdMicrosPerMillionTokens: 3_130_000n,
     outputUsdMicrosPerMillionTokens: 18_750_000n,
   },
+  // The hosted provider maps Luna to regular openai-gpt-56-luna, not Luna Pro.
   "gpt-5.6-luna": {
-    cachedInputUsdMicrosPerMillionTokens: 130_000n,
-    cacheWriteUsdMicrosPerMillionTokens: 1_560_000n,
-    inputUsdMicrosPerMillionTokens: 1_250_000n,
-    outputUsdMicrosPerMillionTokens: 7_500_000n,
+    cachedInputUsdMicrosPerMillionTokens: 30_000n,
+    cacheWriteUsdMicrosPerMillionTokens: 330_000n,
+    inputUsdMicrosPerMillionTokens: 270_000n,
+    outputUsdMicrosPerMillionTokens: 1_600_000n,
   },
 };
 

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -503,14 +503,14 @@ describe("hosted AI usage allowance pricing", () => {
   it("prices Venice GPT-5.6 usage at Venice's official provider rates", () => {
     const cases = [
       {
-        costUsdMicros: 10_440_000n,
+        costUsdMicros: 2_230_000n,
         model: "gpt-5.6-luna",
         providerModel: "openai-gpt-56-luna",
         rates: {
-          cachedInput: "130000",
-          cacheWrite: "1560000",
-          input: "1250000",
-          output: "7500000",
+          cachedInput: "30000",
+          cacheWrite: "330000",
+          input: "270000",
+          output: "1600000",
         },
       },
       {
@@ -559,9 +559,31 @@ describe("hosted AI usage allowance pricing", () => {
           standardCostUsdMicros: testCase.costUsdMicros.toString(),
           tokenPricingBasis: "standard",
         },
-        pricingVersion: "venice-api-pricing-2026-08-04-gpt-5.6-standard",
+        pricingVersion: "venice-api-pricing-2026-08-30-gpt-5.6-standard",
       });
     }
+  });
+
+  it("prices regular Venice Luna without applying Luna Pro rates", () => {
+    expect(priceHostedAiUsageForAllowance({
+      ...BASE_USAGE_RECORD,
+      cachedInputTokens: 0,
+      cacheWriteTokens: 0,
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      providerName: "venice",
+      requestedModel: "gpt-5.6-luna",
+      servedModel: "gpt-5.6-luna",
+      totalTokens: 2_000_000,
+    })).toMatchObject({
+      costUsdMicros: 1_870_000n,
+      counted: true,
+      pricingSnapshot: {
+        providerModel: "openai-gpt-56-luna",
+        standardCostUsdMicros: "1870000",
+      },
+      pricingVersion: "venice-api-pricing-2026-08-30-gpt-5.6-standard",
+    });
   });
 
   it("prices GPT-5.6 Sol tokens at the current Standard and Flex rates", () => {

--- a/packages/assistant-engine/src/inbox-evidence-projection.ts
+++ b/packages/assistant-engine/src/inbox-evidence-projection.ts
@@ -86,6 +86,7 @@ export function projectAttachmentEvidenceForModel(input: {
     sources: input.sources,
   })
   const fragments: ModelEvidenceFragment[] = []
+  const seenSourceTexts = new Set<string>()
 
   for (const source of input.sources) {
     const text = normalizeModelEvidenceText(source.text)
@@ -114,6 +115,11 @@ export function projectAttachmentEvidenceForModel(input: {
     ) {
       continue
     }
+
+    if (seenSourceTexts.has(text)) {
+      continue
+    }
+    seenSourceTexts.add(text)
 
     const clamped = clampText(text, maxFragmentChars)
     fragments.push({

--- a/packages/assistant-engine/test/assistant-attachment-evidence-model.test.ts
+++ b/packages/assistant-engine/test/assistant-attachment-evidence-model.test.ts
@@ -548,6 +548,58 @@ describe('assistant input attachment evidence model materialization', () => {
     expect(bundle.combinedText).toContain('Table cell')
   })
 
+  it('collapses three exact 6,000-character transcript sources to the first', async () => {
+    const vaultRoot = await createTempVaultRoot()
+    const transcript = 'T'.repeat(6_000)
+    const resultPath =
+      'derived/inbox/capture-1/attachments/att-1/attempts/0001/result.json'
+    await writeVaultFile(
+      vaultRoot,
+      resultPath,
+      Buffer.from(JSON.stringify(createParserResult({
+        markdown: transcript,
+        text: transcript,
+      }))),
+    )
+
+    const bundle = await buildAssistantInputAttachmentPromptBundle({
+      attachment: {
+        ...createAttachmentEvidence({
+          kind: 'audio',
+          mime: 'audio/mpeg',
+          rawPath: 'raw/inbox/capture-1/attachments/voice-note.mp3',
+        }),
+        derived: {
+          allowedRoot:
+            'derived/inbox/capture-1/attachments/att-1/attempts/0001',
+          kind: 'parser-result',
+          resultPath,
+        },
+        inlineFragments: [{
+          kind: 'attachment_transcript',
+          label: 'attachment-transcript',
+          text: transcript,
+          truncated: false,
+        }],
+        parseState: 'succeeded',
+      },
+      vaultRoot,
+    })
+
+    expect(transcript).toHaveLength(6_000)
+    expect(bundle.combinedText.split(transcript)).toHaveLength(2)
+    expect(bundle.fragments.filter((fragment) => fragment.text === transcript)).toEqual([
+      {
+        kind: 'attachment_transcript',
+        label: 'attachment-transcript',
+        path: resultPath,
+        text: transcript,
+        truncated: false,
+      },
+    ])
+    expect(bundle.combinedText).toContain('Table cell')
+  })
+
   it('loads parser results sequentially within one per-turn derived evidence budget', async () => {
     const vaultRoot = await createTempVaultRoot()
     const text = 'x'.repeat(8 * 1024 * 1024)

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -625,12 +625,38 @@ describeRealCodex('real Codex voice memo attachment evidence e2e', () => {
         'The synthetic verification phrase is amber lighthouse.',
         'Reply with that two-word phrase.',
       ].join(' ')
+      const parserResultPath =
+        'derived/inbox/capture-voice-evidence/attachments/attachment-voice-evidence/attempts/0001/result.json'
 
       try {
         await initializeVault({
           timezone: 'America/New_York',
           vaultRoot: workingDirectory,
         })
+        const parserResultAbsolutePath = path.join(
+          workingDirectory,
+          parserResultPath,
+        )
+        await mkdir(path.dirname(parserResultAbsolutePath), { recursive: true })
+        await writeFile(parserResultAbsolutePath, JSON.stringify({
+          artifact: {
+            attachmentId: 'attachment-voice-evidence',
+            captureId: 'capture-voice-evidence',
+            fileName: 'voice-note.m4a',
+            kind: 'audio',
+            mime: 'audio/mp4',
+            storedPath:
+              'raw/inbox/capture-voice-evidence/attachments/voice-note.m4a',
+          },
+          blocks: [],
+          createdAt: '2026-08-26T20:00:01.000Z',
+          markdown: transcript,
+          metadata: {},
+          providerId: 'synthetic-transcription',
+          schema: 'murph.parser-output.v1',
+          tables: [],
+          text: transcript,
+        }))
         const promptInput: AssistantAutoReplyPromptInput = {
           actorIsSelf: false,
           attachmentDescriptors: [{
@@ -643,7 +669,11 @@ describeRealCodex('real Codex voice memo attachment evidence e2e', () => {
           attachmentEvidence: {
             attachments: [{
               byteSize: 1_024,
-              derived: null,
+              derived: {
+                allowedRoot: path.posix.dirname(parserResultPath),
+                kind: 'parser-result',
+                resultPath: parserResultPath,
+              },
               descriptorAttachmentId: 'attachment-voice-evidence',
               fileName: 'voice-note.m4a',
               inlineFragments: [{
@@ -700,6 +730,7 @@ describeRealCodex('real Codex voice memo attachment evidence e2e', () => {
           throw new Error(`Expected a ready voice memo prompt, received ${prepared.kind}.`)
         }
         expect(prepared.prompt).toContain(transcript)
+        expect(prepared.prompt.split(transcript)).toHaveLength(2)
 
         const result = await executeRealCodexAppServerTurn({
           approvalPolicy: 'never',

--- a/packages/assistant-engine/test/inbox-evidence-projection.test.ts
+++ b/packages/assistant-engine/test/inbox-evidence-projection.test.ts
@@ -178,4 +178,121 @@ describe('projectAttachmentEvidenceForModel', () => {
     expect(fragments[0]?.text).toContain('[truncated')
     expect(fragments[0]?.text.length).toBeLessThanOrEqual(120)
   })
+
+  it('emits exact duplicate attachment text once and preserves distinct evidence', () => {
+    const repeatedText = 'The synthetic transcript is intentionally duplicated.'
+    const fragments = projectAttachmentEvidenceForModel({
+      attachment: {
+        fileName: 'voice-note.m4a',
+        mime: 'audio/mp4',
+      },
+      sources: [
+        {
+          kind: 'attachment_transcript',
+          label: 'attachment-transcript',
+          path: 'derived/inbox/capture-1/attachment-1/transcript.txt',
+          text: repeatedText,
+        },
+        {
+          kind: 'derived_plain_text',
+          label: 'derived-plain-text',
+          path: 'derived/inbox/capture-1/attachment-1/plain.txt',
+          text: `  ${repeatedText}\n`,
+        },
+        {
+          kind: 'derived_markdown',
+          label: 'derived-markdown',
+          path: 'derived/inbox/capture-1/attachment-1/normalized.md',
+          text: 'A distinct parser note.',
+        },
+      ],
+    })
+
+    expect(fragments).toEqual([
+      {
+        kind: 'attachment_transcript',
+        label: 'attachment-transcript',
+        path: 'derived/inbox/capture-1/attachment-1/transcript.txt',
+        text: repeatedText,
+        truncated: false,
+      },
+      {
+        kind: 'derived_markdown',
+        label: 'derived-markdown',
+        path: 'derived/inbox/capture-1/attachment-1/normalized.md',
+        text: 'A distinct parser note.',
+        truncated: false,
+      },
+    ])
+  })
+
+  it('preserves distinct long sources that clamp to the same visible prefix', () => {
+    const sharedPrefix = 'A'.repeat(500)
+    const fragments = projectAttachmentEvidenceForModel({
+      attachment: {
+        fileName: 'notes.txt',
+        mime: 'text/plain',
+      },
+      maxFragmentChars: 120,
+      sources: [
+        {
+          kind: 'attachment_extracted_text',
+          label: 'first-note',
+          path: 'derived/inbox/capture-1/attachment-1/first.txt',
+          text: `${sharedPrefix}alpha-tail`,
+        },
+        {
+          kind: 'derived_plain_text',
+          label: 'second-note',
+          path: 'derived/inbox/capture-1/attachment-1/second.txt',
+          text: `${sharedPrefix}bravo-tail`,
+        },
+      ],
+    })
+
+    expect(fragments).toHaveLength(2)
+    expect(fragments.map((fragment) => fragment.label)).toEqual([
+      'first-note',
+      'second-note',
+    ])
+  })
+
+  it('retains a structured summary when another source matches its text', () => {
+    const csv = makeCsv(125)
+    const csvSource = {
+      kind: 'attachment_extracted_text' as const,
+      label: 'attachment-extracted-text',
+      path: 'derived/inbox/capture-1/attachment-1/plain.txt',
+      text: csv,
+    }
+    const summary = projectAttachmentEvidenceForModel({
+      attachment: {
+        fileName: 'readings.csv',
+        mime: 'text/csv',
+      },
+      sources: [csvSource],
+    })[0]
+
+    expect(summary?.kind).toBe('attachment_tabular_summary')
+    const fragments = projectAttachmentEvidenceForModel({
+      attachment: {
+        fileName: 'readings.csv',
+        mime: 'text/csv',
+      },
+      sources: [
+        {
+          kind: 'attachment_transcript',
+          label: 'attachment-transcript',
+          path: null,
+          text: summary?.text,
+        },
+        csvSource,
+      ],
+    })
+
+    expect(fragments.map((fragment) => fragment.kind)).toEqual([
+      'attachment_transcript',
+      'attachment_tabular_summary',
+    ])
+  })
 })


### PR DESCRIPTION
## Outcome

- Prices regular Venice Luna usage at the regular Luna rate actually served instead of the Luna Pro rate.
- Emits repeated normalized attachment source bodies once per attachment while retaining the first provenance, structured summaries, and distinct evidence.

## Product UX result

Ready. Allowance now declines at the selected model rate, and a production-realistic voice-memo journey still answers from the attachment without asking for a resend.

## Direct evidence

- Hosted allowance pricing: 119 tests passed.
- Assistant evidence projection and production bundle: 26 tests passed.
- Changelog page: 9 tests passed.
- Assistant-engine and hosted Web typechecks passed.
- Real-Codex voice-memo journey: 1 provider request, complete usage telemetry, exact requested answer, and no unavailable or resend claim.
- Frozen 1M uncached-input plus 1M output reference workload: 8,750,000 to 1,870,000 USD micros, a 78.63% reduction and 4.679x capacity for that workload.
- Three identical 6,000-character source bodies: 18,000 to 6,000 provider-visible characters, a 66.67% reduction and 3x capacity for that evidence slice.

## Non-obvious affected surfaces

- Hosted usage allowance pricing snapshots for Venice Luna.
- Audio and video attachment evidence projection, including inline transcripts and parser result text.
- Structured attachment summaries and long-fragment clamping remain unchanged and have explicit collision coverage.

## Architecture and reuse

- Existing systems reused: the canonical hosted allowance pricer and the existing attachment evidence projector.
- New logic: one corrected provider price row and one invocation-local exact normalized text lookup.
- New abstractions: None; the existing price and projection owners already cover both changes, so an additional abstraction would add no boundary or reuse.
- Complexity intentionally avoided: no price service, dependency, cache, queue, state owner, model router, fuzzy matching, or cross-attachment policy.

## Hot reply path impact

One bounded exact-text lookup is added per existing attachment source. Duplicate prompt content is removed before the provider call; there is no new I/O or model work.

## Provider input impact

Only exact normalized duplicate source bodies within one attachment are removed. Fuzzy matching, cross-attachment dedupe, structured summaries, distinct long tails, model selection, reasoning, tools, and reply policy are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Both runtime changes are independently backward-compatible; mixed-version operation only delays one benefit and does not break or degrade a flow.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · more-accurate-ai-usage

added the member-facing More accurate AI usage entry with sourcePullRequests [2618]. The changelog page test passes.

## LOC breakdown

- Source: +12 / -5
- Tests and fixtures: +229 / -7
- Docs and changelog: +141 / -0
- Config and tooling: +0 / -0
- Generated and other: +0 / -0

ReviewGPT context sensitivity: sensitive - changes customer allowance accounting and provider-visible attachment input.

ReviewGPT first-reviewed head: 9dc42ef16bafc321936806f73311faeba5eb8519




