### PR TITLE
Advance Temporal compatibility controller

### DIFF
--- a/.github/temporal-compatibility-controller.json
+++ b/.github/temporal-compatibility-controller.json
@@ -1,5 +1,5 @@
 {
   "contractVersion": 1,
-  "privateRef": "temporal-compatibility-v1-01e09807adc3376aa5f0658e2ab4a70e17600f66",
-  "privateSha": "01e09807adc3376aa5f0658e2ab4a70e17600f66"
+  "privateRef": "temporal-compatibility-v1-eb054732adde280eca26adbdb80d47ea69c9b587",
+  "privateSha": "eb054732adde280eca26adbdb80d47ea69c9b587"
 }


### PR DESCRIPTION
## Outcome

Pins the public Temporal compatibility controller to the exact private main SHA and its immutable compatibility tag.

## Product UX result

No member-visible behavior changes; this admits the already-merged Temporal runtime fix to the production rollout controller.

## Direct evidence

- The tag resolves exactly to private main `eb054732adde280eca26adbdb80d47ea69c9b587`.
- The controller changes one SHA/ref pair and `git diff --check` passes.

## Affected surfaces

Temporal compatibility admission and private worker deployment control.

## Architecture and reuse

- Existing systems reused: the existing immutable-tag compatibility controller.
- New logic: none.
- New abstractions: none.
- Complexity intentionally avoided: no new service, state owner, dependency, or workflow.

## Hot reply path impact

None.

## Provider-input impact

None.

## Deployment concerns

- Deployment: applicable
- Safe order: merge this controller pin, approve the same private SHA, deploy Temporal, verify Web production, then deploy Cloudflare.
- Supported skew: the private parser accepts legacy public omission until the public writer is live.
- Reversibility: the controller can be advanced again, while workflows that record the new Temporal patch marker remain fix-forward.
- Convergence proof: the deploy controller must promote this exact SHA and prove fresh Workflow and Activity pollers.

## Changelog

- Changelog: not required
- Reason: deployment-controller metadata only.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 2 | 2 |
| Generated/other | 0 | 0 |
| **Total** | **2** | **2** |

ReviewGPT context sensitivity: routine

Reason: one immutable controller ref/SHA pair with no runtime code change.