### PR TITLE
Preserve hosted E2E retries after Cloudflare port races

### DIFF
--- a/agent-docs/exec-plans/active/2026-08-31-hosted-e2e-port-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-31-hosted-e2e-port-retry.md
@@ -61,6 +61,10 @@ Updated: 2026-08-31
   a second port-allocation owner.
 - Fix information loss at the hosted-local stack diagnostic boundary where the
   child output is already owned and redacted.
+- Accept ReviewGPT round 1's production-faithfulness finding: the generic child
+  `Text` readers still inherited the 2,000-character diagnostic-tail default.
+  Preserve the existing 2,000,000-character buffer as the full-text bound and
+  keep the tail readers unchanged.
 
 ## Verification
 
@@ -73,8 +77,11 @@ Updated: 2026-08-31
   - `pnpm complexity:diff`
 - Outcomes: the new regression failed before the implementation and passed
   afterward; the complete focused stack and scenario-helper files passed; all
-  448 harness tests passed with coverage; typecheck and package-boundary proof
+  449 harness tests passed with coverage; typecheck and package-boundary proof
   passed; and complexity debt did not increase.
+- Review remediation proof: a real spawned child now proves the diagnostic tail
+  omits an early collision marker while the bounded full-text reader retains it;
+  the stack regression then consumes those corrected production semantics.
 - Exact-ref end-to-end proof: the public PR's Murph Cloud integration lane owns
   the merged private Temporal checkout and the original two-scenario job. The
   available local private checkout is not that head, so it is not valid proof

--- a/agent-docs/exec-plans/active/2026-08-31-hosted-e2e-port-retry.md
+++ b/agent-docs/exec-plans/active/2026-08-31-hosted-e2e-port-retry.md
@@ -1,0 +1,81 @@
+# Preserve hosted E2E startup failure classification
+
+Status: active
+Created: 2026-08-31
+Updated: 2026-08-31
+
+## Goal
+
+- Make hosted-local E2E startup recover from a transient Worker port bind race
+  through its existing bounded retry, even when another child emits enough
+  startup output to exceed the aggregate diagnostic tail.
+
+## Success criteria
+
+- The failing child's bounded, redacted output remains present in the startup
+  error inspected by the current retry classifier.
+- A focused regression proves a Cloudflare `EADDRINUSE` line cannot be displaced
+  by verbose Temporal output.
+- Non-port startup failures remain non-retryable.
+- Focused tests, package typecheck/boundary verification, and required PR gates
+  pass on the exact pushed head.
+
+## Scope
+
+- In scope: hosted-local startup diagnostics and the existing full-stack E2E
+  retry boundary.
+- Out of scope: new retry owners, CI-level job retries, production Worker
+  behavior, port-manager services, or changes to scenario semantics.
+
+## Constraints
+
+- Technical constraints: preserve redaction, bounded diagnostics, exact child
+  process ownership, and the current three-attempt limit.
+- Product/process constraints: keep the fix local to the current hosted-local
+  lifecycle owner and preserve all user-critical hosted behavior.
+
+## Risks and mitigations
+
+1. Risk: retaining more per-child output could make startup errors unbounded
+   or expose unnecessary diagnostic content.
+   Mitigation: inspect only the already bounded, redacted buffer for the exact
+   exited child and emit one fixed classification instead of copying raw output.
+2. Risk: broader text matching could retry unrelated failures.
+   Mitigation: preserve the current closed port-collision signatures and the
+   existing scenario-owned attempt limit; non-port failures remain unchanged.
+
+## Tasks
+
+1. Add a failing regression for verbose sibling output displacing the exited
+   Cloudflare child's address-in-use diagnostic.
+2. Preserve the port-collision classification from the exact exited child in
+   the primary startup error before aggregate diagnostics are truncated.
+3. Run focused hosted-local harness and full-stack helper tests, then package
+   typecheck/boundary verification.
+4. Inspect and commit the scoped diff, open the PR, and complete exact-head CI
+   and required review gates.
+
+## Decisions
+
+- Keep the existing scenario-owned bounded retry; do not add workflow reruns or
+  a second port-allocation owner.
+- Fix information loss at the hosted-local stack diagnostic boundary where the
+  child output is already owned and redacted.
+
+## Verification
+
+- Completed local proof:
+  - `pnpm exec vitest run --config packages/hosted-local-harness/vitest.config.ts --no-coverage packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts`
+  - `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts`
+  - `pnpm --dir packages/hosted-local-harness typecheck`
+  - `pnpm --dir packages/hosted-local-harness verify:package-boundary`
+  - `pnpm --dir packages/hosted-local-harness test:coverage`
+  - `pnpm complexity:diff`
+- Outcomes: the new regression failed before the implementation and passed
+  afterward; the complete focused stack and scenario-helper files passed; all
+  448 harness tests passed with coverage; typecheck and package-boundary proof
+  passed; and complexity debt did not increase.
+- Exact-ref end-to-end proof: the public PR's Murph Cloud integration lane owns
+  the merged private Temporal checkout and the original two-scenario job. The
+  available local private checkout is not that head, so it is not valid proof
+  for this candidate.

--- a/agent-docs/exec-plans/completed/2026-08-31-hosted-e2e-port-retry.md
+++ b/agent-docs/exec-plans/completed/2026-08-31-hosted-e2e-port-retry.md
@@ -1,6 +1,6 @@
 # Preserve hosted E2E startup failure classification
 
-Status: active
+Status: completed
 Created: 2026-08-31
 Updated: 2026-08-31
 
@@ -82,7 +82,15 @@ Updated: 2026-08-31
 - Review remediation proof: a real spawned child now proves the diagnostic tail
   omits an early collision marker while the bounded full-text reader retains it;
   the stack regression then consumes those corrected production semantics.
+- ReviewGPT: round 1 returned one accepted High finding about the unfaithful
+  full-text fake; round 2 reviewed corrected head
+  `b75646a497893548202f0a4ef1f712a2598d30c1` as a fresh sensitive snapshot and
+  returned `ROUND_OUTCOME: PASS` with no findings.
+- Final parent review: the diff stays within the existing bounded buffer, stack
+  lifecycle, and scenario retry owners; no further simplification or new durable
+  documentation is justified.
 - Exact-ref end-to-end proof: the public PR's Murph Cloud integration lane owns
   the merged private Temporal checkout and the original two-scenario job. The
   available local private checkout is not that head, so it is not valid proof
   for this candidate.
+Completed: 2026-08-31

--- a/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
@@ -245,9 +245,9 @@ export function spawnChildProcess(
     child,
     name,
     stderrTail: (maxChars?: number): string => stderr.read(maxChars),
-    stderrText: (): string => stderr.read(),
+    stderrText: (): string => stderr.read(HOSTED_LOCAL_OUTPUT_BUFFER_MAX_CHARS),
     stdoutTail: (maxChars?: number): string => stdout.read(maxChars),
-    stdoutText: (): string => stdout.read(),
+    stdoutText: (): string => stdout.read(HOSTED_LOCAL_OUTPUT_BUFFER_MAX_CHARS),
   };
 }
 

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -1113,8 +1113,15 @@ export async function startHostedLocalDevStack(input: {
         await Promise.race([
           Promise.all(healthChecks).then(() => undefined),
           waitForFirstChildExit(children).then((child) => {
+            const exitedChild = children.find((candidate) => candidate.child === child.child);
+            const portBindCollision = exitedChild
+              ? childReportedPortBindCollision(exitedChild)
+              : false;
             throw new Error(
-              `${child.name} dev process exited before the hosted local stack became healthy.`,
+              [
+                `${child.name} dev process exited before the hosted local stack became healthy.`,
+                portBindCollision ? "Address already in use was reported by the exited process." : null,
+              ].filter((value): value is string => value !== null).join(" "),
             );
           }),
         ]);
@@ -2925,6 +2932,14 @@ function appendStartupDiagnostics(
       output ? `process output tail:\n${tail(output)}` : null,
       redactHostedLocalDiagnosticText(diagnostics),
     ].filter((value): value is string => value !== null).join("\n"),
+  );
+}
+
+function childReportedPortBindCollision(child: BufferedNamedChildProcess): boolean {
+  return [child.stdoutText(), child.stderrText()].some((output) =>
+    /\bEADDRINUSE\b/u.test(output)
+    || /\baddress already in use\b/ui.test(output)
+    || /\bport \d+ is already in use\b/ui.test(output)
   );
 }
 

--- a/packages/hosted-local-harness/test/dev-hosted-local/runtime.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/runtime.test.ts
@@ -377,6 +377,33 @@ describe("redactHostedLocalDiagnosticText", () => {
 });
 
 describe("spawnChildProcess diagnostics", () => {
+  it("retains bounded full text separately from the diagnostic tail", async () => {
+    const child = spawnChildProcess(
+      "cloudflare",
+      process.execPath,
+      [
+        "-e",
+        "process.stderr.write('Address already in use.\\n' + 'x'.repeat(4000))",
+      ],
+      process.env,
+      { pipeOutput: false },
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      child.child.once("exit", (code) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+
+        reject(new Error(`child exited with ${String(code)}`));
+      });
+    });
+
+    expect(child.stderrTail()).not.toContain("Address already in use");
+    expect(child.stderrText()).toContain("Address already in use");
+  });
+
   it("tails captured child output before running expensive diagnostic redaction", async () => {
     const child = spawnChildProcess(
       "web",

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -3493,6 +3493,35 @@ describe("hosted local dev stack", () => {
     );
   });
 
+  it("preserves an exited child's port-bind classification past verbose sibling output", async () => {
+    const cloudflareChild = createBufferedChild({
+      exitCode: 1,
+      name: "cloudflare",
+      pid: 503,
+      stderrText:
+        "Address already in use (0.0.0.0:43001).\n"
+        + "x".repeat(4_000),
+    });
+    spawnChildProcess
+      .mockReturnValueOnce(cloudflareChild)
+      .mockReturnValueOnce(createBufferedChild({
+        exitCode: null,
+        name: "web",
+        pid: 504,
+        stdoutText: "y".repeat(4_000),
+      }));
+    waitForHealthyHttpEndpoint.mockImplementationOnce(() => new Promise(() => {}));
+    waitForFirstChildExit.mockResolvedValueOnce(cloudflareChild);
+
+    const { startHostedLocalDevStack } = await import("../../src/dev-hosted-local/stack.ts");
+
+    const stack = await startHostedLocalDevStack({
+      env: process.env,
+    });
+
+    await expect(stack.ready).rejects.toThrow("Address already in use");
+  });
+
   it("skips Vercel link and env pull when the caller already provides a Vercel OIDC token", async () => {
     const configModule = await import("../../src/dev-hosted-local/config.ts");
     const vercelModule = await import("../../src/dev-hosted-local/vercel.ts");


### PR DESCRIPTION
## Why and outcome

Murph Cloud's hosted integration lane hit a transient Wrangler port-bind race, but verbose sibling startup output displaced Wrangler's `Address already in use` line from the aggregate diagnostic tail. The existing bounded startup retry therefore received only a generic child-exit error and did not activate.

This preserves the bounded full text separately from the short diagnostic tail, then adds a fixed port-collision classification from the exact exited child's already bounded, redacted buffer. The existing scenario owner can now retry with fresh port reservations; its three-attempt cap and all non-port failure behavior remain unchanged.

## Product UX

Not applicable. This changes internal hosted-local test/dev startup diagnostics and CI recovery only; member-visible behavior and production runtime behavior do not change.

## Evidence

- Red/green regression: `pnpm exec vitest run --config packages/hosted-local-harness/vitest.config.ts --no-coverage packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts`
- Existing bounded-retry and non-port coverage: `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts` (18 passed)
- Production-faithful buffer regression: a real spawned child proves the 2,000-character diagnostic tail drops an early bind marker while the bounded full-text reader retains it.
- Harness coverage lane: `pnpm --dir packages/hosted-local-harness test:coverage` (29 files, 449 passed, 1 skipped)
- Package typecheck: `pnpm --dir packages/hosted-local-harness typecheck`
- Package boundary: `pnpm --dir packages/hosted-local-harness verify:package-boundary`
- Exact-ref end-to-end proof is owned by the Murph Cloud integration checks on this PR because the available local private checkout is not the merged private head.

## Non-obvious affected surfaces

- Hosted-local startup error text: it now retains only a fixed port-collision classification when the exact exited child reported one. The new regression proves verbose sibling output cannot erase that classification.
- Generic hosted-local child buffers: `stdoutText()` and `stderrText()` now return their existing 2,000,000-character bounded/redacted text instead of inheriting the 2,000-character diagnostic-tail default. Tail readers are unchanged, and the real-child regression covers the distinction.
- Cloudflare full-stack scenario startup: no scenario code changes; its existing bounded retry can now observe the classification. Its focused suite proves port races retry and non-port failures do not.

## Architecture and reuse

- Existing systems reused: the exact child identity returned by `waitForFirstChildExit`, its bounded/redacted output buffers, and the scenario's existing three-attempt retry with fresh reservations.
- New logic: the existing full-text readers explicitly use the buffer's established bound; one local predicate recognizes the same closed port-bind signatures and adds a fixed classification to the primary startup error.
- New abstractions: none; the current stack lifecycle owner is sufficient, so no exported API, state owner, or dependency was added.
- Complexity intentionally avoided: no workflow-level rerun, port manager, second allocator, broader retry policy, or raw diagnostic retention.

## Complexity impact

- Guard: pass (`pnpm complexity:diff`); changed-file debt stayed 120 and maximum complexity stayed 140.
- Hotspots: existing `startHostedLocalDevStack` remains at 140 with no increase; `runtime.ts` remains below the threshold with maximum complexity 18. The new local predicate is below the threshold.
- Agent judgment: no further behavior-preserving simplification is justified; extracting a new owner or public error type would add indirection without changing the bounded contract.

## Hot reply path impact

Not applicable. The change is confined to hosted-local test/dev stack startup and adds no operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool/schema guidance, or provider-visible request assembly changed.
- Codex runtime: Not applicable; no prompt, tool/schema guidance, or provider-visible request assembly changed.

## Change-shape breakdown

Classification rule: authored runtime helper code is source; Vitest regression code is tests/fixtures; the execution plan is docs; no binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 3 |
| Tests/fixtures | 56 | 0 |
| Docs | 96 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **170** | **3** |

## Deployment concerns

- Deployment: not applicable
- Reason: this changes only the hosted-local test/dev harness; no production artifact, runtime configuration, database contract, Vercel surface, or Cloudflare deployment surface changes.

## Changelog

- Changelog: not applicable
- Reason: this is internal CI and local-harness reliability work with no member-visible outcome.

## ReviewGPT disposition

- Round 1: `FINDINGS`; one High finding accepted because the generic full-text readers still inherited the diagnostic-tail default and the original fake did not reproduce that behavior.
- Correction: the existing readers now use the existing 2,000,000-character bound explicitly, with a real spawned-child regression. No new owner, retry, state, or dependency was added.
- Round 2: `PASS`; the fresh sensitive full-snapshot review confirmed the finding is resolved and reported no qualifying findings.

ReviewGPT context sensitivity: sensitive

Reason: the change affects hosted-execution startup retry classification even though the patch is narrow and test/dev-only.

ReviewGPT first-reviewed head: e966a0ed93f7da2d2dbf86889c1f1dac9409c889
