### PR TITLE
Restore shared workout summaries after sync

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-31-workout-summary-projection.md
+++ b/agent-docs/exec-plans/active/2026-08-31-workout-summary-projection.md
@@ -1,0 +1,96 @@
+# Restore shared workout summaries from canonical sessions
+
+Status: active
+Created: 2026-08-31
+Updated: 2026-08-31
+
+## Goal
+
+- Restore consented group workout summaries from canonical workout sessions
+  without weakening the intentionally privacy-preserving stored wearable
+  summary format.
+- Collapse the legacy projection's dependence on provenance identifiers that
+  are deliberately removed before persistence.
+
+## Product UX Patch
+
+- Outcome: a group member who shares workout summaries has recent workout
+  counts and minutes appear after canonical device workouts sync.
+- Reaches: the existing consent-aware `workout-days.v0` group shared-data read;
+  sharing permissions and detailed workout visibility do not change.
+- Proof: one canonical activity session survives the persisted query-summary
+  round trip and produces a non-empty shared day, while no-workout and
+  non-granted cases remain unchanged; a focused real-Codex group journey states
+  the available workout summary truthfully.
+
+## Success criteria
+
+- A stored single-provider wearable summary yields a valid paired workout day.
+- Aggregate selection remains fail-closed for genuinely split provider/source
+  evidence, independently authored manual/Murph points, and malformed values.
+- No raw canonical record identifiers are added to stored public summaries.
+- Focused deterministic tests, typechecks, and the real-Codex journey pass.
+- Exact-head review and required CI are green.
+
+## Scope
+
+- In scope: legacy workout-day projection composition, focused query/runtime
+  regressions, group assistant journey coverage, and a public changelog item.
+- Out of scope: provider ingestion, canonical workout storage, consent scopes,
+  detailed `workouts.v0` shape, historical backfills, and manual production
+  repair.
+
+## Constraints
+
+- Technical constraints: retain one canonical stored-summary codec and its
+  privacy boundary; use existing query and share owners; add no new service,
+  state owner, dependency, or compatibility layer.
+- Product/process constraints: preserve unrelated work, use the isolated
+  worktree/PR lane, keep all evidence synthetic and private-free, and follow
+  the assistant verification and completion gates.
+
+## Risks and mitigations
+
+1. Risk: weakening the provenance join could combine unrelated metric points.
+   Mitigation: preserve exact-owner matching by default and admit only
+   non-manual/non-Murph derived activity summaries from one public source.
+2. Risk: changing the stored summary codec could expose canonical identifiers.
+   Mitigation: leave the codec untouched and assert the persisted round trip.
+3. Risk: a narrow unit test could miss the composed failure.
+   Mitigation: test the real persisted query-summary boundary plus the actual
+   share reader and one production-contract real-Codex journey.
+
+## Tasks
+
+1. Add the composed failing regression for a persisted canonical activity
+   session reaching `workout-days.v0`.
+2. Replace the lossy provenance coupling with the smallest canonical evidence
+   derivation and delete obsolete pairing complexity where possible.
+3. Add boundary cases and one focused real-Codex group journey.
+4. Update the public changelog and durable docs only if the architecture
+   contract changes.
+5. Run focused verification, Product UX replay, parent review, exact-head CI,
+   and required ReviewGPT gates.
+
+## Decisions
+
+- Preserve the stored public-summary redaction boundary; canonical record IDs
+  must not be reintroduced merely to satisfy a downstream legacy join.
+- Keep strict source-owner matching for every ordinary metric pair. The only
+  exception is the query-produced, non-manual/non-Murph `activity-summary`
+  pair whose private owner IDs were intentionally redacted after both values
+  were derived from the same selected provider session rollup.
+- Keep `workouts.v0` independent: its time window, detail contract, dedupe,
+  and settlement semantics differ from the daily count-and-minutes projection.
+
+## Verification
+
+- Focused query and assistant-runtime Vitest files covering the composed path.
+- Assistant Engine real-Codex journey selected by one unique test pattern.
+- Live journey reply review: the model read the correct `workout-days.v0`
+  scope and answered the synthetic count/minutes truthfully, but remains Hold
+  because it repeated the identical read. The existing shared-sleep journey
+  reproduces that same current-model action-count regression.
+- Typechecks for every changed production package.
+- `git diff --check`, privacy/identifier scan, Product UX walkthrough, exact
+  pushed-head ReviewGPT, and required GitHub checks.

--- a/agent-docs/exec-plans/completed/2026-08-31-workout-summary-projection.md
+++ b/agent-docs/exec-plans/completed/2026-08-31-workout-summary-projection.md
@@ -1,6 +1,6 @@
 # Restore shared workout summaries from canonical sessions
 
-Status: active
+Status: completed
 Created: 2026-08-31
 Updated: 2026-08-31
 
@@ -62,14 +62,14 @@ Updated: 2026-08-31
 
 ## Tasks
 
-1. Add the composed failing regression for a persisted canonical activity
+1. [x] Add the composed failing regression for a persisted canonical activity
    session reaching `workout-days.v0`.
-2. Replace the lossy provenance coupling with the smallest canonical evidence
+2. [x] Replace the lossy provenance coupling with the smallest canonical evidence
    derivation and delete obsolete pairing complexity where possible.
-3. Add boundary cases and one focused real-Codex group journey.
-4. Update the public changelog and durable docs only if the architecture
+3. [x] Add boundary cases and one focused real-Codex group journey.
+4. [x] Update the public changelog and durable docs only if the architecture
    contract changes.
-5. Run focused verification, Product UX replay, parent review, exact-head CI,
+5. [x] Run focused verification, Product UX replay, parent review, exact-head CI,
    and required ReviewGPT gates.
 
 ## Decisions
@@ -85,12 +85,30 @@ Updated: 2026-08-31
 
 ## Verification
 
-- Focused query and assistant-runtime Vitest files covering the composed path.
+- Assistant Runtime projection suite: 140 tests passed, including the composed
+  canonical-session -> persisted redacted summary -> `workout-days.v0` path.
+- Assistant Runtime typecheck passed.
+- Web changelog page suite: 9 tests passed; Web typecheck passed.
 - Assistant Engine real-Codex journey selected by one unique test pattern.
 - Live journey reply review: the model read the correct `workout-days.v0`
   scope and answered the synthetic count/minutes truthfully, but remains Hold
   because it repeated the identical read. The existing shared-sleep journey
   reproduces that same current-model action-count regression.
-- Typechecks for every changed production package.
-- `git diff --check`, privacy/identifier scan, Product UX walkthrough, exact
-  pushed-head ReviewGPT, and required GitHub checks.
+- `git diff --check`, added-content privacy/identifier scan, and Product UX
+  walkthrough passed.
+- Final sensitive ReviewGPT round passed with no qualifying findings against
+  exact head `cd2c6e9669239b79235dc4c50cfa688108da6dec`; the parent full-diff
+  review also found no production, privacy, test, or architecture issue.
+- Pull request: #2658. Required GitHub checks own broad exact-head verification
+  after this plan-archive-only final commit is pushed.
+
+## Completion
+
+- Restored shared workout count-and-minutes projection with one local pairing
+  predicate and no new persisted state, schema, protocol, service, dependency,
+  migration, backfill, or compatibility layer.
+- Preserved strict source-owner matching as the default and the separate
+  detailed-workout projection contract.
+- Added a public recovery note and synthetic deterministic/model-facing proof
+  without copying confidential production evidence into the repository.
+Completed: 2026-08-31

--- a/apps/web/changelog/entries/2026-08-31/shared-workout-summaries-return-after-sync.json
+++ b/apps/web/changelog/entries/2026-08-31/shared-workout-summaries-return-after-sync.json
@@ -1,0 +1,22 @@
+{
+  "publishedOn": "2026-08-31",
+  "order": 100,
+  "item": {
+    "id": "shared-workout-summaries-return-after-sync",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Shared workout summaries return after sync",
+    "summary": "When a member shares workout summaries with a group, recent connected-device workouts now appear as workout counts and total minutes after sync.",
+    "details": "Sharing permissions stay separate: this restores the existing count-and-minutes summary without exposing detailed workouts, routes, heart rate, or private source identifiers.",
+    "relevanceTags": [
+      "groups",
+      "workouts",
+      "wearables",
+      "reliability",
+      "privacy"
+    ],
+    "sourcePullRequests": [
+      2658
+    ]
+  }
+}

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -7044,6 +7044,145 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
   )
 
   it(
+    'reports available shared workout count and minutes',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-group-workout-summary-e2e-'),
+      )
+      const sharedRequests: unknown[] = []
+
+      try {
+        const skillsRoot = path.join(workingDirectory, 'skills')
+        await materializeAssistantSkill({
+          skillsRoot,
+          slug: 'group-chat',
+        })
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions:
+            buildHostedGroupStatusDeveloperInstructions('shared_read'),
+          dynamicTools: [MURPH_GROUP_SHARED_READ_TOOL],
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          },
+          excludeResumeTurns: true,
+          groupConversation: true,
+          hostedToolContext: {
+            computerToolsAvailable: false,
+            currentHostedDeliveryContext: () => null,
+            currentHostedMailboxItemIds: () => [],
+            groupSharedReader: {
+              request: async (request) => {
+                sharedRequests.push(request)
+                return {
+                  members: [{
+                    currentTurnHandles: [],
+                    displayName: 'Avery',
+                    memberId: 'member_workout_summary',
+                    participantId: 'participant_workout_summary',
+                    projections: [{
+                      dataStatus: 'available',
+                      grantStatus: 'granted',
+                      grantedAt: '2026-07-01T12:00:00.000Z',
+                      projectionScope: {
+                        projectionKind: 'workout-days.v0',
+                      },
+                      projectionScopeKey: 'workout-days.v0',
+                      records: [{
+                        data: {
+                          date: '2026-07-28',
+                          metricSemantics: 'canonical-workout-day',
+                          workoutCount: 1,
+                          workoutMinutes: 42,
+                        },
+                        occurredAt: '2026-07-28T00:00:00.000Z',
+                        recordKey: '2026-07-28.garmin',
+                        source: {
+                          label: 'Garmin',
+                          source: 'garmin',
+                        },
+                      }],
+                    }],
+                  }],
+                  requestedProjectionScopeKeys: ['workout-days.v0'],
+                  status: 'ok',
+                } satisfies AssistantHostedGroupSharedReadResponse
+              },
+            },
+            sendVaultFile: async () => {
+              throw new Error('Vault file sends are unavailable in this test.')
+            },
+            vaultFileSendAvailable: false,
+          },
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: [
+            'Current group message:',
+            '"Avery shares only her daily workout-count-and-total-minutes summary, not detailed workout records. What does that shared summary show for July 28?"',
+          ].join('\n'),
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const sharedReads = readCapabilityRoutingActions(
+          result.jsonEvents,
+        ).filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_GROUP_SHARED_READ_TOOL.name
+        )
+        const finalAnswerEventIndex = result.jsonEvents.findIndex((event) => {
+          const record = readRecord(event)
+          if (readString(record?.method, record?.type) !== 'item/completed') {
+            return false
+          }
+          const item = readRecord(readRecord(record?.params)?.item)
+          return readString(item?.type) === 'agentMessage'
+            && readString(item?.text)?.trim() === result.finalMessage.trim()
+        })
+
+        process.stdout.write(
+          `[group-workout-summary-e2e] ${JSON.stringify({
+            finalMessage: result.finalMessage,
+            sharedReads,
+          })}\n`,
+        )
+        expect(sharedReads).toHaveLength(1)
+        expect(sharedReads[0]).toMatchObject({
+          argumentsValue: {
+            action: 'read_shared',
+            projectionScopes: [{ projectionKind: 'workout-days.v0' }],
+          },
+        })
+        expect(sharedRequests).toEqual([{
+          projectionScopes: [{ projectionKind: 'workout-days.v0' }],
+        }])
+        expect(finalAnswerEventIndex).toBeGreaterThan(
+          sharedReads[0]?.eventIndex ?? Number.MAX_SAFE_INTEGER,
+        )
+        expect(result.finalMessage).toMatch(/Avery/iu)
+        expect(result.finalMessage).toMatch(/(?:1|one)\s+workout/iu)
+        expect(result.finalMessage).toMatch(/42\s+minutes?/iu)
+        expect(result.finalMessage).not.toMatch(
+          /no (?:usable |visible |shared )?workouts?|not (?:available|shared|showing)|sync (?:failed|error)/iu,
+        )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+
+  it(
     'attributes a scheduled weekly group comparison from fresh labeled rows',
     async () => {
       const config = await resolveRealCodexE2eConfig()

--- a/packages/assistant-runtime/src/hosted-runtime/vault-share-projection.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/vault-share-projection.ts
@@ -1510,7 +1510,7 @@ export function selectProjectableWorkoutDays(
     const minuteRow = minuteRowsByDate.get(
       sourceDateKey(countRow.date, countRow.source),
     );
-    if (!minuteRow || !sameMetricSeriesPointSourceOwner(countRow, minuteRow)) {
+    if (!minuteRow || !canPairWorkoutMetricRows(countRow, minuteRow)) {
       continue;
     }
 
@@ -2579,6 +2579,28 @@ function choosePreferredActivitySessionDistanceRow(
 function activitySessionRowCompletenessScore(row: ActivitySessionProjectionRow): number {
   return (parseOptionalTimestampMs(row.startedAt) === null ? 0 : 1)
     + (parseOptionalTimestampMs(row.endedAt) === null ? 0 : 1);
+}
+
+function canPairWorkoutMetricRows(
+  left: WorkoutMetricProjectionRow,
+  right: WorkoutMetricProjectionRow,
+): boolean {
+  if (sameMetricSeriesPointSourceOwner(left, right)) {
+    return true;
+  }
+
+  // Stored provider activity summaries redact canonical record ids. Their
+  // public source/date tuple is the remaining shared owner; manual and Murph
+  // points stay under exact-owner matching because they may be authored alone.
+  const publicSource = left.source?.source;
+  return publicSource !== undefined
+    && publicSource === right.source?.source
+    && publicSource !== "manual"
+    && publicSource !== "murph"
+    && left.sourceFamily === "derived"
+    && right.sourceFamily === "derived"
+    && left.sourceKind === "activity-summary"
+    && right.sourceKind === "activity-summary";
 }
 
 function sameMetricSeriesPointSourceOwner(

--- a/packages/assistant-runtime/test/vault-share-projection.test.ts
+++ b/packages/assistant-runtime/test/vault-share-projection.test.ts
@@ -86,6 +86,7 @@ import {
 
 const TEST_SOURCE_WORKSPACE_VERSION = "7";
 const GARMIN_SOURCE = { label: "Garmin", source: "garmin" } as const;
+const MANUAL_SOURCE = { label: "Manual", source: "manual" } as const;
 const MURPH_SOURCE = { label: "Murph", source: "murph" } as const;
 const OURA_SOURCE = { label: "Oura", source: "oura" } as const;
 const STRAVA_SOURCE = { label: "Strava", source: "strava" } as const;
@@ -183,6 +184,9 @@ const SAUNA_SCOPE = buildHostedVaultShareActivityMinutesProjectionScope({
 const WORKOUTS_SCOPE = hostedVaultShareProjectionKindToScope(
   "workouts.v0",
 );
+const WORKOUT_DAYS_SCOPE = hostedVaultShareProjectionKindToScope(
+  "workout-days.v0",
+);
 const GENERATION_TOKEN = "a".repeat(43);
 
 function activeProjectionResponse(
@@ -234,12 +238,17 @@ type WorkoutMetricRow = Pick<
   | "sourceKind"
   | "statistic"
   | "value"
->;
+> & {
+  source?: ActivitySessionProjectionRow["source"];
+};
 
 function workoutMetricRow(input: {
   date: string;
   metricKey: "workout-count" | "workout-minutes";
   recordIds?: string[];
+  source?: ActivitySessionProjectionRow["source"];
+  sourceFamily?: WorkoutMetricRow["sourceFamily"];
+  sourceKind?: WorkoutMetricRow["sourceKind"];
   value: number;
 }): WorkoutMetricRow {
   const recordIds = input.recordIds ?? [`evt_activity_${input.date}`];
@@ -250,16 +259,19 @@ function workoutMetricRow(input: {
     observedAt: `${input.date}T00:00:00.000Z`,
     pointIds: [`point_${input.metricKey}_${input.value}_${recordIds.join("_")}`],
     recordIds,
-    sourceFamily: "derived",
-    sourceKind: "activity-summary",
+    ...(input.source ? { source: input.source } : {}),
+    sourceFamily: input.sourceFamily ?? "derived",
+    sourceKind: input.sourceKind ?? "activity-summary",
     statistic: "value",
     value: input.value,
   };
 }
 
 function workoutRows(input: {
+  countSource?: ActivitySessionProjectionRow["source"];
   countRecordIds?: string[];
   date: string;
+  minuteSource?: ActivitySessionProjectionRow["source"];
   minuteRecordIds?: string[];
   workoutCount: number;
   workoutMinutes: number;
@@ -274,12 +286,14 @@ function workoutRows(input: {
       date: input.date,
       metricKey: "workout-count",
       recordIds: input.countRecordIds ?? recordIds,
+      source: input.countSource,
       value: input.workoutCount,
     })],
     minuteRows: [workoutMetricRow({
       date: input.date,
       metricKey: "workout-minutes",
       recordIds: input.minuteRecordIds ?? recordIds,
+      source: input.minuteSource,
       value: input.workoutMinutes,
     })],
     nowMs: Date.parse("2026-07-04T00:00:00.000Z"),
@@ -2984,11 +2998,72 @@ describe("selectProjectableMealNutritionDays", () => {
 describe("selectProjectableWorkoutDays", () => {
   const nowMs = Date.parse("2026-07-04T00:00:00.000Z");
 
-  it("maps selected workout session summaries without raw workout details", () => {
+  it("reads persisted provider workout sessions as shared count and minutes", async () => {
+    const vaultRoot = await createActivitySessionVault([{
+      schemaVersion: "murph.event.v1",
+      id: "evt_vault_share_workout_summary_01",
+      kind: "activity_session",
+      occurredAt: "2026-07-03T12:00:00.000Z",
+      dayKey: "2026-07-03",
+      recordedAt: "2026-07-03T12:42:00.000Z",
+      source: "device",
+      externalRef: {
+        system: "garmin",
+        resourceType: "activity_session",
+        resourceId: "garmin-workout-summary-01",
+      },
+      activityType: "strength-training",
+      durationMinutes: 42,
+    }]);
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+
+    try {
+      const selected = await readProjectableWorkoutDays(vaultRoot);
+      expect(selected).toEqual([{
+        data: {
+          date: ACTIVITY_DAY.date,
+          metricSemantics:
+            HOSTED_VAULT_SHARE_CANONICAL_WORKOUT_DAY_SEMANTICS,
+          workoutCount: 1,
+          workoutMinutes: 42,
+        },
+        occurredAt: `${ACTIVITY_DAY.date}T00:00:00.000Z`,
+        recordKey: `${ACTIVITY_DAY.date}.garmin`,
+        source: GARMIN_SOURCE,
+        sourceRevision: expect.stringMatching(SOURCE_REVISION_PATTERN),
+      }]);
+
+      const deliver = vi.fn().mockResolvedValue({ status: "delivered" });
+      await expect(offerHostedVaultShareProjectionBestEffort({
+        vaultRoot,
+        vaultSharePort: {
+          deliver,
+          listActiveProjectionScopes: async () =>
+            activeProjectionResponse(WORKOUT_DAYS_SCOPE),
+        },
+      })).resolves.toEqual({ outcome: "delivered" });
+      expect(deliver).toHaveBeenCalledWith({
+        expectedGenerationToken: GENERATION_TOKEN,
+        projectionKind: "workout-days.v0",
+        projectionScope: WORKOUT_DAYS_SCOPE,
+        records: selected,
+        sourceWorkspaceVersion: TEST_SOURCE_WORKSPACE_VERSION,
+      });
+    } finally {
+      dateNow.mockRestore();
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("maps same-source workout summaries after private owner ids are redacted", () => {
     const selected = selectProjectableWorkoutDays({
       currentDate: utcDateKey(nowMs),
       ...workoutRows({
+        countRecordIds: ["activity-summary:workout-count:2026-07-03"],
+        countSource: GARMIN_SOURCE,
         date: ACTIVITY_DAY.date,
+        minuteRecordIds: ["activity-summary:workout-minutes:2026-07-03"],
+        minuteSource: GARMIN_SOURCE,
         workoutCount: 2,
         workoutMinutes: 85,
       }),
@@ -3004,7 +3079,8 @@ describe("selectProjectableWorkoutDays", () => {
           workoutMinutes: 85,
         },
         occurredAt: `${ACTIVITY_DAY.date}T00:00:00.000Z`,
-        recordKey: ACTIVITY_DAY.date,
+        recordKey: `${ACTIVITY_DAY.date}.garmin`,
+        source: GARMIN_SOURCE,
         sourceRevision: expect.stringMatching(/^[A-Za-z0-9_-]{32}$/u),
       },
     ]);
@@ -3016,16 +3092,79 @@ describe("selectProjectableWorkoutDays", () => {
     ).toEqual(selected);
   });
 
+  it("keeps exact-owner workout metrics projectable", () => {
+    const selected = selectProjectableWorkoutDays({
+      currentDate: utcDateKey(nowMs),
+      ...workoutRows({
+        date: ACTIVITY_DAY.date,
+        workoutCount: 1,
+        workoutMinutes: 42,
+      }),
+    });
+
+    expect(selected).toHaveLength(1);
+  });
+
   it("drops split-provider workout tuples instead of joining count and minutes by date", () => {
     const selected = selectProjectableWorkoutDays({
       currentDate: utcDateKey(nowMs),
       ...workoutRows({
-        countRecordIds: ["evt_garmin_count"],
+        countRecordIds: ["evt_shared_owner"],
+        countSource: GARMIN_SOURCE,
         date: ACTIVITY_DAY.date,
-        minuteRecordIds: ["evt_oura_minutes"],
+        minuteRecordIds: ["evt_shared_owner"],
+        minuteSource: OURA_SOURCE,
         workoutCount: 1,
         workoutMinutes: 85,
       }),
+    });
+
+    expect(selected).toEqual([]);
+  });
+
+  it("keeps independently owned manual and Murph workout metrics separate", () => {
+    for (const source of [MANUAL_SOURCE, MURPH_SOURCE]) {
+      const selected = selectProjectableWorkoutDays({
+        countRows: [workoutMetricRow({
+          date: ACTIVITY_DAY.date,
+          metricKey: "workout-count",
+          recordIds: [`evt_${source.source}_workout_count`],
+          source,
+          value: 1,
+        })],
+        currentDate: utcDateKey(nowMs),
+        minuteRows: [workoutMetricRow({
+          date: ACTIVITY_DAY.date,
+          metricKey: "workout-minutes",
+          recordIds: [`evt_${source.source}_workout_minutes`],
+          source,
+          value: 42,
+        })],
+      });
+
+      expect(selected).toEqual([]);
+    }
+  });
+
+  it("does not apply the redacted-owner exception to mixed metric families", () => {
+    const selected = selectProjectableWorkoutDays({
+      countRows: [workoutMetricRow({
+        date: ACTIVITY_DAY.date,
+        metricKey: "workout-count",
+        recordIds: ["activity-summary:workout-count:2026-07-03"],
+        source: GARMIN_SOURCE,
+        value: 1,
+      })],
+      currentDate: utcDateKey(nowMs),
+      minuteRows: [workoutMetricRow({
+        date: ACTIVITY_DAY.date,
+        metricKey: "workout-minutes",
+        recordIds: ["evt_garmin_workout_minutes"],
+        source: GARMIN_SOURCE,
+        sourceFamily: "event",
+        sourceKind: "observation",
+        value: 42,
+      })],
     });
 
     expect(selected).toEqual([]);


### PR DESCRIPTION
## Outcome

Restores consented daily workout count-and-minutes summaries from canonical provider sessions after sync. The fix preserves the stored-summary privacy boundary and leaves detailed workout sharing unchanged.

## Product UX

- A member with workout-summary sharing enabled now contributes a dated workout count and total minutes after a connected-device workout syncs.
- No-workout, non-granted, cross-provider, and independently authored manual/Murph cases remain fail-closed.
- Detailed workouts, routes, heart rate, and private source identifiers are not added to this projection.

Product purpose verdict: the original empty-snapshot failure is corrected without broadening consent or exposing more data.

## Direct evidence

- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/vault-share-projection.test.ts`: 140 passed, including canonical session -> persisted redacted summary -> `workout-days.v0` delivery.
- `pnpm --dir packages/assistant-runtime typecheck`: passed.
- `pnpm --dir apps/web test -- changelog-page.test.tsx`: 9 passed.
- `pnpm --dir apps/web typecheck`: passed.
- Real-Codex journey: `pnpm test:assistant:live -- --test "reports available shared workout count and minutes"`, `gpt-5.6-terra`, local subscription. The synthetic turn chose `workout-days.v0` and answered the 1-workout/42-minute result truthfully. Verdict: Hold because the current model repeated the identical read; the existing shared-sleep freshness journey reproduced the same baseline action-count regression. The exact-one assertion remains intact.
- Assistant Engine package typecheck remains blocked by an unrelated base error: an existing real-E2E fixture supplies unsupported `timeoutMs`. The changed live test compiled in the focused Vitest lane and executed in the provider lane.
- `git diff --check` and added-line private-identifier scan: passed.

## Non-obvious affected surfaces

- Stored public wearable summaries intentionally redact canonical record IDs, so reconstructed count and minute points receive different metric-specific synthetic IDs.
- Exact source-owner equality remains the default. Only same-provider, non-manual/non-Murph `derived/activity-summary` rows may pair after redaction.
- `workouts.v0` is unchanged; its detail, window, dedupe, timezone, and settlement contracts remain separate.

## Architecture and reuse

- Existing systems reused: stored public summary codec, canonical metric selection, composite source revision, and existing share delivery.
- New logic: one local predicate accepts a redacted same-provider `derived/activity-summary` count-and-minutes pair after exact source-owner equality fails.
- New abstractions: none; the existing projection owner already has every required input and is the narrowest owner for this redaction exception.
- Complexity intentionally avoided: no codec, schema, migration, state owner, service, dependency, compatibility layer, backfill, or reuse of semantically different `workouts.v0`.

Exact source-owner equality remains the default.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` completed with unchanged complexity debt and no new threshold breach.
- Hotspots: existing `selectProjectableWorkoutsDays` (29), `selectProjectableDailyMetricDays` (26), and `selectProjectableHeartRateZoneDays` (23) are unchanged; the new helper stays below the threshold.
- Agent judgment: keep the new predicate local and linear because genericizing evidence identity would broaden semantics and add ownership complexity without reducing an existing hotspot.

Production-source impact remains +23/-1; the additional lines are focused regression and journey proof.

## Runtime and provider impact

Hot reply path: none. This changes background vault-share snapshot materialization, with no new per-turn database or network work.

Provider input: no production prompt, instruction, tool description, or provider payload changed. The only model-facing addition is opt-in synthetic journey coverage.

## Deployment concerns

- Deployment: not applicable
- Reason: the runtime predicate and data-only changelog fragment introduce no schema, protocol, binding, or cross-component compatibility dependency.

## Changelog

- Changelog: updated
- Items: 2026-08-31 · shared-workout-summaries-return-after-sync

## Change shape

- Source: +23/-1
- Tests/fixtures: +285/-7
- Docs/static content: +118/-0
- Config/tooling: +0/-0
- Generated/other: +0/-0

ReviewGPT context sensitivity: sensitive — this changes a consented health-data projection boundary while preserving its privacy contract.
ReviewGPT first-reviewed head: cd2c6e9669239b79235dc4c50cfa688108da6dec