### PR TITLE
Refactor Settings page assembly

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-settings-page-complexity.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-settings-page-complexity.md
@@ -1,0 +1,119 @@
+# Refactor Settings page complexity
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Reduce the cyclomatic complexity and responsibility density of the Settings
+  server page while preserving every existing member-visible setting, state,
+  redirect, and responsive rendering contract.
+
+## Success criteria
+
+- `SettingsPage` has substantially lower cyclomatic complexity than the
+  measured baseline of 262, with cohesive extracted helpers that remain easy
+  to test and review.
+- Existing Settings page tests pass without weakening their assertions.
+- Web typecheck and focused lint pass, or any unrelated blocker is recorded
+  with the narrowest truthful fallback proof.
+- Phone and desktop walkthrough evidence shows the same settings hierarchy,
+  controls, states, accessibility semantics, and responsive layout.
+- The complete privacy-inspected diff is committed, pushed, and opened as a
+  draft PR with the required product, architecture, deployment, LOC, and design
+  proof fields.
+
+## Scope
+
+- In scope: `apps/web/app/(dashboard)/settings/page.tsx`, directly necessary
+  server-only helper modules, and directly relevant Settings page tests.
+- Out of scope: product or visual redesign, billing/device/group/family/privacy
+  behavior changes, new shared component frameworks, dependencies, schema or
+  deployment changes, and unrelated cleanup.
+
+## Constraints
+
+- Technical constraints: preserve the React Server Component boundary,
+  metadata, authorization, data-fetch semantics and ordering, redirects,
+  rendered output, accessibility, responsive layout, and every billing,
+  usage-credit, family, group, account, device, consent, and privacy state.
+- Product/process constraints: Product UX effort is an internal refactor with
+  no intended experience change; use an existing design representation and
+  prove current phone and desktop behavior directly. Treat the required
+  ReviewGPT implementation patch as untrusted input and apply only accepted,
+  privacy-safe intent.
+
+## Risks and mitigations
+
+1. Risk: extraction can accidentally change null/undefined precedence or the
+   order in which auth, redirects, and member data are resolved.
+   Mitigation: preserve the existing top-level control flow, use explicit
+   typed inputs, inspect each moved expression, and run the focused route tests.
+2. Risk: splitting the JSX can alter HTML order, client serialization, anchors,
+   or conditional visibility.
+   Mitigation: extract cohesive server render sections without new wrappers,
+   compare static markup through existing tests, and walk the current route at
+   phone and desktop widths.
+3. Risk: an attractive abstraction can spread product-specific conditionals
+   into a generic framework.
+   Mitigation: keep helpers local and concrete, add no dependency, and prefer
+   deletion or direct derivation over framework-like indirection.
+
+## Tasks
+
+1. Read repository guidance, inspect existing design representation and focused
+   Settings tests, run Frog, and capture the baseline complexity.
+2. Launch the assigned ReviewGPT implementation lane and inspect its response
+   and downloadable patch as untrusted input.
+3. Trace `SettingsPage` inputs, derived state, and render sections; implement
+   the smallest accepted behavior-preserving extraction.
+4. Run focused tests, Web typecheck/lint, complexity measurement, and direct
+   phone/desktop design proof; remediate only in-scope failures.
+5. Inspect the complete diff for behavior, privacy, identifiers, and generated
+   residue, then finish the plan into a scoped commit.
+6. Push the exact head and open a complete draft PR; leave Ready and completion
+   PR gates to the parent coordinator.
+
+## Decisions
+
+- Product UX classification: internal refactor; no user-visible Product UX
+  change is intended. Outcome is unchanged, reaches the existing authenticated
+  Settings journey, and proof is focused route tests plus phone/desktop render
+  comparison.
+- The existing `/settings` production route is the reviewer-openable design
+  representation unless inspection reveals a more specific existing catalog
+  anchor; no synthetic study is warranted for unchanged presentation.
+- The inherited ReviewGPT patch described seven extraction paths. The applied
+  diff contains those seven helpers plus one additional behavior-preserving
+  collapse of duplicated privacy JSX. The collapse retains the same section
+  order, copy, classes, fragment-free DOM, and explicit true/false
+  `authorizationEnabled` value; existing tests cover both Privy states.
+- Changelog is not applicable because the refactor has no member-visible
+  outcome, copy, state, or interaction change.
+
+## Verification
+
+- Commands to run: focused `settings-page.test.ts`, Web typecheck, focused lint,
+  comparable cyclomatic counter, diff/privacy inspection, and browser or
+  equivalent static-render walkthrough at phone and desktop widths.
+- Expected outcomes: all focused behavior contracts pass, the source typechecks
+  and lints, owner complexity drops substantially with bounded helper
+  complexity, and no rendered or product behavior changes are observed.
+- Completed evidence:
+  - exact cyclomatic counter: `SettingsPage` 262 before and 13 after; maximum
+    extracted-helper complexity 60 (`resolveSettingsUsagePresentation`)
+  - focused Settings page suite: 66 tests passed
+  - focused ESLint and Web `typecheck:prepared`: passed
+  - frontend design-proof guard: 12 tests passed
+  - browser walkthrough: the existing health-data consent Settings surface
+    passed at 320, 390, and 1440 pixels with its actions aligned and contained
+  - diff-aware verification completed dependency, workspace-boundary,
+    Temporal, crypto, raw-log, provider-boundary, and Web typecheck phases; its
+    optional full Web suite was stopped without a reported failure to
+    prioritize the draft-PR handoff after the focused owner proof was green
+  - AST comparison confirmed `readSettingsPageData` is unchanged apart from
+    its location; manual diff review confirmed auth, redirect, billing,
+    Family, usage, privacy, JSX order, copy, classes, and responsive contracts
+  - `git diff --check` and privacy/identifier inspection passed
+Completed: 2026-08-30

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -131,60 +131,32 @@ export default async function SettingsPage({
   searchParams: Promise<SettingsSearchParams>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const familyInviteReturnPath = parseHostedFamilyInviteReturnPath(
-    readOnlySearchParamValue(
-      resolvedSearchParams[HOSTED_FAMILY_INVITE_RETURN_PARAM],
-    ),
-  );
-  const openEmailLink =
-    readFirstSearchParamValue(resolvedSearchParams.addEmail) === "true";
-  const addUsageTarget = readOnlySearchParamValue(resolvedSearchParams.addUsage);
-  const openPersonalUsageTopUp = addUsageTarget === "true";
-  const requestedFamilyOwnerUsageTopUp = addUsageTarget === "family";
-  const familyRecoveryRequested = hasExactSettingsSearchParam(
-    resolvedSearchParams,
-    "familyRecovery",
-    "true",
-  );
-  const usageRecoveryInitialOpen = hasExactSettingsSearchParam(
-    resolvedSearchParams,
-    "usageRecovery",
-    "true",
-  );
-  const openVoiceLink =
-    readFirstSearchParamValue(resolvedSearchParams.voice) === "true";
-  const usageTopUpPurchaseReturn = readUsageTopUpPurchaseReturn(
-    resolvedSearchParams,
-  );
-  const groupPaymentMethodSaved =
-    readFirstSearchParamValue(
-      resolvedSearchParams[HOSTED_START_PAID_GROUP_RETURN_PARAM],
-    ) === HOSTED_START_PAID_GROUP_RETURN_VALUE;
-  const planChangeReturn = parseHostedBillingPlanChangeReturnValue(
-    readOnlySearchParamValue(resolvedSearchParams.planUpdate),
-  );
+  const request = resolveSettingsPageRequest(resolvedSearchParams);
   const { authenticated, authenticatedMember, session } =
     await getHostedDashboardPageAuthSnapshot();
   if (!authenticated) {
     if (
-      familyInviteReturnPath === null
-      && !groupPaymentMethodSaved
-      && planChangeReturn === null
-      && usageTopUpPurchaseReturn === null
-      && !familyRecoveryRequested
-      && !usageRecoveryInitialOpen
+      request.familyInviteReturnPath === null
+      && !request.groupPaymentMethodSaved
+      && request.planChangeReturn === null
+      && request.usageTopUpPurchaseReturn === null
+      && !request.familyRecoveryRequested
+      && !request.usageRecoveryInitialOpen
     ) {
       redirect("/");
     }
     return (
       <SettingsAuthRequired
-        familyRecovery={familyRecoveryRequested}
-        usageRecovery={usageRecoveryInitialOpen}
+        familyRecovery={request.familyRecoveryRequested}
+        usageRecovery={request.usageRecoveryInitialOpen}
       />
     );
   }
 
-  if (planChangeReturn === HOSTED_BILLING_PLAN_CHANGE_CANCELED_RETURN_VALUE) {
+  if (
+    request.planChangeReturn
+      === HOSTED_BILLING_PLAN_CHANGE_CANCELED_RETURN_VALUE
+  ) {
     redirect("/settings#subscription");
   }
 
@@ -194,341 +166,149 @@ export default async function SettingsPage({
         memberId: authenticatedMember.id,
         prisma,
         privyUserId: session?.privyUserId,
-        usageReturnPurchaseId: usageTopUpPurchaseReturn?.purchaseId ?? null,
+        usageReturnPurchaseId:
+          request.usageTopUpPurchaseReturn?.purchaseId ?? null,
       })
     : null;
-  const settingsSnapshot = settingsData?.settingsSnapshot ?? null;
-  const consentStatus = settingsData?.consentStatus ?? null;
-  const freshPrivySession = settingsData?.freshPrivySession ?? null;
-  const familyOwner = settingsData?.familyOwner ?? null;
-  const familyDraftRecovery = settingsData?.familyDraftRecovery ?? null;
-  const familyAccess = settingsData?.familyAccess ?? null;
-  const secureApprovalStatus =
-    settingsData?.secureApprovalStatus ?? ({ status: "unavailable" } as const);
-  const usageStatus = settingsData?.usageStatus ?? null;
-  const hasConfirmedGroupMembership =
-    settingsData?.hasConfirmedGroupMembership === true;
-  const usageActivity = settingsData?.usageActivity ?? null;
-  const usageTopUpOfferCodes = settingsData?.usageTopUpOfferCodes ?? [];
-  const usageTopUpActivePurchase = settingsData?.usageTopUpActivePurchase ?? null;
-  const usageTopUpReturnTarget = settingsData?.usageTopUpReturnTarget ?? null;
-  const inferenceConnection = settingsData?.inferenceConnection ?? null;
+  return renderAuthenticatedSettingsPage({
+    authenticated,
+    authenticatedMember,
+    request,
+    session,
+    settingsData,
+  });
+}
+
+type HostedDashboardPageAuthSnapshot = Awaited<
+  ReturnType<typeof getHostedDashboardPageAuthSnapshot>
+>;
+
+function renderAuthenticatedSettingsPage(input: {
+  authenticated: boolean;
+  authenticatedMember: HostedDashboardPageAuthSnapshot["authenticatedMember"];
+  request: ReturnType<typeof resolveSettingsPageRequest>;
+  session: HostedDashboardPageAuthSnapshot["session"];
+  settingsData: Awaited<ReturnType<typeof readSettingsPageData>> | null;
+}) {
+  const {
+    authenticated,
+    authenticatedMember,
+    request: {
+      familyInviteReturnPath,
+      groupPaymentMethodSaved,
+      openEmailLink,
+      openPersonalUsageTopUp,
+      openVoiceLink,
+      planChangeReturn,
+      requestedFamilyOwnerUsageTopUp,
+      resolvedSearchParams,
+      usageRecoveryInitialOpen,
+      usageTopUpPurchaseReturn,
+    },
+    session,
+    settingsData,
+  } = input;
+  const {
+    consentStatus,
+    familyAccess,
+    familyDraftRecovery,
+    familyOwner,
+    freshPrivySession,
+    hasConfirmedGroupMembership,
+    inferenceConnection,
+    secureApprovalStatus,
+    settingsSnapshot,
+    usageActivity,
+    usageStatus,
+    usageTopUpActivePurchase,
+    usageTopUpOfferCodes,
+    usageTopUpReturnTarget,
+  } = normalizeSettingsPageData(settingsData);
   const account = settingsSnapshot?.account ?? null;
   const billingRef = settingsSnapshot?.billingRef ?? null;
   const routing = settingsSnapshot?.routing ?? null;
-  const activeFamilyOwner = familyOwner?.billingActive === true;
-  const familyBillingOwner = familyOwner !== null
-    && isHostedFamilyBillingPortalManageable(familyOwner.billingStatus);
-  const familyOwnerUsageTopUpMember =
-    resolveActiveFamilyOwnerUsageTopUpMember(familyOwner);
-  const sponsoredMember = familyAccess !== null && familyOwner === null;
-  const familyRecurringUpgradeAvailable =
-    activeFamilyOwner && hasHigherHostedFamilyOwnerTier(familyOwner);
-  const usageTopUpOffers = usageTopUpActivePurchase
-    ? []
-    : projectHostedUsageTopUpOffers(usageTopUpOfferCodes);
-  const familyUsageTopUpOffers = activeFamilyOwner && !usageTopUpActivePurchase
-    ? projectHostedUsageTopUpOffers(readHostedConfiguredUsageCreditOfferCodesSafely())
-    : [];
-  const familyUsageTopUpActivePurchase =
-    usageTopUpActivePurchase?.target.kind === "family"
-    && usageTopUpActivePurchase.target.familyGroupId === familyOwner?.groupId
-      ? usageTopUpActivePurchase
-      : null;
-  const personalUsageTopUpActivePurchase =
-    usageTopUpActivePurchase?.target.kind === "personal"
-      ? usageTopUpActivePurchase
-      : usageTopUpActivePurchase && !familyUsageTopUpActivePurchase
-        ? {
-            ...usageTopUpActivePurchase,
-            retryAllowed: false,
-            targetConflict: true as const,
-            url: undefined,
-          }
-        : null;
-  const familyUsageTopUpActiveMemberId =
-    familyUsageTopUpActivePurchase?.target.beneficiaryMemberId ?? null;
-  const familyOwnerUsageTopUpActivePurchase = familyOwnerUsageTopUpMember
-    ? familyUsageTopUpActivePurchase?.target.beneficiaryMemberId ===
-        familyOwnerUsageTopUpMember.memberId
-      ? familyUsageTopUpActivePurchase
-      : usageTopUpActivePurchase
-        ? {
-            ...usageTopUpActivePurchase,
-            retryAllowed: false,
-            targetConflict: true as const,
-            url: undefined,
-          }
-        : null
-    : null;
-  const personalUsageTopUpPurchaseReturn =
-    usageTopUpPurchaseReturn
-    && usageTopUpReturnTarget?.kind === "personal"
-    && resolvedSearchParams.usageFamily === undefined
-    && resolvedSearchParams.usageMember === undefined
-      ? usageTopUpPurchaseReturn
-      : null;
-  const familyUsageTopUpPurchaseReturn =
-    usageTopUpPurchaseReturn
-    && usageTopUpReturnTarget?.kind === "family"
-    && usageTopUpReturnTarget.familyGroupId === familyOwner?.groupId
-    && readOnlySearchParamValue(resolvedSearchParams.usageFamily)
-      === usageTopUpReturnTarget.familyGroupId
-    && readOnlySearchParamValue(resolvedSearchParams.usageMember)
-      === usageTopUpReturnTarget.beneficiaryMemberId
-      ? usageTopUpPurchaseReturn
-      : null;
-  const familyUsageTopUpReturnMemberId =
-    familyUsageTopUpPurchaseReturn
-      ? usageTopUpReturnTarget?.beneficiaryMemberId ?? null
-      : null;
-  const familyOwnerUsageTopUpAvailable =
-    familyOwnerUsageTopUpMember !== null;
-  const familyOwnerUsageTopUpPurchaseReturn =
-    familyOwnerUsageTopUpMember
-    && familyUsageTopUpPurchaseReturn
-    && usageTopUpReturnTarget?.beneficiaryMemberId ===
-      familyOwnerUsageTopUpMember.memberId
-      ? familyUsageTopUpPurchaseReturn
-      : null;
-  const familySettingsUsageTopUpPurchaseReturn =
-    familyOwnerUsageTopUpPurchaseReturn ? null : familyUsageTopUpPurchaseReturn;
-  const familySettingsUsageTopUpReturnMemberId =
-    familyOwnerUsageTopUpPurchaseReturn ? null : familyUsageTopUpReturnMemberId;
-  const billingUsageTopUpUsesFamilyOwner =
-    familyOwnerUsageTopUpAvailable
-    && usageTopUpActivePurchase?.target.kind !== "personal"
-    && personalUsageTopUpPurchaseReturn === null;
-  const billingUsageTopUpPurchaseReturn = billingUsageTopUpUsesFamilyOwner
-    ? familyOwnerUsageTopUpPurchaseReturn
-    : personalUsageTopUpPurchaseReturn;
-  const billingUsageTopUpActivePurchase = billingUsageTopUpPurchaseReturn
-    ? null
-    : billingUsageTopUpUsesFamilyOwner
-      ? familyOwnerUsageTopUpActivePurchase
-      : personalUsageTopUpActivePurchase;
-  const usageRecoveryIsCurrent =
-    usageRecoveryInitialOpen && usageStatus?.status === "exhausted";
-  const usageRecoveryPresentationOpen =
-    usageRecoveryIsCurrent
-    && usageTopUpActivePurchase === null
-    && usageTopUpPurchaseReturn === null;
-  const familyUsageRecoveryAvailable =
-    activeFamilyOwner
-    && usageStatus?.status === "exhausted"
-    && usageTopUpActivePurchase === null
-    && usageTopUpPurchaseReturn === null;
-  const billingUsagePurchaseRecoveryOpen =
-    usageRecoveryIsCurrent
-    && (
-      billingUsageTopUpActivePurchase !== null
-      || billingUsageTopUpPurchaseReturn !== null
-    );
-  const billingUsageTopUpOffers = billingUsageTopUpUsesFamilyOwner
-    ? familyUsageTopUpOffers
-    : usageTopUpOffers;
-  const canStartFamily =
-    authenticatedMember != null &&
-    !familyBillingOwner &&
-    !sponsoredMember &&
-    !authenticatedMember.suspendedAt;
-  const currentPlanCode = parseHostedBillingPlanCode(
-    billingRef?.currentBillingPlanCode,
-  );
-  const directPlanUpdateTarget =
-    !activeFamilyOwner &&
-    !sponsoredMember &&
-    (
-      planChangeReturn === "launch_edge_monthly" ||
-      planChangeReturn === "launch_max_monthly" ||
-      planChangeReturn === "launch_monthly"
-    )
-      ? planChangeReturn
-      : null;
-  const directPlanUpdateActive =
-    directPlanUpdateTarget !== null &&
-    authenticatedMember !== null &&
-    hasHostedMemberOwnActiveAccess(authenticatedMember) &&
-    parseHostedBillingPhase(billingRef?.currentBillingPhase) === "paid" &&
-    currentPlanCode === directPlanUpdateTarget;
-  const planChangePending =
-    directPlanUpdateTarget !== null && !directPlanUpdateActive;
-  const scheduledPlanCode = parseHostedBillingPlanCode(
-    billingRef?.scheduledBillingPlanCode,
-  );
-  const hasScheduledPlanChange = scheduledPlanCode !== null;
-  const groupPlanConfigured = settingsData?.groupPlanAvailable === true;
-  const maxPlanConfigured = settingsData?.maxPlanAvailable === true;
-  const visiblePlanCodes = resolveVisibleHostedBillingPlanCodes({
+  const {
+    activeFamilyOwner,
+    billingUsagePurchaseRecoveryOpen,
+    billingUsageTopUpActivePurchase,
+    billingUsageTopUpOffers,
+    billingUsageTopUpPurchaseReturn,
+    billingUsageTopUpUsesFamilyOwner,
+    familyBillingOwner,
+    familyOwnerUsageTopUpMember,
+    familyRecurringUpgradeAvailable,
+    familySettingsUsageTopUpPurchaseReturn,
+    familySettingsUsageTopUpReturnMemberId,
+    familyUsageRecoveryAvailable,
+    familyUsageTopUpActiveMemberId,
+    familyUsageTopUpActivePurchase,
+    familyUsageTopUpOffers,
+    sponsoredMember,
+    usageRecoveryPresentationOpen,
+  } = resolveSettingsUsagePresentation({
+    familyAccess,
+    familyOwner,
+    resolvedSearchParams,
+    usageRecoveryInitialOpen,
+    usageStatus,
+    usageTopUpActivePurchase,
+    usageTopUpOfferCodes,
+    usageTopUpPurchaseReturn,
+    usageTopUpReturnTarget,
+  });
+  const {
+    canManageBilling,
+    canStartDirectPlan,
+    canStartFamily,
     currentPlanCode,
+    directPlanUpdateActive,
+    directPlanUpdateTarget,
+    groupPlanConfigured,
+    hasScheduledPlanChange,
+    maxPlanConfigured,
+    planChangePending,
+    showGroupPlan,
+    showMaxPlan,
+  } = resolveSettingsBillingPresentation({
+    activeFamilyOwner,
+    authenticatedMember,
+    billingRef,
+    familyBillingOwner,
+    hasConfirmedGroupMembership,
+    planChangeReturn,
+    settingsData,
+    sponsoredMember,
+  });
+  const {
+    canSwitchToEdge,
+    canSwitchToGroup,
+    canUpgradeToEdge,
+    canUpgradeToMax,
+    canUpgradeToPulse,
+  } = resolveSettingsBillingActions({
+    authenticatedMember,
+    billingRef,
     groupPlanConfigured,
     hasConfirmedGroupMembership,
+    hasScheduledPlanChange,
     maxPlanConfigured,
-    scheduledPlanCode,
   });
-  const showGroupPlan = visiblePlanCodes.includes("launch_group_monthly");
-  const showMaxPlan = visiblePlanCodes.includes("launch_max_monthly");
-  const ownPaidBillingActive =
-    authenticatedMember !== null &&
-    hasHostedMemberOwnPaidBilling({
-      billingStatus: authenticatedMember.billingStatus,
-      billingRef: {
-        currentBillingPhase: billingRef?.currentBillingPhase ?? null,
-        currentCheckoutOffer: billingRef?.currentCheckoutOffer ?? null,
-        stripeSubscriptionLookupKey: billingRef?.stripeSubscriptionId
-          ? "configured"
-          : null,
-      },
-      suspendedAt: authenticatedMember.suspendedAt,
-    });
-  const hasRecoverableBilling =
-    authenticatedMember !== null &&
-    hasHostedRecoverableBilling({
-      billingStatus: authenticatedMember.billingStatus,
-      hasExistingSubscription: Boolean(billingRef?.stripeSubscriptionId),
-    });
-  const canStartDirectPlan =
-    !hasScheduledPlanChange &&
-    authenticatedMember !== null &&
-    !activeFamilyOwner &&
-    !sponsoredMember &&
-    !authenticatedMember.suspendedAt &&
-    !ownPaidBillingActive &&
-    !hasRecoverableBilling;
-  const canManageBilling =
-    activeFamilyOwner ||
-    (
-      authenticatedMember !== null &&
-      !authenticatedMember.suspendedAt &&
-      Boolean(billingRef?.stripeCustomerId) &&
-      (ownPaidBillingActive || hasRecoverableBilling)
-    );
-  const canUpgradeToPulse =
-    !hasScheduledPlanChange &&
-    authenticatedMember !== null &&
-    hasHostedMemberOwnActiveAccess(authenticatedMember) &&
-    canUpgradeHostedBillingPlan({
-      currentBillingPhase: billingRef?.currentBillingPhase,
-      currentBillingPlanCode: billingRef?.currentBillingPlanCode,
-      currentCheckoutOffer: billingRef?.currentCheckoutOffer,
-      targetPlanCode: "launch_monthly",
-    });
-  const canUpgradeToEdge =
-    !hasScheduledPlanChange &&
-    authenticatedMember !== null &&
-    hasHostedMemberOwnActiveAccess(authenticatedMember) &&
-    canUpgradeHostedBillingPlan({
-      currentBillingPhase: billingRef?.currentBillingPhase,
-      currentBillingPlanCode: billingRef?.currentBillingPlanCode,
-      currentCheckoutOffer: billingRef?.currentCheckoutOffer,
-      targetPlanCode: "launch_edge_monthly",
-    });
-  const canUpgradeToMax =
-    !hasScheduledPlanChange &&
-    maxPlanConfigured &&
-    authenticatedMember !== null &&
-    hasHostedMemberOwnActiveAccess(authenticatedMember) &&
-    canUpgradeHostedBillingPlan({
-      currentBillingPhase: billingRef?.currentBillingPhase,
-      currentBillingPlanCode: billingRef?.currentBillingPlanCode,
-      currentCheckoutOffer: billingRef?.currentCheckoutOffer,
-      targetPlanCode: "launch_max_monthly",
-    });
-  const canSwitchToEdge =
-    !hasScheduledPlanChange &&
-    authenticatedMember !== null &&
-    canScheduleHostedBillingPlanChange({
-      billingStatus: authenticatedMember.billingStatus,
-      currentBillingPhase: billingRef?.currentBillingPhase,
-      currentBillingPlanCode: billingRef?.currentBillingPlanCode,
-      currentCheckoutOffer: billingRef?.currentCheckoutOffer,
-      stripeCustomerId: billingRef?.stripeCustomerId,
-      stripeSubscriptionId: billingRef?.stripeSubscriptionId,
-      suspendedAt: authenticatedMember.suspendedAt,
-      targetPlanCode: "launch_edge_monthly",
-    });
-  const canSwitchToGroup =
-    !hasScheduledPlanChange &&
-    authenticatedMember !== null &&
-    groupPlanConfigured &&
-    hasConfirmedGroupMembership &&
-    canScheduleHostedBillingPlanChange({
-      billingStatus: authenticatedMember.billingStatus,
-      currentBillingPhase: billingRef?.currentBillingPhase,
-      currentBillingPlanCode: billingRef?.currentBillingPlanCode,
-      currentCheckoutOffer: billingRef?.currentCheckoutOffer,
-      stripeCustomerId: billingRef?.stripeCustomerId,
-      stripeSubscriptionId: billingRef?.stripeSubscriptionId,
-      suspendedAt: authenticatedMember.suspendedAt,
-      targetPlanCode: "launch_group_monthly",
-    });
-  const privySessionMatchesAppSession =
-    freshPrivySession !== null && freshPrivySession.identity.userId === session?.privyUserId;
-  const serverApprovedPrivyLinkedAccounts = privySessionMatchesAppSession
-    ? freshPrivySession.linkedAccounts
-    : null;
-  const accountWithPrivyDisplay = account
-    ? withServerApprovedPrivyAccountHints({
-        snapshot: account,
-        serverApprovedPrivyLinkedAccounts,
-      })
-    : account;
-  const privyAppId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim() || null;
-  const privyClientId = process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID?.trim() || null;
-  const murphPhoneNumber =
-    routing?.linqRecipientPhone ?? routing?.pendingLinqRecipientPhone ?? null;
-  // The member sends this to Murph right after picking a voice, so the reply
-  // comes back as a voice memo in the new voice. Voice memos only deliver over
-  // text and Telegram, so an email-only member gets no redirect.
-  const resolvedVoiceTestOption = account
-    ? resolveMurphContactOptions({
-        contactChannels: {
-          email: Boolean(account.email.murphEmailAddress),
-          telegram: Boolean(account.telegram.telegramUserId),
-          text: Boolean(account.phone.number),
-        },
-        message: {
-          body: "just picked a new voice for you! send me a voice memo so I can hear it",
-        },
-        murphEmailAddress: account.email.murphEmailAddress ?? null,
-        murphPhoneNumber: routing?.linqRecipientPhone ?? null,
-        preferredKind: "text",
-        userEmailAddress: account.email.address,
-      })[0] ?? null
-    : null;
-  const voiceTestContactOption =
-    resolvedVoiceTestOption && resolvedVoiceTestOption.kind !== "email"
-      ? resolvedVoiceTestOption
-      : null;
-  const usageMissionContactOption =
-    usageActivity?.missionsEnabled === true && account
-      ? resolveMurphContactOptions({
-          contactChannels: {
-            email: false,
-            telegram: Boolean(account.telegram.telegramUserId),
-            text: Boolean(account.phone.number),
-          },
-          message: {
-            body: "Hey Murph, what referral options can I choose from?",
-          },
-          murphEmailAddress: account.email.murphEmailAddress ?? null,
-          murphPhoneNumber: routing?.linqRecipientPhone ?? null,
-          preferredKind: "text",
-          userEmailAddress: account.email.address,
-        })[0] ?? null
-      : null;
-  const canStartUsageMissions =
-    usageActivity?.missionsEnabled === true
-    && usageMissionContactOption !== null;
-  const visibleUsageActivity =
-    usageActivity
-    && (
-      canStartUsageMissions
-      || usageActivity.credits.length > 0
-      || usageActivity.missions.length > 0
-    )
-      ? usageActivity
-      : null;
+  const {
+    accountWithPrivyDisplay,
+    murphPhoneNumber,
+    privyAppId,
+    privyClientId,
+    privySessionMatchesAppSession,
+    usageMissionContactOption,
+    visibleUsageActivity,
+    voiceTestContactOption,
+  } = resolveSettingsAccountPresentation({
+    account,
+    freshPrivySession,
+    routing,
+    session,
+    usageActivity,
+  });
 
   const settingsContent = (
     <div className="flex flex-col gap-12">
@@ -718,46 +498,30 @@ export default async function SettingsPage({
       </section>
 
       {privyAppId ? (
-        <>
-          <section className="flex flex-col gap-4">
-            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              Security
-            </div>
-            <HostedPasskeySettings
-              authenticated={authenticated}
-              secureApprovalStatus={secureApprovalStatus}
-            />
-          </section>
-
-          <section id="data-privacy" className="flex scroll-mt-24 flex-col gap-4">
-            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              Data & privacy
-            </div>
-            <HostedHealthDataConsentSettings
-              authenticated={authenticated}
-              initialStatus={consentStatus}
-            />
-            <HostedDataPrivacySettings
-              authenticated={authenticated}
-              authorizationEnabled
-            />
-          </section>
-        </>
-      ) : (
-        <section id="data-privacy" className="flex scroll-mt-24 flex-col gap-4">
+        <section className="flex flex-col gap-4">
           <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            Data & privacy
+            Security
           </div>
-          <HostedHealthDataConsentSettings
+          <HostedPasskeySettings
             authenticated={authenticated}
-            initialStatus={consentStatus}
-          />
-          <HostedDataPrivacySettings
-            authenticated={authenticated}
-            authorizationEnabled={false}
+            secureApprovalStatus={secureApprovalStatus}
           />
         </section>
-      )}
+      ) : null}
+
+      <section id="data-privacy" className="flex scroll-mt-24 flex-col gap-4">
+        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Data & privacy
+        </div>
+        <HostedHealthDataConsentSettings
+          authenticated={authenticated}
+          initialStatus={consentStatus}
+        />
+        <HostedDataPrivacySettings
+          authenticated={authenticated}
+          authorizationEnabled={Boolean(privyAppId)}
+        />
+      </section>
     </div>
   );
 
@@ -766,6 +530,474 @@ export default async function SettingsPage({
       {settingsContent}
     </HostedPrivyProvider>
   ) : settingsContent;
+}
+
+type NormalizedSettingsPageData = ReturnType<typeof normalizeSettingsPageData>;
+type ResolvedSettingsPageRequest = ReturnType<
+  typeof resolveSettingsPageRequest
+>;
+
+type SettingsBillingRef = NonNullable<
+  NormalizedSettingsPageData["settingsSnapshot"]
+>["billingRef"];
+type SettingsAccount = NonNullable<
+  NormalizedSettingsPageData["settingsSnapshot"]
+>["account"];
+type SettingsRouting = NonNullable<
+  NormalizedSettingsPageData["settingsSnapshot"]
+>["routing"];
+
+function resolveSettingsAccountPresentation(input: {
+  account: SettingsAccount | null;
+  freshPrivySession: NormalizedSettingsPageData["freshPrivySession"];
+  routing: SettingsRouting | null;
+  session: HostedDashboardPageAuthSnapshot["session"];
+  usageActivity: NormalizedSettingsPageData["usageActivity"];
+}) {
+  const { account, freshPrivySession, routing, session, usageActivity } = input;
+  const privySessionMatchesAppSession =
+    freshPrivySession !== null
+    && freshPrivySession.identity.userId === session?.privyUserId;
+  const serverApprovedPrivyLinkedAccounts = privySessionMatchesAppSession
+    ? freshPrivySession.linkedAccounts
+    : null;
+  const accountWithPrivyDisplay = account
+    ? withServerApprovedPrivyAccountHints({
+        snapshot: account,
+        serverApprovedPrivyLinkedAccounts,
+      })
+    : account;
+  const murphPhoneNumber =
+    routing?.linqRecipientPhone ?? routing?.pendingLinqRecipientPhone ?? null;
+  // The member sends this to Murph right after picking a voice, so the reply
+  // comes back as a voice memo in the new voice. Voice memos only deliver over
+  // text and Telegram, so an email-only member gets no redirect.
+  const resolvedVoiceTestOption = account
+    ? resolveMurphContactOptions({
+        contactChannels: {
+          email: Boolean(account.email.murphEmailAddress),
+          telegram: Boolean(account.telegram.telegramUserId),
+          text: Boolean(account.phone.number),
+        },
+        message: {
+          body: "just picked a new voice for you! send me a voice memo so I can hear it",
+        },
+        murphEmailAddress: account.email.murphEmailAddress ?? null,
+        murphPhoneNumber: routing?.linqRecipientPhone ?? null,
+        preferredKind: "text",
+        userEmailAddress: account.email.address,
+      })[0] ?? null
+    : null;
+  const voiceTestContactOption =
+    resolvedVoiceTestOption && resolvedVoiceTestOption.kind !== "email"
+      ? resolvedVoiceTestOption
+      : null;
+  const usageMissionContactOption =
+    usageActivity?.missionsEnabled === true && account
+      ? resolveMurphContactOptions({
+          contactChannels: {
+            email: false,
+            telegram: Boolean(account.telegram.telegramUserId),
+            text: Boolean(account.phone.number),
+          },
+          message: {
+            body: "Hey Murph, what referral options can I choose from?",
+          },
+          murphEmailAddress: account.email.murphEmailAddress ?? null,
+          murphPhoneNumber: routing?.linqRecipientPhone ?? null,
+          preferredKind: "text",
+          userEmailAddress: account.email.address,
+        })[0] ?? null
+      : null;
+  const canStartUsageMissions =
+    usageActivity?.missionsEnabled === true
+    && usageMissionContactOption !== null;
+  const visibleUsageActivity =
+    usageActivity
+    && (
+      canStartUsageMissions
+      || usageActivity.credits.length > 0
+      || usageActivity.missions.length > 0
+    )
+      ? usageActivity
+      : null;
+
+  return {
+    accountWithPrivyDisplay,
+    murphPhoneNumber,
+    privyAppId: process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim() || null,
+    privyClientId: process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID?.trim() || null,
+    privySessionMatchesAppSession,
+    usageMissionContactOption,
+    visibleUsageActivity,
+    voiceTestContactOption,
+  };
+}
+
+function resolveSettingsBillingPresentation(input: {
+  activeFamilyOwner: boolean;
+  authenticatedMember: HostedDashboardPageAuthSnapshot["authenticatedMember"];
+  billingRef: SettingsBillingRef | null;
+  familyBillingOwner: boolean;
+  hasConfirmedGroupMembership: boolean;
+  planChangeReturn: ResolvedSettingsPageRequest["planChangeReturn"];
+  settingsData: Awaited<ReturnType<typeof readSettingsPageData>> | null;
+  sponsoredMember: boolean;
+}) {
+  const {
+    activeFamilyOwner,
+    authenticatedMember,
+    billingRef,
+    familyBillingOwner,
+    hasConfirmedGroupMembership,
+    planChangeReturn,
+    settingsData,
+    sponsoredMember,
+  } = input;
+  const canStartFamily =
+    authenticatedMember != null
+    && !familyBillingOwner
+    && !sponsoredMember
+    && !authenticatedMember.suspendedAt;
+  const currentPlanCode = parseHostedBillingPlanCode(
+    billingRef?.currentBillingPlanCode,
+  );
+  const directPlanUpdateTarget =
+    !activeFamilyOwner
+    && !sponsoredMember
+    && (
+      planChangeReturn === "launch_edge_monthly"
+      || planChangeReturn === "launch_max_monthly"
+      || planChangeReturn === "launch_monthly"
+    )
+      ? planChangeReturn
+      : null;
+  const directPlanUpdateActive =
+    directPlanUpdateTarget !== null
+    && authenticatedMember !== null
+    && hasHostedMemberOwnActiveAccess(authenticatedMember)
+    && parseHostedBillingPhase(billingRef?.currentBillingPhase) === "paid"
+    && currentPlanCode === directPlanUpdateTarget;
+  const planChangePending =
+    directPlanUpdateTarget !== null && !directPlanUpdateActive;
+  const scheduledPlanCode = parseHostedBillingPlanCode(
+    billingRef?.scheduledBillingPlanCode,
+  );
+  const hasScheduledPlanChange = scheduledPlanCode !== null;
+  const groupPlanConfigured = settingsData?.groupPlanAvailable === true;
+  const maxPlanConfigured = settingsData?.maxPlanAvailable === true;
+  const visiblePlanCodes = resolveVisibleHostedBillingPlanCodes({
+    currentPlanCode,
+    groupPlanConfigured,
+    hasConfirmedGroupMembership,
+    maxPlanConfigured,
+    scheduledPlanCode,
+  });
+  const ownPaidBillingActive =
+    authenticatedMember !== null
+    && hasHostedMemberOwnPaidBilling({
+      billingStatus: authenticatedMember.billingStatus,
+      billingRef: {
+        currentBillingPhase: billingRef?.currentBillingPhase ?? null,
+        currentCheckoutOffer: billingRef?.currentCheckoutOffer ?? null,
+        stripeSubscriptionLookupKey: billingRef?.stripeSubscriptionId
+          ? "configured"
+          : null,
+      },
+      suspendedAt: authenticatedMember.suspendedAt,
+    });
+  const hasRecoverableBilling =
+    authenticatedMember !== null
+    && hasHostedRecoverableBilling({
+      billingStatus: authenticatedMember.billingStatus,
+      hasExistingSubscription: Boolean(billingRef?.stripeSubscriptionId),
+    });
+  const canStartDirectPlan =
+    !hasScheduledPlanChange
+    && authenticatedMember !== null
+    && !activeFamilyOwner
+    && !sponsoredMember
+    && !authenticatedMember.suspendedAt
+    && !ownPaidBillingActive
+    && !hasRecoverableBilling;
+  const canManageBilling =
+    activeFamilyOwner
+    || (
+      authenticatedMember !== null
+      && !authenticatedMember.suspendedAt
+      && Boolean(billingRef?.stripeCustomerId)
+      && (ownPaidBillingActive || hasRecoverableBilling)
+    );
+
+  return {
+    canManageBilling,
+    canStartDirectPlan,
+    canStartFamily,
+    currentPlanCode,
+    directPlanUpdateActive,
+    directPlanUpdateTarget,
+    groupPlanConfigured,
+    hasScheduledPlanChange,
+    maxPlanConfigured,
+    planChangePending,
+    showGroupPlan: visiblePlanCodes.includes("launch_group_monthly"),
+    showMaxPlan: visiblePlanCodes.includes("launch_max_monthly"),
+  };
+}
+
+function resolveSettingsBillingActions(input: {
+  authenticatedMember: HostedDashboardPageAuthSnapshot["authenticatedMember"];
+  billingRef: SettingsBillingRef | null;
+  groupPlanConfigured: boolean;
+  hasConfirmedGroupMembership: boolean;
+  hasScheduledPlanChange: boolean;
+  maxPlanConfigured: boolean;
+}) {
+  const {
+    authenticatedMember,
+    billingRef,
+    groupPlanConfigured,
+    hasConfirmedGroupMembership,
+    hasScheduledPlanChange,
+    maxPlanConfigured,
+  } = input;
+  const hasActiveAccess = authenticatedMember !== null
+    && hasHostedMemberOwnActiveAccess(authenticatedMember);
+  const upgradeInput = {
+    currentBillingPhase: billingRef?.currentBillingPhase,
+    currentBillingPlanCode: billingRef?.currentBillingPlanCode,
+    currentCheckoutOffer: billingRef?.currentCheckoutOffer,
+  };
+  const switchInput = authenticatedMember
+    ? {
+        billingStatus: authenticatedMember.billingStatus,
+        currentBillingPhase: billingRef?.currentBillingPhase,
+        currentBillingPlanCode: billingRef?.currentBillingPlanCode,
+        currentCheckoutOffer: billingRef?.currentCheckoutOffer,
+        stripeCustomerId: billingRef?.stripeCustomerId,
+        stripeSubscriptionId: billingRef?.stripeSubscriptionId,
+        suspendedAt: authenticatedMember.suspendedAt,
+      }
+    : null;
+
+  return {
+    canSwitchToEdge:
+      !hasScheduledPlanChange
+      && switchInput !== null
+      && canScheduleHostedBillingPlanChange({
+        ...switchInput,
+        targetPlanCode: "launch_edge_monthly",
+      }),
+    canSwitchToGroup:
+      !hasScheduledPlanChange
+      && groupPlanConfigured
+      && hasConfirmedGroupMembership
+      && switchInput !== null
+      && canScheduleHostedBillingPlanChange({
+        ...switchInput,
+        targetPlanCode: "launch_group_monthly",
+      }),
+    canUpgradeToEdge:
+      !hasScheduledPlanChange
+      && hasActiveAccess
+      && canUpgradeHostedBillingPlan({
+        ...upgradeInput,
+        targetPlanCode: "launch_edge_monthly",
+      }),
+    canUpgradeToMax:
+      !hasScheduledPlanChange
+      && maxPlanConfigured
+      && hasActiveAccess
+      && canUpgradeHostedBillingPlan({
+        ...upgradeInput,
+        targetPlanCode: "launch_max_monthly",
+      }),
+    canUpgradeToPulse:
+      !hasScheduledPlanChange
+      && hasActiveAccess
+      && canUpgradeHostedBillingPlan({
+        ...upgradeInput,
+        targetPlanCode: "launch_monthly",
+      }),
+  };
+}
+
+function resolveSettingsUsagePresentation(input: {
+  familyAccess: NormalizedSettingsPageData["familyAccess"];
+  familyOwner: NormalizedSettingsPageData["familyOwner"];
+  resolvedSearchParams: ResolvedSettingsPageRequest["resolvedSearchParams"];
+  usageRecoveryInitialOpen: boolean;
+  usageStatus: NormalizedSettingsPageData["usageStatus"];
+  usageTopUpActivePurchase: NormalizedSettingsPageData["usageTopUpActivePurchase"];
+  usageTopUpOfferCodes: NormalizedSettingsPageData["usageTopUpOfferCodes"];
+  usageTopUpPurchaseReturn: ResolvedSettingsPageRequest["usageTopUpPurchaseReturn"];
+  usageTopUpReturnTarget: NormalizedSettingsPageData["usageTopUpReturnTarget"];
+}) {
+  const {
+    familyAccess,
+    familyOwner,
+    resolvedSearchParams,
+    usageRecoveryInitialOpen,
+    usageStatus,
+    usageTopUpActivePurchase,
+    usageTopUpOfferCodes,
+    usageTopUpPurchaseReturn,
+    usageTopUpReturnTarget,
+  } = input;
+  const activeFamilyOwner = familyOwner?.billingActive === true;
+  const familyBillingOwner = familyOwner !== null
+    && isHostedFamilyBillingPortalManageable(familyOwner.billingStatus);
+  const familyOwnerUsageTopUpMember =
+    resolveActiveFamilyOwnerUsageTopUpMember(familyOwner);
+  const sponsoredMember = familyAccess !== null && familyOwner === null;
+  const familyRecurringUpgradeAvailable =
+    activeFamilyOwner && hasHigherHostedFamilyOwnerTier(familyOwner);
+  const usageTopUpOffers = usageTopUpActivePurchase
+    ? []
+    : projectHostedUsageTopUpOffers(usageTopUpOfferCodes);
+  const familyUsageTopUpOffers = activeFamilyOwner && !usageTopUpActivePurchase
+    ? projectHostedUsageTopUpOffers(
+        readHostedConfiguredUsageCreditOfferCodesSafely(),
+      )
+    : [];
+  const familyUsageTopUpActivePurchase =
+    usageTopUpActivePurchase?.target.kind === "family"
+    && usageTopUpActivePurchase.target.familyGroupId === familyOwner?.groupId
+      ? usageTopUpActivePurchase
+      : null;
+  const personalUsageTopUpActivePurchase =
+    usageTopUpActivePurchase?.target.kind === "personal"
+      ? usageTopUpActivePurchase
+      : usageTopUpActivePurchase && !familyUsageTopUpActivePurchase
+        ? {
+            ...usageTopUpActivePurchase,
+            retryAllowed: false,
+            targetConflict: true as const,
+            url: undefined,
+          }
+        : null;
+  const familyUsageTopUpActiveMemberId =
+    familyUsageTopUpActivePurchase?.target.beneficiaryMemberId ?? null;
+  const familyOwnerUsageTopUpActivePurchase = familyOwnerUsageTopUpMember
+    ? familyUsageTopUpActivePurchase?.target.beneficiaryMemberId ===
+        familyOwnerUsageTopUpMember.memberId
+      ? familyUsageTopUpActivePurchase
+      : usageTopUpActivePurchase
+        ? {
+            ...usageTopUpActivePurchase,
+            retryAllowed: false,
+            targetConflict: true as const,
+            url: undefined,
+          }
+        : null
+    : null;
+  const personalUsageTopUpPurchaseReturn =
+    usageTopUpPurchaseReturn
+    && usageTopUpReturnTarget?.kind === "personal"
+    && resolvedSearchParams.usageFamily === undefined
+    && resolvedSearchParams.usageMember === undefined
+      ? usageTopUpPurchaseReturn
+      : null;
+  const familyUsageTopUpPurchaseReturn =
+    usageTopUpPurchaseReturn
+    && usageTopUpReturnTarget?.kind === "family"
+    && usageTopUpReturnTarget.familyGroupId === familyOwner?.groupId
+    && readOnlySearchParamValue(resolvedSearchParams.usageFamily)
+      === usageTopUpReturnTarget.familyGroupId
+    && readOnlySearchParamValue(resolvedSearchParams.usageMember)
+      === usageTopUpReturnTarget.beneficiaryMemberId
+      ? usageTopUpPurchaseReturn
+      : null;
+  const familyUsageTopUpReturnMemberId = familyUsageTopUpPurchaseReturn
+    ? usageTopUpReturnTarget?.beneficiaryMemberId ?? null
+    : null;
+  const familyOwnerUsageTopUpAvailable =
+    familyOwnerUsageTopUpMember !== null;
+  const familyOwnerUsageTopUpPurchaseReturn =
+    familyOwnerUsageTopUpMember
+    && familyUsageTopUpPurchaseReturn
+    && usageTopUpReturnTarget?.beneficiaryMemberId ===
+      familyOwnerUsageTopUpMember.memberId
+      ? familyUsageTopUpPurchaseReturn
+      : null;
+  const familySettingsUsageTopUpPurchaseReturn =
+    familyOwnerUsageTopUpPurchaseReturn ? null : familyUsageTopUpPurchaseReturn;
+  const familySettingsUsageTopUpReturnMemberId =
+    familyOwnerUsageTopUpPurchaseReturn ? null : familyUsageTopUpReturnMemberId;
+  const billingUsageTopUpUsesFamilyOwner =
+    familyOwnerUsageTopUpAvailable
+    && usageTopUpActivePurchase?.target.kind !== "personal"
+    && personalUsageTopUpPurchaseReturn === null;
+  const billingUsageTopUpPurchaseReturn = billingUsageTopUpUsesFamilyOwner
+    ? familyOwnerUsageTopUpPurchaseReturn
+    : personalUsageTopUpPurchaseReturn;
+  const billingUsageTopUpActivePurchase = billingUsageTopUpPurchaseReturn
+    ? null
+    : billingUsageTopUpUsesFamilyOwner
+      ? familyOwnerUsageTopUpActivePurchase
+      : personalUsageTopUpActivePurchase;
+  const usageRecoveryIsCurrent =
+    usageRecoveryInitialOpen && usageStatus?.status === "exhausted";
+  const usageRecoveryPresentationOpen =
+    usageRecoveryIsCurrent
+    && usageTopUpActivePurchase === null
+    && usageTopUpPurchaseReturn === null;
+  const familyUsageRecoveryAvailable =
+    activeFamilyOwner
+    && usageStatus?.status === "exhausted"
+    && usageTopUpActivePurchase === null
+    && usageTopUpPurchaseReturn === null;
+  const billingUsagePurchaseRecoveryOpen =
+    usageRecoveryIsCurrent
+    && (
+      billingUsageTopUpActivePurchase !== null
+      || billingUsageTopUpPurchaseReturn !== null
+    );
+
+  return {
+    activeFamilyOwner,
+    billingUsagePurchaseRecoveryOpen,
+    billingUsageTopUpActivePurchase,
+    billingUsageTopUpOffers: billingUsageTopUpUsesFamilyOwner
+      ? familyUsageTopUpOffers
+      : usageTopUpOffers,
+    billingUsageTopUpPurchaseReturn,
+    billingUsageTopUpUsesFamilyOwner,
+    familyBillingOwner,
+    familyOwnerUsageTopUpMember,
+    familyRecurringUpgradeAvailable,
+    familySettingsUsageTopUpPurchaseReturn,
+    familySettingsUsageTopUpReturnMemberId,
+    familyUsageRecoveryAvailable,
+    familyUsageTopUpActiveMemberId,
+    familyUsageTopUpActivePurchase,
+    familyUsageTopUpOffers,
+    sponsoredMember,
+    usageRecoveryPresentationOpen,
+  };
+}
+
+function normalizeSettingsPageData(
+  settingsData: Awaited<ReturnType<typeof readSettingsPageData>> | null,
+) {
+  return {
+    consentStatus: settingsData?.consentStatus ?? null,
+    familyAccess: settingsData?.familyAccess ?? null,
+    familyDraftRecovery: settingsData?.familyDraftRecovery ?? null,
+    familyOwner: settingsData?.familyOwner ?? null,
+    freshPrivySession: settingsData?.freshPrivySession ?? null,
+    hasConfirmedGroupMembership:
+      settingsData?.hasConfirmedGroupMembership === true,
+    inferenceConnection: settingsData?.inferenceConnection ?? null,
+    secureApprovalStatus:
+      settingsData?.secureApprovalStatus ?? ({ status: "unavailable" } as const),
+    settingsSnapshot: settingsData?.settingsSnapshot ?? null,
+    usageActivity: settingsData?.usageActivity ?? null,
+    usageStatus: settingsData?.usageStatus ?? null,
+    usageTopUpActivePurchase: settingsData?.usageTopUpActivePurchase ?? null,
+    usageTopUpOfferCodes: settingsData?.usageTopUpOfferCodes ?? [],
+    usageTopUpReturnTarget: settingsData?.usageTopUpReturnTarget ?? null,
+  };
 }
 
 async function readSettingsPageData(input: {
@@ -920,6 +1152,49 @@ function readFirstSearchParamValue(
   value: string | string[] | undefined,
 ): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+function resolveSettingsPageRequest(
+  resolvedSearchParams: SettingsSearchParams,
+) {
+  const addUsageTarget = readOnlySearchParamValue(
+    resolvedSearchParams.addUsage,
+  );
+
+  return {
+    familyInviteReturnPath: parseHostedFamilyInviteReturnPath(
+      readOnlySearchParamValue(
+        resolvedSearchParams[HOSTED_FAMILY_INVITE_RETURN_PARAM],
+      ),
+    ),
+    familyRecoveryRequested: hasExactSettingsSearchParam(
+      resolvedSearchParams,
+      "familyRecovery",
+      "true",
+    ),
+    groupPaymentMethodSaved:
+      readFirstSearchParamValue(
+        resolvedSearchParams[HOSTED_START_PAID_GROUP_RETURN_PARAM],
+      ) === HOSTED_START_PAID_GROUP_RETURN_VALUE,
+    openEmailLink:
+      readFirstSearchParamValue(resolvedSearchParams.addEmail) === "true",
+    openPersonalUsageTopUp: addUsageTarget === "true",
+    openVoiceLink:
+      readFirstSearchParamValue(resolvedSearchParams.voice) === "true",
+    planChangeReturn: parseHostedBillingPlanChangeReturnValue(
+      readOnlySearchParamValue(resolvedSearchParams.planUpdate),
+    ),
+    requestedFamilyOwnerUsageTopUp: addUsageTarget === "family",
+    resolvedSearchParams,
+    usageRecoveryInitialOpen: hasExactSettingsSearchParam(
+      resolvedSearchParams,
+      "usageRecovery",
+      "true",
+    ),
+    usageTopUpPurchaseReturn: readUsageTopUpPurchaseReturn(
+      resolvedSearchParams,
+    ),
+  };
 }
 
 function hasExactSettingsSearchParam(


### PR DESCRIPTION
## Why and outcome

`SettingsPage` had accumulated authentication, billing, Family, usage-credit, account, and privacy presentation derivations in one server component. This refactor keeps those contracts in the same route while extracting cohesive file-local helpers.

The exact cyclomatic counter drops `SettingsPage` from 262 to 13. The largest extracted helper is 60. No member-visible state, copy, DOM, styling, responsive behavior, redirect, read ordering, or payment/privacy authority changes.

## Product UX

- Effort: Internal refactor; no product promise or user-visible behavior changes.
- Walkthrough: Ready.
- Affected paths: signed-out recovery returns and authenticated direct, sponsored, and Family Settings states retain their existing outcomes.
- Exclusions: no redesign, new state, interaction, copy, or settings capability.
- Plan differences: none.

## Evidence

- `pnpm --dir apps/web test:prepared -- test/settings-page.test.ts` — 66 tests passed before and after rebasing.
- Focused ESLint and `pnpm --dir apps/web typecheck:prepared` — passed before and after rebasing.
- `pnpm test:frontend-design-proof` — 12 tests passed.
- Playwright Settings consent walkthrough — passed at 320, 390, and 1440 pixels, including containment, action alignment, and link behavior.
- Exact `/tmp/murph-cyclomatic.mjs` counter — baseline 262; `SettingsPage` 13; maximum extracted helper 60.
- AST comparison — `readSettingsPageData` is unchanged apart from location; manual diff inspection confirmed auth/redirect flow, conditional state, DOM order, copy, classes, and responsive contracts.
- `git diff --check` and direct-identifier/privacy scan — passed.
- Optional `pnpm test:diff` completed dependency policy, workspace boundaries, Temporal, crypto, raw-log, provider-boundary, and Web typecheck phases. Its long full-Web Vitest phase was stopped without an emitted failure after focused proof was green; exact-head CI remains the broad-suite owner.

## Non-obvious affected surfaces

No production behavior changes. The diff relocates existing billing eligibility, Family ownership, usage-credit recovery, account/Privy display, and privacy presentation derivations inside the same server-only route; the focused Settings suite covers these sensitive branches.

## Architecture and reuse

- Existing systems reused: The same page-auth snapshot, sequential Settings data loader, billing/entitlement owners, contact-routing helper, production Settings components, and design studies remain authoritative.
- New logic: None; existing derivations are moved intact, with duplicated privacy JSX collapsed to the same boolean prop and fragment-free DOM.
- New abstractions: Seven concrete file-local helpers separate request parsing, normalized data, account presentation, billing presentation, billing actions, usage presentation, and authenticated rendering.
- Complexity intentionally avoided: No dependency, shared framework, module split, data owner, wrapper DOM, compatibility path, or generic Settings abstraction was added.

## Hot reply path impact

Not applicable. The Settings server page is outside the Foreground Reply Critical Path and adds or moves no reply-path database, network, provider, or awaited operation.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool, schema, generated guidance, or provider-visible assembly changed.
- Group runtime: Not applicable; no prompt, tool, schema, generated guidance, or provider-visible assembly changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/settings#settings-model-provider-save-controls
- Evidence: Reasoned walkthrough is sufficient because the refactor retains the existing JSX, copy, classes, components, and responsive contracts; no screenshot would show a changed visual.
- Coverage: Authenticated and recovery Settings states are covered by the 66-test route matrix, while the repository-owned consent representation passed browser layout checks at 320, 390, and 1440 pixels.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; the archived execution plan is docs; no tests, config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 748 | 473 |
| Tests/fixtures | 0 | 0 |
| Docs | 119 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 867 | 473 |

## Risks

The primary risk is a behavior change hidden by extraction. Mitigations are unchanged data-loader AST proof, the 66-case route suite, both Privy authorization branches, exact post-rebase checks, and direct inspection of billing, Family, usage, privacy, auth, redirect, DOM, and responsive invariants.

## Deployment concerns

- Deployment: not applicable
- Reason: This is a behavior-preserving refactor within one Web route and introduces no schema, protocol, configuration, provider, or cross-deploy compatibility boundary.

## Changelog

- Changelog: not applicable
- Reason: Members cannot observe this internal Settings assembly refactor; it changes no capability, state, copy, recovery, performance, accessibility, or UX outcome.

ReviewGPT context sensitivity: sensitive — this is a large server-rendered Settings refactor across auth, billing, Family, usage-credit, and privacy presentation branches.

ReviewGPT first-reviewed head: 41abfaf209ef817831d09ad4380d9bc82c20f7b3