### PR TITLE
fix(web): send runtime progress alerts overnight

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1,6 +1,6 @@
 # Reliability
 
-Last verified: 2026-08-30
+Last verified: 2026-09-01
 
 ## Current Guardrails
 
@@ -1703,8 +1703,8 @@ Last verified: 2026-08-30
   continuous anomaly cannot hide the first alert for the other. A continuing
   progress incident also becomes eligible for one fresh aggregate reminder six
   hours after its prior successful email plus stable bounded jitter. The
-  existing health reread, quiet-hours check, send lease, and singleton
-  compare-and-swap apply unchanged. Each fresh reminder claim persists a new
+  existing health reread, send lease, and singleton compare-and-swap apply
+  unchanged. Each fresh reminder claim persists a new
   generation identity and exact body before provider entry; an ambiguous retry
   reuses both and therefore cannot acquire a new provider effect. Successful
   delivery advances the send boundary that schedules the next generation. The
@@ -1712,10 +1712,14 @@ Last verified: 2026-08-30
   recover silently.
   Outbound paging requires the shared Resend operational-email sender and
   recipients plus a valid IANA operator timezone; it never falls back to
-  Linq/iMessage. It suppresses sends from 11 PM through 7 AM local time and
-  applies stable bounded jitter after quiet hours and after every provider
-  attempt. No retry, reminder, or post-healthy recurrence may call the provider
-  less than ten minutes after the prior attempt or accepted-send boundary. A
+  Linq/iMessage. The shared policy suppresses sends from 11 PM through 7 AM
+  local time unless a monitor explicitly opts into immediate quiet-hour
+  delivery. Durable runtime-progress stalls are the sole opt-in because waiting
+  can widen a stuck execution loop; runtime-latency and allowance alerts retain
+  quiet hours. The owner applies stable bounded jitter after quiet hours and
+  after every provider attempt. No retry, reminder, or post-healthy recurrence
+  may call the provider less than ten minutes after the prior attempt or
+  accepted-send boundary. A
   retry that may already have succeeded preserves the exact body and current
   generation-scoped idempotency key. The key does not vary with mutable email
   configuration:

--- a/agent-docs/exec-plans/completed/2026-09-01-runtime-progress-overnight-alert.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-runtime-progress-overnight-alert.md
@@ -1,0 +1,78 @@
+# Send runtime progress incidents overnight
+
+Status: completed
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Alert operators immediately when durable hosted-runtime progress is stalled,
+  including during the shared operational-email quiet window, without changing
+  detection, recovery, or delivery ownership.
+
+## Success criteria
+
+- The existing runtime-progress monitor sends first alerts and reminders during
+  operator quiet hours.
+- Latency and allowance monitors retain the shared quiet-hours behavior.
+- Existing pacing, idempotency, health rereads, send leases, and singleton
+  incident state remain unchanged.
+- Focused tests, typecheck, exact-head CI, and ReviewGPT pass.
+
+## Scope
+
+- In scope: one opt-in flag on the existing operational-alert specification,
+  the runtime-progress opt-in, focused tests, and matching reliability/test-map
+  documentation.
+- Out of scope: new monitoring services, tables, queues, notification channels,
+  runtime telemetry, automatic suspension, recovery behavior, or Temporal
+  admission changes.
+
+## Constraints
+
+- Technical constraints: preserve the shared incident owner and make immediate
+  quiet-hour delivery explicit per monitor rather than changing every alert.
+- Product/process constraints: this is earlier incident awareness only; do not
+  describe it as preventing or recovering a stalled workflow.
+
+## Risks and mitigations
+
+1. Risk: overnight alerts create operator noise.
+   Mitigation: opt in only the durable-progress monitor after its existing
+   15-minute stall threshold; preserve coalescing, pacing, and six-hour
+   reminders.
+2. Risk: changing the shared owner accidentally disables quiet hours for other
+   alerts.
+   Mitigation: retain the current default and run latency-monitor quiet-hours
+   coverage alongside the progress tests.
+
+## Tasks
+
+1. Add the narrow per-monitor quiet-hours delivery option and opt in runtime
+   progress.
+2. Prove initial and reminder delivery overnight while retaining default
+   quiet-hour behavior.
+3. Update durable reliability and CI-test ownership docs.
+4. Run focused verification, commit, open the PR, run ReviewGPT concurrently
+   with exact-head CI, remediate accepted findings, and merge.
+
+## Decisions
+
+- Reuse the existing five-minute monitor, incident row, Resend sender, and
+  privacy-safe aggregate payload; add no new operational owner.
+- Defer invocation-ratio telemetry until the active wake-owner PR no longer
+  owns the only correct accepted-progress instrumentation boundary.
+
+## Verification
+
+- Local proof:
+  - `pnpm --dir apps/web test:prepared -- hosted-runtime-progress-alert-monitor.test.ts`
+    passed 16 tests.
+  - `pnpm --dir apps/web test:prepared -- hosted-runtime-latency-alert-monitor.test.ts`
+    passed 45 tests.
+  - `pnpm --dir apps/web typecheck` passed.
+  - `pnpm docs:drift`, `pnpm docs:gardening`, and `git diff --check`
+    passed.
+- Remaining release proof: exact-head required CI is green and final ReviewGPT
+  reports PASS.
+Completed: 2026-09-01

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -498,7 +498,8 @@ are jointly specified by `ARCHITECTURE.md`,
 Hosted runtime-progress monitoring and Linq exact-consume reaction confirmation,
 including consumed conversation exclusion before lane head/count selection,
 canonical device-retry wake timing, bounded raw candidate scans, receipt-backed
-confirmation-failure ownership, and provider-no-replay recovery, are jointly
+confirmation-failure ownership, provider-no-replay recovery, and immediate
+quiet-hour paging for durable runtime-progress incidents, are jointly
 specified by `agent-docs/RELIABILITY.md` and
 `agent-docs/references/hosted-runtime-protocol.md`.
 

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -717,8 +717,9 @@ gate unset and makes no paid request.
   and the same isolated Resend stub, proving paced lost-ack retry,
   identifier-free aggregation, short-window active-incident coalescing,
   six-hour fresh-evidence reminders with stable per-generation identity,
-  quiet-hour deferral, recovery/rearm, and independence from the latency
-  monitor.
+  immediate first-alert and reminder delivery during operator quiet hours,
+  recovery/rearm, and independence from the latency monitor. The latency suite
+  retains the shared quiet-hour deferral default.
 - `apps/web/test/runtime-recheck-verification-postgres.test.ts` is an opt-in
   local-PostgreSQL proof for the allowlisted runtime-recheck recovery witness.
   It executes the production bounded read against the canonical system lane,

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -977,8 +977,8 @@ Hosted onboarding extras:
   row cap; execution that starts after denial is measured from its earliest
   milestone even when ingress is older than that window. The monitor sends
   no alert for scheduled automation turns, including Flex-tier turns, because
-  they do not own a user-ingress reply trace. The monitor sends one email per
-  continuous incident, suppresses sends from 11 PM through 7 AM
+  they do not own a user-ingress reply trace. The latency monitor sends one
+  email per continuous incident, suppresses sends from 11 PM through 7 AM
   operator-local time, and adds up to ten minutes of stable wake/retry jitter.
   The existing seven-day trace cleanup retires a trace only when both ingress
   and latest activity are stale, so recent resumed work remains observable
@@ -1011,8 +1011,10 @@ Hosted onboarding extras:
   lane, age, and pending-item counts only. It has its own singleton incident
   row, so an active reply-latency incident cannot suppress a newly discovered
   progress stall. While one progress incident remains anomalous, the same row
-  sends a fresh aggregate reminder every six hours plus stable jitter, outside
-  quiet hours. Each fresh reminder claim persists a new generation identity
+  sends a fresh aggregate reminder every six hours plus stable jitter,
+  including during quiet hours. The first progress alert also bypasses the
+  shared quiet-hours deferral. Each fresh reminder claim persists a new
+  generation identity
   before Resend, while an ambiguous retry reuses that identity and the exact
   body. The latency monitor remains one email per continuous incident. Recovery
   silently rearms each monitor independently and sends no recovery email.

--- a/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
+++ b/apps/web/src/lib/hosted-operational-alert/incident-email-monitor.ts
@@ -73,6 +73,7 @@ export interface HostedOperationalAlertMonitorSpec<
   kind: string;
   readHealth(input: { now: Date; prisma: Client }): Promise<Health>;
   reminderIntervalMs?: number;
+  sendDuringQuietHours?: true;
   status: {
     alertFailed: string;
     alertSending: string;
@@ -624,6 +625,10 @@ function isHostedOperationalAlertQuietTime<
   spec: HostedOperationalAlertMonitorSpec<Health, Client>;
   timeZone: string;
 }): boolean {
+  if (input.spec.sendDuringQuietHours === true) {
+    return false;
+  }
+
   const local = formatTimeZoneDateTimeParts(input.now, input.timeZone);
   if (
     local.hour >= HOSTED_OPERATIONAL_ALERT_QUIET_HOURS_START_HOUR

--- a/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
+++ b/apps/web/src/lib/hosted-runtime-progress/alert-monitor.ts
@@ -120,6 +120,7 @@ const HOSTED_RUNTIME_PROGRESS_MONITOR_SPEC: HostedOperationalAlertMonitorSpec<
   kind: HOSTED_RUNTIME_PROGRESS_MONITOR_KIND,
   readHealth: readHostedRuntimeProgressHealth,
   reminderIntervalMs: HOSTED_RUNTIME_PROGRESS_REMINDER_INTERVAL_MS,
+  sendDuringQuietHours: true,
   status: MONITOR_STATUS,
   subject: HOSTED_RUNTIME_PROGRESS_MONITOR_SUBJECT,
 };

--- a/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
+++ b/apps/web/test/hosted-runtime-progress-alert-monitor.test.ts
@@ -581,7 +581,35 @@ describe("hosted runtime progress alert monitor", () => {
     expect(sendAlert).toHaveBeenCalledTimes(2);
   });
 
-  it("defers an overdue reminder through quiet hours and resumes in the morning", async () => {
+  it("sends a first progress alert during quiet hours", async () => {
+    const quietNow = instant("2026-08-11T06:20:00.000Z");
+    const fixture = createProgressMonitorFixture([
+      progressRow({
+        progressOriginAt: "2026-08-11T05:00:00.000Z",
+        lane: "system",
+        runtimeKey: "runtime_private",
+      }),
+    ]);
+    const sendAlert = vi.fn(async (_input: AlertSendInput) => {
+      void _input;
+      return { providerMessageId: "provider-message" };
+    });
+
+    const result = await runHostedRuntimeProgressAlertMonitor({
+      env: alertEnv,
+      now: quietNow,
+      prisma: fixture.prisma,
+      sendAlert,
+    });
+
+    expect(result.outcome).toBe("alert_sent");
+    expect(sendAlert).toHaveBeenCalledTimes(1);
+    expect(sendAlert.mock.calls[0]?.[0].text).toContain(
+      "Murph runtime progress alert.",
+    );
+  });
+
+  it("sends an overdue progress reminder during quiet hours", async () => {
     const initialNow = instant("2026-08-11T00:00:00.000Z");
     const fixture = createProgressMonitorFixture([
       progressRow({
@@ -607,15 +635,8 @@ describe("hosted runtime progress alert monitor", () => {
       prisma: fixture.prisma,
       sendAlert,
     });
-    const morning = await runHostedRuntimeProgressAlertMonitor({
-      env: alertEnv,
-      now: instant("2026-08-11T14:20:00.000Z"),
-      prisma: fixture.prisma,
-      sendAlert,
-    });
 
-    expect(overnight.outcome).toBe("deferred_quiet_hours");
-    expect(morning.outcome).toBe("alert_sent");
+    expect(overnight.outcome).toBe("alert_sent");
     expect(sendAlert).toHaveBeenCalledTimes(2);
     expect(sendAlert.mock.calls[1]?.[0].text).toContain(
       "Murph runtime progress reminder.",


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive
Classification reason: Changes incident-email delivery timing at an external-effect boundary.
ReviewGPT first-reviewed head: ef93e8c6b62b1309704d59310ccfb96519166158

## Why and outcome

A durable runtime-progress incident could wait until morning when it began during
the 23:00–07:00 operator quiet window. Runtime-progress first alerts and
six-hour reminders now use the existing email path on the next five-minute
monitor pass during that window. Latency and allowance alerts retain the shared
quiet-hours default.

## Product UX

- Effort: Not applicable — this changes internal operator incident awareness,
  not a member-facing product journey.
- Result: Ready — the operator receives the same aggregate alert earlier;
  members see no UI, message, or workflow change.
- Walkthrough: Covered a new progress incident, an overdue progress reminder,
  and a latency incident during quiet hours. Recovery, member data, and actual
  workflow execution remain unchanged.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared -- hosted-runtime-progress-alert-monitor.test.ts`
  passed 16 tests, including quiet-hour first-alert and reminder delivery;
  `pnpm --dir apps/web test:prepared -- hosted-runtime-latency-alert-monitor.test.ts`
  passed 45 tests, including retained quiet-hour deferral.
- Coverage: `pnpm --dir apps/web typecheck`, exact-range `pnpm docs:drift`,
  `pnpm docs:gardening`, `git diff --check`, and `pnpm complexity:diff` passed.
  Independent architecture review passed. ReviewGPT round 1 on the
  production-code head passed with no qualifying findings; its non-blocking
  stale-README note was corrected in the isolated documentation-only follow-up,
  for which repository policy does not require another final round.

## Non-obvious affected surfaces

- The shared operational-email quiet-hours policy gains one opt-in, proven by
  latency-monitor coverage that retains the default.
- The runtime-progress monitor is the sole opt-in; detection, incident state,
  pacing, idempotency, provider payloads, recovery, and other monitors are
  unchanged.

## Architecture and reuse

- Existing systems reused: The existing five-minute monitor, singleton incident
  row, health reread, send lease, idempotency, pacing, and Resend owner remain
  the only detection and delivery path.
- New logic: One optional literal flag lets an explicitly selected monitor skip
  the existing quiet-hours predicate at both initial and final admission checks.
- New abstractions: None; the existing monitor specification is the sufficient
  policy boundary, so no helper, owner, or persistence surface was added.
- Complexity intentionally avoided: No service, table, queue, scheduler,
  notification channel, recovery state, or monitor-specific fork was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports zero new debt in both changed
  source files.
- Hotspots: No changed-file function exceeds the threshold; maximum complexity
  remains 14 in the shared monitor and 12 in the progress monitor.
- Agent judgment: No further behavior-preserving simplification is justified;
  one optional literal flag and one early return express the policy directly.

## Hot reply path impact

- Path status: Not applicable — this runs in the five-minute operational monitor,
  outside current-message acceptance, provider start, and reply handoff.
- Database calls: None added or moved onto the foreground reply path.
- Network/provider calls: None added or moved onto the foreground reply path.
- Other awaited latency: None added or moved onto the foreground reply path.
- Before/after proof: Focused alert-monitor tests cover the changed cron-owned
  path; foreground reply execution code is untouched.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no prompt, message, history, or instruction
  assembly path changed.
- Tool/schema/generated guidance: Unchanged; no tool or schema surface changed.
- Other provider-visible input: Unchanged; the operational email is not Murph or
  Codex provider input.
- Measurement method: Not run — no provider-input surface changed, so a token
  comparison would not provide relevant evidence.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Vercel instances are compatible because the
  incident schema and provider contract are unchanged; an old instance may
  defer while a new instance may send, with the existing singleton claim
  preventing duplicate ownership.
- Safe order: Deploy Web normally; no Cloudflare or Temporal ordering is
  required.
- Rollback floor: The prior Web SHA safely restores quiet-hour deferral without
  a schema, data, or workflow migration.
- Expected exposure: Only already-eligible runtime-progress first alerts and
  six-hour reminders evaluated between 23:00 and 07:00 operator-local time.
- Reversibility: A normal Vercel rollback fully restores prior behavior.
- Convergence proof: The canonical production alias must resolve to the merged
  SHA; the existing monitor applies the policy on its next five-minute pass.
- Post-deploy checks: Verify the exact production alias SHA and confirm the
  runtime-progress monitor remains healthy; do not manufacture an incident.

## Change-shape breakdown

Classification rule: Authored runtime files are source, focused Vitest coverage
is tests, and Markdown policy/plan/guide files are docs. No binary or generated
files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 0 |
| Tests / fixtures | 30 | 9 |
| Docs | 100 | 14 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **136** | **23** |

## Changelog

- Changelog: not applicable
- Reason: This changes internal operator incident-email timing and has no
  member-visible feature, recovery, UI, or message behavior.
