### PR TITLE
Fit standby containers within production capacity

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -373,7 +373,13 @@ Last verified: 2026-08-30
   uses one 250 ms claim/bind deadline. A miss before slot ownership uses the
   ordinary exact-user fallback; an ambiguous bind after the per-member stop
   target is durably reserved retries that exact target instead of risking two
-  live containers.
+  live containers. The standby class, binding, and migration remain deployed in
+  every mode. Its independent platform-capacity input defaults to one for the
+  never-allocated deployment. Before `allocate`, operators raise it to at least
+  the active-runner maximum and retain that raised value through an `off` or
+  `shadow` rollback; they reduce it only after proving every bound standby target
+  has retired. Mode changes never implicitly narrow capacity beneath persisted
+  same-member targets.
   A coordinator transaction admits at most one winner, then replacement
   provisioning runs under `waitUntil`; alarms re-prove readiness, retry failed
   retirement, expire unbound claim tombstones, and drain stale releases. The

--- a/agent-docs/exec-plans/active/2026-09-01-standby-container-capacity.md
+++ b/agent-docs/exec-plans/active/2026-09-01-standby-container-capacity.md
@@ -1,0 +1,64 @@
+# Standby Container Capacity
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+Fit the current never-allocated standby declaration within Cloudflare's
+production container ceiling without removing the standby class, binding, or
+migration, and preserve enough independent standby capacity for any future
+allocation and rollback lifecycle.
+
+## Proven cause
+
+- Production declares 748 active two-vCPU runners and one two-vCPU deploy-smoke
+  runner. Reusing the active maximum for standby declared another 748 runners,
+  taking composed capacity from the 1,500-vCPU account ceiling to 2,994 vCPU.
+- The renderer derived standby capacity from the active maximum even while
+  standby mode was `off` or `shadow`; the platform rejected the composed
+  declaration before the Worker could deploy.
+- Runtime mode is not a safe capacity owner after allocation because persisted
+  bound standby targets can survive a later mode change.
+
+## Contract
+
+- `CF_STANDBY_CONTAINER_MAX_INSTANCES` independently owns standby platform
+  capacity and defaults to `1`. Runtime mode never implicitly changes it.
+- Current `off` or `shadow` production may deploy the one-instance cap only
+  after read-only evidence proves standby allocation has never produced a bound
+  target.
+- Before future `allocate`, raise standby capacity to at least
+  `CF_CONTAINER_MAX_INSTANCES` while still in `shadow` and prove the live value.
+- On rollback, switch mode to `off` while retaining the raised capacity. Reduce
+  it only after every bound standby target is independently proven retired.
+
+## Remaining gates
+
+1. Prove the current production cohort has never allocated or retained a bound
+   standby target.
+2. Land the private `murph-cloud` workflow mapping, guard, test, documentation,
+   and deploy summary. Set the owning preview and production GitHub Environment
+   variable to `1` after the fallback-compatible workflow is live.
+3. Deploy the exact reviewed public and private heads without enabling
+   `allocate`.
+4. Prove the exact live Worker version, standby binding/class, and container
+   declarations: active `748`, deploy smoke `1`, standby `1`, all at the expected
+   two-vCPU shape.
+5. Confirm the original quota rejection is absent and keep the independent-cap
+   rollback rule in the operator handoff.
+
+## Verification
+
+- Regression coverage proves current production arithmetic:
+  `748 * 2 + 1 * 2 + 1 * 2 = 1,500` vCPU. A raised standby maximum of 748 is
+  separately proven as 2,994 vCPU and is rejected for `allocate` when lower
+  than the active maximum.
+- Focused deploy-automation and rollout tests pass 34 cases; an independent
+  review passes 45 focused cases and finds no public-contract blocker.
+- Cloudflare typecheck, `pnpm complexity:diff`, and `git diff --check` pass.
+- Exact-diff verification passes 152 node test files (2,785 passed, 2 skipped),
+  the six-case container helper, and 15 Workers cases.
+- Pending: private workflow/environment proof, current never-allocated proof,
+  deploy, and live container/binding verification.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1174,9 +1174,8 @@ Set these in the selected GitHub environment as vars:
 - `HOSTED_R2_PRESIGN_BUCKET_NAME`
 
 `CF_STANDBY_CONTAINER_MAX_INSTANCES` is a non-secret deploy input, not a Worker
-runtime variable. Private `cobuildwithus/murph-cloud` must map it in
-`.github/workflows/deploy-cloudflare-hosted.yml` on the `Prepare deploy
-artifacts` step's `env` as
+runtime variable. Private `cobuildwithus/murph-cloud` must map it on the
+`deploy` job's `env` in `.github/workflows/deploy-cloudflare-hosted.yml` as
 `CF_STANDBY_CONTAINER_MAX_INSTANCES: ${{ vars.CF_STANDBY_CONTAINER_MAX_INSTANCES || '1' }}`.
 The owning `preview` and `production` GitHub Environments must both start at
 `1`. A deployment is incomplete until artifact validation shows the rendered

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1159,6 +1159,7 @@ Set these in the selected GitHub environment as vars:
 - `CF_BUNDLES_BUCKET`
 - `CF_BUNDLES_PREVIEW_BUCKET`
 - `CF_PUBLIC_BASE_URL`
+- `CF_STANDBY_CONTAINER_MAX_INSTANCES=1`
 - `HOSTED_WEB_BASE_URL`
 - `HOSTED_WEB_PRODUCTION_BASE_URL`
 - `HOSTED_EXECUTION_VERCEL_OIDC_TEAM_SLUG`
@@ -1171,6 +1172,17 @@ Set these in the selected GitHub environment as vars:
 - `HOSTED_DATABASE_ALERT_PLANETSCALE_ORGANIZATION`
 - `HOSTED_R2_PRESIGN_ACCOUNT_ID`
 - `HOSTED_R2_PRESIGN_BUCKET_NAME`
+
+`CF_STANDBY_CONTAINER_MAX_INSTANCES` is a non-secret deploy input, not a Worker
+runtime variable. Private `cobuildwithus/murph-cloud` must map it in
+`.github/workflows/deploy-cloudflare-hosted.yml` on the `Prepare deploy
+artifacts` step's `env` as
+`CF_STANDBY_CONTAINER_MAX_INSTANCES: ${{ vars.CF_STANDBY_CONTAINER_MAX_INSTANCES || '1' }}`.
+The owning `preview` and `production` GitHub Environments must both start at
+`1`. A deployment is incomplete until artifact validation shows the rendered
+standby maximum and the live Cloudflare container declaration reports the same
+value. Raising it before `allocate`, retaining it through rollback, and reducing
+it after the bound-target drain use that same Environment variable and mapping.
 
 `MURPH_ANDROID_APP_ENABLED` is an optional, fail-closed rollout variable. Leave
 it unset until the public Android app and the compatible Web, Worker, and runner
@@ -1379,6 +1391,12 @@ Core execution tuning:
 - `CF_COMPATIBILITY_DATE` defaults to `2026-03-27`
 - `CF_CONTAINER_INSTANCE_TYPE` defaults to `{"vcpu":2,"memory_mib":6144,"disk_mb":6000}`. This restores the two-vCPU production shape after measured cold-start and same-size workspace-restore regressions on the smaller allocation. The post-completion conversation idle lease remains independently configured at ten minutes.
 - `CF_CONTAINER_MAX_INSTANCES` defaults to `1000`
+- `CF_STANDBY_CONTAINER_MAX_INSTANCES` defaults to `1` and independently owns
+  the `StandbyRunnerContainer` platform declaration. Before enabling standby
+  allocation, set it to at least `CF_CONTAINER_MAX_INSTANCES`; retain that
+  raised value through `off` or `shadow` rollback until every bound standby
+  target has been proven retired. Current never-allocated production remains at
+  `1`.
 - `CF_MAX_EVENT_ATTEMPTS` defaults to `3`
 - `CF_RETRY_DELAY_MS` defaults to `30000`
 - `CF_WEB_CONTROL_TIMEOUT_MS` defaults to `30000`
@@ -1395,7 +1413,10 @@ Core execution tuning:
   release-scoped ENAM standby and measures readiness without allocating it;
   `allocate` lets `UserRunner` claim it with a 250 ms total coordinator/bind
   deadline and uses the unchanged exact-user cold path when no ready slot is
-  available. Invalid values fail deploy/runtime parsing closed.
+  available. Invalid values fail deploy/runtime parsing closed. The rendered
+  `StandbyRunnerContainer` remains declared in every mode so its class, binding,
+  and migration history stay available. Mode changes do not change its platform
+  capacity; `CF_STANDBY_CONTAINER_MAX_INSTANCES` owns that separate lifecycle.
 - `HOSTED_EXECUTION_VERCEL_OIDC_ENVIRONMENT` defaults to `production` for
   direct/local artifact rendering. The manual deploy workflow derives it from
   the selected `preview` or `production` target; do not configure a conflicting
@@ -1419,7 +1440,14 @@ effective standby mode, expected Worker release, and runner bundle/source
 fingerprints first. Then use `shadow` for at least one ordinary
 observation window and verify that exactly one current-release ENAM slot stays
 ready, failed/stale slots retire, and no processing reports a claimed standby.
-Only then set `allocate`; no Web or Temporal deploy is required.
+Before any future `allocate` activation, raise
+`CF_STANDBY_CONTAINER_MAX_INSTANCES` to at least
+`CF_CONTAINER_MAX_INSTANCES`, deploy and prove that live declaration while the
+mode remains `shadow`, and budget the account-wide container ceiling for the
+active runner, deploy-smoke runner, and standby declaration together. Reduce
+the configured maxima or raise the Cloudflare account limit first when that
+composed maximum would exceed capacity. Only then set `allocate`; no Web or
+Temporal deploy is required.
 
 At the current 2-vCPU, 6-GiB-memory, 6-GB-disk shape, one continuously ready
 slot costs about $40.52 per average 730-hour month for allocated memory and
@@ -1429,12 +1457,17 @@ preflight. In `allocate`, temporarily add the
 ordinary cost of claimed same-member containers until their existing idle
 lifecycle retires them. Check current Cloudflare rates before activation.
 
-The immediate operational rollback is to set the mode to `off`; current and
-stale release coordinators converge by retiring only coordinator-owned slots,
-while already bound member containers finish or stop through their exact
-`UserRunner` owner. Once migration `v7` has deployed, do not roll Worker code
-back to a version that removes the new class exports, bindings, or migration
-history. Forward-deploy compatible code with mode `off` instead.
+This release's deployment claim is limited to current `off` or `shadow`
+production after proving that `allocate` has never bound a standby target. In
+that state, the one-instance declaration is safe and preserves the class,
+binding, and migration history. After any future allocation, the immediate
+operational rollback is mode `off` while retaining the raised independent
+standby capacity: runtime mode `off` retires coordinator-owned slots while
+already-bound member containers finish or stop through their exact `UserRunner`
+owner. Reduce `CF_STANDBY_CONTAINER_MAX_INSTANCES` back to `1` only after proving
+that every bound standby target has retired. Once migration `v7` has deployed,
+do not roll Worker code back to a version that removes the new class exports,
+bindings, or migration history.
 
 Observability:
 
@@ -1691,6 +1724,7 @@ If the selected GitHub environment already defines container sizing overrides, u
 
 - `CF_CONTAINER_INSTANCE_TYPE={"vcpu":2,"memory_mib":6144,"disk_mb":6000}`
 - `CF_CONTAINER_MAX_INSTANCES=1000`
+- `CF_STANDBY_CONTAINER_MAX_INSTANCES=1`
 
 When hosted email sender identity is configured, deploy automation renders one native `send_email` binding named `HOSTED_EMAIL` and constrains it with `allowed_sender_addresses` to that resolved sender address. Hosted email outbound send no longer requires a runtime Cloudflare account id or email-send API token inside the Worker.
 

--- a/apps/cloudflare/scripts/deploy-automation/environment.ts
+++ b/apps/cloudflare/scripts/deploy-automation/environment.ts
@@ -3,6 +3,7 @@ import {
   MURPH_ANDROID_APP_ENABLED_ENV,
 } from "@murphai/hosted-execution/env";
 
+import { readHostedStandbyMode } from "../../src/standby-runner-contract.ts";
 import {
   HOSTED_WORKER_OPTIONAL_VAR_DEFAULTS,
   HOSTED_WORKER_REQUIRED_VAR_NAMES,
@@ -48,6 +49,7 @@ const DEFAULT_CONTAINER_INSTANCE_TYPE: HostedContainerInstanceType = {
   vcpu: 2,
 };
 const DEFAULT_CONTAINER_MAX_INSTANCES = 1000;
+const DEFAULT_STANDBY_CONTAINER_MAX_INSTANCES = 1;
 const RUNNER_COMMIT_RESPONSE_MARGIN_MS = 5_000;
 
 export interface HostedDeployAutomationEnvironment {
@@ -62,6 +64,7 @@ export interface HostedDeployAutomationEnvironment {
   retryDelayMs: string;
   runnerCommitTimeoutMs: string;
   runnerReadyTimeoutMs: string;
+  standbyContainerMaxInstances: number;
   traceHeadSamplingRate: number;
   webControlTimeoutMs: string;
   workerName: string;
@@ -111,6 +114,25 @@ export function readHostedDeployAutomationEnvironment(
   const workerName = requireConfiguredString(source.CF_WORKER_NAME, "CF_WORKER_NAME");
   const timeouts = readHostedDeployAutomationTimeouts(source);
   const workerVars = readHostedWorkerVars(source);
+  const containerMaxInstances = normalizePositiveInteger(
+    source.CF_CONTAINER_MAX_INSTANCES,
+    DEFAULT_CONTAINER_MAX_INSTANCES,
+    "CF_CONTAINER_MAX_INSTANCES",
+  );
+  const standbyContainerMaxInstances = normalizePositiveInteger(
+    source.CF_STANDBY_CONTAINER_MAX_INSTANCES,
+    DEFAULT_STANDBY_CONTAINER_MAX_INSTANCES,
+    "CF_STANDBY_CONTAINER_MAX_INSTANCES",
+  );
+  if (
+    readHostedStandbyMode(workerVars) === "allocate"
+    && standbyContainerMaxInstances < containerMaxInstances
+  ) {
+    throw new Error(
+      "CF_STANDBY_CONTAINER_MAX_INSTANCES must be at least "
+      + "CF_CONTAINER_MAX_INSTANCES before standby allocation is enabled.",
+    );
+  }
   assertHostedR2Configuration({
     bundlesBucketName,
     workerVars,
@@ -126,11 +148,7 @@ export function readHostedDeployAutomationEnvironment(
       DEFAULT_CONTAINER_INSTANCE_TYPE,
       "CF_CONTAINER_INSTANCE_TYPE",
     ),
-    containerMaxInstances: normalizePositiveInteger(
-      source.CF_CONTAINER_MAX_INSTANCES,
-      DEFAULT_CONTAINER_MAX_INSTANCES,
-      "CF_CONTAINER_MAX_INSTANCES",
-    ),
+    containerMaxInstances,
     logHeadSamplingRate: normalizeSamplingRate(
       source.CF_LOG_HEAD_SAMPLING_RATE,
       DEFAULT_LOG_HEAD_SAMPLING_RATE,
@@ -152,6 +170,7 @@ export function readHostedDeployAutomationEnvironment(
       "20000",
       "CF_RUNNER_READY_TIMEOUT_MS",
     ),
+    standbyContainerMaxInstances,
     traceHeadSamplingRate: normalizeSamplingRate(
       source.CF_TRACE_HEAD_SAMPLING_RATE,
       DEFAULT_TRACE_HEAD_SAMPLING_RATE,

--- a/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
+++ b/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
@@ -104,7 +104,7 @@ export function buildHostedWranglerDeployConfig(
       buildRunnerContainerConfig({
         className: "StandbyRunnerContainer",
         constraints: { regions: ["ENAM"] },
-        maxInstances: environment.containerMaxInstances,
+        maxInstances: environment.standbyContainerMaxInstances,
         rolloutActiveGracePeriodSeconds:
           RUNNER_CONTAINER_ROLLOUT_ACTIVE_GRACE_PERIOD_SECONDS,
       }),

--- a/apps/cloudflare/test/container-image-contract.test.ts
+++ b/apps/cloudflare/test/container-image-contract.test.ts
@@ -59,6 +59,7 @@ function createDeployEnvironment() {
     retryDelayMs: "30000",
     runnerCommitTimeoutMs: "45000",
     runnerReadyTimeoutMs: "20000",
+    standbyContainerMaxInstances: 1,
     traceHeadSamplingRate: 0.1,
     webControlTimeoutMs: "30000",
     workerName: "murph-hosted",

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -336,9 +336,9 @@ describe("hosted deploy automation helpers", () => {
         image: "../../../Dockerfile.cloudflare-hosted-runner",
         image_build_context: "..",
         instance_type: "standard-1",
-        max_instances: 250,
+        max_instances: 1,
         rollout_active_grace_period: 300,
-        rollout_step_percentage: [10, 25, 50, 100],
+        rollout_step_percentage: [100],
         ssh: { enabled: false },
       },
     ]);
@@ -506,6 +506,95 @@ describe("hosted deploy automation helpers", () => {
     expect(config.vars.TELEGRAM_BOT_USERNAME).toBe("hosted_bot");
     expect(config.vars.HOSTED_EXECUTION_RUNNER_BASE_URL).toBeUndefined();
     expect(config.secrets?.required).toEqual([...HOSTED_WORKER_REQUIRED_SECRET_NAMES]);
+  });
+
+  it.each([
+    ["current off", "off", undefined, 1, [100], 1_500],
+    ["current shadow", "shadow", undefined, 1, [100], 1_500],
+    ["raised allocate", "allocate", "748", 748, [10, 25, 50, 100], 2_994],
+    ["raised off rollback", "off", "748", 748, [10, 25, 50, 100], 2_994],
+    ["raised shadow rollback", "shadow", "748", 748, [10, 25, 50, 100], 2_994],
+  ] as const)(
+    "renders %s standby capacity without changing its durable declaration",
+    (
+      _scenario,
+      standbyMode,
+      configuredStandbyMaxInstances,
+      expectedStandbyMaxInstances,
+      expectedRolloutSteps,
+      expectedDeclaredMaxVcpu,
+    ) => {
+      const environment = readHostedDeployAutomationEnvironment({
+        CF_BUNDLES_BUCKET: "hosted-bundles",
+        CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
+        CF_CONTAINER_MAX_INSTANCES: "748",
+        CF_STANDBY_CONTAINER_MAX_INSTANCES: configuredStandbyMaxInstances,
+        CF_WORKER_NAME: "hosted-worker",
+        ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
+        HOSTED_EXECUTION_STANDBY_MODE: standbyMode,
+      });
+      const config = buildHostedWranglerDeployConfig(environment) as {
+        containers: Array<{
+          class_name: string;
+          constraints?: { regions: string[] };
+          instance_type: string | {
+            disk_mb: number;
+            memory_mib: number;
+            vcpu: number;
+          };
+          max_instances: number;
+          rollout_step_percentage: number[];
+        }>;
+        durable_objects: {
+          bindings: Array<{ class_name: string; name: string }>;
+        };
+        migrations: Array<{ new_sqlite_classes: string[]; tag: string }>;
+      };
+
+      expect(config.containers).toMatchObject([
+        { class_name: "RunnerContainer", max_instances: 748 },
+        { class_name: "DeploySmokeRunnerContainer", max_instances: 1 },
+        {
+          class_name: "StandbyRunnerContainer",
+          constraints: { regions: ["ENAM"] },
+          max_instances: expectedStandbyMaxInstances,
+          rollout_step_percentage: expectedRolloutSteps,
+        },
+      ]);
+      const declaredMaxVcpu = config.containers.reduce((total, container) => {
+        if (typeof container.instance_type === "string") {
+          throw new TypeError("Expected the production custom container shape.");
+        }
+        return total + container.max_instances * container.instance_type.vcpu;
+      }, 0);
+      expect(declaredMaxVcpu).toBe(expectedDeclaredMaxVcpu);
+      expect(config.durable_objects.bindings).toContainEqual({
+        class_name: "StandbyRunnerContainer",
+        name: "STANDBY_RUNNER_CONTAINER",
+      });
+      expect(config.migrations).toContainEqual({
+        new_sqlite_classes: [
+          "StandbyRunnerCoordinatorDurableObject",
+          "StandbyRunnerContainer",
+        ],
+        tag: "v7",
+      });
+    },
+  );
+
+  it("requires full independent standby capacity before allocation", () => {
+    expect(() => readHostedDeployAutomationEnvironment({
+      CF_BUNDLES_BUCKET: "hosted-bundles",
+      CF_BUNDLES_PREVIEW_BUCKET: "hosted-bundles-preview",
+      CF_CONTAINER_MAX_INSTANCES: "748",
+      CF_STANDBY_CONTAINER_MAX_INSTANCES: "747",
+      CF_WORKER_NAME: "hosted-worker",
+      ...REQUIRED_HOSTED_CRYPTO_WORKER_VARS,
+      HOSTED_EXECUTION_STANDBY_MODE: "allocate",
+    })).toThrow(
+      "CF_STANDBY_CONTAINER_MAX_INSTANCES must be at least "
+      + "CF_CONTAINER_MAX_INSTANCES before standby allocation is enabled.",
+    );
   });
 
   it("passes an explicit preview OIDC environment through to generated Worker vars", () => {

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -45,12 +45,12 @@
         "memory_mib": 6144,
         "disk_mb": 6000
       },
-      "max_instances": 1000,
+      "max_instances": 1,
       "constraints": {
         "regions": ["ENAM"]
       },
       "rollout_active_grace_period": 300,
-      "rollout_step_percentage": [10, 25, 50, 100],
+      "rollout_step_percentage": [100],
       "ssh": { "enabled": false }
     }
   ],


### PR DESCRIPTION
## Why and outcome

Production deploys declared the full active-runner maximum on both the active and standby container classes. At the current two-vCPU shape that asked Cloudflare for 2,994 vCPU of maximum container capacity, above the account ceiling, so standby application creation failed and prevented the incident fix from shipping.

This change gives the standby declaration an independent capacity input that defaults to one. Current off/shadow deployment fits exactly within the existing ceiling, while any future `allocate` activation fails preflight unless operators first raise and retain standby capacity for the complete bound-target lifecycle.

## Product UX

- Not applicable: this is internal deployment-capacity configuration. It does not change a member journey, UI, copy, or product policy; the member-visible runtime recovery remains in PR #2679.

## Evidence

- Production failure: the only deploy that reached standby application creation rendered active 748, smoke 1, and standby 748 at two vCPU each; Cloudflare rejected the new standby application for exceeding account capacity.
- Current-production safety: standby application count and standby running/allocated instance count are both zero. The deployed mode is `off`, all standby deploy attempts failed, and no runtime/control evidence shows an allocated or retained standby target.
- Base red proof: off/shadow rendered standby `748` with gradual rollout steps instead of `1` with an immediate single step.
- Head arithmetic regression: `748×2 + 1×2 + 1×2 = 1,500` vCPU. Raising standby to 748 produces 2,994 and `allocate` is rejected unless standby capacity is at least active capacity.
- `pnpm test:diff:local`: exit 0 on the stable diff — 152 Node files (2,785 passed, 2 skipped), 6 container-helper tests, and 15 Workers tests.
- Focused independent review: 45/45 tests passed; Cloudflare typecheck, `pnpm complexity:diff`, `git diff --check`, and privacy/secret scan passed.

## Non-obvious affected surfaces

- Private deploy workflow and GitHub Environments: the new non-secret input requires an explicit fallback mapping and both preview/production values set to `1`; PR #2681 is not deployment-complete without that private half and live parity proof.
- Future standby allocation: `allocate` must raise standby capacity to at least the active maximum before activation and retain it through off/shadow rollback until every bound target retires. Covered by deploy preflight tests and durable reliability/deploy guidance.
- Checked-in Wrangler scaffold: standby defaults to one instance and one immediate rollout step while class, ENAM constraint, binding, image, and migration remain unchanged. Covered by the container contract and rendered-config regressions.

## Architecture and reuse

- Existing systems reused: the existing deploy environment parser, Wrangler renderer, standby mode contract, Durable Object class/binding/migration, and Cloudflare container declaration remain the only owners.
- New logic: one deploy-only positive-integer input independently sizes `StandbyRunnerContainer`; existing preflight rejects `allocate` when it is below active capacity.
- New abstractions: no service, state owner, queue, lifecycle enum, binding, migration, or dependency was added; the new field stays inside the existing deployment environment object.
- Complexity intentionally avoided: capacity is not derived from mode, so rollback needs no target scan or reconciliation machinery; operators retain the raised value until existing owners prove target retirement.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: no changed function exceeds the tracked threshold; complexity debt remains zero and no maximum increased.
- Agent judgment: no further behavior-preserving simplification is justified; a separate input is the smallest shape that preserves both today's one-slot deployment and future bound-target rollback safety.

## Hot reply path impact

- Not applicable: deploy-time Wrangler rendering changes no runtime request path and adds no database, network, provider, or awaited operation to the Foreground Reply Critical Path.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool/schema guidance, model request assembly, or provider-visible input changed.
- Codex runtime: Not applicable; no prompt, tool/schema guidance, model request assembly, or provider-visible input changed.

## Change-shape breakdown

Classification is by path and role: deploy automation logic is source, Vitest files are tests/fixtures, durable guidance and the active execution plan are docs, and the checked-in Wrangler scaffold is config/tooling. No generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 25 | 6 |
| Tests/fixtures | 92 | 2 |
| Docs | 112 | 9 |
| Config/tooling | 2 | 2 |
| Generated/other | 0 | 0 |
| **Total** | **231** | **19** |

## Deployment concerns

- Deployment: applicable
- Supported skew: old/new Worker and runner bundles use the same Durable Object classes, bindings, migrations, and runtime vars; this input affects deploy-time container capacity only.
- Safe order: land the public capacity and runtime fixes, land the private workflow fallback, set preview and production Environment values to `1`, then run the protected production workflow with immediate container rollout.
- Rollback floor: current production has no standby application or bound target, so cap `1` is safe. After any future allocation, retain the raised cap through mode rollback until all bound targets are proven retired.
- Expected exposure: before the coordinated deploy, production continues running the pre-fix Worker and the affected runtime remains stalled; a partial Worker activation without successful container creation is not completion.
- Reversibility: current off-mode capacity can remain at `1`; reverting this public change would only reintroduce the deploy quota failure. Future post-allocation reduction is forbidden until target retirement is proven.
- Convergence proof: the rendered artifact and live Cloudflare declarations must report active `748`, smoke `1`, standby `1`, with the intended Worker version at 100%.
- Post-deploy checks: verify Worker fingerprint/bindings, list and inspect all three container applications, run the hosted smoke, inspect bounded error aggregates, and confirm the exact stalled cohort advances.

## Changelog

- Changelog: not applicable
- Reason: internal deploy-capacity plumbing only; PR #2679 owns the member-visible recovery outcome and changelog entry.

## Risks

- Lowering capacity after a future allocated standby target exists could reject starts. The deploy contract therefore separates capacity from mode and forbids reduction until bound-target retirement is proven.
- The public default is not treated as complete private wiring; workflow mapping, Environment values, and live declaration parity remain explicit deployment gates.

ReviewGPT context sensitivity: sensitive — production Cloudflare container capacity and rollback contract change.

ReviewGPT first-reviewed head: 4eb3786f9d002c3835b9ee8701bae7cdc6ee89ef