### PR TITLE
chore(temporal): pin bounded readmission worker

### DIFF
--- a/.github/temporal-compatibility-controller.json
+++ b/.github/temporal-compatibility-controller.json
@@ -1,5 +1,5 @@
 {
   "contractVersion": 1,
-  "privateRef": "temporal-compatibility-v1-66d6bf2e368b947c9f14c8b28d128445ad3ebbcc",
-  "privateSha": "66d6bf2e368b947c9f14c8b28d128445ad3ebbcc"
+  "privateRef": "temporal-compatibility-v1-0de246b2a7d9f0a1b92e9e87f7263e3470dc38b8",
+  "privateSha": "0de246b2a7d9f0a1b92e9e87f7263e3470dc38b8"
 }

--- a/apps/web/changelog/entries/2026-08-29/device-sync-follow-through.json
+++ b/apps/web/changelog/entries/2026-08-29/device-sync-follow-through.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 3,
     "title": "Connected data keeps moving",
-    "summary": "Murph now finishes retained wearable imports before starting another scheduled sync pass, helping connected activity and health data reach follow-up work without repeated delay.",
-    "details": "Scheduled sync checks resume only after retained imports finish. Murph may need more than one pass to work through the backlog, and it does not mark data processed until the import succeeds or reaches a confirmed failure.",
+    "summary": "Murph now keeps delayed wearable imports moving alongside routine background work, helping connected activity and health data reach follow-up work without repeated delay.",
+    "details": "Recovery stays bounded so retained imports can catch up without holding up other background work. Murph may need more than one pass to work through the backlog, and it does not mark data processed until the import succeeds or reaches a confirmed failure.",
     "relevanceTags": ["wearables", "assistant", "reliability"],
-    "sourcePullRequests": [2568]
+    "sourcePullRequests": [2568, 2640]
   }
 }


### PR DESCRIPTION
## Why and outcome

Pins the protected Temporal compatibility controller to the exact merged private worker commit and immutable lightweight tag so the bounded device-sync readmission fix can deploy. The existing changelog item now describes bounded catch-up alongside other background work.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Members with delayed connected-device imports keep the existing sync flow and controls. After rollout, retained work gets bounded opportunities to catch up without starving other background work. The only visible change in this PR is clearer changelog copy; there is no new state, control, or recovery action.

## Evidence

- Direct: The public controller points to the exact private merge SHA and tag; the remote lightweight tag resolves to that same SHA. Focused controller contracts pass 35/35, changelog tests pass 39/39, Web typecheck passes, and both staged/unstaged diff checks pass.
- Coverage: The controller suite proves exact-SHA selection, immutable-tag admission, dispatch/run identity, reader completeness, cancellation bounds, and workflow status publication. Changelog tests exercise schema, ordering, route fragments, and source-PR metadata.

## Non-obvious affected surfaces

- Protected public-to-private Temporal compatibility admission.
- Private worker deployment selection and patch-marker rollout floor.
- The existing member-visible device-sync recovery changelog item.

## Architecture and reuse

- Existing systems reused: the exact-SHA compatibility controller, immutable private tag contract, and existing changelog item.
- New logic: None; the approved private ref/SHA advance and existing copy is corrected.
- New abstractions: None; the current controller and changelog owners are sufficient.
- Complexity intentionally avoided: no alternate release path, mutable reference, state, service, dependency, compatibility shim, or controller branch.

## Hot reply path impact

- Path status: Not applicable — no runtime application code changes.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The base-to-head diff contains only the controller pin and changelog item.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: [production changelog](https://www.withmurph.ai/changelog)
- Evidence: Content-only edit to an existing production-rendered changelog card; no component, layout, typography, interaction, or responsive behavior changed, so an additional screenshot adds no proof.
- Coverage: Existing changelog rendering/schema tests pass 39/39; the changed item uses the same production card at all viewports and introduces no new visual state.

## Risks

ReviewGPT context sensitivity: sensitive

Classification reason: This pin admits a new Temporal patch marker and production worker; post-marker rollback is fix-forward to a compatible reader. Per explicit release direction, another ReviewGPT round is not a predeploy blocker and later findings will be handled retroactively without weakening rollout or replay invariants.

## Deployment concerns

- Deployment: applicable
- Supported skew: The existing worker remains valid until the immutable tag, public pin, and protected exact-SHA approvals align; no application runtime consumes this controller file.
- Safe order: Merge/tag the private worker, merge this public pin, set classification, set the bridge SHA, set the rollout SHA last, then rerun exact-main private Verify.
- Rollback floor: Before the new marker activates, keep Current on the existing worker; after activation, never route an older reader because histories can contain the new patch marker.
- Expected exposure: The inactive candidate receives zero workflow traffic until health proof, followed by one direct Current-only promotion under the patch-introducing policy.
- Reversibility: Pre-promotion rollout is reversible by withholding exact approval; post-promotion recovery is fix-forward to a reader that contains the new marker.
- Convergence proof: The workflow must prove exact public main, exact private tag/SHA, fresh workflow and activity pollers, matching generations, and exact Current-only routing.
- Post-deploy checks: Require the deploy and direct-promotion logs to succeed, prove two fresh Current pollers, retain the former Current for 900 seconds, verify its suspension, then prove the fixed predeploy cohort and global imported-ahead fleet converge to zero across T1/T2.

## Change-shape breakdown

Classification rule: The changelog JSON is authored member-facing documentation; the controller JSON is deployment configuration. No binary or generated files change.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 3 | 3 |
| Config / tooling | 2 | 2 |
| Generated / other | 0 | 0 |
| **Total** | **5** | **5** |

## Changelog

- Changelog: updated
- Items: 2026-08-29 · device-sync-follow-through
