### PR TITLE
fix(cloudflare): accept provider version advances

### DIFF
--- a/apps/cloudflare/scripts/container-release-receipt.ts
+++ b/apps/cloudflare/scripts/container-release-receipt.ts
@@ -305,7 +305,7 @@ export function buildContainerReleaseEntries(input: {
         case "modified":
           if (!before
             || before.applicationId !== after.applicationId
-            || after.version !== before.version + 1) {
+            || after.version <= before.version) {
             throw invalidReleaseTransition();
           }
           disposition = "updated";

--- a/apps/cloudflare/test/container-release-receipt.test.ts
+++ b/apps/cloudflare/test/container-release-receipt.test.ts
@@ -286,7 +286,7 @@ describe("container release receipt", () => {
     ];
     const after: CloudflareContainerApplicationIdentity[] = [
       identity("app-z", "id-z", 1, "image-created"),
-      identity("app-b", "id-b", 5, "image-updated"),
+      identity("app-b", "id-b", 6, "image-updated"),
       identity("app-a", "id-a", 2, "image-stable"),
     ];
 
@@ -299,7 +299,7 @@ describe("container release receipt", () => {
           className: "AContainer",
           disposition: "updated",
           imageSha256: "9ff7d52d53b3639b959907155509b1795020364a2db9fdf186ba499792689655",
-          version: 5,
+          version: 6,
         },
         {
           applicationName: "app-a",
@@ -336,7 +336,7 @@ describe("container release receipt", () => {
       })).toThrow("Container release evidence did not form an exact provider transition.");
     });
 
-    it("requires modified identity continuity and exactly one provider version advance", () => {
+    it("requires modified identity continuity and a newer provider version", () => {
       const modifiedAction = [
         { action: "modified", applicationName: "app", className: "Container" },
       ] as const;
@@ -353,7 +353,7 @@ describe("container release receipt", () => {
       })).toThrow("Container release evidence did not form an exact provider transition.");
       expect(() => buildContainerReleaseEntries({
         actions: modifiedAction,
-        after: [identity("app", "id", 4, "new-image")],
+        after: [identity("app", "id", 1, "new-image")],
         before: [identity("app", "id", 2, "old-image")],
       })).toThrow("Container release evidence did not form an exact provider transition.");
     });


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive
ReviewGPT current-candidate disposition: not awaited per the incident owner's explicit merge instruction

## Why and outcome

Cloudflare successfully modified each managed container application during the protected production release, but the release receipt rejected the provider result because it assumed every modification increments an application version by exactly one. Wrangler's modification path updates the application and creates a rollout, so the provider can legitimately advance the version more than once.

This keeps the receipt fail-closed while accepting the real provider transition: a modified application must retain its application ID and move to a strictly newer version. Equal, older, missing, and identity-changing transitions still fail.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: Members waiting for hosted background and device work to recover.
- Result: A successfully applied Cloudflare container release can proceed to endpoint, live-model, and whole-release verification.
- Exclusions: No member-facing UI, assistant behavior, runtime protocol, or persisted state changes.

## Evidence

- Cloudflare typecheck: passed.
- Focused container receipt and deploy-worker suites: 55 passed.
- Regression proof accepts a version advance from 4 to 6 while preserving rejection coverage for equal, older, missing, and different-identity transitions.
- `pnpm complexity:diff --base origin/main`: passed with no debt or maximum regression.
- `git diff --check`: passed.
- Diff privacy scan: no private identifiers, home paths, credentials, or secret values.
- Two protected production attempts independently applied all three container modifications and then failed at this exact receipt assumption.
- ReviewGPT is intentionally not awaited per the incident owner's explicit instruction; required GitHub checks remain the merge gate.

## Non-obvious affected surfaces

- Only the post-Wrangler container release receipt transition check changes.
- Exact image digests, application names/classes/IDs, rendered capacities, Worker version, rollout convergence, deploy outcome, endpoint smoke, and live-model smoke remain independently verified by the existing protected workflow.
- Same-version or regressing provider state still fails closed.

## Architecture and reuse

- Reuses the existing before/after provider snapshots and release receipt verifier.
- Changes one comparison; adds no state, service, abstraction, dependency, compatibility layer, or retry mechanism.

## Complexity impact

- Guard: pass.
- Hotspots: no new or worsened hotspots.
- Agent judgment: strict monotonicity is the smallest invariant matching the provider's demonstrated modification semantics.

## Hot reply path impact

- Not applicable: deployment tooling only; no production request or reply path changes.

## Murph initial provider input impact

- Murph: Not applicable.
- Codex: Not applicable.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests/fixtures | 3 | 3 |
| Docs/content | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 4 | 4 |

## Deployment concerns

- Deployment: applicable
- Safe order: Merge this verifier correction, then rerun the protected Cloudflare production workflow with immediate container rollout.
- Supported skew: The correction only reads provider release evidence and is compatible with the already deployed Worker/container runtime.
- Rollback floor: No schema or state changes.
- Post-deploy checks: Require a green deploy receipt, endpoint smoke, live-model smoke, exact live Cloudflare state, and production backlog convergence.

## Changelog

- Changelog: not applicable
- Reason: deployment-verifier correction with no independent member-visible product change.
