### PR TITLE
Speed up Cloudflare container readiness probes

### DIFF
--- a/.agents/friction-log/20260830174923-hosted-local-docker/friction.md
+++ b/.agents/friction-log/20260830174923-hosted-local-docker/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Hosted-local Docker plugin discovery accepts directories without Buildx'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Hosted-local should select a Docker CLI plugin directory only when it contains an executable `docker-buildx`, and doctor should fail early with a clear prerequisite error when Buildx is unavailable.
+
+## Current Behavior
+
+The harness selects the first existing candidate directory. An empty earlier candidate hides a later valid Homebrew candidate, so Wrangler fails during container image preparation because its Buildx-only flags are parsed by the legacy builder. Startup cleanup then removes the isolated Docker config before Docker diagnostics run, which can replace the useful build failure with misleading socket and plugin errors.
+
+## Possible Solution
+
+Require an executable `docker-buildx` when selecting a plugin directory, include `docker buildx version` in doctor, and collect Docker diagnostics before removing the isolated Docker config.
+
+## Minimal Reproducible Example
+
+Create an empty first plugin candidate and a later candidate containing an executable synthetic `docker-buildx`. Start a hosted-local Containers scenario. The harness selects the empty directory and Wrangler exits before workerd starts, even though a valid later candidate exists.
+
+## Context
+
+A production-shaped cold-start E2E required an explicit `DOCKER_CONFIG` workaround despite Buildx already being installed. The failure occurred before the application readiness path and obscured unrelated performance verification.

--- a/.agents/friction-log/20260831195102-cloudflare-mixed-vitest/friction.md
+++ b/.agents/friction-log/20260831195102-cloudflare-mixed-vitest/friction.md
@@ -1,0 +1,41 @@
+---
+title: 'Cloudflare mixed Vitest projects do not release coordinator'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Every project in the Cloudflare Node Vitest workspace should finish and release
+the coordinator when all tests settle.
+
+## Current Behavior
+
+The existing runner, platform, and deploy projects exit together in the
+canonical command, and the actual-package Containers helper exits alone or
+beside either platform or deploy. Running all four projects in one process
+remains alive without new output beyond the clean three-project duration,
+forcing a bounded interruption. The optional no-cache parallel verifier can
+also hit an older nondeterministic coordinator shutdown hang in the original
+three-project workspace.
+
+## Possible Solution
+
+Make mixed-project handle ownership visible in Vitest diagnostics. The local
+workaround gives the real-package helper a dedicated Vitest config and runs it
+after the three existing projects.
+
+## Minimal Reproducible Example
+
+Register the helper alongside the three Cloudflare Node workspace projects and
+observe that the process does not exit. Then move the helper into a dedicated
+config and run it after the original workspace; both invocations exit
+successfully.
+
+## Context
+
+An actual-package readiness regression test needs a dedicated
+`cloudflare:workers` alias and package de-externalization. Sequential execution
+keeps the canonical suite deterministic without weakening that production-code
+coverage.
+
+<!-- Describe how this affected you, and what you were trying to accomplish. -->

--- a/agent-docs/exec-plans/completed/2026-08-30-container-readiness-probe.md
+++ b/agent-docs/exec-plans/completed/2026-08-30-container-readiness-probe.md
@@ -1,0 +1,202 @@
+# Bound Cloudflare container port probes
+
+Status: completed
+Created: 2026-08-30
+Updated: 2026-08-31
+
+## Goal
+
+- Remove the avoidable multi-second cold-start stall caused by a pre-listen
+  Cloudflare TCP-port probe remaining pending after the runner has begun
+  listening, without changing runtime admission, fencing, health, or lifecycle
+  ownership.
+- Product UX classification: Patch.
+- Outcome: cold hosted replies no longer inherit an avoidable readiness-proxy
+  wait when the runner itself is already starting normally.
+- Reaches: existing cold hosted conversation startup across the shared
+  RunnerContainer path; no channel, audience, permission, or response behavior
+  changes.
+- Proof: the real patched dependency must beat the production timing model by
+  at least 2 seconds while preserving one start, sequential settled probes,
+  healthy-state publication, onStart, abort, crash, and strict /health behavior.
+  The production image and local platform path must be exercised as far as the
+  host can faithfully support, with any architecture/emulation blocker recorded
+  instead of treating distorted local timing as managed-platform evidence.
+
+## Success criteria
+
+- `@cloudflare/containers` remains the lifecycle owner through
+  `startAndWaitForPorts`; no raw container-start or duplicate readiness path is
+  introduced.
+- Murph opts into a 1,500 ms per-probe deadline while retaining the existing
+  250 ms retry interval and outer readiness budget.
+- An actual-package deterministic A/B matching the observed production phase
+  timings shows more than 2,000 ms median-path savings in the modeled
+  start-to-ports span.
+- The same test proves timed-out probes abort and settle before retry, the
+  platform start and onStart each happen once, and state becomes healthy only
+  after a successful port probe.
+- Caller abort and true container-crash cases remain fail-closed with no late
+  healthy transition or dangling probe.
+- Focused RunnerContainer tests, Cloudflare typecheck/build, dependency guards,
+  and isolated Node/Workers projects pass. The exact production image builds;
+  any inability to complete the production-shaped hosted-local delivery
+  scenario is recorded with the failing infrastructure layer and next proof.
+- The benchmark reports start-to-ports, process-to-listen, and listen-to-ports
+  spans so a later managed-Cloudflare canary can accept only a >=2 second p50
+  win with no failure-rate regression.
+
+## Scope
+
+- In scope:
+  - Pin and locally patch the current Cloudflare Containers helper.
+  - Add an opt-in per-port-probe timeout that defaults to upstream behavior.
+  - Configure the three RunnerContainer startup paths to use the bounded probe.
+  - Add actual-package lifecycle/timing coverage and expose existing benchmark
+    phase timestamps as aggregate durations.
+  - Reconcile hosted runtime and deploy documentation.
+- Out of scope:
+  - Bypassing `startAndWaitForPorts`, changing runtime health or write-fence
+    semantics, changing the runner image, or shortening the outer startup
+    deadline.
+  - Deploying to Cloudflare or claiming that local Docker proves the managed
+    port-proxy latency improvement.
+  - An upstream Cloudflare pull request.
+
+## Constraints
+
+- Technical constraints:
+  - Every probe retry must use a real AbortSignal and await fetch rejection;
+    a naked Promise.race is not acceptable because it can leave overlapping
+    requests.
+  - Defaults for unconfigured package consumers stay at 5,000 ms.
+  - Strict runner `/health`, bundle/source fingerprint, poison, cleanup, and
+    generation checks remain after port connectivity.
+  - The dependency is exact-version pinned so a lock refresh cannot silently
+    drop the local patch.
+- Product/process constraints:
+  - Local proof may establish correctness and the modeled saving only. A
+    managed-Cloudflare canary remains the release proof for the real >=2 second
+    median outcome.
+  - Production evidence stays aggregate and identifier-free.
+  - No upstream PR or production deployment is part of this task.
+
+## Risks and mitigations
+
+1. Risk: A short timeout abandons the JavaScript wait but not the native fetch,
+   causing overlapping probes.
+   Mitigation: use the helper's AbortSignal path and assert max in-flight probes
+   is one and zero remain unsettled after success, abort, and crash.
+2. Risk: Reimplementing readiness skips Cloudflare state, monitor, or hook
+   behavior.
+   Mitigation: preserve `startAndWaitForPorts` and patch only its opt-in probe
+   deadline.
+3. Risk: Faster polling observes a transient false `container.running` value.
+   Mitigation: retain current error semantics, include true-crash coverage, and
+   require a managed canary to show no increase in crash, restart, cleanup, or
+   startup-failure rates before rollout.
+4. Risk: Local Docker passes while the managed Cloudflare proxy behaves
+   differently.
+   Mitigation: keep the claim explicitly conditional on a later 30-50 sample
+   managed canary; do not deploy in this task.
+
+## Tasks
+
+1. Capture the current helper/version and benchmark ownership boundary.
+2. Add the real-package deterministic failing timing/lifecycle reproduction.
+3. Upgrade to the current patch release, add the local dependency patch, and
+   opt RunnerContainer into a 1,500 ms probe deadline.
+4. Add call-site, abort, crash, no-overlap, and benchmark-output coverage.
+5. Run dependency, focused, package, image, and hosted-local verification.
+6. Complete Product UX walkthrough, review gates, documentation, plan closure,
+   and a scoped local commit handoff. Do not open an upstream pull request or
+   deploy the patch.
+
+## Decisions
+
+- Keep Cloudflare's lifecycle helper instead of adding a custom start/probe
+  implementation.
+- Add an opt-in timeout rather than changing the package-wide default; this
+  keeps unrelated consumers at upstream behavior and permits an exact A/B in
+  the actual-package test.
+- Use 1,500 ms: this is Cloudflare's prior helper value, production `/health`
+  is roughly 50 ms p50, and the production-shaped timing model still clears the
+  requested two-second saving with fewer aborted probes than 500 ms.
+- Use `@cloudflare/containers` 0.3.7 as the patch base because it includes the
+  latest directly relevant start/stop state-race correction while retaining
+  the same hard-coded 5 second probes.
+- A 24-hour aggregate direct-cold cohort had 16 causal samples: accepted to
+  runner-job p50 was about 6.35 seconds and readiness p50 was about 4.81
+  seconds. Nine samples with the newer subdivisions had start-to-ports p50
+  4.476 seconds, process-to-listen p50 0.939 seconds,
+  listen-to-ports p50 2.776 seconds, and final health p50 0.053 seconds. These
+  aggregates identify the port-proxy wait rather than Node boot or health as
+  the removable median bucket.
+- The actual-package timing model reproduces 4.475 seconds with the unchanged
+  default and 1.850 seconds with the 1.5 second opt-in, a modeled 2.625 second
+  saving. This is a counterfactual for the measured phase, not a claim that
+  local Docker reproduces managed Cloudflare latency.
+- Cloudflare originally added a bounded probe to stop readiness fetches from
+  hanging, [first near 300 ms](https://github.com/cloudflare/containers/commit/674380f1aa7b3cc468ca44f41df808243d6d63e1),
+  [then 1.5 seconds](https://github.com/cloudflare/containers/commit/69a978a320378b427ba06640d362e11cfc2b37ae).
+  The value later [became five seconds](https://github.com/cloudflare/containers/commit/168fb9697f5b583aad712eb3f6e00b5b280d074f)
+  in an unrelated scheduling change without a documented safety rationale.
+  There is no exact open issue. Draft
+  [containers PR 109](https://github.com/cloudflare/containers/pull/109)
+  proposed a configurable timeout, while stale
+  [containers PR 188](https://github.com/cloudflare/containers/pull/188)
+  proposes composable readiness but keeps five-second built-in probes.
+- Public Workerd source shows request abort
+  [closes the probe](https://github.com/cloudflare/workerd/blob/29ee6949f48c3bd97b5bec542777f53ef42a3397/src/workerd/api/http.c%2B%2B#L1676-L1739)
+  and [tears down its tunnel](https://github.com/cloudflare/workerd/blob/29ee6949f48c3bd97b5bec542777f53ef42a3397/src/workerd/api/container.c%2B%2B#L1097-L1106)
+  rather than stopping the container. Managed peer-side implementation remains
+  private, so a managed canary is still required before rollout.
+
+## Verification results
+
+- The actual patched package passes six lifecycle tests covering the 2.625
+  second modeled saving, both modified probe sites, direct prewarm start,
+  listener cleanup, caller abort, true crash, sequential retries, and no late
+  healthy transition.
+- RunnerContainer passes 1,216 tests. The platform project passes 1,293 tests
+  with two intentional skips; the deploy project passes 244; the Workers
+  project passes 15. Cloudflare typecheck and build pass.
+- Frozen install, dependency policy, ignored-build policy, exact patch hash,
+  exact installed-package resolution, and dry-run application to pristine 0.3.7
+  pass. The dependency audit reports the same existing 79 advisories as the
+  untouched lockfile, so this patch adds none.
+- The canonical Node command passes 2,759 tests with two intentional skips.
+  The three existing projects run in their original workspace, and the six
+  actual-package helper tests use a dedicated config because registering that
+  alias-sensitive helper in the mixed workspace could keep Vitest alive after
+  the tests settled.
+- The optional parallel verifier passed typecheck and all 15 Workers-runtime
+  tests, then its unchanged no-cache Node workspace process remained alive for
+  12 minutes without a reported test failure. The exact owned process tree was
+  interrupted cleanly; the canonical serial Node command above is green, while
+  this pre-existing no-cache/coordinator shutdown flake remains explicit.
+- The exact production amd64 Dockerfile and runner artifact build. Local
+  Workerd, its container proxy, the production entrypoint, Node startup, abort,
+  and cleanup were exercised. A full delivery benchmark did not produce valid
+  samples: the ARM path hits the known QEMU child-subreaper bug, while isolated
+  whole-system x86 emulation is too slow for the existing 60-second deploy
+  smoke and distorts latency. No production code or image entrypoint was changed
+  to make the repro pass.
+- Release proof remains 30–50 alternating managed fresh starts. Require at
+  least a two-second p50 improvement, no new startup-failure category or failed
+  start increase, and candidate p95 no more than one second slower before
+  widening traffic.
+
+## Residuals and handoff
+
+- The inherited implicit `containerFetch()` auto-start fallback retains the
+  upstream five-second timeout. The three authoritative Murph startup paths use
+  1.5 seconds, so the fallback is outside the measured median path and remains
+  conservative.
+- The published package's source maps all point to source files omitted from
+  the npm artifact. This patch does not regenerate one already-unusable map;
+  runtime code and declarations are patched and verified.
+- Changelog: not applicable to this local, unshipped patch. Do not publish a
+  numeric member-visible claim until the managed canary proves it.
+- No upstream pull request or production deployment is part of this handoff.
+Completed: 2026-08-31

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -2688,6 +2688,14 @@ This matches the runner readiness ceiling without weakening invalidated-shell
 or destroy-settlement checks. Accepted background invocations begin their
 pending I/O before acceptance; Durable Object
 `waitUntil()` is not a lifecycle mechanism and is not used.
+Within that unchanged outer budget, the shell-prewarm, direct cold-start, and
+deploy-smoke paths make each native TCP readiness request abortable after 1.5
+seconds and retry sequentially on the existing 250 ms interval. The helper
+awaits cancellation before another probe begins. A probe timeout is therefore
+only a retry signal: it cannot publish healthy state, run `onStart`, invoke
+workspace work, or replace the existing crash and caller-abort paths. The
+helper's inherited implicit `containerFetch()` auto-start fallback retains the
+upstream five-second default.
 Container readiness receives at most 15 wall-clock seconds, including time
 queued for the container lifecycle lock. Once readiness-triggered cleanup starts, the RPC
 allows one absolute five-second fail-closed cleanup deadline shared by the
@@ -3774,6 +3782,9 @@ An actual cold readiness RPC also carries optional numeric-only subdivisions.
 `freshStartContainerOnStartAtEpochMs` records Cloudflare's lifecycle hook; and
 `freshStartContainerPortsReadyAtEpochMs` records resolution of
 `startAndWaitForPorts`, after both the configured port and `onStart` are ready.
+The local cold-start benchmark reports start-to-ports, process-to-listen, and
+listen-to-ports percentiles from these stamps so a hosted canary can distinguish
+container boot time from managed port-proxy delay.
 The explicit private health fetch is bounded by
 `freshStartContainerHealthStartedAtEpochMs` and
 `freshStartContainerHealthFinishedAtEpochMs`, followed by

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1220,6 +1220,19 @@ Normal deploy smoke targets the public Worker banner and health endpoints after 
 
 The Worker also enforces that fingerprint contract on the normal user path. Before a warm or newly started runner receives a workspace invocation, its `/health` response must report the bundle and source fingerprints embedded in the generated Worker config. A stale warm shell is destroyed and restarted. Direct cold readiness may destroy and replace one stale bundle/source image inside the same lifecycle operation, using only the original caller deadline; the replacement must pass the exact architecture and fingerprint checks. A second mismatch, any other readiness failure, unsettled cleanup, an expired deadline, or changed container ownership still fails closed without receiving user work. Post-deploy smoke remains the rollout proof, while per-invocation admission prevents the window between a direct Worker deploy and that smoke from serving work through an old runner.
 
+The Worker pins and locally patches `@cloudflare/containers` so the
+shell-prewarm, direct cold-start, and deploy-smoke paths time out one TCP
+readiness request after 1.5 seconds while the existing total startup deadline,
+health validation, lifecycle hooks, and failure cleanup remain unchanged. The
+helper's implicit `containerFetch()` auto-start fallback retains the upstream
+five-second default. This is a Worker-only dependency change with no runner
+image, schema, or persisted-data migration. Before widening traffic, compare
+30–50 alternating fresh starts for the prior and candidate Worker versions.
+Require at least a 2-second p50 improvement, no new startup-failure category or
+increase in failed starts, and a candidate p95 no more than one second slower
+than the prior version. Rollback is the prior Worker version; no data rollback
+is needed.
+
 The production smoke also runs one real `gpt-5.6-terra` model turn inside the deployed runner container (`HOSTED_EXECUTION_SMOKE_LIVE_MODEL_TURN=true`, set by the deploy workflow's `live_model_turn` input, default on). The container runs a single non-interactive `codex exec` in a scratch workspace with the injected-credential placeholder; the Worker egress intercept authorizes exactly one deploy-smoke fenced `POST /v1/responses` request for `gpt-5.6-terra` and injects the real Worker-owned `OPENAI_API_KEY`, so the smoke proves the rollout target's OpenAI auth, account availability, quota, request compatibility, and network path without the raw key ever entering the container. The container accepts the smoke only when Codex JSONL reports the final agent output as exactly `OK`. Cost posture: exactly one bounded model turn per production deploy; the flag is never set in per-PR CI or hosted-local E2E, so those paths are byte-for-byte unchanged.
 
 ## Venice Provider Activation

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -584,6 +584,15 @@ handlers. The runner does not run a separate post-request PID sweep over the
 native Codex App Server; warm lifecycle is owned by the existing Codex
 app-server slot and explicit runner cleanup paths.
 
+The shell-prewarm, direct cold-start, and deploy-smoke paths give each native
+TCP readiness request a 1.5 second deadline and retry sequentially on the
+existing 250 ms interval. The overall readiness budget is unchanged. A probe
+timeout cannot publish `healthy`, call workspace code, or fail the container by
+itself; the patched Containers helper awaits the aborted request before
+retrying, and only its existing successful lifecycle path publishes healthy
+state and runs `onStart`. Its implicit `containerFetch()` auto-start fallback
+retains the upstream five-second default.
+
 Legacy artifact `GET` requests attach a validated read-purpose header and one
 UUID correlation id that is stable across replay-safe retries. Runner and Worker
 structured logs use only those fields plus bounded timing/status metadata; they

--- a/apps/cloudflare/package.json
+++ b/apps/cloudflare/package.json
@@ -24,7 +24,9 @@
     "build": "node ../../scripts/rm-paths.mjs dist && node ../../scripts/run-typescript.mjs package -b tsconfig.build.json --pretty false",
     "typecheck": "node ../../scripts/run-typescript.mjs package -p tsconfig.typecheck.json --pretty false",
     "test": "pnpm typecheck && pnpm test:node",
-    "test:node": "pnpm --dir ../.. exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage",
+    "test:node": "pnpm test:node:workspace && pnpm test:node:containers-helper",
+    "test:node:workspace": "pnpm --dir ../.. exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage",
+    "test:node:containers-helper": "pnpm --dir ../.. exec vitest run --config apps/cloudflare/vitest.containers-helper.config.ts --no-coverage",
     "test:e2e:local": "pnpm test:e2e:hosted-local && pnpm test:e2e:workers:local",
     "test:e2e:hosted-local": "pnpm --dir ../.. hosted-local e2e",
     "test:e2e:workers:local": "pnpm test:workers",
@@ -61,7 +63,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "@cloudflare/containers": "^0.3.6",
+    "@cloudflare/containers": "0.3.7",
     "@linqapp/sdk": "0.34.0",
     "@murphai/assistant-engine": "workspace:*",
     "@murphai/assistant-runtime": "workspace:*",

--- a/apps/cloudflare/scripts/verify-fast.sh
+++ b/apps/cloudflare/scripts/verify-fast.sh
@@ -187,3 +187,14 @@ workers_pid="$!"
 register_background_pid "$workers_pid"
 
 wait_for_background_jobs "$node_pid" "$workers_pid"
+
+# The helper project bundles the real Cloudflare package with a dedicated
+# cloudflare:workers shim. Keep that one-second harness out of the heavy mixed
+# project process so Vitest can deterministically release every worker.
+pnpm --dir "$repo_root" exec vitest run \
+  --config apps/cloudflare/vitest.containers-helper.config.ts \
+  --no-coverage \
+  --cache=false &
+helper_pid="$!"
+register_background_pid "$helper_pid"
+wait_for_background_jobs "$helper_pid"

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -70,6 +70,8 @@ const RUNNER_DIRECT_R2_PRESIGNED_PUT_SMOKE_URL =
 const RUNNER_LIVE_MODEL_TURN_SMOKE_MIN_TIMEOUT_MS = 90_000;
 const RUNNER_RUNTIME_WAKE_URL = "http://container/internal/runtime-wake";
 const RUNNER_WAIT_INTERVAL_MS = 250;
+// Per attempt only; the outer readiness budget and strict /health gate remain authoritative.
+const RUNNER_PORT_PROBE_TIMEOUT_MS = 1_500;
 const RUNNER_STOPPED_REQUEST_SETTLE_MS = 1_000;
 const RUNNER_DESTROY_SETTLE_TIMEOUT_MS = 5_000;
 const DEFAULT_RUNNER_READY_TIMEOUT_MS = 20_000;
@@ -1022,6 +1024,7 @@ export class RunnerContainer extends Container {
             await this.start(undefined, {
               portToCheck: RUNNER_PORT,
               signal,
+              portProbeTimeoutMS: RUNNER_PORT_PROBE_TIMEOUT_MS,
             });
             return { action: "start_issued", kind: "started" };
           } finally {
@@ -2534,6 +2537,7 @@ export class RunnerContainer extends Container {
             instanceGetTimeoutMS: readinessTimeoutMs,
             portReadyTimeoutMS: readinessTimeoutMs,
             waitInterval: RUNNER_WAIT_INTERVAL_MS,
+            portProbeTimeoutMS: RUNNER_PORT_PROBE_TIMEOUT_MS,
           },
         });
         if (options.startupFailureObservation) {
@@ -2777,6 +2781,7 @@ export class RunnerContainer extends Container {
         instanceGetTimeoutMS: timeoutMs,
         portReadyTimeoutMS: timeoutMs,
         waitInterval: RUNNER_WAIT_INTERVAL_MS,
+        portProbeTimeoutMS: RUNNER_PORT_PROBE_TIMEOUT_MS,
       },
     });
     if (!this.recordContainerReady(

--- a/apps/cloudflare/test/containers-helper-readiness.test.ts
+++ b/apps/cloudflare/test/containers-helper-readiness.test.ts
@@ -1,0 +1,483 @@
+import { Container } from "@cloudflare/containers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const runnerPort = 8_080;
+const productionStartToListenMs = 1_650;
+const productionStickyProbeReleaseMs = 4_425;
+const readyProbeResponseMs = 50;
+const runnerPollIntervalMs = 250;
+const boundedProbeTimeoutMs = 1_500;
+
+interface ProbeStats {
+  abortedProbeCount: number;
+  healthyAtMs: number | null;
+  inFlightProbeCount: number;
+  maxInFlightProbeCount: number;
+  onErrorCount: number;
+  onStartCount: number;
+  probeStartedAtMs: number[];
+  settledProbeCount: number;
+  startCount: number;
+  stateTransitions: string[];
+}
+
+interface ProbeHarness {
+  abortContext: ReturnType<typeof vi.fn>;
+  crash(exitCode?: number): void;
+  runner: Container;
+  stats: ProbeStats;
+}
+
+describe("patched Cloudflare container readiness probes", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cuts the production-shaped sticky-probe path by more than two seconds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
+
+    const baseline = await runTimingVariant();
+    vi.setSystemTime(new Date("2026-08-30T12:01:00.000Z"));
+    const bounded = await runTimingVariant(boundedProbeTimeoutMs);
+
+    expect(baseline.stats.healthyAtMs).toBe(4_475);
+    expect(baseline.stats.abortedProbeCount).toBe(0);
+    expect(baseline.stats.probeStartedAtMs).toEqual([0, 4_425]);
+
+    expect(bounded.stats.healthyAtMs).toBe(1_850);
+    expect(bounded.stats.abortedProbeCount).toBe(1);
+    expect(bounded.stats.probeStartedAtMs).toEqual([
+      0,
+      1_750,
+      1_800,
+    ]);
+    expect(
+      (baseline.stats.healthyAtMs ?? 0) - (bounded.stats.healthyAtMs ?? 0),
+    ).toBeGreaterThan(2_000);
+
+    for (const result of [baseline, bounded]) {
+      expect(result.stats.startCount).toBe(1);
+      expect(result.stats.onStartCount).toBe(1);
+      expect(result.stats.onErrorCount).toBe(0);
+      expect(result.stats.maxInFlightProbeCount).toBe(1);
+      expect(result.stats.inFlightProbeCount).toBe(0);
+      expect(result.stats.settledProbeCount).toBe(
+        result.stats.probeStartedAtMs.length,
+      );
+      expect(result.stats.stateTransitions).toEqual([
+        "stopped",
+        "running",
+        "healthy",
+      ]);
+      await expect(result.runner.getState()).resolves.toMatchObject({
+        status: "healthy",
+      });
+      expect(result.abortContext).not.toHaveBeenCalled();
+    }
+  });
+
+  it("applies the bounded probe to the direct start path used by shell prewarm", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:01:30.000Z"));
+    const harness = await createProbeHarness({
+      listeningAtMs: productionStartToListenMs,
+      stickyProbeReleaseMs: productionStickyProbeReleaseMs,
+    });
+    const started = harness.runner.start(undefined, {
+      portProbeTimeoutMS: boundedProbeTimeoutMs,
+      portToCheck: runnerPort,
+      retries: 32,
+      waitInterval: runnerPollIntervalMs,
+    });
+
+    await vi.advanceTimersByTimeAsync(8_000);
+    await started;
+
+    expect(harness.stats.probeStartedAtMs).toEqual([0, 1_750]);
+    expect(harness.stats.abortedProbeCount).toBe(1);
+    expect(harness.stats.maxInFlightProbeCount).toBe(1);
+    expect(harness.stats.inFlightProbeCount).toBe(0);
+    expect(harness.stats.startCount).toBe(1);
+    expect(harness.stats.onStartCount).toBe(1);
+    expect(harness.stats.onErrorCount).toBe(0);
+    expect(harness.stats.stateTransitions).toEqual(["running"]);
+    await expect(harness.runner.getState()).resolves.toMatchObject({
+      status: "running",
+    });
+  });
+
+  it("bounds a sticky port-confirmation probe after the initial start probe succeeds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:01:40.000Z"));
+
+    const runVariant = async (
+      portProbeTimeoutMS?: number,
+    ): Promise<ProbeHarness> => {
+      const harness = await createProbeHarness({
+        listeningAtMs: 0,
+        stickyProbeNumbers: [2],
+        stickyProbeReleaseMs: productionStickyProbeReleaseMs,
+      });
+      const readiness = harness.runner.startAndWaitForPorts({
+        cancellationOptions: {
+          instanceGetTimeoutMS: 8_000,
+          ...(portProbeTimeoutMS === undefined ? {} : { portProbeTimeoutMS }),
+          portReadyTimeoutMS: 8_000,
+          waitInterval: runnerPollIntervalMs,
+        },
+        ports: runnerPort,
+      });
+
+      await vi.advanceTimersByTimeAsync(8_000);
+      await readiness;
+      return harness;
+    };
+
+    const baseline = await runVariant();
+    vi.setSystemTime(new Date("2026-08-30T12:01:50.000Z"));
+    const bounded = await runVariant(boundedProbeTimeoutMs);
+
+    expect(baseline.stats.healthyAtMs).toBe(4_425);
+    expect(baseline.stats.probeStartedAtMs).toEqual([0, 50]);
+    expect(bounded.stats.healthyAtMs).toBe(1_850);
+    expect(bounded.stats.probeStartedAtMs).toEqual([0, 50, 1_800]);
+    expect(bounded.stats.abortedProbeCount).toBe(1);
+    expect(bounded.stats.maxInFlightProbeCount).toBe(1);
+    expect(bounded.stats.inFlightProbeCount).toBe(0);
+    expect(bounded.stats.settledProbeCount).toBe(3);
+    expect(bounded.stats.onStartCount).toBe(1);
+    expect(bounded.stats.stateTransitions).toEqual([
+      "stopped",
+      "running",
+      "healthy",
+    ]);
+  });
+
+  it("removes each per-probe listener forwarded from the outer abort signal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:01:45.000Z"));
+    const harness = await createProbeHarness({
+      listeningAtMs: productionStartToListenMs,
+      stickyProbeReleaseMs: productionStickyProbeReleaseMs,
+    });
+    const abortController = new AbortController();
+    const addEventListener = vi.spyOn(
+      abortController.signal,
+      "addEventListener",
+    );
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    );
+    const readiness = harness.runner.startAndWaitForPorts({
+      cancellationOptions: {
+        abort: abortController.signal,
+        instanceGetTimeoutMS: 8_000,
+        portProbeTimeoutMS: boundedProbeTimeoutMs,
+        portReadyTimeoutMS: 8_000,
+        waitInterval: runnerPollIntervalMs,
+      },
+      ports: runnerPort,
+    });
+
+    await vi.advanceTimersByTimeAsync(8_000);
+    await readiness;
+
+    const forwardedListenerCount = addEventListener.mock.calls.filter(
+      ([eventName, _listener, options]) =>
+        eventName === "abort"
+        && typeof options === "object"
+        && options !== null
+        && "once" in options
+        && options.once === true,
+    ).length;
+    expect(forwardedListenerCount).toBeGreaterThan(2);
+    expect(removeEventListener.mock.calls.filter(
+      ([eventName]) => eventName === "abort",
+    )).toHaveLength(forwardedListenerCount);
+  });
+
+  it("propagates caller abort without a retry or late healthy transition", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:02:00.000Z"));
+    const harness = await createProbeHarness({
+      listeningAtMs: 10_000,
+      stickyProbeReleaseMs: 10_000,
+    });
+    const abortController = new AbortController();
+    const readiness = harness.runner.startAndWaitForPorts({
+      cancellationOptions: {
+        abort: abortController.signal,
+        instanceGetTimeoutMS: 8_000,
+        portProbeTimeoutMS: boundedProbeTimeoutMs,
+        portReadyTimeoutMS: 8_000,
+        waitInterval: runnerPollIntervalMs,
+      },
+      ports: runnerPort,
+    });
+    const rejection = expect(readiness).rejects.toThrow(
+      "Aborted waiting for container to start",
+    );
+
+    setTimeout(() => abortController.abort(new DOMException("Timed out", "TimeoutError")), 200);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+
+    expect(harness.stats.startCount).toBe(1);
+    expect(harness.stats.probeStartedAtMs).toEqual([0]);
+    expect(harness.stats.abortedProbeCount).toBe(1);
+    expect(harness.stats.maxInFlightProbeCount).toBe(1);
+    expect(harness.stats.inFlightProbeCount).toBe(0);
+    expect(harness.stats.onStartCount).toBe(0);
+    expect(harness.stats.stateTransitions).not.toContain("healthy");
+    expect(harness.abortContext).not.toHaveBeenCalled();
+  });
+
+  it("preserves true-crash handling without publishing healthy state", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:03:00.000Z"));
+    const harness = await createProbeHarness({
+      crashAtMs: 100,
+      listeningAtMs: 10_000,
+      stickyProbeReleaseMs: 10_000,
+    });
+    const readiness = harness.runner.startAndWaitForPorts({
+      cancellationOptions: {
+        instanceGetTimeoutMS: 8_000,
+        portProbeTimeoutMS: boundedProbeTimeoutMs,
+        portReadyTimeoutMS: 8_000,
+        waitInterval: runnerPollIntervalMs,
+      },
+      ports: runnerPort,
+    });
+    const rejection = expect(readiness).rejects.toThrow(
+      "container exited with unexpected exit code: 17",
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+
+    expect(harness.stats.startCount).toBe(1);
+    expect(harness.stats.onErrorCount).toBe(1);
+    expect(harness.stats.onStartCount).toBe(0);
+    expect(harness.stats.maxInFlightProbeCount).toBe(1);
+    expect(harness.stats.inFlightProbeCount).toBe(0);
+    expect(harness.stats.stateTransitions).not.toContain("healthy");
+    await expect(harness.runner.getState()).resolves.toMatchObject({
+      status: "stopped",
+    });
+    expect(harness.abortContext).not.toHaveBeenCalled();
+  });
+});
+
+async function runTimingVariant(
+  portProbeTimeoutMS?: number,
+): Promise<ProbeHarness> {
+  const harness = await createProbeHarness({
+    listeningAtMs: productionStartToListenMs,
+    stickyProbeReleaseMs: productionStickyProbeReleaseMs,
+  });
+  const readiness = harness.runner.startAndWaitForPorts({
+    cancellationOptions: {
+      instanceGetTimeoutMS: 8_000,
+      ...(portProbeTimeoutMS === undefined ? {} : { portProbeTimeoutMS }),
+      portReadyTimeoutMS: 8_000,
+      waitInterval: runnerPollIntervalMs,
+    },
+    ports: runnerPort,
+  });
+
+  await vi.advanceTimersByTimeAsync(8_000);
+  await readiness;
+  return harness;
+}
+
+async function createProbeHarness(options: {
+  crashAtMs?: number;
+  listeningAtMs: number;
+  stickyProbeNumbers?: readonly number[];
+  stickyProbeReleaseMs: number;
+}): Promise<ProbeHarness> {
+  const startedAtMs = Date.now();
+  const state = new Map<string, unknown>();
+  const constructorOperations: Promise<unknown>[] = [];
+  const stats: ProbeStats = {
+    abortedProbeCount: 0,
+    healthyAtMs: null,
+    inFlightProbeCount: 0,
+    maxInFlightProbeCount: 0,
+    onErrorCount: 0,
+    onStartCount: 0,
+    probeStartedAtMs: [],
+    settledProbeCount: 0,
+    startCount: 0,
+    stateTransitions: [],
+  };
+  let running = false;
+  let crashScheduled = false;
+  let rejectMonitor: (error: Error) => void = () => undefined;
+  const monitor = new Promise<void>((_resolve, reject) => {
+    rejectMonitor = reject;
+  });
+  // Workerd owns this RPC promise outside the Node event loop. Attach a test-only
+  // observer so its intentional rejection is not reported as an unhandled Node promise
+  // before the helper inspects it on the next readiness iteration.
+  void monitor.catch(() => undefined);
+
+  const elapsedMs = (): number => Date.now() - startedAtMs;
+  const crash = (exitCode = 17): void => {
+    running = false;
+    rejectMonitor(new Error(`container exited with unexpected exit code: ${exitCode}`));
+  };
+  const containerBinding = {
+    destroy: vi.fn(async () => {
+      crash(137);
+    }),
+    get running() {
+      return running;
+    },
+    getTcpPort: vi.fn((_port: number) => ({
+      fetch: async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        const probeStartedAtMs = elapsedMs();
+        stats.probeStartedAtMs.push(probeStartedAtMs);
+        const probeNumber = stats.probeStartedAtMs.length;
+        stats.inFlightProbeCount += 1;
+        stats.maxInFlightProbeCount = Math.max(
+          stats.maxInFlightProbeCount,
+          stats.inFlightProbeCount,
+        );
+
+        return await new Promise<Response>((resolve, reject) => {
+          let settled = false;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const signal = init?.signal;
+          const finish = (callback: () => void): void => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            if (timer !== null) {
+              clearTimeout(timer);
+            }
+            signal?.removeEventListener("abort", onAbort);
+            stats.inFlightProbeCount -= 1;
+            stats.settledProbeCount += 1;
+            callback();
+          };
+          const onAbort = (): void => {
+            stats.abortedProbeCount += 1;
+            finish(() => reject(
+              signal?.reason instanceof Error
+                ? signal.reason
+                : new DOMException("The operation was aborted", "AbortError"),
+            ));
+          };
+
+          if (signal?.aborted) {
+            onAbort();
+            return;
+          }
+          signal?.addEventListener("abort", onAbort, { once: true });
+
+          if (
+            options.crashAtMs !== undefined
+            && !crashScheduled
+            && probeStartedAtMs < options.crashAtMs
+          ) {
+            crashScheduled = true;
+            timer = setTimeout(() => {
+              crash();
+              finish(() => reject(new Error("the container is not listening")));
+            }, options.crashAtMs - probeStartedAtMs);
+            return;
+          }
+
+          const useStickyRelease = options.stickyProbeNumbers?.includes(
+            probeNumber,
+          ) ?? probeStartedAtMs < options.listeningAtMs;
+          const completesAtMs = useStickyRelease
+            ? options.stickyProbeReleaseMs
+            : probeStartedAtMs + readyProbeResponseMs;
+          timer = setTimeout(() => {
+            finish(() => resolve(new Response(null, { status: 204 })));
+          }, Math.max(0, completesAtMs - elapsedMs()));
+        });
+      },
+    })),
+    monitor: vi.fn(() => monitor),
+    signal: vi.fn((_signal: number) => undefined),
+    start: vi.fn((_config: unknown) => {
+      running = true;
+      stats.startCount += 1;
+    }),
+  };
+  const storage = {
+    delete: vi.fn(async (key: string) => {
+      state.delete(key);
+    }),
+    get: vi.fn(async (key: string) => state.get(key)),
+    kv: {
+      get: vi.fn((key: string) => state.get(key)),
+      put: vi.fn((key: string, value: unknown) => {
+        state.set(key, value);
+      }),
+    },
+    put: vi.fn(async (key: string, value: unknown) => {
+      state.set(key, value);
+      if (
+        value
+        && typeof value === "object"
+        && "status" in value
+        && typeof value.status === "string"
+      ) {
+        stats.stateTransitions.push(value.status);
+        if (value.status === "healthy") {
+          stats.healthyAtMs = elapsedMs();
+        }
+      }
+    }),
+    setAlarm: vi.fn(async (_atMs: number) => undefined),
+    sql: {
+      exec: vi.fn((_query: string, ..._values: readonly unknown[]) => []),
+    },
+    sync: vi.fn(async () => undefined),
+  };
+  const abortContext = vi.fn();
+  const context = {
+    abort: abortContext,
+    blockConcurrencyWhile: vi.fn((operation: () => Promise<unknown>) => {
+      const result = Promise.resolve().then(operation);
+      constructorOperations.push(result);
+      return result;
+    }),
+    container: containerBinding,
+    storage,
+  };
+
+  class ProbeContainer extends Container {
+    defaultPort = runnerPort;
+    requiredPorts = [runnerPort];
+
+    override onError(_error: unknown): void {
+      stats.onErrorCount += 1;
+    }
+
+    override onStart(): void {
+      stats.onStartCount += 1;
+    }
+  }
+
+  const runner = new ProbeContainer(context as never, {});
+  await Promise.all(constructorOperations);
+
+  return {
+    abortContext,
+    crash,
+    runner,
+    stats,
+  };
+}

--- a/apps/cloudflare/test/hosted-local-cold-start-benchmark-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-cold-start-benchmark-e2e.test.ts
@@ -86,6 +86,10 @@ const replyText = "Cold-start benchmark reply.";
 const setupReplyText = "Cold-start benchmark setup complete.";
 const productionMedianPayloadBytes = 14_000_000;
 const streamDevLogs = process.env.MURPH_E2E_STREAM_DEV_LOGS === "1";
+const setupTimeoutMs =
+  process.env.MURPH_HOSTED_LOCAL_E2E_EXTENDED_SETUP_TIMEOUT === "1"
+    ? 900_000
+    : 300_000;
 const execFileAsync = promisify(execFile);
 
 interface ColdStartSample {
@@ -96,6 +100,9 @@ interface ColdStartSample {
   automationBootstrapMs?: number;
   archiveExtractMs?: number;
   cleanupMs?: number;
+  containerListeningToPortsReadyMs?: number;
+  containerProcessToListeningMs?: number;
+  containerStartToPortsReadyMs?: number;
   dataKeyUnwrapMs?: number;
   decryptMs?: number;
   durableRootReplaceMs?: number;
@@ -170,7 +177,7 @@ describe("hosted local cold-start benchmark e2e", () => {
       resetLocalDatabase: true,
       resetPersistDir: true,
     });
-  }, 300_000);
+  }, setupTimeoutMs);
 
   it("measures independent cold hosted executions", async () => {
     const measuredSamples: ColdStartSample[] = [];
@@ -459,6 +466,7 @@ async function runColdStartTrial(
   const phaseBreakdown = requirePhaseBreakdown(trace.phaseBreakdown);
   const restore = requireRestoreBreakdown(phaseBreakdown);
   const importBreakdown = phaseBreakdown.import;
+  const orchestration = phaseBreakdown.orchestration;
   const preProviderBreakdown = phaseBreakdown.preProvider;
 
   return {
@@ -485,6 +493,36 @@ async function runColdStartTrial(
     ),
     archiveExtractMs: requireTiming(restore.archiveExtractMs, "archiveExtractMs"),
     cleanupMs: requireTiming(restore.cleanupMs, "cleanupMs"),
+    containerListeningToPortsReadyMs: elapsedEpochMs(
+      requireTiming(
+        orchestration?.freshStartContainerListeningAtEpochMs,
+        "freshStartContainerListeningAtEpochMs",
+      ),
+      requireTiming(
+        orchestration?.freshStartContainerPortsReadyAtEpochMs,
+        "freshStartContainerPortsReadyAtEpochMs",
+      ),
+    ),
+    containerProcessToListeningMs: elapsedEpochMs(
+      requireTiming(
+        orchestration?.freshStartContainerProcessStartedAtEpochMs,
+        "freshStartContainerProcessStartedAtEpochMs",
+      ),
+      requireTiming(
+        orchestration?.freshStartContainerListeningAtEpochMs,
+        "freshStartContainerListeningAtEpochMs",
+      ),
+    ),
+    containerStartToPortsReadyMs: elapsedEpochMs(
+      requireTiming(
+        orchestration?.freshStartContainerStartIssuedAtEpochMs,
+        "freshStartContainerStartIssuedAtEpochMs",
+      ),
+      requireTiming(
+        orchestration?.freshStartContainerPortsReadyAtEpochMs,
+        "freshStartContainerPortsReadyAtEpochMs",
+      ),
+    ),
     dataKeyUnwrapMs: requireTiming(restore.dataKeyUnwrapMs, "dataKeyUnwrapMs"),
     decryptMs: requireTiming(restore.decryptMs, "decryptMs"),
     durableRootReplaceMs: requireTiming(
@@ -975,6 +1013,9 @@ function buildSamplePercentileRecord(
     "automationBootstrapMs",
     "archiveExtractMs",
     "cleanupMs",
+    "containerListeningToPortsReadyMs",
+    "containerProcessToListeningMs",
+    "containerStartToPortsReadyMs",
     "dataKeyUnwrapMs",
     "decryptMs",
     "durableRootReplaceMs",

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -1954,6 +1954,10 @@ describe("RunnerContainer", () => {
       .toBeLessThanOrEqual(timing.readyObservedAtEpochMs);
 
     expect(startAndWaitForPorts).toHaveBeenCalledOnce();
+    expect(startAndWaitForPorts.mock.calls[0]?.[0]?.cancellationOptions)
+      .toMatchObject({
+        portProbeTimeoutMS: 1_500,
+      });
     const healthCalls = containerFetch.mock.calls.filter(([url]) =>
       String(url).endsWith("/health")
     );
@@ -3500,6 +3504,7 @@ describe("RunnerContainer", () => {
     expect(start).toHaveBeenCalledOnce();
     expect(start.mock.calls[0]?.[1]).toMatchObject({
       portToCheck: 8080,
+      portProbeTimeoutMS: 1_500,
       signal: expect.any(AbortSignal),
     });
     expect(startAndWaitForPorts).not.toHaveBeenCalled();
@@ -3852,6 +3857,10 @@ describe("RunnerContainer", () => {
     expect(healthCalls).toHaveLength(1);
     expect(executeCalls).toHaveLength(1);
     expect(startAndWaitForPorts).toHaveBeenCalledTimes(1);
+    expect(startAndWaitForPorts.mock.calls[0]?.[0]?.cancellationOptions)
+      .toMatchObject({
+        portProbeTimeoutMS: 1_500,
+      });
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
         component: "container",
@@ -4625,6 +4634,10 @@ describe("RunnerContainer", () => {
       status: 200,
     });
     expect(startAndWaitForPorts).toHaveBeenCalledTimes(1);
+    expect(startAndWaitForPorts.mock.calls[0]?.[0]?.cancellationOptions)
+      .toMatchObject({
+        portProbeTimeoutMS: 1_500,
+      });
     expect(containerFetch).toHaveBeenCalledTimes(2);
     expect(container.envVars).toEqual(EXPECTED_RUNNER_CONTAINER_ENV);
     expect(destroy).toHaveBeenCalledTimes(1);
@@ -10587,6 +10600,7 @@ describe("RunnerContainer", () => {
       expect(startAndWaitForPorts).toHaveBeenCalledTimes(1);
       expect(startAndWaitForPorts.mock.calls[0]?.[0]?.cancellationOptions).toMatchObject({
         instanceGetTimeoutMS: expectedTimeoutMs,
+        portProbeTimeoutMS: 1_500,
         portReadyTimeoutMS: expectedTimeoutMs,
       });
     }

--- a/apps/cloudflare/test/stubs/cloudflare-workers-containers-helper.ts
+++ b/apps/cloudflare/test/stubs/cloudflare-workers-containers-helper.ts
@@ -1,0 +1,26 @@
+export class DurableObject<Env = unknown> {
+  protected readonly ctx: unknown;
+  protected readonly env: Env;
+
+  constructor(ctx: unknown, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+
+  protected sql(
+    _strings: TemplateStringsArray,
+    ..._values: readonly unknown[]
+  ): readonly unknown[] {
+    return [];
+  }
+}
+
+export class WorkerEntrypoint<Env = unknown, Props = unknown> {
+  protected readonly ctx: { props: Props };
+  protected readonly env: Env;
+
+  constructor(ctx: { props: Props }, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/apps/cloudflare/vitest.containers-helper.config.ts
+++ b/apps/cloudflare/vitest.containers-helper.config.ts
@@ -1,0 +1,45 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+import {
+  resolveMurphAppVitestMaxWorkers,
+  resolveMurphVitestConcurrency,
+} from "../../config/vitest-parallelism.js";
+import { murphVitestTempGlobalSetup } from "../../config/vitest-temp-lifecycle.js";
+import { murphVitestNoTimeouts } from "../../config/vitest-timeouts.js";
+
+const cloudflareDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: "cloudflare:workers",
+        replacement: path.resolve(
+          cloudflareDir,
+          "test/stubs/cloudflare-workers-containers-helper.ts",
+        ),
+      },
+    ],
+  },
+  ssr: {
+    noExternal: ["@cloudflare/containers"],
+  },
+  test: {
+    ...murphVitestNoTimeouts,
+    name: "cloudflare-containers-helper",
+    environment: "node",
+    globalSetup: [murphVitestTempGlobalSetup],
+    maxWorkers: resolveMurphAppVitestMaxWorkers(),
+    ...resolveMurphVitestConcurrency(),
+    include: [
+      path.join(
+        cloudflareDir,
+        "test",
+        "containers-helper-readiness.test.ts",
+      ),
+    ],
+  },
+});

--- a/apps/cloudflare/vitest.node.workspace.ts
+++ b/apps/cloudflare/vitest.node.workspace.ts
@@ -103,6 +103,7 @@ const cloudflareNodeVitestProjectSpecs = resolveVitestBucketFiles(
   {
     ignorePatterns: [
       "*e2e.test.ts",
+      "containers-helper-readiness.test.ts",
       "workers/*.test.ts",
       "workers/**/*.test.ts",
     ],

--- a/apps/web/changelog/entries/2026-08-27/faster-replies-after-idle-time.json
+++ b/apps/web/changelog/entries/2026-08-27/faster-replies-after-idle-time.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 2,
     "title": "Faster wake-ups for replies",
-    "summary": "When Murph's hosted assistant wakes with current local state, it now skips repeated setup checks before working on your message.",
-    "details": "Older state still receives the full compatibility checks, and a newer unsupported version still stops safely without rewriting its data.",
+    "summary": "When Murph's hosted assistant wakes after idle time, it now skips unnecessary setup work and retries a stalled startup check sooner before working on your message.",
+    "details": "Older saved state still receives full compatibility checks. Overall startup and health checks remain in place, and unsupported state or true startup failures still stop safely.",
     "relevanceTags": ["assistant", "performance", "reliability"],
-    "sourcePullRequests": [2462]
+    "sourcePullRequests": [2462, 2669]
   }
 }

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -1364,6 +1364,7 @@ describe('monorepo release flow coverage audit', () => {
         .map((line) => line.trim()),
     ).toEqual(
       [
+        "'@cloudflare/containers@0.3.7': patches/@cloudflare__containers@0.3.7.patch",
         "'@cobuild/repo-tools@0.1.17': patches/@cobuild__repo-tools@0.1.17.patch",
         "'@cobuild/review-gpt@0.5.139': patches/@cobuild__review-gpt@0.5.139.patch",
         'incur@0.4.5: patches/incur@0.4.5.patch',

--- a/patches/@cloudflare__containers@0.3.7.patch
+++ b/patches/@cloudflare__containers@0.3.7.patch
@@ -1,0 +1,92 @@
+diff --git a/dist/lib/container.js b/dist/lib/container.js
+index b7567e230cf5d6168a3b6d5e1fbb1fc009eaf235..0fdb81c36857408879f8104a7c093daef3d3c4cb 100644
+--- a/dist/lib/container.js
++++ b/dist/lib/container.js
+@@ -84,16 +84,20 @@ function getExitCodeFromError(error) {
+  */
+ function addTimeoutSignal(existingSignal, timeoutMs) {
+     const controller = new AbortController();
++    const forwardExistingAbort = () => controller.abort();
+     // Forward existing signal abort
+     if (existingSignal?.aborted) {
+         controller.abort();
+         return controller.signal;
+     }
+-    existingSignal?.addEventListener('abort', () => controller.abort());
++    existingSignal?.addEventListener('abort', forwardExistingAbort, { once: true });
+     // Add timeout
+     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+-    // Clean up timeout if signal is aborted early
+-    controller.signal.addEventListener('abort', () => clearTimeout(timeoutId));
++    // Clean up timeout and the forwarded listener when either signal aborts.
++    controller.signal.addEventListener('abort', () => {
++        clearTimeout(timeoutId);
++        existingSignal?.removeEventListener('abort', forwardExistingAbort);
++    }, { once: true });
+     return controller.signal;
+ }
+ // ==== Glob helpers ====
+@@ -577,6 +581,7 @@ export class Container extends DurableObject {
+             waitInterval: pollInterval,
+             retries: waitOptions?.retries ?? Math.ceil(TIMEOUT_TO_GET_CONTAINER_MS / pollInterval),
+             portToCheck,
++            portProbeTimeoutMS: waitOptions?.portProbeTimeoutMS,
+         }, startOptions);
+         this.setupMonitorCallbacks();
+         // TODO: We should consider an onHealthy callback
+@@ -614,6 +619,7 @@ export class Container extends DurableObject {
+             retries: containerGetRetries,
+             waitInterval: pollInterval,
+             portToCheck: portsToCheck[0],
++            portProbeTimeoutMS: resolvedCancellationOptions.portProbeTimeoutMS,
+         };
+         // Start the container if it's not running
+         const triesUsed = await this.startContainerIfNotRunning(waitOptions, resolvedStartOptions);
+@@ -626,6 +632,7 @@ export class Container extends DurableObject {
+                 waitInterval: pollInterval,
+                 retries: triesLeft,
+                 portToCheck: port,
++                portProbeTimeoutMS: resolvedCancellationOptions.portProbeTimeoutMS,
+             });
+         }
+         this.setupMonitorCallbacks();
+@@ -660,7 +667,7 @@ export class Container extends DurableObject {
+         // Try to connect to the port multiple times
+         for (let i = 0; i < tries; i++) {
+             try {
+-                const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
++                const combinedSignal = addTimeoutSignal(waitOptions.signal, waitOptions.portProbeTimeoutMS ?? PING_TIMEOUT_MS);
+                 await tcpPort.fetch(`http://${this.pingEndpoint}`, { signal: combinedSignal });
+                 // Successfully connected to this port
+                 break;
+@@ -1386,7 +1393,7 @@ export class Container extends DurableObject {
+             // TODO: Make this the port I'm trying to get!
+             const port = this.container.getTcpPort(waitOptions.portToCheck);
+             try {
+-                const combinedSignal = addTimeoutSignal(waitOptions.signal, PING_TIMEOUT_MS);
++                const combinedSignal = addTimeoutSignal(waitOptions.signal, waitOptions.portProbeTimeoutMS ?? PING_TIMEOUT_MS);
+                 await port.fetch('http://containerstarthealthcheck', { signal: combinedSignal });
+                 return tries;
+             }
+diff --git a/dist/types/index.d.ts b/dist/types/index.d.ts
+index 93a2ee71d2b874ee9a0704cb5ddf1ba6d3b3a7ad..b3fd51ef705152444392555f7e8c5dde941a3815 100644
+--- a/dist/types/index.d.ts
++++ b/dist/types/index.d.ts
+@@ -62,6 +62,8 @@ export interface CancellationOptions {
+     portReadyTimeoutMS?: number;
+     /** time to wait between polling, in milliseconds */
+     waitInterval?: number;
++    /** max time to wait for one TCP readiness probe, in milliseconds */
++    portProbeTimeoutMS?: number;
+ }
+ /**
+  * Options for waitForPort()
+@@ -75,6 +77,8 @@ export interface WaitOptions {
+     retries?: number;
+     /** Time to wait in between polling port for readiness, in milliseconds */
+     waitInterval?: number;
++    /** Max time to wait for one TCP readiness probe, in milliseconds */
++    portProbeTimeoutMS?: number;
+ }
+ /**
+  * Represents a scheduled task within a Container

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ overrides:
   fast-xml-parser@5.7.2>fast-xml-builder: 1.2.0
 
 patchedDependencies:
+  '@cloudflare/containers@0.3.7':
+    hash: 1f85f122210f2e6cb141f20bb4657d7b31b6bae5f5f91face7259905cf78bb1a
+    path: patches/@cloudflare__containers@0.3.7.patch
   '@cobuild/repo-tools@0.1.17':
     hash: 679266b778f8ed833acc0ead5be87d57dbcff877ce899a72fbec8052563ab4fb
     path: patches/@cobuild__repo-tools@0.1.17.patch
@@ -126,8 +129,8 @@ importers:
   apps/cloudflare:
     dependencies:
       '@cloudflare/containers':
-        specifier: ^0.3.6
-        version: 0.3.6
+        specifier: 0.3.7
+        version: 0.3.7(patch_hash=1f85f122210f2e6cb141f20bb4657d7b31b6bae5f5f91face7259905cf78bb1a)
       '@linqapp/sdk':
         specifier: 0.34.0
         version: 0.34.0
@@ -1445,8 +1448,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@cloudflare/containers@0.3.6':
-    resolution: {integrity: sha512-8RrbK/Et165gjvXccui3pgkUuySVWysTC6bJRXfgqmbCA2vAmh8pm7cAKDh2nZFR/GSjW4BgxeKpffCTD8SJEg==}
+  '@cloudflare/containers@0.3.7':
+    resolution: {integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -11055,7 +11058,7 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@cloudflare/containers@0.3.6': {}
+  '@cloudflare/containers@0.3.7(patch_hash=1f85f122210f2e6cb141f20bb4657d7b31b6bae5f5f91face7259905cf78bb1a)': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,6 +91,7 @@ minimumReleaseAgeExclude:
 nodeVersion: 24.14.1
 packageManagerStrictVersion: true
 patchedDependencies:
+  '@cloudflare/containers@0.3.7': patches/@cloudflare__containers@0.3.7.patch
   '@cobuild/repo-tools@0.1.17': patches/@cobuild__repo-tools@0.1.17.patch
   '@cobuild/review-gpt@0.5.139': patches/@cobuild__review-gpt@0.5.139.patch
   incur@0.4.5: patches/incur@0.4.5.patch


### PR DESCRIPTION
## Why and outcome

Cold hosted replies spend avoidable time waiting for Cloudflare's first synthetic container-readiness fetch. The runner process is already listening, but that pre-listen fetch can remain pinned until the helper's fixed five-second per-attempt deadline.

This pins @cloudflare/containers to 0.3.7, applies a local pnpm patch that makes only the per-probe deadline configurable, and selects 1.5 seconds on Murph's explicit prewarm, authoritative cold-start, and deploy-smoke paths. Cloudflare's five-second default, the outer readiness budget, strict health check, crash handling, fencing, and cleanup remain unchanged.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: The affected person is an established hosted member whose private assistant must wake after being idle. The observable outcome is less avoidable waiting before Murph starts the reply. Warm paths and non-hosted paths are unchanged; a true crash or failed health check still stops safely. A production-shaped actual-package replay proves the timing mechanism, while the managed-platform median remains a post-deploy canary gate.

## Evidence

- Direct: The actual patched package reproduces the production-shaped sticky first probe. Readiness falls from 4.475 seconds to 1.850 seconds, a 2.625-second modeled reduction, with one container start, one in-flight probe maximum, and no late healthy transition. Redacted production phase aggregates independently isolate the existing delay after the Node listener is available.
- Coverage: Cloudflare canonical Node command: 2,759 passed and 2 intentional skips; Workers runtime: 15 passed; patched-package lifecycle suite: 6 passed; RunnerContainer owner suite: 1,216 passed. Cloudflare typecheck/build, frozen install, dependency guards, patch hash/application checks, and exact production amd64 image build pass. The changelog archive test passes 9/9 and Web typecheck passes.
- Remaining direct gap: The exact production image, Workerd proxy, entrypoint, Node startup, abort, and cleanup paths were exercised locally, but ARM/QEMU distortion prevented a trustworthy full delivery timing sample. Rollout therefore requires the managed fresh-start canary described below.

## Non-obvious affected surfaces

- The pnpm dependency patch changes @cloudflare/containers runtime JavaScript and declarations while preserving the upstream default for every caller that omits the option.
- Shell prewarm start, authoritative cold start/retry, and forced-cold deploy smoke all select the bounded probe.
- The inherited containerFetch implicit auto-start fallback intentionally retains the conservative five-second default.
- The cold-start benchmark reports start-to-ports, process-to-listen, and listen-to-ports phases so the canary can distinguish platform movement from application boot.
- The actual-package test uses a dedicated Vitest config because its cloudflare:workers shim and de-externalized package graph must not share the ordinary Node workspace.
- The existing public faster-wake-up changelog item now attributes this PR and describes both contributing improvements.

## Architecture and reuse

- Existing systems reused: Cloudflare Container.start/startAndWaitForPorts, the existing sequential retry loop, monitor callbacks, outer cancellation budget, strict /health check, runner fingerprints, fences, and cleanup ownership.
- New logic: One optional portProbeTimeoutMS value is threaded to both native TCP readiness fetch sites; Murph passes 1,500 ms at its three explicit startup call sites and omission still resolves to 5,000 ms.
- New abstractions: None. The change adds one option to the existing cancellation/wait contract rather than introducing another lifecycle owner.
- Complexity intentionally avoided: No raw container start, Promise.race wrapper, overlapping probes, new queue, new state, new fallback owner, or container protocol change.

## Hot reply path impact

- Path status: Touched. This shortens an existing readiness wait on the foreground reply critical path; it does not add or move another stage onto that path.
- Database calls: None added or moved.
- Network/provider calls: No new call type. Existing getTcpPort().fetch readiness attempts remain strictly sequential. In a continuously unavailable 20-second outer budget, the shorter per-attempt bound can make roughly 12 attempts instead of roughly 4, with a 250 ms interval and at most one request in flight. Provider calls and the strict post-readiness /health request are unchanged.
- Other awaited latency: None added. Crash monitoring, onStart, fingerprint validation, write-fence revalidation, and cleanup keep their current ordering and bounds.
- Before/after proof: The actual-package production-shaped replay is 4.475 seconds before and 1.850 seconds after. Listener cleanup, caller abort, real rejected-monitor crash, both modified probe sites, no overlap, and no late healthy publication are covered.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run because no prompt, model request, tool/schema, generated guidance, wrapper, or conversation-history surface changed.

## Design proof

- Design page: [Changelog archive study](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: This is a content-only edit to an existing changelog item; no renderer, component, visual, style, or interaction changed. The focused server-rendered archive test proves the updated copy and attribution load through the production component, so an additional image would not add proof.
- Coverage: The existing responsive archive study owns the unchanged presentation. The changed JSON copy and source attribution are covered by the fragment loader and 9/9 changelog-page tests.

## Risks

- Managed peer-side container transport code is private, so local source can prove request/tunnel cancellation and lifecycle behavior but cannot replace a managed rollout canary.
- A synthetic readiness endpoint that legitimately takes longer than 1.5 seconds to return headers would retry more often. Murph's endpoint responds immediately after listen, the strict health request remains separate, attempts do not overlap, and the unchanged outer budget still fails closed.
- The implicit containerFetch auto-start fallback retains five seconds and is outside the authoritative median path.

ReviewGPT context sensitivity: sensitive
Classification reason: This changes Cloudflare hosted-execution startup timing, retry cadence, and a production deployment boundary.
ReviewGPT first-reviewed head: 946d9f2385abf74f7db84da2770f6f273b1ea572

## Deployment concerns

- Deployment: applicable
- Supported skew: The Worker/container protocol and persisted state are unchanged. New Worker code works with existing warm runner containers, while old Worker isolates simply keep the prior five-second readiness behavior.
- Safe order: Deploy the Cloudflare Worker first, verify forced-cold readiness, then deploy the Web changelog. Web and container application releases are otherwise independent.
- Rollback floor: No schema, persisted state, or container protocol changes exist; reverting the Worker restores the five-second per-probe behavior safely.
- Expected exposure: During Worker isolate convergence, some cold starts may retain the old latency for one rollout window. Correctness and fail-closed startup behavior are unchanged.
- Reversibility: Revert the Worker dependency patch and three call-site options; no data repair or container image rollback is required.
- Convergence proof: Run the forced-cold deploy smoke, confirm the current Worker version, then compare 30-50 alternating managed fresh starts against the prior variant.
- Post-deploy checks: Require at least a 2-second p50 improvement, no new or increased startup-failure category, and candidate p95 no more than 1 second slower before widening traffic.

## Complexity impact

- Guard: pass; pnpm complexity:diff reports no increase in complexity debt or maximum complexity for the current head.
- Hotspots: Existing wakeRuntime (74), ensureContainerReady (36), destroyIfRunning (26), classifyHostedRunnerContainerErrorResponse (24), and invokeHostedExecution (21) remain above the threshold; every reported delta is zero.
- Agent judgment: No hotspot expansion is justified here. The production change adds one constant and forwards one option through the existing readiness owner, while the isolated Vitest config contains no executable branch logic.

## Change-shape breakdown

Classification rule: Production runtime/declaration patches are Source; test files and stubs are Tests / fixtures; plans, owner docs, Frog entries, and changelog copy are Docs; manifests, lock/workspace metadata, test configs, and verification scripts are Config / tooling. No binary or generated file changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 97 | 0 |
| Tests / fixtures | 566 | 1 |
| Docs | 303 | 3 |
| Config / tooling | 70 | 7 |
| Generated / other | 0 | 0 |
| **Total** | **1036** | **11** |

## Changelog

- Changelog: updated
- Items: 2026-08-27 · faster-replies-after-idle-time
