### PR TITLE
fix(web): disable slash-named Vercel preview deploys

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-31-vercel-preview-glob.md
+++ b/agent-docs/exec-plans/active/2026-08-31-vercel-preview-glob.md
@@ -1,0 +1,67 @@
+# Prevent slash-named Vercel preview deployments
+
+Status: active
+Created: 2026-08-31
+Updated: 2026-08-31
+
+## Goal
+
+- Prevent Vercel's Git integration from creating automatic Preview deployments
+  for non-production branches, including the repository's slash-named task
+  branches, while preserving automatic production deploys from `main`.
+
+## Success criteria
+
+- `apps/web/vercel.json` uses a branch pattern that covers names containing `/`.
+- Focused regression proof evaluates representative slash-named branches as
+  disabled and `main` as enabled under Vercel's documented matching rules.
+- The scoped Vercel configuration test and repository complexity check pass.
+- The exact pushed PR head passes required CI and the routed final ReviewGPT gate.
+
+## Scope
+
+- In scope: Vercel Git automatic-deployment admission and its focused config test.
+- Out of scope: canceling existing deployments, changing production build logic,
+  changing the ignored-build classifier, or changing manual/custom-environment
+  deployment commands.
+
+## Constraints
+
+- Technical constraints: preserve `main` production admission and the current
+  ignored-build behavior; use Vercel's existing `git.deploymentEnabled` owner.
+- Product/process constraints: internal-only behavior, no Product UX or public
+  changelog entry; use the deploy-surface PR and final-review workflow.
+
+## Risks and mitigations
+
+1. Risk: the broader glob could disable production deploys.
+   Mitigation: keep the explicit `main: true` rule and exercise the documented
+   any-true-wins behavior in focused proof.
+2. Risk: a structural assertion could repeat the original false confidence.
+   Mitigation: evaluate representative slash and non-slash branch names with
+   Node's glob matcher rather than checking JSON shape alone.
+
+## Tasks
+
+1. Replace the single-segment wildcard with a globstar fallback.
+2. Extend the existing production-deployment configuration test with semantic
+   branch cases.
+3. Run focused tests, config validation, complexity proof, and inspect the diff.
+4. Commit, open the PR, run exact-head ReviewGPT concurrently with CI, and
+   resolve any accepted findings.
+
+## Decisions
+
+- Reuse `git.deploymentEnabled`; no new script, dependency, or state owner.
+- Use `**` rather than enumerating task-branch prefixes because the requirement
+  is every non-`main` automatic Git deployment.
+
+## Verification
+
+- Commands to run:
+  - `pnpm --dir apps/web test:prepared -- test/production-migration-guard.test.ts`
+  - `pnpm --dir apps/web typecheck`
+  - `pnpm complexity:diff`
+  - `git diff --check`
+- Expected outcomes: the focused suite proves `main` enabled and representative
+  non-production branches disabled; complexity and whitespace checks pass.

--- a/agent-docs/exec-plans/completed/2026-08-31-vercel-preview-glob.md
+++ b/agent-docs/exec-plans/completed/2026-08-31-vercel-preview-glob.md
@@ -1,6 +1,6 @@
 # Prevent slash-named Vercel preview deployments
 
-Status: active
+Status: completed
 Created: 2026-08-31
 Updated: 2026-08-31
 
@@ -65,3 +65,14 @@ Updated: 2026-08-31
   - `git diff --check`
 - Expected outcomes: the focused suite proves `main` enabled and representative
   non-production branches disabled; complexity and whitespace checks pass.
+
+## Completion evidence
+
+- Focused hosted Web config suite: 68 tests passed.
+- Hosted Web typecheck: passed.
+- Complexity diff, docs drift, and whitespace checks: passed.
+- Live Vercel check: no deployment record was created for either pushed
+  slash-named candidate head.
+- ReviewGPT round 1: `ROUND_OUTCOME: PASS` with no findings.
+- Required GitHub checks on the reviewed candidate head: all passed.
+Completed: 2026-08-31

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -2585,10 +2585,31 @@ fi
       };
     };
 
-    assert.deepEqual(vercelJson.git?.deploymentEnabled, {
+    const deploymentEnabled = vercelJson.git?.deploymentEnabled;
+    assert.deepEqual(deploymentEnabled, {
       main: true,
-      "*": false,
+      "**": false,
     });
+
+    const isDeploymentEnabled = (branch: string): boolean => {
+      const matchingRules = Object.entries(deploymentEnabled ?? {}).filter(
+        ([pattern]) => path.matchesGlob(branch, pattern),
+      );
+      return (
+        matchingRules.length === 0
+        || matchingRules.some(([, enabled]) => enabled)
+      );
+    };
+
+    assert.equal(isDeploymentEnabled("main"), true);
+    for (const branch of [
+      "release",
+      "frog/sync",
+      "codex/warm-standby-experiment",
+      "fix/checkpoint-empty-probe-liveness",
+    ]) {
+      assert.equal(isDeploymentEnabled(branch), false, branch);
+    }
   });
 
   test("generates Prisma before direct local Next dev starts", async () => {

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,7 +5,7 @@
   "git": {
     "deploymentEnabled": {
       "main": true,
-      "*": false
+      "**": false
     }
   },
   "crons": [


### PR DESCRIPTION
## Why and outcome

Vercel was still creating Preview deployment attempts for task branches because the `*` fallback in `git.deploymentEnabled` did not match branch names containing `/`. Replace it with a globstar so only `main` receives automatic Git deployments.

## Product UX

Not applicable. This is internal deployment automation and changes no member-visible product behavior or interface.

## Evidence

- `pnpm --dir apps/web test:prepared -- test/production-migration-guard.test.ts` — 68 tests passed; representative slash-named branches are disabled and `main` remains enabled.
- `pnpm --dir apps/web typecheck` — passed.
- `pnpm complexity:diff` — passed; no authored source complexity change.
- `pnpm docs:drift` and `git diff --check` — passed.
- Live Vercel API check — zero deployments exist for exact final head `f1d4be73ae5d38843eb5cda08a38b9c8106b8e86`.

## Non-obvious affected surfaces

- Vercel Git automatic deployment admission: non-`main` pushes, including slash-named task branches, no longer create Preview attempts. The focused branch-matching test and exact-head live check cover this behavior.
- Existing ignored-build classification remains unchanged; it still handles manual/custom-environment and production build decisions after a deployment has been admitted.

## Architecture and reuse

- Existing systems reused: the checked-in `apps/web/vercel.json` `git.deploymentEnabled` owner and the existing production migration/config test.
- New logic: one globstar fallback plus test-local evaluation of Vercel's documented matching behavior.
- New abstractions: none; the test keeps the matcher local to the existing config assertion.
- Complexity intentionally avoided: no workflow, dashboard-only setting, dependency, deployment service, or second configuration owner was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` passed and reported no authored JavaScript or TypeScript source changes to analyze.
- Hotspots: none; only configuration and focused test coverage changed.
- Agent judgment: no further simplification is justified beyond the one-character glob correction and direct regression cases.

## Hot reply path impact

Not applicable. The foreground reply critical path is unchanged; no database, provider, network, timeout, or retry operation moved.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request changed.
- Group runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible request changed.

## Change-shape breakdown

Classification rule: production configuration is config/tooling; Vitest assertions are tests/fixtures. No binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 23 | 2 |
| Docs | 78 | 0 |
| Config/tooling | 1 | 1 |
| Generated/other | 0 | 0 |
| Total | 102 | 3 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Runtime versions are unaffected. Branch heads without this config may retain the prior Git-admission behavior until they incorporate the fix.
- Safe order: Merge the config normally; `main: true` preserves the production deployment created by the merge, while branch heads containing the fix stop creating automatic previews.
- Rollback floor: There is no runtime rollback floor; reverting the glob restores the previous Preview admission behavior.
- Expected exposure: Existing queued Preview attempts are not removed and may still reach the ignored-build cancellation step. Fixed heads create no new attempts.
- Reversibility: Revert `**` to `*` to restore the former rule.
- Convergence proof: The semantic config test passes and Vercel created no deployment for the exact pushed slash-named candidate head.
- Post-deploy checks: Confirm the merge creates the normal `main` production deployment and the next slash-named task-branch push creates no Vercel deployment record.

## Changelog

- Changelog: not applicable
- Reason: Internal Vercel deployment admission only; members cannot observe this change.

ReviewGPT context sensitivity: sensitive — production deployment configuration changes.
ReviewGPT first-reviewed head: 09ee54ebe89db64d0cd9cba210e165e3b4a24e1e


