### PR TITLE
test(runtime): align abort lifecycle expectations

### DIFF
--- a/apps/cloudflare/test/container-entrypoint-abort.test.ts
+++ b/apps/cloudflare/test/container-entrypoint-abort.test.ts
@@ -394,7 +394,8 @@ describe("container entrypoint abort boundary", () => {
         poisoned: false,
       });
     });
-    expect(stopWarmCodex).not.toHaveBeenCalled();
+    expect(stopWarmCodex).toHaveBeenCalledTimes(1);
+    expect(stopWarmCodex).toHaveBeenCalledWith("hosted-workspace-restore");
 
     const replacement = await fetch(
       `http://127.0.0.1:${address.port}/internal/workspace-invocation`,
@@ -408,6 +409,11 @@ describe("container entrypoint abort boundary", () => {
     );
     expect(replacement.status).toBe(200);
     expect(mocks.runHostedWorkspaceInvocation).toHaveBeenCalledTimes(2);
+    expect(stopWarmCodex).toHaveBeenCalledTimes(2);
+    expect(stopWarmCodex).toHaveBeenNthCalledWith(
+      2,
+      "hosted-workspace-restore",
+    );
   });
 
   it("releases a preempted invocation without waiting for heavy hydration", async () => {
@@ -508,7 +514,8 @@ describe("container entrypoint abort boundary", () => {
       poisoned: false,
     });
     expect(mocks.runHostedWorkspaceInvocation).not.toHaveBeenCalled();
-    expect(stopWarmCodex).not.toHaveBeenCalled();
+    expect(stopWarmCodex).toHaveBeenCalledTimes(1);
+    expect(stopWarmCodex).toHaveBeenCalledWith("hosted-workspace-restore");
   });
 
   it("rejects replacement invocations until an aborted workspace invocation settles", async () => {


### PR DESCRIPTION
## Outcome

Align the two abort-path assertions with the already-merged mandatory pre-restore Codex stop. This is test-only and unblocks the protected production deploy; no production source or behavior changes.

ReviewGPT context sensitivity: routine — test expectations only.

## Product UX

- Effort: Patch
- Outcome: No user-facing behavior change; restores continue to stop the old Codex process before replacing its workspace.
- Reaches: Hosted runtime deploy verification only.
- Proof: Full abort-boundary test file passes.

## Evidence

- apps/cloudflare/test/container-entrypoint-abort.test.ts: 6/6 pass.
- The two affected cases each prove exactly one pre-restore stop with reason hosted-workspace-restore; the replacement invocation proves its own second pre-restore stop.
- git diff --check passes.

## Non-obvious affected surfaces

The assertions still prove abort does not add a second post-abort teardown. They now separately account for the required predecessor stop added by the merged lifecycle fix.

## Architecture and reuse

- Existing systems reused: the existing injected stopWarmCodex lifecycle seam and abort-boundary tests.
- New logic: none; assertions now count the already-merged pre-restore stop.
- New abstractions: none, because the existing lifecycle seam and test harness already express the boundary.
- Complexity intentionally avoided: no production branch, retry, teardown path, state owner, or compatibility shim.

## Hot reply path impact

None; test-only.

## Murph initial provider input impact

None; test-only.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 9 | 2 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 9 | 2 |

## Deployment concerns

- Deployment: not applicable
- Reason: This PR changes test expectations only; the already-merged runtime fix still deploys separately through the protected Cloudflare workflow.

## Changelog

- Changelog: not applicable
- Reason: Test-only expectation correction; the user-visible recovery is already documented by PR #2617.