### PR TITLE
Refactor Linq webhook planner complexity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-08-30-linq-webhook-planner-complexity.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-linq-webhook-planner-complexity.md
@@ -1,0 +1,118 @@
+# Reduce Linq webhook planner cyclomatic complexity
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Reduce the cyclomatic complexity of `planHostedOnboardingLinqWebhook` by
+  extracting cohesive planning seams while preserving every existing webhook
+  admission, routing, retry, persistence, and wake decision.
+
+## Success criteria
+
+- The planner is materially simpler under the same AST complexity measure used
+  for the baseline.
+- Focused hosted-onboarding and Linq tests prove unchanged behavior at the
+  extracted seams, including duplicate, retry, membership, routing, group, and
+  delivery-result paths.
+- Hosted Web lint/typecheck and focused tests pass, or any unrelated baseline
+  blocker is recorded precisely.
+- The final diff adds no dependency, state owner, compatibility path, or policy
+  duplication and passes privacy and identifier review.
+- A scoped commit is pushed and a draft pull request records verification and
+  deployment concerns.
+
+## Scope
+
+- In scope: `apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts`,
+  directly owned pure helpers, and focused tests required to prove the refactor.
+- Out of scope: product behavior changes, schema changes, provider contract
+  changes, new services or queues, broad Linq cleanup, and unrelated complexity
+  hotspots.
+
+## Constraints
+
+- Technical constraints: preserve signature and admission trust, route/member/
+  line authority, group setup and retry behavior, transaction and lock order,
+  KMS/crypto lifetime, source correlation, idempotency, mailbox/outbox/wake
+  decisions, error mapping, data minimization, and deploy skew.
+- Product/process constraints: obtain the required implementation ReviewGPT
+  patch first; treat it as untrusted; inspect every proposed path and hunk; use
+  the smallest accepted behavior-preserving decomposition; keep the pull request
+  draft and do not launch final completion gates from this lane.
+
+## Risks and mitigations
+
+1. Risk: helper extraction silently changes statement order or transaction
+   boundaries.
+   Mitigation: keep orchestration order explicit, extract pure decisions before
+   effectful boundaries, and compare focused behavior tests before and after.
+2. Risk: decomposing provider events duplicates authorization or retry policy.
+   Mitigation: keep canonical checks at their existing owners and pass explicit
+   already-validated data into helpers.
+3. Risk: a broad generated patch creates architecture churn.
+   Mitigation: review each proposed hunk, reject unrelated or speculative work,
+   and implement accepted pieces manually with a narrow diff.
+
+## Tasks
+
+1. [x] Read repository workflow, architecture, security, reliability, and Linq
+   onboarding contracts; inspect existing Frog entries.
+2. [x] Preserve and inspect the inherited implementation-lane patch. The task
+   handoff explicitly excluded further ReviewGPT or specialist passes.
+3. [x] Map the planner's current branches, effects, tests, and baseline complexity.
+4. [x] Extract cohesive planning helpers without changing behavior or authority.
+5. [x] Reuse the existing direct planner suites; no additional seam fixture was
+   needed because they already exercise the moved family, active-member,
+   first-contact, duplicate, retry, group, and delivery-result branches.
+6. [x] Run focused tests, Web lint/typecheck, complexity measurement, and final
+   diff/privacy review.
+7. [x] Prepare the completed plan, scoped commit inputs, and complete draft pull
+   request evidence. External branch and pull-request delivery follows the
+   archived commit.
+
+## Decisions
+
+- This is an internal behavior-preserving refactor, so Product UX is unchanged;
+  the relevant affected people are direct-message members, group participants,
+  pending group owners, and retrying provider deliveries.
+- Keep the exported planner signature and effect owners intact. Prefer pure
+  event-specific decision helpers over a replacement dispatcher or new state
+  machine.
+- Keep the branch-local family, active-member direct, and first-contact
+  planners in this module. They share the existing transaction and prepared
+  authority lifetime and do not introduce another dispatcher, service, state
+  owner, or compatibility layer.
+- Restore the original explicit-null family-token decision instead of using a
+  truthiness shortcut, preserving the exact prior input classification.
+
+## Verification
+
+- Commands to run: focused Vitest files discovered from the planner import
+  graph; Web lint/typecheck commands from repository guidance; the baseline
+  complexity script or equivalent AST measure; `git diff --check`; privacy and
+  identifier scans over the final diff.
+- Expected outcomes: focused behavior remains green; type/lint checks pass;
+  complexity falls materially; only the planner, directly owned tests, and this
+  completed plan change.
+
+## Results
+
+- The exact AST counter reduced `planHostedOnboardingLinqWebhook` from 222 to
+  94. The largest extracted helper is the first-contact planner at 76; the
+  family and active-member helpers measure 31 and 25 respectively.
+- An AST effect-site comparison found the same 55 awaited call sites and callee
+  counts before and after extraction. The 165 string literals in the planner
+  composition also match exactly.
+- Focused hosted Web Vitest proof passed 5 files and 395 tests covering direct
+  dispatch, thread/group routing, mailbox-root preparation, read-receipt
+  authority, duplicates, retries, and home-route recovery.
+- Hosted Web typecheck, focused ESLint, `git diff --check`, and the final
+  identifier/privacy scan passed.
+- Product UX, frontend rendering, changelog, schema, provider-input, and
+  cross-deploy compatibility are unchanged. Exact-head CI remains the broad
+  PR verification owner; the requested diff-aware Web lane is reported
+  separately from this focused local proof.
+Completed: 2026-08-30

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1314,7 +1314,7 @@ function hasSameHostedLinqMessageEdit(
     && existing.parts[0].value === requested.parts[0].value;
 }
 
-export async function planHostedOnboardingLinqWebhook(input: {
+type HostedOnboardingLinqWebhookPlannerInput = {
   affirmativeReaction?: boolean;
   event: HostedLinqWebhookEvent;
   firstContactAdmissionDecision?: HostedLinqFirstContactAdmissionDecision | null;
@@ -1330,7 +1330,11 @@ export async function planHostedOnboardingLinqWebhook(input: {
   prisma: Prisma.TransactionClient;
   requireFirstContactAdmission?: boolean;
   requiredPendingGroupSetupCandidateId?: string | null;
-}): Promise<HostedOnboardingLinqDirectPlan> {
+};
+
+export async function planHostedOnboardingLinqWebhook(
+  input: HostedOnboardingLinqWebhookPlannerInput,
+): Promise<HostedOnboardingLinqDirectPlan> {
   if (input.event.event_type !== "message.received") {
     return logHostedLinqWebhookPlannerDecisionAndReturn(
       buildIgnoredLinqWebhookPlan(input.event.event_type),
@@ -1758,349 +1762,19 @@ export async function planHostedOnboardingLinqWebhook(input: {
 
   }
 
-  const buildUnassignableHomeLinePlan = (routeStage: string) =>
-    logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan("unassignable-home-line"),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: "unassignable-home-line",
-        routeStage,
-      }),
-    );
-  const buildHomeLineCapacityExhaustedPlan = (routeStage: string) =>
-    logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan("home-line-capacity-exhausted"),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: "home-line-capacity-exhausted",
-        routeStage,
-      }),
-    );
-  const buildRouteBindingBlockedPlan = (
-    bindingResult: HostedLinqHomeLineRouteBindingResult,
-    routeStages: {
-      capacityExhausted: string;
-      redirect: string;
-      unassignable: string;
-      unattestedDirect: string;
-      unknownHome: string;
-    },
-  ): HostedOnboardingLinqDirectPlan | null => {
-    if (bindingResult.kind === "bind") {
-      return null;
-    }
-
-    if (bindingResult.kind === "unassignable") {
-      return buildUnassignableHomeLinePlan(routeStages.unassignable);
-    }
-
-    if (bindingResult.kind === "capacity_exhausted") {
-      return buildHomeLineCapacityExhaustedPlan(routeStages.capacityExhausted);
-    }
-
-    if (bindingResult.kind === "redirect_to_home") {
-      if (!existingMember) {
-        return buildUnassignableHomeLinePlan(routeStages.unassignable);
-      }
-
-      return logHostedLinqWebhookPlannerDecisionAndReturn(
-        buildConversationHomeRedirectResponse({
-          chatId: summary.chatId,
-          homeRecipientPhone: bindingResult.homeRecipientPhone,
-          memberId: existingMember.id,
-          messageId: summary.messageId,
-          occurredAt: context.occurredAt,
-          sourceEventId: input.event.event_id,
-        }),
-        buildHostedLinqWebhookPlannerDetails(input.event, context, {
-          existingMemberActive: existingMemberEffectiveActive,
-          existingMemberMatch,
-          homeRoutePresent: true,
-          reason: "redirect-to-home",
-          routeDecision: bindingResult.kind,
-          routeStage: routeStages.redirect,
-        }),
-      );
-    }
-
-    if (bindingResult.kind === "ignore_unattested_direct") {
-      return logHostedLinqWebhookPlannerDecisionAndReturn(
-        buildIgnoredLinqWebhookPlan("unattested-direct-chat"),
-        buildHostedLinqWebhookPlannerDetails(input.event, context, {
-          existingMemberActive: existingMemberEffectiveActive,
-          existingMemberMatch,
-          homeRoutePresent: true,
-          reason: "unattested-direct-chat",
-          routeDecision: bindingResult.kind,
-          routeStage: routeStages.unattestedDirect,
-        }),
-      );
-    }
-
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan("unknown-home-line"),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        homeRoutePresent: true,
-        reason: "unknown-home-line",
-        routeDecision: bindingResult.kind,
-        routeStage: routeStages.unknownHome,
-      }),
-    );
-  };
-
-  const familyInviteCode = await resolveHostedFamilyInviteTokenForInbound({
-    prisma: input.prisma,
-    text: summary.text,
+  const familyPlan = await planHostedLinqFamilyInviteWebhook({
+    context,
+    directMailboxPreparationProvided,
+    existingMember,
+    existingMemberActive: Boolean(existingMemberEffectiveActive),
+    existingMemberMatch,
+    input,
+    memberRouteBindingAuthority,
+    participantContact,
+    preparedDirectRoutingAuthority,
   });
-  const familyInviteTokenPresent = familyInviteCode !== null;
-  const preparedFamilyCryptoDomainRoots =
-    familyInviteCode
-      && existingMember
-      && directMailboxPreparationProvided
-      && preparedDirectRoutingAuthority?.preparedFamilyInvite?.kind
-        === "pending_acceptance"
-      ? (() => {
-          if (
-            preparedDirectRoutingAuthority.preparedFamilyInvite.inviteCode
-              !== familyInviteCode
-            || !preparedDirectRoutingAuthority.preparedCryptoDomainRoots
-            || !preparedDirectRoutingAuthority.preparedFamilyOwnerNotification
-          ) {
-            throw hostedLinqDirectMailboxPreparationRequired("member");
-          }
-          return preparedDirectRoutingAuthority.preparedCryptoDomainRoots;
-        })()
-      : undefined;
-  let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromPhoneTx>> = null;
-  let familyActivationWake: HostedWebhookWakeHandoff | null = null;
-  let familySignupNotificationMemberId: string | null = null;
-  let familyDraftCheckoutConflict = false;
-  let familyStripeEffectPending = false;
-  let familyRouteBlockedPlan: HostedOnboardingLinqDirectPlan | null = null;
-  const familyRouteBlockedError = new Error("Hosted Linq family route is not bindable.");
-  if (participantContact.kind === "phone") {
-    try {
-      familyAcceptance = await acceptHostedFamilyInviteFromPhoneTx({
-        ...(familyInviteCode && preparedDirectRoutingAuthority
-          ? {
-              acceptedMember: {
-                currentIdentity: preparedDirectRoutingAuthority.identityState,
-                member: existingMember!,
-                preparedControlRoot:
-                  preparedDirectRoutingAuthority.preparedControlRoot,
-              },
-              preparedInvite: preparedDirectRoutingAuthority.preparedFamilyInvite,
-            }
-          : {}),
-        now: new Date(occurredAt),
-        onAcceptedMemberLocked: async ({ acceptedMemberId }) => {
-          const bindingResult = await resolveIncomingHostedLinqHomeLineRouteBindingTx({
-            incomingChatId: summary.chatId,
-            incomingDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
-            incomingRecipientPhone: recipientPhoneNumber,
-            memberAuthority: memberRouteBindingAuthority?.kind === "pending-contact"
-              ? { kind: "member-identity" }
-              : memberRouteBindingAuthority,
-            memberId: acceptedMemberId,
-            ...(preparedDirectRoutingAuthority
-              && preparedDirectRoutingAuthority.memberId === acceptedMemberId
-              ? {
-                  preparedRoutingState:
-                    preparedDirectRoutingAuthority.routingState,
-                }
-              : {}),
-            prisma: input.prisma,
-          });
-          familyRouteBlockedPlan = buildRouteBindingBlockedPlan(bindingResult, {
-            capacityExhausted: "ignored-home-line-capacity-exhausted",
-            redirect: "family-invite-redirect",
-            unassignable: "ignored-unassignable-home-line",
-            unattestedDirect: "family-invite-ignored-unattested-direct",
-            unknownHome: "family-invite-ignored-home-line",
-          });
-          if (familyRouteBlockedPlan) {
-            throw familyRouteBlockedError;
-          }
-          if (bindingResult.kind !== "bind") {
-            familyRouteBlockedPlan = buildUnassignableHomeLinePlan(
-              "ignored-unassignable-home-line",
-            );
-            throw familyRouteBlockedError;
-          }
-
-          await upsertHostedMemberHomeLinqBindingTx({
-            clearPending: true,
-            homeLineAssignedAt: bindingResult.homeLineAssignedAt,
-            linqChatId: summary.chatId,
-            memberId: acceptedMemberId,
-            participantContact,
-            prisma: input.prisma,
-            recipientPhone: bindingResult.recipientPhone,
-          });
-        },
-        onAcceptedMemberActivated: (activation) => {
-          if (activation.activated) {
-            familySignupNotificationMemberId = activation.memberId;
-          }
-          if (activation.hostedExecutionEventId && activation.hostedExecutionMailboxItemId) {
-            familyActivationWake = {
-              eventId: activation.hostedExecutionEventId,
-              mailboxItemId: activation.hostedExecutionMailboxItemId,
-              source: "linq",
-              userId: activation.memberId,
-            };
-          }
-        },
-        ...(preparedFamilyCryptoDomainRoots && preparedDirectRoutingAuthority
-          ? {
-              onAcceptedMemberValidated: async ({ acceptedMemberId }) => {
-                if (acceptedMemberId !== preparedDirectRoutingAuthority.memberId) {
-                  throw hostedLinqDirectMailboxPreparationRequired("member");
-                }
-                await revalidatePreparedHostedLinqDirectIngressRootTx({
-                  memberId: acceptedMemberId,
-                  prepared: preparedDirectRoutingAuthority,
-                  prisma: input.prisma,
-                });
-              },
-            }
-          : {}),
-        phoneNumber: participantContact.value,
-        ...(preparedFamilyCryptoDomainRoots
-          ? { preparedCryptoDomainRoots: preparedFamilyCryptoDomainRoots }
-          : {}),
-        ...(preparedDirectRoutingAuthority?.preparedFamilyOwnerNotification
-          ? {
-              preparedOwnerNotification:
-                preparedDirectRoutingAuthority.preparedFamilyOwnerNotification,
-            }
-          : {}),
-        text: summary.text,
-        tx: input.prisma,
-      });
-    } catch (error) {
-      if (error === familyRouteBlockedError && familyRouteBlockedPlan) {
-        return familyRouteBlockedPlan;
-      }
-      if (
-        isHostedOnboardingError(error)
-        && error.code === HOSTED_FAMILY_DRAFT_CHECKOUT_ACTIVE_ERROR_CODE
-      ) {
-        familyDraftCheckoutConflict = true;
-      } else if (isHostedStripeEffectPendingError(error)) {
-        familyStripeEffectPending = true;
-      } else if (error instanceof HostedDomainRootPreparationMismatchError) {
-        throw hostedLinqDirectMailboxPreparationRequired("member");
-      } else if (!isExpectedHostedLinqFamilyInviteAcceptanceMiss(error)) {
-        throw error;
-      }
-    }
-  }
-
-  if (familyAcceptance) {
-    const dailyState = await incrementHostedLinqInboundDailyState({
-      memberId: familyAcceptance.memberId,
-      occurredAt,
-      prisma: input.prisma,
-    });
-
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildFamilyInviteAcceptedResponse({
-        chatId: summary.chatId,
-        memberId: familyAcceptance.memberId,
-        message: buildHostedFamilyInviteAcceptedReplyText({
-          memberId: familyAcceptance.memberId,
-        }),
-        messageId: summary.messageId,
-        occurredAt,
-        ...(familySignupNotificationMemberId
-          ? {
-              signupNotificationMemberId:
-                familySignupNotificationMemberId,
-            }
-          : {}),
-        sourceEventId: input.event.event_id,
-        ...(familyActivationWake ? { wakeHandoff: familyActivationWake } : {}),
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        dailyInboundCount: dailyState.inboundCount,
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: "family-invite-accepted",
-        routeStage: "family-invite-accepted",
-      }),
-    );
-  }
-
-  if (familyDraftCheckoutConflict) {
-    if (!existingMember) {
-      throw hostedOnboardingError({
-        code: "HOSTED_FAMILY_DRAFT_RECOVERY_MEMBER_MISSING",
-        httpStatus: 500,
-        message: "The Family invite recovery member could not be resolved.",
-        retryable: true,
-      });
-    }
-    if (!familyInviteCode) {
-      throw hostedOnboardingError({
-        code: "HOSTED_FAMILY_DRAFT_RECOVERY_INVITE_MISSING",
-        httpStatus: 500,
-        message: "The Family invite recovery link could not be resolved.",
-        retryable: true,
-      });
-    }
-    const dailyState = await incrementHostedLinqInboundDailyState({
-      memberId: existingMember.id,
-      occurredAt,
-      prisma: input.prisma,
-    });
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildFamilyInviteDraftRecoveryResponse({
-        chatId: summary.chatId,
-        memberId: existingMember.id,
-        message: buildHostedFamilyDraftCheckoutConflictReplyText({
-          inviteCode: familyInviteCode,
-        }),
-        messageId: summary.messageId,
-        occurredAt,
-        sourceEventId: input.event.event_id,
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        dailyInboundCount: dailyState.inboundCount,
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: "family-invite-draft-recovery-required",
-        routeStage: "family-invite-draft-recovery-required",
-      }),
-    );
-  }
-
-  if (familyStripeEffectPending) {
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan(HOSTED_STRIPE_EFFECT_PENDING_VISIBLE_REASON),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: HOSTED_STRIPE_EFFECT_PENDING_VISIBLE_REASON,
-        routeStage: "family-invite-stripe-effect-pending",
-      }),
-    );
-  }
-
-  if (familyInviteTokenPresent) {
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildIgnoredLinqWebhookPlan("family-invite-not-accepted"),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        reason: "family-invite-not-accepted",
-        routeStage: "ignored-family-invite-token",
-      }),
-    );
+  if (familyPlan) {
+    return familyPlan;
   }
 
   if (existingMember && !existingMemberEffectiveActive) {
@@ -2272,213 +1946,99 @@ export async function planHostedOnboardingLinqWebhook(input: {
           }),
         );
       }
-
     }
   }
 
   if (existingMember && existingMemberEffectiveActive) {
-    const preparedDirectMailbox = directMailboxPreparationProvided
-      ? preparedDirectRoutingAuthority
-      : null;
-    if (directMailboxPreparationProvided) {
-      if (!preparedDirectMailbox) {
-        throw hostedLinqDirectMailboxPreparationRequired("member");
-      }
-    }
-
-    const bindingResult = await resolveIncomingHostedLinqHomeLineRouteBindingTx({
-      acceptManagedInboundLine:
-        existingMemberMatch === "phone-identity"
-        && isHostedLinqIMessageService(messageEvent.data.service),
-      incomingChatId: summary.chatId,
-      incomingDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
-      incomingRecipientPhone: recipientPhoneNumber,
-      memberAuthority: memberRouteBindingAuthority,
-      memberId: existingMember.id,
-      ...(preparedDirectMailbox
-        ? { preparedRoutingState: preparedDirectMailbox.routingState }
-        : {}),
-      prisma: input.prisma,
-    });
-    const blockedPlan = buildRouteBindingBlockedPlan(bindingResult, {
-      capacityExhausted: "active-member-ignored-home-line-capacity-exhausted",
-      redirect: "active-member-redirect",
-      unassignable: "active-member-ignored-unassignable-home-line",
-      unattestedDirect: "active-member-ignored-unattested-direct",
-      unknownHome: "active-member-ignored-home-line",
-    });
-    if (blockedPlan) {
-      return blockedPlan;
-    }
-    if (bindingResult.kind !== "bind") {
-      return buildUnassignableHomeLinePlan("active-member-ignored-unassignable-home-line");
-    }
-
-    const dailyState = await incrementHostedLinqInboundDailyState({
-      memberId: existingMember.id,
-      occurredAt,
-      prisma: input.prisma,
-    });
-
-    // Daily quota suppression intentionally remains ahead of both route
-    // binding and mailbox append, so a suppressed message changes neither.
-    const admissionPlan = groupJoinContext
-      ? null
-      : await planHostedLinqDailyQuotaAdmissionDenied({
-          context,
-          dailyState,
-          dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
-          event: input.event,
-          logDetails: {
-            existingMemberActive: true,
-            existingMemberMatch,
-            routeDecision: bindingResult.kind,
-          },
-          memberId: existingMember.id,
-          routeStages: {
-            dailyQuotaReached: "active-member-daily-quota-reached",
-            dailyQuotaReply: "active-member-daily-quota-reply",
-          },
-        });
-    if (admissionPlan) {
-      return {
-        ...admissionPlan,
-        postCommitGroupJoinConfirmationMemberIds: [existingMember.id],
-      };
-    }
-
-    const mailboxParticipantIdentity = await bindHostedMemberHomeLinqChat({
-      chatId: summary.chatId,
-      homeLineAssignedAt: bindingResult.homeLineAssignedAt,
-      memberId: existingMember.id,
+    return planHostedLinqActiveMemberDirectWebhook({
+      context,
+      directMailboxPreparationProvided,
+      existingMember,
+      existingMemberEffectiveActive,
+      existingMemberMatch,
+      groupJoinContext,
+      input,
+      memberRouteBindingAuthority,
       participantContact,
-      prisma: input.prisma,
-      recipientPhone: bindingResult.recipientPhone,
-    }) ?? participantContact;
-
-    if (await hasConflictingHostedLinqInstantFirstTurnForChatTx({
-      eventId: input.event.event_id,
-      linqChatId: summary.chatId,
-      prisma: input.prisma,
-    })) {
-      throw hostedOnboardingError({
-        code: "HOSTED_LINQ_INSTANT_FIRST_TURN_RETRY",
-        details: { reason: "earlier-chat-reply-unresolved" },
-        httpStatus: 503,
-        message:
-          "An earlier Web-owned reply is still reconciling for this chat.",
-        retryable: true,
-      });
-    }
-
-    if (groupJoinContext) {
-      const invite = await issueHostedInviteTx({
-        channel: "linq",
-        memberId: existingMember.id,
-        prisma: input.prisma,
-      });
-      return logHostedLinqWebhookPlannerDecisionAndReturn(
-        buildSignupLinkResponse({
-          chatId: summary.chatId,
-          groupJoinCode: groupJoinContext.joinCode,
-          groupJoinOutreachId: groupJoinContext.outreachId,
-          inviteCode: invite.inviteCode,
-          inviteId: invite.id,
-          memberId: existingMember.id,
-          messageId: summary.messageId,
-          occurredAt,
-          service: messageEvent.data.service ?? null,
-          sourceEventId: input.event.event_id,
-          threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
-        }),
-        buildHostedLinqWebhookPlannerDetails(input.event, context, {
-          dailyInboundCount: dailyState.inboundCount,
-          existingMemberActive: true,
-          existingMemberMatch,
-          reason: "sent-signup-link",
-          routeDecision: bindingResult.kind,
-          routeStage: "active-member-group-join-link",
-        }),
-      );
-    }
-
-    const mailboxWake = buildHostedLinqConversationWakeForMailbox({
-      eventId: input.event.event_id,
-      linqMessage: {
-        ...(input.affirmativeReaction ? { affirmativeReaction: true } : {}),
-        chatId: summary.chatId,
-        from: participantContact.value,
-        isFromMe: summary.isFromMe,
-        messageId: summary.messageId,
-        reactionEligible: input.affirmativeReaction
-          ? false
-          : isHostedLinqMessageReactionEligible({
-              parts: messageEvent.data.message.parts,
-              service: messageEvent.data.service ?? null,
-            }),
-        threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
-        ...(messageEvent.data.message.reply_to?.message_id === undefined
-          ? {}
-          : { replyToMessageId: messageEvent.data.message.reply_to.message_id }),
-        ...(messageEvent.data.message.reply_to?.part_index === undefined
-          ? {}
-          : { replyToPartIndex: messageEvent.data.message.reply_to.part_index }),
-        ...(messageEvent.data.service === undefined ? {} : { service: messageEvent.data.service }),
-      },
-      occurredAt,
-      participantContact: mailboxParticipantIdentity,
-      rawParts: messageEvent.data.message.parts,
-      userId: existingMember.id,
+      preparedDirectRoutingAuthority,
     });
-
-    const sourceMessageLookupKey = requireHostedLinqSourceMessageLookupKey(
-      summary.messageId,
-    );
-    if (preparedDirectMailbox) {
-      await revalidatePreparedHostedLinqDirectIngressRootTx({
-        memberId: existingMember.id,
-        prepared: preparedDirectMailbox,
-        prisma: input.prisma,
-      });
-    }
-    const mailboxAppend = preparedDirectMailbox?.preparedIngressRoot
-      ? await appendHostedMailboxEnvelopeWithPreparedCryptoTx({
-          envelope: mailboxWake,
-          prepared: preparedDirectMailbox.preparedIngressRoot,
-          sourceMessageLookupKey,
-          tx: input.prisma,
-        })
-      : await appendHostedMailboxEnvelopeWithSourceMessageTx({
-          envelope: mailboxWake,
-          sourceMessageLookupKey,
-          tx: input.prisma,
-        });
-
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildActiveMemberDirectPlan({
-        desiredSideEffects: [],
-        postCommitGroupJoinConfirmationMemberIds: [existingMember.id],
-        response: {
-          ok: true,
-          ignored: false,
-          reason: "wake-appended-active-member",
-        },
-        wakeHandoffs: [{
-          eventId: input.event.event_id, linqChatId: summary.chatId, mailboxItemId: mailboxAppend.item.id, source: "linq", userId: existingMember.id,
-          wakeMailboxCheckpoint: { lane: mailboxAppend.item.lane, laneSeq: mailboxAppend.item.laneSeq },
-        }],
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        dailyInboundCount: dailyState.inboundCount,
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        mailboxAppendPresent: true,
-        reason: "wake-appended-active-member",
-        routeDecision: bindingResult.kind,
-        routeStage: "active-member-appended",
-      }),
-    );
   }
+
+  return planHostedLinqFirstContactWebhook({
+    context,
+    existingMember,
+    existingMemberActive: Boolean(existingMemberEffectiveActive),
+    existingMemberMatch,
+    groupJoinContext,
+    instantStartOwner,
+    memberRouteBindingAuthority,
+    participantContact,
+    plannerInput: input,
+    preparedDirectRoutingAuthority,
+  });
+}
+
+async function planHostedLinqFirstContactWebhook(planner: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  existingMember: HostedMemberCoreState | null;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  groupJoinContext: Awaited<ReturnType<typeof readHostedGroupJoinOutreachReplyContextTx>>;
+  instantStartOwner: HostedLinqInstantStartOwner | null;
+  memberRouteBindingAuthority: HostedLinqHomeLineRouteBindingAuthority | null;
+  participantContact: HostedLinqParticipantContact;
+  plannerInput: HostedOnboardingLinqWebhookPlannerInput;
+  preparedDirectRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+}): Promise<HostedOnboardingLinqDirectPlan> {
+  const {
+    context,
+    existingMember,
+    existingMemberActive,
+    existingMemberMatch,
+    groupJoinContext,
+    instantStartOwner,
+    memberRouteBindingAuthority,
+    participantContact,
+    plannerInput: input,
+    preparedDirectRoutingAuthority,
+  } = planner;
+  const { messageEvent, occurredAt, recipientPhoneNumber, summary } = context;
+  const existingMemberEffectiveActive = existingMemberActive;
+  const buildUnassignableHomeLinePlan = (routeStage: string) =>
+    buildHostedLinqUnassignableHomeLinePlan({
+      context,
+      event: input.event,
+      existingMemberActive,
+      existingMemberMatch,
+      routeStage,
+    });
+  const buildHomeLineCapacityExhaustedPlan = (routeStage: string) =>
+    buildHostedLinqHomeLineCapacityExhaustedPlan({
+      context,
+      event: input.event,
+      existingMemberActive,
+      existingMemberMatch,
+      routeStage,
+    });
+  const buildRouteBindingBlockedPlan = (
+    bindingResult: HostedLinqHomeLineRouteBindingResult,
+    routeStages: {
+      capacityExhausted: string;
+      redirect: string;
+      unassignable: string;
+      unattestedDirect: string;
+      unknownHome: string;
+    },
+  ): HostedOnboardingLinqDirectPlan | null =>
+    buildHostedLinqRouteBindingBlockedPlan({
+      bindingResult,
+      context,
+      event: input.event,
+      existingMember,
+      existingMemberActive,
+      existingMemberMatch,
+      routeStages,
+    });
 
   if (!isHostedLinqDeliverableFirstContact({
     event: messageEvent,
@@ -2892,6 +2452,676 @@ export async function planHostedOnboardingLinqWebhook(input: {
       existingMemberMatch,
       reason: "sent-signup-link",
       routeStage: "first-contact-signup-link",
+    }),
+  );
+}
+
+async function planHostedLinqActiveMemberDirectWebhook(input: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  directMailboxPreparationProvided: boolean;
+  existingMember: HostedMemberCoreState;
+  existingMemberEffectiveActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  groupJoinContext: Awaited<ReturnType<typeof readHostedGroupJoinOutreachReplyContextTx>>;
+  input: HostedOnboardingLinqWebhookPlannerInput;
+  memberRouteBindingAuthority: HostedLinqHomeLineRouteBindingAuthority | null;
+  participantContact: HostedLinqParticipantContact;
+  preparedDirectRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+}): Promise<HostedOnboardingLinqDirectPlan> {
+  const {
+    context,
+    directMailboxPreparationProvided,
+    existingMember,
+    existingMemberEffectiveActive,
+    existingMemberMatch,
+    groupJoinContext,
+    memberRouteBindingAuthority,
+    participantContact,
+    preparedDirectRoutingAuthority,
+  } = input;
+  const { messageEvent, occurredAt, recipientPhoneNumber, summary } = context;
+  const plannerInput = input.input;
+  const preparedDirectMailbox = directMailboxPreparationProvided
+    ? preparedDirectRoutingAuthority
+    : null;
+  if (directMailboxPreparationProvided && !preparedDirectMailbox) {
+    throw hostedLinqDirectMailboxPreparationRequired("member");
+  }
+
+  const bindingResult = await resolveIncomingHostedLinqHomeLineRouteBindingTx({
+    acceptManagedInboundLine:
+      existingMemberMatch === "phone-identity"
+      && isHostedLinqIMessageService(messageEvent.data.service),
+    incomingChatId: summary.chatId,
+    incomingDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
+    incomingRecipientPhone: recipientPhoneNumber,
+    memberAuthority: memberRouteBindingAuthority,
+    memberId: existingMember.id,
+    ...(preparedDirectMailbox
+      ? { preparedRoutingState: preparedDirectMailbox.routingState }
+      : {}),
+    prisma: plannerInput.prisma,
+  });
+  const blockedPlan = buildHostedLinqRouteBindingBlockedPlan({
+    bindingResult,
+    context,
+    event: plannerInput.event,
+    existingMember,
+    existingMemberActive: existingMemberEffectiveActive,
+    existingMemberMatch,
+    routeStages: {
+      capacityExhausted: "active-member-ignored-home-line-capacity-exhausted",
+      redirect: "active-member-redirect",
+      unassignable: "active-member-ignored-unassignable-home-line",
+      unattestedDirect: "active-member-ignored-unattested-direct",
+      unknownHome: "active-member-ignored-home-line",
+    },
+  });
+  if (blockedPlan) {
+    return blockedPlan;
+  }
+  if (bindingResult.kind !== "bind") {
+    return buildHostedLinqUnassignableHomeLinePlan({
+      context,
+      event: plannerInput.event,
+      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberMatch,
+      routeStage: "active-member-ignored-unassignable-home-line",
+    });
+  }
+
+  const dailyState = await incrementHostedLinqInboundDailyState({
+    memberId: existingMember.id,
+    occurredAt,
+    prisma: plannerInput.prisma,
+  });
+
+  // Daily quota suppression intentionally remains ahead of both route binding
+  // and mailbox append, so a suppressed message changes neither.
+  const admissionPlan = groupJoinContext
+    ? null
+    : await planHostedLinqDailyQuotaAdmissionDenied({
+        context,
+        dailyState,
+        dailyTextLimit: HOSTED_LINQ_DAILY_TEXT_LIMIT,
+        event: plannerInput.event,
+        logDetails: {
+          existingMemberActive: true,
+          existingMemberMatch,
+          routeDecision: bindingResult.kind,
+        },
+        memberId: existingMember.id,
+        routeStages: {
+          dailyQuotaReached: "active-member-daily-quota-reached",
+          dailyQuotaReply: "active-member-daily-quota-reply",
+        },
+      });
+  if (admissionPlan) {
+    return {
+      ...admissionPlan,
+      postCommitGroupJoinConfirmationMemberIds: [existingMember.id],
+    };
+  }
+
+  const mailboxParticipantIdentity = await bindHostedMemberHomeLinqChat({
+    chatId: summary.chatId,
+    homeLineAssignedAt: bindingResult.homeLineAssignedAt,
+    memberId: existingMember.id,
+    participantContact,
+    prisma: plannerInput.prisma,
+    recipientPhone: bindingResult.recipientPhone,
+  }) ?? participantContact;
+
+  if (await hasConflictingHostedLinqInstantFirstTurnForChatTx({
+    eventId: plannerInput.event.event_id,
+    linqChatId: summary.chatId,
+    prisma: plannerInput.prisma,
+  })) {
+    throw hostedOnboardingError({
+      code: "HOSTED_LINQ_INSTANT_FIRST_TURN_RETRY",
+      details: { reason: "earlier-chat-reply-unresolved" },
+      httpStatus: 503,
+      message: "An earlier Web-owned reply is still reconciling for this chat.",
+      retryable: true,
+    });
+  }
+
+  if (groupJoinContext) {
+    const invite = await issueHostedInviteTx({
+      channel: "linq",
+      memberId: existingMember.id,
+      prisma: plannerInput.prisma,
+    });
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildSignupLinkResponse({
+        chatId: summary.chatId,
+        groupJoinCode: groupJoinContext.joinCode,
+        groupJoinOutreachId: groupJoinContext.outreachId,
+        inviteCode: invite.inviteCode,
+        inviteId: invite.id,
+        memberId: existingMember.id,
+        messageId: summary.messageId,
+        occurredAt,
+        service: messageEvent.data.service ?? null,
+        sourceEventId: plannerInput.event.event_id,
+        threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
+      }),
+      buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+        dailyInboundCount: dailyState.inboundCount,
+        existingMemberActive: true,
+        existingMemberMatch,
+        reason: "sent-signup-link",
+        routeDecision: bindingResult.kind,
+        routeStage: "active-member-group-join-link",
+      }),
+    );
+  }
+
+  const mailboxWake = buildHostedLinqConversationWakeForMailbox({
+    eventId: plannerInput.event.event_id,
+    linqMessage: {
+      ...(plannerInput.affirmativeReaction ? { affirmativeReaction: true } : {}),
+      chatId: summary.chatId,
+      from: participantContact.value,
+      isFromMe: summary.isFromMe,
+      messageId: summary.messageId,
+      reactionEligible: plannerInput.affirmativeReaction
+        ? false
+        : isHostedLinqMessageReactionEligible({
+            parts: messageEvent.data.message.parts,
+            service: messageEvent.data.service ?? null,
+          }),
+      threadIsDirect: resolveHostedLinqThreadIsDirect(messageEvent),
+      ...(messageEvent.data.message.reply_to?.message_id === undefined
+        ? {}
+        : { replyToMessageId: messageEvent.data.message.reply_to.message_id }),
+      ...(messageEvent.data.message.reply_to?.part_index === undefined
+        ? {}
+        : { replyToPartIndex: messageEvent.data.message.reply_to.part_index }),
+      ...(messageEvent.data.service === undefined
+        ? {}
+        : { service: messageEvent.data.service }),
+    },
+    occurredAt,
+    participantContact: mailboxParticipantIdentity,
+    rawParts: messageEvent.data.message.parts,
+    userId: existingMember.id,
+  });
+
+  const sourceMessageLookupKey = requireHostedLinqSourceMessageLookupKey(
+    summary.messageId,
+  );
+  if (preparedDirectMailbox) {
+    await revalidatePreparedHostedLinqDirectIngressRootTx({
+      memberId: existingMember.id,
+      prepared: preparedDirectMailbox,
+      prisma: plannerInput.prisma,
+    });
+  }
+  const mailboxAppend = preparedDirectMailbox?.preparedIngressRoot
+    ? await appendHostedMailboxEnvelopeWithPreparedCryptoTx({
+        envelope: mailboxWake,
+        prepared: preparedDirectMailbox.preparedIngressRoot,
+        sourceMessageLookupKey,
+        tx: plannerInput.prisma,
+      })
+    : await appendHostedMailboxEnvelopeWithSourceMessageTx({
+        envelope: mailboxWake,
+        sourceMessageLookupKey,
+        tx: plannerInput.prisma,
+      });
+
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    buildActiveMemberDirectPlan({
+      desiredSideEffects: [],
+      postCommitGroupJoinConfirmationMemberIds: [existingMember.id],
+      response: {
+        ok: true,
+        ignored: false,
+        reason: "wake-appended-active-member",
+      },
+      wakeHandoffs: [{
+        eventId: plannerInput.event.event_id,
+        linqChatId: summary.chatId,
+        mailboxItemId: mailboxAppend.item.id,
+        source: "linq",
+        userId: existingMember.id,
+        wakeMailboxCheckpoint: {
+          lane: mailboxAppend.item.lane,
+          laneSeq: mailboxAppend.item.laneSeq,
+        },
+      }],
+    }),
+    buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+      dailyInboundCount: dailyState.inboundCount,
+      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberMatch,
+      mailboxAppendPresent: true,
+      reason: "wake-appended-active-member",
+      routeDecision: bindingResult.kind,
+      routeStage: "active-member-appended",
+    }),
+  );
+}
+
+async function planHostedLinqFamilyInviteWebhook(input: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  directMailboxPreparationProvided: boolean;
+  existingMember: HostedMemberCoreState | null;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  input: HostedOnboardingLinqWebhookPlannerInput;
+  memberRouteBindingAuthority: HostedLinqHomeLineRouteBindingAuthority | null;
+  participantContact: HostedLinqParticipantContact;
+  preparedDirectRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+}): Promise<HostedOnboardingLinqDirectPlan | null> {
+  const {
+    context,
+    directMailboxPreparationProvided,
+    existingMember,
+    existingMemberActive,
+    existingMemberMatch,
+    memberRouteBindingAuthority,
+    participantContact,
+    preparedDirectRoutingAuthority,
+  } = input;
+  const plannerInput = input.input;
+  const { messageEvent, occurredAt, recipientPhoneNumber, summary } = context;
+  const familyInviteCode = await resolveHostedFamilyInviteTokenForInbound({
+    prisma: plannerInput.prisma,
+    text: summary.text,
+  });
+  const preparedFamilyCryptoDomainRoots =
+    familyInviteCode
+      && existingMember
+      && directMailboxPreparationProvided
+      && preparedDirectRoutingAuthority?.preparedFamilyInvite?.kind
+        === "pending_acceptance"
+      ? (() => {
+          if (
+            preparedDirectRoutingAuthority.preparedFamilyInvite.inviteCode
+              !== familyInviteCode
+            || !preparedDirectRoutingAuthority.preparedCryptoDomainRoots
+            || !preparedDirectRoutingAuthority.preparedFamilyOwnerNotification
+          ) {
+            throw hostedLinqDirectMailboxPreparationRequired("member");
+          }
+          return preparedDirectRoutingAuthority.preparedCryptoDomainRoots;
+        })()
+      : undefined;
+  let familyAcceptance: Awaited<ReturnType<typeof acceptHostedFamilyInviteFromPhoneTx>> = null;
+  let familyActivationWake: HostedWebhookWakeHandoff | null = null;
+  let familySignupNotificationMemberId: string | null = null;
+  let familyDraftCheckoutConflict = false;
+  let familyStripeEffectPending = false;
+  let familyRouteBlockedPlan: HostedOnboardingLinqDirectPlan | null = null;
+  const familyRouteBlockedError = new Error(
+    "Hosted Linq family route is not bindable.",
+  );
+  if (participantContact.kind === "phone") {
+    try {
+      familyAcceptance = await acceptHostedFamilyInviteFromPhoneTx({
+        ...(familyInviteCode && preparedDirectRoutingAuthority
+          ? {
+              acceptedMember: {
+                currentIdentity: preparedDirectRoutingAuthority.identityState,
+                member: existingMember!,
+                preparedControlRoot:
+                  preparedDirectRoutingAuthority.preparedControlRoot,
+              },
+              preparedInvite: preparedDirectRoutingAuthority.preparedFamilyInvite,
+            }
+          : {}),
+        now: new Date(occurredAt),
+        onAcceptedMemberLocked: async ({ acceptedMemberId }) => {
+          const bindingResult = await resolveIncomingHostedLinqHomeLineRouteBindingTx({
+            incomingChatId: summary.chatId,
+            incomingDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
+            incomingRecipientPhone: recipientPhoneNumber,
+            memberAuthority: memberRouteBindingAuthority?.kind === "pending-contact"
+              ? { kind: "member-identity" }
+              : memberRouteBindingAuthority,
+            memberId: acceptedMemberId,
+            ...(preparedDirectRoutingAuthority
+              && preparedDirectRoutingAuthority.memberId === acceptedMemberId
+              ? {
+                  preparedRoutingState:
+                    preparedDirectRoutingAuthority.routingState,
+                }
+              : {}),
+            prisma: plannerInput.prisma,
+          });
+          familyRouteBlockedPlan = buildHostedLinqRouteBindingBlockedPlan({
+            bindingResult,
+            context,
+            event: plannerInput.event,
+            existingMember,
+            existingMemberActive,
+            existingMemberMatch,
+            routeStages: {
+              capacityExhausted: "ignored-home-line-capacity-exhausted",
+              redirect: "family-invite-redirect",
+              unassignable: "ignored-unassignable-home-line",
+              unattestedDirect: "family-invite-ignored-unattested-direct",
+              unknownHome: "family-invite-ignored-home-line",
+            },
+          });
+          if (familyRouteBlockedPlan) {
+            throw familyRouteBlockedError;
+          }
+          if (bindingResult.kind !== "bind") {
+            familyRouteBlockedPlan = buildHostedLinqUnassignableHomeLinePlan({
+              context,
+              event: plannerInput.event,
+              existingMemberActive,
+              existingMemberMatch,
+              routeStage: "ignored-unassignable-home-line",
+            });
+            throw familyRouteBlockedError;
+          }
+
+          await upsertHostedMemberHomeLinqBindingTx({
+            clearPending: true,
+            homeLineAssignedAt: bindingResult.homeLineAssignedAt,
+            linqChatId: summary.chatId,
+            memberId: acceptedMemberId,
+            participantContact,
+            prisma: plannerInput.prisma,
+            recipientPhone: bindingResult.recipientPhone,
+          });
+        },
+        onAcceptedMemberActivated: (activation) => {
+          if (activation.activated) {
+            familySignupNotificationMemberId = activation.memberId;
+          }
+          if (
+            activation.hostedExecutionEventId
+            && activation.hostedExecutionMailboxItemId
+          ) {
+            familyActivationWake = {
+              eventId: activation.hostedExecutionEventId,
+              mailboxItemId: activation.hostedExecutionMailboxItemId,
+              source: "linq",
+              userId: activation.memberId,
+            };
+          }
+        },
+        ...(preparedFamilyCryptoDomainRoots && preparedDirectRoutingAuthority
+          ? {
+              onAcceptedMemberValidated: async ({ acceptedMemberId }) => {
+                if (acceptedMemberId !== preparedDirectRoutingAuthority.memberId) {
+                  throw hostedLinqDirectMailboxPreparationRequired("member");
+                }
+                await revalidatePreparedHostedLinqDirectIngressRootTx({
+                  memberId: acceptedMemberId,
+                  prepared: preparedDirectRoutingAuthority,
+                  prisma: plannerInput.prisma,
+                });
+              },
+            }
+          : {}),
+        phoneNumber: participantContact.value,
+        ...(preparedFamilyCryptoDomainRoots
+          ? { preparedCryptoDomainRoots: preparedFamilyCryptoDomainRoots }
+          : {}),
+        ...(preparedDirectRoutingAuthority?.preparedFamilyOwnerNotification
+          ? {
+              preparedOwnerNotification:
+                preparedDirectRoutingAuthority.preparedFamilyOwnerNotification,
+            }
+          : {}),
+        text: summary.text,
+        tx: plannerInput.prisma,
+      });
+    } catch (error) {
+      if (error === familyRouteBlockedError && familyRouteBlockedPlan) {
+        return familyRouteBlockedPlan;
+      }
+      if (
+        isHostedOnboardingError(error)
+        && error.code === HOSTED_FAMILY_DRAFT_CHECKOUT_ACTIVE_ERROR_CODE
+      ) {
+        familyDraftCheckoutConflict = true;
+      } else if (isHostedStripeEffectPendingError(error)) {
+        familyStripeEffectPending = true;
+      } else if (error instanceof HostedDomainRootPreparationMismatchError) {
+        throw hostedLinqDirectMailboxPreparationRequired("member");
+      } else if (!isExpectedHostedLinqFamilyInviteAcceptanceMiss(error)) {
+        throw error;
+      }
+    }
+  }
+
+  if (familyAcceptance) {
+    const dailyState = await incrementHostedLinqInboundDailyState({
+      memberId: familyAcceptance.memberId,
+      occurredAt,
+      prisma: plannerInput.prisma,
+    });
+
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildFamilyInviteAcceptedResponse({
+        chatId: summary.chatId,
+        memberId: familyAcceptance.memberId,
+        message: buildHostedFamilyInviteAcceptedReplyText({
+          memberId: familyAcceptance.memberId,
+        }),
+        messageId: summary.messageId,
+        occurredAt,
+        ...(familySignupNotificationMemberId
+          ? { signupNotificationMemberId: familySignupNotificationMemberId }
+          : {}),
+        sourceEventId: plannerInput.event.event_id,
+        ...(familyActivationWake ? { wakeHandoff: familyActivationWake } : {}),
+      }),
+      buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+        dailyInboundCount: dailyState.inboundCount,
+        existingMemberActive,
+        existingMemberMatch,
+        reason: "family-invite-accepted",
+        routeStage: "family-invite-accepted",
+      }),
+    );
+  }
+
+  if (familyDraftCheckoutConflict) {
+    if (!existingMember) {
+      throw hostedOnboardingError({
+        code: "HOSTED_FAMILY_DRAFT_RECOVERY_MEMBER_MISSING",
+        httpStatus: 500,
+        message: "The Family invite recovery member could not be resolved.",
+        retryable: true,
+      });
+    }
+    if (!familyInviteCode) {
+      throw hostedOnboardingError({
+        code: "HOSTED_FAMILY_DRAFT_RECOVERY_INVITE_MISSING",
+        httpStatus: 500,
+        message: "The Family invite recovery link could not be resolved.",
+        retryable: true,
+      });
+    }
+    const dailyState = await incrementHostedLinqInboundDailyState({
+      memberId: existingMember.id,
+      occurredAt,
+      prisma: plannerInput.prisma,
+    });
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildFamilyInviteDraftRecoveryResponse({
+        chatId: summary.chatId,
+        memberId: existingMember.id,
+        message: buildHostedFamilyDraftCheckoutConflictReplyText({
+          inviteCode: familyInviteCode,
+        }),
+        messageId: summary.messageId,
+        occurredAt,
+        sourceEventId: plannerInput.event.event_id,
+      }),
+      buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+        dailyInboundCount: dailyState.inboundCount,
+        existingMemberActive,
+        existingMemberMatch,
+        reason: "family-invite-draft-recovery-required",
+        routeStage: "family-invite-draft-recovery-required",
+      }),
+    );
+  }
+
+  if (familyStripeEffectPending) {
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildIgnoredLinqWebhookPlan(HOSTED_STRIPE_EFFECT_PENDING_VISIBLE_REASON),
+      buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+        existingMemberActive,
+        existingMemberMatch,
+        reason: HOSTED_STRIPE_EFFECT_PENDING_VISIBLE_REASON,
+        routeStage: "family-invite-stripe-effect-pending",
+      }),
+    );
+  }
+
+  return familyInviteCode !== null
+    ? logHostedLinqWebhookPlannerDecisionAndReturn(
+        buildIgnoredLinqWebhookPlan("family-invite-not-accepted"),
+        buildHostedLinqWebhookPlannerDetails(plannerInput.event, context, {
+          existingMemberActive,
+          existingMemberMatch,
+          reason: "family-invite-not-accepted",
+          routeStage: "ignored-family-invite-token",
+        }),
+      )
+    : null;
+}
+
+function buildHostedLinqUnassignableHomeLinePlan(input: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  event: HostedLinqWebhookEvent;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  routeStage: string;
+}): HostedOnboardingLinqDirectPlan {
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    buildIgnoredLinqWebhookPlan("unassignable-home-line"),
+    buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      reason: "unassignable-home-line",
+      routeStage: input.routeStage,
+    }),
+  );
+}
+
+function buildHostedLinqHomeLineCapacityExhaustedPlan(input: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  event: HostedLinqWebhookEvent;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  routeStage: string;
+}): HostedOnboardingLinqDirectPlan {
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    buildIgnoredLinqWebhookPlan("home-line-capacity-exhausted"),
+    buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      reason: "home-line-capacity-exhausted",
+      routeStage: input.routeStage,
+    }),
+  );
+}
+
+function buildHostedLinqRouteBindingBlockedPlan(input: {
+  bindingResult: HostedLinqHomeLineRouteBindingResult;
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  event: HostedLinqWebhookEvent;
+  existingMember: HostedMemberCoreState | null;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  routeStages: {
+    capacityExhausted: string;
+    redirect: string;
+    unassignable: string;
+    unattestedDirect: string;
+    unknownHome: string;
+  };
+}): HostedOnboardingLinqDirectPlan | null {
+  if (input.bindingResult.kind === "bind") {
+    return null;
+  }
+
+  if (input.bindingResult.kind === "unassignable") {
+    return buildHostedLinqUnassignableHomeLinePlan({
+      context: input.context,
+      event: input.event,
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      routeStage: input.routeStages.unassignable,
+    });
+  }
+
+  if (input.bindingResult.kind === "capacity_exhausted") {
+    return buildHostedLinqHomeLineCapacityExhaustedPlan({
+      context: input.context,
+      event: input.event,
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      routeStage: input.routeStages.capacityExhausted,
+    });
+  }
+
+  const { occurredAt, summary } = input.context;
+  if (input.bindingResult.kind === "redirect_to_home") {
+    if (!input.existingMember) {
+      return buildHostedLinqUnassignableHomeLinePlan({
+        context: input.context,
+        event: input.event,
+        existingMemberActive: input.existingMemberActive,
+        existingMemberMatch: input.existingMemberMatch,
+        routeStage: input.routeStages.unassignable,
+      });
+    }
+
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildConversationHomeRedirectResponse({
+        chatId: summary.chatId,
+        homeRecipientPhone: input.bindingResult.homeRecipientPhone,
+        memberId: input.existingMember.id,
+        messageId: summary.messageId,
+        occurredAt,
+        sourceEventId: input.event.event_id,
+      }),
+      buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+        existingMemberActive: input.existingMemberActive,
+        existingMemberMatch: input.existingMemberMatch,
+        homeRoutePresent: true,
+        reason: "redirect-to-home",
+        routeDecision: input.bindingResult.kind,
+        routeStage: input.routeStages.redirect,
+      }),
+    );
+  }
+
+  if (input.bindingResult.kind === "ignore_unattested_direct") {
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildIgnoredLinqWebhookPlan("unattested-direct-chat"),
+      buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+        existingMemberActive: input.existingMemberActive,
+        existingMemberMatch: input.existingMemberMatch,
+        homeRoutePresent: true,
+        reason: "unattested-direct-chat",
+        routeDecision: input.bindingResult.kind,
+        routeStage: input.routeStages.unattestedDirect,
+      }),
+    );
+  }
+
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    buildIgnoredLinqWebhookPlan("unknown-home-line"),
+    buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      homeRoutePresent: true,
+      reason: "unknown-home-line",
+      routeDecision: input.bindingResult.kind,
+      routeStage: input.routeStages.unknownHome,
     }),
   );
 }


### PR DESCRIPTION
## Outcome

- Reduces `planHostedOnboardingLinqWebhook` cyclomatic complexity from 222 to 94 without changing webhook admission, routing, persistence, retry, or wake behavior.
- Extracts module-local family-invite, active-member direct, first-contact, and route-result planning helpers while preserving the exported planner contract.

## Product UX

- Product UX: not applicable.
- Reason: This is an internal behavior-preserving refactor. Direct-message members, group participants, pending group owners, and retrying provider deliveries retain the same replies, ignores, recovery, and delivery timing.

## Evidence

- Web typecheck and focused ESLint passed on the rebased head.
- Focused Linq Vitest passed: 5 files and 395 tests covering dispatch, thread routing, mailbox root prewarm, read-receipt authority, and home-route recovery.
- Exact AST counter: target 222 before, 94 after; largest extracted helper 76.
- AST comparison found the same 55 awaited effect-site/callee counts and all 165 string literals across the original and refactored planner composition.
- Rebase range-diff preserved patch identity; `git diff --check` and direct-identifier/credential scans passed.

## Non-obvious affected surfaces

- Family invite acceptance, recovery, Stripe-effect-pending handling, and activation wake handoff.
- Existing-member route reclassification, group-join reply correlation, first-contact admission, instant start, fallback lines, daily accounting, and duplicate webhook repair.
- Prepared mailbox/identity/routing crypto revalidation, mailbox append/checkpoint handoff, and home-line capacity decisions.

## Architecture and reuse

- **Existing systems reused:** The existing transaction client, route/member authority owners, result builders, mailbox/outbox owners, and retry/error contracts remain canonical.
- **New logic:** None; four existing branch clusters are moved behind explicit inputs without changing their statements, literal values, or effect calls.
- **New abstractions:** Module-local family-invite, active-member, first-contact, and route-result helpers; no public surface or cross-module framework is added.
- **Complexity intentionally avoided:** No dependency, state owner, dispatcher, queue, schema, compatibility shim, duplicated policy, or external API is introduced.

## Hot reply path impact

- No database, crypto, provider, network, or awaited call was added, removed, or moved onto the foreground reply critical path; static comparison finds the same 55 awaited call sites and callee counts.
- Calls retain their prior order inside the same planner transaction. Timeout, retry, fallback, idempotency, mailbox, wake, and error behavior are unchanged.

## Murph initial provider input impact

- Individual runtime: Not applicable; no provider-visible prompt, message part, metadata, attachment, route payload, model request, tool/schema guidance, or provider selection changed.
- Group runtime: Not applicable for the same reason; only internal Web planner function boundaries changed.

## Risks

- The primary risk is accidental reordering across route/member locks, prepared crypto revalidation, accounting, mailbox append, and wake construction. The unchanged 55 awaited effect-site inventory plus 395 focused tests cover those boundaries.
- The family-token tail retains the original explicit `null` classification rather than a truthiness shortcut.

## Change-shape breakdown

Classification: production TypeScript is source; the completed execution plan is docs; no tests, fixtures, config/tooling, generated files, or binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1164 | 934 |
| Tests/fixtures | 0 | 0 |
| Docs | 118 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1282** | **934** |

## Deployment concerns

- Deployment: not applicable
- Reason: One hosted Web module changes internally with no schema, persisted shape, provider contract, environment, independently deployed consumer, or rollback-floor change.

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving source decomposition with no member-visible outcome.

ReviewGPT context sensitivity: sensitive — this is a large external-ingress planner refactor across routing authority, transactions, idempotency, retry, mailbox, and wake boundaries.

ReviewGPT first-reviewed head: fc0f2c3b80d4f0b1fd84535adaacc7afdd8c5d61

## Anomaly retrospective

- Trigger: authored production-source churn is 2,098 lines (1,164 added and 934 deleted), just over the mandatory 2,000-line threshold. The first-reviewed head and current head are identical; review-driven growth is zero.
- Original requirement: materially reduce the 222-complexity webhook planner while preserving every admission, authority, transaction, lock, crypto, persistence, retry, mailbox, and wake decision.
- Original shape: one exported planner interleaved family-invite, active-member direct, first-contact, and route-result construction branches. Current shape: the same exported transaction/orchestration owner plus module-local helpers for exactly those four existing branch concepts.
- Owner inventory: no durable owner, state, queue, schema, API, transaction, lock, retry policy, wake policy, or compatibility path was added or removed. The same 55 awaited effect sites and 165 string literals remain in the same composed planner path.
- Options considered: reverting misses the requested complexity reduction; shrinking by re-inlining one coherent branch merely to clear 98 churn lines would raise coordinator complexity and game the threshold without deleting a concept; splitting would make multiple PRs edit the same transaction-sensitive planner and create a less reviewable intermediate shape; redesigning around a registry or state machine would add machinery.
- Decision: explicitly continue this exact shape. The four helpers are the smallest responsibility-complete branch seams, keep the exported planner as the sole effect/order owner, and avoid replacement architecture. Focused 395-test proof plus exact effect/literal inventories cover the preserved behavior. Further expansion requires a new retrospective.