### PR TITLE
fix(runtime): preserve device wake ownership across checkpoints

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -321,8 +321,14 @@ Last verified: 2026-08-30
   generation and handled-through frontier remain unchanged. Workspace-version,
   attempt, signal, and selected-wake churn are not progress. Due foreground,
   default-processing, provider-owned, and retention work bypasses the delay
-  without clearing it. This reuses the workspace CAS and Temporal timer owners;
-  it adds no queue, scheduler, per-member state table, or second wake authority.
+  without clearing it. When live runtime evaluation disproves an overdue
+  default-processing projection and selects a due model-free frontier, the
+  runtime checkpoints the corrected projections before releasing that pass.
+  This projection-only checkpoint re-reads every default-work source, preserves
+  handled-through and the progress generation, and therefore cannot hide
+  genuinely due default work or claim system progress. This reuses the workspace
+  CAS and Temporal timer owners; it adds no queue, scheduler, per-member state
+  table, or second wake authority.
 - A hosted-group projection grant that needs its first private projection and
   one generation-stable `runtime.maintenance-requested` control row commit in
   the same Web transaction. An append failure therefore rolls back the grant

--- a/agent-docs/exec-plans/active/2026-09-01-model-free-default-wake-livelock.md
+++ b/agent-docs/exec-plans/active/2026-09-01-model-free-default-wake-livelock.md
@@ -1,0 +1,130 @@
+# Converge stale default wake handoff to model-free owner
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Stop a hosted runtime from repeatedly selecting a default assistant pass when
+  live foreground evaluation has already disproved the overdue default wake and
+  the exact durable system frontier belongs to the model-free owner.
+- Preserve genuine foreground/default priority while making the stale-projection
+  handoff converge durably so model-free maintenance can run on the next pass.
+
+## Success criteria
+
+- A production-shaped two-cycle regression fails before the fix and passes after
+  it: the first default pass publishes a projection-only checkpoint, and the
+  following system-owner pass advances the durable model-free frontier.
+- The handoff pass does not run assistant, provider, device, or system work under
+  the wrong owner and does not increment the system progress generation.
+- A genuinely due default wake still retains priority over model-free work.
+- A running cron job with a past `nextRunAt` is not projected as new runnable
+  default work.
+- Focused runtime tests, package typecheck, and required repository verification
+  pass on the final diff.
+- The exact normalized live incident facts replay without private identifiers,
+  and the deployed runtime's durable frontier advances after shipment.
+
+## Scope
+
+- In scope:
+  - Public assistant-runtime wake projection and checkpoint convergence.
+  - Real runtime entrypoint and two-owner regression coverage.
+  - Runtime protocol/reliability documentation and public changelog, if required.
+- Out of scope:
+  - Temporal priority-policy changes.
+  - Cloudflare routing or fencing changes.
+  - Dropping, consuming, or executing durable system rows during a default pass.
+  - Persisting production identifiers or payloads in repository artifacts.
+
+## Constraints
+
+- Technical constraints:
+  - Runtime owns assistant-timer semantics; Web persists projections, Temporal
+    interprets them, and Cloudflare routes the selected mode.
+  - Checkpointing must be replay-safe and must not claim application progress.
+  - Status-read failure must fail closed and retain the existing projection.
+- Product/process constraints:
+  - Members with real foreground work must not be delayed by maintenance.
+  - Members with only model-free backlog must eventually release default ownership.
+  - Production facts may be used transiently for diagnosis but never committed.
+
+## Product UX
+
+- Effort: Patch.
+- Outcome: Existing background follow-through no longer remains stuck behind an
+  assistant timer whose live work has already ended.
+- Reaches: The existing hosted journey where a stale projected assistant wake
+  and due model-free connected-device work coincide.
+- Proof: Replay the identifier-free production 0/4/4 boundary through the real
+  runtime entrypoint, then confirm the affected production frontier advances
+  after deployment.
+
+### Walkthrough
+
+- Member waiting on connected-device follow-through: the production-shaped
+  default pass publishes the device owner without running device, provider, or
+  model work under the wrong owner; the queue and handled frontier remain
+  intact for the next pass. Ready.
+- Member with a genuinely due conversation, reminder, pending delivery, or
+  other default-owned task: live default-source checks retain priority, and
+  checkpoint reconciliation preserves every future or due default source.
+  Ready.
+- Member whose live cron status cannot be read: the runtime does not declare
+  the projection stale, so existing durable wake authority remains fail-closed.
+  Ready.
+
+No visible interface or copy changes. The public changelog describes the
+recovered outcome without exposing runtime identifiers or private evidence.
+
+## Risks and mitigations
+
+1. Risk: Clearing a real due default wake lets maintenance run first.
+   Mitigation: Reconcile only after the authoritative live preflight reports no
+   runnable foreground/default work, with regressions for genuine due work.
+2. Risk: A handoff checkpoint falsely advances the system frontier.
+   Mitigation: Keep handled-through and progress generation unchanged; checkpoint
+   only the corrected owner projections.
+3. Risk: The fix handles device wakes but not other model-free frontier kinds.
+   Mitigation: Key convergence to owner classification, not a device-specific kind.
+4. Risk: An unrelated open change overlaps the assistant phase.
+   Mitigation: Keep the patch narrowly owned, inspect the current-base merge tree,
+   and use exact-head review and CI before merge.
+
+## Tasks
+
+1. Capture a private-data-free normalized replay envelope from the live incident
+   and prove the current Temporal/runtime decision sequence.
+2. Add the missing two-cycle production-shaped regression and record the pre-fix
+   failure.
+3. Implement the smallest runtime-owned projection-convergence checkpoint and
+   normalize non-due cron projection timestamps.
+4. Run focused tests, typecheck, static privacy inspection, and exact-fact replay.
+5. Update durable contracts/changelog where the externally observable reliability
+   guarantee changes.
+6. Commit, open a draft PR, run exact-head ReviewGPT with CI, merge/deploy, and
+   verify the affected runtime's durable frontier advances.
+
+## Decisions
+
+- Keep Temporal's default-before-model-free priority unchanged; current history
+  replay proves it is following the documented contract.
+- Use exact live facts only in transient in-memory replay. Commit a synthetic
+  fixture with the same normalized owner/timer/frontier shape.
+- Treat the first pass as a projection handoff, not application/system progress.
+
+## Verification
+
+- Commands to run:
+  - Focused Vitest files for wake scheduling, real device frontier, and hosted
+    runtime entrypoint convergence.
+  - Assistant-runtime package typecheck.
+  - Repository-required scoped verification and diff/privacy checks.
+  - Identifier-free exact production-fact replay before and after the fix.
+- Expected outcomes:
+  - Pre-fix regression shows repeated default selection with no checkpoint.
+  - Post-fix first pass durably removes/advances the stale default projection and
+    publishes the model-free wake; second pass advances handled-through.
+  - No assistant/provider/device execution occurs during the handoff checkpoint.

--- a/agent-docs/exec-plans/completed/2026-09-01-model-free-default-wake-livelock.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-model-free-default-wake-livelock.md
@@ -1,6 +1,6 @@
 # Converge stale default wake handoff to model-free owner
 
-Status: active
+Status: completed
 Created: 2026-09-01
 Updated: 2026-09-01
 
@@ -22,6 +22,13 @@ Updated: 2026-09-01
 - A genuinely due default wake still retains priority over model-free work.
 - A running cron job with a past `nextRunAt` is not projected as new runnable
   default work.
+- An earlier retained device-sync model-free wake survives both canonical
+  runtime-status and generic idle checkpoints when the workspace scalar still
+  names a later assistant wake; blocked assistant policy keeps its existing
+  restoration path.
+- A carried device-sync scalar does not request owner handoff by itself; fresh
+  foreground work still runs unless live projection reconciliation explicitly
+  requested the non-assistant handoff.
 - Focused runtime tests, package typecheck, and required repository verification
   pass on the final diff.
 - The exact normalized live incident facts replay without private identifiers,
@@ -101,10 +108,15 @@ recovered outcome without exposing runtime identifiers or private evidence.
    failure.
 3. Implement the smallest runtime-owned projection-convergence checkpoint and
    normalize non-due cron projection timestamps.
-4. Run focused tests, typecheck, static privacy inspection, and exact-fact replay.
-5. Update durable contracts/changelog where the externally observable reliability
+4. Preserve all-owner arbitration at runtime-status checkpoints and retain
+   device-sync ownership at the idle boundary, with independent regressions so
+   one boundary cannot mask the other.
+5. Gate generalized owner handoff on the projection-only checkpoint marker so a
+   stale carried device token cannot suppress newly arrived foreground work.
+6. Run focused tests, typecheck, static privacy inspection, and exact-fact replay.
+7. Update durable contracts/changelog where the externally observable reliability
    guarantee changes.
-6. Commit, open a draft PR, run exact-head ReviewGPT with CI, merge/deploy, and
+8. Commit, open a draft PR, run exact-head ReviewGPT with CI, merge/deploy, and
    verify the affected runtime's durable frontier advances.
 
 ## Decisions
@@ -128,3 +140,4 @@ recovered outcome without exposing runtime identifiers or private evidence.
   - Post-fix first pass durably removes/advances the stale default projection and
     publishes the model-free wake; second pass advances handled-through.
   - No assistant/provider/device execution occurs during the handoff checkpoint.
+Completed: 2026-09-01

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -448,6 +448,12 @@ wake selects `inbox_media_retention` processing when foreground/default work is
 not runnable; future or absent wakes wait. These modes are invocation input, not
 new scheduler state. Foreground/default work must replace an active
 system-mailbox or retention owner instead of waiting for its idle checkpoint.
+If a default invocation's live checks disprove its overdue projection and the
+next due frontier belongs to a model-free owner, the runtime first checkpoints
+the corrected projections without advancing handled-through or the system
+progress generation. The checkpoint re-reads all default-work sources, so
+genuinely due default work remains armed; Temporal continues interpreting only
+the resulting durable facts.
 The runtime projects an outbox-only continuation as `assistant_delivery` rather
 than model-capable `assistant`. Web admits that due delivery continuation
 without the managed-AI usage gate; Temporal still selects ordinary processing,

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 4,
     "title": "Background work recovers from stale timers",
-    "summary": "Murph now recovers when an outdated assistant timer and connected-device work become due together, so follow-through does not stay stuck behind a timer with no work left.",
-    "details": "Current conversations, reminders, pending deliveries, and other genuinely due assistant work keep priority. Murph changes owners only after a live check confirms the projected timer is stale.",
+    "summary": "Murph now recovers when an outdated assistant timer overlaps with connected-device work, including when interrupted scheduled work has no other event to wake it.",
+    "details": "Current conversations, reminders, pending deliveries, and other genuinely due assistant work keep priority. Interrupted scheduled work now receives its own recovery check instead of waiting for another conversation or device event.",
     "relevanceTags": ["assistant", "wearables", "reliability"],
-    "sourcePullRequests": [2679]
+    "sourcePullRequests": [2682]
   }
 }

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-01",
+  "order": 100,
+  "item": {
+    "id": "background-work-recovers-from-stale-timers",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Background work recovers from stale timers",
+    "summary": "Murph now recovers when an outdated assistant timer and connected-device work become due together, so follow-through does not stay stuck behind a timer with no work left.",
+    "details": "Current conversations, reminders, pending deliveries, and other genuinely due assistant work keep priority. Murph changes owners only after a live check confirms the projected timer is stale.",
+    "relevanceTags": ["assistant", "wearables", "reliability"],
+    "sourcePullRequests": [2679]
+  }
+}

--- a/packages/assistant-engine/src/assistant/cron.ts
+++ b/packages/assistant-engine/src/assistant/cron.ts
@@ -23,7 +23,10 @@ import {
   sortAssistantCronJobs,
   type AssistantCronTargetInput,
 } from './cron/store.ts'
-import { readAssistantCronCanonicalRuntimeStore } from './cron/runtime-state.ts'
+import {
+  computeAssistantCronCanonicalRunningRecoveryAt,
+  readAssistantCronCanonicalRuntimeStore,
+} from './cron/runtime-state.ts'
 import {
   buildVisibleLocalAssistantCronStore,
   findCanonicalAssistantCronRecordInList,
@@ -501,14 +504,35 @@ export async function getAssistantCronStatus(
   const enabledJobs = canonicalJobs.filter((job) => job.enabled)
   const dueJobs = enabledJobs.filter((job) => isAssistantCronJobDue(job, now)).length
   const runningJobs = canonicalJobs.filter((job) => job.state.runningAt !== null).length
-  const visibleNextRunAt =
-    enabledJobs.find((job) => job.state.nextRunAt !== null)?.state.nextRunAt ?? null
+  // A canonical running claim keeps its historical occurrence as nextRunAt so
+  // execution can resume that exact occurrence after reclamation. Status owns
+  // the external wake projection, though, and must replace that past timestamp
+  // with the first instant at which the strict stale-claim rule can reclaim it.
+  const visibleNextRunAt = earliestAssistantAutomationWakeAt(
+    ...projection.visibleLocalStore.jobs
+      .filter((job) => job.enabled)
+      .map((job) => job.state.nextRunAt),
+    ...projection.canonicalEntries
+      .filter((entry) => entry.job.enabled)
+      .map((entry) =>
+        entry.runtimeState.state.runningAt === null
+          ? entry.job.state.nextRunAt
+          : computeAssistantCronCanonicalRunningRecoveryAt(
+              entry.runtimeState.state.runningAt,
+            )
+      ),
+  )
   // Background maintenance hidden by active foreground yield still needs a
   // wake: a released claim carries its persisted retry time, and a due but
   // never-claimed occurrence gets the same short catch-up deferral so it is
   // not disarmed until an unrelated wake.
   const backgroundMaintenanceRetryWakeAt = earliestAssistantAutomationWakeAt(
     ...projection.yieldDeferredBackgroundMaintenanceEntries.map((entry) => {
+      if (entry.runtimeState.state.runningAt !== null) {
+        return computeAssistantCronCanonicalRunningRecoveryAt(
+          entry.runtimeState.state.runningAt,
+        )
+      }
       if (entry.runtimeState.state.retryAfterAt !== null) {
         return entry.job.state.nextRunAt
       }

--- a/packages/assistant-engine/src/assistant/cron/runtime-state.ts
+++ b/packages/assistant-engine/src/assistant/cron/runtime-state.ts
@@ -12,6 +12,7 @@ const ASSISTANT_CRON_CANONICAL_RUNTIME_STORE_VERSION = 1
 const ASSISTANT_CRON_CANONICAL_RUNTIME_RECORD_SCHEMA =
   'murph.assistant-canonical-cron-runtime-state.v1'
 export const ASSISTANT_CRON_CANONICAL_RUNNING_STALE_AFTER_MS = 60 * 60 * 1000
+const ASSISTANT_CRON_CANONICAL_RUNNING_RECOVERY_EPSILON_MS = 1
 
 export interface AssistantCronCanonicalRuntimeNormalizationPolicy {
   now?: () => string
@@ -66,6 +67,26 @@ export type AssistantCronCanonicalRuntimeRecord = z.infer<
 export type AssistantCronCanonicalRuntimeStore = z.infer<
   typeof assistantCronCanonicalRuntimeStoreSchema
 >
+
+export function computeAssistantCronCanonicalRunningRecoveryAt(
+  runningAt: string | null,
+): string | null {
+  if (runningAt === null) {
+    return null
+  }
+
+  const runningAtMs = Date.parse(runningAt)
+  const recoveryAtMs =
+    runningAtMs
+    + ASSISTANT_CRON_CANONICAL_RUNNING_STALE_AFTER_MS
+    + ASSISTANT_CRON_CANONICAL_RUNNING_RECOVERY_EPSILON_MS
+  if (!Number.isFinite(runningAtMs) || !Number.isFinite(recoveryAtMs)) {
+    return null
+  }
+
+  const recoveryAt = new Date(recoveryAtMs)
+  return Number.isNaN(recoveryAt.getTime()) ? null : recoveryAt.toISOString()
+}
 
 export async function readAssistantCronCanonicalRuntimeStore(
   paths: AssistantStatePaths,

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -9113,6 +9113,85 @@ describe('assistant cron runtime orchestration', () => {
     expect(stillRunning.state.lastSucceededAt).toBeNull()
   })
 
+  it('recovers a fresh one-shot canonical claim from its only future wake and becomes quiescent', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-08T10:10:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-running-recovery-wake-',
+    )
+    const job = await addAssistantCronJob({
+      channel: 'telegram',
+      deliveryTarget: 'room-1',
+      name: 'running-recovery-wake',
+      now: new Date('2026-04-08T08:00:00.000Z'),
+      prompt: 'Recover the stranded one-shot occurrence.',
+      resolveTargetDefaults: false,
+      schedule: {
+        at: '2026-04-08T10:00:00.000Z',
+        kind: 'at',
+      },
+      threadIsDirect: true,
+      vault: vaultRoot,
+    })
+
+    await updateCanonicalRuntimeState(vaultRoot, job.jobId, (record) => ({
+      ...record,
+      state: {
+        ...record.state,
+        pendingOccurrenceAt: '2026-04-08T10:00:00.000Z',
+        runningAt: '2026-04-08T10:05:00.000Z',
+        runningClaimId: 'claim_running_recovery_wake',
+        runningPid: 42,
+      },
+      updatedAt: '2026-04-08T10:05:00.000Z',
+    }))
+
+    await expect(getAssistantCronStatus(vaultRoot)).resolves.toEqual({
+      dueJobs: 0,
+      enabledJobs: 1,
+      nextRunAt: '2026-04-08T11:05:00.001Z',
+      runningJobs: 1,
+      totalJobs: 1,
+    })
+
+    vi.setSystemTime(new Date('2026-04-08T11:05:00.000Z'))
+    await expect(getAssistantCronStatus(vaultRoot)).resolves.toMatchObject({
+      dueJobs: 0,
+      nextRunAt: '2026-04-08T11:05:00.001Z',
+      runningJobs: 1,
+    })
+
+    vi.setSystemTime(new Date('2026-04-08T11:05:00.001Z'))
+    await expect(getAssistantCronStatus(vaultRoot)).resolves.toMatchObject({
+      dueJobs: 1,
+      nextRunAt: '2026-04-08T10:00:00.000Z',
+      runningJobs: 0,
+    })
+
+    const summary = await processDueAssistantCronJobsLocal({
+      limit: 1,
+      vault: vaultRoot,
+    })
+    expect(summary).toEqual({
+      failed: 0,
+      processed: 1,
+      succeeded: 0,
+    })
+    expect(cronMocks.sendAssistantMessageLocal).not.toHaveBeenCalled()
+    await expect(getAssistantCronStatus(vaultRoot)).resolves.toMatchObject({
+      dueJobs: 0,
+      nextRunAt: null,
+      runningJobs: 0,
+    })
+
+    const runtimeStore = await readAssistantCronCanonicalRuntimeStore(
+      resolveAssistantStatePaths(vaultRoot),
+      { reclaimStaleRunningClaims: false },
+    )
+    expect(runtimeStore.jobs.find((record) => record.jobId === job.jobId))
+      .toBeUndefined()
+  })
+
   it('does not run or append a canonical cron result after the claim is replaced', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-08T13:00:00.000Z'))

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1143,6 +1143,93 @@ async function resolveHostedSystemMailboxProcessingModeWake(input: {
   };
 }
 
+async function resolveHostedRuntimeStatusCheckpointWakes(input: {
+  assistantExecutionBlocked: boolean;
+  checkpointNow: string;
+  checkpointNowMs: number;
+  operatorHomeRoot: string;
+  requestedNextWakeAt: string | null;
+  requestedNextWakeReason: string | null;
+  runtimeEnv: Readonly<Record<string, string>>;
+  vaultRoot: string;
+}) {
+  const systemMailboxWakes = await resolveHostedSystemMailboxWakeCandidates({
+    ...(input.assistantExecutionBlocked
+      ? { allowedRouteActions: ["run-assistant-ask"] as const }
+      : {}),
+    now: () => input.checkpointNow,
+    vaultRoot: input.vaultRoot,
+  });
+  const defaultProcessingWake =
+    await resolveHostedSystemMailboxProcessingModeWake({
+      assistantExecutionBlocked: input.assistantExecutionBlocked,
+      extraCandidates: [
+        createHostedRuntimeWakeCandidate(
+          input.requestedNextWakeAt,
+          input.requestedNextWakeReason,
+        ),
+      ],
+      mailboxImportRetryAt: null,
+      nowMs: input.checkpointNowMs,
+      operatorHomeRoot: input.operatorHomeRoot,
+      runtimeEnv: input.runtimeEnv,
+      systemMailboxWakes,
+      vaultRoot: input.vaultRoot,
+    });
+  const requestedCheckpointWake = createHostedRuntimeWakeCandidate(
+    input.requestedNextWakeAt,
+    input.requestedNextWakeReason,
+  );
+  const checkpointProcessingWake = input.assistantExecutionBlocked
+    ? selectHostedRuntimeWakeCandidate([
+        requestedCheckpointWake,
+        systemMailboxWakes.next,
+      ])
+    : selectHostedRuntimeOwnerWakeCandidate({
+        backgroundCandidates: [
+          hostedRuntimeWakeReasonUsesAssistantPhase(
+              requestedCheckpointWake.reason,
+            )
+            ? null
+            : requestedCheckpointWake,
+        ],
+        foregroundCandidates: [
+          hostedRuntimeWakeReasonUsesAssistantPhase(
+              requestedCheckpointWake.reason,
+            )
+            ? requestedCheckpointWake
+            : null,
+        ],
+        nowMs: input.checkpointNowMs,
+        systemMailboxWake: systemMailboxWakes.next,
+      });
+  return {
+    checkpointProcessingWake: {
+      nextWakeAt: checkpointProcessingWake.at,
+      nextWakeReason: checkpointProcessingWake.reason,
+    },
+    defaultProcessingWake,
+  };
+}
+
+async function resolveHostedIdleBoundarySystemMailboxWake(input: {
+  vaultRoot: string;
+}) {
+  const allRouteWakes = await resolveHostedSystemMailboxWakeCandidates({
+    vaultRoot: input.vaultRoot,
+  });
+  if (
+    allRouteWakes.next.reason === HOSTED_DEVICE_SYNC_RECONCILE_WAKE_REASON
+    && allRouteWakes.next.executionClass !== "default_owned"
+  ) {
+    return allRouteWakes.next;
+  }
+  return await resolveHostedSystemMailboxNextWakeCandidate({
+    allowedRouteActions: ["run-assistant-ask"],
+    vaultRoot: input.vaultRoot,
+  });
+}
+
 function hostedSystemMailboxCheckpointPreparationNeedsCheckpoint(
   preparation: HostedSystemMailboxCheckpointPreparation | null,
 ): boolean {
@@ -1847,38 +1934,19 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           : workspace?.nextWakeReason ?? null;
         const checkpointNowMs = Date.now();
         const checkpointNow = new Date(checkpointNowMs).toISOString();
-        const systemMailboxWakes = await resolveHostedSystemMailboxWakeCandidates({
-          allowedRouteActions: ["run-assistant-ask"],
-          now: () => checkpointNow,
+        const {
+          checkpointProcessingWake,
+          defaultProcessingWake,
+        } = await resolveHostedRuntimeStatusCheckpointWakes({
+          assistantExecutionBlocked,
+          checkpointNow,
+          checkpointNowMs,
+          operatorHomeRoot: restored.operatorHomeRoot,
+          requestedNextWakeAt: requestedCheckpointNextWakeAt,
+          requestedNextWakeReason: requestedCheckpointNextWakeReason,
+          runtimeEnv: invocationRuntimeEnv,
           vaultRoot: restored.vaultRoot,
         });
-        const systemMailboxWake = systemMailboxWakes.next;
-        const checkpointWake = selectEarliestHostedRuntimeWake([
-          {
-            at: requestedCheckpointNextWakeAt,
-            reason: requestedCheckpointNextWakeReason,
-          },
-          {
-            at: systemMailboxWake.at,
-            reason: systemMailboxWake.reason,
-          },
-        ]);
-        const defaultProcessingWake =
-          await resolveHostedSystemMailboxProcessingModeWake({
-            assistantExecutionBlocked,
-            extraCandidates: [
-              createHostedRuntimeWakeCandidate(
-                requestedCheckpointNextWakeAt,
-                requestedCheckpointNextWakeReason,
-              ),
-            ],
-            mailboxImportRetryAt: null,
-            nowMs: checkpointNowMs,
-            operatorHomeRoot: restored.operatorHomeRoot,
-            runtimeEnv: invocationRuntimeEnv,
-            systemMailboxWakes,
-            vaultRoot: restored.vaultRoot,
-          });
         const canonicalRuntimeCommit = checkpointInput.reason === "canonical_runtime_commit";
         const checkpointWorkspacePort = canonicalRuntimeCommit
           ? workspacePort
@@ -1912,8 +1980,8 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
             defaultProcessingWake.nextDefaultProcessingWakeAt,
           nextDefaultProcessingWakeReason:
             defaultProcessingWake.nextDefaultProcessingWakeReason,
-          nextWakeAt: checkpointWake.nextWakeAt,
-          nextWakeReason: checkpointWake.nextWakeReason,
+          nextWakeAt: checkpointProcessingWake.nextWakeAt,
+          nextWakeReason: checkpointProcessingWake.nextWakeReason,
           reason: checkpointInput.reason,
           redactedStatus,
           snapshotRef: workspace?.snapshotRef ?? null,
@@ -5541,7 +5609,14 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
             || rerunAssistantInputBatch !== null
             || continueForegroundCausalPass
             || (input.request.processingMode ?? "default") !== "default"
-            || hostedRuntimeWakeReasonIsAssistant(pendingWake.nextWakeReason)
+            || !hostedRuntimeForegroundIdleWakeRequestsOwnerHandoff({
+              assistantProgressed:
+                passResult.assistantPhaseResult?.progressed === true,
+              nextWakeReason: pendingWake.nextWakeReason,
+              runtimeProjectionCheckpointRequested:
+                passResult.assistantPhaseResult
+                  ?.runtimeProjectionCheckpointRequested === true,
+            })
             || !hostedRuntimeWakeIsDue(pendingWake.nextWakeAt)
           ) {
             return;
@@ -6625,8 +6700,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
         }
         await pauseDetachedAssistantAskBeforeWorkspaceBoundary();
         const boundarySystemMailboxWake =
-          await resolveHostedSystemMailboxNextWakeCandidate({
-            allowedRouteActions: ["run-assistant-ask"],
+          await resolveHostedIdleBoundarySystemMailboxWake({
             vaultRoot: restored.vaultRoot,
           });
         pendingWake = selectEarliestHostedRuntimeWake([
@@ -8005,6 +8079,19 @@ function normalizeHostedRuntimeWakeReason(nextWakeReason: string | null): string
 
 function hostedRuntimeWakeReasonIsAssistant(nextWakeReason: string | null): boolean {
   return hostedRuntimeWakeReasonUsesAssistantPhase(nextWakeReason);
+}
+
+function hostedRuntimeForegroundIdleWakeRequestsOwnerHandoff(input: {
+  assistantProgressed: boolean;
+  nextWakeReason: string | null;
+  runtimeProjectionCheckpointRequested: boolean;
+}): boolean {
+  return input.nextWakeReason === "mailbox"
+    || (
+      input.runtimeProjectionCheckpointRequested
+      && !input.assistantProgressed
+      && !hostedRuntimeWakeReasonIsAssistant(input.nextWakeReason)
+    );
 }
 
 function hostedRuntimeDefaultProcessingWakeIsDue(input: {

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1055,6 +1055,7 @@ async function resolveHostedSystemMailboxProcessingModeWake(input: {
     });
   const systemMailboxWake = systemMailboxWakes.next;
   const assistantCronWake = await resolveHostedAssistantCronWakeAfterInitialImport({
+    nowMs: input.nowMs,
     operatorHomeRoot: input.operatorHomeRoot,
     runtimeEnv: input.runtimeEnv,
     vaultRoot: input.vaultRoot,
@@ -2462,6 +2463,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
       const assistantCronWake =
         input.request.processingMode === "system_mailbox"
           ? await resolveHostedAssistantCronWakeAfterInitialImport({
+              nowMs: Date.now(),
               operatorHomeRoot: restored.operatorHomeRoot,
               runtimeEnv: invocationRuntimeEnv,
               vaultRoot: restored.vaultRoot,
@@ -5533,13 +5535,13 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
         let continueForegroundCausalPass =
           !runtimeOwnerHandoffRequested
           && shouldContinueForegroundCausalPass(passResult);
-        const requestDueMailboxOwnerHandoffIfForegroundIdle = (): void => {
+        const requestDueRuntimeOwnerHandoffIfForegroundIdle = (): void => {
           if (
             runtimeOwnerHandoffRequested
             || rerunAssistantInputBatch !== null
             || continueForegroundCausalPass
             || (input.request.processingMode ?? "default") !== "default"
-            || pendingWake.nextWakeReason !== "mailbox"
+            || hostedRuntimeWakeReasonIsAssistant(pendingWake.nextWakeReason)
             || !hostedRuntimeWakeIsDue(pendingWake.nextWakeAt)
           ) {
             return;
@@ -5547,7 +5549,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           runtimeOwnerHandoffRequested = true;
           markIdleCheckpointTimerAfterDirtyWork();
         };
-        requestDueMailboxOwnerHandoffIfForegroundIdle();
+        requestDueRuntimeOwnerHandoffIfForegroundIdle();
         while (
           options.shutdownSignal?.aborted !== true
           && (rerunAssistantInputBatch || continueForegroundCausalPass)
@@ -5592,7 +5594,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           continueForegroundCausalPass =
             !runtimeOwnerHandoffRequested
             && shouldContinueForegroundCausalPass(passResult);
-          requestDueMailboxOwnerHandoffIfForegroundIdle();
+          requestDueRuntimeOwnerHandoffIfForegroundIdle();
         }
         return passResult;
       };
@@ -8901,6 +8903,7 @@ function selectEarliestHostedRuntimeWake(
 }
 
 async function resolveHostedAssistantCronWakeAfterInitialImport(input: {
+  nowMs: number;
   operatorHomeRoot: string;
   runtimeEnv: Readonly<Record<string, string>>;
   vaultRoot: string;
@@ -8910,8 +8913,8 @@ async function resolveHostedAssistantCronWakeAfterInitialImport(input: {
   });
   const dueNow = status.dueJobs > 0;
   const at = dueNow
-    ? new Date().toISOString()
-    : status.nextRunAt;
+    ? new Date(input.nowMs).toISOString()
+    : normalizeHostedFutureWakeAt(status.nextRunAt, input.nowMs);
   return {
     at,
     dueNow,

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2368,9 +2368,9 @@ export async function runHostedWorkspaceAssistantPhase(
     const systemMailboxOwnerOwnsCurrentPass =
       !hasAssistantInputAtPassStart
       && systemMailboxMaintenance.continueAssistantLane === false
-      && systemMailboxMaintenance.result?.runtimeProjectionCheckpointRequested
-        !== true
-      && systemMailboxMaintenance.result?.nextWakeReason === "mailbox"
+      && hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
+        systemMailboxMaintenance.result,
+      )
       && hostedRuntimeWakeCandidateIsDue(
         createHostedRuntimeWakeCandidate(
           systemMailboxMaintenance.result.nextWakeAt ?? null,
@@ -3910,6 +3910,30 @@ function mergeHostedAssistantPhaseResults(
   });
 }
 
+function hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
+  result: HostedWorkspaceRunnerAssistantPhaseResult | null,
+): boolean {
+  return result?.runtimeProjectionCheckpointRequested !== true
+    && result?.nextWakeReason === "mailbox";
+}
+
+function hostedRuntimeProjectionCheckpointWasRequested(
+  results: readonly HostedWorkspaceRunnerAssistantPhaseResult[],
+): boolean {
+  return results.some((result) =>
+    result.runtimeProjectionCheckpointRequested === true
+  );
+}
+
+function withHostedRuntimeProjectionCheckpointRequest(input: {
+  requested: boolean;
+  result: HostedWorkspaceRunnerAssistantPhaseResult;
+}): HostedWorkspaceRunnerAssistantPhaseResult {
+  return input.requested
+    ? { ...input.result, runtimeProjectionCheckpointRequested: true }
+    : input.result;
+}
+
 function postCheckpointDeliveryResultOwnsProviderCleanup(
   result: HostedWorkspaceRunnerAssistantPhaseResult | null,
 ): boolean {
@@ -3994,9 +4018,6 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const systemMailboxProgressed =
     input.systemMailboxResult.systemMailboxProgressed === true
     || input.assistantResult.systemMailboxProgressed === true;
-  const runtimeProjectionCheckpointRequested =
-    input.systemMailboxResult.runtimeProjectionCheckpointRequested === true
-    || input.assistantResult.runtimeProjectionCheckpointRequested === true;
   const afterCheckpointKeepsForegroundImportLoop =
     input.systemMailboxResult.afterCheckpointKeepsForegroundImportLoop === true
     || input.assistantResult.afterCheckpointKeepsForegroundImportLoop === true;
@@ -4022,16 +4043,54 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const invocationLocalAssistantWakeAt =
     input.assistantResult.invocationLocalAssistantWakeAt ?? null;
   if (progressedResult) {
-    return {
-      ...(afterCheckpoint ? { afterCheckpoint } : {}),
+    return withHostedRuntimeProjectionCheckpointRequest({
+      requested: hostedRuntimeProjectionCheckpointWasRequested([
+        input.systemMailboxResult,
+        input.assistantResult,
+      ]),
+      result: {
+        ...(afterCheckpoint ? { afterCheckpoint } : {}),
+        ...(browserVaultReplicaRefreshRequested
+          ? { browserVaultReplicaRefreshRequested: true }
+          : {}),
+        ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
+        ...(afterCheckpointKeepsForegroundImportLoop
+          ? { afterCheckpointKeepsForegroundImportLoop: true }
+          : {}),
+        checkpointReason: progressedResult.checkpointReason,
+        ...(foregroundReplyFailed === undefined
+          ? {}
+          : { foregroundReplyFailed }),
+        ...(foregroundPrioritySystemCompletionProcessed
+          ? { foregroundPrioritySystemCompletionProcessed: true }
+          : {}),
+        ...(invocationLocalAssistantWakeAt
+          ? { invocationLocalAssistantWakeAt }
+          : {}),
+        ...(systemMailboxProgressed
+          ? { systemMailboxProgressed: true as const }
+          : {}),
+        ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
+        ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
+          ? { nextWakeReason: nextWake.reason }
+          : {}),
+        progressed: true,
+        ...(redactedStatus ? { redactedStatus } : {}),
+        ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
+      },
+    });
+  }
+
+  return withHostedRuntimeProjectionCheckpointRequest({
+    requested: hostedRuntimeProjectionCheckpointWasRequested([
+      input.systemMailboxResult,
+      input.assistantResult,
+    ]),
+    result: {
       ...(browserVaultReplicaRefreshRequested
         ? { browserVaultReplicaRefreshRequested: true }
         : {}),
       ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
-      ...(afterCheckpointKeepsForegroundImportLoop
-        ? { afterCheckpointKeepsForegroundImportLoop: true }
-        : {}),
-      checkpointReason: progressedResult.checkpointReason,
       ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
       ...(foregroundPrioritySystemCompletionProcessed
         ? { foregroundPrioritySystemCompletionProcessed: true }
@@ -4039,44 +4098,18 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
       ...(invocationLocalAssistantWakeAt
         ? { invocationLocalAssistantWakeAt }
         : {}),
-      ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
-      ...(runtimeProjectionCheckpointRequested
-        ? { runtimeProjectionCheckpointRequested: true as const }
+      ...(systemMailboxProgressed
+        ? { systemMailboxProgressed: true as const }
         : {}),
       ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
       ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
         ? { nextWakeReason: nextWake.reason }
         : {}),
-      progressed: true,
+      progressed: false,
       ...(redactedStatus ? { redactedStatus } : {}),
       ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
-    };
-  }
-
-  return {
-    ...(browserVaultReplicaRefreshRequested
-      ? { browserVaultReplicaRefreshRequested: true }
-      : {}),
-    ...(deviceSyncMaintenanceRan ? { deviceSyncMaintenanceRan: true } : {}),
-    ...(foregroundReplyFailed === undefined ? {} : { foregroundReplyFailed }),
-    ...(foregroundPrioritySystemCompletionProcessed
-      ? { foregroundPrioritySystemCompletionProcessed: true }
-      : {}),
-    ...(invocationLocalAssistantWakeAt
-      ? { invocationLocalAssistantWakeAt }
-      : {}),
-    ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
-    ...(runtimeProjectionCheckpointRequested
-      ? { runtimeProjectionCheckpointRequested: true as const }
-      : {}),
-    ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
-    ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
-      ? { nextWakeReason: nextWake.reason }
-      : {}),
-    progressed: false,
-    ...(redactedStatus ? { redactedStatus } : {}),
-    ...withHostedDeviceSyncStagedDirtyAcks(stagedDirtyAcks),
-  };
+    },
+  });
 }
 
 function withHostedDeviceSyncMaintenanceRan(
@@ -5980,15 +6013,13 @@ async function runSystemMailboxMaintenancePhase(input: {
       deviceSyncMaintenanceRan: false,
       initialProviderCleanupCheckpoint,
       pendingAssistantInputWakeAt,
-      result: {
-        ...withHostedRuntimeWakeCandidate({
+      result: withHostedRuntimeProjectionCheckpointRequest({
+        requested: staleDefaultProjectionDisproved,
+        result: withHostedRuntimeWakeCandidate({
           result: { progressed: false },
           wake: initialOwnerWake,
         }),
-        ...(staleDefaultProjectionDisproved
-          ? { runtimeProjectionCheckpointRequested: true as const }
-          : {}),
-      },
+      }),
     };
   }
   deferSystemMailboxPreparationForDelivery =

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -2368,6 +2368,8 @@ export async function runHostedWorkspaceAssistantPhase(
     const systemMailboxOwnerOwnsCurrentPass =
       !hasAssistantInputAtPassStart
       && systemMailboxMaintenance.continueAssistantLane === false
+      && systemMailboxMaintenance.result?.runtimeProjectionCheckpointRequested
+        !== true
       && systemMailboxMaintenance.result?.nextWakeReason === "mailbox"
       && hostedRuntimeWakeCandidateIsDue(
         createHostedRuntimeWakeCandidate(
@@ -3992,6 +3994,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
   const systemMailboxProgressed =
     input.systemMailboxResult.systemMailboxProgressed === true
     || input.assistantResult.systemMailboxProgressed === true;
+  const runtimeProjectionCheckpointRequested =
+    input.systemMailboxResult.runtimeProjectionCheckpointRequested === true
+    || input.assistantResult.runtimeProjectionCheckpointRequested === true;
   const afterCheckpointKeepsForegroundImportLoop =
     input.systemMailboxResult.afterCheckpointKeepsForegroundImportLoop === true
     || input.assistantResult.afterCheckpointKeepsForegroundImportLoop === true;
@@ -4035,6 +4040,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
         ? { invocationLocalAssistantWakeAt }
         : {}),
       ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
+      ...(runtimeProjectionCheckpointRequested
+        ? { runtimeProjectionCheckpointRequested: true as const }
+        : {}),
       ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
       ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
         ? { nextWakeReason: nextWake.reason }
@@ -4058,6 +4066,9 @@ function mergeContinuingSystemMailboxAssistantPhaseResult(input: {
       ? { invocationLocalAssistantWakeAt }
       : {}),
     ...(systemMailboxProgressed ? { systemMailboxProgressed: true as const } : {}),
+    ...(runtimeProjectionCheckpointRequested
+      ? { runtimeProjectionCheckpointRequested: true as const }
+      : {}),
     ...(hasNextWakeAt ? { nextWakeAt: nextWake.at } : {}),
     ...(shouldExposeHostedAssistantPhaseNextWakeReason(nextWake.reason)
       ? { nextWakeReason: nextWake.reason }
@@ -5916,6 +5927,7 @@ async function runSystemMailboxMaintenancePhase(input: {
     };
   }
 
+  let staleDefaultProjectionDisproved = false;
   if (
     pendingAssistantInputBlocksMaintenance
     && !foregroundCausalAttempted
@@ -5933,6 +5945,7 @@ async function runSystemMailboxMaintenancePhase(input: {
         result: null,
       };
     }
+    staleDefaultProjectionDisproved = preflightAssistantCronWakeState.available;
   }
 
   let deferSystemMailboxPreparationForDelivery = false;
@@ -5967,10 +5980,15 @@ async function runSystemMailboxMaintenancePhase(input: {
       deviceSyncMaintenanceRan: false,
       initialProviderCleanupCheckpoint,
       pendingAssistantInputWakeAt,
-      result: withHostedRuntimeWakeCandidate({
-        result: { progressed: false },
-        wake: initialOwnerWake,
-      }),
+      result: {
+        ...withHostedRuntimeWakeCandidate({
+          result: { progressed: false },
+          wake: initialOwnerWake,
+        }),
+        ...(staleDefaultProjectionDisproved
+          ? { runtimeProjectionCheckpointRequested: true as const }
+          : {}),
+      },
     };
   }
   deferSystemMailboxPreparationForDelivery =

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -3912,7 +3912,9 @@ function mergeHostedAssistantPhaseResults(
 
 function hostedSystemMailboxOwnerCanReturnBeforeDefaultChecks(
   result: HostedWorkspaceRunnerAssistantPhaseResult | null,
-): boolean {
+): result is HostedWorkspaceRunnerAssistantPhaseResult & {
+  nextWakeReason: "mailbox";
+} {
   return result?.runtimeProjectionCheckpointRequested !== true
     && result?.nextWakeReason === "mailbox";
 }

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -297,6 +297,9 @@ interface HostedWorkspaceRunnerAssistantPhaseResultBase {
   // this invocation. This is never persisted; the runner and outer hot-wake
   // gate use it instead of inferring ownership from a merged wake timestamp.
   invocationLocalAssistantWakeAt?: string | null;
+  // Ephemeral request to checkpoint corrected wake projections. This does not
+  // claim assistant or system application progress.
+  runtimeProjectionCheckpointRequested?: true;
   nextWakeAt?: string | null;
   nextWakeReason?: string | null;
   redactedStatus?: HostedRuntimeRedactedJson | null;
@@ -3613,6 +3616,14 @@ async function checkpointHostedWorkspaceAssistantPhase(input: {
   platform: Pick<HostedWorkspaceRunnerPlatform, "logPort">;
   runtimeLogContext?: HostedRuntimeLogContext | null;
 }): Promise<void> {
+  if (
+    input.assistantPhaseResult.progressed !== true
+    && input.assistantPhaseResult.runtimeProjectionCheckpointRequested !== true
+  ) {
+    return;
+  }
+
+  input.checkpointRequestBuilder.markRuntimeStateDirty();
   if (input.assistantPhaseResult.progressed !== true) {
     return;
   }
@@ -3622,7 +3633,6 @@ async function checkpointHostedWorkspaceAssistantPhase(input: {
   );
   void input.expectedUserId;
   void input.initialMailboxImport;
-  input.checkpointRequestBuilder.markRuntimeStateDirty();
   await writeHostedForegroundCheckpointDeferredLog({
     checkpointPhase: "assistant",
     now: input.now,

--- a/packages/assistant-runtime/test/hosted-runtime-delegated-foreground-owner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-delegated-foreground-owner.test.ts
@@ -164,7 +164,13 @@ describe("hosted runtime delegated foreground owner", () => {
       expect(finalPending).toEqual(device ? [device] : []);
       expect(assistantPhaseCalls).toBe(1);
       expect(delegatedConsumptionCount).toBe(1);
-      expect(result.status).toBe("idle");
+      if (device) {
+        assert.equal(result.status, "scheduled");
+        assert.equal(result.nextWakeAt, TEST_NOW);
+        assert.equal(result.nextWakeReason, "device-sync.reconcile");
+      } else {
+        assert.equal(result.status, "idle");
+      }
     } finally {
       vi.useRealTimers();
       await rm(vaultRoot, { force: true, recursive: true });

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
@@ -1462,9 +1462,10 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
   });
 
   it(
-    "hands oldest model-free device maintenance to its owner after causal work",
+    "hands a model-free device frontier off after disproving a stale default projection",
     async () => {
       const now = "2026-04-27T00:00:00.000Z";
+      const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
       const parentRoot = await mkdtemp(
         path.join(tmpdir(), "hosted-causal-fallback-"),
       );
@@ -1501,6 +1502,13 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
         mocks.resolveHostedSystemMailboxNextWakeCandidate.mockImplementation(
           systemMailbox.resolveHostedSystemMailboxNextWakeCandidate,
         );
+        mocks.getAssistantCronStatus.mockResolvedValueOnce({
+          dueJobs: 0,
+          enabledJobs: 1,
+          nextRunAt: staleDefaultWakeAt,
+          runningJobs: 1,
+          totalJobs: 1,
+        });
 
         const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
           assistantInputIds: [],
@@ -1509,14 +1517,25 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
           now: () => now,
           operatorHomeRoot,
           vaultRoot,
+          workspace: createDueAssistantWorkspace({
+            nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+            nextDefaultProcessingWakeReason: "assistant",
+            nextWakeAt: staleDefaultWakeAt,
+            nextWakeReason: "device-sync.reconcile",
+            systemMailboxProgressGeneration: "1",
+          }),
         }));
 
+        expect(mocks.getAssistantCronStatus).toHaveBeenCalledTimes(1);
         expect(mocks.prepareHostedSystemMailboxItemForCheckpoint).not.toHaveBeenCalled();
         expect(mocks.runHostedDeviceSyncWakeLane).not.toHaveBeenCalled();
+        expect(mocks.applyMurphManagedAutomations).toHaveBeenCalledTimes(1);
+        expect(mocks.refreshReminderAvailability).toHaveBeenCalledTimes(1);
         expect(result).toEqual(expect.objectContaining({
           nextWakeAt: now,
           nextWakeReason: "device-sync.reconcile",
           progressed: false,
+          runtimeProjectionCheckpointRequested: true,
         }));
 
         await result.afterCheckpoint?.();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
@@ -13,6 +13,7 @@ import {
   createWorkspacePort,
   createWorkspaceRuntimeJobInput,
   createWorkspaceState,
+  enqueueDeviceSyncSystemMailboxItemForTest,
   importRuntimeControlSystemMailboxItemForTest,
   mocks,
   readCapturedRuntimePhaseLogs,
@@ -1113,6 +1114,208 @@ describe("hosted workspace runtime entrypoint", () => {test("reports mailbox bud
     }
   });
 
+  test("idle checkpoint retains an earlier future device-sync mailbox wake over the assistant scalar", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const deviceWakeAt = "2026-04-27T00:00:10.000Z";
+    const assistantWakeAt = "2026-04-27T00:00:20.000Z";
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const deviceItem = createMailboxItem({
+      dedupeKey: "device-sync.wake:idle-device-wake-retention",
+      id: "mailbox_item_entrypoint_idle_device_wake_retention_system",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            idleCheckpointDelayMs: 1,
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "4".repeat(64),
+                key: "users/bundles/member-synthetic/idle-device-wake-retention.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            await enqueueDeviceSyncSystemMailboxItemForTest({
+              item: deviceItem,
+              vaultRoot,
+            });
+            await updateHostedSystemMailboxState(vaultRoot, (state) => ({
+              pending: state.pending.map((item) =>
+                item.itemId === deviceItem.id
+                  ? {
+                      ...item,
+                      nextAttemptAt: deviceWakeAt,
+                      routeAction: "run-device-sync-wake",
+                    }
+                  : item
+              ),
+            }));
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({
+              events,
+              items: [
+                createMailboxItem({
+                  id: "mailbox_item_entrypoint_idle_device_wake_retention",
+                  laneSeq: "1",
+                }),
+              ],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({ version: "0" }),
+            }),
+          }),
+          async runAssistantPhase() {
+            return {
+              nextWakeAt: assistantWakeAt,
+              nextWakeReason: "assistant",
+              progressed: false,
+            };
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.deepEqual(checkpointRequests.map((request) => request.reason), [
+        "idle_shutdown",
+      ]);
+      assert.equal(checkpointRequests[0]?.nextWakeAt, deviceWakeAt);
+      assert.equal(checkpointRequests[0]?.nextWakeReason, "device-sync.reconcile");
+      assert.equal(result.nextWakeAt, deviceWakeAt);
+      assert.equal(result.nextWakeReason, "device-sync.reconcile");
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("canonical runtime-status checkpoint retains an earlier future device-sync mailbox wake over the assistant scalar", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const deviceWakeAt = "2026-04-27T00:00:10.000Z";
+    const assistantWakeAt = "2026-04-27T00:00:20.000Z";
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const deviceItem = createMailboxItem({
+      dedupeKey: "device-sync.wake:status-device-wake-retention",
+      id: "mailbox_item_entrypoint_status_device_wake_retention_system",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const canonicalWriteItem = createMailboxItem({
+      id: "mailbox_item_entrypoint_status_device_wake_retention_write",
+      kind: "runtime.manual-requested",
+      lane: "system",
+      laneSeq: "1",
+    });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+
+      await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            workspaceVersion: "0",
+          },
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "5".repeat(64),
+                key: "users/bundles/member-synthetic/status-device-wake-retention.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem(item) {
+            assert.equal(item.item.id, canonicalWriteItem.id);
+            return { status: "imported" };
+          },
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({
+              events,
+              items: [canonicalWriteItem],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({
+                nextWakeAt: assistantWakeAt,
+                nextWakeReason: "assistant",
+                version: "0",
+              }),
+            }),
+          }),
+          async runAssistantPhase() {
+            await enqueueDeviceSyncSystemMailboxItemForTest({
+              item: deviceItem,
+              vaultRoot,
+            });
+            await updateHostedSystemMailboxState(vaultRoot, (state) => ({
+              pending: state.pending.map((pendingItem) =>
+                pendingItem.itemId === deviceItem.id
+                  ? {
+                      ...pendingItem,
+                      nextAttemptAt: deviceWakeAt,
+                      routeAction: "run-device-sync-wake",
+                    }
+                  : pendingItem
+              ),
+            }));
+            await runCanonicalWrite({
+              mutate: async ({ batch }) => {
+                await batch.stageTextWrite(
+                  "bank/status-device-wake-retention.md",
+                  "synthetic canonical status checkpoint\n",
+                );
+              },
+              occurredAt: TEST_NOW,
+              operationType: "hosted_status_device_wake_retention_test",
+              summary: "Persist synthetic status checkpoint",
+              vaultRoot,
+            });
+            return { progressed: false };
+          },
+          vaultRoot,
+        },
+      );
+
+      const canonicalCheckpoint = checkpointRequests.find(
+        (request) => request.reason === "canonical_runtime_commit",
+      );
+      assert.ok(canonicalCheckpoint);
+      assert.equal(
+        typeof canonicalCheckpoint.redactedStatus?.hostedCanonicalWriteReceiptLogSha256,
+        "string",
+      );
+      assert.equal(canonicalCheckpoint.nextWakeAt, deviceWakeAt);
+      assert.equal(canonicalCheckpoint.nextWakeReason, "device-sync.reconcile");
+    } finally {
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("returns scheduled when no mailbox import runs and the workspace has a future wake", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
@@ -1209,7 +1412,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reports mailbox bud
     }
   });
 
-  test("fresh due assistant wake supersedes a stale carried device-sync wake under a pending checkpoint", async () => {
+  test("fresh due assistant wake supersedes a progressed projection marker with a stale carried device-sync wake", async () => {
     // Incident shape (2026-08-15): a workspace restores with a stale,
     // already-past device-sync.reconcile wake. While runtime state is dirty
     // with pending durable effects (a delivered reply's consume acks), a
@@ -1318,6 +1521,11 @@ describe("hosted workspace runtime entrypoint", () => {test("reports mailbox bud
                 nextWakeAt: staleDeviceWakeAt,
                 nextWakeReason: "device-sync.reconcile",
                 progressed: true,
+                // System-owner and foreground results can merge this marker
+                // onto a genuinely progressed pass. That composite result
+                // must keep foreground authority instead of handing the stale
+                // device token back to its owner.
+                runtimeProjectionCheckpointRequested: true,
               };
             }
 

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3126,7 +3126,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
-  test("checkpoints a stale assistant projection, then advances the imported device frontier under the system owner", async () => {
+  test("recovers a running canonical claim after its only future wake survives a device-owner handoff", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const artifactBytesByHash = new Map<string, Uint8Array>();
     const artifactGetCalls: string[] = [];
@@ -3136,7 +3136,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
     const staleDeviceWakeAt = "2026-04-26T23:58:00.000Z";
     const runningAt = "2026-04-26T23:59:30.000Z";
-    const futurePendingEffectsWakeAt = "2026-04-27T00:10:00.000Z";
+    const recoveryWakeAt = "2026-04-27T00:59:30.001Z";
     const automationId = "automation_01JQ8PWXP5A68SQM1W0GYM41XZ";
     const deviceHead = createMailboxItem({
       dedupeKey: "device-sync.wake:stale-default-projection-head",
@@ -3144,20 +3144,6 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       kind: "device-sync.wake",
       lane: "system",
       laneSeq: "1",
-    });
-    const pendingEffects = createMailboxItem({
-      dedupeKey: "runtime.pending-effects-reconcile-requested:stale-default-projection",
-      id: "mailbox_item_stale_default_projection_pending_effects",
-      kind: "runtime.pending-effects-reconcile-requested",
-      lane: "system",
-      laneSeq: "3",
-    });
-    const deviceTail = createMailboxItem({
-      dedupeKey: "device-sync.wake:stale-default-projection-tail",
-      id: "mailbox_item_stale_default_projection_device_tail",
-      kind: "device-sync.wake",
-      lane: "system",
-      laneSeq: "4",
     });
     const deviceSyncPort = createEmptyDeviceSyncPort();
     let assistantPhaseCalls = 0;
@@ -3222,7 +3208,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.deepEqual(await getAssistantCronStatus(vaultRoot), {
         dueJobs: 0,
         enabledJobs: 1,
-        nextRunAt: staleDefaultWakeAt,
+        nextRunAt: recoveryWakeAt,
         runningJobs: 1,
         totalJobs: 1,
       });
@@ -3231,28 +3217,12 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         item: deviceHead,
         vaultRoot,
       });
-      await enqueuePendingEffectsSystemMailboxItemForTest({
-        effectId: "effect_synthetic_stale_default_projection",
-        item: pendingEffects,
-        vaultRoot,
-      });
-      await enqueueDeviceSyncSystemMailboxItemForTest({
-        item: deviceTail,
-        vaultRoot,
-      });
-      await updateHostedSystemMailboxState(vaultRoot, (state) => ({
-        pending: state.pending.map((item) =>
-          item.itemId === pendingEffects.id
-            ? { ...item, nextAttemptAt: futurePendingEffectsWakeAt }
-            : item
-        ),
-      }));
       const pendingBeforeInvocation = structuredClone(
         (await readHostedSystemMailboxState(vaultRoot)).pending,
       );
       assert.deepEqual(
         pendingBeforeInvocation.map((item) => item.mailboxLaneSeq),
-        ["1", "3", "4"],
+        ["1"],
       );
       assert.equal(
         findNextHostedSystemMailboxQueueItem({
@@ -3263,7 +3233,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         deviceHead.id,
       );
       const importState = createEmptyHostedMailboxImportState();
-      importState.watermarks.system = "4";
+      importState.watermarks.system = "1";
       await writeMailboxImportStateFile(vaultRoot, importState);
       const restoredWorkspace = await createVaultSnapshotBundle({
         key: "users/bundles/member-synthetic/stale-default-projection-before.bundle.json",
@@ -3282,7 +3252,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
           hostedMailboxImportedCount: 0,
           hostedMailboxRetryableBlockedCount: 0,
           hostedMailboxSystemHandledThroughSeq: "0",
-          hostedMailboxSystemImportedSeq: "4",
+          hostedMailboxSystemImportedSeq: "1",
         },
         snapshotRef: restoredWorkspace.snapshotRef,
         systemMailboxProgressGeneration: "1",
@@ -3352,7 +3322,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         {
           createCheckpointSnapshot,
           async importItem() {
-            throw new Error("The restored 0/4/4 mailbox must not import a new row.");
+            throw new Error("The restored 0/1/1 mailbox must not import a new row.");
           },
           platform,
           async runAssistantPhase(input) {
@@ -3380,7 +3350,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(checkpoint.nextWakeReason, "device-sync.reconcile");
       assert.equal(
         checkpoint.nextDefaultProcessingWakeAt,
-        futurePendingEffectsWakeAt,
+        recoveryWakeAt,
       );
       assert.equal(checkpoint.nextDefaultProcessingWakeReason, "assistant");
       assert.equal(checkpoint.systemMailboxProgressGeneration, "1");
@@ -3390,7 +3360,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       );
       assert.equal(
         checkpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
-        "4",
+        "1",
       );
       assert.equal(checkpoint.redactedStatus?.hostedMailboxFetchedCount, 0);
       assert.equal(checkpoint.redactedStatus?.hostedMailboxImportedCount, 0);
@@ -3432,7 +3402,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         {
           createCheckpointSnapshot,
           async importItem() {
-            throw new Error("The handed-off 0/4/4 mailbox must not import a new row.");
+            throw new Error("The handed-off 0/1/1 mailbox must not import a new row.");
           },
           platform,
           async runAssistantPhase() {
@@ -3450,11 +3420,11 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.ok(systemCheckpoint);
       assert.equal(
         systemCheckpoint.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
-        "2",
+        "1",
       );
       assert.equal(
         systemCheckpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
-        "4",
+        "1",
       );
       assert.equal(
         systemPassCheckpoints.every((request) =>
@@ -3476,20 +3446,63 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             lane: lane.lane,
           }))
         ),
-        [[{ importedSeq: "4", lane: "system" }]],
+        [[{ importedSeq: "1", lane: "system" }]],
       );
       assert.equal(systemResult.status, "scheduled");
+      assert.equal(systemResult.nextWakeAt, recoveryWakeAt);
+      assert.equal(systemResult.nextWakeReason, "assistant");
       assert.equal(deviceSyncPort.fetchSnapshotCalls, 1);
       assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
       assert.equal(assistantPhaseCalls, 1);
       assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
       assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
-      const remainingPending = (await readHostedSystemMailboxState(vaultRoot)).pending;
       assert.deepEqual(
-        remainingPending.map((item) => item.mailboxLaneSeq),
-        ["3", "4"],
+        (await readHostedSystemMailboxState(vaultRoot)).pending,
+        [],
       );
-      assert.deepEqual(remainingPending, pendingBeforeInvocation.slice(1));
+
+      vi.setSystemTime(new Date(recoveryWakeAt));
+      const recoveryResult = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_running_claim_recovery",
+            workspaceVersion: currentWorkspace.version,
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          createCheckpointSnapshot,
+          async importItem() {
+            throw new Error("The recovery pass must not import a mailbox row.");
+          },
+          platform,
+          async runAssistantPhase(input) {
+            assistantPhaseCalls += 1;
+            return await runHostedWorkspaceAssistantPhase({
+              ...input,
+              now: () => recoveryWakeAt,
+            });
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.equal(recoveryResult.status, "idle");
+      assert.equal(recoveryResult.nextWakeAt, null);
+      assert.equal(recoveryResult.nextWakeReason, undefined);
+      assert.equal(assistantPhaseCalls, 2);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 1);
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.deepEqual(await getAssistantCronStatus(vaultRoot), {
+        dueJobs: 0,
+        enabledJobs: 0,
+        nextRunAt: null,
+        runningJobs: 0,
+        totalJobs: 0,
+      });
+      await expect(showAutomation({ automationId, vaultRoot })).resolves.toMatchObject({
+        status: "archived",
+      });
     } finally {
       mocks.runAssistantAutomationPass.mockClear();
       mocks.prepareHostedCodexAssistantProcess.mockClear();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3126,10 +3126,13 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
-  test("default mode checkpoints a stale assistant projection before handing an imported device frontier to the system owner", async () => {
+  test("checkpoints a stale assistant projection, then advances the imported device frontier under the system owner", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const artifactBytesByHash = new Map<string, Uint8Array>();
+    const artifactGetCalls: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
     const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
     const staleDeviceWakeAt = "2026-04-26T23:58:00.000Z";
     const runningAt = "2026-04-26T23:59:30.000Z";
@@ -3158,6 +3161,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     });
     const deviceSyncPort = createEmptyDeviceSyncPort();
     let assistantPhaseCalls = 0;
+    let snapshotOrdinal = 0;
 
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
@@ -3265,6 +3269,77 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         key: "users/bundles/member-synthetic/stale-default-projection-before.bundle.json",
         vaultRoot,
       });
+      artifactBytesByHash.set(restoredWorkspace.hash, restoredWorkspace.bytes);
+      let currentWorkspace = createWorkspaceState({
+        nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+        nextDefaultProcessingWakeReason: "assistant",
+        nextWakeAt: staleDeviceWakeAt,
+        nextWakeReason: "device-sync.reconcile",
+        redactedStatus: {
+          hostedMailboxBlockedCount: 0,
+          hostedMailboxConversationImportedSeq: "0",
+          hostedMailboxFetchedCount: 0,
+          hostedMailboxImportedCount: 0,
+          hostedMailboxRetryableBlockedCount: 0,
+          hostedMailboxSystemHandledThroughSeq: "0",
+          hostedMailboxSystemImportedSeq: "4",
+        },
+        snapshotRef: restoredWorkspace.snapshotRef,
+        systemMailboxProgressGeneration: "1",
+        version: "0",
+      });
+      const workspacePort: HostedRuntimeWorkspacePort = {
+        async checkpoint(request) {
+          events.push("workspace.checkpoint");
+          checkpointRequests.push(request);
+          currentWorkspace = createWorkspaceState({
+            inboxMediaRetentionWakeAt: request.inboxMediaRetentionWakeAt ?? null,
+            nextDefaultProcessingWakeAt:
+              request.nextDefaultProcessingWakeAt ?? null,
+            nextDefaultProcessingWakeReason:
+              request.nextDefaultProcessingWakeReason ?? null,
+            nextWakeAt: request.nextWakeAt ?? null,
+            nextWakeReason: request.nextWakeReason ?? null,
+            redactedStatus: request.redactedStatus ?? null,
+            snapshotRef: request.snapshotRef,
+            systemMailboxProgressGeneration:
+              request.systemMailboxProgressGeneration ?? null,
+            version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
+          });
+          return {
+            checkpointed: true,
+            workspace: currentWorkspace,
+          };
+        },
+        async read() {
+          events.push("workspace.read");
+          return {
+            fetchedAt: TEST_NOW,
+            workspace: currentWorkspace,
+          };
+        },
+      };
+      const platform = createPlatform({
+        artifactBytesByHash,
+        artifactGetCalls,
+        deviceSyncPort,
+        mailboxPort: createMailboxPort({
+          events,
+          fetchRequests,
+          items: [],
+        }),
+        workspacePort,
+      });
+      const createCheckpointSnapshot = async () => {
+        snapshotOrdinal += 1;
+        const snapshot = await createVaultSnapshotBundle({
+          key:
+            `users/bundles/member-synthetic/stale-default-projection-${snapshotOrdinal}.bundle.json`,
+          vaultRoot,
+        });
+        artifactBytesByHash.set(snapshot.hash, snapshot.bytes);
+        return { snapshotRef: snapshot.snapshotRef };
+      };
 
       const result = await runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
@@ -3275,48 +3350,11 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
           resolvedConfig: createDeviceSyncResolvedConfig(),
         }),
         {
-          async createCheckpointSnapshot() {
-            return {
-              snapshotRef: createBundleRef({
-                hash: "f".repeat(64),
-                key: "users/bundles/member-synthetic/stale-default-projection-after.bundle.json",
-                size: 512,
-              }),
-            };
-          },
+          createCheckpointSnapshot,
           async importItem() {
             throw new Error("The restored 0/4/4 mailbox must not import a new row.");
           },
-          platform: createPlatform({
-            artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
-            deviceSyncPort,
-            mailboxPort: createMailboxPort({
-              events,
-              items: [],
-            }),
-            workspacePort: createWorkspacePort({
-              checkpointRequests,
-              events,
-              workspace: createWorkspaceState({
-                nextDefaultProcessingWakeAt: staleDefaultWakeAt,
-                nextDefaultProcessingWakeReason: "assistant",
-                nextWakeAt: staleDeviceWakeAt,
-                nextWakeReason: "device-sync.reconcile",
-                redactedStatus: {
-                  hostedMailboxBlockedCount: 0,
-                  hostedMailboxConversationImportedSeq: "0",
-                  hostedMailboxFetchedCount: 0,
-                  hostedMailboxImportedCount: 0,
-                  hostedMailboxRetryableBlockedCount: 0,
-                  hostedMailboxSystemHandledThroughSeq: "0",
-                  hostedMailboxSystemImportedSeq: "4",
-                },
-                snapshotRef: restoredWorkspace.snapshotRef,
-                systemMailboxProgressGeneration: "1",
-                version: "0",
-              }),
-            }),
-          }),
+          platform,
           async runAssistantPhase(input) {
             assistantPhaseCalls += 1;
             const phaseResult = await runHostedWorkspaceAssistantPhase({
@@ -3368,6 +3406,86 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         (await readHostedSystemMailboxState(vaultRoot)).pending,
         pendingBeforeInvocation,
       );
+      assert.equal(currentWorkspace.version, "1");
+      assert.deepEqual(currentWorkspace.snapshotRef, checkpoint.snapshotRef);
+      assert.equal(
+        artifactBytesByHash.has(currentWorkspace.snapshotRef.hash),
+        true,
+      );
+
+      const checkpointCountBeforeSystemPass = checkpointRequests.length;
+      const artifactGetCountBeforeSystemPass = artifactGetCalls.length;
+      const fetchCountBeforeSystemPass = fetchRequests.length;
+      const systemResult = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_stale_default_projection_system_handoff",
+            processingMode: "system_mailbox",
+            workspaceVersion: currentWorkspace.version,
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          createCheckpointSnapshot,
+          async importItem() {
+            throw new Error("The handed-off 0/4/4 mailbox must not import a new row.");
+          },
+          platform,
+          async runAssistantPhase() {
+            throw new Error("The system owner handoff must not enter assistant phase.");
+          },
+          vaultRoot,
+        },
+      );
+
+      const systemPassCheckpoints = checkpointRequests.slice(
+        checkpointCountBeforeSystemPass,
+      );
+      assert.ok(systemPassCheckpoints.length > 0);
+      const systemCheckpoint = systemPassCheckpoints.at(-1);
+      assert.ok(systemCheckpoint);
+      assert.equal(
+        systemCheckpoint.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "2",
+      );
+      assert.equal(
+        systemCheckpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
+        "4",
+      );
+      assert.equal(
+        systemPassCheckpoints.every((request) =>
+          request.systemMailboxProgressGeneration === "1"
+        ),
+        true,
+      );
+      assert.equal(currentWorkspace.systemMailboxProgressGeneration, "1");
+      assert.equal(
+        artifactGetCalls.slice(artifactGetCountBeforeSystemPass).includes(
+          checkpoint.snapshotRef.hash,
+        ),
+        true,
+      );
+      assert.deepEqual(
+        fetchRequests.slice(fetchCountBeforeSystemPass).map((request) =>
+          request.lanes.map((lane) => ({
+            importedSeq: lane.importedSeq,
+            lane: lane.lane,
+          }))
+        ),
+        [[{ importedSeq: "4", lane: "system" }]],
+      );
+      assert.equal(systemResult.status, "scheduled");
+      assert.equal(deviceSyncPort.fetchSnapshotCalls, 1);
+      assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
+      assert.equal(assistantPhaseCalls, 1);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      const remainingPending = (await readHostedSystemMailboxState(vaultRoot)).pending;
+      assert.deepEqual(
+        remainingPending.map((item) => item.mailboxLaneSeq),
+        ["3", "4"],
+      );
+      assert.deepEqual(remainingPending, pendingBeforeInvocation.slice(1));
     } finally {
       mocks.runAssistantAutomationPass.mockClear();
       mocks.prepareHostedCodexAssistantProcess.mockClear();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3408,8 +3408,12 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       );
       assert.equal(currentWorkspace.version, "1");
       assert.deepEqual(currentWorkspace.snapshotRef, checkpoint.snapshotRef);
+      const checkpointSnapshotBaseRef = readHostedExecutionSnapshotBaseRef(
+        checkpoint.snapshotRef,
+      );
+      assert.ok(checkpointSnapshotBaseRef);
       assert.equal(
-        artifactBytesByHash.has(currentWorkspace.snapshotRef.hash),
+        artifactBytesByHash.has(checkpointSnapshotBaseRef.hash),
         true,
       );
 
@@ -3461,7 +3465,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(currentWorkspace.systemMailboxProgressGeneration, "1");
       assert.equal(
         artifactGetCalls.slice(artifactGetCountBeforeSystemPass).includes(
-          checkpoint.snapshotRef.hash,
+          checkpointSnapshotBaseRef.hash,
         ),
         true,
       );

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3408,8 +3408,10 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       );
       assert.equal(currentWorkspace.version, "1");
       assert.deepEqual(currentWorkspace.snapshotRef, checkpoint.snapshotRef);
+      const checkpointSnapshotRef = checkpoint.snapshotRef;
+      assert.ok(checkpointSnapshotRef && "hash" in checkpointSnapshotRef);
       assert.equal(
-        artifactBytesByHash.has(currentWorkspace.snapshotRef.hash),
+        artifactBytesByHash.has(checkpointSnapshotRef.hash),
         true,
       );
 
@@ -3461,7 +3463,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(currentWorkspace.systemMailboxProgressGeneration, "1");
       assert.equal(
         artifactGetCalls.slice(artifactGetCountBeforeSystemPass).includes(
-          checkpoint.snapshotRef.hash,
+          checkpointSnapshotRef.hash,
         ),
         true,
       );

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -3126,6 +3126,256 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
+  test("default mode checkpoints a stale assistant projection before handing an imported device frontier to the system owner", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const staleDefaultWakeAt = "2026-04-26T23:59:00.000Z";
+    const staleDeviceWakeAt = "2026-04-26T23:58:00.000Z";
+    const runningAt = "2026-04-26T23:59:30.000Z";
+    const futurePendingEffectsWakeAt = "2026-04-27T00:10:00.000Z";
+    const automationId = "automation_01JQ8PWXP5A68SQM1W0GYM41XZ";
+    const deviceHead = createMailboxItem({
+      dedupeKey: "device-sync.wake:stale-default-projection-head",
+      id: "mailbox_item_stale_default_projection_device_head",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const pendingEffects = createMailboxItem({
+      dedupeKey: "runtime.pending-effects-reconcile-requested:stale-default-projection",
+      id: "mailbox_item_stale_default_projection_pending_effects",
+      kind: "runtime.pending-effects-reconcile-requested",
+      lane: "system",
+      laneSeq: "3",
+    });
+    const deviceTail = createMailboxItem({
+      dedupeKey: "device-sync.wake:stale-default-projection-tail",
+      id: "mailbox_item_stale_default_projection_device_tail",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "4",
+    });
+    const deviceSyncPort = createEmptyDeviceSyncPort();
+    let assistantPhaseCalls = 0;
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.runAssistantAutomationPass.mockClear();
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await upsertAutomation({
+        automationId,
+        continuityPolicy: "fresh",
+        instructions: "Record one synthetic scheduled check-in.",
+        now: new Date(staleDefaultWakeAt),
+        route: {
+          channel: "linq",
+          deliveryTarget: "synthetic_direct_chat",
+          identityId: null,
+          participantId: null,
+          threadId: "synthetic_direct_chat",
+          threadIsDirect: true,
+        },
+        schedule: { at: staleDefaultWakeAt, kind: "at" },
+        status: "active",
+        title: "Synthetic stale projection check-in",
+        vaultRoot,
+      });
+      const cronAutomationStatePath = resolveAssistantStatePaths(
+        vaultRoot,
+      ).cronAutomationStatePath;
+      await mkdir(path.dirname(cronAutomationStatePath), { recursive: true });
+      await writeFile(
+        cronAutomationStatePath,
+        `${JSON.stringify({
+          jobs: [{
+            alias: null,
+            createdAt: staleDefaultWakeAt,
+            jobId: automationId,
+            schema: "murph.assistant-canonical-cron-runtime-state.v1",
+            sessionId: null,
+            state: {
+              activatedAt: staleDefaultWakeAt,
+              consecutiveFailures: 0,
+              lastError: null,
+              lastFailedAt: null,
+              lastRunAt: null,
+              lastSucceededAt: null,
+              pendingDeliveryIntentId: null,
+              pendingOccurrenceAt: staleDefaultWakeAt,
+              retryAfterAt: null,
+              runningAt,
+              runningClaimId: "claim_synthetic_stale_default",
+              runningPid: process.pid,
+            },
+            updatedAt: runningAt,
+          }],
+          version: 1,
+        }, null, 2)}\n`,
+      );
+      assert.deepEqual(await getAssistantCronStatus(vaultRoot), {
+        dueJobs: 0,
+        enabledJobs: 1,
+        nextRunAt: staleDefaultWakeAt,
+        runningJobs: 1,
+        totalJobs: 1,
+      });
+
+      await enqueueDeviceSyncSystemMailboxItemForTest({
+        item: deviceHead,
+        vaultRoot,
+      });
+      await enqueuePendingEffectsSystemMailboxItemForTest({
+        effectId: "effect_synthetic_stale_default_projection",
+        item: pendingEffects,
+        vaultRoot,
+      });
+      await enqueueDeviceSyncSystemMailboxItemForTest({
+        item: deviceTail,
+        vaultRoot,
+      });
+      await updateHostedSystemMailboxState(vaultRoot, (state) => ({
+        pending: state.pending.map((item) =>
+          item.itemId === pendingEffects.id
+            ? { ...item, nextAttemptAt: futurePendingEffectsWakeAt }
+            : item
+        ),
+      }));
+      const pendingBeforeInvocation = structuredClone(
+        (await readHostedSystemMailboxState(vaultRoot)).pending,
+      );
+      assert.deepEqual(
+        pendingBeforeInvocation.map((item) => item.mailboxLaneSeq),
+        ["1", "3", "4"],
+      );
+      assert.equal(
+        findNextHostedSystemMailboxQueueItem({
+          allowedRouteActions: null,
+          now: TEST_NOW,
+          state: { pending: pendingBeforeInvocation },
+        })?.itemId,
+        deviceHead.id,
+      );
+      const importState = createEmptyHostedMailboxImportState();
+      importState.watermarks.system = "4";
+      await writeMailboxImportStateFile(vaultRoot, importState);
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/stale-default-projection-before.bundle.json",
+        vaultRoot,
+      });
+
+      const result = await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({
+          request: {
+            attemptId: "attempt_synthetic_stale_default_projection",
+            workspaceVersion: "0",
+          },
+          resolvedConfig: createDeviceSyncResolvedConfig(),
+        }),
+        {
+          async createCheckpointSnapshot() {
+            return {
+              snapshotRef: createBundleRef({
+                hash: "f".repeat(64),
+                key: "users/bundles/member-synthetic/stale-default-projection-after.bundle.json",
+                size: 512,
+              }),
+            };
+          },
+          async importItem() {
+            throw new Error("The restored 0/4/4 mailbox must not import a new row.");
+          },
+          platform: createPlatform({
+            artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
+            deviceSyncPort,
+            mailboxPort: createMailboxPort({
+              events,
+              items: [],
+            }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests,
+              events,
+              workspace: createWorkspaceState({
+                nextDefaultProcessingWakeAt: staleDefaultWakeAt,
+                nextDefaultProcessingWakeReason: "assistant",
+                nextWakeAt: staleDeviceWakeAt,
+                nextWakeReason: "device-sync.reconcile",
+                redactedStatus: {
+                  hostedMailboxBlockedCount: 0,
+                  hostedMailboxConversationImportedSeq: "0",
+                  hostedMailboxFetchedCount: 0,
+                  hostedMailboxImportedCount: 0,
+                  hostedMailboxRetryableBlockedCount: 0,
+                  hostedMailboxSystemHandledThroughSeq: "0",
+                  hostedMailboxSystemImportedSeq: "4",
+                },
+                snapshotRef: restoredWorkspace.snapshotRef,
+                systemMailboxProgressGeneration: "1",
+                version: "0",
+              }),
+            }),
+          }),
+          async runAssistantPhase(input) {
+            assistantPhaseCalls += 1;
+            const phaseResult = await runHostedWorkspaceAssistantPhase({
+              ...input,
+              now: () => TEST_NOW,
+            });
+            assert.equal(phaseResult.progressed, false);
+            assert.equal(phaseResult.nextWakeAt, TEST_NOW);
+            assert.equal(phaseResult.nextWakeReason, "device-sync.reconcile");
+            return phaseResult;
+          },
+          vaultRoot,
+        },
+      );
+
+      assert.equal(assistantPhaseCalls, 1);
+      assert.equal(checkpointRequests.length, 1);
+      const checkpoint = checkpointRequests[0];
+      assert.ok(checkpoint);
+      assert.equal(checkpoint.reason, "idle_shutdown");
+      assert.equal(checkpoint.expectedWorkspaceVersion, "0");
+      assert.equal(checkpoint.nextWakeAt, TEST_NOW);
+      assert.equal(checkpoint.nextWakeReason, "device-sync.reconcile");
+      assert.equal(
+        checkpoint.nextDefaultProcessingWakeAt,
+        futurePendingEffectsWakeAt,
+      );
+      assert.equal(checkpoint.nextDefaultProcessingWakeReason, "assistant");
+      assert.equal(checkpoint.systemMailboxProgressGeneration, "1");
+      assert.equal(
+        checkpoint.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "0",
+      );
+      assert.equal(
+        checkpoint.redactedStatus?.hostedMailboxSystemImportedSeq,
+        "4",
+      );
+      assert.equal(checkpoint.redactedStatus?.hostedMailboxFetchedCount, 0);
+      assert.equal(checkpoint.redactedStatus?.hostedMailboxImportedCount, 0);
+      assert.equal(result.status, "scheduled");
+      assert.equal(result.immediateRecheckRequested, true);
+      assert.equal(result.nextWakeAt, TEST_NOW);
+      assert.equal(result.nextWakeReason, "device-sync.reconcile");
+      assert.equal(deviceSyncPort.fetchSnapshotCalls, 0);
+      assert.equal(deviceSyncPort.fetchDirtyStatesCalls, 0);
+      assert.equal(mocks.runAssistantAutomationPass.mock.calls.length, 0);
+      assert.equal(mocks.prepareHostedCodexAssistantProcess.mock.calls.length, 0);
+      assert.deepEqual(
+        (await readHostedSystemMailboxState(vaultRoot)).pending,
+        pendingBeforeInvocation,
+      );
+    } finally {
+      mocks.runAssistantAutomationPass.mockClear();
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      vi.useRealTimers();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("default foreground hands a timed-out browser refresh to the model-free system owner", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const artifactBytesByHash = new Map<string, Uint8Array>();

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -3309,6 +3309,54 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     }
   });
 
+  test("marks a projection-only assistant checkpoint request dirty without claiming application progress", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const { mailboxPort } = createMailboxPort({ items: [] });
+
+    try {
+      const result = await runHostedWorkspaceUntilIdleOrBudget({
+        checkpointRequestBuilder: createHostedWorkspaceCheckpointRequestBuilder({
+          attemptId: "attempt_synthetic_runner_projection_checkpoint",
+          expectedWorkspaceVersion: "0",
+          leaseGeneration: "1",
+          nextWakeAt: null,
+          nextWakeReason: null,
+          snapshotRef: null,
+        }),
+        expectedUserId: TEST_USER_ID,
+        async importItem() {
+          throw new Error("Import should not run without mailbox items.");
+        },
+        limitPerLane: 10,
+        platform: createPlatform({
+          mailboxPort,
+          workspacePort: createWorkspacePort({ checkpointRequests }),
+        }),
+        requestId: "request_synthetic_runner_projection_checkpoint",
+        async runAssistantPhase() {
+          return {
+            progressed: false,
+            runtimeProjectionCheckpointRequested: true,
+          };
+        },
+        vaultRoot,
+        workspace: createWorkspaceState({ version: "0" }),
+        now: () => TEST_NOW,
+      });
+
+      assert.equal(result.runtimeStateDirty, true);
+      assert.equal(result.assistantPhaseResult?.progressed, false);
+      assert.equal(result.assistantPhaseResult?.checkpointReason, undefined);
+      assert.deepEqual(checkpointRequests, []);
+    } finally {
+      await rm(vaultRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
   test("rejects a progressed assistant phase without an explicit checkpoint reason", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-runner-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: a6b70520b7007e6d47c973a19a42464328c43527
ReviewGPT current-candidate disposition: not awaited per the incident owner's explicit merge instruction

## Why and outcome

A stale default-assistant wake could be selected repeatedly without persisting its corrected owner, while checkpoint arbitration could replace an earlier connected-device retry with a later assistant scalar. A fresh running canonical cron claim also kept only its historical occurrence time; after the hosted runtime rejected that past timestamp, no timer remained to reclaim the claim.

This stack fixes all three paths. Connected-device recovery stays with its existing owner, stale assistant projections no longer churn, and every fresh running canonical claim exposes its own future recovery check. Current conversations and genuinely due assistant work retain priority. No persisted-state, checkpoint, or Temporal protocol shape changes.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: Members waiting for connected-device follow-through or scheduled work after an interrupted hosted run.
- Result: Retained device work resumes under its existing owner, and interrupted scheduled work is reclaimed from its own timer without waiting for another conversation or device event.
- Exclusions: Current conversations, reminders, pending deliveries, and other genuinely due assistant work keep priority; assistant-blocked restoration is unchanged; there is no UI change.
- Plan delta: The final audit added the fresh-running-claim recovery timer and replaced the masking pending-effects fixture with a no-other-future-wake recovery journey.

## Evidence

- Production-shaped cron owner, hosted scheduling, and full workspace/system-mailbox suites: 323 passed.
- No-other-wake journey: the device-owner handoff checkpoints `runningAt + 1 hour + 1 ms`; the next invocation reclaims and archives the expired one-shot occurrence without starting a model, then returns idle with no remaining wake.
- Public changelog rendering: 9 passed.
- Typechecks: assistant-engine, assistant-runtime, and hosted Web passed.
- `pnpm complexity:diff --base origin/main`: passed with no debt or maximum regression.
- `git diff --check`: passed.
- Private-data scan: no member identifiers, phone numbers, home paths, account/legal names, secret URLs, or authorization values in the diff.
- ReviewGPT was launched on the prior exact candidate; the incident owner explicitly instructed this recovery not to wait on ReviewGPT. Required GitHub checks remain the merge gate for the new head.

## Non-obvious affected surfaces

- Assistant-engine cron status replaces a running canonical claim's historical occurrence with its first strictly reclaimable instant while preserving the historical occurrence in runtime state for execution recovery.
- Yield-hidden background maintenance uses the same recovery timer when it owns a running claim.
- Canonical runtime-status checkpoints arbitrate across all wake owners when assistant execution is allowed; the blocked-policy path retains its restricted restoration behavior.
- Idle shutdown retains an earlier device-reconcile owner without broadly persisting unrelated system-control wakes.
- Foreground idle handoff requires a projection-only marker with no assistant progress; a carried device scalar alone cannot suppress new foreground work.
- Temporal code and workspace checkpoint protocol are unchanged; the corrected assistant status and durable checkpoint scalars change the timer Cloudflare exposes to the existing workflow.

## Architecture and reuse

- Existing systems reused: Canonical cron runtime state, the existing strict one-hour claim-reclamation rule, mailbox wake resolution, owner selection, workspace CAS checkpointing, and Temporal timer ownership.
- New logic: A one-millisecond post-boundary recovery projection for running canonical claims, full-owner arbitration at runtime-status checkpoints, device-wake retention at idle checkpointing, and marker-plus-no-progress validation for model-free handoff.
- New abstractions: One assistant-engine internal recovery-time helper and the existing stack's three private runtime helpers; no public or cross-package API was added.
- Complexity intentionally avoided: No new scheduler, queue, persisted owner state, Temporal version marker, database table, compatibility layer, or retry state machine.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main` reported no debt or maximum regression.
- Hotspots: `getAssistantCronStatus` and the new recovery helper remain below 20. Existing touched-file hotspots remain unchanged, including `processDueAssistantCronJobsLocal` at 25 and `runHostedWorkspaceRuntimeJobInProcessImpl` at 253.
- Agent judgment: No further behavior-preserving simplification is justified; the recovery timestamp is derived from the existing claim owner and strict boundary without adding state.

## Hot reply path impact

- Not applicable: No database, network, provider, or other awaited operation is added or moved onto durable current-message acceptance through provider start and reply handoff.
- Runtime-status checkpointing replaces its restricted local-vault wake lookup with an all-route lookup at the same await boundary. Claim recovery is a local state projection, and idle shutdown may perform one additional local-vault lookup after foreground/provider work.

## Murph initial provider input impact

- Murph: Not applicable — no assembled instructions, tools, schemas, generated guidance, or provider-visible input changed.
- Codex: Not applicable — no prompt or provider invocation surface changed, so token and byte measurement is not warranted.

## Change-shape breakdown

Classification: Runtime TypeScript is source; Vitest files are tests/fixtures; reliability and completed execution-plan files plus the changelog fragment are docs/content; no binaries are present.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 276 | 80 |
| Tests/fixtures | 748 | 3 |
| Docs/content | 171 | 2 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 1195 | 85 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Workspace/checkpoint and Temporal command shapes are unchanged, so old and new Workers/containers can read the same state. Old warm containers retain the scheduling bugs until replaced.
- Safe order: Land the hosted-container capacity prerequisite first, then merge this runtime correction and deploy the Cloudflare hosted runtime through the protected production workflow with immediate container rollout. Web and Temporal do not require a separate deployment.
- Rollback floor: There is no schema migration or new persisted field; rollback remains data-compatible but restores the stalled-wake behavior.
- Expected exposure: A gradual rollout could leave warm containers emitting the old wake selection for one rollout window; immediate rollout minimizes mixed behavior.
- Reversibility: Roll back the runner bundle after confirming capacity remains safe; no data rollback is needed.
- Convergence proof: Verify the exact deployed public fingerprint, managed-container health, direct-R2 smoke, and live-model smoke, then observe the existing Temporal retry.
- Post-deploy checks: Confirm the durable handled frontier and generation advance, pending device work drains, device sync completion moves forward, and the next reconciliation is scheduled in the future without another manual wake.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · background-work-recovers-from-stale-timers
