### PR TITLE
chore(temporal): pin current-reader hotfix

### DIFF
--- a/.github/temporal-compatibility-controller.json
+++ b/.github/temporal-compatibility-controller.json
@@ -1,5 +1,5 @@
 {
   "contractVersion": 1,
-  "privateRef": "temporal-compatibility-v1-5b972ebceb72aea46edbabebed2748375c8c94bf",
-  "privateSha": "5b972ebceb72aea46edbabebed2748375c8c94bf"
+  "privateRef": "temporal-compatibility-v1-01e09807adc3376aa5f0658e2ab4a70e17600f66",
+  "privateSha": "01e09807adc3376aa5f0658e2ab4a70e17600f66"
 }


### PR DESCRIPTION
## Why and outcome

The protected Temporal rollout correctly failed because the public controller still pinned the pre-hotfix private SHA. This repins it to the exact private main revision that retains the currently routed reader, allowing the existing fail-closed compatibility controller to admit the replacement worker.

## Product UX

- Effort: Not applicable — release-policy metadata only
- Result: Ready
- Walkthrough: No user-facing UI or product behavior changes; this restores the intended production rollout path.

## Evidence

- Direct: private tag resolves exactly to `01e09807adc3376aa5f0658e2ab4a70e17600f66`; focused controller contract tests pass 35/35
- Coverage: The changed claim is only exact private tag/SHA pinning; the controller suite covers tag, head, reader, dispatch, and attestation binding.

## Non-obvious affected surfaces

Temporal compatibility selection and protected private worker deployment admission. No runtime source changes.

## Architecture and reuse

- Existing systems reused: existing public controller JSON, immutable private tag, compatibility CI, and private deploy admission
- New logic: None
- New abstractions: None; one canonical pin remains the source of truth
- Complexity intentionally avoided: no bypass service, compatibility shim, queue, or alternate deployment path

## Hot reply path impact

- Path status: Not applicable — release metadata only
- Database calls: None
- Network/provider calls: None
- Other awaited latency: None
- Before/after proof: Focused controller tests pass 35/35

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no provider-input surface changed

## Risks

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: protected Temporal deployment compatibility pin -->
ReviewGPT is intentionally deferred per the user's explicit ship-first instruction; later findings will be handled retroactively.

## Deployment concerns

- Deployment: applicable
- Supported skew: public main may pin the private candidate before its approval latch changes; deploy remains fail-closed
- Safe order: merge this pin, then set both exact private approval variables to the pinned SHA with rollout approval last, rerun exact-main Verify, and let the serialized controller promote
- Rollback floor: currently routed private reader remains in the supported-reader manifest
- Expected exposure: none until exact private approval and protected deploy
- Reversibility: restore the prior controller pin before any candidate promotion
- Convergence proof: private tag, private main, and this public pin must resolve to the same SHA
- Post-deploy checks: prove direct Current promotion, fresh Workflow/Activity pollers, former-Current retirement, and zero production backlog at T1/T2

## Change-shape breakdown

Classification rule: the sole JSON controller file is config/tooling; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 2 | 2 |
| Generated / other | 0 | 0 |
| **Total** | **2** | **2** |

## Changelog

- Changelog: not applicable
- Reason: internal release-policy correction; no member-visible product change

