### PR TITLE
chore(canary): expose latency failure dimensions

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-01-2026-09-01-production-canary-latency-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-2026-09-01-production-canary-latency-telemetry.md
@@ -1,0 +1,104 @@
+# Production canary latency telemetry
+
+Status: completed
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Make the next Linq production-conversation canary latency failure identify
+  the failing turn and the breached latency measurement without logging any
+  conversation, account, phone, provider, or member data.
+
+## Success criteria
+
+- A latency-budget failure carries a closed metric value, a one-based canary
+  turn, and bounded elapsed and budget milliseconds.
+- Focused tests prove both send-to-reply and inter-reply-gap classifications.
+- Passing output and every non-latency failure keep their existing behavior.
+- The exact pushed PR head passes focused proof, required CI, and final
+  ReviewGPT review before any autonomous telemetry-only merge is considered.
+
+## Scope
+
+- In scope: the existing production-canary script, its focused tests, and any
+  minimal owning operational documentation required for the telemetry schema.
+- Out of scope: latency correction, budgets, canary traffic, prompts, provider
+  behavior, retries, production state, device sync, and new telemetry storage.
+
+## Constraints
+
+- Technical constraints: reuse the existing failure record; emit at most one
+  failure record per run; use only low-cardinality enums and bounded integers;
+  preserve control flow and provider interactions exactly.
+- Product/process constraints: ReviewGPT authors the telemetry patch; the local
+  owner applies only an exact inspected artifact and owns validation, Git, PR,
+  final review, and deployment eligibility.
+
+## Risks and mitigations
+
+1. Risk: diagnostics expose message or identity data.
+   Mitigation: permit only turn, metric, elapsed milliseconds, and budget
+   milliseconds; never include prompts, replies, phone numbers, IDs, or errors.
+2. Risk: instrumentation changes canary timing or failure semantics.
+   Mitigation: derive fields from clocks already read at the existing failure
+   branch and preserve the same threshold and throw point.
+
+## Tasks
+
+1. Obtain a scoped ReviewGPT attachment against the clean task worktree.
+2. Inspect exact question agreement, privacy, cardinality, volume, behavior,
+   runtime cost, device boundary, and ownership overlap.
+3. Apply the accepted patch and run focused tests, typecheck/lint, complexity,
+   privacy/log guards, and completion audits.
+4. Commit, push, open the PR, start CI and final ReviewGPT on the exact head,
+   and resolve every accepted finding.
+5. Merge and deploy only if every telemetry-only autonomous gate is proven;
+   otherwise leave the PR ready for the exact human action.
+
+## Decisions
+
+- The exact question is whether a failing run breached send-to-reply latency or
+  inter-reply spacing, and on which of the three turns.
+- Competing hypotheses are first-contact/provisioning latency, later hosted
+  runtime latency, or only inter-reply spacing while send-to-reply remains
+  within budget.
+- No active PR, issue, worktree, task, or recent merge owns this exact canary
+  diagnostic question. Adjacent mailbox and Linq fixes were inspected and are
+  independent owners.
+- Frog is not used because this is production behavior, which the Frog skill
+  explicitly excludes.
+- ReviewGPT v1 was rejected as disproportionate: it added an error class,
+  runtime validator, reporter export, and 147 lines for the two diagnostic
+  branches. ReviewGPT v2 is accepted exactly: 34 added lines, no new runtime
+  owner or abstraction, and the existing terminal error path is retained.
+
+## Verification
+
+- Commands to run: focused Web Vitest and CI contract tests, Web typecheck and
+  targeted lint, `pnpm complexity:diff`, `pnpm logs:guard`, `git diff --check`,
+  repository completion audits, final ReviewGPT, and exact-head required CI.
+- Expected outcomes: the two latency branches are distinguishable with safe
+  bounded fields; no content or identity appears; no behavior changes; all
+  scoped checks and exact-head gates pass.
+
+## Outcome
+
+- The existing terminal latency error now records the one-based turn, closed
+  metric, bounded elapsed milliseconds, and fixed budget milliseconds.
+- Exact-boundary send-to-reply and inter-reply-gap-only failures have distinct
+  focused regression proof. Passing behavior, non-latency errors, shutdown,
+  thresholds, traffic, provider calls, and production state are unchanged.
+- Local proof passed: ReviewGPT artifact reverse-application, four focused Web
+  tests, three CI contract tests, Web typecheck, targeted ESLint, raw-log
+  privacy guard, complexity diff with no hotspot increase, and diff hygiene.
+- Changelog is not applicable because this is internal failure telemetry and
+  changes no member-visible behavior.
+
+## Later verification query
+
+- After the next eligible Vercel production deployment, inspect the single
+  intended Linq Production Canary run and aggregate only `turn`,
+  `failureMetric`, `latencyMs`, and `budgetMs` from its terminal failure record.
+  If the run passes, retain the existing three-turn success latency output.
+Completed: 2026-09-01

--- a/apps/web/scripts/run-production-conversation-canary.ts
+++ b/apps/web/scripts/run-production-conversation-canary.ts
@@ -82,14 +82,21 @@ export async function runLinqProductionCanary(
       const reply = await replyPromise;
       const replyAt = performance.now();
       const latencyMs = Math.round(replyAt - sentAt);
+      if (latencyMs >= CANARY_REPLY_BUDGET_MS) {
+        throwCanaryFailure(
+          `reply-latency-budget-exceeded; turn=${turn}; metric=send_to_reply; elapsed_ms=${Math.min(CANARY_REPLY_WAIT_MS, latencyMs)}; budget_ms=${CANARY_REPLY_BUDGET_MS}`,
+        );
+      }
+      const interReplyGapMs = previousReplyAt === null
+        ? null
+        : replyAt - previousReplyAt;
       if (
-        latencyMs >= CANARY_REPLY_BUDGET_MS
-        || (
-          previousReplyAt !== null
-          && replyAt - previousReplyAt >= CANARY_REPLY_BUDGET_MS
-        )
+        interReplyGapMs !== null
+        && interReplyGapMs >= CANARY_REPLY_BUDGET_MS
       ) {
-        throwCanaryFailure("reply-latency-budget-exceeded");
+        throwCanaryFailure(
+          `reply-latency-budget-exceeded; turn=${turn}; metric=inter_reply_gap; elapsed_ms=${Math.min(CANARY_REPLY_WAIT_MS, Math.round(interReplyGapMs))}; budget_ms=${CANARY_REPLY_BUDGET_MS}`,
+        );
       }
       assertLinqProductionCanaryReply({ reply, turn });
       turns.push({ latencyMs, turn });

--- a/apps/web/test/run-production-conversation-canary.test.ts
+++ b/apps/web/test/run-production-conversation-canary.test.ts
@@ -132,16 +132,32 @@ describe("production conversation canary runner", () => {
     expect(mocks.stop).toHaveBeenCalledOnce();
   });
 
-  it("rejects a reply at the exact latency boundary and still stops", async () => {
+  it("reports an exact-boundary send-to-reply failure and still stops", async () => {
     mocks.now = [0, 20_000];
     mocks.sendResults = [true];
     mocks.messages = [
       inboundMessage({ text: MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE }),
     ];
 
-    await expect(runLinqProductionCanary(TEST_ENV)).rejects.toMatchObject({
-      name: "reply-latency-budget-exceeded",
-    });
+    await expect(runLinqProductionCanary(TEST_ENV)).rejects.toHaveProperty(
+      "name",
+      "reply-latency-budget-exceeded; turn=1; metric=send_to_reply; elapsed_ms=20000; budget_ms=20000",
+    );
+    expect(mocks.stop).toHaveBeenCalledOnce();
+  });
+
+  it("reports an inter-reply-gap-only failure and still stops", async () => {
+    mocks.now = [0, 10_000, 15_000, 30_000];
+    mocks.sendResults = [true, true];
+    mocks.messages = [
+      inboundMessage({ text: MURPH_ASSISTANT_SIGNUP_WELCOME_MESSAGE }),
+      inboundMessage({ text: "A later reply." }),
+    ];
+
+    await expect(runLinqProductionCanary(TEST_ENV)).rejects.toHaveProperty(
+      "name",
+      "reply-latency-budget-exceeded; turn=2; metric=inter_reply_gap; elapsed_ms=20000; budget_ms=20000",
+    );
     expect(mocks.stop).toHaveBeenCalledOnce();
   });
 });

--- a/scripts/linq-production-canary-ci.test.mjs
+++ b/scripts/linq-production-canary-ci.test.mjs
@@ -73,5 +73,6 @@ test("Linq production canary runner proves the welcome and three bounded replies
   assert.match(runner, /message\.platform !== "imessage"/u);
   assert.match(runner, /message\.sender\?\.id !== input\.userId/u);
   assert.match(runner, /space\.id !== input\.spaceId/u);
+  assert.match(runner, /const code = error instanceof Error \? error\.name : "unknown";\s+console\.error\(`Linq production canary failed \(\$\{code\}\)\.`\);/u);
   assert.doesNotMatch(runner, /console\.(?:log|info)\([^\n]*(?:reply|prompt|phone)/u);
 });


### PR DESCRIPTION
## Why and outcome

Repeated Linq production-conversation canary failures reported only
`reply-latency-budget-exceeded`, leaving the failing turn and measurement
unknown. This telemetry-only change keeps the existing journey and thresholds
unchanged while adding the one-based turn, closed latency metric, bounded
elapsed milliseconds, and fixed budget to the existing terminal failure line.

The next natural canary failure can distinguish first-contact or later
send-to-reply latency from inter-reply spacing without logging message content,
identity, provider payloads, or raw errors.

## Product UX

- Product UX: not applicable. This is internal failure telemetry for a
  synthetic production canary; it changes no member-visible behavior, copy,
  interaction, timing, delivery, or recovery.

## Evidence

- ReviewGPT v2 artifact reverse-application check passed, proving the accepted
  implementation was applied exactly.
- `node --test scripts/linq-production-canary-ci.test.mjs` — 3/3 passed.
- Focused Web Vitest — 4/4 passed, including exact-boundary send-to-reply and
  inter-reply-gap-only failures.
- Web typecheck and targeted ESLint passed.
- `pnpm logs:guard`, `pnpm provider-requests:guard`, `pnpm complexity:diff`,
  and `git diff --check` passed.

## Non-obvious affected surfaces

- GitHub's deployment-triggered Linq Production Canary terminal log now carries
  closed diagnostic fields. The workflow trigger, credentials, reset route,
  canary prompts, production traffic, and provider calls are unchanged.
- No application runtime, database, Cloudflare Worker, Temporal workflow,
  billing path, device-sync surface, or canonical state changes.

## Architecture and reuse

- Existing systems reused: the current canary clock reads, failure constructor,
  terminal catch, GitHub Actions log, and focused runner tests.
- New logic: two explicit threshold branches select `send_to_reply` or
  `inter_reply_gap` and add bounded numeric context to the existing error name.
- New abstractions: none; no telemetry owner, class, helper, backend, schema, or
  persisted state was added.
- Complexity intentionally avoided: ReviewGPT v1's error class, runtime
  validator, and exported reporter were rejected; v2 keeps the existing owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reported no debt or maximum regression.
- Hotspots: no changed function exceeds 20; runner maximum remains 11.
- Agent judgment: no further behavior-preserving simplification is justified;
  the two named branches are the observation being distinguished.

## Hot reply path impact

- Not applicable. The change runs only in the synthetic production canary after
  replies arrive and adds no database, network, provider, retry, or awaited work
  to Murph's member foreground reply path.

## Murph initial provider input impact

- Hosted runtime: not applicable; canary prompts and all provider-visible input
  are byte-for-byte unchanged.
- Local runtime: not applicable; this script is not part of local assistant
  provider-input assembly.

## ReviewGPT provenance

- ReviewGPT authored both implementation proposals from the privacy-safe packet.
- V1 was rejected as disproportionate at 147 added lines.
- V2 was accepted and applied exactly at 34 added lines across the existing
  runner, focused test, and CI contract.

ReviewGPT context sensitivity: sensitive — production canary diagnostics sit on an external messaging journey, even though provider behavior is unchanged.

ReviewGPT first-reviewed head: 37466684e78a2e76dd7d10b5ec3b17b9c9f2bf42

## Design proof

- Not applicable. No hosted Web UI or user-visible state changes.

## Change-shape breakdown

Classification uses base-to-head authored line counts; the CI contract is a
test, and the completed execution plan is documentation.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 13 | 6 |
| Tests/fixtures | 21 | 4 |
| Docs | 104 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **138** | **10** |

## Deployment concerns

- Deployment: applicable
- Supported skew: the canary script runs from the exact deployed Web commit and
  writes no shared schema or state, so mixed runtime versions cannot interact.
- Safe order: merge to `main`; the next canonical Vercel production deployment
  naturally triggers the exact-revision canary.
- Rollback floor: reverting the commit restores the prior single-code failure
  line; there is no persisted compatibility floor.
- Expected exposure: only canary failure text differs for a deployment whose
  exact SHA contains this commit.
- Reversibility: ordinary non-force revert; no provider, data, or secret action.
- Convergence proof: GitHub verifies the canary selected the same Vercel
  production SHA before executing.
- Post-deploy checks: inspect the intended Linq Production Canary run and
  aggregate only turn, metric, elapsed milliseconds, and budget milliseconds.

## Changelog

- Changelog: not applicable
- Reason: internal synthetic-canary failure telemetry only; no member-visible
  behavior changes.

## Risks

- Privacy: the failure line contains only a closed code, turn 1..3, a closed
  metric, and bounded integers; content and identity are excluded by design.
- Behavior: thresholds, throws, reset, traffic, sends, waits, shutdown, and
  non-latency output remain unchanged.
