### PR TITLE
Give Murph the member-local current clock

### DIFF
--- a/.agents/friction-log/20260831024541-cloudflare-runner-deadline/friction.md
+++ b/.agents/friction-log/20260831024541-cloudflare-runner-deadline/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Cloudflare runner deadline test can wait forever on synthetic generation drift'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The runner-container deadline cleanup test should deterministically abort the caller deadline and finish promptly in focused and CI execution.
+
+## Current Behavior
+
+The test reports the current wall clock as the container state's `lastChange` on every read. A slower cleanup read can therefore make an unchanged synthetic container look like a newer generation. Production correctly refuses to destroy that apparently newer generation, while the test waits indefinitely for destroy to start because the runner Vitest project has unbounded test and hook timeouts.
+
+## Possible Solution
+
+Update the synthetic `lastChange` only when the mocked container actually changes state.
+
+## Minimal Reproducible Example
+
+Run the runner-container test filtered to the stale-rollout deadline-cleanup case with a bounded diagnostic timeout. It intermittently reaches the diagnostic timeout instead of completing.
+
+## Context
+
+This can stall the required application-verification job without a failing assertion, hiding the responsible test and consuming a CI runner until the workflow is cancelled.

--- a/agent-docs/exec-plans/active/2026-08-30-member-local-clock-context.md
+++ b/agent-docs/exec-plans/active/2026-08-30-member-local-clock-context.md
@@ -1,0 +1,149 @@
+# Give Murph trusted member-local current time
+
+Status: active
+Created: 2026-08-30
+Updated: 2026-08-30
+
+## Goal
+
+- Restore the existing promise that Murph reasons and answers from the member's
+  actual current local clock instead of treating the hosted process's UTC clock
+  as member-local time.
+- Keep the canonical vault timezone and one turn-resolved host instant as the
+  only time authorities; add no state, provider call, scheduler, or conversion
+  path owned by the model.
+
+## Success criteria
+
+- The production prompt-time resolver captures one current instant alongside
+  the already-resolved canonical timezone and local date.
+- Verified private hosted turns render that instant into an explicit local
+  clock plus its UTC instant in dynamic turn context; unknown-timezone private
+  turns remain explicitly UTC-only and never claim a member-local clock.
+- Group, unverified-external, and non-hosted turns do not receive a personal
+  current-local-clock claim from this context.
+- Deterministic boundary tests fail without the correction and prove both the
+  known-timezone and unknown-timezone prompt shapes without conflicting
+  guidance.
+- One focused production-derived real-Codex journey answers a synthetic current-
+  time question from the supplied local clock and does not report the UTC clock
+  as local time.
+- Relevant focused tests and the Assistant Engine typecheck pass; exact-head PR
+  CI and the required preliminary Product UX/prompt specialist review resolve
+  with no accepted findings left open.
+
+## Scope
+
+- In scope:
+  - `packages/assistant-engine` prompt-time resolution, turn planning, prompt
+    composition, deterministic coverage, and one focused live journey.
+  - A privacy-safe public changelog item for the member-visible correction.
+- Out of scope:
+  - Changing the canonical vault timezone owner, signup timezone capture,
+    schedules, reminders, runtime clocks, delivery behavior, or persisted state.
+  - Reconstructing or storing any private conversation from the reported
+    incident.
+
+## Constraints
+
+- Technical constraints:
+  - Resolve the date and clock from one host instant and use existing
+    timezone-aware formatting.
+  - Keep per-turn time in dynamic context so a warm Codex thread does not retain
+    a stale clock.
+  - Preserve the current UTC-only fallback when canonical timezone loading
+    fails.
+- Product/process constraints:
+  - Product UX Patch. Affected journeys are a verified private hosted member
+    with a canonical timezone and a turn whose canonical timezone is unknown.
+  - Keep screenshots, transcripts, identifiers, and production rows out of
+    tests, docs, changelog, commits, and PR text.
+  - Use the worktree/PR lane, focused local proof, the real-Codex journey,
+    preliminary Product UX/prompt review, parent final review, exact-head CI,
+    scoped commit, and plan closure.
+
+## Risks and mitigations
+
+1. Risk: A current-time line placed in thread-stable context becomes stale.
+   Mitigation: Compose it only in dynamic per-turn context from the turn's one
+   resolved prompt-time snapshot.
+2. Risk: A room or unknown-timezone context is mislabeled as a participant's
+   personal local time.
+   Mitigation: Limit the local-clock line to private hosted turns, omit it from
+   room and unverified contexts, and retain an explicit UTC-only
+   unknown-timezone branch.
+3. Risk: The new line conflicts with existing date/timestamp guidance and the
+   model chooses the server clock again.
+   Mitigation: Assert the complete production prompt includes the trusted clock
+   line and has no instruction that authorizes runtime-clock inference; review
+   the actual focused live reply.
+
+## Tasks
+
+1. Finish the evidence trace through current code, runtime metadata, recent
+   history, prompt ownership, and existing tests.
+2. Add deterministic failing coverage for known and unknown timezone contexts,
+   then implement the smallest prompt-time and prompt-composition correction.
+3. Add the focused real-Codex journey and privacy-safe changelog item; run
+   focused tests, typecheck, direct reply review, diff/privacy checks, and the
+   Product UX walkthrough.
+4. Commit and push the candidate, open a draft PR, run the preliminary Product
+   UX/prompt specialist pass concurrently with draft PR CI, resolve findings,
+   complete parent final review, close the plan, mark the final head Ready for
+   required CI, and retire the worktree after the PR reaches a terminal merged
+   or closed state.
+
+## Decisions
+
+- Root cause is at the existing prompt-time owner: it retains local date and
+  timezone but discards the current instant, leaving Codex to convert a separate
+  UTC process clock despite prompt warnings not to do so.
+- Reuse the existing timezone-aware prompt instant formatter instead of adding
+  another clock/conversion abstraction.
+- Production aggregate logs in the reported time window show normal assistant
+  pass and delivery completion with no corresponding runtime failure; this is a
+  prompt-context defect, not a transport or wake failure.
+- The local clock is private-hosted dynamic turn context only. It is not added
+  to cached/thread-stable instructions, group rooms, unverified routes, local
+  CLI turns, persisted state, or runtime configuration.
+
+## Progress
+
+- Added failing-first deterministic coverage for the captured instant,
+  UTC/local date rollover, dynamic-only placement, group omission, and
+  unknown-timezone UTC-only behavior; the final rerun passes all 217 focused
+  assertions after the correction.
+- The final Assistant Engine typecheck and task-diff whitespace/privacy checks
+  pass.
+- The focused `gpt-5.6-terra` local-subscription journey passed on an
+  authenticated alternate home after an earlier final rerun stopped before any
+  model action. The synthetic reply used the expected local clock, made zero
+  tool or command actions, did not present UTC as local, and received a `Ready`
+  UX verdict.
+- Complete normalized first-request capture through the pinned Codex App Server
+  measured the private direct turn at 28,903 to 28,977 `o200k_harmony` tokens
+  (+74, +0.2560%) and 134,083 to 134,321 UTF-8 bytes (+238, +0.1775%). The
+  group turn remained byte-for-byte identical at 24,888 tokens and 115,715
+  bytes. The direct delta is entirely the new dynamic clock fragment; tool,
+  schema, generated guidance, and all other selected provider-visible fields
+  are unchanged.
+
+## Verification
+
+- Commands to run:
+  - Focused Assistant Engine Vitest files covering prompt time and turn prompt
+    composition.
+  - `pnpm --filter @murphai/assistant-engine typecheck`
+  - `pnpm test:assistant:live -- --test "uses the trusted member-local current clock"`
+  - Changelog fragment validation/focused Web test selected from its owner docs.
+  - `git diff --check` plus targeted identifier/privacy scans of the task diff.
+  - Exact-head required GitHub checks and the preliminary
+    `completion-specialists` Product UX/prompt pass.
+- Expected outcomes:
+  - Known timezone: the prompt contains the local clock and same UTC instant;
+    the synthetic reply reports the local clock and rejects the UTC-local
+    interpretation.
+  - Unknown timezone: the prompt gives UTC only and says member-local time is
+    unknown.
+  - No extra provider call, delivery, state, persisted field, or deployment
+    ordering requirement is introduced.

--- a/agent-docs/exec-plans/completed/2026-08-30-member-local-clock-context.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-member-local-clock-context.md
@@ -1,6 +1,6 @@
 # Give Murph trusted member-local current time
 
-Status: active
+Status: completed
 Created: 2026-08-30
 Updated: 2026-08-30
 
@@ -127,6 +127,14 @@ Updated: 2026-08-30
   bytes. The direct delta is entirely the new dynamic clock fragment; tool,
   schema, generated guidance, and all other selected provider-visible fields
   are unchanged.
+- The privacy-safe changelog entry passes its 9 focused archive tests and Web
+  typecheck; the PR architecture, deployment, and changelog body guards pass.
+- The exact-head preliminary Product UX, prompt, and coverage specialist review
+  returned `SPECIALIST_OUTCOME: PASS` with no findings. The frontend lens was
+  correctly inapplicable to the content-only changelog entry.
+- Parent final review re-read the complete patch and walked prompt-time
+  resolution through attempt planning and dynamic prompt composition. It found
+  no residual implementation, privacy, scope, or proof gap.
 
 ## Verification
 
@@ -147,3 +155,4 @@ Updated: 2026-08-30
     unknown.
   - No extra provider call, delivery, state, persisted field, or deployment
     ordering requirement is introduced.
+Completed: 2026-08-30

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -2168,20 +2168,23 @@ describe("RunnerContainer", () => {
     const destroyStarted = createDeferred<void>();
     const releaseDestroy = createDeferred<void>();
     let containerRef: RunnerContainer | null = null;
+    let lastChange = Date.now();
     let status: "running" | "stopped" = "stopped";
     let healthChecks = 0;
     const startAndWaitForPorts = vi.fn(async () => {
       status = "running";
+      lastChange = Date.now();
       containerRef?.onStart();
     });
     const destroy = vi.fn(async () => {
       destroyStarted.resolve(undefined);
       await releaseDestroy.promise;
       status = "stopped";
+      lastChange = Date.now();
       containerRef?.onStop({ exitCode: 0, reason: "exit" });
     });
     const getState = vi.fn(async () => ({
-      lastChange: Date.now(),
+      lastChange,
       status,
     }));
     const { container } = createContainerDouble({

--- a/apps/web/changelog/entries/2026-08-30/current-time-answers-stay-local.json
+++ b/apps/web/changelog/entries/2026-08-30/current-time-answers-stay-local.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-08-30",
+  "order": 100,
+  "item": {
+    "id": "current-time-answers-stay-local",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Current-time answers stay local",
+    "summary": "When your timezone is known, Murph now uses the current local clock for time-sensitive answers instead of treating UTC as your time.",
+    "details": "If a trustworthy local timezone is unavailable, Murph keeps the answer in UTC and says local time is unknown rather than guessing.",
+    "relevanceTags": ["assistant", "timezones", "reliability"],
+    "sourcePullRequests": [2638]
+  }
+}

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -886,6 +886,7 @@ export async function resolveAssistantRouteTurnPlan(input: {
       channel: resolvedChannel,
       canonicalTimeZoneAvailable:
         input.promptTimeContext.canonicalTimeZoneAvailable !== false,
+      currentInstant: input.promptTimeContext.currentInstant,
       currentLocalDate: input.promptTimeContext.currentLocalDate,
       currentTimeZone: input.promptTimeContext.currentTimeZone,
       conversationScope,

--- a/packages/assistant-engine/src/assistant/prompt-time.ts
+++ b/packages/assistant-engine/src/assistant/prompt-time.ts
@@ -7,6 +7,7 @@ import { loadVault } from '@murphai/core'
 
 export interface AssistantPromptTimeContext {
   canonicalTimeZoneAvailable?: boolean
+  currentInstant?: string
   currentLocalDate: string
   currentTimeZone: string
 }
@@ -14,12 +15,14 @@ export interface AssistantPromptTimeContext {
 export interface ResolvedAssistantPromptTimeContext
   extends AssistantPromptTimeContext {
   canonicalTimeZoneAvailable: boolean
+  currentInstant: string
 }
 
 export async function resolveAssistantPromptTimeContext(
   vaultRoot: string,
 ): Promise<ResolvedAssistantPromptTimeContext> {
   const fallbackTimeZone = 'UTC'
+  const currentInstant = new Date().toISOString()
   let currentTimeZone = fallbackTimeZone
   let canonicalTimeZoneAvailable = false
 
@@ -38,7 +41,8 @@ export async function resolveAssistantPromptTimeContext(
 
   return {
     canonicalTimeZoneAvailable,
-    currentLocalDate: toLocalDayKey(new Date(), currentTimeZone),
+    currentInstant,
+    currentLocalDate: toLocalDayKey(new Date(currentInstant), currentTimeZone),
     currentTimeZone,
   }
 }

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -41,6 +41,10 @@ import {
 import {
   ASSISTANT_GROUP_SHARED_FRESHNESS_INSTRUCTION,
 } from "./group-shared-freshness.js";
+import {
+  formatAssistantPromptInstant,
+  formatAssistantPromptUtcInstant,
+} from "./prompt-time.js";
 
 const MURPH_IOS_APP_STORE_URL =
   "https://apps.apple.com/us/app/murph-ai/id6786145859";
@@ -67,6 +71,7 @@ export interface AssistantSystemPromptInput {
   channel: string | null;
   cliAccess: Pick<AssistantCliAccessContext, "rawCommand" | "setupCommand">;
   canonicalTimeZoneAvailable?: boolean;
+  currentInstant?: string;
   currentLocalDate: string;
   currentTimeZone: string;
   conversationScope?: AssistantConversationScope;
@@ -949,6 +954,13 @@ function buildDynamicTurnContextPrompt(input: AssistantSystemPromptInput): strin
     timeZone: input.currentTimeZone,
   });
   return joinPromptSections(
+    buildAssistantCurrentTimeLineText({
+      canonicalTimeZoneAvailable: input.canonicalTimeZoneAvailable !== false,
+      conversationScope,
+      currentInstant: input.currentInstant ?? null,
+      currentTimeZone: input.currentTimeZone,
+      hostedRuntime: input.hostedRuntime === true,
+    }),
     buildAssistantCurrentDateLineText(
       input.currentLocalDate,
       input.canonicalTimeZoneAvailable !== false,
@@ -1088,6 +1100,28 @@ function buildAssistantCurrentDateLineText(
   return canonicalTimeZoneAvailable
     ? `Today's date for the user is ${formattedDate}.`
     : `The current UTC date is ${formattedDate}; the member-local date is unknown for this turn.`;
+}
+
+function buildAssistantCurrentTimeLineText(input: {
+  canonicalTimeZoneAvailable: boolean;
+  conversationScope: AssistantConversationScope;
+  currentInstant: string | null;
+  currentTimeZone: string;
+  hostedRuntime: boolean;
+}): string | null {
+  if (
+    !input.currentInstant
+    || !input.hostedRuntime
+    || input.conversationScope !== "direct"
+  ) {
+    return null;
+  }
+
+  if (!input.canonicalTimeZoneAvailable) {
+    return `Current time authority: ${formatAssistantPromptUtcInstant(input.currentInstant)} (UTC only). The member-local clock is unknown; do not infer or relabel a local clock from the runtime environment.`;
+  }
+
+  return `Current local clock for the user (${input.currentTimeZone}): ${formatAssistantPromptInstant(input.currentInstant, input.currentTimeZone)}. This host-rendered value is the authority for current member-local time; do not use or relabel the runtime UTC clock as local.`;
 }
 
 function buildAssistantProductBaseUrlLineText(

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -1824,6 +1824,9 @@ describe('assistant automation scanner', () => {
     const sentInput = replyMocks.sendAssistantMessage.mock.calls[0]?.[0]
     expect(sentInput?.promptTimeContext).toEqual({
       canonicalTimeZoneAvailable: false,
+      currentInstant: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u,
+      ),
       currentLocalDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/u),
       currentTimeZone: 'UTC',
     })

--- a/packages/assistant-engine/test/assistant-automation-support.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-support.test.ts
@@ -1330,6 +1330,23 @@ describe('assistant auto-reply prompt builder support', () => {
     })
   })
 
+  it('captures one prompt instant and derives its local date from the vault timezone', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2027-02-14T07:17:05.678Z'))
+    const { vaultRoot } = await createTempVault('assistant-prompt-time-context-')
+    await initializeVault({
+      timezone: 'America/Los_Angeles',
+      vaultRoot,
+    })
+
+    await expect(resolveAssistantPromptTimeContext(vaultRoot)).resolves.toEqual({
+      canonicalTimeZoneAvailable: true,
+      currentInstant: '2027-02-14T07:17:05.678Z',
+      currentLocalDate: '2027-02-13',
+      currentTimeZone: 'America/Los_Angeles',
+    })
+  })
+
   it('keeps the turn-resolved timezone when vault metadata changes during assembly', async () => {
     const { vaultRoot } = await createTempVault('assistant-automation-timezone-stable-')
     await initializeVault({

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -206,6 +206,7 @@ import {
 import {
   buildAssistantMaintenanceSystemPromptWithCacheMetadata,
   buildAssistantSystemPrompt,
+  buildAssistantSystemPromptLayers,
 } from '../src/assistant/system-prompt.ts'
 import {
   ASSISTANT_FIRST_CONTACT_WELCOME_MESSAGE,
@@ -3774,6 +3775,98 @@ describeRealCodex('real Codex video-analysis detail e2e', () => {
       }
     },
     480_000,
+  )
+})
+
+describeRealCodex('real Codex member-local current clock e2e', () => {
+  it(
+    'uses the trusted member-local current clock',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-member-local-clock-e2e-'),
+      )
+
+      try {
+        const layers = buildAssistantSystemPromptLayers({
+          assistantCliContract: null,
+          assistantContextSnapshotPrompt: null,
+          assistantHostedDeviceConnectAvailable: false,
+          assistantHostedDeviceConnectProviders: [],
+          assistantKnowledgeToolsAvailable: false,
+          channel: 'linq',
+          cliAccess: {
+            rawCommand: 'vault-cli',
+            setupCommand: 'murph',
+          },
+          conversationScope: 'direct',
+          currentInstant: '2027-02-14T07:17:05.678Z',
+          currentLocalDate: '2027-02-13',
+          currentTimeZone: 'America/Los_Angeles',
+          hostedRuntime: true,
+          modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+          ordinaryInboundTurn: true,
+          turnTrigger: 'automation-auto-reply',
+        })
+        const developerInstructions = [
+          layers.staticCacheableCorePrompt,
+          layers.stableRouteCapabilityPrompt,
+          layers.threadContextPrompt,
+        ].filter((section) => section.length > 0).join('\n\n')
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions,
+          dynamicTools: [],
+          env: config.env,
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: resolveAssistantProviderPrompt({
+            dynamicTools: [],
+            prompt: 'Give my current local clock time in one sentence.',
+            providerConfig: normalizeAssistantProviderConfig({
+              provider: 'codex-cli',
+            }),
+            turnContextPrompt: layers.dynamicTurnContextPrompt,
+            workingDirectory,
+          }),
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+
+        process.stdout.write(
+          `[member-local-clock-e2e] ${JSON.stringify({
+            actionCount: actions.length,
+            reply: result.finalMessage,
+          })}\n`,
+        )
+
+        expect(actions).toEqual([])
+        expect(result.finalMessage).toMatch(/\b11:17\b/iu)
+        expect(result.finalMessage).toMatch(
+          /p\.?m\.?|Pacific|PST|America\/Los_Angeles/iu,
+        )
+        expect(result.finalMessage).not.toMatch(/\b0?7:17\b/iu)
+        expect(result.finalMessage).not.toMatch(/\bUTC\b/iu)
+        expect(
+          result.finalMessage.trim().split(/\s+/u).length,
+        ).toBeLessThanOrEqual(24)
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
   )
 })
 
@@ -11511,6 +11604,7 @@ describeRealCodex('real Codex recurring reminder conversation e2e', () => {
           prompt,
           promptTimeContext: {
             canonicalTimeZoneAvailable: true,
+            currentInstant: '2026-08-27T16:00:00.000Z',
             currentLocalDate: '2026-08-27',
             currentTimeZone: 'America/New_York',
           },

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -474,13 +474,21 @@ describe('assistant Codex turn planning', () => {
   it('reuses one UTC-only time authority when the member timezone is unknown', async () => {
     const promptTimeContext = {
       canonicalTimeZoneAvailable: false,
-      currentLocalDate: '2026-08-11',
+      currentInstant: '2027-02-14T07:17:05.678Z',
+      currentLocalDate: '2027-02-14',
       currentTimeZone: 'UTC',
     } as const
     const session = createSession()
     const executionPlan = await buildCodexTurnExecutionPlan({
       input: {
         ...createMessageInput(),
+        executionContext: {
+          hosted: {
+            dynamicContextPrompts: [],
+            memberId: 'member-utc-only-time-fixture',
+            userEnvKeys: [],
+          },
+        },
         promptTimeContext,
       },
       plan: createSharedPlan(),
@@ -500,7 +508,10 @@ describe('assistant Codex turn planning', () => {
       "The member's canonical timezone is unknown for this turn.",
     )
     expect(attemptPlan.routePlan.systemPrompt).toContain(
-      'The current UTC date is August 11, 2026; the member-local date is unknown for this turn.',
+      'The current UTC date is February 14, 2027; the member-local date is unknown for this turn.',
+    )
+    expect(attemptPlan.routePlan.turnContextPrompt).toContain(
+      'Current time authority: 2027-02-14T07:17:05.678Z (UTC only). The member-local clock is unknown',
     )
     expect(attemptPlan.routePlan.systemPrompt).not.toContain(
       "The user's canonical timezone for this vault is UTC.",

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -2307,8 +2307,11 @@ describe('assistant system prompt cache stability', () => {
         assistantContextSnapshotPrompt:
           'Vault overview for user A.\n\nActive experiment context for user A.',
         channel: 'telegram',
-        currentLocalDate: '2026-04-15',
-        currentTimeZone: 'Asia/Kuala_Lumpur',
+        currentInstant: '2027-02-14T07:17:05.678Z',
+        currentLocalDate: '2027-02-13',
+        currentTimeZone: 'America/Los_Angeles',
+        conversationScope: 'direct',
+        hostedRuntime: true,
         murphProductBaseUrl: 'http://localhost:3000',
       }),
       cacheInput,
@@ -2318,8 +2321,11 @@ describe('assistant system prompt cache stability', () => {
         assistantContextSnapshotPrompt:
           'Vault overview for user B.\n\nActive experiment context for user B.',
         channel: 'sms',
-        currentLocalDate: '2026-04-16',
+        currentInstant: '2027-07-02T03:04:05.678Z',
+        currentLocalDate: '2027-07-01',
         currentTimeZone: 'America/Los_Angeles',
+        conversationScope: 'direct',
+        hostedRuntime: true,
         murphProductBaseUrl: 'https://withmurph.ai',
       }),
       cacheInput,
@@ -2350,13 +2356,20 @@ describe('assistant system prompt cache stability', () => {
       promptA.cacheMetadata.dynamicContextStartsAfterStaticCore,
     )
 
-    expect(stablePrefix).not.toContain('Asia/Kuala_Lumpur')
-    expect(stablePrefix).not.toContain('2026-04-15')
+    expect(stablePrefix).not.toContain('America/Los_Angeles')
+    expect(stablePrefix).not.toContain('2027-02-13')
+    expect(stablePrefix).not.toContain('2027-02-14T07:17:05.678Z')
     expect(stablePrefix).not.toContain('http://localhost:3000')
     expect(stablePrefix).not.toContain('Vault overview for user A.')
     expect(stablePrefix).not.toContain('Active experiment context for user A.')
     expect(dynamicSuffix).toContain('The user\'s canonical timezone')
-    expect(dynamicSuffix).toContain('Asia/Kuala_Lumpur')
+    expect(dynamicSuffix).toContain('America/Los_Angeles')
+    expect(dynamicSuffix).toContain(
+      'Current local clock for the user (America/Los_Angeles): 2027-02-13 23:17:05 [UTC 2027-02-14T07:17:05.678Z].',
+    )
+    expect(promptB.layers.dynamicTurnContextPrompt).toContain(
+      'Current local clock for the user (America/Los_Angeles): 2027-07-01 20:04:05 [UTC 2027-07-02T03:04:05.678Z].',
+    )
     expect(dynamicSuffix).toContain('Vault overview for user A.')
     expect(promptB.prompt).toContain('Vault overview for user B.')
     expect(promptB.prompt).toContain('Active experiment context for user B.')

--- a/packages/assistant-engine/test/system-prompt.dynamic-context.test.ts
+++ b/packages/assistant-engine/test/system-prompt.dynamic-context.test.ts
@@ -55,16 +55,25 @@ describe('assistant dynamic context prompt blocks', () => {
     const hostedDirectLayers = buildAssistantSystemPromptLayers({
       ...baseConversationInput,
       conversationScope: 'direct',
+      currentInstant: '2027-02-14T07:17:05.678Z',
+      currentLocalDate: '2027-02-13',
+      currentTimeZone: 'America/Los_Angeles',
       hostedRuntime: true,
     })
     const hostedGroupLayers = buildAssistantSystemPromptLayers({
       ...baseConversationInput,
       conversationScope: 'group',
+      currentInstant: '2027-02-14T07:17:05.678Z',
+      currentLocalDate: '2027-02-13',
+      currentTimeZone: 'America/Los_Angeles',
       hostedRuntime: true,
     })
 
     expect(hostedDirectLayers.threadContextPrompt).toContain(
       "use the user's current local time to adapt suggestions about meals, sleep, caffeine, and exercise",
+    )
+    expect(hostedDirectLayers.dynamicTurnContextPrompt).toContain(
+      'Current local clock for the user (America/Los_Angeles): 2027-02-13 23:17:05 [UTC 2027-02-14T07:17:05.678Z].',
     )
     expect(hostedGroupLayers.staticCacheableCorePrompt).toContain(
       'The room runtime is not a participant.',
@@ -75,12 +84,24 @@ describe('assistant dynamic context prompt blocks', () => {
     expect(hostedGroupLayers.threadContextPrompt).not.toContain(
       'use the user\'s current local time',
     )
+    expect(hostedGroupLayers.dynamicTurnContextPrompt).not.toContain(
+      'Current local clock for the user',
+    )
+    expect(hostedGroupLayers.dynamicTurnContextPrompt).not.toContain(
+      '2027-02-14T07:17:05.678Z',
+    )
     expect(
       buildAssistantSystemPromptLayers({
         ...baseConversationInput,
         conversationScope: 'direct',
       }).threadContextPrompt,
     ).not.toContain('use the user\'s current local time')
+    expect(
+      buildAssistantSystemPromptLayers({
+        ...baseConversationInput,
+        conversationScope: 'direct',
+      }).dynamicTurnContextPrompt,
+    ).not.toContain('Current local clock for the user')
   })
 
   it.each(['direct', 'group'] as const)(


### PR DESCRIPTION
## Why and outcome

Hosted turns already knew the member's canonical timezone, but the provider received only that timezone plus a separate UTC runtime clock. That left the model to perform the conversion and could produce a UTC-as-local answer.

This captures one turn instant at the existing prompt-time owner and renders an authoritative member-local clock in private hosted dynamic context. If the canonical timezone is unavailable, the turn stays explicitly UTC-only instead of guessing.

## Product UX

- Effort: Product UX Patch
- Result: Ready
- Affected people: a verified private hosted member with a canonical timezone, and a private hosted member whose canonical timezone is unavailable.
- Exclusions: group rooms, unverified external routes, and non-hosted turns do not receive a personal local-clock claim.
- Walkthrough: the known-timezone journey answers from the supplied local clock with no tool action or implementation language; the unknown-timezone journey identifies UTC as the only authority and does not invent local time.
- Difference from plan: None.

## Evidence

- Focused prompt-time and turn-composition proof: 4 files passed; 217 tests passed.
- Assistant Engine package typecheck passed.
- Focused real-Codex journey on `gpt-5.6-terra` with local subscription auth passed: one provider request, zero actions, the expected synthetic local clock, no UTC-as-local answer, and a `Ready` reply-review verdict.
- Complete normalized first-request capture found a +74-token/+238-byte private-turn delta and a byte-for-byte-identical group request.
- Changelog archive proof: 9 tests passed; Web typecheck passed.
- CI on the prior candidate exposed one stale automation propagation assertion after the production behavior passed focused proof; the assertion now covers the captured ISO instant, and its narrow reproducer plus Assistant Engine typecheck pass.
- `git diff --check` and targeted task-diff privacy checks passed.
- The required app job then stalled twice in an unrelated Cloudflare runner test. A bounded reproducer proved its synthetic state advanced `lastChange` without a real container transition, so production correctly refused to destroy an apparently newer generation while the test waited forever. The fixture now advances `lastChange` only on start and stop.
- Repair proof on final head `d934f649f7b464fffc512249f710b70094e440f8`: the formerly hanging case passed 10/10 with a five-second watchdog; the complete file passed 227 tests; the three-worker runner project passed 32 files and 1,216 tests; the complete three-worker node workspace passed 152 files and 2,755 tests with 2 skipped; Cloudflare typecheck passed.
- All required GitHub checks passed on final head `d934f649f7b464fffc512249f710b70094e440f8`; a fresh current-base `git merge-tree --write-tree` proof is clean (`51e3e1c2d6641edc56d8d1d264ab21030e337045`).

## Non-obvious affected surfaces

- The volatile clock is placed only in per-turn dynamic context, preserving the stable prompt prefix and avoiding stale time in warm threads.
- Codex's native UTC system-time reminder remains unchanged; the new host-rendered line tells private hosted turns which local value is authoritative.
- Unknown-timezone turns preserve the existing fail-closed UTC fallback. Group, unverified, and non-hosted prompt surfaces remain free of a personal clock.
- The public changelog records the corrected behavior without reproducing private incident evidence.

## Preliminary specialist review

- Result: `SPECIALIST_OUTCOME: PASS` on reviewed head `3d0214e5158c577b3fc5390df286d871b3770f65`.
- Product UX: applicable; the reviewer found the product purpose complete and coherent across the known-timezone, unknown-timezone, group, and non-hosted journeys.
- Prompt: applicable; the reviewer confirmed the narrow authority rule, per-turn dynamic placement, stable-prefix preservation, and lack of unnecessary instruction machinery.
- Coverage: applicable; the deterministic owner proof plus production-derived real-Codex journey establish the model-boundary claim.
- Frontend: not applicable because the Web change is an authored content-only changelog entry.
- Findings: none. Parent disposition requires no remediation.

## Final ReviewGPT gate

Not applicable. The production change is prompt-primary mechanical context plumbing with no persisted state, schema, API, auth/trust authority, external egress, concurrency, retry, billing, or cross-owner protocol change. The required Product UX/prompt specialist pass and parent final review own the applicable review.

## Architecture and reuse

- Existing systems reused: the canonical vault timezone, existing prompt-time resolver, existing timezone-aware instant formatters, dynamic turn-context layer, and current UTC-only fallback.
- New logic: capture one ISO instant per turn and render one authoritative local-clock line only for private hosted context.
- New abstractions: No new abstraction was added; the resolved prompt-time context extends its existing value object with the captured instant.
- Complexity intentionally avoided: no process-wide timezone mutation, state owner, provider call, scheduler, compatibility layer, runtime protocol field, or model-owned conversion path.

## Hot reply path impact

Prompt assembly on the foreground reply path now parses and formats the already-captured instant once for an eligible private hosted turn. It adds or moves zero database calls, network/provider calls, awaited operations, transactions, retries, or timeouts. The existing vault load remains the only asynchronous time-context operation; its unknown-timezone fallback is unchanged. Group turns skip the added fragment. The complete first-request measurement below is the direct before/after proof.

## Murph initial provider input impact

- Individual turn: 28,903 to 28,977 `o200k_harmony` tokens, +74 (+0.2560%); 134,083 to 134,321 UTF-8 bytes, +238 (+0.1775%).
- Group turn: unchanged at 24,888 tokens and 115,715 UTF-8 bytes; 0 tokens (+0.0000%) and 0 bytes (+0.0000%).
- Attribution: the entire individual delta is one assembled dynamic-context clock fragment inside `input`. Tool/schema/generated guidance and every other selected provider-visible field are unchanged. The group requests are byte-for-byte identical.
- Method: pinned Codex App Server 0.151.0, `gpt-5.6-terra`, low reasoning, production code mode, identical synthetic Linq fixtures, and a local scripted Responses endpoint. Each complete first `/v1/responses` body serialized `include`, `input`, `instructions`, `parallel_tool_calls`, `text`, `tool_choice`, and `tools` when present; these code-mode requests had no top-level `instructions` or `tools`. Base omitted only the new `currentInstant` boundary from the same candidate fixture. Volatile paths, generated IDs, UUIDs, and the native system-UTC reminder were normalized. Request-shaping fields (`model`, `reasoning`, `store`, `stream`, `prompt_cache_key`, `client_metadata`) and transport headers were excluded identically.

## Change-shape breakdown

Classification uses `git diff --numstat origin/main...HEAD`; runtime prompt code and the changelog fragment are source, behavior journeys are tests/fixtures, and the completed execution plan is docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 54 | 1 |
| Tests/fixtures | 171 | 9 |
| Docs | 182 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **407** | **10** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new hosted runner containers are contract-compatible; no Web-to-Worker, Worker-to-container, schema, or persisted-state coordination is required.
- Safe order: no tandem deploy is required. If sequenced, deploy the hosted assistant bundle before the Web changelog so the public note does not lead runtime convergence.
- Rollback floor: none; revert either artifact independently with no data cleanup.
- Expected exposure: warm old runner containers may retain the previous prompt until replacement and can still misinterpret the UTC clock during that window.
- Reversibility: the new runner prompt can be reverted independently; unknown-timezone behavior remains fail-closed in either version.
- Convergence proof: confirm the exact live runner bundle/source fingerprint, then run one bounded private current-time smoke with a known canonical timezone.
- Post-deploy checks: verify the reply uses the member-local clock, inspect bounded metadata-only turn completion, and confirm the changelog item renders.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · current-time-answers-stay-local


