### PR TITLE
Fix checkpoint wake liveness races

### DIFF
--- a/.agents/friction-log/20260831181230-hosted-local-e2e/friction.md
+++ b/.agents/friction-log/20260831181230-hosted-local-e2e/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Hosted-local E2E does not preflight external Temporal protocol compatibility'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+When hosted-local is given an external Temporal worker package, it should fail before stack startup if that package cannot parse the current checkout’s hosted-execution reconciliation contract.
+
+## Current Behavior
+
+A worker package resolving hosted-execution 1.3.1 starts against a 1.3.2 checkout. The foreground journey runs, then unrelated Environment cases wait for their full deadlines because the older exact-key parser rejects newer system-progress fields.
+
+## Possible Solution
+
+Add a secret-free startup handshake or package-contract preflight that proves the external worker accepts the current reconciliation facts schema before E2E scenarios start.
+
+## Minimal Reproducible Example
+
+1. Use the documented external Temporal worker package setting with a worker that resolves hosted-execution 1.3.1.
+2. Run the hosted-local foreground-reply-priority E2E from a 1.3.2 checkout.
+3. Observe that setup succeeds, reply-priority cases run, and later Environment cases time out on an invalid protocol response.
+
+## Context
+
+This delayed focused liveness verification and obscured successful reply-path evidence behind cross-version failures.

--- a/agent-docs/exec-plans/active/2026-08-31-checkpoint-empty-probe-liveness.md
+++ b/agent-docs/exec-plans/active/2026-08-31-checkpoint-empty-probe-liveness.md
@@ -1,0 +1,98 @@
+# Preserve checkpoint-raced reply liveness
+
+Status: active
+Created: 2026-08-31
+Updated: 2026-08-31
+
+## Goal
+
+- Remove the proven snapshot-completion and invocation-return races that can
+  defer already-due assistant work by another recovery window, without adding
+  a scheduler, queue, state owner, or recovery loop.
+
+## Evidence boundary
+
+- Production evidence proves that one canary reply spent about 375 seconds
+  inside Murph before outbound dispatch. Linq accepted it about 148
+  milliseconds after dispatch and delivered it about 1.3 seconds after
+  dispatch, so Linq was not the source of the delay.
+- Surviving timing is consistent with two roughly three-minute checkpoint
+  windows. Canary cleanup removed the historical mailbox, workspace, latency,
+  and runtime-attempt rows needed to attribute the exact production
+  interleaving. Do not claim an instruction-level production cause that those
+  retained facts cannot prove.
+- A proposed foreground checkpoint shortcut was rejected and removed after
+  review showed its decisive phase was synthetic and its predicate was broader
+  than the causal wake. It is not part of this change.
+
+## Success criteria
+
+- The real Cloudflare snapshot port proves RED that a wake after an ambiguous
+  `/complete` transport loss vetoes the one exact replay.
+- A composed real runtime-entrypoint, snapshot-bridge, coalescing-wake, and
+  fake-clock regression proves that losing the response after remote commit can
+  add exactly one 180-second idle window before due assistant work runs.
+- The snapshot heartbeat remains live through the exact replay even after the
+  construction signal is aborted.
+- The real coalescing wake signal proves RED that a wake accepted after the
+  package's final drain is surfaced through the existing immediate-recheck
+  result edge.
+- Focused suites, adjacent controls, typechecks, and a hosted-local foreground
+  reply journey run before handoff.
+
+## Constraints
+
+- Preserve checkpoint-before-continuation ordering and the routine idle floor.
+- Keep one canonical `/complete` deadline, at most one identical replay, and
+  existing terminal HTTP and payload-validation behavior.
+- Reuse the existing coalesced wake and positive-only
+  `immediateRecheckRequested` handoff.
+- Add no dependency, persisted marker, manager, or feature-specific liveness
+  state.
+
+## Implementation
+
+1. Snapshot completion no longer lets a queued wake veto the one exact,
+   replay-safe disambiguation request after canonical publication has started.
+2. Entering `/complete` transfers the existing heartbeat to the
+   noninterruptible completion/replay lifetime and stops it in the existing
+   completion `finally`.
+3. When the package invocation settles, Cloudflare closes wake admission and
+   drains the coalesced signal in the same synchronous turn. An already
+   accepted wake sets the existing immediate-recheck result; later wakes are
+   rejected to the outer reconciliation owner.
+
+## Verification
+
+- RED proof:
+  - Exact completion transport loss plus a following wake failed without
+    replay.
+  - The same replay test failed without completion-owned heartbeat continuity:
+    the heartbeat count remained unchanged after the wake.
+  - A wake injected after the package's final drain was accepted but omitted
+    from the returned handoff.
+  - The composed checkpoint test measured one additional exact 180-second
+    window after the remote commit on unchanged behavior.
+- Current GREEN proof:
+  - Cloudflare snapshot platform: 203/203.
+  - Cloudflare invocation adapter: 11/11.
+  - Assistant checkpoint races: 20/20.
+  - Broader foreground-input, checkpoint-wake, collapse, and shutdown controls:
+    80/80.
+  - Assistant-runtime and Cloudflare typechecks pass.
+- Hosted-local proof:
+  - Foreground reply modes completed in 15.1 seconds, 2.4 seconds, 5.6
+    seconds, and 11.0 seconds against a 30-second deadline and a configured
+    180-second idle floor.
+  - The overall multi-case command did not pass: three Environment-work cases
+    reached an external Temporal protocol mismatch. The sibling worker resolves
+    `@murphai/hosted-execution` 1.3.1, whose exact-key parser lacks the current
+    1.3.2 system-progress fields returned by this checkout. This blocks a
+    full-suite green result but is outside this diff; report it rather than
+    weakening either contract.
+
+## Remaining work
+
+1. Run diff/privacy checks and the required completion reviews.
+2. Commit the scoped change, open the PR, and complete the repository review
+   gates.

--- a/agent-docs/exec-plans/completed/2026-08-31-checkpoint-empty-probe-liveness.md
+++ b/agent-docs/exec-plans/completed/2026-08-31-checkpoint-empty-probe-liveness.md
@@ -1,6 +1,6 @@
 # Preserve checkpoint-raced reply liveness
 
-Status: active
+Status: completed
 Created: 2026-08-31
 Updated: 2026-08-31
 
@@ -80,6 +80,7 @@ Updated: 2026-08-31
   - Broader foreground-input, checkpoint-wake, collapse, and shutdown controls:
     80/80.
   - Assistant-runtime and Cloudflare typechecks pass.
+  - `pnpm complexity:diff` passes with no changed-file hotspot increase.
 - Hosted-local proof:
   - Foreground reply modes completed in 15.1 seconds, 2.4 seconds, 5.6
     seconds, and 11.0 seconds against a 30-second deadline and a configured
@@ -91,8 +92,13 @@ Updated: 2026-08-31
     full-suite green result but is outside this diff; report it rather than
     weakening either contract.
 
-## Remaining work
+## Completion
 
-1. Run diff/privacy checks and the required completion reviews.
-2. Commit the scoped change, open the PR, and complete the repository review
-   gates.
+- Diff, privacy, architecture, and parent final reviews passed.
+- Exact-head CI passed every fresh required workflow.
+- Final ReviewGPT round 1 passed with no findings after inspecting the full
+  pushed patch. An earlier 79-second response with unknown model evidence was
+  discarded below the repository trust floor and did not count.
+- The scoped source fix is net deletion and adds no scheduler, queue, persisted
+  marker, dependency, or state owner.
+Completed: 2026-08-31

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -93,6 +93,10 @@ invocation compares its invocation provider with the live Web-owned preference.
 A mismatch stops that invocation from servicing further wakes, makes its dirty
 workspace checkpoint, and returns the existing `immediateRecheckRequested` edge
 so Cloudflare releases the provider-specific invocation and starts a fresh one.
+When the package invocation settles, Cloudflare closes runtime-wake admission
+and drains the coalesced signal in the same synchronous turn. An already
+accepted wake becomes that same positive immediate-recheck edge; a later wake
+is rejected for the existing outer reconciliation owner.
 A failed best-effort signal
 leaves the durable preference intact; the next invocation and the mandatory
 provider-entry revalidation remain the recovery path. The signal carries no
@@ -218,7 +222,10 @@ preservation and stops heartbeat liveness before detached session cleanup.
 If `/complete` loses its response at the transport boundary, the runtime replays
 that exact completion request at most once under the original heartbeat,
 stored write-fence headers, and remaining commit timeout; non-OK HTTP responses
-and parse/validation failures are terminal. After Web accepts the checkpoint,
+and parse/validation failures are terminal. A queued runtime wake does not veto
+this exact replay because the original publication was already
+non-interruptible; the wake remains available after the canonical result. After
+Web accepts the checkpoint,
 the runtime stops heartbeating and best-effort records completion; a failed
 marker falls back to stale-heartbeat expiry. Absent, mismatched, completed, or
 stale sessions do not delay replacement. This

--- a/apps/cloudflare/src/hosted-workspace-invocation.ts
+++ b/apps/cloudflare/src/hosted-workspace-invocation.ts
@@ -96,6 +96,16 @@ export interface HostedWorkspaceInvocationOptions {
   waitForBackgroundAssistantWork(signal: AbortSignal | null): Promise<void>;
 }
 
+function preserveAcceptedRuntimeWake(
+  result: HostedAssistantWorkspaceRuntimeJobResult,
+  acceptedRuntimeWake: boolean,
+): HostedAssistantWorkspaceRuntimeJobResult {
+  if (!acceptedRuntimeWake) {
+    return result;
+  }
+  return { ...result, immediateRecheckRequested: true };
+}
+
 export function buildHostedExecutionJobRuntime(input: {
   requestedRuntime: HostedAssistantRuntimeConfig;
   supervisorEnv: Readonly<Record<string, string | undefined>>;
@@ -264,7 +274,14 @@ export async function runHostedWorkspaceInvocation(
       vaultRoot,
       waitForBackgroundAssistantWork: options.waitForBackgroundAssistantWork,
     });
-    return assertHostedExecutionRunnerJobResult(result, job);
+    acceptingRuntimeWakes = false;
+    return assertHostedExecutionRunnerJobResult(
+      preserveAcceptedRuntimeWake(
+        result,
+        runtimeWakeSignal.consumePending() !== null,
+      ),
+      job,
+    );
   } finally {
     acceptingRuntimeWakes = false;
   }

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -113,7 +113,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
 }): NonNullable<HostedRuntimePlatform["workspaceSnapshotPort"]> {
   const sessionRuntimeState = new Map<string, {
     headers: Headers;
-    signal: AbortSignal | null;
   }>();
   const sessionHeartbeatStops = new Map<string, () => void>();
   const readSessionWriteFenceHeaders = async (
@@ -251,11 +250,10 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
           phase: "session_complete_write_fence_headers",
         });
       }
+      startSessionHeartbeat(snapshotId, headers);
       headers.set("content-type", "application/json; charset=utf-8");
-      // Canonical publication stays non-interruptible once `/complete` starts.
-      // The session signal only prevents replay after foreground cancellation.
-      const sessionCancellationSignal =
-        sessionRuntimeState.get(snapshotId)?.signal ?? null;
+      // Canonical publication and its one exact replay stay non-interruptible
+      // once `/complete` starts.
       const body = JSON.stringify({
         archive: request.ref.archive,
         checkpointRequest: request.checkpointRequest,
@@ -313,13 +311,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
         try {
           payload = await complete(Math.max(0, deadlineMs - Date.now()));
         } catch (error) {
-          throwHostedWorkspaceSnapshotInterruptionWhenCausedBySignal(
-            error,
-            sessionCancellationSignal,
-          );
-          if (sessionCancellationSignal?.aborted) {
-            throw error;
-          }
           const replayTimeoutMs = deadlineMs - Date.now();
           if (
             replayTimeoutMs <= 0
@@ -327,15 +318,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
           ) {
             throw error;
           }
-          try {
-            payload = await complete(replayTimeoutMs);
-          } catch (replayError) {
-            throwHostedWorkspaceSnapshotInterruptionWhenCausedBySignal(
-              replayError,
-              sessionCancellationSignal,
-            );
-            throw replayError;
-          }
+          payload = await complete(replayTimeoutMs);
         }
       } finally {
         stopSessionHeartbeat(snapshotId);
@@ -821,7 +804,6 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
       }
       sessionRuntimeState.set(started.snapshotId, {
         headers: new Headers(headers),
-        signal: signal ?? null,
       });
       startSessionHeartbeat(started.snapshotId, headers, signal);
       return started;

--- a/apps/cloudflare/test/hosted-workspace-invocation.test.ts
+++ b/apps/cloudflare/test/hosted-workspace-invocation.test.ts
@@ -10,25 +10,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@murphai/assistant-runtime", async () => {
+  const actual = await vi.importActual<typeof import("@murphai/assistant-runtime")>(
+    "@murphai/assistant-runtime",
+  );
   return {
     clearHostedBrowserVaultWarmSourceStateHash:
       mocks.clearHostedBrowserVaultWarmSourceStateHash,
-    createCoalescingRuntimeWakeSignal: () => {
-      let pending = false;
-      return {
-        consumePending: () => {
-          if (!pending) {
-            return null;
-          }
-          pending = false;
-          return { notifiedAtEpochMs: Date.now() };
-        },
-        notify: () => {
-          pending = true;
-        },
-        wait: async () => ({ notifiedAtEpochMs: Date.now() }),
-      };
-    },
+    createCoalescingRuntimeWakeSignal: actual.createCoalescingRuntimeWakeSignal,
   };
 });
 
@@ -247,7 +235,10 @@ describe("runHostedWorkspaceInvocation", () => {
         TELEGRAM_API_BASE_URL: "https://telegram.example.test",
       },
       waitForBackgroundAssistantWork,
-    })).resolves.toEqual(runtimeResult);
+    })).resolves.toEqual({
+      ...runtimeResult,
+      immediateRecheckRequested: true,
+    });
 
     const expectedVaultRoot = resolveHostedRunnerWarmWorkspaceVaultRoot(job.request.userId);
     const capturedInput = capturedInvocationInputs[0];
@@ -377,6 +368,68 @@ describe("runHostedWorkspaceInvocation", () => {
     expect(providerRequest.headers.get(HOSTED_RUNNER_BOUND_USER_ID_HEADER)).toBe(
       job.request.userId,
     );
+  });
+
+  it("does not lose a runtime wake accepted after the package's final drain", async () => {
+    let reachFinalDrain!: () => void;
+    const finalDrainReached = new Promise<void>((resolve) => {
+      reachFinalDrain = resolve;
+    });
+    let releasePackage!: () => void;
+    const packageReleased = new Promise<void>((resolve) => {
+      releasePackage = resolve;
+    });
+    let resolveRuntimeWakeReady!: (sendWake: () => boolean) => void;
+    const runtimeWakeReady = new Promise<() => boolean>((resolve) => {
+      resolveRuntimeWakeReady = resolve;
+    });
+    mocks.runPackageHostedWorkspaceInvocation.mockImplementation(
+      async (input: Record<string, unknown>) => {
+        const runtimeWakeSignal = requireObjectRecord(
+          input.runtimeWakeSignal,
+          "captured runtimeWakeSignal",
+        );
+        const consumePending = requireCallable(
+          runtimeWakeSignal.consumePending,
+          "captured runtimeWakeSignal.consumePending",
+        );
+        expect(consumePending()).toBeNull();
+        reachFinalDrain();
+        await packageReleased;
+        return {
+          nextWakeAt: null,
+          redactedStatus: { importedCount: 0 },
+          status: "idle" as const,
+        };
+      },
+    );
+
+    const invocation = runHostedWorkspaceInvocation(createWorkspaceJob({
+      forwardedEnv: {
+        HOSTED_ASSISTANT_MODEL: "gpt-job",
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        NODE_ENV: "production",
+      },
+    }), {
+      onRuntimeWakeReady(sendWake) {
+        resolveRuntimeWakeReady(sendWake);
+      },
+      supervisorEnv: {
+        HOSTED_ASSISTANT_MODEL: "gpt-supervisor",
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        NODE_ENV: "production",
+      },
+      waitForBackgroundAssistantWork,
+    });
+
+    await finalDrainReached;
+    const sendRuntimeWake = await runtimeWakeReady;
+    const wakeAccepted = sendRuntimeWake();
+    releasePackage();
+    const result = await invocation;
+
+    expect(wakeAccepted).toBe(true);
+    expect(result.immediateRecheckRequested).toBe(true);
   });
 
   it("validates preview private-image publication from the per-job platform origin", async () => {

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -3128,14 +3128,14 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       ref,
     })).rejects.toThrow("Hosted workspace snapshot complete failed with HTTP 409.");
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const completeRequest = requireFetchRequest(fetchMock.mock.calls[2], "workspace snapshot complete");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const completeRequest = requireFetchRequest(fetchMock.mock.calls[3], "workspace snapshot complete");
     expect(completeRequest.method).toBe("POST");
     expect(completeRequest.headers.get("x-hosted-runtime-attempt-id")).toBe("attempt_1");
     expect(completeRequest.headers.get("x-hosted-runtime-lease-generation")).toBe("9");
     expect(completeRequest.headers.get("x-hosted-runtime-workspace-version")).toBe("4");
     await vi.advanceTimersByTimeAsync(10_000);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("replays one transport-ambiguous snapshot completion with the identical payload and headers", async () => {
@@ -3288,7 +3288,8 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(responseBodyRead).toBe(false);
   });
 
-  it("does not replay or erase a completion transport failure when a wake follows it", async () => {
+  it("replays an exact completion after transport loss even when a wake follows it", async () => {
+    vi.useFakeTimers();
     const ref = createWorkspaceSnapshotV2Ref({ encryptedByteSize: 4 });
     const dataKeyBase64 = encodeHostedWorkspaceSnapshotV2DataKey(
       Uint8Array.from({ length: 32 }, (_, index) => index + 1),
@@ -3297,7 +3298,9 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     const abortReason = new Error("foreground wake interrupted snapshot completion");
     const completionStarted = createDeferred<void>();
     const completionFailure = createDeferred<Response>();
+    const completionReplay = createDeferred<Response>();
     let completionCalls = 0;
+    let heartbeatCalls = 0;
     const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
       const request = requireFetchRequest(args, "cancelled workspace snapshot completion");
       if (request.url.endsWith("/workspace-snapshots/start")) {
@@ -3308,6 +3311,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         });
       }
       if (request.url.endsWith(`/workspace-snapshots/${ref.snapshotId}/heartbeat`)) {
+        heartbeatCalls += 1;
         return new Response(JSON.stringify({ alive: true, ok: true }), {
           headers: { "content-type": "application/json; charset=utf-8" },
           status: 200,
@@ -3315,8 +3319,11 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       }
       if (request.url.endsWith(`/workspace-snapshots/${ref.snapshotId}/complete`)) {
         completionCalls += 1;
-        completionStarted.resolve();
-        return await completionFailure.promise;
+        if (completionCalls === 1) {
+          completionStarted.resolve();
+          return await completionFailure.promise;
+        }
+        return await completionReplay.promise;
       }
       return new Response("unexpected", { status: 500 });
     });
@@ -3325,27 +3332,36 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       fetchImpl: fetchMock as typeof fetch,
     });
 
-    await platform.workspaceSnapshotPort!.startSnapshotSession({
-      expectedWorkspaceVersion: "4",
-      reason: "idle_shutdown",
-      signal: abortController.signal,
-    });
-    const completion = platform.workspaceSnapshotPort!.completeSnapshotSession({
-      checkpointRequest: createWorkspaceSnapshotCheckpointRequest(ref),
-      ref,
-    });
-    await completionStarted.promise;
-    completionFailure.reject(new TypeError("fetch failed"));
-    abortController.abort(abortReason);
+    try {
+      await platform.workspaceSnapshotPort!.startSnapshotSession({
+        expectedWorkspaceVersion: "4",
+        reason: "idle_shutdown",
+        signal: abortController.signal,
+      });
+      await vi.waitFor(() => expect(heartbeatCalls).toBe(1));
+      const completion = platform.workspaceSnapshotPort!.completeSnapshotSession({
+        checkpointRequest: createWorkspaceSnapshotCheckpointRequest(ref),
+        ref,
+      });
+      await completionStarted.promise;
+      completionFailure.reject(new TypeError("fetch failed"));
+      abortController.abort(abortReason);
+      await vi.waitFor(() => expect(completionCalls).toBe(2));
+      const heartbeatCountAfterWake = heartbeatCalls;
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() =>
+        expect(heartbeatCalls).toBeGreaterThan(heartbeatCountAfterWake)
+      );
+      completionReplay.resolve(createWorkspaceSnapshotCompleteResponse(ref));
 
-    await expect(completion).rejects.toThrow("Hosted workspace snapshot complete request failed.");
-    await expect(completion).rejects.not.toBe(abortReason);
-    await expect(completion).rejects.toMatchObject({
-      phase: "session_complete_request",
-      timeoutMs: expect.any(Number),
-    });
+      const completed = await completion;
 
-    expect(completionCalls).toBe(1);
+      expect(completed.snapshotRef).toEqual(ref);
+      expect(completionCalls).toBe(2);
+    } finally {
+      completionReplay.resolve(createWorkspaceSnapshotCompleteResponse(ref));
+      vi.useRealTimers();
+    }
   });
 
   it("terminates snapshot completion after a second transport closure", async () => {
@@ -3542,7 +3558,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       });
       await vi.waitFor(() => expect(completionHeaders).toHaveLength(2));
       await vi.advanceTimersByTimeAsync(2_000);
-      await vi.waitFor(() => expect(heartbeatHeaders).toHaveLength(2));
+      await vi.waitFor(() => expect(heartbeatHeaders).toHaveLength(3));
 
       expect(Object.fromEntries(completionHeaders[0] ?? [])).toEqual(expect.objectContaining({
         "x-hosted-runtime-attempt-id": "attempt_1",
@@ -3550,7 +3566,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         "x-hosted-runtime-workspace-version": "4",
       }));
       expect(completionHeaders[1]).toEqual(completionHeaders[0]);
-      expect(Object.fromEntries(heartbeatHeaders[1] ?? [])).toEqual(expect.objectContaining({
+      expect(Object.fromEntries(heartbeatHeaders.at(-1) ?? [])).toEqual(expect.objectContaining({
         "x-hosted-runtime-attempt-id": "attempt_1",
         "x-hosted-runtime-lease-generation": "9",
         "x-hosted-runtime-workspace-version": "4",
@@ -3695,8 +3711,8 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }));
     expect(completed.snapshotRef).toEqual(ref);
     expect(recordCheckpoint).not.toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const completeRequest = requireFetchRequest(fetchMock.mock.calls[2], "workspace snapshot complete");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const completeRequest = requireFetchRequest(fetchMock.mock.calls[3], "workspace snapshot complete");
     expect(completeRequest.method).toBe("POST");
     expect(completeRequest.headers.get("x-hosted-runtime-attempt-id")).toBe("attempt_1");
     expect(completeRequest.headers.get("x-hosted-runtime-lease-generation")).toBe("9");
@@ -9634,7 +9650,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       ref,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     const startRequest = requireFetchRequest(fetchMock.mock.calls[1], "advanced snapshot start");
     expect(startRequest.headers.get("x-hosted-runtime-attempt-id")).toBe("attempt_1");
     expect(startRequest.headers.get("x-hosted-runtime-lease-generation")).toBe("9");
@@ -9643,7 +9659,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expectedWorkspaceVersion: "5",
       reason: "idle_shutdown",
     }));
-    const completeRequest = requireFetchRequest(fetchMock.mock.calls[3], "advanced snapshot complete");
+    const completeRequest = requireFetchRequest(fetchMock.mock.calls[4], "advanced snapshot complete");
     expect(completeRequest.headers.get("x-hosted-runtime-attempt-id")).toBe("attempt_1");
     expect(completeRequest.headers.get("x-hosted-runtime-lease-generation")).toBe("9");
     expect(completeRequest.headers.get("x-hosted-runtime-workspace-version")).toBe("5");

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-races.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-races.test.ts
@@ -1629,145 +1629,301 @@ describe("hosted workspace runtime entrypoint", () => {test("retained post-check
     }
   });
 
-  test("runtime wakes that interrupt checkpoint publication do not service same-key due wakes before checkpoint", async () => {
-    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-runtime-idle-checkpoint-"));
+  test("a committed checkpoint response lost to its self-wake does not defer due assistant work for another idle window", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(tmpdir(), "murph-runtime-committed-checkpoint-self-wake-"),
+    );
+    const vaultRoot = path.join(workspaceRoot, "durable", "vault");
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const idleCheckpointDelayMs = 180_000;
     const assistantOneObserved = createDeferred<void>();
     const assistantTwoObserved = createDeferred<void>();
+    const firstCompletionResponseLost = createDeferred<void>();
+    const firstSnapshotInterrupted = createDeferred<void>();
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    const shutdownController = new AbortController();
+    const startedAtMs = Date.parse(TEST_NOW);
     let assistantPhaseCalls = 0;
-    let snapshotAttempt = 0;
+    let archiveBuilds = 0;
+    let completionCalls = 0;
+    let firstRemoteCommitAtMs: number | null = null;
+    let firstSnapshotInterruptionReason: unknown = null;
+    let remoteCommittedWorkspace: HostedWorkspaceState | null = null;
+    let assistantServicedAtMs: number | null = null;
+    let sessionStarts = 0;
+    let resultPromise: ReturnType<typeof runHostedWorkspaceRuntimeJobInProcess> | null = null;
 
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
       vi.setSystemTime(new Date(TEST_NOW));
+      await mkdir(path.join(workspaceRoot, "durable", "home"), { recursive: true });
+      await mkdir(path.join(workspaceRoot, "scratch"), { recursive: true });
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
-      const resultPromise = withRealTimeout(
-        runHostedWorkspaceRuntimeJobInProcess(
-          createWorkspaceRuntimeJobInput({
-            request: {
-              attemptId: "attempt_synthetic_same_key_checkpoint_interrupt",
-              idleCheckpointDelayMs,
-              leaseGeneration: "9",
-              userId: TEST_USER_ID,
-              workspaceVersion: "4",
+      const workspaceSnapshotPort: NonNullable<
+        HostedRuntimePlatform["workspaceSnapshotPort"]
+      > = {
+        async abortSnapshotSession() {
+          throw new Error("A completion-attempted session must not be aborted.");
+        },
+        async completeSnapshotSession(input) {
+          completionCalls += 1;
+          events.push(`snapshot.complete:${completionCalls}`);
+          if (remoteCommittedWorkspace === null) {
+            remoteCommittedWorkspace = createWorkspaceState({
+              nextWakeAt: input.checkpointRequest.nextWakeAt ?? null,
+              nextWakeReason: input.checkpointRequest.nextWakeReason ?? null,
+              redactedStatus: input.checkpointRequest.redactedStatus ?? null,
+              snapshotRef: input.ref,
+              version: "5",
+            });
+            events.push(`remote.commit:${remoteCommittedWorkspace.version}`);
+          }
+          if (completionCalls === 1) {
+            firstRemoteCommitAtMs = Date.now();
+            runtimeWakeSignal.notify({ notifiedAtEpochMs: Date.now() });
+            await withRealTimeout(
+              firstSnapshotInterrupted.promise,
+              5_000,
+              () => `Snapshot signal did not observe its self-wake: ${events.join(",")}`,
+            );
+            events.push("snapshot.response-lost:1");
+            firstCompletionResponseLost.resolve();
+            // Model the Cloudflare port's one exact internal transport replay;
+            // the canonical result remains the already committed v5 workspace.
+            completionCalls += 1;
+            events.push(`snapshot.complete:${completionCalls}`);
+          }
+          return {
+            checkpoint: {
+              checkpointed: true,
+              workspace: remoteCommittedWorkspace,
             },
+            snapshotRef: input.ref,
+          };
+        },
+        async putSnapshotObjectDirect() {
+          return {
+            snapshotDirectR2PresignElapsedMs: 1,
+            snapshotDirectR2PutElapsedMs: 1,
+          };
+        },
+        async restoreWorkspaceSnapshot() {
+          throw new Error("This test starts from a materialized workspace.");
+        },
+        async startSnapshotSession() {
+          sessionStarts += 1;
+          const snapshotId = `committed_checkpoint_self_wake_${sessionStarts}`;
+          const objectKey =
+            `users/${TEST_USER_ID}/workspace-snapshots/${snapshotId}.snapshot.enc`;
+          return {
+            encryption: {
+              aad: buildHostedWorkspaceSnapshotV2Aad({
+                objectKey,
+                snapshotId,
+                userId: TEST_USER_ID,
+              }),
+              dataKeyBase64: "synthetic-data-key",
+              ivBase64: "synthetic-iv",
+              rootKeyId: "synthetic-root-key",
+              scheme: HOSTED_WORKSPACE_SNAPSHOT_V2_ENCRYPTION_SCHEME,
+              wrappedDataKey: "synthetic-wrapped-data-key",
+            },
+            limits: {
+              maxSinglePartEncryptedBytes: 1_024,
+              warnEncryptedBytes: 512,
+            },
+            objectKey,
+            snapshotId,
+          };
+        },
+      };
+      const platform = createPlatform({
+        mailboxPort: createMailboxPort({
+          events,
+          items: [],
+        }),
+        workspacePort: createWorkspacePort({
+          checkpointRequests,
+          events,
+          workspace: createWorkspaceState({
+            nextWakeAt: TEST_NOW,
+            nextWakeReason: "assistant",
+            version: "4",
           }),
-          {
-            async createCheckpointSnapshot(snapshotInput) {
-              snapshotAttempt += 1;
-              events.push(`snapshot:${snapshotAttempt}:${snapshotInput.reason}`);
-              if (snapshotAttempt === 1) {
-                throw new HostedRuntimeCheckpointInterruptedByWakeError();
-              }
-              return {
-                snapshotRef: createBundleRef({
-                  hash: `${snapshotAttempt}`.repeat(64).slice(0, 64),
-                  key:
-                    "users/bundles/member-synthetic/"
-                    + `runtime-same-key-checkpoint-interrupt-${snapshotAttempt}.bundle.json`,
-                  size: 640,
-                }),
-              };
-            },
-            async importItem(item) {
-              events.push(`mailbox.importItem:${item.item.id}`);
-              return { status: "imported" };
-            },
-            platform: createPlatform({
-              mailboxPort: createMailboxPort({
-                events,
-                items: [],
-              }),
-              workspacePort: createWorkspacePort({
-                checkpointRequests,
-                events,
-                workspace: createWorkspaceState({
-                  nextWakeAt: TEST_NOW,
-                  nextWakeReason: "assistant",
-                  version: "4",
-                }),
-              }),
-            }),
-            async runAssistantPhase(input) {
-              assistantPhaseCalls += 1;
-              events.push(
-                `assistant.phase:${assistantPhaseCalls}:`
-                  + `${input.workspace?.nextWakeAt ?? "none"}:`
-                  + `${input.workspace?.nextWakeReason ?? "none"}`,
-              );
-              if (assistantPhaseCalls === 1) {
-                assistantOneObserved.resolve();
-                return {
-                  afterCheckpoint: async () => ({
-                    checkpointReason: "provider_cleanup",
-                    nextWakeAt: TEST_NOW,
-                    nextWakeReason: "assistant",
-                  }),
-                  checkpointReason: "canonical_runtime_commit",
-                  nextWakeAt: TEST_NOW,
-                  nextWakeReason: "assistant",
-                  progressed: true,
-                  redactedStatus: {
-                    hostedAssistantProgressed: true,
-                  },
-                };
-              }
-
-              if (assistantPhaseCalls === 2) {
-                assistantTwoObserved.resolve();
-                return {
-                  checkpointReason: "assistant_runtime_commit",
-                  nextWakeAt: null,
-                  nextWakeReason: null,
-                  progressed: true,
-                  redactedStatus: {
-                    hostedAssistantProgressed: true,
-                  },
-                };
-              }
-
-              throw new Error("Interrupted same-key due wake should service exactly once.");
-            },
-            vaultRoot,
+        }),
+        workspaceSnapshotPort,
+      });
+      const runtimeJobInput = createWorkspaceRuntimeJobInput({
+        request: {
+          attemptId: "attempt_synthetic_committed_checkpoint_self_wake",
+          idleCheckpointDelayMs,
+          leaseGeneration: "9",
+          userId: TEST_USER_ID,
+          workspaceVersion: "4",
+        },
+      });
+      const runtimeConfig = runtimeJobInput.runtime;
+      assert.ok(runtimeConfig);
+      const snapshotArchiveBuilder: HostedWorkspaceSnapshotArchiveBuilder = {
+        async buildEncryptedSnapshot(input) {
+          archiveBuilds += 1;
+          if (archiveBuilds === 1) {
+            assert.ok(input.signal);
+            const recordInterruption = () => {
+              firstSnapshotInterruptionReason = input.signal?.reason;
+              events.push("snapshot.signal-aborted:1");
+              firstSnapshotInterrupted.resolve();
+            };
+            if (input.signal.aborted) {
+              recordInterruption();
+            } else {
+              input.signal.addEventListener("abort", recordInterruption, { once: true });
+            }
+          }
+          const temporaryDirectoryPath = await mkdtemp(
+            path.join(input.outputDir, "synthetic-snapshot-"),
+          );
+          const encryptedFilePath = path.join(
+            temporaryDirectoryPath,
+            "snapshot.enc",
+          );
+          await writeFile(encryptedFilePath, "encrypted snapshot", "utf8");
+          return {
+            compression: HOSTED_WORKSPACE_SNAPSHOT_COMPRESSION,
+            encryptedByteSize: 18,
+            encryptedFilePath,
+            encryptedObjectSha256: "a".repeat(64),
+            fileCount: input.archiveEntries.length,
+            plaintextArchiveSha256: "b".repeat(64),
+            temporaryDirectoryPath,
+            totalPlainBytes: 18,
+          };
+        },
+      };
+      const bridgeOptions = createHostedWorkspaceRuntimeBridgeJobOptions({
+        decodeMailboxPayload: {
+          async decode() {
+            return {
+              reasonCode: "unused_in_snapshot_control_test",
+              retryable: false,
+              status: "blocked",
+            };
           },
-        ),
-        15_000,
-        () => events.join(","),
-      );
+        },
+        platform,
+        readCurrentLease: async () => ({
+          attemptId: runtimeJobInput.request.attemptId,
+          leaseGeneration: runtimeJobInput.request.leaseGeneration,
+          providerEgressToken: runtimeJobInput.request.providerEgressToken ?? null,
+          userId: runtimeJobInput.request.userId,
+          workspaceVersion: runtimeJobInput.request.workspaceVersion,
+        }),
+        request: runtimeJobInput.request,
+        runtime: runtimeConfig,
+        snapshotArchiveBuilder,
+        snapshotDiagnosticsHashSecret: "f".repeat(64),
+        vaultRoot,
+        waitForBackgroundAssistantWork: async () => undefined,
+      });
+
+      resultPromise = runHostedWorkspaceRuntimeJobInProcess(runtimeJobInput, {
+        createCheckpointSnapshot: bridgeOptions.createCheckpointSnapshot,
+        async importItem(item) {
+          events.push(`mailbox.importItem:${item.item.id}`);
+          return { status: "imported" };
+        },
+        platform,
+        runtimeWakeSignal,
+        async runAssistantPhase(input) {
+          assistantPhaseCalls += 1;
+          events.push(
+            `assistant.phase:${assistantPhaseCalls}:`
+              + `${input.workspace?.nextWakeAt ?? "none"}:`
+              + `${input.workspace?.nextWakeReason ?? "none"}`,
+          );
+          if (assistantPhaseCalls === 1) {
+            assistantOneObserved.resolve();
+            return {
+              afterCheckpoint: async () => ({
+                checkpointReason: "provider_cleanup",
+                nextWakeAt: TEST_NOW,
+                nextWakeReason: "assistant",
+              }),
+              checkpointReason: "canonical_runtime_commit",
+              nextWakeAt: TEST_NOW,
+              nextWakeReason: "assistant",
+              progressed: true,
+              redactedStatus: {
+                hostedAssistantProgressed: true,
+              },
+            };
+          }
+
+          if (assistantPhaseCalls === 2) {
+            assistantServicedAtMs = Date.now();
+            assistantTwoObserved.resolve();
+            return {
+              checkpointReason: "assistant_runtime_commit",
+              nextWakeAt: null,
+              nextWakeReason: null,
+              progressed: true,
+              redactedStatus: {
+                hostedAssistantProgressed: true,
+              },
+            };
+          }
+
+          throw new Error("Interrupted same-key due wake should service exactly once.");
+        },
+        shutdownSignal: shutdownController.signal,
+        vaultRoot,
+      });
 
       await withRealTimeout(assistantOneObserved.promise, 15_000, () => events.join(","));
       await waitForFakeTimerScheduled(() => events.join(","));
       await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
+      await withRealTimeout(
+        firstCompletionResponseLost.promise,
+        15_000,
+        () => events.join(","),
+      );
       await withRealTimeout(assistantTwoObserved.promise, 15_000, () => events.join(","));
+
       assert.ok(
-        requireEventIndex(events, "snapshot:2:idle_shutdown")
+        requireEventIndex(events, "snapshot.complete:2")
           < requireEventIndex(events, `assistant.phase:2:${TEST_NOW}:assistant`),
       );
-
-      await waitForFakeTimerScheduled(() => events.join(","));
-      await vi.advanceTimersByTimeAsync(idleCheckpointDelayMs);
-      const result = await resultPromise;
-
-      assert.deepEqual(events.filter((event) => event.startsWith("snapshot:")), [
-        "snapshot:1:idle_shutdown",
-        "snapshot:2:idle_shutdown",
-        "snapshot:3:idle_shutdown",
-      ]);
-      assert.deepEqual(checkpointRequests.map((request) => [
-        request.reason,
-        request.nextWakeAt,
-        request.nextWakeReason,
-      ]), [
-        ["idle_shutdown", TEST_NOW, "assistant"],
-        ["idle_shutdown", null, null],
-      ]);
-      assert.equal(result.nextWakeAt, null);
-      assert.equal(result.status, "idle");
+      assert.ok(
+        requireEventIndex(events, "remote.commit:5")
+          < requireEventIndex(events, "snapshot.response-lost:1"),
+      );
+      assert.ok(
+        firstSnapshotInterruptionReason
+          instanceof HostedRuntimeCheckpointInterruptedByWakeError,
+      );
+      assert.equal(checkpointRequests.length, 0);
+      if (firstRemoteCommitAtMs === null || assistantServicedAtMs === null) {
+        throw new Error(`Missing latency timestamp: ${events.join(",")}`);
+      }
+      const assistantDelayAfterRemoteCommitMs =
+        assistantServicedAtMs - firstRemoteCommitAtMs;
+      assert.ok(
+        assistantDelayAfterRemoteCommitMs < idleCheckpointDelayMs,
+        "A remotely committed checkpoint response lost to its self-wake "
+          + "must not make due assistant work wait for another idle window: "
+          + JSON.stringify({
+            events,
+            firstRemoteCommitAtMs: firstRemoteCommitAtMs - startedAtMs,
+            assistantDelayAfterRemoteCommitMs,
+            assistantServicedAtMs: assistantServicedAtMs - startedAtMs,
+          }),
+      );
     } finally {
+      shutdownController.abort(new Error("Test cleanup."));
+      await resultPromise?.catch(() => undefined);
       vi.useRealTimers();
-      await removeTempRoot(vaultRoot);
+      await removeTempRoot(workspaceRoot);
     }
   });
 


### PR DESCRIPTION
## Why and outcome

One production canary reply spent about 375 seconds inside Murph before outbound dispatch; Linq then accepted it in about 148 ms and delivered it in about 1.3 s. Canary cleanup removed the attempt-level evidence needed to name that exact production interleaving, but focused regressions reproduced two real checkpoint/wake races with the matching extra 180-second window.

This change removes both races: a wake can no longer veto the one safe exact replay of an ambiguously completed checkpoint, and a wake accepted at invocation return is handed to the existing immediate-recheck owner instead of disappearing.

## Product UX

- Effort: Patch.
- Walkthrough: Ready. The affected person sends a current message while hosted execution is checkpointing; due reply work resumes without consuming another idle window.
- Direct journey: four foreground-reply modes completed in 15.1 s, 2.4 s, 5.6 s, and 11.0 s against a 30-second deadline with the normal 180-second idle floor.
- Exclusions: no reply copy, assistant reasoning, provider input, routing, UI, or background-work policy changed.

## Evidence

- RED: the real snapshot port lost the first `/complete` response, received its self-wake after remote commit, and failed instead of making its one exact replay.
- RED: without completion-owned heartbeat transfer, heartbeat activity stopped after that wake.
- RED: the real coalescing signal accepted a wake after the package's final drain, but the returned result omitted the handoff.
- RED: the composed runtime-entrypoint/snapshot-bridge/fake-clock regression measured one additional exact 180-second window after remote commit on the prior behavior.
- GREEN: Cloudflare snapshot platform 203/203; invocation adapter 11/11; assistant checkpoint races 20/20; adjacent foreground/checkpoint/collapse/shutdown controls 80/80.
- GREEN: Cloudflare and assistant-runtime typechecks; `pnpm complexity:diff`.
- GREEN: final ReviewGPT round 1 completed a full-patch audit of the first-reviewed head with `ROUND_OUTCOME: PASS` and no findings.
- Hosted-local caveat: the relevant foreground modes passed, but the overall multi-case command later failed three unrelated Environment cases because the configured external Temporal worker resolves hosted-execution 1.3.1 while this checkout is 1.3.2. The older exact-key parser rejects current system-progress fields; that harness gap is recorded in Frog rather than weakening either protocol.

## Non-obvious affected surfaces

- Snapshot-session heartbeat ownership: `/complete` now transfers the existing heartbeat from interruptible construction to the noninterruptible completion/replay lifetime. The transport-loss/wake regression proves the heartbeat remains live.
- Runtime-wake admission at container return: admission closes and the existing coalesced signal drains in one synchronous turn. The late-admission regression proves accepted work becomes the existing immediate-recheck result edge.
- Hosted-runtime protocol documentation: the replay and final wake-handoff contracts now describe their actual owners.

## Architecture and reuse

- Existing systems reused: the existing replay-safe idempotent `/complete`, coalescing wake signal, heartbeat, and positive-only `immediateRecheckRequested` handoff.
- New logic: one queued wake no longer vetoes an already-authoritative checkpoint replay; return closes admission and drains once.
- New abstractions: one local pure helper preserves the accepted-wake result without increasing the existing invocation hotspot; there is no new service, scheduler, queue, persisted marker, or state owner.
- Complexity intentionally avoided: the fix deletes obsolete per-session signal state and reuses the original deadline, one-replay cap, outer reconciliation owner, and existing failure classifications.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff` reports no changed-file debt or maximum increase.
- Hotspots: `runHostedWorkspaceInvocation` remains 47 and `putSnapshotObjectDirect` remains 28; neither increases. The source diff is net deletion.
- Agent judgment: no further behavior-preserving simplification is justified; collapsing the two owner-boundary rules further would hide their distinct lifecycle contracts.

## Hot reply path impact

Applicable only to checkpoint-raced recovery of already-accepted current work. No database or provider call is added. After one ambiguous `/complete` transport failure, the existing exact replay may now run once serially even when a wake is queued; it uses the original deadline, retries no terminal HTTP or validation failure, and has no loop. Completion starts one fire-and-forget heartbeat and retains the existing interval cadence until its existing `finally` stops it. A late accepted wake sets the existing result edge, which can cause at most one existing best-effort owner-release callback (bounded to 2 s) after runtime completion recording; failure retains outer durable reconciliation. The composed regression changes this case from an extra exact 180-second idle window to servicing due work before that window, and hosted-local foreground modes remained below 15.1 s.

## Murph initial provider input impact

- Native hosted runtime: Not applicable; no prompt, tool schema, generated guidance, model selection, or provider-request assembly changed.
- Codex runtime: Not applicable for the same reason. Token/byte measurement would not add evidence because no provider-input surface changed.

## Risks

- Exact production instruction-level attribution is intentionally not claimed because canary cleanup removed historical mailbox, workspace, latency, and runtime-attempt rows.
- Replay remains bounded to one identical request under one deadline, and the server's existing idempotency/conflict checks remain authoritative.

## Change shape

Classification rule: authored runtime TypeScript is source; Vitest files are tests/fixtures; the protocol reference, completed plan, and Frog entry are docs; no binary or generated file changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 22 | 23 |
| Tests/fixtures | 385 | 160 |
| Docs | 138 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 545 | 184 |

## Deployment concerns

- Deployment: applicable
- Supported skew: no API, persisted-state, request, or result shape changed; old/new Web and Worker/container combinations remain compatible.
- Safe order: deploy the normal Cloudflare Worker/container release; no Web tandem deploy is required.
- Rollback floor: the previous Cloudflare release remains schema-compatible, but restores the two races.
- Expected exposure: old warm containers may retain the old behavior only during the ordinary gradual replacement window.
- Reversibility: roll back the Cloudflare release normally; no data migration or cleanup is needed.
- Convergence proof: confirm the deployed Worker version and new runner health, then run the production canary.
- Post-deploy checks: verify canary replies do not consume the 180-second idle floor and inspect bounded snapshot-completion, immediate-recheck, and outbound-latency aggregates.

## Changelog

- Changelog: not applicable
- Reason: this is an internal hosted-runtime reliability correction with no new member-facing capability or copy.

ReviewGPT context sensitivity: sensitive — changes cross-owner runtime wake, retry, heartbeat, and idempotency behavior.

ReviewGPT first-reviewed head: 4e8c794905b15bcbd7cacf0e6986566b59eda09c
