### PR TITLE
Fix Cloudflare container release receipts

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-cloudflare-release-receipt-current-detail.md
+++ b/agent-docs/exec-plans/active/2026-09-01-cloudflare-release-receipt-current-detail.md
@@ -1,0 +1,49 @@
+# Cloudflare release receipt current-detail proof
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Make the protected Cloudflare deploy receipt identify the exact container application state produced by the current Wrangler deploy, so certification cannot compare a delayed application-list snapshot with current application detail.
+
+## Success criteria
+
+- Exact-name application discovery resolves each provider application through its authoritative detail endpoint before the receipt records version or image identity.
+- A Wrangler `modified` action cannot publish a receipt when the post-deploy detail state is byte-for-byte unchanged from the pre-deploy detail state.
+- Focused tests reproduce a stale list result paired with a current detail result and prove the receipt uses only the current detail.
+- The protected production workflow reports deploy success, smoke success, and release convergence for one exact Worker and all three exact container applications.
+
+## Scope
+
+- In scope: the public Cloudflare deploy receipt reader, its focused tests, and the deploy contract documentation.
+- Out of scope: runtime wake ownership, container rollout policy, provider capacity, or a second deployment owner.
+
+## Root-cause evidence
+
+- Two consecutive protected deploys recorded receipts whose three container versions were each exactly one snapshot behind the final provider detail state, and whose image digests all differed from that final state.
+- The Worker version and tag matched exactly, all three final container rollouts completed, and no other protected deploy workflow overlapped.
+- The receipt writer currently records version and image from the container application list response, while certification resolves the same application through the detail endpoint.
+
+## Plan
+
+1. Resolve list-discovered application identifiers through exact application detail reads before parsing receipt identity.
+2. Reject an unchanged post-deploy detail state when Wrangler reports `modified`.
+3. Add focused stale-list/current-detail, malformed-detail, redaction, and unchanged-transition regressions.
+4. Run focused Cloudflare tests, app typecheck, complexity, diff/privacy review, exact-head CI, merge, and protected deployment.
+5. Verify exact release convergence and then recheck the independent residual runtime backlog.
+
+## Deployment concerns
+
+- The public receipt producer must merge before the next protected private deployment consumes it.
+- Old private verification remains compatible with the schema-1 receipt; only the evidence source changes.
+- A failed detail read stops before publishing a receipt. A successful receipt continues to require exact Worker traffic, container version, image, capacity, and terminal rollout proof.
+
+## Verification
+
+- Passed: 59 focused Cloudflare receipt and deploy-helper tests.
+- Passed: `apps/cloudflare` package typecheck.
+- Passed: cyclomatic-complexity diff; the changed receipt owner remains below the threshold with no new debt.
+- Passed: `git diff --check` and parent inspection of the complete source, test, documentation, and plan diff.
+- Pending: exact-head required GitHub Actions, merge, protected production deployment, exact release certification, and independent runtime-backlog recovery proof.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -30,13 +30,16 @@ exact Worker version ID, and one sorted entry per rendered container: applicatio
 and class names, `created`/`updated`/`unchanged`, the provider application
 version, and a SHA-256 digest of the provider image reference. The helper keeps
 raw application IDs, image references, account identifiers, tokens, and provider
-errors out of the receipt. The provider application version is a final-state
-snapshot, not a deploy counter; an `updated` entry requires the existing provider
-application identity to remain continuous. A later protected observer must match
-the receipt to 100% Worker traffic and the final container versions, image
-digests, capacities, and rollout outcomes. Land this public producer before
-enabling a private workflow that requires the receipt; the reverse order
-intentionally fails closed.
+errors out of the receipt. Exact-name application discovery uses the provider
+list only to resolve one application identifier; both the pre-deploy and
+post-deploy receipt snapshots come from that application's detail endpoint.
+The provider application version is a final-state snapshot, not a deploy
+counter; an `updated` entry requires the existing provider application identity
+to remain continuous and the detail snapshot's version or image to change. A
+later protected observer must match the receipt to 100% Worker traffic and the
+final container versions, image digests, capacities, and rollout outcomes. Land
+this public producer before enabling a private workflow that requires the
+receipt; the reverse order intentionally fails closed.
 Docker runner smoke derives a separate `.deploy/runner-smoke-bundle/` from the validated production bundle and overlays smoke-only entrypoints there, so the production `.deploy/runner-bundle/` remains the deploy artifact after smoke.
 Runner bundle assembly esbuild-bundles two boot-critical surfaces with byte budgets and assembly-time probes: the in-container `vault-cli` binary (`scripts/runner-bundle/bundle-cli.ts`) and the container entrypoint itself (`scripts/runner-bundle/bundle-entrypoint.ts`, output `dist-bundled/`, run by the image CMD). The Node-only CLI chunks use native UTF-8 output so existing Unicode literals are not expanded into ASCII escapes; assembly retains absolute entry-chunk and static-startup-closure caps, while canonical Ubuntu x86_64 host-support CI builds the exact candidate and its exact first parent in isolated sibling checkouts and permits total output growth only up to `max(96 KiB, floor(1% of base total))`. The CLI probe creates private synthetic initialized-vault fixtures, requires exact bundled/unbundled parity for populated `memory show --format json`, and separately preserves the successful empty result when canonical memory is absent. The bundled entrypoint cuts cold-boot module loading from ~960 file reads to ~27 chunk reads on lazily pulled image layers; package resolvers that derive asset paths from their own module location are pinned to the installed package copies via Dockerfile ENV (`MURPH_ASSISTANT_SKILLS_ROOT`, `MURPH_ASSISTANT_CLI_SURFACE_PREBUILT_ARTIFACT_PATH`, `MURPH_HEALTH_COMMONS_PACKAGE_ROOT`). Health Commons stays installed in the runner bundle for its compact protocol and biomarker desired-direction artifacts, while its JS is inlined and assembly probes set the same package-root pin for bundled and unbundled parity. The web-only Health Commons artifact tree remains excluded. Zod stays installed for deferred package-loader paths, but production assembly removes declaration files, TypeScript source, the legacy v3 runtime, and unused mini variants after verifying that staged JavaScript imports only the retained root and v4 surfaces.
 The device-sync package boundary suite also walks the static source graph from the runner's runtime-config entrypoint and rejects provider runtime modules, importer modules, and the Junction SDK. This focused gate catches boot-closure ownership regressions before the packed-bundle guard validates the final esbuild metafile.

--- a/apps/cloudflare/scripts/container-release-receipt.ts
+++ b/apps/cloudflare/scripts/container-release-receipt.ts
@@ -247,7 +247,7 @@ export function createCloudflareContainerApplicationLister(input: {
     url.searchParams.set("name", applicationName);
 
     try {
-      const response = await fetchImpl(url, {
+      const requestInit = {
         cache: "no-store",
         headers: {
           Accept: "application/json",
@@ -255,11 +255,38 @@ export function createCloudflareContainerApplicationLister(input: {
         },
         method: "GET",
         signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
-      });
+      } as const;
+      const response = await fetchImpl(url, requestInit);
       if (!response.ok) {
         throw invalidProviderState();
       }
-      return readExhaustiveCloudflareResult(await response.json());
+      const listedApplications = readExhaustiveCloudflareResult(
+        await response.json(),
+      );
+
+      return await Promise.all(listedApplications.map(async (listedApplication) => {
+        const reference = parseProviderApplicationReference(listedApplication);
+        const detailUrl = new URL(
+          `${CLOUDFLARE_API_BASE_URL}/accounts/${encodeURIComponent(input.accountId)}`
+            + `/containers/applications/${encodeURIComponent(reference.applicationId)}`,
+        );
+        const detailResponse = await fetchImpl(detailUrl, {
+          ...requestInit,
+          signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
+        });
+        if (!detailResponse.ok) {
+          throw invalidProviderState();
+        }
+        const detail = readCloudflareResultObject(await detailResponse.json());
+        const identity = parseProviderIdentity(detail);
+        if (
+          identity.applicationId !== reference.applicationId
+          || identity.applicationName !== reference.applicationName
+        ) {
+          throw invalidProviderState();
+        }
+        return detail;
+      }));
     } catch {
       throw invalidProviderState();
     }
@@ -304,7 +331,8 @@ export function buildContainerReleaseEntries(input: {
           break;
         case "modified":
           if (!before
-            || before.applicationId !== after.applicationId) {
+            || before.applicationId !== after.applicationId
+            || (before.version === after.version && before.image === after.image)) {
             throw invalidReleaseTransition();
           }
           disposition = "updated";
@@ -357,6 +385,26 @@ function readExhaustiveCloudflareResult(value: unknown): readonly unknown[] {
     throw invalidProviderState();
   }
   return value.result;
+}
+
+function readCloudflareResultObject(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isRecord(value) || value.success !== true || !isRecord(value.result)) {
+    throw invalidProviderState();
+  }
+  return value.result;
+}
+
+function parseProviderApplicationReference(value: unknown): Readonly<{
+  applicationId: string;
+  applicationName: string;
+}> {
+  if (!isRecord(value)) {
+    throw invalidProviderState();
+  }
+  return {
+    applicationId: readRequiredNonemptyString(value, "id", invalidProviderState),
+    applicationName: readRequiredNonemptyString(value, "name", invalidProviderState),
+  };
 }
 
 function parseProviderIdentity(value: unknown): CloudflareContainerApplicationIdentity {

--- a/apps/cloudflare/test/container-release-receipt.test.ts
+++ b/apps/cloudflare/test/container-release-receipt.test.ts
@@ -197,13 +197,18 @@ describe("container release receipt", () => {
       )).rejects.toThrow("Cloudflare container application state was incomplete or malformed.");
     });
 
-    it("lists one exact application through a no-cache, filtered Cloudflare request", async () => {
-      const fetchImpl = vi.fn(async (_input: URL, _init: RequestInit) => ({
-        json: async () => ({
-          result: [providerIdentity("exact-app", "id", 4, "image")],
-          result_info: { next_page_token: "", total_count: 1 },
-          success: true,
-        }),
+    it("resolves a stale exact-name list result through current application detail", async () => {
+      const fetchImpl = vi.fn(async (input: URL, _init: RequestInit) => ({
+        json: async () => input.pathname.endsWith("/containers/applications")
+          ? {
+              result: [providerIdentity("exact-app", "id", 4, "stale-image")],
+              result_info: { next_page_token: "", total_count: 1 },
+              success: true,
+            }
+          : {
+              result: providerIdentity("exact-app", "id", 5, "current-image"),
+              success: true,
+            },
         ok: true,
       }));
       const listApplications = createCloudflareContainerApplicationLister({
@@ -213,15 +218,28 @@ describe("container release receipt", () => {
       });
 
       await expect(listApplications("exact-app")).resolves.toEqual([
-        providerIdentity("exact-app", "id", 4, "image"),
+        providerIdentity("exact-app", "id", 5, "current-image"),
       ]);
-      expect(fetchImpl).toHaveBeenCalledTimes(1);
-      const request = fetchImpl.mock.calls[0];
-      expect(request?.[0].toString()).toBe(
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      const listRequest = fetchImpl.mock.calls[0];
+      expect(listRequest?.[0].toString()).toBe(
         "https://api.cloudflare.com/client/v4/accounts/account-fixture/containers/applications"
           + "?name=exact-app",
       );
-      expect(request?.[1]).toEqual({
+      expect(listRequest?.[1]).toEqual({
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Authorization: "Bearer token-fixture",
+        },
+        method: "GET",
+        signal: expect.any(AbortSignal),
+      });
+      const detailRequest = fetchImpl.mock.calls[1];
+      expect(detailRequest?.[0].toString()).toBe(
+        "https://api.cloudflare.com/client/v4/accounts/account-fixture/containers/applications/id",
+      );
+      expect(detailRequest?.[1]).toEqual({
         cache: "no-store",
         headers: {
           Accept: "application/json",
@@ -271,6 +289,55 @@ describe("container release receipt", () => {
         );
         expect(error.message).not.toMatch(/sensitive|transport|URL/iu);
       }
+    });
+
+    it.each([
+      { result: [], success: true },
+      { result: providerIdentity("wrong-app", "id", 5, "current-image"), success: true },
+      { result: providerIdentity("exact-app", "wrong-id", 5, "current-image"), success: true },
+    ])("rejects malformed or mismatched application detail", async (detailPayload) => {
+      const fetchImpl = vi.fn(async (input: URL) => ({
+        json: async () => input.pathname.endsWith("/containers/applications")
+          ? {
+              result: [providerIdentity("exact-app", "id", 4, "stale-image")],
+              success: true,
+            }
+          : detailPayload,
+        ok: true,
+      }));
+      const listApplications = createCloudflareContainerApplicationLister({
+        accountId: "account-fixture",
+        apiToken: "token-fixture",
+        fetchImpl,
+      });
+
+      await expect(listApplications("exact-app")).rejects.toThrow(
+        "Cloudflare container application state was incomplete or malformed.",
+      );
+    });
+
+    it("redacts transport detail from application-detail failures", async () => {
+      const fetchImpl = vi.fn(async (input: URL) => {
+        if (input.pathname.endsWith("/containers/applications")) {
+          return {
+            json: async () => ({
+              result: [providerIdentity("exact-app", "id", 4, "stale-image")],
+              success: true,
+            }),
+            ok: true,
+          };
+        }
+        throw new Error("sensitive detail transport failure");
+      });
+      const listApplications = createCloudflareContainerApplicationLister({
+        accountId: "sensitive-account-fixture",
+        apiToken: "sensitive-token-fixture",
+        fetchImpl,
+      });
+
+      await expect(listApplications("exact-app")).rejects.toThrow(
+        "Cloudflare container application state was incomplete or malformed.",
+      );
     });
   });
 
@@ -350,6 +417,11 @@ describe("container release receipt", () => {
         actions: modifiedAction,
         after: [identity("app", "id", 2, "new-image")],
         before: [],
+      })).toThrow("Container release evidence did not form an exact provider transition.");
+      expect(() => buildContainerReleaseEntries({
+        actions: modifiedAction,
+        after: [identity("app", "id", 2, "old-image")],
+        before: [identity("app", "id", 2, "old-image")],
       })).toThrow("Container release evidence did not form an exact provider transition.");
 
       expect(buildContainerReleaseEntries({


### PR DESCRIPTION
## Why and outcome

Two protected production deploys completed Wrangler deployment, managed-container smoke, exact Worker traffic, and all three container rollouts, but certification compared an application-list snapshot with current application detail. The list result lagged every container by one snapshot and produced an immutable receipt for the previous image.

This change keeps exact-name list discovery, then resolves the discovered provider identity through the application-detail endpoint before recording either the pre-deploy or post-deploy receipt. A Wrangler `modified` action also fails closed when provider detail remains unchanged.

## Product UX

Not applicable. This is an internal deployment-integrity correction with no member-facing surface or product behavior change.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/container-release-receipt.test.ts apps/cloudflare/test/deploy-worker-version-cli.test.ts apps/cloudflare/test/deploy-worker-version.test.ts` — 59 passed.
- `pnpm --dir apps/cloudflare typecheck` — passed.
- `pnpm complexity:diff` — passed; no changed hotspot above 20.
- `git diff --check` — passed.
- Production reproduction: two consecutive protected runs recorded all three receipt versions exactly one snapshot behind final detail, with different image digests, while the Worker matched and no second deploy workflow overlapped.
- ReviewGPT skipped by explicit user instruction.

## Non-obvious affected surfaces

- Protected Cloudflare deploy receipt collection: each of the three applications now performs one exact-name list read and one exact detail read in both pre-deploy and post-deploy phases. The maximum provider-read count changes from 6 list requests to 6 list plus 6 detail requests; calls remain sequential, read-only, no-cache, individually bounded to 30 seconds, and outside product/runtime paths.
- Container transition validation: `modified` can no longer publish an unchanged detail snapshot. Focused transition tests preserve non-monotonic provider snapshot versions while rejecting stale identical state.

## Architecture and reuse

- Existing systems reused: Wrangler remains the mutation owner; Cloudflare's exact-name list remains identity discovery; the existing application-detail API and schema-1 receipt remain the authoritative observation and handoff.
- New logic: Resolve each listed application ID through detail and require a changed version or image for a reported modification.
- New abstractions: None; the correction stays inside the existing receipt reader and transition classifier.
- Complexity intentionally avoided: No second receipt schema, reconciliation store, deployment queue, or permissive verifier fallback was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` completed successfully for the authored TypeScript change.
- Hotspots: None; every changed source function remains below the repository's complexity threshold of 20.
- Agent judgment: No further behavior-preserving simplification is justified because list discovery and detail resolution remain cohesive in the existing reader.

## Hot reply path impact

Not applicable. This code runs only in the protected deploy job and adds no database, network, or awaited work to the foreground reply critical path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changed.
- Group runtime: Not applicable; no prompt, tool schema, generated guidance, or provider-visible input changed.

## Change-shape breakdown

Classification: deploy helper implementation is source; Vitest is tests/fixtures; deploy contract and execution plan are docs; no generated or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 52 | 4 |
| Tests/fixtures | 84 | 12 |
| Docs | 59 | 7 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **195** | **23** |

## Deployment concerns

- Deployment: applicable
- Supported skew: The private verifier already accepts the unchanged schema-1 receipt; only the public producer's evidence source changes.
- Safe order: Merge this public producer first, then dispatch the protected private-main Cloudflare workflow.
- Rollback floor: None; receipts are run-scoped and ephemeral. Reverting restores the prior false-negative certification risk but does not alter runtime state.
- Expected exposure: One protected deploy window; the currently active release remains live while certification is repaired.
- Reversibility: Revert the public receipt producer before a later deploy if necessary; no persisted migration or compatibility bridge is involved.
- Convergence proof: Require deploy success, managed-container smoke success, one exact Worker version at 100%, and exact version/image/capacity/terminal-rollout matches for all three applications.
- Post-deploy checks: Confirm `release_converged=true`, then inspect bounded runtime error aggregates and aggregate dirty-work/backlog movement independently.

## Changelog

- Changelog: not applicable
- Reason: Internal deployment certification integrity only; members receive no new or changed product behavior from this diff.
