### PR TITLE
Advance Temporal compatibility controller to final worker

### DIFF
--- a/.github/temporal-compatibility-controller.json
+++ b/.github/temporal-compatibility-controller.json
@@ -1,5 +1,5 @@
 {
   "contractVersion": 1,
-  "privateRef": "temporal-compatibility-v1-942744ba3d22ca0f72f7e25775c62ce16382ac54",
-  "privateSha": "942744ba3d22ca0f72f7e25775c62ce16382ac54"
+  "privateRef": "temporal-compatibility-v1-32e32a60b30b5d02ed7c3f51c921a11bf2c28820",
+  "privateSha": "32e32a60b30b5d02ed7c3f51c921a11bf2c28820"
 }


### PR DESCRIPTION
## Outcome

Bind the public Temporal compatibility controller to the exact merged private worker revision and its immutable lightweight tag.

## Product UX

No interface, reply, or member-state behavior changes. This is a release-control pointer update required before the protected worker controller can deploy the already-merged recovery operator.

## Direct evidence

- `node --test scripts/hosted-orchestration-compatibility.test.mjs`: 35 passed.
- `git diff --check`: passed.
- The referenced private tag exists and targets the same exact commit recorded in this policy.

## Non-obvious affected surfaces

- Public Temporal compatibility CI dispatches the exact private reader matrix from this immutable ref.
- The private deployment controller independently requires this public policy before any forward rollout mutation.

## Architecture and reuse

- Existing systems reused: the existing public compatibility-controller policy and immutable private lightweight tag.
- New logic: none; this advances the existing exact-SHA pointer only.
- New abstractions: none are required because the existing policy already owns the public-to-private release binding.
- Complexity intentionally avoided: no duplicate release state, workflow, runtime path, dependency, or compatibility layer.

## Complexity impact

- Guard: Not applicable because this changes only JSON release metadata and no authored JavaScript or TypeScript.
- Hotspots: The only touched hotspot is the existing exact-SHA policy binding; no executable path changes.
- Agent judgment: Advancing the single existing pointer avoids duplicate release state and keeps the controller fail-closed.

## Hot reply path impact

None.

## Provider-input impact

None.

## Deployment concerns

Merge before rerunning or completing the private Temporal worker rollout for the referenced revision.

## Changelog

Not applicable; protected release metadata only.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 2 | 2 |
| Generated / other | 0 | 0 |
| **Total** | **2** | **2** |
