### PR TITLE
fix(cloudflare): certify active rollout target

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-cloudflare-release-receipt-current-detail.md
+++ b/agent-docs/exec-plans/active/2026-09-01-cloudflare-release-receipt-current-detail.md
@@ -6,13 +6,13 @@ Updated: 2026-09-01
 
 ## Goal
 
-- Make the protected Cloudflare deploy receipt identify the exact container application state produced by the current Wrangler deploy, so certification cannot compare a delayed application-list snapshot with current application detail.
+- Make the protected Cloudflare deploy receipt identify the exact container release started by the current Wrangler deploy, while certification independently proves that release became final.
 
 ## Success criteria
 
 - Exact-name application discovery resolves each provider application through its authoritative detail endpoint before the receipt records version or image identity.
-- A Wrangler `modified` action waits through bounded provider-detail propagation and cannot publish a receipt while the post-deploy detail state is byte-for-byte unchanged from the pre-deploy detail state.
-- Focused tests reproduce a stale list result paired with a current detail result and prove the receipt uses only the current detail.
+- A Wrangler `modified` action accepts only a new active rollout whose authoritative current state matches the pre-deploy application and records that rollout's target version and image.
+- Focused tests reproduce stale application detail during an active rollout and prove the receipt records the exact target without mistaking a pre-existing rollout for the current deploy.
 - The protected production workflow reports deploy success, smoke success, and release convergence for one exact Worker and all three exact container applications.
 
 ## Scope
@@ -26,12 +26,14 @@ Updated: 2026-09-01
 - The Worker version and tag matched exactly, all three final container rollouts completed, and no other protected deploy workflow overlapped.
 - The receipt writer currently records version and image from the container application list response, while certification resolves the same application through the detail endpoint.
 - After the detail-source correction, Wrangler reported all three applications modified and moved the Worker to the exact new version, while the immediate post-deploy detail reads still returned every pre-deploy container version. The one-shot receipt classification therefore rejected a real asynchronous provider transition before smoke or certification could start.
+- A bounded two-minute retry still failed after all three Wrangler updates succeeded. Cloudflare's application summary showed the large runner rollout was not terminal, matching Cloudflare's documented contract that deploy success means a rollout started and that the effective application can remain on the preceding image while instances are replaced.
+- Cloudflare's rollout resource already owns the exact `current_version`, `current_configuration`, `target_version`, and `target_configuration` required to identify the release before convergence. The private certifier already polls until application detail matches that target and the rollout is complete.
 
 ## Plan
 
 1. Resolve list-discovered application identifiers through exact application detail reads before parsing receipt identity.
-2. Poll the post-deploy detail snapshots for at most two minutes after Wrangler succeeds, and reject an unchanged state at the deadline.
-3. Add focused stale-list/current-detail, delayed-transition, malformed-detail, redaction, and unchanged-transition regressions.
+2. Resolve a newly active rollout after Wrangler succeeds and derive the immutable receipt from its authoritative target while application detail is still current-state stale.
+3. Add focused stale-list/current-detail, active-target, reused-rollout, malformed-detail, redaction, and unchanged-transition regressions.
 4. Run focused Cloudflare tests, app typecheck, complexity, diff/privacy review, exact-head CI, merge, and protected deployment.
 5. Verify exact release convergence and then recheck the independent residual runtime backlog.
 
@@ -39,11 +41,11 @@ Updated: 2026-09-01
 
 - The public receipt producer must merge before the next protected private deployment consumes it.
 - Old private verification remains compatible with the schema-1 receipt; only the evidence source changes.
-- A detail state that remains unreadable or stale through the bounded poll stops before publishing a receipt. A successful receipt continues to require exact Worker traffic, container version, image, capacity, and terminal rollout proof.
+- An active rollout that is unreadable, reused from before this deploy, or does not join the pre-deploy current state to one exact target stops before publishing a receipt. A successful receipt continues to require exact Worker traffic, container version, image, capacity, and terminal rollout proof.
 
 ## Verification
 
-- Passed: 61 focused Cloudflare receipt and deploy-helper tests, including delayed provider-detail convergence and fail-closed exhaustion.
+- Passed: 65 focused Cloudflare receipt and deploy-helper tests, including active-rollout target evidence, delayed provider-detail convergence, and fail-closed exhaustion.
 - Passed: `apps/cloudflare` package typecheck.
 - Passed: cyclomatic-complexity diff; the changed receipt owner remains below the threshold with no new debt.
 - Passed: `git diff --check` and parent inspection of the complete source, test, documentation, and plan diff.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -34,13 +34,19 @@ errors out of the receipt. Exact-name application discovery uses the provider
 list only to resolve one application identifier; both the pre-deploy and
 post-deploy receipt snapshots come from that application's detail endpoint.
 After Wrangler reports a successful container change, the deploy helper waits
-up to two minutes for those detail snapshots to expose the exact transition;
-the bounded poll fails closed instead of issuing a stale receipt.
-The provider application version is a final-state snapshot, not a deploy
-counter; an `updated` entry requires the existing provider application identity
-to remain continuous and the detail snapshot's version or image to change. A
-later protected observer must match the receipt to 100% Worker traffic and the
-final container versions, image digests, capacities, and rollout outcomes. Land
+up to two minutes for the provider to expose the exact transition. While a
+rollout is active, the receipt uses that new rollout's authoritative target
+version and image only when its current version and image match the pre-deploy
+application and its identifier differs from any pre-existing active rollout.
+If the rollout has already completed, the receipt uses the transitioned
+application detail instead. Unreadable, reused, reverted, replaced, or
+unrelated rollout evidence fails closed instead of issuing a stale receipt.
+The provider application version is a release identity, not a deploy counter;
+an `updated` entry requires the existing provider application identity to
+remain continuous and either a newly active target or a completed detail
+transition. A later protected observer must match the receipt to 100% Worker
+traffic and the final container versions, image digests, capacities, and rollout
+outcomes. Land
 this public producer before enabling a private workflow that requires the
 receipt; the reverse order intentionally fails closed.
 Docker runner smoke derives a separate `.deploy/runner-smoke-bundle/` from the validated production bundle and overlays smoke-only entrypoints there, so the production `.deploy/runner-bundle/` remains the deploy artifact after smoke.

--- a/apps/cloudflare/scripts/container-release-receipt.ts
+++ b/apps/cloudflare/scripts/container-release-receipt.ts
@@ -16,10 +16,19 @@ export interface WranglerContainerAction {
 
 /** Raw provider identity retained only long enough to classify this deploy. */
 export interface CloudflareContainerApplicationIdentity {
+  activeRollout?: CloudflareContainerRolloutIdentity;
   applicationId: string;
   applicationName: string;
   image: string;
   version: number;
+}
+
+export interface CloudflareContainerRolloutIdentity {
+  currentImage: string;
+  currentVersion: number;
+  rolloutId: string;
+  targetImage: string;
+  targetVersion: number;
 }
 
 export interface ContainerReleaseEntry {
@@ -43,6 +52,16 @@ export type ReadUtf8File = (
 export type ListCloudflareContainerApplications = (
   applicationName: string,
 ) => Promise<unknown>;
+
+export type ReadCloudflareContainerRollout = (
+  applicationId: string,
+  rolloutId: string,
+) => Promise<unknown>;
+
+export interface CloudflareContainerProvider {
+  listApplications: ListCloudflareContainerApplications;
+  readRollout: ReadCloudflareContainerRollout;
+}
 
 export type CloudflareContainerFetch = (
   input: URL,
@@ -195,6 +214,7 @@ export async function readCloudflareContainerApplicationIdentities(
   expectedContainers: readonly RenderedContainerIdentity[],
   listApplications: ListCloudflareContainerApplications,
   phase: ContainerApplicationReadPhase,
+  readRollout?: ReadCloudflareContainerRollout,
 ): Promise<CloudflareContainerApplicationIdentity[]> {
   assertUniqueRenderedContainers(expectedContainers, invalidProviderState);
   const identities: CloudflareContainerApplicationIdentity[] = [];
@@ -211,7 +231,27 @@ export async function readCloudflareContainerApplicationIdentities(
       throw invalidProviderState();
     }
 
-    const applications = response.map(parseProviderIdentity);
+    const applications = await Promise.all(response.map(async (application) => {
+      const identity = parseProviderIdentity(application);
+      const activeRolloutId = parseProviderActiveRolloutId(application);
+      if (!activeRolloutId) {
+        return identity;
+      }
+      if (!readRollout) {
+        throw invalidProviderState();
+      }
+
+      let rollout: unknown;
+      try {
+        rollout = await readRollout(identity.applicationId, activeRolloutId);
+      } catch {
+        throw invalidProviderState();
+      }
+      return {
+        ...identity,
+        activeRollout: parseProviderRolloutIdentity(rollout, activeRolloutId),
+      };
+    }));
     if (phase === "before" && applications.length === 0) {
       continue;
     }
@@ -227,17 +267,26 @@ export async function readCloudflareContainerApplicationIdentities(
   return identities.sort(compareByApplicationName);
 }
 
-export function createCloudflareContainerApplicationLister(input: {
+export function createCloudflareContainerProvider(input: {
   accountId: string;
   apiToken: string;
   fetchImpl?: CloudflareContainerFetch;
-}): ListCloudflareContainerApplications {
+}): CloudflareContainerProvider {
   if (!isConfiguredSingleLine(input.accountId) || !isConfiguredSingleLine(input.apiToken)) {
     throw invalidProviderState();
   }
   const fetchImpl = input.fetchImpl ?? defaultCloudflareFetch;
+  const createRequestInit = () => ({
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${input.apiToken}`,
+    },
+    method: "GET",
+    signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
+  } as const);
 
-  return async (applicationName) => {
+  const listApplications: ListCloudflareContainerApplications = async (applicationName) => {
     if (!APPLICATION_NAME_PATTERN.test(applicationName)) {
       throw invalidProviderState();
     }
@@ -249,16 +298,7 @@ export function createCloudflareContainerApplicationLister(input: {
     url.searchParams.set("name", applicationName);
 
     try {
-      const requestInit = {
-        cache: "no-store",
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${input.apiToken}`,
-        },
-        method: "GET",
-        signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
-      } as const;
-      const response = await fetchImpl(url, requestInit);
+      const response = await fetchImpl(url, createRequestInit());
       if (!response.ok) {
         throw invalidProviderState();
       }
@@ -272,10 +312,7 @@ export function createCloudflareContainerApplicationLister(input: {
           `${CLOUDFLARE_API_BASE_URL}/accounts/${encodeURIComponent(input.accountId)}`
             + `/containers/applications/${encodeURIComponent(reference.applicationId)}`,
         );
-        const detailResponse = await fetchImpl(detailUrl, {
-          ...requestInit,
-          signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
-        });
+        const detailResponse = await fetchImpl(detailUrl, createRequestInit());
         if (!detailResponse.ok) {
           throw invalidProviderState();
         }
@@ -293,6 +330,29 @@ export function createCloudflareContainerApplicationLister(input: {
       throw invalidProviderState();
     }
   };
+
+  const readRollout: ReadCloudflareContainerRollout = async (applicationId, rolloutId) => {
+    if (!isConfiguredSingleLine(applicationId) || !isConfiguredSingleLine(rolloutId)) {
+      throw invalidProviderState();
+    }
+    const rolloutUrl = new URL(
+      `${CLOUDFLARE_API_BASE_URL}/accounts/${encodeURIComponent(input.accountId)}`
+        + `/containers/applications/${encodeURIComponent(applicationId)}`
+        + `/rollouts/${encodeURIComponent(rolloutId)}`,
+    );
+
+    try {
+      const response = await fetchImpl(rolloutUrl, createRequestInit());
+      if (!response.ok) {
+        throw invalidProviderState();
+      }
+      return readCloudflareResultObject(await response.json());
+    } catch {
+      throw invalidProviderState();
+    }
+  };
+
+  return { listApplications, readRollout };
 }
 
 export function buildContainerReleaseEntries(input: {
@@ -324,26 +384,36 @@ export function buildContainerReleaseEntries(input: {
       }
 
       let disposition: ContainerReleaseEntry["disposition"];
+      let releasedImage = after.image;
+      let releasedVersion = after.version;
       switch (action.action) {
         case "created":
-          if (before || after.version !== 1) {
+          if (before || after.version !== 1 || after.activeRollout) {
             throw invalidReleaseTransition();
           }
           disposition = "created";
           break;
-        case "modified":
-          if (!before
-            || before.applicationId !== after.applicationId
+        case "modified": {
+          if (!before || before.applicationId !== after.applicationId) {
+            throw invalidReleaseTransition();
+          }
+          const rolloutTarget = resolveNewActiveRolloutTarget(before, after);
+          if (rolloutTarget) {
+            releasedImage = rolloutTarget.image;
+            releasedVersion = rolloutTarget.version;
+          } else if (before.activeRollout
             || (before.version === after.version && before.image === after.image)) {
             throw invalidReleaseTransition();
           }
           disposition = "updated";
           break;
+        }
         case "unchanged":
           if (!before
             || before.applicationId !== after.applicationId
             || before.version !== after.version
-            || before.image !== after.image) {
+            || before.image !== after.image
+            || !sameActiveRollout(before.activeRollout, after.activeRollout)) {
             throw invalidReleaseTransition();
           }
           disposition = "unchanged";
@@ -354,8 +424,8 @@ export function buildContainerReleaseEntries(input: {
         applicationName: action.applicationName,
         className: action.className,
         disposition,
-        imageSha256: createHash("sha256").update(after.image).digest("hex"),
-        version: after.version,
+        imageSha256: createHash("sha256").update(releasedImage).digest("hex"),
+        version: releasedVersion,
       };
     });
 }
@@ -366,6 +436,7 @@ export async function waitForCloudflareContainerReleaseEntries(input: {
   expectedContainers: readonly RenderedContainerIdentity[];
   listApplications: ListCloudflareContainerApplications;
   maxAttempts?: number;
+  readRollout?: ReadCloudflareContainerRollout;
   retryDelayMs?: number;
   sleep?: (delayMs: number) => Promise<void>;
 }): Promise<ContainerReleaseEntry[]> {
@@ -384,6 +455,7 @@ export async function waitForCloudflareContainerReleaseEntries(input: {
         input.expectedContainers,
         input.listApplications,
         "after",
+        input.readRollout,
       );
       return buildContainerReleaseEntries({
         actions: input.actions,
@@ -467,6 +539,90 @@ function parseProviderIdentity(value: unknown): CloudflareContainerApplicationId
   return { applicationId, applicationName, image, version };
 }
 
+function parseProviderActiveRolloutId(value: unknown): string | null {
+  if (!isRecord(value)) {
+    throw invalidProviderState();
+  }
+  const activeRolloutId = value.active_rollout_id;
+  if (activeRolloutId === undefined || activeRolloutId === null) {
+    return null;
+  }
+  if (typeof activeRolloutId !== "string" || !isConfiguredSingleLine(activeRolloutId)) {
+    throw invalidProviderState();
+  }
+  return activeRolloutId;
+}
+
+function parseProviderRolloutIdentity(
+  value: unknown,
+  expectedRolloutId: string,
+): CloudflareContainerRolloutIdentity {
+  if (!isRecord(value)
+    || !isRecord(value.current_configuration)
+    || !isRecord(value.target_configuration)
+    || value.id !== expectedRolloutId
+    || (value.status !== "pending"
+      && value.status !== "progressing"
+      && value.status !== "completed")) {
+    throw invalidProviderState();
+  }
+  const currentVersion = readPositiveSafeInteger(value, "current_version", invalidProviderState);
+  const targetVersion = readPositiveSafeInteger(value, "target_version", invalidProviderState);
+  return {
+    currentImage: readRequiredNonemptyString(
+      value.current_configuration,
+      "image",
+      invalidProviderState,
+    ),
+    currentVersion,
+    rolloutId: expectedRolloutId,
+    targetImage: readRequiredNonemptyString(
+      value.target_configuration,
+      "image",
+      invalidProviderState,
+    ),
+    targetVersion,
+  };
+}
+
+function resolveNewActiveRolloutTarget(
+  before: CloudflareContainerApplicationIdentity,
+  after: CloudflareContainerApplicationIdentity,
+): Readonly<{ image: string; version: number }> | null {
+  const rollout = after.activeRollout;
+  if (!rollout) {
+    return null;
+  }
+  const priorRolloutId = before.activeRollout?.rolloutId;
+  const applicationMatchesCurrent = after.version === rollout.currentVersion
+    && after.image === rollout.currentImage;
+  const applicationMatchesTarget = after.version === rollout.targetVersion
+    && after.image === rollout.targetImage;
+  if (rollout.rolloutId === priorRolloutId
+    || rollout.currentVersion !== before.version
+    || rollout.currentImage !== before.image
+    || (rollout.currentVersion === rollout.targetVersion
+      && rollout.currentImage === rollout.targetImage)
+    || (!applicationMatchesCurrent && !applicationMatchesTarget)) {
+    throw invalidReleaseTransition();
+  }
+  return { image: rollout.targetImage, version: rollout.targetVersion };
+}
+
+function sameActiveRollout(
+  left: CloudflareContainerRolloutIdentity | undefined,
+  right: CloudflareContainerRolloutIdentity | undefined,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return left.rolloutId === right.rolloutId
+    && left.currentVersion === right.currentVersion
+    && left.currentImage === right.currentImage
+    && left.targetVersion === right.targetVersion
+    && left.targetImage === right.targetImage;
+}
+
 function indexProviderIdentities(
   identities: readonly CloudflareContainerApplicationIdentity[],
 ): Map<string, CloudflareContainerApplicationIdentity> {
@@ -480,7 +636,8 @@ function indexProviderIdentities(
       || !isConfiguredSingleLine(identity.image)
       || typeof identity.version !== "number"
       || !Number.isSafeInteger(identity.version)
-      || identity.version <= 0) {
+      || identity.version <= 0
+      || !isValidProviderRolloutIdentity(identity.activeRollout)) {
       throw invalidReleaseTransition();
     }
     if (indexed.has(identity.applicationName)) {
@@ -489,6 +646,19 @@ function indexProviderIdentities(
     indexed.set(identity.applicationName, identity);
   }
   return indexed;
+}
+
+function isValidProviderRolloutIdentity(
+  rollout: CloudflareContainerRolloutIdentity | undefined,
+): boolean {
+  return rollout === undefined
+    || (isConfiguredSingleLine(rollout.rolloutId)
+      && isConfiguredSingleLine(rollout.currentImage)
+      && Number.isSafeInteger(rollout.currentVersion)
+      && rollout.currentVersion > 0
+      && isConfiguredSingleLine(rollout.targetImage)
+      && Number.isSafeInteger(rollout.targetVersion)
+      && rollout.targetVersion > 0);
 }
 
 function assertUniqueProviderIdentities(
@@ -540,6 +710,18 @@ function readRequiredNonemptyString(
 ): string {
   const value = readOptionalNonemptyString(record, key);
   if (!value) {
+    throw createError();
+  }
+  return value;
+}
+
+function readPositiveSafeInteger(
+  record: Record<string, unknown>,
+  key: string,
+  createError: () => Error,
+): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
     throw createError();
   }
   return value;

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -15,7 +15,7 @@ import {
 import { assertHostedDeployEnvironmentAsync } from "./deploy-preflight.js";
 import { resolveDeployWorkerCliPaths } from "./deploy-worker-version-paths.js";
 import {
-  createCloudflareContainerApplicationLister,
+  createCloudflareContainerProvider,
   parseWranglerContainerActions,
   parseWranglerWorkerVersionId,
   readCloudflareContainerApplicationIdentities,
@@ -63,14 +63,15 @@ export async function runDeployWorkerVersionCli(
           source: env,
         });
         const renderedContainers = await readRenderedContainerIdentities(input.configPath);
-        const listApplications = createCloudflareContainerApplicationLister({
+        const containerProvider = createCloudflareContainerProvider({
           accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
           apiToken: requireConfiguredString(env.CLOUDFLARE_API_TOKEN, "CLOUDFLARE_API_TOKEN"),
         });
         const before = await readCloudflareContainerApplicationIdentities(
           renderedContainers,
-          listApplications,
+          containerProvider.listApplications,
           "before",
+          containerProvider.readRollout,
         );
         const deployOutput = await runWranglerLoggedCaptured([
           "deploy",
@@ -94,7 +95,8 @@ export async function runDeployWorkerVersionCli(
             actions,
             before,
             expectedContainers: renderedContainers,
-            listApplications,
+            listApplications: containerProvider.listApplications,
+            readRollout: containerProvider.readRollout,
           }),
           workerVersionId: parseWranglerWorkerVersionId(
             `${deployOutput.stdout}\n${deployOutput.stderr}`,

--- a/apps/cloudflare/test/container-release-receipt.test.ts
+++ b/apps/cloudflare/test/container-release-receipt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   buildContainerReleaseEntries,
-  createCloudflareContainerApplicationLister,
+  createCloudflareContainerProvider,
   parseWranglerContainerActions,
   parseWranglerWorkerVersionId,
   readCloudflareContainerApplicationIdentities,
@@ -212,7 +212,7 @@ describe("container release receipt", () => {
             },
         ok: true,
       }));
-      const listApplications = createCloudflareContainerApplicationLister({
+      const { listApplications } = createCloudflareContainerProvider({
         accountId: "account-fixture",
         apiToken: "token-fixture",
         fetchImpl,
@@ -251,13 +251,55 @@ describe("container release receipt", () => {
       });
     });
 
+    it("reads the exact active rollout through the provider application boundary", async () => {
+      const fetchImpl = vi.fn(async (input: URL) => ({
+        json: async () => input.pathname.endsWith("/rollouts/rollout-current")
+          ? {
+              result: providerRollout(
+                "rollout-current",
+                5,
+                "current-image",
+                6,
+                "target-image",
+              ),
+              success: true,
+            }
+          : { result: {}, success: true },
+        ok: true,
+      }));
+      const provider = createCloudflareContainerProvider({
+        accountId: "account-fixture",
+        apiToken: "token-fixture",
+        fetchImpl,
+      });
+
+      await expect(provider.readRollout("app-id", "rollout-current")).resolves.toEqual(
+        providerRollout("rollout-current", 5, "current-image", 6, "target-image"),
+      );
+      expect(fetchImpl).toHaveBeenCalledWith(
+        new URL(
+          "https://api.cloudflare.com/client/v4/accounts/account-fixture"
+            + "/containers/applications/app-id/rollouts/rollout-current",
+        ),
+        {
+          cache: "no-store",
+          headers: {
+            Accept: "application/json",
+            Authorization: "Bearer token-fixture",
+          },
+          method: "GET",
+          signal: expect.any(AbortSignal),
+        },
+      );
+    });
+
     it.each([
       { result: [], success: false },
       { result: {}, success: true },
       { result: [], result_info: { next_page_token: "more" }, success: true },
       { result: [], result_info: { total_count: 1 }, success: true },
     ])("rejects invalid or non-exhaustive Cloudflare list responses", async (payload) => {
-      const listApplications = createCloudflareContainerApplicationLister({
+      const { listApplications } = createCloudflareContainerProvider({
         accountId: "account-fixture",
         apiToken: "token-fixture",
         fetchImpl: async () => ({ json: async () => payload, ok: true }),
@@ -269,7 +311,7 @@ describe("container release receipt", () => {
     });
 
     it("redacts transport, response, URL, and credential detail from list failures", async () => {
-      const listApplications = createCloudflareContainerApplicationLister({
+      const { listApplications } = createCloudflareContainerProvider({
         accountId: "sensitive-account-fixture",
         apiToken: "sensitive-token-fixture",
         fetchImpl: async () => {
@@ -306,7 +348,7 @@ describe("container release receipt", () => {
           : detailPayload,
         ok: true,
       }));
-      const listApplications = createCloudflareContainerApplicationLister({
+      const { listApplications } = createCloudflareContainerProvider({
         accountId: "account-fixture",
         apiToken: "token-fixture",
         fetchImpl,
@@ -330,7 +372,7 @@ describe("container release receipt", () => {
         }
         throw new Error("sensitive detail transport failure");
       });
-      const listApplications = createCloudflareContainerApplicationLister({
+      const { listApplications } = createCloudflareContainerProvider({
         accountId: "sensitive-account-fixture",
         apiToken: "sensitive-token-fixture",
         fetchImpl,
@@ -480,6 +522,75 @@ describe("container release receipt", () => {
       expect(listApplications).toHaveBeenCalledTimes(2);
     });
 
+    it("uses a new active rollout target while application detail remains on current state", async () => {
+      const modifiedAction = [
+        { action: "modified", applicationName: "app", className: "Container" },
+      ] as const;
+      const before = [identity("app", "id", 2, "old-image")];
+      const listApplications = vi.fn(async () => [
+        providerIdentity("app", "id", 2, "old-image", "rollout-new"),
+      ]);
+      const readRollout = vi.fn(async () =>
+        providerRollout("rollout-new", 2, "old-image", 3, "new-image")
+      );
+
+      await expect(waitForCloudflareContainerReleaseEntries({
+        actions: modifiedAction,
+        before,
+        expectedContainers: [{ applicationName: "app", className: "Container" }],
+        listApplications,
+        maxAttempts: 1,
+        readRollout,
+      })).resolves.toEqual([
+        {
+          applicationName: "app",
+          className: "Container",
+          disposition: "updated",
+          imageSha256: "97e67a5645969953f1a4cfe2ea75649864ff99789189cdd3f6db03e59f8a8ebf",
+          version: 3,
+        },
+      ]);
+      expect(readRollout).toHaveBeenCalledWith("id", "rollout-new");
+    });
+
+    it("rejects an already-active rollout as evidence for a new modified action", () => {
+      const modifiedAction = [
+        { action: "modified", applicationName: "app", className: "Container" },
+      ] as const;
+      const activeRollout = rolloutIdentity(
+        "rollout-existing",
+        2,
+        "old-image",
+        3,
+        "new-image",
+      );
+
+      expect(() => buildContainerReleaseEntries({
+        actions: modifiedAction,
+        after: [{ ...identity("app", "id", 2, "old-image"), activeRollout }],
+        before: [{ ...identity("app", "id", 2, "old-image"), activeRollout }],
+      })).toThrow("Container release evidence did not form an exact provider transition.");
+    });
+
+    it("rejects a prior rollout completing without a new active rollout identity", () => {
+      const modifiedAction = [
+        { action: "modified", applicationName: "app", className: "Container" },
+      ] as const;
+      const priorRollout = rolloutIdentity(
+        "rollout-existing",
+        2,
+        "old-image",
+        3,
+        "intermediate-image",
+      );
+
+      expect(() => buildContainerReleaseEntries({
+        actions: modifiedAction,
+        after: [identity("app", "id", 3, "intermediate-image")],
+        before: [{ ...identity("app", "id", 2, "old-image"), activeRollout: priorRollout }],
+      })).toThrow("Container release evidence did not form an exact provider transition.");
+    });
+
     it("fails closed when modified application detail never exposes a transition", async () => {
       const modifiedAction = [
         { action: "modified", applicationName: "app", className: "Container" },
@@ -535,13 +646,42 @@ function providerIdentity(
   id: string,
   version: number,
   image: string,
+  activeRolloutId?: string,
 ): Record<string, unknown> {
   return {
+    ...(activeRolloutId ? { active_rollout_id: activeRolloutId } : {}),
     configuration: { image },
     id,
     name: applicationName,
     version,
   };
+}
+
+function providerRollout(
+  rolloutId: string,
+  currentVersion: number,
+  currentImage: string,
+  targetVersion: number,
+  targetImage: string,
+): Record<string, unknown> {
+  return {
+    current_configuration: { image: currentImage },
+    current_version: currentVersion,
+    id: rolloutId,
+    status: "progressing",
+    target_configuration: { image: targetImage },
+    target_version: targetVersion,
+  };
+}
+
+function rolloutIdentity(
+  rolloutId: string,
+  currentVersion: number,
+  currentImage: string,
+  targetVersion: number,
+  targetImage: string,
+) {
+  return { currentImage, currentVersion, rolloutId, targetImage, targetVersion };
 }
 
 function identity(

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -8,7 +8,7 @@ const wranglerMocks = vi.hoisted(() => ({
   runWranglerLoggedCaptured: vi.fn(),
 }));
 const receiptMocks = vi.hoisted(() => ({
-  createCloudflareContainerApplicationLister: vi.fn(),
+  createCloudflareContainerProvider: vi.fn(),
   parseWranglerContainerActions: vi.fn(),
   parseWranglerWorkerVersionId: vi.fn(),
   readCloudflareContainerApplicationIdentities: vi.fn(),
@@ -22,8 +22,7 @@ vi.mock("../scripts/wrangler-runner.js", () => ({
   runWranglerLoggedCaptured: wranglerMocks.runWranglerLoggedCaptured,
 }));
 vi.mock("../scripts/container-release-receipt.js", () => ({
-  createCloudflareContainerApplicationLister:
-    receiptMocks.createCloudflareContainerApplicationLister,
+  createCloudflareContainerProvider: receiptMocks.createCloudflareContainerProvider,
   parseWranglerContainerActions: receiptMocks.parseWranglerContainerActions,
   parseWranglerWorkerVersionId: receiptMocks.parseWranglerWorkerVersionId,
   readCloudflareContainerApplicationIdentities:
@@ -41,8 +40,11 @@ describe("runDeployWorkerVersionCli", () => {
     wranglerMocks.runWranglerLogged.mockReset();
     wranglerMocks.runWranglerLoggedCaptured.mockReset();
     wranglerMocks.runWranglerLoggedCaptured.mockResolvedValue({ stderr: "", stdout: "deploy" });
-    receiptMocks.createCloudflareContainerApplicationLister.mockReset();
-    receiptMocks.createCloudflareContainerApplicationLister.mockReturnValue(vi.fn());
+    receiptMocks.createCloudflareContainerProvider.mockReset();
+    receiptMocks.createCloudflareContainerProvider.mockReturnValue({
+      listApplications: vi.fn(),
+      readRollout: vi.fn(),
+    });
     receiptMocks.parseWranglerContainerActions.mockReset();
     receiptMocks.parseWranglerContainerActions.mockReturnValue([]);
     receiptMocks.parseWranglerWorkerVersionId.mockReset();
@@ -141,6 +143,7 @@ describe("runDeployWorkerVersionCli", () => {
       CF_WORKER_NAME: "hosted-worker",
     };
     const listApplications = vi.fn();
+    const readRollout = vi.fn();
     const before = [{
       applicationId: "provider-app-id",
       applicationName: "hosted-worker-runnercontainer",
@@ -152,7 +155,10 @@ describe("runDeployWorkerVersionCli", () => {
       applicationName: "hosted-worker-runnercontainer",
       className: "RunnerContainer",
     }];
-    receiptMocks.createCloudflareContainerApplicationLister.mockReturnValue(listApplications);
+    receiptMocks.createCloudflareContainerProvider.mockReturnValue({
+      listApplications,
+      readRollout,
+    });
     receiptMocks.readCloudflareContainerApplicationIdentities.mockResolvedValueOnce(before);
     receiptMocks.parseWranglerContainerActions.mockReturnValue(actions);
 
@@ -194,12 +200,18 @@ describe("runDeployWorkerVersionCli", () => {
     expect(receiptMocks.readRenderedContainerIdentities).toHaveBeenCalledWith(
       "/tmp/wrangler.generated.jsonc",
     );
-    expect(receiptMocks.createCloudflareContainerApplicationLister).toHaveBeenCalledWith({
+    expect(receiptMocks.createCloudflareContainerProvider).toHaveBeenCalledWith({
       accountId: "account-fixture",
       apiToken: "token-fixture",
     });
     expect(receiptMocks.readCloudflareContainerApplicationIdentities)
-      .toHaveBeenNthCalledWith(1, renderedContainers, listApplications, "before");
+      .toHaveBeenNthCalledWith(
+        1,
+        renderedContainers,
+        listApplications,
+        "before",
+        readRollout,
+      );
     expect(receiptMocks.parseWranglerContainerActions).toHaveBeenCalledWith(
       "deploy\n",
       renderedContainers,
@@ -210,6 +222,7 @@ describe("runDeployWorkerVersionCli", () => {
       before,
       expectedContainers: renderedContainers,
       listApplications,
+      readRollout,
     });
   });
 


### PR DESCRIPTION
## Why and outcome

The last protected production run proved that a two-minute detail poll is still the wrong ownership boundary: Wrangler successfully started all three container rollouts, but effective application detail remained on the preceding release while the large Runner rollout was still replacing instances. Cloudflare documents deploy success as rollout-start, not rollout-complete.

This change records an updated container from the provider-authored active rollout target when that rollout is new for this deploy and its current version/image exactly match the pre-deploy application. The private certifier remains responsible for waiting until that target becomes the terminal effective release.

## Product UX

Not applicable. This is an internal deployment-integrity correction with no member-facing surface or product behavior change.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.config.ts apps/cloudflare/test/container-release-receipt.test.ts apps/cloudflare/test/deploy-worker-version-cli.test.ts apps/cloudflare/test/deploy-worker-version.test.ts` - 65 passed.
- `pnpm --dir apps/cloudflare typecheck` - passed.
- `pnpm complexity:diff` - passed; no changed hotspot above 20.
- `git diff --check` - passed.
- Production reproduction: all three Wrangler mutations succeeded, the Worker moved to the exact tagged version, and receipt generation exhausted its two-minute detail poll before smoke because effective application state was not yet terminal.
- ReviewGPT skipped by explicit user instruction.

## Non-obvious affected surfaces

- Protected Cloudflare deployment only. Active-rollout reads use the existing authenticated Cloudflare application boundary and per-request timeout.
- A receipt accepts only a rollout identifier not present in the pre-deploy snapshot, exact application identity continuity, exact rollout-current/pre-deploy equality, and one exact rollout target.
- Existing, replaced, reverted, malformed, or causally ambiguous rollout evidence fails closed. Raw provider identifiers, image references, credentials, and errors remain outside the receipt.

## Architecture and reuse

- Existing systems reused: Wrangler mutation ownership, exact-name application discovery, authoritative application detail, Cloudflare's active-rollout resource, schema-1 receipt, and the private terminal-convergence certifier.
- New logic: resolve the current active rollout and classify its target at the existing receipt owner.
- New abstractions: one small provider pair for application and rollout reads; no new dependency or persisted state.
- Complexity intentionally avoided: no receipt schema change, duplicated rollout watcher, deployment queue, or verifier fallback.

## Complexity impact

- Guard: pass - `pnpm complexity:diff` completed successfully.
- Hotspots: None; every changed source function remains below the repository threshold of 20.
- Agent judgment: reading the rollout target at the existing provider boundary is smaller and more accurate than extending deployment waits or duplicating release state.

## Hot reply path impact

Not applicable. Provider reads occur only inside a protected deploy job.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, guidance, or model-visible input changed.
- Group runtime: Not applicable; no prompt, tool schema, guidance, or model-visible input changed.

## Change-shape breakdown

Classification: deploy helper implementation is source; Vitest is tests/fixtures; deploy contract and execution plan are docs; no generated or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 215 | 31 |
| Tests/fixtures | 167 | 14 |
| Docs | 22 | 14 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **404** | **59** |

## Deployment concerns

- Deployment: applicable
- Supported skew: The private verifier already accepts the unchanged schema-1 receipt and already verifies the target version, image, capacity, Worker traffic, and terminal rollout.
- Safe order: Merge this public producer first, then dispatch the protected private-main Cloudflare workflow.
- Rollback floor: None; receipts are run-scoped and ephemeral.
- Expected exposure: The already-applied Worker remains live while receipt production is repaired.
- Reversibility: Revert this helper before a later deploy; no migration or compatibility bridge is involved.
- Convergence proof: Require deploy success, smoke success, one exact Worker version at 100%, and exact version/image/capacity/completed-rollout matches for all three applications.
- Post-deploy checks: Confirm `release_converged=true`, then independently recheck bounded runtime error aggregates and dirty-sync backlog movement.

## Changelog

- Changelog: not applicable
- Reason: Internal deployment certification integrity only; member-visible behavior is unchanged.
