### PR TITLE
fix(cloudflare): ratchet runner bundle total

### DIFF
--- a/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
+++ b/apps/cloudflare/scripts/runner-bundle/bundle-entrypoint.ts
@@ -315,7 +315,11 @@ export const RUNNER_ENTRYPOINT_BUNDLE_DIRECTORY_NAME = "dist-bundled";
 // graph without adding a forbidden boot input. Exact macOS production assembly
 // measured 11,592,493B total on 2026-08-30; ratchet only the total baseline and
 // retain the fixed cross-platform allowance and all startup-specific gates.
-const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_592_493 + 32_768;
+// Runtime progress non-starvation and bounded receipt replay extend those same
+// lazy paths without changing the boot graph. Four canonical Linux production
+// gates measured 11,632,316B total on 2026-08-31; ratchet only the total
+// baseline and retain the fixed allowance and all startup-specific gates.
+const RUNNER_ENTRYPOINT_BUNDLE_TOTAL_BYTES_BUDGET = 11_632_316 + 32_768;
 const RUNNER_ENTRYPOINT_BUNDLE_ENTRY_BASELINE_BYTES = 64_257;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CLOSURE_BASELINE_BYTES = 1_950_662;
 const RUNNER_ENTRYPOINT_BUNDLE_STATIC_CHUNK_COUNT_BUDGET = 24;

--- a/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
+++ b/apps/cloudflare/test/runner-bundle-entrypoint-bundle.test.ts
@@ -647,7 +647,7 @@ describe("runner bundle container-entrypoint esbuild step", () => {
       entryBytes: 64_257 + 12_000,
       staticClosureBytes: 1_950_662 + 96_000,
       staticChunkCount: 24,
-      totalBytes: 11_592_493 + 32_768,
+      totalBytes: 11_632_316 + 32_768,
     });
   });
 


### PR DESCRIPTION
Outcome: Ratchets the runner entrypoint total-byte baseline to the exact value measured identically by all four production gates. The existing 32 KiB allowance and entry, static-closure, chunk-count, and forbidden-import guards remain unchanged.

Product UX: No user-facing behavior changes; this unblocks deployment of the already-merged reminder non-starvation fix.

Evidence: Production run 33420642327 measured 11,632,316 B in four independent gates. The focused bundle-budget suite passed 43/43, Cloudflare typecheck passed, and git diff --check passed. Independent review confirmed the growth is intended lazy-runtime composition rather than boot-graph or packaging leakage.

Affected surfaces: Cloudflare runner bundle assembly budget and its locked unit expectation only.

Architecture and reuse: Reuses the existing measured-baseline ratchet; no new abstraction, dependency, or relaxed startup gate.

Hot reply path: No runtime control-flow change. Provider-input impact: None.

Deployment concerns: After merge, rerun the protected Cloudflare production workflow with the already-live exact Web and Temporal revisions; require all E2E gates, worker deploy, endpoint smoke, and summary to pass.

Changelog: None; deployment tooling only.

LOC: source/config/tooling +5/-1; tests +1/-1; docs +0/-0; generated/other +0/-0; total +6/-2.