### PR TITLE
fix(hosted): preserve Linq prewarm attribution

### DIFF
--- a/.agents/friction-log/20260830195008-linq-webhook-e2e/friction.md
+++ b/.agents/friction-log/20260830195008-linq-webhook-e2e/friction.md
@@ -5,7 +5,7 @@ severity: 'minor'
 
 ## Expected Behavior
 
-Every synthetic Linq webhook member created by the hosted-local scenario is admitted by the scenario's generated local inbound allowlist.
+Every member label accepted by the hosted-local Linq webhook factory is represented in the scenario's generated local inbound allowlist.
 
 ## Current Behavior
 

--- a/.agents/friction-log/20260830195008-linq-webhook-e2e/friction.md
+++ b/.agents/friction-log/20260830195008-linq-webhook-e2e/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Linq webhook E2E member labels can drift from local inbound allowlist'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Every synthetic Linq webhook member created by the hosted-local scenario is admitted by the scenario's generated local inbound allowlist.
+
+## Current Behavior
+
+The member labels used by the tests and the labels used to build the allowlist are separate string lists. Adding a test with a new label can leave its generated phone absent from the allowlist, so the webhook is correctly ignored before the behavior under test runs.
+
+## Possible Solution
+
+Use one typed label tuple for both member creation and allowlist generation.
+
+## Minimal Reproducible Example
+
+Add a hosted-local webhook case that calls `createActiveLinqWebhookMember("synthetic-case")` without separately adding `synthetic-case` to the allowlist builder, then run the Linq webhook E2E.
+
+## Context
+
+This drift made the cross-repository integration aggregate fail after an otherwise independent public-main change.

--- a/apps/cloudflare/test/hosted-local-linq-webhook-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-linq-webhook-e2e.test.ts
@@ -46,6 +46,17 @@ const hostedLinqParticipantAddedDetailedContext =
 const linqWebhookRunId = Date.now();
 const hostedLinqGroupIsolationGuestUserId =
   `member_local_linq_webhook_group_isolation_guest_${linqWebhookRunId}`;
+const linqWebhookMemberLabels = [
+  "reply",
+  "message-routing-prewarm",
+  "app-card",
+  "typing-prewarm",
+  "rapid",
+  "group-isolation",
+  "pdf",
+  "image",
+] as const;
+type LinqWebhookMemberLabel = (typeof linqWebhookMemberLabels)[number];
 
 const streamDevLogs = process.env.MURPH_E2E_STREAM_DEV_LOGS === "1";
 const workerPersistDirOverride = process.env.MURPH_E2E_CF_PERSIST_DIR?.trim() || null;
@@ -53,7 +64,7 @@ const localDatabaseUrl = process.env.DATABASE_URL?.trim() || undefined;
 
 let linqStub: HostedLocalLinqStub | null = null;
 let scenario: HostedLocalFullStackScenario | null = null;
-const linqWebhookMemberCountersByLabel = new Map<string, number>();
+const linqWebhookMemberCountersByLabel = new Map<LinqWebhookMemberLabel, number>();
 
 interface ActiveLinqWebhookMember {
   chatId: string;
@@ -1357,7 +1368,9 @@ async function activateLinqWebhookMember(userId: string): Promise<ActiveLinqWebh
   };
 }
 
-async function createActiveLinqWebhookMember(label: string): Promise<ActiveLinqWebhookMember> {
+async function createActiveLinqWebhookMember(
+  label: LinqWebhookMemberLabel,
+): Promise<ActiveLinqWebhookMember> {
   const labelCounter = (linqWebhookMemberCountersByLabel.get(label) ?? 0) + 1;
   linqWebhookMemberCountersByLabel.set(label, labelCounter);
   const userId = `member_local_linq_webhook_${label}_${linqWebhookRunId}_${labelCounter}`;
@@ -1414,20 +1427,11 @@ function buildLinqWebhookScenarioEnv(linq: HostedLocalLinqStub): NodeJS.ProcessE
 }
 
 function buildLinqWebhookLocalInboundAllowlist(): string {
-  const memberPhones = [
-    "reply",
-    "app-card",
-    "typing-prewarm",
-    "rapid",
-    "group-isolation",
-    "pdf",
-    "image",
-  ]
-    .map((label) =>
-      buildLinqRecipientPhoneNumber(
-        `member_local_linq_webhook_${label}_${linqWebhookRunId}_1`,
-      )
-    );
+  const memberPhones = linqWebhookMemberLabels.map((label) =>
+    buildLinqRecipientPhoneNumber(
+      `member_local_linq_webhook_${label}_${linqWebhookRunId}_1`,
+    )
+  );
   return [
     ...memberPhones,
     buildLinqRecipientPhoneNumber(hostedLinqGroupIsolationGuestUserId),

--- a/apps/web/src/lib/hosted-runtime-latency/store.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/store.ts
@@ -1030,6 +1030,10 @@ function buildHostedIngressLatencySanitizedJsonObjectSql(
             THEN jsonb_typeof(leaf.value) = 'string'
               AND (leaf.value #>> '{}')
                 ~ '^web-ingress-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            WHEN 'shell_prewarm_attempt_id'
+            THEN jsonb_typeof(leaf.value) = 'string'
+              AND (leaf.value #>> '{}')
+                ~ '^web-prewarm-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
             WHEN 'opaque_identifier'
             THEN jsonb_typeof(leaf.value) = 'string'
               AND length(leaf.value #>> '{}') <= 192

--- a/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
@@ -793,7 +793,11 @@ describe.skipIf(!runPostgresProof)(
           orchestration: {
             runtimeInvocationOrchestrationAttemptId:
               "web-ingress-123e4567-e89b-42d3-a456-426614174000",
+            shellPrewarmExpectedOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
             shellPrewarmFirstHintAtEpochMs: 1_775_908_800_001,
+            shellPrewarmOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
             shellPrewarmOutcome: "start_issued_warm",
             shellPrewarmSource: "linq-typing-started",
             triggeredByWebDirect: true,
@@ -803,6 +807,12 @@ describe.skipIf(!runPostgresProof)(
           schemaVersion: 1,
         });
         expect(requireJsonRecord(providerRows[1]?.phaseBreakdownJson)).toEqual({
+          orchestration: {
+            shellPrewarmExpectedOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+            shellPrewarmOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+          },
           preProvider: { outboxScanPerformed: true },
           provider: { sessionResolveMs: 10 },
           schemaVersion: 1,
@@ -906,9 +916,8 @@ describe.skipIf(!runPostgresProof)(
           where: { assistantInputId: { in: assistantInputIds } },
         });
         for (const row of ordinaryRows) {
-          const assistant = requireJsonRecord(
-            requireJsonRecord(row.phaseBreakdownJson).assistant,
-          );
+          const phaseBreakdown = requireJsonRecord(row.phaseBreakdownJson);
+          const assistant = requireJsonRecord(phaseBreakdown.assistant);
           expect(assistant).toMatchObject({
             firstCodexOutputObservedAtEpochMs: firstOutputAt.getTime(),
             linqTypingAcceptedAtEpochMs: new Date(
@@ -918,6 +927,12 @@ describe.skipIf(!runPostgresProof)(
               "2026-08-09T12:00:50.000Z",
             ).getTime(),
             progressUpdateAcceptedAtEpochMs: earliestProgressAt.getTime(),
+          });
+          expect(requireJsonRecord(phaseBreakdown.orchestration)).toMatchObject({
+            shellPrewarmExpectedOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+            shellPrewarmOrchestrationAttemptId:
+              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
           });
         }
 
@@ -1250,7 +1265,11 @@ async function createLatencySetWriteFixture(
               directEnsureOrchestrationAttemptId: "wrong-type",
               runtimeInvocationOrchestrationAttemptId:
                 "web-ingress-123e4567-e89b-42d3-a456-426614174000",
+              shellPrewarmExpectedOrchestrationAttemptId:
+                "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
               shellPrewarmFirstHintAtEpochMs: 1_775_908_800_001,
+              shellPrewarmOrchestrationAttemptId:
+                "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
               shellPrewarmOutcome: "start_issued_warm",
               shellPrewarmSource: "linq-typing-started",
               triggeredByWebDirect: true,
@@ -1265,7 +1284,13 @@ async function createLatencySetWriteFixture(
           }
         : index === 1
           ? {
-              orchestration: { shellPrewarmOutcome: "wrong-type" },
+              orchestration: {
+                shellPrewarmExpectedOrchestrationAttemptId:
+                  "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+                shellPrewarmOrchestrationAttemptId:
+                  "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+                shellPrewarmOutcome: "wrong-type",
+              },
               schemaVersion: 1,
             }
           : undefined,

--- a/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
@@ -807,12 +807,6 @@ describe.skipIf(!runPostgresProof)(
           schemaVersion: 1,
         });
         expect(requireJsonRecord(providerRows[1]?.phaseBreakdownJson)).toEqual({
-          orchestration: {
-            shellPrewarmExpectedOrchestrationAttemptId:
-              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
-            shellPrewarmOrchestrationAttemptId:
-              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
-          },
           preProvider: { outboxScanPerformed: true },
           provider: { sessionResolveMs: 10 },
           schemaVersion: 1,
@@ -912,7 +906,7 @@ describe.skipIf(!runPostgresProof)(
         ]);
 
         const ordinaryRows = await observer.hostedIngressLatencyTrace.findMany({
-          select: { phaseBreakdownJson: true },
+          select: { assistantInputId: true, phaseBreakdownJson: true },
           where: { assistantInputId: { in: assistantInputIds } },
         });
         for (const row of ordinaryRows) {
@@ -928,12 +922,16 @@ describe.skipIf(!runPostgresProof)(
             ).getTime(),
             progressUpdateAcceptedAtEpochMs: earliestProgressAt.getTime(),
           });
-          expect(requireJsonRecord(phaseBreakdown.orchestration)).toMatchObject({
-            shellPrewarmExpectedOrchestrationAttemptId:
-              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
-            shellPrewarmOrchestrationAttemptId:
-              "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
-          });
+          if (row.assistantInputId === assistantInputIds[0]) {
+            expect(requireJsonRecord(phaseBreakdown.orchestration)).toMatchObject({
+              shellPrewarmExpectedOrchestrationAttemptId:
+                "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+              shellPrewarmOrchestrationAttemptId:
+                "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+            });
+          } else {
+            expect(phaseBreakdown.orchestration).toBeUndefined();
+          }
         }
 
         const terminalAt = new Date("2026-08-09T12:01:00.000Z");
@@ -1286,9 +1284,9 @@ async function createLatencySetWriteFixture(
           ? {
               orchestration: {
                 shellPrewarmExpectedOrchestrationAttemptId:
-                  "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+                  "web-prewarm-not-a-uuid",
                 shellPrewarmOrchestrationAttemptId:
-                  "web-prewarm-123e4567-e89b-42d3-a456-426614174000",
+                  "web-prewarm-123e4567-e89b-12d3-a456-426614174000",
                 shellPrewarmOutcome: "wrong-type",
               },
               schemaVersion: 1,

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -14,6 +14,7 @@ import {
   type HostedIngressLatencyDashboardInput,
 } from "@/src/lib/hosted-runtime-latency/store";
 import {
+  HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_RULES,
   HOSTED_RUNTIME_LATENCY_TRACE_ASSISTANT_INPUT_MAX_IDS,
 } from "@murphai/hosted-execution/runtime-control";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -2557,6 +2558,14 @@ describe("hosted runtime latency dashboard store", () => {
       wake: { foregroundImportStartedAtEpochMs: 1_777_000_001_011 },
     });
     const setBasedSql = prisma.readSetBasedMutationSql().join("\n");
+    const sharedRuleKinds = new Set(
+      Object.values(HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_RULES)
+        .flatMap((phaseRules) => Object.values(phaseRules))
+        .map((rule) => rule.kind),
+    );
+    for (const ruleKind of sharedRuleKinds) {
+      expect(setBasedSql).toContain(`WHEN '${ruleKind}'`);
+    }
     expect(setBasedSql).toContain("WHEN 'opaque_identifier'");
     expect(setBasedSql).toContain("length(leaf.value #>> '{}') <= 192");
     expect(setBasedSql).toContain("~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'");


### PR DESCRIPTION
## Why and outcome

A new Linq message-routing E2E member was omitted from its generated local inbound allowlist, so the safety guard correctly stopped the journey before prewarm. Once admitted, later PostgreSQL latency updates exposed a second defect: the shared sanitizer dropped the two new shell-prewarm correlation IDs.

This uses one typed E2E member-label source and teaches the existing Web latency sanitizer the canonical shell-prewarm attempt-ID rule, preserving causal attribution without weakening ingress or adding runtime machinery.

## Product UX

Not applicable. This is internal hosted-runtime diagnostics and test-fixture repair; member-visible messaging, states, and behavior are unchanged.

## Evidence

- Focused local PostgreSQL proof: 1 passed, 4 skipped in hosted-runtime-latency-postgres-concurrency.test.ts; valid UUIDv4 IDs survive both set writers while malformed IDs are removed.
- Focused latency-store unit proof: 39 passed, including exhaustive shared-rule/generated-SQL parity.
- Web package typecheck passed.
- Cloudflare package typecheck passed.
- The original integration failure was reproduced through the local inbound guard; after the fixture correction, the focused Linq journey reached the persisted prewarm-attribution assertion and exposed the sanitizer loss.
- [Full paired public/private integration](https://github.com/cobuildwithus/murph-cloud/actions/runs/33351432315) passed against the exact reviewed runtime candidate, including the Linq webhook media/device-connect journey. The current head adds only the accepted test-boundary assertions; runtime source is unchanged.
- Preliminary coverage findings are resolved: the composed journey is proven by the paired run, and the PostgreSQL regression now covers malformed shell-prewarm IDs. No accepted finding remains unresolved.
- Final ReviewGPT round 1 passed on the immutable first-reviewed head.

## Non-obvious affected surfaces

- Web-hosted ingress latency trace persistence: provider-start and assistant-milestone set writes re-sanitize existing phase JSON. The PostgreSQL regression proves both shell-prewarm IDs now survive both writers.
- Hosted-local Linq ingress admission: test members and their generated allowlist now share one typed label tuple. Production admission rules are unchanged.

## Architecture and reuse

- Existing systems reused: the existing latency leaf-rule taxonomy, set-based PostgreSQL sanitizer, Linq E2E member factory, and local inbound allowlist builder.
- New logic: one missing SQL CASE for canonical web-prewarm UUIDv4 IDs.
- New abstractions: one readonly test-label tuple whose inferred union constrains member creation.
- Complexity intentionally avoided: no compatibility layer, new state owner, alternate sanitizer, or weakened ingress guard.

## Hot reply path impact

The existing provider-start and assistant-milestone trace updates remain on their current path. This adds zero database or network calls and changes no ordering, timeout, retry, or fallback behavior; the same single set-based statement now retains two already-validated diagnostic leaves. The focused PostgreSQL proof covers the before-failing and after-preserved behavior.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool schema, model request, or generated guidance changed.
- Codex runtime: Not applicable; no prompt, tool schema, model request, or generated guidance changed.

## Change-shape breakdown

Classification is by file purpose; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 0 |
| Tests/fixtures | 57 | 21 |
| Docs | 24 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 85 | 21 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing readers already accept traces with these optional IDs present or absent; no cross-service wire or schema shape changes.
- Safe order: Web may deploy independently; Worker, container, and private Temporal require no change.
- Rollback floor: None beyond the existing Web schema; rollback affects optional diagnostic completeness only.
- Expected exposure: During Web rollout, older instances may still drop the IDs on later trace merges.
- Reversibility: Revert the Web change; no migration or backfill is required.
- Convergence proof: A newly completed message-routing trace retains equal expected and observed prewarm IDs after provider and assistant updates.
- Post-deploy checks: Confirm new message-routing traces retain both prewarm IDs and show no sanitizer persistence errors.

## Changelog

- Changelog: not applicable
- Reason: This repairs internal CI fixture ownership and diagnostic persistence without changing member-visible behavior.

ReviewGPT context sensitivity: sensitive
Reason: the production diff touches persisted hosted-runtime diagnostics on the foreground reply path.

ReviewGPT first-reviewed head: 1c273f37b810a4a45407691e32e05e662d321476
