### PR TITLE
Add bounded runtime rechecks to ops maintenance

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-31-ops-stalled-runtime-recheck.md
+++ b/agent-docs/exec-plans/active/2026-08-31-ops-stalled-runtime-recheck.md
@@ -1,0 +1,128 @@
+# Bounded Ops stalled-runtime rechecks
+
+Status: active
+Created: 2026-08-31
+Updated: 2026-08-31
+
+## Goal
+
+- Give an authorized operator a reusable bounded control on
+  `/ops/runtime-maintenance` that accepts member ids and sends one payload-free
+  runtime recheck to each selected runtime. Seed the control from a discovery
+  list using the proven legacy device-sync stall signature. Reuse the existing
+  progress-health predicate and Temporal signal; add no mailbox item,
+  scheduler, queue, schema, or durable recovery owner.
+
+## Success criteria
+
+- The page shows the current active legacy device-sync stall cohort with its
+  aggregate count, per-runtime pending count, and stall start time.
+- The operator can paste comma- or newline-separated member ids. One explicit
+  action rechecks at most three normalized, deduplicated ids sequentially,
+  stops on the first signal failure, and removes only acknowledged ids so a
+  failed or unsent id remains retryable.
+- Candidate selection uses the runtime-progress monitor's existing 15-minute,
+  retention, mailbox-high-water, and active-access rules.
+- The operation sends `runtime_recheck_requested` only. It never appends work,
+  resets usage, or changes canonical workspace/mailbox state.
+- Focused service, route, selector, UI, typecheck, lint, and rendered proof pass.
+
+## Scope
+
+- In scope: the existing runtime-maintenance page and API, reusable legacy
+  device-sync stall candidate selection, focused tests, and a synthetic design
+  representation.
+- Out of scope: automatic fleet recovery, new monitoring state, mailbox repair,
+  usage changes, direct production mutation during development, or changes to
+  Temporal/Cloudflare runtime behavior.
+
+## Constraints
+
+- Technical constraints: keep scans bounded by the existing progress monitor;
+  keep provider calls outside database work; signal sequentially; preserve the
+  current ops allowlist and same-origin mutation gate; return only the minimum
+  operator diagnostics; tolerate recovery between selection and signal.
+- Product/process constraints: Feature-level Product UX because this adds an
+  operator action surface. The user explicitly approved adding it to this page.
+  Keep the action visually and semantically distinct from maintenance wakes,
+  which append mailbox work.
+
+## Risks and mitigations
+
+1. Risk: a duplicated predicate targets the wrong runtimes after the monitor
+   evolves.
+   Mitigation: factor and reuse the monitor's active alertable-row reader.
+2. Risk: repeated clicks create noisy duplicate wake signals.
+   Mitigation: cap each batch at three, advance only past successful signals,
+   and clearly show the current queue and result; the signal itself is
+   payload-free and creates no work authority.
+3. Risk: a discovered runtime recovers before the operator sends the signal.
+   Mitigation: the payload-free recheck only asks the workflow to reread
+   canonical facts; manually entered ids pass the existing active-access gate.
+4. Risk: a failing signal hides untouched ids.
+   Mitigation: stop on the first failure and remove only acknowledged ids from
+   the operator's input.
+
+## Tasks
+
+1. Extract one bounded active alertable-row reader from the current progress
+   monitor without changing alert semantics.
+2. Add a legacy device-sync stall overview and a generic bounded member-id
+   recheck operation to the existing authenticated route and service, reusing
+   the payload-free signal.
+3. Add the distinct stalled-runtime section and result states to the existing
+   page, plus a production-component design study.
+4. Add focused selector, service, route, and UI-facing contract tests.
+5. Run focused verification, Product UX walkthrough, rendered/browser proof,
+   final cross-cutting review, exact-head CI, merge, deploy, and live aggregate
+   verification.
+
+## Decisions
+
+- Keep the existing mailbox-appending maintenance wake untouched. A strict
+  operation discriminator on the existing route/service prevents the new
+  action from falling through to that different authority.
+- Keep candidate discovery separate from effect authority. The read path finds
+  the incident cohort; the mutation accepts at most three explicit ids and the
+  existing signal path independently revalidates active runtime access.
+- Target only valid active stalled `system` lanes whose pending head is
+  `device-sync.wake`, whose overdue wake reason is `device-sync.reconcile`, and
+  whose default-processing wake and system-progress generation remain absent.
+  These durable facts identify the proven legacy projection without a brittle
+  deployment timestamp or `updated_at` cutoff.
+- Sort the operator cohort by runtime id for a simple stable cursor. The
+  selector still reports the canonical progress origin for diagnosis.
+
+## Product UX plan
+
+- Outcome: an authorized operator can identify the proven legacy device-sync
+  stalls or paste ids for another incident, then safely request runtime
+  rechecks without manually searching unrelated workspaces.
+- Entry and promise: the operator opens Runtime maintenance, loads the freshly
+  generated legacy device-sync cohort or pastes comma/newline-separated ids,
+  and explicitly sends up to three rechecks. The page reports accepted/failed
+  signals immediately; actual recovery remains observable only after a later
+  checkpoint/progress refresh.
+- Affected people: an operator with candidates, an operator after the cohort
+  drains, and an operator whose batch partially fails. Members see no new
+  surface, message, mailbox work, or usage change.
+- Recovery: failed signals remain retryable; recovered runtimes disappear on a
+  fresh read; scan truncation is visible and does not claim a complete fleet.
+- Done when: all states are truthful, the control cannot imply that signal
+  acceptance equals runtime recovery, and the operator can work through the
+  current bounded cohort without repeating successful rows in one session.
+
+## Verification
+
+- Passed: 71 focused Vitest cases covering the progress selector, generic
+  recheck service and route, payload-free signal boundary, and UI states.
+- Passed: the six-case PostgreSQL progress-monitor boundary suite against an
+  isolated migrated development database; the database was removed afterward.
+- Passed: Hosted Web typecheck, scoped ESLint, `git diff --check`, and the
+  changed-file privacy/identifier scan.
+- Ready: desktop and 390px browser walkthroughs of the production-component
+  design study, including populated and partial-failure states. The mobile
+  result has no horizontal overflow; the empty and pending/error states are
+  covered by focused rendered tests.
+- Pending: required exact-head GitHub Actions, final ReviewGPT, merge, deploy,
+  and live read-only verification.

--- a/agent-docs/exec-plans/active/2026-08-31-ops-stalled-runtime-recheck.md
+++ b/agent-docs/exec-plans/active/2026-08-31-ops-stalled-runtime-recheck.md
@@ -120,6 +120,8 @@ Updated: 2026-08-31
   isolated migrated development database; the database was removed afterward.
 - Passed: Hosted Web typecheck, scoped ESLint, `git diff --check`, and the
   changed-file privacy/identifier scan.
+- Passed: `pnpm complexity:diff`; the new panel adds no complexity debt and its
+  maximum function complexity is 16, below the threshold of 20.
 - Ready: desktop and 390px browser walkthroughs of the production-component
   design study, including populated and partial-failure states. The mobile
   result has no horizontal overflow; the empty and pending/error states are

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -2424,6 +2424,21 @@ can wake one explicit workspace, and caps batch wakes to a tiny window that
 stops on the first signal failure. It is not a scheduler, queue, or generic
 admin job framework.
 
+The same surface has a separate facts-only runtime recheck. An operator may
+submit up to three normalized, deduplicated hosted member ids; Web first
+requires an existing workspace, then the signal owner independently rechecks
+active runtime access. The signals run sequentially under one bounded deadline
+and stop on the first unknown result. Each accepted request sends only
+`runtime_recheck_requested`: it appends no mailbox item, changes no usage, and
+grants no new work authority. Signal acceptance proves only that the runtime was
+asked to reread canonical facts, not that recovery completed.
+
+Automatic discovery may seed that same explicit-id control with active
+checkpointed system lanes matching the legacy device-sync stall signature for
+at least 15 minutes. Discovery and effect authority stay separate; manually
+entered ids do not need to match that incident signature, while every mutation
+still passes the workspace and live-access guards above.
+
 An already-dormant workspace that persisted `nextWakeAt = null` before a
 wake-preservation fix cannot self-start merely because the fixed runtime has
 been deployed. Recover it through the same bounded maintenance surface rather

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/page.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 
 import { requireHostedOpsPageAccess } from "@/src/lib/hosted-ops/access";
-import { readHostedRuntimeMaintenanceOverview } from "@/src/lib/hosted-ops/runtime-maintenance";
+import {
+  readHostedRuntimeMaintenanceOverview,
+  readHostedRuntimeStalledRecheckOverview,
+} from "@/src/lib/hosted-ops/runtime-maintenance";
 import { getHostedDashboardPageAuthSnapshot } from "@/src/lib/hosted-onboarding/page-auth";
 
 import { RuntimeMaintenanceClient } from "./runtime-maintenance-client";
@@ -21,7 +24,15 @@ export const metadata: Metadata = {
 export default async function RuntimeMaintenanceOpsPage() {
   await getHostedDashboardPageAuthSnapshot();
   await requireHostedOpsPageAccess();
-  const overview = await readHostedRuntimeMaintenanceOverview();
+  const [overview, stalledRecheckOverview] = await Promise.all([
+    readHostedRuntimeMaintenanceOverview(),
+    readHostedRuntimeStalledRecheckOverview(),
+  ]);
 
-  return <RuntimeMaintenanceClient initialOverview={overview} />;
+  return (
+    <RuntimeMaintenanceClient
+      initialOverview={overview}
+      initialStalledRecheckOverview={stalledRecheckOverview}
+    />
+  );
 }

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
@@ -26,25 +26,46 @@ import type {
   HostedRuntimeMaintenanceOverview,
   HostedRuntimeMaintenanceWakeResult,
   HostedRuntimeMaintenanceWorkspace,
+  HostedRuntimeRecheckResult,
+  HostedRuntimeStalledRecheckOverview,
 } from "@/src/lib/hosted-ops/runtime-maintenance";
 import type { HostedOpsJunctionDiagnosticResult } from "@/src/lib/hosted-ops/device-sync-diagnostic-types";
 
+import {
+  parseRuntimeRecheckUserIds,
+  removeSignaledRuntimeRecheckUserIds,
+  RuntimeRecheckPanel,
+  type RuntimeRecheckError,
+} from "./runtime-recheck-panel";
+
 interface RuntimeMaintenanceClientProps {
   initialOverview: HostedRuntimeMaintenanceOverview;
+  initialStalledRecheckOverview: HostedRuntimeStalledRecheckOverview;
 }
 
 type PendingAction =
   | { kind: "junction-diagnostic" }
   | { kind: "refresh" }
+  | { kind: "refresh-stalled-discovery" }
+  | { kind: "recheck-runtime-batch" }
   | { kind: "wake-batch"; limit: number }
   | { kind: "wake-user"; userId: string };
 
 export function RuntimeMaintenanceClient({
   initialOverview,
+  initialStalledRecheckOverview,
 }: RuntimeMaintenanceClientProps) {
   const [overview, setOverview] = useState(initialOverview);
   const [currentCursor, setCurrentCursor] = useState<string | null>(null);
   const [wakeResult, setWakeResult] = useState<HostedRuntimeMaintenanceWakeResult | null>(null);
+  const [stalledRecheckOverview, setStalledRecheckOverview] = useState(
+    initialStalledRecheckOverview,
+  );
+  const [runtimeRecheckUserIdsText, setRuntimeRecheckUserIdsText] = useState("");
+  const [runtimeRecheckResult, setRuntimeRecheckResult] =
+    useState<HostedRuntimeRecheckResult | null>(null);
+  const [runtimeRecheckError, setRuntimeRecheckError] =
+    useState<RuntimeRecheckError | null>(null);
   const [junctionDiagnosticResult, setJunctionDiagnosticResult] =
     useState<HostedOpsJunctionDiagnosticResult | null>(null);
   const [pending, setPending] = useState<PendingAction | null>(null);
@@ -125,6 +146,60 @@ export function RuntimeMaintenanceClient({
     }
   }
 
+  async function refreshStalledDiscovery(): Promise<void> {
+    setPending({ kind: "refresh-stalled-discovery" });
+    setRuntimeRecheckError(null);
+    try {
+      const nextOverview = await fetchStalledRecheckOverview();
+      setStalledRecheckOverview(nextOverview);
+    } catch (refreshError) {
+      setRuntimeRecheckError({
+        kind: "read",
+        message: describeClientError(refreshError),
+      });
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function recheckRuntimeBatch(): Promise<void> {
+    const parsedInput = parseRuntimeRecheckUserIds(runtimeRecheckUserIdsText);
+    const userIds = parsedInput.userIds.slice(0, 3);
+    if (parsedInput.invalidEntries.length > 0 || userIds.length === 0) {
+      return;
+    }
+
+    setPending({ kind: "recheck-runtime-batch" });
+    setRuntimeRecheckError(null);
+    setRuntimeRecheckResult(null);
+    try {
+      const result = await requestJson<HostedRuntimeRecheckResult>(
+        "/api/ops/runtime-maintenance",
+        {
+          body: JSON.stringify({
+            operation: "recheck-runtimes",
+            userIds,
+          }),
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+        },
+      );
+      setRuntimeRecheckResult(result);
+      setRuntimeRecheckUserIdsText((currentValue) => (
+        removeSignaledRuntimeRecheckUserIds(currentValue, result)
+      ));
+    } catch (recheckError) {
+      setRuntimeRecheckError({
+        kind: "request",
+        message: describeClientError(recheckError),
+      });
+    } finally {
+      setPending(null);
+    }
+  }
+
   async function runJunctionDiagnostic(formData: FormData): Promise<void> {
     setPending({ kind: "junction-diagnostic" });
     setJunctionDiagnosticError(null);
@@ -167,8 +242,8 @@ export function RuntimeMaintenanceClient({
             <h1 className="mt-2 font-serif text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
               Runtime maintenance
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-              Wake active hosted workspaces that already have a checkpoint snapshot so runtime idle maintenance can run.
+            <p className="mt-3 max-w-2xl text-pretty text-sm leading-6 text-muted-foreground">
+              Inspect and recover active hosted runtimes without changing member usage or creating member-visible work.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -312,6 +387,29 @@ export function RuntimeMaintenanceClient({
           <JunctionDiagnosticResultPanel result={junctionDiagnosticResult} />
         ) : null}
       </section>
+
+      <RuntimeRecheckPanel
+        disabled={pending !== null}
+        error={runtimeRecheckError}
+        onInputChange={setRuntimeRecheckUserIdsText}
+        onRecheck={() => void recheckRuntimeBatch()}
+        onRefresh={() => void refreshStalledDiscovery()}
+        onUseDetectedCandidates={() => {
+          setRuntimeRecheckUserIdsText((currentValue) => {
+            const queuedUserIds = parseRuntimeRecheckUserIds(currentValue).userIds;
+            return [...new Set([
+              ...queuedUserIds,
+              ...stalledRecheckOverview.candidates.map((candidate) => candidate.userId),
+            ])].join("\n");
+          });
+          setRuntimeRecheckError(null);
+          setRuntimeRecheckResult(null);
+        }}
+        overview={stalledRecheckOverview}
+        pendingAction={readRuntimeRecheckPendingAction(pending)}
+        result={runtimeRecheckResult}
+        userIdsText={runtimeRecheckUserIdsText}
+      />
 
       <section
         aria-busy={pending !== null}
@@ -811,6 +909,17 @@ async function fetchOverview(input: {
   );
 }
 
+async function fetchStalledRecheckOverview(): Promise<HostedRuntimeStalledRecheckOverview> {
+  const params = new URLSearchParams({
+    limit: "100",
+    operation: "recheck-stalled-device-sync",
+  });
+
+  return requestJson<HostedRuntimeStalledRecheckOverview>(
+    `/api/ops/runtime-maintenance?${params.toString()}`,
+  );
+}
+
 function readJsonErrorMessage(payload: unknown): string | null {
   if (!payload || typeof payload !== "object" || !("error" in payload)) {
     return null;
@@ -839,7 +948,25 @@ function describeMaintenancePendingAction(pending: PendingAction | null): string
   if (pending.kind === "junction-diagnostic") {
     return "";
   }
+  if (
+    pending.kind === "refresh-stalled-discovery"
+    || pending.kind === "recheck-runtime-batch"
+  ) {
+    return "";
+  }
   return `Waking ${pending.userId}.`;
+}
+
+function readRuntimeRecheckPendingAction(
+  pending: PendingAction | null,
+): "recheck" | "refresh" | null {
+  if (pending?.kind === "refresh-stalled-discovery") {
+    return "refresh";
+  }
+  if (pending?.kind === "recheck-runtime-batch") {
+    return "recheck";
+  }
+  return null;
 }
 
 function readFormDataString(formData: FormData, key: string): string | null {

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-recheck-panel.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-recheck-panel.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import {
+  AlertCircleIcon,
+  CheckCircle2Icon,
+  PlayIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import { Label } from "@/src/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import { Textarea } from "@/src/components/ui/textarea";
+import type {
+  HostedRuntimeRecheckResult,
+  HostedRuntimeStalledRecheckOverview,
+} from "@/src/lib/hosted-ops/runtime-maintenance";
+
+export type RuntimeRecheckError = {
+  kind: "read" | "request";
+  message: string;
+};
+
+const HOSTED_MEMBER_ID_PATTERN = /^hbm_[A-Za-z0-9_-]+$/u;
+const HOSTED_MEMBER_ID_MAX_LENGTH = 128;
+
+export function parseRuntimeRecheckUserIds(value: string): {
+  invalidEntries: string[];
+  userIds: string[];
+} {
+  const invalidEntries: string[] = [];
+  const userIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of value.split(/[\n,]/u)) {
+    const userId = entry.trim();
+    if (!userId || seen.has(userId)) {
+      continue;
+    }
+    seen.add(userId);
+    if (
+      userId.length > HOSTED_MEMBER_ID_MAX_LENGTH
+      || !HOSTED_MEMBER_ID_PATTERN.test(userId)
+    ) {
+      invalidEntries.push(userId);
+    } else {
+      userIds.push(userId);
+    }
+  }
+
+  return { invalidEntries, userIds };
+}
+
+export function removeSignaledRuntimeRecheckUserIds(
+  value: string,
+  result: HostedRuntimeRecheckResult,
+): string {
+  const signaledUserIds = new Set(
+    result.results
+      .filter((entry) => entry.status === "signaled")
+      .map((entry) => entry.userId),
+  );
+  return parseRuntimeRecheckUserIds(value).userIds
+    .filter((userId) => !signaledUserIds.has(userId))
+    .join("\n");
+}
+
+export function RuntimeRecheckPanel({
+  disabled,
+  error,
+  onInputChange,
+  onRecheck,
+  onRefresh,
+  onUseDetectedCandidates,
+  overview,
+  pendingAction,
+  result,
+  userIdsText,
+}: {
+  disabled: boolean;
+  error: RuntimeRecheckError | null;
+  onInputChange: (value: string) => void;
+  onRecheck: () => void;
+  onRefresh: () => void;
+  onUseDetectedCandidates: () => void;
+  overview: HostedRuntimeStalledRecheckOverview;
+  pendingAction: "recheck" | "refresh" | null;
+  result: HostedRuntimeRecheckResult | null;
+  userIdsText: string;
+}) {
+  const parsedInput = parseRuntimeRecheckUserIds(userIdsText);
+  const hasInvalidInput = parsedInput.invalidEntries.length > 0;
+  const queuedCount = parsedInput.userIds.length;
+  const nextBatchCount = Math.min(queuedCount, 3);
+  const failedCount = result?.results.filter((entry) => entry.status === "failed").length ?? 0;
+  const signaledCount = result?.results.length
+    ? result.results.length - failedCount
+    : 0;
+
+  return (
+    <section
+      aria-busy={pendingAction !== null}
+      aria-labelledby="runtime-rechecks-title"
+      className="overflow-hidden rounded-xl border border-border/70 bg-card/90"
+    >
+      <div className="flex flex-col gap-4 border-b border-border/70 px-5 py-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-2xl">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-chart-5">
+            Runtime recovery
+          </span>
+          <h2
+            className="mt-1 font-serif text-xl font-semibold tracking-tight text-foreground"
+            id="runtime-rechecks-title"
+          >
+            Runtime rechecks
+          </h2>
+          <p className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
+            Signal specific member runtimes to reread their existing canonical work. Rechecks do not add mailbox items, change usage, or prove that recovery completed.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:items-end">
+          <div className="flex flex-wrap gap-2">
+            <Badge className="tabular-nums" variant="secondary">
+              {formatInteger(overview.totalCandidateCount)} detected
+            </Badge>
+            {overview.candidates.length < overview.totalCandidateCount ? (
+              <Badge className="tabular-nums" variant="outline">
+                {formatInteger(overview.candidates.length)} shown
+              </Badge>
+            ) : null}
+            <Badge className="tabular-nums" variant="outline">
+              Captured {formatDateTime(overview.generatedAt)}
+            </Badge>
+            {overview.scanTruncated ? (
+              <Badge variant="outline">Scan truncated</Badge>
+            ) : null}
+          </div>
+          <Button
+            disabled={disabled}
+            onClick={onRefresh}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <RefreshCwIcon data-icon="inline-start" />
+            {pendingAction === "refresh" ? "Refreshing..." : "Refresh discovery"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="border-b border-border/70 px-5 py-5">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <Label
+              className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+              htmlFor="runtime-recheck-user-ids"
+            >
+              Member IDs
+            </Label>
+            <Badge className="tabular-nums" variant={hasInvalidInput ? "destructive" : "outline"}>
+              {formatInteger(queuedCount)} queued
+            </Badge>
+          </div>
+          <Textarea
+            aria-describedby="runtime-recheck-user-ids-help"
+            aria-invalid={hasInvalidInput}
+            className="min-h-28 resize-y font-mono text-xs leading-5"
+            disabled={disabled}
+            id="runtime-recheck-user-ids"
+            onChange={(event) => onInputChange(event.currentTarget.value)}
+            placeholder={"hbm_member_one, hbm_member_two\nhbm_member_three"}
+            rows={4}
+            spellCheck={false}
+            value={userIdsText}
+          />
+          <div
+            aria-live="polite"
+            className={hasInvalidInput
+              ? "min-h-5 text-sm text-destructive"
+              : "min-h-5 text-sm text-muted-foreground"}
+            id="runtime-recheck-user-ids-help"
+          >
+            {describeQueuedRuntimeIds(parsedInput)}
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Button
+            disabled={disabled || hasInvalidInput || overview.candidates.length === 0}
+            onClick={onUseDetectedCandidates}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Use detected candidates
+          </Button>
+          <Button
+            disabled={disabled || hasInvalidInput || queuedCount === 0}
+            onClick={onRecheck}
+            size="sm"
+            type="button"
+          >
+            <PlayIcon data-icon="inline-start" />
+            {pendingAction === "recheck"
+              ? "Requesting..."
+              : `Recheck next ${formatInteger(nextBatchCount)}`}
+          </Button>
+        </div>
+
+        <div aria-live="polite" className="min-h-5 pt-3 text-sm text-muted-foreground">
+          {pendingAction === "refresh"
+            ? "Refreshing automatic legacy-stall discovery. The member ID queue is unchanged."
+            : pendingAction === "recheck"
+              ? `Requesting ${formatInteger(nextBatchCount)} runtime recheck${nextBatchCount === 1 ? "" : "s"}.`
+              : ""}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="px-5 pt-4">
+          <Alert variant="destructive">
+            <AlertCircleIcon data-icon="inline-start" />
+            <AlertDescription className="min-w-0 break-words">
+              <p>{error.message}</p>
+              <p>
+                {error.kind === "request"
+                  ? "Recheck status is unknown. The member IDs remain queued; verify runtime progress before retrying."
+                  : "Automatic discovery could not refresh. The member ID queue is unchanged."}
+              </p>
+            </AlertDescription>
+          </Alert>
+        </div>
+      ) : null}
+
+      {result ? (
+        <div className="mx-5 mt-4 rounded-lg border border-border/70 bg-muted/20">
+          <div className="flex flex-col gap-2 border-b border-border/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="font-serif text-base font-semibold tracking-tight text-foreground">
+                Recheck result
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Generated {formatDateTime(result.generatedAt)}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge className="tabular-nums" variant="secondary">
+                {formatInteger(signaledCount)} requested
+              </Badge>
+              {failedCount > 0 ? (
+                <Badge className="tabular-nums" variant="destructive">
+                  {formatInteger(failedCount)} failed
+                </Badge>
+              ) : null}
+            </div>
+          </div>
+          <div className="divide-y divide-border/70">
+            {result.results.map((entry) => (
+              <div
+                className="grid min-w-0 gap-2 px-4 py-3 text-sm sm:grid-cols-[auto_minmax(0,1fr)_minmax(0,1.4fr)] sm:items-center"
+                key={`${entry.userId}:${entry.status}`}
+              >
+                <Badge variant={entry.status === "signaled" ? "secondary" : "destructive"}>
+                  {entry.status === "signaled" ? (
+                    <CheckCircle2Icon data-icon="inline-start" />
+                  ) : (
+                    <AlertCircleIcon data-icon="inline-start" />
+                  )}
+                  {entry.status === "signaled" ? "Requested" : "Failed"}
+                </Badge>
+                <span className="min-w-0 break-all font-mono text-xs text-foreground">
+                  {entry.userId}
+                </span>
+                <span className="min-w-0 break-words text-xs text-muted-foreground">
+                  {entry.status === "signaled"
+                    ? "Signal acknowledged; removed from queue"
+                    : entry.errorMessage}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-border/70 px-4 py-3 text-pretty text-xs leading-5 text-muted-foreground">
+            Acknowledged IDs are removed from the queue. Failed and unsent IDs remain. A recheck request is not proof of recovery.
+          </div>
+        </div>
+      ) : null}
+
+      <div className="pt-5">
+        <div className="flex flex-col gap-2 px-5 pb-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
+              Automatic discovery
+            </span>
+            <h3 className="mt-1 font-serif text-lg font-semibold tracking-tight text-foreground">
+              Detected legacy device-sync stalls
+            </h3>
+            <p className="mt-1 max-w-2xl text-pretty text-sm leading-6 text-muted-foreground">
+              Active runtimes matching the proven legacy signature: a system mailbox head stuck on a device-sync wake for at least 15 minutes.
+            </p>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            “Use detected candidates” adds this captured list to the queue.
+          </span>
+        </div>
+
+        {overview.candidates.length > 0 ? (
+          <>
+            <div className="divide-y divide-border/70 border-t border-border/70 sm:hidden">
+              {overview.candidates.map((candidate) => (
+                <div className="px-5 py-4" key={candidate.userId}>
+                  <p className="break-all font-mono text-xs leading-5 text-foreground">
+                    {candidate.userId}
+                  </p>
+                  <dl className="mt-3 grid grid-cols-2 gap-3">
+                    <div>
+                      <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                        Pending items
+                      </dt>
+                      <dd className="mt-1 font-mono text-xs tabular-nums text-foreground">
+                        {candidate.pendingItemCount}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                        Stalled since
+                      </dt>
+                      <dd className="mt-1 font-mono text-xs text-foreground">
+                        {formatDateTime(candidate.stalledSince)}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              ))}
+            </div>
+            <div className="hidden sm:block">
+              <Table className="text-[13px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="pl-5">User</TableHead>
+                    <TableHead className="text-right">Pending system items</TableHead>
+                    <TableHead className="pr-5">Stalled since</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {overview.candidates.map((candidate) => (
+                    <TableRow key={candidate.userId}>
+                      <TableCell className="max-w-[30rem] whitespace-normal break-all pl-5 font-mono text-xs text-foreground">
+                        {candidate.userId}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs tabular-nums">
+                        {candidate.pendingItemCount}
+                      </TableCell>
+                      <TableCell className="pr-5 font-mono text-xs">
+                        {formatDateTime(candidate.stalledSince)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </>
+        ) : (
+          <p className="px-5 pb-7 pt-2 text-pretty text-sm leading-6 text-muted-foreground">
+            No active runtimes currently match the legacy stall signature. You can still enter member IDs above.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function describeQueuedRuntimeIds(input: ReturnType<typeof parseRuntimeRecheckUserIds>): string {
+  if (input.invalidEntries.length > 0) {
+    return `${formatInteger(input.invalidEntries.length)} invalid member ID${input.invalidEntries.length === 1 ? "" : "s"}. Use hbm_ followed by letters, numbers, underscores, or hyphens (128 characters max).`;
+  }
+  if (input.userIds.length === 0) {
+    return "No member IDs queued. Paste comma- or newline-separated IDs, or use the detected candidates.";
+  }
+
+  const nextBatchCount = Math.min(input.userIds.length, 3);
+  return `${formatInteger(input.userIds.length)} unique member ID${input.userIds.length === 1 ? "" : "s"} queued. The next request sends ${formatInteger(nextBatchCount)}.`;
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(new Date(value));
+}

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-recheck-panel.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-recheck-panel.tsx
@@ -101,10 +101,6 @@ export function RuntimeRecheckPanel({
   const hasInvalidInput = parsedInput.invalidEntries.length > 0;
   const queuedCount = parsedInput.userIds.length;
   const nextBatchCount = Math.min(queuedCount, 3);
-  const failedCount = result?.results.filter((entry) => entry.status === "failed").length ?? 0;
-  const signaledCount = result?.results.length
-    ? result.results.length - failedCount
-    : 0;
 
   return (
     <section
@@ -241,140 +237,166 @@ export function RuntimeRecheckPanel({
         </div>
       ) : null}
 
-      {result ? (
-        <div className="mx-5 mt-4 rounded-lg border border-border/70 bg-muted/20">
-          <div className="flex flex-col gap-2 border-b border-border/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h3 className="font-serif text-base font-semibold tracking-tight text-foreground">
-                Recheck result
-              </h3>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Generated {formatDateTime(result.generatedAt)}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Badge className="tabular-nums" variant="secondary">
-                {formatInteger(signaledCount)} requested
-              </Badge>
-              {failedCount > 0 ? (
-                <Badge className="tabular-nums" variant="destructive">
-                  {formatInteger(failedCount)} failed
-                </Badge>
-              ) : null}
-            </div>
+      <RuntimeRecheckResultPanel result={result} />
+      <RuntimeRecheckDiscovery overview={overview} />
+    </section>
+  );
+}
+
+function RuntimeRecheckResultPanel({
+  result,
+}: {
+  result: HostedRuntimeRecheckResult | null;
+}) {
+  if (!result) {
+    return null;
+  }
+
+  const failedCount = result.results.filter(
+    (entry) => entry.status === "failed",
+  ).length;
+  const signaledCount = result.results.length - failedCount;
+
+  return (
+    <div className="mx-5 mt-4 rounded-lg border border-border/70 bg-muted/20">
+      <div className="flex flex-col gap-2 border-b border-border/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="font-serif text-base font-semibold tracking-tight text-foreground">
+            Recheck result
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Generated {formatDateTime(result.generatedAt)}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge className="tabular-nums" variant="secondary">
+            {formatInteger(signaledCount)} requested
+          </Badge>
+          {failedCount > 0 ? (
+            <Badge className="tabular-nums" variant="destructive">
+              {formatInteger(failedCount)} failed
+            </Badge>
+          ) : null}
+        </div>
+      </div>
+      <div className="divide-y divide-border/70">
+        {result.results.map((entry) => (
+          <div
+            className="grid min-w-0 gap-2 px-4 py-3 text-sm sm:grid-cols-[auto_minmax(0,1fr)_minmax(0,1.4fr)] sm:items-center"
+            key={`${entry.userId}:${entry.status}`}
+          >
+            <Badge variant={entry.status === "signaled" ? "secondary" : "destructive"}>
+              {entry.status === "signaled" ? (
+                <CheckCircle2Icon data-icon="inline-start" />
+              ) : (
+                <AlertCircleIcon data-icon="inline-start" />
+              )}
+              {entry.status === "signaled" ? "Requested" : "Failed"}
+            </Badge>
+            <span className="min-w-0 break-all font-mono text-xs text-foreground">
+              {entry.userId}
+            </span>
+            <span className="min-w-0 break-words text-xs text-muted-foreground">
+              {entry.status === "signaled"
+                ? "Signal acknowledged; removed from queue"
+                : entry.errorMessage}
+            </span>
           </div>
-          <div className="divide-y divide-border/70">
-            {result.results.map((entry) => (
-              <div
-                className="grid min-w-0 gap-2 px-4 py-3 text-sm sm:grid-cols-[auto_minmax(0,1fr)_minmax(0,1.4fr)] sm:items-center"
-                key={`${entry.userId}:${entry.status}`}
-              >
-                <Badge variant={entry.status === "signaled" ? "secondary" : "destructive"}>
-                  {entry.status === "signaled" ? (
-                    <CheckCircle2Icon data-icon="inline-start" />
-                  ) : (
-                    <AlertCircleIcon data-icon="inline-start" />
-                  )}
-                  {entry.status === "signaled" ? "Requested" : "Failed"}
-                </Badge>
-                <span className="min-w-0 break-all font-mono text-xs text-foreground">
-                  {entry.userId}
-                </span>
-                <span className="min-w-0 break-words text-xs text-muted-foreground">
-                  {entry.status === "signaled"
-                    ? "Signal acknowledged; removed from queue"
-                    : entry.errorMessage}
-                </span>
+        ))}
+      </div>
+      <div className="border-t border-border/70 px-4 py-3 text-pretty text-xs leading-5 text-muted-foreground">
+        Acknowledged IDs are removed from the queue. Failed and unsent IDs remain. A recheck request is not proof of recovery.
+      </div>
+    </div>
+  );
+}
+
+function RuntimeRecheckDiscovery({
+  overview,
+}: {
+  overview: HostedRuntimeStalledRecheckOverview;
+}) {
+  return (
+    <div className="pt-5">
+      <div className="flex flex-col gap-2 px-5 pb-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
+            Automatic discovery
+          </span>
+          <h3 className="mt-1 font-serif text-lg font-semibold tracking-tight text-foreground">
+            Detected legacy device-sync stalls
+          </h3>
+          <p className="mt-1 max-w-2xl text-pretty text-sm leading-6 text-muted-foreground">
+            Active runtimes matching the proven legacy signature: a system mailbox head stuck on a device-sync wake for at least 15 minutes.
+          </p>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          “Use detected candidates” adds this captured list to the queue.
+        </span>
+      </div>
+
+      {overview.candidates.length > 0 ? (
+        <>
+          <div className="divide-y divide-border/70 border-t border-border/70 sm:hidden">
+            {overview.candidates.map((candidate) => (
+              <div className="px-5 py-4" key={candidate.userId}>
+                <p className="break-all font-mono text-xs leading-5 text-foreground">
+                  {candidate.userId}
+                </p>
+                <dl className="mt-3 grid grid-cols-2 gap-3">
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                      Pending items
+                    </dt>
+                    <dd className="mt-1 font-mono text-xs tabular-nums text-foreground">
+                      {candidate.pendingItemCount}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                      Stalled since
+                    </dt>
+                    <dd className="mt-1 font-mono text-xs text-foreground">
+                      {formatDateTime(candidate.stalledSince)}
+                    </dd>
+                  </div>
+                </dl>
               </div>
             ))}
           </div>
-          <div className="border-t border-border/70 px-4 py-3 text-pretty text-xs leading-5 text-muted-foreground">
-            Acknowledged IDs are removed from the queue. Failed and unsent IDs remain. A recheck request is not proof of recovery.
-          </div>
-        </div>
-      ) : null}
-
-      <div className="pt-5">
-        <div className="flex flex-col gap-2 px-5 pb-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-chart-5">
-              Automatic discovery
-            </span>
-            <h3 className="mt-1 font-serif text-lg font-semibold tracking-tight text-foreground">
-              Detected legacy device-sync stalls
-            </h3>
-            <p className="mt-1 max-w-2xl text-pretty text-sm leading-6 text-muted-foreground">
-              Active runtimes matching the proven legacy signature: a system mailbox head stuck on a device-sync wake for at least 15 minutes.
-            </p>
-          </div>
-          <span className="text-xs text-muted-foreground">
-            “Use detected candidates” adds this captured list to the queue.
-          </span>
-        </div>
-
-        {overview.candidates.length > 0 ? (
-          <>
-            <div className="divide-y divide-border/70 border-t border-border/70 sm:hidden">
-              {overview.candidates.map((candidate) => (
-                <div className="px-5 py-4" key={candidate.userId}>
-                  <p className="break-all font-mono text-xs leading-5 text-foreground">
-                    {candidate.userId}
-                  </p>
-                  <dl className="mt-3 grid grid-cols-2 gap-3">
-                    <div>
-                      <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-                        Pending items
-                      </dt>
-                      <dd className="mt-1 font-mono text-xs tabular-nums text-foreground">
-                        {candidate.pendingItemCount}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-                        Stalled since
-                      </dt>
-                      <dd className="mt-1 font-mono text-xs text-foreground">
-                        {formatDateTime(candidate.stalledSince)}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              ))}
-            </div>
-            <div className="hidden sm:block">
-              <Table className="text-[13px]">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="pl-5">User</TableHead>
-                    <TableHead className="text-right">Pending system items</TableHead>
-                    <TableHead className="pr-5">Stalled since</TableHead>
+          <div className="hidden sm:block">
+            <Table className="text-[13px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="pl-5">User</TableHead>
+                  <TableHead className="text-right">Pending system items</TableHead>
+                  <TableHead className="pr-5">Stalled since</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overview.candidates.map((candidate) => (
+                  <TableRow key={candidate.userId}>
+                    <TableCell className="max-w-[30rem] whitespace-normal break-all pl-5 font-mono text-xs text-foreground">
+                      {candidate.userId}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs tabular-nums">
+                      {candidate.pendingItemCount}
+                    </TableCell>
+                    <TableCell className="pr-5 font-mono text-xs">
+                      {formatDateTime(candidate.stalledSince)}
+                    </TableCell>
                   </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {overview.candidates.map((candidate) => (
-                    <TableRow key={candidate.userId}>
-                      <TableCell className="max-w-[30rem] whitespace-normal break-all pl-5 font-mono text-xs text-foreground">
-                        {candidate.userId}
-                      </TableCell>
-                      <TableCell className="text-right font-mono text-xs tabular-nums">
-                        {candidate.pendingItemCount}
-                      </TableCell>
-                      <TableCell className="pr-5 font-mono text-xs">
-                        {formatDateTime(candidate.stalledSince)}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          </>
-        ) : (
-          <p className="px-5 pb-7 pt-2 text-pretty text-sm leading-6 text-muted-foreground">
-            No active runtimes currently match the legacy stall signature. You can still enter member IDs above.
-          </p>
-        )}
-      </div>
-    </section>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      ) : (
+        <p className="px-5 pb-7 pt-2 text-pretty text-sm leading-6 text-muted-foreground">
+          No active runtimes currently match the legacy stall signature. You can still enter member IDs above.
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/app/api/ops/runtime-maintenance/route.ts
+++ b/apps/web/app/api/ops/runtime-maintenance/route.ts
@@ -1,8 +1,11 @@
 import {
   readHostedRuntimeMaintenanceOverview,
+  readHostedRuntimeStalledRecheckOverview,
   signalHostedRuntimeMaintenanceBatch,
+  signalHostedRuntimeRecheckBatch,
 } from "@/src/lib/hosted-ops/runtime-maintenance";
 import { requireHostedOpsRequestAccess } from "@/src/lib/hosted-ops/access";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
 import {
   jsonOk,
   readHostedOnboardingJsonObject,
@@ -14,10 +17,20 @@ export const fetchCache = "force-no-store";
 export const revalidate = 0;
 
 const HOSTED_RUNTIME_MAINTENANCE_BODY_LIMIT_BYTES = 4 * 1024;
+const STALLED_RECHECK_DISCOVERY_OPERATION = "recheck-stalled-device-sync";
+const RUNTIME_RECHECK_OPERATION = "recheck-runtimes";
 
 export const GET = withJsonError(async (request: Request) => {
   await requireHostedOpsRequestAccess(request);
   const url = new URL(request.url);
+  const operation = url.searchParams.get("operation");
+
+  if (operation === STALLED_RECHECK_DISCOVERY_OPERATION) {
+    return jsonOk(await readHostedRuntimeStalledRecheckOverview({
+      limit: url.searchParams.get("limit"),
+    }));
+  }
+  assertKnownRuntimeMaintenanceOperation(operation);
 
   return jsonOk(await readHostedRuntimeMaintenanceOverview({
     cursor: url.searchParams.get("cursor"),
@@ -34,6 +47,15 @@ export const POST = withJsonError(async (request: Request) => {
     tooLargeErrorCode: "HOSTED_RUNTIME_MAINTENANCE_REQUEST_TOO_LARGE",
     tooLargeErrorMessage: "Hosted runtime maintenance request body is too large.",
   });
+  const operation = readRuntimeMaintenanceOperation(body);
+
+  if (operation === RUNTIME_RECHECK_OPERATION) {
+    return jsonOk(await signalHostedRuntimeRecheckBatch({
+      abortSignal: request.signal,
+      userIds: readRequiredStringArrayField(body, "userIds"),
+    }));
+  }
+  assertKnownRuntimeMaintenanceOperation(operation);
 
   return jsonOk(await signalHostedRuntimeMaintenanceBatch({
     cursor: readOptionalStringField(body, "cursor"),
@@ -53,4 +75,50 @@ function readOptionalStringField(
 function readOptionalLimitField(body: Record<string, unknown>): number | string | null {
   const value = body.limit;
   return typeof value === "string" || typeof value === "number" ? value : null;
+}
+
+function readRequiredStringArrayField(
+  body: Record<string, unknown>,
+  key: string,
+): string[] {
+  const value = body[key];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw invalidRuntimeMaintenanceOperation(
+      `Hosted runtime maintenance ${key} must be an array of strings.`,
+    );
+  }
+  return value;
+}
+
+function readRuntimeMaintenanceOperation(
+  body: Record<string, unknown>,
+): string | null {
+  if (!Object.hasOwn(body, "operation")) {
+    return null;
+  }
+  const operation = body.operation;
+  if (typeof operation !== "string") {
+    throw invalidRuntimeMaintenanceOperation(
+      "Hosted runtime maintenance operation must be a string.",
+    );
+  }
+  return operation;
+}
+
+function assertKnownRuntimeMaintenanceOperation(
+  operation: string | null,
+): asserts operation is null {
+  if (operation !== null) {
+    throw invalidRuntimeMaintenanceOperation(
+      "Hosted runtime maintenance operation is not supported.",
+    );
+  }
+}
+
+function invalidRuntimeMaintenanceOperation(message: string): Error {
+  return hostedOnboardingError({
+    code: "HOSTED_RUNTIME_MAINTENANCE_OPERATION_INVALID",
+    httpStatus: 400,
+    message,
+  });
 }

--- a/apps/web/app/design/runtime-maintenance-study.tsx
+++ b/apps/web/app/design/runtime-maintenance-study.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { RuntimeRecheckPanel } from "../(dashboard)/ops/runtime-maintenance/runtime-recheck-panel";
+
+type RuntimeRecheckPanelProps = ComponentProps<
+  typeof RuntimeRecheckPanel
+>;
+
+const DESIGN_STALLED_RECHECK_OVERVIEW: RuntimeRecheckPanelProps["overview"] = {
+  candidates: [{
+    pendingItemCount: "13",
+    stalledSince: "2026-08-31T14:15:00.000Z",
+    userId: "hbm_demo_alpha",
+  }, {
+    pendingItemCount: "8",
+    stalledSince: "2026-08-31T14:22:00.000Z",
+    userId: "hbm_demo_bravo",
+  }, {
+    pendingItemCount: "3",
+    stalledSince: "2026-08-31T14:31:00.000Z",
+    userId: "hbm_demo_charlie",
+  }],
+  generatedAt: "2026-08-31T15:00:00.000Z",
+  limit: 100,
+  scanTruncated: false,
+  totalCandidateCount: 5,
+};
+
+const DESIGN_STALLED_RECHECK_RESULT: NonNullable<
+  RuntimeRecheckPanelProps["result"]
+> = {
+  generatedAt: "2026-08-31T15:01:00.000Z",
+  requestedCount: 2,
+  results: [{
+    status: "signaled",
+    userId: "hbm_demo_alpha",
+  }, {
+    errorMessage: "The runtime did not acknowledge the signal before the request deadline.",
+    errorName: "TimeoutError",
+    status: "failed",
+    userId: "hbm_demo_bravo",
+  }],
+};
+
+export function RuntimeMaintenanceStudy() {
+  return (
+    <div
+      className="scroll-mt-24"
+      data-design-section="stalled-runtime-rechecks"
+      inert
+    >
+      <RuntimeRecheckPanel
+        disabled={false}
+        error={null}
+        onInputChange={() => undefined}
+        onRecheck={() => undefined}
+        onRefresh={() => undefined}
+        onUseDetectedCandidates={() => undefined}
+        overview={DESIGN_STALLED_RECHECK_OVERVIEW}
+        pendingAction={null}
+        result={DESIGN_STALLED_RECHECK_RESULT}
+        userIdsText={"hbm_demo_bravo\nhbm_demo_charlie\nhbm_demo_manual"}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -62,6 +62,7 @@ import { HomepageAuthWarmRuntimeStudy } from "./homepage-auth-warm-runtime-study
 import { JoinFamilyBillingRecoveryStudy } from "./join-family-billing-recovery-study";
 import { OpsUsageStudy } from "./ops-usage-study";
 import { OpsOperatorTaskStudy } from "./ops-operator-task-study";
+import { RuntimeMaintenanceStudy } from "./runtime-maintenance-study";
 import {
   PersonaOnboardingStudy,
   PersonaSettingsStudy,
@@ -791,6 +792,15 @@ export function SectionsContent({
 
       {category === "ops" ? (
         <>
+          <Separator />
+
+          <StudySection
+            id="stalled-runtime-rechecks"
+            title="Runtime rechecks and legacy-stall discovery"
+          >
+            <RuntimeMaintenanceStudy />
+          </StudySection>
+
           <Separator />
 
           <StudySection title="Ops usage search and recovery">

--- a/apps/web/src/lib/hosted-ops/runtime-maintenance.ts
+++ b/apps/web/src/lib/hosted-ops/runtime-maintenance.ts
@@ -4,16 +4,31 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 
 import {
   signalHostedRuntimeMaintenanceRuntime,
+  signalHostedRuntimeRecheckRuntime,
   type HostedRuntimeSignalResult,
 } from "../hosted-orchestration/signal-runtime";
+import {
+  createHostedPostCommitDeadline,
+  waitForHostedPostCommitOperation,
+} from "../hosted-onboarding/bounded-post-commit";
 import { hostedOnboardingError } from "../hosted-onboarding/errors";
 import { activeHostedMemberAccessWhere } from "../hosted-onboarding/member-access";
+import {
+  readHostedRuntimeStalledRecheckCandidates,
+  type HostedRuntimeStalledRecheckCandidate,
+  type HostedRuntimeStalledRecheckCandidateScan,
+} from "../hosted-runtime-progress/alert-monitor";
 import { getPrisma } from "../prisma";
 
 export const HOSTED_RUNTIME_MAINTENANCE_DEFAULT_READ_LIMIT = 20;
 export const HOSTED_RUNTIME_MAINTENANCE_MAX_READ_LIMIT = 100;
 export const HOSTED_RUNTIME_MAINTENANCE_DEFAULT_WAKE_LIMIT = 1;
 export const HOSTED_RUNTIME_MAINTENANCE_MAX_WAKE_LIMIT = 3;
+export const HOSTED_RUNTIME_STALLED_RECHECK_DEFAULT_READ_LIMIT = 100;
+export const HOSTED_RUNTIME_STALLED_RECHECK_MAX_READ_LIMIT = 100;
+export const HOSTED_RUNTIME_RECHECK_MAX_SIGNAL_LIMIT = 3;
+const HOSTED_RUNTIME_MEMBER_ID_MAX_LENGTH = 128;
+const HOSTED_RUNTIME_MEMBER_ID_PATTERN = /^hbm_[A-Za-z0-9_-]+$/u;
 
 export interface HostedRuntimeMaintenanceWorkspace {
   checkpointedAt: string | null;
@@ -38,6 +53,32 @@ export interface HostedRuntimeMaintenanceWakeResult {
   results: HostedRuntimeMaintenanceWakeUserResult[];
 }
 
+export interface HostedRuntimeStalledRecheckOverview {
+  candidates: HostedRuntimeStalledRecheckCandidate[];
+  generatedAt: string;
+  limit: number;
+  scanTruncated: boolean;
+  totalCandidateCount: number;
+}
+
+export interface HostedRuntimeRecheckResult {
+  generatedAt: string;
+  requestedCount: number;
+  results: HostedRuntimeRecheckUserResult[];
+}
+
+export type HostedRuntimeRecheckUserResult =
+  | {
+      status: "signaled";
+      userId: string;
+    }
+  | {
+      errorMessage: string;
+      errorName: string;
+      status: "failed";
+      userId: string;
+    };
+
 export type HostedRuntimeMaintenanceWakeUserResult =
   | {
       checkpointedAt: string | null;
@@ -59,6 +100,12 @@ export type HostedRuntimeMaintenanceWakeUserResult =
 
 type HostedRuntimeMaintenanceSignal =
   (input: Parameters<typeof signalHostedRuntimeMaintenanceRuntime>[0]) => Promise<HostedRuntimeSignalResult>;
+
+type HostedRuntimeRecheckSignal =
+  (input: Parameters<typeof signalHostedRuntimeRecheckRuntime>[0]) => Promise<HostedRuntimeSignalResult>;
+
+type ReadHostedRuntimeStalledRecheckCandidates =
+  (input: Parameters<typeof readHostedRuntimeStalledRecheckCandidates>[0]) => Promise<HostedRuntimeStalledRecheckCandidateScan>;
 
 export async function readHostedRuntimeMaintenanceOverview(input: {
   cursor?: string | null;
@@ -175,6 +222,94 @@ export async function signalHostedRuntimeMaintenanceBatch(input: {
   };
 }
 
+export async function readHostedRuntimeStalledRecheckOverview(input: {
+  limit?: number | string | null;
+  now?: Date;
+  prisma?: PrismaClient;
+  readCandidates?: ReadHostedRuntimeStalledRecheckCandidates;
+} = {}): Promise<HostedRuntimeStalledRecheckOverview> {
+  const now = input.now ?? new Date();
+  const limit = normalizePositiveInteger(
+    input.limit,
+    HOSTED_RUNTIME_STALLED_RECHECK_DEFAULT_READ_LIMIT,
+    HOSTED_RUNTIME_STALLED_RECHECK_MAX_READ_LIMIT,
+  );
+  const readCandidates = input.readCandidates
+    ?? readHostedRuntimeStalledRecheckCandidates;
+  const scan = await readCandidates({
+    now,
+    prisma: input.prisma ?? getPrisma(),
+  });
+
+  return {
+    candidates: scan.candidates.slice(0, limit),
+    generatedAt: now.toISOString(),
+    limit,
+    scanTruncated: scan.scanTruncated,
+    totalCandidateCount: scan.candidates.length,
+  };
+}
+
+export async function signalHostedRuntimeRecheckBatch(input: {
+  abortSignal?: AbortSignal;
+  prisma?: PrismaClient;
+  signalRuntimeRecheck?: HostedRuntimeRecheckSignal;
+  userIds: readonly string[];
+}): Promise<HostedRuntimeRecheckResult> {
+  const prisma = input.prisma ?? getPrisma();
+  const userIds = normalizeRuntimeRecheckUserIds(input.userIds);
+  const workspaceRows = await prisma.hostedWorkspace.findMany({
+    select: { userId: true },
+    where: { userId: { in: userIds } },
+  });
+  const workspaceUserIds = new Set(workspaceRows.map((row) => row.userId));
+  const signalRuntimeRecheck = input.signalRuntimeRecheck
+    ?? signalHostedRuntimeRecheckRuntime;
+  const deadlineMs = createHostedPostCommitDeadline(undefined);
+  const results: HostedRuntimeRecheckUserResult[] = [];
+
+  for (const userId of userIds) {
+    if (!workspaceUserIds.has(userId)) {
+      results.push({
+        errorMessage: "No hosted runtime workspace exists for this member id.",
+        errorName: "HostedRuntimeWorkspaceNotFound",
+        status: "failed",
+        userId,
+      });
+      break;
+    }
+    try {
+      await waitForHostedPostCommitOperation({
+        deadlineMs,
+        operation: (abortSignal) => signalRuntimeRecheck({
+          abortSignal,
+          prisma,
+          userId,
+        }),
+        signal: input.abortSignal,
+      });
+      results.push({
+        status: "signaled",
+        userId,
+      });
+    } catch (error) {
+      results.push({
+        errorMessage: describeStalledRecheckSignalError(error),
+        errorName: error instanceof Error ? error.name : typeof error,
+        status: "failed",
+        userId,
+      });
+      break;
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    requestedCount: userIds.length,
+    results,
+  };
+}
+
 async function readHostedRuntimeMaintenanceCandidateForUser(input: {
   prisma: PrismaClient;
   userId: string;
@@ -262,8 +397,47 @@ function normalizeOptionalIdentifier(value: string | null | undefined): string |
   return normalized ? normalized : null;
 }
 
+function normalizeRuntimeRecheckUserIds(
+  values: readonly string[],
+): string[] {
+  const userIds = [...new Set(values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0))];
+  if (userIds.length === 0) {
+    throw hostedOnboardingError({
+      code: "HOSTED_RUNTIME_RECHECK_USER_IDS_REQUIRED",
+      httpStatus: 400,
+      message: "At least one runtime member id is required.",
+    });
+  }
+  if (userIds.length > HOSTED_RUNTIME_RECHECK_MAX_SIGNAL_LIMIT) {
+    throw hostedOnboardingError({
+      code: "HOSTED_RUNTIME_RECHECK_LIMIT_EXCEEDED",
+      httpStatus: 400,
+      message: `At most ${HOSTED_RUNTIME_RECHECK_MAX_SIGNAL_LIMIT} runtime member ids can be rechecked at once.`,
+    });
+  }
+  if (userIds.some((userId) => (
+    userId.length > HOSTED_RUNTIME_MEMBER_ID_MAX_LENGTH
+    || !HOSTED_RUNTIME_MEMBER_ID_PATTERN.test(userId)
+  ))) {
+    throw hostedOnboardingError({
+      code: "HOSTED_RUNTIME_RECHECK_USER_ID_INVALID",
+      httpStatus: 400,
+      message: "Every runtime recheck target must be a valid hosted member id.",
+    });
+  }
+  return userIds;
+}
+
 function describeMaintenanceSignalError(error: unknown): string {
   return error instanceof Error
     ? "Maintenance signal failed. Check server logs for details."
     : "Maintenance signal failed.";
+}
+
+function describeStalledRecheckSignalError(error: unknown): string {
+  return error instanceof Error
+    ? "Runtime recheck status is unknown. Refresh progress before retrying."
+    : "Runtime recheck status is unknown.";
 }

--- a/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
+++ b/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
@@ -46,11 +46,18 @@ type HostedRuntimeProgressPrismaClient =
 
 export interface HostedRuntimeProgressHealthRow {
   chronologyInvalid: boolean;
+  headKind: string;
   lane: string;
+  nextDefaultProcessingWakeAt: Date | null;
+  nextDefaultProcessingWakeReason: string | null;
+  nextWakeAt: Date | null;
+  nextWakeReason: string | null;
   pendingCount: bigint;
   progressOriginAt: Date;
   runtimeKey: string;
+  systemMailboxProgressGeneration: bigint | null;
   usageBlocked: boolean;
+  workspaceCheckpointedAt: Date | null;
 }
 
 type HostedRuntimeProgressQueryRow = HostedRuntimeProgressHealthRow;
@@ -68,6 +75,17 @@ export interface HostedRuntimeProgressHealth {
   stalledRuntimeCount: number;
   stalledSystemLaneCount: number;
   thresholdMs: number;
+}
+
+export interface HostedRuntimeStalledRecheckCandidate {
+  pendingItemCount: string;
+  stalledSince: string;
+  userId: string;
+}
+
+export interface HostedRuntimeStalledRecheckCandidateScan {
+  candidates: HostedRuntimeStalledRecheckCandidate[];
+  scanTruncated: boolean;
 }
 
 export type HostedRuntimeProgressAlertMonitorOutcome =
@@ -155,6 +173,85 @@ export async function readHostedRuntimeProgressHealth(input: {
 } = {}): Promise<HostedRuntimeProgressHealth> {
   const now = input.now ?? new Date();
   const prisma = input.prisma ?? getPrisma();
+  const observation = await readHostedRuntimeProgressObservation({ now, prisma });
+
+  return summarizeHostedRuntimeProgressRows({
+    activeRuntimeKeys: [
+      ...new Set(observation.alertableRows.map((row) => row.runtimeKey)),
+    ],
+    excludedInactiveLaneCount: observation.excludedInactiveLaneCount,
+    excludedUsageBlockedConversationLaneCount:
+      observation.excludedUsageBlockedConversationLaneCount,
+    now,
+    rows: observation.alertableRows,
+    scanTruncated: observation.scanTruncated,
+  });
+}
+
+export async function readHostedRuntimeStalledRecheckCandidates(input: {
+  now?: Date;
+  prisma?: Pick<
+    PrismaClient,
+    "$queryRaw" | "hostedMember" | "hostedThreadContainerParticipant"
+  >;
+} = {}): Promise<HostedRuntimeStalledRecheckCandidateScan> {
+  const now = input.now ?? new Date();
+  const prisma = input.prisma ?? getPrisma();
+  const stalledBefore = new Date(
+    now.getTime() - HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
+  );
+  const observation = await readHostedRuntimeProgressObservation({ now, prisma });
+  const candidates = observation.alertableRows
+    .filter((row) => (
+      classifyHostedRuntimeProgressRow(row, now) === "stalled"
+      && row.lane === "system"
+      && row.headKind === "device-sync.wake"
+      && row.nextWakeAt !== null
+      && row.nextWakeAt <= stalledBefore
+      && row.nextWakeReason === "device-sync.reconcile"
+      && row.nextDefaultProcessingWakeAt === null
+      && row.nextDefaultProcessingWakeReason === null
+      && row.systemMailboxProgressGeneration === null
+      && row.workspaceCheckpointedAt !== null
+    ))
+    .map((row) => ({
+      pendingItemCount: row.pendingCount.toString(),
+      stalledSince: row.progressOriginAt.toISOString(),
+      userId: row.runtimeKey,
+    }))
+    .sort(compareHostedRuntimeRecheckCandidates);
+
+  return {
+    candidates,
+    scanTruncated: observation.scanTruncated,
+  };
+}
+
+interface HostedRuntimeProgressObservation {
+  alertableRows: HostedRuntimeProgressQueryRow[];
+  excludedInactiveLaneCount: number;
+  excludedUsageBlockedConversationLaneCount: number;
+  scanTruncated: boolean;
+}
+
+function compareHostedRuntimeRecheckCandidates(
+  left: HostedRuntimeStalledRecheckCandidate,
+  right: HostedRuntimeStalledRecheckCandidate,
+): number {
+  if (left.userId < right.userId) {
+    return -1;
+  }
+  return left.userId > right.userId ? 1 : 0;
+}
+
+async function readHostedRuntimeProgressObservation(input: {
+  now: Date;
+  prisma: Pick<
+    PrismaClient,
+    "$queryRaw" | "hostedMember" | "hostedThreadContainerParticipant"
+  >;
+}): Promise<HostedRuntimeProgressObservation> {
+  const { now, prisma } = input;
   const stalledBefore = new Date(
     now.getTime() - HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
   );
@@ -227,14 +324,12 @@ export async function readHostedRuntimeProgressHealth(input: {
 
   const scanTruncated =
     candidateRowCount > HOSTED_RUNTIME_PROGRESS_READ_LIMIT;
-  return summarizeHostedRuntimeProgressRows({
-    activeRuntimeKeys: [...new Set(alertableRows.map((row) => row.runtimeKey))],
+  return {
+    alertableRows,
     excludedInactiveLaneCount,
     excludedUsageBlockedConversationLaneCount,
-    now,
-    rows: alertableRows,
     scanTruncated,
-  });
+  };
 }
 
 interface HostedRuntimeProgressReadCursor {
@@ -330,7 +425,15 @@ async function readHostedRuntimeProgressCandidatePage(input: {
     workspace_evidence AS (
       SELECT
         lagging_lane.*,
+        workspace.checkpointed_at AS workspace_checkpointed_at,
+        workspace.next_default_processing_wake_at
+          AS workspace_next_default_processing_wake_at,
+        workspace.next_default_processing_wake_reason
+          AS workspace_next_default_processing_wake_reason,
         workspace.next_wake_at AS workspace_next_wake_at,
+        workspace.next_wake_reason AS workspace_next_wake_reason,
+        workspace.system_mailbox_progress_generation
+          AS workspace_system_mailbox_progress_generation,
         CASE
           WHEN jsonb_typeof(
             workspace.redacted_status_json
@@ -429,8 +532,15 @@ async function readHostedRuntimeProgressCandidatePage(input: {
     progress_lane AS (
       SELECT
         progress_evidence.user_id,
+        progress_evidence.head_kind,
         progress_evidence.lane,
         progress_evidence.pending_count,
+        progress_evidence.workspace_checkpointed_at,
+        progress_evidence.workspace_next_default_processing_wake_at,
+        progress_evidence.workspace_next_default_processing_wake_reason,
+        progress_evidence.workspace_next_wake_at,
+        progress_evidence.workspace_next_wake_reason,
+        progress_evidence.workspace_system_mailbox_progress_generation,
         CASE
           WHEN progress_evidence.lane = 'system'
             AND progress_evidence.head_kind = 'device-sync.wake'
@@ -487,11 +597,21 @@ async function readHostedRuntimeProgressCandidatePage(input: {
     )
     SELECT
       progress_lane.chronology_invalid AS "chronologyInvalid",
+      progress_lane.head_kind AS "headKind",
       progress_lane.lane,
+      progress_lane.workspace_next_default_processing_wake_at
+        AS "nextDefaultProcessingWakeAt",
+      progress_lane.workspace_next_default_processing_wake_reason
+        AS "nextDefaultProcessingWakeReason",
+      progress_lane.workspace_next_wake_at AS "nextWakeAt",
+      progress_lane.workspace_next_wake_reason AS "nextWakeReason",
       progress_lane.pending_count AS "pendingCount",
       progress_lane.progress_origin_at AS "progressOriginAt",
       progress_lane.user_id AS "runtimeKey",
-      progress_lane.usage_blocked AS "usageBlocked"
+      progress_lane.workspace_system_mailbox_progress_generation
+        AS "systemMailboxProgressGeneration",
+      progress_lane.usage_blocked AS "usageBlocked",
+      progress_lane.workspace_checkpointed_at AS "workspaceCheckpointedAt"
     FROM progress_lane
     WHERE (
       progress_lane.chronology_invalid
@@ -532,30 +652,20 @@ export function summarizeHostedRuntimeProgressRows(input: {
       excludedInactiveLaneCount += 1;
       continue;
     }
-    if (row.chronologyInvalid) {
+    const disposition = classifyHostedRuntimeProgressRow(row, input.now);
+    if (disposition === "invalid") {
       invalidRowCount += 1;
       continue;
     }
-    if (row.usageBlocked && row.lane === "conversation") {
+    if (disposition === "usage_blocked") {
       excludedUsageBlockedConversationLaneCount += 1;
       continue;
     }
+    if (disposition === "fresh") {
+      continue;
+    }
+
     const progressOriginAtMs = row.progressOriginAt.getTime();
-    if (
-      !Number.isFinite(progressOriginAtMs)
-      || progressOriginAtMs > input.now.getTime()
-      || row.pendingCount <= 0n
-      || (row.lane !== "conversation" && row.lane !== "system")
-    ) {
-      invalidRowCount += 1;
-      continue;
-    }
-    if (
-      input.now.getTime() - progressOriginAtMs
-        < HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS
-    ) {
-      continue;
-    }
 
     stalledLaneCount += 1;
     stalledRuntimeKeys.add(row.runtimeKey);
@@ -586,6 +696,38 @@ export function summarizeHostedRuntimeProgressRows(input: {
     stalledSystemLaneCount,
     thresholdMs: HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
   };
+}
+
+type HostedRuntimeProgressRowDisposition =
+  | "fresh"
+  | "invalid"
+  | "stalled"
+  | "usage_blocked";
+
+function classifyHostedRuntimeProgressRow(
+  row: HostedRuntimeProgressHealthRow,
+  now: Date,
+): HostedRuntimeProgressRowDisposition {
+  if (row.chronologyInvalid) {
+    return "invalid";
+  }
+  if (row.usageBlocked && row.lane === "conversation") {
+    return "usage_blocked";
+  }
+
+  const progressOriginAtMs = row.progressOriginAt.getTime();
+  if (
+    !Number.isFinite(progressOriginAtMs)
+    || progressOriginAtMs > now.getTime()
+    || row.pendingCount <= 0n
+    || (row.lane !== "conversation" && row.lane !== "system")
+  ) {
+    return "invalid";
+  }
+  return now.getTime() - progressOriginAtMs
+      >= HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS
+    ? "stalled"
+    : "fresh";
 }
 
 function buildHostedRuntimeProgressAlertDetails(input: {

--- a/apps/web/test/hosted-runtime-maintenance-ops.test.ts
+++ b/apps/web/test/hosted-runtime-maintenance-ops.test.ts
@@ -10,9 +10,11 @@ const mocks = vi.hoisted(() => ({
     findFirst: vi.fn(),
     findMany: vi.fn(),
   },
+  readHostedRuntimeStalledRecheckCandidates: vi.fn(),
   requireActiveHostedAppSession: vi.fn(),
   requireActiveHostedAppSessionFromRequest: vi.fn(),
   signalHostedRuntimeMaintenanceRuntime: vi.fn(),
+  signalHostedRuntimeRecheckRuntime: vi.fn(),
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/app-session", () => ({
@@ -31,6 +33,13 @@ vi.mock("@/src/lib/prisma", () => ({
 vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
   signalHostedRuntimeMaintenanceRuntime:
     mocks.signalHostedRuntimeMaintenanceRuntime,
+  signalHostedRuntimeRecheckRuntime:
+    mocks.signalHostedRuntimeRecheckRuntime,
+}));
+
+vi.mock("@/src/lib/hosted-runtime-progress/alert-monitor", () => ({
+  readHostedRuntimeStalledRecheckCandidates:
+    mocks.readHostedRuntimeStalledRecheckCandidates,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -78,6 +87,14 @@ describe("hosted runtime maintenance ops", () => {
     mocks.signalHostedRuntimeMaintenanceRuntime.mockResolvedValue({
       signalAccepted: true,
       workflowId: "hosted-user-runtime:member_001",
+    });
+    mocks.signalHostedRuntimeRecheckRuntime.mockResolvedValue({
+      signalAccepted: true,
+      workflowId: "hosted-user-runtime:member_001",
+    });
+    mocks.readHostedRuntimeStalledRecheckCandidates.mockResolvedValue({
+      candidates: [],
+      scanTruncated: false,
     });
     mocks.hostedWorkspace.count.mockResolvedValue(0);
     mocks.hostedWorkspace.findMany.mockResolvedValue([]);
@@ -241,6 +258,195 @@ describe("hosted runtime maintenance ops", () => {
     });
   });
 
+  it("reads a bounded stalled runtime recheck overview", async () => {
+    mocks.readHostedRuntimeStalledRecheckCandidates.mockResolvedValue({
+      candidates: [
+        stalledRecheckCandidate("member_001", "2"),
+        stalledRecheckCandidate("member_002", "3"),
+        stalledRecheckCandidate("member_003", "5"),
+      ],
+      scanTruncated: true,
+    });
+    const generatedAt = new Date("2026-08-31T14:00:00.000Z");
+
+    await expect(runtimeMaintenanceService.readHostedRuntimeStalledRecheckOverview({
+      limit: 1,
+      now: generatedAt,
+    })).resolves.toEqual({
+      candidates: [stalledRecheckCandidate("member_001", "2")],
+      generatedAt: generatedAt.toISOString(),
+      limit: 1,
+      scanTruncated: true,
+      totalCandidateCount: 3,
+    });
+    expect(mocks.readHostedRuntimeStalledRecheckCandidates).toHaveBeenCalledWith({
+      now: generatedAt,
+      prisma,
+    });
+  });
+
+  it("normalizes, deduplicates, and signals up to three runtime rechecks sequentially", async () => {
+    mocks.hostedWorkspace.findMany.mockResolvedValue([
+      { userId: "hbm_002" },
+      { userId: "hbm_001" },
+      { userId: "hbm_003" },
+    ]);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const signalOrder: string[] = [];
+    mocks.signalHostedRuntimeRecheckRuntime.mockImplementation(async (input) => {
+      signalOrder.push(input.userId);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return {
+        signalAccepted: true,
+        workflowId: `hosted-user-runtime:${input.userId}`,
+      };
+    });
+
+    const result = await runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: [
+        " hbm_002 ",
+        "hbm_001",
+        "hbm_002",
+        "hbm_003",
+      ],
+    });
+
+    expect(signalOrder).toEqual(["hbm_002", "hbm_001", "hbm_003"]);
+    expect(maxInFlight).toBe(1);
+    expect(mocks.hostedWorkspace.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.hostedWorkspace.findMany).toHaveBeenCalledWith({
+      select: { userId: true },
+      where: {
+        userId: {
+          in: ["hbm_002", "hbm_001", "hbm_003"],
+        },
+      },
+    });
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(3);
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      requestedCount: 3,
+      results: [
+        { status: "signaled", userId: "hbm_002" },
+        { status: "signaled", userId: "hbm_001" },
+        { status: "signaled", userId: "hbm_003" },
+      ],
+    });
+    expect(mocks.readHostedRuntimeStalledRecheckCandidates).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty and over-limit runtime recheck batches before signaling", async () => {
+    await expect(runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: [" ", ""],
+    })).rejects.toMatchObject({
+      code: "HOSTED_RUNTIME_RECHECK_USER_IDS_REQUIRED",
+      httpStatus: 400,
+    });
+    await expect(runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: [
+        "hbm_001",
+        "hbm_002",
+        "hbm_003",
+        "hbm_004",
+      ],
+    })).rejects.toMatchObject({
+      code: "HOSTED_RUNTIME_RECHECK_LIMIT_EXCEEDED",
+      httpStatus: 400,
+    });
+
+    expect(mocks.hostedWorkspace.findMany).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid runtime member ids before reading workspaces", async () => {
+    await expect(runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: ["member_001"],
+    })).rejects.toMatchObject({
+      code: "HOSTED_RUNTIME_RECHECK_USER_ID_INVALID",
+      httpStatus: 400,
+    });
+    await expect(runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: [`hbm_${"a".repeat(125)}`],
+    })).rejects.toMatchObject({
+      code: "HOSTED_RUNTIME_RECHECK_USER_ID_INVALID",
+      httpStatus: 400,
+    });
+
+    expect(mocks.hostedWorkspace.findMany).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
+  });
+
+  it("stops at a missing workspace without sending a Temporal signal", async () => {
+    mocks.hostedWorkspace.findMany.mockResolvedValue([
+      { userId: "hbm_002" },
+    ]);
+
+    const result = await runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: ["hbm_missing", "hbm_002"],
+    });
+
+    expect(mocks.hostedWorkspace.findMany).toHaveBeenCalledTimes(1);
+    expect(mocks.hostedWorkspace.findMany).toHaveBeenCalledWith({
+      select: { userId: true },
+      where: {
+        userId: {
+          in: ["hbm_missing", "hbm_002"],
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      requestedCount: 2,
+      results: [
+        {
+          errorName: "HostedRuntimeWorkspaceNotFound",
+          status: "failed",
+          userId: "hbm_missing",
+        },
+      ],
+    });
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+  });
+
+  it("stops runtime rechecks on the first unknown signal result", async () => {
+    mocks.hostedWorkspace.findMany.mockResolvedValue([
+      { userId: "hbm_001" },
+      { userId: "hbm_002" },
+      { userId: "hbm_003" },
+    ]);
+    mocks.signalHostedRuntimeRecheckRuntime.mockImplementation(async (input) => {
+      if (input.userId === "hbm_002") {
+        throw new DOMException("Timed out", "TimeoutError");
+      }
+      return {
+        signalAccepted: true,
+        workflowId: `hosted-user-runtime:${input.userId}`,
+      };
+    });
+
+    const result = await runtimeMaintenanceService.signalHostedRuntimeRecheckBatch({
+      userIds: ["hbm_001", "hbm_002", "hbm_003"],
+    });
+
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      results: [
+        { status: "signaled", userId: "hbm_001" },
+        {
+          errorName: "TimeoutError",
+          status: "failed",
+          userId: "hbm_002",
+        },
+      ],
+    });
+    expect(mocks.readHostedRuntimeStalledRecheckCandidates).not.toHaveBeenCalled();
+  });
+
   it("requires an active checkpointed workspace for explicit user wakes", async () => {
     mocks.hostedWorkspace.findFirst.mockResolvedValue(null);
 
@@ -358,6 +564,127 @@ describe("hosted runtime maintenance ops", () => {
     });
   });
 
+  it("lists stalled candidates and explicitly signals selected runtimes", async () => {
+    mocks.readHostedRuntimeStalledRecheckCandidates.mockResolvedValue({
+      candidates: [
+        stalledRecheckCandidate("member_001", "2"),
+        stalledRecheckCandidate("member_002", "4"),
+      ],
+      scanTruncated: false,
+    });
+
+    const getRequest = new Request(
+      "https://join.example.test/api/ops/runtime-maintenance?operation=recheck-stalled-device-sync&limit=1",
+    );
+    const getResponse = await runtimeMaintenanceRoute.GET(getRequest);
+
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.headers.get("Cache-Control")).toBe("no-store");
+    await expect(getResponse.json()).resolves.toMatchObject({
+      candidates: [{ userId: "member_001" }],
+      limit: 1,
+      totalCandidateCount: 2,
+    });
+    mocks.hostedWorkspace.findMany.mockResolvedValue([
+      { userId: "hbm_002" },
+    ]);
+
+    const postRequest = new Request(
+      "https://join.example.test/api/ops/runtime-maintenance",
+      {
+        body: JSON.stringify({
+          operation: "recheck-runtimes",
+          userIds: ["hbm_002"],
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      },
+    );
+    const postResponse = await runtimeMaintenanceRoute.POST(postRequest);
+
+    expect(postResponse.status).toBe(200);
+    expect(mocks.assertHostedOnboardingMutationOrigin).toHaveBeenCalledWith(
+      postRequest,
+    );
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      abortSignal: expect.any(AbortSignal),
+      prisma,
+      userId: "hbm_002",
+    });
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+    await expect(postResponse.json()).resolves.toMatchObject({
+      requestedCount: 1,
+      results: [{ status: "signaled", userId: "hbm_002" }],
+    });
+  });
+
+  it("rejects unknown operations before they can fall through to maintenance", async () => {
+    const getResponse = await runtimeMaintenanceRoute.GET(new Request(
+      "https://join.example.test/api/ops/runtime-maintenance?operation=recheck-stalled-runtime",
+    ));
+    const postResponse = await runtimeMaintenanceRoute.POST(new Request(
+      "https://join.example.test/api/ops/runtime-maintenance",
+      {
+        body: JSON.stringify({
+          limit: 1,
+          operation: "recheck-stalled-runtime",
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          origin: "https://join.example.test",
+        },
+        method: "POST",
+      },
+    ));
+
+    expect(getResponse.status).toBe(400);
+    expect(postResponse.status).toBe(400);
+    await expect(getResponse.json()).resolves.toMatchObject({
+      error: { code: "HOSTED_RUNTIME_MAINTENANCE_OPERATION_INVALID" },
+    });
+    await expect(postResponse.json()).resolves.toMatchObject({
+      error: { code: "HOSTED_RUNTIME_MAINTENANCE_OPERATION_INVALID" },
+    });
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
+  });
+
+  it("strictly rejects malformed runtime recheck user id arrays", async () => {
+    const invalidUserIds = [
+      "member_001",
+      ["member_001", 2],
+    ];
+
+    for (const userIds of invalidUserIds) {
+      const response = await runtimeMaintenanceRoute.POST(new Request(
+        "https://join.example.test/api/ops/runtime-maintenance",
+        {
+          body: JSON.stringify({
+            operation: "recheck-runtimes",
+            userIds,
+          }),
+          headers: {
+            "Content-Type": "application/json",
+            origin: "https://join.example.test",
+          },
+          method: "POST",
+        },
+      ));
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: "HOSTED_RUNTIME_MAINTENANCE_OPERATION_INVALID" },
+      });
+    }
+
+    expect(mocks.readHostedRuntimeStalledRecheckCandidates).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeMaintenanceRuntime).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
+  });
+
   it("signals maintenance through the authenticated same-origin ops route", async () => {
     mocks.hostedWorkspace.count.mockResolvedValue(1);
     mocks.hostedWorkspace.findMany.mockResolvedValue([
@@ -471,5 +798,13 @@ function workspaceRow(userId: string, version: string) {
     updatedAt: new Date("2026-06-01T12:05:00.000Z"),
     userId,
     version: BigInt(version),
+  };
+}
+
+function stalledRecheckCandidate(userId: string, pendingItemCount = "1") {
+  return {
+    pendingItemCount,
+    stalledSince: "2026-08-31T13:00:00.000Z",
+    userId,
   };
 }

--- a/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
@@ -9,6 +9,7 @@ import {
   HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS,
   HOSTED_RUNTIME_PROGRESS_STALL_THRESHOLD_MS,
   readHostedRuntimeProgressHealth,
+  readHostedRuntimeStalledRecheckCandidates,
   runHostedRuntimeProgressAlertMonitor,
   summarizeHostedRuntimeProgressRows,
   type HostedRuntimeProgressHealthRow,
@@ -119,6 +120,87 @@ describe("hosted runtime progress health", () => {
       scanTruncated: true,
     });
   });
+
+  it("selects only the durable legacy device-sync stall signature", async () => {
+    const fixture = createProgressMonitorFixture([
+      stalledDeviceSyncRow("runtime_z", { pendingCount: 7n }),
+      stalledDeviceSyncRow("runtime_fresh", {
+        progressOriginAt: "2026-08-10T15:45:00.001Z",
+      }),
+      stalledDeviceSyncRow("runtime_wrong_head", {
+        headKind: "runtime.maintenance-requested",
+      }),
+      stalledDeviceSyncRow("runtime_conversation", {
+        lane: "conversation",
+      }),
+      stalledDeviceSyncRow("runtime_missing_wake", {
+        nextWakeAt: null,
+      }),
+      stalledDeviceSyncRow("runtime_fresh_wake", {
+        nextWakeAt: instant("2026-08-10T15:45:00.001Z"),
+      }),
+      stalledDeviceSyncRow("runtime_wrong_wake_reason", {
+        nextWakeReason: "assistant.default-processing",
+      }),
+      stalledDeviceSyncRow("runtime_default_wake", {
+        nextDefaultProcessingWakeAt: instant("2026-08-10T15:10:00.000Z"),
+      }),
+      stalledDeviceSyncRow("runtime_default_wake_reason", {
+        nextDefaultProcessingWakeReason: "assistant.default-processing",
+      }),
+      stalledDeviceSyncRow("runtime_current_generation", {
+        systemMailboxProgressGeneration: 0n,
+      }),
+      stalledDeviceSyncRow("runtime_without_checkpoint", {
+        workspaceCheckpointedAt: null,
+      }),
+      stalledDeviceSyncRow("runtime_a", { pendingCount: 3n }),
+    ]);
+
+    await expect(readHostedRuntimeStalledRecheckCandidates({
+      now,
+      prisma: fixture.prisma,
+    })).resolves.toEqual({
+      candidates: [
+        {
+          pendingItemCount: "3",
+          stalledSince: "2026-08-10T15:00:00.000Z",
+          userId: "runtime_a",
+        },
+        {
+          pendingItemCount: "7",
+          stalledSince: "2026-08-10T15:00:00.000Z",
+          userId: "runtime_z",
+        },
+      ],
+      scanTruncated: false,
+    });
+  });
+
+  it("reports when the bounded stalled-recheck scan truncates", async () => {
+    const repeatedRow = stalledDeviceSyncRow("runtime_inactive");
+    const queryRaw = vi.fn(async () => Array.from(
+      { length: 20_001 },
+      () => repeatedRow,
+    ));
+
+    await expect(readHostedRuntimeStalledRecheckCandidates({
+      now,
+      prisma: {
+        $queryRaw: queryRaw,
+        hostedMember: {
+          findMany: vi.fn(async () => []),
+        },
+        hostedThreadContainerParticipant: {
+          findMany: vi.fn(async () => []),
+        },
+      } as never,
+    })).resolves.toEqual({
+      candidates: [],
+      scanTruncated: true,
+    });
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("hosted runtime progress alert monitor", () => {
@@ -167,6 +249,30 @@ describe("hosted runtime progress alert monitor", () => {
     expect(sql).toContain(
       "progress_evidence.first_unimported_system_created_at",
     );
+    expect(sql).toContain("pending_head.kind AS head_kind");
+    expect(sql).toContain(
+      "workspace.checkpointed_at AS workspace_checkpointed_at",
+    );
+    expect(sql).toContain(
+      "workspace.next_default_processing_wake_at AS workspace_next_default_processing_wake_at",
+    );
+    expect(sql).toContain(
+      "workspace.next_default_processing_wake_reason AS workspace_next_default_processing_wake_reason",
+    );
+    expect(sql).toContain(
+      "workspace.system_mailbox_progress_generation AS workspace_system_mailbox_progress_generation",
+    );
+    expect(sql).toContain('progress_lane.head_kind AS "headKind"');
+    expect(sql).toContain(
+      'AS "nextDefaultProcessingWakeAt"',
+    );
+    expect(sql).toContain(
+      'AS "nextDefaultProcessingWakeReason"',
+    );
+    expect(sql).toContain('AS "nextWakeAt"');
+    expect(sql).toContain('AS "nextWakeReason"');
+    expect(sql).toContain('AS "systemMailboxProgressGeneration"');
+    expect(sql).toContain('AS "workspaceCheckpointedAt"');
     expect(sql).not.toContain("head_consumed_at");
   });
 
@@ -644,20 +750,66 @@ describe("hosted runtime progress alert monitor", () => {
 
 function progressRow(input: {
   chronologyInvalid?: boolean;
+  headKind?: string;
   progressOriginAt: string;
   lane: string;
+  nextDefaultProcessingWakeAt?: Date | null;
+  nextDefaultProcessingWakeReason?: string | null;
+  nextWakeAt?: Date | null;
+  nextWakeReason?: string | null;
   pendingCount?: bigint;
   runtimeKey: string;
+  systemMailboxProgressGeneration?: bigint | null;
   usageBlocked?: boolean;
+  workspaceCheckpointedAt?: Date | null;
 }): HostedRuntimeProgressHealthRow {
   return {
     chronologyInvalid: input.chronologyInvalid ?? false,
+    headKind: input.headKind ?? "test.pending-work",
     progressOriginAt: instant(input.progressOriginAt),
     lane: input.lane,
+    nextDefaultProcessingWakeAt:
+      input.nextDefaultProcessingWakeAt ?? null,
+    nextDefaultProcessingWakeReason:
+      input.nextDefaultProcessingWakeReason ?? null,
+    nextWakeAt: input.nextWakeAt ?? null,
+    nextWakeReason: input.nextWakeReason ?? null,
     pendingCount: input.pendingCount ?? 1n,
     runtimeKey: input.runtimeKey,
+    systemMailboxProgressGeneration:
+      input.systemMailboxProgressGeneration ?? null,
     usageBlocked: input.usageBlocked ?? false,
+    workspaceCheckpointedAt: input.workspaceCheckpointedAt ?? null,
   };
+}
+
+function stalledDeviceSyncRow(
+  runtimeKey: string,
+  overrides: Omit<Partial<HostedRuntimeProgressHealthRow>, "progressOriginAt"> & {
+    progressOriginAt?: string;
+  } = {},
+): HostedRuntimeProgressHealthRow {
+  return progressRow({
+    headKind: overrides.headKind ?? "device-sync.wake",
+    lane: overrides.lane ?? "system",
+    nextDefaultProcessingWakeAt:
+      overrides.nextDefaultProcessingWakeAt ?? null,
+    nextDefaultProcessingWakeReason:
+      overrides.nextDefaultProcessingWakeReason ?? null,
+    nextWakeAt: overrides.nextWakeAt === undefined
+      ? instant("2026-08-10T15:00:00.000Z")
+      : overrides.nextWakeAt,
+    nextWakeReason: overrides.nextWakeReason ?? "device-sync.reconcile",
+    pendingCount: overrides.pendingCount,
+    progressOriginAt:
+      overrides.progressOriginAt ?? "2026-08-10T15:00:00.000Z",
+    runtimeKey,
+    systemMailboxProgressGeneration:
+      overrides.systemMailboxProgressGeneration ?? null,
+    workspaceCheckpointedAt: overrides.workspaceCheckpointedAt === undefined
+      ? instant("2026-08-10T15:05:00.000Z")
+      : overrides.workspaceCheckpointedAt,
+  });
 }
 
 function createProgressMonitorFixture(

--- a/apps/web/test/runtime-recheck-panel.test.tsx
+++ b/apps/web/test/runtime-recheck-panel.test.tsx
@@ -1,0 +1,144 @@
+import { createElement, type ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  parseRuntimeRecheckUserIds,
+  removeSignaledRuntimeRecheckUserIds,
+  RuntimeRecheckPanel,
+} from "../app/(dashboard)/ops/runtime-maintenance/runtime-recheck-panel";
+import { RuntimeMaintenanceStudy } from "../app/design/runtime-maintenance-study";
+
+type PanelProps = ComponentProps<typeof RuntimeRecheckPanel>;
+
+const OVERVIEW: PanelProps["overview"] = {
+  candidates: [{
+    pendingItemCount: "13",
+    stalledSince: "2026-08-31T14:15:00.000Z",
+    userId: "hbm_test_alpha",
+  }, {
+    pendingItemCount: "8",
+    stalledSince: "2026-08-31T14:20:00.000Z",
+    userId: "hbm_test_bravo",
+  }],
+  generatedAt: "2026-08-31T15:00:00.000Z",
+  limit: 100,
+  scanTruncated: false,
+  totalCandidateCount: 2,
+};
+
+const BASE_PROPS: PanelProps = {
+  disabled: false,
+  error: null,
+  onInputChange: () => undefined,
+  onRecheck: () => undefined,
+  onRefresh: () => undefined,
+  onUseDetectedCandidates: () => undefined,
+  overview: OVERVIEW,
+  pendingAction: null,
+  result: null,
+  userIdsText: "hbm_test_alpha, hbm_test_bravo\nhbm_test_manual",
+};
+
+describe("RuntimeRecheckPanel", () => {
+  test("parses comma and newline input, trims whitespace, and deduplicates IDs", () => {
+    const tooLongUserId = `hbm_${"a".repeat(125)}`;
+    expect(parseRuntimeRecheckUserIds(
+      ` hbm_one, hbm_two\nhbm_one\nmember_three\n${tooLongUserId} `,
+    )).toEqual({
+      invalidEntries: ["member_three", tooLongUserId],
+      userIds: ["hbm_one", "hbm_two"],
+    });
+  });
+
+  test("keeps reusable member-ID controls separate from legacy-stall discovery", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RuntimeRecheckPanel, BASE_PROPS),
+    );
+
+    expect(markup).toContain("Runtime rechecks");
+    expect(markup).toContain("3 unique member IDs queued");
+    expect(markup).toContain("Recheck next 3");
+    expect(markup).toContain("Use detected candidates");
+    expect(markup).toContain("Detected legacy device-sync stalls");
+    expect(markup).toContain("hbm_test_manual");
+  });
+
+  test("removes only acknowledged IDs after a partial batch result", () => {
+    expect(removeSignaledRuntimeRecheckUserIds(
+      "hbm_test_alpha\nhbm_test_bravo\nhbm_test_manual",
+      {
+        generatedAt: "2026-08-31T15:01:00.000Z",
+        requestedCount: 3,
+        results: [{
+          status: "signaled",
+          userId: "hbm_test_alpha",
+        }, {
+          errorMessage: "Request deadline reached.",
+          errorName: "TimeoutError",
+          status: "failed",
+          userId: "hbm_test_bravo",
+        }],
+      },
+    )).toBe("hbm_test_bravo\nhbm_test_manual");
+  });
+
+  test("communicates pending and ambiguous request states without dropping queued IDs", () => {
+    const pendingMarkup = renderToStaticMarkup(
+      createElement(RuntimeRecheckPanel, {
+        ...BASE_PROPS,
+        disabled: true,
+        pendingAction: "recheck",
+      }),
+    );
+    const errorMarkup = renderToStaticMarkup(
+      createElement(RuntimeRecheckPanel, {
+        ...BASE_PROPS,
+        error: {
+          kind: "request",
+          message: "Request deadline reached.",
+        },
+      }),
+    );
+
+    expect(pendingMarkup).toContain('aria-busy="true"');
+    expect(pendingMarkup).toContain("Requesting 3 runtime rechecks.");
+    expect(errorMarkup).toContain("Recheck status is unknown.");
+    expect(errorMarkup).toContain("member IDs remain queued");
+  });
+
+  test("labels partial results and preserves the non-recovery boundary", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RuntimeRecheckPanel, {
+        ...BASE_PROPS,
+        result: {
+          generatedAt: "2026-08-31T15:01:00.000Z",
+          requestedCount: 2,
+          results: [{
+            status: "signaled",
+            userId: "hbm_test_alpha",
+          }, {
+            errorMessage: "Request deadline reached.",
+            errorName: "TimeoutError",
+            status: "failed",
+            userId: "hbm_test_bravo",
+          }],
+        },
+        userIdsText: "hbm_test_bravo\nhbm_test_manual",
+      }),
+    );
+
+    expect(markup).toContain("Signal acknowledged; removed from queue");
+    expect(markup).toContain("Failed and unsent IDs remain");
+    expect(markup).toContain("A recheck request is not proof of recovery.");
+    expect(markup).toContain("hbm_test_manual");
+  });
+
+  test("renders the exact production panel in the ops screenshot study", () => {
+    const markup = renderToStaticMarkup(createElement(RuntimeMaintenanceStudy));
+
+    expect(markup).toContain('data-design-section="stalled-runtime-rechecks"');
+    expect(markup).toContain("Runtime rechecks");
+    expect(markup).toContain("Recheck result");
+  });
+});


### PR DESCRIPTION
## Why and outcome

Authorized operators need a safe way to ask specific hosted runtimes to reread canonical facts without manufacturing mailbox work or resetting usage. This adds a reusable comma/newline member-ID queue to Runtime maintenance, plus optional discovery for the proven legacy device-sync stall signature.

Each explicit request validates and deduplicates IDs, requires existing workspaces, signals at most three runtimes sequentially, and stops on the first unknown result. Signal acknowledgement is reported separately from recovery.

## Product UX

Feature-level Product UX — **Ready**. Operators with a detected cohort, an unrelated explicit ID list, no detected stalls, or a partial failure all receive truthful next actions. Members see no message, mailbox item, usage change, or new product surface. Desktop and phone walkthroughs matched the approved plan.

## Evidence

- `pnpm --dir apps/web typecheck`
- Scoped ESLint for all touched Web source and tests
- 72 focused Vitest cases across selector, service/route, payload-free signal, and UI contracts
- Six real-PostgreSQL selector cases against an isolated migrated development database
- Browser walkthrough at 1440px desktop and 390x844 phone; populated and partial-failure states rendered the production component, and the phone surface had no horizontal overflow
- `pnpm complexity:diff`, `git diff --check`, and changed-file privacy/identifier scan

ReviewGPT first-reviewed head: 359cf7c75c7c4d0d732ca0e6a2e6ce54886df115

## Non-obvious affected surfaces

- Hosted runtime progress monitoring: the existing bounded SQL observation now projects the workspace/head fields needed by discovery. Existing focused and PostgreSQL monitor suites prove alert classification remains unchanged.
- Temporal hosted runtime workflow: the ops action reuses the existing `runtime_recheck_requested` signal. Its existing signal-boundary test plus the new service tests prove there is no mailbox append or usage mutation.

## Architecture and reuse

- **Existing systems reused:** ops allowlist and same-origin gate, canonical progress observation, active-access reader, workspace owner, bounded post-commit deadline, and payload-free Temporal recheck signal.
- **New logic:** one legacy-signature projection, strict generic ID batch validation, a bounded sequential dispatcher, and one controlled ops panel.
- **New abstractions:** one production `RuntimeRecheckPanel` component, composed from local result and discovery sections, so the authenticated page and reviewer-openable design study render the same surface; no new service, state owner, or dependency.
- **Complexity intentionally avoided:** no scheduler, queue, database schema, mailbox repair, retry manager, automatic fleet mutation, deployment cutoff, or duplicated progress query.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports no new complexity debt; the new panel's maximum function complexity is 16 against a threshold of 20.
- Hotspots: the only reported hotspot is the pre-existing `JunctionDiagnosticResultPanel` at 22, unchanged by this patch; no task-authored function exceeds 20.
- Agent judgment: extracting result and discovery rendering into small local components keeps each responsibility explicit without adding state, dependencies, or a cross-file abstraction.

## Hot reply path impact

Not applicable. The change is confined to an authenticated ops page/API and does not alter durable conversation acceptance, provider start, or reply handoff.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible assembly changed.
- Group runtime: Not applicable for the same reason.

## Design proof

- Design page: [Runtime rechecks and legacy-stall discovery](https://www.withmurph.ai/screenshots/ops#stalled-runtime-rechecks)
- Evidence: the repository-owned study renders the real production panel with synthetic populated and partial-failure data; direct browser review covered hierarchy, queue/result clarity, responsive layout, and the non-recovery warning.
- Coverage: populated and partial-failure states at 1440px and 390x844; empty, invalid, pending, and ambiguous-request states in focused rendered tests.

## Change-shape breakdown

Classification is path-based from `origin/main...HEAD`; authored app/design/runtime files are source, `apps/web/test/**` is tests/fixtures, and `agent-docs/**` is docs. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1,055 | 27 |
| Tests/fixtures | 631 | 0 |
| Docs | 145 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **1,831** | **27** |

## Deployment concerns

- Deployment: applicable
- Supported skew: the new Web route sends an existing payload-free signal already accepted by current Temporal and runner deployments; old Web simply lacks the operator control.
- Safe order: deploy Web by the normal Vercel production path; no Cloudflare, Temporal worker, database, or tandem rollout is required.
- Rollback floor: no new rollback floor is introduced because this patch adds no schema, persisted protocol field, mailbox kind, or runtime parser requirement.
- Expected exposure: only allowlisted operators can load the page or call the API, and members receive no message, usage change, or new work.
- Reversibility: rolling Web back removes discovery and the explicit recheck control without leaving new persisted state or requiring cleanup.
- Convergence proof: focused signal tests prove current runtimes accept `runtime_recheck_requested`; service tests prove sequential maximum-three dispatch and failure stopping.
- Post-deploy checks: verify the production Web SHA and alias, load the ops detector count, send one intentional canary, then confirm later checkpoint or progress evidence before continuing.

## Changelog

- Changelog: not applicable
- Reason: this is an allowlisted internal operations and recovery surface with no member-visible product change.
