### PR TITLE
Fix stale default wake owner livelock

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -321,8 +321,14 @@ Last verified: 2026-08-30
   generation and handled-through frontier remain unchanged. Workspace-version,
   attempt, signal, and selected-wake churn are not progress. Due foreground,
   default-processing, provider-owned, and retention work bypasses the delay
-  without clearing it. This reuses the workspace CAS and Temporal timer owners;
-  it adds no queue, scheduler, per-member state table, or second wake authority.
+  without clearing it. When live runtime evaluation disproves an overdue
+  default-processing projection and selects a due model-free frontier, the
+  runtime checkpoints the corrected projections before releasing that pass.
+  This projection-only checkpoint re-reads every default-work source, preserves
+  handled-through and the progress generation, and therefore cannot hide
+  genuinely due default work or claim system progress. This reuses the workspace
+  CAS and Temporal timer owners; it adds no queue, scheduler, per-member state
+  table, or second wake authority.
 - A hosted-group projection grant that needs its first private projection and
   one generation-stable `runtime.maintenance-requested` control row commit in
   the same Web transaction. An append failure therefore rolls back the grant

--- a/agent-docs/exec-plans/active/2026-09-01-model-free-default-wake-livelock.md
+++ b/agent-docs/exec-plans/active/2026-09-01-model-free-default-wake-livelock.md
@@ -1,0 +1,130 @@
+# Converge stale default wake handoff to model-free owner
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Stop a hosted runtime from repeatedly selecting a default assistant pass when
+  live foreground evaluation has already disproved the overdue default wake and
+  the exact durable system frontier belongs to the model-free owner.
+- Preserve genuine foreground/default priority while making the stale-projection
+  handoff converge durably so model-free maintenance can run on the next pass.
+
+## Success criteria
+
+- A production-shaped two-cycle regression fails before the fix and passes after
+  it: the first default pass publishes a projection-only checkpoint, and the
+  following system-owner pass advances the durable model-free frontier.
+- The handoff pass does not run assistant, provider, device, or system work under
+  the wrong owner and does not increment the system progress generation.
+- A genuinely due default wake still retains priority over model-free work.
+- A running cron job with a past `nextRunAt` is not projected as new runnable
+  default work.
+- Focused runtime tests, package typecheck, and required repository verification
+  pass on the final diff.
+- The exact normalized live incident facts replay without private identifiers,
+  and the deployed runtime's durable frontier advances after shipment.
+
+## Scope
+
+- In scope:
+  - Public assistant-runtime wake projection and checkpoint convergence.
+  - Real runtime entrypoint and two-owner regression coverage.
+  - Runtime protocol/reliability documentation and public changelog, if required.
+- Out of scope:
+  - Temporal priority-policy changes.
+  - Cloudflare routing or fencing changes.
+  - Dropping, consuming, or executing durable system rows during a default pass.
+  - Persisting production identifiers or payloads in repository artifacts.
+
+## Constraints
+
+- Technical constraints:
+  - Runtime owns assistant-timer semantics; Web persists projections, Temporal
+    interprets them, and Cloudflare routes the selected mode.
+  - Checkpointing must be replay-safe and must not claim application progress.
+  - Status-read failure must fail closed and retain the existing projection.
+- Product/process constraints:
+  - Members with real foreground work must not be delayed by maintenance.
+  - Members with only model-free backlog must eventually release default ownership.
+  - Production facts may be used transiently for diagnosis but never committed.
+
+## Product UX
+
+- Effort: Patch.
+- Outcome: Existing background follow-through no longer remains stuck behind an
+  assistant timer whose live work has already ended.
+- Reaches: The existing hosted journey where a stale projected assistant wake
+  and due model-free connected-device work coincide.
+- Proof: Replay the identifier-free production 0/4/4 boundary through the real
+  runtime entrypoint, then confirm the affected production frontier advances
+  after deployment.
+
+### Walkthrough
+
+- Member waiting on connected-device follow-through: the production-shaped
+  default pass publishes the device owner without running device, provider, or
+  model work under the wrong owner; the queue and handled frontier remain
+  intact for the next pass. Ready.
+- Member with a genuinely due conversation, reminder, pending delivery, or
+  other default-owned task: live default-source checks retain priority, and
+  checkpoint reconciliation preserves every future or due default source.
+  Ready.
+- Member whose live cron status cannot be read: the runtime does not declare
+  the projection stale, so existing durable wake authority remains fail-closed.
+  Ready.
+
+No visible interface or copy changes. The public changelog describes the
+recovered outcome without exposing runtime identifiers or private evidence.
+
+## Risks and mitigations
+
+1. Risk: Clearing a real due default wake lets maintenance run first.
+   Mitigation: Reconcile only after the authoritative live preflight reports no
+   runnable foreground/default work, with regressions for genuine due work.
+2. Risk: A handoff checkpoint falsely advances the system frontier.
+   Mitigation: Keep handled-through and progress generation unchanged; checkpoint
+   only the corrected owner projections.
+3. Risk: The fix handles device wakes but not other model-free frontier kinds.
+   Mitigation: Key convergence to owner classification, not a device-specific kind.
+4. Risk: An unrelated open change overlaps the assistant phase.
+   Mitigation: Keep the patch narrowly owned, inspect the current-base merge tree,
+   and use exact-head review and CI before merge.
+
+## Tasks
+
+1. Capture a private-data-free normalized replay envelope from the live incident
+   and prove the current Temporal/runtime decision sequence.
+2. Add the missing two-cycle production-shaped regression and record the pre-fix
+   failure.
+3. Implement the smallest runtime-owned projection-convergence checkpoint and
+   normalize non-due cron projection timestamps.
+4. Run focused tests, typecheck, static privacy inspection, and exact-fact replay.
+5. Update durable contracts/changelog where the externally observable reliability
+   guarantee changes.
+6. Commit, open a draft PR, run exact-head ReviewGPT with CI, merge/deploy, and
+   verify the affected runtime's durable frontier advances.
+
+## Decisions
+
+- Keep Temporal's default-before-model-free priority unchanged; current history
+  replay proves it is following the documented contract.
+- Use exact live facts only in transient in-memory replay. Commit a synthetic
+  fixture with the same normalized owner/timer/frontier shape.
+- Treat the first pass as a projection handoff, not application/system progress.
+
+## Verification
+
+- Commands to run:
+  - Focused Vitest files for wake scheduling, real device frontier, and hosted
+    runtime entrypoint convergence.
+  - Assistant-runtime package typecheck.
+  - Repository-required scoped verification and diff/privacy checks.
+  - Identifier-free exact production-fact replay before and after the fix.
+- Expected outcomes:
+  - Pre-fix regression shows repeated default selection with no checkpoint.
+  - Post-fix first pass durably removes/advances the stale default projection and
+    publishes the model-free wake; second pass advances handled-through.
+  - No assistant/provider/device execution occurs during the handoff checkpoint.

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -448,6 +448,12 @@ wake selects `inbox_media_retention` processing when foreground/default work is
 not runnable; future or absent wakes wait. These modes are invocation input, not
 new scheduler state. Foreground/default work must replace an active
 system-mailbox or retention owner instead of waiting for its idle checkpoint.
+If a default invocation's live checks disprove its overdue projection and the
+next due frontier belongs to a model-free owner, the runtime first checkpoints
+the corrected projections without advancing handled-through or the system
+progress generation. The checkpoint re-reads all default-work sources, so
+genuinely due default work remains armed; Temporal continues interpreting only
+the resulting durable facts.
 The runtime projects an outbox-only continuation as `assistant_delivery` rather
 than model-capable `assistant`. Web admits that due delivery continuation
 without the managed-AI usage gate; Temporal still selects ordinary processing,

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-01",
+  "order": 100,
+  "item": {
+    "id": "background-work-recovers-from-stale-timers",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Background work recovers from stale timers",
+    "summary": "Murph now recovers when an outdated assistant timer and connected-device work become due together, so follow-through does not stay stuck behind a timer with no work left.",
+    "details": "Current conversations, reminders, pending deliveries, and other genuinely due assistant work keep priority. Murph changes owners only after a live check confirms the projected timer is stale.",
+    "relevanceTags": ["assistant", "wearables", "reliability"],
+    "sourcePullRequests": [2679]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1055,6 +1055,7 @@ async function resolveHostedSystemMailboxProcessingModeWake(input: {
     });
   const systemMailboxWake = systemMailboxWakes.next;
   const assistantCronWake = await resolveHostedAssistantCronWakeAfterInitialImport({
+    nowMs: input.nowMs,
     operatorHomeRoot: input.operatorHomeRoot,
     runtimeEnv: input.runtimeEnv,
     vaultRoot: input.vaultRoot,
@@ -2462,6 +2463,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
       const assistantCronWake =
         input.request.processingMode === "system_mailbox"
           ? await resolveHostedAssistantCronWakeAfterInitialImport({
+              nowMs: Date.now(),
               operatorHomeRoot: restored.operatorHomeRoot,
               runtimeEnv: invocationRuntimeEnv,
               vaultRoot: restored.vaultRoot,
@@ -5533,13 +5535,13 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
         let continueForegroundCausalPass =
           !runtimeOwnerHandoffRequested
           && shouldContinueForegroundCausalPass(passResult);
-        const requestDueMailboxOwnerHandoffIfForegroundIdle = (): void => {
+        const requestDueRuntimeOwnerHandoffIfForegroundIdle = (): void => {
           if (
             runtimeOwnerHandoffRequested
             || rerunAssistantInputBatch !== null
             || continueForegroundCausalPass
             || (input.request.processingMode ?? "default") !== "default"
-            || pendingWake.nextWakeReason !== "mailbox"
+            || hostedRuntimeWakeReasonIsAssistant(pendingWake.nextWakeReason)
             || !hostedRuntimeWakeIsDue(pendingWake.nextWakeAt)
           ) {
             return;
@@ -5547,7 +5549,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           runtimeOwnerHandoffRequested = true;
           markIdleCheckpointTimerAfterDirtyWork();
         };
-        requestDueMailboxOwnerHandoffIfForegroundIdle();
+        requestDueRuntimeOwnerHandoffIfForegroundIdle();
         while (
           options.shutdownSignal?.aborted !== true
           && (rerunAssistantInputBatch || continueForegroundCausalPass)
@@ -5592,7 +5594,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           continueForegroundCausalPass =
             !runtimeOwnerHandoffRequested
             && shouldContinueForegroundCausalPass(passResult);
-          requestDueMailboxOwnerHandoffIfForegroundIdle();
+          requestDueRuntimeOwnerHandoffIfForegroundIdle();
         }
         return passResult;
       };
@@ -8901,6 +8903,7 @@ function selectEarliestHostedRuntimeWake(
 }
 
 async function resolveHostedAssistantCronWakeAfterInitialImport(input: {
+  nowMs: number;
   operatorHomeRoot: string;
   runtimeEnv: Readonly<Record<string, string>>;
   vaultRoot: string;
@@ -8910,8 +8913,8 @@ async function resolveHostedAssistantCronWakeAfterInitialImport(input: {
   });
   const dueNow = status.dueJobs > 0;
   const at = dueNow
-    ? new Date().toISOString()
-    : status.nextRunAt;
+    ? new Date(input.nowMs).toISOString()
+    : normalizeHostedFutureWakeAt(status.nextRunAt, input.nowMs);
   return {
     at,
     dueNow,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2368,9 +2368,9 @@ export async function runHostedWorkspaceAssistantPhase(
     const systemMailboxOwnerOwnsCurrentPass =
       !hasAssistantInputAtPassStart
       && systemMailboxMaintenance.continueAssistantLane === false
-      && systemMailboxMaintenance.result?.runtimeProjectionCheckpointRequested
-        !== true
-      && systemMailboxMaintenance.result?.nextWakeReason === "mailbox"
+      && hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
+        systemMailboxMaintenance.result,
+      )
       && hostedRuntimeWakeCandidateIsDue(
         createHostedRuntimeWakeCandidate(
           systemMailboxMaintenance.result.nextWakeAt ?? null,
@@ -3910,6 +3910,30 @@ function mergeHostedAssistantPhaseResults(
   });
 }
 
+function hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
+  result: HostedWorkspaceRunnerAssistantPhaseResult | null,
+): boolean {
+  return result?.runtimeProjectionCheckpointRequested !== true
+    && result?.nextWakeReason === "mailbox";
+}
+
+function hostedRuntimeProjectionCheckpointWasRequested(
+  results: readonly HostedWorkspaceRunnerAssistantPhaseResult[],
+): boolean {
+  return results.some((result) =>
+    result.runtimeProjectionCheckpointRequested === true
+  );
+}
+
+function withHostedRuntimeProjectionCheckpointRequest(input: {
+  requested: boolean;
+  result: HostedWorkspaceRunnerAssistantPhaseResult;
+}): HostedWorkspaceRunnerAssistantPhaseResult {
+  return input.requested
+    ? { ...input.result, runtimeProjectionCheckpointRequested: true }
+    : input.result;
+}
+
 function postCheckpointDeliveryResultOwnsProviderCleanup(
   result: HostedWorkspaceRunnerAssistantPhaseResult | null,
 ): boolean {
@@ -3994,9 +4018,6 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const systemMailboxProgressed =
     input.systemMailboxResult.systemMailboxProgressed === true
     || input.assistantResult.systemMailboxProgressed === true;
-  const runtimeProjectionCheckpointRequested =
-    input.systemMailboxResult.runtimeProjectionCheckpointRequested === true
-    || input.assistantResult.runtimeProjectionCheckpointRequested === true;
   const afterCheckpointKeepsForegroundImportLoop =
     input.systemMailboxResult.afterCheckpointKeepsForegroundImportLoop === true
     || input.assistantResult.afterCheckpointKeepsForegroundImportLoop === true;
@@ -4022,16 +4043,54 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const invocationLocalAssistantWakeAt =
     input.assistantResult.invocationLocalAssistantWakeAt ?? null;
   if (progressedResult) {
-    return {
-      ...(afterCheckpoint ? { afterCheckpoint } : {}),
+    return withHostedRuntimeProjectionCheckpointRequest({
+      requested: hostedRuntimeProjectionCheckpointWasRequested([
+        input.systemMailboxResult,
+        input.assistantResult,
+      ]),
+      result: {
+        ...(afterCheckpoint ? { afterCheckpoint } : {}),
+        ...(browserVaultReplicaRefreshRequested
+          ? { browserVaultReplicaRefreshRequested: true }
+          : {}),
+        ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
+        ...(afterCheckpointKeepsForegroundImportLoop
+          ? { afterCheckpointKeepsForegroundImportLoop: true }
+          : {}),
+        checkpointReason: progressedResult.checkpointReason,
+        ...(foregroundReplyFailed === undefined
+          ? {}
+          : { foregroundReplyFailed }),
+        ...(foregroundPrioritySystemCompletionProcessed
+          ? { foregroundPrioritySystemCompletionProcessed: true }
+          : {}),
+        ...(invocationLocalAssistantWakeAt
+          ? { invocationLocalAssistantWakeAt }
+          : {}),
+        ...(systemMailboxProgressed
+          ? { systemMailboxProgressed: true as const }
+          : {}),
+        ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
+        ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
+          ? { nextWakeReason: nextWake.reason }
+          : {}),
+        progressed: true,
+        ...(redactedStatus ? { redactedStatus } : {}),
+        ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
+      },
+    });
+  }
+
+  return withHostedRuntimeProjectionCheckpointRequest({
+    requested: hostedRuntimeProjectionCheckpointWasRequested([
+      input.systemMailboxResult,
+      input.assistantResult,
+    ]),
+    result: {
       ...(browserVaultReplicaRefreshRequested
         ? { browserVaultReplicaRefreshRequested: true }
         : {}),
       ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
-      ...(afterCheckpointKeepsForegroundImportLoop
-        ? { afterCheckpointKeepsForegroundImportLoop: true }
-        : {}),
-      checkpointReason: progressedResult.checkpointReason,
       ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
       ...(foregroundPrioritySystemCompletionProcessed
         ? { foregroundPrioritySystemCompletionProcessed: true }
@@ -4039,44 +4098,18 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
       ...(invocationLocalAssistantWakeAt
         ? { invocationLocalAssistantWakeAt }
         : {}),
-      ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
-      ...(runtimeProjectionCheckpointRequested
-        ? { runtimeProjectionCheckpointRequested: true as const }
+      ...(systemMailboxProgressed
+        ? { systemMailboxProgressed: true as const }
         : {}),
       ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
       ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
         ? { nextWakeReason: nextWake.reason }
         : {}),
-      progressed: true,
+      progressed: false,
       ...(redactedStatus ? { redactedStatus } : {}),
       ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
-    };
-  }
-
-  return {
-    ...(browserVaultReplicaRefreshRequested
-      ? { browserVaultReplicaRefreshRequested: true }
-      : {}),
-    ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
-    ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
-    ...(foregroundPrioritySystemCompletionProcessed
-      ? { foregroundPrioritySystemCompletionProcessed: true }
-      : {}),
-    ...(invocationLocalAssistantWakeAt
-      ? { invocationLocalAssistantWakeAt }
-      : {}),
-    ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
-    ...(runtimeProjectionCheckpointRequested
-      ? { runtimeProjectionCheckpointRequested: true as const }
-      : {}),
-    ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
-    ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
-      ? { nextWakeReason: nextWake.reason }
-      : {}),
-    progressed: false,
-    ...(redactedStatus ? { redactedStatus } : {}),
-    ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
-  };
+    },
+  });
 }
 
 function withHostedDeviceSyncMaintenanceRan(
@@ -5980,15 +6013,13 @@ async function runSystemMailboxMaintenancePhase(input: {
       deviceSyncMaintenanceRan: false,
       initialProviderCleanupCheckpoint,
       pendingAssistantInputWakeAt,
-      result: {
-        ...withHostedRuntimeWakeCandidate({
+      result: withHostedRuntimeProjectionCheckpointRequest({
+        requested: staleDefaultProjectionDisproved,
+        result: withHostedRuntimeWakeCandidate({
           result: { progressed: false },
           wake: initialOwnerWake,
         }),
-        ...(staleDefaultProjectionDisproved
-          ? { runtimeProjectionCheckpointRequested: true as const }
-          : {}),
-      },
+      }),
     };
   }
   deferSystemMailboxPreparationForDelivery =

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2368,6 +2368,8 @@ export async function runHostedWorkspaceAssistantPhase(
     const systemMailboxOwnerOwnsCurrentPass =
       !hasAssistantInputAtPassStart
       && systemMailboxMaintenance.continueAssistantLane === false
+      && systemMailboxMaintenance.result?.runtimeProjectionCheckpointRequested
+        !== true
       && systemMailboxMaintenance.result?.nextWakeReason === "mailbox"
       && hostedRuntimeWakeCandidateIsDue(
         createHostedRuntimeWakeCandidate(
@@ -3992,6 +3994,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const systemMailboxProgressed =
     input.systemMailboxResult.systemMailboxProgressed === true
     || input.assistantResult.systemMailboxProgressed === true;
+  const runtimeProjectionCheckpointRequested =
+    input.systemMailboxResult.runtimeProjectionCheckpointRequested === true
+    || input.assistantResult.runtimeProjectionCheckpointRequested === true;
   const afterCheckpointKeepsForegroundImportLoop =
     input.systemMailboxResult.afterCheckpointKeepsForegroundImportLoop === true
     || input.assistantResult.afterCheckpointKeepsForegroundImportLoop === true;
@@ -4035,6 +4040,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
         ? { invocationLocalAssistantWakeAt }
         : {}),
       ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
+      ...(runtimeProjectionCheckpointRequested
+        ? { runtimeProjectionCheckpointRequested: true as const }
+        : {}),
       ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
       ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
         ? { nextWakeReason: nextWake.reason }
@@ -4058,6 +4066,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
       ? { invocationLocalAssistantWakeAt }
       : {}),
     ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
+    ...(runtimeProjectionCheckpointRequested
+      ? { runtimeProjectionCheckpointRequested: true as const }
+      : {}),
     ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
     ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
       ? { nextWakeReason: nextWake.reason }
@@ -5916,6 +5927,7 @@ async function runSystemMailboxMaintenancePhase(input: {
     };
   }
 
+  let staleDefaultProjectionDisproved = false;
   if (
     pendingAssistantInputBlocksMaintenance
     && !foregroundCausalAttempted
@@ -5933,6 +5945,7 @@ async function runSystemMailboxMaintenancePhase(input: {
         result: null,
       };
     }
+    staleDefaultProjectionDisproved = preflightAssistantCronWakeState.available;
   }
 
   let deferSystemMailboxPreparationForDelivery = false;
@@ -5967,10 +5980,15 @@ async function runSystemMailboxMaintenancePhase(input: {
       deviceSyncMaintenanceRan: false,
       initialProviderCleanupCheckpoint,
       pendingAssistantInputWakeAt,
-      result: withHostedRuntimeWakeCandidate({
-        result: { progressed: false },
-        wake: initialOwnerWake,
-      }),
+      result: {
+        ...withHostedRuntimeWakeCandidate({
+          result: { progressed: false },
+          wake: initialOwnerWake,
+        }),
+        ...(staleDefaultProjectionDisproved
+          ? { runtimeProjectionCheckpointRequested: true as const }
+          : {}),
+      },
     };
   }
   deferSystemMailboxPreparationForDelivery =

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -3912,7 +3912,9 @@ function mergeHostedAssistantPhaseResults(
 
 function hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
   result: HostedWorkspaceRunnerAssistantPhaseResult | null,
-): boolean {
+): result is HostedWorkspaceRunnerAssistantPhaseResult & {
+  nextWakeReason: "mailbox";
+} {
   return result?.runtimeProjectionCheckpointRequested !== true
     && result?.nextWakeReason === "mailbox";
 }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -297,6 +297,9 @@ interface HostedWorkspaceRunnerAssistantPhaseResultBase {
   // this invocation. This is never persisted; the runner and outer hot-wake
   // gate use it instead of inferring ownership from a merged wake timestamp.
   invocationLocalAssistantWakeAt?: string | null;
+  // Ephemeral request to checkpoint corrected wake projections. This does not
+  // claim assistant or system application progress.
+  runtimeProjectionCheckpointRequested?: true;
   nextWakeAt?: string | null;
   nextWakeReason?: string | null;
   redactedStatus?: HostedRuntimeRedactedJson | null;
@@ -3613,6 +3616,14 @@ async function checkpointHostedWorkspaceAssistantPhase(input: {
   platform: Pick<HostedWorkspaceRunnerPlatform, "logPort">;
   runtimeLogContext?: HostedRuntimeLogContext | null;
 }): Promise<void> {
+  if (
+    input.assistantPhaseResult.progressed !== true
+    && input.assistantPhaseResult.runtimeProjectionCheckpointRequested !== true
+  ) {
+    return;
+  }
+
+  input.checkpointRequestBuilder.markRuntimeStateDirty();
   if (input.assistantPhaseResult.progressed !== true) {
     return;
   }
@@ -3622,7 +3633,6 @@ async function checkpointHostedWorkspaceAssistantPhase(input: {
   );
   void input.expectedUserId;
   void input.initialMailboxImport;
-  input.checkpointRequestBuilder.markRuntimeStateDirty();
   await writeHostedForegroundCheckpointDeferredLog({
     checkpointPhase: "assistant",
     now: input.now,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
@@ -1462,9 +1462,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
   });
 
   it(
-    "hands oldest model-free device maintenance to its owner after causal work",
+    "hands a model-free device frontier off after disproving a stale default projection",
     async () => {
       const now = "2026-04-27T00:00:00.000Z";
+      const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
       const parentRoot = await mkdtemp(
         path.join(tmpdir(), "hosted-causal-fallback-"),
       );
@@ -1501,6 +1502,13 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
         mocks.resolveHostedSystemMailboxNextWakeCandidate.mockImplementation(
           systemMailbox.resolveHostedSystemMailboxNextWakeCandidate,
         );
+        mocks.getAssistantCronStatus.mockResolvedValueOnce({
+          dueJobs: 0,
+          enabledJobs: 1,
+          nextRunAt: staleDefaultWakeAt,
+          runningJobs: 1,
+          totalJobs: 1,
+        });
 
         const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
           assistantInputIds: [],
@@ -1509,14 +1517,25 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
           now: () => now,
           operatorHomeRoot,
           vaultRoot,
+          workspace: createDueAssistantWorkspace({
+            nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+            nextDefaultProcessingWakeReason: "assistant",
+            nextWakeAt: staleDefaultWakeAt,
+            nextWakeReason: "device-sync.reconcile",
+            systemMailboxProgressGeneration: "1",
+          }),
         }));
 
+        expect(mocks.getAssistantCronStatus).toHaveBeenCalledTimes(1);
         expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).not.toHaveBeenCalled();
         expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
+        expect(mocks.applyMurphManagedAutomations).toHaveBeenCalledTimes(1);
+        expect(mocks.refreshReminderAvailability).toHaveBeenCalledTimes(1);
         expect(result).toEqual(expect.objectContaining({
           nextWakeAt: now,
           nextWakeReason: "device-sync.reconcile",
           progressed: false,
+          runtimeProjectionCheckpointRequested: true,
         }));
 
         await result.afterCheckpoint?.();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3126,10 +3126,13 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
-  test("default mode checkpoints a stale assistant projection before handing an imported device frontier to the system owner", async () => {
+  test("checkpoints a stale assistant projection, then advances the imported device frontier under the system owner", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const artifactBytesByHash = new Map<string, Uint8Array>();
+    const artifactGetCalls: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
     const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
     const staleDeviceWakeAt = "2026-04-26T23:58:00.000Z";
     const runningAt = "2026-04-26T23:59:30.000Z";
@@ -3158,6 +3161,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     });
     const deviceSyncPort = createEmptyDeviceSyncPort();
     let assistantPhaseCalls = 0;
+    let snapshotOrdinal = 0;
 
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
@@ -3265,6 +3269,77 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         key: "users/bundles/member-synthetic/stale-default-projection-before.bundle.json",
         vaultRoot,
       });
+      artifactBytesByHash.set(restoredWorkspace.hash, restoredWorkspace.bytes);
+      let currentWorkspace = createWorkspaceState({
+        nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+        nextDefaultProcessingWakeReason: "assistant",
+        nextWakeAt: staleDeviceWakeAt,
+        nextWakeReason: "device-sync.reconcile",
+        redactedStatus: {
+          hostedMailboxBlockedCount: 0,
+          hostedMailboxConversationImportedSeq: "0",
+          hostedMailboxFetchedCount: 0,
+          hostedMailboxImportedCount: 0,
+          hostedMailboxRetryableBlockedCount: 0,
+          hostedMailboxSystemHandledThroughSeq: "0",
+          hostedMailboxSystemImportedSeq: "4",
+        },
+        snapshotRef: restoredWorkspace.snapshotRef,
+        systemMailboxProgressGeneration: "1",
+        version: "0",
+      });
+      const workspacePort: HostedRuntimeWorkspacePort = {
+        async checkpoint(request) {
+          events.push("workspace.checkpoint");
+          checkpointRequests.push(request);
+          currentWorkspace = createWorkspaceState({
+            inboxMediaRetentionWakeAt: request.inboxMediaRetentionWakeAt ?? null,
+            nextDefaultProcessingWakeAt:
+              request.nextDefaultProcessingWakeAt ?? null,
+            nextDefaultProcessingWakeReason:
+              request.nextDefaultProcessingWakeReason ?? null,
+            nextWakeAt: request.nextWakeAt ?? null,
+            nextWakeReason: request.nextWakeReason ?? null,
+            redactedStatus: request.redactedStatus ?? null,
+            snapshotRef: request.snapshotRef,
+            systemMailboxProgressGeneration:
+              request.systemMailboxProgressGeneration ?? null,
+            version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
+          });
+          return {
+            checkpointed: true,
+            workspace: currentWorkspace,
+          };
+        },
+        async read() {
+          events.push("workspace.read");
+          return {
+            fetchedAt: TEST_NOW,
+            workspace: currentWorkspace,
+          };
+        },
+      };
+      const platform = createPlatform({
+        artifactBytesByHash,
+        artifactGetCalls,
+        deviceSyncPort,
+        mailboxPort: createMailboxPort({
+          events,
+          fetchRequests,
+          items: [],
+        }),
+        workspacePort,
+      });
+      const createCheckpointSnapshot = async () => {
+        snapshotOrdinal += 1;
+        const snapshot = await createVaultSnapshotBundle({
+          key:
+            `users/bundles/member-synthetic/stale-default-projection-${snapshotOrdinal}.bundle.json`,
+          vaultRoot,
+        });
+        artifactBytesByHash.set(snapshot.hash, snapshot.bytes);
+        return { snapshotRef: snapshot.snapshotRef };
+      };
 
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
@@ -3275,48 +3350,11 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
           resolvedConfig: createDeviceSyncResolvedConfig(),
         }),
         {
-          async createCheckpointSnapshot() {
-            return {
-              snapshotRef: createBundleRef({
-                hash: "f".repeat(64),
-                key: "users/bundles/member-synthetic/stale-default-projection-after.bundle.json",
-                size: 512,
-              }),
-            };
-          },
+          createCheckpointSnapshot,
           async importItem() {
             throw new Error("The restored 0/4/4 mailbox must not import a new row.");
           },
-          platform: createPlatform({
-            artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
-            deviceSyncPort,
-            mailboxPort: createMailboxPort({
-              events,
-              items: [],
-            }),
-            workspacePort: createWorkspacePort({
-              checkpointRequests,
-              events,
-              workspace: createWorkspaceState({
-                nextDefaultProcessingWakeAt: staleDefaultWakeAt,
-                nextDefaultProcessingWakeReason: "assistant",
-                nextWakeAt: staleDeviceWakeAt,
-                nextWakeReason: "device-sync.reconcile",
-                redactedStatus: {
-                  hostedMailboxBlockedCount: 0,
-                  hostedMailboxConversationImportedSeq: "0",
-                  hostedMailboxFetchedCount: 0,
-                  hostedMailboxImportedCount: 0,
-                  hostedMailboxRetryableBlockedCount: 0,
-                  hostedMailboxSystemHandledThroughSeq: "0",
-                  hostedMailboxSystemImportedSeq: "4",
-                },
-                snapshotRef: restoredWorkspace.snapshotRef,
-                systemMailboxProgressGeneration: "1",
-                version: "0",
-              }),
-            }),
-          }),
+          platform,
           async runAssistantPhase(input) {
             assistantPhaseCalls += 1;
             const phaseResult = await runHostedWorkspaceAssistantPhase({
@@ -3368,6 +3406,86 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         (await readHostedSystemMailboxState(vaultRoot)).pending,
         pendingBeforeInvocation,
       );
+      assert.equal(currentWorkspace.version, "1");
+      assert.deepEqual(currentWorkspace.snapshotRef, checkpoint.snapshotRef);
+      assert.equal(
+        artifactBytesByHash.has(currentWorkspace.snapshotRef.hash),
+        true,
+      );
+
+      const checkpointCountBeforeSystemPass = checkpointRequests.length;
+      const artifactGetCountBeforeSystemPass = artifactGetCalls.length;
+      const fetchCountBeforeSystemPass = fetchRequests.length;
+      const systemResult = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_stale_default_projection_system_handoff",
+            processingMode: "system_mailbox",
+            workspaceVersion: currentWorkspace.version,
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          createCheckpointSnapshot,
+          async importItem() {
+            throw new Error("The handed-off 0/4/4 mailbox must not import a new row.");
+          },
+          platform,
+          async runAssistantPhase() {
+            throw new Error("The system owner handoff must not enter assistant phase.");
+          },
+          vaultRoot,
+        },
+      );
+
+      const systemPassCheckpoints = checkpointRequests.slice(
+        checkpointCountBeforeSystemPass,
+      );
+      assert.ok(systemPassCheckpoints.length > 0);
+      const systemCheckpoint = systemPassCheckpoints.at(-1);
+      assert.ok(systemCheckpoint);
+      assert.equal(
+        systemCheckpoint.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "2",
+      );
+      assert.equal(
+        systemCheckpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
+        "4",
+      );
+      assert.equal(
+        systemPassCheckpoints.every((request) =>
+          request.systemMailboxProgressGeneration === "1"
+        ),
+        true,
+      );
+      assert.equal(currentWorkspace.systemMailboxProgressGeneration, "1");
+      assert.equal(
+        artifactGetCalls.slice(artifactGetCountBeforeSystemPass).includes(
+          checkpoint.snapshotRef.hash,
+        ),
+        true,
+      );
+      assert.deepEqual(
+        fetchRequests.slice(fetchCountBeforeSystemPass).map((request) =>
+          request.lanes.map((lane) => ({
+            importedSeq: lane.importedSeq,
+            lane: lane.lane,
+          }))
+        ),
+        [[{ importedSeq: "4", lane: "system" }]],
+      );
+      assert.equal(systemResult.status, "scheduled");
+      assert.equal(deviceSyncPort.fetchSnapshotCalls, 1);
+      assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
+      assert.equal(assistantPhaseCalls, 1);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      const remainingPending = (await readHostedSystemMailboxState(vaultRoot)).pending;
+      assert.deepEqual(
+        remainingPending.map((item) => item.mailboxLaneSeq),
+        ["3", "4"],
+      );
+      assert.deepEqual(remainingPending, pendingBeforeInvocation.slice(1));
     } finally {
       mocks.runAssistantAutomationPass.mockClear();
       mocks.prepareHostedCodexAssistantProcess.mockClear();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3408,8 +3408,12 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       );
       assert.equal(currentWorkspace.version, "1");
       assert.deepEqual(currentWorkspace.snapshotRef, checkpoint.snapshotRef);
+      const checkpointSnapshotBaseRef = readHostedExecutionSnapshotBaseRef(
+        checkpoint.snapshotRef,
+      );
+      assert.ok(checkpointSnapshotBaseRef);
       assert.equal(
-        artifactBytesByHash.has(currentWorkspace.snapshotRef.hash),
+        artifactBytesByHash.has(checkpointSnapshotBaseRef.hash),
         true,
       );
 
@@ -3461,7 +3465,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(currentWorkspace.systemMailboxProgressGeneration, "1");
       assert.equal(
         artifactGetCalls.slice(artifactGetCountBeforeSystemPass).includes(
-          checkpoint.snapshotRef.hash,
+          checkpointSnapshotBaseRef.hash,
         ),
         true,
       );

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3126,6 +3126,256 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
+  test("default mode checkpoints a stale assistant projection before handing an imported device frontier to the system owner", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
+    const staleDeviceWakeAt = "2026-04-26T23:58:00.000Z";
+    const runningAt = "2026-04-26T23:59:30.000Z";
+    const futurePendingEffectsWakeAt = "2026-04-27T00:10:00.000Z";
+    const automationId = "automation_01JQ8PWXP5A68SQM1W0GYM41XZ";
+    const deviceHead = createMailboxItem({
+      dedupeKey: "device-sync.wake:stale-default-projection-head",
+      id: "mailbox_item_stale_default_projection_device_head",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const pendingEffects = createMailboxItem({
+      dedupeKey: "runtime.pending-effects-reconcile-requested:stale-default-projection",
+      id: "mailbox_item_stale_default_projection_pending_effects",
+      kind: "runtime.pending-effects-reconcile-requested",
+      lane: "system",
+      laneSeq: "3",
+    });
+    const deviceTail = createMailboxItem({
+      dedupeKey: "device-sync.wake:stale-default-projection-tail",
+      id: "mailbox_item_stale_default_projection_device_tail",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "4",
+    });
+    const deviceSyncPort = createEmptyDeviceSyncPort();
+    let assistantPhaseCalls = 0;
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.runAssistantAutomationPass.mockClear();
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await upsertAutomation({
+        automationId,
+        continuityPolicy: "fresh",
+        instructions: "Record one synthetic scheduled check-in.",
+        now: new Date(staleDefaultWakeAt),
+        route: {
+          channel: "linq",
+          deliveryTarget: "synthetic_direct_chat",
+          identityId: null,
+          participantId: null,
+          threadId: "synthetic_direct_chat",
+          threadIsDirect: true,
+        },
+        schedule: { at: staleDefaultWakeAt, kind: "at" },
+        status: "active",
+        title: "Synthetic stale projection check-in",
+        vaultRoot,
+      });
+      const cronAutomationStatePath = resolveAssistantStatePaths(
+        vaultRoot,
+      ).cronAutomationStatePath;
+      await mkdir(path.dirname(cronAutomationStatePath), { recursive: true });
+      await writeFile(
+        cronAutomationStatePath,
+        `${JSON.stringify({
+          jobs: [{
+            alias: null,
+            createdAt: staleDefaultWakeAt,
+            jobId: automationId,
+            schema: "murph.assistant-canonical-cron-runtime-state.v1",
+            sessionId: null,
+            state: {
+              activatedAt: staleDefaultWakeAt,
+              consecutiveFailures: 0,
+              lastError: null,
+              lastFailedAt: null,
+              lastRunAt: null,
+              lastSucceededAt: null,
+              pendingDeliveryIntentId: null,
+              pendingOccurrenceAt: staleDefaultWakeAt,
+              retryAfterAt: null,
+              runningAt,
+              runningClaimId: "claim_synthetic_stale_default",
+              runningPid: process.pid,
+            },
+            updatedAt: runningAt,
+          }],
+          version: 1,
+        }, null, 2)}\n`,
+      );
+      assert.deepEqual(await getAssistantCronStatus(vaultRoot), {
+        dueJobs: 0,
+        enabledJobs: 1,
+        nextRunAt: staleDefaultWakeAt,
+        runningJobs: 1,
+        totalJobs: 1,
+      });
+
+      await enqueueDeviceSyncSystemMailboxItemForTest({
+        item: deviceHead,
+        vaultRoot,
+      });
+      await enqueuePendingEffectsSystemMailboxItemForTest({
+        effectId: "effect_synthetic_stale_default_projection",
+        item: pendingEffects,
+        vaultRoot,
+      });
+      await enqueueDeviceSyncSystemMailboxItemForTest({
+        item: deviceTail,
+        vaultRoot,
+      });
+      await updateHostedSystemMailboxState(vaultRoot, (state) => ({
+        pending: state.pending.map((item) =>
+          item.itemId === pendingEffects.id
+            ? { ...item, nextAttemptAt: futurePendingEffectsWakeAt }
+            : item
+        ),
+      }));
+      const pendingBeforeInvocation = structuredClone(
+        (await readHostedSystemMailboxState(vaultRoot)).pending,
+      );
+      assert.deepEqual(
+        pendingBeforeInvocation.map((item) => item.mailboxLaneSeq),
+        ["1", "3", "4"],
+      );
+      assert.equal(
+        findNextHostedSystemMailboxQueueItem({
+          allowedRouteActions: null,
+          now: TEST_NOW,
+          state: { pending: pendingBeforeInvocation },
+        })?.itemId,
+        deviceHead.id,
+      );
+      const importState = createEmptyHostedMailboxImportState();
+      importState.watermarks.system = "4";
+      await writeMailboxImportStateFile(vaultRoot, importState);
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/stale-default-projection-before.bundle.json",
+        vaultRoot,
+      });
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_stale_default_projection",
+            workspaceVersion: "0",
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "f".repeat(64),
+                key: "users/bundles/member-synthetic/stale-default-projection-after.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            throw new Error("The restored 0/4/4 mailbox must not import a new row.");
+          },
+          platform: createPlatform({
+            artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
+            deviceSyncPort,
+            mailboxPort: createMailboxPort({
+              events,
+              items: [],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({
+                nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+                nextDefaultProcessingWakeReason: "assistant",
+                nextWakeAt: staleDeviceWakeAt,
+                nextWakeReason: "device-sync.reconcile",
+                redactedStatus: {
+                  hostedMailboxBlockedCount: 0,
+                  hostedMailboxConversationImportedSeq: "0",
+                  hostedMailboxFetchedCount: 0,
+                  hostedMailboxImportedCount: 0,
+                  hostedMailboxRetryableBlockedCount: 0,
+                  hostedMailboxSystemHandledThroughSeq: "0",
+                  hostedMailboxSystemImportedSeq: "4",
+                },
+                snapshotRef: restoredWorkspace.snapshotRef,
+                systemMailboxProgressGeneration: "1",
+                version: "0",
+              }),
+            }),
+          }),
+          async runAssistantPhase(input) {
+            assistantPhaseCalls += 1;
+            const phaseResult = await runHostedWorkspaceAssistantPhase({
+              ...input,
+              now: () => TEST_NOW,
+            });
+            assert.equal(phaseResult.progressed, false);
+            assert.equal(phaseResult.nextWakeAt, TEST_NOW);
+            assert.equal(phaseResult.nextWakeReason, "device-sync.reconcile");
+            return phaseResult;
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.equal(assistantPhaseCalls, 1);
+      assert.equal(checkpointRequests.length, 1);
+      const checkpoint = checkpointRequests[0];
+      assert.ok(checkpoint);
+      assert.equal(checkpoint.reason, "idle_shutdown");
+      assert.equal(checkpoint.expectedWorkspaceVersion, "0");
+      assert.equal(checkpoint.nextWakeAt, TEST_NOW);
+      assert.equal(checkpoint.nextWakeReason, "device-sync.reconcile");
+      assert.equal(
+        checkpoint.nextDefaultProcessingWakeAt,
+        futurePendingEffectsWakeAt,
+      );
+      assert.equal(checkpoint.nextDefaultProcessingWakeReason, "assistant");
+      assert.equal(checkpoint.systemMailboxProgressGeneration, "1");
+      assert.equal(
+        checkpoint.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "0",
+      );
+      assert.equal(
+        checkpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
+        "4",
+      );
+      assert.equal(checkpoint.redactedStatus?.hostedMailboxFetchedCount, 0);
+      assert.equal(checkpoint.redactedStatus?.hostedMailboxImportedCount, 0);
+      assert.equal(result.status, "scheduled");
+      assert.equal(result.immediateRecheckRequested, true);
+      assert.equal(result.nextWakeAt, TEST_NOW);
+      assert.equal(result.nextWakeReason, "device-sync.reconcile");
+      assert.equal(deviceSyncPort.fetchSnapshotCalls, 0);
+      assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.deepEqual(
+        (await readHostedSystemMailboxState(vaultRoot)).pending,
+        pendingBeforeInvocation,
+      );
+    } finally {
+      mocks.runAssistantAutomationPass.mockClear();
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("default foreground hands a timed-out browser refresh to the model-free system owner", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const artifactBytesByHash = new Map<string, Uint8Array>();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -3309,6 +3309,54 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     }
   });
 
+  test("marks a projection-only assistant checkpoint request dirty without claiming application progress", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const { mailboxPort } = createMailboxPort({ items: [] });
+
+    try {
+      const result = await runHostedWorkspaceUntilIdleOrBudget({
+        checkpointRequestBuilder: createHostedWorkspaceCheckpointRequestBuilder({
+          attemptId: "attempt_synthetic_runner_projection_checkpoint",
+          expectedWorkspaceVersion: "0",
+          leaseGeneration: "1",
+          nextWakeAt: null,
+          nextWakeReason: null,
+          snapshotRef: null,
+        }),
+        expectedUserId: TEST_USER_ID,
+        async importItem() {
+          throw new Error("Import should not run without mailbox items.");
+        },
+        limitPerLane: 10,
+        platform: createPlatform({
+          mailboxPort,
+          workspacePort: createWorkspacePort({ checkpointRequests }),
+        }),
+        requestId: "request_synthetic_runner_projection_checkpoint",
+        async runAssistantPhase() {
+          return {
+            progressed: false,
+            runtimeProjectionCheckpointRequested: true,
+          };
+        },
+        vaultRoot,
+        workspace: createWorkspaceState({ version: "0" }),
+        now: () => TEST_NOW,
+      });
+
+      assert.equal(result.runtimeStateDirty, true);
+      assert.equal(result.assistantPhaseResult?.progressed, false);
+      assert.equal(result.assistantPhaseResult?.checkpointReason, undefined);
+      assert.deepEqual(checkpointRequests, []);
+    } finally {
+      await rm(vaultRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
   test("rejects a progressed assistant phase without an explicit checkpoint reason", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];


### PR DESCRIPTION
## Why and outcome

A stale durable `default` wake could keep winning Temporal arbitration after live runtime state had already disproved that wake. When the next durable item belonged to a model-free system owner, the default pass handed it off with `progressed: false`; the runner therefore skipped the projection checkpoint, leaving the stale default wake durable and recreating the same pass indefinitely.

This change checkpoints that corrected runtime projection without claiming application progress. The next arbitration selects the actual system owner, while genuine default work keeps its existing priority.

## Product UX

- Effort: Patch.
- Walkthrough: Ready.
- Affected people: members whose background device or maintenance work is blocked behind a stale default timer now converge automatically.
- Material exclusions: fresh conversation input, genuinely due assistant/reminder work, and ordinary foreground replies retain their existing priority and behavior.

## Evidence

- Production incident evidence: the exact alert cohort stayed imported but unhandled while Temporal repeatedly selected `default`; SDK replay of both alert-window and current histories passed, ruling out workflow nondeterminism.
- Production-shaped local replay: a transient, identifier-redacted copy of the exact failing envelope preserved its relative 0/4/4 watermarks, expired-position gap, three live item kinds/order, stale assistant projection, running canonical cron state, and model-free device frontier. It passed on this head with one projection-only checkpoint, unchanged generation/handled state, and an immediate device-owner recheck. No production row or identifier was persisted.
- Untouched `origin/main` red proof: the committed composed regression failed at `checkpointRequests.length` with `0 !== 1`; the assistant phase returned the device-owner wake but emitted no projection checkpoint.
- Head two-cycle proof: the same normalized 0/4/4 fixture restores checkpoint 1's real snapshot in `system_mailbox` mode, consumes live sequence 1, advances handled-through to 2 across the expired sequence gap, preserves live sequences 3/4 byte-for-byte, and keeps generation unchanged. Assistant/Codex preparation remains unused; one empty device snapshot read performs no external wearable-provider execution.
- `pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts --no-coverage`: 85 passed.
- `pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts --no-coverage`: 122 passed.
- `pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts --no-coverage`: 51 passed.
- `pnpm --filter @murphai/assistant-runtime typecheck`: passed.
- Focused changelog page test: 9 passed; `pnpm --dir apps/web typecheck`: passed.

## Non-obvious affected surfaces

- Default-pass owner handoff: a projection-only checkpoint request must survive phase-result merges and generic-mailbox preflight so the corrected wake set is actually published. Covered by the phase and runner regressions.
- Outer hosted-runtime pass loop: a due non-assistant owner is handed off only after late foreground/rerun work is exhausted. Covered by the composed entrypoint regression and existing late-input coverage.
- Canonical cron projection: a running job's historical `nextRunAt` is normalized to a future retry instead of republishing an already-past default wake. Covered by the real canonical-cron setup in the composed regression.
- Hosted execution deployment: the runner bundle must roll immediately because already-warm old containers retain the bug. The durable wire and checkpoint schema are unchanged.

## Architecture and reuse

- Existing systems reused: the runtime remains the owner of wake semantics/projection, Web persists the checkpoint, Temporal mechanically interprets durable facts, and the existing system-mailbox owner handles the selected item.
- New logic: one ephemeral phase-result marker asks the existing checkpoint builder to persist a corrected projection without incrementing progress, plus existing wake normalization and post-foreground owner handoff are applied at their current boundaries.
- New abstractions: no persisted state, queue, schema, service, or lifecycle was added; three small local helpers only preserve and test the ephemeral marker through existing result composition.
- Complexity intentionally avoided: Temporal priority was not changed, system work was not executed from the wrong owner, and no reconciliation loop or compatibility shim was introduced.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: changed hotspot maxima are unchanged; `workspace-assistant-phase.ts` complexity debt decreased from 423 to 422 after extracting the local result helpers.
- Agent judgment: no further behavior-preserving simplification is justified; the composed regression is intentionally large because it exercises the real canonical cron, queue, snapshot, checkpoint, and entrypoint boundary together.

## Hot reply path impact

- Not applicable: the correction is limited to an idle default pass after no fresh or rerunnable foreground input remains. It adds no database, network, provider, or awaited operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool/schema guidance, model request assembly, or provider-visible input changed.
- Codex runtime: Not applicable; no prompt, tool/schema guidance, model request assembly, or provider-visible input changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: the existing changelog archive renderer loads the new content-only entry; no renderer, component, style, interaction, or responsive behavior changed.
- Coverage: the focused SSR/page test covers the changed archive fragment; the existing phone and desktop archive study remains representative, so a new screenshot adds no proof.

## Change-shape breakdown

Classification is by path and role; authored runtime implementation is source, test files are tests/fixtures, durable guidance, active execution plan, and changelog content are docs, and no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 107 | 43 |
| Tests/fixtures | 436 | 1 |
| Docs | 158 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **701** | **46** |

## Deployment concerns

- Deployment: applicable
- Supported skew: the wire/checkpoint schema is unchanged, so old and new Worker/container bundles interoperate; an old warm runner may continue the livelock until replaced.
- Safe order: land the separate standby-capacity cap first, then deploy the public Cloudflare Worker and runner bundle with immediate container rollout. No Web or Temporal deployment is required.
- Rollback floor: rollback is data-safe because the change neither consumes the model-free item nor increments its progress generation; rollback can reintroduce the livelock.
- Expected exposure: until all warm runners are replaced, an affected runtime routed to an old container can remain stalled.
- Reversibility: revert the runner change and repeat an immediate rollout; pending durable work remains intact.
- Convergence proof: require the exact alert cohort to advance handled-through to its imported frontier and Temporal to select the system owner; a new checkpoint timestamp alone is explicitly insufficient.
- Post-deploy checks: verify the deployed fingerprint, bounded runtime error aggregates, owner-selection history, handled-through advancement, and zero recurrence of stale-default progress alerts.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · background-work-recovers-from-stale-timers

## Risks

- A projection-only checkpoint marks runtime state dirty but intentionally leaves system progress generation and handled-through unchanged.
- Failure to read live cron status fails closed: the runtime does not classify the durable default projection as stale.
- Fresh foreground work is rechecked before the outer pass yields to a non-assistant owner.

ReviewGPT context sensitivity: sensitive — hosted execution ordering and durable wake projection change.

ReviewGPT first-reviewed head: 2b7556bab6b77d11e08e7dda1e3915b67e617d59